### PR TITLE
feat: add telegram bot setup dialog

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
@@ -11,6 +11,7 @@ const defaultTelegramBots: TelegramBot[] = [
   {
     id: "bot_123",
     username: "test_bot",
+    avatarUrl: null,
     agent: { id: "compose_1", name: "default-agent" },
     isOwner: true,
     isConnected: true,
@@ -46,6 +47,7 @@ function statusToBot(status: TelegramBotStatus): TelegramBot {
   return {
     id: status.id,
     username: status.username,
+    avatarUrl: status.avatarUrl,
     agent: status.agent,
     isOwner: status.isOwner,
     isConnected: status.isConnected,
@@ -231,6 +233,9 @@ export const apiIntegrationsTelegramHandlers = [
       const status: TelegramBotStatus = {
         ...existing,
         tokenStatus: "valid",
+        avatarUrl:
+          existing.avatarUrl ??
+          `/api/integrations/telegram/${encodeURIComponent(existing.id)}/avatar`,
       };
       mockTelegramStatuses[status.id] = structuredClone(status);
       mockTelegramList.bots = mockTelegramList.bots.map((bot) => {
@@ -254,6 +259,7 @@ export const apiIntegrationsTelegramHandlers = [
           ? "registered_bot"
           : `registered_bot_${mockRegisterCounter}`,
       agent: { id: agentId, name: "default-agent" },
+      avatarUrl: `/api/integrations/telegram/${encodeURIComponent(id)}/avatar`,
       isOwner: true,
       isConnected: false,
       tokenStatus: "valid",

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-telegram.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-telegram.test.ts
@@ -40,6 +40,7 @@ function telegramStatus(
   return {
     id,
     username: `${id}_bot`,
+    avatarUrl: null,
     agent: { id: "compose_1", name: "Default agent" },
     isOwner: true,
     isConnected: false,

--- a/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
@@ -11,6 +11,7 @@ import { featureSwitch$ } from "../external/feature-switch.ts";
 import { accept } from "../../lib/accept.ts";
 
 const internalReload$ = state(0);
+const internalTelegramAddDialogOpen$ = state(false);
 const internalTelegramBotTokenForm$ = state("");
 const internalTelegramBotAgentForm$ = state<string | null>(null);
 const internalTelegramSavingBotId$ = state<string | null>(null);
@@ -23,6 +24,10 @@ const internalTelegramReinstallingBotId$ = state<string | null>(null);
 
 export const telegramBotTokenForm$ = computed((get) => {
   return get(internalTelegramBotTokenForm$);
+});
+
+export const telegramAddDialogOpen$ = computed((get) => {
+  return get(internalTelegramAddDialogOpen$);
 });
 
 export const telegramBotAgentForm$ = computed((get) => {
@@ -59,6 +64,14 @@ export const telegramReinstallingBotId$ = computed((get) => {
 
 export const setTelegramBotTokenForm$ = command(({ set }, value: string) => {
   set(internalTelegramBotTokenForm$, value);
+});
+
+export const setTelegramAddDialogOpen$ = command(({ set }, open: boolean) => {
+  set(internalTelegramAddDialogOpen$, open);
+  if (!open) {
+    set(internalTelegramBotTokenForm$, "");
+    set(internalTelegramBotAgentForm$, null);
+  }
 });
 
 export const setTelegramBotAgentForm$ = command(
@@ -113,6 +126,7 @@ export const setTelegramReinstallingBotId$ = command(
 );
 
 export const resetTelegramSettingsUi$ = command(({ set }) => {
+  set(internalTelegramAddDialogOpen$, false);
   set(internalTelegramBotTokenForm$, "");
   set(internalTelegramBotAgentForm$, null);
   set(internalTelegramSavingBotId$, null);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
@@ -53,6 +53,7 @@ function telegramStatus(
   return {
     id,
     username: `${id}_bot`,
+    avatarUrl: null,
     agent: { id: ZERO_AGENT_ID, name: "Zero" },
     isOwner: true,
     isConnected: false,
@@ -83,10 +84,18 @@ describe("telegram settings page", () => {
   });
 
   it("lists multiple Telegram bots", async () => {
+    const alphaAvatarPath = `/${[
+      "api",
+      "integrations",
+      "telegram",
+      "alpha",
+      "avatar",
+    ].join("/")}`;
     setMockTelegramIntegration({
       statuses: [
         telegramStatus("alpha", {
           username: "alpha_bot",
+          avatarUrl: alphaAvatarPath,
           isConnected: true,
         }),
         telegramStatus("beta", {
@@ -100,27 +109,67 @@ describe("telegram settings page", () => {
     await waitFor(() => {
       expect(screen.getByText("@alpha_bot")).toBeInTheDocument();
       expect(screen.getByText("@beta_bot")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("telegram-bot-avatar-fallback-beta"),
+      ).toBeInTheDocument();
       expect(screen.getByTestId("telegram-bot-count")).toHaveTextContent(
-        "2 bots",
+        "This organization has 2 Telegram bots",
       );
     });
+
+    const alphaAvatar = screen.getByTestId("telegram-bot-avatar-alpha");
+    expect(alphaAvatar).toHaveAttribute(
+      "src",
+      `http://localhost:3000${alphaAvatarPath}`,
+    );
+    fireEvent.error(alphaAvatar);
+    expect(
+      screen.getByTestId("telegram-bot-avatar-fallback-alpha"),
+    ).toBeInTheDocument();
   });
 
   it("shows the empty state and redirects to connect after adding a Telegram bot", async () => {
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
+
     setMockTelegramIntegration({ statuses: [] });
     setupTelegramPage();
 
     await waitFor(() => {
       expect(screen.getByText("No Telegram bots yet")).toBeInTheDocument();
+      expect(screen.getByTestId("telegram-bot-count")).toHaveTextContent(
+        "This organization has no Telegram bots",
+      );
     });
 
     click(screen.getByText("Add bot"));
     const dialog = await screen.findByRole("dialog");
 
+    const botFatherLink = within(dialog).getByText("@BotFather");
+    expect(botFatherLink).toHaveAttribute("href", "https://t.me/BotFather");
     expect(within(dialog).getByText("/newbot")).toBeInTheDocument();
     expect(within(dialog).getByText("/setprivacy")).toBeInTheDocument();
     expect(within(dialog).getByText("/setdomain")).toBeInTheDocument();
     expect(within(dialog).getByText(location.hostname)).toBeInTheDocument();
+
+    click(within(dialog).getByLabelText("Copy /newbot"));
+    await waitFor(() => {
+      expect(within(dialog).getByLabelText("Copy /newbot")).toHaveTextContent(
+        "copied!",
+      );
+    });
+    click(within(dialog).getByLabelText("Copy /setprivacy"));
+    click(within(dialog).getByLabelText("Copy /setdomain"));
+    click(within(dialog).getByLabelText(`Copy ${location.hostname}`));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("/newbot");
+      expect(writeText).toHaveBeenCalledWith("/setprivacy");
+      expect(writeText).toHaveBeenCalledWith("/setdomain");
+      expect(writeText).toHaveBeenCalledWith(location.hostname);
+      expect(writeText).not.toHaveBeenCalledWith("@BotFather");
+    });
 
     await waitFor(() => {
       expect(screen.getByLabelText("Default agent")).toHaveTextContent("Zero");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import type { TelegramBotStatus } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
@@ -113,12 +113,21 @@ describe("telegram settings page", () => {
     await waitFor(() => {
       expect(screen.getByText("No Telegram bots yet")).toBeInTheDocument();
     });
+
+    click(screen.getByText("Add bot"));
+    const dialog = await screen.findByRole("dialog");
+
+    expect(within(dialog).getByText("/newbot")).toBeInTheDocument();
+    expect(within(dialog).getByText("/setprivacy")).toBeInTheDocument();
+    expect(within(dialog).getByText("/setdomain")).toBeInTheDocument();
+    expect(within(dialog).getByText(location.hostname)).toBeInTheDocument();
+
     await waitFor(() => {
       expect(screen.getByLabelText("Default agent")).toHaveTextContent("Zero");
     });
 
     await fill(screen.getByLabelText("Bot token"), "123:token");
-    click(screen.getByText("Add bot"));
+    click(within(dialog).getByText("Add bot"));
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
@@ -19,6 +19,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
 } from "@vm0/ui/components/ui/dialog";
 import { Input } from "@vm0/ui/components/ui/input";
 import {
@@ -46,6 +47,7 @@ import {
   disconnectTelegramAccount$,
   registerTelegramBot$,
   reinstallTelegramBot$,
+  setTelegramAddDialogOpen$,
   setTelegramReinstallDialogBotId$,
   setTelegramReinstallingBotId$,
   setTelegramReinstallTokenForm$,
@@ -55,6 +57,7 @@ import {
   setTelegramUninstallDialogBotId$,
   setTelegramUninstallingBotId$,
   setTelegramUnlinkingBotId$,
+  telegramAddDialogOpen$,
   telegramBotAgentForm$,
   telegramBots$,
   telegramBotTokenForm$,
@@ -77,6 +80,9 @@ interface DefaultAgentLabel {
   id: string | null;
   displayName: string | null;
 }
+
+const TELEGRAM_COMMAND_CLASS =
+  "rounded border border-border bg-background px-1 py-0.5 font-mono text-xs";
 
 function agentLabel(
   agent: TeamComposeItem | { id: string; name: string },
@@ -178,7 +184,123 @@ function TelegramStatusBadge({ bot }: { bot: TelegramBot }) {
   );
 }
 
-function AddTelegramBotForm({
+function getTelegramLoginDomain(): string {
+  if (typeof location === "undefined" || !location.hostname) {
+    return "your app domain";
+  }
+  return location.hostname;
+}
+
+function TelegramCommand({ command }: { command: string }) {
+  return <code className={TELEGRAM_COMMAND_CLASS}>{command}</code>;
+}
+
+function AddTelegramBotInstructions({ domain }: { domain: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-muted/30 p-4">
+      <ol className="list-decimal space-y-3 pl-4 text-sm leading-relaxed text-muted-foreground">
+        <li>
+          Open{" "}
+          <a
+            href="https://t.me/BotFather"
+            target="_blank"
+            rel="noreferrer"
+            className="font-medium text-foreground underline-offset-4 hover:underline"
+          >
+            @BotFather
+          </a>
+          , send <TelegramCommand command="/newbot" />, choose a name and
+          username, then copy the bot token.
+        </li>
+        <li>
+          If the bot should respond to normal group chat messages, send{" "}
+          <TelegramCommand command="/setprivacy" />, choose the bot, and disable
+          privacy mode. With privacy enabled, Telegram only sends commands,
+          replies, and mentions from groups.
+        </li>
+        <li>
+          For Telegram web login, send <TelegramCommand command="/setdomain" />,
+          choose the bot, and set the domain to{" "}
+          <code className={TELEGRAM_COMMAND_CLASS}>{domain}</code>.
+        </li>
+      </ol>
+    </div>
+  );
+}
+
+function AddTelegramBotFields({
+  agents,
+  defaultAgent,
+  agentId,
+  botToken,
+  selectedAgentLabel,
+  disabled,
+  adding,
+  onBotTokenChange,
+  onAgentChange,
+}: {
+  agents: TeamComposeItem[];
+  defaultAgent: DefaultAgentLabel;
+  agentId: string | undefined;
+  botToken: string;
+  selectedAgentLabel: string;
+  disabled: boolean;
+  adding: boolean;
+  onBotTokenChange: (value: string) => void;
+  onAgentChange: (value: string) => void;
+}) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-[1fr_16rem]">
+      <div className="min-w-0">
+        <label
+          htmlFor="telegram-bot-token"
+          className="mb-2 block text-sm font-medium text-foreground"
+        >
+          Bot token
+        </label>
+        <Input
+          id="telegram-bot-token"
+          type="password"
+          value={botToken}
+          disabled={disabled || adding}
+          autoComplete="off"
+          placeholder="123456:ABC-DEF"
+          onChange={(event) => {
+            onBotTokenChange(event.target.value);
+          }}
+        />
+      </div>
+      <div className="min-w-0">
+        <label
+          htmlFor="telegram-new-bot-agent"
+          className="mb-2 block text-sm font-medium text-foreground"
+        >
+          Default agent
+        </label>
+        <Select
+          value={agentId ?? ""}
+          disabled={disabled || adding || agents.length === 0}
+          onValueChange={onAgentChange}
+        >
+          <SelectTrigger id="telegram-new-bot-agent">
+            <SelectValue placeholder={selectedAgentLabel} />
+          </SelectTrigger>
+          <SelectContent>
+            {agents.map((agent) => {
+              return (
+                <SelectItem key={agent.id} value={agent.id}>
+                  {agentLabel(agent, defaultAgent)}
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
+function AddTelegramBotDialog({
   agents,
   defaultAgent,
   disabled,
@@ -188,7 +310,9 @@ function AddTelegramBotForm({
   disabled: boolean;
 }) {
   const botToken = useGet(telegramBotTokenForm$);
+  const open = useGet(telegramAddDialogOpen$);
   const selectedAgentId = useGet(telegramBotAgentForm$);
+  const domain = getTelegramLoginDomain();
   const preferredAgentId = selectedAgentId ?? defaultAgent.id ?? agents[0]?.id;
   const selectedAgent =
     agents.find((agent) => {
@@ -200,6 +324,7 @@ function AddTelegramBotForm({
     : (defaultAgent.displayName ?? "Select agent");
   const setBotToken = useSet(setTelegramBotTokenForm$);
   const setAgentId = useSet(setTelegramBotAgentForm$);
+  const setOpen = useSet(setTelegramAddDialogOpen$);
   const navigate = useSet(detachedNavigateTo$);
   const pageSignal = useGet(pageSignal$);
   const [registerLoadable, registerBot] = useLoadableSet(registerTelegramBot$);
@@ -207,95 +332,96 @@ function AddTelegramBotForm({
   const canSubmit = botToken.trim().length > 0 && !disabled && !adding;
 
   return (
-    <form
-      className="zero-card p-4 sm:p-5"
-      aria-label="Add Telegram bot"
-      onSubmit={(event) => {
-        event.preventDefault();
-        if (!canSubmit) {
-          return;
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!adding) {
+          setOpen(nextOpen);
         }
-
-        detach(
-          registerBot(
-            {
-              botToken: botToken.trim(),
-              ...(agentId ? { defaultAgentId: agentId } : {}),
-            },
-            pageSignal,
-          ).then((bot) => {
-            setBotToken("");
-            setAgentId(null);
-            navigate(ROUTES.telegramConnect, {
-              searchParams: new URLSearchParams({ bot: bot.id }),
-            });
-          }),
-          Reason.DomCallback,
-        );
       }}
     >
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
-        <div className="min-w-0 flex-1">
-          <label
-            htmlFor="telegram-bot-token"
-            className="mb-2 block text-sm font-medium text-foreground"
+      <div className="flex justify-end">
+        <DialogTrigger asChild>
+          <Button
+            type="button"
+            disabled={disabled}
+            className="h-10 shrink-0 gap-2"
           >
-            Bot token
-          </label>
-          <Input
-            id="telegram-bot-token"
-            type="password"
-            value={botToken}
-            disabled={disabled || adding}
-            autoComplete="off"
-            placeholder="123456:ABC-DEF"
-            onChange={(event) => {
-              setBotToken(event.target.value);
-            }}
-          />
-        </div>
-        <div className="min-w-0 sm:w-64">
-          <label
-            htmlFor="telegram-new-bot-agent"
-            className="mb-2 block text-sm font-medium text-foreground"
-          >
-            Default agent
-          </label>
-          <Select
-            value={agentId ?? ""}
-            disabled={disabled || adding || agents.length === 0}
-            onValueChange={(value) => {
-              setAgentId(value);
-            }}
-          >
-            <SelectTrigger id="telegram-new-bot-agent">
-              <SelectValue placeholder={selectedAgentLabel} />
-            </SelectTrigger>
-            <SelectContent>
-              {agents.map((agent) => {
-                return (
-                  <SelectItem key={agent.id} value={agent.id}>
-                    {agentLabel(agent, defaultAgent)}
-                  </SelectItem>
-                );
-              })}
-            </SelectContent>
-          </Select>
-        </div>
-        <Button
-          type="submit"
-          disabled={!canSubmit}
-          className="h-10 shrink-0 gap-2"
-        >
-          {adding ? (
-            <IconLoader2 size={16} className="animate-spin" />
-          ) : (
             <IconPlus size={16} />
-          )}
-          {adding ? "Adding..." : "Add bot"}
-        </Button>
+            Add bot
+          </Button>
+        </DialogTrigger>
       </div>
-    </form>
+      <DialogContent className="sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>Add Telegram bot</DialogTitle>
+          <DialogDescription>
+            Create the bot in BotFather, then register its token here.
+          </DialogDescription>
+        </DialogHeader>
+        <AddTelegramBotInstructions domain={domain} />
+        <form
+          className="flex flex-col gap-4"
+          aria-label="Register Telegram bot"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (!canSubmit) {
+              return;
+            }
+
+            detach(
+              registerBot(
+                {
+                  botToken: botToken.trim(),
+                  ...(agentId ? { defaultAgentId: agentId } : {}),
+                },
+                pageSignal,
+              ).then((bot) => {
+                setBotToken("");
+                setAgentId(null);
+                setOpen(false);
+                navigate(ROUTES.telegramConnect, {
+                  searchParams: new URLSearchParams({ bot: bot.id }),
+                });
+              }),
+              Reason.DomCallback,
+            );
+          }}
+        >
+          <AddTelegramBotFields
+            agents={agents}
+            defaultAgent={defaultAgent}
+            agentId={agentId}
+            botToken={botToken}
+            selectedAgentLabel={selectedAgentLabel}
+            disabled={disabled}
+            adding={adding}
+            onBotTokenChange={setBotToken}
+            onAgentChange={setAgentId}
+          />
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={adding}
+              onClick={() => {
+                setOpen(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!canSubmit} className="gap-2">
+              {adding ? (
+                <IconLoader2 size={16} className="animate-spin" />
+              ) : (
+                <IconPlus size={16} />
+              )}
+              {adding ? "Adding..." : "Add bot"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -862,7 +988,7 @@ export function ZeroTelegramSettingsPage() {
             <TelegramSettingsSkeleton />
           ) : (
             <>
-              <AddTelegramBotForm
+              <AddTelegramBotDialog
                 agents={agents}
                 defaultAgent={defaultAgent}
                 disabled={agentsLoading}

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
@@ -1,3 +1,4 @@
+import { Component } from "react";
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
@@ -8,6 +9,7 @@ import {
   IconLoader2,
   IconPlus,
   IconRefresh,
+  IconRobot,
 } from "@tabler/icons-react";
 import type { TelegramBot } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
@@ -37,6 +39,8 @@ import {
 } from "@vm0/ui/components/ui/popover";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
+import { apiBase$ } from "../../signals/fetch.ts";
+import { writeToClipboard } from "../../signals/zero-page/clipboard.ts";
 import {
   defaultAgentId$,
   defaultAgentName$,
@@ -82,7 +86,8 @@ interface DefaultAgentLabel {
 }
 
 const TELEGRAM_COMMAND_CLASS =
-  "rounded border border-border bg-background px-1 py-0.5 font-mono text-xs";
+  "cursor-pointer rounded border border-border bg-background px-1 py-0.5 font-mono text-xs text-foreground transition-colors hover:bg-accent active:bg-accent/80";
+const BOT_FATHER_HANDLE = "@BotFather";
 
 function agentLabel(
   agent: TeamComposeItem | { id: string; name: string },
@@ -146,12 +151,62 @@ function botRouteLabel(
 function TelegramSettingsSkeleton() {
   return (
     <div
-      className="flex flex-col gap-3"
+      className="flex flex-col gap-4"
       data-testid="telegram-settings-loading"
     >
-      <Skeleton className="h-32 w-full rounded-xl" />
-      <Skeleton className="h-24 w-full rounded-xl" />
-      <Skeleton className="h-24 w-full rounded-xl" />
+      <Skeleton className="h-4 w-64 max-w-full" />
+      <div className="zero-card overflow-hidden">
+        {[0, 1, 2].map((index) => {
+          return (
+            <div key={index}>
+              <div className="flex flex-col gap-4 px-4 py-4 sm:flex-row sm:items-center sm:px-5">
+                <div className="flex min-w-0 flex-1 items-center gap-3">
+                  <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Skeleton className="h-4 w-32" />
+                      <Skeleton className="h-6 w-24 rounded-lg" />
+                    </div>
+                    <Skeleton className="h-4 w-40 max-w-full" />
+                  </div>
+                </div>
+                <div className="grid gap-2 sm:w-[360px] sm:grid-cols-[1fr_auto]">
+                  <Skeleton className="h-9 w-full rounded-md" />
+                  <div className="flex items-center justify-end gap-1.5">
+                    <Skeleton className="h-9 w-20 rounded-md" />
+                    <Skeleton className="h-8 w-8 rounded-md" />
+                  </div>
+                </div>
+              </div>
+              {index < 2 ? (
+                <div className="mx-5 border-b border-border/50" />
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function AddTelegramBotButtonSkeleton() {
+  return <Skeleton className="h-10 w-[105px] shrink-0 rounded-md" />;
+}
+
+function telegramBotCountLabel(count: number): string {
+  if (count === 0) {
+    return "This organization has no Telegram bots";
+  }
+  return `This organization has ${String(count)} Telegram ${count === 1 ? "bot" : "bots"}`;
+}
+
+function TelegramBotCount({ count }: { count: number }) {
+  return (
+    <div
+      data-testid="telegram-bot-count"
+      className="text-sm text-muted-foreground"
+    >
+      {telegramBotCountLabel(count)}
     </div>
   );
 }
@@ -184,6 +239,73 @@ function TelegramStatusBadge({ bot }: { bot: TelegramBot }) {
   );
 }
 
+function TelegramBotIconFallback({ botId }: { botId: string }) {
+  return (
+    <div
+      className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#2AABEE]/10 text-[#2AABEE]"
+      data-testid={`telegram-bot-avatar-fallback-${botId}`}
+    >
+      <IconRobot className="h-5 w-5" stroke={1.75} />
+    </div>
+  );
+}
+
+class TelegramBotAvatar extends Component<
+  { bot: TelegramBot; avatarUrl: string | null },
+  { failed: boolean }
+> {
+  state: { failed: boolean } = {
+    failed: false,
+  };
+
+  componentDidUpdate(previousProps: {
+    bot: TelegramBot;
+    avatarUrl: string | null;
+  }) {
+    if (
+      previousProps.bot.id !== this.props.bot.id ||
+      previousProps.avatarUrl !== this.props.avatarUrl
+    ) {
+      this.setState({ failed: false });
+    }
+  }
+
+  render() {
+    const { bot, avatarUrl } = this.props;
+    if (!avatarUrl || this.state.failed) {
+      return <TelegramBotIconFallback botId={bot.id} />;
+    }
+
+    return (
+      <img
+        src={avatarUrl}
+        alt=""
+        loading="lazy"
+        className="h-10 w-10 shrink-0 rounded-full object-cover"
+        data-testid={`telegram-bot-avatar-${bot.id}`}
+        onError={() => {
+          this.setState({ failed: true });
+        }}
+      />
+    );
+  }
+}
+
+function resolveTelegramBotAvatarUrl(
+  avatarUrl: string | null | undefined,
+  apiBase: string,
+): string | null {
+  if (!avatarUrl) {
+    return null;
+  }
+  if (/^[a-z][a-z\d+.-]*:/i.test(avatarUrl)) {
+    return avatarUrl;
+  }
+  const base = apiBase.endsWith("/") ? apiBase.slice(0, -1) : apiBase;
+  const path = avatarUrl.startsWith("/") ? avatarUrl : `/${avatarUrl}`;
+  return `${base}${path}`;
+}
+
 function getTelegramLoginDomain(): string {
   if (typeof location === "undefined" || !location.hostname) {
     return "your app domain";
@@ -191,8 +313,61 @@ function getTelegramLoginDomain(): string {
   return location.hostname;
 }
 
+class CopyableTelegramValue extends Component<
+  { value: string },
+  { copied: boolean }
+> {
+  state: { copied: boolean } = {
+    copied: false,
+  };
+
+  #resetTimer: number | null = null;
+
+  componentWillUnmount() {
+    if (this.#resetTimer !== null) {
+      window.clearTimeout(this.#resetTimer);
+    }
+  }
+
+  copyValue = () => {
+    const { value } = this.props;
+    detach(
+      writeToClipboard(value).then((copied) => {
+        if (!copied) {
+          return;
+        }
+        if (this.#resetTimer !== null) {
+          window.clearTimeout(this.#resetTimer);
+        }
+        this.setState({ copied: true });
+        this.#resetTimer = window.setTimeout(() => {
+          this.setState({ copied: false });
+          this.#resetTimer = null;
+        }, 1500);
+      }),
+      Reason.DomCallback,
+    );
+  };
+
+  render() {
+    const { value } = this.props;
+
+    return (
+      <button
+        type="button"
+        className={TELEGRAM_COMMAND_CLASS}
+        aria-label={`Copy ${value}`}
+        title="Click to copy"
+        onClick={this.copyValue}
+      >
+        {this.state.copied ? "copied!" : value}
+      </button>
+    );
+  }
+}
+
 function TelegramCommand({ command }: { command: string }) {
-  return <code className={TELEGRAM_COMMAND_CLASS}>{command}</code>;
+  return <CopyableTelegramValue value={command} />;
 }
 
 function AddTelegramBotInstructions({ domain }: { domain: string }) {
@@ -207,7 +382,7 @@ function AddTelegramBotInstructions({ domain }: { domain: string }) {
             rel="noreferrer"
             className="font-medium text-foreground underline-offset-4 hover:underline"
           >
-            @BotFather
+            {BOT_FATHER_HANDLE}
           </a>
           , send <TelegramCommand command="/newbot" />, choose a name and
           username, then copy the bot token.
@@ -221,7 +396,7 @@ function AddTelegramBotInstructions({ domain }: { domain: string }) {
         <li>
           For Telegram web login, send <TelegramCommand command="/setdomain" />,
           choose the bot, and set the domain to{" "}
-          <code className={TELEGRAM_COMMAND_CLASS}>{domain}</code>.
+          <CopyableTelegramValue value={domain} />.
         </li>
       </ol>
     </div>
@@ -340,7 +515,7 @@ function AddTelegramBotDialog({
         }
       }}
     >
-      <div className="flex justify-end">
+      <div className="flex shrink-0 justify-end">
         <DialogTrigger asChild>
           <Button
             type="button"
@@ -625,6 +800,7 @@ function TelegramBotRow({
   const unlinkingBotId = useGet(telegramUnlinkingBotId$);
   const uninstallingBotId = useGet(telegramUninstallingBotId$);
   const reinstallingBotId = useGet(telegramReinstallingBotId$);
+  const apiBase = useGet(apiBase$);
   const saving = savingBotId === bot.id;
   const unlinking = unlinkingBotId === bot.id;
   const uninstalling = uninstallingBotId === bot.id;
@@ -633,13 +809,12 @@ function TelegramBotRow({
     disabled || saving || unlinking || uninstalling || reinstalling;
   const options = buildBotAgentOptions(bot, agents, defaultAgent);
   const routeLabel = botRouteLabel(bot, agents, defaultAgent);
+  const avatarUrl = resolveTelegramBotAvatarUrl(bot.avatarUrl, apiBase);
 
   return (
     <div className="flex flex-col gap-4 px-4 py-4 sm:flex-row sm:items-center sm:px-5">
-      <div className="flex min-w-0 flex-1 items-start gap-3">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[#2AABEE]/10">
-          <img src={telegramIconImg} alt="" className="h-7 w-7" />
-        </div>
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <TelegramBotAvatar bot={bot} avatarUrl={avatarUrl} />
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
             <div className="min-w-0 truncate text-sm font-medium text-foreground">
@@ -940,10 +1115,7 @@ export function ZeroTelegramSettingsPage() {
     bots.find((bot) => {
       return bot.id === reinstallDialogBotId;
     }) ?? null;
-  const loading =
-    botsLoadable.state === "loading" &&
-    bots.length === 0 &&
-    agents.length === 0;
+  const loading = botsLoadable.state === "loading" && bots.length === 0;
   const hasError =
     botsLoadable.state === "hasError" || agentsLoadable.state === "hasError";
   const agentsLoading = agentsLoadable.state === "loading";
@@ -952,28 +1124,29 @@ export function ZeroTelegramSettingsPage() {
     <div className="flex flex-1 flex-col min-h-0">
       <header className="shrink-0 bg-transparent px-4 pt-10 pb-3 sm:px-6">
         <div className="mx-auto max-w-[900px]">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-            <div className="min-w-0">
-              <div className="mb-3 flex items-center gap-3">
-                <span className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-[#2AABEE]/10">
-                  <img src={telegramIconImg} alt="" className="h-7 w-7" />
-                </span>
-                <div className="min-w-0">
-                  <h1 className="truncate text-lg font-semibold tracking-tight text-foreground">
-                    Telegram
-                  </h1>
-                  <p className="mt-0.5 text-sm text-muted-foreground">
-                    Manage bot routing for this workspace
-                  </p>
-                </div>
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-[#2AABEE]/10">
+                <img src={telegramIconImg} alt="" className="h-7 w-7" />
+              </span>
+              <div className="min-w-0">
+                <h1 className="truncate text-lg font-semibold tracking-tight text-foreground">
+                  Telegram
+                </h1>
+                <p className="mt-0.5 text-sm text-muted-foreground">
+                  Manage bot routing for this workspace
+                </p>
               </div>
             </div>
-            <span
-              data-testid="telegram-bot-count"
-              className="inline-flex w-fit items-center rounded-lg border border-border bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground"
-            >
-              {bots.length} {bots.length === 1 ? "bot" : "bots"}
-            </span>
+            {!hasError && loading ? (
+              <AddTelegramBotButtonSkeleton />
+            ) : !hasError ? (
+              <AddTelegramBotDialog
+                agents={agents}
+                defaultAgent={defaultAgent}
+                disabled={agentsLoading}
+              />
+            ) : null}
           </div>
         </div>
       </header>
@@ -988,11 +1161,7 @@ export function ZeroTelegramSettingsPage() {
             <TelegramSettingsSkeleton />
           ) : (
             <>
-              <AddTelegramBotDialog
-                agents={agents}
-                defaultAgent={defaultAgent}
-                disabled={agentsLoading}
-              />
+              <TelegramBotCount count={bots.length} />
               <TelegramBotList
                 bots={bots}
                 agents={agents}

--- a/turbo/apps/web/app/api/integrations/telegram/[botId]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/[botId]/__tests__/route.test.ts
@@ -109,6 +109,11 @@ describe("/api/integrations/telegram/[botId]", () => {
         expect.objectContaining({
           id: botId,
           username: `bot_${botId}`,
+          avatarUrl: expect.stringContaining(
+            `http://localhost:3000/api/integrations/telegram/${encodeURIComponent(
+              botId,
+            )}/avatar?exp=`,
+          ),
           isOwner: true,
           isConnected: false,
           domainConfigured: false,

--- a/turbo/apps/web/app/api/integrations/telegram/[botId]/avatar/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/[botId]/avatar/__tests__/route.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { HttpResponse, http } from "msw";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  createTestTelegramInstallation,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  uniqueNumericId,
+  type UserContext,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { server } from "../../../../../../../src/mocks/server";
+import { buildTelegramBotAvatarUrl } from "../../../../../../../src/lib/zero/telegram/avatar-url";
+
+const context = testContext();
+
+function avatarUrl(botId: string): string {
+  return `http://localhost:3000/api/integrations/telegram/${botId}/avatar`;
+}
+
+function routeParams(botId: string) {
+  return { params: Promise.resolve({ botId }) };
+}
+
+function mockTelegramAvatarDownload(botId: string, fileBytes: Buffer) {
+  server.use(
+    http.post(
+      "https://api.telegram.org/bottest-bot-token/getUserProfilePhotos",
+      async ({ request }) => {
+        const body = (await request.json()) as {
+          user_id?: string | number;
+          limit?: number;
+        };
+        expect(body).toMatchObject({ user_id: Number(botId), limit: 1 });
+        return HttpResponse.json({
+          ok: true,
+          result: {
+            total_count: 1,
+            photos: [
+              [
+                {
+                  file_id: "small-avatar",
+                  file_unique_id: "small-unique",
+                  width: 64,
+                  height: 64,
+                },
+                {
+                  file_id: "large-avatar",
+                  file_unique_id: "large-unique",
+                  width: 320,
+                  height: 320,
+                  file_size: fileBytes.length,
+                },
+              ],
+            ],
+          },
+        });
+      },
+    ),
+    http.post(
+      "https://api.telegram.org/bottest-bot-token/getFile",
+      async ({ request }) => {
+        const body = (await request.json()) as { file_id?: string };
+        expect(body.file_id).toBe("large-avatar");
+        return HttpResponse.json({
+          ok: true,
+          result: {
+            file_id: "large-avatar",
+            file_unique_id: "large-unique",
+            file_size: fileBytes.length,
+            file_path: "photos/avatar.jpg",
+          },
+        });
+      },
+    ),
+    http.get(
+      "https://api.telegram.org/file/bottest-bot-token/photos/avatar.jpg",
+      () => {
+        return new HttpResponse(fileBytes, {
+          status: 200,
+          headers: {
+            "content-type": "image/jpeg",
+            "content-length": String(fileBytes.length),
+          },
+        });
+      },
+    ),
+  );
+}
+
+describe("GET /api/integrations/telegram/[botId]/avatar", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(
+      createTestRequest(avatarUrl("tg-bot")),
+      routeParams("tg-bot"),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 404 when the bot is not visible in the active org", async () => {
+    const response = await GET(
+      createTestRequest(avatarUrl("missing-bot")),
+      routeParams("missing-bot"),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("streams the largest Telegram profile photo for the bot", async () => {
+    const botId = uniqueNumericId();
+    await createTestTelegramInstallation({
+      telegramBotId: botId,
+      orgId: user.orgId,
+      ownerUserId: user.userId,
+    });
+    const fileBytes = Buffer.from("telegram avatar bytes");
+    mockTelegramAvatarDownload(botId, fileBytes);
+
+    const response = await GET(
+      createTestRequest(avatarUrl(botId)),
+      routeParams(botId),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/jpeg");
+    expect(response.headers.get("cache-control")).toBe("private, max-age=300");
+
+    const receivedBytes = Buffer.from(await response.arrayBuffer());
+    expect(receivedBytes.equals(fileBytes)).toBe(true);
+  });
+
+  it("streams a signed bot avatar URL without an Authorization header", async () => {
+    const botId = uniqueNumericId();
+    await createTestTelegramInstallation({
+      telegramBotId: botId,
+      orgId: user.orgId,
+      ownerUserId: user.userId,
+    });
+    mockClerk({ userId: null });
+    const fileBytes = Buffer.from("signed telegram avatar bytes");
+    mockTelegramAvatarDownload(botId, fileBytes);
+
+    const response = await GET(
+      createTestRequest(buildTelegramBotAvatarUrl(botId)),
+      routeParams(botId),
+    );
+
+    expect(response.status).toBe(200);
+    const receivedBytes = Buffer.from(await response.arrayBuffer());
+    expect(receivedBytes.equals(fileBytes)).toBe(true);
+  });
+
+  it("returns 404 when Telegram has no profile photo for the bot", async () => {
+    const botId = uniqueId("tg-bot-no-avatar");
+    await createTestTelegramInstallation({
+      telegramBotId: botId,
+      orgId: user.orgId,
+      ownerUserId: user.userId,
+    });
+
+    server.use(
+      http.post(
+        "https://api.telegram.org/bottest-bot-token/getUserProfilePhotos",
+        () => {
+          return HttpResponse.json({
+            ok: true,
+            result: {
+              total_count: 0,
+              photos: [],
+            },
+          });
+        },
+      ),
+    );
+
+    const response = await GET(
+      createTestRequest(avatarUrl(botId)),
+      routeParams(botId),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/turbo/apps/web/app/api/integrations/telegram/[botId]/avatar/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/[botId]/avatar/route.ts
@@ -1,0 +1,235 @@
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../../src/lib/auth/get-auth-context";
+import { resolveOrg } from "../../../../../../src/lib/zero/org/resolve-org";
+import { decryptSecretValue } from "../../../../../../src/lib/shared/crypto/secrets-encryption";
+import { inferMimetype } from "../../../../../../src/lib/shared/mimetype";
+import { logger } from "../../../../../../src/lib/shared/logger";
+import { verifyTelegramBotAvatarUrlSignature } from "../../../../../../src/lib/zero/telegram/avatar-url";
+import {
+  buildFileDownloadUrl,
+  createTelegramClient,
+  getFile,
+  getUserProfilePhotos,
+  type TelegramUserProfilePhoto,
+} from "../../../../../../src/lib/zero/telegram/client";
+
+const log = logger("api:telegram:integration-bot-avatar");
+
+const MAX_AVATAR_SIZE_BYTES = 10 * 1024 * 1024;
+
+function errorResponse(
+  status: number,
+  message: string,
+  code: string,
+): NextResponse {
+  return NextResponse.json({ error: { message, code } }, { status });
+}
+
+function parseContentLength(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const size = Number(value);
+  if (!Number.isSafeInteger(size) || size < 0) return undefined;
+  return size;
+}
+
+function selectLargestProfilePhoto(
+  photos: TelegramUserProfilePhoto[],
+): TelegramUserProfilePhoto | null {
+  if (photos.length === 0) {
+    return null;
+  }
+
+  return photos.reduce((largest, photo) => {
+    return photo.width * photo.height > largest.width * largest.height
+      ? photo
+      : largest;
+  }, photos[0]!);
+}
+
+function telegramProfileUserId(botId: string): string | number {
+  const numericBotId = Number(botId);
+  if (Number.isSafeInteger(numericBotId) && String(numericBotId) === botId) {
+    return numericBotId;
+  }
+  return botId;
+}
+
+async function loadBotToken(params: {
+  botId: string;
+  orgId?: string;
+}): Promise<string | null> {
+  const where = params.orgId
+    ? and(
+        eq(telegramInstallations.telegramBotId, params.botId),
+        eq(telegramInstallations.orgId, params.orgId),
+      )
+    : eq(telegramInstallations.telegramBotId, params.botId);
+
+  const [installation] = await globalThis.services.db
+    .select({
+      encryptedBotToken: telegramInstallations.encryptedBotToken,
+    })
+    .from(telegramInstallations)
+    .where(where)
+    .limit(1);
+
+  if (!installation) {
+    return null;
+  }
+
+  return decryptSecretValue(
+    installation.encryptedBotToken,
+    globalThis.services.env.SECRETS_ENCRYPTION_KEY,
+  );
+}
+
+async function resolveBotTokenForRequest(
+  request: Request,
+  botId: string,
+): Promise<string | NextResponse> {
+  const requestUrl = new URL(request.url);
+  const hasValidSignature = verifyTelegramBotAvatarUrlSignature({
+    botId,
+    expiresAt: requestUrl.searchParams.get("exp"),
+    signature: requestUrl.searchParams.get("sig"),
+  });
+
+  if (hasValidSignature) {
+    const botToken = await loadBotToken({ botId });
+    return (
+      botToken ?? errorResponse(404, "Telegram bot not found", "NOT_FOUND")
+    );
+  }
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+  if (!authCtx) {
+    return errorResponse(401, "Not authenticated", "UNAUTHORIZED");
+  }
+
+  const { org } = await resolveOrg(authCtx);
+  const botToken = await loadBotToken({ botId, orgId: org.orgId });
+  return botToken ?? errorResponse(404, "Telegram bot not found", "NOT_FOUND");
+}
+
+/**
+ * GET /api/integrations/telegram/[botId]/avatar
+ *
+ * Proxies the bot's Telegram profile photo without exposing the bot token.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ botId: string }> },
+): Promise<Response> {
+  initServices();
+
+  const { botId } = await params;
+  const botTokenResult = await resolveBotTokenForRequest(request, botId);
+  if (botTokenResult instanceof NextResponse) {
+    return botTokenResult;
+  }
+  const botToken = botTokenResult;
+
+  try {
+    const client = createTelegramClient(botToken);
+    const profilePhotos = await getUserProfilePhotos(
+      client,
+      telegramProfileUserId(botId),
+      1,
+    );
+    const photo = selectLargestProfilePhoto(profilePhotos.photos[0] ?? []);
+    if (!photo) {
+      return errorResponse(404, "Telegram bot avatar not found", "NOT_FOUND");
+    }
+
+    if (photo.file_size && photo.file_size > MAX_AVATAR_SIZE_BYTES) {
+      return errorResponse(
+        413,
+        `Avatar exceeds maximum size of ${MAX_AVATAR_SIZE_BYTES} bytes`,
+        "PAYLOAD_TOO_LARGE",
+      );
+    }
+
+    const file = await getFile(client, photo.file_id);
+    if (!file.file_path) {
+      return errorResponse(
+        404,
+        "Telegram avatar does not have a downloadable path",
+        "NOT_FOUND",
+      );
+    }
+
+    if (file.file_size && file.file_size > MAX_AVATAR_SIZE_BYTES) {
+      return errorResponse(
+        413,
+        `Avatar exceeds maximum size of ${MAX_AVATAR_SIZE_BYTES} bytes`,
+        "PAYLOAD_TOO_LARGE",
+      );
+    }
+
+    const downloadResponse = await fetch(
+      buildFileDownloadUrl(botToken, file.file_path),
+      { signal: request.signal },
+    );
+
+    if (!downloadResponse.ok) {
+      log.warn("Telegram bot avatar download failed", {
+        botId,
+        status: downloadResponse.status,
+      });
+      return errorResponse(
+        502,
+        `Failed to download avatar from Telegram: ${downloadResponse.status}`,
+        "BAD_GATEWAY",
+      );
+    }
+
+    const responseContentType =
+      downloadResponse.headers.get("content-type") ?? "";
+    if (responseContentType.includes("text/html")) {
+      log.warn("Telegram returned HTML for bot avatar", {
+        botId,
+        contentType: responseContentType,
+      });
+      return errorResponse(
+        502,
+        "Telegram returned an unexpected response",
+        "BAD_GATEWAY",
+      );
+    }
+
+    const contentLength = downloadResponse.headers.get("content-length");
+    const contentLengthBytes = parseContentLength(contentLength);
+    if (
+      contentLengthBytes !== undefined &&
+      contentLengthBytes > MAX_AVATAR_SIZE_BYTES
+    ) {
+      return errorResponse(
+        413,
+        `Avatar exceeds maximum size of ${MAX_AVATAR_SIZE_BYTES} bytes`,
+        "PAYLOAD_TOO_LARGE",
+      );
+    }
+
+    const fileName = file.file_path.split("/").pop() ?? photo.file_id;
+    const mimetype = responseContentType || inferMimetype(fileName);
+    const headers = new Headers();
+    headers.set("Content-Type", mimetype);
+    headers.set("Cache-Control", "private, max-age=300");
+    if (contentLength) {
+      headers.set("Content-Length", contentLength);
+    }
+
+    return new Response(downloadResponse.body, { status: 200, headers });
+  } catch (error) {
+    log.warn("Telegram bot avatar proxy failed", { botId, error });
+    return errorResponse(
+      502,
+      "Failed to load Telegram bot avatar",
+      "BAD_GATEWAY",
+    );
+  }
+}

--- a/turbo/apps/web/app/api/integrations/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/__tests__/route.test.ts
@@ -93,6 +93,11 @@ describe("/api/integrations/telegram", () => {
           expect.objectContaining({
             id: firstBotId,
             username: `bot_${firstBotId}`,
+            avatarUrl: expect.stringContaining(
+              `http://localhost:3000/api/integrations/telegram/${encodeURIComponent(
+                firstBotId,
+              )}/avatar?exp=`,
+            ),
             isOwner: true,
             isConnected: true,
             agent: expect.objectContaining({ id: expect.any(String) }),
@@ -100,6 +105,11 @@ describe("/api/integrations/telegram", () => {
           expect.objectContaining({
             id: secondBotId,
             username: `bot_${secondBotId}`,
+            avatarUrl: expect.stringContaining(
+              `http://localhost:3000/api/integrations/telegram/${encodeURIComponent(
+                secondBotId,
+              )}/avatar?exp=`,
+            ),
             isOwner: false,
             isConnected: false,
             agent: expect.objectContaining({ id: expect.any(String) }),

--- a/turbo/apps/web/app/api/integrations/telegram/telegram-status.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/telegram-status.ts
@@ -18,6 +18,7 @@ import { logger } from "../../../../src/lib/shared/logger";
 import { listConnectors } from "../../../../src/lib/zero/connector/connector-service";
 import { listSecrets } from "../../../../src/lib/zero/secret/secret-service";
 import { checkTelegramDomain } from "../../../../src/lib/zero/telegram/check-domain";
+import { buildTelegramBotAvatarUrl } from "../../../../src/lib/zero/telegram/avatar-url";
 import {
   getMe,
   isTelegramApiError,
@@ -187,6 +188,7 @@ export async function buildTelegramBot(
   return {
     id: installation.telegramBotId,
     username: installation.botUsername,
+    avatarUrl: buildTelegramBotAvatarUrl(installation.telegramBotId),
     agent: compose ? { id: compose.id, name: compose.name } : null,
     isOwner: installation.ownerUserId === userId,
     isConnected: !!userLink,
@@ -215,6 +217,7 @@ export async function buildTelegramBotStatus(
   return {
     id: installation.telegramBotId,
     username: installation.botUsername,
+    avatarUrl: buildTelegramBotAvatarUrl(installation.telegramBotId),
     agent: compose ? { id: compose.id, name: compose.name } : null,
     isOwner: installation.ownerUserId === userId,
     isConnected: !!userLink,

--- a/turbo/apps/web/src/lib/zero/telegram/avatar-url.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/avatar-url.ts
@@ -1,0 +1,59 @@
+import { env } from "../../../env";
+import {
+  computeHmacSignature,
+  verifyHmacSignature,
+} from "../../infra/callback/hmac";
+
+const AVATAR_URL_TTL_SECONDS = 24 * 60 * 60;
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+export function buildTelegramBotAvatarUrl(botId: string): string {
+  const { SECRETS_ENCRYPTION_KEY, VM0_API_URL } = env();
+  const path = `/api/integrations/telegram/${encodeURIComponent(botId)}/avatar`;
+  const expiresAt = Math.floor(Date.now() / 1000) + AVATAR_URL_TTL_SECONDS;
+  const signature = computeHmacSignature(
+    botId,
+    SECRETS_ENCRYPTION_KEY,
+    expiresAt,
+  );
+  const query = new URLSearchParams({
+    exp: String(expiresAt),
+    sig: signature,
+  });
+  const signedPath = `${path}?${query.toString()}`;
+
+  if (!VM0_API_URL) {
+    return signedPath;
+  }
+  return `${trimTrailingSlash(VM0_API_URL)}${signedPath}`;
+}
+
+export function verifyTelegramBotAvatarUrlSignature(params: {
+  botId: string;
+  expiresAt: string | null;
+  signature: string | null;
+}): boolean {
+  if (!params.expiresAt || !params.signature) {
+    return false;
+  }
+
+  const expiresAt = Number(params.expiresAt);
+  if (!Number.isSafeInteger(expiresAt)) {
+    return false;
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (expiresAt < now) {
+    return false;
+  }
+
+  return verifyHmacSignature(
+    params.botId,
+    env().SECRETS_ENCRYPTION_KEY,
+    expiresAt,
+    params.signature,
+  );
+}

--- a/turbo/apps/web/src/lib/zero/telegram/client.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/client.ts
@@ -304,6 +304,19 @@ interface TelegramFile {
   file_path?: string;
 }
 
+export interface TelegramUserProfilePhoto {
+  file_id: string;
+  file_unique_id: string;
+  width: number;
+  height: number;
+  file_size?: number;
+}
+
+interface TelegramUserProfilePhotos {
+  total_count: number;
+  photos: TelegramUserProfilePhoto[][];
+}
+
 /**
  * Get file info and download path from Telegram.
  * The returned file_path can be used to download via:
@@ -316,6 +329,24 @@ export async function getFile(
   return callTelegramApi<TelegramFile>(client.token, "getFile", {
     file_id: fileId,
   });
+}
+
+/**
+ * Get profile photos for a Telegram user or bot.
+ */
+export async function getUserProfilePhotos(
+  client: TelegramClient,
+  userId: string | number,
+  limit = 1,
+): Promise<TelegramUserProfilePhotos> {
+  return callTelegramApi<TelegramUserProfilePhotos>(
+    client.token,
+    "getUserProfilePhotos",
+    {
+      user_id: userId,
+      limit,
+    },
+  );
 }
 
 /**

--- a/turbo/packages/api-contracts/src/contracts/zero-integrations-telegram.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-integrations-telegram.ts
@@ -16,6 +16,7 @@ const telegramTokenStatusSchema = z.enum(["valid", "invalid", "unknown"]);
 const telegramBotSchema = z.object({
   id: z.string(),
   username: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
   agent: z.object({ id: z.string(), name: z.string() }).nullable(),
   isOwner: z.boolean(),
   isConnected: z.boolean(),


### PR DESCRIPTION
## Summary
- Replace the inline Telegram bot add form with an Add bot button and dialog
- Add BotFather setup guidance for /newbot, group privacy via /setprivacy, and login domain via /setdomain
- Track add-dialog open state and cover the new flow in settings page tests

## Tests
- pnpm -F @vm0/app test src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types