### PR TITLE
feat(core): register codex framework + tighten compose schema enum

### DIFF
--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -691,7 +691,7 @@ describe("compose command", () => {
   });
 
   describe("framework validation", () => {
-    it("should pass unsupported framework to server (server-side validation)", async () => {
+    it("should reject unsupported framework client-side", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
         `version: "1.0"
@@ -701,33 +701,15 @@ agents:
     framework: unsupported-framework`,
       );
 
-      server.use(
-        http.get("http://localhost:3000/api/agent/composes", () => {
-          return HttpResponse.json(
-            { error: { message: "Not found", code: "NOT_FOUND" } },
-            { status: 404 },
-          );
-        }),
-        http.post("http://localhost:3000/api/agent/composes", () => {
-          return HttpResponse.json(
-            {
-              error: {
-                message:
-                  'Unsupported framework: "unsupported-framework". Supported frameworks: claude-code',
-                code: "BAD_REQUEST",
-              },
-            },
-            { status: 400 },
-          );
-        }),
-      );
-
       await expect(async () => {
         await composeCommand.parseAsync(["node", "cli", "vm0.yaml"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Unsupported framework"),
+        expect.stringContaining("agent.framework"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid option"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });

--- a/turbo/apps/web/app/api/agent/composes/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/route.test.ts
@@ -715,8 +715,10 @@ describe("Agent Compose Upsert Behavior", () => {
 
       expect(response.status).toBe(400);
       const data = await response.json();
-      expect(data.error.message).toContain("Unsupported framework");
-      expect(data.error.message).toContain(SUPPORTED_FRAMEWORKS.join(", "));
+      expect(data.error.message).toContain("Invalid option");
+      for (const framework of SUPPORTED_FRAMEWORKS) {
+        expect(data.error.message).toContain(framework);
+      }
     });
 
     it("should accept claude-code framework", async () => {

--- a/turbo/apps/web/src/lib/infra/agent-compose/__tests__/resolve-artifacts.test.ts
+++ b/turbo/apps/web/src/lib/infra/agent-compose/__tests__/resolve-artifacts.test.ts
@@ -85,7 +85,9 @@ describe("resolveComposeArtifacts", () => {
     const compose: AgentComposeYaml = {
       version: "1",
       agents: {
-        "my-agent": { framework: "not-a-real-framework" },
+        "my-agent": {
+          framework: "not-a-real-framework",
+        } as unknown as AgentComposeYaml["agents"][string],
       },
       artifacts: [{ name: "a", mount_path: MOUNT_PATH_TEMPLATE }],
     };

--- a/turbo/apps/web/src/lib/infra/agent-compose/types.ts
+++ b/turbo/apps/web/src/lib/infra/agent-compose/types.ts
@@ -2,6 +2,8 @@
  * Agent compose types matching agent.yaml format
  */
 
+import type { SupportedFramework } from "@vm0/core/frameworks";
+
 /**
  * Volume configuration for static dependencies
  * Each volume requires explicit name and version
@@ -35,7 +37,7 @@ export interface ArtifactConfig {
  */
 interface AgentDefinition {
   description?: string;
-  framework: string;
+  framework: SupportedFramework;
   volumes?: string[]; // Format: "volume-key:/mount/path"
   environment?: Record<string, string>; // Environment variables using ${{ vars.X }}, ${{ secrets.X }} syntax
   /**

--- a/turbo/apps/web/src/lib/infra/framework/framework-config.ts
+++ b/turbo/apps/web/src/lib/infra/framework/framework-config.ts
@@ -21,6 +21,9 @@ const FRAMEWORK_DEFAULTS: Record<SupportedFramework, FrameworkDefaults> = {
   "claude-code": {
     workingDir: "/home/user/workspace",
   },
+  codex: {
+    workingDir: "/home/user/workspace",
+  },
 };
 
 /**

--- a/turbo/packages/api-contracts/src/contracts/composes.ts
+++ b/turbo/packages/api-contracts/src/contracts/composes.ts
@@ -166,7 +166,7 @@ const artifactsArraySchema = z.array(artifactConfigSchema).refine((items) => {
  */
 const agentDefinitionSchema = z.object({
   description: z.string().optional(),
-  framework: z.string().min(1, "Framework is required"),
+  framework: z.enum(["claude-code", "codex"]),
   volumes: z.array(z.string()).optional(),
   environment: z.record(z.string(), z.string()).optional(),
   /**

--- a/turbo/packages/core/src/__tests__/frameworks.spec.ts
+++ b/turbo/packages/core/src/__tests__/frameworks.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { agentDefinitionSchema } from "@vm0/api-contracts/contracts/composes";
 import {
   SUPPORTED_FRAMEWORKS,
   isSupportedFramework,
@@ -14,14 +15,29 @@ describe("frameworks", () => {
       expect(SUPPORTED_FRAMEWORKS).toContain("claude-code");
     });
 
-    it("has exactly 1 framework", () => {
-      expect(SUPPORTED_FRAMEWORKS).toHaveLength(1);
+    it("includes codex", () => {
+      expect(SUPPORTED_FRAMEWORKS).toContain("codex");
+    });
+
+    it("has exactly 2 frameworks", () => {
+      expect(SUPPORTED_FRAMEWORKS).toHaveLength(2);
+    });
+
+    it("matches the composes contract framework enum", () => {
+      const schemaFrameworks = agentDefinitionSchema.shape.framework.options;
+      expect([...SUPPORTED_FRAMEWORKS].sort()).toEqual(
+        [...schemaFrameworks].sort(),
+      );
     });
   });
 
   describe("isSupportedFramework", () => {
     it("returns true for claude-code", () => {
       expect(isSupportedFramework("claude-code")).toBe(true);
+    });
+
+    it("returns true for codex", () => {
+      expect(isSupportedFramework("codex")).toBe(true);
     });
 
     it("returns false for undefined", () => {
@@ -65,7 +81,7 @@ describe("frameworks", () => {
     it("lists supported frameworks in error message", () => {
       expect(() => {
         return assertSupportedFramework("unknown");
-      }).toThrow("Supported frameworks: claude-code");
+      }).toThrow("Supported frameworks: claude-code, codex");
     });
   });
 
@@ -90,6 +106,10 @@ describe("frameworks", () => {
       expect(getFrameworkDisplayName("claude-code")).toBe("Claude Code");
     });
 
+    it('returns "Codex" for codex', () => {
+      expect(getFrameworkDisplayName("codex")).toBe("Codex");
+    });
+
     it("throws for unknown framework", () => {
       expect(() => {
         return getFrameworkDisplayName("unknown");
@@ -100,6 +120,10 @@ describe("frameworks", () => {
   describe("getInstructionsFilename", () => {
     it('returns "CLAUDE.md" for claude-code', () => {
       expect(getInstructionsFilename("claude-code")).toBe("CLAUDE.md");
+    });
+
+    it('returns "AGENTS.md" for codex', () => {
+      expect(getInstructionsFilename("codex")).toBe("AGENTS.md");
     });
 
     it('returns "CLAUDE.md" for undefined (defaults to claude-code)', () => {

--- a/turbo/packages/core/src/frameworks.ts
+++ b/turbo/packages/core/src/frameworks.ts
@@ -7,7 +7,7 @@
 /**
  * Supported framework identifiers
  */
-export const SUPPORTED_FRAMEWORKS = ["claude-code"] as const;
+export const SUPPORTED_FRAMEWORKS = ["claude-code", "codex"] as const;
 
 export type SupportedFramework = (typeof SUPPORTED_FRAMEWORKS)[number];
 
@@ -65,6 +65,7 @@ export function getValidatedFramework(
  */
 const FRAMEWORK_DISPLAY_NAMES: Record<SupportedFramework, string> = {
   "claude-code": "Claude Code",
+  codex: "Codex",
 };
 
 /**
@@ -84,6 +85,7 @@ export function getFrameworkDisplayName(framework: string): string {
  */
 const FRAMEWORK_INSTRUCTIONS_FILENAMES: Record<SupportedFramework, string> = {
   "claude-code": "CLAUDE.md",
+  codex: "AGENTS.md",
 };
 
 /**
@@ -91,6 +93,7 @@ const FRAMEWORK_INSTRUCTIONS_FILENAMES: Record<SupportedFramework, string> = {
  *
  * Each framework expects instructions at a specific filename:
  * - claude-code: CLAUDE.md (read from ~/.claude/)
+ * - codex: AGENTS.md (read from ~/.codex/)
  *
  * Used by CLI (upload) and web API (read) to ensure a symmetric contract.
  *


### PR DESCRIPTION
## Summary

Foundation work for epic #11386 (codex compose framework support). Registers `codex` in the `@vm0/core` framework registry and tightens the API contract so the framework field rejects unknown values at the boundary.

- Adds `"codex"` to `SUPPORTED_FRAMEWORKS`, `FRAMEWORK_DISPLAY_NAMES` (`"Codex"`), and `FRAMEWORK_INSTRUCTIONS_FILENAMES` (`"AGENTS.md"`).
- Tightens `agentDefinitionSchema.framework` from `z.string().min(1)` to `z.enum(["claude-code", "codex"])` so typos / unknown frameworks reject at HTTP 400 instead of failing later in `getValidatedFramework()`.
- Adds invariant test in `frameworks.spec.ts` (in `@vm0/core`, which can import from `@vm0/api-contracts`) that asserts `SUPPORTED_FRAMEWORKS` and `agentDefinitionSchema.shape.framework.options` stay in sync.
- Updates the existing `toHaveLength(1)` and `"Supported frameworks: claude-code"` assertions and adds positive cases for codex across `isSupportedFramework`, `getFrameworkDisplayName`, and `getInstructionsFilename`.
- Fixes downstream type breakage surfaced by the schema tightening:
  - `apps/web/src/lib/infra/framework/framework-config.ts` — adds a `codex` entry to the `Record<SupportedFramework, FrameworkDefaults>` map (placeholder `workingDir`; refined in #11415).
  - `apps/web/src/lib/infra/agent-compose/types.ts` — narrows hand-rolled `AgentDefinition.framework` from `string` to `SupportedFramework` to match the contract.
  - `apps/web/.../resolve-artifacts.test.ts` — `as unknown as` cast for the deliberately-invalid framework string used in a runtime-error test.

### Why inline (Q8 from epic #11386)

`@vm0/core` already depends on `@vm0/api-contracts`. Importing `SUPPORTED_FRAMEWORKS` into `composes.ts` would create a cycle. The enum is inlined; the invariant test enforces the two declarations stay in sync. The broader refactor (relocating framework metadata into `@vm0/api-contracts`) is explicitly deferred per the epic decision.

Closes #11414. Foundation for #11386.

## Test plan

- [x] `pnpm -F @vm0/core exec vitest run frameworks.spec.ts` passes (24 tests, including new invariant test).
- [x] `pnpm -F @vm0/api-contracts exec vitest run` passes (79 tests).
- [x] `pnpm -F web exec vitest run src/lib/infra/agent-compose` passes (31 tests).
- [x] `pnpm check-types` clean across all packages.
- [x] `pnpm turbo run lint` clean.
- [x] `pnpm format` no changes.
- [x] `pnpm knip` no new issues.
- [x] Manual: `agentDefinitionSchema.safeParse({ framework: "codex" })` succeeds, `safeParse({ framework: "typo" })` fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)