### PR TITLE
feat: add telegram beta badges

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
@@ -107,6 +107,9 @@ describe("telegram settings page", () => {
     setupTelegramPage();
 
     await waitFor(() => {
+      expect(screen.getByTestId("telegram-beta-badge")).toHaveTextContent(
+        "Beta",
+      );
       expect(screen.getByText("@alpha_bot")).toBeInTheDocument();
       expect(screen.getByText("@beta_bot")).toBeInTheDocument();
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -109,6 +109,9 @@ describe("works page - telegram integration card", () => {
     await waitFor(() => {
       expect(screen.getByText("Slack")).toBeInTheDocument();
       expect(screen.getByText("Telegram")).toBeInTheDocument();
+      expect(screen.getByTestId("telegram-beta-badge")).toHaveTextContent(
+        "Beta",
+      );
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/beta-badge.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/beta-badge.tsx
@@ -1,0 +1,11 @@
+export function BetaBadge() {
+  return (
+    <span
+      aria-label="Beta"
+      className="inline-flex shrink-0 items-center rounded-sm bg-[#2AABEE] px-1.5 py-0.5 text-[10px] font-medium uppercase leading-none text-white"
+      data-testid="telegram-beta-badge"
+    >
+      Beta
+    </span>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
@@ -78,6 +78,7 @@ import {
 import { ROUTES } from "../../signals/route-paths.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
+import { BetaBadge } from "./components/settings/beta-badge.tsx";
 import telegramIconImg from "./components/settings/icons/telegram.svg";
 
 interface DefaultAgentLabel {
@@ -1130,9 +1131,12 @@ export function ZeroTelegramSettingsPage() {
                 <img src={telegramIconImg} alt="" className="h-7 w-7" />
               </span>
               <div className="min-w-0">
-                <h1 className="truncate text-lg font-semibold tracking-tight text-foreground">
-                  Telegram
-                </h1>
+                <div className="flex min-w-0 items-center gap-2">
+                  <h1 className="truncate text-lg font-semibold tracking-tight text-foreground">
+                    Telegram
+                  </h1>
+                  <BetaBadge />
+                </div>
                 <p className="mt-0.5 text-sm text-muted-foreground">
                   Manage bot routing for this workspace
                 </p>

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -37,6 +37,7 @@ import {
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
 import { ROUTES } from "../../signals/route-paths.ts";
+import { BetaBadge } from "./components/settings/beta-badge.tsx";
 import slackIconImg from "./components/settings/icons/slack.svg";
 import telegramIconImg from "./components/settings/icons/telegram.svg";
 
@@ -294,7 +295,12 @@ function TelegramCard() {
           <img src={telegramIconImg} alt="" className="h-7 w-7" />
         </div>
         <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <div className="text-sm font-medium text-foreground">Telegram</div>
+          <div className="flex min-w-0 items-center gap-2">
+            <div className="truncate text-sm font-medium text-foreground">
+              Telegram
+            </div>
+            <BetaBadge />
+          </div>
           <div className="truncate text-sm text-muted-foreground">
             {summary}
           </div>


### PR DESCRIPTION
## Summary
- add a reusable blue Beta badge for Telegram beta surfaces
- show the badge on /works and /settings/telegram
- cover both placements in existing page tests

## Tests
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-works-page.test.tsx src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- pre-commit: prettier, knip, full check-types