### PR TITLE
feat: trigger telegram and activity updates with ably

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
@@ -7,13 +7,14 @@ import { createCursorPagination } from "../cursor-pagination.ts";
 import { zeroOnboardingStatus$ } from "../zero-page/zero-onboarding.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { createRunLoop } from "../zero-page/polling.ts";
-import { setLoop } from "../utils.ts";
+import { raceUnderSignal } from "../utils.ts";
 import { delay } from "signal-timers";
 import { accept } from "../../lib/accept.ts";
 import {
   autoScrollActivityDetail$,
   scrollToBottomActivityDetail$,
 } from "./activity-detail-scroll.ts";
+import { setAblyLoop$ } from "../realtime.ts";
 
 // ---------------------------------------------------------------------------
 // Filters — URL-derived
@@ -258,15 +259,26 @@ export const setupActivityLogLoop$ = command(
     // would be a no-op.
     await delay(0, { signal });
     set(scrollToBottomActivityDetail$);
-    await setLoop(
-      (sig) => {
-        const finished = set(run.checkFinished$, sig);
-        set(autoScrollActivityDetail$);
-        return finished;
-      },
-      3000,
-      signal,
-    );
+
+    const onRunChanged$ = command(async ({ set }, sig: AbortSignal) => {
+      const finished = await set(run.checkFinished$, sig);
+      sig.throwIfAborted();
+      set(autoScrollActivityDetail$);
+      return finished;
+    });
+
+    const finished = await set(onRunChanged$, signal);
+    signal.throwIfAborted();
+    if (finished) {
+      return;
+    }
+
+    await raceUnderSignal(signal, (childSignal) => {
+      return [
+        set(setAblyLoop$, `run:changed:${runId}`, onRunChanged$, childSignal),
+        set(setAblyLoop$, "queue:changed", onRunChanged$, childSignal),
+      ];
+    });
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/polling.ts
+++ b/turbo/apps/platform/src/signals/zero-page/polling.ts
@@ -100,6 +100,7 @@ function createQueuePosition(runId: string) {
 
   return {
     queuePosition$: computed(async (get) => {
+      get(internalReload$);
       const createClient = get(zeroClient$);
       const client = createClient(zeroQueuePositionContract);
       const result = await accept(

--- a/turbo/apps/platform/src/signals/zero-page/telegram-settings-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/telegram-settings-page.ts
@@ -2,7 +2,9 @@ import { command } from "ccstate";
 import { createElement } from "react";
 import {
   isTelegramIntegrationEnabled$,
+  reloadTelegramBots$,
   resetTelegramSettingsUi$,
+  startTelegramSettingsRealtime$,
 } from "./zero-telegram.ts";
 import { ZeroTelegramSettingsPage } from "../../views/zero-page/zero-telegram-settings-page.tsx";
 import { detachedNavigateTo$ } from "../route.ts";
@@ -11,6 +13,9 @@ import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { logger } from "../log.ts";
+
+const L = logger("TelegramSettingsPage");
 
 export const setupTelegramSettingsPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -23,6 +28,7 @@ export const setupTelegramSettingsPage$ = command(
     }
 
     set(resetTelegramSettingsUi$);
+    set(reloadTelegramBots$);
     set(updatePage$, createElement(ZeroTelegramSettingsPage), "sidebar");
     set(updateDocumentTitle$, "Telegram");
     await set(hideAppSkeleton$, signal);
@@ -30,5 +36,12 @@ export const setupTelegramSettingsPage$ = command(
     if (await set(onboardGuard$, signal)) {
       return;
     }
+
+    set(startTelegramSettingsRealtime$, signal).catch((error: unknown) => {
+      if (error instanceof Error && error.name === "AbortError") {
+        return;
+      }
+      L.error("Telegram settings realtime failed", error);
+    });
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
@@ -9,6 +9,7 @@ import {
 import { zeroClient$ } from "../api-client.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { accept } from "../../lib/accept.ts";
+import { setAblyLoop$ } from "../realtime.ts";
 
 const internalReload$ = state(0);
 const internalTelegramAddDialogOpen$ = state(false);
@@ -152,11 +153,22 @@ export const telegramBots$ = computed(async (get): Promise<TelegramBot[]> => {
   return result.body.bots;
 });
 
-const reloadTelegramBots$ = command(({ set }) => {
+export const reloadTelegramBots$ = command(({ set }) => {
   set(internalReload$, (prev) => {
     return prev + 1;
   });
 });
+
+export const startTelegramSettingsRealtime$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    const onTelegramChanged$ = command(({ set }) => {
+      set(reloadTelegramBots$);
+      return false;
+    });
+
+    await set(setAblyLoop$, "telegram:changed", onTelegramChanged$, signal);
+  },
+);
 
 export const registerTelegramBot$ = command(
   async (

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -11,6 +11,7 @@ import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { logsByIdContract } from "@vm0/api-contracts/contracts/logs";
 import { zeroRunAgentEventsContract } from "@vm0/api-contracts/contracts/zero-runs";
 import { setMockComposesList } from "../../../mocks/handlers/api-agents.ts";
+import { hasSubscription, triggerAblyEvent } from "../../../mocks/ably.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -42,6 +43,8 @@ function makeLogDetail(overrides: Partial<LogDetail>): LogDetail {
 describe("activity detail polling with initially empty events", () => {
   it("should pick up events that appear after the initial empty fetch", async () => {
     let eventFetchCount = 0;
+    let eventsAvailable = false;
+    let status: LogDetail["status"] = "running";
 
     setMockComposesList([]);
     server.use(
@@ -49,16 +52,16 @@ describe("activity detail polling with initially empty events", () => {
         return respond(
           200,
           makeLogDetail({
-            // Stay "running" so polling continues
-            status: eventFetchCount < 3 ? "running" : "completed",
+            status,
           }),
         );
       }),
       mockApi(zeroRunAgentEventsContract.getAgentEvents, ({ respond }) => {
         eventFetchCount++;
 
-        // First 2 fetches return empty events (run just started)
-        if (eventFetchCount <= 2) {
+        // Initial fetches can legitimately be empty while the run is still
+        // writing events.
+        if (!eventsAvailable) {
           return respond(200, {
             events: [],
             hasMore: false,
@@ -99,9 +102,15 @@ describe("activity detail polling with initially empty events", () => {
       ).toBeInTheDocument();
     });
 
-    // The polling loop auto-iterates (setLoop yields via setTimeout(0) in
-    // VITEST, so each iteration runs as fast as React can flush). Wait for
-    // the events to arrive naturally.
+    const topic = "run:changed:a0000000-0000-4000-a000-000000000099";
+    await waitFor(() => {
+      expect(hasSubscription(topic)).toBeTruthy();
+    });
+
+    status = "completed";
+    eventsAvailable = true;
+    triggerAblyEvent(topic);
+
     await waitFor(() => {
       expect(screen.getByText("Polled response arrived")).toBeInTheDocument();
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
@@ -13,6 +13,7 @@ import {
   getMockTelegramIntegration,
   setMockTelegramIntegration,
 } from "../../../mocks/handlers/api-integrations-telegram.ts";
+import { hasSubscription, triggerAblyEvent } from "../../../mocks/ably.ts";
 import { resetMockOrg, setMockOrg } from "../../../mocks/handlers/api-org.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 import { pathname$, searchParams$ } from "../../../signals/route.ts";
@@ -126,6 +127,35 @@ describe("telegram settings page", () => {
     expect(
       screen.getByTestId("telegram-bot-avatar-fallback-alpha"),
     ).toBeInTheDocument();
+  });
+
+  it("refreshes connection status when Telegram changes over Ably", async () => {
+    setMockTelegramIntegration({
+      statuses: [telegramStatus("alpha", { username: "alpha_bot" })],
+    });
+    setupTelegramPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("@alpha_bot")).toBeInTheDocument();
+      expect(screen.getByText("Not connected")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(hasSubscription("telegram:changed")).toBeTruthy();
+    });
+
+    setMockTelegramIntegration({
+      statuses: [
+        telegramStatus("alpha", {
+          username: "alpha_bot",
+          isConnected: true,
+        }),
+      ],
+    });
+    triggerAblyEvent("telegram:changed");
+
+    await waitFor(() => {
+      expect(screen.getByText("Connected")).toBeInTheDocument();
+    });
   });
 
   it("shows the empty state and redirects to connect after adding a Telegram bot", async () => {

--- a/turbo/apps/web/app/api/integrations/telegram/[botId]/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/[botId]/route.ts
@@ -14,6 +14,7 @@ import {
   buildTelegramBotStatus,
   type TelegramInstallation,
 } from "../telegram-status";
+import { publishTelegramOrgChangedSafely } from "../../../../../src/lib/zero/telegram/realtime";
 
 const patchBodySchema = z.object({
   defaultAgentId: z.string().trim().min(1),
@@ -177,6 +178,8 @@ export async function PATCH(
     )
     .returning();
 
+  await publishTelegramOrgChangedSafely(visible.installation.orgId);
+
   return NextResponse.json(
     await buildTelegramBotStatus(
       updated ?? visible.installation,
@@ -238,6 +241,8 @@ export async function DELETE(
         visible.installation.telegramBotId,
       ),
     );
+
+  await publishTelegramOrgChangedSafely(visible.installation.orgId);
 
   return new NextResponse(null, { status: 204 });
 }

--- a/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
@@ -16,6 +16,7 @@ import {
   signTestConnectParams,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { signConnectParams } from "../../../../../../src/lib/zero/telegram/connect-token";
+import { mockAblyPublish } from "../../../../../../src/__tests__/ably-mock";
 
 const TEST_BOT_TOKEN = "test-bot-token";
 
@@ -86,6 +87,7 @@ function linkRequest(
 describe("/api/integrations/telegram/link", () => {
   beforeEach(() => {
     context.setupMocks();
+    mockAblyPublish.mockClear();
     server.use(telegramOauthHead("0"));
   });
 
@@ -251,6 +253,7 @@ describe("/api/integrations/telegram/link", () => {
 
       const response = await DELETE(linkRequest("DELETE"));
       expect(response.status).toBe(204);
+      expect(mockAblyPublish).toHaveBeenCalledWith("telegram:changed", null);
 
       // Verify link is gone
       const getResponse = await GET(linkRequest("GET"));
@@ -368,6 +371,7 @@ describe("/api/integrations/telegram/link", () => {
       expect(response.status).toBe(200);
       expect(data.botUsername).toBe(`bot_${telegramBotId}`);
       expect(data.telegramUserId).toBe(String(telegramUserId));
+      expect(mockAblyPublish).toHaveBeenCalledWith("telegram:changed", null);
 
       // Verify link was created
       const getResponse = await GET(linkRequest("GET"));
@@ -560,6 +564,7 @@ describe("/api/integrations/telegram/link", () => {
       expect(response.status).toBe(200);
       expect(data.botUsername).toBe(`bot_${telegramBotId}`);
       expect(data.telegramUserId).toBe(telegramUserId);
+      expect(mockAblyPublish).toHaveBeenCalledWith("telegram:changed", null);
 
       // Verify link was created
       const getResponse = await GET(linkRequest("GET"));

--- a/turbo/apps/web/app/api/integrations/telegram/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/route.ts
@@ -25,6 +25,7 @@ import {
 import { verifyConnectSignature } from "../../../../../src/lib/zero/telegram/connect-token";
 import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
 import { checkTelegramDomain } from "../../../../../src/lib/zero/telegram/check-domain";
+import { publishTelegramUserChangedSafely } from "../../../../../src/lib/zero/telegram/realtime";
 
 const log = logger("api:telegram:link");
 
@@ -145,6 +146,8 @@ export async function DELETE(request: Request) {
       { status: 404 },
     );
   }
+
+  await publishTelegramUserChangedSafely(userId);
 
   return new NextResponse(null, { status: 204 });
 }

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -18,6 +18,7 @@ import { logger } from "../../../../../../src/lib/shared/logger";
 import { decryptSecretsMap } from "../../../../../../src/lib/shared/crypto/secrets-encryption";
 import { isOfficialRunnerGroup } from "../../../../../../src/lib/infra/run/runner-group";
 import { recordSandboxOperation } from "../../../../../../src/lib/infra/metrics";
+import { publishRunChangedForUserSafely } from "../../../../../../src/lib/infra/run/run-realtime";
 
 const log = logger("api:runners:jobs:claim");
 
@@ -122,6 +123,10 @@ const router = tsr.router(runnersJobClaimContract, {
     if (!run) {
       return createErrorResponse("NOT_FOUND", "Run not found");
     }
+
+    await publishRunChangedForUserSafely(run.userId, runId, {
+      status: "running",
+    });
 
     log.debug(`Job ${runId} claimed`);
 

--- a/turbo/apps/web/app/api/telegram/register/route.ts
+++ b/turbo/apps/web/app/api/telegram/register/route.ts
@@ -19,6 +19,7 @@ import { buildTelegramWebhookUrl } from "../../../../src/lib/zero/telegram/webho
 import { resolveOrg } from "../../../../src/lib/zero/org/resolve-org";
 import { buildTelegramBotStatus } from "../../integrations/telegram/telegram-status";
 import { getWorkspaceAgentDisplayLabel } from "../../../../src/lib/zero/telegram/handlers/shared";
+import { publishTelegramOrgChangedSafely } from "../../../../src/lib/zero/telegram/realtime";
 
 const registerBodySchema = z.object({
   botToken: z.string().min(1),
@@ -230,6 +231,8 @@ async function handleExistingInstallation(params: {
     .where(eq(telegramInstallations.telegramBotId, existing.telegramBotId))
     .returning();
 
+  await publishTelegramOrgChangedSafely(orgId);
+
   return NextResponse.json(
     await buildTelegramBotStatus(updated ?? existing, userId, "valid"),
   );
@@ -371,6 +374,8 @@ export async function POST(request: Request) {
 
     return configureError;
   }
+
+  await publishTelegramOrgChangedSafely(org.orgId);
 
   return NextResponse.json(
     await buildTelegramBotStatus(installation, userId, "valid"),

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -24,6 +24,7 @@ import {
 import { processOrgCredits } from "../../../../../src/lib/zero/credit/credit-service";
 import { processOrgUsageEvents } from "../../../../../src/lib/zero/credit/usage-event-service";
 import { waitForAgentEventPrefixVisible } from "../../../../../src/lib/infra/run/agent-event-visibility";
+import { publishRunChangedForUserSafely } from "../../../../../src/lib/infra/run/run-realtime";
 import { after } from "next/server";
 import { env } from "../../../../../src/env";
 
@@ -160,6 +161,9 @@ const router = tsr.router(webhookCompleteContract, {
         // Dispatch callbacks so the user gets notified about the failure
         // (previously this path returned without dispatching)
         if (transitioned) {
+          await publishRunChangedForUserSafely(run.userId, body.runId, {
+            status: "failed",
+          });
           scheduleTerminalSideEffects(
             body.runId,
             "failed",
@@ -232,6 +236,9 @@ const router = tsr.router(webhookCompleteContract, {
         };
       }
 
+      await publishRunChangedForUserSafely(run.userId, body.runId, {
+        status: "completed",
+      });
       finalStatus = "completed";
       log.debug(`Run ${body.runId} completed successfully`);
     } else {
@@ -264,6 +271,9 @@ const router = tsr.router(webhookCompleteContract, {
         };
       }
 
+      await publishRunChangedForUserSafely(run.userId, body.runId, {
+        status: "failed",
+      });
       finalStatus = "failed";
       log.warn(`Run ${body.runId} failed: ${errorMessage}`);
     }

--- a/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
@@ -28,6 +28,7 @@ import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { server } from "../../../../../../src/mocks/server";
 import { randomUUID } from "crypto";
 import * as axiomModule from "../../../../../../src/lib/shared/axiom";
+import { mockAblyPublish } from "../../../../../../src/__tests__/ably-mock";
 
 /**
  * Forward an MSW-intercepted fetch to the matching Next.js route handler so
@@ -85,6 +86,7 @@ describe("POST /api/webhooks/agent/events", () => {
     ingestToAxiomSpy = vi
       .spyOn(axiomModule, "ingestToAxiom")
       .mockReturnValue(true);
+    mockAblyPublish.mockClear();
 
     // Reset auth mock for webhook tests (which use token auth)
     mockClerk({ userId: null });
@@ -410,6 +412,10 @@ describe("POST /api/webhooks/agent/events", () => {
           }),
         ]),
       );
+      expect(mockAblyPublish).toHaveBeenCalledWith(`run:changed:${testRunId}`, {
+        firstSequence: 0,
+        lastSequence: 1,
+      });
     });
   });
 

--- a/turbo/apps/web/app/api/webhooks/agent/events/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/route.ts
@@ -10,6 +10,7 @@ import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../src/lib/auth/get-sandbox-auth";
 import { logger } from "../../../../../src/lib/shared/logger";
 import { dispatchToEventConsumers } from "../../../../../src/lib/infra/event-consumer";
+import { publishRunChangedForUserSafely } from "../../../../../src/lib/infra/run/run-realtime";
 
 const log = logger("webhook:events");
 
@@ -75,6 +76,10 @@ const router = tsr.router(webhookEventsContract, {
     await dispatchToEventConsumers(body.runId, body.events, {
       userId,
       orgId: run.orgId,
+    });
+    await publishRunChangedForUserSafely(userId, body.runId, {
+      firstSequence,
+      lastSequence,
     });
     log.debug(
       `Events ${firstSequence}-${lastSequence} dispatched for run ${body.runId} (${Date.now() - dispatchStart}ms)`,

--- a/turbo/apps/web/app/api/webhooks/agent/heartbeat/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/heartbeat/route.ts
@@ -9,7 +9,6 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../src/lib/auth/get-sandbox-auth";
 import { dispatchProgressCallbacks } from "../../../../../src/lib/infra/callback";
-import { publishRunChangedForUser } from "../../../../../src/lib/infra/run/run-realtime";
 import { logger } from "../../../../../src/lib/shared/logger";
 import { after } from "next/server";
 
@@ -54,17 +53,10 @@ const router = tsr.router(webhookHeartbeatContract, {
 
     // Dispatch progress notifications to integration callbacks (non-blocking).
     // Keeps status indicators alive (e.g. Slack's assistant typing indicator).
-    after(async () => {
-      await Promise.all([
-        dispatchProgressCallbacks(body.runId).catch((err) => {
-          return log.debug("Failed to dispatch progress callbacks", { err });
-        }),
-        publishRunChangedForUser(userId, body.runId, {
-          reason: "heartbeat",
-        }).catch((err) => {
-          return log.debug("Failed to publish run heartbeat signal", { err });
-        }),
-      ]);
+    after(() => {
+      dispatchProgressCallbacks(body.runId).catch((err) => {
+        return log.debug("Failed to dispatch progress callbacks", { err });
+      });
     });
 
     return {

--- a/turbo/apps/web/app/api/webhooks/agent/heartbeat/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/heartbeat/route.ts
@@ -9,6 +9,7 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../src/lib/auth/get-sandbox-auth";
 import { dispatchProgressCallbacks } from "../../../../../src/lib/infra/callback";
+import { publishRunChangedForUser } from "../../../../../src/lib/infra/run/run-realtime";
 import { logger } from "../../../../../src/lib/shared/logger";
 import { after } from "next/server";
 
@@ -53,10 +54,17 @@ const router = tsr.router(webhookHeartbeatContract, {
 
     // Dispatch progress notifications to integration callbacks (non-blocking).
     // Keeps status indicators alive (e.g. Slack's assistant typing indicator).
-    after(() => {
-      dispatchProgressCallbacks(body.runId).catch((err) => {
-        return log.debug("Failed to dispatch progress callbacks", { err });
-      });
+    after(async () => {
+      await Promise.all([
+        dispatchProgressCallbacks(body.runId).catch((err) => {
+          return log.debug("Failed to dispatch progress callbacks", { err });
+        }),
+        publishRunChangedForUser(userId, body.runId, {
+          reason: "heartbeat",
+        }).catch((err) => {
+          return log.debug("Failed to publish run heartbeat signal", { err });
+        }),
+      ]);
     });
 
     return {

--- a/turbo/apps/web/src/lib/infra/run/run-realtime.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-realtime.ts
@@ -1,0 +1,54 @@
+import { eq } from "drizzle-orm";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { publishUserSignal } from "../realtime/client";
+import { logger } from "../../shared/logger";
+
+const log = logger("run:realtime");
+
+function runChangedTopic(runId: string): string {
+  return `run:changed:${runId}`;
+}
+
+export async function publishRunChangedForUser(
+  userId: string,
+  runId: string,
+  payload: unknown = null,
+): Promise<void> {
+  await publishUserSignal([userId], runChangedTopic(runId), payload);
+}
+
+async function publishRunChanged(
+  runId: string,
+  payload: unknown = null,
+): Promise<void> {
+  const [run] = await globalThis.services.db
+    .select({ userId: agentRuns.userId })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+
+  if (!run) {
+    return;
+  }
+
+  await publishRunChangedForUser(run.userId, runId, payload);
+}
+
+export async function publishRunChangedForUserSafely(
+  userId: string,
+  runId: string,
+  payload: unknown = null,
+): Promise<void> {
+  await publishRunChangedForUser(userId, runId, payload).catch((error) => {
+    log.warn("Failed to publish run changed signal", { runId, error });
+  });
+}
+
+export async function publishRunChangedSafely(
+  runId: string,
+  payload: unknown = null,
+): Promise<void> {
+  await publishRunChanged(runId, payload).catch((error) => {
+    log.warn("Failed to publish run changed signal", { runId, error });
+  });
+}

--- a/turbo/apps/web/src/lib/infra/run/run-realtime.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-realtime.ts
@@ -9,7 +9,7 @@ function runChangedTopic(runId: string): string {
   return `run:changed:${runId}`;
 }
 
-export async function publishRunChangedForUser(
+async function publishRunChangedForUser(
   userId: string,
   runId: string,
   payload: unknown = null,

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -3,6 +3,7 @@ import { env } from "../../../env";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { transitionRunStatus, dispatchTerminalSideEffects } from "./run-status";
+import { publishRunChangedSafely } from "./run-realtime";
 import {
   agentComposeVersions,
   agentComposes,
@@ -281,6 +282,7 @@ export async function markRunFailed(
 
   // Dispatch callbacks (e.g., loop schedule advancement) if transition succeeded
   if (transitioned) {
+    await publishRunChangedSafely(runId, { status: "failed" });
     await dispatchTerminalSideEffects(runId, "failed", errorMessage);
   }
 

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/shared.ts
@@ -30,6 +30,7 @@ import {
   extractTelegramMessageEntities,
   formatCurrentTelegramEntitiesForPrompt,
 } from "../entities";
+import { publishTelegramUserChangedSafely } from "../realtime";
 import { logger } from "../../../shared/logger";
 import type { TelegramHandlerUpdate } from "./types";
 import type { UserInfoOptions } from "../../integration-prompt";
@@ -243,9 +244,11 @@ export async function linkTelegramUserToVm0User(params: {
 
   if (existingTelegramLink) {
     if (existingTelegramLink.vm0UserId === params.vm0UserId) {
+      const userLink = await touchTelegramUserLink(existingTelegramLink);
+      await publishTelegramUserChangedSafely(params.vm0UserId);
       return {
         ok: true,
-        userLink: await touchTelegramUserLink(existingTelegramLink),
+        userLink,
       };
     }
 
@@ -269,9 +272,11 @@ export async function linkTelegramUserToVm0User(params: {
 
   if (existingVm0Link) {
     if (existingVm0Link.telegramUserId === params.telegramUserId) {
+      const userLink = await touchTelegramUserLink(existingVm0Link);
+      await publishTelegramUserChangedSafely(params.vm0UserId);
       return {
         ok: true,
-        userLink: await touchTelegramUserLink(existingVm0Link),
+        userLink,
       };
     }
 
@@ -288,9 +293,11 @@ export async function linkTelegramUserToVm0User(params: {
         .where(eq(telegramUserLinks.id, existingVm0Link.id))
         .returning();
 
+      const userLink = updated ?? existingVm0Link;
+      await publishTelegramUserChangedSafely(params.vm0UserId);
       return {
         ok: true,
-        userLink: updated ?? existingVm0Link,
+        userLink,
       };
     }
 
@@ -312,6 +319,7 @@ export async function linkTelegramUserToVm0User(params: {
     .returning();
 
   if (inserted) {
+    await publishTelegramUserChangedSafely(params.vm0UserId);
     return { ok: true, userLink: inserted };
   }
 

--- a/turbo/apps/web/src/lib/zero/telegram/realtime.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/realtime.ts
@@ -1,0 +1,34 @@
+import { publishUserSignal } from "../../infra/realtime/client";
+import { logger } from "../../shared/logger";
+import { publishOrgSignal } from "../realtime";
+
+const log = logger("telegram:realtime");
+
+const TELEGRAM_CHANGED_TOPIC = "telegram:changed";
+
+async function publishTelegramUserChanged(userId: string): Promise<void> {
+  await publishUserSignal([userId], TELEGRAM_CHANGED_TOPIC);
+}
+
+export async function publishTelegramUserChangedSafely(
+  userId: string,
+): Promise<void> {
+  await publishTelegramUserChanged(userId).catch((error) => {
+    log.warn("Failed to publish Telegram user change signal", {
+      userId,
+      error,
+    });
+  });
+}
+
+async function publishTelegramOrgChanged(orgId: string): Promise<void> {
+  await publishOrgSignal(orgId, TELEGRAM_CHANGED_TOPIC);
+}
+
+export async function publishTelegramOrgChangedSafely(
+  orgId: string,
+): Promise<void> {
+  await publishTelegramOrgChanged(orgId).catch((error) => {
+    log.warn("Failed to publish Telegram org change signal", { orgId, error });
+  });
+}

--- a/turbo/apps/web/src/lib/zero/zero-run-cancel.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-cancel.ts
@@ -2,6 +2,7 @@ import { eq, and } from "drizzle-orm";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { transitionRunStatus } from "../infra/run/run-status";
+import { publishRunChangedForUserSafely } from "../infra/run/run-realtime";
 import { notFound, runNotCancellable } from "@vm0/api-services/errors";
 import { publishOrgSignal } from "./realtime";
 
@@ -84,6 +85,9 @@ export async function cancelRun(
   if (cancelled) {
     // Notify all org members whose queue view should refresh.
     await publishOrgSignal(run.orgId, "queue:changed");
+    await publishRunChangedForUserSafely(run.userId, runId, {
+      status: "cancelled",
+    });
 
     return {
       runId,

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -58,6 +58,7 @@ import {
 import { logger } from "../shared/logger";
 import { publishOrgSignal } from "./realtime";
 import { publishChatThreadRunUpdated } from "./chat-thread/chat-message-service";
+import { publishRunChangedForUserSafely } from "../infra/run/run-realtime";
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
 import type { QueueResponse } from "@vm0/api-contracts/contracts/runs";
@@ -250,6 +251,11 @@ export async function drainOrgQueue(
           err,
         });
       });
+      publishRunChangedForUserSafely(dequeued.userId, dequeued.runId, {
+        status: "pending",
+      }).catch((err: unknown) => {
+        log.error("Failed to publish run changed after dequeue", { err });
+      });
 
       // Decrypt CreateRunParams (outside transaction — no lock held)
       const decryptedMap = decryptSecretsMap(
@@ -296,6 +302,7 @@ export async function drainOrgQueue(
 
 interface DequeuedEntry {
   runId: string;
+  userId: string;
   encryptedParams: string | null;
 }
 
@@ -423,6 +430,7 @@ async function dequeueNextAtomic(
         log.debug(`Dequeued run ${row.run_id} for org ${orgId}`);
         return {
           runId: row.run_id,
+          userId: row.user_id,
           encryptedParams: row.encrypted_params,
         };
       }


### PR DESCRIPTION
## Summary
- replace activity detail timer polling with Ably-triggered refreshes for run and queue changes
- refresh settings/telegram bot connection status from `telegram:changed` Ably signals
- publish run and Telegram change signals from backend status/link/update paths

## Tests
- `pnpm --dir apps/platform check-types`
- `pnpm --dir apps/web check-types`
- `pnpm --dir apps/platform lint`
- `pnpm --dir apps/web lint`
- `pnpm --dir apps/platform exec vitest run src/views/activity-page/__tests__/activity-paged-events.test.tsx src/views/activity-page/__tests__/activity-detail-polling.test.tsx src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx --no-file-parallelism --maxWorkers 1 --reporter verbose`
- `pnpm --dir apps/web exec vitest run app/api/integrations/telegram/link/__tests__/route.test.ts --no-file-parallelism --maxWorkers 1 --reporter verbose`

## Notes
- pre-commit `knip --cache` still reports existing unused devDependency `next-fast-dev` in `apps/web/package.json`; no new unused exports remain from this PR.