### PR TITLE
fix: ensure migration always runs and all promote jobs gate on it

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -469,7 +469,8 @@ jobs:
       ]
     if: >-
       !failure() && !cancelled() &&
-      needs.release-please.outputs.web_release_created == 'true'
+      needs.release-please.outputs.web_release_created == 'true' &&
+      needs.migrate-production.result == 'success'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260419
@@ -595,7 +596,8 @@ jobs:
       ]
     if: >-
       !failure() && !cancelled() &&
-      needs.release-please.outputs.api_release_created == 'true'
+      needs.release-please.outputs.api_release_created == 'true' &&
+      needs.migrate-production.result == 'success'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260419
@@ -825,7 +827,8 @@ jobs:
       ]
     if: >-
       !failure() && !cancelled() &&
-      needs.release-please.outputs.app_release_created == 'true'
+      needs.release-please.outputs.app_release_created == 'true' &&
+      needs.migrate-production.result == 'success'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260419
@@ -1580,7 +1583,8 @@ jobs:
       ]
     if: >-
       !failure() && !cancelled() &&
-      needs.release-please.outputs.runner_rs_release_created == 'true'
+      needs.release-please.outputs.runner_rs_release_created == 'true' &&
+      needs.migrate-production.result == 'success'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -72,7 +72,13 @@ jobs:
   # downtime: builds stage first, then migrate, then promote traffic.)
   migrate-production:
     needs: [release-please, builds-complete]
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    # always() prevents GitHub Actions from propagating "skipped" when upstream
+    # build jobs (build-runner-production, etc.) are skipped. The explicit
+    # builds-complete.result check gates on actual build success.
+    if: >-
+      always() &&
+      needs.release-please.outputs.releases_created == 'true' &&
+      needs.builds-complete.result == 'success'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260419


### PR DESCRIPTION
## Summary
Two fixes to the release-please workflow migration and promote pipeline:

1. **Prevent `migrate-production` from being skipped** when build jobs are conditionally skipped. Added `always()` and explicit `needs.builds-complete.result == 'success'` check so migration runs whenever builds-complete succeeds, regardless of upstream skip propagation.

2. **Add `migrate-production.result == 'success'` gate to all promote jobs** (web, api, app, runner). Without this explicit check, promote jobs ran even when migration was skipped, causing DB schema and application code to diverge.

## Root cause
PR #11318 fixed `builds-complete` from being skipped, but:
- `migrate-production` still inherited "skipped" from transitive upstream build jobs
- Promote jobs had `migrate-production` in `needs` but used `!failure() && !cancelled()` in their `if` which doesn't prevent running when migration is skipped (skipped != failed)

## Evidence
Latest release run (web-v12.314.0):
- `builds-complete`: **success**
- `migrate-production`: **skipped** 
- `promote-web-production`: **success** (promoted without migration!)

## Test plan
- [ ] Merge and verify the next release runs `migrate-production` when `builds-complete` succeeds
- [ ] Verify promote jobs are skipped when `migrate-production` is skipped/failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)