### PR TITLE
chore(api): forward unimplemented legacy routes to www.vm0.ai

### DIFF
--- a/turbo/apps/api/vercel.json
+++ b/turbo/apps/api/vercel.json
@@ -2,5 +2,15 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm build",
   "framework": null,
-  "installCommand": "cd ../.. && pnpm install"
+  "installCommand": "cd ../.. && pnpm install",
+  "rewrites": [
+    {
+      "source": "/api/v1/chat-threads/messages",
+      "destination": "https://www.vm0.ai/api/v1/chat-threads/messages"
+    },
+    {
+      "source": "/api/agent/:path*",
+      "destination": "https://www.vm0.ai/api/agent/:path*"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

api.vm0.ai is being repointed at the apps/api project, but a few endpoints still live on the web app. Add Vercel rewrites in `apps/api/vercel.json` so legacy traffic that has not been migrated yet is proxied to www.vm0.ai instead of 404'ing.

Currently forwarded:
- `POST /api/v1/chat-threads/messages`
- `/api/agent/*` (runs list, run detail, telemetry)

Each rewrite should be deleted as the matching endpoint lands in apps/api.

## Notes on method matching

Vercel `rewrites` cannot discriminate by HTTP method (`has` only supports header/cookie/host/query). That's not actually a problem here:
- The literal `/api/v1/chat-threads/messages` path does not collide with the handled `/api/v1/chat-threads/<uuid>` shape — apps/api still receives the GET-by-id traffic.
- No `/api/agent/*` route is implemented in apps/api, so method-agnostic forwarding is correct.

## Test plan

- [ ] After deploy, hit `GET /api/v1/chat-threads/<uuid>` on api.vm0.ai → served by apps/api (200)
- [ ] After deploy, hit `POST /api/v1/chat-threads/messages` on api.vm0.ai → proxied to www, response from web backend
- [ ] After deploy, hit `GET /api/agent/runs` on api.vm0.ai → proxied to www
- [ ] Spot-check the api.vm0.ai traffic dashboard for any path that's now 404'ing — add a rewrite if so

🤖 Generated with [Claude Code](https://claude.com/claude-code)