### PR TITLE
fix: thread auth options through shadow probe to eliminate false mismatch

### DIFF
--- a/turbo/apps/api/src/signals/routes/health-auth-probe.ts
+++ b/turbo/apps/api/src/signals/routes/health-auth-probe.ts
@@ -36,7 +36,9 @@ const probe$ = command(
   async (
     { get, set },
     signal: AbortSignal,
-  ): Promise<{ readonly status: 200; readonly body: AuthContext } | AuthErrorResponse> => {
+  ): Promise<
+    { readonly status: 200; readonly body: AuthContext } | AuthErrorResponse
+  > => {
     const query = get(rawQuery$);
 
     const options: {
@@ -67,7 +69,11 @@ const probe$ = command(
     const result = await set(requiredAuthContext$, options, signal);
     if ("status" in result) {
       // PAT-only routes: rewrite 401 message to match requireApiKeyAuth phrasing
-      if (options.accept?.length === 1 && options.accept[0] === "pat" && result.status === 401) {
+      if (
+        options.accept?.length === 1 &&
+        options.accept[0] === "pat" &&
+        result.status === 401
+      ) {
         return {
           status: 401 as const,
           body: {
@@ -92,7 +98,8 @@ const probe$ = command(
         status: 403 as const,
         body: {
           error: {
-            message: "This endpoint does not accept the provided credential type",
+            message:
+              "This endpoint does not accept the provided credential type",
             code: "FORBIDDEN",
           },
         },

--- a/turbo/apps/api/src/signals/routes/health-auth-probe.ts
+++ b/turbo/apps/api/src/signals/routes/health-auth-probe.ts
@@ -1,11 +1,16 @@
 import { initContract } from "@ts-rest/core";
-import { computed } from "ccstate";
+import { command } from "ccstate";
 import { z } from "zod";
 
-import { authContext$ } from "../auth/auth-context";
-import { authRoute } from "../auth/auth-route";
-import type { AuthContext } from "../../types/auth";
+import {
+  requiredAuthContext$,
+  setAuthContext$,
+  type AuthErrorResponse,
+} from "../auth/auth-context";
+import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
+import type { AuthContext, AuthTokenType } from "../../types/auth";
 import type { RouteEntry } from "../route";
+import { rawQuery$ } from "../context/hono";
 
 const c = initContract();
 
@@ -27,15 +32,76 @@ const probeRoute = c.router({
   },
 });
 
-const returnAuthContext$ = computed(
-  (get): { readonly status: 200; readonly body: AuthContext } => {
-    return { status: 200 as const, body: get(authContext$) };
-  },
-);
+const probe$ = command(
+  async (
+    { get, set },
+    signal: AbortSignal,
+  ): Promise<{ readonly status: 200; readonly body: AuthContext } | AuthErrorResponse> => {
+    const query = get(rawQuery$);
 
-const probe$ = authRoute(
-  { acceptAnySandboxCapability: true },
-  returnAuthContext$,
+    const options: {
+      requiredCapability?: ZeroCapability;
+      acceptAnySandboxCapability?: boolean;
+      accept?: readonly AuthTokenType[];
+    } = {};
+
+    if (query.acceptAnySandboxCapability === "true") {
+      options.acceptAnySandboxCapability = true;
+    }
+    if (query.requiredCapability) {
+      options.requiredCapability = query.requiredCapability as ZeroCapability;
+    }
+    if (query.accept) {
+      options.accept = query.accept.split(",") as AuthTokenType[];
+    }
+
+    // Backward-compat: no params defaults to the old permissive behaviour
+    if (
+      !options.acceptAnySandboxCapability &&
+      !options.requiredCapability &&
+      !options.accept
+    ) {
+      options.acceptAnySandboxCapability = true;
+    }
+
+    const result = await set(requiredAuthContext$, options, signal);
+    if ("status" in result) {
+      // PAT-only routes: rewrite 401 message to match requireApiKeyAuth phrasing
+      if (options.accept?.length === 1 && options.accept[0] === "pat" && result.status === 401) {
+        return {
+          status: 401 as const,
+          body: {
+            error: { message: "API key required", code: "UNAUTHORIZED" },
+          },
+        };
+      }
+      return result;
+    }
+
+    // Post-filter: reject token types not in the accept list
+    if (options.accept && !options.accept.includes(result.tokenType)) {
+      if (options.accept.length === 1 && options.accept[0] === "pat") {
+        return {
+          status: 401 as const,
+          body: {
+            error: { message: "API key required", code: "UNAUTHORIZED" },
+          },
+        };
+      }
+      return {
+        status: 403 as const,
+        body: {
+          error: {
+            message: "This endpoint does not accept the provided credential type",
+            code: "FORBIDDEN",
+          },
+        },
+      };
+    }
+
+    set(setAuthContext$, result);
+    return { status: 200 as const, body: result };
+  },
 );
 
 export const healthAuthProbeRoutes: readonly RouteEntry[] = [

--- a/turbo/apps/web/src/lib/auth/require-auth.ts
+++ b/turbo/apps/web/src/lib/auth/require-auth.ts
@@ -20,10 +20,19 @@ function scheduleShadowCheck(
   result: AuthContext | AuthErrorResponse,
   authHeader: string | undefined,
   cookieHeader?: string,
+  authOptions?: {
+    requiredCapability?: string;
+    acceptAnySandboxCapability?: boolean;
+    accept?: string;
+  },
 ): void {
   try {
     after(async () => {
-      await shadowCompareAuth(result, { authHeader, cookieHeader });
+      await shadowCompareAuth(result, {
+        authHeader,
+        cookieHeader,
+        ...authOptions,
+      });
     });
   } catch {
     // Outside a Next.js request scope (e.g. unit tests) — skip silently.
@@ -45,10 +54,14 @@ export async function requireAuth(
   },
 ): Promise<AuthContext | AuthErrorResponse> {
   const cookieHeader = options?.cookieHeader;
+  const shadowOpts = {
+    requiredCapability: options?.requiredCapability,
+    acceptAnySandboxCapability: options?.acceptAnySandboxCapability,
+  };
   const authCtx = await getAuthContext(authHeader, options);
 
   if (authCtx) {
-    scheduleShadowCheck(authCtx, authHeader, cookieHeader);
+    scheduleShadowCheck(authCtx, authHeader, cookieHeader, shadowOpts);
     return authCtx;
   }
 
@@ -76,7 +89,7 @@ export async function requireAuth(
                 },
               },
             };
-        scheduleShadowCheck(capabilityErr, authHeader, cookieHeader);
+        scheduleShadowCheck(capabilityErr, authHeader, cookieHeader, shadowOpts);
         return capabilityErr;
       }
     }
@@ -89,7 +102,7 @@ export async function requireAuth(
       error: { message: "Not authenticated", code: "UNAUTHORIZED" },
     },
   };
-  scheduleShadowCheck(unauthorized, authHeader, cookieHeader);
+  scheduleShadowCheck(unauthorized, authHeader, cookieHeader, shadowOpts);
   return unauthorized;
 }
 
@@ -121,6 +134,7 @@ export async function requireApiKeyAuth(
   authHeader: string | undefined,
   cookieHeader?: string,
 ): Promise<AuthContext | AuthErrorResponse> {
+  const shadowOpts = { accept: "pat" as const };
   const unauthorized: AuthErrorResponse = {
     status: 401 as const,
     body: {
@@ -128,19 +142,19 @@ export async function requireApiKeyAuth(
     },
   };
   if (!authHeader?.startsWith("Bearer ")) {
-    scheduleShadowCheck(unauthorized, authHeader, cookieHeader);
+    scheduleShadowCheck(unauthorized, authHeader, cookieHeader, shadowOpts);
     return unauthorized;
   }
   const token = authHeader.substring(7);
   if (!isPatToken(token)) {
-    scheduleShadowCheck(unauthorized, authHeader, cookieHeader);
+    scheduleShadowCheck(unauthorized, authHeader, cookieHeader, shadowOpts);
     return unauthorized;
   }
   const authCtx = await getAuthContext(authHeader);
   if (!authCtx || authCtx.tokenType !== "pat" || !authCtx.orgId) {
-    scheduleShadowCheck(unauthorized, authHeader, cookieHeader);
+    scheduleShadowCheck(unauthorized, authHeader, cookieHeader, shadowOpts);
     return unauthorized;
   }
-  scheduleShadowCheck(authCtx, authHeader, cookieHeader);
+  scheduleShadowCheck(authCtx, authHeader, cookieHeader, shadowOpts);
   return authCtx;
 }

--- a/turbo/apps/web/src/lib/auth/require-auth.ts
+++ b/turbo/apps/web/src/lib/auth/require-auth.ts
@@ -89,7 +89,12 @@ export async function requireAuth(
                 },
               },
             };
-        scheduleShadowCheck(capabilityErr, authHeader, cookieHeader, shadowOpts);
+        scheduleShadowCheck(
+          capabilityErr,
+          authHeader,
+          cookieHeader,
+          shadowOpts,
+        );
         return capabilityErr;
       }
     }

--- a/turbo/apps/web/src/lib/auth/shadow-check.ts
+++ b/turbo/apps/web/src/lib/auth/shadow-check.ts
@@ -16,6 +16,9 @@ interface ShadowOptions {
   readonly authHeader: string | undefined;
   readonly cookieHeader?: string;
   readonly route?: string;
+  readonly requiredCapability?: string;
+  readonly acceptAnySandboxCapability?: boolean;
+  readonly accept?: string;
 }
 
 const COMPARED_FIELDS = [
@@ -52,13 +55,27 @@ async function probeApi(
   apiUrl: string,
   authHeader: string,
   cookieHeader?: string,
+  params?: {
+    requiredCapability?: string;
+    acceptAnySandboxCapability?: boolean;
+    accept?: string;
+  },
 ): Promise<ApiResponse> {
-  const target = new URL("/health/auth", apiUrl).toString();
+  const target = new URL("/health/auth", apiUrl);
+  if (params?.requiredCapability) {
+    target.searchParams.set("requiredCapability", params.requiredCapability);
+  }
+  if (params?.acceptAnySandboxCapability) {
+    target.searchParams.set("acceptAnySandboxCapability", "true");
+  }
+  if (params?.accept) {
+    target.searchParams.set("accept", params.accept);
+  }
   const headers: Record<string, string> = { authorization: authHeader };
   if (cookieHeader) {
     headers.cookie = cookieHeader;
   }
-  const response = await fetch(target, {
+  const response = await fetch(target.toString(), {
     method: "GET",
     headers,
     signal: AbortSignal.timeout(2000),
@@ -238,6 +255,11 @@ export async function shadowCompareAuth(
     apiUrl,
     options.authHeader,
     options.cookieHeader,
+    {
+      requiredCapability: options.requiredCapability,
+      acceptAnySandboxCapability: options.acceptAnySandboxCapability,
+      accept: options.accept,
+    },
   );
   const event = compare(webResult, apiResponse, options.route);
 

--- a/turbo/packages/api-contracts/src/contracts/health.ts
+++ b/turbo/packages/api-contracts/src/contracts/health.ts
@@ -24,9 +24,15 @@ export const healthAuthContract = c.router({
     method: "GET",
     path: "/health/auth",
     headers: authHeadersSchema,
+    query: z.object({
+      requiredCapability: z.string().optional(),
+      acceptAnySandboxCapability: z.string().optional(),
+      accept: z.string().optional(),
+    }),
     responses: {
       200: healthResponseSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
     },
     summary: "Check authenticated API health",
   },
@@ -43,5 +49,9 @@ export type HealthAuthRouteResponse =
   | HealthRouteResponse
   | {
       readonly status: 401;
+      readonly body: ApiErrorResponse;
+    }
+  | {
+      readonly status: 403;
       readonly body: ApiErrorResponse;
     };


### PR DESCRIPTION
## Summary
- Auth shadow check was producing false-positive mismatches because the API `/health/auth` probe hardcoded `acceptAnySandboxCapability: true` while web routes enforce `requiredCapability`
- Thread `requiredCapability` / `acceptAnySandboxCapability` / `accept` from `requireAuth` through the shadow check chain to the API probe as query params
- API probe now dynamically builds auth options from query params and enforces the same policy as web
- Backward compatible: no query params defaults to old permissive behavior

## Changes
- **web/require-auth.ts**: `scheduleShadowCheck` accepts auth options; `requireAuth` passes capability options; `requireApiKeyAuth` passes `accept=pat`
- **web/shadow-check.ts**: `probeApi` appends query params to `/health/auth` URL
- **api/health-auth-probe.ts**: replaces static `authRoute({ acceptAnySandboxCapability: true })` with dynamic command that reads `rawQuery$` and calls `requiredAuthContext$`
- **api-contracts/health.ts**: adds query schema + 403 response

## Test plan
- [ ] Existing `/health/auth` tests pass (backward compat)
- [ ] Deploy and verify `auth shadow check mismatch` count drops to zero in Axiom

🤖 Generated with [Claude Code](https://claude.com/claude-code)