### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -132,7 +132,7 @@ ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the rootfs cache via script hash)
 GO_VERSION="1.26.2"
-CLAUDE_CODE_VERSION="2.1.119"
+CLAUDE_CODE_VERSION="2.1.121"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.26.0"


### PR DESCRIPTION
## Summary

Routine update of pinned package versions in `crates/runner/scripts/build-rootfs.sh`.

## Updates

| Package | Old | New |
|---------|-----|-----|
| Claude Code CLI | 2.1.119 | 2.1.121 |

The following pinned versions are already up to date and were left unchanged:
- Go: 1.26.2
- @googleworkspace/cli: 0.22.5
- @xdevplatform/xurl: 1.0.3
- agent-browser: 0.26.0

## Test plan

- [ ] CI builds the rootfs successfully with the new Claude Code version