### PR TITLE
feat(api): per-route opentelemetry traces routed to axiom

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -15,6 +15,9 @@
   "dependencies": {
     "@clerk/backend": "^3.4.1",
     "@hono/node-server": "^1.19.14",
+    "@hono/otel": "^1.1.1",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
     "@opentelemetry/instrumentation-pg": "^0.67.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@sentry/node": "^10.50.0",

--- a/turbo/apps/api/src/__tests__/instrument.test.ts
+++ b/turbo/apps/api/src/__tests__/instrument.test.ts
@@ -32,6 +32,23 @@ describe("instrument", () => {
     );
   });
 
+  it("uses an OTLP exporter (not 'auto') when AXIOM telemetry env is set", async () => {
+    const { OTLPTraceExporter } =
+      await import("@opentelemetry/exporter-trace-otlp-http");
+    await importInstrument((envModule) => {
+      envModule.mockEnv("VERCEL_GIT_COMMIT_SHA", "abc123");
+      envModule.mockEnv("AXIOM_TOKEN_TELEMETRY", "axiom-token");
+      envModule.mockEnv("AXIOM_DATASET_SUFFIX", "prod");
+    });
+
+    const call = context.mocks.otel.registerOTel.mock.calls.at(-1);
+    if (!call) {
+      throw new Error("registerOTel was not called");
+    }
+    const exporter = (call[0] as { traceExporter: unknown }).traceExporter;
+    expect(exporter).toBeInstanceOf(OTLPTraceExporter);
+  });
+
   it("does not initialize Sentry without a DSN", async () => {
     await importInstrument((envModule) => {
       envModule.mockEnv("SENTRY_DSN", undefined);

--- a/turbo/apps/api/src/app-factory.ts
+++ b/turbo/apps/api/src/app-factory.ts
@@ -1,6 +1,8 @@
+import { httpInstrumentationMiddleware } from "@hono/otel";
+import { context as otelContext, propagation } from "@opentelemetry/api";
 import * as Sentry from "@sentry/node";
 // oxlint-disable-next-line no-restricted-imports -- app-factory owns the Hono instance, confirmed by ethan@vm0.ai
-import { type Context, Hono } from "hono";
+import { type Context, type MiddlewareHandler, Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 
 import { env } from "./lib/env";
@@ -76,6 +78,26 @@ async function proxyToWeb(context: Context, webUrl: string): Promise<Response> {
   });
 }
 
+// Stamp the matched route template into OTel baggage so child spans (db
+// queries, outbound fetches) can carry `http.route` without reaching back
+// into the parent SERVER span. Any code further down the call tree —
+// including PgInstrumentation's requestHook in instrument.ts — reads it
+// from `propagation.getActiveBaggage()`.
+const httpRouteBaggage: MiddlewareHandler = async (c, next) => {
+  const route = c.req.routePath;
+  if (!route) {
+    return next();
+  }
+  const current = propagation.getActiveBaggage() ?? propagation.createBaggage();
+  const baggage = current.setEntry("http.route", { value: route });
+  await otelContext.with(
+    propagation.setBaggage(otelContext.active(), baggage),
+    () => {
+      return next();
+    },
+  );
+};
+
 function shouldCaptureError(error: Error): boolean {
   return !(error instanceof HTTPException) || error.status >= 500;
 }
@@ -109,6 +131,13 @@ interface CreateAppOptions {
 export function createApp({ routes = ROUTES, signal }: CreateAppOptions): Hono {
   const app = new Hono();
   app.onError(handleError);
+
+  // OpenTelemetry: each request gets a SERVER span named after its matched
+  // route template (e.g. `GET /api/v1/chat-threads/:threadId`). The baggage
+  // middleware then propagates that template down so child spans inherit
+  // `http.route` for direct slicing without trace_id joins.
+  app.use("*", httpInstrumentationMiddleware({ serviceName: "vm0-api" }));
+  app.use("*", httpRouteBaggage);
 
   for (const { route, handler } of routes) {
     app.on(route.method, route.path, honoSignalHandler(handler, route, signal));

--- a/turbo/apps/api/src/instrument.ts
+++ b/turbo/apps/api/src/instrument.ts
@@ -1,3 +1,5 @@
+import { propagation } from "@opentelemetry/api";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { PgInstrumentation } from "@opentelemetry/instrumentation-pg";
 import { ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
 import { init } from "@sentry/node";
@@ -7,22 +9,49 @@ import { env } from "./lib/env";
 
 const OTEL_SERVICE_NAME = "vm0-api";
 
+const HTTP_ROUTE_BAGGAGE_KEY = "http.route";
+
+function buildAxiomTraceExporter(): OTLPTraceExporter | "auto" {
+  const token = env("AXIOM_TOKEN_TELEMETRY");
+  const suffix = env("AXIOM_DATASET_SUFFIX");
+  if (!token || !suffix) {
+    return "auto";
+  }
+  return new OTLPTraceExporter({
+    url: "https://api.axiom.co/v1/traces",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "x-axiom-dataset": `vm0-traces-${suffix}`,
+    },
+  });
+}
+
 function setupOpenTelemetry() {
   const serviceVersion = env("VERCEL_GIT_COMMIT_SHA");
   if (!serviceVersion) {
     return;
   }
 
+  // Copy the matched route template from baggage onto every db span the
+  // hono request triggers. Lets dashboards slice "SQL P99 by URL template"
+  // without joining on trace_id.
   const pgInstrumentation = new PgInstrumentation({
     ignoreConnectSpans: true,
-    requireParentSpan: true,
+    requestHook: (span) => {
+      const route = propagation
+        .getActiveBaggage()
+        ?.getEntry(HTTP_ROUTE_BAGGAGE_KEY)?.value;
+      if (route) {
+        span.setAttribute("http.route", route);
+      }
+    },
   });
 
   registerOTel({
     serviceName: OTEL_SERVICE_NAME,
     attributes: { [ATTR_SERVICE_VERSION]: serviceVersion },
     instrumentations: [pgInstrumentation],
-    traceExporter: "auto",
+    traceExporter: buildAxiomTraceExporter(),
   });
 }
 

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -15,6 +15,8 @@ const SCHEMA = {
   VITEST: z.enum(["true", "false"]).optional(),
   VM0_DEBUG: z.string().optional(),
   VM0_WEB_URL: z.url().optional(),
+  AXIOM_TOKEN_TELEMETRY: z.string().optional(),
+  AXIOM_DATASET_SUFFIX: z.enum(["dev", "prod"]).optional(),
 } as const;
 
 const baseEnv = createEnv<undefined, typeof SCHEMA>({

--- a/turbo/apps/web/src/lib/shared/axiom/datasets.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/datasets.ts
@@ -24,6 +24,7 @@ export const DATASETS = {
   REQUEST_LOG: "request-log",
   SANDBOX_OP_LOG: "sandbox-op-log",
   RUN_CONTEXT: "run-context",
+  TRACES: "traces",
 } as const;
 
 /**

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -76,6 +76,15 @@ importers:
       '@hono/node-server':
         specifier: ^1.19.14
         version: 1.19.14(hono@4.12.15)
+      '@hono/otel':
+        specifier: ^1.1.1
+        version: 1.1.1(hono@4.12.15)
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.215.0
+        version: 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-pg':
         specifier: ^0.67.0
         version: 0.67.0(@opentelemetry/api@1.9.1)
@@ -84,7 +93,7 @@ importers:
         version: 1.40.0
       '@sentry/node':
         specifier: ^10.50.0
-        version: 10.50.0
+        version: 10.50.0(@opentelemetry/exporter-trace-otlp-http@0.215.0(@opentelemetry/api@1.9.1))
       '@t3-oss/env-core':
         specifier: ^0.13.11
         version: 0.13.11(typescript@5.9.3)(zod@4.3.6)
@@ -93,7 +102,7 @@ importers:
         version: 3.4.4(@aws-sdk/credential-provider-web-identity@3.972.35)
       '@vercel/otel':
         specifier: ^2.1.2
-        version: 2.1.2(@opentelemetry/api-logs@0.215.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))
+        version: 2.1.2(@opentelemetry/api-logs@0.215.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))
       '@vm0/api-contracts':
         specifier: workspace:*
         version: link:../../packages/api-contracts
@@ -173,7 +182,7 @@ importers:
     devDependencies:
       '@sentry/node':
         specifier: ^10.50.0
-        version: 10.50.0
+        version: 10.50.0(@opentelemetry/exporter-trace-otlp-http@0.215.0(@opentelemetry/api@1.9.1))
       '@ts-rest/core':
         specifier: 3.53.0-rc.1
         version: 3.53.0-rc.1(@types/node@24.3.0)
@@ -1946,6 +1955,11 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@hono/otel@1.1.1':
+    resolution: {integrity: sha512-zmTMS0uMMzwjO8f4IG0eFoDlr5D7XwJgiCFSHEa5MMZJRHwuSrRI78SLjn5XdFedttSlSgDwHUsf91hly16MSQ==}
+    peerDependencies:
+      hono: '>=4.0.0'
+
   '@hono/vite-build@1.11.1':
     resolution: {integrity: sha512-EQJmFL7G+71MXZQ/mmywNl4qW6DSyjTdC30cq7mlDS451a1/jE86old0M2DCWzNGCO50sv7CzQDYkz4L5dq5VQ==}
     engines: {node: '>=18.14.1'}
@@ -2458,6 +2472,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-trace-otlp-http@0.215.0':
+    resolution: {integrity: sha512-k4J9ISeGpb0Bm/wCrlcrbroMFTkiWMrdhNxQGrlktxLy127Yzd4/7nrTawn5d/ApktYTknvdixsE6++34Qfi1w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-amqplib@0.60.0':
     resolution: {integrity: sha512-q/B2IvoVXRm1M00MvhnzpMN6rKYOszPXVsALi6u0ss4AYHe+TidZEtLW9N1ZhrobI1dSriHnBqqtAOZVAv07sg==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -2728,8 +2748,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/otlp-exporter-base@0.215.0':
+    resolution: {integrity: sha512-lHrfbmeLSmesGSkkHiqDwOzfaEMSWXdc7q6UoLfbW8byONCb+bE/zkAr0kapN4US1baT/2nbpNT7Cn9XoB96Vg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/otlp-transformer@0.208.0':
     resolution: {integrity: sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.215.0':
+    resolution: {integrity: sha512-cWwBvaV+vkXHkSoTYR8hGw+AW03UlgTr6xtrUKOMeum3T+8vffYXIfXu6KY5MLu8O9QtoBKqaKWw9I5xoOepng==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2756,8 +2788,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
+  '@opentelemetry/sdk-logs@0.215.0':
+    resolution: {integrity: sha512-y3ucOmphzc4vgBTyIGchs+N/1rkACmoka8QalT2z1LBNM232Z17zMYayHcMl+dgMoOadZ0b72UZv7mDtqy1cFA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
   '@opentelemetry/sdk-metrics@2.2.0':
     resolution: {integrity: sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.7.0':
+    resolution: {integrity: sha512-Vd7h95av/LYRsAVN7wbprvvJnHkq7swMXAo7Uad0Uxf9jl6NSReLa0JNivrcc5BVIx/vl2t+cgdVQQbnVhsR9w==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
@@ -8118,6 +8162,10 @@ packages:
     resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
+  protobufjs@8.0.3:
+    resolution: {integrity: sha512-LBYnMWkKLB8fE/ljROPDbCl7mgLSlI+oBe1fAAr5MTqFg4TIi0tYrVVurJvQggOjnUYMQtEZBjrej59ojMNTHQ==}
+    engines: {node: '>=12.0.0'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -10560,6 +10608,12 @@ snapshots:
     dependencies:
       hono: 4.12.15
 
+  '@hono/otel@1.1.1(hono@4.12.15)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+      hono: 4.12.15
+
   '@hono/vite-build@1.11.1(hono@4.12.15)':
     dependencies:
       hono: 4.12.15
@@ -10941,6 +10995,15 @@ snapshots:
       '@opentelemetry/otlp-exporter-base': 0.208.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.215.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/instrumentation-amqplib@0.60.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -11333,6 +11396,12 @@ snapshots:
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/otlp-exporter-base@0.215.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.215.0(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -11343,6 +11412,17 @@ snapshots:
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
       protobufjs: 7.5.5
+
+  '@opentelemetry/otlp-transformer@0.215.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.215.0
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+      protobufjs: 8.0.3
 
   '@opentelemetry/redis-common@0.38.3': {}
 
@@ -11365,11 +11445,25 @@ snapshots:
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/sdk-logs@0.215.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.215.0
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
   '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-metrics@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -12525,7 +12619,7 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@sentry/node-core@10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+  '@sentry/node-core@10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
     dependencies:
       '@sentry/core': 10.50.0
       '@sentry/opentelemetry': 10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
@@ -12533,6 +12627,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -12577,7 +12672,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/node@10.50.0':
+  '@sentry/node@10.50.0(@opentelemetry/exporter-trace-otlp-http@0.215.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@fastify/otel': 0.18.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
@@ -12607,7 +12702,7 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.40.0
       '@prisma/instrumentation': 7.6.0(@opentelemetry/api@1.9.1)
       '@sentry/core': 10.50.0
-      '@sentry/node-core': 10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/node-core': 10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       '@sentry/opentelemetry': 10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       import-in-the-middle: 3.0.1
     transitivePeerDependencies:
@@ -13921,14 +14016,14 @@ snapshots:
 
   '@vercel/oidc@3.2.1': {}
 
-  '@vercel/otel@2.1.2(@opentelemetry/api-logs@0.215.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))':
+  '@vercel/otel@2.1.2(@opentelemetry/api-logs@0.215.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.215.0
       '@opentelemetry/instrumentation': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
@@ -17209,6 +17304,11 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
+      '@types/node': 24.3.0
+      long: 5.3.2
+
+  protobufjs@8.0.3:
+    dependencies:
       '@types/node': 24.3.0
       long: 5.3.2
 


### PR DESCRIPTION
## Summary

Adds proper per-route OpenTelemetry tracing for apps/api and routes the spans to a new `vm0-traces-{prod,dev}` Axiom dataset. The shape follows directly from earlier discussion of "per-URL request RED + per-SQL RED + SQL drilldown by URL template".

What changed:

- **`@hono/otel` middleware** in `app-factory.ts`. Each request now produces a SERVER span named after the matched route template (e.g. `GET /api/v1/chat-threads/:threadId`) with `http.route` set. This is the basis for per-route RED — Axiom can `count() / histogram()` over these spans grouped by `http.route`.
- **Baggage middleware** that puts `http.route` into OTel baggage. Child spans created during request handling (db, outbound fetch) inherit the baggage automatically.
- **`PgInstrumentation` `requestHook`** that reads `http.route` from baggage and stamps it onto every db span. So you can directly slice "P99 SQL latency by URL template" without joining on `trace_id`. Also removes `requireParentSpan: true`: now that hono creates a parent span, the guard is unnecessary, and dropping it means we never lose db spans to ordering races.
- **OTLP HTTP exporter** in `instrument.ts` pointed at `https://api.axiom.co/v1/traces` with `X-Axiom-Dataset: vm0-traces-{suffix}`. Falls back to Vercel's auto-collector when `AXIOM_TOKEN_TELEMETRY` / `AXIOM_DATASET_SUFFIX` are unset (e.g. tests, ephemeral previews).
- **`DATASETS.TRACES`** added on the web side for the shared dataset name convention.

No new env vars: `AXIOM_TOKEN_TELEMETRY` and `AXIOM_DATASET_SUFFIX` are already wired through `web-api-env` action and listed in `turbo.json` globalEnv.

## Pre-merge checklist

- [ ] **Create the Axiom datasets** `vm0-traces-prod` and `vm0-traces-dev` and confirm `AXIOM_TOKEN_TELEMETRY` has write permission to both.

## Test plan

- [x] `pnpm vitest` (128 passed)
- [x] `pnpm lint`, `pnpm check-types`
- [ ] After merge + production deploy, hit a few api routes and verify spans appear in Axiom `vm0-traces-prod`:
  - SERVER span with `name = "GET /api/v1/chat-threads/:threadId"`, attribute `http.route` set
  - CLIENT span (kind=CLIENT, db.system=postgresql) with `http.route` denormalized — confirms baggage propagation worked
- [ ] In Axiom, build a quick request-RED query: `count() by http.route, http.response.status_code` over the SERVER spans
- [ ] In Axiom, build a SQL-RED query grouping db spans by `http.route` to validate drill-down works

## Notes for follow-up

- Metrics (`http.server.request.duration`, etc.) are *also* emitted by `@hono/otel`, but this PR only configures a trace exporter. We can add an OTLP metric exporter later if Axiom-derived metrics from spans turn out to be too coarse.
- If we ever want a real waterfall / parent-child join in Axiom Traces UI, the data is already shaped correctly — no further code changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)