### PR TITLE
feat(cli): codex JSONL event parser + factory dispatch

### DIFF
--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -609,6 +609,428 @@ describe("logs command", () => {
     });
   });
 
+  describe("codex framework events", () => {
+    it("should render thread.started, agent_message, and turn.completed", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "0199a213-81c0-7800-8aa1-bbab2a035a53",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "item_1",
+                      type: "agent_message",
+                      text: "Codex says hello",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "turn.completed",
+                    usage: {
+                      input_tokens: 24763,
+                      cached_input_tokens: 24448,
+                      output_tokens: 122,
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Started");
+      expect(logCalls).toContain("0199a213-81c0-7800-8aa1-bbab2a035a53");
+      expect(logCalls).toContain("Codex says hello");
+      expect(logCalls).toContain("Codex Completed");
+    });
+
+    it("should render command_execution as Bash tool with output", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: "cmd_1",
+                      type: "command_execution",
+                      command: "bash -lc ls",
+                      status: "in_progress",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "cmd_1",
+                      type: "command_execution",
+                      command: "bash -lc ls",
+                      exit_code: 0,
+                      output: "README.md\nsrc",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Bash");
+      expect(logCalls).toContain("bash -lc ls");
+      expect(logCalls).toContain("README.md");
+    });
+
+    it("should mark command_execution with non-zero exit_code as error", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: "cmd_1",
+                      type: "command_execution",
+                      command: "ls /nonexistent",
+                      status: "in_progress",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "cmd_1",
+                      type: "command_execution",
+                      command: "ls /nonexistent",
+                      exit_code: 1,
+                      output: "ls: cannot access '/nonexistent'",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("ls /nonexistent");
+      expect(logCalls).toContain("✗");
+      expect(logCalls).toContain("ls: cannot access '/nonexistent'");
+    });
+
+    it("should render file_edit, file_write, and file_read tools", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: "edit_1",
+                      type: "file_edit",
+                      path: "/workspace/src/main.ts",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "edit_1",
+                      type: "file_edit",
+                      path: "/workspace/src/main.ts",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: "write_1",
+                      type: "file_write",
+                      path: "/workspace/README.md",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 4,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:03Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "write_1",
+                      type: "file_write",
+                      path: "/workspace/README.md",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 5,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:04Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: "read_1",
+                      type: "file_read",
+                      path: "/workspace/package.json",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 6,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:05Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "read_1",
+                      type: "file_read",
+                      path: "/workspace/package.json",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Edit");
+      expect(logCalls).toContain("/workspace/src/main.ts");
+      expect(logCalls).toContain("Write");
+      expect(logCalls).toContain("/workspace/README.md");
+      expect(logCalls).toContain("Read");
+      expect(logCalls).toContain("/workspace/package.json");
+    });
+
+    it("should render reasoning items with [thinking] prefix", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "reason_1",
+                      type: "reasoning",
+                      text: "Considering the trade-offs",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("[thinking] Considering the trade-offs");
+    });
+
+    it("should render file_change as a [files] text event", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "change_1",
+                      type: "file_change",
+                      changes: [
+                        { kind: "add", path: "/workspace/new.ts" },
+                        { kind: "modify", path: "/workspace/existing.ts" },
+                        { kind: "delete", path: "/workspace/old.ts" },
+                      ],
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("[files]");
+      expect(logCalls).toContain("Created: /workspace/new.ts");
+      expect(logCalls).toContain("Modified: /workspace/existing.ts");
+      expect(logCalls).toContain("Deleted: /workspace/old.ts");
+    });
+
+    it("should render turn.failed as Codex Failed", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.failed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.failed",
+                    error: "Rate limit exceeded",
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Failed");
+    });
+
+    it("should render top-level error event as a failure result", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "error",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "error",
+                    message: "API connection failed",
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Failed");
+    });
+  });
+
   describe("system log", () => {
     it("should display system log with --system flag", async () => {
       server.use(

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -12,7 +12,7 @@ import {
 import { getApiUrl } from "../../lib/api/config";
 import { parseTime } from "../../lib/utils/time-parser";
 import { formatBytes } from "../../lib/utils/file-utils";
-import { ClaudeEventParser } from "../../lib/events/claude-event-parser";
+import { parseEvent } from "../../lib/events/event-parser-factory";
 import { EventRenderer } from "../../lib/events/event-renderer";
 import { paginate } from "../../lib/utils/paginate";
 import { searchCommand } from "./search";
@@ -240,9 +240,13 @@ function createLogRenderer(verbose: boolean): EventRenderer {
 /**
  * Render an agent event with timestamp for historical log viewing
  */
-function renderAgentEvent(event: RunEvent, renderer: EventRenderer): void {
+function renderAgentEvent(
+  event: RunEvent,
+  renderer: EventRenderer,
+  framework: string,
+): void {
   const eventData = event.eventData as Record<string, unknown>;
-  const parsed = ClaudeEventParser.parse(eventData);
+  const parsed = parseEvent(eventData, framework);
   if (parsed) {
     parsed.timestamp = new Date(event.createdAt);
     renderer.render(parsed);
@@ -460,9 +464,10 @@ async function showAgentEvents(
 
   // Create renderer for log viewing (with timestamps, always verbose)
   const renderer = createLogRenderer(true);
+  const framework = firstResponse.framework;
 
   for (const event of events) {
-    renderAgentEvent(event, renderer);
+    renderAgentEvent(event, renderer, framework);
   }
 
   console.log(chalk.dim(`View on platform: ${platformUrl}`));

--- a/turbo/apps/cli/src/commands/logs/search.ts
+++ b/turbo/apps/cli/src/commands/logs/search.ts
@@ -6,7 +6,7 @@ import {
   type LogsSearchResponse,
 } from "../../lib/api";
 import { parseTime } from "../../lib/utils/time-parser";
-import { ClaudeEventParser } from "../../lib/events/claude-event-parser";
+import { parseEvent } from "../../lib/events/event-parser-factory";
 import { EventRenderer } from "../../lib/events/event-renderer";
 import { withErrorHandler } from "../../lib/command";
 
@@ -23,11 +23,15 @@ interface SearchOptions {
 }
 
 /**
- * Render a single agent event using EventRenderer
+ * Render a single agent event using EventRenderer.
+ *
+ * Search responses do not yet carry a per-result framework, so we let the
+ * factory default to claude-code. Codex events in search results render as
+ * nothing until the search contract is extended (tracked separately).
  */
 function renderEvent(event: RunEvent, renderer: EventRenderer): void {
   const eventData = event.eventData as Record<string, unknown>;
-  const parsed = ClaudeEventParser.parse(eventData);
+  const parsed = parseEvent(eventData);
   if (parsed) {
     parsed.timestamp = new Date(event.createdAt);
     renderer.render(parsed);

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -331,7 +331,7 @@ export async function pollEvents(
     for (const event of response.events) {
       const eventData = event.eventData as Record<string, unknown>;
 
-      const parsed = parseEvent(eventData);
+      const parsed = parseEvent(eventData, response.framework);
       if (parsed) {
         renderer.render(parsed);
       }

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
@@ -171,6 +171,60 @@ describe("zero logs view command", () => {
     expect(errorCalls).toContain("zero logs list");
   });
 
+  it("should render codex framework events", async () => {
+    server.use(
+      http.get(
+        "http://localhost:3000/api/zero/runs/:id/telemetry/agent",
+        () => {
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 1,
+                eventType: "thread.started",
+                createdAt: "2024-01-15T10:30:00Z",
+                eventData: {
+                  type: "thread.started",
+                  thread_id: "thread-zero-1",
+                },
+              },
+              {
+                sequenceNumber: 2,
+                eventType: "item.completed",
+                createdAt: "2024-01-15T10:30:01Z",
+                eventData: {
+                  type: "item.completed",
+                  item: {
+                    id: "msg_1",
+                    type: "agent_message",
+                    text: "Codex zero output",
+                  },
+                },
+              },
+              {
+                sequenceNumber: 3,
+                eventType: "turn.completed",
+                createdAt: "2024-01-15T10:30:02Z",
+                eventData: {
+                  type: "turn.completed",
+                  usage: { input_tokens: 100, output_tokens: 20 },
+                },
+              },
+            ],
+            framework: "codex",
+            hasMore: false,
+          });
+        },
+      ),
+    );
+
+    await zeroLogsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("Codex Started");
+    expect(logCalls).toContain("Codex zero output");
+    expect(logCalls).toContain("Codex Completed");
+  });
+
   it("should handle authentication error", async () => {
     server.use(
       http.get(

--- a/turbo/apps/cli/src/commands/zero/logs/index.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/index.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { getZeroRunAgentEvents, type RunEvent } from "../../../lib/api";
 import { parseTime } from "../../../lib/utils/time-parser";
-import { ClaudeEventParser } from "../../../lib/events/claude-event-parser";
+import { parseEvent } from "../../../lib/events/event-parser-factory";
 import { EventRenderer } from "../../../lib/events/event-renderer";
 import { paginate } from "../../../lib/utils/paginate";
 import { withErrorHandler } from "../../../lib/command";
@@ -12,9 +12,13 @@ import { searchCommand } from "./search";
 
 const PAGE_LIMIT = 100;
 
-function renderAgentEvent(event: RunEvent, renderer: EventRenderer): void {
+function renderAgentEvent(
+  event: RunEvent,
+  renderer: EventRenderer,
+  framework: string,
+): void {
   const eventData = event.eventData as Record<string, unknown>;
-  const parsed = ClaudeEventParser.parse(eventData);
+  const parsed = parseEvent(eventData, framework);
   if (parsed) {
     parsed.timestamp = new Date(event.createdAt);
     renderer.render(parsed);
@@ -93,9 +97,10 @@ async function showAgentEvents(
     showTimestamp: true,
     verbose: true,
   });
+  const framework = firstResponse.framework;
 
   for (const event of events) {
-    renderAgentEvent(event, renderer);
+    renderAgentEvent(event, renderer, framework);
   }
 }
 

--- a/turbo/apps/cli/src/commands/zero/logs/search.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/search.ts
@@ -6,7 +6,7 @@ import {
   type LogsSearchResponse,
 } from "../../../lib/api";
 import { parseTime } from "../../../lib/utils/time-parser";
-import { ClaudeEventParser } from "../../../lib/events/claude-event-parser";
+import { parseEvent } from "../../../lib/events/event-parser-factory";
 import { EventRenderer } from "../../../lib/events/event-renderer";
 import { withErrorHandler } from "../../../lib/command";
 import { isUUID } from "../../run/shared";
@@ -25,7 +25,7 @@ export interface LogsSearchCliOptions {
 
 function renderEvent(event: RunEvent, renderer: EventRenderer): void {
   const eventData = event.eventData as Record<string, unknown>;
-  const parsed = ClaudeEventParser.parse(eventData);
+  const parsed = parseEvent(eventData);
   if (parsed) {
     parsed.timestamp = new Date(event.createdAt);
     renderer.render(parsed);

--- a/turbo/apps/cli/src/commands/zero/run/shared.ts
+++ b/turbo/apps/cli/src/commands/zero/run/shared.ts
@@ -178,7 +178,7 @@ export async function pollZeroEvents(
     // 2. Parse and render each event
     for (const event of contiguousEvents) {
       const eventData = event.eventData as Record<string, unknown>;
-      const parsed = parseEvent(eventData);
+      const parsed = parseEvent(eventData, eventsResponse.framework);
       if (parsed) {
         renderer.render(parsed);
       }

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -1,0 +1,331 @@
+/**
+ * Event parser for OpenAI Codex CLI JSONL events
+ * Converts raw JSONL events into simplified, user-friendly format
+ *
+ * Codex event types:
+ * - thread.started: Session initialization
+ * - turn.started/turn.completed/turn.failed: Turn lifecycle
+ * - item.started/item.updated/item.completed: Individual items (messages, commands, etc.)
+ * - error: Unrecoverable errors
+ */
+
+import type { ParsedEvent } from "./claude-event-parser";
+
+interface ThreadStartedEvent {
+  type: "thread.started";
+  thread_id: string;
+}
+
+interface TurnStartedEvent {
+  type: "turn.started";
+}
+
+interface TurnCompletedEvent {
+  type: "turn.completed";
+  usage?: {
+    input_tokens?: number;
+    cached_input_tokens?: number;
+    output_tokens?: number;
+  };
+}
+
+interface TurnFailedEvent {
+  type: "turn.failed";
+  error?: string;
+}
+
+interface FileChange {
+  kind: "add" | "modify" | "delete";
+  path: string;
+}
+
+interface CodexItem {
+  id: string;
+  type: string;
+  status?: string;
+  // For command_execution
+  command?: string;
+  exit_code?: number;
+  output?: string;
+  aggregated_output?: string;
+  // For agent_message
+  text?: string;
+  // For file operations
+  path?: string;
+  diff?: string;
+  // For file_change
+  changes?: FileChange[];
+  // For reasoning (text field is used)
+}
+
+interface ItemEvent {
+  type: "item.started" | "item.updated" | "item.completed";
+  item: CodexItem;
+}
+
+interface ErrorEvent {
+  type: "error";
+  message?: string;
+  error?: string;
+}
+
+type RawCodexEvent =
+  | ThreadStartedEvent
+  | TurnStartedEvent
+  | TurnCompletedEvent
+  | TurnFailedEvent
+  | ItemEvent
+  | ErrorEvent
+  | Record<string, unknown>;
+
+export class CodexEventParser {
+  /**
+   * Parse a raw Codex CLI JSONL event into a simplified format
+   * Returns null if the event type is unknown or malformed
+   */
+  static parse(rawEvent: RawCodexEvent): ParsedEvent | null {
+    if (!rawEvent || typeof rawEvent !== "object" || !("type" in rawEvent)) {
+      return null;
+    }
+
+    const eventType = rawEvent.type as string;
+
+    // Thread started = init event
+    if (eventType === "thread.started") {
+      return this.parseThreadStarted(rawEvent as ThreadStartedEvent);
+    }
+
+    // Turn completed = result event
+    if (eventType === "turn.completed") {
+      return this.parseTurnCompleted(rawEvent as TurnCompletedEvent);
+    }
+
+    // Turn failed = result event with error
+    if (eventType === "turn.failed") {
+      return this.parseTurnFailed(rawEvent as TurnFailedEvent);
+    }
+
+    // Item events (started, updated, completed)
+    if (eventType.startsWith("item.")) {
+      return this.parseItemEvent(rawEvent as ItemEvent);
+    }
+
+    // Error event
+    if (eventType === "error") {
+      return this.parseErrorEvent(rawEvent as ErrorEvent);
+    }
+
+    // Turn started - we skip this, not useful for display
+    return null;
+  }
+
+  private static parseThreadStarted(
+    event: ThreadStartedEvent,
+  ): ParsedEvent | null {
+    return {
+      type: "init",
+      timestamp: new Date(),
+      data: {
+        framework: "codex",
+        sessionId: event.thread_id,
+        tools: [],
+      },
+    };
+  }
+
+  private static parseTurnCompleted(
+    event: TurnCompletedEvent,
+  ): ParsedEvent | null {
+    return {
+      type: "result",
+      timestamp: new Date(),
+      data: {
+        success: true,
+        result: "",
+        durationMs: 0,
+        numTurns: 1,
+        cost: 0,
+        usage: event.usage || {},
+      },
+    };
+  }
+
+  private static parseTurnFailed(event: TurnFailedEvent): ParsedEvent | null {
+    return {
+      type: "result",
+      timestamp: new Date(),
+      data: {
+        success: false,
+        result: event.error || "Turn failed",
+        durationMs: 0,
+        numTurns: 1,
+        cost: 0,
+        usage: {},
+      },
+    };
+  }
+
+  private static parseItemEvent(event: ItemEvent): ParsedEvent | null {
+    const item = event.item;
+    if (!item) {
+      return null;
+    }
+
+    const itemType = item.type;
+
+    if (itemType === "agent_message" && item.text) {
+      return { type: "text", timestamp: new Date(), data: { text: item.text } };
+    }
+    if (itemType === "command_execution") {
+      return this.parseCommandExecution(event);
+    }
+    if (itemType === "file_edit" || itemType === "file_write") {
+      return this.parseFileEditOrWrite(event);
+    }
+    if (itemType === "file_read") {
+      return this.parseFileRead(event);
+    }
+    if (itemType === "file_change") {
+      return this.parseFileChange(item);
+    }
+    if (itemType === "reasoning" && item.text) {
+      return {
+        type: "text",
+        timestamp: new Date(),
+        data: { text: `[thinking] ${item.text}` },
+      };
+    }
+
+    return null;
+  }
+
+  private static parseCommandExecution(event: ItemEvent): ParsedEvent | null {
+    const item = event.item;
+
+    if (event.type === "item.started" && item.command) {
+      return {
+        type: "tool_use",
+        timestamp: new Date(),
+        data: {
+          tool: "Bash",
+          toolUseId: item.id,
+          input: { command: item.command },
+        },
+      };
+    }
+
+    if (event.type === "item.completed") {
+      const output = item.aggregated_output ?? item.output ?? "";
+      return {
+        type: "tool_result",
+        timestamp: new Date(),
+        data: {
+          toolUseId: item.id,
+          result: output,
+          isError: item.exit_code !== 0,
+        },
+      };
+    }
+
+    return null;
+  }
+
+  private static parseFileEditOrWrite(event: ItemEvent): ParsedEvent | null {
+    const item = event.item;
+
+    if (event.type === "item.started" && item.path) {
+      return {
+        type: "tool_use",
+        timestamp: new Date(),
+        data: {
+          tool: item.type === "file_edit" ? "Edit" : "Write",
+          toolUseId: item.id,
+          input: { file_path: item.path },
+        },
+      };
+    }
+
+    if (event.type === "item.completed") {
+      return {
+        type: "tool_result",
+        timestamp: new Date(),
+        data: {
+          toolUseId: item.id,
+          result: item.diff || "File operation completed",
+          isError: false,
+        },
+      };
+    }
+
+    return null;
+  }
+
+  private static parseFileRead(event: ItemEvent): ParsedEvent | null {
+    const item = event.item;
+
+    if (event.type === "item.started" && item.path) {
+      return {
+        type: "tool_use",
+        timestamp: new Date(),
+        data: {
+          tool: "Read",
+          toolUseId: item.id,
+          input: { file_path: item.path },
+        },
+      };
+    }
+
+    if (event.type === "item.completed") {
+      return {
+        type: "tool_result",
+        timestamp: new Date(),
+        data: {
+          toolUseId: item.id,
+          result: "File read completed",
+          isError: false,
+        },
+      };
+    }
+
+    return null;
+  }
+
+  private static parseFileChange(item: CodexItem): ParsedEvent | null {
+    if (!item.changes || item.changes.length === 0) {
+      return null;
+    }
+
+    const changes = item.changes
+      .map((c) => {
+        const action =
+          c.kind === "add"
+            ? "Created"
+            : c.kind === "modify"
+              ? "Modified"
+              : "Deleted";
+        return `${action}: ${c.path}`;
+      })
+      .join("\n");
+
+    return {
+      type: "text",
+      timestamp: new Date(),
+      data: { text: `[files]\n${changes}` },
+    };
+  }
+
+  private static parseErrorEvent(event: ErrorEvent): ParsedEvent | null {
+    return {
+      type: "result",
+      timestamp: new Date(),
+      data: {
+        success: false,
+        result: event.message || event.error || "Unknown error",
+        durationMs: 0,
+        numTurns: 0,
+        cost: 0,
+        usage: {},
+      },
+    };
+  }
+}

--- a/turbo/apps/cli/src/lib/events/event-parser-factory.ts
+++ b/turbo/apps/cli/src/lib/events/event-parser-factory.ts
@@ -1,17 +1,27 @@
 /**
- * Factory for creating the appropriate event parser based on framework type
- * Also supports auto-detection from event format
+ * Factory for creating the appropriate event parser based on framework.
  */
 
+import { getValidatedFramework } from "@vm0/core";
 import { ClaudeEventParser, type ParsedEvent } from "./claude-event-parser";
+import { CodexEventParser } from "./codex-event-parser";
 
 /**
- * Parse an event using the Claude Code parser
- * @param rawEvent The raw event data from the API
+ * Parse a raw JSONL event using the parser for the given framework.
+ * Defaults to claude-code when framework is undefined.
+ *
+ * @param rawEvent The raw event payload from the API
+ * @param framework Framework identifier from the events response
  * @returns Parsed event or null if not parseable
+ * @throws Error if framework is defined but not supported
  */
 export function parseEvent(
   rawEvent: Record<string, unknown>,
+  framework?: string,
 ): ParsedEvent | null {
+  const validated = getValidatedFramework(framework);
+  if (validated === "codex") {
+    return CodexEventParser.parse(rawEvent);
+  }
   return ClaudeEventParser.parse(rawEvent);
 }


### PR DESCRIPTION
## Summary

Closes #11421.

- Restore `CodexEventParser` at `apps/cli/src/lib/events/codex-event-parser.ts` to normalize Codex CLI JSONL events (thread.started, turn.started/completed/failed, item.started/updated/completed, error) to the same `ParsedEvent` shape as Claude. Item subtypes covered: `agent_message`, `reasoning`, `command_execution`, `file_edit`, `file_write`, `file_read`, `file_change`.
- Replace the previous claude-only `parseEvent` re-export with a framework dispatch factory in `event-parser-factory.ts`. The factory uses `getValidatedFramework` from `@vm0/core` and routes to `CodexEventParser.parse` when framework is `codex`, otherwise to `ClaudeEventParser.parse`.
- Thread the `framework` field from agent events responses into all parser call sites: `commands/run/shared.ts`, `commands/zero/run/shared.ts`, `commands/logs/index.ts`, `commands/zero/logs/index.ts`. Search call sites (`commands/logs/search.ts`, `commands/zero/logs/search.ts`) default to claude-code with an inline note — `searchResultSchema` does not yet carry `framework`; this gap will be filed as a follow-up issue.
- Add integration tests under `commands/logs/__tests__/index.test.ts` (`describe("codex framework events")`) and a happy-path test in `commands/zero/logs/__tests__/view.test.ts`. Tests drive `command.parseAsync()` against MSW and assert rendered output, per project testing conventions.

## Test plan

- [x] `pnpm turbo run lint --filter=@vm0/cli` — passes
- [x] `pnpm check-types` — passes
- [x] `pnpm format` — clean
- [x] `pnpm -F @vm0/cli exec vitest` — 1094/1094 passing
- [x] `pnpm knip` — no issues
- [x] Grep gate: no leftover direct `ClaudeEventParser` imports outside the parser module
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)