### PR TITLE
feat(web-infra): framework-aware defaults for codex

### DIFF
--- a/turbo/apps/web/src/lib/infra/agent-compose/types.ts
+++ b/turbo/apps/web/src/lib/infra/agent-compose/types.ts
@@ -41,8 +41,11 @@ interface AgentDefinition {
   volumes?: string[]; // Format: "volume-key:/mount/path"
   environment?: Record<string, string>; // Environment variables using ${{ vars.X }}, ${{ secrets.X }} syntax
   /**
-   * Path to instructions file (e.g., AGENTS.md).
-   * Auto-uploaded as volume and mounted at /home/user/.claude/CLAUDE.md
+   * Path to instructions file (e.g., AGENTS.md or CLAUDE.md).
+   * Auto-uploaded as a volume and mounted at the framework's instructions
+   * directory:
+   *   - claude-code: /home/user/.claude/CLAUDE.md
+   *   - codex: /home/user/.codex/AGENTS.md
    */
   instructions?: string;
   /**

--- a/turbo/apps/web/src/lib/infra/framework/__tests__/framework-config.test.ts
+++ b/turbo/apps/web/src/lib/infra/framework/__tests__/framework-config.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveFrameworkWorkingDir,
+  resolveFrameworkInstructionsMountPath,
+  resolveFrameworkApiKeyEnvVar,
+} from "../framework-config";
+
+describe("framework-config", () => {
+  describe("resolveFrameworkInstructionsMountPath", () => {
+    it("returns /home/user/.claude for claude-code", () => {
+      expect(resolveFrameworkInstructionsMountPath("claude-code")).toBe(
+        "/home/user/.claude",
+      );
+    });
+    it("returns /home/user/.codex for codex", () => {
+      expect(resolveFrameworkInstructionsMountPath("codex")).toBe(
+        "/home/user/.codex",
+      );
+    });
+  });
+
+  describe("resolveFrameworkApiKeyEnvVar", () => {
+    it("returns ANTHROPIC_API_KEY for claude-code", () => {
+      expect(resolveFrameworkApiKeyEnvVar("claude-code")).toBe(
+        "ANTHROPIC_API_KEY",
+      );
+    });
+    it("returns OPENAI_API_KEY for codex", () => {
+      expect(resolveFrameworkApiKeyEnvVar("codex")).toBe("OPENAI_API_KEY");
+    });
+  });
+
+  describe("resolveFrameworkWorkingDir (regression)", () => {
+    it("returns /home/user/workspace for claude-code", () => {
+      expect(resolveFrameworkWorkingDir("claude-code")).toBe(
+        "/home/user/workspace",
+      );
+    });
+    it("returns /home/user/workspace for codex", () => {
+      expect(resolveFrameworkWorkingDir("codex")).toBe("/home/user/workspace");
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/infra/framework/framework-config.ts
+++ b/turbo/apps/web/src/lib/infra/framework/framework-config.ts
@@ -1,8 +1,10 @@
 /**
  * Server-side framework configuration
  *
- * Provides working directory resolution based on framework.
- * Uses SUPPORTED_FRAMEWORKS from @vm0/core as the source of truth.
+ * Provides per-framework defaults: working directory, instructions mount
+ * path, and the API-key environment variable name expected in the compose
+ * environment block. Uses SUPPORTED_FRAMEWORKS from @vm0/core as the
+ * source of truth.
  */
 
 import type { SupportedFramework } from "@vm0/core/frameworks";
@@ -12,6 +14,8 @@ import type { SupportedFramework } from "@vm0/core/frameworks";
  */
 interface FrameworkDefaults {
   workingDir: string;
+  instructionsMountPath: string;
+  apiKeyEnvVar: string;
 }
 
 /**
@@ -20,9 +24,13 @@ interface FrameworkDefaults {
 const FRAMEWORK_DEFAULTS: Record<SupportedFramework, FrameworkDefaults> = {
   "claude-code": {
     workingDir: "/home/user/workspace",
+    instructionsMountPath: "/home/user/.claude",
+    apiKeyEnvVar: "ANTHROPIC_API_KEY",
   },
   codex: {
     workingDir: "/home/user/workspace",
+    instructionsMountPath: "/home/user/.codex",
+    apiKeyEnvVar: "OPENAI_API_KEY",
   },
 };
 
@@ -36,4 +44,28 @@ export function resolveFrameworkWorkingDir(
   framework: SupportedFramework,
 ): string {
   return FRAMEWORK_DEFAULTS[framework].workingDir;
+}
+
+/**
+ * Resolve the instructions mount path for a framework
+ *
+ * @param framework - The supported framework
+ * @returns The mount path where instructions volume is attached
+ */
+export function resolveFrameworkInstructionsMountPath(
+  framework: SupportedFramework,
+): string {
+  return FRAMEWORK_DEFAULTS[framework].instructionsMountPath;
+}
+
+/**
+ * Resolve the API-key environment variable name for a framework
+ *
+ * @param framework - The supported framework
+ * @returns The env var name the compose environment block must declare
+ */
+export function resolveFrameworkApiKeyEnvVar(
+  framework: SupportedFramework,
+): string {
+  return FRAMEWORK_DEFAULTS[framework].apiKeyEnvVar;
 }

--- a/turbo/apps/web/src/lib/infra/run/utils/__tests__/validate-framework-api-key.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/utils/__tests__/validate-framework-api-key.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { validateFrameworkApiKey } from "../validate-framework-api-key";
+import type { AgentComposeYaml } from "../../../agent-compose/types";
+
+function makeCompose(
+  framework: "claude-code" | "codex",
+  environment?: Record<string, string>,
+): AgentComposeYaml {
+  return {
+    version: "1",
+    agents: {
+      "test-agent": {
+        framework,
+        environment,
+      },
+    },
+  };
+}
+
+describe("validateFrameworkApiKey", () => {
+  describe("claude-code (exempt — gated by checkModelProviderConfigured)", () => {
+    it("returns silently with literal ANTHROPIC_API_KEY", () => {
+      expect(() => {
+        validateFrameworkApiKey(
+          makeCompose("claude-code", { ANTHROPIC_API_KEY: "sk-ant-..." }),
+        );
+      }).not.toThrow();
+    });
+    it("returns silently with no environment block at all", () => {
+      expect(() => {
+        validateFrameworkApiKey(makeCompose("claude-code"));
+      }).not.toThrow();
+    });
+    it("returns silently when environment is empty (org-provider injection path)", () => {
+      expect(() => {
+        validateFrameworkApiKey(makeCompose("claude-code", {}));
+      }).not.toThrow();
+    });
+  });
+
+  describe("codex", () => {
+    it("accepts compose with literal OPENAI_API_KEY", () => {
+      expect(() => {
+        validateFrameworkApiKey(
+          makeCompose("codex", { OPENAI_API_KEY: "sk-..." }),
+        );
+      }).not.toThrow();
+    });
+    it("accepts compose with secret-reference OPENAI_API_KEY", () => {
+      expect(() => {
+        validateFrameworkApiKey(
+          makeCompose("codex", {
+            OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
+          }),
+        );
+      }).not.toThrow();
+    });
+    it("rejects compose without OPENAI_API_KEY", () => {
+      expect(() => {
+        validateFrameworkApiKey(makeCompose("codex", {}));
+      }).toThrow(/OPENAI_API_KEY/);
+    });
+    it("rejects compose with no environment block", () => {
+      expect(() => {
+        validateFrameworkApiKey(makeCompose("codex"));
+      }).toThrow(/OPENAI_API_KEY/);
+    });
+    it("rejects compose with claude-only key", () => {
+      expect(() => {
+        validateFrameworkApiKey(
+          makeCompose("codex", { ANTHROPIC_API_KEY: "sk-ant-..." }),
+        );
+      }).toThrow(/OPENAI_API_KEY/);
+    });
+    it("error message names the framework", () => {
+      expect(() => {
+        validateFrameworkApiKey(makeCompose("codex", {}));
+      }).toThrow(/codex/);
+    });
+  });
+
+  it("returns silently when compose has no agents", () => {
+    const empty: AgentComposeYaml = { version: "1", agents: {} };
+    expect(() => {
+      validateFrameworkApiKey(empty);
+    }).not.toThrow();
+  });
+});

--- a/turbo/apps/web/src/lib/infra/run/utils/index.ts
+++ b/turbo/apps/web/src/lib/infra/run/utils/index.ts
@@ -1,2 +1,3 @@
 export { extractWorkingDir } from "./extract-working-dir";
 export { extractCliAgentType } from "./extract-cli-agent-type";
+export { validateFrameworkApiKey } from "./validate-framework-api-key";

--- a/turbo/apps/web/src/lib/infra/run/utils/validate-framework-api-key.ts
+++ b/turbo/apps/web/src/lib/infra/run/utils/validate-framework-api-key.ts
@@ -1,0 +1,39 @@
+import { getValidatedFramework } from "@vm0/core/frameworks";
+import { badRequest } from "@vm0/api-services/errors";
+import { resolveFrameworkApiKeyEnvVar } from "../../framework/framework-config";
+import type { AgentComposeYaml } from "../../agent-compose/types";
+
+/**
+ * Validate that a compose's environment block declares the framework's
+ * required API-key env var.
+ *
+ * claude-code is exempt: the org-level model-provider system
+ * (`checkModelProviderConfigured`) already gates runs that lack
+ * `ANTHROPIC_API_KEY` and supports runtime injection from the org's default
+ * provider. Frameworks without an org-level injection path (codex today)
+ * must declare the key in the compose `environment` — either as a literal
+ * value or as a `${{ secrets.X }}` placeholder; the runner resolves the
+ * placeholder at execution time and surfaces its own error if the secret
+ * is missing.
+ *
+ * @throws BadRequestError if the env var is absent for a framework that
+ *   requires compose-level declaration.
+ */
+export function validateFrameworkApiKey(compose: AgentComposeYaml): void {
+  const agents = compose.agents ? Object.values(compose.agents) : [];
+  const agent = agents[0];
+  if (!agent) return;
+
+  const framework = getValidatedFramework(agent.framework);
+  if (framework === "claude-code") return;
+
+  const requiredVar = resolveFrameworkApiKeyEnvVar(framework);
+  const env = agent.environment ?? {};
+  if (!(requiredVar in env)) {
+    throw badRequest(
+      `Compose with framework "${framework}" requires ${requiredVar} ` +
+        `in agent environment. Set it as a literal value or as a secret ` +
+        `reference: \${{ secrets.${requiredVar} }}`,
+    );
+  }
+}

--- a/turbo/apps/web/src/lib/infra/storage/__tests__/instruction-upload.test.ts
+++ b/turbo/apps/web/src/lib/infra/storage/__tests__/instruction-upload.test.ts
@@ -107,6 +107,34 @@ describe("uploadInstructionsServerSide", () => {
     expect(context.mocks.s3.putS3Object).toHaveBeenCalledTimes(2);
   });
 
+  it("uploads codex instructions as AGENTS.md when framework=codex", async () => {
+    const result = await uploadInstructionsServerSide({
+      orgId,
+      agentName: "codex-agent",
+      content: "# Codex instructions",
+      framework: "codex",
+    });
+
+    expect(result.storageName).toBe("agent-instructions@codex-agent");
+
+    const archiveCall = context.mocks.s3.putS3Object.mock.calls.find((c) => {
+      return typeof c[1] === "string" && c[1].endsWith("/archive.tar.gz");
+    });
+    expect(archiveCall).toBeDefined();
+    const tarBuffer = gunzipSync(archiveCall![2] as Buffer);
+    const fileContent = extractFileFromTar(tarBuffer, "AGENTS.md");
+    expect(fileContent).not.toBeNull();
+    expect(fileContent!.toString("utf-8")).toBe("# Codex instructions");
+
+    const manifestCall = context.mocks.s3.putS3Object.mock.calls.find((c) => {
+      return typeof c[1] === "string" && c[1].endsWith("/manifest.json");
+    });
+    expect(manifestCall).toBeDefined();
+    const manifestBody = JSON.parse(manifestCall![2] as string);
+    expect(manifestBody.files).toHaveLength(1);
+    expect(manifestBody.files[0].path).toBe("AGENTS.md");
+  });
+
   it("should return different versionId for different content", async () => {
     const resultA = await uploadInstructionsServerSide({
       orgId,

--- a/turbo/apps/web/src/lib/infra/storage/storage-resolver.ts
+++ b/turbo/apps/web/src/lib/infra/storage/storage-resolver.ts
@@ -9,20 +9,22 @@ import type {
 import { getValidatedFramework } from "@vm0/core/frameworks";
 import { expandVariablesInString } from "@vm0/core/variable-expander";
 import { getInstructionsStorageName } from "@vm0/core/storage-names";
+import { resolveFrameworkInstructionsMountPath } from "../framework/framework-config";
 
 /**
- * Get the mount path for instructions based on framework
+ * Get the mount path for instructions based on framework.
  *
  * Each framework expects instructions at a specific location:
- * - claude-code: ~/.claude/
+ * - claude-code: /home/user/.claude
+ * - codex: /home/user/.codex
  *
- * @param framework - The framework name (e.g., "claude-code")
+ * @param framework - The framework name (undefined defaults to claude-code)
  * @returns The mount path for instructions
  * @throws Error if framework is defined but not supported
  */
 function getInstructionsMountPath(framework?: string): string {
-  getValidatedFramework(framework);
-  return "/home/user/.claude";
+  const validated = getValidatedFramework(framework);
+  return resolveFrameworkInstructionsMountPath(validated);
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -7,6 +7,7 @@ import {
   noModelProvider,
 } from "@vm0/api-services/errors";
 import { canAccessCompose } from "../infra/agent/compose-access";
+import { validateFrameworkApiKey } from "../infra/run/utils";
 import { logger } from "../shared/logger";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { ORG_SENTINEL_USER_ID } from "./org/org-sentinel";
@@ -111,7 +112,7 @@ export function authorizeCompose(
 }
 
 /**
- * Validate image access for new runs.
+ * Validate compose requirements for new runs.
  *
  * Skipped when resuming from checkpoint or continuing a session.
  */
@@ -121,6 +122,7 @@ export async function validateComposeRequirements(
   if (!composeContent?.agents) {
     return;
   }
+  validateFrameworkApiKey(composeContent);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Web infra layer is now framework-aware for codex composes.
- `framework-config.ts` extends per-framework defaults with `instructionsMountPath` and `apiKeyEnvVar`; `storage-resolver` mounts instructions at `/home/user/.codex` (claude-code keeps `/home/user/.claude`).
- `validateFrameworkApiKey` enforces compose-level presence of the framework's API-key env var (literal value or `${{ secrets.X }}` placeholder) for frameworks without org-level injection. claude-code is exempt because `checkModelProviderConfigured` already gates its org-level fallback.
- Hooked into the shared `validateComposeRequirements` so all three dispatch entry points (`/api/agent/runs/route.ts`, `zero-run-service.ts`, `zero-run-queue-service.ts`) get the check on new runs.
- `agent-compose/types.ts` JSDoc now describes both frameworks' instruction paths.

Per epic #11386 locked decisions, this is **infra-layer only** — the zero-layer model-provider system stays claude-code-only.

Closes #11415.

## Test plan
- [x] `framework-config.test.ts` (new) — both frameworks for `resolveFrameworkWorkingDir`, `resolveFrameworkInstructionsMountPath`, `resolveFrameworkApiKeyEnvVar`.
- [x] `validate-framework-api-key.test.ts` (new) — claude-code exempt path; codex literal/placeholder accept; missing-key and claude-only-key reject.
- [x] `instruction-upload.test.ts` — added codex case asserting `AGENTS.md` in tar archive + manifest. Existing claude-code case (`CLAUDE.md`) still green.
- [x] Full web vitest run: `pnpm -F web exec vitest run` — 4003/4003 pass.
- [x] `pnpm check-types`, `pnpm turbo run lint`, `pnpm format`, `pnpm knip` — all clean.

## Definition of Done (mirrors issue checklist)
- [x] `framework-config.ts` exposes `resolveFrameworkInstructionsMountPath` + `resolveFrameworkApiKeyEnvVar`.
- [x] `storage-resolver.ts:getInstructionsMountPath` returns `/home/user/.codex` for codex, `/home/user/.claude` for claude-code.
- [x] `validateFrameworkApiKey` rejects codex composes without `OPENAI_API_KEY`; accepts placeholder references.
- [x] `validateComposeRequirements` invokes `validateFrameworkApiKey` on every dispatch.
- [x] `instruction-upload.test.ts` covers `framework: "codex"` writing `AGENTS.md`.
- [x] JSDoc in `agent-compose/types.ts:45` is framework-agnostic.
- [x] All pre-commit checks pass.
- [x] No regressions in existing route.test.ts / build-zero-context.test.ts / credit-check.test.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)