### PR TITLE
fix(runner): drain network log writes before upload

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -513,8 +513,9 @@ def response(flow: http.HTTPFlow) -> None:
         host = flow.request.pretty_host
         port = flow.request.port
 
-    # Log network entry for this run (always MITM mode with full HTTP details)
-    # [NETWORK_LOG_FIELDS] — source of truth for network log fields
+    # Log HTTP network entry for this run. DNS/kmsg rows are produced by the
+    # Rust runner; api-contracts is the shared network-log schema boundary.
+    # [NETWORK_LOG_FIELDS]
     network_log_path = flow.metadata.get("vm_network_log_path", "")
     proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
     if network_log_path:
@@ -620,7 +621,7 @@ def error(flow: http.HTTPFlow) -> None:
     request_size = len(flow.request.raw_content or b"")
     error_msg = flow.error.msg if flow.error else "unknown error"
 
-    # [NETWORK_LOG_FIELDS] — keep in sync with response() and runs.ts schema
+    # [NETWORK_LOG_FIELDS] — HTTP error fields; api-contracts is the shared schema boundary.
     log_entry: dict = {
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()),
         "type": "http",
@@ -727,7 +728,7 @@ def _log_tcp(flow: tcp.TCPFlow) -> None:
     host = server_addr[0] if server_addr else "unknown"
     port = server_addr[1] if server_addr else 0
 
-    # [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
+    # [NETWORK_LOG_FIELDS] — TCP fields; api-contracts is the shared schema boundary.
     log_entry = {
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()),
         "type": "tcp",

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -26,6 +26,7 @@ use crate::idle_pool::{
 };
 use crate::kmsg_log;
 use crate::lock;
+use crate::network_log_manager::NetworkLogManager;
 use crate::network_logs;
 use crate::paths::{HomePaths, LogPaths, RunnerPaths, touch_mtime};
 use crate::prefetch;
@@ -220,14 +221,14 @@ pub async fn run_start(
 
     let registry_handle = mitm.registry_handle();
 
-    // Start background kmsg monitor for non-TCP traffic logging.
-    let ip_log_map = kmsg_log::new_ip_log_map();
-    let kmsg_handle = kmsg_log::spawn(ip_log_map.clone())
+    // Start background DNS/kmsg monitors for Rust-side network logging.
+    let network_log_manager = NetworkLogManager::new();
+    let kmsg_handle = kmsg_log::spawn(network_log_manager.clone())
         .map_err(|e| RunnerError::Internal(format!("kmsg monitor: {e}")))?;
 
     // Start DNS proxy (dnsmasq) for domain-level DNS interception and logging.
-    // Shares ip_log_map with kmsg — both use source IP (peer veth) as key.
-    let dns_handle = dns::start(ip_log_map.clone())
+    // Shares NetworkLogManager with kmsg — both use source IP (peer veth) as key.
+    let dns_handle = dns::start(network_log_manager.clone())
         .await
         .map_err(|e| RunnerError::Internal(format!("dns proxy: {e}")))?;
 
@@ -335,7 +336,7 @@ pub async fn run_start(
         registry: registry_handle,
         http,
         log_paths,
-        ip_log_map,
+        network_log_manager,
         home: home.clone(),
     });
 
