### PR TITLE
fix(runner): isolate axiom tracing filter

### DIFF
--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -19,6 +19,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::field::{Field, Visit};
 use tracing::{Event, Metadata, Subscriber};
+use tracing_subscriber::filter::{self, FilterFn};
 use tracing_subscriber::layer::{Context, Layer};
 use tracing_subscriber::registry::LookupSpan;
 
@@ -61,10 +62,10 @@ const DEBUG_FIELD_MAX_BYTES: usize = 4 * 1024;
 const DEFAULT_AXIOM_URL: &str = "https://api.axiom.co";
 const SERVICE_NAME: &str = "runner";
 /// Target used for this layer's own diagnostics (channel-full warnings,
-/// non-success ingest responses, HTTP errors). Filtered out in `enabled()`
-/// so diagnostics reach stderr + the rolling log file via the fmt layer
-/// without looping back into this layer and re-flooding the dispatcher.
-const INTERNAL_TARGET: &str = "runner::axiom_layer::internal";
+/// non-success ingest responses, HTTP errors). Filtered out by the Axiom
+/// per-layer filter so diagnostics can still reach local logging without
+/// looping back into this layer and re-flooding the dispatcher.
+pub(crate) const INTERNAL_TARGET: &str = "runner::axiom_layer::internal";
 
 /// Holds the dispatcher task. `shutdown().await` drains the queue; dropping
 /// without calling `shutdown` leaves the tokio runtime to abort the task.
@@ -155,6 +156,24 @@ pub(crate) struct AxiomLayer {
     dropped: AtomicU64,
 }
 
