### PR TITLE
feat(platform): hide mobile hamburger when MobileNativeV1 is on

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -288,6 +288,24 @@ describe("mobile bottom tab bar - hidden when feature switch off (MOBILE-TAB-005
   });
 });
 
+describe("mobile top bar - hamburger hidden when redesign on (MOBILE-TOP-001)", () => {
+  it("does not render the Open menu hamburger when MobileNativeV1 is enabled", async () => {
+    mockBaseAPIs();
+    detachedSetupPage({
+      context,
+      path: "/agents",
+      featureSwitches: mobileNativeOn(),
+    });
+
+    // Bottom tab bar appears once the redesign is on — wait for that as a
+    // settled-render signal rather than racing the hamburger query.
+    await waitFor(() => {
+      expect(screen.getByTestId("mobile-bottom-tab-bar")).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("Open menu")).not.toBeInTheDocument();
+  });
+});
+
 describe("mobile bottom tab bar - active tab highlighted (MOBILE-TAB-002)", () => {
   it("marks the Teammates tab as the current page on /agents", async () => {
     mockBaseAPIs();

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -206,8 +206,7 @@ function MobileTopBar() {
   // the same sidebar overlay as the hamburger, so the top-bar hamburger is
   // redundant. Hide it.
   const features = useLastResolved(featureSwitch$);
-  const hideHamburger =
-    features?.[FeatureSwitchKey.MobileNativeV1] ?? false;
+  const hideHamburger = features?.[FeatureSwitchKey.MobileNativeV1] ?? false;
 
   return (
     <div className="md:hidden shrink-0 flex items-center h-12 px-3 gap-2 bg-background border-b border-border/50 z-10">

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -202,18 +202,27 @@ function MobileTopBar() {
 
   const activeId = useGet(activeRoute$);
 
+  // When the mobile redesign is on, the bottom tab bar's "More" tab opens
+  // the same sidebar overlay as the hamburger, so the top-bar hamburger is
+  // redundant. Hide it.
+  const features = useLastResolved(featureSwitch$);
+  const hideHamburger =
+    features?.[FeatureSwitchKey.MobileNativeV1] ?? false;
+
   return (
     <div className="md:hidden shrink-0 flex items-center h-12 px-3 gap-2 bg-background border-b border-border/50 z-10">
-      <button
-        type="button"
-        onClick={() => {
-          setExpanded(true);
-        }}
-        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-        aria-label="Open menu"
-      >
-        <IconMenu2 size={18} stroke={1.8} />
-      </button>
+      {!hideHamburger && (
+        <button
+          type="button"
+          onClick={() => {
+            setExpanded(true);
+          }}
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+          aria-label="Open menu"
+        >
+          <IconMenu2 size={18} stroke={1.8} />
+        </button>
+      )}
       {breadcrumb && (
         <div className="flex-1 min-w-0 flex items-center gap-2 min-w-0">
           {breadcrumb.avatarAgentId && <AgentAvatarInTopBar />}


### PR DESCRIPTION
## Summary

PR 3 of the mobile redesign. Once the bottom tab bar (PR #11331) is in place, the top-bar hamburger button is just a second entry into the same sidebar overlay that the **More** tab already opens. This PR hides the hamburger on mobile when \`MobileNativeV1\` is enabled.

## What it does

- \`MobileTopBar\` reads \`featureSwitch\$\` and skips rendering the hamburger when \`MobileNativeV1\` is on.
- Breadcrumb (page section + name) and action buttons (auto-read toggle, new-chat / invite) keep rendering — those remain useful.
- Switch off (default) → byte-identical to current behavior.

## Stack

- Base: \`ming/mobile-home-chats-list\` (PR #11332)
- Which is based on: \`ming/mobile-bottom-tab-bar\` (PR #11331)

Each PR adds a tiny, reviewable diff. Toggling the \`MobileNativeV1\` switch on the Lab page enables the cumulative redesign across all three.

## Test plan

- [x] \`pnpm run check-types\` clean
- [x] \`pnpm run lint\` clean
- [x] \`sidebar-layout.test.tsx\` 16/16 (added MOBILE-TOP-001)
- [ ] Manual: enable \`MobileNativeV1\` on /lab; load /agents on mobile viewport; confirm hamburger gone, breadcrumb still shows
- [ ] Manual: switch off; reload; confirm hamburger reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)