### PR TITLE
revert: route deepseek-v4-pro back to direct DeepSeek API

### DIFF
--- a/turbo/apps/web/src/__tests__/vm0-provider.test.ts
+++ b/turbo/apps/web/src/__tests__/vm0-provider.test.ts
@@ -154,17 +154,13 @@ describe("VM0 managed model provider", () => {
       expect(getVm0ApiModel("kimi-k2.6")).toBe("kimi-k2.6");
     });
 
-    it("should resolve deepseek-v4-pro to openrouter-api-key with upstream id", () => {
+    it("should resolve DeepSeek V4 models to deepseek-api-key", () => {
       expect(getVm0ConcreteProviderType("deepseek-v4-pro")).toBe(
-        "openrouter-api-key",
+        "deepseek-api-key",
       );
-      expect(getVm0Vendor("deepseek-v4-pro")).toBe("openrouter");
-      expect(getVm0ApiModel("deepseek-v4-pro")).toBe(
-        "deepseek/deepseek-v4-pro",
-      );
-    });
+      expect(getVm0Vendor("deepseek-v4-pro")).toBe("deepseek");
+      expect(getVm0ApiModel("deepseek-v4-pro")).toBe("deepseek-v4-pro");
 
-    it("should resolve deepseek-v4-flash to deepseek-api-key", () => {
       expect(getVm0ConcreteProviderType("deepseek-v4-flash")).toBe(
         "deepseek-api-key",
       );
@@ -235,7 +231,7 @@ describe("VM0 managed model provider", () => {
   });
 
   describe("deepseek v4 routing integration", () => {
-    it("should inject deepseek/deepseek-v4-pro as ANTHROPIC_MODEL when resolving vm0 deepseek-v4-pro provider", async () => {
+    it("should inject deepseek-v4-pro as ANTHROPIC_MODEL when resolving vm0 deepseek-v4-pro provider", async () => {
       const userId = uniqueId("ds-v4-pro-route");
       const { orgId } = await setupOrg(
         userId,
@@ -246,9 +242,9 @@ describe("VM0 managed model provider", () => {
       await insertOrgDefaultModelProvider(orgId, "vm0", "deepseek-v4-pro");
       await insertVm0ApiKeys([
         {
-          vendor: "openrouter",
-          model: "deepseek/deepseek-v4-pro",
-          apiKey: "sk-or-v1-dstestkey-pro",
+          vendor: "deepseek",
+          model: "deepseek-v4-pro",
+          apiKey: "sk-dstestkey-pro",
           label: "deepseek-v4-pro test key",
         },
       ]);
@@ -260,12 +256,15 @@ describe("VM0 managed model provider", () => {
       );
 
       expect(result.resolvedModelProvider).toBe("vm0");
-      expect(result.concreteProviderType).toBe("openrouter-api-key");
+      expect(result.concreteProviderType).toBe("deepseek-api-key");
       expect(result.selectedModel).toBe("deepseek-v4-pro");
       expect(result.injectedEnvironment?.ANTHROPIC_MODEL).toBe(
-        "deepseek/deepseek-v4-pro",
+        "deepseek-v4-pro",
       );
-      expect(result.secrets?.OPENROUTER_API_KEY).toBeDefined();
+      expect(result.injectedEnvironment?.ANTHROPIC_BASE_URL).toBe(
+        "https://api.deepseek.com/anthropic",
+      );
+      expect(result.secrets?.DEEPSEEK_API_KEY).toBeDefined();
     });
 
     it("should inject deepseek-v4-flash as ANTHROPIC_MODEL when resolving vm0 deepseek-v4-flash provider", async () => {

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -83,9 +83,8 @@ export const VM0_MODEL_TO_PROVIDER: Record<string, Vm0ModelConfig> = {
     vendor: "minimax",
   },
   "deepseek-v4-pro": {
-    concreteType: "openrouter-api-key",
-    vendor: "openrouter",
-    apiModel: "deepseek/deepseek-v4-pro",
+    concreteType: "deepseek-api-key",
+    vendor: "deepseek",
   },
   "deepseek-v4-flash": {
     concreteType: "deepseek-api-key",


### PR DESCRIPTION
## Summary

Reverts #11412 — `deepseek-v4-pro` was migrated from direct DeepSeek API to OpenRouter, but OpenRouter has been unstable in production.

## Change

- Restores `deepseek-v4-pro` to use `deepseek-api-key` provider directly
- Reverts vendor from `openrouter` back to `deepseek`
- Reverts test assertions to match

## Related

- Reverts: #11412

🤖 Generated with [Claude Code](https://claude.com/claude-code)