### PR TITLE
fix(runner): clean up outer job panic bookkeeping

### DIFF
--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -173,7 +173,7 @@ impl CompletionReady {
                 Some(reuse_result),
             )
             .await;
-        status.remove_run(run_id).await;
+        status.remove_run_if_matching(run_id, sandbox_id).await;
         cleanup_state.mark_status_removed();
         budget.release();
     }

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -1,10 +1,73 @@
 use sandbox::SandboxId;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 
 use crate::ids::RunId;
 use crate::provider::JobProvider;
 use crate::resource_budget::BudgetLease;
 use crate::status::StatusTracker;
 use crate::types::SandboxReuseResult;
+
+/// Ownership facts known by the outer runner task for panic cleanup.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum RunCleanupDisposition {
+    /// The sandbox may still be active, or ownership is otherwise uncertain.
+    ActiveOrUnknown,
+    /// The sandbox has been accepted by the idle pool.
+    IdlePoolOwned,
+    /// The active sandbox was explicitly destroyed and destroy returned normally.
+    DestroyCompleted,
+    /// Normal completion already removed the active run from status.
+    StatusRemoved,
+}
+
+/// Shared monotonic cleanup state for a claimed run.
+#[derive(Clone, Debug)]
+pub(super) struct RunCleanupState {
+    state: Arc<AtomicU8>,
+}
+
+impl RunCleanupState {
+    const ACTIVE_OR_UNKNOWN: u8 = 0;
+    const DESTROY_COMPLETED: u8 = 1;
+    const IDLE_POOL_OWNED: u8 = 2;
+    const STATUS_REMOVED: u8 = 3;
+
+    pub(super) fn new() -> Self {
+        Self {
+            state: Arc::new(AtomicU8::new(Self::ACTIVE_OR_UNKNOWN)),
+        }
+    }
+
+    pub(super) fn disposition(&self) -> RunCleanupDisposition {
+        match self.state.load(Ordering::Acquire) {
+            Self::STATUS_REMOVED => RunCleanupDisposition::StatusRemoved,
+            Self::IDLE_POOL_OWNED => RunCleanupDisposition::IdlePoolOwned,
+            Self::DESTROY_COMPLETED => RunCleanupDisposition::DestroyCompleted,
+            _ => RunCleanupDisposition::ActiveOrUnknown,
+        }
+    }
+
+    pub(super) fn mark_idle_pool_owned(&self) {
+        self.mark_at_least(Self::IDLE_POOL_OWNED);
+    }
+
+    pub(super) fn mark_destroy_completed(&self) {
+        self.mark_at_least(Self::DESTROY_COMPLETED);
+    }
+
+    pub(super) fn mark_status_removed(&self) {
+        self.mark_at_least(Self::STATUS_REMOVED);
+    }
+
+    fn mark_at_least(&self, next: u8) {
+        let _ = self
+            .state
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                (next > current).then_some(next)
+            });
+    }
+}
 
 /// Budget ownership while a claimed job is active in the outer task.
 pub(super) struct ActiveBudgetLease(BudgetLease);
@@ -90,6 +153,7 @@ impl CompletionReady {
         self,
         provider: &dyn JobProvider,
         status: &StatusTracker,
+        cleanup_state: &RunCleanupState,
     ) {
         let Self { payload, budget } = self;
         let CompletionPayload {
@@ -110,6 +174,7 @@ impl CompletionReady {
             )
             .await;
         status.remove_run(run_id).await;
+        cleanup_state.mark_status_removed();
         budget.release();
     }
 }

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -17,7 +17,7 @@ pub(super) enum RunCleanupDisposition {
     IdlePoolOwned,
     /// The active sandbox was explicitly destroyed and destroy returned normally.
     DestroyCompleted,
-    /// Normal completion already removed the active run from status.
+    /// Normal completion already cleared, or no longer owns, active status.
     StatusRemoved,
 }
 

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -2530,6 +2530,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn completion_ready_does_not_remove_reinserted_active_run() {
+        let (budget, lease) = test_budget_lease();
+        let budget_count_at_complete = Arc::new(AtomicUsize::new(usize::MAX));
+        let active_runs_at_complete = Arc::new(AtomicUsize::new(usize::MAX));
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let provider = CompletionOrderProvider {
+            budget: Arc::clone(&budget),
+            budget_count_at_complete,
+            active_runs_at_complete,
+            status_path: status_path.clone(),
+        };
+        let cleanup_state = RunCleanupState::new();
+        let run_id = RunId::new_v4();
+        let completed_sandbox_id = SandboxId::new_v4();
+        let current_sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, completed_sandbox_id).await;
+        status.add_run(run_id, current_sandbox_id).await;
+
+        CompletionReady::new(
+            test_completion_payload(run_id, completed_sandbox_id),
+            BudgetOwnership::active(ActiveBudgetLease::new(lease)),
+        )
+        .complete_and_release(&provider, &status, &cleanup_state)
+        .await;
+
+        assert_eq!(
+            status_active_run_records(&status_path).await,
+            vec![(run_id.to_string(), current_sandbox_id.to_string())],
+        );
+        assert_eq!(
+            cleanup_state.disposition(),
+            RunCleanupDisposition::StatusRemoved,
+        );
+        assert_eq!(budget.allocated().2, 0);
+    }
+
+    #[tokio::test]
     async fn rejected_park_budget_is_recovered_as_active_and_released_after_completion() {
         let (budget, lease) = test_budget_lease();
         let budget_count_at_complete = Arc::new(AtomicUsize::new(usize::MAX));
@@ -2693,6 +2732,47 @@ mod tests {
         let (_idle_sessions, active_runs) =
             status_idle_sessions_and_active_runs(&status_path).await;
         assert!(active_runs.is_empty());
+        assert_eq!(orphans.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn panic_cleanup_destroy_completed_does_not_remove_reinserted_active_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = Arc::new(StatusTracker::new(status_path.clone(), 4, None, None));
+        let idle_pool: SharedIdlePool =
+            Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
+                default_timeout: Duration::from_secs(300),
+                max_idle: 10,
+            })));
+        let tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
+            Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let orphans = OrphanedActiveRuns::new();
+        let cleanup_state = RunCleanupState::new();
+        let run_id = RunId::new_v4();
+        let completed_sandbox_id = SandboxId::new_v4();
+        let current_sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, completed_sandbox_id).await;
+        status.add_run(run_id, current_sandbox_id).await;
+        tokens.lock().await.insert(run_id, CancellationToken::new());
+        cleanup_state.mark_destroy_completed();
+
+        cleanup_panicked_job(
+            run_id,
+            completed_sandbox_id,
+            Arc::clone(&tokens),
+            Arc::clone(&status),
+            idle_pool,
+            cleanup_state,
+            orphans.clone(),
+        )
+        .await;
+
+        assert!(!tokens.lock().await.contains_key(&run_id));
+        assert_eq!(
+            status_active_run_records(&status_path).await,
+            vec![(run_id.to_string(), current_sandbox_id.to_string())],
+        );
         assert_eq!(orphans.len().await, 0);
     }
 
@@ -5253,6 +5333,24 @@ mod tests {
             .collect();
         run_ids.sort_unstable();
         (sessions, run_ids)
+    }
+
+    async fn status_active_run_records(status_path: &std::path::Path) -> Vec<(String, String)> {
+        let raw = tokio::fs::read_to_string(status_path).await.unwrap();
+        let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let mut records: Vec<(String, String)> = status["active_runs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|run| {
+                (
+                    run["run_id"].as_str().unwrap().to_string(),
+                    run["sandbox_id"].as_str().unwrap().to_string(),
+                )
+            })
+            .collect();
+        records.sort_unstable();
+        records
     }
 
     async fn status_idle_sessions(status_path: &std::path::Path) -> Vec<String> {

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -2553,6 +2553,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn panic_cleanup_status_removed_only_clears_cancel_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = Arc::new(StatusTracker::new(status_path.clone(), 4, None, None));
+        let idle_pool: SharedIdlePool =
+            Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
+                default_timeout: Duration::from_secs(300),
+                max_idle: 10,
+            })));
+        let tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
+            Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let orphans = OrphanedActiveRuns::new();
+        let cleanup_state = RunCleanupState::new();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, sandbox_id).await;
+        status.remove_run(run_id).await;
+        tokens.lock().await.insert(run_id, CancellationToken::new());
+        cleanup_state.mark_status_removed();
+
+        cleanup_panicked_job(
+            run_id,
+            sandbox_id,
+            Arc::clone(&tokens),
+            Arc::clone(&status),
+            idle_pool,
+            cleanup_state,
+            orphans.clone(),
+        )
+        .await;
+
+        assert!(!tokens.lock().await.contains_key(&run_id));
+        let (_idle_sessions, active_runs) =
+            status_idle_sessions_and_active_runs(&status_path).await;
+        assert!(active_runs.is_empty());
+        assert_eq!(orphans.len().await, 0);
+    }
+
+    #[tokio::test]
     async fn panic_cleanup_active_unknown_keeps_active_and_registers_orphan() {
         let dir = tempfile::tempdir().unwrap();
         let status_path = dir.path().join("status.json");
@@ -2678,6 +2717,41 @@ mod tests {
         assert_eq!(idle_sessions, vec!["sess-idle-owned-cleanup"]);
         assert!(active_runs.is_empty());
         assert_eq!(orphans.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn orphan_reaper_stale_snapshot_does_not_remove_reinserted_active_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let orphans = OrphanedActiveRuns::new();
+        let run_id = RunId::new_v4();
+        let stale_sandbox_id = SandboxId::new_v4();
+        let current_sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, stale_sandbox_id).await;
+        orphans.insert(run_id, stale_sandbox_id).await;
+        let stale_records = orphans.snapshot().await;
+
+        status.add_run(run_id, current_sandbox_id).await;
+        orphans.insert(run_id, current_sandbox_id).await;
+
+        reap_orphaned_active_runs_with_firecrackers(
+            &orphans,
+            &status,
+            stale_records,
+            &[],
+            false,
+            OrphanReapMode::ShutdownFinal.absent_scans_before_remove(),
+        )
+        .await;
+
+        let (_idle_sessions, active_runs) =
+            status_idle_sessions_and_active_runs(&status_path).await;
+        assert_eq!(active_runs, vec![run_id.to_string()]);
+        let remaining = orphans.snapshot().await;
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].run_id, run_id);
+        assert_eq!(remaining[0].sandbox_id, current_sandbox_id);
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1458,7 +1458,7 @@ async fn finalize_sandbox_for_completion(
                         run_id,
                     );
                     // Push fresh idle state to status.json BEFORE
-                    // `status.remove_run` (below) clears the run_id
+                    // conditional active-run removal (below) clears the run_id
                     // from active_runs. Without this, doctor would
                     // briefly see the FC as unknown (neither active
                     // nor idle) until the next idle_cleanup tick
