### PR TITLE
fix: prevent migrate-production from skipping when build jobs are skipped

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -72,7 +72,13 @@ jobs:
   # downtime: builds stage first, then migrate, then promote traffic.)
   migrate-production:
     needs: [release-please, builds-complete]
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    # always() prevents GitHub Actions from propagating "skipped" when upstream
+    # build jobs (build-runner-production, etc.) are skipped. The explicit
+    # builds-complete.result check gates on actual build success.
+    if: >-
+      always() &&
+      needs.release-please.outputs.releases_created == 'true' &&
+      needs.builds-complete.result == 'success'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260419


### PR DESCRIPTION
## Summary
- `migrate-production` was still being skipped even after `builds-complete` succeeded, because GitHub Actions propagates "skipped" status through transitive dependencies
- Add `always()` to `migrate-production`'s `if` condition and explicitly check `needs.builds-complete.result == 'success'`

## Root cause
PR #11318 changed `builds-complete` to use `always()` instead of `!cancelled()`, which fixed `builds-complete` itself. But `migrate-production` still inherited "skipped" from the upstream build jobs (build-runner-production, build-api-production, etc.) that were conditionally skipped — even though `builds-complete` ran and succeeded.

Evidence from the latest release run:
- `builds-complete`: **success**
- `migrate-production`: **skipped** (should have run)

## Test plan
- [ ] Merge this PR and verify the next release run executes `migrate-production` when `builds-complete` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)