### PR TITLE
fix: align telegram typing and markdown responses

### DIFF
--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -83,10 +83,36 @@ impl Drop for DnsProxy {
 ///
 /// Checks both TCP and UDP because dnsmasq binds both protocols.
 fn find_available_port() -> std::io::Result<u16> {
-    let tcp = std::net::TcpListener::bind("0.0.0.0:0")?;
-    let port = tcp.local_addr()?.port();
-    let _udp = std::net::UdpSocket::bind(("0.0.0.0", port))?;
-    Ok(port)
+    const MAX_PORT_PROBE_ATTEMPTS: usize = 64;
+
+    find_available_port_from(
+        (0..MAX_PORT_PROBE_ATTEMPTS).map(|_| std::net::TcpListener::bind("0.0.0.0:0")),
+    )
+}
+
+fn find_available_port_from<I>(tcp_candidates: I) -> std::io::Result<u16>
+where
+    I: IntoIterator<Item = std::io::Result<std::net::TcpListener>>,
+{
+    let mut last_addr_in_use = None;
+    for tcp in tcp_candidates {
+        let tcp = tcp?;
+        let port = tcp.local_addr()?.port();
+        match std::net::UdpSocket::bind(("0.0.0.0", port)) {
+            Ok(_udp) => return Ok(port),
+            Err(err) if err.kind() == std::io::ErrorKind::AddrInUse => {
+                last_addr_in_use = Some(err);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    Err(last_addr_in_use.unwrap_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::AddrInUse,
+            "could not find a port available for both TCP and UDP",
+        )
+    }))
 }
 
 /// Start dnsmasq and spawn a background task to parse its query log.
@@ -455,5 +481,18 @@ mod tests {
     fn find_available_port_returns_nonzero() {
         let port = find_available_port().unwrap();
         assert!(port > 0);
+    }
+
+    #[test]
+    fn find_available_port_retries_when_udp_candidate_is_in_use() {
+        let busy_udp = std::net::UdpSocket::bind("0.0.0.0:0").unwrap();
+        let busy_port = busy_udp.local_addr().unwrap().port();
+        let busy_tcp = std::net::TcpListener::bind(("0.0.0.0", busy_port)).unwrap();
+        let free_tcp = std::net::TcpListener::bind("0.0.0.0:0").unwrap();
+        let free_port = free_tcp.local_addr().unwrap().port();
+
+        let port = find_available_port_from([Ok(busy_tcp), Ok(free_tcp)]).unwrap();
+
+        assert_eq!(port, free_port);
     }
 }

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
@@ -33,27 +33,7 @@ interface TelegramCallbackPayload {
   agentId: string;
   existingSessionId: string | null;
   isDM: boolean;
-  thinkingMessageId: string | null;
-}
-
-function telegramSendMessage() {
-  const calls: Array<{ chat_id: string; text: string }> = [];
-  const handler = http.post(
-    `https://api.telegram.org/bot${TEST_BOT_TOKEN}/sendMessage`,
-    async ({ request }) => {
-      const body = (await request.json()) as { chat_id: string; text: string };
-      calls.push(body);
-      return HttpResponse.json({
-        ok: true,
-        result: {
-          message_id: 999,
-          chat: { id: 123 },
-          text: body.text,
-        },
-      });
-    },
-  );
-  return { ...handler, calls };
+  thinkingMessageId?: string | null;
 }
 
 function telegramSendChatAction() {
@@ -65,24 +45,27 @@ function telegramSendChatAction() {
   );
 }
 
-function telegramEditMessageText() {
-  const calls: Array<{
-    chat_id: string;
-    message_id: number;
-    text: string;
-  }> = [];
+interface TelegramSendMessageBody {
+  chat_id: string;
+  text: string;
+  parse_mode?: string;
+  reply_parameters?: { message_id: number };
+}
+
+function telegramSendMessage() {
+  const calls: TelegramSendMessageBody[] = [];
   const handler = http.post(
-    `https://api.telegram.org/bot${TEST_BOT_TOKEN}/editMessageText`,
+    `https://api.telegram.org/bot${TEST_BOT_TOKEN}/sendMessage`,
     async ({ request }) => {
-      const body = (await request.json()) as {
-        chat_id: string;
-        message_id: number;
-        text: string;
-      };
+      const body = (await request.json()) as TelegramSendMessageBody;
       calls.push(body);
       return HttpResponse.json({
         ok: true,
-        result: { message_id: 100, chat: { id: 123 }, text: body.text },
+        result: {
+          message_id: 999,
+          chat: { id: 123 },
+          text: body.text,
+        },
       });
     },
   );
@@ -131,7 +114,6 @@ async function setupTelegramCallback() {
     agentId: composeId,
     existingSessionId: null,
     isDM: false,
-    thinkingMessageId: "100",
   };
 
   const { secret } = await createTestCallback({
@@ -250,7 +232,8 @@ describe("POST /api/internal/callbacks/telegram", () => {
       expect(data.success).toBe(true);
 
       // Telegram API was called
-      expect(deleteMessageHandler.mocked).toHaveBeenCalledTimes(1);
+      expect(chatActionHandler.mocked).toHaveBeenCalledTimes(1);
+      expect(deleteMessageHandler.mocked).not.toHaveBeenCalled();
       expect(sendMessageHandler.mocked).toHaveBeenCalledTimes(1);
       const text = sendMessageHandler.calls[0]?.text ?? "";
       expect(text).not.toContain("🤖");
@@ -289,6 +272,120 @@ describe("POST /api/internal/callbacks/telegram", () => {
       expect(text).toContain(`/activities/${runId}`);
     });
 
+    it("renders markdown for group mention replies", async () => {
+      const { runId, payload, secret } = await setupTelegramCallback();
+
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        { eventData: { result: "**Done** with `code`" } },
+      ]);
+
+      const chatActionHandler = telegramSendChatAction();
+      const sendMessageHandler = telegramSendMessage();
+      server.use(chatActionHandler.handler, sendMessageHandler.handler);
+
+      const request = createSignedCallbackRequest(
+        "http://localhost/api/internal/callbacks/telegram",
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const sent = sendMessageHandler.calls[0]!;
+      expect(sent.text).toContain("<b>Done</b> with <code>code</code>");
+      expect(sent.parse_mode).toBe("HTML");
+      expect(sent.reply_parameters).toEqual({
+        message_id: Number(payload.messageId),
+      });
+    });
+
+    it("renders connector authorization links in agent replies", async () => {
+      const { runId, payload, secret } = await setupTelegramCallback();
+
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        {
+          eventData: {
+            result: [
+              "Notion 还没有连接，需要先授权。",
+              "",
+              "请点击这个链接完成连接：",
+              "[连接 Notion](https://tunnel-yuma-vm0-app.vm7.ai/connectors/notion/connect?agentId=b431c9a7-4f78-4977-aba1-dec4c04b212c)",
+            ].join("\n"),
+          },
+        },
+      ]);
+
+      const chatActionHandler = telegramSendChatAction();
+      const sendMessageHandler = telegramSendMessage();
+      server.use(chatActionHandler.handler, sendMessageHandler.handler);
+
+      const request = createSignedCallbackRequest(
+        "http://localhost/api/internal/callbacks/telegram",
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const sent = sendMessageHandler.calls[0]!;
+      expect(sent.parse_mode).toBe("HTML");
+      expect(sent.text).toContain(
+        '<a href="https://tunnel-yuma-vm0-app.vm7.ai/connectors/notion/connect?agentId=b431c9a7-4f78-4977-aba1-dec4c04b212c">连接 Notion</a>',
+      );
+      expect(sent.text).not.toContain("[连接 Notion](");
+    });
+
+    it("renders markdown for DM replies without reply quoting", async () => {
+      const { runId, payload, secret } = await setupTelegramCallback();
+
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        { eventData: { result: "**Done** with `code`" } },
+      ]);
+
+      const chatActionHandler = telegramSendChatAction();
+      const sendMessageHandler = telegramSendMessage();
+      server.use(chatActionHandler.handler, sendMessageHandler.handler);
+
+      const request = createSignedCallbackRequest(
+        "http://localhost/api/internal/callbacks/telegram",
+        { runId, status: "completed", payload: { ...payload, isDM: true } },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const sent = sendMessageHandler.calls[0]!;
+      expect(sent.text).toContain("<b>Done</b> with <code>code</code>");
+      expect(sent.reply_parameters).toBeUndefined();
+    });
+
+    it("should delete legacy thinking placeholder when present", async () => {
+      const { runId, payload, secret } = await setupTelegramCallback();
+
+      const chatActionHandler = telegramSendChatAction();
+      const deleteMessageHandler = telegramDeleteMessage();
+      const sendMessageHandler = telegramSendMessage();
+      server.use(
+        chatActionHandler.handler,
+        deleteMessageHandler.handler,
+        sendMessageHandler.handler,
+      );
+
+      const request = createSignedCallbackRequest(
+        "http://localhost/api/internal/callbacks/telegram",
+        {
+          runId,
+          status: "completed",
+          payload: { ...payload, thinkingMessageId: "100" },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(deleteMessageHandler.mocked).toHaveBeenCalledTimes(1);
+    });
+
     it("should return 200 and send error message on failed run", async () => {
       const { runId, payload, secret } = await setupTelegramCallback();
 
@@ -319,21 +416,43 @@ describe("POST /api/internal/callbacks/telegram", () => {
 
       expect(sendMessageHandler.mocked).toHaveBeenCalledTimes(1);
     });
+
+    it("renders markdown links in failed run messages", async () => {
+      const { runId, payload, secret } = await setupTelegramCallback();
+
+      const chatActionHandler = telegramSendChatAction();
+      const sendMessageHandler = telegramSendMessage();
+      server.use(chatActionHandler.handler, sendMessageHandler.handler);
+
+      const request = createSignedCallbackRequest(
+        "http://localhost/api/internal/callbacks/telegram",
+        {
+          runId,
+          status: "failed",
+          error: "请先 [连接 Notion](https://example.com/connect?agentId=123)",
+          payload,
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const sent = sendMessageHandler.calls[0]!;
+      expect(sent.parse_mode).toBe("HTML");
+      expect(sent.text).toContain(
+        '<a href="https://example.com/connect?agentId=123">连接 Notion</a>',
+      );
+      expect(sent.text).not.toContain("[连接 Notion](");
+    });
   });
 
   describe("Progress Callback", () => {
     it("should refresh typing indicator and return early without sending a message", async () => {
-      const { runId, payload, secret, composeName } =
-        await setupTelegramCallback();
+      const { runId, payload, secret } = await setupTelegramCallback();
 
       const chatActionHandler = telegramSendChatAction();
-      const editHandler = telegramEditMessageText();
       const sendMessageHandler = telegramSendMessage();
-      server.use(
-        chatActionHandler.handler,
-        editHandler.handler,
-        sendMessageHandler.handler,
-      );
+      server.use(chatActionHandler.handler, sendMessageHandler.handler);
 
       const request = createSignedCallbackRequest(
         "http://localhost/api/internal/callbacks/telegram",
@@ -348,29 +467,23 @@ describe("POST /api/internal/callbacks/telegram", () => {
 
       // Should refresh typing indicator
       expect(chatActionHandler.mocked).toHaveBeenCalledTimes(1);
-      // Should edit thinking message back to thinking state
-      expect(editHandler.mocked).toHaveBeenCalledTimes(1);
-      expect(editHandler.calls[0]?.text).toBe(
-        `<i>${composeName} is thinking...</i>`,
-      );
-      expect(editHandler.calls[0]?.text).not.toContain("🤖");
       // Should NOT send a new message
       expect(sendMessageHandler.mocked).not.toHaveBeenCalled();
     });
 
-    it("should skip editing when no thinkingMessageId is set", async () => {
+    it("should ignore legacy thinking placeholders on progress", async () => {
       const { runId, payload, secret } = await setupTelegramCallback();
 
       const chatActionHandler = telegramSendChatAction();
-      const editHandler = telegramEditMessageText();
-      server.use(chatActionHandler.handler, editHandler.handler);
+      const sendMessageHandler = telegramSendMessage();
+      server.use(chatActionHandler.handler, sendMessageHandler.handler);
 
       const request = createSignedCallbackRequest(
         "http://localhost/api/internal/callbacks/telegram",
         {
           runId,
           status: "progress",
-          payload: { ...payload, thinkingMessageId: null },
+          payload: { ...payload, thinkingMessageId: "100" },
         },
         secret,
       );
@@ -378,7 +491,7 @@ describe("POST /api/internal/callbacks/telegram", () => {
 
       expect(response.status).toBe(200);
       expect(chatActionHandler.mocked).toHaveBeenCalledTimes(1);
-      expect(editHandler.mocked).not.toHaveBeenCalled();
+      expect(sendMessageHandler.mocked).not.toHaveBeenCalled();
     });
   });
 
@@ -500,7 +613,6 @@ describe("POST /api/internal/callbacks/telegram", () => {
         agentId: "compose-123",
         existingSessionId: null,
         isDM: false,
-        thinkingMessageId: null,
       };
 
       const request = createSignedCallbackRequest(

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
@@ -11,7 +11,6 @@ import {
   createTelegramClient,
   sendMessage,
   sendChatAction,
-  editMessageText,
   deleteMessage,
 } from "../../../../../src/lib/zero/telegram/client";
 import {
@@ -25,7 +24,6 @@ import {
   storeTelegramMessage,
   resolveTelegramAuditLogsUrl,
   getAgentDisplayLabel,
-  formatTelegramThinkingMessage,
 } from "../../../../../src/lib/zero/telegram/handlers/shared";
 import { env } from "../../../../../src/env";
 import type { TelegramCallbackPayload } from "../../../../../src/lib/infra/callback/callback-payloads";
@@ -131,12 +129,13 @@ async function handleCompletion(ctx: CompletionContext): Promise<void> {
 
   const agent = await resolveAgentInfo(agentId);
 
-  // Delete thinking placeholder message
+  // Delete legacy thinking placeholder messages from runs created before
+  // Telegram switched to typing-only feedback.
   if (thinkingMessageId) {
     try {
       await deleteMessage(client, chatId, Number(thinkingMessageId));
     } catch (err) {
-      log.debug("Failed to delete thinking message", {
+      log.debug("Failed to delete legacy thinking placeholder", {
         thinkingMessageId,
         error: err,
       });
@@ -279,16 +278,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (status === "progress") {
     try {
       await sendChatAction(client, payload.chatId, "typing");
-      if (payload.thinkingMessageId) {
-        const agent = await resolveAgentInfo(payload.agentId);
-        const thinkingText = formatTelegramThinkingMessage(agent.label);
-        await editMessageText(
-          client,
-          payload.chatId,
-          Number(payload.thinkingMessageId),
-          thinkingText,
-        );
-      }
     } catch (err) {
       log.debug("Failed to refresh typing indicator", { runId, error: err });
     }

--- a/turbo/apps/web/app/api/internal/event-consumers/telegram-typing/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/event-consumers/telegram-typing/__tests__/route.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { HttpResponse } from "msw";
+import { POST } from "../route";
+import {
+  createTestCallback,
+  createTestCompose,
+  createSignedCallbackRequest,
+  createTelegramCallbackInstallation,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { server } from "../../../../../../src/mocks/server";
+import { http } from "../../../../../../src/__tests__/msw";
+import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
+
+const SECRETS_ENCRYPTION_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const TEST_BOT_TOKEN = "123456:ABC-test-telegram-typing";
+const CONSUMER_URL =
+  "http://localhost:3000/api/internal/event-consumers/telegram-typing";
+
+const context = testContext();
+
+function signed(body: unknown) {
+  return createSignedCallbackRequest(
+    CONSUMER_URL,
+    body,
+    SECRETS_ENCRYPTION_KEY,
+  );
+}
+
+function telegramSendChatAction() {
+  const calls: Array<{ chat_id: string; action: string }> = [];
+  const handler = http.post(
+    `https://api.telegram.org/bot${TEST_BOT_TOKEN}/sendChatAction`,
+    async ({ request }) => {
+      const body = (await request.json()) as {
+        chat_id: string;
+        action: string;
+      };
+      calls.push(body);
+      return HttpResponse.json({ ok: true, result: true });
+    },
+  );
+  return { ...handler, calls };
+}
+
+describe("POST /api/internal/event-consumers/telegram-typing", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("rejects invalid signatures", async () => {
+    const request = createSignedCallbackRequest(
+      CONSUMER_URL,
+      { runId: "r", events: [], context: {} },
+      "wrong-key",
+    );
+    const response = await POST(request);
+    expect(response.status).toBe(401);
+  });
+
+  it("refreshes typing for pending Telegram callbacks", async () => {
+    const user = await context.setupUser();
+    const { composeId } = await createTestCompose(uniqueId("tg-typing"));
+    const { installationId, userLinkId } =
+      await createTelegramCallbackInstallation(
+        composeId,
+        user.userId,
+        TEST_BOT_TOKEN,
+      );
+    const { runId } = await seedTestRun(user.userId, composeId);
+
+    await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/telegram",
+      payload: {
+        installationId,
+        chatId: "chat-123",
+        messageId: "msg-1",
+        rootMessageId: null,
+        userLinkId,
+        agentId: composeId,
+        existingSessionId: null,
+        isDM: true,
+      },
+    });
+
+    const sendChatAction = telegramSendChatAction();
+    server.use(sendChatAction.handler);
+
+    const response = await POST(
+      signed({
+        runId,
+        events: [{ type: "assistant", sequenceNumber: 1 }],
+        context: { userId: user.userId, orgId: user.orgId },
+      }),
+    );
+    await context.mocks.flushAfter();
+
+    expect(response.status).toBe(200);
+    expect(sendChatAction.mocked).toHaveBeenCalledTimes(1);
+    expect(sendChatAction.calls[0]).toEqual({
+      chat_id: "chat-123",
+      action: "typing",
+    });
+  });
+
+  it("does nothing when the run has no Telegram callbacks", async () => {
+    const user = await context.setupUser();
+    const { composeId } = await createTestCompose(uniqueId("tg-typing-none"));
+    const { runId } = await seedTestRun(user.userId, composeId);
+    const sendChatAction = telegramSendChatAction();
+    server.use(sendChatAction.handler);
+
+    const response = await POST(
+      signed({
+        runId,
+        events: [{ type: "tool_result", sequenceNumber: 1 }],
+        context: { userId: user.userId, orgId: user.orgId },
+      }),
+    );
+    await context.mocks.flushAfter();
+
+    expect(response.status).toBe(200);
+    expect(sendChatAction.mocked).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/web/app/api/internal/event-consumers/telegram-typing/route.ts
+++ b/turbo/apps/web/app/api/internal/event-consumers/telegram-typing/route.ts
@@ -1,6 +1,4 @@
-import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
-import { after } from "next/server";
+import { after, NextResponse, type NextRequest } from "next/server";
 import { and, eq } from "drizzle-orm";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";

--- a/turbo/apps/web/app/api/internal/event-consumers/telegram-typing/route.ts
+++ b/turbo/apps/web/app/api/internal/event-consumers/telegram-typing/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { after } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+import { initServices } from "../../../../../src/lib/init-services";
+import { verifyEventConsumer } from "../../../../../src/lib/infra/event-consumer";
+import { decryptSecretValue } from "../../../../../src/lib/shared/crypto/secrets-encryption";
+import {
+  createTelegramClient,
+  sendChatAction,
+} from "../../../../../src/lib/zero/telegram/client";
+import { env } from "../../../../../src/env";
+import { logger } from "../../../../../src/lib/shared/logger";
+
+const log = logger("event-consumer:telegram-typing");
+
+interface TelegramTypingTarget {
+  installationId: string;
+  chatId: string;
+}
+
+function parseTelegramTypingTarget(
+  payload: unknown,
+): TelegramTypingTarget | undefined {
+  if (!payload || typeof payload !== "object") {
+    return undefined;
+  }
+  const data = payload as Record<string, unknown>;
+  if (
+    typeof data.installationId !== "string" ||
+    typeof data.chatId !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    installationId: data.installationId,
+    chatId: data.chatId,
+  };
+}
+
+async function refreshTelegramTypingForRun(runId: string): Promise<number> {
+  const callbacks = await globalThis.services.db
+    .select({
+      url: agentRunCallbacks.url,
+      payload: agentRunCallbacks.payload,
+    })
+    .from(agentRunCallbacks)
+    .where(
+      and(
+        eq(agentRunCallbacks.runId, runId),
+        eq(agentRunCallbacks.status, "pending"),
+      ),
+    );
+
+  const targets = new Map<string, TelegramTypingTarget>();
+  for (const callback of callbacks) {
+    if (!callback.url.endsWith("/api/internal/callbacks/telegram")) {
+      continue;
+    }
+    const target = parseTelegramTypingTarget(callback.payload);
+    if (target) {
+      targets.set(`${target.installationId}:${target.chatId}`, target);
+    }
+  }
+
+  if (targets.size === 0) {
+    return 0;
+  }
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  let refreshed = 0;
+
+  for (const target of targets.values()) {
+    const [installation] = await globalThis.services.db
+      .select({
+        encryptedBotToken: telegramInstallations.encryptedBotToken,
+      })
+      .from(telegramInstallations)
+      .where(eq(telegramInstallations.telegramBotId, target.installationId))
+      .limit(1);
+
+    if (!installation) {
+      continue;
+    }
+
+    const botToken = decryptSecretValue(
+      installation.encryptedBotToken,
+      SECRETS_ENCRYPTION_KEY,
+    );
+    const client = createTelegramClient(botToken);
+    await sendChatAction(client, target.chatId, "typing");
+    refreshed++;
+  }
+
+  return refreshed;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  initServices();
+
+  const result = await verifyEventConsumer(request);
+  if (!result.ok) {
+    return result.response;
+  }
+
+  const { runId, events } = result.data;
+
+  after(() => {
+    return refreshTelegramTypingForRun(runId).catch((error) => {
+      log.debug("Failed to refresh Telegram typing from events", {
+        runId,
+        batch: events.length,
+        error,
+      });
+    });
+  });
+
+  return NextResponse.json({ scheduled: true });
+}

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -27,6 +27,14 @@ const WEBHOOK_SECRET = "webhook-secret";
 const TELEGRAM_USER_ID = 12345;
 const TEST_AGENT_DISPLAY_NAME = "Telegram Helper";
 
+interface TelegramSendMessageBody {
+  chat_id: string;
+  text: string;
+  reply_markup?: {
+    inline_keyboard: Array<Array<{ text: string; url: string }>>;
+  };
+}
+
 function createWebhookRequest(body: Record<string, unknown>): Request {
   return new Request("http://localhost/api/telegram/webhook/test", {
     method: "POST",
@@ -39,14 +47,11 @@ function createWebhookRequest(body: Record<string, unknown>): Request {
 }
 
 function telegramSendMessage() {
-  const calls: Array<{ chat_id: string; text: string }> = [];
+  const calls: TelegramSendMessageBody[] = [];
   const handler = http.post(
     `https://api.telegram.org/bot${TEST_BOT_TOKEN}/sendMessage`,
     async ({ request }) => {
-      const body = (await request.json()) as {
-        chat_id: string;
-        text: string;
-      };
+      const body = (await request.json()) as TelegramSendMessageBody;
       calls.push(body);
       return HttpResponse.json({
         ok: true,
@@ -57,31 +62,13 @@ function telegramSendMessage() {
   return { ...handler, calls };
 }
 
-function telegramEditMessageText() {
-  const calls: Array<{
-    chat_id: string;
-    message_id: number;
-    text: string;
-  }> = [];
-  const handler = http.post(
-    `https://api.telegram.org/bot${TEST_BOT_TOKEN}/editMessageText`,
-    async ({ request }) => {
-      const body = (await request.json()) as {
-        chat_id: string;
-        message_id: number;
-        text: string;
-      };
-      calls.push(body);
-      return HttpResponse.json({
-        ok: true,
-        result: {
-          message_id: body.message_id,
-          chat: { id: TELEGRAM_USER_ID },
-        },
-      });
+function telegramSendChatAction() {
+  return http.post(
+    `https://api.telegram.org/bot${TEST_BOT_TOKEN}/sendChatAction`,
+    () => {
+      return HttpResponse.json({ ok: true, result: true });
     },
   );
-  return { ...handler, calls };
 }
 
 async function updateAgentDisplayName(
@@ -253,7 +240,13 @@ describe("Telegram bot commands", () => {
       const text = sendMsg.calls[0]?.text ?? "";
       // Should redirect to Telegram DM instead of exposing the signed connect URL
       expect(text).toContain("connect your account");
-      expect(text).toContain("?start=connect");
+      expect(text).not.toContain("?start=connect");
+      expect(text).not.toContain("<a href=");
+      expect(sendMsg.calls[0]?.reply_markup).toEqual({
+        inline_keyboard: [
+          [{ text: "Connect", url: "https://t.me/test_bot?start=connect" }],
+        ],
+      });
       // Should NOT contain the actual connect URL with telegramUserId
       expect(text).not.toContain("/telegram/connect?bot=");
     });
@@ -288,7 +281,7 @@ describe("Telegram bot commands", () => {
       expect(text).not.toContain(composeName);
     });
 
-    it("should send platform link with bot param when user is not connected", async () => {
+    it("should send platform link button when user is not connected", async () => {
       const sendMsg = telegramSendMessage();
       server.use(sendMsg.handler);
 
@@ -311,8 +304,12 @@ describe("Telegram bot commands", () => {
       expect(sendMsg.mocked).toHaveBeenCalled();
       const text = sendMsg.calls[0]?.text ?? "";
       expect(text).toContain("To use Zero in Telegram");
-      expect(text).toContain("/telegram/connect?bot=");
-      expect(text).toContain(">Connect</a>");
+      expect(text).not.toContain("/telegram/connect?bot=");
+      expect(text).not.toContain("<a href=");
+      const buttonUrl =
+        sendMsg.calls[0]?.reply_markup?.inline_keyboard[0]?.[0]?.url ?? "";
+      expect(buttonUrl).toContain("/telegram/connect?bot=");
+      expect(buttonUrl).toContain("tgUser=99999");
     });
   });
 
@@ -498,6 +495,9 @@ describe("Telegram bot commands", () => {
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       expect(sendMsg.calls[0]?.text).toContain("connect your account");
+      const buttonUrl =
+        sendMsg.calls[0]?.reply_markup?.inline_keyboard[0]?.[0]?.url ?? "";
+      expect(buttonUrl).toContain("/telegram/connect?bot=");
     });
 
     it("should be ignored in group chats", async () => {
@@ -541,8 +541,8 @@ describe("Telegram bot commands", () => {
 
     it("should send queued message for DM when run is queued", async () => {
       const sendMsg = telegramSendMessage();
-      const editMsg = telegramEditMessageText();
-      server.use(sendMsg.handler, editMsg.handler);
+      const sendChatAction = telegramSendChatAction();
+      server.use(sendMsg.handler, sendChatAction.handler);
 
       const request = createWebhookRequest({
         update_id: 1,
@@ -560,24 +560,18 @@ describe("Telegram bot commands", () => {
       expect(response.status).toBe(200);
       await context.mocks.flushAfter();
 
-      expect(sendMsg.calls[0]?.text).toContain(
-        `${TEST_AGENT_DISPLAY_NAME} is thinking`,
-      );
+      expect(sendChatAction.mocked).toHaveBeenCalledTimes(1);
+      expect(sendMsg.calls[0]?.text).toContain("Run queued");
+      expect(sendMsg.calls[0]?.text).not.toContain("thinking");
       expect(sendMsg.calls[0]?.text).not.toContain(composeId);
       expect(sendMsg.calls[0]?.text).not.toContain(composeName);
-
-      // Queued notification edits the thinking message (not a new sendMessage)
-      const queuedMsg = editMsg.calls.find((c) => {
-        return c.text.includes("Run queued");
-      });
-      expect(queuedMsg).toBeDefined();
-      expect(queuedMsg?.text).toContain("concurrency limit reached");
+      expect(sendMsg.calls[0]?.text).toContain("concurrency limit reached");
     });
 
     it("should send queued message for group mention when run is queued", async () => {
       const sendMsg = telegramSendMessage();
-      const editMsg = telegramEditMessageText();
-      server.use(sendMsg.handler, editMsg.handler);
+      const sendChatAction = telegramSendChatAction();
+      server.use(sendMsg.handler, sendChatAction.handler);
 
       const request = createWebhookRequest({
         update_id: 1,
@@ -596,29 +590,20 @@ describe("Telegram bot commands", () => {
       expect(response.status).toBe(200);
       await context.mocks.flushAfter();
 
-      expect(sendMsg.calls[0]?.text).toContain(
-        `${TEST_AGENT_DISPLAY_NAME} is thinking`,
-      );
+      expect(sendChatAction.mocked).toHaveBeenCalledTimes(1);
+      expect(sendMsg.calls[0]?.text).toContain("Run queued");
+      expect(sendMsg.calls[0]?.text).not.toContain("thinking");
       expect(sendMsg.calls[0]?.text).not.toContain(composeId);
       expect(sendMsg.calls[0]?.text).not.toContain(composeName);
-
-      // Queued notification edits the thinking message (not a new sendMessage)
-      const queuedMsg = editMsg.calls.find((c) => {
-        return c.text.includes("Run queued");
-      });
-      expect(queuedMsg).toBeDefined();
-      expect(queuedMsg?.text).toContain("concurrency limit reached");
+      expect(sendMsg.calls[0]?.text).toContain("concurrency limit reached");
     });
   });
 
-  describe("thinking message agent label", () => {
-    beforeEach(async () => {
-      await updateAgentDisplayName(composeId, "");
-    });
-
-    it("should fall back to the agent name when displayName is blank", async () => {
+  describe("typing indicator", () => {
+    it("should send typing without posting a thinking message", async () => {
       const sendMsg = telegramSendMessage();
-      server.use(sendMsg.handler);
+      const sendChatAction = telegramSendChatAction();
+      server.use(sendMsg.handler, sendChatAction.handler);
 
       const request = createWebhookRequest({
         update_id: 1,
@@ -636,7 +621,8 @@ describe("Telegram bot commands", () => {
       expect(response.status).toBe(200);
       await context.mocks.flushAfter();
 
-      expect(sendMsg.calls[0]?.text).toContain(`${composeName} is thinking`);
+      expect(sendChatAction.mocked).toHaveBeenCalledTimes(1);
+      expect(sendMsg.mocked).not.toHaveBeenCalled();
     });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import type { NextRequest } from "next/server";
 import { POST } from "../route";
 import { POST as axiomConsumerPOST } from "../../../../internal/event-consumers/axiom/route";
 import { POST as chatAssistantConsumerPOST } from "../../../../internal/event-consumers/chat-assistant/route";
+import { POST as telegramTypingConsumerPOST } from "../../../../internal/event-consumers/telegram-typing/route";
 import {
   createTestRequest,
   createTestCompose,
@@ -101,6 +102,12 @@ describe("POST /api/webhooks/agent/events", () => {
         "http://localhost:3000/api/internal/event-consumers/chat-assistant",
         ({ request }) => {
           return forwardToConsumer(request, chatAssistantConsumerPOST);
+        },
+      ),
+      http.post(
+        "http://localhost:3000/api/internal/event-consumers/telegram-typing",
+        ({ request }) => {
+          return forwardToConsumer(request, telegramTypingConsumerPOST);
         },
       ),
     );

--- a/turbo/apps/web/src/lib/infra/callback/callback-payloads.ts
+++ b/turbo/apps/web/src/lib/infra/callback/callback-payloads.ts
@@ -15,7 +15,8 @@ export interface TelegramCallbackPayload {
   agentId: string;
   existingSessionId: string | null;
   isDM: boolean;
-  thinkingMessageId: string | null;
+  /** @deprecated Legacy placeholder cleanup only. New Telegram runs use typing. */
+  thinkingMessageId?: string | null;
 }
 
 export interface SlackOrgCallbackPayload {

--- a/turbo/apps/web/src/lib/infra/event-consumer/registry.ts
+++ b/turbo/apps/web/src/lib/infra/event-consumer/registry.ts
@@ -18,6 +18,10 @@ export const eventConsumers: EventConsumerConfig[] = [
     eventTypes: ["assistant"],
   },
   {
+    name: "telegram-typing",
+    path: "/api/internal/event-consumers/telegram-typing",
+  },
+  {
     name: "voice-chat",
     path: "/api/internal/event-consumers/voice-chat",
     eventTypes: ["assistant"],

--- a/turbo/apps/web/src/lib/zero/telegram/__tests__/client.test.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/__tests__/client.test.ts
@@ -220,6 +220,79 @@ describe("sendMessage", () => {
       reply_parameters: { message_id: 50 },
     });
   });
+
+  it("should include reply_markup when provided", async () => {
+    let capturedBody: unknown;
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/sendMessage`,
+      async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          ok: true,
+          result: { message_id: 101, chat: { id: 42 } },
+        });
+      },
+    );
+    server.use(handler.handler);
+
+    const client = createTelegramClient(TEST_TOKEN);
+    await sendMessage(client, 42, "connect", {
+      replyMarkup: {
+        inline_keyboard: [[{ text: "Connect", url: "https://example.com" }]],
+      },
+    });
+
+    expect(capturedBody).toEqual({
+      chat_id: 42,
+      text: "connect",
+      parse_mode: "HTML",
+      reply_markup: {
+        inline_keyboard: [[{ text: "Connect", url: "https://example.com" }]],
+      },
+    });
+  });
+
+  it("should convert raw markdown links before sending HTML", async () => {
+    let capturedBody: unknown;
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/sendMessage`,
+      async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          ok: true,
+          result: { message_id: 102, chat: { id: 42 } },
+        });
+      },
+    );
+    server.use(handler.handler);
+
+    const client = createTelegramClient(TEST_TOKEN);
+    await sendMessage(
+      client,
+      42,
+      [
+        "Notion 还没有连接，需要先授权。",
+        "",
+        "请点击这个链接完成连接：",
+        "[连接 Notion](https://tunnel-yuma-vm0-app.vm7.ai/connectors/notion/connect?agentId=b431c9a7-4f78-4977-aba1-dec4c04b212c)",
+        "",
+        '<a href="https://example.com/logs">📋 Audit</a>',
+      ].join("\n"),
+    );
+
+    expect(capturedBody).toEqual({
+      chat_id: 42,
+      text: [
+        "Notion 还没有连接，需要先授权。",
+        "",
+        "请点击这个链接完成连接：",
+        '<a href="https://tunnel-yuma-vm0-app.vm7.ai/connectors/notion/connect?agentId=b431c9a7-4f78-4977-aba1-dec4c04b212c">连接 Notion</a>',
+        "",
+        '<a href="https://example.com/logs">📋 Audit</a>',
+      ].join("\n"),
+      parse_mode: "HTML",
+    });
+  });
 });
 
 describe("sendChatAction", () => {
@@ -271,6 +344,36 @@ describe("editMessageText", () => {
       chat_id: 42,
       message_id: 99,
       text: "edited",
+      parse_mode: "HTML",
+    });
+  });
+
+  it("should convert raw markdown links before editing HTML", async () => {
+    let capturedBody: unknown;
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/editMessageText`,
+      async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          ok: true,
+          result: { message_id: 99, chat: { id: 42 }, text: "edited" },
+        });
+      },
+    );
+    server.use(handler.handler);
+
+    const client = createTelegramClient(TEST_TOKEN);
+    await editMessageText(
+      client,
+      42,
+      99,
+      "请先 [连接 Notion](https://example.com/connect?agentId=123)",
+    );
+
+    expect(capturedBody).toEqual({
+      chat_id: 42,
+      message_id: 99,
+      text: '请先 <a href="https://example.com/connect?agentId=123">连接 Notion</a>',
       parse_mode: "HTML",
     });
   });

--- a/turbo/apps/web/src/lib/zero/telegram/__tests__/format.test.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/__tests__/format.test.ts
@@ -4,6 +4,7 @@ import {
   markdownToTelegramHtml,
   splitMessage,
   buildTelegramResponse,
+  buildTelegramErrorResponse,
 } from "../format";
 
 describe("escapeHtml", () => {
@@ -38,6 +39,15 @@ describe("markdownToTelegramHtml", () => {
   it("should convert links", () => {
     expect(markdownToTelegramHtml("[click](https://example.com)")).toBe(
       '<a href="https://example.com">click</a>',
+    );
+  });
+
+  it("should convert connector authorization links", () => {
+    const input =
+      "[连接 Notion](https://tunnel-yuma-vm0-app.vm7.ai/connectors/notion/connect?agentId=b431c9a7-4f78-4977-aba1-dec4c04b212c)";
+
+    expect(markdownToTelegramHtml(input)).toBe(
+      '<a href="https://tunnel-yuma-vm0-app.vm7.ai/connectors/notion/connect?agentId=b431c9a7-4f78-4977-aba1-dec4c04b212c">连接 Notion</a>',
     );
   });
 
@@ -112,6 +122,37 @@ describe("buildTelegramResponse", () => {
     );
 
     expect(result).toContain("<b>bold</b> and <code>code</code>");
+  });
+
+  it("should render connector authorization links", () => {
+    const result = buildTelegramResponse(
+      [
+        "Notion 还没有连接，需要先授权。",
+        "",
+        "请点击这个链接完成连接：",
+        "[连接 Notion](https://tunnel-yuma-vm0-app.vm7.ai/connectors/notion/connect?agentId=b431c9a7-4f78-4977-aba1-dec4c04b212c)",
+      ].join("\n"),
+      "https://example.com/logs",
+    );
+
+    expect(result).toContain(
+      '<a href="https://tunnel-yuma-vm0-app.vm7.ai/connectors/notion/connect?agentId=b431c9a7-4f78-4977-aba1-dec4c04b212c">连接 Notion</a>',
+    );
+    expect(result).not.toContain("[连接 Notion](");
+  });
+});
+
+describe("buildTelegramErrorResponse", () => {
+  it("should convert markdown links in error details", () => {
+    const result = buildTelegramErrorResponse(
+      "请先 [连接 Notion](https://example.com/connect?agentId=123)",
+      "https://example.com/logs",
+    );
+
+    expect(result).toContain(
+      '<a href="https://example.com/connect?agentId=123">连接 Notion</a>',
+    );
+    expect(result).not.toContain("[连接 Notion](");
   });
 });
 

--- a/turbo/apps/web/src/lib/zero/telegram/client.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/client.ts
@@ -1,5 +1,6 @@
 import { logger } from "../../shared/logger";
 import { env } from "../../../env";
+import { normalizeTelegramHtmlText } from "./format";
 
 const log = logger("telegram:client");
 
@@ -56,7 +57,7 @@ export function isTelegramApiError(error: unknown): error is TelegramApiError {
   );
 }
 
-export interface TelegramSentMessage {
+interface TelegramSentMessage {
   message_id: number;
   chat: { id: number };
   text?: string;
@@ -64,6 +65,20 @@ export interface TelegramSentMessage {
 
 export interface TelegramClient {
   token: string;
+}
+
+export interface TelegramInlineKeyboardButton {
+  text: string;
+  url: string;
+}
+
+export interface TelegramInlineKeyboardMarkup {
+  inline_keyboard: TelegramInlineKeyboardButton[][];
+}
+
+export interface TelegramSendMessageOptions {
+  replyToMessageId?: number;
+  replyMarkup?: TelegramInlineKeyboardMarkup;
 }
 
 function isE2eTelegramMockEnabled(): boolean {
@@ -159,15 +174,16 @@ export async function sendMessage(
   client: TelegramClient,
   chatId: string | number,
   text: string,
-  options?: { replyToMessageId?: number },
+  options?: TelegramSendMessageOptions,
 ): Promise<TelegramSentMessage> {
   return callTelegramApi<TelegramSentMessage>(client.token, "sendMessage", {
     chat_id: chatId,
-    text,
+    text: normalizeTelegramHtmlText(text),
     parse_mode: "HTML",
     ...(options?.replyToMessageId && {
       reply_parameters: { message_id: options.replyToMessageId },
     }),
+    ...(options?.replyMarkup && { reply_markup: options.replyMarkup }),
   });
 }
 
@@ -226,7 +242,7 @@ export async function editMessageText(
   return callTelegramApi<TelegramSentMessage>(client.token, "editMessageText", {
     chat_id: chatId,
     message_id: messageId,
-    text,
+    text: normalizeTelegramHtmlText(text),
     parse_mode: "HTML",
   });
 }

--- a/turbo/apps/web/src/lib/zero/telegram/format.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/format.ts
@@ -93,6 +93,41 @@ export function markdownToTelegramHtml(markdown: string): string {
   return result;
 }
 
+function convertMarkdownLinksInHtmlText(text: string): string {
+  return text
+    .replace(
+      /!\[([^\]\n]*)\]\((https?:\/\/[^)\s]+)\)/g,
+      (_match, alt: string, url: string) => {
+        const label = alt ? `🖼 ${alt}` : "🖼 image";
+        return `<a href="${escapeHtml(url)}">${escapeHtml(label)}</a>`;
+      },
+    )
+    .replace(
+      /(?<!!)\[([^\]\n]+)\]\((https?:\/\/[^)\s]+)\)/g,
+      (_match, label: string, url: string) => {
+        return `<a href="${escapeHtml(url)}">${escapeHtml(label)}</a>`;
+      },
+    );
+}
+
+const TELEGRAM_HTML_MARKUP_PATTERN =
+  /<\/?(?:a|b|strong|i|em|u|ins|s|strike|del|span|tg-spoiler|code|pre|blockquote)\b|&(?:lt|gt|amp|quot|#x27);/i;
+
+/**
+ * Normalize text for Telegram's HTML parse mode.
+ *
+ * Most call sites already pass Telegram HTML. This catches raw Markdown
+ * messages that reach the client layer directly, without double-escaping
+ * existing Telegram HTML.
+ */
+export function normalizeTelegramHtmlText(text: string): string {
+  if (TELEGRAM_HTML_MARKUP_PATTERN.test(text)) {
+    return convertMarkdownLinksInHtmlText(text);
+  }
+
+  return markdownToTelegramHtml(text);
+}
+
 /**
  * Build a structured Telegram response with converted content and audit footer.
  */
@@ -125,7 +160,7 @@ export function buildTelegramErrorResponse(
   logsUrl?: string,
 ): string {
   const header = `❌ <b>Agent Execution Error</b>`;
-  const content = escapeHtml(errorDetail);
+  const content = markdownToTelegramHtml(errorDetail);
   if (!logsUrl) {
     return `${header}\n\n${content}`;
   }

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/__tests__/adapt-telegram-trigger.test.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/__tests__/adapt-telegram-trigger.test.ts
@@ -11,7 +11,6 @@ const baseCallback: TelegramCallbackPayload = {
   agentId: "compose-1",
   existingSessionId: null,
   isDM: false,
-  thinkingMessageId: null,
 };
 
 describe("adaptTelegramTrigger", () => {

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/commands.ts
@@ -7,6 +7,8 @@ import { createTelegramClient, sendMessage } from "../client";
 import {
   resolveUserLink,
   buildConnectUrl,
+  buildTelegramConnectReplyMarkup,
+  buildTelegramPrivateConnectReplyMarkup,
   formatTelegramAlreadyConnectedMessage,
   formatTelegramCommandError,
   formatTelegramCommandSuccess,
@@ -76,7 +78,12 @@ export async function handleConnectCommand(
       client,
       chatId,
       formatTelegramPrivateConnectPrompt(installation.botUsername),
-      replyOptions,
+      {
+        ...replyOptions,
+        replyMarkup: buildTelegramPrivateConnectReplyMarkup(
+          installation.botUsername,
+        ),
+      },
     );
     return;
   }
@@ -86,7 +93,9 @@ export async function handleConnectCommand(
     fromUserId,
     botToken,
   );
-  await sendMessage(client, chatId, formatTelegramConnectPrompt(connectUrl));
+  await sendMessage(client, chatId, formatTelegramConnectPrompt(), {
+    replyMarkup: buildTelegramConnectReplyMarkup(connectUrl),
+  });
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/direct-message.ts
@@ -2,9 +2,9 @@ import { eq } from "drizzle-orm";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { decryptSecretValue } from "../../../shared/crypto/secrets-encryption";
 import { env } from "../../../../env";
-import { createTelegramClient, sendMessage, deleteMessage } from "../client";
+import { createTelegramClient, sendMessage } from "../client";
 import {
-  sendThinkingMessage,
+  sendTypingAction,
   sendQueuedNotification,
   enrichTelegramPrompt,
   formatReplyQuote,
@@ -17,6 +17,7 @@ import {
   resolveUserLink,
   buildConnectUrl,
   resolveTelegramAuditLogsUrl,
+  buildTelegramConnectReplyMarkup,
   formatTelegramConnectPrompt,
 } from "./shared";
 import { fetchTelegramContext } from "../context";
@@ -71,7 +72,9 @@ export async function handleTelegramDirectMessage(
       fromUserId,
       botToken,
     );
-    await sendMessage(client, chatId, formatTelegramConnectPrompt(connectUrl));
+    await sendMessage(client, chatId, formatTelegramConnectPrompt(), {
+      replyMarkup: buildTelegramConnectReplyMarkup(connectUrl),
+    });
     return;
   }
 
@@ -88,8 +91,8 @@ export async function handleTelegramDirectMessage(
   }
   const agentName = getAgentDisplayLabel(defaultAgent);
 
-  // 4. Send thinking placeholder message
-  const thinkingMessage = await sendThinkingMessage(client, chatId, agentName);
+  // 4. Send typing indicator
+  await sendTypingAction(client, chatId);
 
   // 5. Store incoming message
   await storeTelegramMessage(installationId, chatId, message);
@@ -173,14 +176,11 @@ export async function handleTelegramDirectMessage(
       agentId: composeId,
       existingSessionId: existingSessionId ?? null,
       isDM: true,
-      thinkingMessageId: thinkingMessage
-        ? String(thinkingMessage.message_id)
-        : null,
     },
   });
 
   if (status === "queued") {
-    await sendQueuedNotification(client, chatId, thinkingMessage);
+    await sendQueuedNotification(client, chatId);
   } else if (status === "failed") {
     log.error("Failed to dispatch agent run (DM)", {
       chatId,
@@ -189,9 +189,6 @@ export async function handleTelegramDirectMessage(
       runId,
       response,
     });
-    if (thinkingMessage) {
-      await deleteMessage(client, chatId, thinkingMessage.message_id);
-    }
     const errorDetail =
       response ?? "An unexpected error occurred. Please try again later.";
     const linkUrl = await resolveTelegramAuditLogsUrl({

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/mention.ts
@@ -2,9 +2,9 @@ import { eq } from "drizzle-orm";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { decryptSecretValue } from "../../../shared/crypto/secrets-encryption";
 import { env } from "../../../../env";
-import { createTelegramClient, sendMessage, deleteMessage } from "../client";
+import { createTelegramClient, sendMessage } from "../client";
 import {
-  sendThinkingMessage,
+  sendTypingAction,
   sendQueuedNotification,
   enrichTelegramPrompt,
   formatReplyQuote,
@@ -16,6 +16,7 @@ import {
   resolveSessionCompose,
   resolveUserLink,
   resolveTelegramAuditLogsUrl,
+  buildTelegramPrivateConnectReplyMarkup,
   formatTelegramPrivateConnectPrompt,
 } from "./shared";
 import { fetchTelegramContext } from "../context";
@@ -77,7 +78,12 @@ export async function handleTelegramMention(
       client,
       chatId,
       formatTelegramPrivateConnectPrompt(installation.botUsername),
-      { replyToMessageId: message.message_id },
+      {
+        replyToMessageId: message.message_id,
+        replyMarkup: buildTelegramPrivateConnectReplyMarkup(
+          installation.botUsername,
+        ),
+      },
     );
     return;
   }
@@ -96,10 +102,8 @@ export async function handleTelegramMention(
   }
   const agentName = getAgentDisplayLabel(defaultAgent);
 
-  // 4. Send thinking placeholder message (reply to user's message in groups)
-  const thinkingMessage = await sendThinkingMessage(client, chatId, agentName, {
-    replyToMessageId: message.message_id,
-  });
+  // 4. Send typing indicator
+  await sendTypingAction(client, chatId);
 
   // 5. Store incoming message
   await storeTelegramMessage(installationId, chatId, message);
@@ -172,14 +176,11 @@ export async function handleTelegramMention(
       agentId: composeId,
       existingSessionId: existingSessionId ?? null,
       isDM: false,
-      thinkingMessageId: thinkingMessage
-        ? String(thinkingMessage.message_id)
-        : null,
     },
   });
 
   if (status === "queued") {
-    await sendQueuedNotification(client, chatId, thinkingMessage, {
+    await sendQueuedNotification(client, chatId, {
       replyToMessageId: message.message_id,
     });
   } else if (status === "failed") {
@@ -190,9 +191,6 @@ export async function handleTelegramMention(
       runId,
       response,
     });
-    if (thinkingMessage) {
-      await deleteMessage(client, chatId, thinkingMessage.message_id);
-    }
     const errorDetail =
       response ?? "An unexpected error occurred. Please try again later.";
     const linkUrl = await resolveTelegramAuditLogsUrl({

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/new-session.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/new-session.ts
@@ -7,6 +7,7 @@ import { createTelegramClient, sendMessage } from "../client";
 import {
   resolveUserLink,
   buildConnectUrl,
+  buildTelegramConnectReplyMarkup,
   formatTelegramCommandSuccess,
   formatTelegramConnectPrompt,
 } from "./shared";
@@ -58,7 +59,9 @@ export async function handleNewSessionCommand(
       fromUserId,
       botToken,
     );
-    await sendMessage(client, chatId, formatTelegramConnectPrompt(connectUrl));
+    await sendMessage(client, chatId, formatTelegramConnectPrompt(), {
+      replyMarkup: buildTelegramConnectReplyMarkup(connectUrl),
+    });
     return;
   }
 

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/shared.ts
@@ -13,9 +13,10 @@ import { ensureStorageExists } from "../../../infra/storage/storage-service";
 import { loadFeatureSwitchOverrides } from "../../user/feature-switches-service";
 import {
   sendMessage,
-  editMessageText,
+  sendChatAction,
   type TelegramClient,
-  type TelegramSentMessage,
+  type TelegramInlineKeyboardMarkup,
+  type TelegramSendMessageOptions,
 } from "../client";
 import { escapeHtml } from "../format";
 import { signConnectParams } from "../connect-token";
@@ -467,8 +468,16 @@ function normalizedBotUsername(botUsername: string | null | undefined): string {
   return botUsername?.replace(/^@/, "").trim() ?? "";
 }
 
-export function formatTelegramConnectPrompt(connectUrl: string): string {
-  return `To use Zero in Telegram, please connect your account first.\n\n<a href="${escapeHtml(connectUrl)}">Connect</a>`;
+export function formatTelegramConnectPrompt(): string {
+  return "To use Zero in Telegram, please connect your account first.";
+}
+
+export function buildTelegramConnectReplyMarkup(
+  connectUrl: string,
+): TelegramInlineKeyboardMarkup {
+  return {
+    inline_keyboard: [[{ text: "Connect", url: connectUrl }]],
+  };
 }
 
 export function formatTelegramPrivateConnectPrompt(
@@ -479,7 +488,20 @@ export function formatTelegramPrivateConnectPrompt(
     return "To use Zero in Telegram, please connect your account first.\n\nSend me /connect in a private message.";
   }
 
-  return `To use Zero in Telegram, please connect your account first.\n\n<a href="https://t.me/${escapeHtml(username)}?start=connect">Connect</a>`;
+  return "To use Zero in Telegram, please connect your account first.";
+}
+
+export function buildTelegramPrivateConnectReplyMarkup(
+  botUsername: string | null | undefined,
+): TelegramInlineKeyboardMarkup | undefined {
+  const username = normalizedBotUsername(botUsername);
+  if (!username) {
+    return undefined;
+  }
+
+  return buildTelegramConnectReplyMarkup(
+    `https://t.me/${encodeURIComponent(username)}?start=connect`,
+  );
 }
 
 export function formatTelegramAlreadyConnectedMessage(
@@ -498,10 +520,6 @@ export function formatTelegramCommandSuccess(message: string): string {
 
 export function formatTelegramCommandError(message: string): string {
   return `❌ <b>Error</b>\n${escapeHtml(message)}`;
-}
-
-export function formatTelegramThinkingMessage(agentName: string): string {
-  return `<i>${escapeHtml(agentName)} is thinking...</i>`;
 }
 
 export function formatTelegramHelpMessage(
@@ -559,22 +577,14 @@ export function buildConnectUrl(
   return `${appUrl}/telegram/connect?bot=${telegramBotId}&tgUser=${telegramUserId}&ts=${ts}&sig=${sig}`;
 }
 
-/**
- * Send a thinking placeholder message that persists until the agent responds.
- * Returns the sent message so its ID can be passed to the callback for deletion.
- */
-export async function sendThinkingMessage(
+export async function sendTypingAction(
   client: TelegramClient,
   chatId: string | number,
-  agentName: string,
-  options?: { replyToMessageId?: number },
-): Promise<TelegramSentMessage | undefined> {
-  const text = formatTelegramThinkingMessage(agentName);
+): Promise<void> {
   try {
-    return await sendMessage(client, chatId, text, options);
+    await sendChatAction(client, chatId, "typing");
   } catch (err) {
-    log.warn("Failed to send thinking message", { chatId, error: err });
-    return undefined;
+    log.debug("Failed to send typing action", { chatId, error: err });
   }
 }
 
@@ -582,25 +592,14 @@ const QUEUED_MESSAGE =
   "⏳ Run queued — concurrency limit reached. Will start automatically when a slot is available.";
 
 /**
- * Update the thinking message to show queued status, or send a new message if
- * no thinking message exists.
+ * Send a queued status message when the run could not start immediately.
  */
 export async function sendQueuedNotification(
   client: TelegramClient,
   chatId: string | number,
-  thinkingMessage: TelegramSentMessage | undefined,
-  options?: { replyToMessageId?: number },
+  options?: TelegramSendMessageOptions,
 ): Promise<void> {
-  if (thinkingMessage) {
-    await editMessageText(
-      client,
-      chatId,
-      thinkingMessage.message_id,
-      QUEUED_MESSAGE,
-    );
-  } else {
-    await sendMessage(client, chatId, QUEUED_MESSAGE, options);
-  }
+  await sendMessage(client, chatId, QUEUED_MESSAGE, options);
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/start.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/start.ts
@@ -8,6 +8,7 @@ import {
   linkTelegramUserToVm0User,
   resolveUserLink,
   buildConnectUrl,
+  buildTelegramConnectReplyMarkup,
   formatTelegramAlreadyConnectedMessage,
   formatTelegramCommandError,
   formatTelegramCommandSuccess,
@@ -97,7 +98,9 @@ export async function handleStartCommand(
       fromUserId,
       botToken,
     );
-    await sendMessage(client, chatId, formatTelegramConnectPrompt(connectUrl));
+    await sendMessage(client, chatId, formatTelegramConnectPrompt(), {
+      replyMarkup: buildTelegramConnectReplyMarkup(connectUrl),
+    });
     return;
   }
 


### PR DESCRIPTION
## Summary
- replace thinking placeholders with typing feedback and refresh Telegram typing from event batches
- switch Telegram connect prompts to native inline keyboard buttons
- normalize Telegram replies from standard Markdown to Telegram HTML so links render in DM and mention replies

## Tests
- pnpm exec vitest run app/api/internal/event-consumers/telegram-typing/__tests__/route.test.ts app/api/webhooks/agent/events/__tests__/route.test.ts app/api/internal/callbacks/telegram/__tests__/route.test.ts app/api/internal/callbacks/slack/org/__tests__/route.test.ts app/api/telegram/webhook/__tests__/commands.test.ts app/api/telegram/webhook/__tests__/route.test.ts src/lib/zero/telegram/__tests__/client.test.ts src/lib/zero/telegram/__tests__/format.test.ts src/lib/zero/telegram/handlers/__tests__/adapt-telegram-trigger.test.ts
- pnpm exec eslint <touched files>
- pnpm run check-types
- git diff --check

Fixes #11266