### PR TITLE
fix: bind control socket before sandbox running

### DIFF
--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -102,20 +102,49 @@ async fn write_frame(stream: &mut UnixStream, data: &[u8]) -> io::Result<()> {
 /// The server accepts connections on `sock_path`, reads an [`ExecRequest`],
 /// executes it via the shared `VsockHost`, and writes back an [`ExecResponse`].
 ///
-/// Returns a `JoinHandle` that the caller should abort on shutdown.
+/// Returns a `JoinHandle` that the caller should abort on shutdown. Binding
+/// happens before this function returns, so bind failures are reported to the
+/// caller instead of being hidden in the background task.
 pub fn spawn_server(
+    sock_path: PathBuf,
+    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+) -> io::Result<JoinHandle<()>> {
+    Ok(bind_server(sock_path, guest)?.spawn())
+}
+
+/// A control socket server whose listener has already been bound.
+pub struct BoundControlServer {
+    sock_path: PathBuf,
+    listener: UnixListener,
+    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+}
+
+impl BoundControlServer {
+    /// Spawn the accept loop for this pre-bound control socket.
+    pub fn spawn(self) -> JoinHandle<()> {
+        spawn_bound_server(self.listener, self.sock_path, self.guest)
+    }
+}
+
+/// Bind the control socket before spawning the accept loop.
+pub fn bind_server(
+    sock_path: PathBuf,
+    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+) -> io::Result<BoundControlServer> {
+    let listener = UnixListener::bind(&sock_path)?;
+    Ok(BoundControlServer {
+        sock_path,
+        listener,
+        guest,
+    })
+}
+
+fn spawn_bound_server(
+    listener: UnixListener,
     sock_path: PathBuf,
     guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
-        let listener = match UnixListener::bind(&sock_path) {
-            Ok(l) => l,
-            Err(e) => {
-                warn!(path = %sock_path.display(), error = %e, "failed to bind control socket");
-                return;
-            }
-        };
-
         info!(path = %sock_path.display(), "control socket listening");
 
         loop {
@@ -443,10 +472,7 @@ mod tests {
 
         // Server with no guest connected.
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
-        let handle = spawn_server(sock_path.clone(), guest);
-
-        // Give the server a moment to bind.
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        let handle = bind_server(sock_path.clone(), guest).unwrap().spawn();
 
         let request = ExecRequest {
             command: "ps aux".into(),
@@ -466,6 +492,18 @@ mod tests {
         }
 
         handle.abort();
+    }
+
+    #[tokio::test]
+    async fn bind_server_reports_bind_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let _existing = UnixListener::bind(&sock_path).unwrap();
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+
+        let result = bind_server(sock_path, guest);
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -98,7 +98,7 @@ async fn write_frame(stream: &mut UnixStream, data: &[u8]) -> io::Result<()> {
 // -----------------------------------------------------------------------
 
 /// A control socket server whose listener has already been bound.
-pub struct BoundControlServer {
+pub(crate) struct BoundControlServer {
     sock_path: PathBuf,
     listener: UnixListener,
     guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
@@ -106,13 +106,13 @@ pub struct BoundControlServer {
 
 impl BoundControlServer {
     /// Spawn the accept loop for this pre-bound control socket.
-    pub fn spawn(self) -> JoinHandle<()> {
+    pub(crate) fn spawn(self) -> JoinHandle<()> {
         spawn_bound_server(self.listener, self.sock_path, self.guest)
     }
 }
 
 /// Bind the control socket before spawning the accept loop.
-pub fn bind_server(
+pub(crate) fn bind_server(
     sock_path: PathBuf,
     guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
 ) -> io::Result<BoundControlServer> {

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -97,21 +97,6 @@ async fn write_frame(stream: &mut UnixStream, data: &[u8]) -> io::Result<()> {
 // Server
 // -----------------------------------------------------------------------
 
-/// Spawn the control socket server for a running sandbox.
-///
-/// The server accepts connections on `sock_path`, reads an [`ExecRequest`],
-/// executes it via the shared `VsockHost`, and writes back an [`ExecResponse`].
-///
-/// Returns a `JoinHandle` that the caller should abort on shutdown. Binding
-/// happens before this function returns, so bind failures are reported to the
-/// caller instead of being hidden in the background task.
-pub fn spawn_server(
-    sock_path: PathBuf,
-    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
-) -> io::Result<JoinHandle<()>> {
-    Ok(bind_server(sock_path, guest)?.spawn())
-}
-
 /// A control socket server whose listener has already been bound.
 pub struct BoundControlServer {
     sock_path: PathBuf,

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -477,6 +477,7 @@ mod tests {
         }
 
         handle.abort();
+        let _ = handle.await;
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -488,7 +488,10 @@ mod tests {
 
         let result = bind_server(sock_path, guest);
 
-        assert!(result.is_err());
+        let Err(err) = result else {
+            panic!("binding an occupied control socket should fail");
+        };
+        assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -971,11 +971,29 @@ impl Sandbox for FirecrackerSandbox {
 
         *self.guest.lock().await = Some(Arc::new(vsock_guest));
 
+        let control_sock_path = self.sock_paths.control_sock();
+        let control_server =
+            match control::bind_server(control_sock_path.clone(), Arc::clone(&self.guest)) {
+                Ok(server) => server,
+                Err(e) => {
+                    self.guest.lock().await.take();
+                    self.kill_process().await;
+                    return Err(SandboxError::Start {
+                        message: format!(
+                            "control socket bind {}: {e}",
+                            control_sock_path.display()
+                        ),
+                    });
+                }
+            };
+
         // Use CAS to avoid overwriting Stopped if the process crashed between
         // spawn and vsock connect (the process monitor may have already
         // recorded process exit).
         if !self.transition(SandboxState::Created, SandboxState::Running) {
             self.guest.lock().await.take();
+            drop(control_server);
+            let _ = tokio::fs::remove_file(&control_sock_path).await;
             self.kill_process().await;
             return Err(SandboxError::Start {
                 message: "process exited during startup".into(),
@@ -983,10 +1001,7 @@ impl Sandbox for FirecrackerSandbox {
         }
 
         // Start control socket server for `runner exec`.
-        self.control_server = Some(control::spawn_server(
-            self.sock_paths.control_sock(),
-            Arc::clone(&self.guest),
-        ));
+        self.control_server = Some(control_server.spawn());
 
         // Spawn balloon controller to reclaim unused guest memory.
         self.balloon_controller = Some(balloon::spawn(


### PR DESCRIPTION
## Summary
- bind sandbox control sockets before publishing the sandbox as Running
- report control socket bind failures during sandbox startup instead of hiding them in the background task
- remove the fixed 50ms bind wait from `client_server_no_guest` and add bind failure coverage

Fixes #11324

## Tests
- `cargo fmt --all --manifest-path crates/Cargo.toml -- --check`
- `git diff --check`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc control::tests::client_server_no_guest -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc control::tests::bind_server_reports_bind_failure -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc --lib`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings`