### PR TITLE
fix(seo): return 410 Gone for retired /docs/* paths

### DIFF
--- a/turbo/apps/web/app/docs/[[...slug]]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/docs/[[...slug]]/__tests__/route.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { GET, HEAD } from "../route";
+
+describe("retired /docs catch-all", () => {
+  it("returns 410 Gone with HTML body on GET", async () => {
+    const response = GET();
+    const body = await response.text();
+
+    expect(response.status).toBe(410);
+    expect(response.headers.get("content-type")).toContain("text/html");
+    expect(response.headers.get("x-robots-tag")).toBe("noindex");
+    expect(body).toContain("This page has been removed");
+  });
+
+  it("returns 410 Gone with empty body on HEAD", async () => {
+    const response = HEAD();
+    const body = await response.text();
+
+    expect(response.status).toBe(410);
+    expect(response.headers.get("x-robots-tag")).toBe("noindex");
+    expect(body).toBe("");
+  });
+});

--- a/turbo/apps/web/app/docs/[[...slug]]/route.ts
+++ b/turbo/apps/web/app/docs/[[...slug]]/route.ts
@@ -1,0 +1,39 @@
+// Old documentation lived at docs.vm0.ai and was retired. The Vercel domain
+// for docs.vm0.ai now redirects to www.vm0.ai/docs/*, so anything Google still
+// has indexed (Quick Start, tutorials, integrations, etc.) lands on this app.
+// Returning 410 Gone — instead of letting it 404 — tells search engines the
+// pages are permanently removed and triggers faster de-indexing.
+
+const HTML_BODY = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Page removed | VM0</title>
+<style>
+  body { font-family: system-ui, -apple-system, sans-serif; max-width: 480px; margin: 10vh auto; padding: 0 24px; color: #1a1a1a; }
+  h1 { font-size: 24px; margin: 0 0 12px; }
+  p { line-height: 1.6; color: #555; }
+  a { color: #0066cc; }
+</style>
+</head>
+<body>
+<h1>This page has been removed</h1>
+<p>The VM0 documentation has been retired. Visit the <a href="/">homepage</a> for current resources.</p>
+</body>
+</html>`;
+
+const HEADERS = {
+  "Content-Type": "text/html; charset=utf-8",
+  "X-Robots-Tag": "noindex",
+  "Cache-Control": "public, max-age=3600",
+};
+
+export function GET(): Response {
+  return new Response(HTML_BODY, { status: 410, headers: HEADERS });
+}
+
+export function HEAD(): Response {
+  return new Response(null, { status: 410, headers: HEADERS });
+}


### PR DESCRIPTION
## Summary

The docs subdomain (`docs.vm0.ai`) was retired but its Vercel domain still 307-redirects every path to `www.vm0.ai/docs/*`, where Next.js 404s. Google sees this as a redirect-chain ending in 404 — the worst possible signal for SEO. Affected URLs include `/docs/quick-start`, `/docs/tutorial/my-first-agent`, `/docs/integration/supabase`, `/docs/product-philosophy`, and others Google still has indexed.

This PR adds a catch-all route at `/docs/[[...slug]]` that returns **HTTP 410 Gone** (with `X-Robots-Tag: noindex`) for any path under `/docs/`. 410 is the correct semantic for "permanently removed" and triggers significantly faster de-indexing than 404.

## Why now

Surfaced from the Search Console **Pages** report:

- 35 URLs in "未找到 (404)"
- 15 URLs in "网页会自动重定向"
- Most likely traceable to the docs redirect chain

Independent of this PR, the `docs.vm0.ai` redirect at the Vercel domain level is also worth removing (or pointed at a 410-only endpoint) so the chain becomes a single 410 hop. That requires Vercel dashboard access and is a follow-up.

## Changes

- `turbo/apps/web/app/docs/[[...slug]]/route.ts` — catch-all 410 handler with minimal HTML body and `noindex` header
- `turbo/apps/web/app/docs/[[...slug]]/__tests__/route.test.ts` — vitest coverage for GET and HEAD

## Test plan

- [ ] CI passes (lint, types, vitest)
- [ ] After deploy, `curl -I https://www.vm0.ai/docs/quick-start` returns `HTTP/2 410`
- [ ] Submit "Validate fix" in Search Console for the affected URL groups; expect error count to drop within 2–4 weeks