### PR TITLE
test: cover network log upload branches

### DIFF
--- a/crates/runner/src/network_logs.rs
+++ b/crates/runner/src/network_logs.rs
@@ -87,7 +87,20 @@ pub async fn upload_network_logs(
 
 #[cfg(test)]
 mod tests {
+    use httpmock::prelude::*;
+    use serde_json::json;
+
     use super::*;
+
+    const SANDBOX_TOKEN: &str = "sandbox-token";
+
+    fn http_for_server(server: &MockServer) -> HttpClient {
+        HttpClient::new(server.base_url()).unwrap()
+    }
+
+    fn network_log_file(dir: &tempfile::TempDir) -> std::path::PathBuf {
+        dir.path().join("network.jsonl")
+    }
 
     #[test]
     fn network_log_preserves_all_fields() {
@@ -126,5 +139,160 @@ mod tests {
         let invalid = "not json at all";
         assert!(serde_json::from_str::<NetworkLog>(valid).is_ok());
         assert!(serde_json::from_str::<NetworkLog>(invalid).is_err());
+    }
+
+    #[tokio::test]
+    async fn upload_network_logs_posts_payload_and_keeps_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = network_log_file(&dir);
+        let run_id = RunId::nil();
+        let first = json!({
+            "timestamp": "2026-02-15T10:00:00Z",
+            "action": "ALLOW",
+            "host": "api.github.com",
+            "status": 200,
+        });
+        let second = json!({
+            "timestamp": "2026-02-15T10:00:01Z",
+            "action": "DENY",
+            "host": "blocked.example",
+            "status": 403,
+        });
+        let content = format!(
+            "{}\n{}\n",
+            serde_json::to_string(&first).unwrap(),
+            serde_json::to_string(&second).unwrap()
+        );
+        tokio::fs::write(&path, &content).await.unwrap();
+
+        let server = MockServer::start_async().await;
+        let expected = json!({
+            "runId": run_id.to_string(),
+            "networkLogs": [first, second],
+        });
+        let upload = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/api/webhooks/agent/telemetry")
+                    .header("authorization", format!("Bearer {SANDBOX_TOKEN}"))
+                    .json_body(expected.clone());
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{"success":true}"#);
+            })
+            .await;
+
+        let http = http_for_server(&server);
+        upload_network_logs(&http, run_id, SANDBOX_TOKEN, &path).await;
+
+        upload.assert_calls_async(1).await;
+        assert_eq!(tokio::fs::read_to_string(&path).await.unwrap(), content);
+    }
+
+    #[tokio::test]
+    async fn upload_network_logs_skips_malformed_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = network_log_file(&dir);
+        let run_id = RunId::nil();
+        let valid = json!({
+            "timestamp": "2026-02-15T10:00:00Z",
+            "host": "valid.example",
+        });
+        tokio::fs::write(
+            &path,
+            format!(
+                "{}\nnot json with invalid.example\n\n",
+                serde_json::to_string(&valid).unwrap()
+            ),
+        )
+        .await
+        .unwrap();
+
+        let server = MockServer::start_async().await;
+        let expected = json!({
+            "runId": run_id.to_string(),
+            "networkLogs": [valid],
+        });
+        let upload = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/api/webhooks/agent/telemetry")
+                    .json_body(expected.clone());
+                then.status(200);
+            })
+            .await;
+
+        let http = http_for_server(&server);
+        upload_network_logs(&http, run_id, SANDBOX_TOKEN, &path).await;
+
+        upload.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn upload_network_logs_returns_without_post_for_empty_missing_or_unreadable_input() {
+        let server = MockServer::start_async().await;
+        let upload = server
+            .mock_async(|when, then| {
+                when.method(POST).path("/api/webhooks/agent/telemetry");
+                then.status(200);
+            })
+            .await;
+        let http = http_for_server(&server);
+        let run_id = RunId::nil();
+        let dir = tempfile::tempdir().unwrap();
+
+        upload_network_logs(&http, run_id, SANDBOX_TOKEN, &network_log_file(&dir)).await;
+
+        let empty = dir.path().join("empty.jsonl");
+        tokio::fs::write(&empty, " \n\t\n").await.unwrap();
+        upload_network_logs(&http, run_id, SANDBOX_TOKEN, &empty).await;
+
+        upload_network_logs(&http, run_id, SANDBOX_TOKEN, dir.path()).await;
+
+        upload.assert_calls_async(0).await;
+    }
+
+    #[tokio::test]
+    async fn upload_network_logs_returns_without_retry_when_server_rejects() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = network_log_file(&dir);
+        tokio::fs::write(&path, r#"{"host":"reject.example"}"#)
+            .await
+            .unwrap();
+
+        let server = MockServer::start_async().await;
+        let upload = server
+            .mock_async(|when, then| {
+                when.method(POST).path("/api/webhooks/agent/telemetry");
+                then.status(500);
+            })
+            .await;
+
+        let http = http_for_server(&server);
+        upload_network_logs(&http, RunId::nil(), SANDBOX_TOKEN, &path).await;
+
+        upload.assert_calls_async(1).await;
+        assert!(path.exists());
+    }
+
+    #[tokio::test]
+    async fn upload_network_logs_returns_on_transport_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = network_log_file(&dir);
+        tokio::fs::write(&path, r#"{"host":"transport-error.example"}"#)
+            .await
+            .unwrap();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let api_url = format!("http://{}", listener.local_addr().unwrap());
+        let accept_once = tokio::spawn(async move {
+            let _ = listener.accept().await;
+        });
+
+        let http = HttpClient::new(api_url).unwrap();
+        upload_network_logs(&http, RunId::nil(), SANDBOX_TOKEN, &path).await;
+
+        accept_once.await.unwrap();
+        assert!(path.exists());
     }
 }

--- a/crates/runner/src/network_logs.rs
+++ b/crates/runner/src/network_logs.rs
@@ -87,6 +87,9 @@ pub async fn upload_network_logs(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use httpmock::prelude::*;
     use serde_json::json;
 
@@ -285,14 +288,29 @@ mod tests {
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let api_url = format!("http://{}", listener.local_addr().unwrap());
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let accept_attempts = attempts.clone();
+        let stop_accepting = Arc::new(tokio::sync::Notify::new());
+        let stop_signal = stop_accepting.clone();
         let accept_once = tokio::spawn(async move {
-            let _ = listener.accept().await;
+            loop {
+                tokio::select! {
+                    accepted = listener.accept() => {
+                        if accepted.is_ok() {
+                            accept_attempts.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                    () = stop_signal.notified() => break,
+                }
+            }
         });
 
         let http = HttpClient::new(api_url).unwrap();
         upload_network_logs(&http, RunId::nil(), SANDBOX_TOKEN, &path).await;
 
+        stop_accepting.notify_one();
         accept_once.await.unwrap();
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
         assert!(path.exists());
     }
 }


### PR DESCRIPTION
## Summary

- add direct coverage for `upload_network_logs` success, malformed-line filtering, no-op inputs, HTTP rejection, and transport errors
- assert telemetry payload shape through `httpmock`, including `runId` and parsed `networkLogs`
- assert successful uploads keep the local JSONL file for debugging/log GC

Fixes #11326

## Tests

- `cargo fmt --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner network_logs::tests`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- pre-commit hook: crates cargo-fmt + cargo-clippy
