### PR TITLE
refactor: remove fully-enabled feature switches (AudioInput, ChatArtifactsDrawer, TelegramIntegration)

### DIFF
--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -3,8 +3,6 @@ import {
   zeroVoiceIoQuotaContract,
   type AudioInputQuotaResponse,
 } from "@vm0/api-contracts/contracts/zero-voice-io-quota";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { featureSwitch$ } from "../external/feature-switch.ts";
 import { fetch$ } from "../fetch.ts";
 import { zeroClient$ } from "../api-client.ts";
 import {
@@ -43,12 +41,10 @@ export const sttTranscribing$ = computed((get) => {
   return get(internalTranscribing$);
 });
 
-export const audioInputAvailable$ = computed(async (get) => {
-  const features = await get(featureSwitch$);
-  const featureEnabled = features[FeatureSwitchKey.AudioInput] ?? false;
+export const audioInputAvailable$ = computed(async () => {
   const hasMic =
     typeof navigator !== "undefined" && !!navigator.mediaDevices?.getUserMedia;
-  return featureEnabled && hasMic;
+  return hasMic;
 });
 
 /**

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -41,7 +41,7 @@ export const sttTranscribing$ = computed((get) => {
   return get(internalTranscribing$);
 });
 
-export const audioInputAvailable$ = computed(async () => {
+export const audioInputAvailable$ = computed(() => {
   const hasMic =
     typeof navigator !== "undefined" && !!navigator.mediaDevices?.getUserMedia;
   return hasMic;

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-telegram.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-telegram.test.ts
@@ -119,4 +119,3 @@ describe("zero telegram signals", () => {
     expect(getMockTelegramIntegration().statuses.bot_alpha).toBeUndefined();
   });
 });
-

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-telegram.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-telegram.test.ts
@@ -1,8 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { TelegramBotStatus } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
-import { pathname$ } from "../../route.ts";
 import {
   registerTelegramBot$,
   telegramBots$,

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-telegram.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-telegram.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { TelegramBotStatus } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { pathname$ } from "../../route.ts";
 import {
-  isTelegramIntegrationEnabled$,
   registerTelegramBot$,
   telegramBots$,
   uninstallTelegramBot$,
@@ -18,17 +16,10 @@ import {
 
 const context = testContext();
 
-function setup({
-  path = "/",
-  enabled = false,
-}: {
-  path?: string;
-  enabled?: boolean;
-} = {}) {
+function setup({ path = "/" }: { path?: string } = {}) {
   detachedSetupPage({
     context,
     path,
-    featureSwitches: { [FeatureSwitchKey.TelegramIntegration]: enabled },
     withoutRender: true,
   });
 }
@@ -57,22 +48,6 @@ function telegramStatus(
 }
 
 describe("zero telegram signals", () => {
-  it("derives frontend enablement from feature switches", async () => {
-    setup({ enabled: true });
-
-    await expect(
-      context.store.get(isTelegramIntegrationEnabled$),
-    ).resolves.toBeTruthy();
-  });
-
-  it("keeps the frontend gate disabled when the switch is off", async () => {
-    setup({ enabled: false });
-
-    await expect(
-      context.store.get(isTelegramIntegrationEnabled$),
-    ).resolves.toBeFalsy();
-  });
-
   it("loads multiple Telegram bots from the multi-bot API", async () => {
     setMockTelegramIntegration({
       statuses: [
@@ -83,7 +58,7 @@ describe("zero telegram signals", () => {
         }),
       ],
     });
-    setup({ enabled: true });
+    setup();
 
     await expect(context.store.get(telegramBots$)).resolves.toMatchObject([
       { id: "bot_alpha", agent: { id: "compose_1" } },
@@ -93,7 +68,7 @@ describe("zero telegram signals", () => {
 
   it("registers a bot and refreshes the list state", async () => {
     setMockTelegramIntegration({ statuses: [] });
-    setup({ enabled: true });
+    setup();
 
     const registered = await context.store.set(
       registerTelegramBot$,
@@ -115,7 +90,7 @@ describe("zero telegram signals", () => {
     setMockTelegramIntegration({
       statuses: [telegramStatus("bot_alpha")],
     });
-    setup({ enabled: true });
+    setup();
 
     await context.store.set(
       updateTelegramBotAgent$,
@@ -135,7 +110,7 @@ describe("zero telegram signals", () => {
     setMockTelegramIntegration({
       statuses: [telegramStatus("bot_alpha"), telegramStatus("bot_beta")],
     });
-    setup({ enabled: true });
+    setup();
 
     await context.store.set(uninstallTelegramBot$, "bot_alpha", context.signal);
 
@@ -146,20 +121,3 @@ describe("zero telegram signals", () => {
   });
 });
 
-describe("telegram settings route gating", () => {
-  it("redirects away from /settings/telegram when the switch is disabled", async () => {
-    setup({ path: "/settings/telegram", enabled: false });
-
-    await vi.waitFor(() => {
-      expect(context.store.get(pathname$)).toBe("/works");
-    });
-  });
-
-  it("keeps /settings/telegram reachable when the switch is enabled", async () => {
-    setup({ path: "/settings/telegram", enabled: true });
-
-    await vi.waitFor(() => {
-      expect(context.store.get(pathname$)).toBe("/settings/telegram");
-    });
-  });
-});

--- a/turbo/apps/platform/src/signals/zero-page/telegram-settings-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/telegram-settings-page.ts
@@ -1,7 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
 import {
-  isTelegramIntegrationEnabled$,
   reloadTelegramBots$,
   resetTelegramSettingsUi$,
   startTelegramSettingsRealtime$,
@@ -19,14 +18,6 @@ const L = logger("TelegramSettingsPage");
 
 export const setupTelegramSettingsPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const enabled = await get(isTelegramIntegrationEnabled$);
-    signal.throwIfAborted();
-
-    if (!enabled) {
-      set(detachedNavigateTo$, ROUTES.works, { replace: true });
-      return;
-    }
-
     set(resetTelegramSettingsUi$);
     set(reloadTelegramBots$);
     set(updatePage$, createElement(ZeroTelegramSettingsPage), "sidebar");

--- a/turbo/apps/platform/src/signals/zero-page/telegram-settings-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/telegram-settings-page.ts
@@ -6,8 +6,7 @@ import {
   startTelegramSettingsRealtime$,
 } from "./zero-telegram.ts";
 import { ZeroTelegramSettingsPage } from "../../views/zero-page/zero-telegram-settings-page.tsx";
-import { detachedNavigateTo$ } from "../route.ts";
-import { ROUTES } from "../route-paths.ts";
+
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
@@ -17,7 +16,7 @@ import { logger } from "../log.ts";
 const L = logger("TelegramSettingsPage");
 
 export const setupTelegramSettingsPage$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
+  async ({ set }, signal: AbortSignal) => {
     set(resetTelegramSettingsUi$);
     set(reloadTelegramBots$);
     set(updatePage$, createElement(ZeroTelegramSettingsPage), "sidebar");

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -15,7 +15,7 @@ import { currentChatAgentDisplayName$ } from "../agent-chat.ts";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import { ROUTES } from "../route-paths.ts";
 import { slackOrgData$ } from "./zero-slack.ts";
-import { isTelegramIntegrationEnabled$ } from "./zero-telegram.ts";
+
 import { reloadBillingStatus$ } from "./billing.ts";
 import { reloadAgentById$, reloadAgents$ } from "../agent.ts";
 import { reloadPinnedAgents$ } from "./zero-pinned-agents.ts";
@@ -224,7 +224,7 @@ export const onboardingDisplayName$ = computed(async (get) => {
   return await get(currentChatAgentDisplayName$);
 });
 
-export const onboardingShowTelegram$ = isTelegramIntegrationEnabled$;
+export const onboardingShowTelegram$ = computed(async () => true);
 
 export const completeOnboarding$ = command(
   async ({ get, set }, signal: AbortSignal) => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -224,7 +224,7 @@ export const onboardingDisplayName$ = computed(async (get) => {
   return await get(currentChatAgentDisplayName$);
 });
 
-export const onboardingShowTelegram$ = computed(async () => true);
+export const onboardingShowTelegram$ = computed(() => true);
 
 export const completeOnboarding$ = command(
   async ({ get, set }, signal: AbortSignal) => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -224,7 +224,9 @@ export const onboardingDisplayName$ = computed(async (get) => {
   return await get(currentChatAgentDisplayName$);
 });
 
-export const onboardingShowTelegram$ = computed(() => true);
+export const onboardingShowTelegram$ = computed(() => {
+  return true;
+});
 
 export const completeOnboarding$ = command(
   async ({ get, set }, signal: AbortSignal) => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
@@ -1,6 +1,5 @@
 import { command, computed, state } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   zeroIntegrationsTelegramContract,
   type TelegramBot,
@@ -8,7 +7,6 @@ import {
   type TelegramSetupStatus,
 } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import { zeroClient$ } from "../api-client.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
 import { accept } from "../../lib/accept.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { writeToClipboard } from "./clipboard.ts";
@@ -291,11 +289,6 @@ export const resetTelegramSettingsUi$ = command(({ set }) => {
   set(internalTelegramReinstallDialogBotId$, null);
   set(internalTelegramReinstallTokenForm$, "");
   set(internalTelegramReinstallingBotId$, null);
-});
-
-export const isTelegramIntegrationEnabled$ = computed(async (get) => {
-  const features = await get(featureSwitch$);
-  return features[FeatureSwitchKey.TelegramIntegration] ?? false;
 });
 
 export const telegramBots$ = computed(async (get): Promise<TelegramBot[]> => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
@@ -17,8 +17,6 @@ import {
 } from "@vm0/api-contracts/contracts/onboarding";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-
 const context = testContext();
 const mockApi = createMockApi(context);
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
@@ -291,26 +291,12 @@ describe("onboarding add to Slack → works page", () => {
 // ---------------------------------------------------------------------------
 
 describe("onboarding set up Telegram → settings page", () => {
-  it("should show Telegram only when the Telegram feature is enabled", async () => {
-    mockAdminOnboarding();
-
-    detachedSetupPage({
-      context,
-      path: "/onboarding",
-      featureSwitches: { [FeatureSwitchKey.TelegramIntegration]: false },
-    });
-    await walkAdminToWhereStep();
-
-    expect(screen.queryByText(/Add .+ to Telegram/)).not.toBeInTheDocument();
-  });
-
   it("should navigate to /settings/telegram after saving the agent", async () => {
     mockAdminOnboarding();
 
     detachedSetupPage({
       context,
       path: "/onboarding",
-      featureSwitches: { [FeatureSwitchKey.TelegramIntegration]: true },
     });
     await walkAdminToWhereStep();
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-mic-button.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-mic-button.test.tsx
@@ -3,7 +3,6 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { zeroVoiceIoQuotaContract } from "@vm0/api-contracts/contracts/zero-voice-io-quota";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { server } from "../../../mocks/server.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -156,29 +155,12 @@ describe("chat-d-032: mic button visibility with feature switch", () => {
     clearMediaDevices();
   });
 
-  it("should not render mic button when VoiceIO feature switch is off", async () => {
+  it("should render mic button when VoiceIO is enabled and browser supports getUserMedia", async () => {
     mockChatLifecycle();
 
     detachedSetupPage({
       context,
       path: CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.AudioInput]: false },
-    });
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Send")).toBeInTheDocument();
-    });
-
-    expect(screen.queryByLabelText("Voice input")).not.toBeInTheDocument();
-  });
-
-  it("should render mic button when VoiceIO feature switch is on and browser supports getUserMedia", async () => {
-    mockChatLifecycle();
-
-    detachedSetupPage({
-      context,
-      path: CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.AudioInput]: true },
     });
 
     await waitFor(() => {
@@ -193,7 +175,6 @@ describe("chat-d-032: mic button visibility with feature switch", () => {
     detachedSetupPage({
       context,
       path: CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.AudioInput]: true },
     });
 
     await waitFor(() => {
@@ -221,7 +202,6 @@ describe("chat-i-033: mic button recording interaction", () => {
     detachedSetupPage({
       context,
       path: CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.AudioInput]: true },
     });
 
     const micButton = await waitFor(() => {
@@ -255,7 +235,6 @@ describe("chat-i-034: mic button transcription appends to draft", () => {
     detachedSetupPage({
       context,
       path: CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.AudioInput]: true },
     });
 
     const textarea = await waitFor(() => {
@@ -293,7 +272,6 @@ describe("chat-i-034: mic button transcription appends to draft", () => {
     detachedSetupPage({
       context,
       path: CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.AudioInput]: true },
     });
 
     const textarea = await waitFor(() => {
@@ -338,7 +316,6 @@ describe("chat-i-035: mic button gates on audio input quota", () => {
     detachedSetupPage({
       context,
       path: CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.AudioInput]: true },
     });
 
     const micButton = await waitFor(() => {
@@ -370,7 +347,6 @@ describe("chat-i-035: mic button gates on audio input quota", () => {
     detachedSetupPage({
       context,
       path: CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.AudioInput]: true },
     });
 
     const micButton = await waitFor(() => {
@@ -395,7 +371,6 @@ describe("chat-i-035: mic button gates on audio input quota", () => {
     detachedSetupPage({
       context,
       path: CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.AudioInput]: true },
     });
 
     const micButton = await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -821,7 +821,6 @@ describe("zero chat thread page display - artifacts drawer", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
-      featureSwitches: { [FeatureSwitchKey.ChatArtifactsDrawer]: true },
     });
 
     const button = await waitFor(() => {
@@ -907,7 +906,6 @@ describe("zero chat thread page display - artifacts drawer", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ChatArtifactsDrawer]: true },
     });
 
     const button = await waitFor(() => {
@@ -934,22 +932,6 @@ describe("zero chat thread page display - artifacts drawer", () => {
     expect(artifactsRequests).toBeGreaterThanOrEqual(2);
   });
 
-  it("hides the artifacts button when the feature switch is off", async () => {
-    mockChatLifecycle();
-
-    detachedSetupPage({
-      context,
-      path: "/chats/thread-test-1",
-      featureSwitches: { [FeatureSwitchKey.ChatArtifactsDrawer]: false },
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("Send a message to start the conversation"),
-      ).toBeInTheDocument();
-    });
-    expect(screen.queryByLabelText("Open artifacts")).not.toBeInTheDocument();
-  });
 });
 
 // CHAT-D-043: Message status indicators render in ChatMessageRow

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -931,7 +931,6 @@ describe("zero chat thread page display - artifacts drawer", () => {
     });
     expect(artifactsRequests).toBeGreaterThanOrEqual(2);
   });
-
 });
 
 // CHAT-D-043: Message status indicators render in ChatMessageRow

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import type { TelegramBotStatus } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
   click,
@@ -75,7 +74,6 @@ function setupTelegramPage() {
   detachedSetupPage({
     context,
     path: "/settings/telegram",
-    featureSwitches: { [FeatureSwitchKey.TelegramIntegration]: true },
   });
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -93,9 +93,9 @@ describe("works page - slack integration status display", () => {
 });
 
 describe("works page - telegram integration card", () => {
-  it("renders Telegram below Slack when the Telegram feature is enabled", async () => {
+  it("renders Telegram below Slack", async () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
-    renderWorksPageWithTelegram(true);
+    renderWorksPage();
 
     await waitFor(() => {
       expect(screen.getByText("Slack")).toBeInTheDocument();
@@ -106,19 +106,9 @@ describe("works page - telegram integration card", () => {
     });
   });
 
-  it("hides Telegram when the Telegram feature is disabled", async () => {
-    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
-    renderWorksPageWithTelegram(false);
-
-    await waitFor(() => {
-      expect(screen.getByText("Slack")).toBeInTheDocument();
-    });
-    expect(screen.queryByText("Telegram")).not.toBeInTheDocument();
-  });
-
   it("opens Telegram settings from the Telegram card", async () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
-    renderWorksPageWithTelegram(true);
+    renderWorksPage();
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -14,7 +14,6 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   zeroIntegrationsSlackContract,
   type SlackOrgStatus,
@@ -52,14 +51,6 @@ function mockSlackAPI(overrides: Partial<SlackOrgStatus> = {}) {
 
 function renderWorksPage() {
   detachedSetupPage({ context, path: "/works" });
-}
-
-function renderWorksPageWithTelegram(enabled: boolean) {
-  detachedSetupPage({
-    context,
-    path: "/works",
-    featureSwitches: { [FeatureSwitchKey.TelegramIntegration]: enabled },
-  });
 }
 
 describe("works page - slack integration status display", () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -208,13 +208,6 @@ function PinPillButton({ thread }: { thread: ChatThreadSignals }) {
 }
 
 function ArtifactsButton({ thread }: { thread: ChatThreadSignals }) {
-  const features = useLastResolved(featureSwitch$);
-  const enabled = features?.[FeatureSwitchKey.ChatArtifactsDrawer] ?? false;
-
-  if (!enabled) {
-    return null;
-  }
-
   return <ArtifactsButtonInner thread={thread} />;
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -31,7 +31,6 @@ import {
   setShowUninstallDialog$,
 } from "../../signals/zero-page/zero-slack.ts";
 import {
-  isTelegramIntegrationEnabled$,
   telegramBots$,
 } from "../../signals/zero-page/zero-telegram.ts";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -314,18 +313,6 @@ function TelegramCard() {
   );
 }
 
-function TelegramCardGate() {
-  const enabledLoadable = useLoadable(isTelegramIntegrationEnabled$);
-  const enabled =
-    enabledLoadable.state === "hasData" ? enabledLoadable.data : false;
-
-  if (!enabled) {
-    return null;
-  }
-
-  return <TelegramCard />;
-}
-
 export function ZeroWorksPage() {
   const displayNameLoadable = useLoadable(currentChatAgentDisplayName$);
   const displayName =
@@ -349,7 +336,7 @@ export function ZeroWorksPage() {
       <main className="flex-1 overflow-auto px-4 sm:px-6 pt-3 pb-8">
         <div className="mx-auto max-w-[900px] flex flex-col gap-4">
           <SlackCard displayName={displayName} />
-          <TelegramCardGate />
+          <TelegramCard />
         </div>
       </main>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -30,9 +30,7 @@ import {
   showUninstallDialog$,
   setShowUninstallDialog$,
 } from "../../signals/zero-page/zero-slack.ts";
-import {
-  telegramBots$,
-} from "../../signals/zero-page/zero-telegram.ts";
+import { telegramBots$ } from "../../signals/zero-page/zero-telegram.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
 import { ROUTES } from "../../signals/route-paths.ts";

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { GET } from "../route";
 import { POST } from "../../../route";
 import {
@@ -13,7 +12,6 @@ import {
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
-import { seedUserFeatureSwitches } from "../../../../../../../src/__tests__/db-test-seeders/feature-switches";
 import { recordRunUploadedFile } from "../../../../../../../src/lib/zero/uploads/run-uploaded-files";
 
 const context = testContext();
@@ -45,25 +43,7 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
     expect(response.status).toBe(401);
   });
 
-  it("returns 403 when the feature switch is disabled by override", async () => {
-    await seedUserFeatureSwitches(testOrgId, testUserId, {
-      [FeatureSwitchKey.ChatArtifactsDrawer]: false,
-    });
-
-    const response = await GET(
-      createTestRequest(
-        "http://localhost:3000/api/zero/chat-threads/thread-id/artifacts",
-      ),
-    );
-
-    expect(response.status).toBe(403);
-  });
-
   it("returns run uploaded files grouped by run", async () => {
-    await seedUserFeatureSwitches(testOrgId, testUserId, {
-      [FeatureSwitchKey.ChatArtifactsDrawer]: true,
-    });
-
     const createRes = await POST(
       createTestRequest("http://localhost:3000/api/zero/chat-threads", {
         method: "POST",
@@ -110,10 +90,6 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
   });
 
   it("uses chat message run ownership when zero run chat thread is missing", async () => {
-    await seedUserFeatureSwitches(testOrgId, testUserId, {
-      [FeatureSwitchKey.ChatArtifactsDrawer]: true,
-    });
-
     const createRes = await POST(
       createTestRequest("http://localhost:3000/api/zero/chat-threads", {
         method: "POST",

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/route.ts
@@ -1,12 +1,9 @@
 import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../../src/lib/auth/get-auth-context";
 import { getChatThreadArtifacts } from "../../../../../../src/lib/zero/chat-thread";
-import { loadFeatureSwitchOverrides } from "../../../../../../src/lib/zero/user/feature-switches-service";
 import { isNotFound } from "@vm0/api-services/errors";
 
 const router = tsr.router(chatThreadArtifactsContract, {
@@ -16,19 +13,6 @@ const router = tsr.router(chatThreadArtifactsContract, {
     const authCtx = await getAuthContext(headers.authorization);
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
-    }
-
-    const overrides = await loadFeatureSwitchOverrides(
-      authCtx.orgId,
-      authCtx.userId,
-    );
-    const enabled = isFeatureEnabled(FeatureSwitchKey.ChatArtifactsDrawer, {
-      orgId: authCtx.orgId,
-      userId: authCtx.userId,
-      overrides,
-    });
-    if (!enabled) {
-      return createErrorResponse("FORBIDDEN", "Chat artifacts are not enabled");
     }
 
     try {

--- a/turbo/apps/web/app/api/zero/voice-io/stt/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/stt/__tests__/route.test.ts
@@ -24,18 +24,6 @@ import {
   dailyDurationKey,
 } from "../../../../../../src/lib/zero/voice-io/audio-input-policy";
 
-vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@vm0/core/feature-switch")>();
-  return {
-    ...actual,
-    isFeatureEnabled: vi.fn().mockReturnValue(true),
-  };
-});
-
-const { isFeatureEnabled } = await import("@vm0/core/feature-switch");
-const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
-
 vi.hoisted(() => {
   vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
 });
@@ -105,7 +93,6 @@ function createSttRequest(file?: File): Request {
 describe("POST /api/zero/voice-io/stt", () => {
   beforeEach(() => {
     context.setupMocks();
-    mockIsFeatureEnabled.mockReturnValue(true);
     vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
     reloadEnv();
   });
@@ -118,15 +105,6 @@ describe("POST /api/zero/voice-io/stt", () => {
     expect(body.error.code).toBe("UNAUTHORIZED");
   });
 
-  it("should return 403 when feature flag is disabled", async () => {
-    const userId = uniqueId("stt-ff");
-    await setupOrg(userId);
-    mockIsFeatureEnabled.mockReturnValue(false);
-    const response = await POST(createSttRequest(createAudioFile()));
-    const body = await response.json();
-    expect(response.status).toBe(403);
-    expect(body.error.code).toBe("FORBIDDEN");
-  });
 
   it("should return 400 when no file is provided", async () => {
     const userId = uniqueId("stt-nofile");

--- a/turbo/apps/web/app/api/zero/voice-io/stt/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/stt/__tests__/route.test.ts
@@ -105,7 +105,6 @@ describe("POST /api/zero/voice-io/stt", () => {
     expect(body.error.code).toBe("UNAUTHORIZED");
   });
 
-
   it("should return 400 when no file is provided", async () => {
     const userId = uniqueId("stt-nofile");
     await setupOrg(userId);

--- a/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
@@ -1,9 +1,6 @@
 import { NextResponse } from "next/server";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
 import { initServices } from "../../../../../src/lib/init-services";
-import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
 import { getOrgTierSafe } from "../../../../../src/lib/zero/org/org-metadata-service";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
 import { recordBehavior } from "../../../../../src/lib/zero/behavior/user-behavior-count-service";
@@ -97,24 +94,7 @@ export async function POST(request: Request): Promise<Response> {
   }
   const orgId = authCtx.orgId;
 
-  // 2. Feature switch check
-  const overrides = await loadFeatureSwitchOverrides(
-    authCtx.orgId,
-    authCtx.userId,
-  );
-  const enabled = isFeatureEnabled(FeatureSwitchKey.AudioInput, {
-    orgId: authCtx.orgId,
-    userId: authCtx.userId,
-    overrides,
-  });
-  if (!enabled) {
-    return NextResponse.json(
-      { error: { message: "Audio input is not enabled", code: "FORBIDDEN" } },
-      { status: 403 },
-    );
-  }
-
-  // 3. Quota check (free tier has a per-user limit; pro/team are unlimited)
+  // 2. Quota check (free tier has a per-user limit; pro/team are unlimited)
   const orgTier = await getOrgTierSafe(orgId);
   const quota = await checkAudioInputQuota(orgId, authCtx.userId, orgTier);
   if (!quota.allowed) {

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -34,12 +34,11 @@ export enum FeatureSwitchKey {
   ComputerUse = "computerUse",
   Lab = "lab",
   AuditLink = "auditLink",
-  AudioInput = "audioInput",
   AudioOutput = "audioOutput",
   AutoSkill = "autoSkill",
   TestOauthConnector = "testOauthConnector",
   ChatHeaderNewButton = "chatHeaderNewButton",
-  ChatArtifactsDrawer = "chatArtifactsDrawer",
+
   ChatManualHistory = "chatManualHistory",
   ChatMessageStartButton = "chatMessageStartButton",
   FreshdeskConnector = "freshdeskConnector",
@@ -48,7 +47,7 @@ export enum FeatureSwitchKey {
   ApiKeys = "apiKeys",
   ConnectorCategories = "connectorCategories",
   PlatformConnectors = "platformConnectors",
-  TelegramIntegration = "telegramIntegration",
+
   Trinity = "trinity",
   ZapierConnector = "zapierConnector",
 }

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -65,7 +65,7 @@ describe("getAllFeatureStates", () => {
     const states = getAllFeatureStates();
     // Globally enabled switches should be true
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
-    expect(states[FeatureSwitchKey.TelegramIntegration]).toBe(true);
+    expect(states[FeatureSwitchKey.Dummy]).toBe(true);
   });
 
   it("should enable switches when orgId matches enabledOrgIdHashes", () => {
@@ -87,7 +87,7 @@ describe("getAllFeatureStates", () => {
     });
     expect(states[FeatureSwitchKey.PlatformConnectors]).toBe(false);
     expect(states[FeatureSwitchKey.ConnectorCategories]).toBe(false);
-    expect(states[FeatureSwitchKey.TelegramIntegration]).toBe(true);
+    expect(states[FeatureSwitchKey.Dummy]).toBe(true);
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -187,12 +187,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Show audit log links in integration replies",
     enabled: false,
   },
-  [FeatureSwitchKey.AudioInput]: {
-    maintainer: "lancy@vm0.ai",
-    description:
-      "Enable voice input (microphone + STT) in chat — gates the mic button and the /api/zero/voice-io/stt route",
-    enabled: true,
-  },
   [FeatureSwitchKey.AudioOutput]: {
     maintainer: "lancy@vm0.ai",
     description:
@@ -215,12 +209,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Replace the Invite people button in the agent chat page header with a New button that creates a new chat thread",
     enabled: false,
-  },
-  [FeatureSwitchKey.ChatArtifactsDrawer]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Show an artifacts button in the chat header that opens a drawer listing uploaded files grouped by run",
-    enabled: true,
   },
   [FeatureSwitchKey.ChatManualHistory]: {
     maintainer: "linghan@vm0.ai",
@@ -274,12 +262,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "endpoint 404s. Staff-only during rollout.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
-  [FeatureSwitchKey.TelegramIntegration]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Show the Telegram integration settings UI. The backend Telegram routes do not consult this frontend rollout flag.",
-    enabled: true,
   },
   [FeatureSwitchKey.Trinity]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- Removes three feature switches that have been 100% rolled out and are no longer needed as gates
- **AudioInput** — voice mic+STT always enabled
- **ChatArtifactsDrawer** — artifacts drawer always shown
- **TelegramIntegration** — Telegram settings always accessible

## Changes
- Removed enum keys from `FeatureSwitchKey`
- Removed switch definitions from `FEATURE_SWITCHES` registry
- Removed gating logic from server routes and client signals
- Updated all affected tests

## Test plan
- [ ] Voice input mic button renders and works in chat
- [ ] Artifacts drawer opens from chat header
- [ ] Telegram settings page accessible from /works and /settings/telegram
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)