@@ -1132,9 +1133,9 @@ fn spawn_job(
 
     // Captured for the post-complete deferred work below: the panic-arm
     // empty `JobTelemetry` construction, the final `telemetry.flush()`, and
-    // the mitm `upload_network_logs()` POST. `context` gets moved into the
-    // inner executor task and `exec_config` with it, so we snapshot the
-    // token and bump the Arc before spawning.
+    // the network-log upload. `context` gets moved into the inner executor
+    // task and `exec_config` with it, so we snapshot the token and bump the
+    // Arc before spawning.
     let sandbox_token = context.sandbox_token.clone();
     let exec_config_for_deferred = Arc::clone(&exec_config);
 
@@ -1381,18 +1382,26 @@ fn spawn_job(
         // user-visible run-complete signal isn't blocked on these uploads.
         // They're still awaited (not spawned) so the surrounding `jobs`
         // JoinSet drains them on graceful shutdown — no data loss on SIGTERM.
-        // Flush and upload run concurrently — they share no state and both
-        // target the telemetry endpoint, so parallelism shortens the drain
-        // window (~383 ms + ~1.6 s → ~1.6 s).
+        // Telemetry flush runs concurrently with network-log drain + upload.
+        // Network-log upload must wait for accepted Rust-side DNS/kmsg writes
+        // before reading the per-run JSONL snapshot.
         let network_log_path = exec_config_for_deferred.log_paths.network_log(run_id);
-        tokio::join!(
-            telemetry.flush(),
+        let network_log_upload = async {
+            exec_config_for_deferred
+                .network_log_manager
+                .flush_path(&network_log_path)
+                .await;
             network_logs::upload_network_logs(
                 &exec_config_for_deferred.http,
                 run_id,
                 &sandbox_token,
                 &network_log_path,
-            ),
+            )
+            .await;
+        };
+        tokio::join!(
+            telemetry.flush(),
+            network_log_upload,
         );
 
         Some(run_id)
@@ -2265,7 +2274,7 @@ mod tests {
                 registry,
                 http: crate::http::HttpClient::new(api_url.to_string()).unwrap(),
                 log_paths: crate::paths::LogPaths::new(log_dir),
-                ip_log_map: kmsg_log::new_ip_log_map(),
+                network_log_manager: NetworkLogManager::new(),
                 home,
             }),
             firecracker: config::FirecrackerConfig {
@@ -2435,9 +2444,11 @@ mod tests {
         const MOCK_DELAY: Duration = Duration::from_millis(400);
 
         let server = MockServer::start_async().await;
-        let telemetry_mock = server
+        let network_log_mock = server
             .mock_async(|when, then| {
-                when.method(POST).path("/api/webhooks/agent/telemetry");
+                when.method(POST)
+                    .path("/api/webhooks/agent/telemetry")
+                    .body_includes("networkLogs");
                 then.delay(MOCK_DELAY)
                     .status(200)
                     .header("content-type", "application/json")
@@ -2445,8 +2456,15 @@ mod tests {
             })
             .await;
 
-        let (config, env) =
+        let (mut config, env) =
             mock_run_config_with_api_url(test_profiles(), 8, 32768, 4, &server.base_url());
+        let write_started = Arc::new(tokio::sync::Notify::new());
+        let release_write = Arc::new(tokio::sync::Notify::new());
+        let network_log_manager =
+            NetworkLogManager::new_with_write_gate(write_started.clone(), release_write.clone());
+        Arc::get_mut(&mut config.exec_config)
+            .expect("test config should not share exec_config before run starts")
+            .network_log_manager = network_log_manager.clone();
 
         // Seed a network log file so `upload_network_logs` has a payload to POST
         // (otherwise it early-returns on NotFound and the assertion below would
@@ -2456,9 +2474,29 @@ mod tests {
         std::fs::create_dir_all(network_log_path.parent().unwrap()).unwrap();
         std::fs::write(
             &network_log_path,
-            r#"{"timestamp":"2026-01-01T00:00:00","action":"ALLOW","host":"example.com","method":"GET","url":"https://example.com/","status":200}"#,
+            concat!(
+                r#"{"timestamp":"2026-01-01T00:00:00","action":"ALLOW","host":"example.com","method":"GET","url":"https://example.com/","status":200}"#,
+                "\n",
+            ),
         )
         .unwrap();
+        network_log_manager
+            .register_source_ip("10.200.0.200", network_log_path.clone())
+            .await;
+        assert!(
+            network_log_manager
+                .append_for_ip(
+                    "10.200.0.200",
+                    serde_json::json!({
+                        "timestamp": "2026-01-01T00:00:01Z",
+                        "type": "dns",
+                        "host": "pending.example",
+                        "port": 53,
+                    }),
+                )
+                .await
+        );
+        write_started.notified().await;
 
         let run_handle = tokio::spawn(run(config));
         push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
@@ -2468,6 +2506,7 @@ mod tests {
             .wait_completion(run_id, Duration::from_secs(5))
             .await;
         assert!(completion.is_some(), "job should complete");
+        release_write.notify_one();
 
         // Drain shutdown — must block on each `spawn_job` closure's deferred
         // `tokio::join!(flush, upload)` via the outer `jobs` JoinSet.
@@ -2475,14 +2514,7 @@ mod tests {
         shutdown(&env, run_handle).await;
         let shutdown_elapsed = shutdown_start.elapsed();
 
-        // At least one POST: the mitm network-log upload (and likely a second
-        // for sandbox-op telemetry like `vm_create`). The endpoint must have
-        // been hit — a fire-and-forget refactor that dropped the await on
-        // runtime shutdown would fail this.
-        assert!(
-            telemetry_mock.calls_async().await >= 1,
-            "telemetry endpoint should receive deferred post-complete upload"
-        );
+        network_log_mock.assert_calls_async(1).await;
 
         // Stronger invariant: drain must actually WAIT for the deferred work.
         // With a 400 ms mock delay, a well-behaved drain takes ≥ the delay;

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -2459,7 +2459,7 @@ mod tests {
         let (mut config, env) =
             mock_run_config_with_api_url(test_profiles(), 8, 32768, 4, &server.base_url());
         let write_started = Arc::new(tokio::sync::Notify::new());
-        let release_write = Arc::new(tokio::sync::Notify::new());
+        let release_write = Arc::new(tokio::sync::Semaphore::new(0));
         let network_log_manager =
             NetworkLogManager::new_with_write_gate(write_started.clone(), release_write.clone());
         Arc::get_mut(&mut config.exec_config)
@@ -2506,7 +2506,7 @@ mod tests {
             .wait_completion(run_id, Duration::from_secs(5))
             .await;
         assert!(completion.is_some(), "job should complete");
-        release_write.notify_one();
+        release_write.add_permits(1);
 
         // Drain shutdown — must block on each `spawn_job` closure's deferred
         // `tokio::join!(flush, upload)` via the outer `jobs` JoinSet.

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -2448,7 +2448,7 @@ mod tests {
             .mock_async(|when, then| {
                 when.method(POST)
                     .path("/api/webhooks/agent/telemetry")
-                    .body_includes("networkLogs");
+                    .body_includes("pending.example");
                 then.delay(MOCK_DELAY)
                     .status(200)
                     .header("content-type", "application/json")

--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -13,17 +13,16 @@
 //! subnet and redirects to dnsmasq before the packet reaches FORWARD/POSTROUTING.
 //!
 //! Log format: dnsmasq `--log-queries` outputs to stderr, parsed by a background
-//! async task that writes per-VM network JSONL entries (same pattern as kmsg_log).
+//! async task that submits per-VM network JSON rows through `NetworkLogManager`.
 
-use std::path::Path;
 use std::process::Stdio;
 
 use chrono::{DateTime, Utc};
 use tokio::io::AsyncBufReadExt;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
-use crate::kmsg_log::IpLogMap;
+use crate::network_log_manager::NetworkLogManager;
 
 /// Handle to the dnsmasq process and its log monitor.
 pub struct DnsProxy {
@@ -93,7 +92,7 @@ fn find_available_port() -> std::io::Result<u16> {
 ///
 /// dnsmasq listens on a dynamically allocated port and forwards to upstream DNS.
 /// Retries up to 3 times with a fresh port if the initial bind fails (TOCTOU race).
-pub async fn start(ip_log_map: IpLogMap) -> std::io::Result<DnsProxy> {
+pub async fn start(network_log_manager: NetworkLogManager) -> std::io::Result<DnsProxy> {
     const MAX_ATTEMPTS: u32 = 3;
     let mut last_err = None;
     for attempt in 1..=MAX_ATTEMPTS {
@@ -105,7 +104,7 @@ pub async fn start(ip_log_map: IpLogMap) -> std::io::Result<DnsProxy> {
                 continue;
             }
         };
-        match try_start(port, &ip_log_map).await {
+        match try_start(port, network_log_manager.clone()).await {
             Ok(proxy) => return Ok(proxy),
             Err(e) => {
                 if attempt < MAX_ATTEMPTS {
@@ -121,7 +120,7 @@ pub async fn start(ip_log_map: IpLogMap) -> std::io::Result<DnsProxy> {
 }
 
 /// Try to start dnsmasq on the given port. Returns the proxy handle on success.
-async fn try_start(port: u16, ip_log_map: &IpLogMap) -> std::io::Result<DnsProxy> {
+async fn try_start(port: u16, network_log_manager: NetworkLogManager) -> std::io::Result<DnsProxy> {
     let port_str = port.to_string();
 
     let mut child = tokio::process::Command::new("dnsmasq")
@@ -167,9 +166,8 @@ async fn try_start(port: u16, ip_log_map: &IpLogMap) -> std::io::Result<DnsProxy
 
     let cancel = CancellationToken::new();
     let token = cancel.clone();
-    let ip_log_map = ip_log_map.clone();
     let task = tokio::spawn(async move {
-        if let Err(e) = tail_stderr(stderr, &ip_log_map, token).await {
+        if let Err(e) = tail_stderr(stderr, network_log_manager, token).await {
             warn!(error = %e, "dns log monitor exited");
         }
     });
@@ -195,7 +193,7 @@ async fn try_start(port: u16, ip_log_map: &IpLogMap) -> std::io::Result<DnsProxy
 /// We only parse `query[...]` lines — they contain the domain and source IP.
 async fn tail_stderr(
     stderr: tokio::process::ChildStderr,
-    ip_log_map: &IpLogMap,
+    network_log_manager: NetworkLogManager,
     cancel: CancellationToken,
 ) -> std::io::Result<()> {
     let mut lines = tokio::io::BufReader::new(stderr).lines();
@@ -218,19 +216,10 @@ async fn tail_stderr(
                 };
 
                 if let Some(entry) = parse_query_line(&line) {
-                    let log_path = {
-                        let map = ip_log_map.lock().await;
-                        map.get(&entry.source_ip).cloned()
-                    };
-                    if let Some(path) = log_path {
-                        // Move the blocking file I/O off the tokio worker thread.
-                        // Capture the timestamp *before* the spawn so it reflects
-                        // query time, not write time (which may lag under load).
-                        let timestamp = Utc::now();
-                        tokio::task::spawn_blocking(move || {
-                            write_jsonl(&path, &entry, timestamp);
-                        });
-                    }
+                    // Capture the timestamp before handing the row to the manager so
+                    // it reflects query time, not delayed write time.
+                    let timestamp = Utc::now();
+                    append_query_entry(&network_log_manager, &entry, timestamp).await;
                 }
             }
         }
@@ -274,36 +263,24 @@ fn parse_query_line(line: &str) -> Option<DnsQueryEntry> {
     Some(DnsQueryEntry { source_ip, domain })
 }
 
-/// Append a JSON line to the network log file.
-///
-/// `timestamp` is captured by the caller (on the tokio worker) so the recorded
-/// time reflects when the DNS query was observed, not when this function —
-/// which runs on a tokio blocking thread — finally executes.
-fn write_jsonl(path: &Path, entry: &DnsQueryEntry, timestamp: DateTime<Utc>) {
-    use std::io::Write;
-    use std::os::unix::fs::OpenOptionsExt;
+async fn append_query_entry(
+    network_log_manager: &NetworkLogManager,
+    entry: &DnsQueryEntry,
+    timestamp: DateTime<Utc>,
+) -> bool {
+    network_log_manager
+        .append_for_ip(&entry.source_ip, network_log_row(entry, timestamp))
+        .await
+}
 
-    // [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
-    let json = serde_json::json!({
+fn network_log_row(entry: &DnsQueryEntry, timestamp: DateTime<Utc>) -> serde_json::Value {
+    // [NETWORK_LOG_FIELDS] — shared schema consumed by api-contracts.
+    serde_json::json!({
         "timestamp": timestamp.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
         "type": "dns",
         "host": entry.domain,
         "port": 53,
-    });
-
-    let mut line = serde_json::to_string(&json).unwrap_or_default();
-    line.push('\n');
-
-    let result = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .mode(0o644)
-        .open(path)
-        .and_then(|mut f| f.write_all(line.as_bytes()));
-
-    if let Err(e) = result {
-        debug!(path = %path.display(), error = %e, "failed to write dns network log");
-    }
+    })
 }
 
 #[cfg(test)]
@@ -391,13 +368,9 @@ mod tests {
     }
 
     #[test]
-    fn write_jsonl_serializes_provided_timestamp() {
-        // Locks the contract that `write_jsonl` must use the `timestamp`
-        // parameter rather than calling `Utc::now()` internally — the whole
-        // point of the parameter is to record observation time, not the
-        // delayed write time after spawn_blocking.
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("dns.jsonl");
+    fn network_log_row_serializes_provided_timestamp() {
+        // Locks the contract that row construction must use the provided
+        // timestamp rather than calling `Utc::now()` internally.
         let entry = DnsQueryEntry {
             source_ip: "10.200.0.2".to_string(),
             domain: "example.com".to_string(),
@@ -405,21 +378,22 @@ mod tests {
         let ts = DateTime::parse_from_rfc3339("2024-01-15T10:30:45.123Z")
             .unwrap()
             .with_timezone(&Utc);
-        write_jsonl(&path, &entry, ts);
-        let content = std::fs::read_to_string(&path).unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        let parsed = network_log_row(&entry, ts);
         assert_eq!(parsed["timestamp"], "2024-01-15T10:30:45.123Z");
     }
 
-    #[test]
-    fn write_jsonl_creates_file() {
+    #[tokio::test]
+    async fn append_query_entry_registered_source_writes_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("dns.jsonl");
+        let manager = NetworkLogManager::new();
+        manager.register_source_ip("10.200.0.2", path.clone()).await;
         let entry = DnsQueryEntry {
             source_ip: "10.200.0.2".to_string(),
             domain: "api.github.com".to_string(),
         };
-        write_jsonl(&path, &entry, Utc::now());
+        assert!(append_query_entry(&manager, &entry, Utc::now()).await);
+        manager.flush_path(&path).await;
         let content = std::fs::read_to_string(&path).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
         assert_eq!(parsed["type"], "dns");
@@ -428,27 +402,64 @@ mod tests {
         assert!(parsed["timestamp"].is_string());
     }
 
-    #[test]
-    fn write_jsonl_appends_multiple_entries() {
+    #[tokio::test]
+    async fn append_query_entry_appends_multiple_entries() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("dns.jsonl");
+        let manager = NetworkLogManager::new();
+        manager.register_source_ip("10.0.0.1", path.clone()).await;
         for domain in ["a.com", "b.com", "c.com"] {
-            write_jsonl(
-                &path,
-                &DnsQueryEntry {
-                    source_ip: "10.0.0.1".to_string(),
-                    domain: domain.to_string(),
-                },
-                Utc::now(),
+            assert!(
+                append_query_entry(
+                    &manager,
+                    &DnsQueryEntry {
+                        source_ip: "10.0.0.1".to_string(),
+                        domain: domain.to_string(),
+                    },
+                    Utc::now(),
+                )
+                .await
             );
         }
+        manager.flush_path(&path).await;
         let content = std::fs::read_to_string(&path).unwrap();
         let lines: Vec<&str> = content.lines().collect();
         assert_eq!(lines.len(), 3);
-        for (i, domain) in ["a.com", "b.com", "c.com"].iter().enumerate() {
-            let parsed: serde_json::Value = serde_json::from_str(lines[i]).unwrap();
-            assert_eq!(parsed["host"], *domain);
-        }
+        let hosts: std::collections::HashSet<String> = lines
+            .iter()
+            .map(|line| {
+                let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
+                parsed["host"].as_str().unwrap().to_string()
+            })
+            .collect();
+        assert_eq!(
+            hosts,
+            ["a.com", "b.com", "c.com"]
+                .into_iter()
+                .map(str::to_string)
+                .collect()
+        );
+    }
+
+    #[tokio::test]
+    async fn append_query_entry_without_mapping_is_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ignored.jsonl");
+        let manager = NetworkLogManager::new();
+
+        assert!(
+            !append_query_entry(
+                &manager,
+                &DnsQueryEntry {
+                    source_ip: "10.0.0.1".to_string(),
+                    domain: "ignored.test".to_string(),
+                },
+                Utc::now(),
+            )
+            .await
+        );
+        manager.flush_path(&path).await;
+        assert!(!path.exists());
     }
 
     #[test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -398,10 +398,10 @@ async fn unregister_proxy(config: &ExecutorConfig, context: &ExecutionContext, s
 /// Post-job cleanup: copy logs, unregister proxy.
 ///
 /// Called after `run_in_sandbox` completes, whether the sandbox will be
-/// parked (keep-alive) or destroyed. The mitmproxy network-log upload is
-/// deliberately **not** done here — `spawn_job` (in `cmd/start.rs`) runs
-/// it after `provider.complete` so the user-visible run-complete signal
-/// isn't blocked on the best-effort upload (~1.6 s saved per job).
+/// parked (keep-alive) or destroyed. The network-log upload is deliberately
+/// **not** done here — `spawn_job` (in `cmd/start.rs`) runs it after
+/// `provider.complete` so the user-visible run-complete signal isn't blocked
+/// on the best-effort upload (~1.6 s saved per job).
 async fn post_job_cleanup(
     sandbox: &dyn Sandbox,
     config: &ExecutorConfig,

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -21,7 +21,7 @@ const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
 use crate::idle_pool::ReusableIdleSandbox;
-use crate::kmsg_log;
+use crate::network_log_manager::NetworkLogManager;
 use crate::paths::{HomePaths, LogPaths, guest};
 use crate::proxy::{self, ProxyRegistryHandle};
 use crate::telemetry::JobTelemetry;
@@ -36,7 +36,7 @@ pub struct ExecutorConfig {
     pub registry: ProxyRegistryHandle,
     pub http: HttpClient,
     pub log_paths: LogPaths,
-    pub ip_log_map: kmsg_log::IpLogMap,
+    pub network_log_manager: NetworkLogManager,
     pub home: HomePaths,
 }
 
@@ -357,7 +357,7 @@ async fn execute_reused_sandbox(
     }
 }
 
-/// Register a VM in the proxy registry and IP log map.
+/// Register a VM in the proxy registry and network log manager.
 async fn register_proxy(config: &ExecutorConfig, context: &ExecutionContext, source_ip: &str) {
     let network_log_path = config.log_paths.network_log(context.run_id);
     let proxy_log_path = config.log_paths.proxy_log(context.run_id);
@@ -379,18 +379,20 @@ async fn register_proxy(config: &ExecutorConfig, context: &ExecutionContext, sou
         warn!(run_id = %context.run_id, error = %e, "failed to register VM in proxy");
     }
     config
-        .ip_log_map
-        .lock()
+        .network_log_manager
+        .register_source_ip(source_ip, network_log_path)
         .await
-        .insert(source_ip.to_string(), network_log_path);
 }
 
-/// Unregister a VM from the proxy registry and IP log map.
+/// Unregister a VM from the proxy registry and network log manager.
 async fn unregister_proxy(config: &ExecutorConfig, context: &ExecutionContext, source_ip: &str) {
     if let Err(e) = config.registry.unregister_vm(source_ip).await {
         warn!(run_id = %context.run_id, error = %e, "failed to unregister VM from proxy");
     }
-    config.ip_log_map.lock().await.remove(source_ip);
+    config
+        .network_log_manager
+        .unregister_source_ip(source_ip)
+        .await;
 }
 
 /// Post-job cleanup: copy logs, unregister proxy.
@@ -2518,7 +2520,7 @@ mod tests {
             registry: proxy::ProxyRegistryHandle::new(registry_path, lock_path),
             http: crate::http::HttpClient::new("http://localhost:9999".into()).unwrap(),
             log_paths: LogPaths::new(log_dir),
-            ip_log_map: kmsg_log::new_ip_log_map(),
+            network_log_manager: NetworkLogManager::new(),
             home: HomePaths::with_root(dir.to_path_buf()),
         }
     }

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -3,31 +3,20 @@
 //!
 //! The iptables rule added by `sandbox-fc` logs non-TCP packets with prefix
 //! `VM0:<peer_ip>:`. This module tails `dmesg -w`, parses those entries,
-//! looks up the network log path via an in-memory IP map, and appends a
-//! JSON line matching the format used by the mitmproxy addon.
+//! and submits JSON rows through `NetworkLogManager` for per-run attribution
+//! and flushable file writes.
 
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use tokio::io::AsyncBufReadExt;
-use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
+
+use crate::network_log_manager::NetworkLogManager;
 
 /// Prefix used in iptables `--log-prefix` to identify our log lines.
 const LOG_PREFIX: &str = "VM0:";
-
-/// Shared map from source IP → network log path, updated by executor on
-/// register/unregister.
-pub type IpLogMap = Arc<Mutex<HashMap<String, PathBuf>>>;
-
-/// Create a new empty IP-to-log-path map.
-pub fn new_ip_log_map() -> IpLogMap {
-    Arc::new(Mutex::new(HashMap::new()))
-}
 
 /// Handle to the background kmsg monitor. Call [`KmsgHandle::stop`] during
 /// shutdown to cancel the async task and kill the `dmesg -w` child process.
@@ -80,7 +69,7 @@ impl Drop for KmsgHandle {
 /// Spawn a background async task that tails `dmesg -w` and writes
 /// network log entries. Returns a handle; call [`KmsgHandle::stop`] during
 /// shutdown so the tokio runtime can exit cleanly.
-pub fn spawn(ip_log_map: IpLogMap) -> std::io::Result<KmsgHandle> {
+pub fn spawn(network_log_manager: NetworkLogManager) -> std::io::Result<KmsgHandle> {
     let mut child = tokio::process::Command::new("dmesg")
         .args(["-w"])
         .stdout(Stdio::piped())
@@ -119,7 +108,7 @@ pub fn spawn(ip_log_map: IpLogMap) -> std::io::Result<KmsgHandle> {
     }
 
     let task = tokio::spawn(async move {
-        run_loop(&ip_log_map, token, stdout).await;
+        run_loop(network_log_manager, token, stdout).await;
     });
     Ok(KmsgHandle {
         cancel,
@@ -131,7 +120,7 @@ pub fn spawn(ip_log_map: IpLogMap) -> std::io::Result<KmsgHandle> {
 /// Read kernel log lines from `dmesg -w` stdout, parse iptables LOG
 /// entries, and write matching entries to per-run network JSONL files.
 async fn run_loop(
-    ip_log_map: &IpLogMap,
+    network_log_manager: NetworkLogManager,
     cancel: CancellationToken,
     stdout: tokio::process::ChildStdout,
 ) {
@@ -151,19 +140,10 @@ async fn run_loop(
                 }
 
                 if let Some(entry) = parse_log_message(&line) {
-                    let log_path = {
-                        let map = ip_log_map.lock().await;
-                        map.get(&entry.source_ip).cloned()
-                    };
-                    if let Some(path) = log_path {
-                        // Move the blocking file I/O off the tokio worker thread.
-                        // Capture the timestamp *before* the spawn so it reflects
-                        // observation time, not write time (which may lag under load).
-                        let timestamp = Utc::now();
-                        tokio::task::spawn_blocking(move || {
-                            write_jsonl(&path, &entry, timestamp);
-                        });
-                    }
+                    // Capture the timestamp before handing the row to the manager so
+                    // it reflects observation time, not delayed write time.
+                    let timestamp = Utc::now();
+                    append_log_entry(&network_log_manager, &entry, timestamp).await;
                 }
             }
         }
@@ -232,37 +212,25 @@ fn extract_field<'a>(line: &'a str, key: &str) -> Option<&'a str> {
         .find_map(|tok| tok.strip_prefix(key))
 }
 
-/// Append a JSON line to the network log file.
-///
-/// `timestamp` is captured by the caller (on the tokio worker) so the recorded
-/// time reflects when the packet was observed, not when this function — which
-/// runs on a tokio blocking thread — finally executes.
-fn write_jsonl(path: &Path, entry: &LogEntry, timestamp: DateTime<Utc>) {
-    use std::io::Write;
-    use std::os::unix::fs::OpenOptionsExt;
+async fn append_log_entry(
+    network_log_manager: &NetworkLogManager,
+    entry: &LogEntry,
+    timestamp: DateTime<Utc>,
+) -> bool {
+    network_log_manager
+        .append_for_ip(&entry.source_ip, network_log_row(entry, timestamp))
+        .await
+}
 
-    // [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
-    let json = serde_json::json!({
+fn network_log_row(entry: &LogEntry, timestamp: DateTime<Utc>) -> serde_json::Value {
+    // [NETWORK_LOG_FIELDS] — shared schema consumed by api-contracts.
+    serde_json::json!({
         "timestamp": timestamp.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
         "type": entry.protocol,
         "host": entry.dst_ip,
         "port": entry.dst_port,
         "request_size": entry.packet_size,
-    });
-
-    let mut line = serde_json::to_string(&json).unwrap_or_default();
-    line.push('\n');
-
-    let result = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .mode(0o644)
-        .open(path)
-        .and_then(|mut f| f.write_all(line.as_bytes()));
-
-    if let Err(e) = result {
-        debug!(path = %path.display(), error = %e, "failed to write non-TCP network log");
-    }
+    })
 }
 
 #[cfg(test)]
@@ -368,13 +336,9 @@ mod tests {
     }
 
     #[test]
-    fn write_jsonl_serializes_provided_timestamp() {
-        // Locks the contract that `write_jsonl` must use the `timestamp`
-        // parameter rather than calling `Utc::now()` internally — the whole
-        // point of the parameter is to record observation time, not the
-        // delayed write time after spawn_blocking.
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("test.jsonl");
+    fn network_log_row_serializes_provided_timestamp() {
+        // Locks the contract that row construction must use the provided
+        // timestamp rather than calling `Utc::now()` internally.
         let entry = LogEntry {
             source_ip: "10.200.0.2".to_string(),
             dst_ip: "8.8.8.8".to_string(),
@@ -385,16 +349,16 @@ mod tests {
         let ts = DateTime::parse_from_rfc3339("2024-01-15T10:30:45.123Z")
             .unwrap()
             .with_timezone(&Utc);
-        write_jsonl(&path, &entry, ts);
-        let content = std::fs::read_to_string(&path).unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        let parsed = network_log_row(&entry, ts);
         assert_eq!(parsed["timestamp"], "2024-01-15T10:30:45.123Z");
     }
 
-    #[test]
-    fn write_jsonl_creates_file() {
+    #[tokio::test]
+    async fn append_log_entry_registered_source_writes_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.jsonl");
+        let manager = NetworkLogManager::new();
+        manager.register_source_ip("10.200.0.2", path.clone()).await;
         let entry = LogEntry {
             source_ip: "10.200.0.2".to_string(),
             dst_ip: "8.8.8.8".to_string(),
@@ -402,7 +366,8 @@ mod tests {
             protocol: "udp".to_string(),
             packet_size: 64,
         };
-        write_jsonl(&path, &entry, Utc::now());
+        assert!(append_log_entry(&manager, &entry, Utc::now()).await);
+        manager.flush_path(&path).await;
         let content = std::fs::read_to_string(&path).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
         assert_eq!(parsed["host"], "8.8.8.8");
@@ -414,9 +379,7 @@ mod tests {
     }
 
     #[test]
-    fn write_jsonl_icmp_entry() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("icmp.jsonl");
+    fn network_log_row_icmp_entry() {
         let entry = LogEntry {
             source_ip: "10.200.0.2".to_string(),
             dst_ip: "1.1.1.1".to_string(),
@@ -424,38 +387,76 @@ mod tests {
             protocol: "icmp".to_string(),
             packet_size: 84,
         };
-        write_jsonl(&path, &entry, Utc::now());
-        let content = std::fs::read_to_string(&path).unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        let parsed = network_log_row(&entry, Utc::now());
         assert_eq!(parsed["type"], "icmp");
         assert_eq!(parsed["port"], 0);
         assert_eq!(parsed["request_size"], 84);
     }
 
-    #[test]
-    fn write_jsonl_appends_multiple_entries() {
+    #[tokio::test]
+    async fn append_log_entry_appends_multiple_entries() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("multi.jsonl");
+        let manager = NetworkLogManager::new();
+        manager.register_source_ip("10.0.0.1", path.clone()).await;
         for dst in ["8.8.8.8", "1.1.1.1", "9.9.9.9"] {
-            write_jsonl(
-                &path,
+            assert!(
+                append_log_entry(
+                    &manager,
+                    &LogEntry {
+                        source_ip: "10.0.0.1".to_string(),
+                        dst_ip: dst.to_string(),
+                        dst_port: 53,
+                        protocol: "udp".to_string(),
+                        packet_size: 64,
+                    },
+                    Utc::now(),
+                )
+                .await
+            );
+        }
+        manager.flush_path(&path).await;
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 3);
+        let hosts: std::collections::HashSet<String> = lines
+            .iter()
+            .map(|line| {
+                let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
+                parsed["host"].as_str().unwrap().to_string()
+            })
+            .collect();
+        assert_eq!(
+            hosts,
+            ["8.8.8.8", "1.1.1.1", "9.9.9.9"]
+                .into_iter()
+                .map(str::to_string)
+                .collect()
+        );
+    }
+
+    #[tokio::test]
+    async fn append_log_entry_without_mapping_is_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ignored.jsonl");
+        let manager = NetworkLogManager::new();
+
+        assert!(
+            !append_log_entry(
+                &manager,
                 &LogEntry {
                     source_ip: "10.0.0.1".to_string(),
-                    dst_ip: dst.to_string(),
+                    dst_ip: "8.8.8.8".to_string(),
                     dst_port: 53,
                     protocol: "udp".to_string(),
                     packet_size: 64,
                 },
                 Utc::now(),
-            );
-        }
-        let content = std::fs::read_to_string(&path).unwrap();
-        let lines: Vec<&str> = content.lines().collect();
-        assert_eq!(lines.len(), 3);
-        for (i, dst) in ["8.8.8.8", "1.1.1.1", "9.9.9.9"].iter().enumerate() {
-            let parsed: serde_json::Value = serde_json::from_str(lines[i]).unwrap();
-            assert_eq!(parsed["host"], *dst);
-        }
+            )
+            .await
+        );
+        manager.flush_path(&path).await;
+        assert!(!path.exists());
     }
 
     #[test]

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -14,6 +14,7 @@ mod ids;
 mod image_hash;
 mod kmsg_log;
 mod lock;
+mod network_log_manager;
 mod network_logs;
 mod paths;
 mod prefetch;

--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -4,6 +4,8 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+#[cfg(test)]
+use tokio::sync::Semaphore;
 use tokio::sync::{Mutex, Notify};
 use tracing::{debug, warn};
 
@@ -47,7 +49,7 @@ impl PathState {
 #[derive(Clone)]
 struct WriteGate {
     started: Arc<Notify>,
-    release: Arc<Notify>,
+    release: Arc<Semaphore>,
 }
 
 impl NetworkLogManager {
@@ -56,7 +58,7 @@ impl NetworkLogManager {
     }
 
     #[cfg(test)]
-    pub(crate) fn new_with_write_gate(started: Arc<Notify>, release: Arc<Notify>) -> Self {
+    pub(crate) fn new_with_write_gate(started: Arc<Notify>, release: Arc<Semaphore>) -> Self {
         Self {
             inner: Arc::new(Inner {
                 state: Mutex::new(State::default()),
@@ -132,7 +134,7 @@ impl NetworkLogManager {
             #[cfg(test)]
             if let Some(gate) = write_gate {
                 gate.started.notify_one();
-                gate.release.notified().await;
+                let _permit = gate.release.acquire().await.expect("write gate closed");
             }
 
             let write_path = path.clone();
@@ -235,7 +237,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("network.jsonl");
         let started = Arc::new(Notify::new());
-        let release = Arc::new(Notify::new());
+        let release = Arc::new(Semaphore::new(0));
         let manager = NetworkLogManager::new_with_write_gate(started.clone(), release.clone());
 
         manager.register_source_ip("10.200.0.2", path.clone()).await;
@@ -257,12 +259,78 @@ mod tests {
             "flush should wait while the accepted write is pending"
         );
 
-        release.notify_one();
+        release.add_permits(1);
         flush.await;
 
         let lines = read_json_lines(&path);
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0]["host"], "held.test");
+    }
+
+    #[tokio::test]
+    async fn flush_path_waits_for_all_pending_writes_for_same_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Semaphore::new(0));
+        let manager = NetworkLogManager::new_with_write_gate(started.clone(), release.clone());
+
+        manager.register_source_ip("10.200.0.2", path.clone()).await;
+        manager.register_source_ip("10.200.0.3", path.clone()).await;
+
+        let first_started = started.notified();
+        assert!(
+            manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"first.test"}))
+                .await
+        );
+        first_started.await;
+
+        let second_started = started.notified();
+        assert!(
+            manager
+                .append_for_ip("10.200.0.3", json!({"type":"dns","host":"second.test"}))
+                .await
+        );
+        second_started.await;
+
+        let mut flush = std::pin::pin!(manager.flush_path(&path));
+        let pending = poll_fn(|cx| match flush.as_mut().poll(cx) {
+            Poll::Ready(()) => Poll::Ready(false),
+            Poll::Pending => Poll::Ready(true),
+        })
+        .await;
+        assert!(
+            pending,
+            "flush should wait while both accepted writes are pending"
+        );
+
+        release.add_permits(1);
+        let still_pending = poll_fn(|cx| match flush.as_mut().poll(cx) {
+            Poll::Ready(()) => Poll::Ready(false),
+            Poll::Pending => Poll::Ready(true),
+        })
+        .await;
+        assert!(
+            still_pending,
+            "flush should still wait after only one pending write is released"
+        );
+
+        release.add_permits(1);
+        flush.await;
+
+        let lines = read_json_lines(&path);
+        let hosts: std::collections::HashSet<String> = lines
+            .iter()
+            .map(|line| line["host"].as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(
+            hosts,
+            ["first.test", "second.test"]
+                .into_iter()
+                .map(str::to_string)
+                .collect()
+        );
     }
 
     #[tokio::test]
@@ -306,7 +374,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("network.jsonl");
         let started = Arc::new(Notify::new());
-        let release = Arc::new(Notify::new());
+        let release = Arc::new(Semaphore::new(0));
         let manager = NetworkLogManager::new_with_write_gate(started.clone(), release.clone());
 
         manager.register_source_ip("10.200.0.2", path.clone()).await;
@@ -318,12 +386,57 @@ mod tests {
         started.notified().await;
 
         manager.unregister_source_ip("10.200.0.2").await;
-        release.notify_one();
+        release.add_permits(1);
         manager.flush_path(&path).await;
 
         let lines = read_json_lines(&path);
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0]["host"], "accepted.test");
+    }
+
+    #[tokio::test]
+    async fn pending_old_write_stays_on_old_path_after_reregister() {
+        let dir = tempfile::tempdir().unwrap();
+        let old_path = dir.path().join("old.jsonl");
+        let new_path = dir.path().join("new.jsonl");
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Semaphore::new(0));
+        let manager = NetworkLogManager::new_with_write_gate(started.clone(), release.clone());
+
+        manager
+            .register_source_ip("10.200.0.2", old_path.clone())
+            .await;
+        let old_started = started.notified();
+        assert!(
+            manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"old.test"}))
+                .await
+        );
+        old_started.await;
+
+        manager.unregister_source_ip("10.200.0.2").await;
+        manager
+            .register_source_ip("10.200.0.2", new_path.clone())
+            .await;
+        let new_started = started.notified();
+        assert!(
+            manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"new.test"}))
+                .await
+        );
+        new_started.await;
+
+        release.add_permits(2);
+        manager.flush_path(&old_path).await;
+        manager.flush_path(&new_path).await;
+
+        let old_lines = read_json_lines(&old_path);
+        assert_eq!(old_lines.len(), 1);
+        assert_eq!(old_lines[0]["host"], "old.test");
+
+        let new_lines = read_json_lines(&new_path);
+        assert_eq!(new_lines.len(), 1);
+        assert_eq!(new_lines[0]["host"], "new.test");
     }
 
     #[tokio::test]

--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -1,0 +1,356 @@
+use std::collections::HashMap;
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::sync::{Mutex, Notify};
+use tracing::{debug, warn};
+
+/// Coordinates Rust-side DNS/kmsg network log attribution and file writes.
+///
+/// Source-IP lookup and pending-write registration happen under the same lock,
+/// so `flush_path` cannot miss a row that was already accepted for that path.
+#[derive(Clone, Default)]
+pub struct NetworkLogManager {
+    inner: Arc<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    state: Mutex<State>,
+    #[cfg(test)]
+    write_gate: Option<WriteGate>,
+}
+
+#[derive(Default)]
+struct State {
+    source_paths: HashMap<String, PathBuf>,
+    pending_paths: HashMap<PathBuf, PathState>,
+}
+
+struct PathState {
+    pending: usize,
+    notify: Arc<Notify>,
+}
+
+impl PathState {
+    fn new() -> Self {
+        Self {
+            pending: 0,
+            notify: Arc::new(Notify::new()),
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct WriteGate {
+    started: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+impl NetworkLogManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_write_gate(started: Arc<Notify>, release: Arc<Notify>) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                state: Mutex::new(State::default()),
+                write_gate: Some(WriteGate { started, release }),
+            }),
+        }
+    }
+
+    pub async fn register_source_ip(&self, source_ip: impl Into<String>, path: PathBuf) {
+        let mut state = self.inner.state.lock().await;
+        state.source_paths.insert(source_ip.into(), path);
+    }
+
+    pub async fn unregister_source_ip(&self, source_ip: &str) {
+        let mut state = self.inner.state.lock().await;
+        state.source_paths.remove(source_ip);
+    }
+
+    /// Accept a JSON network-log row for a source IP.
+    ///
+    /// Returns `true` when the source IP was mapped and the write was accepted.
+    /// The actual append is asynchronous; call `flush_path` before reading the
+    /// file when a complete snapshot is required.
+    pub async fn append_for_ip(&self, source_ip: &str, row: serde_json::Value) -> bool {
+        let line = match serde_json::to_string(&row) {
+            Ok(mut line) => {
+                line.push('\n');
+                line
+            }
+            Err(e) => {
+                warn!(source_ip, error = %e, "failed to serialize network log row");
+                return false;
+            }
+        };
+
+        let path = {
+            let mut state = self.inner.state.lock().await;
+            let Some(path) = state.source_paths.get(source_ip).cloned() else {
+                return false;
+            };
+            let path_state = state
+                .pending_paths
+                .entry(path.clone())
+                .or_insert_with(PathState::new);
+            path_state.pending += 1;
+            path
+        };
+
+        self.spawn_append(path, line);
+        true
+    }
+
+    /// Wait until all currently accepted Rust-side writes for `path` finish.
+    pub async fn flush_path(&self, path: &Path) {
+        loop {
+            let notified = {
+                let state = self.inner.state.lock().await;
+                let Some(path_state) = state.pending_paths.get(path) else {
+                    return;
+                };
+                path_state.notify.clone().notified_owned()
+            };
+            notified.await;
+        }
+    }
+
+    fn spawn_append(&self, path: PathBuf, line: String) {
+        let manager = self.clone();
+        #[cfg(test)]
+        let write_gate = self.inner.write_gate.clone();
+
+        tokio::spawn(async move {
+            #[cfg(test)]
+            if let Some(gate) = write_gate {
+                gate.started.notify_one();
+                gate.release.notified().await;
+            }
+
+            let write_path = path.clone();
+            let result = tokio::task::spawn_blocking(move || append_line(&write_path, &line)).await;
+
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    debug!(path = %path.display(), error = %e, "failed to write network log");
+                }
+                Err(e) => {
+                    warn!(path = %path.display(), error = %e, "network log writer task failed");
+                }
+            }
+
+            manager.complete_path(path).await;
+        });
+    }
+
+    async fn complete_path(&self, path: PathBuf) {
+        let notify = {
+            let mut state = self.inner.state.lock().await;
+            let Some(path_state) = state.pending_paths.get_mut(&path) else {
+                debug!(path = %path.display(), "network log write completed for unknown path");
+                return;
+            };
+
+            if path_state.pending == 0 {
+                debug!(path = %path.display(), "network log pending count already zero");
+                return;
+            }
+
+            path_state.pending -= 1;
+            if path_state.pending == 0 {
+                state.pending_paths.remove(&path).map(|state| state.notify)
+            } else {
+                None
+            }
+        };
+
+        if let Some(notify) = notify {
+            notify.notify_waiters();
+        }
+    }
+}
+
+fn append_line(path: &Path, line: &str) -> std::io::Result<()> {
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .mode(0o644)
+        .open(path)
+        .and_then(|mut f| f.write_all(line.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::{Future, poll_fn};
+    use std::task::Poll;
+
+    use serde_json::json;
+
+    use super::*;
+
+    fn read_json_lines(path: &Path) -> Vec<serde_json::Value> {
+        std::fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn append_for_ip_writes_json_line_to_registered_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let manager = NetworkLogManager::new();
+
+        manager.register_source_ip("10.200.0.2", path.clone()).await;
+        assert!(
+            manager
+                .append_for_ip(
+                    "10.200.0.2",
+                    json!({"type":"dns","host":"example.com","port":53}),
+                )
+                .await
+        );
+
+        manager.flush_path(&path).await;
+
+        let lines = read_json_lines(&path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["type"], "dns");
+        assert_eq!(lines[0]["host"], "example.com");
+        assert_eq!(lines[0]["port"], 53);
+    }
+
+    #[tokio::test]
+    async fn flush_path_waits_for_accepted_pending_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let manager = NetworkLogManager::new_with_write_gate(started.clone(), release.clone());
+
+        manager.register_source_ip("10.200.0.2", path.clone()).await;
+        assert!(
+            manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"held.test"}))
+                .await
+        );
+        started.notified().await;
+
+        let mut flush = std::pin::pin!(manager.flush_path(&path));
+        let pending = poll_fn(|cx| match flush.as_mut().poll(cx) {
+            Poll::Ready(()) => Poll::Ready(false),
+            Poll::Pending => Poll::Ready(true),
+        })
+        .await;
+        assert!(
+            pending,
+            "flush should wait while the accepted write is pending"
+        );
+
+        release.notify_one();
+        flush.await;
+
+        let lines = read_json_lines(&path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["host"], "held.test");
+    }
+
+    #[tokio::test]
+    async fn append_failure_decrements_pending_and_flush_completes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing").join("network.jsonl");
+        let manager = NetworkLogManager::new();
+
+        manager.register_source_ip("10.200.0.2", path.clone()).await;
+        assert!(
+            manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"bad-path.test"}))
+                .await
+        );
+
+        manager.flush_path(&path).await;
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn append_after_unregister_is_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let manager = NetworkLogManager::new();
+
+        manager.register_source_ip("10.200.0.2", path.clone()).await;
+        manager.unregister_source_ip("10.200.0.2").await;
+
+        assert!(
+            !manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"old.test"}))
+                .await
+        );
+        manager.flush_path(&path).await;
+
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn accepted_write_lands_after_unregister() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let manager = NetworkLogManager::new_with_write_gate(started.clone(), release.clone());
+
+        manager.register_source_ip("10.200.0.2", path.clone()).await;
+        assert!(
+            manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"accepted.test"}))
+                .await
+        );
+        started.notified().await;
+
+        manager.unregister_source_ip("10.200.0.2").await;
+        release.notify_one();
+        manager.flush_path(&path).await;
+
+        let lines = read_json_lines(&path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["host"], "accepted.test");
+    }
+
+    #[tokio::test]
+    async fn reregistered_source_ip_routes_to_new_path_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let old_path = dir.path().join("old.jsonl");
+        let new_path = dir.path().join("new.jsonl");
+        let manager = NetworkLogManager::new();
+
+        manager
+            .register_source_ip("10.200.0.2", old_path.clone())
+            .await;
+        manager.unregister_source_ip("10.200.0.2").await;
+        manager
+            .register_source_ip("10.200.0.2", new_path.clone())
+            .await;
+
+        assert!(
+            manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"new.test"}))
+                .await
+        );
+        manager.flush_path(&new_path).await;
+
+        assert!(!old_path.exists());
+        let lines = read_json_lines(&new_path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["host"], "new.test");
+    }
+}

--- a/crates/runner/src/network_logs.rs
+++ b/crates/runner/src/network_logs.rs
@@ -27,7 +27,7 @@ struct NetworkLogPayload {
 
 /// Upload network logs from the per-run JSONL file.
 /// Reads the file at `path`, POSTs to telemetry endpoint,
-/// and deletes the file on success. Best-effort — failures only warn.
+/// and keeps the local file for debugging/log GC. Best-effort — failures only warn.
 pub async fn upload_network_logs(
     http: &HttpClient,
     run_id: RunId,

--- a/crates/runner/src/network_logs.rs
+++ b/crates/runner/src/network_logs.rs
@@ -7,12 +7,13 @@ use tracing::{info, warn};
 use crate::http::HttpClient;
 use crate::ids::RunId;
 
-/// Network log entry from mitmproxy JSONL.
+/// Network log entry from the per-run JSONL file.
 ///
-/// [NETWORK_LOG_FIELDS] — fields are defined in mitm_addon.py (source of truth).
+/// [NETWORK_LOG_FIELDS] — shared schema boundary is api-contracts; producers
+/// include mitmproxy plus Rust-side DNS/kmsg logging.
 /// Uses a transparent `serde_json::Value` wrapper so all fields pass through
 /// to Axiom without needing a struct field for each one. This avoids silently
-/// dropping new fields added to the Python addon.
+/// dropping fields added by any producer.
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(transparent)]
 struct NetworkLog(serde_json::Value);
@@ -24,7 +25,7 @@ struct NetworkLogPayload {
     network_logs: Vec<NetworkLog>,
 }
 
-/// Upload network logs from the mitmproxy JSONL file.
+/// Upload network logs from the per-run JSONL file.
 /// Reads the file at `path`, POSTs to telemetry endpoint,
 /// and deletes the file on success. Best-effort — failures only warn.
 pub async fn upload_network_logs(


### PR DESCRIPTION
## Summary
- add `NetworkLogManager` to atomically resolve source IPs and track pending Rust-side DNS/kmsg writes
- flush accepted Rust-side network log writes before deferred upload reads the per-run JSONL file
- update DNS/kmsg tests and network-log schema comments for the multi-producer model

Closes #11315

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p runner network_log`
- `cargo test --manifest-path crates/Cargo.toml -p runner dns::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner kmsg_log::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner deferred_network_log_upload_drains_on_graceful_shutdown`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`

Note: local pre-commit ruff hooks could not run because `ruff` is not installed in this environment; Rust fmt/clippy hooks passed.
