### PR TITLE
fix: shut down control server with sandbox runtime

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2769,10 +2769,12 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uuid",
  "vsock-host",
+ "vsock-proto",
  "which",
 ]
 

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -16,6 +16,7 @@ hex.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["process", "fs", "rt", "rt-multi-thread", "macros", "sync", "io-util", "net", "time"] }
+tokio-util.workspace = true
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 vsock-host.workspace = true
@@ -26,6 +27,7 @@ clap = { workspace = true, features = ["derive"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber.workspace = true
+vsock-proto.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -11,6 +11,7 @@
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -20,7 +21,8 @@ use sandbox::{RemoteExecResult, SandboxControl, SandboxControlError};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
-use tokio::task::JoinHandle;
+use tokio::task::{JoinHandle, JoinSet};
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 use vsock_host::VsockHost;
 
@@ -64,6 +66,8 @@ pub enum ExecResponse {
 
 /// Maximum frame size: 64 MiB (generous for large stdout/stderr).
 const MAX_FRAME_SIZE: u32 = 64 * 1024 * 1024;
+const CONTROL_SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
+const CONTROL_HANDLER_SHUTDOWN_GRACE: Duration = Duration::from_millis(250);
 
 /// Read a length-prefixed frame from the stream.
 async fn read_frame(stream: &mut UnixStream) -> io::Result<Vec<u8>> {
@@ -99,15 +103,145 @@ async fn write_frame(stream: &mut UnixStream, data: &[u8]) -> io::Result<()> {
 
 /// A control socket server whose listener has already been bound.
 pub(crate) struct BoundControlServer {
-    sock_path: PathBuf,
-    listener: UnixListener,
+    sock_path: Option<SocketPathGuard>,
+    listener: Option<UnixListener>,
     guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
 }
 
 impl BoundControlServer {
     /// Spawn the accept loop for this pre-bound control socket.
-    pub(crate) fn spawn(self) -> JoinHandle<()> {
-        spawn_bound_server(self.listener, self.sock_path, self.guest)
+    pub(crate) fn spawn(mut self, shutdown: CancellationToken) -> ControlServerHandle {
+        let Some(listener) = self.listener.take() else {
+            return ControlServerHandle::stopped(self.sock_path.take(), shutdown);
+        };
+        let Some(sock_path) = self.sock_path.take() else {
+            drop(listener);
+            return ControlServerHandle::stopped(None, shutdown);
+        };
+
+        let task = spawn_bound_server(
+            listener,
+            sock_path.clone(),
+            Arc::clone(&self.guest),
+            shutdown.clone(),
+        );
+        ControlServerHandle {
+            sock_path: Some(sock_path),
+            shutdown,
+            task: Some(task),
+        }
+    }
+
+    pub(crate) fn close(mut self) {
+        self.close_inner();
+    }
+
+    fn close_inner(&mut self) {
+        drop(self.listener.take());
+        if let Some(sock_path) = self.sock_path.take() {
+            sock_path.unlink_once();
+        }
+    }
+}
+
+impl Drop for BoundControlServer {
+    fn drop(&mut self) {
+        self.close_inner();
+    }
+}
+
+/// Runtime handle for an active control socket server.
+pub(crate) struct ControlServerHandle {
+    sock_path: Option<SocketPathGuard>,
+    shutdown: CancellationToken,
+    task: Option<JoinHandle<()>>,
+}
+
+impl ControlServerHandle {
+    fn stopped(sock_path: Option<SocketPathGuard>, shutdown: CancellationToken) -> Self {
+        Self {
+            sock_path,
+            shutdown,
+            task: None,
+        }
+    }
+
+    pub(crate) async fn shutdown(&mut self) {
+        self.shutdown.cancel();
+        self.unlink_socket();
+
+        let Some(mut task) = self.task.take() else {
+            return;
+        };
+
+        let timeout = tokio::time::sleep(CONTROL_SERVER_SHUTDOWN_TIMEOUT);
+        tokio::pin!(timeout);
+        tokio::select! {
+            result = &mut task => {
+                log_server_join(result);
+            }
+            () = &mut timeout => {
+                task.abort();
+                log_server_join(task.await);
+            }
+        }
+    }
+
+    fn unlink_socket(&mut self) {
+        if let Some(sock_path) = self.sock_path.take() {
+            sock_path.unlink_once();
+        }
+    }
+
+    pub(crate) fn abort(&mut self) {
+        self.shutdown.cancel();
+        self.unlink_socket();
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+impl Drop for ControlServerHandle {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}
+
+#[derive(Clone)]
+struct SocketPathGuard {
+    inner: Arc<SocketPathGuardInner>,
+}
+
+/// Shared ownership of a Unix socket pathname unlink.
+///
+/// The listener task and lifecycle handle can both observe shutdown. Unlinking
+/// exactly once avoids a later drop removing a socket that has been recreated at
+/// the same path.
+struct SocketPathGuardInner {
+    path: PathBuf,
+    unlinked: AtomicBool,
+}
+
+impl SocketPathGuard {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            inner: Arc::new(SocketPathGuardInner {
+                path,
+                unlinked: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    fn path(&self) -> &Path {
+        &self.inner.path
+    }
+
+    fn unlink_once(&self) {
+        if self.inner.unlinked.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        remove_socket_path(&self.inner.path);
     }
 }
 
@@ -116,50 +250,135 @@ pub(crate) fn bind_server(
     sock_path: PathBuf,
     guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
 ) -> io::Result<BoundControlServer> {
-    let listener = UnixListener::bind(&sock_path)?;
+    let listener = bind_unix_listener(&sock_path)?;
+    let sock_path = SocketPathGuard::new(sock_path);
     Ok(BoundControlServer {
-        sock_path,
-        listener,
+        sock_path: Some(sock_path),
+        listener: Some(listener),
         guest,
     })
 }
 
+fn bind_unix_listener(sock_path: &Path) -> io::Result<UnixListener> {
+    let listener = std::os::unix::net::UnixListener::bind(sock_path)?;
+    if let Err(e) = listener.set_nonblocking(true) {
+        remove_socket_path(sock_path);
+        return Err(e);
+    }
+    UnixListener::from_std(listener).inspect_err(|_| remove_socket_path(sock_path))
+}
+
+fn remove_socket_path(sock_path: &Path) {
+    match std::fs::remove_file(sock_path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+        Err(e) => warn!(path = %sock_path.display(), error = %e, "remove control socket"),
+    }
+}
+
 fn spawn_bound_server(
     listener: UnixListener,
-    sock_path: PathBuf,
+    sock_path: SocketPathGuard,
     guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    shutdown: CancellationToken,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
-        info!(path = %sock_path.display(), "control socket listening");
+        info!(path = %sock_path.path().display(), "control socket listening");
+
+        let mut handlers = JoinSet::new();
 
         loop {
-            let (stream, _) = match listener.accept().await {
-                Ok(conn) => conn,
-                Err(e) => {
-                    warn!(error = %e, "control socket accept error");
-                    continue;
-                }
-            };
+            tokio::select! {
+                biased;
 
-            let guest = Arc::clone(&guest);
-            tokio::spawn(async move {
-                if let Err(e) = handle_connection(stream, guest).await {
-                    warn!(error = %e, "control connection handler error");
+                () = shutdown.cancelled() => {
+                    break;
                 }
-            });
+
+                joined = handlers.join_next(), if !handlers.is_empty() => {
+                    log_handler_join(joined);
+                }
+
+                accepted = listener.accept() => {
+                    let (stream, _) = match accepted {
+                        Ok(conn) => conn,
+                        Err(e) => {
+                            warn!(error = %e, "control socket accept error");
+                            continue;
+                        }
+                    };
+
+                    let guest = Arc::clone(&guest);
+                    let handler_shutdown = shutdown.clone();
+                    handlers.spawn(async move {
+                        if let Err(e) = handle_connection(stream, guest, handler_shutdown).await {
+                            warn!(error = %e, "control connection handler error");
+                        }
+                    });
+                }
+            }
         }
+
+        drop(listener);
+        sock_path.unlink_once();
+        shutdown_handlers(&mut handlers).await;
     })
+}
+
+fn log_server_join(joined: Result<(), tokio::task::JoinError>) {
+    if let Err(e) = joined
+        && !e.is_cancelled()
+    {
+        warn!(error = %e, "control socket server task failed");
+    }
+}
+
+fn log_handler_join(joined: Option<Result<(), tokio::task::JoinError>>) {
+    if let Some(Err(e)) = joined
+        && !e.is_cancelled()
+    {
+        warn!(error = %e, "control connection task failed");
+    }
+}
+
+async fn shutdown_handlers(handlers: &mut JoinSet<()>) {
+    let drain = async {
+        while let Some(joined) = handlers.join_next().await {
+            log_handler_join(Some(joined));
+        }
+    };
+
+    if tokio::time::timeout(CONTROL_HANDLER_SHUTDOWN_GRACE, drain)
+        .await
+        .is_ok()
+    {
+        return;
+    }
+
+    handlers.abort_all();
+    while let Some(joined) = handlers.join_next().await {
+        log_handler_join(Some(joined));
+    }
 }
 
 /// Handle a single control socket connection.
 async fn handle_connection(
     mut stream: UnixStream,
     guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    shutdown: CancellationToken,
 ) -> io::Result<()> {
-    let frame = read_frame(&mut stream).await?;
+    let frame = tokio::select! {
+        biased;
+        () = shutdown.cancelled() => return Ok(()),
+        result = read_frame(&mut stream) => result?,
+    };
 
     let response = match serde_json::from_slice::<ExecRequest>(&frame) {
-        Ok(request) => execute(request, &guest).await,
+        Ok(request) => tokio::select! {
+            biased;
+            () = shutdown.cancelled() => return Ok(()),
+            response = execute(request, &guest) => response,
+        },
         Err(e) => ExecResponse::Error {
             error: format!("invalid request: {e}"),
         },
@@ -167,7 +386,11 @@ async fn handle_connection(
 
     let response_json = serde_json::to_vec(&response)
         .map_err(|e| io::Error::other(format!("serialize response: {e}")))?;
-    write_frame(&mut stream, &response_json).await?;
+    tokio::select! {
+        biased;
+        () = shutdown.cancelled() => return Ok(()),
+        result = write_frame(&mut stream, &response_json) => result?,
+    }
 
     Ok(())
 }
@@ -356,6 +579,8 @@ fn resolve_control_socket(input: &str) -> Result<PathBuf, SandboxControlError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::sync::oneshot;
+    use vsock_proto::{Decoder, MSG_EXEC, MSG_PING, MSG_PONG, MSG_READY, RawMessage};
 
     #[tokio::test]
     async fn exec_remote_empty_id() {
@@ -457,7 +682,9 @@ mod tests {
 
         // Server with no guest connected.
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
-        let handle = bind_server(sock_path.clone(), guest).unwrap().spawn();
+        let mut handle = bind_server(sock_path.clone(), guest)
+            .unwrap()
+            .spawn(CancellationToken::new());
 
         let request = ExecRequest {
             command: "ps aux".into(),
@@ -476,8 +703,159 @@ mod tests {
             ExecResponse::Success { .. } => panic!("expected error when guest is None"),
         }
 
-        handle.abort();
-        let _ = handle.await;
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn bound_control_server_close_removes_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+
+        let server = bind_server(sock_path.clone(), guest).unwrap();
+        assert!(sock_path.exists());
+
+        server.close();
+
+        assert!(!sock_path.exists());
+    }
+
+    #[tokio::test]
+    async fn bound_control_server_drop_removes_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+
+        {
+            let _server = bind_server(sock_path.clone(), guest).unwrap();
+            assert!(sock_path.exists());
+        }
+
+        assert!(!sock_path.exists());
+    }
+
+    #[tokio::test]
+    async fn control_server_shutdown_removes_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let mut handle = bind_server(sock_path.clone(), guest)
+            .unwrap()
+            .spawn(CancellationToken::new());
+
+        assert!(sock_path.exists());
+
+        handle.shutdown().await;
+        handle.shutdown().await;
+
+        assert!(!sock_path.exists());
+        let err = UnixStream::connect(&sock_path).await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[tokio::test]
+    async fn control_server_cancel_removes_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let shutdown = CancellationToken::new();
+        let mut handle = bind_server(sock_path.clone(), guest)
+            .unwrap()
+            .spawn(shutdown.clone());
+
+        shutdown.cancel();
+        wait_for_socket_removed(&sock_path).await;
+
+        handle.shutdown().await;
+        assert!(!sock_path.exists());
+    }
+
+    #[tokio::test]
+    async fn control_server_cancel_cancels_pending_connection() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let shutdown = CancellationToken::new();
+        let mut handle = bind_server(sock_path.clone(), guest)
+            .unwrap()
+            .spawn(shutdown.clone());
+        let mut stream = UnixStream::connect(&sock_path).await.unwrap();
+        stream.write_u32(1024).await.unwrap();
+
+        shutdown.cancel();
+        wait_for_socket_removed(&sock_path).await;
+
+        tokio::time::timeout(Duration::from_secs(1), handle.shutdown())
+            .await
+            .unwrap();
+        assert!(!sock_path.exists());
+    }
+
+    #[tokio::test]
+    async fn control_server_shutdown_cancels_pending_connection() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let mut handle = bind_server(sock_path.clone(), guest)
+            .unwrap()
+            .spawn(CancellationToken::new());
+        let mut stream = UnixStream::connect(&sock_path).await.unwrap();
+        stream.write_u32(1024).await.unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), handle.shutdown())
+            .await
+            .unwrap();
+
+        assert!(!sock_path.exists());
+    }
+
+    #[tokio::test]
+    async fn control_server_shutdown_cancels_in_flight_vsock_exec() {
+        let dir = tempfile::tempdir().unwrap();
+        let vsock_base = dir.path().join("vsock");
+        let host_task = {
+            let vsock_base = vsock_base.display().to_string();
+            tokio::spawn(async move {
+                VsockHost::wait_for_connection(&vsock_base, Duration::from_secs(5)).await
+            })
+        };
+        let (exec_seen_tx, exec_seen_rx) = oneshot::channel();
+        let guest_task = tokio::spawn(mock_guest_holds_exec(vsock_base, exec_seen_tx));
+        let vsock = host_task.await.unwrap().unwrap();
+
+        let sock_path = dir.path().join("control.sock");
+        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
+        let mut handle = bind_server(sock_path.clone(), guest)
+            .unwrap()
+            .spawn(CancellationToken::new());
+        let client = tokio::spawn({
+            let sock_path = sock_path.clone();
+            async move {
+                let request = ExecRequest {
+                    command: "sleep 30".into(),
+                    timeout_secs: 30,
+                    sudo: false,
+                };
+                send_exec(&sock_path, &request, Duration::from_secs(30)).await
+            }
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), exec_seen_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), handle.shutdown())
+            .await
+            .unwrap();
+
+        let client_result = tokio::time::timeout(Duration::from_secs(1), client)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(client_result.is_err());
+
+        guest_task.abort();
+        let _ = guest_task.await;
     }
 
     #[tokio::test]
@@ -487,12 +865,94 @@ mod tests {
         let _existing = UnixListener::bind(&sock_path).unwrap();
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
 
-        let result = bind_server(sock_path, guest);
+        let result = bind_server(sock_path.clone(), guest);
 
         let Err(err) = result else {
             panic!("binding an occupied control socket should fail");
         };
         assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
+        assert!(sock_path.exists());
+    }
+
+    async fn wait_for_socket_removed(sock_path: &Path) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while sock_path.exists() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    async fn wait_for_socket_exists(sock_path: &Path) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !sock_path.exists() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    async fn mock_vsock_handshake(stream: &mut UnixStream, decoder: &mut Decoder) {
+        let ready = vsock_proto::encode(MSG_READY, 0, &[]).unwrap();
+        stream.write_all(&ready).await.unwrap();
+
+        let message = read_vsock_message(stream, decoder).await;
+        assert_eq!(message.msg_type, MSG_PING);
+
+        let pong = vsock_proto::encode(MSG_PONG, message.seq, &[]).unwrap();
+        stream.write_all(&pong).await.unwrap();
+    }
+
+    async fn read_vsock_message(stream: &mut UnixStream, decoder: &mut Decoder) -> RawMessage {
+        let mut buf = [0u8; 1024];
+        loop {
+            let n = stream.read(&mut buf).await.unwrap();
+            assert_ne!(n, 0, "vsock stream closed before next message");
+
+            let mut messages = decoder.decode(&buf[..n]).unwrap();
+            if !messages.is_empty() {
+                assert_eq!(
+                    messages.len(),
+                    1,
+                    "mock guest expected one message at a time"
+                );
+                return messages.remove(0);
+            }
+        }
+    }
+
+    async fn mock_guest_holds_exec(vsock_base: PathBuf, exec_seen: oneshot::Sender<()>) {
+        let listener_path = PathBuf::from(format!(
+            "{}_{}",
+            vsock_base.display(),
+            vsock_proto::VSOCK_PORT
+        ));
+        wait_for_socket_exists(&listener_path).await;
+
+        let mut stream = UnixStream::connect(&listener_path).await.unwrap();
+        let mut decoder = Decoder::new();
+        mock_vsock_handshake(&mut stream, &mut decoder).await;
+
+        let mut exec_seen = Some(exec_seen);
+        let mut buf = [0u8; 4096];
+        loop {
+            let n = stream.read(&mut buf).await.unwrap();
+            if n == 0 {
+                return;
+            }
+            let messages = decoder.decode(&buf[..n]).unwrap();
+            for message in messages {
+                if message.msg_type == MSG_EXEC {
+                    if let Some(tx) = exec_seen.take() {
+                        let _ = tx.send(());
+                    }
+                    tokio::time::sleep(Duration::from_secs(30)).await;
+                    return;
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -14,6 +14,7 @@ use sandbox::{
 };
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
 use tracing::{info, trace, warn};
 use vsock_host::VsockHost;
 
@@ -289,7 +290,7 @@ pub struct FirecrackerSandbox {
     /// mutex immediately, allowing concurrent vsock operations.
     guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
     /// Control socket server for `runner exec`.
-    control_server: Option<tokio::task::JoinHandle<()>>,
+    control_server: Option<control::ControlServerHandle>,
     /// Balloon memory reclaim controller.
     balloon_controller: Option<tokio::task::JoinHandle<()>>,
     /// Sender for leaked resource cleanup. When Drop fires without prior
@@ -470,7 +471,7 @@ impl FirecrackerSandbox {
     }
 
     /// Start using a fresh boot with `--config-file --api-sock`.
-    async fn start_fresh(&mut self) -> sandbox::Result<()> {
+    async fn start_fresh(&mut self, runtime_cancel: CancellationToken) -> sandbox::Result<()> {
         let config = self.build_config();
         let config_json =
             serde_json::to_string_pretty(&config).map_err(|e| SandboxError::Start {
@@ -512,6 +513,7 @@ impl FirecrackerSandbox {
             Arc::clone(&self.state_publish_lock),
             self.state_tx.clone(),
             Arc::clone(&self.guest),
+            runtime_cancel,
         ));
 
         // Wait for API socket readiness so the balloon controller can connect.
@@ -542,7 +544,10 @@ impl FirecrackerSandbox {
     }
 
     /// Start from a snapshot using `--api-sock` and bind mounts.
-    async fn start_from_snapshot(&mut self) -> sandbox::Result<()> {
+    async fn start_from_snapshot(
+        &mut self,
+        runtime_cancel: CancellationToken,
+    ) -> sandbox::Result<()> {
         let snapshot =
             self.factory_config
                 .snapshot
@@ -625,6 +630,7 @@ impl FirecrackerSandbox {
             Arc::clone(&self.state_publish_lock),
             self.state_tx.clone(),
             Arc::clone(&self.guest),
+            runtime_cancel,
         ));
 
         // Wait for Firecracker API to be ready, but bail early if the
@@ -674,9 +680,9 @@ impl FirecrackerSandbox {
         }
     }
 
-    fn abort_runtime_tasks(&mut self) {
-        if let Some(h) = self.control_server.take() {
-            h.abort();
+    async fn shutdown_runtime_tasks(&mut self) {
+        if let Some(mut h) = self.control_server.take() {
+            h.shutdown().await;
         }
         if let Some(h) = self.balloon_controller.take() {
             h.abort();
@@ -691,7 +697,7 @@ async fn abort_and_join<T>(task: tokio::task::JoinHandle<T>) {
 
 impl Drop for FirecrackerSandbox {
     fn drop(&mut self) {
-        if let Some(h) = self.control_server.take() {
+        if let Some(mut h) = self.control_server.take() {
             h.abort();
         }
         if let Some(h) = self.balloon_controller.take() {
@@ -807,6 +813,7 @@ fn monitor_process(
     state_publish_lock: Arc<Mutex<()>>,
     state_tx: watch::Sender<SandboxState>,
     guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    runtime_cancel: CancellationToken,
 ) -> ProcessMonitorHandle {
     let process_group_pid = child.id();
 
@@ -849,6 +856,7 @@ fn monitor_process(
             Ok(status) => trace!(id = %id, %status, "process monitor observed exit"),
             Err(error) => warn!(id = %id, %error, "process monitor failed to wait for child"),
         }
+        runtime_cancel.cancel();
 
         let prev = {
             let _guard = state_publish_guard(&state_publish_lock);
@@ -922,6 +930,8 @@ impl Sandbox for FirecrackerSandbox {
             });
         }
 
+        let runtime_cancel = CancellationToken::new();
+
         // Start the vsock listener BEFORE launching Firecracker.
         // The UDS must be bound before the guest tries to connect.
         let vsock_path = self.sock_paths.vsock().display().to_string();
@@ -930,9 +940,9 @@ impl Sandbox for FirecrackerSandbox {
         });
 
         let start_result = if self.factory_config.snapshot.is_some() {
-            self.start_from_snapshot().await
+            self.start_from_snapshot(runtime_cancel.clone()).await
         } else {
-            self.start_fresh().await
+            self.start_fresh(runtime_cancel.clone()).await
         };
 
         if let Err(e) = start_result {
@@ -992,8 +1002,7 @@ impl Sandbox for FirecrackerSandbox {
         // recorded process exit).
         if !self.transition(SandboxState::Created, SandboxState::Running) {
             self.guest.lock().await.take();
-            drop(control_server);
-            let _ = tokio::fs::remove_file(&control_sock_path).await;
+            control_server.close();
             self.kill_process().await;
             return Err(SandboxError::Start {
                 message: "process exited during startup".into(),
@@ -1001,7 +1010,7 @@ impl Sandbox for FirecrackerSandbox {
         }
 
         // Start control socket server for `runner exec`.
-        self.control_server = Some(control_server.spawn());
+        self.control_server = Some(control_server.spawn(runtime_cancel));
 
         // Spawn balloon controller to reclaim unused guest memory.
         self.balloon_controller = Some(balloon::spawn(
@@ -1017,19 +1026,19 @@ impl Sandbox for FirecrackerSandbox {
     async fn stop(&mut self) -> sandbox::Result<()> {
         if !self.transition(SandboxState::Running, SandboxState::Stopping) {
             if self.current_state() == SandboxState::Crashed {
-                self.abort_runtime_tasks();
+                self.shutdown_runtime_tasks().await;
                 self.guest.lock().await.take();
                 self.kill_process().await;
             }
             return Ok(());
         }
 
-        self.abort_runtime_tasks();
-        // abort() without await: unlike `park_inner` (which awaits to become
-        // the sole writer to /balloon), stop() is about to kill the FC
-        // process entirely, so any in-flight controller PATCHes against the
-        // dying API socket are harmless — the subsequent kill_process call
-        // tears down FC regardless of balloon state.
+        self.shutdown_runtime_tasks().await;
+        // The control server is awaited so its socket path becomes
+        // undiscoverable before teardown continues. The balloon controller is
+        // only aborted: stop() is about to kill the FC process entirely, so
+        // any in-flight controller PATCH against the dying API socket is
+        // harmless.
 
         // Skip vsock graceful shutdown for parked sandboxes — vCPUs are
         // paused and cannot process the message. No in-flight user work
@@ -1057,14 +1066,13 @@ impl Sandbox for FirecrackerSandbox {
     async fn kill(&mut self) -> sandbox::Result<()> {
         if !self.transition(SandboxState::Running, SandboxState::Stopping) {
             if self.current_state() == SandboxState::Crashed {
-                self.abort_runtime_tasks();
+                self.shutdown_runtime_tasks().await;
                 self.guest.lock().await.take();
                 self.kill_process().await;
             }
             return Ok(());
         }
-        self.abort_runtime_tasks();
-        // abort() without await — same rationale as `stop()`.
+        self.shutdown_runtime_tasks().await;
         self.guest.lock().await.take();
         self.kill_process().await;
         self.publish_state(SandboxState::Stopped);
@@ -1539,6 +1547,16 @@ mod tests {
         .unwrap();
     }
 
+    async fn wait_for_path_removed(path: &Path) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while path.exists() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
     #[test]
     fn process_state_publish_updates_atomic_and_watch_together() {
         let state = AtomicU8::new(SandboxState::Created as u8);
@@ -1660,6 +1678,7 @@ mod tests {
         let state_publish_lock = Arc::new(Mutex::new(()));
         let (state_tx, state_rx) = watch::channel(SandboxState::Running);
         let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let runtime_cancel = CancellationToken::new();
         let mut child = monitored_cat_process();
         let stdin = child.stdin.take();
 
@@ -1670,10 +1689,14 @@ mod tests {
             Arc::clone(&state_publish_lock),
             state_tx,
             guest,
+            runtime_cancel.clone(),
         );
 
         drop(stdin);
 
+        tokio::time::timeout(Duration::from_secs(1), runtime_cancel.cancelled())
+            .await
+            .unwrap();
         tokio::time::timeout(Duration::from_secs(1), wait_for_backend_crash(state_rx))
             .await
             .unwrap();
@@ -1683,6 +1706,38 @@ mod tests {
         );
 
         handle.wait().await;
+    }
+
+    #[tokio::test]
+    async fn process_monitor_cancels_control_server_after_exit() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let state = Arc::new(AtomicU8::new(SandboxState::Running as u8));
+        let state_publish_lock = Arc::new(Mutex::new(()));
+        let (state_tx, _state_rx) = watch::channel(SandboxState::Running);
+        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let runtime_cancel = CancellationToken::new();
+        let mut control = crate::control::bind_server(sock_path.clone(), Arc::clone(&guest))
+            .unwrap()
+            .spawn(runtime_cancel.clone());
+        let mut child = monitored_cat_process();
+        let stdin = child.stdin.take();
+
+        let handle = monitor_process(
+            "test-sandbox",
+            child,
+            Arc::clone(&state),
+            Arc::clone(&state_publish_lock),
+            state_tx,
+            guest,
+            runtime_cancel,
+        );
+
+        drop(stdin);
+        wait_for_path_removed(&sock_path).await;
+
+        handle.wait().await;
+        control.shutdown().await;
     }
 
     /// The lifecycle stream stores the latest state, so late subscribers still
@@ -1703,6 +1758,7 @@ mod tests {
             Arc::clone(&state_publish_lock),
             state_tx.clone(),
             guest,
+            CancellationToken::new(),
         );
 
         drop(stdin);
@@ -1737,6 +1793,7 @@ mod tests {
             Arc::clone(&state_publish_lock),
             state_tx.clone(),
             guest,
+            CancellationToken::new(),
         );
 
         drop(stdin);
@@ -1768,6 +1825,7 @@ mod tests {
             Arc::clone(&state_publish_lock),
             state_tx.clone(),
             guest,
+            CancellationToken::new(),
         );
 
         drop(stdin);
@@ -1811,6 +1869,7 @@ mod tests {
             Arc::clone(&state_publish_lock),
             state_tx.clone(),
             guest,
+            CancellationToken::new(),
         );
 
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -1856,6 +1915,7 @@ mod tests {
             Arc::clone(&state_publish_lock),
             state_tx,
             guest,
+            CancellationToken::new(),
         );
 
         handle.wait().await;


### PR DESCRIPTION
## Summary
- add a lifecycle handle for the sandbox-fc control server
- cancel and drain control connections when the sandbox runtime exits or stops
- clean up control socket paths on close, drop, shutdown, and startup failure
- add coverage for shutdown, cancellation, pending connections, in-flight exec, and bind failure edges

Closes #11395

## Tests
- cargo fmt --all --manifest-path crates/Cargo.toml -- --check
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets
- cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings
- git diff --check