### PR TITLE
refactor(runner): encapsulate idle vm lifecycle

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1301,7 +1301,7 @@ fn spawn_job(
                                     true
                                 }
                                 ParkResult::Rejected(rejected) => {
-                                    info!(run_id = %run_id, session_id, "idle pool full, destroying VM");
+                                    info!(run_id = %run_id, session_id, "idle parking rejected, destroying VM");
                                     drop(pool);
                                     // Pool unchanged (park rejected) — no status
                                     // update needed. The rejected sandbox was just

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -5311,6 +5311,87 @@ mod tests {
         shutdown(&env, run_handle).await;
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn parking_gate_closing_after_sandbox_park_rejects_and_waits_for_destroy() {
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let park_entered = Arc::new(tokio::sync::Notify::new());
+        let park_release = Arc::new(tokio::sync::Notify::new());
+        let destroy_entered = Arc::new(tokio::sync::Notify::new());
+        let destroy_release = Arc::new(tokio::sync::Notify::new());
+        overrides.set_park_gate(Arc::clone(&park_entered), Arc::clone(&park_release));
+        overrides.set_destroy_gate(Arc::clone(&destroy_entered), Arc::clone(&destroy_release));
+
+        let park_entered_wait = park_entered.notified();
+        tokio::pin!(park_entered_wait);
+        park_entered_wait.as_mut().enable();
+        let destroy_entered_wait = destroy_entered.notified();
+        tokio::pin!(destroy_entered_wait);
+        destroy_entered_wait.as_mut().enable();
+
+        let counter = Arc::clone(&overrides);
+        let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
+        let budget = Arc::clone(&config.budget);
+        let idle_pool = Arc::clone(&config.idle_pool);
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = RunId::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(run_id, "sess-race-rejected")),
+        );
+
+        tokio::time::timeout(Duration::from_secs(5), park_entered_wait)
+            .await
+            .expect("sandbox park should start");
+        assert_eq!(counter.park_call_count(), 1);
+        assert_eq!(env.parking_gate.state(), ParkingState::Open);
+
+        env.drain();
+        assert_eq!(env.parking_gate.state(), ParkingState::SoftDraining);
+
+        park_release.notify_one();
+        tokio::time::timeout(Duration::from_secs(5), destroy_entered_wait)
+            .await
+            .expect("rejected parked sandbox should be destroyed");
+        assert_eq!(
+            counter.destroy_call_count(),
+            1,
+            "rejected VM should be sent to destroy exactly once"
+        );
+        assert_eq!(
+            budget.allocated().2,
+            1,
+            "rejected VM must retain budget while destroy is in-flight"
+        );
+        assert_eq!(
+            idle_pool.lock().await.len(),
+            0,
+            "closed gate must reject the candidate instead of parking it"
+        );
+        {
+            let completions = env.handle.completions.lock().unwrap();
+            assert!(
+                !completions.iter().any(|c| c.run_id == run_id),
+                "provider.complete must wait until rejected VM destroy finishes"
+            );
+        }
+
+        destroy_release.notify_one();
+        let c = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(c.is_some(), "job should complete after destroy finishes");
+        assert_eq!(c.unwrap().exit_code, 0);
+
+        wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
+        assert_eq!(idle_pool.lock().await.len(), 0);
+
+        shutdown(&env, run_handle).await;
+    }
+
     /// When the runner takes a sandbox out of the idle pool for reuse and
     /// `Sandbox::unpark()` returns an error, the idle entry is destroyed
     /// and the runner falls through to a fresh sandbox create.

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -21,8 +21,9 @@ use crate::executor::{self, ExecutorConfig};
 use crate::host;
 use crate::http::HttpClient;
 use crate::idle_pool::{
-    IdleDestroyPayload, IdleEntry, IdlePool, IdlePoolConfig, IdlePoolSnapshot, ParkResult,
-    ParkingGate, ReusableIdleSandbox,
+    IdleDestroyJob, IdleDestroyPayload, IdlePool, IdlePoolConfig, IdlePoolSnapshot,
+    IdleUnparkResult, ParkCandidate, ParkCandidateParts, ParkResult, ParkingGate,
+    ReusableIdleSandbox,
 };
 use crate::kmsg_log;
 use crate::lock;
@@ -620,7 +621,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         count = expired.len(),
                         "reclaiming expired idle VMs for resource pressure"
                     );
-                    destroy_idle_entries_and_wait(expired, "budget_pressure_expired").await;
+                    destroy_idle_jobs_and_wait(expired, "budget_pressure_expired").await;
                     continue;
                 }
 
@@ -630,15 +631,15 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 // requires knowing session_id before claim, tracked separately.
                 if let Some(evicted) = evict_oldest_idle_entry(&idle_pool, &status).await {
                     info!(
-                        session_id = %evicted.session_id,
-                        profile = %evicted.profile_name,
-                        vcpu = evicted.budget_lease.vcpu(),
-                        memory_mb = evicted.budget_lease.memory_mb(),
+                        session_id = %evicted.session_id(),
+                        profile = %evicted.profile_name(),
+                        vcpu = evicted.budget_vcpu(),
+                        memory_mb = evicted.budget_memory_mb(),
                         "evicting idle VM for resource pressure"
                     );
-                    // Wait for the destroy task so the idle entry's lease is
+                    // Wait for the destroy task so the idle VM's lease is
                     // dropped before the loop re-checks can_afford().
-                    destroy_idle_entries_and_wait(vec![evicted], "budget_pressure_oldest").await;
+                    destroy_idle_jobs_and_wait(vec![evicted], "budget_pressure_oldest").await;
                     continue;
                 }
             }
@@ -701,7 +702,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 let expired = pool.evict_expired();
                 for entry in &expired {
                     info!(
-                        profile = %entry.profile_name,
+                        profile = %entry.profile_name(),
                         "idle VM expired, destroying"
                     );
                 }
@@ -710,7 +711,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 drop(pool);
                 set_idle_status_snapshot(&status, snapshot).await;
                 for entry in expired {
-                    spawn_destroy_idle_entry(&mut destroy_tasks, entry, "idle_expired");
+                    spawn_idle_destroy_job(&mut destroy_tasks, entry, "idle_expired");
                 }
             }
             // Heartbeat: report runner state to the server
