### PR TITLE
fix: refine telegram settings feedback

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-telegram.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-telegram.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import type { TelegramBotStatus } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -86,6 +87,13 @@ describe("zero telegram signals", () => {
   });
 
   it("updates a bot default agent and refreshes mock state", async () => {
+    const toastId = "telegram-agent-toast";
+    const loadingSpy = vi.spyOn(toast, "loading").mockImplementation(() => {
+      return toastId as ReturnType<typeof toast.loading>;
+    });
+    const successSpy = vi.spyOn(toast, "success").mockImplementation(() => {
+      return toastId as ReturnType<typeof toast.success>;
+    });
     setMockTelegramIntegration({
       statuses: [telegramStatus("bot_alpha")],
     });
@@ -100,9 +108,15 @@ describe("zero telegram signals", () => {
     expect(getMockTelegramIntegration().statuses.bot_alpha).toMatchObject({
       agent: { id: "compose_2" },
     });
+    expect(loadingSpy).toHaveBeenCalledWith("Updating default agent...");
+    expect(successSpy).toHaveBeenCalledWith("Default agent updated", {
+      id: toastId,
+    });
     await expect(context.store.get(telegramBots$)).resolves.toMatchObject([
       { id: "bot_alpha", agent: { id: "compose_2" } },
     ]);
+    loadingSpy.mockRestore();
+    successSpy.mockRestore();
   });
 
   it("disconnects a bot and refreshes the list state", async () => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
@@ -430,6 +430,10 @@ export const updateTelegramBotAgent$ = command(
     input: { botId: string; defaultAgentId: string },
     signal: AbortSignal,
   ): Promise<TelegramBotStatus> => {
+    const toastId = toast.loading("Updating default agent...");
+    signal.addEventListener("abort", () => {
+      return toast.dismiss(toastId);
+    });
     const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
     const result = await accept(
       client.updateBot({
@@ -439,10 +443,22 @@ export const updateTelegramBotAgent$ = command(
         fetchOptions: { signal },
       }),
       [200],
-    );
+      { toast: false },
+    ).catch((error: unknown) => {
+      if (signal.aborted) {
+        toast.dismiss(toastId);
+      } else {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to update Telegram bot";
+        toast.error(message, { id: toastId });
+      }
+      throw error;
+    });
     signal.throwIfAborted();
     set(reloadTelegramBots$);
-    toast.success("Telegram bot updated");
+    toast.success("Default agent updated", { id: toastId });
     return (result as { body: TelegramBotStatus }).body;
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx
@@ -222,6 +222,9 @@ describe("telegram settings page", () => {
       expect(
         within(dialog).getByText("Set the Telegram login domain"),
       ).toBeInTheDocument();
+      expect(
+        within(dialog).getByText(/allow the connect flow for this bot/),
+      ).toBeInTheDocument();
     });
     setMockTelegramIntegration({
       setupStatus: {
@@ -236,6 +239,11 @@ describe("telegram settings page", () => {
     await waitFor(() => {
       expect(within(dialog).getByText("/setprivacy")).toBeInTheDocument();
       expect(within(dialog).getByText("disable")).toBeInTheDocument();
+      expect(
+        within(dialog).getByText(
+          /read group context around mentions and replies/,
+        ),
+      ).toBeInTheDocument();
       expect(
         within(dialog).queryByText("If you keep privacy mode on"),
       ).not.toBeInTheDocument();
@@ -269,6 +277,9 @@ describe("telegram settings page", () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText("Default agent")).toHaveTextContent("Zero");
+      expect(
+        within(dialog).getByText(/mention the bot in a group or send it a DM/),
+      ).toBeInTheDocument();
       expect(
         within(dialog).queryByText(
           "Privacy mode still appears to be on. Turn it off in BotFather, then try again.",

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
@@ -578,7 +578,8 @@ function AddTelegramDomainStep({
         <div className="leading-relaxed">
           In {BOT_FATHER_HANDLE}, send <TelegramCommand command="/setdomain" />,
           choose this bot, and set the domain to{" "}
-          <CopyableTelegramValue value={domain} />.
+          <CopyableTelegramValue value={domain} />. Telegram uses this domain to
+          allow the connect flow for this bot.
         </div>
       </div>
       {confirmed ? (
@@ -608,7 +609,8 @@ function AddTelegramPrivacyStep({
         <div className="leading-relaxed">
           In {BOT_FATHER_HANDLE}, send <TelegramCommand command="/setprivacy" />
           , choose this bot, then{" "}
-          <strong className="font-medium">disable</strong> privacy mode.
+          <strong className="font-medium">disable</strong> privacy mode. This
+          lets the agent read group context around mentions and replies.
         </div>
       </div>
       {confirmed ? (
@@ -648,7 +650,9 @@ function AddTelegramCreateStep({
         <div>
           {setupStatus?.username
             ? `VM0 will register @${setupStatus.username} and configure its webhook.`
-            : "VM0 will register this bot and configure its webhook."}
+            : "VM0 will register this bot and configure its webhook."}{" "}
+          After setup, mention the bot in a group or send it a DM to talk with
+          the selected agent.
         </div>
       </div>
       <AddTelegramBotAgentField
@@ -1499,11 +1503,6 @@ function TelegramBotRow({
           uninstalling={uninstalling}
           reinstalling={reinstalling}
         />
-        {canManage && saving ? (
-          <div className="text-xs text-muted-foreground sm:col-span-2">
-            Saving agent...
-          </div>
-        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show Telegram default-agent updates with a loading toast instead of inline row text
- clarify Telegram onboarding domain, privacy, and post-setup conversation steps
- add tests for the updated toast and onboarding copy

## Testing
- pnpm test src/signals/zero-page/__tests__/zero-telegram.test.ts --no-file-parallelism --maxWorkers 1
- pnpm test src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx --no-file-parallelism --maxWorkers 1
- pnpm lint
- pnpm check-types
- pre-commit: prettier, knip, turbo check-types, commitlint