### PR TITLE
feat(usage): show schedule description on insights widget

### DIFF
--- a/turbo/apps/platform/src/views/usage-page/__tests__/test-fixtures.ts
+++ b/turbo/apps/platform/src/views/usage-page/__tests__/test-fixtures.ts
@@ -12,6 +12,7 @@ export const usageInsightFixture: Readonly<UsageInsightResponse> = {
     {
       scheduleId: "s1",
       scheduleName: "My Schedule",
+      scheduleDescription: null,
       credits: 300,
       tokens: 600,
     },

--- a/turbo/apps/platform/src/views/usage-page/__tests__/usage-insight-components.test.tsx
+++ b/turbo/apps/platform/src/views/usage-page/__tests__/usage-insight-components.test.tsx
@@ -110,12 +110,14 @@ describe("usage insight view - loading, error, and data states", () => {
               {
                 scheduleId: "s1",
                 scheduleName: "Morning Digest",
+                scheduleDescription: null,
                 credits: 150,
                 tokens: 300,
               },
               {
                 scheduleId: "s2",
                 scheduleName: "Evening Report",
+                scheduleDescription: null,
                 credits: 80,
                 tokens: 160,
               },
@@ -581,18 +583,21 @@ describe("usage insight schedules table - rendering and interactions", () => {
               {
                 scheduleId: "s1",
                 scheduleName: "Daily Sync",
+                scheduleDescription: null,
                 credits: 100,
                 tokens: 200,
               },
               {
                 scheduleId: "s2",
                 scheduleName: "Weekly Review",
+                scheduleDescription: null,
                 credits: 200,
                 tokens: 400,
               },
               {
                 scheduleId: "s3",
                 scheduleName: "Monthly Report",
+                scheduleDescription: null,
                 credits: 150,
                 tokens: 300,
               },
@@ -629,12 +634,14 @@ describe("usage insight schedules table - rendering and interactions", () => {
               {
                 scheduleId: "s1",
                 scheduleName: "Daily Standup",
+                scheduleDescription: null,
                 credits: 50,
                 tokens: 100,
               },
               {
                 scheduleId: "s2",
                 scheduleName: "Weekly Planning",
+                scheduleDescription: null,
                 credits: 200,
                 tokens: 400,
               },
@@ -672,6 +679,7 @@ describe("usage insight schedules table - rendering and interactions", () => {
               {
                 scheduleId: "s1",
                 scheduleName: "Visible Schedule",
+                scheduleDescription: null,
                 credits: 30,
                 tokens: 60,
               },
@@ -695,6 +703,51 @@ describe("usage insight schedules table - rendering and interactions", () => {
     });
 
     expect(screen.getByText("+4 more schedules")).toBeInTheDocument();
+  });
+
+  it("prefers scheduleDescription over scheduleName when both are present", async () => {
+    server.use(
+      mockApi(zeroUsageInsightContract.get, ({ respond }) => {
+        return respond(
+          200,
+          makeFixture({
+            buckets: [],
+            schedules: [
+              {
+                scheduleId: "s1",
+                scheduleName: "default",
+                scheduleDescription: "Daily morning brief",
+                credits: 100,
+                tokens: 200,
+              },
+              {
+                scheduleId: "s2",
+                scheduleName: "default",
+                scheduleDescription: null,
+                credits: 80,
+                tokens: 160,
+              },
+            ],
+            scheduleOtherCount: 0,
+            scheduleOtherCredits: 0,
+            chats: [],
+            chatOtherCount: 0,
+            chatOtherCredits: 0,
+            grandTotalCredits: 180,
+            grandTotalTokens: 360,
+          }),
+        );
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/_/usage" });
+
+    // s1: description present → render description
+    await waitFor(() => {
+      expect(screen.getByText("Daily morning brief")).toBeInTheDocument();
+    });
+    // s2: no description → fall back to name
+    expect(screen.getByText("default")).toBeInTheDocument();
   });
 
   it("uses singular form for scheduleOtherCount of 1", async () => {

--- a/turbo/apps/platform/src/views/usage-page/components/usage-insight-schedules-table.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/usage-insight-schedules-table.tsx
@@ -83,7 +83,7 @@ export function UsageInsightSchedulesTable({
                 }}
               >
                 <span className="text-sm font-medium truncate decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-2">
-                  {row.scheduleName}
+                  {row.scheduleDescription?.trim() || row.scheduleName}
                 </span>
                 <div className="h-1.5 rounded-full bg-foreground/10 overflow-hidden">
                   <div

--- a/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/insight/__tests__/route.test.ts
@@ -533,6 +533,71 @@ describe("GET /api/zero/usage/insight", () => {
     });
   });
 
+  it("returns scheduleDescription alongside scheduleName for scheduled runs", async () => {
+    const { userId, orgId } = await context.user;
+    // Two separate agents, both with a "default" schedule — the unique
+    // constraint is (agent_id, name, org_id, user_id), so duplicate names
+    // can only collide across agents. This mirrors the real-world dashboard
+    // case where multiple "default" schedules need to be told apart.
+    const { composeId: agentA } = await seedTestCompose({
+      userId,
+      name: uniqueId("compose-a"),
+      orgId,
+    });
+    const { composeId: agentB } = await seedTestCompose({
+      userId,
+      name: uniqueId("compose-b"),
+      orgId,
+    });
+
+    const describedScheduleId = await seedTestSchedule({
+      agentId: agentA,
+      userId,
+      orgId,
+      name: "default",
+      description: "Daily morning brief",
+    });
+    const undescribedScheduleId = await seedTestSchedule({
+      agentId: agentB,
+      userId,
+      orgId,
+      name: "default",
+    });
+
+    for (const [agentId, scheduleId] of [
+      [agentA, describedScheduleId],
+      [agentB, undescribedScheduleId],
+    ] as const) {
+      const { runId } = await seedTestRun(userId, agentId, {
+        triggerSource: "schedule",
+        scheduleId,
+        status: "completed",
+      });
+      await insertTestCreditUsageForRun({
+        runId,
+        orgId,
+        userId,
+        creditsCharged: 50,
+        status: "processed",
+      });
+    }
+
+    const response = await GET(
+      makeRequest({ range: "7d", groupBy: "source", tz: "UTC" }),
+    );
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as UsageInsightResponse;
+
+    const described = data.schedules.find((s) => {
+      return s.scheduleId === describedScheduleId;
+    });
+    const undescribed = data.schedules.find((s) => {
+      return s.scheduleId === undescribedScheduleId;
+    });
+    expect(described?.scheduleDescription).toBe("Daily morning brief");
+    expect(undescribed?.scheduleDescription).toBeNull();
+  });
+
   it("scope isolation — other user's activity in same org is invisible", async () => {
     const { userId, orgId } = await context.user;
     const otherUserId = uniqueId("other-user");

--- a/turbo/apps/web/src/__tests__/db-test-seeders/schedules.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/schedules.ts
@@ -94,6 +94,7 @@ export async function seedTestSchedule(params: {
   userId: string;
   orgId: string;
   name?: string;
+  description?: string;
 }): Promise<string> {
   initServices();
   const [sched] = await globalThis.services.db
@@ -103,6 +104,7 @@ export async function seedTestSchedule(params: {
       userId: params.userId,
       orgId: params.orgId,
       name: params.name ?? uniqueId("sched"),
+      description: params.description,
       cronExpression: "0 0 * * *",
       prompt: "test",
     })

--- a/turbo/apps/web/src/lib/zero/billing/usage-insight-ledger.ts
+++ b/turbo/apps/web/src/lib/zero/billing/usage-insight-ledger.ts
@@ -236,6 +236,7 @@ export async function queryUsageInsightTopSchedules(
   const rows = await db.execute<{
     schedule_id: string | null;
     schedule_name: string | null;
+    schedule_description: string | null;
     credits: string;
     tokens: string;
     rn: string;
@@ -246,6 +247,7 @@ export async function queryUsageInsightTopSchedules(
         SELECT
           zr.schedule_id,
           COALESCE(zas.name, 'Unnamed schedule') AS schedule_name,
+          zas.description AS schedule_description,
           COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS credits,
           COALESCE(SUM(${USAGE_ROW_ALIAS}.tokens), 0)::bigint AS tokens,
           ROW_NUMBER() OVER (ORDER BY SUM(${USAGE_ROW_ALIAS}.credits_charged) DESC NULLS LAST) AS rn
@@ -253,13 +255,14 @@ export async function queryUsageInsightTopSchedules(
         INNER JOIN zero_runs zr ON zr.id = ${USAGE_ROW_ALIAS}.run_id
         LEFT JOIN zero_agent_schedules zas ON zas.id = zr.schedule_id
         WHERE zr.schedule_id IS NOT NULL
-        GROUP BY zr.schedule_id, zas.name
+        GROUP BY zr.schedule_id, zas.name, zas.description
       )
       SELECT * FROM agg WHERE rn <= 100
       UNION ALL
       SELECT
         NULL AS schedule_id,
         'others' AS schedule_name,
+        NULL AS schedule_description,
         COALESCE(SUM(credits), 0)::bigint AS credits,
         COALESCE(SUM(tokens), 0)::bigint AS tokens,
         101 AS rn
@@ -279,6 +282,7 @@ export async function queryUsageInsightTopSchedules(
       schedules.push({
         scheduleId: row.schedule_id,
         scheduleName: row.schedule_name ?? "Unnamed schedule",
+        scheduleDescription: row.schedule_description,
         credits: Number(row.credits),
         tokens: Number(row.tokens),
       });

--- a/turbo/packages/api-contracts/src/contracts/zero-usage-insight.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-usage-insight.ts
@@ -13,6 +13,7 @@ const usageInsightBucketSchema = z.object({
 const usageInsightScheduleRowSchema = z.object({
   scheduleId: z.string(),
   scheduleName: z.string(),
+  scheduleDescription: z.string().nullable(),
   credits: z.number(),
   tokens: z.number(),
 });


### PR DESCRIPTION
## Summary

The Schedules widget on the Usage page rendered `scheduleName` only, so multiple schedules sharing a common name (e.g. several `default` schedules across different agents) appeared as indistinguishable rows.

This PR plumbs the schedule `description` through the usage-insight stack and renders it as the primary label, falling back to `name` when description is null/empty.

- API contract — add `scheduleDescription: string | null` to `UsageInsightScheduleRow`
- Backend SQL — select `zas.description` in `queryUsageInsightTopSchedules` and group by it
- Frontend widget — render `row.scheduleDescription?.trim() || row.scheduleName`
- Test seeder — `seedTestSchedule` accepts an optional `description`

## Test plan

- [x] `vitest run app/api/zero/usage/insight/__tests__/route.test.ts -t "scheduleDescription"` — new route test passes (described row returns description, undescribed row returns null)
- [x] `vitest run src/views/usage-page/__tests__/usage-insight-components.test.tsx` — 20/20 pass, including new "prefers scheduleDescription over scheduleName" case
- [x] `pnpm -F web -F @vm0/app check-types` — clean
- [ ] Manual: visit /usage with a real account that has multiple `default` schedules — confirm rows are distinguishable

Note: an unrelated TZ-shift test in the same route file is failing on `main` as well (date arithmetic edge case on 2026-04-28). Not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)