### PR TITLE
fix: use telegram agent display names

### DIFF
--- a/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
@@ -8,16 +8,23 @@ import {
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import {
   createTestCompose,
+  createTestRequest,
   getTestTelegramBotToken,
   updateOrgDefaultAgent,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
+import { PATCH as updateComposeMetadata } from "../../../agent/composes/[id]/metadata/route";
 
 const context = testContext();
 
 const TEST_BOT_TOKEN = "123456:ABC-test-token";
 const NEW_BOT_TOKEN = "123456:ABC-new-token";
+const TEST_AGENT_DISPLAY_NAME = "Telegram Register Helper";
+
+interface TelegramSetMyCommandsBody {
+  commands: Array<{ command: string; description: string }>;
+}
 
 function telegramGetMe(
   botId: string,
@@ -58,9 +65,15 @@ function telegramSetWebhook(succeed = true, token = TEST_BOT_TOKEN) {
 }
 
 function telegramSetMyCommands(token = TEST_BOT_TOKEN) {
-  return http.post(`https://api.telegram.org/bot${token}/setMyCommands`, () => {
-    return HttpResponse.json({ ok: true, result: true });
-  });
+  const calls: TelegramSetMyCommandsBody[] = [];
+  const handler = http.post(
+    `https://api.telegram.org/bot${token}/setMyCommands`,
+    async ({ request }) => {
+      calls.push((await request.json()) as TelegramSetMyCommandsBody);
+      return HttpResponse.json({ ok: true, result: true });
+    },
+  );
+  return { ...handler, calls };
 }
 
 function telegramOauthHead() {
@@ -77,6 +90,20 @@ function registerRequest(body: Record<string, unknown>) {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
+}
+
+async function updateAgentDisplayName(composeId: string): Promise<void> {
+  const response = await updateComposeMetadata(
+    createTestRequest(
+      `http://localhost:3000/api/agent/composes/${composeId}/metadata`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ displayName: TEST_AGENT_DISPLAY_NAME }),
+      },
+    ),
+  );
+  expect(response.status).toBe(200);
 }
 
 /** Generate a unique numeric bot ID for test isolation */
@@ -129,6 +156,7 @@ describe("POST /api/telegram/register", () => {
 
     const botId = testBotId();
     const { composeId, name } = await createTestCompose(uniqueId("agent"));
+    await updateAgentDisplayName(composeId);
 
     const getMeHandler = telegramGetMe(botId, `bot_${botId}`);
     const setWebhookHandler = telegramSetWebhook(true);
@@ -160,6 +188,18 @@ describe("POST /api/telegram/register", () => {
     expect(getMeHandler.mocked).toHaveBeenCalledTimes(1);
     expect(setWebhookHandler.mocked).toHaveBeenCalledTimes(1);
     expect(setCommandsHandler.mocked).toHaveBeenCalledTimes(1);
+    expect(setCommandsHandler.calls[0]?.commands).toEqual(
+      expect.arrayContaining([
+        {
+          command: "connect",
+          description: `Connect to ${TEST_AGENT_DISPLAY_NAME}`,
+        },
+        {
+          command: "disconnect",
+          description: `Disconnect from ${TEST_AGENT_DISPLAY_NAME}`,
+        },
+      ]),
+    );
   });
 
   it("uses the active org default agent when defaultAgentId is omitted", async () => {

--- a/turbo/apps/web/app/api/telegram/register/route.ts
+++ b/turbo/apps/web/app/api/telegram/register/route.ts
@@ -18,6 +18,7 @@ import { logger } from "../../../../src/lib/shared/logger";
 import { buildTelegramWebhookUrl } from "../../../../src/lib/zero/telegram/webhook-url";
 import { resolveOrg } from "../../../../src/lib/zero/org/resolve-org";
 import { buildTelegramBotStatus } from "../../integrations/telegram/telegram-status";
+import { getWorkspaceAgentDisplayLabel } from "../../../../src/lib/zero/telegram/handlers/shared";
 
 const registerBodySchema = z.object({
   botToken: z.string().min(1),
@@ -104,6 +105,7 @@ async function configureTelegramBot(params: {
   telegramBotId: string;
   webhookSecret: string;
   requestUrl: string;
+  agentName: string;
 }): Promise<NextResponse | undefined> {
   const baseUrl = getWebhookBaseUrl(params.requestUrl);
   const webhookUrl = buildTelegramWebhookUrl(baseUrl, params.telegramBotId);
@@ -125,8 +127,11 @@ async function configureTelegramBot(params: {
 
   await setMyCommands(params.botToken, [
     { command: "new_session", description: "Start a new conversation" },
-    { command: "connect", description: "Connect to Zero" },
-    { command: "disconnect", description: "Disconnect from Zero" },
+    { command: "connect", description: `Connect to ${params.agentName}` },
+    {
+      command: "disconnect",
+      description: `Disconnect from ${params.agentName}`,
+    },
     { command: "help", description: "Show available commands" },
   ]).catch((error) => {
     log.warn("Failed to register bot commands", { error });
@@ -197,11 +202,13 @@ async function handleExistingInstallation(params: {
   }
 
   const webhookSecret = generateCallbackSecret();
+  const agentName = await getWorkspaceAgentDisplayLabel(resolvedAgentId);
   const configureError = await configureTelegramBot({
     botToken: body.botToken,
     telegramBotId: existing.telegramBotId,
     webhookSecret,
     requestUrl,
+    agentName,
   });
   if (configureError) {
     return configureError;
@@ -346,11 +353,13 @@ export async function POST(request: Request) {
   }
 
   // 6. Set webhook and commands with Telegram
+  const agentName = await getWorkspaceAgentDisplayLabel(resolvedAgentId);
   const configureError = await configureTelegramBot({
     botToken: body.botToken,
     telegramBotId: installation.telegramBotId,
     webhookSecret,
     requestUrl: request.url,
+    agentName,
   });
   if (configureError) {
     // Rollback: delete the installation

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -138,7 +138,9 @@ describe("Telegram bot commands", () => {
       await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
-      expect(sendMsg.calls[0]?.text).toContain("Zero Telegram Bot Help");
+      expect(sendMsg.calls[0]?.text).toContain(
+        `${TEST_AGENT_DISPLAY_NAME} Telegram Bot Help`,
+      );
     });
 
     it("should ignore command targeted at a different bot", async () => {
@@ -186,7 +188,9 @@ describe("Telegram bot commands", () => {
       await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
-      expect(sendMsg.calls[0]?.text).toContain("Zero Telegram Bot Help");
+      expect(sendMsg.calls[0]?.text).toContain(
+        `${TEST_AGENT_DISPLAY_NAME} Telegram Bot Help`,
+      );
     });
 
     it("should handle case-insensitive @botUsername matching", async () => {
@@ -210,7 +214,9 @@ describe("Telegram bot commands", () => {
       await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
-      expect(sendMsg.calls[0]?.text).toContain("Zero Telegram Bot Help");
+      expect(sendMsg.calls[0]?.text).toContain(
+        `${TEST_AGENT_DISPLAY_NAME} Telegram Bot Help`,
+      );
     });
   });
 
@@ -240,6 +246,7 @@ describe("Telegram bot commands", () => {
       const text = sendMsg.calls[0]?.text ?? "";
       // Should redirect to Telegram DM instead of exposing the signed connect URL
       expect(text).toContain("connect your account");
+      expect(text).toContain(TEST_AGENT_DISPLAY_NAME);
       expect(text).not.toContain("?start=connect");
       expect(text).not.toContain("<a href=");
       expect(sendMsg.calls[0]?.reply_markup).toEqual({
@@ -276,8 +283,7 @@ describe("Telegram bot commands", () => {
       expect(sendMsg.mocked).toHaveBeenCalled();
       const text = sendMsg.calls[0]?.text ?? "";
       expect(text).toContain("already connected");
-      expect(text).toContain("start chatting with your agent");
-      expect(text).not.toContain(TEST_AGENT_DISPLAY_NAME);
+      expect(text).toContain(`start chatting with ${TEST_AGENT_DISPLAY_NAME}`);
       expect(text).not.toContain(composeName);
     });
 
@@ -303,7 +309,7 @@ describe("Telegram bot commands", () => {
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       const text = sendMsg.calls[0]?.text ?? "";
-      expect(text).toContain("To use Zero in Telegram");
+      expect(text).toContain(`To use ${TEST_AGENT_DISPLAY_NAME} in Telegram`);
       expect(text).not.toContain("/telegram/connect?bot=");
       expect(text).not.toContain("<a href=");
       const buttonUrl =
@@ -335,7 +341,10 @@ describe("Telegram bot commands", () => {
       await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
-      expect(sendMsg.calls[0]?.text).toContain("disconnected");
+      const text = sendMsg.calls[0]?.text ?? "";
+      expect(text).toContain("disconnected");
+      expect(text).toContain(TEST_AGENT_DISPLAY_NAME);
+      expect(text).not.toContain(composeName);
 
       // Verify user link was deleted
       const exists = await telegramUserLinkExists(
@@ -393,12 +402,12 @@ describe("Telegram bot commands", () => {
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       const text = sendMsg.calls[0]?.text ?? "";
-      expect(text).toContain("Zero Telegram Bot Help");
+      expect(text).toContain(`${TEST_AGENT_DISPLAY_NAME} Telegram Bot Help`);
       expect(text).toContain("/new_session");
       expect(text).toContain("/connect");
       expect(text).toContain("/disconnect");
-      expect(text).toContain("Connect to Zero");
-      expect(text).toContain("Disconnect from Zero");
+      expect(text).toContain(`Connect to ${TEST_AGENT_DISPLAY_NAME}`);
+      expect(text).toContain(`Disconnect from ${TEST_AGENT_DISPLAY_NAME}`);
     });
 
     it("should match Slack-style help without admin-only copy", async () => {
@@ -494,7 +503,9 @@ describe("Telegram bot commands", () => {
       await context.mocks.flushAfter();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
-      expect(sendMsg.calls[0]?.text).toContain("connect your account");
+      const text = sendMsg.calls[0]?.text ?? "";
+      expect(text).toContain("connect your account");
+      expect(text).toContain(TEST_AGENT_DISPLAY_NAME);
       const buttonUrl =
         sendMsg.calls[0]?.reply_markup?.inline_keyboard[0]?.[0]?.url ?? "";
       expect(buttonUrl).toContain("/telegram/connect?bot=");

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -317,6 +317,33 @@ describe("Telegram bot commands", () => {
       expect(buttonUrl).toContain("/telegram/connect?bot=");
       expect(buttonUrl).toContain("tgUser=99999");
     });
+
+    it("should escape agent display name in connect prompts", async () => {
+      await updateAgentDisplayName(composeId, "Helper <b>& Co");
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: 99999, type: "private" },
+          from: { id: 99999, username: "unknown_user" },
+          text: "/connect",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ telegramBotId: installationId }),
+      });
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      expect(sendMsg.mocked).toHaveBeenCalled();
+      const text = sendMsg.calls[0]?.text ?? "";
+      expect(text).toContain("Helper &lt;b&gt;&amp; Co");
+      expect(text).not.toContain("Helper <b>& Co");
+    });
   });
 
   describe("/disconnect command", () => {

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/commands.ts
@@ -15,6 +15,7 @@ import {
   formatTelegramConnectPrompt,
   formatTelegramHelpMessage,
   formatTelegramPrivateConnectPrompt,
+  getWorkspaceAgentDisplayLabel,
 } from "./shared";
 import { logger } from "../../../shared/logger";
 import type { TelegramHandlerUpdate } from "./types";
@@ -60,11 +61,17 @@ export async function handleConnectCommand(
       : undefined;
 
   if (userLink) {
+    const agentName = await getWorkspaceAgentDisplayLabel(
+      installation.defaultComposeId,
+    );
     await sendMessage(
       client,
       chatId,
       formatTelegramCommandSuccess(
-        formatTelegramAlreadyConnectedMessage(installation.botUsername),
+        formatTelegramAlreadyConnectedMessage(
+          installation.botUsername,
+          agentName,
+        ),
       ),
       replyOptions,
     );
@@ -74,10 +81,13 @@ export async function handleConnectCommand(
   // In group chats, don't expose the connect URL publicly to prevent
   // other users from hijacking the link. Direct users to DM instead.
   if (message.chat.type !== "private") {
+    const agentName = await getWorkspaceAgentDisplayLabel(
+      installation.defaultComposeId,
+    );
     await sendMessage(
       client,
       chatId,
-      formatTelegramPrivateConnectPrompt(installation.botUsername),
+      formatTelegramPrivateConnectPrompt(installation.botUsername, agentName),
       {
         ...replyOptions,
         replyMarkup: buildTelegramPrivateConnectReplyMarkup(
@@ -93,7 +103,10 @@ export async function handleConnectCommand(
     fromUserId,
     botToken,
   );
-  await sendMessage(client, chatId, formatTelegramConnectPrompt(), {
+  const agentName = await getWorkspaceAgentDisplayLabel(
+    installation.defaultComposeId,
+  );
+  await sendMessage(client, chatId, formatTelegramConnectPrompt(agentName), {
     replyMarkup: buildTelegramConnectReplyMarkup(connectUrl),
   });
 }
@@ -145,6 +158,10 @@ export async function handleDisconnectCommand(
     return;
   }
 
+  const agentName = await getWorkspaceAgentDisplayLabel(
+    installation.defaultComposeId,
+  );
+
   // Delete user link
   await globalThis.services.db
     .delete(telegramUserLinks)
@@ -154,7 +171,7 @@ export async function handleDisconnectCommand(
     client,
     chatId,
     formatTelegramCommandSuccess(
-      "You have been disconnected and your agent access has been revoked.",
+      `You have been disconnected and your access to ${agentName} has been revoked.`,
     ),
     replyOptions,
   );
@@ -199,11 +216,14 @@ export async function handleHelpCommand(
     message.chat.type !== "private"
       ? { replyToMessageId: message.message_id }
       : undefined;
+  const agentName = await getWorkspaceAgentDisplayLabel(
+    installation.defaultComposeId,
+  );
 
   await sendMessage(
     client,
     chatId,
-    formatTelegramHelpMessage(installation.botUsername),
+    formatTelegramHelpMessage(installation.botUsername, agentName),
     replyOptions,
   );
 }

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/direct-message.ts
@@ -19,6 +19,7 @@ import {
   resolveTelegramAuditLogsUrl,
   buildTelegramConnectReplyMarkup,
   formatTelegramConnectPrompt,
+  getWorkspaceAgentDisplayLabel,
 } from "./shared";
 import { fetchTelegramContext } from "../context";
 import { runAgentForTelegram } from "./run-agent";
@@ -67,12 +68,15 @@ export async function handleTelegramDirectMessage(
   const userLink = await resolveUserLink(installationId, fromUserId);
 
   if (!userLink) {
+    const agentName = await getWorkspaceAgentDisplayLabel(
+      installation.defaultComposeId,
+    );
     const connectUrl = buildConnectUrl(
       installation.telegramBotId,
       fromUserId,
       botToken,
     );
-    await sendMessage(client, chatId, formatTelegramConnectPrompt(), {
+    await sendMessage(client, chatId, formatTelegramConnectPrompt(agentName), {
       replyMarkup: buildTelegramConnectReplyMarkup(connectUrl),
     });
     return;

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/mention.ts
@@ -18,6 +18,7 @@ import {
   resolveTelegramAuditLogsUrl,
   buildTelegramPrivateConnectReplyMarkup,
   formatTelegramPrivateConnectPrompt,
+  getWorkspaceAgentDisplayLabel,
 } from "./shared";
 import { fetchTelegramContext } from "../context";
 import { runAgentForTelegram } from "./run-agent";
@@ -74,10 +75,13 @@ export async function handleTelegramMention(
   const userLink = await resolveUserLink(installationId, fromUserId);
 
   if (!userLink) {
+    const agentName = await getWorkspaceAgentDisplayLabel(
+      installation.defaultComposeId,
+    );
     await sendMessage(
       client,
       chatId,
-      formatTelegramPrivateConnectPrompt(installation.botUsername),
+      formatTelegramPrivateConnectPrompt(installation.botUsername, agentName),
       {
         replyToMessageId: message.message_id,
         replyMarkup: buildTelegramPrivateConnectReplyMarkup(

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/new-session.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/new-session.ts
@@ -10,6 +10,7 @@ import {
   buildTelegramConnectReplyMarkup,
   formatTelegramCommandSuccess,
   formatTelegramConnectPrompt,
+  getWorkspaceAgentDisplayLabel,
 } from "./shared";
 import { logger } from "../../../shared/logger";
 import type { TelegramHandlerUpdate } from "./types";
@@ -54,12 +55,15 @@ export async function handleNewSessionCommand(
 
   const userLink = await resolveUserLink(installationId, fromUserId);
   if (!userLink) {
+    const agentName = await getWorkspaceAgentDisplayLabel(
+      installation.defaultComposeId,
+    );
     const connectUrl = buildConnectUrl(
       installation.telegramBotId,
       fromUserId,
       botToken,
     );
-    await sendMessage(client, chatId, formatTelegramConnectPrompt(), {
+    await sendMessage(client, chatId, formatTelegramConnectPrompt(agentName), {
       replyMarkup: buildTelegramConnectReplyMarkup(connectUrl),
     });
     return;

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/shared.ts
@@ -478,7 +478,7 @@ function normalizedBotUsername(botUsername: string | null | undefined): string {
 export function formatTelegramConnectPrompt(
   agentName: string = "Zero",
 ): string {
-  return `To use ${agentName} in Telegram, please connect your account first.`;
+  return `To use ${escapeHtml(agentName)} in Telegram, please connect your account first.`;
 }
 
 export function buildTelegramConnectReplyMarkup(

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/shared.ts
@@ -464,12 +464,21 @@ export function getAgentDisplayLabel(agent: {
   return name || "zero";
 }
 
+export async function getWorkspaceAgentDisplayLabel(
+  composeId: string,
+): Promise<string> {
+  const agent = await getWorkspaceAgent(composeId);
+  return agent ? getAgentDisplayLabel(agent) : "Zero";
+}
+
 function normalizedBotUsername(botUsername: string | null | undefined): string {
   return botUsername?.replace(/^@/, "").trim() ?? "";
 }
 
-export function formatTelegramConnectPrompt(): string {
-  return "To use Zero in Telegram, please connect your account first.";
+export function formatTelegramConnectPrompt(
+  agentName: string = "Zero",
+): string {
+  return `To use ${agentName} in Telegram, please connect your account first.`;
 }
 
 export function buildTelegramConnectReplyMarkup(
@@ -482,13 +491,14 @@ export function buildTelegramConnectReplyMarkup(
 
 export function formatTelegramPrivateConnectPrompt(
   botUsername: string | null | undefined,
+  agentName: string = "Zero",
 ): string {
   const username = normalizedBotUsername(botUsername);
   if (!username) {
-    return "To use Zero in Telegram, please connect your account first.\n\nSend me /connect in a private message.";
+    return `${formatTelegramConnectPrompt(agentName)}\n\nSend me /connect in a private message.`;
   }
 
-  return "To use Zero in Telegram, please connect your account first.";
+  return formatTelegramConnectPrompt(agentName);
 }
 
 export function buildTelegramPrivateConnectReplyMarkup(
@@ -506,12 +516,13 @@ export function buildTelegramPrivateConnectReplyMarkup(
 
 export function formatTelegramAlreadyConnectedMessage(
   botUsername: string | null | undefined,
+  agentName: string = "Zero",
 ): string {
   const username = normalizedBotUsername(botUsername);
   const target = username
     ? `Mention @${username} in a group or send a DM`
     : "Send a DM";
-  return `You are already connected.\n${target} to start chatting with your agent.`;
+  return `You are already connected.\n${target} to start chatting with ${agentName}.`;
 }
 
 export function formatTelegramCommandSuccess(message: string): string {
@@ -524,22 +535,24 @@ export function formatTelegramCommandError(message: string): string {
 
 export function formatTelegramHelpMessage(
   botUsername: string | null | undefined,
+  agentName: string = "Zero",
 ): string {
   const username = normalizedBotUsername(botUsername);
+  const label = escapeHtml(agentName);
   const groupUsage = username
-    ? `• <code>@${escapeHtml(username)} &lt;message&gt;</code> - Send a message to your agent\n`
+    ? `• <code>@${escapeHtml(username)} &lt;message&gt;</code> - Send a message to ${label}\n`
     : "";
 
   return [
-    "<b>Zero Telegram Bot Help</b>",
+    `<b>${label} Telegram Bot Help</b>`,
     "",
     "<b>Commands</b>",
-    "• <code>/connect</code> - Connect to Zero",
+    `• <code>/connect</code> - Connect to ${label}`,
     "• <code>/new_session</code> - Start a new conversation",
-    "• <code>/disconnect</code> - Disconnect from Zero",
+    `• <code>/disconnect</code> - Disconnect from ${label}`,
     "",
     "<b>Usage</b>",
-    `${groupUsage}• Send a DM to chat with your agent`,
+    `${groupUsage}• Send a DM to chat with ${label}`,
   ].join("\n");
 }
 

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/start.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/start.ts
@@ -13,6 +13,7 @@ import {
   formatTelegramCommandError,
   formatTelegramCommandSuccess,
   formatTelegramConnectPrompt,
+  getWorkspaceAgentDisplayLabel,
 } from "./shared";
 import { logger } from "../../../shared/logger";
 import type { TelegramHandlerUpdate } from "./types";
@@ -84,11 +85,17 @@ export async function handleStartCommand(
     // No token or deep link from group chat (/start connect) → prompt login
     const userLink = await resolveUserLink(installationId, fromUserId);
     if (userLink) {
+      const agentName = await getWorkspaceAgentDisplayLabel(
+        installation.defaultComposeId,
+      );
       await sendMessage(
         client,
         chatId,
         formatTelegramCommandSuccess(
-          formatTelegramAlreadyConnectedMessage(installation.botUsername),
+          formatTelegramAlreadyConnectedMessage(
+            installation.botUsername,
+            agentName,
+          ),
         ),
       );
       return;
@@ -98,7 +105,10 @@ export async function handleStartCommand(
       fromUserId,
       botToken,
     );
-    await sendMessage(client, chatId, formatTelegramConnectPrompt(), {
+    const agentName = await getWorkspaceAgentDisplayLabel(
+      installation.defaultComposeId,
+    );
+    await sendMessage(client, chatId, formatTelegramConnectPrompt(agentName), {
       replyMarkup: buildTelegramConnectReplyMarkup(connectUrl),
     });
     return;
@@ -148,12 +158,15 @@ export async function handleStartCommand(
   // Auto-grant permission. The installation's orgId was snapshot at
   // registration and is the authoritative org for this bot.
   await ensureOrgAndArtifact(payload.vm0UserId, installation.orgId);
+  const agentName = await getWorkspaceAgentDisplayLabel(
+    installation.defaultComposeId,
+  );
 
   await sendMessage(
     client,
     chatId,
     formatTelegramCommandSuccess(
-      "Account linked.\nSend me a message to start chatting with your agent.",
+      `Account linked.\nSend me a message to start chatting with ${agentName}.`,
     ),
   );
 


### PR DESCRIPTION
## Summary
- Use the selected agent display label in Telegram connect, help, linked, unlink, and start messages
- Register Telegram bot command descriptions with the agent display label
- Update webhook and register route tests for display-name-aware copy

## Tests
- pnpm test app/api/telegram/webhook/__tests__/commands.test.ts app/api/telegram/webhook/__tests__/route.test.ts app/api/telegram/register/__tests__/route.test.ts