### PR TITLE
feat(platform): land mobile users on /chats instead of default agent chat

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/home-page-setup.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/home-page-setup.test.ts
@@ -1,11 +1,12 @@
 /**
  * Tests for setupHomePage$ — the route setup at "/" that decides whether
- * to land users on the default agent's chat (desktop) or the chats list
- * (mobile).
+ * to land users on the default agent's chat (desktop / switch-off) or the
+ * chats list (mobile + MobileNativeV1 enabled).
  */
 
 import { describe, expect, it, vi } from "vitest";
 import { waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../location.ts";
@@ -43,11 +44,19 @@ function mockBaseAPIs() {
   ]);
 }
 
+function mobileNativeOn(): Partial<Record<FeatureSwitchKey, boolean>> {
+  return { [FeatureSwitchKey.MobileNativeV1]: true };
+}
+
 describe("home page setup - desktop redirects to default agent chat (HOME-D-001)", () => {
   it("redirects / to /agents/:id/chat on desktop", async () => {
     mockMobileViewport(false);
     mockBaseAPIs();
-    detachedSetupPage({ context, path: "/" });
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: mobileNativeOn(),
+    });
 
     await waitFor(() => {
       expect(pathname()).toBe(`/agents/${DEFAULT_AGENT_ID}/chat`);
@@ -56,13 +65,29 @@ describe("home page setup - desktop redirects to default agent chat (HOME-D-001)
 });
 
 describe("home page setup - mobile redirects to chats list (HOME-D-002)", () => {
-  it("redirects / to /chats on mobile viewport", async () => {
+  it("redirects / to /chats on mobile when MobileNativeV1 is on", async () => {
+    mockMobileViewport(true);
+    mockBaseAPIs();
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: mobileNativeOn(),
+    });
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats");
+    });
+  });
+});
+
+describe("home page setup - mobile keeps default chat when switch off (HOME-D-003)", () => {
+  it("falls back to /agents/:id/chat on mobile when MobileNativeV1 is off", async () => {
     mockMobileViewport(true);
     mockBaseAPIs();
     detachedSetupPage({ context, path: "/" });
 
     await waitFor(() => {
-      expect(pathname()).toBe("/chats");
+      expect(pathname()).toBe(`/agents/${DEFAULT_AGENT_ID}/chat`);
     });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/home-page-setup.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/home-page-setup.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for setupHomePage$ — the route setup at "/" that decides whether
+ * to land users on the default agent's chat (desktop) or the chats list
+ * (mobile).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { waitFor } from "@testing-library/react";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { pathname } from "../../location.ts";
+import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
+
+const context = testContext();
+const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+function mockMobileViewport(isMobile: boolean) {
+  vi.spyOn(window, "matchMedia").mockImplementation((query: string) => {
+    return {
+      matches: query === "(max-width: 767px)" ? isMobile : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as MediaQueryList;
+  });
+}
+
+function mockBaseAPIs() {
+  setMockTeam([
+    {
+      id: DEFAULT_AGENT_ID,
+      displayName: null,
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      headVersionId: "version_1",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  ]);
+}
+
+describe("home page setup - desktop redirects to default agent chat (HOME-D-001)", () => {
+  it("redirects / to /agents/:id/chat on desktop", async () => {
+    mockMobileViewport(false);
+    mockBaseAPIs();
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/agents/${DEFAULT_AGENT_ID}/chat`);
+    });
+  });
+});
+
+describe("home page setup - mobile redirects to chats list (HOME-D-002)", () => {
+  it("redirects / to /chats on mobile viewport", async () => {
+    mockMobileViewport(true);
+    mockBaseAPIs();
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats");
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
@@ -1,8 +1,10 @@
 import { command } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import { checkSettingsParam$ } from "./settings/org-manage-dialog.ts";
 import { homeAgentId$ } from "../agent.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
 
 // Matches Tailwind's md breakpoint (768px). Below this width we treat the
 // viewport as mobile and land users on the chats list instead of the
@@ -24,9 +26,15 @@ export const setupHomePage$ = command(
 
     await set(checkSettingsParam$, signal);
 
-    // On mobile, the home entry point is the chats list — skip the
-    // default-agent redirect so users land on /chats instead.
-    if (isMobileViewport()) {
+    const features = await get(featureSwitch$);
+    signal.throwIfAborted();
+    const mobileNativeEnabled =
+      features[FeatureSwitchKey.MobileNativeV1] ?? false;
+
+    // On mobile (and only when the redesign is enabled), the home entry
+    // point is the chats list — skip the default-agent redirect so users
+    // land on /chats instead.
+    if (mobileNativeEnabled && isMobileViewport()) {
       set(detachedNavigateTo$, "/chats", { replace: true });
       return;
     }

--- a/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
@@ -4,6 +4,18 @@ import { checkSettingsParam$ } from "./settings/org-manage-dialog.ts";
 import { homeAgentId$ } from "../agent.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
 
+// Matches Tailwind's md breakpoint (768px). Below this width we treat the
+// viewport as mobile and land users on the chats list instead of the
+// default agent's chat thread, since that's the canonical mobile entry point.
+const MOBILE_MEDIA_QUERY = "(max-width: 767px)";
+
+function isMobileViewport(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    window.matchMedia(MOBILE_MEDIA_QUERY).matches
+  );
+}
+
 export const setupHomePage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     if (await set(onboardGuard$, signal)) {
@@ -11,6 +23,13 @@ export const setupHomePage$ = command(
     }
 
     await set(checkSettingsParam$, signal);
+
+    // On mobile, the home entry point is the chats list — skip the
+    // default-agent redirect so users land on /chats instead.
+    if (isMobileViewport()) {
+      set(detachedNavigateTo$, "/chats", { replace: true });
+      return;
+    }
 
     // Redirect bare / to /agents/:id/chat, forwarding ?prompt= and ?queue= if present
     const homeAgentId = await get(homeAgentId$);


### PR DESCRIPTION
## Summary

PR 2 of the mobile redesign. On mobile viewports, hitting `/` now redirects to **`/chats`** (the existing `ZeroChatListPage`) so the user's entry point is the chats list — matching the design direction \"首页就是 chats\". Desktop behavior is unchanged.

## Why

Today every mobile session lands on `/agents/:id/chat` (the default agent's thread), so the chats list is only reachable by opening the sidebar drawer. That doesn't match the bottom-tab mental model from PR 1, where tapping the **Chats** tab should produce a list view, not the same single thread.

## What it does

- `setupHomePage$` checks `window.matchMedia(\"(max-width: 767px)\")` (Tailwind's `md` breakpoint).
- On mobile → `replace`-navigates to `/chats`.
- On desktop → existing behavior (redirects to `/agents/:id/chat` with `?prompt=` and `?queue=` forwarding intact).
- No new component or new route; reuses `ZeroChatListPage` already shipped at `/chats`.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm run lint` clean
- [x] New tests `home-page-setup.test.ts` — 2 cases (HOME-D-001, HOME-D-002)
- [x] Existing `sidebar-layout.test.tsx` + `zero-chat-list-page.test.tsx` — 24/24 unaffected
- [ ] Manual: open mobile viewport, hit `/`, confirm lands on `/chats`
- [ ] Manual: open desktop viewport, hit `/`, confirm lands on `/agents/:id/chat`
- [ ] Manual: tap **Chats** tab from a chat thread on mobile, confirm goes to list

## Together with #11331

PR 1 (#11331) adds the bottom tab bar; this PR makes the **Chats** tab actually arrive on a list view. Either order is mergeable but together they form the mobile entry experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)