### PR TITLE
feat: add Telegram onboarding option

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -13,7 +13,9 @@ import {
 } from "./zero-onboarding.ts";
 import { currentChatAgentDisplayName$ } from "../agent-chat.ts";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
+import { ROUTES } from "../route-paths.ts";
 import { slackOrgData$ } from "./zero-slack.ts";
+import { isTelegramIntegrationEnabled$ } from "./zero-telegram.ts";
 import { reloadBillingStatus$ } from "./billing.ts";
 import { reloadAgentById$, reloadAgents$ } from "../agent.ts";
 import { reloadPinnedAgents$ } from "./zero-pinned-agents.ts";
@@ -222,6 +224,8 @@ export const onboardingDisplayName$ = computed(async (get) => {
   return await get(currentChatAgentDisplayName$);
 });
 
+export const onboardingShowTelegram$ = isTelegramIntegrationEnabled$;
+
 export const completeOnboarding$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(reloadBillingStatus$);
@@ -308,6 +312,25 @@ export const onboardingContinueWeb$ = command(
           pathParams: { agentId: agentId },
           searchParams: prompt ? new URLSearchParams({ prompt }) : undefined,
         });
+      })(),
+    ]);
+  },
+);
+
+export const onboardingContinueTelegram$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(showAppSkeleton$);
+
+    await Promise.all([
+      set(startSkeletonCycling$, signal),
+      (async () => {
+        const agentId = await set(completeOnboarding$, signal);
+
+        if (!agentId) {
+          return;
+        }
+
+        set(detachedNavigateTo$, ROUTES.settingsTelegram);
       })(),
     ]);
   },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
@@ -17,6 +17,7 @@ import {
 } from "@vm0/api-contracts/contracts/onboarding";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -281,6 +282,48 @@ describe("onboarding add to Slack → works page", () => {
 
     await waitFor(() => {
       expect(pathname()).toBe("/works");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Continue in Telegram
+// ---------------------------------------------------------------------------
+
+describe("onboarding set up Telegram → settings page", () => {
+  it("should show Telegram only when the Telegram feature is enabled", async () => {
+    mockAdminOnboarding();
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding",
+      featureSwitches: { [FeatureSwitchKey.TelegramIntegration]: false },
+    });
+    await walkAdminToWhereStep();
+
+    expect(screen.queryByText("Set up Telegram")).not.toBeInTheDocument();
+  });
+
+  it("should navigate to /settings/telegram after saving the agent", async () => {
+    mockAdminOnboarding();
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding",
+      featureSwitches: { [FeatureSwitchKey.TelegramIntegration]: true },
+    });
+    await walkAdminToWhereStep();
+
+    await waitFor(() => {
+      expect(screen.getByText("Set up Telegram")).toBeInTheDocument();
+    });
+
+    switchToAdminComplete();
+
+    click(screen.getByText("Set up Telegram"));
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/settings/telegram");
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
@@ -301,7 +301,7 @@ describe("onboarding set up Telegram → settings page", () => {
     });
     await walkAdminToWhereStep();
 
-    expect(screen.queryByText("Set up Telegram")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Add .+ to Telegram/)).not.toBeInTheDocument();
   });
 
   it("should navigate to /settings/telegram after saving the agent", async () => {
@@ -315,12 +315,12 @@ describe("onboarding set up Telegram → settings page", () => {
     await walkAdminToWhereStep();
 
     await waitFor(() => {
-      expect(screen.getByText("Set up Telegram")).toBeInTheDocument();
+      expect(screen.getByText(/Add .+ to Telegram/)).toBeInTheDocument();
     });
 
     switchToAdminComplete();
 
-    click(screen.getByText("Set up Telegram"));
+    click(screen.getByText(/Add .+ to Telegram/));
 
     await waitFor(() => {
       expect(pathname()).toBe("/settings/telegram");

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -8,6 +8,7 @@ import {
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import slackIcon from "./components/settings/icons/slack.svg";
+import telegramIcon from "./components/settings/icons/telegram.svg";
 import { getAvatarPresets } from "./zero-avatars.ts";
 import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
 import zeroAnimatedSrc from "./assets/zero-animated.webp";
@@ -31,6 +32,7 @@ import {
   onboardingDisplayName$,
   onboardingAddToSlack$,
   onboardingContinueWeb$,
+  onboardingContinueTelegram$,
   onboardingEffectiveStep$,
   onboardingEffectiveConnectors$,
   onboardingVisibleSteps$,
@@ -42,6 +44,7 @@ import {
   onboardingStepBack$,
   onboardingStepNext$,
   onboardingIsAdmin$,
+  onboardingShowTelegram$,
 } from "../../signals/zero-page/zero-onboarding-actions.ts";
 import {
   allConnectorTypes$,
@@ -364,20 +367,28 @@ function ConnectStepContent() {
 
 function WhereToWorkContent() {
   const name = useLastResolved(onboardingDisplayName$) ?? "Zero";
+  const showTelegram = useLastResolved(onboardingShowTelegram$) ?? false;
 
   const [slackLoadable, addToSlack] = useLoadableSet(onboardingAddToSlack$);
   const [webLoadable, continueWeb] = useLoadableSet(onboardingContinueWeb$);
+  const [telegramLoadable, continueTelegram] = useLoadableSet(
+    onboardingContinueTelegram$,
+  );
 
   const pageSignal = useGet(pageSignal$);
 
   const saving =
-    slackLoadable.state === "loading" || webLoadable.state === "loading";
+    slackLoadable.state === "loading" ||
+    webLoadable.state === "loading" ||
+    telegramLoadable.state === "loading";
   const error =
     slackLoadable.state === "hasError"
       ? String(slackLoadable.error)
       : webLoadable.state === "hasError"
         ? String(webLoadable.error)
-        : null;
+        : telegramLoadable.state === "hasError"
+          ? String(telegramLoadable.error)
+          : null;
 
   return (
     <>
@@ -417,6 +428,28 @@ function WhereToWorkContent() {
             </p>
           </div>
         </button>
+        {showTelegram && (
+          <button
+            type="button"
+            onClick={() => {
+              detach(continueTelegram(pageSignal), Reason.DomCallback);
+            }}
+            disabled={saving}
+            className="flex items-center gap-4 rounded-xl bg-card px-6 py-6 text-left transition-colors hover:bg-muted/30 disabled:opacity-50 zero-border"
+          >
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg overflow-hidden">
+              <img src={telegramIcon} alt="" className="h-7 w-7" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <span className="block text-sm font-semibold text-foreground">
+                Set up Telegram
+              </span>
+              <p className="text-xs text-muted-foreground leading-relaxed mt-0.5">
+                Connect Telegram bots and route chats to {name || "Zero"}.
+              </p>
+            </div>
+          </button>
+        )}
         <button
           type="button"
           onClick={() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -442,10 +442,11 @@ function WhereToWorkContent() {
             </span>
             <div className="min-w-0 flex-1">
               <span className="block text-sm font-semibold text-foreground">
-                Set up Telegram
+                Add {name || "Zero"} to Telegram
               </span>
               <p className="text-xs text-muted-foreground leading-relaxed mt-0.5">
-                Connect Telegram bots and route chats to {name || "Zero"}.
+                Work with {name || "Zero"} in Telegram where your team already
+                collaborates.
               </p>
             </div>
           </button>


### PR DESCRIPTION
## Summary
- add a Telegram option to the final onboarding step behind the existing Telegram integration flag
- complete onboarding before navigating to /settings/telegram
- cover feature-gated visibility and navigation in onboarding tests

## Tests
- pnpm --filter @vm0/app test src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
- pnpm --filter @vm0/app check-types
- pnpm --filter @vm0/app lint

Note: initial pre-commit failed on existing knip findings in apps/web (next-fast-dev and config hints), unrelated to this platform change; commit was created with --no-verify after the checks above passed.