### PR TITLE
feat(guest-agent): codex command path + framework dispatch

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -1,4 +1,4 @@
-//! CLI command building and execution for Claude Code.
+//! CLI command building and execution for Claude Code / Codex.
 
 use crate::constants;
 use crate::env;
@@ -7,6 +7,7 @@ use crate::events;
 use crate::masker::SecretMasker;
 use crate::paths;
 use crate::timing;
+use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
 use std::collections::HashMap;
 use std::process::Stdio;
@@ -54,9 +55,12 @@ impl ReapState {
     }
 }
 
-/// Build the CLI command + args.
+/// Build the CLI command + args based on `CLI_AGENT_TYPE`.
 pub fn build_cli_command() -> Result<Vec<String>, AgentError> {
-    Ok(build_claude_command(env::use_mock_claude()))
+    match env::Framework::from_env() {
+        env::Framework::ClaudeCode => Ok(build_claude_command(env::use_mock_claude())),
+        env::Framework::Codex => Ok(build_codex_command(env::use_mock_codex())),
+    }
 }
 
 /// Build the argument list from explicit parameters (testable).
@@ -145,6 +149,107 @@ fn build_claude_command(use_mock: bool) -> Vec<String> {
     cmd
 }
 
+/// Build the codex argument list (testable).
+///
+/// Resume is a positional sub-subcommand (`codex exec resume <id> <prompt>`),
+/// not a `--resume <id>` flag. No `--` separator before the prompt: codex
+/// has no variadic flags here, so `--` would propagate as a literal arg.
+fn build_codex_args(working_dir: &str, model: &str, resume_id: &str, prompt: &str) -> Vec<String> {
+    let mut args = vec![
+        "exec".to_string(),
+        "--json".to_string(),
+        "--sandbox".to_string(),
+        "danger-full-access".to_string(),
+        "--skip-git-repo-check".to_string(),
+        "-C".to_string(),
+        working_dir.to_string(),
+    ];
+
+    if !model.is_empty() {
+        args.push("-m".to_string());
+        args.push(model.to_string());
+    }
+
+    if !resume_id.is_empty() {
+        log_info!(LOG_TAG, "Resuming codex session: {resume_id}");
+        args.push("resume".to_string());
+        args.push(resume_id.to_string());
+        args.push(prompt.to_string());
+    } else {
+        log_info!(LOG_TAG, "Starting new codex session");
+        args.push(prompt.to_string());
+    }
+
+    args
+}
+
+fn build_codex_command(use_mock: bool) -> Vec<String> {
+    let bin = if use_mock {
+        log_info!(LOG_TAG, "Using mock-codex for testing");
+        env::mock_codex_path()
+    } else {
+        "codex".to_string()
+    };
+
+    let mut cmd = vec![bin];
+    cmd.extend(build_codex_args(
+        env::working_dir(),
+        env::openai_model(),
+        env::resume_session_id(),
+        env::prompt(),
+    ));
+    cmd
+}
+
+/// Best-effort codex setup: create `$HOME/.codex` and pipe `OPENAI_API_KEY`
+/// into `codex login --with-api-key`. Login failure is non-fatal — `codex
+/// exec` reads `OPENAI_API_KEY` directly from the process env, so the env
+/// path covers authn even when the login subcommand isn't available.
+pub fn setup_codex() -> Result<(), AgentError> {
+    use std::io::Write as _;
+
+    let codex_home = format!("{}/.codex", env::home_dir());
+    std::fs::create_dir_all(&codex_home)?;
+    log_info!(LOG_TAG, "Codex home directory: {codex_home}");
+
+    let api_key = env::openai_api_key();
+    if api_key.is_empty() {
+        log_info!(LOG_TAG, "OPENAI_API_KEY not set, skipping codex login");
+        return Ok(());
+    }
+
+    let login_start = Instant::now();
+    let result = std::process::Command::new("codex")
+        .args(["login", "--with-api-key"])
+        .env("CODEX_HOME", &codex_home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            if let Some(mut stdin) = child.stdin.take() {
+                let _ = stdin.write_all(api_key.as_bytes());
+            }
+            child.wait_with_output()
+        });
+    let success = matches!(&result, Ok(o) if o.status.success());
+    if success {
+        log_info!(LOG_TAG, "Codex authenticated with API key");
+    } else {
+        match &result {
+            Ok(o) => {
+                let stderr = String::from_utf8_lossy(&o.stderr);
+                log_warn!(LOG_TAG, "codex login failed (non-fatal): {stderr}");
+            }
+            Err(e) => {
+                log_warn!(LOG_TAG, "codex login spawn failed (non-fatal): {e}");
+            }
+        }
+    }
+    record_sandbox_op("codex_login", login_start.elapsed(), success, None);
+    Ok(())
+}
+
 struct PreparedEvent {
     sequence: u32,
     payload: serde_json::Value,
@@ -207,17 +312,27 @@ pub async fn execute_cli(
         .stderr(Stdio::piped())
         .process_group(0);
 
-    // Suppress Claude CLI features that are unnecessary or harmful in a
-    // sandbox: startup network calls (statsig, Datadog, Segment, GCS
-    // update check, GitHub) add ~2s latency, telemetry has no receiver,
-    // and the CLI version is baked into the rootfs image.
-    cmd.env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
-    cmd.env("CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY", "1");
-    cmd.env("CLAUDE_CODE_DISABLE_TERMINAL_TITLE", "1");
-    cmd.env("DISABLE_AUTOUPDATER", "1");
-    cmd.env("DISABLE_ERROR_REPORTING", "1");
-    cmd.env("DISABLE_INSTALLATION_CHECKS", "1");
-    cmd.env("DISABLE_TELEMETRY", "1");
+    match env::Framework::from_env() {
+        env::Framework::ClaudeCode => {
+            // Suppress Claude CLI features that are unnecessary or harmful in a
+            // sandbox: startup network calls (statsig, Datadog, Segment, GCS
+            // update check, GitHub) add ~2s latency, telemetry has no receiver,
+            // and the CLI version is baked into the rootfs image.
+            cmd.env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
+            cmd.env("CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY", "1");
+            cmd.env("CLAUDE_CODE_DISABLE_TERMINAL_TITLE", "1");
+            cmd.env("DISABLE_AUTOUPDATER", "1");
+            cmd.env("DISABLE_ERROR_REPORTING", "1");
+            cmd.env("DISABLE_INSTALLATION_CHECKS", "1");
+            cmd.env("DISABLE_TELEMETRY", "1");
+        }
+        env::Framework::Codex => {
+            // `codex login` and `codex exec` both honor CODEX_HOME; pin
+            // it to $HOME/.codex so the login state from setup_codex
+            // is visible to exec.
+            cmd.env("CODEX_HOME", format!("{}/.codex", env::home_dir()));
+        }
+    }
 
     let mut child = cmd.spawn()?;
 
@@ -670,6 +785,98 @@ mod tests {
         // accessor against itself and was tautological.
         let cmd = build_claude_command_for_test(true);
         assert_eq!(cmd[0], env::DEFAULT_MOCK_CLAUDE_PATH);
+    }
+
+    // -----------------------------------------------------------------
+    // build_codex_args / build_codex_command
+    // -----------------------------------------------------------------
+
+    fn build_codex_args_for_test(
+        working_dir: &str,
+        model: &str,
+        resume_id: &str,
+        prompt: &str,
+    ) -> Vec<String> {
+        disable_system_log();
+        build_codex_args(working_dir, model, resume_id, prompt)
+    }
+
+    fn build_codex_command_for_test(use_mock: bool) -> Vec<String> {
+        disable_system_log();
+        build_codex_command(use_mock)
+    }
+
+    #[test]
+    fn build_codex_args_basic_shape() {
+        let args = build_codex_args_for_test("/workspace", "", "", "hello");
+        assert_eq!(args[0], "exec");
+        assert_eq!(args[1], "--json");
+        let s_idx = args.iter().position(|a| a == "--sandbox").unwrap();
+        assert_eq!(args[s_idx + 1], "danger-full-access");
+        assert!(args.contains(&"--skip-git-repo-check".to_string()));
+        let c_idx = args.iter().position(|a| a == "-C").unwrap();
+        assert_eq!(args[c_idx + 1], "/workspace");
+        assert_eq!(args.last().unwrap(), "hello");
+    }
+
+    #[test]
+    fn build_codex_args_omits_model_when_empty() {
+        let args = build_codex_args_for_test("/wd", "", "", "p");
+        assert!(!args.contains(&"-m".to_string()));
+    }
+
+    #[test]
+    fn build_codex_args_with_model() {
+        let args = build_codex_args_for_test("/wd", "gpt-5", "", "p");
+        let m_idx = args.iter().position(|a| a == "-m").unwrap();
+        assert_eq!(args[m_idx + 1], "gpt-5");
+    }
+
+    #[test]
+    fn build_codex_args_resume_uses_positional_subcommand() {
+        let args = build_codex_args_for_test("/wd", "", "thread-abc", "follow up");
+        let r_idx = args.iter().position(|a| a == "resume").unwrap();
+        assert_eq!(args[r_idx + 1], "thread-abc");
+        assert_eq!(args[r_idx + 2], "follow up");
+        // resume is a positional sub-subcommand, NOT a --resume flag
+        assert!(!args.contains(&"--resume".to_string()));
+    }
+
+    #[test]
+    fn build_codex_args_resume_layout_is_resume_id_prompt() {
+        let args = build_codex_args_for_test("/wd", "", "id1", "p1");
+        let r_idx = args.iter().position(|a| a == "resume").unwrap();
+        assert_eq!(args.len(), r_idx + 3);
+        assert_eq!(args[r_idx + 1], "id1");
+        assert_eq!(args[r_idx + 2], "p1");
+    }
+
+    #[test]
+    fn build_codex_args_no_double_dash_separator() {
+        // Codex has no variadic flags here; a bare `--` separator would
+        // propagate as a literal arg to the codex CLI.
+        let args = build_codex_args_for_test("/wd", "gpt-5", "id", "hello");
+        assert!(!args.contains(&"--".to_string()));
+    }
+
+    #[test]
+    fn build_codex_args_prompt_last_in_no_resume_path() {
+        let args = build_codex_args_for_test("/wd", "gpt-5", "", "the prompt");
+        assert_eq!(args.last().unwrap(), "the prompt");
+    }
+
+    #[test]
+    fn build_codex_command_uses_codex_binary() {
+        let cmd = build_codex_command_for_test(false);
+        assert_eq!(cmd[0], "codex");
+    }
+
+    #[test]
+    fn build_codex_command_uses_mock_binary() {
+        // Mirrors `build_claude_command_uses_mock_binary`: assert against
+        // the default const so regressions in the install path surface.
+        let cmd = build_codex_command_for_test(true);
+        assert_eq!(cmd[0], env::DEFAULT_MOCK_CODEX_PATH);
     }
 
     #[test]

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -11,6 +11,31 @@ fn env_or_empty(name: &str) -> String {
     std::env::var(name).unwrap_or_default()
 }
 
+/// CLI framework dispatched by the runner via `CLI_AGENT_TYPE`. Unknown
+/// values fall back to `ClaudeCode` so a misconfigured runner can't
+/// crash the guest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Framework {
+    ClaudeCode,
+    Codex,
+}
+
+impl Framework {
+    pub fn from_env() -> Self {
+        match cli_agent_type() {
+            "codex" => Framework::Codex,
+            "" | "claude-code" => Framework::ClaudeCode,
+            other => {
+                log_warn!(
+                    LOG_TAG,
+                    "Unknown CLI_AGENT_TYPE={other:?}, defaulting to claude-code"
+                );
+                Framework::ClaudeCode
+            }
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Core
 // ---------------------------------------------------------------------------
@@ -49,6 +74,35 @@ pub const DEFAULT_MOCK_CLAUDE_PATH: &str = "/usr/local/bin/guest-mock-claude";
 static MOCK_CLAUDE_PATH: LazyLock<String> = LazyLock::new(|| {
     std::env::var("VM0_MOCK_CLAUDE_PATH").unwrap_or_else(|_| DEFAULT_MOCK_CLAUDE_PATH.to_string())
 });
+
+// ---------------------------------------------------------------------------
+// Codex framework env vars
+// ---------------------------------------------------------------------------
+
+static CLI_AGENT_TYPE: LazyLock<String> = LazyLock::new(|| env_or_empty("CLI_AGENT_TYPE"));
+static OPENAI_API_KEY: LazyLock<String> = LazyLock::new(|| env_or_empty("OPENAI_API_KEY"));
+static OPENAI_MODEL: LazyLock<String> = LazyLock::new(|| env_or_empty("OPENAI_MODEL"));
+
+/// `USE_MOCK_CODEX` accepts both `"true"` and `"1"` (matches the Codex
+/// epic's documented invocation shape `USE_MOCK_CODEX=1`). The
+/// claude-side `USE_MOCK_CLAUDE` historically only accepts `"true"`;
+/// the asymmetry is intentional.
+static USE_MOCK_CODEX: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("USE_MOCK_CODEX")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false)
+});
+
+/// Production install location for the mock-codex binary, mirroring
+/// `DEFAULT_MOCK_CLAUDE_PATH`.
+pub const DEFAULT_MOCK_CODEX_PATH: &str = "/usr/local/bin/guest-mock-codex";
+
+static MOCK_CODEX_PATH: LazyLock<String> = LazyLock::new(|| {
+    std::env::var("VM0_MOCK_CODEX_PATH").unwrap_or_else(|_| DEFAULT_MOCK_CODEX_PATH.to_string())
+});
+
+static HOME_DIR: LazyLock<String> =
+    LazyLock::new(|| std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string()));
 /// Read an optional `u64` env var, falling back to `default` when it's
 /// unset or unparseable. Emits a stderr warning on the unparseable case so
 /// the mistake is visible in runner logs rather than silently absorbed.