@@ -2475,12 +2475,12 @@ mod tests {
         assert_eq!(
             active_runs_at_complete.load(Ordering::SeqCst),
             1,
-            "status.remove_run must happen after provider.complete",
+            "active status removal must happen after provider.complete",
         );
         assert_eq!(
             status_active_run_count(&status_path).await,
             0,
-            "status.remove_run should complete before active budget release returns",
+            "active status removal should complete before active budget release returns",
         );
         assert_eq!(
             cleanup_state.disposition(),

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1971,8 +1971,25 @@ async fn reap_orphaned_active_runs(
         status,
         non_idle_records,
         &discovered.firecrackers,
+        firecracker_discovery_incomplete_for_current_runner(&discovered.firecrackers).await,
     )
     .await;
+}
+
+async fn firecracker_discovery_incomplete_for_current_runner(
+    firecrackers: &[process::FirecrackerProcessInfo],
+) -> bool {
+    let current_runner_pid = std::process::id();
+    for firecracker in firecrackers
+        .iter()
+        .filter(|firecracker| firecracker.base_dir.is_none())
+    {
+        match process::process_has_ancestor(firecracker.pid, &[current_runner_pid]).await {
+            Some(false) => {}
+            Some(true) | None => return true,
+        }
+    }
+    false
 }
 
 async fn reap_orphaned_active_runs_with_firecrackers(
@@ -1980,9 +1997,8 @@ async fn reap_orphaned_active_runs_with_firecrackers(
     status: &StatusTracker,
     records: Vec<OrphanedActiveRun>,
     firecrackers: &[process::FirecrackerProcessInfo],
+    discovery_incomplete_for_current_runner: bool,
 ) {
-    let discovery_incomplete =
-        process::firecracker_discovery_has_unresolved_sandbox_id(firecrackers);
     for record in records {
         let sandbox_id = record.sandbox_id.to_string();
         if process::firecracker_process_exists_for_sandbox_id(firecrackers, &sandbox_id) {
@@ -1997,10 +2013,7 @@ async fn reap_orphaned_active_runs_with_firecrackers(
             continue;
         }
 
-        if discovery_incomplete {
-            orphaned_active_runs
-                .reset_absent_scans_if_matching(record.run_id, record.sandbox_id)
-                .await;
+        if discovery_incomplete_for_current_runner {
             warn!(
                 run_id = %record.run_id,
                 sandbox_id = %record.sandbox_id,
@@ -2696,6 +2709,7 @@ mod tests {
             &status,
             orphans.snapshot().await,
             &[],
+            false,
         )
         .await;
 
@@ -2709,6 +2723,7 @@ mod tests {
             &status,
             orphans.snapshot().await,
             &[],
+            false,
         )
         .await;
 
@@ -2719,7 +2734,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn orphan_reaper_defers_when_firecracker_discovery_is_incomplete() {
+    async fn orphan_reaper_defers_incomplete_discovery_without_resetting_absent_confirmation() {
         let dir = tempfile::tempdir().unwrap();
         let status_path = dir.path().join("status.json");
         let status = StatusTracker::new(status_path.clone(), 4, None, None);
@@ -2734,6 +2749,7 @@ mod tests {
             &status,
             orphans.snapshot().await,
             &[],
+            false,
         )
         .await;
         let unresolved_firecracker = process::FirecrackerProcessInfo {
@@ -2747,6 +2763,7 @@ mod tests {
             &status,
             orphans.snapshot().await,
             &[unresolved_firecracker],
+            true,
         )
         .await;
 
@@ -2760,16 +2777,16 @@ mod tests {
             &status,
             orphans.snapshot().await,
             &[],
+            false,
         )
         .await;
         let (_idle_sessions, active_runs) =
             status_idle_sessions_and_active_runs(&status_path).await;
-        assert_eq!(
-            active_runs,
-            vec![run_id.to_string()],
-            "incomplete discovery should reset absent confirmation"
+        assert!(
+            active_runs.is_empty(),
+            "incomplete discovery should not count as absent, but should not globally reset prior conclusive absence"
         );
-        assert_eq!(orphans.len().await, 1);
+        assert_eq!(orphans.len().await, 0);
     }
 
     #[tokio::test]
@@ -2794,6 +2811,7 @@ mod tests {
             &status,
             orphans.snapshot().await,
             &[firecracker],
+            false,
         )
         .await;
 

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -495,7 +495,7 @@ impl OrphanedActiveRuns {
         }
     }
 
-    async fn remove_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) {
+    async fn remove_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) -> bool {
         let mut runs = self.inner.lock().await;
         let removed =
             matches!(runs.get(&run_id), Some(current) if current.sandbox_id == sandbox_id);
@@ -503,6 +503,7 @@ impl OrphanedActiveRuns {
             runs.remove(&run_id);
             self.len.fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
         }
+        removed
     }
 
     async fn reset_absent_scans_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) {
@@ -1910,12 +1911,12 @@ async fn cleanup_panicked_job(
     match cleanup_state.disposition() {
         RunCleanupDisposition::StatusRemoved => {}
         RunCleanupDisposition::DestroyCompleted => {
-            status.remove_run(run_id).await;
+            status.remove_run_if_matching(run_id, sandbox_id).await;
         }
         RunCleanupDisposition::IdlePoolOwned => {
             let snapshot = idle_pool.lock().await.status_snapshot();
             set_idle_status_snapshot(&status, snapshot).await;
-            status.remove_run(run_id).await;
+            status.remove_run_if_matching(run_id, sandbox_id).await;
         }
         RunCleanupDisposition::ActiveOrUnknown => {
             warn!(
@@ -1952,6 +1953,29 @@ async fn reap_orphaned_active_runs(
         return;
     }
 
+    reap_orphaned_active_run_records(
+        orphaned_active_runs,
+        idle_pool,
+        status,
+        records,
+        mode,
+        process_discovery_override,
+    )
+    .await;
+}
+
+async fn reap_orphaned_active_run_records(
+    orphaned_active_runs: &OrphanedActiveRuns,
+    idle_pool: &SharedIdlePool,
+    status: &StatusTracker,
+    records: Vec<OrphanedActiveRun>,
+    mode: OrphanReapMode,
+    process_discovery_override: Option<&OrphanReapProcessDiscovery>,
+) {
+    if records.is_empty() {
+        return;
+    }
+
     let pool = idle_pool.lock().await;
     let idle_snapshot = pool.status_snapshot();
     let idle_owned_records: Vec<OrphanedActiveRun> = records
@@ -1963,17 +1987,19 @@ async fn reap_orphaned_active_runs(
     let mut non_idle_records = Vec::new();
     let mut refreshed_idle_status = false;
     for record in records {
-        if idle_owned_records
-            .iter()
-            .any(|idle_record| idle_record.run_id == record.run_id)
-        {
+        if idle_owned_records.contains(&record) {
+            if !orphaned_active_runs
+                .remove_if_matching(record.run_id, record.sandbox_id)
+                .await
+            {
+                continue;
+            }
             if !refreshed_idle_status {
                 set_idle_status_snapshot(status, idle_snapshot.clone()).await;
                 refreshed_idle_status = true;
             }
-            status.remove_run(record.run_id).await;
-            orphaned_active_runs
-                .remove_if_matching(record.run_id, record.sandbox_id)
+            status
+                .remove_run_if_matching(record.run_id, record.sandbox_id)
                 .await;
             info!(
                 run_id = %record.run_id,
@@ -2092,9 +2118,14 @@ async fn reap_orphaned_active_runs_with_firecrackers(
             continue;
         }
 
-        status.remove_run(record.run_id).await;
-        orphaned_active_runs
+        if !orphaned_active_runs
             .remove_if_matching(record.run_id, record.sandbox_id)
+            .await
+        {
+            continue;
+        }
+        status
+            .remove_run_if_matching(record.run_id, record.sandbox_id)
             .await;
         info!(
             run_id = %record.run_id,
@@ -2569,7 +2600,7 @@ mod tests {
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
-        status.remove_run(run_id).await;
+        status.remove_run_if_matching(run_id, sandbox_id).await;
         tokens.lock().await.insert(run_id, CancellationToken::new());
         cleanup_state.mark_status_removed();
 
@@ -2742,6 +2773,62 @@ mod tests {
             &[],
             false,
             OrphanReapMode::ShutdownFinal.absent_scans_before_remove(),
+        )
+        .await;
+
+        let (_idle_sessions, active_runs) =
+            status_idle_sessions_and_active_runs(&status_path).await;
+        assert_eq!(active_runs, vec![run_id.to_string()]);
+        let remaining = orphans.snapshot().await;
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].run_id, run_id);
+        assert_eq!(remaining[0].sandbox_id, current_sandbox_id);
+    }
+
+    #[tokio::test]
+    async fn orphan_reaper_stale_idle_owned_snapshot_does_not_remove_reinserted_active_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let idle_pool: SharedIdlePool =
+            Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
+                default_timeout: Duration::from_secs(300),
+                max_idle: 10,
+            })));
+        let orphans = OrphanedActiveRuns::new();
+        let run_id = RunId::new_v4();
+        let stale_sandbox_id = SandboxId::new_v4();
+        let current_sandbox_id = SandboxId::new_v4();
+        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        let candidate = ParkCandidate::from_parked_parts(ParkCandidateParts {
+            sandbox: Box::new(MockSandbox::new("stale-idle-owned-reaper")),
+            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+            session_id: "sess-stale-idle-owned-reaper".into(),
+            sandbox_id: stale_sandbox_id,
+            profile_name: "vm0/default".into(),
+            budget_lease: lease,
+            source_ip: "10.0.0.1".into(),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+        });
+        assert!(matches!(
+            idle_pool.lock().await.park(candidate),
+            ParkResult::Parked
+        ));
+        status.add_run(run_id, stale_sandbox_id).await;
+        orphans.insert(run_id, stale_sandbox_id).await;
+        let stale_records = orphans.snapshot().await;
+
+        status.add_run(run_id, current_sandbox_id).await;
+        orphans.insert(run_id, current_sandbox_id).await;
+
+        reap_orphaned_active_run_records(
+            &orphans,
+            &idle_pool,
+            &status,
+            stale_records,
+            OrphanReapMode::Immediate,
+            None,
         )
         .await;
 

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -21,7 +21,7 @@ use crate::executor::{self, ExecutorConfig};
 use crate::host;
 use crate::http::HttpClient;
 use crate::idle_pool::{
-    IdleDestroyJob, IdleDestroyPayload, IdlePool, IdlePoolConfig, IdlePoolSnapshot,
+    DestroyOutcome, IdleDestroyJob, IdleDestroyPayload, IdlePool, IdlePoolConfig, IdlePoolSnapshot,
     IdleUnparkResult, ParkCandidate, ParkCandidateParts, ParkResult, ParkingGate,
     ReusableIdleSandbox, StorageFingerprints,
 };
@@ -31,6 +31,7 @@ use crate::network_log_manager::NetworkLogManager;
 use crate::network_logs;
 use crate::paths::{HomePaths, LogPaths, RunnerPaths, touch_mtime};
 use crate::prefetch;
+use crate::process;
 use crate::provider::{ApiProvider, JobProvider, LocalProvider};
 use crate::proxy;
 use crate::resource_budget::{BudgetLease, ResourceBudget};
@@ -45,7 +46,10 @@ mod mitm_restart;
 mod signals;
 
 use identity::load_or_generate_runner_id;
-use job_lifecycle::{ActiveBudgetLease, BudgetOwnership, CompletionPayload, CompletionReady};
+use job_lifecycle::{
+    ActiveBudgetLease, BudgetOwnership, CompletionPayload, CompletionReady, RunCleanupDisposition,
+    RunCleanupState,
+};
 use mitm_restart::{
     MITM_BACKOFF_INITIAL, MITM_BACKOFF_MAX, MITM_MAX_CONSECUTIVE_FAILURES, MitmRestartHandle,
     finish_mitm_restart_before_shutdown, handle_mitm_restart_result, maybe_spawn_mitm_restart,
@@ -367,6 +371,8 @@ pub async fn run_start(
         kmsg_handle,
         dns_handle,
         signal_source: SignalSource::Real(signals),
+        #[cfg(test)]
+        outer_job_panic: None,
     };
 
     run(config).await
@@ -402,6 +408,8 @@ struct RunConfig {
     /// pre-built `SignalController` so they can drive mode transitions
     /// through the lifecycle controller.
     signal_source: SignalSource,
+    #[cfg(test)]
+    outer_job_panic: Option<OuterJobPanicPoint>,
 }
 
 enum SignalSource {
@@ -413,6 +421,85 @@ enum SignalSource {
     /// below; non-test code matches on it but never builds it.
     #[cfg_attr(not(test), allow(dead_code))]
     Override(SignalController),
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OuterJobPanicPoint {
+    ActiveOrUnknown,
+    IdlePoolOwned,
+    DestroyCompleted,
+}
+
+#[cfg(test)]
+fn maybe_panic_outer_job(
+    configured: Option<OuterJobPanicPoint>,
+    point: OuterJobPanicPoint,
+    run_id: RunId,
+) {
+    if configured == Some(point) {
+        panic!("simulated outer job panic at {point:?} for {run_id}");
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct OrphanedActiveRun {
+    run_id: RunId,
+    sandbox_id: SandboxId,
+}
+
+/// Claimed runs whose outer task is gone but whose VM ownership is uncertain.
+#[derive(Clone)]
+struct OrphanedActiveRuns {
+    inner: Arc<tokio::sync::Mutex<BTreeMap<RunId, SandboxId>>>,
+    len: Arc<std::sync::atomic::AtomicUsize>,
+    notify: Arc<tokio::sync::Notify>,
+}
+
+impl OrphanedActiveRuns {
+    fn new(notify: Arc<tokio::sync::Notify>) -> Self {
+        Self {
+            inner: Arc::new(tokio::sync::Mutex::new(BTreeMap::new())),
+            len: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            notify,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len.load(std::sync::atomic::Ordering::Acquire) == 0
+    }
+
+    async fn insert(&self, run_id: RunId, sandbox_id: SandboxId) {
+        let mut runs = self.inner.lock().await;
+        if runs.insert(run_id, sandbox_id).is_none() {
+            self.len.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        }
+        drop(runs);
+        self.notify.notify_one();
+    }
+
+    async fn remove_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) {
+        let mut runs = self.inner.lock().await;
+        let removed = matches!(runs.get(&run_id), Some(current) if *current == sandbox_id);
+        if removed {
+            runs.remove(&run_id);
+            self.len.fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
+        }
+    }
+
+    async fn snapshot(&self) -> Vec<OrphanedActiveRun> {
+        self.inner
+            .lock()
+            .await
+            .iter()
+            .map(|(&run_id, &sandbox_id)| OrphanedActiveRun { run_id, sandbox_id })
+            .collect()
+    }
+
+    #[cfg(test)]
+    async fn len(&self) -> usize {
+        self.inner.lock().await.len()
+    }
 }
 
 async fn run(config: RunConfig) -> RunnerResult<()> {
@@ -440,6 +527,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         kmsg_handle,
         dns_handle,
         signal_source,
+        #[cfg(test)]
+        outer_job_panic,
     } = config;
 
     // Build per-profile factories via the sandbox runtime.
@@ -545,6 +634,13 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // immediate heartbeat after parking a VM, so the server learns about the
     // new heldSession without waiting for the next 10-second tick.
     let park_notify = Arc::new(tokio::sync::Notify::new());
+    let orphan_reap_notify = Arc::new(tokio::sync::Notify::new());
+    let orphaned_active_runs = OrphanedActiveRuns::new(Arc::clone(&orphan_reap_notify));
+    let mut orphan_reap_tick = tokio::time::interval_at(
+        tokio::time::Instant::now() + Duration::from_secs(10),
+        Duration::from_secs(10),
+    );
+    orphan_reap_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     let hb_ctx = HeartbeatContext {
         idle_pool: &idle_pool,
@@ -568,8 +664,12 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         exec_config: Arc::clone(&exec_config),
         idle_pool: Arc::clone(&idle_pool),
         status: Arc::clone(&status),
+        cancel_tokens: Arc::clone(&cancel_tokens),
+        orphaned_active_runs: orphaned_active_runs.clone(),
         parking_gate: parking_gate.clone(),
         park_notify: Arc::clone(&park_notify),
+        #[cfg(test)]
+        outer_job_panic,
     };
     let mut draining_idle_pool_drained = false;
     loop {
@@ -681,6 +781,16 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             // stale cancel tokens until drain, budget exhaustion, or shutdown.
             result = jobs.join_next(), if !jobs.is_empty() => {
                 handle_job_result(result, &cancel_tokens).await;
+                if !orphaned_active_runs.is_empty() {
+                    reap_orphaned_active_runs(&orphaned_active_runs, &idle_pool, &status).await;
+                }
+            }
+            // Reconcile active runs left visible after an outer job-task panic.
+            _ = orphan_reap_notify.notified(), if !orphaned_active_runs.is_empty() => {
+                reap_orphaned_active_runs(&orphaned_active_runs, &idle_pool, &status).await;
+            }
+            _ = orphan_reap_tick.tick(), if !orphaned_active_runs.is_empty() => {
+                reap_orphaned_active_runs(&orphaned_active_runs, &idle_pool, &status).await;
             }
             // Reap completed destroy tasks
             Some(result) = destroy_tasks.join_next(), if !destroy_tasks.is_empty() => {
@@ -774,6 +884,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             tokio::select! {
                 result = jobs.join_next() => {
                     handle_job_result(result, &cancel_tokens).await;
+                    if !orphaned_active_runs.is_empty() {
+                        reap_orphaned_active_runs(&orphaned_active_runs, &idle_pool, &status).await;
+                    }
                 }
                 Some(result) = destroy_tasks.join_next() => {
                     if let Err(e) = result {
@@ -1080,6 +1193,8 @@ struct SpawnContext {
     exec_config: Arc<ExecutorConfig>,
     idle_pool: SharedIdlePool,
     status: Arc<StatusTracker>,
+    cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+    orphaned_active_runs: OrphanedActiveRuns,
     /// Current lifecycle parking permission. This is checked at job
     /// completion so soft-drain/resume races do not depend on a stale
     /// spawn-time mode snapshot.
@@ -1088,6 +1203,8 @@ struct SpawnContext {
     /// This eliminates the up-to-10s blind spot where the server doesn't know
     /// which runner holds a newly-parked session.
     park_notify: Arc<tokio::sync::Notify>,
+    #[cfg(test)]
+    outer_job_panic: Option<OuterJobPanicPoint>,
 }
 
 struct FinalizeContext {
@@ -1105,6 +1222,9 @@ struct FinalizeContext {
     parking_gate: ParkingGate,
     exit_code: i32,
     cancel: CancellationToken,
+    cleanup_state: RunCleanupState,
+    #[cfg(test)]
+    outer_job_panic: Option<OuterJobPanicPoint>,
 }
 
 async fn finalize_sandbox_for_completion(
@@ -1132,6 +1252,9 @@ async fn finalize_sandbox_for_completion(
         parking_gate,
         exit_code,
         cancel,
+        cleanup_state,
+        #[cfg(test)]
+        outer_job_panic,
     } = ctx;
 
     let cancelled = cancel.is_cancelled();
@@ -1157,7 +1280,7 @@ async fn finalize_sandbox_for_completion(
                 error = %e,
                 "sandbox park failed, destroying instead of parking"
             );
-            stop_and_destroy_sandbox(
+            let destroy_outcome = stop_and_destroy_sandbox(
                 sandbox,
                 &**factory,
                 ActiveCleanupContext {
@@ -1169,6 +1292,15 @@ async fn finalize_sandbox_for_completion(
                 },
             )
             .await;
+            if destroy_outcome == DestroyOutcome::Completed {
+                cleanup_state.mark_destroy_completed();
+            }
+            #[cfg(test)]
+            maybe_panic_outer_job(
+                outer_job_panic,
+                OuterJobPanicPoint::DestroyCompleted,
+                run_id,
+            );
             BudgetOwnership::active(active_lease)
         } else if cancel.is_cancelled() {
             info!(
@@ -1176,7 +1308,7 @@ async fn finalize_sandbox_for_completion(
                 session_id,
                 "job cancelled while parking, destroying VM"
             );
-            stop_and_destroy_sandbox(
+            let destroy_outcome = stop_and_destroy_sandbox(
                 sandbox,
                 &**factory,
                 ActiveCleanupContext {
@@ -1188,6 +1320,15 @@ async fn finalize_sandbox_for_completion(
                 },
             )
             .await;
+            if destroy_outcome == DestroyOutcome::Completed {
+                cleanup_state.mark_destroy_completed();
+            }
+            #[cfg(test)]
+            maybe_panic_outer_job(
+                outer_job_panic,
+                OuterJobPanicPoint::DestroyCompleted,
+                run_id,
+            );
             BudgetOwnership::active(active_lease)
         } else {
             let mut pool = idle_pool.lock().await;
@@ -1198,7 +1339,7 @@ async fn finalize_sandbox_for_completion(
                     "job cancelled before idle pool ownership transfer, destroying VM"
                 );
                 drop(pool);
-                stop_and_destroy_sandbox(
+                let destroy_outcome = stop_and_destroy_sandbox(
                     sandbox,
                     &**factory,
                     ActiveCleanupContext {
@@ -1210,6 +1351,15 @@ async fn finalize_sandbox_for_completion(
                     },
                 )
                 .await;
+                if destroy_outcome == DestroyOutcome::Completed {
+                    cleanup_state.mark_destroy_completed();
+                }
+                #[cfg(test)]
+                maybe_panic_outer_job(
+                    outer_job_panic,
+                    OuterJobPanicPoint::DestroyCompleted,
+                    run_id,
+                );
                 return CompletionReady::new(
                     completion_payload,
                     BudgetOwnership::active(active_lease),
@@ -1228,6 +1378,13 @@ async fn finalize_sandbox_for_completion(
             match pool.park(candidate) {
                 ParkResult::Parked => {
                     info!(run_id = %run_id, session_id, "VM parked for reuse");
+                    cleanup_state.mark_idle_pool_owned();
+                    #[cfg(test)]
+                    maybe_panic_outer_job(
+                        outer_job_panic,
+                        OuterJobPanicPoint::IdlePoolOwned,
+                        run_id,
+                    );
                     // Push fresh idle state to status.json BEFORE
                     // `status.remove_run` (below) clears the run_id
                     // from active_runs. Without this, doctor would
@@ -1243,6 +1400,13 @@ async fn finalize_sandbox_for_completion(
                 }
                 ParkResult::Replaced(evicted) => {
                     info!(run_id = %run_id, session_id, "VM parked, evicting previous");
+                    cleanup_state.mark_idle_pool_owned();
+                    #[cfg(test)]
+                    maybe_panic_outer_job(
+                        outer_job_panic,
+                        OuterJobPanicPoint::IdlePoolOwned,
+                        run_id,
+                    );
                     let snapshot = pool.status_snapshot();
                     drop(pool);
                     set_idle_status_snapshot(&status, snapshot).await;
@@ -1264,14 +1428,24 @@ async fn finalize_sandbox_for_completion(
                     // park()ed above; destroying a parked sandbox is
                     // safe — see Replaced arm for rationale.
                     let (payload, lease) = rejected.into_active_destroy_parts();
-                    destroy_idle_payload_and_wait(payload, "park_rejected").await;
+                    let destroy_outcome =
+                        destroy_idle_payload_and_wait(payload, "park_rejected").await;
+                    if destroy_outcome == DestroyOutcome::Completed {
+                        cleanup_state.mark_destroy_completed();
+                    }
+                    #[cfg(test)]
+                    maybe_panic_outer_job(
+                        outer_job_panic,
+                        OuterJobPanicPoint::DestroyCompleted,
+                        run_id,
+                    );
                     BudgetOwnership::active(ActiveBudgetLease::from_rejected_park(lease))
                 }
             }
         }
     } else {
         // No parkable session — stop + destroy.
-        stop_and_destroy_sandbox(
+        let destroy_outcome = stop_and_destroy_sandbox(
             sandbox,
             &**factory,
             ActiveCleanupContext {
@@ -1289,6 +1463,15 @@ async fn finalize_sandbox_for_completion(
             },
         )
         .await;
+        if destroy_outcome == DestroyOutcome::Completed {
+            cleanup_state.mark_destroy_completed();
+        }
+        #[cfg(test)]
+        maybe_panic_outer_job(
+            outer_job_panic,
+            OuterJobPanicPoint::DestroyCompleted,
+            run_id,
+        );
         BudgetOwnership::active(active_lease)
     };
 
@@ -1342,6 +1525,15 @@ fn spawn_job(
     let park_notify = Arc::clone(&ctx.park_notify);
     let parking_gate = ctx.parking_gate.clone();
     let factory_for_cleanup = Arc::clone(&factory);
+    let cleanup_state = RunCleanupState::new();
+    let cleanup_state_for_body = cleanup_state.clone();
+    let cleanup_state_for_panic = cleanup_state.clone();
+    let cancel_tokens_for_panic = Arc::clone(&ctx.cancel_tokens);
+    let status_for_panic = Arc::clone(&status);
+    let idle_pool_for_panic = Arc::clone(&idle_pool);
+    let orphaned_active_runs_for_panic = ctx.orphaned_active_runs.clone();
+    #[cfg(test)]
+    let outer_job_panic = ctx.outer_job_panic;
 
     // Captured for the post-complete deferred work below: the panic-arm
     // empty `JobTelemetry` construction, the final `telemetry.flush()`, and
@@ -1354,135 +1546,167 @@ fn spawn_job(
     let reused = reuse_entry.is_some();
 
     jobs.spawn(async move {
-        // Inner spawn isolates panics: if execute_job panics, the outer task
-        // still reports completion and releases budget.
-        let cancel = job_cancel.clone();
+        let body = async move {
+            #[cfg(test)]
+            maybe_panic_outer_job(outer_job_panic, OuterJobPanicPoint::ActiveOrUnknown, run_id);
 
-        let inner = tokio::spawn(async move {
-            if let Some(idle_entry) = reuse_entry {
-                executor::execute_job_reuse(idle_entry, context, &exec_config, cancel).await
-            } else {
-                executor::execute_job(
-                    &**factory,
-                    context,
-                    executor::NewSandboxDispatch {
-                        id: sandbox_id,
-                        reuse_result,
-                    },
-                    &exec_config,
-                    &params,
-                    cancel,
-                )
-                .await
-            }
-        });
+            // Inner spawn isolates panics: if execute_job panics, the outer task
+            // still reports completion and releases budget.
+            let cancel = job_cancel.clone();
 
-        let (exit_code, err, sandbox, source_ip, guest_session_id, telemetry) = match inner.await {
-            Ok((outcome, telemetry)) => {
-                let err = if job_cancel.is_cancelled() {
-                    Some("cancelled by user".to_string())
+            let inner = tokio::spawn(async move {
+                if let Some(idle_entry) = reuse_entry {
+                    executor::execute_job_reuse(idle_entry, context, &exec_config, cancel).await
                 } else {
-                    outcome.error
+                    executor::execute_job(
+                        &**factory,
+                        context,
+                        executor::NewSandboxDispatch {
+                            id: sandbox_id,
+                            reuse_result,
+                        },
+                        &exec_config,
+                        &params,
+                        cancel,
+                    )
+                    .await
+                }
+            });
+
+            let (exit_code, err, sandbox, source_ip, guest_session_id, telemetry) =
+                match inner.await {
+                    Ok((outcome, telemetry)) => {
+                        let err = if job_cancel.is_cancelled() {
+                            Some("cancelled by user".to_string())
+                        } else {
+                            outcome.error
+                        };
+                        (
+                            outcome.exit_code,
+                            err,
+                            outcome.sandbox,
+                            outcome.source_ip,
+                            outcome.guest_session_id,
+                            telemetry,
+                        )
+                    }
+                    Err(e) => {
+                        // Panic lost the in-flight telemetry buffer; substitute an
+                        // empty collector so the post-complete flush path stays
+                        // unconditional. `flush` early-returns on empty pending_ops.
+                        let empty_telemetry = JobTelemetry::new(
+                            exec_config_for_deferred.http.clone(),
+                            run_id,
+                            sandbox_token.clone(),
+                        );
+                        (
+                            1,
+                            Some(format!("executor task panicked: {e}")),
+                            None,
+                            String::new(),
+                            None,
+                            empty_telemetry,
+                        )
+                    }
                 };
-                (
-                    outcome.exit_code,
-                    err,
-                    outcome.sandbox,
-                    outcome.source_ip,
-                    outcome.guest_session_id,
-                    telemetry,
-                )
+
+            // Single sink for any claimed job's terminal state. Cancellation gets
+            // its own info marker; everything else with `err` set is a failure
+            // (panics, executor internal errors, non-zero exits with
+            // stderr/guest error file); otherwise the job finished normally.
+            let cancelled_for_log = job_cancel.is_cancelled();
+            match (cancelled_for_log, err.as_deref()) {
+                (true, _) => info!(run_id = %run_id, exit_code, reused, "job cancelled"),
+                (false, Some(e)) => {
+                    error!(run_id = %run_id, exit_code, reused, error = %e, "job execution failed");
+                }
+                (false, None) => info!(run_id = %run_id, exit_code, reused, "job finished"),
             }
-            Err(e) => {
-                // Panic lost the in-flight telemetry buffer; substitute an
-                // empty collector so the post-complete flush path stays
-                // unconditional. `flush` early-returns on empty pending_ops.
-                let empty_telemetry = JobTelemetry::new(
-                    exec_config_for_deferred.http.clone(),
+
+            let completion_payload =
+                CompletionPayload::new(run_id, exit_code, err, sandbox_id, reuse_result);
+            // Cancellation can arrive after terminal logging or while
+            // `sandbox.park()` is in flight. Pass the live token so finalization
+            // can re-check immediately before idle-pool ownership transfer.
+            let completion_ready = finalize_sandbox_for_completion(
+                sandbox,
+                ActiveBudgetLease::new(active_lease),
+                completion_payload,
+                FinalizeContext {
                     run_id,
-                    sandbox_token.clone(),
-                );
-                (
-                    1,
-                    Some(format!("executor task panicked: {e}")),
-                    None,
-                    String::new(),
-                    None,
-                    empty_telemetry,
-                )
-            }
-        };
-
-        // Single sink for any claimed job's terminal state. Cancellation gets
-        // its own info marker; everything else with `err` set is a failure
-        // (panics, executor internal errors, non-zero exits with
-        // stderr/guest error file); otherwise the job finished normally.
-        let cancelled_for_log = job_cancel.is_cancelled();
-        match (cancelled_for_log, err.as_deref()) {
-            (true, _) => info!(run_id = %run_id, exit_code, reused, "job cancelled"),
-            (false, Some(e)) => {
-                error!(run_id = %run_id, exit_code, reused, error = %e, "job execution failed");
-            }
-            (false, None) => info!(run_id = %run_id, exit_code, reused, "job finished"),
-        }
-
-        let completion_payload =
-            CompletionPayload::new(run_id, exit_code, err, sandbox_id, reuse_result);
-        // Cancellation can arrive after terminal logging or while
-        // `sandbox.park()` is in flight. Pass the live token so finalization
-        // can re-check immediately before idle-pool ownership transfer.
-        let completion_ready = finalize_sandbox_for_completion(
-            sandbox,
-            ActiveBudgetLease::new(active_lease),
-            completion_payload,
-            FinalizeContext {
-                run_id,
-                sandbox_id,
-                profile_name,
-                session_id,
-                guest_session_id,
-                source_ip,
-                storage_fingerprints,
-                factory: factory_for_cleanup,
-                idle_pool,
-                status: Arc::clone(&status),
-                park_notify,
-                parking_gate,
-                exit_code,
-                cancel: job_cancel,
-            },
-        )
-        .await;
-
-        // Structural guarantee: claim (in provider) is always paired with complete.
-        completion_ready
-            .complete_and_release(provider.as_ref(), status.as_ref())
-            .await;
-
-        // Best-effort telemetry, deferred past `provider.complete` so the
-        // user-visible run-complete signal isn't blocked on these uploads.
-        // They're still awaited (not spawned) so the surrounding `jobs`
-        // JoinSet drains them on graceful shutdown — no data loss on SIGTERM.
-        // Telemetry flush runs concurrently with network-log drain + upload.
-        // Network-log upload must wait for accepted Rust-side DNS/kmsg writes
-        // before reading the per-run JSONL snapshot.
-        let network_log_path = exec_config_for_deferred.log_paths.network_log(run_id);
-        let network_log_upload = async {
-            exec_config_for_deferred
-                .network_log_manager
-                .flush_path(&network_log_path)
-                .await;
-            network_logs::upload_network_logs(
-                &exec_config_for_deferred.http,
-                run_id,
-                &sandbox_token,
-                &network_log_path,
+                    sandbox_id,
+                    profile_name,
+                    session_id,
+                    guest_session_id,
+                    source_ip,
+                    storage_fingerprints,
+                    factory: factory_for_cleanup,
+                    idle_pool,
+                    status: Arc::clone(&status),
+                    park_notify,
+                    parking_gate,
+                    exit_code,
+                    cancel: job_cancel,
+                    cleanup_state: cleanup_state_for_body.clone(),
+                    #[cfg(test)]
+                    outer_job_panic,
+                },
             )
             .await;
-        };
-        tokio::join!(telemetry.flush(), network_log_upload,);
 
-        Some(run_id)
+            // Structural guarantee: claim (in provider) is always paired with complete.
+            completion_ready
+                .complete_and_release(provider.as_ref(), status.as_ref(), &cleanup_state_for_body)
+                .await;
+
+            // Best-effort telemetry, deferred past `provider.complete` so the
+            // user-visible run-complete signal isn't blocked on these uploads.
+            // They're still awaited (not spawned) so the surrounding `jobs`
+            // JoinSet drains them on graceful shutdown — no data loss on SIGTERM.
+            // Telemetry flush runs concurrently with network-log drain + upload.
+            // Network-log upload must wait for accepted Rust-side DNS/kmsg writes
+            // before reading the per-run JSONL snapshot.
+            let network_log_path = exec_config_for_deferred.log_paths.network_log(run_id);
+            let network_log_upload = async {
+                exec_config_for_deferred
+                    .network_log_manager
+                    .flush_path(&network_log_path)
+                    .await;
+                network_logs::upload_network_logs(
+                    &exec_config_for_deferred.http,
+                    run_id,
+                    &sandbox_token,
+                    &network_log_path,
+                )
+                .await;
+            };
+            tokio::join!(telemetry.flush(), network_log_upload,);
+
+            Some(run_id)
+        };
+
+        match AssertUnwindSafe(body).catch_unwind().await {
+            Ok(result) => result,
+            Err(payload) => {
+                let cleanup = cleanup_panicked_job(
+                    run_id,
+                    sandbox_id,
+                    cancel_tokens_for_panic,
+                    status_for_panic,
+                    idle_pool_for_panic,
+                    cleanup_state_for_panic,
+                    orphaned_active_runs_for_panic,
+                );
+                if AssertUnwindSafe(cleanup).catch_unwind().await.is_err() {
+                    error!(
+                        run_id = %run_id,
+                        sandbox_id = %sandbox_id,
+                        "outer job panic cleanup panicked"
+                    );
+                }
+                std::panic::resume_unwind(payload);
+            }
+        }
     });
 }
 
@@ -1601,6 +1825,124 @@ async fn add_run_with_idle_status_snapshot(
     }
 }
 
+async fn cleanup_panicked_job(
+    run_id: RunId,
+    sandbox_id: SandboxId,
+    cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
+    status: Arc<StatusTracker>,
+    idle_pool: SharedIdlePool,
+    cleanup_state: RunCleanupState,
+    orphaned_active_runs: OrphanedActiveRuns,
+) {
+    cancel_tokens.lock().await.remove(&run_id);
+
+    match cleanup_state.disposition() {
+        RunCleanupDisposition::StatusRemoved => {}
+        RunCleanupDisposition::DestroyCompleted => {
+            status.remove_run(run_id).await;
+        }
+        RunCleanupDisposition::IdlePoolOwned => {
+            let snapshot = idle_pool.lock().await.status_snapshot();
+            set_idle_status_snapshot(&status, snapshot).await;
+            status.remove_run(run_id).await;
+        }
+        RunCleanupDisposition::ActiveOrUnknown => {
+            warn!(
+                run_id = %run_id,
+                sandbox_id = %sandbox_id,
+                "outer job task panicked before sandbox ownership was proven; leaving active run visible for orphan reconciliation"
+            );
+            orphaned_active_runs.insert(run_id, sandbox_id).await;
+        }
+    }
+}
+
+async fn reap_orphaned_active_runs(
+    orphaned_active_runs: &OrphanedActiveRuns,
+    idle_pool: &SharedIdlePool,
+    status: &StatusTracker,
+) {
+    let records = orphaned_active_runs.snapshot().await;
+    if records.is_empty() {
+        return;
+    }
+
+    let pool = idle_pool.lock().await;
+    let idle_snapshot = pool.status_snapshot();
+    let idle_owned_records: Vec<OrphanedActiveRun> = records
+        .iter()
+        .copied()
+        .filter(|record| pool.contains_sandbox_id(record.sandbox_id))
+        .collect();
+    drop(pool);
+    let mut non_idle_records = Vec::new();
+    let mut refreshed_idle_status = false;
+    for record in records {
+        if idle_owned_records
+            .iter()
+            .any(|idle_record| idle_record.run_id == record.run_id)
+        {
+            if !refreshed_idle_status {
+                set_idle_status_snapshot(status, idle_snapshot.clone()).await;
+                refreshed_idle_status = true;
+            }
+            status.remove_run(record.run_id).await;
+            orphaned_active_runs
+                .remove_if_matching(record.run_id, record.sandbox_id)
+                .await;
+            info!(
+                run_id = %record.run_id,
+                sandbox_id = %record.sandbox_id,
+                "orphaned active run reconciled as idle-pool owned"
+            );
+        } else {
+            non_idle_records.push(record);
+        }
+    }
+
+    if non_idle_records.is_empty() {
+        return;
+    }
+
+    let discovered = process::discover_all().await;
+    reap_orphaned_active_runs_with_firecrackers(
+        orphaned_active_runs,
+        status,
+        non_idle_records,
+        &discovered.firecrackers,
+    )
+    .await;
+}
+
+async fn reap_orphaned_active_runs_with_firecrackers(
+    orphaned_active_runs: &OrphanedActiveRuns,
+    status: &StatusTracker,
+    records: Vec<OrphanedActiveRun>,
+    firecrackers: &[process::FirecrackerProcessInfo],
+) {
+    for record in records {
+        let sandbox_id = record.sandbox_id.to_string();
+        if process::firecracker_process_exists_for_sandbox_id(firecrackers, &sandbox_id) {
+            warn!(
+                run_id = %record.run_id,
+                sandbox_id = %record.sandbox_id,
+                "orphaned active run still has a live non-idle Firecracker process; keeping active status visible"
+            );
+            continue;
+        }
+
+        status.remove_run(record.run_id).await;
+        orphaned_active_runs
+            .remove_if_matching(record.run_id, record.sandbox_id)
+            .await;
+        info!(
+            run_id = %record.run_id,
+            sandbox_id = %record.sandbox_id,
+            "orphaned active run removed after Firecracker process was absent"
+        );
+    }
+}
+
 fn spawn_idle_destroy_job(
     destroy_tasks: &mut JoinSet<()>,
     job: IdleDestroyJob,
@@ -1630,11 +1972,17 @@ async fn destroy_idle_job(job: IdleDestroyJob, _context: &'static str) {
     job.run().await;
 }
 
-async fn destroy_idle_payload_and_wait(payload: IdleDestroyPayload, context: &'static str) {
+async fn destroy_idle_payload_and_wait(
+    payload: IdleDestroyPayload,
+    context: &'static str,
+) -> DestroyOutcome {
     let handle = tokio::spawn(payload.stop_and_destroy());
     match handle.await {
-        Ok(()) => {}
-        Err(e) => warn!(context, error = %e, "idle payload destroy task panicked"),
+        Ok(outcome) => outcome,
+        Err(e) => {
+            warn!(context, error = %e, "idle payload destroy task panicked");
+            DestroyOutcome::Uncertain
+        }
     }
 }
 
@@ -1652,7 +2000,8 @@ async fn stop_and_destroy_sandbox(
     mut sandbox: Box<dyn Sandbox>,
     factory: &dyn SandboxFactory,
     context: ActiveCleanupContext<'_>,
-) {
+) -> DestroyOutcome {
+    let mut uncertain = false;
     match AssertUnwindSafe(sandbox.stop()).catch_unwind().await {
         Ok(Ok(())) => {}
         Ok(Err(e)) => warn!(
@@ -1664,14 +2013,17 @@ async fn stop_and_destroy_sandbox(
             error = %e,
             "sandbox stop failed during active cleanup"
         ),
-        Err(_) => warn!(
-            run_id = %context.run_id,
-            sandbox_id = %context.sandbox_id,
-            profile_name = context.profile_name,
-            session_id = context.session_id.unwrap_or("<none>"),
-            reason = context.reason,
-            "sandbox stop panicked during active cleanup"
-        ),
+        Err(_) => {
+            warn!(
+                run_id = %context.run_id,
+                sandbox_id = %context.sandbox_id,
+                profile_name = context.profile_name,
+                session_id = context.session_id.unwrap_or("<none>"),
+                reason = context.reason,
+                "sandbox stop panicked during active cleanup"
+            );
+            uncertain = true;
+        }
     }
     if AssertUnwindSafe(factory.destroy(sandbox))
         .catch_unwind()
@@ -1686,6 +2038,12 @@ async fn stop_and_destroy_sandbox(
             reason = context.reason,
             "sandbox destroy panicked during active cleanup"
         );
+        uncertain = true;
+    }
+    if uncertain {
+        DestroyOutcome::Uncertain
+    } else {
+        DestroyOutcome::Completed
     }
 }
 
@@ -1904,6 +2262,7 @@ mod tests {
             active_runs_at_complete: Arc::clone(&active_runs_at_complete),
             status_path: status_path.clone(),
         };
+        let cleanup_state = RunCleanupState::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
@@ -1912,7 +2271,7 @@ mod tests {
             test_completion_payload(run_id, sandbox_id),
             BudgetOwnership::active(ActiveBudgetLease::new(lease)),
         )
-        .complete_and_release(&provider, &status)
+        .complete_and_release(&provider, &status, &cleanup_state)
         .await;
 
         assert_eq!(
@@ -1929,6 +2288,10 @@ mod tests {
             status_active_run_count(&status_path).await,
             0,
             "status.remove_run should complete before active budget release returns",
+        );
+        assert_eq!(
+            cleanup_state.disposition(),
+            RunCleanupDisposition::StatusRemoved,
         );
         assert_eq!(budget.allocated().2, 0);
     }
@@ -1948,6 +2311,7 @@ mod tests {
             active_runs_at_complete,
             status_path,
         };
+        let cleanup_state = RunCleanupState::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
@@ -1956,13 +2320,17 @@ mod tests {
             test_completion_payload(run_id, sandbox_id),
             BudgetOwnership::idle_owned(),
         )
-        .complete_and_release(&provider, &status)
+        .complete_and_release(&provider, &status, &cleanup_state)
         .await;
 
         assert_eq!(
             budget.allocated().2,
             1,
             "idle-owned completion must not release the park candidate budget",
+        );
+        assert_eq!(
+            cleanup_state.disposition(),
+            RunCleanupDisposition::StatusRemoved,
         );
         drop(park_candidate_lease);
         assert_eq!(budget.allocated().2, 0);
@@ -1982,6 +2350,7 @@ mod tests {
             active_runs_at_complete,
             status_path,
         };
+        let cleanup_state = RunCleanupState::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
@@ -1990,7 +2359,7 @@ mod tests {
             test_completion_payload(run_id, sandbox_id),
             BudgetOwnership::active(ActiveBudgetLease::from_rejected_park(lease)),
         )
-        .complete_and_release(&provider, &status)
+        .complete_and_release(&provider, &status, &cleanup_state)
         .await;
 
         assert_eq!(
@@ -2006,6 +2375,243 @@ mod tests {
         let (budget, lease) = test_budget_lease();
         drop(ActiveBudgetLease::new(lease));
         assert_eq!(budget.allocated().2, 0);
+    }
+
+    #[test]
+    fn run_cleanup_state_does_not_downgrade_precise_ownership() {
+        let state = RunCleanupState::new();
+
+        state.mark_idle_pool_owned();
+        state.mark_destroy_completed();
+        assert_eq!(state.disposition(), RunCleanupDisposition::IdlePoolOwned);
+
+        state.mark_status_removed();
+        state.mark_idle_pool_owned();
+        assert_eq!(state.disposition(), RunCleanupDisposition::StatusRemoved);
+    }
+
+    #[tokio::test]
+    async fn panic_cleanup_active_unknown_keeps_active_and_registers_orphan() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = Arc::new(StatusTracker::new(status_path.clone(), 4, None, None));
+        let idle_pool: SharedIdlePool =
+            Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
+                default_timeout: Duration::from_secs(300),
+                max_idle: 10,
+            })));
+        let tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
+            Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let orphans = OrphanedActiveRuns::new(Arc::new(tokio::sync::Notify::new()));
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, sandbox_id).await;
+        tokens.lock().await.insert(run_id, CancellationToken::new());
+
+        cleanup_panicked_job(
+            run_id,
+            sandbox_id,
+            Arc::clone(&tokens),
+            Arc::clone(&status),
+            idle_pool,
+            RunCleanupState::new(),
+            orphans.clone(),
+        )
+        .await;
+
+        assert!(!tokens.lock().await.contains_key(&run_id));
+        let (_idle_sessions, active_runs) =
+            status_idle_sessions_and_active_runs(&status_path).await;
+        assert_eq!(active_runs, vec![run_id.to_string()]);
+        assert_eq!(orphans.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn panic_cleanup_destroy_completed_removes_active_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = Arc::new(StatusTracker::new(status_path.clone(), 4, None, None));
+        let idle_pool: SharedIdlePool =
+            Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
+                default_timeout: Duration::from_secs(300),
+                max_idle: 10,
+            })));
+        let tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
+            Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let orphans = OrphanedActiveRuns::new(Arc::new(tokio::sync::Notify::new()));
+        let cleanup_state = RunCleanupState::new();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, sandbox_id).await;
+        tokens.lock().await.insert(run_id, CancellationToken::new());
+        cleanup_state.mark_destroy_completed();
+
+        cleanup_panicked_job(
+            run_id,
+            sandbox_id,
+            Arc::clone(&tokens),
+            Arc::clone(&status),
+            idle_pool,
+            cleanup_state,
+            orphans.clone(),
+        )
+        .await;
+
+        assert!(!tokens.lock().await.contains_key(&run_id));
+        let (_idle_sessions, active_runs) =
+            status_idle_sessions_and_active_runs(&status_path).await;
+        assert!(active_runs.is_empty());
+        assert_eq!(orphans.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn panic_cleanup_idle_pool_owned_refreshes_idle_status_before_removing_active() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = Arc::new(StatusTracker::new(status_path.clone(), 4, None, None));
+        let idle_pool: SharedIdlePool =
+            Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
+                default_timeout: Duration::from_secs(300),
+                max_idle: 10,
+            })));
+        let tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
+            Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let orphans = OrphanedActiveRuns::new(Arc::new(tokio::sync::Notify::new()));
+        let cleanup_state = RunCleanupState::new();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        let candidate = ParkCandidate::from_parked_parts(ParkCandidateParts {
+            sandbox: Box::new(MockSandbox::new("idle-owned-cleanup")),
+            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+            session_id: "sess-idle-owned-cleanup".into(),
+            sandbox_id,
+            profile_name: "vm0/default".into(),
+            budget_lease: lease,
+            source_ip: "10.0.0.1".into(),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+        });
+        assert!(matches!(
+            idle_pool.lock().await.park(candidate),
+            ParkResult::Parked
+        ));
+        status.add_run(run_id, sandbox_id).await;
+        tokens.lock().await.insert(run_id, CancellationToken::new());
+        cleanup_state.mark_idle_pool_owned();
+
+        cleanup_panicked_job(
+            run_id,
+            sandbox_id,
+            Arc::clone(&tokens),
+            Arc::clone(&status),
+            Arc::clone(&idle_pool),
+            cleanup_state,
+            orphans.clone(),
+        )
+        .await;
+
+        assert!(!tokens.lock().await.contains_key(&run_id));
+        let (idle_sessions, active_runs) = status_idle_sessions_and_active_runs(&status_path).await;
+        assert_eq!(idle_sessions, vec!["sess-idle-owned-cleanup"]);
+        assert!(active_runs.is_empty());
+        assert_eq!(orphans.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn orphan_reaper_removes_active_run_when_idle_pool_owns_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let idle_pool: SharedIdlePool =
+            Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
+                default_timeout: Duration::from_secs(300),
+                max_idle: 10,
+            })));
+        let orphans = OrphanedActiveRuns::new(Arc::new(tokio::sync::Notify::new()));
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        let candidate = ParkCandidate::from_parked_parts(ParkCandidateParts {
+            sandbox: Box::new(MockSandbox::new("idle-owned-reaper")),
+            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+            session_id: "sess-idle-owned-reaper".into(),
+            sandbox_id,
+            profile_name: "vm0/default".into(),
+            budget_lease: lease,
+            source_ip: "10.0.0.1".into(),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+        });
+        assert!(matches!(
+            idle_pool.lock().await.park(candidate),
+            ParkResult::Parked
+        ));
+        status.add_run(run_id, sandbox_id).await;
+        orphans.insert(run_id, sandbox_id).await;
+
+        reap_orphaned_active_runs(&orphans, &idle_pool, &status).await;
+
+        let (idle_sessions, active_runs) = status_idle_sessions_and_active_runs(&status_path).await;
+        assert_eq!(idle_sessions, vec!["sess-idle-owned-reaper"]);
+        assert!(active_runs.is_empty());
+        assert_eq!(orphans.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn orphan_reaper_removes_active_run_when_firecracker_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let orphans = OrphanedActiveRuns::new(Arc::new(tokio::sync::Notify::new()));
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, sandbox_id).await;
+        orphans.insert(run_id, sandbox_id).await;
+
+        reap_orphaned_active_runs_with_firecrackers(
+            &orphans,
+            &status,
+            vec![OrphanedActiveRun { run_id, sandbox_id }],
+            &[],
+        )
+        .await;
+
+        let (_idle_sessions, active_runs) =
+            status_idle_sessions_and_active_runs(&status_path).await;
+        assert!(active_runs.is_empty());
+        assert_eq!(orphans.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn orphan_reaper_preserves_active_run_when_firecracker_live() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let orphans = OrphanedActiveRuns::new(Arc::new(tokio::sync::Notify::new()));
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, sandbox_id).await;
+        orphans.insert(run_id, sandbox_id).await;
+        let firecracker = process::FirecrackerProcessInfo {
+            pid: 1234,
+            ppid: Some(1),
+            sandbox_id: sandbox_id.to_string(),
+            base_dir: None,
+        };
+
+        reap_orphaned_active_runs_with_firecrackers(
+            &orphans,
+            &status,
+            vec![OrphanedActiveRun { run_id, sandbox_id }],
+            &[firecracker],
+        )
+        .await;
+
+        let (_idle_sessions, active_runs) =
+            status_idle_sessions_and_active_runs(&status_path).await;
+        assert_eq!(active_runs, vec![run_id.to_string()]);
+        assert_eq!(orphans.len().await, 1);
     }
 
     struct PanickingDestroyFactory;
@@ -2585,6 +3191,7 @@ mod tests {
                 lifecycle: lifecycle.clone(),
                 handler_abort: None,
             }),
+            outer_job_panic: None,
         };
 
         let env = MockRunEnv {
@@ -4177,6 +4784,34 @@ mod tests {
         status_idle_sessions_and_active_runs(status_path).await.0
     }
 
+    async fn wait_status_idle_sessions_and_active_runs(
+        status_path: &std::path::Path,
+        expected_idle_sessions: &[&str],
+        expected_active_runs: &[String],
+        timeout: Duration,
+    ) {
+        let mut expected_idle_sessions: Vec<String> = expected_idle_sessions
+            .iter()
+            .map(|session| (*session).to_string())
+            .collect();
+        expected_idle_sessions.sort_unstable();
+        let mut expected_active_runs = expected_active_runs.to_vec();
+        expected_active_runs.sort_unstable();
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let (idle_sessions, active_runs) =
+                status_idle_sessions_and_active_runs(status_path).await;
+            if idle_sessions == expected_idle_sessions && active_runs == expected_active_runs {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "status did not reach expected idle={expected_idle_sessions:?} active={expected_active_runs:?} within {timeout:?} (actual idle={idle_sessions:?} active={active_runs:?})",
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
     async fn publish_idle_status(pool: &SharedIdlePool, status: &StatusTracker) {
         let snapshot = pool.lock().await.status_snapshot();
         assert!(
@@ -5597,6 +6232,93 @@ mod tests {
         assert!(
             active_runs.is_empty(),
             "create failure should remove active run from status"
+        );
+
+        shutdown(&env, run_handle).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn outer_job_panic_after_idle_pool_owned_cleans_token_and_active_status() {
+        let (mut config, env) = mock_run_config_with_overrides(
+            test_profiles(),
+            8,
+            16384,
+            4,
+            Arc::new(sandbox_mock::MockSandboxOverrides::new()),
+        );
+        config.outer_job_panic = Some(OuterJobPanicPoint::IdlePoolOwned);
+        let idle_pool = Arc::clone(&config.idle_pool);
+        let cancel_tokens = Arc::clone(&config.cancel_tokens);
+        let status_path = env._temp_dir.path().join("status.json");
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = RunId::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(run_id, "sess-outer-panic-idle")),
+        );
+
+        wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
+        wait_cancel_token_removed(&cancel_tokens, run_id, Duration::from_secs(5)).await;
+        wait_status_idle_sessions_and_active_runs(
+            &status_path,
+            &["sess-outer-panic-idle"],
+            &[],
+            Duration::from_secs(5),
+        )
+        .await;
+        assert!(
+            !env.handle
+                .completions
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|completion| completion.run_id == run_id),
+            "outer job panic must not synthesize provider completion"
+        );
+
+        shutdown(&env, run_handle).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn outer_job_panic_after_destroy_completed_cleans_token_and_active_status() {
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let destroy_entered = Arc::new(tokio::sync::Notify::new());
+        let destroy_release = Arc::new(tokio::sync::Notify::new());
+        overrides.set_destroy_gate(Arc::clone(&destroy_entered), Arc::clone(&destroy_release));
+        let destroy_entered_wait = destroy_entered.notified();
+        tokio::pin!(destroy_entered_wait);
+        destroy_entered_wait.as_mut().enable();
+
+        let (mut config, env) =
+            mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
+        config.outer_job_panic = Some(OuterJobPanicPoint::DestroyCompleted);
+        let cancel_tokens = Arc::clone(&config.cancel_tokens);
+        let status_path = env._temp_dir.path().join("status.json");
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = RunId::new_v4();
+        push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+
+        tokio::time::timeout(Duration::from_secs(5), destroy_entered_wait)
+            .await
+            .expect("active destroy should start");
+        let _token = wait_cancel_token(&cancel_tokens, run_id, Duration::from_secs(5)).await;
+        destroy_release.notify_one();
+
+        wait_cancel_token_removed(&cancel_tokens, run_id, Duration::from_secs(5)).await;
+        wait_status_idle_sessions_and_active_runs(&status_path, &[], &[], Duration::from_secs(5))
+            .await;
+        assert!(
+            !env.handle
+                .completions
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|completion| completion.run_id == run_id),
+            "outer job panic must not synthesize provider completion"
         );
 
         shutdown(&env, run_handle).await;

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -60,6 +60,7 @@ use signals::{EarlySignals, SignalController};
 /// tick is deferred by one period via `interval_at` — see the comment
 /// at the interval construction in `run()`.
 const HEARTBEAT_PERIOD: Duration = Duration::from_secs(10);
+const ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE: u8 = 2;
 
 #[derive(Args)]
 pub struct StartArgs {
@@ -448,20 +449,24 @@ struct OrphanedActiveRun {
     sandbox_id: SandboxId,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct OrphanedActiveRunState {
+    sandbox_id: SandboxId,
+    absent_scans: u8,
+}
+
 /// Claimed runs whose outer task is gone but whose VM ownership is uncertain.
 #[derive(Clone)]
 struct OrphanedActiveRuns {
-    inner: Arc<tokio::sync::Mutex<BTreeMap<RunId, SandboxId>>>,
+    inner: Arc<tokio::sync::Mutex<BTreeMap<RunId, OrphanedActiveRunState>>>,
     len: Arc<std::sync::atomic::AtomicUsize>,
-    notify: Arc<tokio::sync::Notify>,
 }
 
 impl OrphanedActiveRuns {
-    fn new(notify: Arc<tokio::sync::Notify>) -> Self {
+    fn new() -> Self {
         Self {
             inner: Arc::new(tokio::sync::Mutex::new(BTreeMap::new())),
             len: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            notify,
         }
     }
 
@@ -470,21 +475,49 @@ impl OrphanedActiveRuns {
     }
 
     async fn insert(&self, run_id: RunId, sandbox_id: SandboxId) {
+        let state = OrphanedActiveRunState {
+            sandbox_id,
+            absent_scans: 0,
+        };
         let mut runs = self.inner.lock().await;
-        if runs.insert(run_id, sandbox_id).is_none() {
-            self.len.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        match runs.entry(run_id) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(state);
+                self.len.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                entry.insert(state);
+            }
         }
-        drop(runs);
-        self.notify.notify_one();
     }
 
     async fn remove_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) {
         let mut runs = self.inner.lock().await;
-        let removed = matches!(runs.get(&run_id), Some(current) if *current == sandbox_id);
+        let removed =
+            matches!(runs.get(&run_id), Some(current) if current.sandbox_id == sandbox_id);
         if removed {
             runs.remove(&run_id);
             self.len.fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
         }
+    }
+
+    async fn reset_absent_scans_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) {
+        let mut runs = self.inner.lock().await;
+        if let Some(current) = runs.get_mut(&run_id)
+            && current.sandbox_id == sandbox_id
+        {
+            current.absent_scans = 0;
+        }
+    }
+
+    async fn mark_absent_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) -> Option<u8> {
+        let mut runs = self.inner.lock().await;
+        let current = runs.get_mut(&run_id)?;
+        if current.sandbox_id != sandbox_id {
+            return None;
+        }
+        current.absent_scans = current.absent_scans.saturating_add(1);
+        Some(current.absent_scans)
     }
 
     async fn snapshot(&self) -> Vec<OrphanedActiveRun> {
@@ -492,7 +525,10 @@ impl OrphanedActiveRuns {
             .lock()
             .await
             .iter()
-            .map(|(&run_id, &sandbox_id)| OrphanedActiveRun { run_id, sandbox_id })
+            .map(|(&run_id, state)| OrphanedActiveRun {
+                run_id,
+                sandbox_id: state.sandbox_id,
+            })
             .collect()
     }
 
@@ -634,8 +670,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // immediate heartbeat after parking a VM, so the server learns about the
     // new heldSession without waiting for the next 10-second tick.
     let park_notify = Arc::new(tokio::sync::Notify::new());
-    let orphan_reap_notify = Arc::new(tokio::sync::Notify::new());
-    let orphaned_active_runs = OrphanedActiveRuns::new(Arc::clone(&orphan_reap_notify));
+    let orphaned_active_runs = OrphanedActiveRuns::new();
     let mut orphan_reap_tick = tokio::time::interval_at(
         tokio::time::Instant::now() + Duration::from_secs(10),
         Duration::from_secs(10),
@@ -782,15 +817,22 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             result = jobs.join_next(), if !jobs.is_empty() => {
                 handle_job_result(result, &cancel_tokens).await;
                 if !orphaned_active_runs.is_empty() {
-                    reap_orphaned_active_runs(&orphaned_active_runs, &idle_pool, &status).await;
+                    reap_orphaned_active_runs(
+                        &orphaned_active_runs,
+                        &idle_pool,
+                        &status,
+                        OrphanReapMode::Immediate,
+                    ).await;
                 }
             }
             // Reconcile active runs left visible after an outer job-task panic.
-            _ = orphan_reap_notify.notified(), if !orphaned_active_runs.is_empty() => {
-                reap_orphaned_active_runs(&orphaned_active_runs, &idle_pool, &status).await;
-            }
             _ = orphan_reap_tick.tick(), if !orphaned_active_runs.is_empty() => {
-                reap_orphaned_active_runs(&orphaned_active_runs, &idle_pool, &status).await;
+                reap_orphaned_active_runs(
+                    &orphaned_active_runs,
+                    &idle_pool,
+                    &status,
+                    OrphanReapMode::ConfirmAbsent,
+                ).await;
             }
             // Reap completed destroy tasks
             Some(result) = destroy_tasks.join_next(), if !destroy_tasks.is_empty() => {
@@ -885,7 +927,12 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 result = jobs.join_next() => {
                     handle_job_result(result, &cancel_tokens).await;
                     if !orphaned_active_runs.is_empty() {
-                        reap_orphaned_active_runs(&orphaned_active_runs, &idle_pool, &status).await;
+                        reap_orphaned_active_runs(
+                            &orphaned_active_runs,
+                            &idle_pool,
+                            &status,
+                            OrphanReapMode::Immediate,
+                        ).await;
                     }
                 }
                 Some(result) = destroy_tasks.join_next() => {
@@ -1857,10 +1904,20 @@ async fn cleanup_panicked_job(
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OrphanReapMode {
+    /// Fast path after a job task is reaped. Only reconciles ownership that is
+    /// already proven by in-memory runner state.
+    Immediate,
+    /// Periodic path allowed to advance `/proc` absence confirmation.
+    ConfirmAbsent,
+}
+
 async fn reap_orphaned_active_runs(
     orphaned_active_runs: &OrphanedActiveRuns,
     idle_pool: &SharedIdlePool,
     status: &StatusTracker,
+    mode: OrphanReapMode,
 ) {
     let records = orphaned_active_runs.snapshot().await;
     if records.is_empty() {
@@ -1904,6 +1961,10 @@ async fn reap_orphaned_active_runs(
         return;
     }
 
+    if mode == OrphanReapMode::Immediate {
+        return;
+    }
+
     let discovered = process::discover_all().await;
     reap_orphaned_active_runs_with_firecrackers(
         orphaned_active_runs,
@@ -1920,13 +1981,47 @@ async fn reap_orphaned_active_runs_with_firecrackers(
     records: Vec<OrphanedActiveRun>,
     firecrackers: &[process::FirecrackerProcessInfo],
 ) {
+    let discovery_incomplete =
+        process::firecracker_discovery_has_unresolved_sandbox_id(firecrackers);
     for record in records {
         let sandbox_id = record.sandbox_id.to_string();
         if process::firecracker_process_exists_for_sandbox_id(firecrackers, &sandbox_id) {
+            orphaned_active_runs
+                .reset_absent_scans_if_matching(record.run_id, record.sandbox_id)
+                .await;
             warn!(
                 run_id = %record.run_id,
                 sandbox_id = %record.sandbox_id,
                 "orphaned active run still has a live non-idle Firecracker process; keeping active status visible"
+            );
+            continue;
+        }
+
+        if discovery_incomplete {
+            orphaned_active_runs
+                .reset_absent_scans_if_matching(record.run_id, record.sandbox_id)
+                .await;
+            warn!(
+                run_id = %record.run_id,
+                sandbox_id = %record.sandbox_id,
+                "Firecracker discovery was incomplete; keeping orphaned active run visible"
+            );
+            continue;
+        }
+
+        let Some(absent_scans) = orphaned_active_runs
+            .mark_absent_if_matching(record.run_id, record.sandbox_id)
+            .await
+        else {
+            continue;
+        };
+        if absent_scans < ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE {
+            warn!(
+                run_id = %record.run_id,
+                sandbox_id = %record.sandbox_id,
+                absent_scans,
+                required_absent_scans = ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+                "orphaned active run Firecracker absent; waiting for confirmation before removing active status"
             );
             continue;
         }
@@ -1938,6 +2033,7 @@ async fn reap_orphaned_active_runs_with_firecrackers(
         info!(
             run_id = %record.run_id,
             sandbox_id = %record.sandbox_id,
+            absent_scans,
             "orphaned active run removed after Firecracker process was absent"
         );
     }
@@ -2402,7 +2498,7 @@ mod tests {
             })));
         let tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
             Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-        let orphans = OrphanedActiveRuns::new(Arc::new(tokio::sync::Notify::new()));
+        let orphans = OrphanedActiveRuns::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
@@ -2438,7 +2534,7 @@ mod tests {
             })));
         let tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
             Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-        let orphans = OrphanedActiveRuns::new(Arc::new(tokio::sync::Notify::new()));
+        let orphans = OrphanedActiveRuns::new();
         let cleanup_state = RunCleanupState::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
@@ -2476,7 +2572,7 @@ mod tests {
             })));
         let tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
             Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-        let orphans = OrphanedActiveRuns::new(Arc::new(tokio::sync::Notify::new()));
+        let orphans = OrphanedActiveRuns::new();
         let cleanup_state = RunCleanupState::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
@@ -2528,7 +2624,7 @@ mod tests {
                 default_timeout: Duration::from_secs(300),
                 max_idle: 10,
             })));
-        let orphans = OrphanedActiveRuns::new(Arc::new(tokio::sync::Notify::new()));
+        let orphans = OrphanedActiveRuns::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
@@ -2550,7 +2646,7 @@ mod tests {
         status.add_run(run_id, sandbox_id).await;
         orphans.insert(run_id, sandbox_id).await;
 
-        reap_orphaned_active_runs(&orphans, &idle_pool, &status).await;
+        reap_orphaned_active_runs(&orphans, &idle_pool, &status, OrphanReapMode::Immediate).await;
 
         let (idle_sessions, active_runs) = status_idle_sessions_and_active_runs(&status_path).await;
         assert_eq!(idle_sessions, vec!["sess-idle-owned-reaper"]);
@@ -2559,11 +2655,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn orphan_reaper_removes_active_run_when_firecracker_absent() {
+    async fn orphan_reaper_immediate_mode_does_not_count_absent_scan() {
         let dir = tempfile::tempdir().unwrap();
         let status_path = dir.path().join("status.json");
         let status = StatusTracker::new(status_path.clone(), 4, None, None);
-        let orphans = OrphanedActiveRuns::new(Arc::new(tokio::sync::Notify::new()));
+        let idle_pool: SharedIdlePool =
+            Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
+                default_timeout: Duration::from_secs(300),
+                max_idle: 10,
+            })));
+        let orphans = OrphanedActiveRuns::new();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, sandbox_id).await;
+        orphans.insert(run_id, sandbox_id).await;
+
+        reap_orphaned_active_runs(&orphans, &idle_pool, &status, OrphanReapMode::Immediate).await;
+        reap_orphaned_active_runs(&orphans, &idle_pool, &status, OrphanReapMode::ConfirmAbsent)
+            .await;
+
+        let (_idle_sessions, active_runs) =
+            status_idle_sessions_and_active_runs(&status_path).await;
+        assert_eq!(active_runs, vec![run_id.to_string()]);
+        assert_eq!(orphans.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn orphan_reaper_removes_active_run_after_two_absent_scans() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let orphans = OrphanedActiveRuns::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
@@ -2572,7 +2694,20 @@ mod tests {
         reap_orphaned_active_runs_with_firecrackers(
             &orphans,
             &status,
-            vec![OrphanedActiveRun { run_id, sandbox_id }],
+            orphans.snapshot().await,
+            &[],
+        )
+        .await;
+
+        let (_idle_sessions, active_runs) =
+            status_idle_sessions_and_active_runs(&status_path).await;
+        assert_eq!(active_runs, vec![run_id.to_string()]);
+        assert_eq!(orphans.len().await, 1);
+
+        reap_orphaned_active_runs_with_firecrackers(
+            &orphans,
+            &status,
+            orphans.snapshot().await,
             &[],
         )
         .await;
@@ -2584,11 +2719,65 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn orphan_reaper_defers_when_firecracker_discovery_is_incomplete() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let orphans = OrphanedActiveRuns::new();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, sandbox_id).await;
+        orphans.insert(run_id, sandbox_id).await;
+
+        reap_orphaned_active_runs_with_firecrackers(
+            &orphans,
+            &status,
+            orphans.snapshot().await,
+            &[],
+        )
+        .await;
+        let unresolved_firecracker = process::FirecrackerProcessInfo {
+            pid: 1234,
+            ppid: Some(1),
+            sandbox_id: "pid-1234".to_string(),
+            base_dir: None,
+        };
+        reap_orphaned_active_runs_with_firecrackers(
+            &orphans,
+            &status,
+            orphans.snapshot().await,
+            &[unresolved_firecracker],
+        )
+        .await;
+
+        let (_idle_sessions, active_runs) =
+            status_idle_sessions_and_active_runs(&status_path).await;
+        assert_eq!(active_runs, vec![run_id.to_string()]);
+        assert_eq!(orphans.len().await, 1);
+
+        reap_orphaned_active_runs_with_firecrackers(
+            &orphans,
+            &status,
+            orphans.snapshot().await,
+            &[],
+        )
+        .await;
+        let (_idle_sessions, active_runs) =
+            status_idle_sessions_and_active_runs(&status_path).await;
+        assert_eq!(
+            active_runs,
+            vec![run_id.to_string()],
+            "incomplete discovery should reset absent confirmation"
+        );
+        assert_eq!(orphans.len().await, 1);
+    }
+
+    #[tokio::test]
     async fn orphan_reaper_preserves_active_run_when_firecracker_live() {
         let dir = tempfile::tempdir().unwrap();
         let status_path = dir.path().join("status.json");
         let status = StatusTracker::new(status_path.clone(), 4, None, None);
-        let orphans = OrphanedActiveRuns::new(Arc::new(tokio::sync::Notify::new()));
+        let orphans = OrphanedActiveRuns::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
@@ -2603,7 +2792,7 @@ mod tests {
         reap_orphaned_active_runs_with_firecrackers(
             &orphans,
             &status,
-            vec![OrphanedActiveRun { run_id, sandbox_id }],
+            orphans.snapshot().await,
             &[firecracker],
         )
         .await;

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -372,6 +372,7 @@ pub async fn run_start(
         kmsg_handle,
         dns_handle,
         signal_source: SignalSource::Real(signals),
+        orphan_reap_process_discovery: None,
         #[cfg(test)]
         outer_job_panic: None,
     };
@@ -404,6 +405,9 @@ struct RunConfig {
     min_memory_mb: u32,
     kmsg_handle: kmsg_log::KmsgHandle,
     dns_handle: dns::DnsProxy,
+    /// Deterministic process snapshot for orphan-reaper tests. Production leaves
+    /// this unset and scans `/proc`.
+    orphan_reap_process_discovery: Option<OrphanReapProcessDiscovery>,
     /// How the run's mode channel is driven. Production supplies the signal
     /// streams registered at the top of `run_start`; tests supply a
     /// pre-built `SignalController` so they can drive mode transitions
@@ -538,6 +542,12 @@ impl OrphanedActiveRuns {
     }
 }
 
+#[derive(Clone)]
+struct OrphanReapProcessDiscovery {
+    firecrackers: Arc<Vec<process::FirecrackerProcessInfo>>,
+    incomplete_for_current_runner: bool,
+}
+
 async fn run(config: RunConfig) -> RunnerResult<()> {
     let RunConfig {
         id: runner_id,
@@ -562,6 +572,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         min_memory_mb,
         kmsg_handle,
         dns_handle,
+        orphan_reap_process_discovery,
         signal_source,
         #[cfg(test)]
         outer_job_panic,
@@ -822,6 +833,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         &idle_pool,
                         &status,
                         OrphanReapMode::Immediate,
+                        orphan_reap_process_discovery.as_ref(),
                     ).await;
                 }
             }
@@ -832,6 +844,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     &idle_pool,
                     &status,
                     OrphanReapMode::ConfirmAbsent,
+                    orphan_reap_process_discovery.as_ref(),
                 ).await;
             }
             // Reap completed destroy tasks
@@ -932,6 +945,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                             &idle_pool,
                             &status,
                             OrphanReapMode::Immediate,
+                            orphan_reap_process_discovery.as_ref(),
                         ).await;
                     }
                 }
@@ -950,6 +964,16 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 () = sleep_until_retry(&mitm_retry.restart_at) => {}
             }
         }
+    }
+    if !orphaned_active_runs.is_empty() {
+        reap_orphaned_active_runs(
+            &orphaned_active_runs,
+            &idle_pool,
+            &status,
+            OrphanReapMode::ShutdownFinal,
+            orphan_reap_process_discovery.as_ref(),
+        )
+        .await;
     }
     // Wait for any in-flight destroy tasks (from cleanup tick, profile
     // mismatch eviction, etc.) so their factory Arcs are dropped before
@@ -1911,6 +1935,9 @@ enum OrphanReapMode {
     Immediate,
     /// Periodic path allowed to advance `/proc` absence confirmation.
     ConfirmAbsent,
+    /// Shutdown path: no future periodic tick is guaranteed, so a single
+    /// conclusive absent scan is enough to clear stale active status.
+    ShutdownFinal,
 }
 
 async fn reap_orphaned_active_runs(
@@ -1918,6 +1945,7 @@ async fn reap_orphaned_active_runs(
     idle_pool: &SharedIdlePool,
     status: &StatusTracker,
     mode: OrphanReapMode,
+    process_discovery_override: Option<&OrphanReapProcessDiscovery>,
 ) {
     let records = orphaned_active_runs.snapshot().await;
     if records.is_empty() {
@@ -1965,15 +1993,39 @@ async fn reap_orphaned_active_runs(
         return;
     }
 
-    let discovered = process::discover_all().await;
+    let discovered;
+    let (firecrackers, discovery_incomplete_for_current_runner) =
+        if let Some(discovery) = process_discovery_override {
+            (
+                discovery.firecrackers.as_slice(),
+                discovery.incomplete_for_current_runner,
+            )
+        } else {
+            discovered = process::discover_all().await;
+            (
+                discovered.firecrackers.as_slice(),
+                firecracker_discovery_incomplete_for_current_runner(&discovered.firecrackers).await,
+            )
+        };
     reap_orphaned_active_runs_with_firecrackers(
         orphaned_active_runs,
         status,
         non_idle_records,
-        &discovered.firecrackers,
-        firecracker_discovery_incomplete_for_current_runner(&discovered.firecrackers).await,
+        firecrackers,
+        discovery_incomplete_for_current_runner,
+        mode.absent_scans_before_remove(),
     )
     .await;
+}
+
+impl OrphanReapMode {
+    fn absent_scans_before_remove(self) -> u8 {
+        match self {
+            Self::Immediate => ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            Self::ConfirmAbsent => ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+            Self::ShutdownFinal => 1,
+        }
+    }
 }
 
 async fn firecracker_discovery_incomplete_for_current_runner(
@@ -1998,6 +2050,7 @@ async fn reap_orphaned_active_runs_with_firecrackers(
     records: Vec<OrphanedActiveRun>,
     firecrackers: &[process::FirecrackerProcessInfo],
     discovery_incomplete_for_current_runner: bool,
+    absent_scans_before_remove: u8,
 ) {
     for record in records {
         let sandbox_id = record.sandbox_id.to_string();
@@ -2028,12 +2081,12 @@ async fn reap_orphaned_active_runs_with_firecrackers(
         else {
             continue;
         };
-        if absent_scans < ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE {
+        if absent_scans < absent_scans_before_remove {
             warn!(
                 run_id = %record.run_id,
                 sandbox_id = %record.sandbox_id,
                 absent_scans,
-                required_absent_scans = ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+                required_absent_scans = absent_scans_before_remove,
                 "orphaned active run Firecracker absent; waiting for confirmation before removing active status"
             );
             continue;
@@ -2659,7 +2712,14 @@ mod tests {
         status.add_run(run_id, sandbox_id).await;
         orphans.insert(run_id, sandbox_id).await;
 
-        reap_orphaned_active_runs(&orphans, &idle_pool, &status, OrphanReapMode::Immediate).await;
+        reap_orphaned_active_runs(
+            &orphans,
+            &idle_pool,
+            &status,
+            OrphanReapMode::Immediate,
+            None,
+        )
+        .await;
 
         let (idle_sessions, active_runs) = status_idle_sessions_and_active_runs(&status_path).await;
         assert_eq!(idle_sessions, vec!["sess-idle-owned-reaper"]);
@@ -2683,9 +2743,22 @@ mod tests {
         status.add_run(run_id, sandbox_id).await;
         orphans.insert(run_id, sandbox_id).await;
 
-        reap_orphaned_active_runs(&orphans, &idle_pool, &status, OrphanReapMode::Immediate).await;
-        reap_orphaned_active_runs(&orphans, &idle_pool, &status, OrphanReapMode::ConfirmAbsent)
-            .await;
+        reap_orphaned_active_runs(
+            &orphans,
+            &idle_pool,
+            &status,
+            OrphanReapMode::Immediate,
+            None,
+        )
+        .await;
+        reap_orphaned_active_runs(
+            &orphans,
+            &idle_pool,
+            &status,
+            OrphanReapMode::ConfirmAbsent,
+            None,
+        )
+        .await;
 
         let (_idle_sessions, active_runs) =
             status_idle_sessions_and_active_runs(&status_path).await;
@@ -2710,6 +2783,7 @@ mod tests {
             orphans.snapshot().await,
             &[],
             false,
+            ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
         )
         .await;
 
@@ -2724,6 +2798,34 @@ mod tests {
             orphans.snapshot().await,
             &[],
             false,
+            ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
+        )
+        .await;
+
+        let (_idle_sessions, active_runs) =
+            status_idle_sessions_and_active_runs(&status_path).await;
+        assert!(active_runs.is_empty());
+        assert_eq!(orphans.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn orphan_reaper_shutdown_final_removes_active_run_after_one_absent_scan() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let orphans = OrphanedActiveRuns::new();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, sandbox_id).await;
+        orphans.insert(run_id, sandbox_id).await;
+
+        reap_orphaned_active_runs_with_firecrackers(
+            &orphans,
+            &status,
+            orphans.snapshot().await,
+            &[],
+            false,
+            OrphanReapMode::ShutdownFinal.absent_scans_before_remove(),
         )
         .await;
 
@@ -2750,6 +2852,7 @@ mod tests {
             orphans.snapshot().await,
             &[],
             false,
+            ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
         )
         .await;
         let unresolved_firecracker = process::FirecrackerProcessInfo {
@@ -2764,6 +2867,7 @@ mod tests {
             orphans.snapshot().await,
             &[unresolved_firecracker],
             true,
+            ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
         )
         .await;
 
@@ -2778,6 +2882,7 @@ mod tests {
             orphans.snapshot().await,
             &[],
             false,
+            ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
         )
         .await;
         let (_idle_sessions, active_runs) =
@@ -2812,6 +2917,7 @@ mod tests {
             orphans.snapshot().await,
             &[firecracker],
             false,
+            ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
         )
         .await;
 
@@ -3393,6 +3499,7 @@ mod tests {
             min_memory_mb,
             kmsg_handle: kmsg_log::KmsgHandle::noop(),
             dns_handle: crate::dns::DnsProxy::noop(),
+            orphan_reap_process_discovery: None,
             signal_source: SignalSource::Override(SignalController {
                 mode_rx,
                 lifecycle: lifecycle.clone(),
@@ -5006,8 +5113,17 @@ mod tests {
         expected_active_runs.sort_unstable();
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
-            let (idle_sessions, active_runs) =
-                status_idle_sessions_and_active_runs(status_path).await;
+            let Some((idle_sessions, active_runs)) =
+                status_idle_sessions_and_active_runs_if_exists(status_path).await
+            else {
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "status file {} was not written within {timeout:?}",
+                    status_path.display(),
+                );
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                continue;
+            };
             if idle_sessions == expected_idle_sessions && active_runs == expected_active_runs {
                 return;
             }
@@ -5016,6 +5132,19 @@ mod tests {
                 "status did not reach expected idle={expected_idle_sessions:?} active={expected_active_runs:?} within {timeout:?} (actual idle={idle_sessions:?} active={active_runs:?})",
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    async fn status_idle_sessions_and_active_runs_if_exists(
+        status_path: &std::path::Path,
+    ) -> Option<(Vec<String>, Vec<String>)> {
+        match tokio::fs::try_exists(status_path).await {
+            Ok(true) => Some(status_idle_sessions_and_active_runs(status_path).await),
+            Ok(false) => None,
+            Err(err) => panic!(
+                "failed to check status file {}: {err}",
+                status_path.display()
+            ),
         }
     }
 
@@ -6487,6 +6616,50 @@ mod tests {
         );
 
         shutdown(&env, run_handle).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn outer_job_panic_active_unknown_reconciles_on_shutdown_final_scan() {
+        let (mut config, env) = mock_run_config_with_overrides(
+            test_profiles(),
+            8,
+            16384,
+            4,
+            Arc::new(sandbox_mock::MockSandboxOverrides::new()),
+        );
+        config.outer_job_panic = Some(OuterJobPanicPoint::ActiveOrUnknown);
+        config.orphan_reap_process_discovery = Some(OrphanReapProcessDiscovery {
+            firecrackers: Arc::new(Vec::new()),
+            incomplete_for_current_runner: false,
+        });
+        let cancel_tokens = Arc::clone(&config.cancel_tokens);
+        let status_path = env._temp_dir.path().join("status.json");
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = RunId::new_v4();
+        push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+
+        wait_cancel_token_removed(&cancel_tokens, run_id, Duration::from_secs(5)).await;
+        wait_status_idle_sessions_and_active_runs(
+            &status_path,
+            &[],
+            &[run_id.to_string()],
+            Duration::from_secs(5),
+        )
+        .await;
+
+        shutdown(&env, run_handle).await;
+        wait_status_idle_sessions_and_active_runs(&status_path, &[], &[], Duration::from_secs(5))
+            .await;
+        assert!(
+            !env.handle
+                .completions
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|completion| completion.run_id == run_id),
+            "outer job panic must not synthesize provider completion"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -273,6 +273,15 @@ pub struct IdlePoolSnapshot {
     pub idle_vms: Vec<IdleVm>,
 }
 
+/// Result of an explicit sandbox destroy attempt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DestroyOutcome {
+    /// `SandboxFactory::destroy` returned normally and no stop panic was observed.
+    Completed,
+    /// Cleanup fell back to panic/drop behavior, so process teardown is not proven.
+    Uncertain,
+}
+
 /// Reusable sandbox state handed to the executor after a successful unpark.
 ///
 /// The budget lease is intentionally not part of this payload. The outer job
@@ -320,12 +329,16 @@ pub(crate) struct IdleDestroyPayload {
 
 impl IdleDestroyPayload {
     /// Stop the sandbox and destroy it via its factory.
-    pub(crate) async fn stop_and_destroy(self) {
+    pub(crate) async fn stop_and_destroy(self) -> DestroyOutcome {
         let mut sandbox = self.sandbox;
+        let mut uncertain = false;
         match AssertUnwindSafe(sandbox.stop()).catch_unwind().await {
             Ok(Ok(())) => {}
             Ok(Err(e)) => tracing::warn!(error = %e, "failed to stop idle sandbox"),
-            Err(_) => tracing::warn!("idle sandbox stop panicked"),
+            Err(_) => {
+                tracing::warn!("idle sandbox stop panicked");
+                uncertain = true;
+            }
         }
         if AssertUnwindSafe(self.factory.destroy(sandbox))
             .catch_unwind()
@@ -333,6 +346,12 @@ impl IdleDestroyPayload {
             .is_err()
         {
             tracing::warn!("idle sandbox destroy panicked");
+            uncertain = true;
+        }
+        if uncertain {
+            DestroyOutcome::Uncertain
+        } else {
+            DestroyOutcome::Completed
         }
     }
 }
@@ -355,7 +374,7 @@ impl IdleDestroyJob {
             session_id: _,
             profile_name: _,
         } = self;
-        payload.stop_and_destroy().await;
+        let _ = payload.stop_and_destroy().await;
         drop(budget_lease);
     }
 
@@ -624,6 +643,13 @@ impl IdlePool {
             revision: self.revision,
             idle_vms: vms,
         }
+    }
+
+    /// Return true when the idle pool currently owns `sandbox_id`.
+    pub fn contains_sandbox_id(&self, sandbox_id: SandboxId) -> bool {
+        self.entries
+            .values()
+            .any(|entry| entry.sandbox_id == sandbox_id)
     }
 
     /// Return a sorted-by-session_id snapshot of the idle pool suitable
@@ -937,6 +963,20 @@ mod tests {
     fn held_snapshot_empty_pool() {
         let pool = IdlePool::new(pool_config(0));
         assert!(pool.held_snapshot().is_empty());
+    }
+
+    #[test]
+    fn contains_sandbox_id_tracks_current_idle_ownership() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let candidate = make_candidate_for("s1", 2, 2048);
+        let sandbox_id = candidate.sandbox_id;
+        assert!(!pool.contains_sandbox_id(sandbox_id));
+
+        assert!(matches!(pool.park(candidate), ParkResult::Parked));
+        assert!(pool.contains_sandbox_id(sandbox_id));
+
+        assert!(pool.take("s1").is_some());
+        assert!(!pool.contains_sandbox_id(sandbox_id));
     }
 
     #[test]

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -276,7 +276,8 @@ pub struct IdlePoolSnapshot {
 /// Result of an explicit sandbox destroy attempt.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum DestroyOutcome {
-    /// `SandboxFactory::destroy` returned normally and no stop panic was observed.
+    /// `SandboxFactory::destroy` returned normally and no panic was observed.
+    /// A non-panic `stop()` error is logged, then destroy still proves teardown.
     Completed,
     /// Cleanup fell back to panic/drop behavior, so process teardown is not proven.
     Uncertain,

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -315,14 +315,25 @@ pub fn firecracker_process_exists_for_sandbox_id(
         .any(|process| process.sandbox_id == sandbox_id)
 }
 
-/// Return true when at least one Firecracker process was found but its
-/// workspace-derived sandbox ID could not be resolved from `/proc/{pid}/cwd`.
-pub fn firecracker_discovery_has_unresolved_sandbox_id(
-    firecrackers: &[FirecrackerProcessInfo],
-) -> bool {
-    firecrackers
-        .iter()
-        .any(|process| process.base_dir.is_none())
+/// Walk the ppid chain from `pid` upward to determine whether it descends from
+/// one of `ancestor_pids`.
+///
+/// Returns `None` when the chain cannot be read, so callers can choose whether
+/// to treat an unreadable process tree as conservative or absent.
+pub async fn process_has_ancestor(pid: u32, ancestor_pids: &[u32]) -> Option<bool> {
+    let mut current = pid;
+    // Max depth prevents infinite loops from circular pid references.
+    for _ in 0..16 {
+        let ppid = read_ppid(current).await?;
+        if ancestor_pids.contains(&ppid) {
+            return Some(true);
+        }
+        if ppid <= 1 {
+            return Some(false);
+        }
+        current = ppid;
+    }
+    Some(false)
 }
 
 // ---------------------------------------------------------------------------
@@ -640,29 +651,6 @@ mod tests {
         assert!(!firecracker_process_exists_for_sandbox_id(
             &processes, "sandbox"
         ));
-    }
-
-    #[test]
-    fn firecracker_discovery_has_unresolved_sandbox_id_checks_base_dir() {
-        let resolved = FirecrackerProcessInfo {
-            pid: 42,
-            ppid: Some(1),
-            sandbox_id: "sandbox-a".to_string(),
-            base_dir: Some(PathBuf::from("/var/lib/vm0-runner")),
-        };
-        let unresolved = FirecrackerProcessInfo {
-            pid: 43,
-            ppid: Some(1),
-            sandbox_id: "pid-43".to_string(),
-            base_dir: None,
-        };
-
-        assert!(!firecracker_discovery_has_unresolved_sandbox_id(&[
-            resolved
-        ]));
-        assert!(firecracker_discovery_has_unresolved_sandbox_id(&[
-            unresolved
-        ]));
     }
 
     // -- Mitmdump parser tests --

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -315,6 +315,16 @@ pub fn firecracker_process_exists_for_sandbox_id(
         .any(|process| process.sandbox_id == sandbox_id)
 }
 
+/// Return true when at least one Firecracker process was found but its
+/// workspace-derived sandbox ID could not be resolved from `/proc/{pid}/cwd`.
+pub fn firecracker_discovery_has_unresolved_sandbox_id(
+    firecrackers: &[FirecrackerProcessInfo],
+) -> bool {
+    firecrackers
+        .iter()
+        .any(|process| process.base_dir.is_none())
+}
+
 // ---------------------------------------------------------------------------
 // Orphan detection
 // ---------------------------------------------------------------------------
@@ -630,6 +640,29 @@ mod tests {
         assert!(!firecracker_process_exists_for_sandbox_id(
             &processes, "sandbox"
         ));
+    }
+
+    #[test]
+    fn firecracker_discovery_has_unresolved_sandbox_id_checks_base_dir() {
+        let resolved = FirecrackerProcessInfo {
+            pid: 42,
+            ppid: Some(1),
+            sandbox_id: "sandbox-a".to_string(),
+            base_dir: Some(PathBuf::from("/var/lib/vm0-runner")),
+        };
+        let unresolved = FirecrackerProcessInfo {
+            pid: 43,
+            ppid: Some(1),
+            sandbox_id: "pid-43".to_string(),
+            base_dir: None,
+        };
+
+        assert!(!firecracker_discovery_has_unresolved_sandbox_id(&[
+            resolved
+        ]));
+        assert!(firecracker_discovery_has_unresolved_sandbox_id(&[
+            unresolved
+        ]));
     }
 
     // -- Mitmdump parser tests --

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -305,6 +305,16 @@ pub async fn discover_all() -> DiscoveredProcesses {
     }
 }
 
+/// Return true when the discovered Firecracker list contains `sandbox_id`.
+pub fn firecracker_process_exists_for_sandbox_id(
+    firecrackers: &[FirecrackerProcessInfo],
+    sandbox_id: &str,
+) -> bool {
+    firecrackers
+        .iter()
+        .any(|process| process.sandbox_id == sandbox_id)
+}
+
 // ---------------------------------------------------------------------------
 // Orphan detection
 // ---------------------------------------------------------------------------
@@ -602,6 +612,24 @@ mod tests {
     #[test]
     fn is_firecracker_empty() {
         assert!(!is_firecracker_cmdline(&[]));
+    }
+
+    #[test]
+    fn firecracker_process_exists_for_sandbox_id_matches_exact_id() {
+        let processes = vec![FirecrackerProcessInfo {
+            pid: 42,
+            ppid: Some(1),
+            sandbox_id: "sandbox-a".to_string(),
+            base_dir: None,
+        }];
+
+        assert!(firecracker_process_exists_for_sandbox_id(
+            &processes,
+            "sandbox-a"
+        ));
+        assert!(!firecracker_process_exists_for_sandbox_id(
+            &processes, "sandbox"
+        ));
     }
 
     // -- Mitmdump parser tests --

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -167,12 +167,19 @@ impl StatusTracker {
         applied
     }
 
-    /// Drop an active run from the status file. Silently succeeds if
-    /// `run_id` was not present.
-    pub async fn remove_run(&self, run_id: RunId) {
+    /// Drop an active run only if it still points at the expected sandbox.
+    ///
+    /// Returns `false` if another task already removed the run or reused the
+    /// `run_id` with a different sandbox.
+    pub async fn remove_run_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) -> bool {
         let mut state = self.state.lock().await;
-        state.active_runs.remove(&run_id);
-        self.write_status(&state).await;
+        let removed =
+            matches!(state.active_runs.get(&run_id), Some(current) if *current == sandbox_id);
+        if removed {
+            state.active_runs.remove(&run_id);
+            self.write_status(&state).await;
+        }
+        removed
     }
 
     /// Replace the idle VM list in the status file with `idle_vms`.
@@ -333,13 +340,45 @@ mod tests {
         let status = read_status(&path);
         assert_eq!(status["active_runs"].as_array().unwrap().len(), 2);
 
-        tracker.remove_run(run1).await;
+        assert!(tracker.remove_run_if_matching(run1, sb1).await);
 
         let status = read_status(&path);
         let runs = status["active_runs"].as_array().unwrap();
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0]["run_id"], run2.to_string());
         assert_eq!(runs[0]["sandbox_id"], sb2.to_string());
+    }
+
+    #[tokio::test]
+    async fn remove_run_if_matching_preserves_replaced_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let tracker = StatusTracker::new(path.clone(), 4, None, None);
+
+        let run_id = RunId::new_v4();
+        let old_sandbox_id = SandboxId::new_v4();
+        let current_sandbox_id = SandboxId::new_v4();
+
+        tracker.write_initial().await;
+        tracker.add_run(run_id, old_sandbox_id).await;
+        tracker.add_run(run_id, current_sandbox_id).await;
+
+        assert!(!tracker.remove_run_if_matching(run_id, old_sandbox_id).await);
+
+        let status = read_status(&path);
+        let runs = status["active_runs"].as_array().unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0]["run_id"], run_id.to_string());
+        assert_eq!(runs[0]["sandbox_id"], current_sandbox_id.to_string());
+
+        assert!(
+            tracker
+                .remove_run_if_matching(run_id, current_sandbox_id)
+                .await
+        );
+
+        let status = read_status(&path);
+        assert!(status["active_runs"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -86,8 +86,8 @@ pub struct StatusTracker {
 struct MutableState {
     mode: RunnerMode,
     /// Map of run_id → sandbox_id for all active runs. Keyed by run_id so
-    /// `remove_run(run_id)` stays O(log n); the paired `sandbox_id` is the
-    /// join key used by doctor and kill to find the FC process.
+    /// conditional active-run removal stays O(log n); the paired `sandbox_id`
+    /// is the join key used by doctor and kill to find the FC process.
     ///
     /// BTreeMap (not HashMap) for deterministic iteration order — status.json
     /// output should be stable across runs for readability and diffing.

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -61,6 +61,9 @@ impl LeakCleaner {
         device_pool: std::sync::Arc<tokio::sync::Mutex<nbd_cow::pool::DevicePool>>,
         netns_pool: std::sync::Arc<tokio::sync::Mutex<NetnsPool>>,
     ) -> Self {
+        // Drop cannot await, and losing a leak report can strand host resources.
+        // Keep this unbounded: reports only come from exceptional cleanup paths,
+        // with runner GC as the final backstop if the cleaner stalls.
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
         let handle = tokio::spawn(drain_leaked_resources(

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -1658,11 +1658,14 @@ mod tests {
     fn leaked_resources_unbounded_send_accepts_burst() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
 
-        tx.send(test_leaked_resource("first", 0)).unwrap();
-        tx.send(test_leaked_resource("second", 1)).unwrap();
+        for index in 0..64 {
+            tx.send(test_leaked_resource(&format!("leaked-{index}"), index))
+                .unwrap();
+        }
 
-        assert_eq!(rx.try_recv().unwrap().sandbox_id, "first");
-        assert_eq!(rx.try_recv().unwrap().sandbox_id, "second");
+        for index in 0..64 {
+            assert_eq!(rx.try_recv().unwrap().sandbox_id, format!("leaked-{index}"));
+        }
     }
 
     #[tokio::test]
@@ -1671,8 +1674,10 @@ mod tests {
         let live_sender_clone = tx.clone();
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
 
-        tx.send(test_leaked_resource("first", 0)).unwrap();
-        tx.send(test_leaked_resource("second", 1)).unwrap();
+        for index in 0..64 {
+            tx.send(test_leaked_resource(&format!("leaked-{index}"), index))
+                .unwrap();
+        }
 
         let cleaned = Arc::new(tokio::sync::Mutex::new(Vec::new()));
         let cleaned_clone = Arc::clone(&cleaned);
@@ -1693,10 +1698,8 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert_eq!(
-            *cleaned.lock().await,
-            vec!["first".to_string(), "second".to_string()]
-        );
+        let expected: Vec<String> = (0..64).map(|index| format!("leaked-{index}")).collect();
+        assert_eq!(*cleaned.lock().await, expected);
         assert!(matches!(
             live_sender_clone.send(test_leaked_resource("late", 2)),
             Err(tokio::sync::mpsc::error::SendError(_))

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -24,11 +24,6 @@ pub(crate) const DESTROY_RETRIES: u32 = 5;
 /// Delay between COW device destroy retries.
 pub(crate) const DESTROY_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
 
-/// Channel capacity for leaked sandbox resource cleanup.
-/// 32 is generous — the channel only receives messages on exceptional paths
-/// such as executor panics or cancelled create transactions.
-const LEAK_CHANNEL_CAPACITY: usize = 32;
-
 /// Maximum time to wait for leaked-resource cleanup during normal shutdown.
 ///
 /// Shutdown is the graceful path, so already-queued leak reports should drain
@@ -56,7 +51,7 @@ pub(crate) struct LeakedResources {
 /// already-queued resources, and finish. `Drop` cannot await, so it aborts as a
 /// best-effort fallback.
 struct LeakCleaner {
-    tx: Option<tokio::sync::mpsc::Sender<LeakedResources>>,
+    tx: Option<tokio::sync::mpsc::UnboundedSender<LeakedResources>>,
     shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
     handle: Option<tokio::task::JoinHandle<()>>,
 }
@@ -66,7 +61,7 @@ impl LeakCleaner {
         device_pool: std::sync::Arc<tokio::sync::Mutex<nbd_cow::pool::DevicePool>>,
         netns_pool: std::sync::Arc<tokio::sync::Mutex<NetnsPool>>,
     ) -> Self {
-        let (tx, rx) = tokio::sync::mpsc::channel(LEAK_CHANNEL_CAPACITY);
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
         let handle = tokio::spawn(drain_leaked_resources(
             rx,
@@ -81,7 +76,7 @@ impl LeakCleaner {
         }
     }
 
-    fn sender(&self) -> Option<tokio::sync::mpsc::Sender<LeakedResources>> {
+    fn sender(&self) -> Option<tokio::sync::mpsc::UnboundedSender<LeakedResources>> {
         self.tx.clone()
     }
 
@@ -203,7 +198,7 @@ struct SandboxCreateTransaction {
     sock_dir: Option<PathBuf>,
     network: Option<PooledNetns>,
     cow_device: Option<NbdCowDevice>,
-    leak_tx: Option<tokio::sync::mpsc::Sender<LeakedResources>>,
+    leak_tx: Option<tokio::sync::mpsc::UnboundedSender<LeakedResources>>,
 }
 
 impl SandboxCreateTransaction {
@@ -214,7 +209,7 @@ impl SandboxCreateTransaction {
 
     fn new_with_leak_tx(
         id: String,
-        leak_tx: Option<tokio::sync::mpsc::Sender<LeakedResources>>,
+        leak_tx: Option<tokio::sync::mpsc::UnboundedSender<LeakedResources>>,
     ) -> Self {
         Self {
             id,
@@ -366,7 +361,7 @@ impl SandboxCreateTransaction {
             || self.cow_device.is_some()
     }
 
-    fn try_send_async_leaked_resources(&mut self) -> bool {
+    fn send_async_leaked_resources(&mut self) -> bool {
         if self.network.is_none() && self.cow_device.is_none() {
             return false;
         }
@@ -391,10 +386,9 @@ impl SandboxCreateTransaction {
             workspace,
         };
 
-        match leak_tx.try_send(leaked) {
+        match leak_tx.send(leaked) {
             Ok(()) => true,
-            Err(tokio::sync::mpsc::error::TrySendError::Full(mut leaked))
-            | Err(tokio::sync::mpsc::error::TrySendError::Closed(mut leaked)) => {
+            Err(tokio::sync::mpsc::error::SendError(mut leaked)) => {
                 self.cow_device = leaked.cow_device.take();
                 self.network = leaked.network.take();
                 self.sock_dir = Some(leaked.sock_dir);
@@ -424,7 +418,7 @@ impl Drop for SandboxCreateTransaction {
         if let Some(slot) = self.slot.take() {
             crate::cow_pool::destroy_slot(slot);
         }
-        if self.try_send_async_leaked_resources() {
+        if self.send_async_leaked_resources() {
             return;
         }
         if let Some(sock_dir) = self.sock_dir.take() {
@@ -496,7 +490,7 @@ async fn destroy_cow_device_with_retries(id: &str, cow_device: &mut NbdCowDevice
 /// Background task that receives leaked sandbox resources from `Drop`
 /// impls and releases them asynchronously (pool indices, namespaces, dirs).
 async fn drain_leaked_resources(
-    rx: tokio::sync::mpsc::Receiver<LeakedResources>,
+    rx: tokio::sync::mpsc::UnboundedReceiver<LeakedResources>,
     shutdown_rx: tokio::sync::oneshot::Receiver<()>,
     device_pool: std::sync::Arc<tokio::sync::Mutex<nbd_cow::pool::DevicePool>>,
     netns_pool: std::sync::Arc<tokio::sync::Mutex<NetnsPool>>,
@@ -512,7 +506,7 @@ async fn drain_leaked_resources(
 }
 
 async fn drain_leaked_resources_with_cleanup<C, Fut>(
-    mut rx: tokio::sync::mpsc::Receiver<LeakedResources>,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<LeakedResources>,
     mut shutdown_rx: tokio::sync::oneshot::Receiver<()>,
     mut cleanup: C,
 ) where
@@ -1525,7 +1519,7 @@ mod tests {
         let sock_dir = tmp.path().join("sock");
         tokio::fs::create_dir_all(&workspace).await.unwrap();
         tokio::fs::create_dir_all(&sock_dir).await.unwrap();
-        let (leak_tx, leak_rx) = tokio::sync::mpsc::channel(1);
+        let (leak_tx, leak_rx) = tokio::sync::mpsc::unbounded_channel();
         drop(leak_rx);
 
         let mut tx = SandboxCreateTransaction::new_with_leak_tx("sandbox".into(), Some(leak_tx));
@@ -1540,14 +1534,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_transaction_drop_with_full_leak_channel_falls_back_to_sync_dirs() {
+    async fn create_transaction_drop_does_not_drop_queued_leak_cleanup_work() {
         let tmp = tempfile::tempdir().unwrap();
         let workspace = tmp.path().join("workspace");
         let sock_dir = tmp.path().join("sock");
         tokio::fs::create_dir_all(&workspace).await.unwrap();
         tokio::fs::create_dir_all(&sock_dir).await.unwrap();
-        let (leak_tx, mut leak_rx) = tokio::sync::mpsc::channel(1);
-        leak_tx.try_send(test_leaked_resource("queued", 7)).unwrap();
+        let (leak_tx, mut leak_rx) = tokio::sync::mpsc::unbounded_channel();
+        leak_tx.send(test_leaked_resource("queued", 7)).unwrap();
 
         let mut tx = SandboxCreateTransaction::new_with_leak_tx("sandbox".into(), Some(leak_tx));
         tx.slot_renamed_to(workspace.clone());
@@ -1556,10 +1550,12 @@ mod tests {
 
         drop(tx);
 
-        assert_eq!(leak_rx.try_recv().unwrap().sandbox_id, "queued");
-        assert!(leak_rx.try_recv().is_err());
-        assert!(!workspace.exists());
-        assert!(!sock_dir.exists());
+        assert_eq!(leak_rx.recv().await.unwrap().sandbox_id, "queued");
+        let leaked = leak_rx.recv().await.unwrap();
+        assert_eq!(leaked.sandbox_id, "sandbox");
+        assert_eq!(leaked.network.unwrap().name, "test-ns");
+        assert_eq!(leaked.sock_dir, sock_dir);
+        assert_eq!(leaked.workspace, workspace);
     }
 
     #[tokio::test]
@@ -1569,7 +1565,7 @@ mod tests {
         let sock_dir = tmp.path().join("sock");
         tokio::fs::create_dir_all(&workspace).await.unwrap();
         tokio::fs::create_dir_all(&sock_dir).await.unwrap();
-        let (leak_tx, mut leak_rx) = tokio::sync::mpsc::channel(1);
+        let (leak_tx, mut leak_rx) = tokio::sync::mpsc::unbounded_channel();
 
         let mut tx = SandboxCreateTransaction::new_with_leak_tx("sandbox".into(), Some(leak_tx));
         tx.slot_renamed_to(workspace.clone());
@@ -1623,7 +1619,7 @@ mod tests {
 
     #[tokio::test]
     async fn leaked_resources_channel_receives_on_send() {
-        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
         tx.send(LeakedResources {
             sandbox_id: "test-sandbox".into(),
@@ -1633,7 +1629,6 @@ mod tests {
             sock_dir: PathBuf::from("/tmp/nonexistent-sock"),
             workspace: PathBuf::from("/tmp/nonexistent-ws"),
         })
-        .await
         .unwrap();
 
         let leaked = rx.recv().await.unwrap();
@@ -1642,8 +1637,8 @@ mod tests {
     }
 
     #[test]
-    fn leaked_resources_try_send_does_not_panic_on_closed_channel() {
-        let (tx, rx) = tokio::sync::mpsc::channel::<LeakedResources>(1);
+    fn leaked_resources_send_does_not_panic_on_closed_channel() {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
         drop(rx);
 
         let resources = LeakedResources {
@@ -1656,29 +1651,28 @@ mod tests {
         };
 
         // Should not panic — just returns Err.
-        assert!(tx.try_send(resources).is_err());
+        assert!(tx.send(resources).is_err());
     }
 
     #[test]
-    fn leaked_resources_try_send_does_not_panic_on_full_channel() {
-        let (tx, _rx) = tokio::sync::mpsc::channel::<LeakedResources>(1);
+    fn leaked_resources_unbounded_send_accepts_burst() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
 
-        // Fill the channel.
-        tx.try_send(test_leaked_resource("first", 0)).unwrap();
+        tx.send(test_leaked_resource("first", 0)).unwrap();
+        tx.send(test_leaked_resource("second", 1)).unwrap();
 
-        // Second send should fail gracefully.
-        let result = tx.try_send(test_leaked_resource("second", 1));
-        assert!(result.is_err());
+        assert_eq!(rx.try_recv().unwrap().sandbox_id, "first");
+        assert_eq!(rx.try_recv().unwrap().sandbox_id, "second");
     }
 
     #[tokio::test]
     async fn drain_leaked_resources_shutdown_closes_receiver_and_drains_buffer() {
-        let (tx, rx) = tokio::sync::mpsc::channel::<LeakedResources>(4);
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
         let live_sender_clone = tx.clone();
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
 
-        tx.send(test_leaked_resource("first", 0)).await.unwrap();
-        tx.send(test_leaked_resource("second", 1)).await.unwrap();
+        tx.send(test_leaked_resource("first", 0)).unwrap();
+        tx.send(test_leaked_resource("second", 1)).unwrap();
 
         let cleaned = Arc::new(tokio::sync::Mutex::new(Vec::new()));
         let cleaned_clone = Arc::clone(&cleaned);
@@ -1704,18 +1698,18 @@ mod tests {
             vec!["first".to_string(), "second".to_string()]
         );
         assert!(matches!(
-            live_sender_clone.try_send(test_leaked_resource("late", 2)),
-            Err(tokio::sync::mpsc::error::TrySendError::Closed(_))
+            live_sender_clone.send(test_leaked_resource("late", 2)),
+            Err(tokio::sync::mpsc::error::SendError(_))
         ));
     }
 
     #[tokio::test]
     async fn drain_leaked_resources_exits_after_sender_close() {
-        let (tx, rx) = tokio::sync::mpsc::channel::<LeakedResources>(4);
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
         let (_shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
 
-        tx.send(test_leaked_resource("first", 0)).await.unwrap();
-        tx.send(test_leaked_resource("second", 1)).await.unwrap();
+        tx.send(test_leaked_resource("first", 0)).unwrap();
+        tx.send(test_leaked_resource("second", 1)).unwrap();
         drop(tx);
 
         let cleaned = Arc::new(tokio::sync::Mutex::new(Vec::new()));
@@ -1736,7 +1730,7 @@ mod tests {
 
     #[tokio::test]
     async fn leak_cleaner_shutdown_signals_drain_with_live_sender_clone() {
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<LeakedResources>(1);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
         let _live_sender_clone = tx.clone();
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
         let drained = Arc::new(AtomicBool::new(false));
@@ -1774,7 +1768,7 @@ mod tests {
             }
         }
 
-        let (tx, _rx) = tokio::sync::mpsc::channel::<LeakedResources>(1);
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
         let (shutdown_tx, _shutdown_rx) = tokio::sync::oneshot::channel();
         let aborted = Arc::new(AtomicBool::new(false));
         let aborted_clone = Arc::clone(&aborted);
@@ -1810,7 +1804,7 @@ mod tests {
             }
         }
 
-        let (tx, _rx) = tokio::sync::mpsc::channel::<LeakedResources>(1);
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
         let (shutdown_tx, _shutdown_rx) = tokio::sync::oneshot::channel();
         let aborted = Arc::new(AtomicBool::new(false));
         let aborted_clone = Arc::clone(&aborted);

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -294,7 +294,7 @@ pub struct FirecrackerSandbox {
     balloon_controller: Option<tokio::task::JoinHandle<()>>,
     /// Sender for leaked resource cleanup. When Drop fires without prior
     /// `factory.destroy()`, pool resources are sent here for async cleanup.
-    leak_tx: Option<tokio::sync::mpsc::Sender<crate::factory::LeakedResources>>,
+    leak_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::factory::LeakedResources>>,
     /// Set to `true` by `factory.destroy()` to suppress Drop-based leak recovery.
     pub(crate) destroyed: bool,
     /// Tracks whether the sandbox is currently in the idle/parked state.
@@ -314,7 +314,7 @@ impl FirecrackerSandbox {
         sock_paths: SockPaths,
         network: PooledNetns,
         cow_device: NbdCowDevice,
-        leak_tx: Option<tokio::sync::mpsc::Sender<crate::factory::LeakedResources>>,
+        leak_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::factory::LeakedResources>>,
     ) -> Self {
         let id = config.id.to_string();
         Self {
@@ -722,10 +722,10 @@ impl Drop for FirecrackerSandbox {
                 sock_dir: self.sock_paths.dir().to_owned(),
                 workspace: self.sandbox_paths.workspace().to_owned(),
             };
-            if tx.try_send(resources).is_err() {
+            if tx.send(resources).is_err() {
                 tracing::warn!(
                     id = %self.id,
-                    "leak cleanup channel full or closed — resources will require runner gc"
+                    "leak cleanup channel closed — resources will require runner gc"
                 );
             }
         }

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -70,6 +70,14 @@ use crate::types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle};
 /// tasks, hence `Send + Sync`. The `Any` bound allows
 /// [`SandboxFactory::destroy()`](crate::SandboxFactory::destroy) to
 /// downcast back to the concrete type for backend-specific cleanup.
+///
+/// # Panic/drop cleanup contract
+/// Production backends must make dropping an active sandbox a best-effort
+/// emergency cleanup path. If runner-side code unwinds before calling
+/// [`SandboxFactory::destroy()`](crate::SandboxFactory::destroy), `Drop`
+/// must not silently leave a VM process and associated host resources alive.
+/// This fallback is only a safety net: callers must not treat drop-triggered
+/// cleanup as proof that explicit destroy completed.
 #[async_trait]
 pub trait Sandbox: Send + Sync + Any {
     // -- identity --


### PR DESCRIPTION
## Summary
- wrap the outer runner job task with panic cleanup that removes cancel tokens and preserves JoinError visibility
- track sandbox cleanup ownership so panic cleanup only removes active status after idle-pool ownership or proven destroy completion
- add an idle-aware orphan active-run reaper for uncertain panic paths, plus backend drop-contract docs

Fixes #11360

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo test --manifest-path crates/Cargo.toml -p sandbox
- git diff --check