### PR TITLE
feat(platform): add Connectors as 5th mobile bottom tab

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -253,8 +253,8 @@ describe("sidebar layout - overlay click collapses sidebar (SIDEBAR-D-054)", () 
   });
 });
 
-describe("mobile bottom tab bar - renders four tabs (MOBILE-TAB-001)", () => {
-  it("renders Chats, Teammates, Schedules, and More tabs when MobileNativeV1 is on", async () => {
+describe("mobile bottom tab bar - renders five tabs (MOBILE-TAB-001)", () => {
+  it("renders Chats, Teammates, Schedules, Connectors, and More tabs when MobileNativeV1 is on", async () => {
     mockBaseAPIs();
     detachedSetupPage({
       context,
@@ -269,7 +269,28 @@ describe("mobile bottom tab bar - renders four tabs (MOBILE-TAB-001)", () => {
     expect(screen.getByTestId("mobile-tab-chats")).toBeInTheDocument();
     expect(screen.getByTestId("mobile-tab-teammates")).toBeInTheDocument();
     expect(screen.getByTestId("mobile-tab-schedules")).toBeInTheDocument();
+    expect(screen.getByTestId("mobile-tab-connectors")).toBeInTheDocument();
     expect(screen.getByTestId("mobile-tab-more")).toBeInTheDocument();
+  });
+});
+
+describe("mobile bottom tab bar - Connectors tab navigates to /connectors (MOBILE-TAB-006)", () => {
+  it("clicking the Connectors tab navigates to /connectors", async () => {
+    mockBaseAPIs();
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: mobileNativeOn(),
+    });
+
+    const connectorsTab = await waitFor(() => {
+      return screen.getByTestId("mobile-tab-connectors");
+    });
+    click(connectorsTab);
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/connectors");
+    });
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/mobile-bottom-tab-bar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mobile-bottom-tab-bar.tsx
@@ -4,6 +4,7 @@ import {
   IconMessageCircle,
   IconUsers,
   IconCalendar,
+  IconPlug,
   IconMenu2,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
@@ -17,9 +18,9 @@ import { setSidebarExpanded$ } from "../../signals/zero-page/zero-nav.ts";
 type TabIcon = (props: { size?: number; stroke?: number }) => ReactNode;
 
 interface MobileTab {
-  readonly id: "chats" | "teammates" | "schedules";
+  readonly id: "chats" | "teammates" | "schedules" | "connectors";
   readonly activeKeys: readonly RouteKey[];
-  readonly pathname: "/" | "/agents" | "/schedules";
+  readonly pathname: "/" | "/agents" | "/schedules" | "/connectors";
   readonly label: string;
   readonly icon: TabIcon;
 }
@@ -52,6 +53,13 @@ const MOBILE_TABS: readonly MobileTab[] = [
     pathname: "/schedules",
     label: "Schedules",
     icon: IconCalendar as TabIcon,
+  },
+  {
+    id: "connectors",
+    activeKeys: ["connectors", "directedConnect", "directedAuthorize"],
+    pathname: "/connectors",
+    label: "Connectors",
+    icon: IconPlug as TabIcon,
   },
 ] as const;
 


### PR DESCRIPTION
## Summary

PR 7 of the mobile redesign. Promotes **Connectors** from a More-page item to a first-class bottom tab. Managing per-agent integrations is a frequent enough workflow to deserve a direct tap target.

## What it does

Adds one entry to \`MOBILE_TABS\`:
- icon: \`IconPlug\` (already imported elsewhere)
- pathname: \`/connectors\` (existing route)
- activeKeys: \`connectors\`, \`directedConnect\`, \`directedAuthorize\`

Layout becomes 5 tabs: Chats / Teammates / Schedules / Connectors / More. At 390 px viewport each tab is ~78 px wide — labels fit comfortably at \`text-xs\`.

## Stack

- Base: \`ming/mobile-chats-agent-switcher\` (PR #11352)
- → \`ming/mobile-drop-index-breadcrumb\` (PR #11348)
- → \`ming/mobile-org-switcher-pill\` (PR #11342)
- → \`ming/mobile-top-bar-org-switcher\` (PR #11338)
- → \`ming/mobile-home-chats-list\` (PR #11332)
- → \`ming/mobile-bottom-tab-bar\` (PR #11331)

## Test plan

- [x] \`pnpm run check-types\` clean
- [x] \`pnpm run lint\` clean
- [x] \`sidebar-layout.test.tsx\` 21/21 (added MOBILE-TAB-006; updated MOBILE-TAB-001 for 5 tabs)
- [ ] Manual: enable \`MobileNativeV1\`; tap Connectors → goes to \`/connectors\`
- [ ] Manual: confirm 5 tabs render without text overflow at 390 px

## Up next

PR 8 will rebuild the **More** page itself: Account settings · Workspace settings · Where Zero works · Insights · Upsell — replacing the desktop sidebar overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)