### PR TITLE
feat: add diagnostic fields to auth shadow check mismatch warn log

### DIFF
--- a/turbo/apps/web/src/lib/auth/shadow-check.ts
+++ b/turbo/apps/web/src/lib/auth/shadow-check.ts
@@ -244,7 +244,16 @@ export async function shadowCompareAuth(
   if (!event.consistent) {
     log.warn("auth shadow check mismatch", {
       route: options.route,
+      tokenType: event.tokenType,
+      webOutcome: event.webOutcome,
+      webStatus: event.webStatus,
+      webErrorCode: event.webErrorCode,
+      apiOutcome: event.apiOutcome,
+      apiStatus: event.apiStatus,
+      apiErrorCode: event.apiErrorCode,
+      apiErrorMessage: event.apiErrorMessage,
       differences: event.differences,
+      differenceDetails: event.differenceDetails,
     });
   }
 }


### PR DESCRIPTION
## Summary

Adds `webOutcome`, `apiOutcome`, `webStatus`, `apiStatus`, `webErrorCode`, `apiErrorCode`, `tokenType`, `apiErrorMessage`, and `differenceDetails` to the auth shadow check mismatch warn log.

## Why

After #11309 fixed the PAT token fallthrough bug, auth shadow mismatches dropped from 532/hr to ~1/hr. The remaining edge cases can't be diagnosed because the log only records `route` and `differences` (which is always `["outcome"]`). We don't know which direction the mismatch goes — is the web side failing while the API passes, or vice versa? Is it a network error?

The `ShadowEvent` object already computes all of this data — we just need to log it.

## Test plan

- [ ] Deploy and observe `vm0-web-logs-prod` in Axiom for new `auth shadow check mismatch` entries with the added fields
- [ ] Confirm `webOutcome` / `apiOutcome` fields reveal the mismatch direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)