### PR TITLE
feat: generate runner api routes

### DIFF
--- a/crates/api-contracts/src/route.rs
+++ b/crates/api-contracts/src/route.rs
@@ -42,7 +42,11 @@ impl Route {
         Self { method, path }
     }
 
-    /// Build an absolute URL for this route from a base API URL.
+    /// Build an absolute URL for a static route from a base API URL.
+    ///
+    /// This appends the generated path verbatim. For routes with path params,
+    /// use the generated `Params` and `route(...)` helpers, then call
+    /// [`ResolvedRoute::url`] on the resolved route.
     #[must_use]
     pub fn url(self, base_url: &str) -> String {
         url_from_base_and_path(base_url, self.path)


### PR DESCRIPTION
## Summary
- add runner poll, heartbeat, claim, and realtime token routes to the Rust route registry
- add safe `Route` helpers for percent-encoded path parameters
- switch runner API calls to generated routes and remove the old hand-written path request helper

## Verification
- `pnpm -F @vm0/api-contracts generate:rust`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts test -- src/rust-bindings/__tests__/routes.test.ts`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p api-contracts --all-targets`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets`
- `cargo clippy --manifest-path crates/Cargo.toml -p api-contracts -p runner --all-targets -- -D warnings`

Closes #11400