### PR TITLE
feat: write llm usage webhook rows to usage_event

### DIFF
--- a/turbo/apps/web/app/api/cron/process-usage-events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/process-usage-events/__tests__/route.test.ts
@@ -17,6 +17,12 @@ import {
   updateOrgStripeFields,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { reloadEnv } from "../../../../../src/env";
+import {
+  TOKEN_CATEGORY_CACHE_CREATION,
+  TOKEN_CATEGORY_CACHE_READ,
+  TOKEN_CATEGORY_INPUT,
+  TOKEN_CATEGORY_OUTPUT,
+} from "../../../../../src/lib/zero/billing/model-usage-categories";
 
 vi.hoisted(() => {
   vi.stubEnv("CRON_SECRET", "test-cron-secret");
@@ -94,6 +100,79 @@ describe("GET /api/cron/process-usage-events", () => {
 
     const record = await findTestUsageEvent(eventId);
     expect(record!.creditsCharged).toBe(1);
+  });
+
+  it("charges model token categories with legacy per-token rounding", async () => {
+    const provider = "claude-sonnet-4-6";
+    const events = [
+      {
+        category: TOKEN_CATEGORY_INPUT,
+        quantity: 1_234_567,
+        unitPrice: 100,
+      },
+      {
+        category: TOKEN_CATEGORY_OUTPUT,
+        quantity: 765_432,
+        unitPrice: 200,
+      },
+      {
+        category: TOKEN_CATEGORY_CACHE_READ,
+        quantity: 10_001,
+        unitPrice: 30,
+      },
+      {
+        category: TOKEN_CATEGORY_CACHE_CREATION,
+        quantity: 2_000_001,
+        unitPrice: 125,
+      },
+    ];
+
+    const seededEvents: Array<{ id: string; expectedCredits: number }> = [];
+    for (const event of events) {
+      await insertTestUsagePricing({
+        kind: "model",
+        provider,
+        category: event.category,
+        unitPrice: event.unitPrice,
+        unitSize: 1_000_000,
+      });
+
+      const id = await insertTestUsageEvent(user.orgId, {
+        userId: user.userId,
+        kind: "model",
+        provider,
+        category: event.category,
+        quantity: event.quantity,
+      });
+      seededEvents.push({
+        id,
+        expectedCredits: Math.ceil(
+          (event.quantity * event.unitPrice) / 1_000_000,
+        ),
+      });
+    }
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const records = await Promise.all(
+      seededEvents.map(async (event) => {
+        return {
+          expectedCredits: event.expectedCredits,
+          record: await findTestUsageEvent(event.id),
+        };
+      }),
+    );
+    for (const { expectedCredits, record } of records) {
+      expect(record!.status).toBe("processed");
+      expect(record!.creditsCharged).toBe(expectedCredits);
+    }
+
+    const expectedTotal = seededEvents.reduce((sum, event) => {
+      return sum + event.expectedCredits;
+    }, 0);
+    const credits = await getOrgCredits(user.orgId);
+    expect(credits).toBe(100_000 - expectedTotal);
   });
 
   it("marks records with no matching pricing as processed with zero charge", async () => {

--- a/turbo/apps/web/app/api/webhooks/agent/usage/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/usage/__tests__/route.test.ts
@@ -6,6 +6,7 @@ import {
   createTestRun,
   createTestSandboxToken,
   findTestCreditUsagesByRunId,
+  findTestUsageEventsByRunId,
   setTestRunModelProvider,
   setTestRunSelectedModel,
 } from "../../../../../../src/__tests__/api-test-helpers";
@@ -17,6 +18,13 @@ import {
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
 import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
+import {
+  MODEL_USAGE_KIND,
+  TOKEN_CATEGORY_CACHE_CREATION,
+  TOKEN_CATEGORY_CACHE_READ,
+  TOKEN_CATEGORY_INPUT,
+  TOKEN_CATEGORY_OUTPUT,
+} from "../../../../../../src/lib/zero/billing/model-usage-categories";
 
 const context = testContext();
 
@@ -25,6 +33,33 @@ describe("POST /api/webhooks/agent/usage", () => {
   let testComposeId: string;
   let testRunId: string;
   let testToken: string;
+
+  const url = "http://localhost:3000/api/webhooks/agent/usage";
+
+  function makeRequest(body: Record<string, unknown>, token = testToken) {
+    return createTestRequest(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  async function expectNoLegacyCreditUsage(runId = testRunId) {
+    expect(await findTestCreditUsagesByRunId(runId)).toHaveLength(0);
+  }
+
+  function quantitiesByCategory(
+    rows: Awaited<ReturnType<typeof findTestUsageEventsByRunId>>,
+  ) {
+    return Object.fromEntries(
+      rows.map((row) => {
+        return [row.category, row.quantity];
+      }),
+    );
+  }
 
   beforeEach(async () => {
     context.setupMocks();
@@ -103,109 +138,196 @@ describe("POST /api/webhooks/agent/usage", () => {
     });
   });
 
-  // ── Happy path: write to credit_usage ──────────────────────────────
+  // ── Happy path: write to usage_event ───────────────────────────────
 
   describe("Write path", () => {
-    it("inserts a row into credit_usage with status='pending'", async () => {
-      const request = createTestRequest(
-        "http://localhost:3000/api/webhooks/agent/usage",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${testToken}`,
+    it("inserts one pending usage_event per positive token class", async () => {
+      const response = await POST(
+        makeRequest({
+          runId: testRunId,
+          usage: {
+            model: "claude-sonnet-4-6",
+            message_id: "msg_happy",
+            input_tokens: 1000,
+            output_tokens: 500,
+            cache_read_input_tokens: 300,
+            cache_creation_input_tokens: 200,
+            web_search_requests: 1,
           },
-          body: JSON.stringify({
-            runId: testRunId,
-            usage: {
-              model: "claude-sonnet-4-6",
-              message_id: "msg_happy",
-              input_tokens: 1000,
-              output_tokens: 500,
-              cache_read_input_tokens: 300,
-              cache_creation_input_tokens: 200,
-              web_search_requests: 1,
-            },
-          }),
-        },
+        }),
       );
-
-      const response = await POST(request);
       expect(response.status).toBe(200);
 
-      const rows = await findTestCreditUsagesByRunId(testRunId);
-      expect(rows).toHaveLength(1);
-      const row = rows[0]!;
-      expect(row.status).toBe("pending");
-      expect(row.inputTokens).toBe(1000);
-      expect(row.outputTokens).toBe(500);
-      expect(row.cacheReadInputTokens).toBe(300);
-      expect(row.cacheCreationInputTokens).toBe(200);
-      expect(row.webSearchRequests).toBe(1);
+      const rows = await findTestUsageEventsByRunId(testRunId);
+      expect(rows).toHaveLength(4);
+      expect(rows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: MODEL_USAGE_KIND,
+            provider: "claude-sonnet-4-6",
+            category: TOKEN_CATEGORY_INPUT,
+            quantity: 1000,
+            status: "pending",
+          }),
+          expect.objectContaining({
+            kind: MODEL_USAGE_KIND,
+            provider: "claude-sonnet-4-6",
+            category: TOKEN_CATEGORY_OUTPUT,
+            quantity: 500,
+            status: "pending",
+          }),
+          expect.objectContaining({
+            kind: MODEL_USAGE_KIND,
+            provider: "claude-sonnet-4-6",
+            category: TOKEN_CATEGORY_CACHE_READ,
+            quantity: 300,
+            status: "pending",
+          }),
+          expect.objectContaining({
+            kind: MODEL_USAGE_KIND,
+            provider: "claude-sonnet-4-6",
+            category: TOKEN_CATEGORY_CACHE_CREATION,
+            quantity: 200,
+            status: "pending",
+          }),
+        ]),
+      );
+      await expectNoLegacyCreditUsage();
     });
 
-    it("deduplicates by (runId, messageId) on retry", async () => {
-      const payload = JSON.stringify({
+    it("skips zero and missing token classes", async () => {
+      const response = await POST(
+        makeRequest({
+          runId: testRunId,
+          usage: {
+            model: "claude-sonnet-4-6",
+            message_id: "msg_sparse",
+            input_tokens: 100,
+            output_tokens: 0,
+            cache_creation_input_tokens: 200,
+          },
+        }),
+      );
+      expect(response.status).toBe(200);
+
+      const rows = await findTestUsageEventsByRunId(testRunId);
+      expect(rows).toHaveLength(2);
+      expect(quantitiesByCategory(rows)).toEqual({
+        [TOKEN_CATEGORY_CACHE_CREATION]: 200,
+        [TOKEN_CATEGORY_INPUT]: 100,
+      });
+      await expectNoLegacyCreditUsage();
+    });
+
+    it("deduplicates by deterministic per-category idempotencyKey on retry", async () => {
+      const body = {
         runId: testRunId,
         usage: {
           model: "claude-sonnet-4-6",
           message_id: "msg_dup",
           input_tokens: 1000,
+          output_tokens: 500,
         },
-      });
-      const makeReq = () => {
-        return createTestRequest(
-          "http://localhost:3000/api/webhooks/agent/usage",
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${testToken}`,
-            },
-            body: payload,
-          },
-        );
       };
 
-      expect((await POST(makeReq())).status).toBe(200);
-      expect((await POST(makeReq())).status).toBe(200);
+      expect((await POST(makeRequest(body))).status).toBe(200);
+      expect((await POST(makeRequest(body))).status).toBe(200);
 
-      const rows = await findTestCreditUsagesByRunId(testRunId);
-      expect(rows).toHaveLength(1);
+      const rows = await findTestUsageEventsByRunId(testRunId);
+      expect(rows).toHaveLength(2);
+      expect(quantitiesByCategory(rows)).toEqual({
+        [TOKEN_CATEGORY_INPUT]: 1000,
+        [TOKEN_CATEGORY_OUTPUT]: 500,
+      });
+      await expectNoLegacyCreditUsage();
     });
 
-    it("writes separate rows for the same run with different messageIds", async () => {
-      const makeReq = (messageId: string, inputTokens: number) => {
-        return createTestRequest(
-          "http://localhost:3000/api/webhooks/agent/usage",
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${testToken}`,
-            },
-            body: JSON.stringify({
-              runId: testRunId,
-              usage: {
-                model: "claude-sonnet-4-6",
-                message_id: messageId,
-                input_tokens: inputTokens,
-              },
-            }),
-          },
-        );
+    it("keeps the first value when a duplicate category arrives with a different quantity", async () => {
+      const firstBody = {
+        runId: testRunId,
+        usage: {
+          model: "claude-sonnet-4-6",
+          message_id: "msg_dup_changed",
+          input_tokens: 1000,
+        },
+      };
+      const secondBody = {
+        runId: testRunId,
+        usage: {
+          model: "claude-sonnet-4-6",
+          message_id: "msg_dup_changed",
+          input_tokens: 9999,
+        },
       };
 
-      expect((await POST(makeReq("msg_main", 100))).status).toBe(200);
-      expect((await POST(makeReq("msg_sub1", 200))).status).toBe(200);
-      expect((await POST(makeReq("msg_sub2", 300))).status).toBe(200);
+      expect((await POST(makeRequest(firstBody))).status).toBe(200);
+      expect((await POST(makeRequest(secondBody))).status).toBe(200);
 
-      const rows = await findTestCreditUsagesByRunId(testRunId);
+      const rows = await findTestUsageEventsByRunId(testRunId);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.quantity).toBe(1000);
+    });
+
+    it("writes separate events for the same run with different messageIds", async () => {
+      const makeBody = (messageId: string, inputTokens: number) => {
+        return {
+          runId: testRunId,
+          usage: {
+            model: "claude-sonnet-4-6",
+            message_id: messageId,
+            input_tokens: inputTokens,
+          },
+        };
+      };
+
+      expect((await POST(makeRequest(makeBody("msg_main", 100)))).status).toBe(
+        200,
+      );
+      expect((await POST(makeRequest(makeBody("msg_sub1", 200)))).status).toBe(
+        200,
+      );
+      expect((await POST(makeRequest(makeBody("msg_sub2", 300)))).status).toBe(
+        200,
+      );
+
+      const rows = await findTestUsageEventsByRunId(testRunId);
       expect(rows).toHaveLength(3);
       const total = rows.reduce((acc, r) => {
-        return acc + r.inputTokens;
+        return acc + r.quantity;
       }, 0);
       expect(total).toBe(600);
+      await expectNoLegacyCreditUsage();
+    });
+
+    it("rejects positive token usage without a stable message_id", async () => {
+      const response = await POST(
+        makeRequest({
+          runId: testRunId,
+          usage: { model: "claude-sonnet-4-6", input_tokens: 100 },
+        }),
+      );
+      expect(response.status).toBe(400);
+
+      const rows = await findTestUsageEventsByRunId(testRunId);
+      expect(rows).toHaveLength(0);
+      await expectNoLegacyCreditUsage();
+    });
+
+    it("accepts usage with no positive token quantities without writing rows", async () => {
+      const response = await POST(
+        makeRequest({
+          runId: testRunId,
+          usage: {
+            model: "claude-sonnet-4-6",
+            web_search_requests: 1,
+          },
+        }),
+      );
+      expect(response.status).toBe(200);
+
+      const rows = await findTestUsageEventsByRunId(testRunId);
+      expect(rows).toHaveLength(0);
+      await expectNoLegacyCreditUsage();
     });
   });
 
@@ -221,81 +343,59 @@ describe("POST /api/webhooks/agent/usage", () => {
       await setTestRunSelectedModel(zeroRunId, "claude-opus-4-1");
       const token = await createTestSandboxToken(user.userId, zeroRunId);
 
-      const request = createTestRequest(
-        "http://localhost:3000/api/webhooks/agent/usage",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({
+      const response = await POST(
+        makeRequest(
+          {
             runId: zeroRunId,
             usage: {
               model: "claude-sonnet-4-6",
               message_id: "msg_prec",
               input_tokens: 10,
             },
-          }),
-        },
+          },
+          token,
+        ),
       );
-      const response = await POST(request);
       expect(response.status).toBe(200);
 
-      const rows = await findTestCreditUsagesByRunId(zeroRunId);
+      const rows = await findTestUsageEventsByRunId(zeroRunId);
       expect(rows).toHaveLength(1);
-      expect(rows[0]!.model).toBe("claude-opus-4-1");
-      expect(rows[0]!.modelProvider).toBe("anthropic-api-key");
+      expect(rows[0]!.provider).toBe("claude-opus-4-1");
+      await expectNoLegacyCreditUsage(zeroRunId);
     });
 
     it("falls back to u.model when selectedModel not set", async () => {
-      const request = createTestRequest(
-        "http://localhost:3000/api/webhooks/agent/usage",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${testToken}`,
+      const response = await POST(
+        makeRequest({
+          runId: testRunId,
+          usage: {
+            model: "claude-sonnet-4-6",
+            message_id: "msg_fallback",
+            input_tokens: 10,
           },
-          body: JSON.stringify({
-            runId: testRunId,
-            usage: {
-              model: "claude-sonnet-4-6",
-              message_id: "msg_fallback",
-              input_tokens: 10,
-            },
-          }),
-        },
+        }),
       );
-      const response = await POST(request);
       expect(response.status).toBe(200);
 
-      const rows = await findTestCreditUsagesByRunId(testRunId);
+      const rows = await findTestUsageEventsByRunId(testRunId);
       expect(rows).toHaveLength(1);
-      expect(rows[0]!.model).toBe("claude-sonnet-4-6");
+      expect(rows[0]!.provider).toBe("claude-sonnet-4-6");
+      await expectNoLegacyCreditUsage();
     });
 
     it("uses 'unknown' when neither selectedModel nor u.model is set", async () => {
-      const request = createTestRequest(
-        "http://localhost:3000/api/webhooks/agent/usage",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${testToken}`,
-          },
-          body: JSON.stringify({
-            runId: testRunId,
-            usage: { message_id: "msg_unknown", input_tokens: 10 },
-          }),
-        },
+      const response = await POST(
+        makeRequest({
+          runId: testRunId,
+          usage: { message_id: "msg_unknown", input_tokens: 10 },
+        }),
       );
-      const response = await POST(request);
       expect(response.status).toBe(200);
 
-      const rows = await findTestCreditUsagesByRunId(testRunId);
+      const rows = await findTestUsageEventsByRunId(testRunId);
       expect(rows).toHaveLength(1);
-      expect(rows[0]!.model).toBe("unknown");
+      expect(rows[0]!.provider).toBe("unknown");
+      await expectNoLegacyCreditUsage();
     });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/usage/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/usage/__tests__/route.test.ts
@@ -299,19 +299,67 @@ describe("POST /api/webhooks/agent/usage", () => {
       await expectNoLegacyCreditUsage();
     });
 
-    it("rejects positive token usage without a stable message_id", async () => {
-      const response = await POST(
-        makeRequest({
-          runId: testRunId,
-          usage: { model: "claude-sonnet-4-6", input_tokens: 100 },
-        }),
+    it("does not deduplicate the same message_id across different runs", async () => {
+      const { runId: secondRunId } = await seedTestRun(
+        user.userId,
+        testComposeId,
       );
-      expect(response.status).toBe(400);
+      const secondToken = await createTestSandboxToken(
+        user.userId,
+        secondRunId,
+      );
+      const makeBody = (runId: string, inputTokens: number) => {
+        return {
+          runId,
+          usage: {
+            model: "claude-sonnet-4-6",
+            message_id: "msg_shared_across_runs",
+            input_tokens: inputTokens,
+          },
+        };
+      };
 
-      const rows = await findTestUsageEventsByRunId(testRunId);
-      expect(rows).toHaveLength(0);
+      expect((await POST(makeRequest(makeBody(testRunId, 100)))).status).toBe(
+        200,
+      );
+      expect(
+        (await POST(makeRequest(makeBody(secondRunId, 200), secondToken)))
+          .status,
+      ).toBe(200);
+
+      const firstRows = await findTestUsageEventsByRunId(testRunId);
+      expect(firstRows).toHaveLength(1);
+      expect(firstRows[0]!.quantity).toBe(100);
+
+      const secondRows = await findTestUsageEventsByRunId(secondRunId);
+      expect(secondRows).toHaveLength(1);
+      expect(secondRows[0]!.quantity).toBe(200);
       await expectNoLegacyCreditUsage();
+      await expectNoLegacyCreditUsage(secondRunId);
     });
+
+    it.each([
+      { name: "omitted", usage: { model: "claude-sonnet-4-6" } },
+      {
+        name: "empty",
+        usage: { model: "claude-sonnet-4-6", message_id: "" },
+      },
+    ])(
+      "rejects positive token usage with $name message_id",
+      async ({ usage }) => {
+        const response = await POST(
+          makeRequest({
+            runId: testRunId,
+            usage: { ...usage, input_tokens: 100 },
+          }),
+        );
+        expect(response.status).toBe(400);
+
+        const rows = await findTestUsageEventsByRunId(testRunId);
+        expect(rows).toHaveLength(0);
+        await expectNoLegacyCreditUsage();
+      },
+    );
 
     it("accepts usage with no positive token quantities without writing rows", async () => {
       const response = await POST(

--- a/turbo/apps/web/app/api/webhooks/agent/usage/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/usage/route.ts
@@ -7,10 +7,14 @@ import { webhookUsageContract } from "@vm0/api-contracts/contracts/webhooks";
 import { initServices } from "../../../../../src/lib/init-services";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { creditUsage } from "@vm0/db/schema/credit-usage";
+import { usageEvent } from "@vm0/db/schema/usage-event";
 import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../src/lib/auth/get-sandbox-auth";
 import { logger } from "../../../../../src/lib/shared/logger";
+import {
+  buildModelUsageEventDrafts,
+  getPositiveModelUsageTokenQuantities,
+} from "../../../../../src/lib/zero/billing/model-usage-event-adapter";
 
 const log = logger("webhooks:usage");
 
@@ -34,13 +38,11 @@ const router = tsr.router(webhookUsageContract, {
 
     const { userId } = auth;
 
-    // Verify run exists and belongs to user; fetch modelProvider from zeroRuns
-    // (same pattern as events webhook — ensures consistency with credit_usage)
+    // Verify run exists and belongs to user.
     const [run] = await globalThis.services.db
       .select({
         id: agentRuns.id,
         orgId: agentRuns.orgId,
-        modelProvider: zeroRuns.modelProvider,
         selectedModel: zeroRuns.selectedModel,
       })
       .from(agentRuns)
@@ -60,40 +62,67 @@ const router = tsr.router(webhookUsageContract, {
       };
     }
 
-    // Insert proxy-reported usage into credit_usage (the billing source).
-    // Rows are charged later by processOrgCredits().  Insertion errors
-    // propagate so the handler returns 5xx and mitmproxy retries via
-    // `_report_usage_with_retry`; swallowing them would silently lose
-    // billing records.
-    //
-    // Model precedence: `run.selectedModel` (the user's run selection) wins
-    // because it is guaranteed to match a row in credit_pricing; `u.model`
-    // (proxy-observed) may carry a variant string that has no pricing entry
-    // and would silently charge zero credits.
     const u = body.usage;
-    await globalThis.services.db
-      .insert(creditUsage)
-      .values({
+    const tokenQuantities = getPositiveModelUsageTokenQuantities(u);
+    if (tokenQuantities.length === 0) {
+      log.debug("Proxy usage contained no positive token quantities", {
         runId: body.runId,
-        orgId: run.orgId,
-        userId,
-        model: run.selectedModel ?? u.model ?? "unknown",
-        modelProvider: run.modelProvider ?? "",
-        inputTokens: u.input_tokens ?? 0,
-        outputTokens: u.output_tokens ?? 0,
-        cacheReadInputTokens: u.cache_read_input_tokens ?? 0,
-        cacheCreationInputTokens: u.cache_creation_input_tokens ?? 0,
-        webSearchRequests: u.web_search_requests ?? 0,
-        messageId: u.message_id ?? null,
-        // status defaults to "pending" via schema default
-      })
+        model: u.model,
+      });
+      return {
+        status: 200 as const,
+        body: {
+          success: true,
+        },
+      };
+    }
+
+    if (!u.message_id) {
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: "usage.message_id is required for billable token usage",
+            code: "BAD_REQUEST",
+          },
+        },
+      };
+    }
+
+    // Insert proxy-reported model usage into usage_event. Rows are charged
+    // later by processUsageEvents(). Insertion errors propagate so mitmproxy
+    // retries rather than silently losing billable records.
+    //
+    // Model precedence stays equivalent to the legacy credit_usage writer:
+    // `run.selectedModel` wins over proxy-observed `u.model`.
+    const provider = run.selectedModel ?? u.model ?? "unknown";
+    const events = buildModelUsageEventDrafts({
+      runId: body.runId,
+      messageId: u.message_id,
+      provider,
+      usage: u,
+    });
+
+    await globalThis.services.db
+      .insert(usageEvent)
+      .values(
+        events.map((event) => {
+          return {
+            runId: body.runId,
+            orgId: run.orgId,
+            userId,
+            ...event,
+          };
+        }),
+      )
       .onConflictDoNothing({
-        target: [creditUsage.runId, creditUsage.messageId],
+        target: [usageEvent.idempotencyKey],
       });
 
     log.debug("Proxy usage recorded", {
       runId: body.runId,
-      model: u.model,
+      provider,
+      eventCount: events.length,
       inputTokens: u.input_tokens,
       outputTokens: u.output_tokens,
     });

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -67,7 +67,7 @@
     "stripe": "^20.4.1",
     "svix": "^1.84.1",
     "tar": "^7.5.11",
-    "uuid": "10.0.0",
+    "uuid": "^10.0.0",
     "web-push": "^3.6.7",
     "zod": "^4.3.6"
   },
@@ -84,7 +84,7 @@
     "@types/pg": "^8.15.5",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
-    "@types/uuid": "10.0.0",
+    "@types/uuid": "^10.0.0",
     "@types/web-push": "^3.6.4",
     "@typescript-eslint/rule-tester": "^8.59.0",
     "@typescript-eslint/utils": "^8.59.0",

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -67,6 +67,7 @@
     "stripe": "^20.4.1",
     "svix": "^1.84.1",
     "tar": "^7.5.11",
+    "uuid": "10.0.0",
     "web-push": "^3.6.7",
     "zod": "^4.3.6"
   },
@@ -83,6 +84,7 @@
     "@types/pg": "^8.15.5",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
+    "@types/uuid": "10.0.0",
     "@types/web-push": "^3.6.4",
     "@typescript-eslint/rule-tester": "^8.59.0",
     "@typescript-eslint/utils": "^8.59.0",

--- a/turbo/apps/web/src/lib/zero/billing/model-usage-event-adapter.ts
+++ b/turbo/apps/web/src/lib/zero/billing/model-usage-event-adapter.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { v5 as uuidV5 } from "uuid";
 import {
   MODEL_USAGE_KIND,
   TOKEN_CATEGORY_CACHE_CREATION,
@@ -79,8 +79,8 @@ function deriveModelUsageEventIdempotencyKey(params: {
   category: string;
 }): string {
   return uuidV5(
-    MODEL_USAGE_EVENT_IDEMPOTENCY_NAMESPACE,
     encodeUuidName([params.runId, params.messageId, params.category]),
+    MODEL_USAGE_EVENT_IDEMPOTENCY_NAMESPACE,
   );
 }
 
@@ -90,24 +90,4 @@ function encodeUuidName(parts: readonly string[]): string {
       return `${Buffer.byteLength(part)}:${part}`;
     })
     .join("\0");
-}
-
-function uuidV5(namespace: string, name: string): string {
-  const namespaceBytes = Buffer.from(namespace.replaceAll("-", ""), "hex");
-  const hash = createHash("sha1");
-  hash.update(namespaceBytes);
-  hash.update(name);
-
-  const bytes = Uint8Array.from(hash.digest().subarray(0, 16));
-  bytes[6] = (bytes[6]! & 0x0f) | 0x50;
-  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
-
-  const hex = Buffer.from(bytes).toString("hex");
-  return [
-    hex.slice(0, 8),
-    hex.slice(8, 12),
-    hex.slice(12, 16),
-    hex.slice(16, 20),
-    hex.slice(20),
-  ].join("-");
 }

--- a/turbo/apps/web/src/lib/zero/billing/model-usage-event-adapter.ts
+++ b/turbo/apps/web/src/lib/zero/billing/model-usage-event-adapter.ts
@@ -25,7 +25,10 @@ type ModelUsageEventDraft = ModelUsageTokenQuantity & {
   provider: string;
 };
 
-const MODEL_USAGE_EVENT_IDEMPOTENCY_PREFIX = "vm0:model-usage-event:v1";
+// UUIDv5 namespace for legacy model-usage webhook idempotency keys. Do not
+// change after release; changing it would make webhook retries insert new rows.
+const MODEL_USAGE_EVENT_IDEMPOTENCY_NAMESPACE =
+  "18a22204-d25e-4170-8973-86477f864bfb";
 
 export function getPositiveModelUsageTokenQuantities(
   usage: LegacyModelUsage,
@@ -75,19 +78,25 @@ function deriveModelUsageEventIdempotencyKey(params: {
   messageId: string;
   category: string;
 }): string {
-  return deterministicUuid([params.runId, params.messageId, params.category]);
+  return uuidV5(
+    MODEL_USAGE_EVENT_IDEMPOTENCY_NAMESPACE,
+    encodeUuidName([params.runId, params.messageId, params.category]),
+  );
 }
 
-function deterministicUuid(parts: readonly string[]): string {
-  const hash = createHash("sha256");
-  hash.update(MODEL_USAGE_EVENT_IDEMPOTENCY_PREFIX);
+function encodeUuidName(parts: readonly string[]): string {
+  return parts
+    .map((part) => {
+      return `${Buffer.byteLength(part)}:${part}`;
+    })
+    .join("\0");
+}
 
-  for (const part of parts) {
-    hash.update("\0");
-    hash.update(String(Buffer.byteLength(part)));
-    hash.update(":");
-    hash.update(part);
-  }
+function uuidV5(namespace: string, name: string): string {
+  const namespaceBytes = Buffer.from(namespace.replaceAll("-", ""), "hex");
+  const hash = createHash("sha1");
+  hash.update(namespaceBytes);
+  hash.update(name);
 
   const bytes = Uint8Array.from(hash.digest().subarray(0, 16));
   bytes[6] = (bytes[6]! & 0x0f) | 0x50;

--- a/turbo/apps/web/src/lib/zero/billing/model-usage-event-adapter.ts
+++ b/turbo/apps/web/src/lib/zero/billing/model-usage-event-adapter.ts
@@ -1,0 +1,101 @@
+import { createHash } from "crypto";
+import {
+  MODEL_USAGE_KIND,
+  TOKEN_CATEGORY_CACHE_CREATION,
+  TOKEN_CATEGORY_CACHE_READ,
+  TOKEN_CATEGORY_INPUT,
+  TOKEN_CATEGORY_OUTPUT,
+} from "./model-usage-categories";
+
+type LegacyModelUsage = {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+};
+
+type ModelUsageTokenQuantity = {
+  category: string;
+  quantity: number;
+};
+
+type ModelUsageEventDraft = ModelUsageTokenQuantity & {
+  idempotencyKey: string;
+  kind: typeof MODEL_USAGE_KIND;
+  provider: string;
+};
+
+const MODEL_USAGE_EVENT_IDEMPOTENCY_PREFIX = "vm0:model-usage-event:v1";
+
+export function getPositiveModelUsageTokenQuantities(
+  usage: LegacyModelUsage,
+): ModelUsageTokenQuantity[] {
+  return [
+    { category: TOKEN_CATEGORY_INPUT, quantity: usage.input_tokens ?? 0 },
+    { category: TOKEN_CATEGORY_OUTPUT, quantity: usage.output_tokens ?? 0 },
+    {
+      category: TOKEN_CATEGORY_CACHE_READ,
+      quantity: usage.cache_read_input_tokens ?? 0,
+    },
+    {
+      category: TOKEN_CATEGORY_CACHE_CREATION,
+      quantity: usage.cache_creation_input_tokens ?? 0,
+    },
+  ].filter((item) => {
+    return item.quantity > 0;
+  });
+}
+
+export function buildModelUsageEventDrafts(params: {
+  runId: string;
+  messageId: string;
+  provider: string;
+  usage: LegacyModelUsage;
+}): ModelUsageEventDraft[] {
+  return getPositiveModelUsageTokenQuantities(params.usage).map((item) => {
+    return {
+      idempotencyKey: deriveModelUsageEventIdempotencyKey({
+        runId: params.runId,
+        messageId: params.messageId,
+        category: item.category,
+      }),
+      kind: MODEL_USAGE_KIND,
+      provider: params.provider,
+      category: item.category,
+      quantity: item.quantity,
+    };
+  });
+}
+
+function deriveModelUsageEventIdempotencyKey(params: {
+  runId: string;
+  messageId: string;
+  category: string;
+}): string {
+  return deterministicUuid([params.runId, params.messageId, params.category]);
+}
+
+function deterministicUuid(parts: readonly string[]): string {
+  const hash = createHash("sha256");
+  hash.update(MODEL_USAGE_EVENT_IDEMPOTENCY_PREFIX);
+
+  for (const part of parts) {
+    hash.update("\0");
+    hash.update(String(Buffer.byteLength(part)));
+    hash.update(":");
+    hash.update(part);
+  }
+
+  const bytes = Uint8Array.from(hash.digest().subarray(0, 16));
+  bytes[6] = (bytes[6]! & 0x0f) | 0x50;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+
+  const hex = Buffer.from(bytes).toString("hex");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join("-");
+}

--- a/turbo/apps/web/src/lib/zero/billing/model-usage-event-adapter.ts
+++ b/turbo/apps/web/src/lib/zero/billing/model-usage-event-adapter.ts
@@ -30,6 +30,9 @@ const MODEL_USAGE_EVENT_IDEMPOTENCY_PREFIX = "vm0:model-usage-event:v1";
 export function getPositiveModelUsageTokenQuantities(
   usage: LegacyModelUsage,
 ): ModelUsageTokenQuantity[] {
+  // web_search_requests is intentionally not mapped yet: there is no
+  // model usage_event category/pricing row for it, so current behavior is
+  // no charge.
   return [
     { category: TOKEN_CATEGORY_INPUT, quantity: usage.input_tokens ?? 0 },
     { category: TOKEN_CATEGORY_OUTPUT, quantity: usage.output_tokens ?? 0 },

--- a/turbo/packages/db/src/schema/credit-usage.ts
+++ b/turbo/packages/db/src/schema/credit-usage.ts
@@ -14,16 +14,18 @@ import { sql } from "drizzle-orm";
 import { agentRuns } from "./agent-run";
 
 /**
- * Proxy-reported per-API-call token usage for credits billing.
- * Each API call observed by mitmproxy creates its own row, keyed by
- * (runId, messageId). Processed later by the deduction processor to
- * charge credits.
+ * Legacy LLM token usage rows for credits billing.
+ *
+ * New proxy-reported model-provider usage is written to usage_event. This
+ * table remains so processOrgCredits() can drain historical and pending rows
+ * during the migration window.
  *
  * Historical rows written by the events webhook prior to the billing
  * source migration have `result_uuid` / `cost_usd` populated and
- * `message_id` null. Post-migration proxy rows have `message_id`
- * populated and `result_uuid` / `cost_usd` null. Both shapes are
- * valid and aggregated identically by downstream consumers.
+ * `message_id` null. Later proxy rows written before the usage_event
+ * migration have `message_id` populated and `result_uuid` / `cost_usd`
+ * null. Both shapes are valid and aggregated identically by downstream
+ * consumers.
  */
 export const creditUsage = pgTable(
   "credit_usage",

--- a/turbo/packages/db/src/schema/usage-pricing.ts
+++ b/turbo/packages/db/src/schema/usage-pricing.ts
@@ -19,11 +19,11 @@ import {
  * many `usage_event.quantity` items make up one unit.  Each row picks the
  * natural granularity for its category:
  *
- *   kind       provider  category       unit_price  unit_size  meaning
- *   ---------  --------  -------------  ----------  ---------  -------------------------------
- *   connector  x         tweet.read     100         1000       $0.0001/read
- *   model      anthropic tokens.input   3000        1000000    $3 / 1M input tokens
- *   image      gemini    output_tokens  100         1          $0.10 per image
+ *   kind       provider            category       unit_price  unit_size  meaning
+ *   ---------  ------------------  -------------  ----------  ---------  -------------------------------
+ *   connector  x                   tweet.read     100         1000       $0.0001/read
+ *   model      claude-sonnet-4-6   tokens.input   3000        1000000    $3 / 1M input tokens
+ *   image      gemini              output_tokens  100         1          $0.10 per image
  */
 export const usagePricing = pgTable(
   "usage_pricing",

--- a/turbo/packages/db/src/schema/usage-pricing.ts
+++ b/turbo/packages/db/src/schema/usage-pricing.ts
@@ -19,11 +19,11 @@ import {
  * many `usage_event.quantity` items make up one unit.  Each row picks the
  * natural granularity for its category:
  *
- *   kind       provider            category       unit_price  unit_size  meaning
- *   ---------  ------------------  -------------  ----------  ---------  -------------------------------
- *   connector  x                   tweet.read     100         1000       $0.0001/read
- *   model      claude-sonnet-4-6   tokens.input   3000        1000000    $3 / 1M input tokens
- *   image      gemini              output_tokens  100         1          $0.10 per image
+ *   kind       provider                  category       unit_price  unit_size  meaning
+ *   ---------  ------------------------  -------------  ----------  ---------  -------------------------------
+ *   connector  x                         tweet.read     100         1000       $0.0001/read
+ *   model      claude-sonnet-4-6         tokens.input   3000        1000000    $3 / 1M input tokens
+ *   image      gemini-2.5-flash-image    output_image   39          1          $0.0387 per image
  */
 export const usagePricing = pgTable(
   "usage_pricing",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -578,7 +578,7 @@ importers:
         specifier: '>=7.5.7'
         version: 7.5.13
       uuid:
-        specifier: 10.0.0
+        specifier: ^10.0.0
         version: 10.0.0
       web-push:
         specifier: ^3.6.7
@@ -621,7 +621,7 @@ importers:
         specifier: ^19.1.9
         version: 19.2.3(@types/react@19.2.14)
       '@types/uuid':
-        specifier: 10.0.0
+        specifier: ^10.0.0
         version: 10.0.0
       '@types/web-push':
         specifier: ^3.6.4

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -577,6 +577,9 @@ importers:
       tar:
         specifier: '>=7.5.7'
         version: 7.5.13
+      uuid:
+        specifier: 10.0.0
+        version: 10.0.0
       web-push:
         specifier: ^3.6.7
         version: 3.6.7
@@ -617,6 +620,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.9
         version: 19.2.3(@types/react@19.2.14)
+      '@types/uuid':
+        specifier: 10.0.0
+        version: 10.0.0
       '@types/web-push':
         specifier: ^3.6.4
         version: 3.6.4
@@ -5278,6 +5284,9 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@types/web-push@3.6.4':
     resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
@@ -13873,6 +13882,8 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@types/uuid@10.0.0': {}
 
   '@types/web-push@3.6.4':
     dependencies:


### PR DESCRIPTION
## Summary
- route legacy `/api/webhooks/agent/usage` writes into `usage_event` model token rows instead of new `credit_usage` rows
- derive deterministic per-run/message/category idempotency keys and require `message_id` for positive billable token usage
- preserve selected-model precedence and add coverage for usage_event writes, retries, and model token billing parity

## Tests
- `pnpm --dir turbo/apps/web test app/api/webhooks/agent/usage/__tests__/route.test.ts`
- `pnpm --dir turbo/apps/web test app/api/cron/process-usage-events/__tests__/route.test.ts`
- `pnpm --dir turbo/apps/web lint`
- `pnpm --dir turbo/apps/web check-types`
- `pnpm --dir turbo/apps/web db:reset`
- `pnpm --dir turbo/apps/web test`
- pre-commit: prettier, knip, turbo check-types

Closes #11319