### PR TITLE
fix: gate audit links behind feature switch

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
@@ -19,6 +19,8 @@ import {
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
+import { seedUserFeatureSwitches } from "../../../../../../../src/__tests__/db-test-seeders/feature-switches";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const context = testContext();
 
@@ -82,7 +84,7 @@ async function givenGitHubCallbackSetup(overrides?: {
 }) {
   const userId = uniqueId("gh-cb-user");
   mockClerk({ userId });
-  await createTestOrg(uniqueId("gh-cb-org"));
+  const org = await createTestOrg(uniqueId("gh-cb-org"));
   const { composeId } = await createTestCompose(uniqueId("gh-callback-agent"));
 
   const { runId } = await seedTestRun(userId, composeId, {
@@ -110,6 +112,7 @@ async function givenGitHubCallbackSetup(overrides?: {
 
   return {
     userId,
+    orgId: org.id,
     composeId,
     runId,
     installation,
@@ -235,7 +238,7 @@ describe("POST /api/internal/callbacks/github/issues", () => {
   });
 
   describe("Successful Callback", () => {
-    it("should post comment to GitHub issue on completed run", async () => {
+    it("should omit audit link when AuditLink switch is off", async () => {
       const { runId, payload, secret, capturedComments } =
         await givenGitHubCallbackSetup();
 
@@ -255,7 +258,29 @@ describe("POST /api/internal/callbacks/github/issues", () => {
       expect(capturedComments[0]!.owner).toBe("test-org");
       expect(capturedComments[0]!.repo).toBe("test-repo");
       expect(capturedComments[0]!.issueNumber).toBe("42");
-      // Verify the comment body includes the logs footer
+      expect(capturedComments[0]!.body).not.toContain("Audit");
+      expect(capturedComments[0]!.body).not.toContain(`/activities/${runId}`);
+    });
+
+    it("should include audit link when AuditLink switch is on", async () => {
+      const { orgId, userId, runId, payload, secret, capturedComments } =
+        await givenGitHubCallbackSetup();
+      await seedUserFeatureSwitches(orgId, userId, {
+        [FeatureSwitchKey.AuditLink]: true,
+      });
+
+      const request = createSignedCallbackRequest(
+        TEST_URL,
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      expect(capturedComments).toHaveLength(1);
       expect(capturedComments[0]!.body).toContain("Audit");
       expect(capturedComments[0]!.body).toContain(`/activities/${runId}`);
     });

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
@@ -7,6 +7,8 @@ import { githubIssueSessions } from "@vm0/db/schema/github-issue-session";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { getInstallationAccessToken } from "../../../../../../src/lib/zero/github/github-app";
 import {
   postIssueComment,
@@ -14,6 +16,7 @@ import {
 } from "../../../../../../src/lib/zero/github/api";
 import { extractRunOutput } from "../../../../../../src/lib/infra/run/extract-run-output";
 import { getAppUrl } from "../../../../../../src/lib/zero/url";
+import { loadFeatureSwitchOverrides } from "../../../../../../src/lib/zero/user/feature-switches-service";
 import { env } from "../../../../../../src/env";
 import type { GitHubIssuesCallbackPayload } from "../../../../../../src/lib/infra/callback/callback-payloads";
 import { logger } from "../../../../../../src/lib/shared/logger";
@@ -132,14 +135,13 @@ async function saveIssueSession(opts: {
 function formatGitHubComment(opts: {
   status: "completed" | "failed";
   agentName: string;
-  runId: string;
+  logsUrl?: string;
   output?: string;
   error?: string;
   triggerCommentBody?: string;
 }): string {
-  const { status, agentName, runId, output, error, triggerCommentBody } = opts;
-  const appUrl = getAppUrl();
-  const logsUrl = `${appUrl}/activities/${encodeURIComponent(runId)}`;
+  const { status, agentName, logsUrl, output, error, triggerCommentBody } =
+    opts;
   const content =
     status === "completed"
       ? (output ?? "Task completed successfully.")
@@ -158,10 +160,38 @@ function formatGitHubComment(opts: {
     parts.push(quoted, "");
   }
 
-  parts.push(`<sub>🤖 **${agentName}**</sub>`, "", content, "");
-  parts.push(`<sub>📋 [Audit](${logsUrl})</sub>`);
+  parts.push(`<sub>🤖 **${agentName}**</sub>`, "", content);
+  if (logsUrl) {
+    parts.push("");
+    parts.push(`<sub>📋 [Audit](${logsUrl})</sub>`);
+  }
 
   return parts.join("\n");
+}
+
+async function resolveGitHubAuditLogsUrl(
+  runId: string,
+): Promise<string | undefined> {
+  const [run] = await globalThis.services.db
+    .select({ userId: agentRuns.userId, orgId: agentRuns.orgId })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+  if (!run) {
+    return undefined;
+  }
+
+  const overrides = await loadFeatureSwitchOverrides(run.orgId, run.userId);
+  const enabled = isFeatureEnabled(FeatureSwitchKey.AuditLink, {
+    userId: run.userId,
+    orgId: run.orgId,
+    overrides,
+  });
+  if (!enabled) {
+    return undefined;
+  }
+
+  return `${getAppUrl()}/activities/${encodeURIComponent(runId)}`;
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -237,7 +267,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const commentBody = formatGitHubComment({
     status,
     agentName: agent.label,
-    runId,
+    logsUrl: await resolveGitHubAuditLogsUrl(runId),
     output: resultData.result ?? undefined,
     error,
     triggerCommentBody: payload.triggerCommentBody,

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
@@ -18,6 +18,8 @@ import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { server } from "../../../../../../src/mocks/server";
 import { http } from "../../../../../../src/__tests__/msw";
 import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
+import { seedUserFeatureSwitches } from "../../../../../../src/__tests__/db-test-seeders/feature-switches";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const context = testContext();
 
@@ -105,7 +107,7 @@ async function setupTelegramCallback() {
   mockClerk({ userId });
 
   // Create org + compose (with version) through API
-  await createTestOrg(uniqueId("org"));
+  const org = await createTestOrg(uniqueId("org"));
   const { composeId, name: composeName } = await createTestCompose(
     uniqueId("telegram-agent"),
   );
@@ -142,6 +144,7 @@ async function setupTelegramCallback() {
     installationId,
     composeId,
     composeName,
+    orgId: org.id,
     userId,
     userLinkId,
     runId,
@@ -223,7 +226,7 @@ describe("POST /api/internal/callbacks/telegram", () => {
   });
 
   describe("Successful Callback", () => {
-    it("should return 200 and send message on completed run", async () => {
+    it("should omit audit link when AuditLink switch is off", async () => {
       const { runId, payload, secret } = await setupTelegramCallback();
 
       const chatActionHandler = telegramSendChatAction();
@@ -251,7 +254,39 @@ describe("POST /api/internal/callbacks/telegram", () => {
       expect(sendMessageHandler.mocked).toHaveBeenCalledTimes(1);
       const text = sendMessageHandler.calls[0]?.text ?? "";
       expect(text).not.toContain("🤖");
+      expect(text).not.toContain("📋 Audit");
+    });
+
+    it("should include audit link when AuditLink switch is on", async () => {
+      const { orgId, userId, runId, payload, secret } =
+        await setupTelegramCallback();
+      await seedUserFeatureSwitches(orgId, userId, {
+        [FeatureSwitchKey.AuditLink]: true,
+      });
+
+      const chatActionHandler = telegramSendChatAction();
+      const deleteMessageHandler = telegramDeleteMessage();
+      const sendMessageHandler = telegramSendMessage();
+      server.use(
+        chatActionHandler.handler,
+        deleteMessageHandler.handler,
+        sendMessageHandler.handler,
+      );
+
+      const request = createSignedCallbackRequest(
+        "http://localhost/api/internal/callbacks/telegram",
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      const text = sendMessageHandler.calls[0]?.text ?? "";
       expect(text).toContain("📋 Audit");
+      expect(text).toContain(`/activities/${runId}`);
     });
 
     it("should return 200 and send error message on failed run", async () => {

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
@@ -23,7 +23,7 @@ import { extractRunOutput } from "../../../../../src/lib/infra/run/extract-run-o
 import {
   saveTelegramThreadSession,
   storeTelegramMessage,
-  buildLogsUrl,
+  resolveTelegramAuditLogsUrl,
   getAgentDisplayLabel,
   formatTelegramThinkingMessage,
 } from "../../../../../src/lib/zero/telegram/handlers/shared";
@@ -157,8 +157,24 @@ async function handleCompletion(ctx: CompletionContext): Promise<void> {
   }
   const runOutput = await extractRunOutput(runId, error);
 
+  const [run] = await globalThis.services.db
+    .select({
+      userId: agentRuns.userId,
+      orgId: agentRuns.orgId,
+      createdAt: agentRuns.createdAt,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+
   // Build response text
-  const logsUrl = buildLogsUrl(runId);
+  const logsUrl = run
+    ? await resolveTelegramAuditLogsUrl({
+        orgId: run.orgId,
+        userId: run.userId,
+        runId,
+      })
+    : undefined;
   let htmlOutput: string;
   let responseText: string | undefined;
   if (status === "completed") {
@@ -193,13 +209,6 @@ async function handleCompletion(ctx: CompletionContext): Promise<void> {
       text: responseText,
     });
   }
-
-  // Get run to find userId for session lookup
-  const [run] = await globalThis.services.db
-    .select({ userId: agentRuns.userId, createdAt: agentRuns.createdAt })
-    .from(agentRuns)
-    .where(eq(agentRuns.id, runId))
-    .limit(1);
 
   // Save thread session mapping
   if (run && botReplyMessageId !== undefined) {

--- a/turbo/apps/web/app/api/zero/email/callbacks/reply/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/email/callbacks/reply/__tests__/route.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render } from "@react-email/components";
+import type { CreateEmailOptions } from "resend";
 import { Resend } from "resend";
 import { POST } from "../route";
 import {
@@ -14,9 +16,11 @@ import {
   createSignedCallbackRequest,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import { createTestEmailThreadSession } from "../../../../../../../src/__tests__/db-test-seeders/email";
+import { seedUserFeatureSwitches } from "../../../../../../../src/__tests__/db-test-seeders/feature-switches";
 import { findTestEmailThreadSession } from "../../../../../../../src/__tests__/db-test-assertions/email";
 import { generateReplyToken } from "../../../../../../../src/lib/zero/email/handlers/shared";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const context = testContext();
 const mockResend = vi.mocked(new Resend(""), true);
@@ -28,6 +32,17 @@ interface ReplyCallbackPayload {
   inboundReferences?: string;
   replyRecipientTo?: string[];
   replyRecipientCc?: string[];
+}
+
+async function renderLastEmailHtml(): Promise<string> {
+  const sentCall = mockResend.emails.send.mock.calls.at(-1);
+  expect(sentCall).toBeDefined();
+  const payload = sentCall![0] as CreateEmailOptions;
+  expect(payload).toHaveProperty("react");
+  if (!("react" in payload) || payload.react == null) {
+    throw new Error("Expected react property on email payload");
+  }
+  return render(payload.react);
 }
 
 describe("POST /api/zero/email/callbacks/reply", () => {
@@ -145,6 +160,10 @@ describe("POST /api/zero/email/callbacks/reply", () => {
       expect(sendArgs.headers["References"]).toBe(
         "<orig-user-msg@mail.example.com> <original-msg-id@vm7.bot> <user-reply@mail.example.com>",
       );
+      const html = await renderLastEmailHtml();
+      expect(html).not.toContain("Audit");
+      expect(html).not.toContain(`/activities/${runId}`);
+      expect(html).toContain("Reply to continue");
 
       // Verify thread session was updated with new messageId
       const updatedSession = await findTestEmailThreadSession(replyToken);
@@ -152,6 +171,54 @@ describe("POST /api/zero/email/callbacks/reply", () => {
       expect(updatedSession!.lastEmailMessageId).toBe(
         "<mock-message-id@vm7.bot>",
       );
+    });
+
+    it("should include audit link when AuditLink switch is on", async () => {
+      const user = await context.setupUser({ prefix: "reply-audit-on" });
+      mockClerk({ userId: user.userId });
+      const { composeId, agentId } = await createTestCompose(
+        uniqueId("reply-agent"),
+      );
+      const agentSession = await createTestAgentSession(user.userId, composeId);
+      const replyToken = generateReplyToken(agentSession.id);
+      const emailSession = await createTestEmailThreadSession({
+        userId: user.userId,
+        agentId,
+        agentSessionId: agentSession.id,
+        replyToToken: replyToken,
+      });
+      const { runId } = await createTestRun(composeId, "Email reply task");
+      await completeTestRun(user.userId, runId);
+      await seedUserFeatureSwitches(user.orgId, user.userId, {
+        [FeatureSwitchKey.AuditLink]: true,
+      });
+
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        { eventData: { result: "Reply output" } },
+      ]);
+
+      const payload: ReplyCallbackPayload = {
+        emailThreadSessionId: emailSession.id,
+        inboundEmailId: "inbound-email-audit-on",
+      };
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/zero/email/callbacks/reply",
+        payload: { ...payload },
+      });
+
+      const request = createSignedCallbackRequest(
+        "http://localhost/api/zero/email/callbacks/reply",
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
+      const html = await renderLastEmailHtml();
+      expect(html).toContain("Audit");
+      expect(html).toContain(`/activities/${runId}`);
     });
 
     it("should fall back to session.lastEmailMessageId when inbound headers are missing", async () => {

--- a/turbo/apps/web/app/api/zero/email/callbacks/reply/route.ts
+++ b/turbo/apps/web/app/api/zero/email/callbacks/reply/route.ts
@@ -11,7 +11,7 @@ import { enqueueEmail } from "../../../../../../src/lib/zero/email/outbox-servic
 import {
   buildReplyToAddress,
   buildFromAddress,
-  buildLogsUrl,
+  resolveEmailAuditLogsUrl,
   buildUnsubscribeUrl,
   buildUnsubscribeHeaders,
 } from "../../../../../../src/lib/zero/email/handlers/shared";
@@ -147,7 +147,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   // Get run output
-  const logsUrl = buildLogsUrl(runId);
+  const logsUrl = await resolveEmailAuditLogsUrl({
+    orgId,
+    userId: session.userId,
+    runId,
+  });
   const rawOutput =
     status === "completed" ? ((await getRunOutputText(runId)) ?? null) : null;
   const output = formatOutput(status, rawOutput, error);

--- a/turbo/apps/web/app/api/zero/email/callbacks/trigger/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/email/callbacks/trigger/__tests__/route.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render } from "@react-email/components";
+import type { CreateEmailOptions } from "resend";
 
 import { Resend } from "resend";
 import { POST } from "../route";
@@ -14,8 +16,10 @@ import {
   createSignedCallbackRequest,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import { findTestEmailThreadSession } from "../../../../../../../src/__tests__/db-test-assertions/email";
+import { seedUserFeatureSwitches } from "../../../../../../../src/__tests__/db-test-seeders/feature-switches";
 import { generateReplyToken } from "../../../../../../../src/lib/zero/email/handlers/shared";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const context = testContext();
 const mockResend = vi.mocked(new Resend(""), true);
@@ -31,6 +35,17 @@ interface TriggerCallbackPayload {
   subject?: string;
   replyRecipientTo?: string[];
   replyRecipientCc?: string[];
+}
+
+async function renderLastEmailHtml(): Promise<string> {
+  const sentCall = mockResend.emails.send.mock.calls.at(-1);
+  expect(sentCall).toBeDefined();
+  const payload = sentCall![0] as CreateEmailOptions;
+  expect(payload).toHaveProperty("react");
+  if (!("react" in payload) || payload.react == null) {
+    throw new Error("Expected react property on email payload");
+  }
+  return render(payload.react);
 }
 
 describe("POST /api/zero/email/callbacks/trigger", () => {
@@ -163,6 +178,50 @@ describe("POST /api/zero/email/callbacks/trigger", () => {
         "In-Reply-To": "<orig-msg-id@example.com>",
         References: "<orig-msg-id@example.com>",
       });
+      const html = await renderLastEmailHtml();
+      expect(html).not.toContain("Audit");
+      expect(html).not.toContain(`/activities/${runId}`);
+      expect(html).toContain("Reply to continue");
+    });
+
+    it("should include audit link when AuditLink switch is on", async () => {
+      const user = await context.setupUser({ prefix: "trigger-audit-on" });
+      mockClerk({ userId: user.userId });
+      const agentName = uniqueId("trigger-agent");
+      const { composeId, agentId } = await createTestCompose(agentName);
+      const { runId } = await createTestRun(composeId, "Test prompt");
+      await completeTestRun(user.userId, runId);
+      await seedUserFeatureSwitches(user.orgId, user.userId, {
+        [FeatureSwitchKey.AuditLink]: true,
+      });
+
+      const replyToken = generateReplyToken(crypto.randomUUID());
+      const payload: TriggerCallbackPayload = {
+        senderEmail: "sender@example.com",
+        agentId,
+        userId: user.userId,
+        inboundEmailId: "email-audit-on",
+        replyToken,
+      };
+
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/zero/email/callbacks/trigger",
+        payload: { ...payload },
+      });
+
+      const request = createSignedCallbackRequest(
+        "http://localhost/api/zero/email/callbacks/trigger",
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
+      const html = await renderLastEmailHtml();
+      expect(html).toContain("Audit");
+      expect(html).toContain(`/activities/${runId}`);
     });
 
     it("should strip existing Re: prefix to prevent duplication", async () => {

--- a/turbo/apps/web/app/api/zero/email/callbacks/trigger/route.ts
+++ b/turbo/apps/web/app/api/zero/email/callbacks/trigger/route.ts
@@ -9,7 +9,7 @@ import { enqueueEmail } from "../../../../../../src/lib/zero/email/outbox-servic
 import {
   buildReplyToAddress,
   buildFromAddress,
-  buildLogsUrl,
+  resolveEmailAuditLogsUrl,
   buildUnsubscribeUrl,
   buildUnsubscribeHeaders,
 } from "../../../../../../src/lib/zero/email/handlers/shared";
@@ -146,7 +146,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const org = await getOrgNameAndSlug(orgId);
 
   // Get run output and session ID
-  const logsUrl = buildLogsUrl(runId);
+  const logsUrl = await resolveEmailAuditLogsUrl({ orgId, userId, runId });
   const rawOutput =
     status === "completed" ? await getRunOutputText(runId) : null;
   const output = formatOutput(status, rawOutput, error);

--- a/turbo/apps/web/src/lib/zero/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/zero/email/handlers/shared.ts
@@ -1,10 +1,13 @@
 import crypto from "crypto";
 import { eq } from "drizzle-orm";
 import { emailThreadSessions } from "@vm0/db/schema/email-thread-session";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { resolveDefaultAgentId } from "../../resolve-default-agent";
 import { env } from "../../../../env";
 import { getAppUrl } from "../../url";
 import { getApiUrl } from "../../../infra/callback/dispatcher";
+import { loadFeatureSwitchOverrides } from "../../user/feature-switches-service";
 
 // ============================================================================
 // Handler Result Type
@@ -223,8 +226,22 @@ export function buildFromAddress(localPart: string): string {
 /**
  * Build the logs URL for a run, linking to the agent detail logs page.
  */
-export function buildLogsUrl(runId: string): string {
+function buildLogsUrl(runId: string): string {
   return `${getAppUrl()}/activities/${encodeURIComponent(runId)}`;
+}
+
+export async function resolveEmailAuditLogsUrl(opts: {
+  orgId: string;
+  userId: string;
+  runId: string;
+}): Promise<string | undefined> {
+  const overrides = await loadFeatureSwitchOverrides(opts.orgId, opts.userId);
+  const enabled = isFeatureEnabled(FeatureSwitchKey.AuditLink, {
+    userId: opts.userId,
+    orgId: opts.orgId,
+    overrides,
+  });
+  return enabled ? buildLogsUrl(opts.runId) : undefined;
 }
 
 // ============================================================================

--- a/turbo/apps/web/src/lib/zero/email/templates/agent-reply.tsx
+++ b/turbo/apps/web/src/lib/zero/email/templates/agent-reply.tsx
@@ -13,7 +13,7 @@ import { UnsubscribeFooter } from "./unsubscribe-footer";
 interface AgentReplyEmailProps {
   agentName: string;
   output: string;
-  logsUrl: string;
+  logsUrl?: string;
   unsubscribeUrl?: string;
 }
 
@@ -37,10 +37,15 @@ export function AgentReplyEmail({
           <Hr style={hrStyle} />
           <Text style={signatureStyle}>{agentName} from VM0</Text>
           <Text style={footerStyle}>
-            <Link href={logsUrl} style={linkStyle}>
-              Audit
-            </Link>{" "}
-            · Reply to continue
+            {logsUrl ? (
+              <>
+                <Link href={logsUrl} style={linkStyle}>
+                  Audit
+                </Link>{" "}
+                ·{" "}
+              </>
+            ) : null}
+            Reply to continue
           </Text>
           <UnsubscribeFooter unsubscribeUrl={unsubscribeUrl} />
         </Container>

--- a/turbo/apps/web/src/lib/zero/email/types.ts
+++ b/turbo/apps/web/src/lib/zero/email/types.ts
@@ -9,7 +9,7 @@ interface AgentReplyTemplate {
   props: {
     agentName: string;
     output: string;
-    logsUrl: string;
+    logsUrl?: string;
     unsubscribeUrl?: string;
   };
 }

--- a/turbo/apps/web/src/lib/zero/telegram/__tests__/format.test.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/__tests__/format.test.ts
@@ -92,6 +92,13 @@ describe("buildTelegramResponse", () => {
     expect(result).toMatch(/^content\n\n/);
   });
 
+  it("should omit the audit footer without a logs URL", () => {
+    const result = buildTelegramResponse("content");
+
+    expect(result).toBe("content");
+    expect(result).not.toContain("Audit");
+  });
+
   it("should not render agent name HTML", () => {
     const result = buildTelegramResponse("hi", "https://example.com/logs");
 

--- a/turbo/apps/web/src/lib/zero/telegram/format.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/format.ts
@@ -98,9 +98,13 @@ export function markdownToTelegramHtml(markdown: string): string {
  */
 export function buildTelegramResponse(
   markdown: string,
-  logsUrl: string,
+  logsUrl?: string,
 ): string {
   const content = markdownToTelegramHtml(markdown);
+  if (!logsUrl) {
+    return content;
+  }
+
   const footer = `<a href="${escapeHtml(logsUrl)}">📋 Audit</a>`;
 
   return `${content}\n\n${footer}`;
@@ -118,10 +122,14 @@ export function buildTelegramResponse(
  */
 export function buildTelegramErrorResponse(
   errorDetail: string,
-  logsUrl: string,
+  logsUrl?: string,
 ): string {
   const header = `❌ <b>Agent Execution Error</b>`;
   const content = escapeHtml(errorDetail);
+  if (!logsUrl) {
+    return `${header}\n\n${content}`;
+  }
+
   const footer = `<a href="${escapeHtml(logsUrl)}">📋 View logs</a>`;
   return `${header}\n\n${content}\n\n${footer}`;
 }

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/direct-message.ts
@@ -16,8 +16,7 @@ import {
   resolveSessionCompose,
   resolveUserLink,
   buildConnectUrl,
-  buildAgentLogsUrl,
-  buildLogsUrl,
+  resolveTelegramAuditLogsUrl,
   formatTelegramConnectPrompt,
 } from "./shared";
 import { fetchTelegramContext } from "../context";
@@ -195,7 +194,11 @@ export async function handleTelegramDirectMessage(
     }
     const errorDetail =
       response ?? "An unexpected error occurred. Please try again later.";
-    const linkUrl = runId ? buildLogsUrl(runId) : buildAgentLogsUrl();
+    const linkUrl = await resolveTelegramAuditLogsUrl({
+      orgId: installation.orgId,
+      userId: userLink.vm0UserId,
+      runId,
+    });
     await sendMessage(
       client,
       chatId,

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/mention.ts
@@ -15,8 +15,7 @@ import {
   getAgentDisplayLabel,
   resolveSessionCompose,
   resolveUserLink,
-  buildAgentLogsUrl,
-  buildLogsUrl,
+  resolveTelegramAuditLogsUrl,
   formatTelegramPrivateConnectPrompt,
 } from "./shared";
 import { fetchTelegramContext } from "../context";
@@ -196,7 +195,11 @@ export async function handleTelegramMention(
     }
     const errorDetail =
       response ?? "An unexpected error occurred. Please try again later.";
-    const linkUrl = runId ? buildLogsUrl(runId) : buildAgentLogsUrl();
+    const linkUrl = await resolveTelegramAuditLogsUrl({
+      orgId: installation.orgId,
+      userId: userLink.vm0UserId,
+      runId,
+    });
     await sendMessage(
       client,
       chatId,

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/shared.ts
@@ -4,10 +4,13 @@ import { telegramMessages } from "@vm0/db/schema/telegram-message";
 import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { getAppUrl } from "../../url";
 import { resolveAgentId } from "../../zero-compose-service";
 import { validateAgentSession } from "../../zero-run-validation";
 import { ensureStorageExists } from "../../../infra/storage/storage-service";
+import { loadFeatureSwitchOverrides } from "../../user/feature-switches-service";
 import {
   sendMessage,
   editMessageText,
@@ -288,15 +291,33 @@ export async function linkTelegramUserToVm0User(params: {
 /**
  * Build the logs URL for a run, linking to the agent detail logs page.
  */
-export function buildLogsUrl(runId: string): string {
+function buildLogsUrl(runId: string): string {
   return `${getAppUrl()}/activities/${encodeURIComponent(runId)}`;
 }
 
 /**
  * Build the agent logs page URL (no specific run).
  */
-export function buildAgentLogsUrl(): string {
+function buildAgentLogsUrl(): string {
   return `${getAppUrl()}/activities`;
+}
+
+export async function resolveTelegramAuditLogsUrl(opts: {
+  orgId: string;
+  userId: string;
+  runId?: string | null;
+}): Promise<string | undefined> {
+  const overrides = await loadFeatureSwitchOverrides(opts.orgId, opts.userId);
+  const enabled = isFeatureEnabled(FeatureSwitchKey.AuditLink, {
+    userId: opts.userId,
+    orgId: opts.orgId,
+    overrides,
+  });
+  if (!enabled) {
+    return undefined;
+  }
+
+  return opts.runId ? buildLogsUrl(opts.runId) : buildAgentLogsUrl();
 }
 
 /**

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -184,7 +184,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   },
   [FeatureSwitchKey.AuditLink]: {
     maintainer: "ethan@vm0.ai",
-    description: "Show audit log links in Slack messages",
+    description: "Show audit log links in integration replies",
     enabled: false,
   },
   [FeatureSwitchKey.AudioInput]: {


### PR DESCRIPTION
## Summary
- Gate Telegram, GitHub issue, and email integration reply audit links behind the existing AuditLink feature switch.
- Make Telegram/email audit footers optional so replies omit Audit UI when the switch is disabled.
- Update AuditLink description and add enabled/disabled coverage for the changed callback paths.

Closes #11265

## Tests
- pnpm --filter web test src/lib/zero/telegram/__tests__/format.test.ts -- --runInBand
- pnpm --filter @vm0/core test src/__tests__/feature-switch.test.ts -- --runInBand
- pnpm --filter web check-types
- pre-commit: prettier, knip, full check-types
- CI: gh pr checks 11296 (all pass)