@@ -184,6 +238,24 @@ pub fn use_mock_claude() -> bool {
 }
 pub fn mock_claude_path() -> String {
     MOCK_CLAUDE_PATH.clone()
+}
+pub fn cli_agent_type() -> &'static str {
+    &CLI_AGENT_TYPE
+}
+pub fn openai_api_key() -> &'static str {
+    &OPENAI_API_KEY
+}
+pub fn openai_model() -> &'static str {
+    &OPENAI_MODEL
+}
+pub fn use_mock_codex() -> bool {
+    *USE_MOCK_CODEX
+}
+pub fn mock_codex_path() -> String {
+    MOCK_CODEX_PATH.clone()
+}
+pub fn home_dir() -> &'static str {
+    &HOME_DIR
 }
 pub fn artifacts() -> &'static [ArtifactEnv] {
     &ARTIFACTS

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -21,20 +21,25 @@ pub enum Framework {
 }
 
 impl Framework {
+    /// Resolve the framework once and cache it. Subsequent calls are a
+    /// `LazyLock` deref — no repeat env reads, no repeat warning logs,
+    /// and a single source of truth if a third framework is added later.
     pub fn from_env() -> Self {
-        match cli_agent_type() {
-            "codex" => Framework::Codex,
-            "" | "claude-code" => Framework::ClaudeCode,
-            other => {
-                log_warn!(
-                    LOG_TAG,
-                    "Unknown CLI_AGENT_TYPE={other:?}, defaulting to claude-code"
-                );
-                Framework::ClaudeCode
-            }
-        }
+        *FRAMEWORK
     }
 }
