### PR TITLE
fix: remove telegram route label

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
@@ -218,7 +218,7 @@ describe("telegram settings page", () => {
       expect(getMockTelegramIntegration().statuses.alpha).toMatchObject({
         agent: { id: SUPPORT_AGENT_ID },
       });
-      expect(screen.getByText("Routes to Support")).toBeInTheDocument();
+      expect(screen.queryByText("Routes to Support")).not.toBeInTheDocument();
     });
   });
 
@@ -252,7 +252,7 @@ describe("telegram settings page", () => {
       expect(getMockTelegramIntegration().statuses.alpha).toMatchObject({
         agent: { id: SUPPORT_AGENT_ID },
       });
-      expect(screen.getByText("Routes to Support")).toBeInTheDocument();
+      expect(screen.queryByText("Routes to Support")).not.toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
@@ -134,20 +134,6 @@ function buildBotAgentOptions(
   ];
 }
 
-function botRouteLabel(
-  bot: TelegramBot,
-  agents: TeamComposeItem[],
-  defaultAgent: DefaultAgentLabel,
-) {
-  if (!bot.agent) {
-    return "No default agent";
-  }
-  const agent = agents.find((item) => {
-    return item.id === bot.agent?.id;
-  });
-  return `Routes to ${agent ? agentLabel(agent, defaultAgent) : agentLabel(bot.agent, defaultAgent)}`;
-}
-
 function TelegramSettingsSkeleton() {
   return (
     <div
@@ -808,7 +794,6 @@ function TelegramBotRow({
   const actionDisabled =
     disabled || saving || unlinking || uninstalling || reinstalling;
   const options = buildBotAgentOptions(bot, agents, defaultAgent);
-  const routeLabel = botRouteLabel(bot, agents, defaultAgent);
   const avatarUrl = resolveTelegramBotAvatarUrl(bot.avatarUrl, apiBase);
 
   return (
@@ -821,9 +806,6 @@ function TelegramBotRow({
               {bot.username ? `@${bot.username}` : "Telegram bot"}
             </div>
             <TelegramStatusBadge bot={bot} />
-          </div>
-          <div className="mt-1 truncate text-sm text-muted-foreground">
-            {routeLabel}
           </div>
           {bot.tokenStatus === "invalid" ? (
             <div className="mt-1 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- remove the secondary "Routes to ..." copy from Telegram bot rows on /settings/telegram
- remove the now-unused route label helper
- update Telegram settings tests to assert the copy stays hidden after agent changes

## Tests
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- pre-commit: prettier, knip, full check-types