### PR TITLE
fix: show result-only chat callback output

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
@@ -359,6 +359,81 @@ describe("POST /api/internal/callbacks/chat", () => {
       expect(resultMsg!.runId).toBe(runId);
     });
 
+    it("should persist the latest non-empty result-only output", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread();
+
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        {
+          eventType: "result",
+          sequenceNumber: 1,
+          eventData: { result: "Preparing final response..." },
+        },
+        {
+          eventType: "result",
+          sequenceNumber: 2,
+          eventData: { result: "Unknown command: /aaa" },
+        },
+      ]);
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "completed",
+            payload: { threadId, agentId },
+          },
+          secret,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+
+      const chatMessages = await getTestChatMessagesByThread(threadId);
+      const resultMsg = chatMessages.find((m) => {
+        return m.role === "assistant" && m.sequenceNumber !== null;
+      });
+      expect(resultMsg).toBeDefined();
+      expect(resultMsg!.content).toBe("Unknown command: /aaa");
+      expect(resultMsg!.sequenceNumber).toBe(2);
+    });
+
+    it("should read result fallback sequence from eventData when needed", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread();
+
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        {
+          eventType: "result",
+          eventData: {
+            sequenceNumber: 4,
+            result: "Unknown command: /aaa",
+          },
+        },
+      ]);
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "completed",
+            payload: { threadId, agentId },
+          },
+          secret,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+
+      const chatMessages = await getTestChatMessagesByThread(threadId);
+      const resultMsg = chatMessages.find((m) => {
+        return m.role === "assistant" && m.sequenceNumber !== null;
+      });
+      expect(resultMsg).toBeDefined();
+      expect(resultMsg!.content).toBe("Unknown command: /aaa");
+      expect(resultMsg!.sequenceNumber).toBe(4);
+    });
+
     it("should not duplicate result output when assistant event exists", async () => {
       const { threadId, runId, secret } = await setupRunAndThread();
 

--- a/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
@@ -322,6 +322,189 @@ describe("POST /api/internal/callbacks/chat", () => {
       expect(eventMsg!.runId).toBe(runId);
     });
 
+    it("should persist result-only output as assistant message on completion", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread();
+
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        {
+          eventType: "result",
+          sequenceNumber: 1,
+          eventData: { result: "Unknown command: /aaa" },
+        },
+      ]);
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "completed",
+            payload: { threadId, agentId },
+          },
+          secret,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+
+      const chatMessages = await getTestChatMessagesByThread(threadId);
+      expect(chatMessages).toHaveLength(2);
+
+      const resultMsg = chatMessages.find((m) => {
+        return m.role === "assistant" && m.sequenceNumber !== null;
+      });
+      expect(resultMsg).toBeDefined();
+      expect(resultMsg!.content).toBe("Unknown command: /aaa");
+      expect(resultMsg!.sequenceNumber).toBe(1);
+      expect(resultMsg!.runId).toBe(runId);
+    });
+
+    it("should not duplicate result output when assistant event exists", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread();
+
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        {
+          eventType: "assistant",
+          sequenceNumber: 0,
+          eventData: {
+            message: {
+              content: [{ type: "text", text: "Assistant answer." }],
+            },
+          },
+        },
+        {
+          eventType: "result",
+          sequenceNumber: 1,
+          eventData: { result: "Assistant answer." },
+        },
+      ]);
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "completed",
+            payload: { threadId, agentId },
+          },
+          secret,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+
+      const chatMessages = await getTestChatMessagesByThread(threadId);
+      const eventMessages = chatMessages.filter((m) => {
+        return m.role === "assistant" && m.sequenceNumber !== null;
+      });
+      expect(eventMessages).toHaveLength(1);
+      expect(eventMessages[0]!.content).toBe("Assistant answer.");
+      expect(eventMessages[0]!.sequenceNumber).toBe(0);
+    });
+
+    it("should not duplicate result fallback when callbacks run concurrently", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread();
+
+      context.mocks.axiom.queryAxiom.mockResolvedValue([
+        {
+          eventType: "result",
+          sequenceNumber: 1,
+          eventData: { result: "Unknown command: /aaa" },
+        },
+      ]);
+
+      const makeRequest = () => {
+        return POST(
+          createSignedCallbackRequest(
+            "http://localhost/api/internal/callbacks/chat",
+            {
+              runId,
+              status: "completed",
+              payload: { threadId, agentId },
+            },
+            secret,
+          ),
+        );
+      };
+
+      const [r1, r2] = await Promise.all([makeRequest(), makeRequest()]);
+      expect(r1.status).toBe(200);
+      expect(r2.status).toBe(200);
+
+      const chatMessages = await getTestChatMessagesByThread(threadId);
+      const eventMessages = chatMessages.filter((m) => {
+        return m.role === "assistant" && m.sequenceNumber !== null;
+      });
+      expect(eventMessages).toHaveLength(1);
+      expect(eventMessages[0]!.content).toBe("Unknown command: /aaa");
+    });
+
+    it("should ignore empty result fallback events", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread();
+
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        {
+          eventType: "result",
+          sequenceNumber: 1,
+          eventData: { result: "   " },
+        },
+      ]);
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "completed",
+            payload: { threadId, agentId },
+          },
+          secret,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+
+      const chatMessages = await getTestChatMessagesByThread(threadId);
+      expect(chatMessages).toHaveLength(1);
+      expect(chatMessages[0]!.role).toBe("user");
+    });
+
+    it("should not insert result fallback when assistant output already exists", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread();
+      await insertTestAssistantEventMessages(runId, threadId, user.userId, [
+        { sequenceNumber: 0, content: "Already streamed." },
+      ]);
+
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        {
+          eventType: "result",
+          sequenceNumber: 1,
+          eventData: { result: "Unknown command: /aaa" },
+        },
+      ]);
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "completed",
+            payload: { threadId, agentId },
+          },
+          secret,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+
+      const chatMessages = await getTestChatMessagesByThread(threadId);
+      const eventMessages = chatMessages.filter((m) => {
+        return m.role === "assistant" && m.sequenceNumber !== null;
+      });
+      expect(eventMessages).toHaveLength(1);
+      expect(eventMessages[0]!.content).toBe("Already streamed.");
+    });
+
     it("should not duplicate assistant messages when callback runs concurrently", async () => {
       // Regression: idempotent inserts via the (run_id, sequence_number)
       // unique index must collapse concurrent callback invocations to a

--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -219,10 +219,11 @@ async function handleCompleted(
   threadId: string,
   userId: string,
 ): Promise<void> {
-  // Final sweep: re-query Axiom and insert any events the live consumer
-  // missed. Inserts are idempotent via the `(run_id, sequence_number)`
-  // unique index, so concurrent writes from the consumer and this sweep
-  // cannot produce duplicates.
+  // Final sweep: re-query Axiom and insert any assistant output the live
+  // consumer missed. Result-only CLI output is inserted only when no assistant
+  // output exists for the run. Inserts are idempotent via the
+  // `(run_id, sequence_number)` unique index, so concurrent writes from the
+  // consumer and this sweep cannot produce duplicates.
   const { assistantItems, resultFallback } = await queryChatOutputEvents(runId);
   if (assistantItems.length > 0) {
     await insertAssistantEventMessages(runId, threadId, userId, assistantItems);
@@ -325,9 +326,9 @@ async function handleFailed(
  * POST /api/internal/callbacks/chat
  *
  * Chat callback handler for agent run completion.
- * Final sweep: inserts any assistant events not yet written by the
- * chat-assistant consumer (via `ON CONFLICT DO NOTHING`), then generates
- * title and sends push notification.
+ * Final sweep: inserts any assistant output not yet written by the
+ * chat-assistant consumer, or terminal result-only output when there is no
+ * assistant output, then generates title and sends push notification.
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   initServices();

--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse, after } from "next/server";
-import { and, eq, isNotNull, sql } from "drizzle-orm";
+import { and, desc, eq, isNotNull, sql } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import { verifyCallback } from "../../../../../src/lib/infra/callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -46,50 +46,99 @@ interface ContentBlock {
   text?: string;
 }
 
-interface AxiomAssistantEvent {
+interface AxiomChatOutputEvent {
+  eventType?: string;
   sequenceNumber?: number;
   eventData?: {
     message?: { content?: ContentBlock[] };
+    result?: string;
     sequenceNumber?: number;
   };
 }
 
+interface AssistantEventItem {
+  sequenceNumber: number;
+  content: string;
+}
+
+interface ResultEventItem {
+  sequenceNumber: number;
+  content: string;
+}
+
 /**
- * Query Axiom for every assistant event for this run and flatten them into
- * `(sequenceNumber, content)` pairs. Used as the final sweep to backfill any
- * events the live consumer dropped.
+ * Query Axiom for terminal chat output. Assistant events remain the primary
+ * source; a result event is kept only as a fallback for result-only CLI
+ * outputs such as Claude Code slash-command messages.
  */
-async function queryAssistantEvents(
-  runId: string,
-): Promise<{ sequenceNumber: number; content: string }[]> {
+async function queryChatOutputEvents(runId: string): Promise<{
+  assistantItems: AssistantEventItem[];
+  resultFallback: ResultEventItem | null;
+}> {
   const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
   const apl = `['${dataset}']
 | where runId == "${runId}"
-| where eventType == "assistant"
+| where eventType == "assistant" or eventType == "result"
 | order by sequenceNumber asc
 | limit 200`;
 
-  const events = await queryAxiom<AxiomAssistantEvent>(apl);
+  const events = await queryAxiom<AxiomChatOutputEvent>(apl);
 
-  const items: { sequenceNumber: number; content: string }[] = [];
+  const assistantItems: AssistantEventItem[] = [];
+  let resultFallback: ResultEventItem | null = null;
   for (const e of events) {
     const seq = e.sequenceNumber ?? e.eventData?.sequenceNumber;
     if (typeof seq !== "number") continue;
+
     const content = e.eventData?.message?.content;
-    if (!content) continue;
-    const parts: string[] = [];
-    for (const block of content) {
-      if (block.type === "text" && typeof block.text === "string") {
-        parts.push(block.text);
+    if (content) {
+      const parts: string[] = [];
+      for (const block of content) {
+        if (block.type === "text" && typeof block.text === "string") {
+          parts.push(block.text);
+        }
       }
+      if (parts.length > 0) {
+        assistantItems.push({
+          sequenceNumber: seq,
+          content: parts.length === 1 ? parts[0]! : parts.join("\n\n"),
+        });
+      }
+      continue;
     }
-    if (parts.length === 0) continue;
-    items.push({
+
+    const result = e.eventData?.result;
+    if (typeof result !== "string") continue;
+    const trimmed = result.trim();
+    if (!trimmed) continue;
+    resultFallback = {
       sequenceNumber: seq,
-      content: parts.length === 1 ? parts[0]! : parts.join("\n\n"),
-    });
+      content: result,
+    };
   }
-  return items;
+  return { assistantItems, resultFallback };
+}
+
+async function latestEventBackedAssistantMessage(
+  runId: string,
+): Promise<{ content: string } | null> {
+  const [message] = await globalThis.services.db
+    .select({ content: chatMessages.content })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.runId, runId),
+        eq(chatMessages.role, "assistant"),
+        isNotNull(chatMessages.sequenceNumber),
+      ),
+    )
+    .orderBy(desc(chatMessages.sequenceNumber))
+    .limit(1);
+
+  if (!message || message.content === null) {
+    return null;
+  }
+  return { content: message.content };
 }
 
 /**
@@ -174,9 +223,25 @@ async function handleCompleted(
   // missed. Inserts are idempotent via the `(run_id, sequence_number)`
   // unique index, so concurrent writes from the consumer and this sweep
   // cannot produce duplicates.
-  const items = await queryAssistantEvents(runId);
-  if (items.length > 0) {
-    await insertAssistantEventMessages(runId, threadId, userId, items);
+  const { assistantItems, resultFallback } = await queryChatOutputEvents(runId);
+  if (assistantItems.length > 0) {
+    await insertAssistantEventMessages(runId, threadId, userId, assistantItems);
+  }
+
+  let lastResultText =
+    assistantItems.length > 0
+      ? assistantItems[assistantItems.length - 1]!.content
+      : null;
+  if (lastResultText === null) {
+    const existingAssistant = await latestEventBackedAssistantMessage(runId);
+    if (existingAssistant) {
+      lastResultText = existingAssistant.content;
+    } else if (resultFallback) {
+      await insertAssistantEventMessages(runId, threadId, userId, [
+        resultFallback,
+      ]);
+      lastResultText = resultFallback.content;
+    }
   }
 
   // Wrap-up latency: gap from last assistant event row to run terminal
@@ -186,10 +251,6 @@ async function handleCompleted(
   after(() => {
     return recordLastEventToComplete(runId);
   });
-
-  // Use last assistant text for downstream (title, summary, notification)
-  const lastResultText =
-    items.length > 0 ? items[items.length - 1]!.content : null;
 
   // Generate run summary (best-effort — errors handled internally)
   await saveRunSummary(runId, "chat", prompt, lastResultText ?? "");

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-message-service.ts
@@ -137,9 +137,11 @@ export async function insertChatMessage(params: {
 }
 
 /**
- * Idempotently insert one assistant row per agent "assistant" event.
+ * Idempotently insert assistant-visible rows keyed by agent event sequence.
+ * Normal callers pass agent "assistant" events; the chat callback can also
+ * pass terminal "result" content for result-only CLI outputs.
  *
- * Keyed by `(run_id, sequence_number)` with a partial unique index, so
+ * Keyed by `(run_id, sequence_number)` with a unique index, so
  * duplicate deliveries (from retries, the event consumer racing the
  * callback's final sweep, or multiple consumers re-processing the same
  * batch) collapse to a single row — no advisory lock, no Axiom re-query.

--- a/turbo/packages/db/src/schema/chat-message.ts
+++ b/turbo/packages/db/src/schema/chat-message.ts
@@ -24,7 +24,9 @@ export type ChatMessageAttachFiles = string[];
  * - Placeholder: inserted on send with `content` NULL and `sequence_number` NULL.
  *   Gives the UI something to render while the run is pending, and carries the
  *   error/terminal state for failed runs (set via the callback).
- * - Event-backed: one row per agent "assistant" event, keyed by
+ * - Event-backed: one row per assistant-visible agent output event. Normal
+ *   rows come from agent "assistant" events; result-only CLI output can be
+ *   projected from a terminal "result" event. Rows are keyed by
  *   `(run_id, sequence_number)` for idempotent, lock-free inserts from both
  *   the event consumer and the callback's final sweep.
  *


### PR DESCRIPTION
## Summary
- Backfill completed chat callbacks from result events when no assistant event output exists
- Preserve assistant events as the primary chat output source to avoid duplicate final summaries
- Add route integration coverage for result-only output, duplicate avoidance, empty results, and pre-existing assistant output

## Tests
- pnpm --filter web test app/api/internal/callbacks/chat/__tests__/route.test.ts
- pnpm --filter web check-types
- pnpm --filter web lint

Fixes #10894