+pub(crate) fn should_ingest(metadata: &Metadata<'_>) -> bool {
+    // Fixed WARN+ threshold. Errors and warnings only; INFO/DEBUG stay out
+    // of Axiom to keep ingest volume predictable. INTERNAL_TARGET is for
+    // this layer's own diagnostics, which should remain local-only.
+    *metadata.level() <= tracing::Level::WARN && metadata.target() != INTERNAL_TARGET
+}
+
+pub(crate) fn ingest_filter() -> FilterFn<fn(&Metadata<'_>) -> bool> {
+    filter::filter_fn(should_ingest as fn(&Metadata<'_>) -> bool)
+}
+
+pub(crate) fn with_ingest_filter<S>(layer: AxiomLayer) -> impl Layer<S> + Send + Sync + 'static
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    layer.with_filter(ingest_filter())
+}
+
 enum Msg {
     Event(Value),
     Close,
@@ -164,20 +183,12 @@ impl<S> Layer<S> for AxiomLayer
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
-    fn enabled(&self, metadata: &Metadata<'_>, _: Context<'_, S>) -> bool {
-        // Fixed WARN+ threshold. Errors and warnings only; INFO/DEBUG stay out
-        // of Axiom to keep ingest volume predictable. The internal-target
-        // check prevents our own diagnostics from feeding back into the
-        // layer (and re-hammering the full channel).
-        *metadata.level() <= tracing::Level::WARN && metadata.target() != INTERNAL_TARGET
-    }
-
     fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
         let value = serialize_event(event);
         if self.tx.try_send(Msg::Event(value)).is_err() {
             // Bounded-channel full or dispatcher gone. Surface periodically
-            // under `INTERNAL_TARGET` so the message hits stderr + rolling
-            // file via the fmt layer but `enabled()` filters it out here.
+            // under `INTERNAL_TARGET`; the Axiom per-layer filter keeps this
+            // diagnostic out of remote ingest if it is observed by tracing.
             let prev = self.dropped.fetch_add(1, Ordering::Relaxed);
             if prev.is_multiple_of(1000) {
                 tracing::warn!(

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -65,7 +65,7 @@ const SERVICE_NAME: &str = "runner";
 /// (non-success ingest responses, HTTP errors) remain visible to local
 /// logging, while the Axiom per-layer filter keeps any observed diagnostics
 /// from looping back into this layer and re-flooding the dispatcher.
-pub(crate) const INTERNAL_TARGET: &str = "runner::axiom_layer::internal";
+const INTERNAL_TARGET: &str = "runner::axiom_layer::internal";
 
 /// Holds the dispatcher task. `shutdown().await` drains the queue; dropping
 /// without calling `shutdown` leaves the tokio runtime to abort the task.

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -61,10 +61,10 @@ const _: () = assert!(
 const DEBUG_FIELD_MAX_BYTES: usize = 4 * 1024;
 const DEFAULT_AXIOM_URL: &str = "https://api.axiom.co";
 const SERVICE_NAME: &str = "runner";
-/// Target used for this layer's own diagnostics (channel-full warnings,
-/// non-success ingest responses, HTTP errors). Filtered out by the Axiom
-/// per-layer filter so diagnostics can still reach local logging without
-/// looping back into this layer and re-flooding the dispatcher.
+/// Target used for this layer's own diagnostics. Dispatcher diagnostics
+/// (non-success ingest responses, HTTP errors) remain visible to local
+/// logging, while the Axiom per-layer filter keeps any observed diagnostics
+/// from looping back into this layer and re-flooding the dispatcher.
 pub(crate) const INTERNAL_TARGET: &str = "runner::axiom_layer::internal";
 
 /// Holds the dispatcher task. `shutdown().await` drains the queue; dropping
@@ -186,9 +186,10 @@ where
     fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
         let value = serialize_event(event);
         if self.tx.try_send(Msg::Event(value)).is_err() {
-            // Bounded-channel full or dispatcher gone. Surface periodically
-            // under `INTERNAL_TARGET`; the Axiom per-layer filter keeps this
-            // diagnostic out of remote ingest if it is observed by tracing.
+            // Bounded-channel full or dispatcher gone. Emit a periodic
+            // best-effort diagnostic under `INTERNAL_TARGET`; if tracing
+            // observes it, the Axiom per-layer filter keeps it out of remote
+            // ingest.
             let prev = self.dropped.fetch_add(1, Ordering::Relaxed);
             if prev.is_multiple_of(1000) {
                 tracing::warn!(

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -156,7 +156,7 @@ pub(crate) struct AxiomLayer {
     dropped: AtomicU64,
 }
 
-pub(crate) fn should_ingest(metadata: &Metadata<'_>) -> bool {
+fn should_ingest(metadata: &Metadata<'_>) -> bool {
     // Fixed WARN+ threshold. Errors and warnings only; INFO/DEBUG stay out
     // of Axiom to keep ingest volume predictable. INTERNAL_TARGET is for
     // this layer's own diagnostics, which should remain local-only.

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -163,7 +163,7 @@ pub(crate) fn should_ingest(metadata: &Metadata<'_>) -> bool {
     *metadata.level() <= tracing::Level::WARN && metadata.target() != INTERNAL_TARGET
 }
 
-pub(crate) fn ingest_filter() -> FilterFn<fn(&Metadata<'_>) -> bool> {
+fn ingest_filter() -> FilterFn<fn(&Metadata<'_>) -> bool> {
     filter::filter_fn(should_ingest as fn(&Metadata<'_>) -> bool)
 }
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -153,6 +153,7 @@ fn init_tracing_with_file(
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_writer(writer)
         .with_ansi(false);
+    let axiom_layer = axiom_layer.map(axiom_layer::with_ingest_filter);
     tracing_subscriber::registry()
         .with(fmt_layer)
         .with(axiom_layer)
@@ -170,6 +171,7 @@ fn init_tracing_with_file(
 /// stdout, which is the wrong sink for a CLI tool.
 fn init_tracing_stderr(axiom_layer: Option<axiom_layer::AxiomLayer>) {
     let fmt_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
+    let axiom_layer = axiom_layer.map(axiom_layer::with_ingest_filter);
     tracing_subscriber::registry()
         .with(fmt_layer)
         .with(axiom_layer)

--- a/crates/runner/tests/axiom_layer.rs
+++ b/crates/runner/tests/axiom_layer.rs
@@ -10,11 +10,74 @@
 #[path = "../src/axiom_layer.rs"]
 mod axiom_layer;
 
+use std::sync::{Arc, Mutex};
+
 use httpmock::Method::POST;
 use httpmock::MockServer;
-use tracing_subscriber::layer::SubscriberExt;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
 
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[derive(Clone, Debug)]
+struct RecordedEvent {
+    level: tracing::Level,
+    target: String,
+    message: Option<String>,
+}
+
+#[derive(Clone, Default)]
+struct RecordingLayer {
+    events: Arc<Mutex<Vec<RecordedEvent>>>,
+}
+
+impl RecordingLayer {
+    fn events(&self) -> Vec<RecordedEvent> {
+        self.events
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
+    }
+}
+
+impl<S> Layer<S> for RecordingLayer
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
+        struct MessageVisitor {
+            message: Option<String>,
+        }
+
+        impl Visit for MessageVisitor {
+            fn record_str(&mut self, field: &Field, value: &str) {
+                if field.name() == "message" {
+                    self.message = Some(value.to_string());
+                }
+            }
+
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" {
+                    self.message = Some(format!("{value:?}"));
+                }
+            }
+        }
+
+        let mut visitor = MessageVisitor { message: None };
+        event.record(&mut visitor);
+
+        let metadata = event.metadata();
+        self.events
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(RecordedEvent {
+                level: *metadata.level(),
+                target: metadata.target().to_string(),
+                message: visitor.message,
+            });
+    }
+}
 
 fn clear_axiom_env() {
     // SAFETY: setenv is not thread-safe, but we hold ENV_LOCK for the
@@ -81,7 +144,7 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
     let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "test-token", "test")
         .expect("init_with_base_url must succeed");
 
-    let subscriber = tracing_subscriber::registry().with(layer);
+    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         tracing::warn!(foo = "bar", "a warning");
@@ -92,6 +155,66 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
     guard.shutdown().await;
 
     content_mock.assert_calls_async(1).await;
+    info_mock.assert_calls_async(0).await;
+}
+
+#[tokio::test]
+async fn axiom_filter_does_not_suppress_sibling_local_layers() {
+    let server = MockServer::start_async().await;
+
+    let warn_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/v1/datasets/vm0-web-logs-test/ingest")
+                .body_includes(r#""level":"warn""#)
+                .body_includes(r#""message":"local warn""#);
+            then.status(200).body("{}");
+        })
+        .await;
+    let info_mock = server
+        .mock_async(|when, then| {
+            when.method(POST).body_includes(r#""message":"local info""#);
+            then.status(200).body("{}");
+        })
+        .await;
+
+    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
+        .expect("init must succeed");
+    let recording = RecordingLayer::default();
+    let subscriber = tracing_subscriber::registry()
+        .with(recording.clone())
+        .with(axiom_layer::with_ingest_filter(layer));
+
+    {
+        let _sub = tracing::subscriber::set_default(subscriber);
+        tracing::info!("local info");
+        tracing::warn!("local warn");
+    }
+    guard.shutdown().await;
+
+    let events = recording.events();
+    assert!(
+        events.iter().any(|event| {
+            event.level == tracing::Level::INFO
+                && event
+                    .message
+                    .as_deref()
+                    .is_some_and(|message| message.contains("local info"))
+        }),
+        "sibling local layer did not record INFO event: {events:?}",
+    );
+    assert!(
+        events.iter().any(|event| {
+            event.level == tracing::Level::WARN
+                && event
+                    .message
+                    .as_deref()
+                    .is_some_and(|message| message.contains("local warn"))
+        }),
+        "sibling local layer did not record WARN event: {events:?}",
+    );
+
+    warn_mock.assert_calls_async(1).await;
     info_mock.assert_calls_async(0).await;
 }
 
@@ -152,7 +275,7 @@ async fn error_field_serializes_with_message_and_source_chain() {
 
     let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
         .expect("init must succeed");
-    let subscriber = tracing_subscriber::registry().with(layer);
+    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         let err = ChainErr {
@@ -188,9 +311,9 @@ async fn burst_past_channel_cap_drops_without_blocking_or_feeding_back() {
         .await;
 
     // Negative: the layer's own "axiom channel full" warning (emitted under
-    // INTERNAL_TARGET every 1000 drops) must NOT reach ingest. `enabled()`
-    // filters INTERNAL_TARGET to prevent the diagnostic from re-entering the
-    // already-full channel and feedback-flooding.
+    // INTERNAL_TARGET every 1000 drops) must NOT reach ingest. The Axiom
+    // per-layer filter excludes INTERNAL_TARGET to prevent the diagnostic
+    // from re-entering the already-full channel and feedback-flooding.
     let feedback = server
         .mock_async(|when, then| {
             when.method(POST).body_includes("axiom channel full");
@@ -200,7 +323,7 @@ async fn burst_past_channel_cap_drops_without_blocking_or_feeding_back() {
 
     let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
         .expect("init must succeed");
-    let subscriber = tracing_subscriber::registry().with(layer);
+    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
 
     // 3000 > CHANNEL_CAP (1024) + 1000 so we both overflow the channel and
     // cross the drop counter's multiple-of-1000 branch at least twice
@@ -266,16 +389,30 @@ async fn non_success_ingest_response_does_not_hang_shutdown_or_panic() {
 
     let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
         .expect("init must succeed");
-    let subscriber = tracing_subscriber::registry().with(layer);
+    let recording = RecordingLayer::default();
+    let subscriber = tracing_subscriber::registry()
+        .with(recording.clone())
+        .with(axiom_layer::with_ingest_filter(layer));
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         tracing::error!("trigger ingest failure");
+        guard.shutdown().await;
     }
 
-    // If the failure path panics or leaks the task, this await never returns
+    // If the failure path panics or leaks the task, shutdown never returns
     // (the test harness enforces its own timeout, so we'd see a hang).
-    guard.shutdown().await;
     mock.assert_calls_async(1).await;
+    let events = recording.events();
+    assert!(
+        events.iter().any(|event| {
+            event.target == axiom_layer::INTERNAL_TARGET
+                && event
+                    .message
+                    .as_deref()
+                    .is_some_and(|message| message.contains("axiom ingest returned non-success"))
+        }),
+        "sibling local layer did not record Axiom internal diagnostic: {events:?}",
+    );
 }
 
 // -- Debug field truncation (DEBUG_FIELD_MAX_BYTES = 4 KiB) ------------------
@@ -305,7 +442,7 @@ async fn debug_field_over_limit_is_truncated_with_marker() {
 
     let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
         .expect("init must succeed");
-    let subscriber = tracing_subscriber::registry().with(layer);
+    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         // 5000 A's → sentinel → 3000 A's. Debug form: `"` + 5000 + sentinel
@@ -338,7 +475,7 @@ async fn debug_field_truncation_walks_to_utf8_char_boundary() {
 
     let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
         .expect("init must succeed");
-    let subscriber = tracing_subscriber::registry().with(layer);
+    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         // 2500 × 2-byte `ñ` = 5000 bytes; Debug adds surrounding quotes →
@@ -381,7 +518,7 @@ async fn debug_field_at_exact_limit_passes_through_unmodified() {
 
     let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
         .expect("init must succeed");
-    let subscriber = tracing_subscriber::registry().with(layer);
+    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         // Debug form of a &str is `"<contents>"` — surrounding quotes cost

--- a/crates/runner/tests/axiom_layer.rs
+++ b/crates/runner/tests/axiom_layer.rs
@@ -177,6 +177,27 @@ async fn axiom_filter_does_not_suppress_sibling_local_layers() {
             then.status(200).body("{}");
         })
         .await;
+    let debug_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .body_includes(r#""message":"local debug""#);
+            then.status(200).body("{}");
+        })
+        .await;
+    let trace_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .body_includes(r#""message":"local trace""#);
+            then.status(200).body("{}");
+        })
+        .await;
+    let internal_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .body_includes(r#""message":"local internal""#);
+            then.status(200).body("{}");
+        })
+        .await;
 
     let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
         .expect("init must succeed");
@@ -188,34 +209,47 @@ async fn axiom_filter_does_not_suppress_sibling_local_layers() {
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         tracing::info!("local info");
+        tracing::debug!("local debug");
+        tracing::trace!("local trace");
         tracing::warn!("local warn");
+        tracing::warn!(target: axiom_layer::INTERNAL_TARGET, "local internal");
     }
     guard.shutdown().await;
 
     let events = recording.events();
+    for (level, message) in [
+        (tracing::Level::INFO, "local info"),
+        (tracing::Level::DEBUG, "local debug"),
+        (tracing::Level::TRACE, "local trace"),
+        (tracing::Level::WARN, "local warn"),
+    ] {
+        assert!(
+            events.iter().any(|event| {
+                event.level == level
+                    && event
+                        .message
+                        .as_deref()
+                        .is_some_and(|seen| seen.contains(message))
+            }),
+            "sibling local layer did not record {level} event {message:?}: {events:?}",
+        );
+    }
     assert!(
         events.iter().any(|event| {
-            event.level == tracing::Level::INFO
+            event.target == axiom_layer::INTERNAL_TARGET
                 && event
                     .message
                     .as_deref()
-                    .is_some_and(|message| message.contains("local info"))
+                    .is_some_and(|seen| seen.contains("local internal"))
         }),
-        "sibling local layer did not record INFO event: {events:?}",
-    );
-    assert!(
-        events.iter().any(|event| {
-            event.level == tracing::Level::WARN
-                && event
-                    .message
-                    .as_deref()
-                    .is_some_and(|message| message.contains("local warn"))
-        }),
-        "sibling local layer did not record WARN event: {events:?}",
+        "sibling local layer did not record internal-target event: {events:?}",
     );
 
     warn_mock.assert_calls_async(1).await;
     info_mock.assert_calls_async(0).await;
+    debug_mock.assert_calls_async(0).await;
+    trace_mock.assert_calls_async(0).await;
+    internal_mock.assert_calls_async(0).await;
 }
 
 #[tokio::test]

--- a/crates/runner/tests/axiom_layer.rs
+++ b/crates/runner/tests/axiom_layer.rs
@@ -19,6 +19,7 @@ use tracing::{Event, Subscriber};
 use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
 
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+const INTERNAL_TARGET: &str = "runner::axiom_layer::internal";
 
 #[derive(Clone, Debug)]
 struct RecordedEvent {
@@ -212,7 +213,7 @@ async fn axiom_filter_does_not_suppress_sibling_local_layers() {
         tracing::debug!("local debug");
         tracing::trace!("local trace");
         tracing::warn!("local warn");
-        tracing::warn!(target: axiom_layer::INTERNAL_TARGET, "local internal");
+        tracing::warn!(target: INTERNAL_TARGET, "local internal");
     }
     guard.shutdown().await;
 
@@ -236,7 +237,7 @@ async fn axiom_filter_does_not_suppress_sibling_local_layers() {
     }
     assert!(
         events.iter().any(|event| {
-            event.target == axiom_layer::INTERNAL_TARGET
+            event.target == INTERNAL_TARGET
                 && event
                     .message
                     .as_deref()
@@ -439,7 +440,7 @@ async fn non_success_ingest_response_does_not_hang_shutdown_or_panic() {
     let events = recording.events();
     assert!(
         events.iter().any(|event| {
-            event.target == axiom_layer::INTERNAL_TARGET
+            event.target == INTERNAL_TARGET
                 && event
                     .message
                     .as_deref()


### PR DESCRIPTION
## Summary
- move Axiom WARN+/internal-target selection to a per-layer tracing filter
- stop Axiom from globally suppressing sibling fmt/file logging
- add regression coverage for local INFO visibility and internal diagnostics

## Tests
- cargo fmt --all --manifest-path crates/Cargo.toml -- --check
- cargo test --manifest-path crates/Cargo.toml -p runner --test axiom_layer --all-features
- cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings

Fixes #11288