### PR TITLE
feat: add tooltip with full name on usage page schedule/chat rows

### DIFF
--- a/turbo/apps/platform/src/views/usage-page/components/usage-insight-chats-table.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/usage-insight-chats-table.tsx
@@ -96,36 +96,38 @@ export function UsageInsightChatsTable({
                     </TooltipTrigger>
                     <TooltipContent side="top" sideOffset={4}>
                       <p className="text-xs">{fullTitle}</p>
-                      <p className="text-[10px] text-muted-foreground mt-0.5">Click to open chat</p>
+                      <p className="text-[10px] text-muted-foreground mt-0.5">
+                        Click to open chat
+                      </p>
                     </TooltipContent>
                   </Tooltip>
-                <div className="h-1.5 rounded-full bg-foreground/10 overflow-hidden">
-                  <div
-                    className="h-full rounded-full"
-                    style={{ width: `${pct}%`, backgroundColor: accent }}
-                  />
-                </div>
-                <span className="text-xs tabular-nums opacity-70 text-right">
-                  {formatValue(value)}
-                </span>
-              </Link>
+                  <div className="h-1.5 rounded-full bg-foreground/10 overflow-hidden">
+                    <div
+                      className="h-full rounded-full"
+                      style={{ width: `${pct}%`, backgroundColor: accent }}
+                    />
+                  </div>
+                  <span className="text-xs tabular-nums opacity-70 text-right">
+                    {formatValue(value)}
+                  </span>
+                </Link>
+              </li>
+            );
+          })}
+          {chatOtherCount > 0 && (
+            <li
+              className={`grid grid-cols-[minmax(0,2fr)_minmax(0,3fr)_3rem] items-center gap-3 -mx-1.5 px-1.5 py-1 transition-opacity duration-150 ${
+                hoveredId === null ? "opacity-100" : "opacity-30"
+              }`}
+            >
+              <span className="text-sm text-muted-foreground truncate col-span-2">
+                +{chatOtherCount} more {chatOtherCount === 1 ? "chat" : "chats"}
+              </span>
+              <span className="text-xs tabular-nums text-muted-foreground text-right">
+                {formatValue(chatOtherCredits)}
+              </span>
             </li>
-          );
-        })}
-        {chatOtherCount > 0 && (
-          <li
-            className={`grid grid-cols-[minmax(0,2fr)_minmax(0,3fr)_3rem] items-center gap-3 -mx-1.5 px-1.5 py-1 transition-opacity duration-150 ${
-              hoveredId === null ? "opacity-100" : "opacity-30"
-            }`}
-          >
-            <span className="text-sm text-muted-foreground truncate col-span-2">
-              +{chatOtherCount} more {chatOtherCount === 1 ? "chat" : "chats"}
-            </span>
-            <span className="text-xs tabular-nums text-muted-foreground text-right">
-              {formatValue(chatOtherCredits)}
-            </span>
-          </li>
-        )}
+          )}
         </ul>
       </TooltipProvider>
     </section>

