### PR TITLE
feat(platform): pinned-agent switcher above mobile chat list

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-list-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-list-page.test.tsx
@@ -387,8 +387,12 @@ describe("mobile chat agent switcher - shown when redesign on (CHAT-LIST-MOBILE-
         screen.getByTestId("mobile-chat-agent-switcher"),
       ).toBeInTheDocument();
     });
-    expect(screen.getByTestId(`mobile-chat-agent-${DEFAULT_AGENT}`)).toBeInTheDocument();
-    expect(screen.getByTestId(`mobile-chat-agent-${PINNED_EXTRA}`)).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`mobile-chat-agent-${DEFAULT_AGENT}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`mobile-chat-agent-${PINNED_EXTRA}`),
+    ).toBeInTheDocument();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-list-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-list-page.test.tsx
@@ -8,12 +8,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { createDeferredPromise } from "../../../signals/utils.ts";
+import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
+import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -319,6 +322,93 @@ describe("zero chat list page - delete confirmation", () => {
 
     await waitFor(() => {
       expect(screen.queryByText("Delete chat?")).not.toBeInTheDocument();
+    });
+  });
+});
+
+// Default agent ID is fixed by the onboarding mock; pinnedAgentIds$ always
+// prepends it to the user-pinned list.
+const DEFAULT_AGENT = "c0000000-0000-4000-a000-000000000001";
+const PINNED_EXTRA = "c0000000-0000-4000-a000-000000000011";
+
+function mockPinnedAgents() {
+  setMockTeam([
+    {
+      id: DEFAULT_AGENT,
+      displayName: "Zero",
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      headVersionId: "version_1",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+    {
+      id: PINNED_EXTRA,
+      displayName: "David",
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      headVersionId: "version_1",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  ]);
+  setMockUserPreferences({ pinnedAgentIds: [PINNED_EXTRA] });
+}
+
+describe("mobile chat agent switcher - hidden when redesign off (CHAT-LIST-MOBILE-001)", () => {
+  it("does not render the pinned-teammates strip with the default switch state", async () => {
+    mockChatThreads(createMockThreads());
+    mockPinnedAgents();
+    detachedSetupPage({ context, path: "/chats" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /Chats with/ }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("mobile-chat-agent-switcher"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("mobile chat agent switcher - shown when redesign on (CHAT-LIST-MOBILE-002)", () => {
+  it("renders one button per pinned agent", async () => {
+    mockChatThreads(createMockThreads());
+    mockPinnedAgents();
+    detachedSetupPage({
+      context,
+      path: "/chats",
+      featureSwitches: { [FeatureSwitchKey.MobileNativeV1]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("mobile-chat-agent-switcher"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByTestId(`mobile-chat-agent-${DEFAULT_AGENT}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`mobile-chat-agent-${PINNED_EXTRA}`)).toBeInTheDocument();
+  });
+});
+
+describe("mobile chat agent switcher - tap switches agent (CHAT-LIST-MOBILE-003)", () => {
+  it("clicking a pinned avatar calls setChatAgentId$ for that agent", async () => {
+    mockChatThreads(createMockThreads());
+    mockPinnedAgents();
+    detachedSetupPage({
+      context,
+      path: "/chats",
+      featureSwitches: { [FeatureSwitchKey.MobileNativeV1]: true },
+    });
+
+    const davidButton = await waitFor(() => {
+      return screen.getByTestId(`mobile-chat-agent-${PINNED_EXTRA}`);
+    });
+    click(davidButton);
+
+    await waitFor(() => {
+      expect(davidButton).toHaveAttribute("aria-pressed", "true");
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/mobile-chat-agent-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mobile-chat-agent-switcher.tsx
@@ -1,0 +1,73 @@
+import { useLastResolved, useResolved, useSet } from "ccstate-react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { cn } from "@vm0/ui";
+import {
+  currentChatAgentId$,
+  setChatAgentId$,
+} from "../../signals/agent-chat.ts";
+import { pinnedAgents$ } from "../../signals/zero-page/zero-pinned-agents.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import { AvatarFromUrl } from "./zero-sidebar-shared.tsx";
+
+/**
+ * Horizontal scroll strip of pinned agents shown above the chat list on
+ * mobile. Tapping an avatar switches which agent's threads are showing.
+ * Gated behind MobileNativeV1.
+ */
+export function MobileChatAgentSwitcher() {
+  const features = useLastResolved(featureSwitch$);
+  const enabled = features?.[FeatureSwitchKey.MobileNativeV1] ?? false;
+
+  const pinned = useLastResolved(pinnedAgents$) ?? [];
+  const currentId = useResolved(currentChatAgentId$);
+  const setAgentId = useSet(setChatAgentId$);
+
+  if (!enabled || pinned.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="md:hidden -mx-4 px-4 pb-3 flex gap-3 overflow-x-auto snap-x"
+      data-testid="mobile-chat-agent-switcher"
+      aria-label="Pinned teammates"
+    >
+      {pinned.map((agent) => {
+        const active = currentId === agent.id;
+        const label = agent.displayName ?? "Agent";
+        return (
+          <button
+            key={agent.id}
+            type="button"
+            onClick={() => {
+              setAgentId(agent.id);
+            }}
+            aria-pressed={active}
+            aria-label={`Switch to ${label}`}
+            data-testid={`mobile-chat-agent-${agent.id}`}
+            className="flex flex-col items-center gap-1 shrink-0 snap-start text-xs font-medium"
+          >
+            <AvatarFromUrl
+              avatarUrl={agent.avatarUrl}
+              alt=""
+              className={cn(
+                "h-12 w-12 rounded-full object-cover object-top transition-shadow",
+                active
+                  ? "ring-2 ring-primary ring-offset-2 ring-offset-background"
+                  : "ring-1 ring-border",
+              )}
+            />
+            <span
+              className={cn(
+                "max-w-[64px] truncate",
+                active ? "text-foreground" : "text-muted-foreground",
+              )}
+            >
+              {label}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
@@ -42,6 +42,7 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
+import { MobileChatAgentSwitcher } from "./mobile-chat-agent-switcher.tsx";
 
 export function ZeroChatListPage() {
   const recentSessionsLoadable = useLastLoadable(chatThreads$);
@@ -94,6 +95,8 @@ export function ZeroChatListPage() {
         <div className="flex items-center gap-3 mb-3">
           <h1 className="text-lg font-semibold">{titleLabel}</h1>
         </div>
+
+        <MobileChatAgentSwitcher />
 
         {/* Search */}
         <div className="flex items-center gap-2 rounded-lg bg-muted/50 px-3 h-10">


### PR DESCRIPTION
## Summary

PR 6 of the mobile redesign. Adds a horizontal-scroll strip of pinned-teammate avatars above the chat list on mobile. Tapping an avatar switches which agent's threads you're viewing — the title (\`Chats with Zero\` / \`Chats with David\`) and the thread list both re-scope automatically because they already read from \`currentChatAgentId\$\`.

## What it does

- New \`MobileChatAgentSwitcher\` composes \`pinnedAgents\$\` + \`currentChatAgentId\$\` + \`setChatAgentId\$\` + \`AvatarFromUrl\`. ~70 lines, pure composition.
- Inserted above the search bar in \`ZeroChatListPage\` (one-line addition).
- Hidden on desktop via \`md:hidden\` (the desktop sidebar already shows pinned agents).
- Gated by \`MobileNativeV1\` — switch off → byte-identical behavior.

## Reuse audit

| Reused | From | Note |
|---|---|---|
| \`pinnedAgents\$\` | \`signals/zero-page/zero-pinned-agents.ts\` | Existing computed signal |
| \`currentChatAgentId\$\` / \`setChatAgentId\$\` | \`signals/agent-chat.ts\` | Existing |
| \`AvatarFromUrl\` | \`zero-sidebar-shared.tsx\` | Existing |
| \`featureSwitch\$\` | \`signals/external/feature-switch.ts\` | Existing |
| \`cn\` | \`@vm0/ui\` | Existing |

No new state, no new commands, no new dropdowns.

## Stack

- Base: \`ming/mobile-drop-index-breadcrumb\` (PR #11348)
- → \`ming/mobile-org-switcher-pill\` (PR #11342)
- → \`ming/mobile-top-bar-org-switcher\` (PR #11338)
- → \`ming/mobile-home-chats-list\` (PR #11332)
- → \`ming/mobile-bottom-tab-bar\` (PR #11331)

Toggle \`MobileNativeV1\` on \`/lab\` to preview the cumulative effect across all 6 PRs.

## Test plan

- [x] \`pnpm run check-types\` clean
- [x] \`pnpm run lint\` clean
- [x] \`zero-chat-list-page.test.tsx\` 17/17 (added CHAT-LIST-MOBILE-001/002/003)
- [ ] Manual: enable \`MobileNativeV1\`; load \`/chats\` on mobile; confirm avatar strip shows
- [ ] Manual: tap a different avatar; confirm title + thread list re-scope
- [ ] Manual: switch off; confirm strip gone, list still works
- [ ] Manual: confirm strip absent on desktop (\`md:hidden\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)