### PR TITLE
fix: prevent builds-complete from skipping when build jobs are skipped

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -424,11 +424,13 @@ jobs:
       - build-e2b-template-production
       - sbom
       - resolve-image-cache
-    # Intentionally uses only !cancelled() (not !failure()) so this job runs even
-    # when upstream build jobs fail. The jq step below performs the actual failure
-    # check and exits 1, making the barrier explicit. Adding !failure() here would
-    # cause this job to be skipped on build failure, hiding the reason for the block.
-    if: ${{ !cancelled() && needs.release-please.outputs.releases_created == 'true' }}
+    # Use always() so this job runs even when upstream build jobs are skipped.
+    # !cancelled() is insufficient — it still propagates "skipped" from needs
+    # dependencies, which causes builds-complete (and transitively
+    # migrate-production) to be skipped whenever any build job is skipped.
+    # The jq step below performs the actual failure check and exits 1, making
+    # the barrier explicit.
+    if: ${{ always() && needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Verify no build failed


### PR DESCRIPTION
## Summary
- `builds-complete` used `!cancelled()` which still propagates "skipped" status from `needs` dependencies
- When any build job was skipped (e.g. no web release), `builds-complete` was skipped → `migrate-production` was skipped
- No migrations have run since April 26 because of this

## Fix
- Changed `!cancelled()` to `always()` so the job always runs when `releases_created == 'true'`
- The jq step already correctly distinguishes "skipped" (acceptable) from "failure" (blocking)

## Risk
- Low — only affects the `if` condition of `builds-complete`
- `!cancelled()` → `always()` is a well-understood GitHub Actions pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)