--- a/turbo/apps/platform/src/views/usage-page/components/usage-insight-chats-table.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/usage-insight-chats-table.tsx
@@ -6,6 +6,12 @@ import {
 } from "../../../signals/usage-page/usage-insight-signals.ts";
 import { Link } from "../../router/link.tsx";
 import { getCardPalette } from "../../../lib/card-palette.ts";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vm0/ui";
 
 function formatValue(n: number): string {
   if (n >= 1_000_000) {
@@ -60,29 +66,39 @@ export function UsageInsightChatsTable({
       <p className="text-5xl font-black leading-none tabular-nums font-serif">
         {totalCount}
       </p>
-      <ul className="flex flex-col gap-2.5 mt-4">
-        {chats.map((row) => {
-          const value = row.credits;
-          const pct = (value / maxValue) * 100;
-          const isActive = hoveredId === null || hoveredId === row.threadId;
-          return (
-            <li key={row.threadId}>
-              <Link
-                pathname="/chats/:threadId"
-                options={{ pathParams: { threadId: row.threadId } }}
-                className={`grid grid-cols-[minmax(0,2fr)_minmax(0,3fr)_3rem] items-center gap-3 -mx-1.5 px-1.5 py-1 rounded-md transition-all duration-150 ${
-                  hoveredId === row.threadId ? "bg-foreground/5" : ""
-                } ${isActive ? "opacity-100" : "opacity-30"}`}
-                onMouseEnter={() => {
-                  setHoveredId(row.threadId);
-                }}
-                onMouseLeave={() => {
-                  setHoveredId(null);
-                }}
-              >
-                <span className="text-sm font-medium truncate decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-2">
-                  {row.threadTitle ?? "(untitled)"}
-                </span>
+      <TooltipProvider delayDuration={300}>
+        <ul className="flex flex-col gap-2.5 mt-4">
+          {chats.map((row) => {
+            const value = row.credits;
+            const pct = (value / maxValue) * 100;
+            const isActive = hoveredId === null || hoveredId === row.threadId;
+            const fullTitle = row.threadTitle ?? "(untitled)";
+            return (
+              <li key={row.threadId}>
+                <Link
+                  pathname="/chats/:threadId"
+                  options={{ pathParams: { threadId: row.threadId } }}
+                  className={`grid grid-cols-[minmax(0,2fr)_minmax(0,3fr)_3rem] items-center gap-3 -mx-1.5 px-1.5 py-1 rounded-md transition-all duration-150 ${
+                    hoveredId === row.threadId ? "bg-foreground/5" : ""
+                  } ${isActive ? "opacity-100" : "opacity-30"}`}
+                  onMouseEnter={() => {
+                    setHoveredId(row.threadId);
+                  }}
+                  onMouseLeave={() => {
+                    setHoveredId(null);
+                  }}
+                >
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="text-sm font-medium truncate decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-2">
+                        {fullTitle}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" sideOffset={4}>
+                      <p className="text-xs">{fullTitle}</p>
+                      <p className="text-[10px] text-muted-foreground mt-0.5">Click to open chat</p>
+                    </TooltipContent>
+                  </Tooltip>
                 <div className="h-1.5 rounded-full bg-foreground/10 overflow-hidden">
                   <div
                     className="h-full rounded-full"
@@ -110,7 +126,8 @@ export function UsageInsightChatsTable({
             </span>
           </li>
         )}
-      </ul>
+        </ul>
+      </TooltipProvider>
     </section>
   );
 }

--- a/turbo/apps/platform/src/views/usage-page/components/usage-insight-schedules-table.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/usage-insight-schedules-table.tsx
@@ -6,6 +6,12 @@ import {
 } from "../../../signals/usage-page/usage-insight-signals.ts";
 import { Link } from "../../router/link.tsx";
 import { getCardPalette } from "../../../lib/card-palette.ts";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vm0/ui";
 
 function formatValue(n: number): string {
   if (n >= 1_000_000) {
@@ -62,29 +68,39 @@ export function UsageInsightSchedulesTable({
       <p className="text-5xl font-black leading-none tabular-nums font-serif">
         {totalCount}
       </p>
-      <ul className="flex flex-col gap-2.5 mt-4">
-        {schedules.map((row) => {
-          const value = row.credits;
-          const pct = (value / maxValue) * 100;
-          const isActive = hoveredId === null || hoveredId === row.scheduleId;
-          return (
-            <li key={row.scheduleId}>
-              <Link
-                pathname="/schedules/:scheduleId"
-                options={{ pathParams: { scheduleId: row.scheduleId } }}
-                className={`grid grid-cols-[minmax(0,2fr)_minmax(0,3fr)_3rem] items-center gap-3 -mx-1.5 px-1.5 py-1 rounded-md transition-all duration-150 ${
-                  hoveredId === row.scheduleId ? "bg-foreground/5" : ""
-                } ${isActive ? "opacity-100" : "opacity-30"}`}
-                onMouseEnter={() => {
-                  setHoveredId(row.scheduleId);
-                }}
-                onMouseLeave={() => {
-                  setHoveredId(null);
-                }}
-              >
-                <span className="text-sm font-medium truncate decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-2">
-                  {row.scheduleDescription?.trim() || row.scheduleName}
-                </span>
+      <TooltipProvider delayDuration={300}>
+        <ul className="flex flex-col gap-2.5 mt-4">
+          {schedules.map((row) => {
+            const value = row.credits;
+            const pct = (value / maxValue) * 100;
+            const isActive = hoveredId === null || hoveredId === row.scheduleId;
+            const fullName = row.scheduleDescription?.trim() || row.scheduleName;
+            return (
+              <li key={row.scheduleId}>
+                <Link
+                  pathname="/schedules/:scheduleId"
+                  options={{ pathParams: { scheduleId: row.scheduleId } }}
+                  className={`grid grid-cols-[minmax(0,2fr)_minmax(0,3fr)_3rem] items-center gap-3 -mx-1.5 px-1.5 py-1 rounded-md transition-all duration-150 ${
+                    hoveredId === row.scheduleId ? "bg-foreground/5" : ""
+                  } ${isActive ? "opacity-100" : "opacity-30"}`}
+                  onMouseEnter={() => {
+                    setHoveredId(row.scheduleId);
+                  }}
+                  onMouseLeave={() => {
+                    setHoveredId(null);
+                  }}
+                >
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="text-sm font-medium truncate decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-2">
+                        {fullName}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" sideOffset={4}>
+                      <p className="text-xs">{fullName}</p>
+                      <p className="text-[10px] text-muted-foreground mt-0.5">Click to open schedule</p>
+                    </TooltipContent>
+                  </Tooltip>
                 <div className="h-1.5 rounded-full bg-foreground/10 overflow-hidden">
                   <div
                     className="h-full rounded-full"
@@ -113,7 +129,8 @@ export function UsageInsightSchedulesTable({
             </span>
           </li>
         )}
-      </ul>
+        </ul>
+      </TooltipProvider>
     </section>
   );
 }

--- a/turbo/apps/platform/src/views/usage-page/components/usage-insight-schedules-table.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/usage-insight-schedules-table.tsx
@@ -74,7 +74,8 @@ export function UsageInsightSchedulesTable({
             const value = row.credits;
             const pct = (value / maxValue) * 100;
             const isActive = hoveredId === null || hoveredId === row.scheduleId;
-            const fullName = row.scheduleDescription?.trim() || row.scheduleName;
+            const fullName =
+              row.scheduleDescription?.trim() || row.scheduleName;
             return (
               <li key={row.scheduleId}>
                 <Link
@@ -98,37 +99,39 @@ export function UsageInsightSchedulesTable({
                     </TooltipTrigger>
                     <TooltipContent side="top" sideOffset={4}>
                       <p className="text-xs">{fullName}</p>
-                      <p className="text-[10px] text-muted-foreground mt-0.5">Click to open schedule</p>
+                      <p className="text-[10px] text-muted-foreground mt-0.5">
+                        Click to open schedule
+                      </p>
                     </TooltipContent>
                   </Tooltip>
-                <div className="h-1.5 rounded-full bg-foreground/10 overflow-hidden">
-                  <div
-                    className="h-full rounded-full"
-                    style={{ width: `${pct}%`, backgroundColor: accent }}
-                  />
-                </div>
-                <span className="text-xs tabular-nums opacity-70 text-right">
-                  {formatValue(value)}
-                </span>
-              </Link>
+                  <div className="h-1.5 rounded-full bg-foreground/10 overflow-hidden">
+                    <div
+                      className="h-full rounded-full"
+                      style={{ width: `${pct}%`, backgroundColor: accent }}
+                    />
+                  </div>
+                  <span className="text-xs tabular-nums opacity-70 text-right">
+                    {formatValue(value)}
+                  </span>
+                </Link>
+              </li>
+            );
+          })}
+          {scheduleOtherCount > 0 && (
+            <li
+              className={`grid grid-cols-[minmax(0,2fr)_minmax(0,3fr)_3rem] items-center gap-3 -mx-1.5 px-1.5 py-1 transition-opacity duration-150 ${
+                hoveredId === null ? "opacity-100" : "opacity-30"
+              }`}
+            >
+              <span className="text-sm text-muted-foreground truncate col-span-2">
+                +{scheduleOtherCount} more{" "}
+                {scheduleOtherCount === 1 ? "schedule" : "schedules"}
+              </span>
+              <span className="text-xs tabular-nums text-muted-foreground text-right">
+                {formatValue(scheduleOtherCredits)}
+              </span>
             </li>
-          );
-        })}
-        {scheduleOtherCount > 0 && (
-          <li
-            className={`grid grid-cols-[minmax(0,2fr)_minmax(0,3fr)_3rem] items-center gap-3 -mx-1.5 px-1.5 py-1 transition-opacity duration-150 ${
-              hoveredId === null ? "opacity-100" : "opacity-30"
-            }`}
-          >
-            <span className="text-sm text-muted-foreground truncate col-span-2">
-              +{scheduleOtherCount} more{" "}
-              {scheduleOtherCount === 1 ? "schedule" : "schedules"}
-            </span>
-            <span className="text-xs tabular-nums text-muted-foreground text-right">
-              {formatValue(scheduleOtherCredits)}
-            </span>
-          </li>
-        )}
+          )}
         </ul>
       </TooltipProvider>
     </section>


### PR DESCRIPTION
## Summary
- Schedule and chat names in usage insight tables were truncated via CSS `truncate` with no way to see the full text
- Added `<Tooltip>` wrapping each name: hover shows the full name plus a "Click to open schedule/chat" hint
- Both `usage-insight-schedules-table.tsx` and `usage-insight-chats-table.tsx` updated

## Test plan
- [ ] Hover truncated schedule name — tooltip shows full name
- [ ] Hover truncated chat name — tooltip shows full title
- [ ] Tooltip shows "Click to open schedule" / "Click to open chat" hint
- [ ] Click navigates to the schedule/chat page

🤖 Generated with [Claude Code](https://claude.com/claude-code)