### PR TITLE
test: stabilize dns port retry test

### DIFF
--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -785,13 +785,36 @@ mod tests {
         assert!(port > 0);
     }
 
+    fn bind_tcp_udp_pair() -> std::io::Result<(std::net::TcpListener, std::net::UdpSocket)> {
+        const MAX_PORT_PROBE_ATTEMPTS: usize = 64;
+
+        let mut last_addr_in_use = None;
+        for _ in 0..MAX_PORT_PROBE_ATTEMPTS {
+            let tcp = std::net::TcpListener::bind("0.0.0.0:0")?;
+            let port = tcp.local_addr()?.port();
+            match std::net::UdpSocket::bind(("0.0.0.0", port)) {
+                Ok(udp) => return Ok((tcp, udp)),
+                Err(err) if err.kind() == std::io::ErrorKind::AddrInUse => {
+                    last_addr_in_use = Some(err);
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        Err(last_addr_in_use.unwrap_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::AddrInUse,
+                "could not find a port available for both TCP and UDP",
+            )
+        }))
+    }
+
     #[test]
     fn find_available_port_retries_when_udp_candidate_is_in_use() {
-        let busy_udp = std::net::UdpSocket::bind("0.0.0.0:0").unwrap();
-        let busy_port = busy_udp.local_addr().unwrap().port();
-        let busy_tcp = std::net::TcpListener::bind(("0.0.0.0", busy_port)).unwrap();
-        let free_tcp = std::net::TcpListener::bind("0.0.0.0:0").unwrap();
+        let (busy_tcp, _busy_udp) = bind_tcp_udp_pair().unwrap();
+        let (free_tcp, free_udp_probe) = bind_tcp_udp_pair().unwrap();
         let free_port = free_tcp.local_addr().unwrap().port();
+        drop(free_udp_probe);
 
         let port = find_available_port_from([Ok(busy_tcp), Ok(free_tcp)]).unwrap();
 


### PR DESCRIPTION
## Summary

- stabilize the DNS available-port retry test by allocating TCP/UDP candidate pairs explicitly
- keep the first candidate's UDP socket open so the retry path is exercised deterministically
- drop the second candidate's UDP probe before calling `find_available_port_from`

Fixes #11372

## Tests

- `cargo fmt --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner dns::tests::find_available_port_retries_when_udp_candidate_is_in_use`
- `for i in $(seq 1 10); do cargo test --manifest-path crates/Cargo.toml -p runner --bin runner --quiet dns::tests::find_available_port_retries_when_udp_candidate_is_in_use || exit 1; done`
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner dns::tests`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
