### PR TITLE
chore(platform): ban react class components

### DIFF
--- a/turbo/apps/platform/custom-eslint/__tests__/no-react-class-component.test.ts
+++ b/turbo/apps/platform/custom-eslint/__tests__/no-react-class-component.test.ts
@@ -1,0 +1,93 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { describe, it, afterAll } from "vitest";
+import rule from "../rules/no-react-class-component.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-react-class-component", rule, {
+  valid: [
+    {
+      code: `
+        import { useState } from "react";
+
+        function Counter() {
+          const [count] = useState(0);
+          return count;
+        }
+      `,
+    },
+    {
+      code: `
+        class ApiError extends Error {}
+      `,
+    },
+    {
+      code: `
+        import { Component } from "./component";
+
+        class LocalWidget extends Component {}
+      `,
+    },
+    {
+      code: `
+        import type { Component } from "react";
+
+        type Props = Component;
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { Component } from "react";
+
+        class LegacyView extends Component {}
+      `,
+      errors: [{ messageId: "noReactClassComponent" }],
+    },
+    {
+      code: `
+        import { PureComponent } from "react";
+
+        class LegacyView extends PureComponent {}
+      `,
+      errors: [{ messageId: "noReactClassComponent" }],
+    },
+    {
+      code: `
+        import { Component as ReactComponent } from "react";
+
+        class LegacyView extends ReactComponent {}
+      `,
+      errors: [{ messageId: "noReactClassComponent" }],
+    },
+    {
+      code: `
+        import * as React from "react";
+
+        class LegacyView extends React.Component {}
+      `,
+      errors: [{ messageId: "noReactClassComponent" }],
+    },
+    {
+      code: `
+        import React from "react";
+
+        class LegacyView extends React["PureComponent"] {}
+      `,
+      errors: [{ messageId: "noReactClassComponent" }],
+    },
+    {
+      code: `
+        import { Component } from "react";
+
+        const LegacyView = class extends Component {};
+      `,
+      errors: [{ messageId: "noReactClassComponent" }],
+    },
+  ],
+});

--- a/turbo/apps/platform/custom-eslint/index.ts
+++ b/turbo/apps/platform/custom-eslint/index.ts
@@ -26,6 +26,7 @@
  * - require-accept: Enforce that zeroClient$ calls are wrapped in accept()
  * - no-get-by-role-name: Avoid *ByRole(role, { name }) for text-content roles — causes ~300ms/call slowdown in happy-dom
  * - no-raw-msw-http: Disallow raw http.* MSW handlers for internal /api/zero/* paths — use mockApi(contract.route, ...)
+ * - no-react-class-component: Disallow React class components — use function components with hooks
  */
 
 import signalDollarSuffix from "./rules/signal-dollar-suffix.ts";
@@ -60,6 +61,7 @@ import noUserClearTab from "./rules/no-user-clear-tab.ts";
 import noDuplicateRouteParam from "./rules/no-duplicate-route-param.ts";
 import noRawMswHttp from "./rules/no-raw-msw-http.ts";
 import noMockApiRawAsync from "./rules/no-mockapi-raw-async.ts";
