### PR TITLE
refactor: clarify usage reporting time semantics

### DIFF
--- a/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
@@ -691,6 +691,42 @@ describe("GET /api/zero/usage/insight", () => {
     expect(totals["others"]).toEqual({ credits: 7, tokens: 0 });
   });
 
+  it("buckets usage_event rows by activity time, not billing time", async () => {
+    context.mocks.date.setSystemTime(new Date("2026-04-23T15:00:00Z"));
+
+    const { userId, orgId } = await context.user;
+    await insertTestUsageEvent(orgId, {
+      userId,
+      kind: "connector",
+      provider: "x",
+      category: "tweet.read",
+      quantity: 1,
+      creditsCharged: 33,
+      status: "processed",
+      createdAt: new Date("2026-04-22T12:00:00Z"),
+      processedAt: new Date("2026-04-23T12:00:00Z"),
+    });
+
+    const yesterdayResponse = await GET(
+      makeRequest({ range: "yesterday", groupBy: "source", tz: "UTC" }),
+    );
+    expect(yesterdayResponse.status).toBe(200);
+    const yesterdayData =
+      (await yesterdayResponse.json()) as UsageInsightResponse;
+    const yesterdayTotals = sumBucketSeries(yesterdayData.buckets);
+
+    expect(yesterdayData.grandTotalCredits).toBe(33);
+    expect(yesterdayTotals["others"]).toEqual({ credits: 33, tokens: 0 });
+
+    const todayResponse = await GET(
+      makeRequest({ range: "today", groupBy: "source", tz: "UTC" }),
+    );
+    expect(todayResponse.status).toBe(200);
+    const todayData = (await todayResponse.json()) as UsageInsightResponse;
+
+    expect(todayData.grandTotalCredits).toBe(0);
+  });
+
   it("includes run-linked usage_event rows in agent buckets and channel totals", async () => {
     const { userId, orgId } = await context.user;
     const agentName = uniqueId("usage-event-agent");

--- a/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
@@ -258,6 +258,9 @@ export async function insertTestUsageEvent(
     creditsCharged?: number;
     runId?: string | null;
     idempotencyKey?: string;
+    /** activityTime for reporting tests: maps to usage_event.created_at. */
+    createdAt?: Date;
+    /** billingTime for reporting tests: maps to usage_event.processed_at. */
     processedAt?: Date | null;
   },
 ): Promise<string> {
@@ -282,6 +285,7 @@ export async function insertTestUsageEvent(
       status: options.status ?? "pending",
       creditsCharged: options.creditsCharged ?? null,
       idempotencyKey: options.idempotencyKey ?? randomUUID(),
+      ...(options.createdAt ? { createdAt: options.createdAt } : {}),
       processedAt,
     })
     .returning({ id: usageEvent.id });

--- a/turbo/apps/web/src/lib/zero/billing/usage-insight-ledger.ts
+++ b/turbo/apps/web/src/lib/zero/billing/usage-insight-ledger.ts
@@ -29,10 +29,10 @@ function pgLit(value: string): string {
 }
 
 function usageBucketExpr(p: UsageInsightSqlParams): string {
-  return `date_trunc(${p.truncLit}, ${USAGE_ROW_ALIAS}.usage_time::timestamptz AT TIME ZONE ${p.tzLit})`;
+  return `date_trunc(${p.truncLit}, ${USAGE_ROW_ALIAS}.activity_time::timestamptz AT TIME ZONE ${p.tzLit})`;
 }
 
-function createdAtWindowPredicate(
+function activityTimeWindowPredicate(
   alias: string,
   p: UsageInsightSqlParams,
 ): string {
@@ -45,12 +45,21 @@ function usageRowTokenExpr(): string {
   return `CASE WHEN ue.kind = ${pgLit(MODEL_USAGE_KIND)} AND ue.category IN (${tokenCategoryList}) THEN ue.quantity ELSE 0 END`;
 }
 
+/**
+ * Reporting time terms:
+ * - activityTime maps to ledger created_at, when usage activity was recorded.
+ * - billingTime maps to ledger processed_at, when credits were settled.
+ *
+ * Usage insight is an activity chart, so it filters and buckets by
+ * activityTime while still requiring processed rows. Delayed billing must not
+ * move usage into a later activity bucket.
+ */
 function usageRowsCte(p: UsageInsightSqlParams): string {
   return `
     usage_rows AS (
       SELECT
         'legacy' AS ledger,
-        cu.created_at AS usage_time,
+        cu.created_at AS activity_time,
         cu.run_id,
         cu.user_id,
         cu.org_id,
@@ -60,13 +69,13 @@ function usageRowsCte(p: UsageInsightSqlParams): string {
       WHERE cu.user_id = ${p.userIdLit}
         AND cu.org_id = ${p.orgIdLit}
         AND cu.status = 'processed'
-        AND ${createdAtWindowPredicate("cu", p)}
+        AND ${activityTimeWindowPredicate("cu", p)}
 
       UNION ALL
 
       SELECT
         'event' AS ledger,
-        ue.created_at AS usage_time,
+        ue.created_at AS activity_time,
         ue.run_id,
         ue.user_id,
         ue.org_id,
@@ -76,7 +85,7 @@ function usageRowsCte(p: UsageInsightSqlParams): string {
       WHERE ue.user_id = ${p.userIdLit}
         AND ue.org_id = ${p.orgIdLit}
         AND ue.status = 'processed'
-        AND ${createdAtWindowPredicate("ue", p)}
+        AND ${activityTimeWindowPredicate("ue", p)}
     )`;
 }
 

--- a/turbo/apps/web/src/lib/zero/billing/usage-reporting-ledger.ts
+++ b/turbo/apps/web/src/lib/zero/billing/usage-reporting-ledger.ts
@@ -10,7 +10,13 @@ import {
   TOKEN_CATEGORY_OUTPUT,
 } from "./model-usage-categories";
 
-interface UsagePeriod {
+/**
+ * Reporting time terms:
+ * - activityTime maps to ledger created_at, when usage activity was recorded.
+ * - billingTime maps to ledger processed_at, when credits were settled.
+ */
+interface BillingWindow {
+  /** Half-open [start, end) window over billingTime. */
   start: Date;
   end: Date;
 }
@@ -38,16 +44,16 @@ interface UsageRunTotalsRow {
 
 /**
  * Reporting aggregate for member usage across the legacy and usage_event
- * ledgers. Uses processed_at so reporting follows the posted ledger time.
+ * ledgers. Member totals are billing-period data, so they use billingTime.
  */
 export async function getMemberUsageTotals(
   db: Database,
   orgId: string,
-  period: UsagePeriod,
+  billingWindow: BillingWindow,
 ): Promise<UsageMemberTotalsRow[]> {
   const [creditRows, eventRows] = await Promise.all([
-    getLegacyMemberUsageTotals(db, orgId, period),
-    getUsageEventMemberUsageTotals(db, orgId, period),
+    getLegacyMemberUsageTotals(db, orgId, billingWindow),
+    getUsageEventMemberUsageTotals(db, orgId, billingWindow),
   ]);
 
   return mergeMemberTotals([...creditRows, ...eventRows]);
@@ -56,7 +62,7 @@ export async function getMemberUsageTotals(
 function getLegacyMemberUsageTotals(
   db: Database,
   orgId: string,
-  period: UsagePeriod,
+  billingWindow: BillingWindow,
 ): Promise<UsageMemberTotalsRow[]> {
   const totalsSelect = {
     userId: creditUsage.userId,
@@ -89,8 +95,8 @@ function getLegacyMemberUsageTotals(
       and(
         eq(creditUsage.orgId, orgId),
         eq(creditUsage.status, "processed"),
-        gte(creditUsage.processedAt, period.start),
-        lt(creditUsage.processedAt, period.end),
+        gte(creditUsage.processedAt, billingWindow.start),
+        lt(creditUsage.processedAt, billingWindow.end),
       ),
     )
     .groupBy(creditUsage.userId);
@@ -99,7 +105,7 @@ function getLegacyMemberUsageTotals(
 function getUsageEventMemberUsageTotals(
   db: Database,
   orgId: string,
-  period: UsagePeriod,
+  billingWindow: BillingWindow,
 ): Promise<UsageMemberTotalsRow[]> {
   const totalsSelect = {
     userId: usageEvent.userId,
@@ -126,8 +132,8 @@ function getUsageEventMemberUsageTotals(
       and(
         eq(usageEvent.orgId, orgId),
         eq(usageEvent.status, "processed"),
-        gte(usageEvent.processedAt, period.start),
-        lt(usageEvent.processedAt, period.end),
+        gte(usageEvent.processedAt, billingWindow.start),
+        lt(usageEvent.processedAt, billingWindow.end),
       ),
     )
     .groupBy(usageEvent.userId);


### PR DESCRIPTION
## Summary
- Rename usage insight internals from generic usage time to activity time while preserving created_at-based buckets.
- Rename member usage reporting windows to billing windows while preserving processed_at-based totals.
- Let usage_event test fixtures pin createdAt independently and add delayed-settlement insight coverage.

## Tests
- pnpm --dir turbo --filter web test app/api/zero/usage/insight/__tests__/route.test.ts app/api/zero/usage/members/__tests__/route.test.ts
- pnpm --dir turbo --filter web check-types
- pnpm --dir turbo --filter web lint
- git diff --check
- pre-commit hook: prettier, knip, turbo check-types

Closes #11299