### PR TITLE
feat(platform): drop top-bar breadcrumb on index pages

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -396,6 +396,49 @@ describe("mobile workspace drawer - shows workspace name (MOBILE-DRAWER-002)", (
   });
 });
 
+describe("mobile top bar - breadcrumb hidden on index pages when redesign on (MOBILE-TOP-004)", () => {
+  it("does not render the mobile breadcrumb on /agents when MobileNativeV1 is on", async () => {
+    mockBaseAPIs();
+    detachedSetupPage({
+      context,
+      path: "/agents",
+      featureSwitches: mobileNativeOn(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mobile-org-switcher")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("mobile-breadcrumb")).not.toBeInTheDocument();
+  });
+});
+
+describe("mobile top bar - breadcrumb kept on detail pages when redesign on (MOBILE-TOP-005)", () => {
+  it("still renders the breadcrumb name on /agents/:id", async () => {
+    setMockTeam([
+      {
+        id: DEFAULT_AGENT_ID,
+        displayName: "My Agent",
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+    detachedSetupPage({
+      context,
+      path: `/agents/${DEFAULT_AGENT_ID}`,
+      featureSwitches: mobileNativeOn(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("breadcrumb-name")).toHaveTextContent(
+        "My Agent",
+      );
+    });
+  });
+});
+
 describe("mobile bottom tab bar - active tab highlighted (MOBILE-TAB-002)", () => {
   it("marks the Teammates tab as the current page on /agents", async () => {
     mockBaseAPIs();

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -209,6 +209,15 @@ function MobileTopBar() {
   const features = useLastResolved(featureSwitch$);
   const mobileNativeOn = features?.[FeatureSwitchKey.MobileNativeV1] ?? false;
 
+  // On index pages the breadcrumb just repeats the bottom-tab label and the
+  // page's own header. Hide it when the redesign is on to give the org pill
+  // and action buttons more room. Detail pages and chat routes still show
+  // the breadcrumb because the agent / schedule name is real context.
+  const isChatPage = isChatRoute(activeId);
+  const hasDetailName = breadcrumb?.name !== undefined;
+  const showBreadcrumb =
+    breadcrumb !== null && (!mobileNativeOn || isChatPage || hasDetailName);
+
   return (
     <div className="md:hidden shrink-0 flex items-center h-12 px-3 gap-2 bg-background border-b border-border/50 z-10">
       {mobileNativeOn ? (
@@ -225,8 +234,11 @@ function MobileTopBar() {
           <IconMenu2 size={18} stroke={1.8} />
         </button>
       )}
-      {breadcrumb && (
-        <div className="flex-1 min-w-0 flex items-center gap-2 min-w-0">
+      {showBreadcrumb && breadcrumb && (
+        <div
+          className="flex-1 min-w-0 flex items-center gap-2 min-w-0"
+          data-testid="mobile-breadcrumb"
+        >
           {breadcrumb.avatarAgentId && <AgentAvatarInTopBar />}
           <div className="flex items-center gap-2 min-w-0">
             <div className="text-sm font-medium text-foreground flex items-center gap-1 min-w-0">
@@ -248,7 +260,7 @@ function MobileTopBar() {
           </div>
         </div>
       )}
-      {!breadcrumb && <div className="flex-1" />}
+      {!showBreadcrumb && <div className="flex-1" />}
       <MobileTopBarActions activeId={activeId} />
     </div>
   );


### PR DESCRIPTION
## Summary

PR 5 of the mobile redesign. On index pages the top-bar breadcrumb just repeats info already shown by (a) the bottom tab and (b) the page's own header. Hide it when \`MobileNativeV1\` is on so the org pill and action buttons get more room.

## What it does

Adds a single conditional in \`MobileTopBar\`:

\`\`\`tsx
const isChatPage = isChatRoute(activeId);
const hasDetailName = breadcrumb?.name !== undefined;
const showBreadcrumb =
  breadcrumb !== null && (!mobileNativeOn || isChatPage || hasDetailName);
\`\`\`

Behavior matrix:

| Route | Switch off | Switch on |
|---|---|---|
| \`/\`, \`/agents/:id/chat\`, \`/chats/:id\` (chat) | breadcrumb | breadcrumb (agent name + avatar = real context) |
| \`/agents/:id\`, \`/schedules/:id\` (detail) | breadcrumb | breadcrumb (entity name = real context) |
| \`/agents\`, \`/schedules\`, \`/works\`, \`/connectors\`, \`/settings\` (index) | breadcrumb | **hidden** |

## Stack

- Base: \`ming/mobile-org-switcher-pill\` (PR #11342)
- → \`ming/mobile-top-bar-org-switcher\` (PR #11338)
- → \`ming/mobile-home-chats-list\` (PR #11332)
- → \`ming/mobile-bottom-tab-bar\` (PR #11331)

Toggle \`MobileNativeV1\` on \`/lab\` to preview cumulative effect across all 5.

## Test plan

- [x] \`pnpm run check-types\` clean
- [x] \`pnpm run lint\` clean
- [x] \`sidebar-layout.test.tsx\` 20/20 (added MOBILE-TOP-004, MOBILE-TOP-005)
- [ ] Manual: enable \`MobileNativeV1\`; load \`/agents\` on mobile; confirm breadcrumb gone, pill + Invite intact
- [ ] Manual: open \`/agents/:id\`; confirm breadcrumb name still shows
- [ ] Manual: open \`/\`; confirm agent name + avatar still show in top bar
- [ ] Manual: switch off; reload \`/agents\`; confirm "Agents" breadcrumb returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)