+import noReactClassComponent from "./rules/no-react-class-component.ts";
 
 const plugin = {
   meta: {
@@ -99,6 +101,7 @@ const plugin = {
     "no-duplicate-route-param": noDuplicateRouteParam,
     "no-raw-msw-http": noRawMswHttp,
     "no-mockapi-raw-async": noMockApiRawAsync,
+    "no-react-class-component": noReactClassComponent,
   },
 };
 

--- a/turbo/apps/platform/custom-eslint/rules/no-react-class-component.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-react-class-component.ts
@@ -1,0 +1,117 @@
+/**
+ * ESLint rule: no-react-class-component
+ *
+ * Prevents adding new React class components. Existing class components must
+ * carry a local eslint-disable with an issue link tracking the refactor.
+ */
+
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { createRule } from "../utils.ts";
+
+const REACT_COMPONENT_BASES = new Set(["Component", "PureComponent"]);
+
+type ClassNode = TSESTree.ClassDeclaration | TSESTree.ClassExpression;
+
+export default createRule({
+  name: "no-react-class-component",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow React class components. Use function components with hooks instead.",
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      noReactClassComponent:
+        "React class components are not allowed. Use a function component with hooks instead.",
+    },
+  },
+  create(context) {
+    const componentBaseNames = new Set<string>();
+    const reactNamespaceNames = new Set<string>();
+
+    function isReactClassSuperClass(superClass: TSESTree.Expression): boolean {
+      if (
+        superClass.type === AST_NODE_TYPES.Identifier &&
+        componentBaseNames.has(superClass.name)
+      ) {
+        return true;
+      }
+
+      if (superClass.type !== AST_NODE_TYPES.MemberExpression) {
+        return false;
+      }
+
+      if (
+        superClass.object.type !== AST_NODE_TYPES.Identifier ||
+        !reactNamespaceNames.has(superClass.object.name)
+      ) {
+        return false;
+      }
+
+      if (superClass.property.type === AST_NODE_TYPES.Identifier) {
+        return REACT_COMPONENT_BASES.has(superClass.property.name);
+      }
+
+      return (
+        superClass.computed &&
+        superClass.property.type === AST_NODE_TYPES.Literal &&
+        typeof superClass.property.value === "string" &&
+        REACT_COMPONENT_BASES.has(superClass.property.value)
+      );
+    }
+
+    function checkClass(node: ClassNode): void {
+      if (!node.superClass || !isReactClassSuperClass(node.superClass)) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: "noReactClassComponent",
+      });
+    }
+
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration): void {
+        if (node.source.value !== "react") {
+          return;
+        }
+
+        if (node.importKind === "type") {
+          return;
+        }
+
+        for (const specifier of node.specifiers) {
+          if (
+            specifier.type === AST_NODE_TYPES.ImportSpecifier &&
+            specifier.importKind === "type"
+          ) {
+            continue;
+          }
+
+          if (specifier.type === AST_NODE_TYPES.ImportDefaultSpecifier) {
+            reactNamespaceNames.add(specifier.local.name);
+            continue;
+          }
+
+          if (specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier) {
+            reactNamespaceNames.add(specifier.local.name);
+            continue;
+          }
+
+          if (
+            specifier.imported.type === AST_NODE_TYPES.Identifier &&
+            REACT_COMPONENT_BASES.has(specifier.imported.name)
+          ) {
+            componentBaseNames.add(specifier.local.name);
+          }
+        }
+      },
+      ClassDeclaration: checkClass,
+      ClassExpression: checkClass,
+    };
+  },
+});

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -46,6 +46,7 @@ export default [
       "ccstate/no-empty-promise-catch": "error",
       "ccstate/no-void-statement": "error",
       "ccstate/no-abort-swallower": "error",
+      "ccstate/no-react-class-component": "error",
       "ccstate/require-accept": "error",
       "ccstate/require-client-signal": "error",
       "ccstate/command-async-signal": "error",

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -214,6 +214,7 @@ function PlainLink({ href, children, ...rest }: ComponentPropsWithoutRef<"a">) {
 
 type ImageLoadStatus = "loading" | "loaded" | "error";
 
+// eslint-disable-next-line ccstate/no-react-class-component -- TODO(#11402): refactor existing class component.
 class MediaImage extends Component<
   {
     src: string;

--- a/turbo/apps/platform/src/views/error-boundary.tsx
+++ b/turbo/apps/platform/src/views/error-boundary.tsx
@@ -23,6 +23,7 @@ interface State {
 
 const L = logger("React");
 
+// eslint-disable-next-line ccstate/no-react-class-component -- TODO(#11402): refactor existing class component.
 export class ErrorBoundary extends Component<Props, State> {
   public state: State = {
     hasError: false,

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -111,6 +111,7 @@ function getTagline(
   return taglines[index % taglines.length];
 }
 
+// eslint-disable-next-line ccstate/no-react-class-component -- TODO(#11402): refactor existing class component.
 class TypewriterText extends Component<
   { text: string; speed?: number },
   { displayed: string }

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -186,6 +186,7 @@ type TextLoadState = {
   text: string;
 };
 
+// eslint-disable-next-line ccstate/no-react-class-component -- TODO(#11402): refactor existing class component.
 class TextPreviewLoader extends Component<
   {
     url: string;
@@ -411,6 +412,7 @@ function ImageLightboxControls({
   );
 }
 
+// eslint-disable-next-line ccstate/no-react-class-component -- TODO(#11402): refactor existing class component.
 class ImageLightboxKeyboardShortcuts extends Component<{
   resetZoom: () => void;
   zoomIn: () => void;
@@ -455,6 +457,7 @@ class ImageLightboxKeyboardShortcuts extends Component<{
   }
 }
 
+// eslint-disable-next-line ccstate/no-react-class-component -- TODO(#11402): refactor existing class component.
 class ImageLightboxContent extends Component<
   {
     closeLightbox: () => void;
@@ -939,6 +942,7 @@ export function PreviewableFileAttachmentChip({
 // AttachmentChip — chip shown in the composer before the message is sent
 // ---------------------------------------------------------------------------
 
+// eslint-disable-next-line ccstate/no-react-class-component -- TODO(#11402): refactor existing class component.
 class ComposerImagePreviewButton extends Component<
   {
     filename: string;

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -234,6 +234,7 @@ type TextPreviewState = {
   text: string;
 };
 
+// eslint-disable-next-line ccstate/no-react-class-component -- TODO(#11402): refactor existing class component.
 class TextPreview extends Component<TextPreviewProps, TextPreviewState> {
   state: TextPreviewState = {
     collapsed: false,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -500,6 +500,7 @@ type ChatImagePreviewButtonProps = {
   url: string;
 };
 
+// eslint-disable-next-line ccstate/no-react-class-component -- TODO(#11402): refactor existing class component.
 class ChatImagePreviewButton extends Component<
   ChatImagePreviewButtonProps,
   { imageStatus: ImageLoadStatus }
@@ -736,6 +737,7 @@ function ArtifactThumbnail({
   );
 }
 
+// eslint-disable-next-line ccstate/no-react-class-component -- TODO(#11402): refactor existing class component.
 class ArtifactThumbnailImage extends Component<
   { url: string },
   { imageStatus: ImageLoadStatus }

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
@@ -107,6 +107,7 @@ function InvalidState({ title, message }: { title: string; message: string }) {
   );
 }
 
+// eslint-disable-next-line ccstate/no-react-class-component -- TODO(#11402): refactor existing class component.
 class TelegramAutoOpen extends Component<{ href: string }> {
   override componentDidMount() {
     window.location.assign(this.props.href);
@@ -216,6 +217,7 @@ function getTelegramLoginDomain(): string {
   return location.hostname;
 }
 
+// eslint-disable-next-line ccstate/no-react-class-component -- TODO(#11402): refactor existing class component.
 class TelegramDomainStatusPoller extends Component<{ onPoll: () => void }> {
   private intervalId: number | null = null;
 

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
@@ -237,6 +237,7 @@ function TelegramBotIconFallback({ botId }: { botId: string }) {
   );
 }
 
+// eslint-disable-next-line ccstate/no-react-class-component -- TODO(#11402): refactor existing class component.
 class TelegramBotAvatar extends Component<
   { bot: TelegramBot; avatarUrl: string | null },
   { failed: boolean }
@@ -300,6 +301,7 @@ function getTelegramLoginDomain(): string {
   return location.hostname;
 }
 
+// eslint-disable-next-line ccstate/no-react-class-component -- TODO(#11402): refactor existing class component.
 class CopyableTelegramValue extends Component<
   { value: string },
   { copied: boolean }


### PR DESCRIPTION
## Summary
- add `ccstate/no-react-class-component` with coverage for React `Component`/`PureComponent` import forms
- enable the rule in platform ESLint config
- add `TODO(#11402)` eslint disables for the 14 existing React class components

## Follow-up
- #11402 tracks removing the temporary disables by refactoring the existing class components

## Verification
- `pnpm --filter @vm0/app test custom-eslint/__tests__/no-react-class-component.test.ts`
- `pnpm --filter @vm0/app lint`
- `pnpm --filter @vm0/app check-types`
- `pnpm format`
- `pnpm lint`
- `pnpm check-types`
- `pnpm test` fails locally because the pulled main test DB schema is stale/missing unrelated columns and tables such as `agent_sessions.artifacts`, `run_uploaded_files`, `telegram_installations.org_id`, and `device_codes.purpose`