### PR TITLE
perf(web): pin dev next.js to 16.1.7 to bypass turbopack cpu regression

### DIFF
--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -71,6 +71,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "next-fast-dev": "npm:next@16.1.7",
     "@tailwindcss/postcss": "^4.1.18",
     "@testing-library/jest-dom": "^6.7.0",
     "@testing-library/react": "^16.1.0",

--- a/turbo/apps/web/scripts/dev.sh
+++ b/turbo/apps/web/scripts/dev.sh
@@ -36,6 +36,43 @@ kill_stale() {
 kill_stale "/tmp/cloudflared-${PORT}.pid" "cloudflared tunnel .*localhost:${PORT}"
 kill_stale "/tmp/stripe-listen.pid" "stripe listen .*--forward-to localhost:${PORT}/api/webhooks/stripe"
 
+# Swap apps/web/node_modules/next to the next-fast-dev alias (next@16.1.7) so
+# `next dev --turbo` avoids the ~4× cpu/cold-build regression introduced in
+# next 16.2.0+. The dependency name is "next-fast-dev" but it resolves to
+# next@16.1.7 via npm: alias. Production `next build` is unaffected — it still
+# uses the real `next` entry (16.2.3+, which carries the CVE-2026-23869 fix).
+#
+# We can't rely on a trap for cleanup because the script ends with `exec next
+# dev …` and the bash process is replaced before any exit handler can fire.
+# Instead, the original target is recorded in a side file and restored on the
+# *next* launch — same idempotent-stale-cleanup pattern that cloudflared and
+# stripe use above.
+SCRIPT_DIR_FOR_LINK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NEXT_LINK="$(cd "$SCRIPT_DIR_FOR_LINK/.." && pwd)/node_modules/next"
+NEXT_FAST_LINK="$(cd "$SCRIPT_DIR_FOR_LINK/.." && pwd)/node_modules/next-fast-dev"
+NEXT_LINK_ORIG_FILE="/tmp/web-next-link-orig.path"
+
+# Pre-launch: if a previous run left the link pointing at the alias, restore
+# it before swapping again so we capture a clean original.
+if [[ -L "$NEXT_LINK" && -L "$NEXT_FAST_LINK" ]] \
+   && [[ "$(readlink "$NEXT_LINK")" == "$(readlink "$NEXT_FAST_LINK")" ]] \
+   && [[ -f "$NEXT_LINK_ORIG_FILE" ]]; then
+  ln -sfn "$(cat "$NEXT_LINK_ORIG_FILE")" "$NEXT_LINK"
+  rm -f "$NEXT_LINK_ORIG_FILE"
+fi
+
+# Now perform the swap. Record the original so the *next* invocation can
+# undo it.
+if [[ -L "$NEXT_FAST_LINK" && -L "$NEXT_LINK" ]]; then
+  NEXT_LINK_ORIG="$(readlink "$NEXT_LINK")"
+  NEXT_FAST_TARGET="$(readlink "$NEXT_FAST_LINK")"
+  if [[ "$NEXT_LINK_ORIG" != "$NEXT_FAST_TARGET" ]]; then
+    echo "$NEXT_LINK_ORIG" > "$NEXT_LINK_ORIG_FILE"
+    ln -sfn "$NEXT_FAST_TARGET" "$NEXT_LINK"
+    echo -e "\033[0;36m[next-fast-dev]\033[0m using next@16.1.7 for dev (avoids 16.2.x turbopack cpu regression)"
+  fi
+fi
+
 # Cleanup background processes on exit
 cleanup() {
   kill_stale "/tmp/cloudflared-${PORT}.pid" ""

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -638,6 +638,9 @@ importers:
       msw:
         specifier: ^2.13.2
         version: 2.13.2(@types/node@24.3.0)(typescript@5.9.3)
+      next-fast-dev:
+        specifier: npm:next@16.1.7
+        version: next@16.1.7(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       oxlint:
         specifier: ^1.57.0
         version: 1.57.0(oxlint-tsgolint@0.21.1)
@@ -2174,16 +2177,31 @@ packages:
     resolution: {integrity: sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==}
     engines: {node: '>=19.0.0'}
 
+  '@next/env@16.1.7':
+    resolution: {integrity: sha512-rJJbIdJB/RQr2F1nylZr/PJzamvNNhfr3brdKP6s/GW850jbtR70QlSfFselvIBbcPUOlQwBakexjFzqLzF6pg==}
+
   '@next/env@16.2.3':
     resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
 
   '@next/eslint-plugin-next@15.5.14':
     resolution: {integrity: sha512-ogBjgsFrPPz19abP3VwcYSahbkUOMMvJjxCOYWYndw+PydeMuLuB4XrvNkNutFrTjC9St2KFULRdKID8Sd/CMQ==}
 
+  '@next/swc-darwin-arm64@16.1.7':
+    resolution: {integrity: sha512-b2wWIE8sABdyafc4IM8r5Y/dS6kD80JRtOGrUiKTsACFQfWWgUQ2NwoUX1yjFMXVsAwcQeNpnucF2ZrujsBBPg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@next/swc-darwin-arm64@16.2.3':
     resolution: {integrity: sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@16.1.7':
+    resolution: {integrity: sha512-zcnVaaZulS1WL0Ss38R5Q6D2gz7MtBu8GZLPfK+73D/hp4GFMrC2sudLky1QibfV7h6RJBJs/gOFvYP0X7UVlQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
     os: [darwin]
 
   '@next/swc-darwin-x64@16.2.3':
@@ -2192,8 +2210,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@next/swc-linux-arm64-gnu@16.1.7':
+    resolution: {integrity: sha512-2ant89Lux/Q3VyC8vNVg7uBaFVP9SwoK2jJOOR0L8TQnX8CAYnh4uctAScy2Hwj2dgjVHqHLORQZJ2wH6VxhSQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@next/swc-linux-arm64-gnu@16.2.3':
     resolution: {integrity: sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-musl@16.1.7':
+    resolution: {integrity: sha512-uufcze7LYv0FQg9GnNeZ3/whYfo+1Q3HnQpm16o6Uyi0OVzLlk2ZWoY7j07KADZFY8qwDbsmFnMQP3p3+Ftprw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2204,8 +2234,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@next/swc-linux-x64-gnu@16.1.7':
+    resolution: {integrity: sha512-KWVf2gxYvHtvuT+c4MBOGxuse5TD7DsMFYSxVxRBnOzok/xryNeQSjXgxSv9QpIVlaGzEn/pIuI6Koosx8CGWA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@next/swc-linux-x64-gnu@16.2.3':
     resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-musl@16.1.7':
+    resolution: {integrity: sha512-HguhaGwsGr1YAGs68uRKc4aGWxLET+NevJskOcCAwXbwj0fYX0RgZW2gsOCzr9S11CSQPIkxmoSbuVaBp4Z3dA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2216,10 +2258,22 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@next/swc-win32-arm64-msvc@16.1.7':
+    resolution: {integrity: sha512-S0n3KrDJokKTeFyM/vGGGR8+pCmXYrjNTk2ZozOL1C/JFdfUIL9O1ATaJOl5r2POe56iRChbsszrjMAdWSv7kQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
   '@next/swc-win32-arm64-msvc@16.2.3':
     resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.1.7':
+    resolution: {integrity: sha512-mwgtg8CNZGYm06LeEd+bNnOUfwOyNem/rOiP14Lsz+AnUY92Zq/LXwtebtUiaeVkhbroRCQ0c8GlR4UT1U+0yg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
     os: [win32]
 
   '@next/swc-win32-x64-msvc@16.2.3':
@@ -7561,6 +7615,27 @@ packages:
       typescript:
         optional: true
 
+  next@16.1.7:
+    resolution: {integrity: sha512-WM0L7WrSvKwoLegLYr6V+mz+RIofqQgVAfHhMp9a88ms0cFX8iX9ew+snpWlSBwpkURJOUdvCEt3uLl3NNzvWg==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
   next@16.2.3:
     resolution: {integrity: sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==}
     engines: {node: '>=20.9.0'}
@@ -10673,31 +10748,57 @@ snapshots:
       '@types/node': 22.19.15
       '@types/pg': 8.20.0
 
+  '@next/env@16.1.7': {}
+
   '@next/env@16.2.3': {}
 
   '@next/eslint-plugin-next@15.5.14':
     dependencies:
       fast-glob: 3.3.1
 
+  '@next/swc-darwin-arm64@16.1.7':
+    optional: true
+
   '@next/swc-darwin-arm64@16.2.3':
+    optional: true
+
+  '@next/swc-darwin-x64@16.1.7':
     optional: true
 
   '@next/swc-darwin-x64@16.2.3':
     optional: true
 
+  '@next/swc-linux-arm64-gnu@16.1.7':
+    optional: true
+
   '@next/swc-linux-arm64-gnu@16.2.3':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.1.7':
     optional: true
 
   '@next/swc-linux-arm64-musl@16.2.3':
     optional: true
 
+  '@next/swc-linux-x64-gnu@16.1.7':
+    optional: true
+
   '@next/swc-linux-x64-gnu@16.2.3':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.1.7':
     optional: true
 
   '@next/swc-linux-x64-musl@16.2.3':
     optional: true
 
+  '@next/swc-win32-arm64-msvc@16.1.7':
+    optional: true
+
   '@next/swc-win32-arm64-msvc@16.2.3':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.1.7':
     optional: true
 
   '@next/swc-win32-x64-msvc@16.2.3':
@@ -16511,6 +16612,31 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@swc/helpers'
+
+  next@16.1.7(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@next/env': 16.1.7
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.12
+      caniuse-lite: 1.0.30001781
+      postcss: 8.5.10
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.1.7
+      '@next/swc-darwin-x64': 16.1.7
+      '@next/swc-linux-arm64-gnu': 16.1.7
+      '@next/swc-linux-arm64-musl': 16.1.7
+      '@next/swc-linux-x64-gnu': 16.1.7
+      '@next/swc-linux-x64-musl': 16.1.7
+      '@next/swc-win32-arm64-msvc': 16.1.7
+      '@next/swc-win32-x64-msvc': 16.1.7
+      '@opentelemetry/api': 1.9.1
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
 
   next@16.2.3(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary

- `next dev --turbo` cold-build CPU is 4× higher on next 16.2.0+ than on 16.1.7. Pin dev to 16.1.7 via an alias devDep + symlink swap; production `next build` keeps 16.2.3 (CVE-2026-23869 patched), so security posture is unchanged.
- Bisected the regression to upstream next 16.1.7 → 16.2.0 (introduced 2026-03-18); 16.2.4 stable and 16.3.0-canary.2 still carry it.

## Data (cold start, GET /robots.txt, 90s sample on 16-core EPYC)

| next | cpu-seconds | peak | first GET | .next size |
|---|---|---|---|---|
| 16.1.6 | 4.5 | 262% | 0.38s | 139M |
| **16.1.7** | **6.8** | **291%** | **0.44s** | **200M** |
| 16.2.0 | 29.9 | 814% | 7.12s | 190M |
| 16.2.1 | 31.1 | 872% | 6.30s | 179M |
| 16.2.3 (current main) | 30.6 | 921% | 4.24s | 181M |
| 16.2.4 (latest stable) | 33.0 | 844% | 4.39s | 181M |
| 16.3.0-canary.2 | 28.8 | 864% | 4.32s | 153M |

next-server is the sole hot process in every run; everything else stays under 0.2%.

## How it works

- `apps/web/package.json` → `devDependencies."next-fast-dev": "npm:next@16.1.7"` (alias). Lockfile retains both 16.1.7 and 16.2.3 builds; pnpm store keeps both.
- `apps/web/scripts/dev.sh`:
  - **Pre-launch idempotent restore**: if a previous run left `node_modules/next` pointing at the alias and a sidecar `/tmp/web-next-link-orig.path` exists, restore it first (mirrors the same kill_stale pattern the script already uses for cloudflared and stripe).
  - **Swap**: write the current `node_modules/next` target to the sidecar, then point the link at the alias target.
  - We can't use a trap to undo on exit because the script ends with `exec next dev …`, which replaces the bash process before any handler can fire — the sidecar is what makes cleanup correct across the next launch.
- Production `next build` resolves `dependencies.next: ^16.2.3` → 16.2.3, gets the CVE-2026-23869 server-components DoS fix, and never sees the alias (devDeps are pruned in the deployed bundle and `next-fast-dev` is not imported anywhere in src).
- Any `pnpm install` between dev runs forcibly re-resolves `node_modules/next` to the canonical 16.2.3 target, so the swap state never survives a real install.

## Verified

- Run 1: link → 16.1.7, sidecar holds 16.2.3, `next-server (v16.1.7)` runs, dev.sh prints `[next-fast-dev] using next@16.1.7 …`
- After SIGINT: bash is gone (exec), link stays at 16.1.7 (expected), sidecar persists
- Run 2: pre-launch detects swap-state-without-bash and restores; then swaps again. End state: link → 16.1.7, sidecar → 16.2.3
- robots.txt cold-build during full `pnpm dev` (5 watchers): peak 121%, 30s avg 6.4%, GET in 0.35s — matches the 16.1.7 baseline

## Why not other options

- **Lock everything to 16.1.7**: re-introduces CVE-2026-23869 in production.
- **Lock everything to 16.2.3 / wait for upstream**: every cold compile burns ~30s of CPU per route.
- **Backport 15.5.x**: drops next 16 features (route types, optimizePackageImports defaults, react 19.2).
- **`pnpm patch` 16.2.3 → 16.1.7-equivalent**: high maintenance overhead per upstream bump.

Upstream tracking: planning to file an issue at vercel/next.js with this bisect data.

## Test plan
- [ ] `pnpm dev` from `turbo/` — verify dev.sh prints `[next-fast-dev] using next@16.1.7`, app renders at localhost:3000, HMR works
- [ ] kill `pnpm dev`, then re-run; verify it boots cleanly via the pre-launch restore
- [ ] CI `build` job still runs against 16.2.3
- [ ] `pnpm install --frozen-lockfile` is clean from a fresh checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)