@@ -925,7 +926,7 @@ async fn handle_discovered_job(job: DiscoveredJob, mut ctx: DiscoveredJobContext
     // its original identity; on a fresh create, allocate a new UUID for the
     // executor's SandboxConfig. This is the join key for doctor and kill.
     let sandbox_id = match &reuse_entry {
-        Some(entry) => entry.sandbox_id,
+        Some(entry) => entry.sandbox_id(),
         None => SandboxId::new_v4(),
     };
     if let Some(snapshot) = idle_snapshot {
@@ -979,47 +980,51 @@ async fn try_reuse_from_pool(
         (taken, snapshot)
     };
     match taken {
-        Some(mut entry) if entry.profile_name == profile_name => {
-            match unpark_sandbox_panic_safe(entry.sandbox.as_mut()).await {
-                Ok(()) => {
-                    info!(
-                        run_id = %run_id,
-                        session_id,
-                        "reusing idle VM for session"
-                    );
-                    // Idle entry already holds budget. Drop the speculative
-                    // fresh-job lease and move the idle lease to the outer job
-                    // task before handing the sandbox to the executor.
-                    drop(job_lease);
-                    let (idle_sandbox, idle_lease) = entry.into_reuse_parts();
-                    (
-                        Some(idle_sandbox),
-                        idle_lease,
-                        SandboxReuseResult::Reused,
-                        snapshot,
-                    )
-                }
-                Err(e) => {
-                    warn!(
-                        run_id = %run_id,
-                        session_id,
-                        error = %e,
-                        "unpark failed, destroying idle VM and falling through to fresh create"
-                    );
-                    spawn_destroy_idle_entry(ctx.destroy_tasks, entry, "reuse_unpark_failed");
-                    (None, job_lease, SandboxReuseResult::UnparkFailed, snapshot)
-                }
+        Some(entry) if entry.profile_name() == profile_name => match entry.try_unpark().await {
+            IdleUnparkResult::Reused {
+                sandbox,
+                budget_lease,
+            } => {
+                info!(
+                    run_id = %run_id,
+                    session_id,
+                    "reusing idle VM for session"
+                );
+                // Idle entry already holds budget. Drop the speculative
+                // fresh-job lease and move the idle lease to the outer job
+                // task before handing the sandbox to the executor.
+                drop(job_lease);
+                (
+                    Some(sandbox),
+                    budget_lease,
+                    SandboxReuseResult::Reused,
+                    snapshot,
+                )
             }
-        }
+            IdleUnparkResult::Failed { destroy_job, error } => {
+                warn!(
+                    run_id = %run_id,
+                    session_id,
+                    error = %error,
+                    "unpark failed, destroying idle VM and falling through to fresh create"
+                );
+                spawn_idle_destroy_job(ctx.destroy_tasks, destroy_job, "reuse_unpark_failed");
+                (None, job_lease, SandboxReuseResult::UnparkFailed, snapshot)
+            }
+        },
         Some(stale) => {
             info!(
                 run_id = %run_id,
                 session_id,
-                old_profile = %stale.profile_name,
+                old_profile = %stale.profile_name(),
                 new_profile = %profile_name,
                 "idle VM profile mismatch, destroying"
             );
-            spawn_destroy_idle_entry(ctx.destroy_tasks, stale, "reuse_profile_mismatch");
+            spawn_idle_destroy_job(
+                ctx.destroy_tasks,
+                stale.into_destroy_job(),
+                "reuse_profile_mismatch",
+            );
             (
                 None,
                 job_lease,
@@ -1253,8 +1258,7 @@ fn spawn_job(
                     match active_lease.take() {
                         Some(lease) => {
                             let mut pool = idle_pool.lock().await;
-                            let idle_timeout = pool.default_timeout();
-                            let entry = IdleEntry {
+                            let candidate = ParkCandidate::new(ParkCandidateParts {
                                 sandbox,
                                 factory: factory_for_cleanup,
                                 session_id: session_id.to_string(),
@@ -1262,11 +1266,9 @@ fn spawn_job(
                                 profile_name,
                                 budget_lease: lease,
                                 source_ip,
-                                parked_at: std::time::Instant::now(),
-                                idle_timeout,
                                 storage_fingerprints,
-                            };
-                            match pool.park(session_id.to_string(), entry) {
+                            });
+                            match pool.park(candidate) {
                                 ParkResult::Parked => {
                                     info!(run_id = %run_id, session_id, "VM parked for reuse");
                                     // Push fresh idle state to status.json BEFORE
@@ -1282,7 +1284,7 @@ fn spawn_job(
                                     park_notify.notify_one();
                                     true
                                 }
-                                ParkResult::Evicted(evicted) => {
+                                ParkResult::Replaced(evicted) => {
                                     info!(run_id = %run_id, session_id, "VM parked, evicting previous");
                                     let snapshot = pool.status_snapshot();
                                     drop(pool);
@@ -1290,22 +1292,22 @@ fn spawn_job(
                                     // Notify immediately — session is already in pool.
                                     // Don't wait for stop_and_destroy which can be slow.
                                     park_notify.notify_one();
-                                    // The evicted entry was park()ed when it entered the
+                                    // The replaced VM was park()ed when it entered the
                                     // pool; destroying a parked sandbox is safe — Drop
                                     // aborts any leftover handles and the FC process is
                                     // killed regardless of balloon state.
-                                    destroy_idle_entries_and_wait(vec![evicted], "park_replaced")
+                                    destroy_idle_jobs_and_wait(vec![evicted], "park_replaced")
                                         .await;
                                     true
                                 }
-                                ParkResult::PoolFull(rejected) => {
+                                ParkResult::Rejected(rejected) => {
                                     info!(run_id = %run_id, session_id, "idle pool full, destroying VM");
                                     drop(pool);
                                     // Pool unchanged (park rejected) — no status
                                     // update needed. The rejected sandbox was just
                                     // park()ed above; destroying a parked sandbox is
-                                    // safe — see Evicted arm for rationale.
-                                    let (payload, lease) = rejected.into_destroy_parts();
+                                    // safe — see Replaced arm for rationale.
+                                    let (payload, lease) = rejected.into_active_destroy_parts();
                                     active_lease = Some(lease);
                                     destroy_idle_payload_and_wait(payload, "park_rejected").await;
                                     false
@@ -1407,14 +1409,6 @@ async fn park_sandbox_panic_safe(sandbox: &mut dyn Sandbox) -> Result<(), String
     }
 }
 
-async fn unpark_sandbox_panic_safe(sandbox: &mut dyn Sandbox) -> Result<(), String> {
-    match AssertUnwindSafe(sandbox.unpark()).catch_unwind().await {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(e)) => Err(e.to_string()),
-        Err(_) => Err("sandbox unpark panicked".into()),
-    }
-}
-
 fn active_cleanup_reason(
     exit_code: i32,
     cancelled: bool,
@@ -1450,10 +1444,10 @@ async fn drain_idle_pool(
     status: &StatusTracker,
     context: &'static str,
 ) {
-    let entries = idle_pool.lock().await.drain();
-    if !entries.is_empty() {
-        info!(count = entries.len(), context, "destroying idle VMs");
-        destroy_idle_entries_and_wait(entries, context).await;
+    let jobs = idle_pool.lock().await.drain();
+    if !jobs.is_empty() {
+        info!(count = jobs.len(), context, "destroying idle VMs");
+        destroy_idle_jobs_and_wait(jobs, context).await;
     }
     let snapshot = idle_pool.lock().await.status_snapshot();
     set_idle_status_snapshot(status, snapshot).await;
@@ -1463,7 +1457,7 @@ async fn drain_idle_pool(
 async fn evict_expired_idle_entries(
     idle_pool: &SharedIdlePool,
     status: &StatusTracker,
-) -> Vec<IdleEntry> {
+) -> Vec<IdleDestroyJob> {
     let mut pool = idle_pool.lock().await;
     let expired = pool.evict_expired();
     if expired.is_empty() {
@@ -1479,7 +1473,7 @@ async fn evict_expired_idle_entries(
 async fn evict_oldest_idle_entry(
     idle_pool: &SharedIdlePool,
     status: &StatusTracker,
-) -> Option<IdleEntry> {
+) -> Option<IdleDestroyJob> {
     let mut pool = idle_pool.lock().await;
     let evicted = pool.evict_oldest()?;
     let snapshot = pool.status_snapshot();
@@ -1522,22 +1516,22 @@ async fn add_run_with_idle_status_snapshot(
     }
 }
 
-fn spawn_destroy_idle_entry(
+fn spawn_idle_destroy_job(
     destroy_tasks: &mut JoinSet<()>,
-    entry: IdleEntry,
+    job: IdleDestroyJob,
     context: &'static str,
 ) {
-    destroy_tasks.spawn(destroy_idle_entry(entry, context));
+    destroy_tasks.spawn(destroy_idle_job(job, context));
 }
 
 /// Destroy idle entries in parallel and wait until their leases are dropped.
-async fn destroy_idle_entries_and_wait(entries: Vec<IdleEntry>, context: &'static str) {
+async fn destroy_idle_jobs_and_wait(jobs: Vec<IdleDestroyJob>, context: &'static str) {
     // Destroy in parallel — each `stop_and_destroy` is ~1–3s (FC shutdown +
     // cgroup/NBD/netns teardown). Serial destroy blows past shutdown and
     // budget-pressure recovery budgets on multi-VM cleanup.
     let mut set = tokio::task::JoinSet::new();
-    for entry in entries {
-        set.spawn(destroy_idle_entry(entry, context));
+    for job in jobs {
+        set.spawn(destroy_idle_job(job, context));
     }
     while let Some(result) = set.join_next().await {
         if let Err(e) = result {
@@ -1547,8 +1541,8 @@ async fn destroy_idle_entries_and_wait(entries: Vec<IdleEntry>, context: &'stati
 }
 
 /// Destroy an idle sandbox entry. Its budget lease is released by Drop.
-async fn destroy_idle_entry(entry: IdleEntry, _context: &'static str) {
-    entry.stop_and_destroy().await;
+async fn destroy_idle_job(job: IdleDestroyJob, _context: &'static str) {
+    job.run().await;
 }
 
 async fn destroy_idle_payload_and_wait(payload: IdleDestroyPayload, context: &'static str) {
@@ -1724,7 +1718,7 @@ mod tests {
     // collect_heartbeat_state: running_count excludes idle VMs
     // -----------------------------------------------------------------------
 
-    use crate::idle_pool::{IdleEntry, IdlePool, IdlePoolConfig, ParkResult, ParkingState};
+    use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkResult, ParkingState};
     use async_trait::async_trait;
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
@@ -1743,9 +1737,9 @@ mod tests {
         m
     }
 
-    fn make_idle_entry(session_id: &str) -> IdleEntry {
+    fn make_park_candidate(session_id: &str) -> ParkCandidate {
         let budget = Arc::new(ResourceBudget::new(1, 1, 1.0, 0));
-        IdleEntry {
+        ParkCandidate::new(ParkCandidateParts {
             sandbox: Box::new(MockSandbox::new("test")),
             factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
             session_id: session_id.into(),
@@ -1753,10 +1747,8 @@ mod tests {
             profile_name: "vm0/default".into(),
             budget_lease: ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap(),
             source_ip: "10.0.0.1".into(),
-            parked_at: std::time::Instant::now(),
-            idle_timeout: Duration::from_secs(300),
             storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        }
+        })
     }
 
     struct PanickingDestroyFactory;
@@ -1945,7 +1937,7 @@ mod tests {
         });
         // Park 1 VM — budget still held, but pool.len() = 1
         assert!(matches!(
-            pool.park("sess-1".into(), make_idle_entry("sess-1")),
+            pool.park(make_park_candidate("sess-1")),
             ParkResult::Parked,
         ));
         let profiles = test_profiles();
@@ -1975,8 +1967,8 @@ mod tests {
             default_timeout: Duration::from_secs(300),
             max_idle: 0,
         });
-        let _ = pool.park("sess-1".into(), make_idle_entry("sess-1"));
-        let _ = pool.park("sess-2".into(), make_idle_entry("sess-2"));
+        let _ = pool.park(make_park_candidate("sess-1"));
+        let _ = pool.park(make_park_candidate("sess-2"));
         let profiles = test_profiles();
 
         let state = collect_heartbeat_state(
@@ -2001,7 +1993,7 @@ mod tests {
             default_timeout: Duration::from_secs(300),
             max_idle: 0,
         });
-        let _ = pool.park("sess-1".into(), make_idle_entry("sess-1"));
+        let _ = pool.park(make_park_candidate("sess-1"));
         let profiles = test_profiles();
 
         let state = collect_heartbeat_state(
@@ -2021,7 +2013,7 @@ mod tests {
     async fn idle_destroy_panic_releases_budget_lease() {
         let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
         let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
-        let entry = IdleEntry {
+        let candidate = ParkCandidate::new(ParkCandidateParts {
             sandbox: Box::new(MockSandbox::new("panic-destroy")),
             factory: Arc::new(Box::new(PanickingDestroyFactory) as Box<dyn SandboxFactory>),
             session_id: "sess-panic".into(),
@@ -2029,12 +2021,16 @@ mod tests {
             profile_name: "vm0/default".into(),
             budget_lease: lease,
             source_ip: "10.0.0.1".into(),
-            parked_at: std::time::Instant::now(),
-            idle_timeout: Duration::from_secs(300),
             storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        };
+        });
+        let mut pool = IdlePool::new(IdlePoolConfig {
+            default_timeout: Duration::from_secs(300),
+            max_idle: 0,
+        });
+        assert!(matches!(pool.park(candidate), ParkResult::Parked));
+        let jobs = pool.drain();
 
-        destroy_idle_entries_and_wait(vec![entry], "test_destroy_panic").await;
+        destroy_idle_jobs_and_wait(jobs, "test_destroy_panic").await;
 
         assert_eq!(budget.allocated(), (0, 0, 0));
     }
@@ -2058,7 +2054,7 @@ mod tests {
         let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
         let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
         let destroy_count = Arc::new(AtomicUsize::new(0));
-        let entry = IdleEntry {
+        let candidate = ParkCandidate::new(ParkCandidateParts {
             sandbox,
             factory: Arc::new(Box::new(RecordingDestroyFactory {
                 destroy_count: Arc::clone(&destroy_count),
@@ -2068,12 +2064,17 @@ mod tests {
             profile_name: "vm0/default".into(),
             budget_lease: lease,
             source_ip: "10.0.0.1".into(),
-            parked_at: std::time::Instant::now(),
-            idle_timeout: Duration::from_secs(300),
             storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        };
+        });
+        let mut pool = IdlePool::new(IdlePoolConfig {
+            default_timeout: Duration::from_secs(300),
+            max_idle: 0,
+        });
+        assert!(matches!(pool.park(candidate), ParkResult::Parked));
+        let mut jobs = pool.drain();
+        assert_eq!(jobs.len(), 1);
 
-        entry.stop_and_destroy().await;
+        jobs.pop().unwrap().run().await;
 
         assert_eq!(destroy_count.load(Ordering::SeqCst), 1);
         assert_eq!(budget.allocated(), (0, 0, 0));
@@ -3628,15 +3629,13 @@ mod tests {
         m
     }
 
-    /// Build an idle entry with all fields configurable.
-    fn make_test_idle_entry(
+    /// Build an active-owned park candidate with all seed fields configurable.
+    fn make_test_park_candidate(
         session_id: &str,
         profile_name: &str,
         budget_lease: BudgetLease,
-        parked_at: std::time::Instant,
-        idle_timeout: Duration,
-    ) -> IdleEntry {
-        IdleEntry {
+    ) -> ParkCandidate {
+        ParkCandidate::new(ParkCandidateParts {
             sandbox: Box::new(MockSandbox::new("idle-test")),
             factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
             session_id: session_id.into(),
@@ -3644,10 +3643,8 @@ mod tests {
             profile_name: profile_name.into(),
             budget_lease,
             source_ip: "10.0.0.1".into(),
-            parked_at,
-            idle_timeout,
             storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        }
+        })
     }
 
     /// Pre-populate idle pool with an entry and reserve its budget. Returns
@@ -3662,16 +3659,10 @@ mod tests {
         memory_mb: u32,
     ) -> SandboxId {
         let budget_lease = ResourceBudget::try_reserve_lease(budget, vcpu, memory_mb).unwrap();
-        let entry = make_test_idle_entry(
-            session_id,
-            profile_name,
-            budget_lease,
-            std::time::Instant::now(),
-            Duration::from_secs(300),
-        );
-        let sandbox_id = entry.sandbox_id;
+        let candidate = make_test_park_candidate(session_id, profile_name, budget_lease);
+        let sandbox_id = candidate.sandbox_id();
         let mut guard = pool.lock().await;
-        let result = guard.park(session_id.into(), entry);
+        let result = guard.park(candidate);
         assert!(matches!(result, ParkResult::Parked));
         sandbox_id
     }
@@ -3714,21 +3705,16 @@ mod tests {
             ResourceBudget::try_reserve_lease(budget, vcpu, memory_mb).expect("reserve budget");
 
         let mut guard = pool.lock().await;
-        let result = guard.park(
-            session_id.to_string(),
-            IdleEntry {
-                sandbox,
-                factory: factory_arc,
-                session_id: session_id.to_string(),
-                sandbox_id,
-                profile_name: profile_name.into(),
-                budget_lease,
-                source_ip: "10.0.0.1".into(),
-                parked_at: std::time::Instant::now(),
-                idle_timeout: Duration::from_secs(300),
-                storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-            },
-        );
+        let result = guard.park(ParkCandidate::new(ParkCandidateParts {
+            sandbox,
+            factory: factory_arc,
+            session_id: session_id.to_string(),
+            sandbox_id,
+            profile_name: profile_name.into(),
+            budget_lease,
+            source_ip: "10.0.0.1".into(),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+        }));
         assert!(matches!(result, ParkResult::Parked));
         sandbox_id
     }
@@ -3795,19 +3781,17 @@ mod tests {
         memory_mb: u32,
     ) {
         let budget_lease = ResourceBudget::try_reserve_lease(budget, vcpu, memory_mb).unwrap();
-        let entry = make_test_idle_entry(
-            session_id,
-            profile_name,
-            budget_lease,
+        let candidate = make_test_park_candidate(session_id, profile_name, budget_lease);
+        let mut guard = pool.lock().await;
+        let result = guard.park_at_for_test(
+            candidate,
             std::time::Instant::now() - Duration::from_secs(400),
             Duration::from_secs(300),
         );
-        let mut guard = pool.lock().await;
-        let result = guard.park(session_id.into(), entry);
         assert!(matches!(result, ParkResult::Parked));
     }
 
-    struct TestIdleEntrySpec<'a> {
+    struct TestParkCandidateSpec<'a> {
         session_id: &'a str,
         profile_name: &'a str,
         vcpu: u32,
@@ -3819,19 +3803,13 @@ mod tests {
     async fn seed_idle_pool_with_timing(
         pool: &SharedIdlePool,
         budget: &Arc<ResourceBudget>,
-        spec: TestIdleEntrySpec<'_>,
+        spec: TestParkCandidateSpec<'_>,
     ) {
         let budget_lease =
             ResourceBudget::try_reserve_lease(budget, spec.vcpu, spec.memory_mb).unwrap();
-        let entry = make_test_idle_entry(
-            spec.session_id,
-            spec.profile_name,
-            budget_lease,
-            spec.parked_at,
-            spec.idle_timeout,
-        );
+        let candidate = make_test_park_candidate(spec.session_id, spec.profile_name, budget_lease);
         let mut guard = pool.lock().await;
-        let result = guard.park(spec.session_id.into(), entry);
+        let result = guard.park_at_for_test(candidate, spec.parked_at, spec.idle_timeout);
         assert!(matches!(result, ParkResult::Parked));
     }
 
@@ -4405,7 +4383,7 @@ mod tests {
         seed_idle_pool_with_timing(
             &idle_pool,
             &budget,
-            TestIdleEntrySpec {
+            TestParkCandidateSpec {
                 session_id: "sess-old-active",
                 profile_name: "vm0/default",
                 vcpu: 2,
@@ -4418,7 +4396,7 @@ mod tests {
         seed_idle_pool_with_timing(
             &idle_pool,
             &budget,
-            TestIdleEntrySpec {
+            TestParkCandidateSpec {
                 session_id: "sess-expired-newer",
                 profile_name: "vm0/large",
                 vcpu: 4,
@@ -4476,7 +4454,7 @@ mod tests {
         seed_idle_pool_with_timing(
             &idle_pool,
             &budget,
-            TestIdleEntrySpec {
+            TestParkCandidateSpec {
                 session_id: "sess-old-active",
                 profile_name: "vm0/large",
                 vcpu: 4,
@@ -4489,7 +4467,7 @@ mod tests {
         seed_idle_pool_with_timing(
             &idle_pool,
             &budget,
-            TestIdleEntrySpec {
+            TestParkCandidateSpec {
                 session_id: "sess-new-active",
                 profile_name: "vm0/default",
                 vcpu: 2,
@@ -4502,7 +4480,7 @@ mod tests {
         seed_idle_pool_with_timing(
             &idle_pool,
             &budget,
-            TestIdleEntrySpec {
+            TestParkCandidateSpec {
                 session_id: "sess-expired-small",
                 profile_name: "vm0/default",
                 // Intentionally smaller than the current min profile. With
@@ -5018,11 +4996,11 @@ mod tests {
         shutdown(&env, run_handle).await;
     }
 
-    /// Test 22: `ParkResult::Evicted` via `guest_session_id`.
+    /// Test 22: `ParkResult::Replaced` via `guest_session_id`.
     ///
     /// A first-run job (no `resume_session`) reads a CLI-generated session ID
     /// from the guest filesystem. When that session already has an entry in
-    /// the idle pool, `pool.park()` returns `Evicted(old)`, the old VM is
+    /// the idle pool, `pool.park()` returns `Replaced(old)`, the old VM is
     /// destroyed, and the new VM takes its place.
     #[tokio::test(start_paused = true)]
     async fn park_evicts_via_guest_session_id() {

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1258,7 +1258,7 @@ fn spawn_job(
                     match active_lease.take() {
                         Some(lease) => {
                             let mut pool = idle_pool.lock().await;
-                            let candidate = ParkCandidate::new(ParkCandidateParts {
+                            let candidate = ParkCandidate::from_parked_parts(ParkCandidateParts {
                                 sandbox,
                                 factory: factory_for_cleanup,
                                 session_id: session_id.to_string(),
@@ -1739,7 +1739,7 @@ mod tests {
 
     fn make_park_candidate(session_id: &str) -> ParkCandidate {
         let budget = Arc::new(ResourceBudget::new(1, 1, 1.0, 0));
-        ParkCandidate::new(ParkCandidateParts {
+        ParkCandidate::from_parked_parts(ParkCandidateParts {
             sandbox: Box::new(MockSandbox::new("test")),
             factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
             session_id: session_id.into(),
@@ -2013,7 +2013,7 @@ mod tests {
     async fn idle_destroy_panic_releases_budget_lease() {
         let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
         let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
-        let candidate = ParkCandidate::new(ParkCandidateParts {
+        let candidate = ParkCandidate::from_parked_parts(ParkCandidateParts {
             sandbox: Box::new(MockSandbox::new("panic-destroy")),
             factory: Arc::new(Box::new(PanickingDestroyFactory) as Box<dyn SandboxFactory>),
             session_id: "sess-panic".into(),
@@ -2054,7 +2054,7 @@ mod tests {
         let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
         let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
         let destroy_count = Arc::new(AtomicUsize::new(0));
-        let candidate = ParkCandidate::new(ParkCandidateParts {
+        let candidate = ParkCandidate::from_parked_parts(ParkCandidateParts {
             sandbox,
             factory: Arc::new(Box::new(RecordingDestroyFactory {
                 destroy_count: Arc::clone(&destroy_count),
@@ -3635,7 +3635,7 @@ mod tests {
         profile_name: &str,
         budget_lease: BudgetLease,
     ) -> ParkCandidate {
-        ParkCandidate::new(ParkCandidateParts {
+        ParkCandidate::from_parked_parts(ParkCandidateParts {
             sandbox: Box::new(MockSandbox::new("idle-test")),
             factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
             session_id: session_id.into(),
@@ -3705,7 +3705,7 @@ mod tests {
             ResourceBudget::try_reserve_lease(budget, vcpu, memory_mb).expect("reserve budget");
 
         let mut guard = pool.lock().await;
-        let result = guard.park(ParkCandidate::new(ParkCandidateParts {
+        let result = guard.park(ParkCandidate::from_parked_parts(ParkCandidateParts {
             sandbox,
             factory: factory_arc,
             session_id: session_id.to_string(),

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -181,10 +181,9 @@ fn record_api_latency(action_type: &str, context: &ExecutionContext, telemetry: 
     }
 }
 
-/// Dispatch inputs for the fresh-create path — the counterpart to
-/// [`IdleEntry`] on the reuse path. Holds the UUID for the new VM and the
-/// categorized reason no idle VM was reused. Both originate in
-/// `cmd/start.rs`; the id becomes the sandbox's identity, the reuse result
+/// Dispatch inputs for the fresh-create path. Holds the UUID for the new VM
+/// and the categorized reason no idle VM was reused. Both originate in
+/// `cmd/start.rs`; the id becomes the sandbox's identity, and the reuse result
 /// is forwarded to the guest for /complete metadata.
 #[derive(Clone, Copy)]
 pub struct NewSandboxDispatch {
@@ -2551,7 +2550,7 @@ mod tests {
             default_timeout: std::time::Duration::from_secs(300),
             max_idle: 0,
         });
-        let candidate = ParkCandidate::new(ParkCandidateParts {
+        let candidate = ParkCandidate::from_parked_parts(ParkCandidateParts {
             sandbox,
             factory: std::sync::Arc::new(
                 Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
@@ -2950,7 +2949,7 @@ mod tests {
             max_idle: 0,
         });
 
-        let entry = ParkCandidate::new(ParkCandidateParts {
+        let entry = ParkCandidate::from_parked_parts(ParkCandidateParts {
             sandbox,
             factory: std::sync::Arc::new(
                 Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
@@ -2999,7 +2998,7 @@ mod tests {
         });
 
         // Park with profile "vm0/default"
-        let entry = ParkCandidate::new(ParkCandidateParts {
+        let entry = ParkCandidate::from_parked_parts(ParkCandidateParts {
             sandbox: Box::new(sandbox_mock::MockSandbox::new("test")),
             factory: std::sync::Arc::new(
                 Box::new(sandbox_mock::MockSandboxFactory::new()) as Box<dyn SandboxFactory>

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -128,9 +128,10 @@ pub async fn execute_job_reuse(
     record_reuse_result(&mut telemetry, SandboxReuseResult::Reused);
     record_api_latency("api_to_vm_start", &context, &mut telemetry);
 
-    let source_ip = idle_sandbox.source_ip;
-    let prev_storage = idle_sandbox.storage_fingerprints;
-    let sandbox = idle_sandbox.sandbox;
+    let idle_parts = idle_sandbox.into_parts();
+    let source_ip = idle_parts.source_ip;
+    let prev_storage = idle_parts.storage_fingerprints;
+    let sandbox = idle_parts.sandbox;
 
     // execute_reused_sandbox never returns Err — it always returns the sandbox
     // in the outcome so the caller can stop + destroy it on failure.
@@ -2536,6 +2537,45 @@ mod tests {
         crate::resource_budget::ResourceBudget::try_reserve_lease(&budget, 2, 2048).unwrap()
     }
 
+    async fn make_reusable_idle_sandbox(
+        sandbox: Box<dyn Sandbox>,
+        source_ip: String,
+        session_id: &str,
+    ) -> (ReusableIdleSandbox, crate::resource_budget::BudgetLease) {
+        use crate::idle_pool::{
+            IdlePool, IdlePoolConfig, IdleUnparkResult, ParkCandidate, ParkCandidateParts,
+            ParkResult,
+        };
+
+        let mut pool = IdlePool::new(IdlePoolConfig {
+            default_timeout: std::time::Duration::from_secs(300),
+            max_idle: 0,
+        });
+        let candidate = ParkCandidate::new(ParkCandidateParts {
+            sandbox,
+            factory: std::sync::Arc::new(
+                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
+            ),
+            session_id: session_id.into(),
+            sandbox_id: SandboxId::new_v4(),
+            profile_name: "vm0/default".into(),
+            budget_lease: test_budget_lease(),
+            source_ip,
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+        });
+        assert!(matches!(pool.park(candidate), ParkResult::Parked));
+        let entry = pool.take(session_id).expect("idle entry should exist");
+        match entry.try_unpark().await {
+            IdleUnparkResult::Reused {
+                sandbox,
+                budget_lease,
+            } => (sandbox, budget_lease),
+            IdleUnparkResult::Failed { error, .. } => {
+                panic!("test idle entry should unpark: {error}");
+            }
+        }
+    }
+
     fn test_telemetry(config: &ExecutorConfig, ctx: &ExecutionContext) -> JobTelemetry {
         crate::telemetry::JobTelemetry::new(
             config.http.clone(),
@@ -2815,24 +2855,9 @@ mod tests {
         assert_eq!(outcome.exit_code, 0);
         let sandbox = outcome.sandbox.expect("sandbox should be alive");
 
-        // Build an idle entry from the outcome
-        let idle_entry = crate::idle_pool::IdleEntry {
-            sandbox,
-            factory: std::sync::Arc::new(
-                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
-            ),
-            session_id: "test-session".into(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: "vm0/default".into(),
-            budget_lease: test_budget_lease(),
-            source_ip: outcome.source_ip,
-            parked_at: std::time::Instant::now(),
-            idle_timeout: std::time::Duration::from_secs(300),
-            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        };
-
         // Reuse the sandbox for a second turn
-        let (idle_sandbox, _lease) = idle_entry.into_reuse_parts();
+        let (idle_sandbox, _lease) =
+            make_reusable_idle_sandbox(sandbox, outcome.source_ip, "test-session").await;
         let cancel = tokio_util::sync::CancellationToken::new();
         let (reuse_outcome, _telemetry) =
             execute_job_reuse(idle_sandbox, minimal_context(), &config, cancel).await;
@@ -2872,22 +2897,6 @@ mod tests {
         assert_eq!(outcome.exit_code, 0);
         let sandbox = outcome.sandbox.expect("sandbox should be alive");
 
-        // Build idle entry
-        let idle_entry = crate::idle_pool::IdleEntry {
-            sandbox,
-            factory: std::sync::Arc::new(
-                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
-            ),
-            session_id: "test-session".into(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: "vm0/default".into(),
-            budget_lease: test_budget_lease(),
-            source_ip: outcome.source_ip,
-            parked_at: std::time::Instant::now(),
-            idle_timeout: std::time::Duration::from_secs(300),
-            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        };
-
         // Second turn: reuse with new session history
         let mut ctx2 = minimal_context();
         ctx2.resume_session = Some(ResumeSession {
@@ -2899,7 +2908,8 @@ mod tests {
         });
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let (idle_sandbox, _lease) = idle_entry.into_reuse_parts();
+        let (idle_sandbox, _lease) =
+            make_reusable_idle_sandbox(sandbox, outcome.source_ip, "test-session").await;
         let (reuse_outcome, _telemetry) =
             execute_job_reuse(idle_sandbox, ctx2, &config, cancel).await;
         assert_eq!(reuse_outcome.exit_code, 0);
@@ -2908,7 +2918,9 @@ mod tests {
 
     #[tokio::test]
     async fn idle_pool_park_and_reuse_cycle() {
-        use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkResult};
+        use crate::idle_pool::{
+            IdlePool, IdlePoolConfig, ParkCandidate, ParkCandidateParts, ParkResult,
+        };
 
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
@@ -2938,7 +2950,7 @@ mod tests {
             max_idle: 0,
         });
 
-        let entry = crate::idle_pool::IdleEntry {
+        let entry = ParkCandidate::new(ParkCandidateParts {
             sandbox,
             factory: std::sync::Arc::new(
                 Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
@@ -2948,23 +2960,29 @@ mod tests {
             profile_name: "vm0/default".into(),
             budget_lease: test_budget_lease(),
             source_ip: outcome.source_ip,
-            parked_at: std::time::Instant::now(),
-            idle_timeout: std::time::Duration::from_secs(300),
             storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        };
+        });
 
-        let result = pool.park("session-1".into(), entry);
+        let result = pool.park(entry);
         assert!(matches!(result, ParkResult::Parked));
         assert_eq!(pool.len(), 1);
 
         // Take from pool for reuse
-        let reuse_entry = pool.take("session-1").expect("should find session");
+        let reuse_entry = pool.take("test-session").expect("should find session");
         assert_eq!(pool.len(), 0);
-        assert_eq!(reuse_entry.profile_name, "vm0/default");
+        assert_eq!(reuse_entry.profile_name(), "vm0/default");
 
         // Execute reuse
         let cancel = tokio_util::sync::CancellationToken::new();
-        let (idle_sandbox, _lease) = reuse_entry.into_reuse_parts();
+        let (idle_sandbox, _lease) = match reuse_entry.try_unpark().await {
+            crate::idle_pool::IdleUnparkResult::Reused {
+                sandbox,
+                budget_lease,
+            } => (sandbox, budget_lease),
+            crate::idle_pool::IdleUnparkResult::Failed { error, .. } => {
+                panic!("test idle entry should unpark: {error}");
+            }
+        };
         let (reuse_outcome, _telemetry) =
             execute_job_reuse(idle_sandbox, minimal_context(), &config, cancel).await;
         assert_eq!(reuse_outcome.exit_code, 0);
@@ -2973,7 +2991,7 @@ mod tests {
 
     #[tokio::test]
     async fn idle_pool_profile_mismatch_returns_none() {
-        use crate::idle_pool::{IdlePool, IdlePoolConfig};
+        use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkCandidate, ParkCandidateParts};
 
         let mut pool = IdlePool::new(IdlePoolConfig {
             default_timeout: std::time::Duration::from_secs(300),
@@ -2981,7 +2999,7 @@ mod tests {
         });
 
         // Park with profile "vm0/default"
-        let entry = crate::idle_pool::IdleEntry {
+        let entry = ParkCandidate::new(ParkCandidateParts {
             sandbox: Box::new(sandbox_mock::MockSandbox::new("test")),
             factory: std::sync::Arc::new(
                 Box::new(sandbox_mock::MockSandboxFactory::new()) as Box<dyn SandboxFactory>
@@ -2991,18 +3009,16 @@ mod tests {
             profile_name: "vm0/default".into(),
             budget_lease: test_budget_lease(),
             source_ip: "10.0.0.1".into(),
-            parked_at: std::time::Instant::now(),
-            idle_timeout: std::time::Duration::from_secs(300),
             storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        };
-        let _ = pool.park("session-1".into(), entry);
+        });
+        let _ = pool.park(entry);
 
         // Take and verify profile
-        let taken = pool.take("session-1").expect("should find");
-        assert_eq!(taken.profile_name, "vm0/default");
+        let taken = pool.take("test-session").expect("should find");
+        assert_eq!(taken.profile_name(), "vm0/default");
 
         // Simulate caller checking profile mismatch
-        let matches_browser = taken.profile_name == "vm0/browser";
+        let matches_browser = taken.profile_name() == "vm0/browser";
         assert!(!matches_browser, "should not match different profile");
     }
 
@@ -3015,23 +3031,9 @@ mod tests {
         let sandbox = MockSandbox::new("reuse-clock-fail");
         sandbox.push_exec_result(Err(sandbox_exec_error("vsock broken")));
 
-        let idle_entry = crate::idle_pool::IdleEntry {
-            sandbox: Box::new(sandbox),
-            factory: std::sync::Arc::new(
-                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
-            ),
-            session_id: "sess-1".into(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: "vm0/default".into(),
-            budget_lease: test_budget_lease(),
-            source_ip: "10.0.0.1".into(),
-            parked_at: std::time::Instant::now(),
-            idle_timeout: std::time::Duration::from_secs(300),
-            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        };
-
         let cancel = tokio_util::sync::CancellationToken::new();
-        let (idle_sandbox, _lease) = idle_entry.into_reuse_parts();
+        let (idle_sandbox, _lease) =
+            make_reusable_idle_sandbox(Box::new(sandbox), "10.0.0.1".into(), "sess-1").await;
         let (outcome, _telemetry) =
             execute_job_reuse(idle_sandbox, minimal_context(), &config, cancel).await;
 
@@ -3058,23 +3060,9 @@ mod tests {
         }));
         sandbox.push_exec_result(Err(sandbox_exec_error("reseed timeout")));
 
-        let idle_entry = crate::idle_pool::IdleEntry {
-            sandbox: Box::new(sandbox),
-            factory: std::sync::Arc::new(
-                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
-            ),
-            session_id: "sess-1".into(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: "vm0/default".into(),
-            budget_lease: test_budget_lease(),
-            source_ip: "10.0.0.1".into(),
-            parked_at: std::time::Instant::now(),
-            idle_timeout: std::time::Duration::from_secs(300),
-            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        };
-
         let cancel = tokio_util::sync::CancellationToken::new();
-        let (idle_sandbox, _lease) = idle_entry.into_reuse_parts();
+        let (idle_sandbox, _lease) =
+            make_reusable_idle_sandbox(Box::new(sandbox), "10.0.0.1".into(), "sess-1").await;
         let (outcome, _telemetry) =
             execute_job_reuse(idle_sandbox, minimal_context(), &config, cancel).await;
 
@@ -3103,23 +3091,9 @@ mod tests {
             session_history: r#"{"type":"init"}"#.into(),
         });
 
-        let idle_entry = crate::idle_pool::IdleEntry {
-            sandbox: Box::new(sandbox),
-            factory: std::sync::Arc::new(
-                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
-            ),
-            session_id: "sess-abc".into(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: "vm0/default".into(),
-            budget_lease: test_budget_lease(),
-            source_ip: "10.0.0.1".into(),
-            parked_at: std::time::Instant::now(),
-            idle_timeout: std::time::Duration::from_secs(300),
-            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        };
-
         let cancel = tokio_util::sync::CancellationToken::new();
-        let (idle_sandbox, _lease) = idle_entry.into_reuse_parts();
+        let (idle_sandbox, _lease) =
+            make_reusable_idle_sandbox(Box::new(sandbox), "10.0.0.1".into(), "sess-abc").await;
         let (outcome, _telemetry) = execute_job_reuse(idle_sandbox, ctx, &config, cancel).await;
 
         assert_eq!(outcome.exit_code, 1);
@@ -3607,23 +3581,9 @@ mod tests {
         .await;
         let sandbox = outcome.sandbox.expect("sandbox should be alive");
 
-        let idle_entry = crate::idle_pool::IdleEntry {
-            sandbox,
-            factory: std::sync::Arc::new(
-                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
-            ),
-            session_id: "test-session".into(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: "vm0/default".into(),
-            budget_lease: test_budget_lease(),
-            source_ip: outcome.source_ip,
-            parked_at: std::time::Instant::now(),
-            idle_timeout: std::time::Duration::from_secs(300),
-            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
-        };
-
         let cancel = tokio_util::sync::CancellationToken::new();
-        let (idle_sandbox, _lease) = idle_entry.into_reuse_parts();
+        let (idle_sandbox, _lease) =
+            make_reusable_idle_sandbox(sandbox, outcome.source_ip, "test-session").await;
         let (_outcome, telemetry) =
             execute_job_reuse(idle_sandbox, minimal_context(), &config, cancel).await;
 

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -167,7 +167,7 @@ pub struct ParkCandidate {
     storage_fingerprints: StorageFingerprints,
 }
 
-pub struct ParkCandidateParts {
+pub(crate) struct ParkCandidateParts {
     pub sandbox: Box<dyn Sandbox>,
     pub factory: Arc<Box<dyn SandboxFactory>>,
     pub session_id: String,
@@ -179,7 +179,8 @@ pub struct ParkCandidateParts {
 }
 
 impl ParkCandidate {
-    pub fn new(parts: ParkCandidateParts) -> Self {
+    /// Build a candidate only after `Sandbox::park()` has returned success.
+    pub(crate) fn from_parked_parts(parts: ParkCandidateParts) -> Self {
         Self {
             sandbox: parts.sandbox,
             factory: parts.factory,
@@ -712,7 +713,7 @@ mod tests {
     }
 
     fn make_candidate_for_with_lease(session_id: &str, budget_lease: BudgetLease) -> ParkCandidate {
-        ParkCandidate::new(ParkCandidateParts {
+        ParkCandidate::from_parked_parts(ParkCandidateParts {
             sandbox: Box::new(MockSandbox::new("test")),
             factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
             session_id: session_id.into(),

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -149,23 +149,116 @@ impl Default for ParkingGate {
     }
 }
 
-/// A sandbox parked in the idle pool, waiting for reuse.
-pub struct IdleEntry {
-    pub sandbox: Box<dyn Sandbox>,
-    pub factory: Arc<Box<dyn SandboxFactory>>,
-    pub session_id: String,
+/// Active-owned sandbox after `Sandbox::park()` succeeds, before idle-pool
+/// ownership is accepted.
+pub struct ParkCandidate {
+    sandbox: Box<dyn Sandbox>,
+    factory: Arc<Box<dyn SandboxFactory>>,
+    session_id: String,
     /// Identity of the parked sandbox. Survives reuse (next job's `run_id`
     /// differs, but `sandbox_id` stays the same) and is the join key for
     /// doctor / kill / workspace-dir naming.
+    sandbox_id: SandboxId,
+    profile_name: String,
+    budget_lease: BudgetLease,
+    source_ip: String,
+    /// Version fingerprints of storages downloaded in the previous turn.
+    /// Used to skip re-downloading unchanged entries on reuse.
+    storage_fingerprints: StorageFingerprints,
+}
+
+pub struct ParkCandidateParts {
+    pub sandbox: Box<dyn Sandbox>,
+    pub factory: Arc<Box<dyn SandboxFactory>>,
+    pub session_id: String,
     pub sandbox_id: SandboxId,
     pub profile_name: String,
     pub budget_lease: BudgetLease,
     pub source_ip: String,
-    pub parked_at: Instant,
-    pub idle_timeout: Duration,
+    pub storage_fingerprints: StorageFingerprints,
+}
+
+impl ParkCandidate {
+    pub fn new(parts: ParkCandidateParts) -> Self {
+        Self {
+            sandbox: parts.sandbox,
+            factory: parts.factory,
+            session_id: parts.session_id,
+            sandbox_id: parts.sandbox_id,
+            profile_name: parts.profile_name,
+            budget_lease: parts.budget_lease,
+            source_ip: parts.source_ip,
+            storage_fingerprints: parts.storage_fingerprints,
+        }
+    }
+
+    fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    #[cfg(test)]
+    pub fn sandbox_id(&self) -> SandboxId {
+        self.sandbox_id
+    }
+
+    fn into_idle_entry(self, parked_at: Instant, idle_timeout: Duration) -> IdleEntry {
+        let Self {
+            sandbox,
+            factory,
+            session_id,
+            sandbox_id,
+            profile_name,
+            budget_lease,
+            source_ip,
+            storage_fingerprints,
+        } = self;
+
+        IdleEntry {
+            sandbox,
+            factory,
+            session_id,
+            sandbox_id,
+            profile_name,
+            budget_lease,
+            source_ip,
+            parked_at,
+            idle_timeout,
+            storage_fingerprints,
+        }
+    }
+
+    fn into_rejected(self) -> RejectedParkCandidate {
+        let Self {
+            sandbox,
+            factory,
+            budget_lease,
+            ..
+        } = self;
+
+        RejectedParkCandidate {
+            payload: IdleDestroyPayload { sandbox, factory },
+            budget_lease,
+        }
+    }
+}
+
+/// A pool-owned sandbox waiting for reuse.
+///
+/// Only `IdlePool` can create this from a [`ParkCandidate`]. This keeps
+/// rejected active-job parks out of the idle-owned lifecycle state.
+pub struct IdleEntry {
+    sandbox: Box<dyn Sandbox>,
+    factory: Arc<Box<dyn SandboxFactory>>,
+    session_id: String,
+    sandbox_id: SandboxId,
+    profile_name: String,
+    budget_lease: BudgetLease,
+    source_ip: String,
+    parked_at: Instant,
+    idle_timeout: Duration,
     /// Version fingerprints of storages downloaded in the previous turn.
     /// Used to skip re-downloading unchanged entries on reuse.
-    pub storage_fingerprints: StorageFingerprints,
+    storage_fingerprints: StorageFingerprints,
 }
 
 /// Idle pool status snapshot paired with a monotonic mutation revision.
@@ -185,21 +278,48 @@ pub struct IdlePoolSnapshot {
 /// task owns the active lease so executor panics cannot release capacity before
 /// provider completion and post-job cleanup finish.
 pub struct ReusableIdleSandbox {
+    sandbox: Box<dyn Sandbox>,
+    sandbox_id: SandboxId,
+    source_ip: String,
+    storage_fingerprints: StorageFingerprints,
+}
+
+pub struct ReusableIdleSandboxParts {
     pub sandbox: Box<dyn Sandbox>,
-    pub sandbox_id: SandboxId,
     pub source_ip: String,
     pub storage_fingerprints: StorageFingerprints,
 }
 
+impl ReusableIdleSandbox {
+    pub fn sandbox_id(&self) -> SandboxId {
+        self.sandbox_id
+    }
+
+    pub fn into_parts(self) -> ReusableIdleSandboxParts {
+        let Self {
+            sandbox,
+            sandbox_id: _,
+            source_ip,
+            storage_fingerprints,
+        } = self;
+
+        ReusableIdleSandboxParts {
+            sandbox,
+            source_ip,
+            storage_fingerprints,
+        }
+    }
+}
+
 /// Physical resources needed to destroy an idle VM, without its budget lease.
-pub struct IdleDestroyPayload {
+pub(crate) struct IdleDestroyPayload {
     sandbox: Box<dyn Sandbox>,
     factory: Arc<Box<dyn SandboxFactory>>,
 }
 
 impl IdleDestroyPayload {
     /// Stop the sandbox and destroy it via its factory.
-    pub async fn stop_and_destroy(self) {
+    pub(crate) async fn stop_and_destroy(self) {
         let mut sandbox = self.sandbox;
         match AssertUnwindSafe(sandbox.stop()).catch_unwind().await {
             Ok(Ok(())) => {}
@@ -216,14 +336,115 @@ impl IdleDestroyPayload {
     }
 }
 
-impl IdleEntry {
-    /// Stop the sandbox and destroy it via its factory.
-    pub async fn stop_and_destroy(self) {
-        let (payload, _lease) = self.into_destroy_parts();
+/// Idle-owned destroy state. The budget lease is released when this job is
+/// consumed after physical cleanup.
+#[must_use = "dropping IdleDestroyJob releases budget without destroying the sandbox"]
+pub struct IdleDestroyJob {
+    payload: IdleDestroyPayload,
+    budget_lease: BudgetLease,
+    session_id: String,
+    profile_name: String,
+}
+
+impl IdleDestroyJob {
+    pub async fn run(self) {
+        let Self {
+            payload,
+            budget_lease,
+            session_id: _,
+            profile_name: _,
+        } = self;
         payload.stop_and_destroy().await;
+        drop(budget_lease);
     }
 
-    pub fn into_reuse_parts(self) -> (ReusableIdleSandbox, BudgetLease) {
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    pub fn profile_name(&self) -> &str {
+        &self.profile_name
+    }
+
+    pub fn budget_vcpu(&self) -> u32 {
+        self.budget_lease.vcpu()
+    }
+
+    pub fn budget_memory_mb(&self) -> u32 {
+        self.budget_lease.memory_mb()
+    }
+}
+
+/// Park was rejected before the idle pool accepted ownership.
+///
+/// The lease belongs back to the active job so completion accounting can stay
+/// reserved until physical destroy and provider completion finish.
+#[must_use = "rejected park candidates must be destroyed while their lease stays active"]
+pub struct RejectedParkCandidate {
+    payload: IdleDestroyPayload,
+    budget_lease: BudgetLease,
+}
+
+impl RejectedParkCandidate {
+    pub(crate) fn into_active_destroy_parts(self) -> (IdleDestroyPayload, BudgetLease) {
+        let Self {
+            payload,
+            budget_lease,
+        } = self;
+        (payload, budget_lease)
+    }
+}
+
+pub enum IdleUnparkResult {
+    Reused {
+        sandbox: ReusableIdleSandbox,
+        budget_lease: BudgetLease,
+    },
+    Failed {
+        destroy_job: IdleDestroyJob,
+        error: String,
+    },
+}
+
+impl IdleEntry {
+    pub fn profile_name(&self) -> &str {
+        &self.profile_name
+    }
+
+    #[cfg(test)]
+    pub fn budget_vcpu(&self) -> u32 {
+        self.budget_lease.vcpu()
+    }
+
+    #[cfg(test)]
+    pub fn budget_memory_mb(&self) -> u32 {
+        self.budget_lease.memory_mb()
+    }
+
+    /// Unpark and consume this idle entry. On failure the entry becomes an
+    /// idle-owned destroy job so callers cannot keep using a partially
+    /// unparked sandbox.
+    pub async fn try_unpark(mut self) -> IdleUnparkResult {
+        match AssertUnwindSafe(self.sandbox.unpark()).catch_unwind().await {
+            Ok(Ok(())) => {
+                let (sandbox, budget_lease) = self.into_reuse_parts();
+                IdleUnparkResult::Reused {
+                    sandbox,
+                    budget_lease,
+                }
+            }
+            Ok(Err(e)) => IdleUnparkResult::Failed {
+                destroy_job: self.into_destroy_job(),
+                error: e.to_string(),
+            },
+            Err(_) => IdleUnparkResult::Failed {
+                destroy_job: self.into_destroy_job(),
+                error: "sandbox unpark panicked".into(),
+            },
+        }
+    }
+
+    fn into_reuse_parts(self) -> (ReusableIdleSandbox, BudgetLease) {
         let Self {
             sandbox,
             sandbox_id,
@@ -244,15 +465,22 @@ impl IdleEntry {
         )
     }
 
-    pub fn into_destroy_parts(self) -> (IdleDestroyPayload, BudgetLease) {
+    pub fn into_destroy_job(self) -> IdleDestroyJob {
         let Self {
             sandbox,
             factory,
+            session_id,
+            profile_name,
             budget_lease,
             ..
         } = self;
 
-        (IdleDestroyPayload { sandbox, factory }, budget_lease)
+        IdleDestroyJob {
+            payload: IdleDestroyPayload { sandbox, factory },
+            budget_lease,
+            session_id,
+            profile_name,
+        }
     }
 }
 
@@ -285,22 +513,43 @@ impl IdlePool {
         }
     }
 
-    /// Park a sandbox in the pool. Returns the previously parked entry
+    /// Park a sandbox in the pool. Returns the previously parked destroy job
     /// for this session if one existed (caller must destroy it).
     ///
-    /// Returns `PoolFull(entry)` if parking is closed/soft-draining or at capacity.
-    pub fn park(&mut self, session_id: String, entry: IdleEntry) -> ParkResult {
+    /// Returns `Rejected(candidate)` if parking is closed/soft-draining or at capacity.
+    pub fn park(&mut self, candidate: ParkCandidate) -> ParkResult {
+        self.park_at(candidate, Instant::now(), self.config.default_timeout)
+    }
+
+    #[cfg(test)]
+    pub fn park_at_for_test(
+        &mut self,
+        candidate: ParkCandidate,
+        parked_at: Instant,
+        idle_timeout: Duration,
+    ) -> ParkResult {
+        self.park_at(candidate, parked_at, idle_timeout)
+    }
+
+    fn park_at(
+        &mut self,
+        candidate: ParkCandidate,
+        parked_at: Instant,
+        idle_timeout: Duration,
+    ) -> ParkResult {
+        let session_id = candidate.session_id().to_string();
         if !self.parking_gate.is_open() {
-            return ParkResult::PoolFull(entry);
+            return ParkResult::Rejected(candidate.into_rejected());
         }
         if self.config.max_idle > 0 && self.entries.len() >= self.config.max_idle {
             // At capacity and this session has no existing entry to replace.
             if !self.entries.contains_key(&session_id) {
-                return ParkResult::PoolFull(entry);
+                return ParkResult::Rejected(candidate.into_rejected());
             }
         }
+        let entry = candidate.into_idle_entry(parked_at, idle_timeout);
         let result = match self.entries.insert(session_id, entry) {
-            Some(evicted) => ParkResult::Evicted(evicted),
+            Some(evicted) => ParkResult::Replaced(evicted.into_destroy_job()),
             None => ParkResult::Parked,
         };
         self.bump_revision();
@@ -318,7 +567,7 @@ impl IdlePool {
     }
 
     /// Remove and return all entries that have exceeded their idle timeout.
-    pub fn evict_expired(&mut self) -> Vec<IdleEntry> {
+    pub fn evict_expired(&mut self) -> Vec<IdleDestroyJob> {
         let now = Instant::now();
         let expired_keys: Vec<String> = self
             .entries
@@ -327,9 +576,10 @@ impl IdlePool {
             .map(|(k, _)| k.clone())
             .collect();
 
-        let expired: Vec<IdleEntry> = expired_keys
+        let expired: Vec<IdleDestroyJob> = expired_keys
             .into_iter()
             .filter_map(|k| self.entries.remove(&k))
+            .map(IdleEntry::into_destroy_job)
             .collect();
         if !expired.is_empty() {
             self.bump_revision();
@@ -339,17 +589,20 @@ impl IdlePool {
 
     /// Evict the oldest idle entry (by park time). Used for resource
     /// pressure relief.
-    pub fn evict_oldest(&mut self) -> Option<IdleEntry> {
+    pub fn evict_oldest(&mut self) -> Option<IdleDestroyJob> {
         let oldest_key = self
             .entries
             .iter()
             .min_by_key(|(_, e)| e.parked_at)
             .map(|(k, _)| k.clone())?;
-        let entry = self.entries.remove(&oldest_key);
-        if entry.is_some() {
+        let job = self
+            .entries
+            .remove(&oldest_key)
+            .map(IdleEntry::into_destroy_job);
+        if job.is_some() {
             self.bump_revision();
         }
-        entry
+        job
     }
 
     /// Return a revisioned sorted-by-session_id snapshot suitable for status.json.
@@ -408,20 +661,19 @@ impl IdlePool {
         self.parking_gate.clone()
     }
 
-    /// The default idle timeout.
-    pub fn default_timeout(&self) -> Duration {
-        self.config.default_timeout
-    }
-
     /// Drain all entries from the pool. Parking permission is controlled by
     /// [`ParkingGate`] so soft-drain resume can reopen parking before
     /// `RunnerMode::Running` becomes visible.
-    pub fn drain(&mut self) -> Vec<IdleEntry> {
-        let entries: Vec<IdleEntry> = self.entries.drain().map(|(_, v)| v).collect();
-        if !entries.is_empty() {
+    pub fn drain(&mut self) -> Vec<IdleDestroyJob> {
+        let jobs: Vec<IdleDestroyJob> = self
+            .entries
+            .drain()
+            .map(|(_, entry)| entry.into_destroy_job())
+            .collect();
+        if !jobs.is_empty() {
             self.bump_revision();
         }
-        entries
+        jobs
     }
 
     fn bump_revision(&mut self) {
@@ -434,10 +686,10 @@ impl IdlePool {
 pub enum ParkResult {
     /// Successfully parked; no previous entry for this session.
     Parked,
-    /// Successfully parked; the returned entry was evicted (same session).
-    Evicted(IdleEntry),
+    /// Successfully parked; the returned job destroys the replaced idle VM.
+    Replaced(IdleDestroyJob),
     /// Pool is at max capacity or disabled; the entry could not be parked.
-    PoolFull(IdleEntry),
+    Rejected(RejectedParkCandidate),
 }
 
 #[cfg(test)]
@@ -455,39 +707,32 @@ mod tests {
         ResourceBudget::try_reserve_lease(&budget, vcpu, memory_mb).unwrap()
     }
 
-    fn make_entry(vcpu: u32, memory_mb: u32) -> IdleEntry {
-        IdleEntry {
-            sandbox: Box::new(MockSandbox::new("test")),
-            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-            session_id: "test-session".into(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: "vm0/default".into(),
-            budget_lease: make_budget_lease(vcpu, memory_mb),
-            source_ip: "10.0.0.1".into(),
-            parked_at: Instant::now(),
-            idle_timeout: Duration::from_secs(300),
-            storage_fingerprints: StorageFingerprints::default(),
-        }
+    fn make_candidate_for(session_id: &str, vcpu: u32, memory_mb: u32) -> ParkCandidate {
+        make_candidate_for_with_lease(session_id, make_budget_lease(vcpu, memory_mb))
     }
 
-    fn make_entry_with_park_time(
-        vcpu: u32,
-        memory_mb: u32,
-        parked_at: Instant,
-        idle_timeout: Duration,
-    ) -> IdleEntry {
-        IdleEntry {
+    fn make_candidate_for_with_lease(session_id: &str, budget_lease: BudgetLease) -> ParkCandidate {
+        ParkCandidate::new(ParkCandidateParts {
             sandbox: Box::new(MockSandbox::new("test")),
             factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-            session_id: "test-session".into(),
+            session_id: session_id.into(),
             sandbox_id: SandboxId::new_v4(),
             profile_name: "vm0/default".into(),
-            budget_lease: make_budget_lease(vcpu, memory_mb),
+            budget_lease,
             source_ip: "10.0.0.1".into(),
-            parked_at,
-            idle_timeout,
             storage_fingerprints: StorageFingerprints::default(),
-        }
+        })
+    }
+
+    fn park_at(
+        pool: &mut IdlePool,
+        session_id: &str,
+        candidate: ParkCandidate,
+        parked_at: Instant,
+        idle_timeout: Duration,
+    ) -> ParkResult {
+        assert_eq!(candidate.session_id(), session_id);
+        pool.park_at_for_test(candidate, parked_at, idle_timeout)
     }
 
     fn pool_config(max_idle: usize) -> IdlePoolConfig {
@@ -502,14 +747,27 @@ mod tests {
         let mut pool = IdlePool::new(pool_config(0));
         assert_eq!(pool.len(), 0);
 
-        let result = pool.park("session-1".into(), make_entry(2, 2048));
+        let result = pool.park(make_candidate_for("session-1", 2, 2048));
         assert!(matches!(result, ParkResult::Parked));
         assert_eq!(pool.len(), 1);
 
         let entry = pool.take("session-1").unwrap();
-        assert_eq!(entry.budget_lease.vcpu(), 2);
-        assert_eq!(entry.budget_lease.memory_mb(), 2048);
+        assert_eq!(entry.budget_vcpu(), 2);
+        assert_eq!(entry.budget_memory_mb(), 2048);
         assert_eq!(pool.len(), 0);
+    }
+
+    #[test]
+    fn park_uses_candidate_session_as_pool_key() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let result = pool.park(make_candidate_for("candidate-session", 2, 2048));
+        assert!(matches!(result, ParkResult::Parked));
+
+        assert!(
+            pool.take("caller-provided-session").is_none(),
+            "park no longer accepts a separate session key"
+        );
+        assert!(pool.take("candidate-session").is_some());
     }
 
     #[test]
@@ -522,38 +780,67 @@ mod tests {
     fn park_same_session_evicts_previous() {
         let mut pool = IdlePool::new(pool_config(0));
 
-        let _ = pool.park("session-1".into(), make_entry(2, 2048));
-        let result = pool.park("session-1".into(), make_entry(4, 4096));
+        let _ = pool.park(make_candidate_for("session-1", 2, 2048));
+        let result = pool.park(make_candidate_for("session-1", 4, 4096));
 
         match result {
-            ParkResult::Evicted(evicted) => {
-                assert_eq!(evicted.budget_lease.vcpu(), 2);
-                assert_eq!(evicted.budget_lease.memory_mb(), 2048);
+            ParkResult::Replaced(evicted) => {
+                assert_eq!(evicted.budget_vcpu(), 2);
+                assert_eq!(evicted.budget_memory_mb(), 2048);
             }
-            _ => panic!("expected Evicted"),
+            _ => panic!("expected Replaced"),
         }
 
         assert_eq!(pool.len(), 1);
         let entry = pool.take("session-1").unwrap();
-        assert_eq!(entry.budget_lease.vcpu(), 4);
+        assert_eq!(entry.budget_vcpu(), 4);
     }
 
     #[test]
     fn park_respects_max_idle() {
         let mut pool = IdlePool::new(pool_config(2));
 
-        let _ = pool.park("s1".into(), make_entry(2, 2048));
-        let _ = pool.park("s2".into(), make_entry(2, 2048));
+        let _ = pool.park(make_candidate_for("s1", 2, 2048));
+        let _ = pool.park(make_candidate_for("s2", 2, 2048));
 
         // Third session should fail
-        let result = pool.park("s3".into(), make_entry(2, 2048));
-        assert!(matches!(result, ParkResult::PoolFull(_)));
+        let result = pool.park(make_candidate_for("s3", 2, 2048));
+        assert!(matches!(result, ParkResult::Rejected(_)));
         assert_eq!(pool.len(), 2);
 
         // But replacing existing session should work
-        let result = pool.park("s1".into(), make_entry(4, 4096));
-        assert!(matches!(result, ParkResult::Evicted(_)));
+        let result = pool.park(make_candidate_for("s1", 4, 4096));
+        assert!(matches!(result, ParkResult::Replaced(_)));
         assert_eq!(pool.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn rejected_park_candidate_returns_active_owned_lease() {
+        let mut pool = IdlePool::new(pool_config(1));
+        let _ = pool.park(make_candidate_for("existing", 2, 2048));
+
+        let rejected_budget = Arc::new(ResourceBudget::new(2, 2048, 1.0, 0));
+        let rejected_lease = ResourceBudget::try_reserve_lease(&rejected_budget, 2, 2048).unwrap();
+        let result = pool.park(make_candidate_for_with_lease("rejected", rejected_lease));
+
+        let ParkResult::Rejected(rejected) = result else {
+            panic!("expected rejected park candidate");
+        };
+        assert_eq!(
+            rejected_budget.allocated().2,
+            1,
+            "rejected candidate must retain active job lease"
+        );
+
+        let (payload, lease) = rejected.into_active_destroy_parts();
+        assert_eq!(
+            rejected_budget.allocated().2,
+            1,
+            "splitting physical destroy from lease must keep active capacity"
+        );
+        payload.stop_and_destroy().await;
+        drop(lease);
+        assert_eq!(rejected_budget.allocated().2, 0);
     }
 
     #[test]
@@ -562,19 +849,20 @@ mod tests {
         let now = Instant::now();
 
         // Entry expired 10s ago
-        let _ = pool.park(
-            "expired".into(),
-            make_entry_with_park_time(
-                2,
-                2048,
-                now - Duration::from_secs(310),
-                Duration::from_secs(300),
-            ),
+        let _ = park_at(
+            &mut pool,
+            "expired",
+            make_candidate_for("expired", 2, 2048),
+            now - Duration::from_secs(310),
+            Duration::from_secs(300),
         );
         // Entry still fresh
-        let _ = pool.park(
-            "fresh".into(),
-            make_entry_with_park_time(2, 2048, now, Duration::from_secs(300)),
+        let _ = park_at(
+            &mut pool,
+            "fresh",
+            make_candidate_for("fresh", 2, 2048),
+            now,
+            Duration::from_secs(300),
         );
 
         let evicted = pool.evict_expired();
@@ -588,22 +876,23 @@ mod tests {
         let mut pool = IdlePool::new(pool_config(0));
         let now = Instant::now();
 
-        let _ = pool.park(
-            "old".into(),
-            make_entry_with_park_time(
-                2,
-                2048,
-                now - Duration::from_secs(100),
-                Duration::from_secs(300),
-            ),
+        let _ = park_at(
+            &mut pool,
+            "old",
+            make_candidate_for("old", 2, 2048),
+            now - Duration::from_secs(100),
+            Duration::from_secs(300),
         );
-        let _ = pool.park(
-            "new".into(),
-            make_entry_with_park_time(4, 4096, now, Duration::from_secs(300)),
+        let _ = park_at(
+            &mut pool,
+            "new",
+            make_candidate_for("new", 4, 4096),
+            now,
+            Duration::from_secs(300),
         );
 
         let evicted = pool.evict_oldest().unwrap();
-        assert_eq!(evicted.budget_lease.vcpu(), 2); // the old one
+        assert_eq!(evicted.budget_vcpu(), 2); // the old one
         assert_eq!(pool.len(), 1);
         assert!(pool.take("new").is_some());
     }
@@ -617,8 +906,8 @@ mod tests {
     #[test]
     fn held_sessions() {
         let mut pool = IdlePool::new(pool_config(0));
-        let _ = pool.park("s1".into(), make_entry(2, 2048));
-        let _ = pool.park("s2".into(), make_entry(2, 2048));
+        let _ = pool.park(make_candidate_for("s1", 2, 2048));
+        let _ = pool.park(make_candidate_for("s2", 2, 2048));
 
         let sessions = pool.held_sessions();
         assert_eq!(sessions, vec!["s1", "s2"]);
@@ -628,12 +917,12 @@ mod tests {
     fn held_snapshot_pairs_and_sorts() {
         // Park in reverse order to ensure sort kicks in.
         let mut pool = IdlePool::new(pool_config(0));
-        let entry_b = make_entry(2, 2048);
+        let entry_b = make_candidate_for("sess-b", 2, 2048);
         let sid_b = entry_b.sandbox_id;
-        let entry_a = make_entry(2, 2048);
+        let entry_a = make_candidate_for("sess-a", 2, 2048);
         let sid_a = entry_a.sandbox_id;
-        let _ = pool.park("sess-b".into(), entry_b);
-        let _ = pool.park("sess-a".into(), entry_a);
+        let _ = pool.park(entry_b);
+        let _ = pool.park(entry_a);
 
         let vms = pool.held_snapshot();
         assert_eq!(vms.len(), 2);
@@ -654,7 +943,7 @@ mod tests {
         let mut pool = IdlePool::new(pool_config(0));
         assert_eq!(pool.status_snapshot().revision, 0);
 
-        let _ = pool.park("s1".into(), make_entry(2, 2048));
+        let _ = pool.park(make_candidate_for("s1", 2, 2048));
         assert_eq!(pool.status_snapshot().revision, 1);
 
         assert!(pool.take("s1").is_some());
@@ -668,7 +957,7 @@ mod tests {
             "empty drain must not create a fake idle_vms mutation",
         );
 
-        let _ = pool.park("s2".into(), make_entry(2, 2048));
+        let _ = pool.park(make_candidate_for("s2", 2, 2048));
         assert_eq!(pool.status_snapshot().revision, 3);
 
         let drained = pool.drain();
@@ -679,8 +968,8 @@ mod tests {
     #[test]
     fn drain() {
         let mut pool = IdlePool::new(pool_config(0));
-        let _ = pool.park("s1".into(), make_entry(2, 2048));
-        let _ = pool.park("s2".into(), make_entry(4, 4096));
+        let _ = pool.park(make_candidate_for("s1", 2, 2048));
+        let _ = pool.park(make_candidate_for("s2", 4, 4096));
 
         let drained = pool.drain();
         assert_eq!(drained.len(), 2);
@@ -692,12 +981,12 @@ mod tests {
     fn park_rejected_while_soft_draining() {
         let mut pool = IdlePool::new(pool_config(0));
         let gate = pool.parking_gate();
-        let _ = pool.park("s1".into(), make_entry(2, 2048));
+        let _ = pool.park(make_candidate_for("s1", 2, 2048));
         gate.soft_drain();
         assert_eq!(pool.parking_state(), ParkingState::SoftDraining);
 
-        let result = pool.park("s2".into(), make_entry(4, 4096));
-        assert!(matches!(result, ParkResult::PoolFull(_)));
+        let result = pool.park(make_candidate_for("s2", 4, 4096));
+        assert!(matches!(result, ParkResult::Rejected(_)));
         assert_eq!(pool.len(), 1);
     }
 
@@ -707,8 +996,8 @@ mod tests {
         let gate = pool.parking_gate();
         gate.close();
 
-        let result = pool.park("s1".into(), make_entry(2, 2048));
-        assert!(matches!(result, ParkResult::PoolFull(_)));
+        let result = pool.park(make_candidate_for("s1", 2, 2048));
+        assert!(matches!(result, ParkResult::Rejected(_)));
         assert_eq!(pool.len(), 0);
     }
 
@@ -718,12 +1007,12 @@ mod tests {
         let gate = pool.parking_gate();
         gate.soft_drain();
         assert!(matches!(
-            pool.park("s1".into(), make_entry(2, 2048)),
-            ParkResult::PoolFull(_)
+            pool.park(make_candidate_for("s1", 2, 2048)),
+            ParkResult::Rejected(_)
         ));
 
         gate.open_after_soft_drain();
-        let result = pool.park("s1".into(), make_entry(2, 2048));
+        let result = pool.park(make_candidate_for("s1", 2, 2048));
         assert!(matches!(result, ParkResult::Parked));
         assert_eq!(pool.len(), 1);
     }
@@ -732,9 +1021,12 @@ mod tests {
     fn evict_expired_none_expired() {
         let mut pool = IdlePool::new(pool_config(0));
         let now = Instant::now();
-        let _ = pool.park(
-            "fresh".into(),
-            make_entry_with_park_time(2, 2048, now, Duration::from_secs(300)),
+        let _ = park_at(
+            &mut pool,
+            "fresh",
+            make_candidate_for("fresh", 2, 2048),
+            now,
+            Duration::from_secs(300),
         );
         let evicted = pool.evict_expired();
         assert!(evicted.is_empty());
@@ -754,23 +1046,19 @@ mod tests {
         let mut pool = IdlePool::new(pool_config(0));
         let now = Instant::now();
 
-        let _ = pool.park(
-            "s1".into(),
-            make_entry_with_park_time(
-                2,
-                2048,
-                now - Duration::from_secs(400),
-                Duration::from_secs(300),
-            ),
+        let _ = park_at(
+            &mut pool,
+            "s1",
+            make_candidate_for("s1", 2, 2048),
+            now - Duration::from_secs(400),
+            Duration::from_secs(300),
         );
-        let _ = pool.park(
-            "s2".into(),
-            make_entry_with_park_time(
-                4,
-                4096,
-                now - Duration::from_secs(310),
-                Duration::from_secs(300),
-            ),
+        let _ = park_at(
+            &mut pool,
+            "s2",
+            make_candidate_for("s2", 4, 4096),
+            now - Duration::from_secs(310),
+            Duration::from_secs(300),
         );
         assert_eq!(pool.len(), 2);
 
@@ -785,29 +1073,25 @@ mod tests {
         let now = Instant::now();
 
         // Short timeout (60s), parked 70s ago → expired
-        let _ = pool.park(
-            "short".into(),
-            make_entry_with_park_time(
-                2,
-                2048,
-                now - Duration::from_secs(70),
-                Duration::from_secs(60),
-            ),
+        let _ = park_at(
+            &mut pool,
+            "short",
+            make_candidate_for("short", 2, 2048),
+            now - Duration::from_secs(70),
+            Duration::from_secs(60),
         );
         // Long timeout (300s), parked 70s ago → NOT expired
-        let _ = pool.park(
-            "long".into(),
-            make_entry_with_park_time(
-                4,
-                4096,
-                now - Duration::from_secs(70),
-                Duration::from_secs(300),
-            ),
+        let _ = park_at(
+            &mut pool,
+            "long",
+            make_candidate_for("long", 4, 4096),
+            now - Duration::from_secs(70),
+            Duration::from_secs(300),
         );
 
         let evicted = pool.evict_expired();
         assert_eq!(evicted.len(), 1);
-        assert_eq!(evicted[0].budget_lease.vcpu(), 2); // only the short-timeout entry
+        assert_eq!(evicted[0].budget_vcpu(), 2); // only the short-timeout entry
         assert_eq!(pool.len(), 1);
         assert!(pool.take("long").is_some());
     }
@@ -816,19 +1100,19 @@ mod tests {
     fn park_max_idle_one() {
         let mut pool = IdlePool::new(pool_config(1));
 
-        let result = pool.park("s1".into(), make_entry(2, 2048));
+        let result = pool.park(make_candidate_for("s1", 2, 2048));
         assert!(matches!(result, ParkResult::Parked));
 
         // Second different session rejected
-        let result = pool.park("s2".into(), make_entry(4, 4096));
-        assert!(matches!(result, ParkResult::PoolFull(_)));
+        let result = pool.park(make_candidate_for("s2", 4, 4096));
+        assert!(matches!(result, ParkResult::Rejected(_)));
         assert_eq!(pool.len(), 1);
 
         // Same session replacement still works
-        let result = pool.park("s1".into(), make_entry(8, 8192));
-        assert!(matches!(result, ParkResult::Evicted(_)));
+        let result = pool.park(make_candidate_for("s1", 8, 8192));
+        assert!(matches!(result, ParkResult::Replaced(_)));
         assert_eq!(pool.len(), 1);
         let entry = pool.take("s1").unwrap();
-        assert_eq!(entry.budget_lease.vcpu(), 8);
+        assert_eq!(entry.budget_vcpu(), 8);
     }
 }

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -689,7 +689,7 @@ pub enum ParkResult {
     Parked,
     /// Successfully parked; the returned job destroys the replaced idle VM.
     Replaced(IdleDestroyJob),
-    /// Pool is at max capacity or disabled; the entry could not be parked.
+    /// Parking is closed/soft-draining or at capacity; the entry could not be parked.
     Rejected(RejectedParkCandidate),
 }
 

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -7,8 +7,8 @@
 //!
 //! For advanced control, create [`MockSandboxOverrides`] and pass it via
 //! [`MockSandboxRuntime::with_overrides`]. This enables pattern-matched exec
-//! results, custom `wait_exit` exit codes, and blocking gates for
-//! cancellation testing.
+//! results, custom `wait_exit` exit codes, and blocking gates for lifecycle
+//! and cancellation testing.
 //!
 //! ```toml
 //! [dev-dependencies]
@@ -61,6 +61,12 @@ enum LifecycleBehavior {
     Panic(String),
 }
 
+#[derive(Clone)]
+struct BlockingGate {
+    entered: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+}
+
 /// Shared behavior overrides propagated from runtime → factory → sandbox.
 ///
 /// Tests create this via [`MockSandboxRuntime::with_overrides`] so every
@@ -88,9 +94,14 @@ pub struct MockSandboxOverrides {
     /// FIFO queue of park results consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
     park_behaviors: Mutex<VecDeque<LifecycleBehavior>>,
+    /// When set, `park` notifies `entered` and then blocks until `release`.
+    park_gate: Mutex<Option<BlockingGate>>,
     /// FIFO queue of unpark results consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
     unpark_behaviors: Mutex<VecDeque<LifecycleBehavior>>,
+    /// When set, factory `destroy` notifies `entered` and then blocks until
+    /// `release`.
+    destroy_gate: Mutex<Option<BlockingGate>>,
     /// Recorded spawn_watch output modes across all sandboxes built from
     /// this override set.
     spawn_watch_calls: Mutex<Vec<SpawnWatchCall>>,
@@ -98,6 +109,9 @@ pub struct MockSandboxOverrides {
     park_calls: Mutex<u32>,
     /// Total `unpark()` calls across all sandboxes built from this override set.
     unpark_calls: Mutex<u32>,
+    /// Total factory `destroy()` calls across all factories built from this
+    /// override set.
+    destroy_calls: Mutex<u32>,
 }
 
 impl MockSandboxOverrides {
@@ -110,10 +124,13 @@ impl MockSandboxOverrides {
             start_results: Mutex::new(VecDeque::new()),
             stop_behaviors: Mutex::new(VecDeque::new()),
             park_behaviors: Mutex::new(VecDeque::new()),
+            park_gate: Mutex::new(None),
             unpark_behaviors: Mutex::new(VecDeque::new()),
+            destroy_gate: Mutex::new(None),
             spawn_watch_calls: Mutex::new(Vec::new()),
             park_calls: Mutex::new(0),
             unpark_calls: Mutex::new(0),
+            destroy_calls: Mutex::new(0),
         }
     }
 
@@ -186,6 +203,16 @@ impl MockSandboxOverrides {
             .push_back(LifecycleBehavior::Panic(message.into()));
     }
 
+    /// Block every `park()` call after recording entry until `release` is
+    /// notified. Used by tests to open deterministic race windows.
+    pub fn set_park_gate(
+        &self,
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    ) {
+        *self.park_gate.lock_ignoring_poison() = Some(BlockingGate { entered, release });
+    }
+
     /// Queue an `unpark()` result applied to the next factory-created sandbox.
     /// Consumed FIFO across all sandboxes; empty queue → default Ok(()).
     pub fn push_unpark_result(&self, result: Result<()>) {
@@ -202,6 +229,16 @@ impl MockSandboxOverrides {
             .push_back(LifecycleBehavior::Panic(message.into()));
     }
 
+    /// Block every factory `destroy()` call after recording entry until
+    /// `release` is notified.
+    pub fn set_destroy_gate(
+        &self,
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    ) {
+        *self.destroy_gate.lock_ignoring_poison() = Some(BlockingGate { entered, release });
+    }
+
     /// Total `park()` calls across all sandboxes built from this override set.
     pub fn park_call_count(&self) -> u32 {
         *self.park_calls.lock_ignoring_poison()
@@ -212,10 +249,24 @@ impl MockSandboxOverrides {
         *self.unpark_calls.lock_ignoring_poison()
     }
 
+    /// Total factory `destroy()` calls across all factories built from this
+    /// override set.
+    pub fn destroy_call_count(&self) -> u32 {
+        *self.destroy_calls.lock_ignoring_poison()
+    }
+
     /// Recorded spawn_watch calls across all sandboxes built from this
     /// override set, in call order.
     pub fn spawn_watch_calls(&self) -> Vec<SpawnWatchCall> {
         self.spawn_watch_calls.lock_ignoring_poison().clone()
+    }
+}
+
+async fn wait_blocking_gate(gate: &Mutex<Option<BlockingGate>>) {
+    let gate = gate.lock_ignoring_poison().clone();
+    if let Some(gate) = gate {
+        gate.entered.notify_waiters();
+        gate.release.notified().await;
     }
 }
 
@@ -343,6 +394,7 @@ impl Sandbox for MockSandbox {
             return Ok(());
         };
         *o.park_calls.lock_ignoring_poison() += 1;
+        wait_blocking_gate(&o.park_gate).await;
         match o.park_behaviors.lock_ignoring_poison().pop_front() {
             Some(LifecycleBehavior::Result(result)) => result,
             #[allow(clippy::panic)]
@@ -527,7 +579,12 @@ impl SandboxFactory for MockSandboxFactory {
         Ok(Box::new(sandbox))
     }
 
-    async fn destroy(&self, _sandbox: Box<dyn Sandbox>) {}
+    async fn destroy(&self, _sandbox: Box<dyn Sandbox>) {
+        if let Some(o) = &self.overrides {
+            *o.destroy_calls.lock_ignoring_poison() += 1;
+            wait_blocking_gate(&o.destroy_gate).await;
+        }
+    }
 
     async fn shutdown(&mut self) {}
 }


### PR DESCRIPTION
## Summary

- Encapsulate idle VM ownership with `ParkCandidate`, `IdleEntry`, `RejectedParkCandidate`, and `IdleDestroyJob`.
- Move idle unpark and destroy transitions behind consuming APIs so sandbox and budget lease ownership remain explicit.
- Update runner reuse, rejection, eviction, drain, and tests to use the new lifecycle types.

## Verification

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `git diff --check`

Closes #11293
