### PR TITLE
feat(rootfs): install codex cli binary in sandbox image

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -133,6 +133,7 @@ ROOTFS_DIR=""
 # Pinned versions (changes here invalidate the rootfs cache via script hash)
 GO_VERSION="1.26.2"
 CLAUDE_CODE_VERSION="2.1.121"
+CODEX_CLI_VERSION="0.125.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.26.0"
@@ -428,6 +429,7 @@ install_runtimes() {
     npm install -g \
       @googleworkspace/cli@${GWS_CLI_VERSION} \
       @xdevplatform/xurl@${XURL_VERSION} \
+      @openai/codex@${CODEX_CLI_VERSION} \
       agent-browser@${AGENT_BROWSER_VERSION}
     npm cache clean --force
   "

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -125,6 +125,13 @@ else
   errors+=("gh CLI not found at /usr/bin/gh")
 fi
 
+# npm-global bins land in /usr/bin (NodeSource Node 24 sets npm prefix to /usr).
+if [[ -f "${MOUNT_DIR}/usr/bin/codex" ]]; then
+  echo "  codex CLI: found"
+else
+  errors+=("codex CLI not found at /usr/bin/codex")
+fi
+
 # Check language runtimes
 # Some binaries use update-alternatives symlinks or versioned names (e.g.
 # php8.3 instead of php, javac under /usr/lib/jvm/). Use glob patterns

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -592,8 +592,15 @@ async fn cleanup_leaked_resource(
 ///   "Invalid API key" but still loads the complete module graph. The claude
 ///   binary is a Bun-compiled executable (not Node.js), so
 ///   `NODE_COMPILE_CACHE` has no effect.
+/// - `codex --help`: codex ships as a Node.js CLI (npm `@openai/codex`); the
+///   `--help` path exits cleanly without credentials yet `require`s the full
+///   module graph and triggers V8 JIT compilation, so the resolved-and-parsed
+///   bytecode is captured in the snapshot. Each warmup is wrapped in its own
+///   `(... || true)` sub-shell so a failure on one framework does not block
+///   the other from warming.
 pub const PREWARM_SCRIPT: &str = "\
-    (claude --print --verbose --output-format stream-json hi 2>/dev/null || true)";
+    (claude --print --verbose --output-format stream-json hi 2>/dev/null || true); \
+    (codex --help >/dev/null 2>&1 || true)";
 
 /// Balloon device configuration (invariant across all sandboxes).
 #[derive(serde::Serialize)]
@@ -1089,6 +1096,21 @@ mod tests {
         let h2 = config_hash();
         assert_eq!(h1, h2);
         assert_eq!(h1.len(), 64); // SHA-256 hex
+    }
+
+    /// Both supported framework CLIs must be warmed during snapshot creation.
+    /// Dropping either one would silently regress cold-start latency for that
+    /// framework's agents — see #11416 / epic #11386.
+    #[test]
+    fn prewarm_script_warms_both_frameworks() {
+        assert!(
+            PREWARM_SCRIPT.contains("claude"),
+            "PREWARM_SCRIPT must warm the claude CLI"
+        );
+        assert!(
+            PREWARM_SCRIPT.contains("codex"),
+            "PREWARM_SCRIPT must warm the codex CLI"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Install pinned `@openai/codex@0.125.0` in the sandbox rootfs alongside `claude` (no separate image variant — single universal rootfs per the epic decision).
- Pre-warm `codex --help` in the Firecracker snapshot next to the existing `claude --print …` warmup so codex agents skip the cold-start cost on first invocation.
- Verify the codex binary actually landed at `/usr/bin/codex` in the post-build verification step.

## Files changed

| File | Change |
|---|---|
| `crates/runner/scripts/build-rootfs.sh` | Pin `CODEX_CLI_VERSION="0.125.0"`; add `@openai/codex@${CODEX_CLI_VERSION}` to the existing combined `npm install -g` block. |
| `crates/runner/scripts/verify-rootfs.sh` | File-existence check for `/usr/bin/codex` (NodeSource Node 24 sets npm prefix to `/usr`, so npm-global bins land in `/usr/bin`, not `/usr/local/bin`). |
| `crates/sandbox-fc/src/factory.rs` | Append `(codex --help …)` warmup to `PREWARM_SCRIPT`; new `prewarm_script_warms_both_frameworks` invariant test guards against either CLI being dropped from warmup. |

## Cache invalidation note

This PR changes both inputs that gate the rootfs/snapshot caches:
- `build-rootfs.sh` content is hashed into the rootfs cache key (header comment lines 5–7).
- `PREWARM_SCRIPT` is part of `InvariantConfig` → `config_hash()` → snapshot cache key.

Result: every cached rootfs and snapshot will rebuild once on first deploy after merge. Expected one-time cost; no API/data impact.

## Image size delta

Expected small (single-digit MB — Codex CLI is a regular npm Node.js package). The exact delta will be visible in the CI rootfs build artifact. The base rootfs is tens of GB so this is rounding error.

## Verification

- `bash -n` syntax-checked both shell scripts.
- `cargo fmt --check`, `cargo clippy -p sandbox-fc -p runner -- -D warnings` clean.
- `cargo test -p sandbox-fc factory::` — 25 passed including the new `prewarm_script_warms_both_frameworks`.
- `cargo test -p runner -- ca_constants_in_sync_across_scripts inject_ca_verifies_bundle_after_update` — 2 passed (CA-sync invariants untouched).
- `npm view @openai/codex` — confirmed `bin: { codex: 'bin/codex.js' }` and \`latest\` dist-tag = `0.125.0`.
- Empirical bin-path check on dev container (Node 24 NodeSource): `npm config get prefix` → `/usr`; existing npm-globals (`agent-browser`) resolve at `/usr/bin/agent-browser`. Confirms the verify path `/usr/bin/codex`.

## Out of scope (tracked in epic #11386)

This PR only ensures the binary is present and warm. Everything else codex-related lives in sibling Wave 1/2 issues:

- `crates/guest-agent/src/cli.rs` codex command path → #11418
- Runner storage mount paths for `~/.codex/...` → #11420
- `crates/guest-mock-codex` crate → #11417
- TS framework registry + compose enum → #11414
- E2E `*-codex.bats` coverage → #11422

## Test plan

- [x] Syntax check on both shell scripts (`bash -n`)
- [x] Rust fmt + clippy clean across `sandbox-fc` and `runner`
- [x] All existing factory tests still pass
- [x] New `prewarm_script_warms_both_frameworks` invariant test passes
- [x] CA-constant sync test still passes (no CA changes here)
- [ ] CI rootfs build job confirms `/usr/bin/codex` is present (verify-rootfs.sh check)
- [ ] First post-merge cold start metrics show codex warmup is captured in the new snapshot

Closes #11416
Part of #11386

🤖 Generated with [Claude Code](https://claude.com/claude-code)