### PR TITLE
fix: improve chat image preview controls

### DIFF
--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -1,8 +1,13 @@
 import MarkdownPreview, {
   type MarkdownPreviewProps,
 } from "@uiw/react-markdown-preview";
+import { IconLoader2, IconPhoto } from "@tabler/icons-react";
 import { useGet } from "ccstate-react";
-import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import {
+  Component,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
 import { theme$ } from "../../signals/theme.ts";
 
 type RewriteArgs = Parameters<
@@ -207,26 +212,65 @@ function PlainLink({ href, children, ...rest }: ComponentPropsWithoutRef<"a">) {
   );
 }
 
-function MediaImage({
-  src,
-  alt,
-  onImageClick,
-}: {
-  src: string;
-  alt: string;
-  onImageClick?: (url: string) => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={() => {
-        onImageClick?.(src);
-      }}
-      className="block max-w-full my-1 rounded-lg overflow-hidden cursor-zoom-in border border-foreground/10"
-    >
-      <img src={src} alt={alt} className="max-h-32 max-w-full object-contain" />
-    </button>
-  );
+type ImageLoadStatus = "loading" | "loaded" | "error";
+
+class MediaImage extends Component<
+  {
+    src: string;
+    alt: string;
+    onImageClick?: (url: string) => void;
+  },
+  { imageStatus: ImageLoadStatus }
+> {
+  state: { imageStatus: ImageLoadStatus } = {
+    imageStatus: "loading",
+  };
+
+  componentDidUpdate(previousProps: Readonly<{ src: string }>) {
+    if (previousProps.src !== this.props.src) {
+      this.setState({ imageStatus: "loading" });
+    }
+  }
+
+  render() {
+    const { src, alt, onImageClick } = this.props;
+    const { imageStatus } = this.state;
+    const showPlaceholder = imageStatus !== "loaded";
+
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          onImageClick?.(src);
+        }}
+        className="relative block max-w-full my-1 overflow-hidden rounded-lg border border-foreground/10 cursor-zoom-in"
+      >
+        {showPlaceholder && (
+          <span className="flex h-32 w-48 max-w-full items-center justify-center bg-muted/70 text-muted-foreground">
+            {imageStatus === "loading" ? (
+              <IconLoader2 size={18} stroke={1.8} className="animate-spin" />
+            ) : (
+              <IconPhoto size={18} stroke={1.5} />
+            )}
+          </span>
+        )}
+        <img
+          src={src}
+          alt={alt}
+          loading="lazy"
+          onLoad={() => {
+            this.setState({ imageStatus: "loaded" });
+          }}
+          onError={() => {
+            this.setState({ imageStatus: "error" });
+          }}
+          className={`max-h-32 max-w-full object-contain ${
+            showPlaceholder ? "absolute inset-0 opacity-0" : ""
+          }`}
+        />
+      </button>
+    );
+  }
 }
 
 function MediaLink({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { chatMessagesContract } from "@vm0/api-contracts/contracts/chat-threads";
@@ -203,6 +203,85 @@ describe("chat-i-059: image preview button opens lightbox", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+  });
+
+  it("shows loading state and supports zoom controls in the image lightbox", async () => {
+    const user = userEvent.setup();
+    const imageUrl = "https://example.com/photo.png";
+
+    server.use(
+      ...mockUploadSuccess({
+        id: "upload-1",
+        filename: "photo.png",
+        contentType: "image/png",
+        size: 2048,
+        url: imageUrl,
+      }),
+    );
+    mockChatAPI();
+
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+    });
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    await user.upload(
+      fileInput!,
+      new File(["img"], "photo.png", { type: "image/png" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        document.querySelector(`img[src="${imageUrl}"]`),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText("Open image preview for photo.png"));
+
+    const image = await screen.findByTestId("attachment-lightbox-image");
+    expect(
+      screen.getByTestId("attachment-lightbox-image-loading"),
+    ).toBeInTheDocument();
+
+    fireEvent.load(image);
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("attachment-lightbox-image-loading"),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText("100%")).toBeInTheDocument();
+    await user.click(screen.getByLabelText("Zoom in"));
+    await waitFor(() => {
+      expect(screen.getByText("125%")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText("Zoom out"));
+    await waitFor(() => {
+      expect(screen.getByText("100%")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText("Zoom in"));
+    await waitFor(() => {
+      expect(screen.getByText("125%")).toBeInTheDocument();
+    });
+    await user.click(screen.getByLabelText("Reset zoom"));
+    await waitFor(() => {
+      expect(screen.getByText("100%")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(document, { key: "=", metaKey: true });
+    await waitFor(() => {
+      expect(screen.getByText("125%")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(document, { key: "-", metaKey: true });
+    await waitFor(() => {
+      expect(screen.getByText("100%")).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -82,12 +82,6 @@ describe("zero chat thread page display - attachment image preview", () => {
       within(previewButton).getByTestId("chat-image-preview-loading"),
     ).toBeInTheDocument();
 
-    const hoverLayer = within(previewButton).getByTestId(
-      "chat-image-preview-hover",
-    );
-    expect(previewButton.className).toContain("group/image-preview");
-    expect(hoverLayer.className).toContain("group-hover/image-preview");
-
     fireEvent.load(previewImage);
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { http, HttpResponse } from "msw";
@@ -73,8 +73,26 @@ describe("zero chat thread page display - attachment image preview", () => {
 
     detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
+    const previewButton = await waitFor(() => {
+      return screen.getByLabelText("Preview photo.png");
+    });
+    const previewImage = within(previewButton).getByAltText("photo.png");
+    expect(previewImage).toBeInTheDocument();
+    expect(
+      within(previewButton).getByTestId("chat-image-preview-loading"),
+    ).toBeInTheDocument();
+
+    const hoverLayer = within(previewButton).getByTestId(
+      "chat-image-preview-hover",
+    );
+    expect(previewButton.className).toContain("group/image-preview");
+    expect(hoverLayer.className).toContain("group-hover/image-preview");
+
+    fireEvent.load(previewImage);
     await waitFor(() => {
-      expect(screen.getByAltText("photo.png")).toBeInTheDocument();
+      expect(
+        within(previewButton).queryByTestId("chat-image-preview-loading"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -8,6 +8,9 @@ import {
   IconPhoto,
   IconVideo,
   IconLoader2,
+  IconZoomIn,
+  IconZoomOut,
+  IconZoomReset,
   IconX,
 } from "@tabler/icons-react";
 import type { ZeroChatAttachment } from "../../signals/chat-page/chat-message.ts";
@@ -31,6 +34,9 @@ import docHtmlIcon from "./assets/doc-html.svg";
 
 const log = logger("zero-attachment-chips");
 const TEXT_PREVIEW_MAX_BYTES = 65_536;
+const IMAGE_LIGHTBOX_MIN_ZOOM = 0.5;
+const IMAGE_LIGHTBOX_MAX_ZOOM = 3;
+const IMAGE_LIGHTBOX_ZOOM_STEP = 0.25;
 
 /**
  * Return the icon path for a known file extension, or null for unknown types.
@@ -316,6 +322,241 @@ export function downloadAttachmentUrl(
   });
 }
 
+type ImageLoadStatus = "loading" | "loaded" | "error";
+type ImageLightboxImageState = {
+  imageStatus: ImageLoadStatus;
+  zoom: number;
+};
+
+function isImageLightboxZoomAtReset(zoom: number): boolean {
+  return Math.abs(zoom - 1) < 0.001;
+}
+
+function clampImageLightboxZoom(zoom: number): number {
+  return Math.min(
+    IMAGE_LIGHTBOX_MAX_ZOOM,
+    Math.max(IMAGE_LIGHTBOX_MIN_ZOOM, zoom),
+  );
+}
+
+function ImageLightboxControls({
+  closeLightbox,
+  download,
+  resetZoom,
+  zoom,
+  zoomIn,
+  zoomOut,
+}: {
+  closeLightbox: () => void;
+  download: () => void;
+  resetZoom: () => void;
+  zoom: number;
+  zoomIn: () => void;
+  zoomOut: () => void;
+}) {
+  return (
+    <div className="absolute top-4 right-4 z-10 flex items-center gap-2">
+      <div className="flex items-center gap-1 rounded-full bg-black/50 p-1 text-white">
+        <button
+          type="button"
+          onClick={zoomOut}
+          disabled={zoom <= IMAGE_LIGHTBOX_MIN_ZOOM}
+          className="rounded-full p-1.5 transition-colors hover:bg-white/15 disabled:pointer-events-none disabled:opacity-40"
+          aria-label="Zoom out"
+          title="Zoom out"
+        >
+          <IconZoomOut size={18} stroke={2} />
+        </button>
+        <span className="min-w-10 text-center text-xs font-medium tabular-nums">
+          {Math.round(zoom * 100)}%
+        </span>
+        <button
+          type="button"
+          onClick={zoomIn}
+          disabled={zoom >= IMAGE_LIGHTBOX_MAX_ZOOM}
+          className="rounded-full p-1.5 transition-colors hover:bg-white/15 disabled:pointer-events-none disabled:opacity-40"
+          aria-label="Zoom in"
+          title="Zoom in"
+        >
+          <IconZoomIn size={18} stroke={2} />
+        </button>
+        <button
+          type="button"
+          onClick={resetZoom}
+          disabled={isImageLightboxZoomAtReset(zoom)}
+          className="rounded-full p-1.5 transition-colors hover:bg-white/15 disabled:pointer-events-none disabled:opacity-40"
+          aria-label="Reset zoom"
+          title="Reset zoom"
+        >
+          <IconZoomReset size={18} stroke={2} />
+        </button>
+      </div>
+      <button
+        type="button"
+        onClick={download}
+        className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors cursor-pointer"
+        aria-label="Download"
+      >
+        <IconDownload size={20} stroke={2} />
+      </button>
+      <button
+        type="button"
+        onClick={closeLightbox}
+        className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors"
+        aria-label="Close"
+      >
+        <IconX size={20} stroke={2} />
+      </button>
+    </div>
+  );
+}
+
+class ImageLightboxKeyboardShortcuts extends Component<{
+  resetZoom: () => void;
+  zoomIn: () => void;
+  zoomOut: () => void;
+}> {
+  componentDidMount() {
+    document.addEventListener("keydown", this.handleKeyDown);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("keydown", this.handleKeyDown);
+  }
+
+  handleKeyDown = (event: KeyboardEvent) => {
+    if (!event.metaKey && !event.ctrlKey) {
+      return;
+    }
+
+    if (event.key === "+" || event.key === "=") {
+      event.preventDefault();
+      event.stopPropagation();
+      this.props.zoomIn();
+      return;
+    }
+
+    if (event.key === "-" || event.key === "_") {
+      event.preventDefault();
+      event.stopPropagation();
+      this.props.zoomOut();
+      return;
+    }
+
+    if (event.key === "0") {
+      event.preventDefault();
+      event.stopPropagation();
+      this.props.resetZoom();
+    }
+  };
+
+  render() {
+    return null;
+  }
+}
+
+class ImageLightboxContent extends Component<
+  {
+    closeLightbox: () => void;
+    pageSignal: AbortSignal;
+    url: string;
+  },
+  ImageLightboxImageState
+> {
+  state: ImageLightboxImageState = {
+    imageStatus: "loading",
+    zoom: 1,
+  };
+
+  componentDidUpdate(previousProps: Readonly<{ url: string }>) {
+    if (previousProps.url !== this.props.url) {
+      this.setState({
+        imageStatus: "loading",
+        zoom: 1,
+      });
+    }
+  }
+
+  setZoom = (nextZoom: number) => {
+    this.setState({ zoom: clampImageLightboxZoom(nextZoom) });
+  };
+
+  zoomOut = () => {
+    this.setZoom(this.state.zoom - IMAGE_LIGHTBOX_ZOOM_STEP);
+  };
+
+  zoomIn = () => {
+    this.setZoom(this.state.zoom + IMAGE_LIGHTBOX_ZOOM_STEP);
+  };
+
+  resetZoom = () => {
+    this.setState({ zoom: 1 });
+  };
+
+  download = () => {
+    const { pageSignal, url } = this.props;
+    detach(
+      downloadAttachmentUrl(url, pageSignal),
+      Reason.DomCallback,
+      "attachment download",
+    );
+  };
+
+  render() {
+    const { closeLightbox, url } = this.props;
+    const { imageStatus, zoom } = this.state;
+
+    return (
+      <>
+        <ImageLightboxKeyboardShortcuts
+          resetZoom={this.resetZoom}
+          zoomIn={this.zoomIn}
+          zoomOut={this.zoomOut}
+        />
+        <ImageLightboxControls
+          closeLightbox={closeLightbox}
+          download={this.download}
+          resetZoom={this.resetZoom}
+          zoom={zoom}
+          zoomIn={this.zoomIn}
+          zoomOut={this.zoomOut}
+        />
+        <div
+          className="relative flex items-center justify-center transition-transform duration-150 animate-in zoom-in-95"
+          style={{ transform: `scale(${String(zoom)})` }}
+        >
+          {imageStatus !== "loaded" && (
+            <div
+              data-testid="attachment-lightbox-image-loading"
+              className="flex h-[min(85vh,480px)] w-[min(90vw,720px)] items-center justify-center rounded-lg bg-black/30 text-white shadow-2xl"
+            >
+              {imageStatus === "loading" ? (
+                <IconLoader2 size={24} stroke={1.8} className="animate-spin" />
+              ) : (
+                <IconPhoto size={24} stroke={1.5} />
+              )}
+            </div>
+          )}
+          <img
+            src={url}
+            alt=""
+            data-testid="attachment-lightbox-image"
+            onLoad={() => {
+              this.setState({ imageStatus: "loaded" });
+            }}
+            onError={() => {
+              this.setState({ imageStatus: "error" });
+            }}
+            className={`max-h-[85vh] max-w-[90vw] rounded-lg object-contain shadow-2xl ${
+              imageStatus === "loaded" ? "" : "absolute inset-0 opacity-0"
+            }`}
+          />
+        </div>
+      </>
+    );
+  }
+}
+
 function ImageLightbox({ url }: { url: string }) {
   const dialogRef = useSet(lightboxDialogRef$);
   const closeLightbox = useSet(closeLightbox$);
@@ -338,36 +579,10 @@ function ImageLightbox({ url }: { url: string }) {
       aria-modal="true"
       data-testid="attachment-lightbox"
     >
-      <div className="absolute top-4 right-4 flex items-center gap-2">
-        <button
-          type="button"
-          onClick={() => {
-            detach(
-              downloadAttachmentUrl(url, pageSignal),
-              Reason.DomCallback,
-              "attachment download",
-            );
-          }}
-          className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors cursor-pointer"
-          aria-label="Download"
-        >
-          <IconDownload size={20} stroke={2} />
-        </button>
-        <button
-          type="button"
-          onClick={() => {
-            return closeLightbox();
-          }}
-          className="p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors"
-          aria-label="Close"
-        >
-          <IconX size={20} stroke={2} />
-        </button>
-      </div>
-      <img
-        src={url}
-        alt=""
-        className="max-h-[85vh] max-w-[90vw] rounded-lg shadow-2xl object-contain animate-in zoom-in-95 duration-200"
+      <ImageLightboxContent
+        closeLightbox={closeLightbox}
+        pageSignal={pageSignal}
+        url={url}
       />
     </div>,
     document.body,
@@ -724,6 +939,99 @@ export function PreviewableFileAttachmentChip({
 // AttachmentChip — chip shown in the composer before the message is sent
 // ---------------------------------------------------------------------------
 
+class ComposerImagePreviewButton extends Component<
+  {
+    filename: string;
+    openImageLightbox: (url: string) => void;
+    url: string | undefined;
+  },
+  { imageStatus: ImageLoadStatus; url: string | null }
+> {
+  state: { imageStatus: ImageLoadStatus; url: string | null } = {
+    imageStatus: "loading",
+    url: null,
+  };
+
+  componentDidUpdate(previousProps: Readonly<{ url: string | undefined }>) {
+    if (previousProps.url !== this.props.url) {
+      this.setState({ imageStatus: "loading", url: null });
+    }
+  }
+
+  renderImage() {
+    const { url } = this.props;
+    const { imageStatus } = this.state;
+    const currentImageStatus =
+      url && this.state.url === url ? imageStatus : "loading";
+
+    if (!url) {
+      return (
+        <IconPhoto
+          size={20}
+          stroke={1.5}
+          className="text-muted-foreground m-auto h-full"
+        />
+      );
+    }
+
+    return (
+      <>
+        {currentImageStatus !== "loaded" && (
+          <span
+            data-testid="composer-image-preview-loading"
+            className="absolute inset-0 flex items-center justify-center bg-muted/70 text-muted-foreground"
+          >
+            {currentImageStatus === "loading" ? (
+              <IconLoader2 size={14} stroke={1.8} className="animate-spin" />
+            ) : (
+              <IconPhoto size={16} stroke={1.5} />
+            )}
+          </span>
+        )}
+        <img
+          src={url}
+          alt=""
+          loading="lazy"
+          onLoad={() => {
+            this.setState({ imageStatus: "loaded", url });
+          }}
+          onError={() => {
+            this.setState({ imageStatus: "error", url });
+          }}
+          className={`h-full w-full object-cover ${
+            currentImageStatus === "loaded" ? "" : "opacity-0"
+          }`}
+        />
+        <span className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover/image-preview:bg-black/30">
+          <IconPhoto
+            size={18}
+            className="text-white opacity-0 drop-shadow transition-opacity group-hover/image-preview:opacity-100"
+          />
+        </span>
+      </>
+    );
+  }
+
+  render() {
+    const { filename, openImageLightbox, url } = this.props;
+
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          return url && openImageLightbox(url);
+        }}
+        disabled={!url}
+        aria-label={`Open image preview for ${filename}`}
+        title={filename}
+        className="group/image-preview relative h-9 w-9 overflow-hidden rounded-lg border border-foreground/10 transition-colors hover:border-foreground/25"
+      >
+        {this.renderImage()}
+      </button>
+    );
+  }
+}
+
 function AttachmentChip({
   attachment,
   onRemove,
@@ -748,34 +1056,11 @@ function AttachmentChip({
         title={attachment.filename}
       >
         {isImage ? (
-          <button
-            type="button"
-            onClick={() => {
-              return url && openImageLightbox(url);
-            }}
-            disabled={!url}
-            aria-label={`Open image preview for ${attachment.filename}`}
-            title={attachment.filename}
-            className="group relative h-9 w-9 rounded-lg overflow-hidden border border-foreground/10 hover:border-foreground/25 transition-colors"
-          >
-            {url ? (
-              <>
-                <img src={url} alt="" className="h-full w-full object-cover" />
-                <span className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/30 transition-colors">
-                  <IconPhoto
-                    size={18}
-                    className="text-white opacity-0 group-hover:opacity-100 transition-opacity drop-shadow"
-                  />
-                </span>
-              </>
-            ) : (
-              <IconPhoto
-                size={20}
-                stroke={1.5}
-                className="text-muted-foreground m-auto h-full"
-              />
-            )}
-          </button>
+          <ComposerImagePreviewButton
+            filename={attachment.filename}
+            openImageLightbox={openImageLightbox}
+            url={url}
+          />
         ) : isVideo ? (
           <IconVideo size={28} stroke={1.5} className="text-muted-foreground" />
         ) : isAudio ? (

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import { Component, type CSSProperties } from "react";
 import {
   useGet,
   useSet,
@@ -22,6 +22,8 @@ import {
   IconEye,
   IconFile,
   IconFileMusic,
+  IconFiles,
+  IconLoader2,
   IconPackage,
   IconVideo,
 } from "@tabler/icons-react";
@@ -485,31 +487,135 @@ function ArtifactDownloadAction({
   );
 }
 
+type ImageLoadStatus = "loading" | "loaded" | "error";
+
+type ChatImagePreviewButtonProps = {
+  alt: string;
+  ariaLabel: string;
+  buttonClassName: string;
+  imageClassName: string;
+  onPreview: () => void;
+  overlayIcon?: "eye" | "photo";
+  placeholderClassName: string;
+  url: string;
+};
+
+class ChatImagePreviewButton extends Component<
+  ChatImagePreviewButtonProps,
+  { imageStatus: ImageLoadStatus }
+> {
+  state: { imageStatus: ImageLoadStatus } = {
+    imageStatus: "loading",
+  };
+
+  componentDidUpdate(previousProps: Readonly<ChatImagePreviewButtonProps>) {
+    if (previousProps.url !== this.props.url) {
+      this.setState({ imageStatus: "loading" });
+    }
+  }
+
+  renderPlaceholder() {
+    const { placeholderClassName } = this.props;
+    const { imageStatus } = this.state;
+
+    if (imageStatus === "loaded") {
+      return null;
+    }
+
+    return (
+      <span
+        data-testid="chat-image-preview-loading"
+        className={cn(
+          "flex items-center justify-center bg-muted/70 text-muted-foreground",
+          placeholderClassName,
+        )}
+      >
+        {imageStatus === "loading" ? (
+          <IconLoader2 size={18} stroke={1.8} className="animate-spin" />
+        ) : (
+          <IconPhoto size={18} stroke={1.5} />
+        )}
+      </span>
+    );
+  }
+
+  renderOverlay() {
+    const { overlayIcon = "photo" } = this.props;
+
+    return (
+      <span
+        data-testid="chat-image-preview-hover"
+        className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-150 group-hover/image-preview:bg-black/30 group-hover/image-preview:opacity-100"
+      >
+        {overlayIcon === "eye" ? (
+          <span className="flex h-9 w-9 items-center justify-center rounded-full bg-black/50 text-white shadow-lg">
+            <IconEye size={18} stroke={1.8} />
+          </span>
+        ) : (
+          <IconPhoto
+            size={18}
+            className="text-white opacity-0 drop-shadow transition-opacity group-hover/image-preview:opacity-100"
+          />
+        )}
+      </span>
+    );
+  }
+
+  render() {
+    const { alt, ariaLabel, buttonClassName, imageClassName, onPreview, url } =
+      this.props;
+    const showPlaceholder = this.state.imageStatus !== "loaded";
+
+    return (
+      <button
+        type="button"
+        onClick={onPreview}
+        className={cn(
+          "group/image-preview relative overflow-hidden",
+          buttonClassName,
+        )}
+        aria-label={ariaLabel}
+      >
+        {this.renderPlaceholder()}
+        <img
+          src={url}
+          alt={alt}
+          loading="lazy"
+          onLoad={() => {
+            this.setState({ imageStatus: "loaded" });
+          }}
+          onError={() => {
+            this.setState({ imageStatus: "error" });
+          }}
+          className={cn(
+            imageClassName,
+            showPlaceholder && "absolute inset-0 opacity-0",
+          )}
+        />
+        {this.renderOverlay()}
+      </button>
+    );
+  }
+}
+
 function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
   const openImageLightbox = useSet(openAttachmentImageLightbox$);
   const previewKind = getArtifactPreviewKind(file);
 
   if (previewKind === "image") {
     return (
-      <button
-        type="button"
-        onClick={() => {
+      <ChatImagePreviewButton
+        alt={`Preview ${file.filename}`}
+        ariaLabel={`Preview ${file.filename}`}
+        buttonClassName="flex h-full w-full items-center justify-center bg-muted"
+        imageClassName="h-full w-full object-contain"
+        onPreview={() => {
           openImageLightbox(file.url);
         }}
-        className="group relative flex h-full w-full items-center justify-center overflow-hidden bg-muted"
-        aria-label={`Preview ${file.filename}`}
-      >
-        <img
-          src={file.url}
-          alt={`Preview ${file.filename}`}
-          className="h-full w-full object-contain"
-        />
-        <span className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-150 group-hover:bg-black/25 group-hover:opacity-100">
-          <span className="flex h-9 w-9 items-center justify-center rounded-full bg-black/50 text-white shadow-lg">
-            <IconEye size={18} stroke={1.8} />
-          </span>
-        </span>
-      </button>
+        overlayIcon="eye"
+        placeholderClassName="h-full w-full"
+        url={file.url}
+      />
     );
   }
 
@@ -620,12 +726,7 @@ function ArtifactThumbnail({
       aria-hidden="true"
     >
       {previewKind === "image" ? (
-        <img
-          src={file.url}
-          alt=""
-          className="h-full w-full object-cover"
-          aria-hidden="true"
-        />
+        <ArtifactThumbnailImage url={file.url} />
       ) : (
         <span className="flex flex-col items-center gap-0.5 text-muted-foreground">
           <ArtifactFileIcon file={file} />
@@ -636,6 +737,57 @@ function ArtifactThumbnail({
       )}
     </div>
   );
+}
+
+class ArtifactThumbnailImage extends Component<
+  { url: string },
+  { imageStatus: ImageLoadStatus }
+> {
+  state: { imageStatus: ImageLoadStatus } = {
+    imageStatus: "loading",
+  };
+
+  componentDidUpdate(previousProps: Readonly<{ url: string }>) {
+    if (previousProps.url !== this.props.url) {
+      this.setState({ imageStatus: "loading" });
+    }
+  }
+
+  render() {
+    const { url } = this.props;
+    const { imageStatus } = this.state;
+    const showPlaceholder = imageStatus !== "loaded";
+
+    return (
+      <>
+        {showPlaceholder && (
+          <span className="flex h-full w-full items-center justify-center bg-muted/70 text-muted-foreground">
+            {imageStatus === "loading" ? (
+              <IconLoader2 size={14} stroke={1.8} className="animate-spin" />
+            ) : (
+              <IconPhoto size={14} stroke={1.5} />
+            )}
+          </span>
+        )}
+        <img
+          src={url}
+          alt=""
+          loading="lazy"
+          onLoad={() => {
+            this.setState({ imageStatus: "loaded" });
+          }}
+          onError={() => {
+            this.setState({ imageStatus: "error" });
+          }}
+          className={cn(
+            "h-full w-full object-cover",
+            showPlaceholder && "absolute inset-0 opacity-0",
+          )}
+          aria-hidden="true"
+        />
+      </>
+    );
+  }
 }
 
 function ArtifactFileRow({
@@ -1550,27 +1702,18 @@ function BodyContentBlocks({
 
         if (block.preview.kind === "image") {
           return (
-            <button
+            <ChatImagePreviewButton
               key={block.id}
-              type="button"
-              onClick={() => {
+              alt={block.preview.filename}
+              ariaLabel={`Preview ${block.preview.filename}`}
+              buttonClassName="w-fit max-w-full rounded-lg border border-foreground/10"
+              imageClassName="max-h-48 max-w-full object-contain"
+              onPreview={() => {
                 openLightbox(block.preview.url);
               }}
-              className="group relative w-fit max-w-full overflow-hidden rounded-lg border border-foreground/10"
-              aria-label={`Preview ${block.preview.filename}`}
-            >
-              <img
-                src={block.preview.url}
-                alt={block.preview.filename}
-                className="max-h-48 max-w-full object-contain"
-              />
-              <span className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/30 transition-colors">
-                <IconPhoto
-                  size={18}
-                  className="text-white opacity-0 group-hover:opacity-100 transition-opacity drop-shadow"
-                />
-              </span>
-            </button>
+              placeholderClassName="h-48 w-64 max-w-full"
+              url={block.preview.url}
+            />
           );
         }
 
@@ -1875,26 +2018,18 @@ function UserMessageAttachments({
       {attachments.map((a) => {
         if (a.isImage) {
           return (
-            <button
+            <ChatImagePreviewButton
               key={a.url}
-              type="button"
-              onClick={() => {
+              alt={a.filename}
+              ariaLabel={`Preview ${a.filename}`}
+              buttonClassName="rounded-lg border border-foreground/10 transition-colors hover:border-foreground/25"
+              imageClassName="h-9 max-w-[72px] object-cover"
+              onPreview={() => {
                 onImageClick(a.url);
               }}
-              className="group relative rounded-lg overflow-hidden border border-foreground/10 hover:border-foreground/25 transition-colors"
-            >
-              <img
-                src={a.url}
-                alt={a.filename}
-                className="h-9 max-w-[72px] object-cover"
-              />
-              <span className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/30 transition-colors">
-                <IconPhoto
-                  size={18}
-                  className="text-white opacity-0 group-hover:opacity-100 transition-opacity drop-shadow"
-                />
-              </span>
-            </button>
+              placeholderClassName="h-9 w-[72px]"
+              url={a.url}
+            />
           );
         }
         if (a.isVideo) {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -22,7 +22,6 @@ import {
   IconEye,
   IconFile,
   IconFileMusic,
-  IconFiles,
   IconLoader2,
   IconPackage,
   IconVideo,
@@ -543,10 +542,7 @@ class ChatImagePreviewButton extends Component<
     const { overlayIcon = "photo" } = this.props;
 
     return (
-      <span
-        data-testid="chat-image-preview-hover"
-        className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-150 group-hover/image-preview:bg-black/30 group-hover/image-preview:opacity-100"
-      >
+      <span className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-150 group-hover/image-preview:bg-black/30 group-hover/image-preview:opacity-100">
         {overlayIcon === "eye" ? (
           <span className="flex h-9 w-9 items-center justify-center rounded-full bg-black/50 text-white shadow-lg">
             <IconEye size={18} stroke={1.8} />


### PR DESCRIPTION
## Summary
- add scoped hover styles and loading placeholders for chat/composer image previews
- add lightbox loading state plus icon and Command/Ctrl zoom controls
- keep image preview zoom limited to explicit controls; no pinch or wheel zoom support

## Validation
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx