### PR TITLE
feat: enable chat artifacts drawer for everyone

### DIFF
--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts
@@ -45,7 +45,11 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
     expect(response.status).toBe(401);
   });
 
-  it("returns 403 when the feature switch is disabled", async () => {
+  it("returns 403 when the feature switch is disabled by override", async () => {
+    await seedUserFeatureSwitches(testOrgId, testUserId, {
+      [FeatureSwitchKey.ChatArtifactsDrawer]: false,
+    });
+
     const response = await GET(
       createTestRequest(
         "http://localhost:3000/api/zero/chat-threads/thread-id/artifacts",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -220,8 +220,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Show an artifacts button in the chat header that opens a drawer listing uploaded files grouped by run",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ChatThreadReadIndicator]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- enable `ChatArtifactsDrawer` globally instead of staff-org only
- keep the forbidden-path route test by explicitly disabling the switch through user overrides

## Testing
- `pnpm --filter @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm exec prettier --check packages/core/src/feature-switch.ts 'apps/web/app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts'`
- `pnpm --filter web exec vitest run 'app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts' -t 'disabled by override'`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx -t 'artifacts'`
- `pnpm --filter @vm0/core lint`
- `pnpm --filter web exec eslint 'app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts' --max-warnings 0`

Note: full web artifacts route test was blocked locally by a stale/dirty DB schema and migration state. `pnpm --filter web exec vitest run 'app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts'` failed because the local DB was missing `chat_threads.last_read_message_id` and `agent_sessions.artifacts`; `pnpm --filter web db:migrate` then failed creating `uq_credit_expires_starter_grant` due duplicate existing `credit_expires_record` rows for `org_test_token`.
