### PR TITLE
fix(platform): cap usage card tooltip width and emphasize click hint

### DIFF
--- a/turbo/apps/platform/src/views/usage-page/components/usage-insight-chats-table.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/usage-insight-chats-table.tsx
@@ -94,10 +94,16 @@ export function UsageInsightChatsTable({
                         {fullTitle}
                       </span>
                     </TooltipTrigger>
-                    <TooltipContent side="top" sideOffset={4}>
-                      <p className="text-xs">{fullTitle}</p>
-                      <p className="text-[10px] text-muted-foreground mt-0.5">
-                        Click to open chat
+                    <TooltipContent
+                      side="top"
+                      sideOffset={4}
+                      className="max-w-xs"
+                    >
+                      <p className="text-xs whitespace-normal break-words">
+                        {fullTitle}
+                      </p>
+                      <p className="text-[11px] mt-1.5 pt-1.5 border-t border-white/15 opacity-80">
+                        Click to open →
                       </p>
                     </TooltipContent>
                   </Tooltip>

--- a/turbo/apps/platform/src/views/usage-page/components/usage-insight-schedules-table.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/usage-insight-schedules-table.tsx
@@ -97,10 +97,16 @@ export function UsageInsightSchedulesTable({
                         {fullName}
                       </span>
                     </TooltipTrigger>
-                    <TooltipContent side="top" sideOffset={4}>
-                      <p className="text-xs">{fullName}</p>
-                      <p className="text-[10px] text-muted-foreground mt-0.5">
-                        Click to open schedule
+                    <TooltipContent
+                      side="top"
+                      sideOffset={4}
+                      className="max-w-xs"
+                    >
+                      <p className="text-xs whitespace-normal break-words">
+                        {fullName}
+                      </p>
+                      <p className="text-[11px] mt-1.5 pt-1.5 border-t border-white/15 opacity-80">
+                        Click to open →
                       </p>
                     </TooltipContent>
                   </Tooltip>


### PR DESCRIPTION
## Summary

On the Usage Insights page, the **Schedules** and **Chats** card tooltips had two issues:

- **Tooltip too wide** — no `max-width`, so long descriptions stretched the tooltip across the screen.
- **"Click to open" hint barely visible** — the hint used `text-muted-foreground`, which renders nearly invisible on the dark tooltip background (`#1a1a1a`).

### Fix

- Add `max-w-xs` and `whitespace-normal break-words` so long text wraps inside a reasonable width.
- Replace muted-foreground hint with a visible separator (`border-t border-white/15`) + `opacity-80` so it reads clearly on dark background.
- Bump hint from `10px` → `11px` and add a `→` arrow to make affordance more obvious.

Applied symmetrically to both `usage-insight-schedules-table.tsx` and `usage-insight-chats-table.tsx`.

## Test plan

- [ ] Tooltip wraps long descriptions instead of stretching horizontally
- [ ] "Click to open →" is readable on dark tooltip background
- [ ] Hover both Schedules and Chats cards on the Usage Insights page
- [ ] Clicking the row still navigates to schedule/chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)