### PR TITLE
fix: load complete activity events before polling

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/polling.ts
+++ b/turbo/apps/platform/src/signals/zero-page/polling.ts
@@ -145,40 +145,21 @@ async function findLastEventSequence(
 }
 
 function createRunPagedEvents(runId: string) {
-  const firstPage = createEventPageComputed(runId);
-  const pagedEventsList$ = state([firstPage]);
+  const initialPagedEventsList$ = computed(async (get) => {
+    const pages = [createEventPageComputed(runId)];
 
-  const finished$ = computed(async (get) => {
-    const pagedEventsList = get(pagedEventsList$);
-    const lastPage = await get(pagedEventsList[pagedEventsList.length - 1]);
-    return !lastPage.hasMore;
-  });
-
-  const reloadAndCheckFinished$ = command(
-    async ({ set, get }, signal: AbortSignal) => {
-      const finished = await get(finished$);
-      signal.throwIfAborted();
-
-      if (finished) {
-        return true;
+    while (true) {
+      const lastPage = await get(pages[pages.length - 1]);
+      if (!lastPage.hasMore) {
+        return pages;
       }
 
-      const pagedEventsList = get(pagedEventsList$);
-      const since = await findLastEventSequence(pagedEventsList, get);
-      signal.throwIfAborted();
+      const since = await findLastEventSequence(pages, get);
+      pages.push(createEventPageComputed(runId, since));
+    }
+  });
 
-      const nextPage$ = createEventPageComputed(runId, since);
-      set(pagedEventsList$, (x) => {
-        return [...x, nextPage$];
-      });
-      return false;
-    },
-  );
-
-  return {
-    checkFinished$: reloadAndCheckFinished$,
-    pagedEventsList$,
-  };
+  return { pagedEventsList$: initialPagedEventsList$ };
 }
 
 export function createRunLoop(runId: string) {
@@ -190,10 +171,8 @@ export function createRunLoop(runId: string) {
 
   const { queuePosition$, reload$: reloadQueuePosition$ } =
     createQueuePosition(runId);
-  const {
-    pagedEventsList$: initialRunPagedEvents$,
-    checkFinished$: initialCheckFinished$,
-  } = createRunPagedEvents(runId);
+  const { pagedEventsList$: initialRunPagedEvents$ } =
+    createRunPagedEvents(runId);
 
   const internalLoopedPagedEvents$ = state<Computed<Promise<PagedRunEvents>>[]>(
     [],
@@ -206,9 +185,8 @@ export function createRunLoop(runId: string) {
   });
 
   const checkFinished$ = command(async ({ set, get }, signal: AbortSignal) => {
-    if (!(await set(initialCheckFinished$, signal))) {
-      return false;
-    }
+    const initialPagedEvents = await get(initialRunPagedEvents$);
+    signal.throwIfAborted();
 
     set(reloadRunStatus$);
     let status = (await get(runDetail$)).status;
@@ -223,9 +201,6 @@ export function createRunLoop(runId: string) {
     if (status === "pending") {
       return false;
     }
-
-    const initialPagedEvents = await get(initialRunPagedEvents$);
-    signal.throwIfAborted();
 
     const loopedPagedEvents = get(internalLoopedPagedEvents$);
     // Walk back across both lists (looped first, then initial) so an empty

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-paged-events.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-paged-events.test.tsx
@@ -9,6 +9,7 @@ import {
 import { zeroRunAgentEventsContract } from "@vm0/api-contracts/contracts/zero-runs";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
 import type {
   LogDetail,
   AgentEventsResponse,
@@ -44,6 +45,92 @@ function makeLogDetail(overrides: Partial<LogDetail>): LogDetail {
 }
 
 describe("activity paged events", () => {
+  it("should wait for all initial event pages before rendering steps", async () => {
+    const secondPageStarted = createDeferredPromise<void>(context.signal);
+    const releaseSecondPage = createDeferredPromise<void>(context.signal);
+    let secondPageStartedResolved = false;
+
+    const page1Event = {
+      sequenceNumber: 0,
+      eventType: "assistant",
+      eventData: {
+        message: { content: [{ type: "text", text: "Page one content" }] },
+      },
+      createdAt: "2026-03-10T14:56:02Z",
+    };
+
+    const page2Event = {
+      sequenceNumber: 1,
+      eventType: "assistant",
+      eventData: {
+        message: { content: [{ type: "text", text: "Page two content" }] },
+      },
+      createdAt: "2026-03-10T14:56:10Z",
+    };
+
+    setMockComposesList([]);
+    server.use(
+      mockApi(logsByIdContract.getById, ({ respond }) => {
+        return respond(200, makeLogDetail({ status: "completed" }));
+      }),
+      mockApi(
+        zeroRunAgentEventsContract.getAgentEvents,
+        async ({ query, respond }) => {
+          const since = query.since;
+
+          if (since === undefined) {
+            return respond(200, {
+              events: [page1Event],
+              hasMore: true,
+              framework: "claude-code",
+            } satisfies AgentEventsResponse);
+          }
+
+          if (since === 0) {
+            if (!secondPageStartedResolved) {
+              secondPageStartedResolved = true;
+              secondPageStarted.resolve();
+            }
+            await releaseSecondPage.promise;
+            return respond(200, {
+              events: [page2Event],
+              hasMore: false,
+              framework: "claude-code",
+            } satisfies AgentEventsResponse);
+          }
+
+          return respond(200, {
+            events: [],
+            hasMore: false,
+            framework: "claude-code",
+          } satisfies AgentEventsResponse);
+        },
+      ),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/activities/a0000000-0000-4000-a000-000000000099",
+    });
+
+    await secondPageStarted.promise;
+
+    expect(screen.queryByText("Page one content")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Test Agent" }),
+    ).not.toBeInTheDocument();
+
+    releaseSecondPage.resolve();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Test Agent" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("Page one content")).toBeInTheDocument();
+    expect(screen.getByText("Page two content")).toBeInTheDocument();
+  });
+
   it("should load multi-page events when hasMore is true then false", async () => {
     let eventFetchCount = 0;
 


### PR DESCRIPTION
## Summary
- fetch all existing activity event pages before rendering the detail steps
- keep the polling loop focused on new incremental events after the initial cursor
- add regression coverage that blocks rendering until all initial pages resolve

## Tests
- pnpm --dir turbo/apps/platform test src/views/activity-page/__tests__/activity-paged-events.test.tsx
- pnpm --dir turbo/apps/platform test src/views/activity-page/__tests__/activity-detail-polling.test.tsx
- pnpm --dir turbo/apps/platform check-types
- pnpm --dir turbo/apps/platform lint
- pre-commit: turbo check-types