### PR TITLE
feat: enable telegram integration for all users

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -65,6 +65,7 @@ describe("getAllFeatureStates", () => {
     const states = getAllFeatureStates();
     // Globally enabled switches should be true
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
+    expect(states[FeatureSwitchKey.TelegramIntegration]).toBe(true);
   });
 
   it("should enable switches when orgId matches enabledOrgIdHashes", () => {
@@ -74,7 +75,6 @@ describe("getAllFeatureStates", () => {
     // PlatformConnectors has STAFF_ORG_ID_HASHES and should be true
     expect(states[FeatureSwitchKey.PlatformConnectors]).toBe(true);
     expect(states[FeatureSwitchKey.ConnectorCategories]).toBe(true);
-    expect(states[FeatureSwitchKey.TelegramIntegration]).toBe(true);
     // Globally enabled should still be true
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
     // Switches without org hashes should remain false
@@ -87,7 +87,7 @@ describe("getAllFeatureStates", () => {
     });
     expect(states[FeatureSwitchKey.PlatformConnectors]).toBe(false);
     expect(states[FeatureSwitchKey.ConnectorCategories]).toBe(false);
-    expect(states[FeatureSwitchKey.TelegramIntegration]).toBe(false);
+    expect(states[FeatureSwitchKey.TelegramIntegration]).toBe(true);
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -279,8 +279,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Show the Telegram integration settings UI. The backend Telegram routes do not consult this frontend rollout flag.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.Trinity]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- enable the Telegram integration feature switch globally
- update feature switch tests to reflect the GA default

## Verification
- pnpm -C turbo exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts
- pnpm -C turbo --filter @vm0/core test -- src/__tests__/feature-switch.test.ts
- pnpm -C turbo --filter @vm0/core lint
- pnpm -C turbo --filter @vm0/core check-types
- pre-commit: repository check-types