+
+static FRAMEWORK: LazyLock<Framework> = LazyLock::new(|| match cli_agent_type() {
+    "codex" => Framework::Codex,
+    "" | "claude-code" => Framework::ClaudeCode,
+    other => {
+        log_warn!(
+            LOG_TAG,
+            "Unknown CLI_AGENT_TYPE={other:?}, defaulting to claude-code"
+        );
+        Framework::ClaudeCode
+    }
+});
 
 // ---------------------------------------------------------------------------
 // Core
@@ -101,8 +106,21 @@ static MOCK_CODEX_PATH: LazyLock<String> = LazyLock::new(|| {
     std::env::var("VM0_MOCK_CODEX_PATH").unwrap_or_else(|_| DEFAULT_MOCK_CODEX_PATH.to_string())
 });
 
-static HOME_DIR: LazyLock<String> =
-    LazyLock::new(|| std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string()));
+/// `$HOME` is always set in the guest sandbox (rootfs init guarantees it).
+/// If it isn't, the rootfs is misconfigured and we want a loud, visible
+/// failure rather than papering over it with a magic path that would
+/// silently land codex auth state in the wrong directory.
+///
+/// # Panics
+/// Panics if `HOME` is unset. This indicates a rootfs/runner contract
+/// violation and is not user-recoverable; the same fail-fast policy as
+/// `load_artifacts` (`VM0_ARTIFACTS`).
+#[allow(clippy::expect_used)]
+fn load_home_dir() -> String {
+    std::env::var("HOME").expect("HOME must be set in guest sandbox (rootfs init contract)")
+}
+
+static HOME_DIR: LazyLock<String> = LazyLock::new(load_home_dir);
 /// Read an optional `u64` env var, falling back to `default` when it's
 /// unset or unparseable. Emits a stderr warning on the unparseable case so
 /// the mistake is visible in runner logs rather than silently absorbed.

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -112,8 +112,12 @@ async fn execute(
     // Pre-warm kernel DNS cache for the CLI's API endpoint.
     // Fire-and-forget: runs in background so the cache is populated by the
     // time the CLI spawns and makes its first HTTPS request.
+    let dns_target = match env::Framework::from_env() {
+        env::Framework::ClaudeCode => "api.anthropic.com:443",
+        env::Framework::Codex => "api.openai.com:443",
+    };
     tokio::spawn(async move {
-        let _ = tokio::net::lookup_host("api.anthropic.com:443").await;
+        let _ = tokio::net::lookup_host(dns_target).await;
     });
 
     // Working directory setup
@@ -127,6 +131,14 @@ async fn execute(
         return 1;
     }
     record_sandbox_op("working_dir_setup", wd_start.elapsed(), true, None);
+
+    // Codex setup: best-effort `codex login`. Failure is non-fatal —
+    // `codex exec` reads `OPENAI_API_KEY` directly from the env.
+    if matches!(env::Framework::from_env(), env::Framework::Codex)
+        && let Err(e) = cli::setup_codex()
+    {
+        log_error!(LOG_TAG, "Codex setup failed (non-fatal, continuing): {e}");
+    }
 
     // Memory is now mounted directly at the Claude Code auto-memory path via
     // manifest.artifacts[] — no runtime symlink needed (see #10602).


### PR DESCRIPTION
## Summary

Adds the guest-side consumer of `CLI_AGENT_TYPE` so that `CLI_AGENT_TYPE=codex` invokes `codex exec --json --sandbox danger-full-access ...` instead of the Claude Code path. Sub-issue of epic #11386.

- `env.rs`: new `Framework` enum (with safe fallback on unknown values) + codex env accessors (`cli_agent_type`, `openai_api_key`, `openai_model`, `use_mock_codex`, `mock_codex_path`, `home_dir`).
- `cli.rs`: `build_codex_args` (testable), `build_codex_command`, `setup_codex` (best-effort `codex login --with-api-key`). `build_cli_command` now matches on `Framework`. Claude env scrubbers are gated to `Framework::ClaudeCode`; `CODEX_HOME` is pinned for `Framework::Codex`.
- `main.rs`: framework-keyed DNS pre-warm (`api.openai.com` for codex) + `setup_codex` dispatch.

The reap FSM and stuck-tool watchdog are intentionally left in place — both are natural no-ops on codex JSONL because `event.type == "result"` is never true and `extract_claude_tool_info` returns empty for non-Claude content blocks.

Sandbox flag hardcoded to `--sandbox danger-full-access` per epic locked decision Q12. Mock binary discovery via `USE_MOCK_CODEX` + `VM0_MOCK_CODEX_PATH` (project-convention naming, not the issue body's `MOCK_CODEX_PATH`); the binary itself lands in #11417.

## Out of scope (split per epic plan)

- codex JSONL → vm0 event mapping → #11421
- codex session resume / checkpoint scan → #11419
- rootfs codex install → #11416
- `guest-mock-codex` crate → #11417
- E2E `*-codex.bats` coverage → #11422

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p guest-agent` — 134 unit (incl. 9 new codex-specific) + 42 integration tests pass
- [x] Argv shape verified by unit tests:
  - `codex exec --json --sandbox danger-full-access --skip-git-repo-check -C <wd> [-m <model>] [resume <id>] <prompt>`
  - resume is positional (`resume <id> <prompt>`), not `--resume <id>`
  - no `--` separator before prompt (would propagate as a literal arg in codex)
- [x] Claude path argv unchanged — existing `build_claude_command_*` tests still green
- [x] Pre-commit hooks pass (lefthook: cargo-fmt, cargo-clippy, commitlint, check-file-size)

Closes #11418

🤖 Generated with [Claude Code](https://claude.com/claude-code)