### PR TITLE
feat: launch usage page

### DIFF
--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -28,7 +28,7 @@ export const ROUTES = {
   signInToken: "/sign-in-token",
   lab: "/_/lab",
   insights: "/insights",
-  usage: "/_/usage",
+  usage: "/usage",
   internalConnectorLogos: "/__internal-connector-logos",
   reportError: "/runs/:runId/report-error",
   redeemCampaign: "/redeem/:campaign",

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
@@ -230,7 +230,7 @@ describe("zero-nav", () => {
         initRoutes$,
         [
           { path: "/", setup: noop$ },
-          { path: "/_/usage", setup: noop$ },
+          { path: "/usage", setup: noop$ },
           { path: "{/*path}", setup: noop$ },
         ],
         context.signal,

--- a/turbo/apps/platform/src/views/usage-page/__tests__/usage-insight-components.test.tsx
+++ b/turbo/apps/platform/src/views/usage-page/__tests__/usage-insight-components.test.tsx
@@ -4,7 +4,7 @@
  * Covers: UsageInsightBarChart, UsageInsightChatsTable,
  * UsageInsightSchedulesTable, UsageInsightSelectors, UsageInsightView
  *
- * Entry point: detachedSetupPage({ context, path: "/_/usage" })
+ * Entry point: detachedSetupPage({ context, path: "/usage" })
  * Mock (external): HTTP via MSW zeroUsageInsightContract
  * Real (internal): All signals, components, rendering
  */
@@ -48,7 +48,7 @@ describe("usage insight view - loading, error, and data states", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(
@@ -70,7 +70,7 @@ describe("usage insight view - loading, error, and data states", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(
@@ -143,7 +143,7 @@ describe("usage insight view - loading, error, and data states", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(
@@ -201,7 +201,7 @@ describe("usage insight bar chart - chart rendering", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     // Wait for the credits label to appear
     await waitFor(() => {
@@ -232,7 +232,7 @@ describe("usage insight bar chart - chart rendering", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     // The breakdown list renders when stackOrder.length > 1 && total > 0.
     // With 3 categories (chat, slack, others), the breakdown list should appear.
@@ -274,7 +274,7 @@ describe("usage insight bar chart - chart rendering", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(
@@ -299,7 +299,7 @@ describe("usage insight bar chart - chart rendering", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(
@@ -332,7 +332,7 @@ describe("usage insight bar chart - chart rendering", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(
@@ -370,7 +370,7 @@ describe("usage insight chats table - rendering and interactions", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(
@@ -414,7 +414,7 @@ describe("usage insight chats table - rendering and interactions", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     // Wait for the chat titles to appear
     await waitFor(() => {
@@ -460,7 +460,7 @@ describe("usage insight chats table - rendering and interactions", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(screen.getByText("Design Review")).toBeInTheDocument();
@@ -495,7 +495,7 @@ describe("usage insight chats table - rendering and interactions", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(screen.getByText("2")).toBeInTheDocument();
@@ -528,7 +528,7 @@ describe("usage insight chats table - rendering and interactions", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(screen.getByText("Visible Chat")).toBeInTheDocument();
@@ -562,7 +562,7 @@ describe("usage insight chats table - rendering and interactions", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     // The breakdown list shows "5.0K" for the Big Chat row (5000 >= 1000)
     await waitFor(() => {
@@ -596,7 +596,7 @@ describe("usage insight schedules table - rendering and interactions", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(
@@ -653,7 +653,7 @@ describe("usage insight schedules table - rendering and interactions", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     // Wait for schedule content to appear, then verify count "3" is visible
     await waitFor(() => {
@@ -697,7 +697,7 @@ describe("usage insight schedules table - rendering and interactions", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(screen.getByText("Daily Standup")).toBeInTheDocument();
@@ -735,7 +735,7 @@ describe("usage insight schedules table - rendering and interactions", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(screen.getByText("Visible Schedule")).toBeInTheDocument();
@@ -779,7 +779,7 @@ describe("usage insight schedules table - rendering and interactions", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     // s1: description present → render description
     await waitFor(() => {
@@ -809,7 +809,7 @@ describe("usage insight schedules table - rendering and interactions", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     // When scheduleOtherCount is 1, the "+1 more schedule" row appears (singular)
     await waitFor(() => {
@@ -839,7 +839,7 @@ describe("usage insight selectors - date range dropdown", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/usage-page/__tests__/usage-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/usage-page/__tests__/usage-page-interaction.test.tsx
@@ -42,7 +42,7 @@ function emptyUsageInsight() {
   };
 }
 
-describe("/_/usage page - selector interactions", () => {
+describe("/usage page - selector interactions", () => {
   it("re-fetches with range=7d when Last 7 days is selected", async () => {
     let capturedRange: string | undefined;
 
@@ -53,7 +53,7 @@ describe("/_/usage page - selector interactions", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(
@@ -93,7 +93,7 @@ describe("/_/usage page - selector interactions", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(
@@ -119,7 +119,7 @@ describe("/_/usage page - selector interactions", () => {
   });
 });
 
-describe("/_/usage page - bucket densification", () => {
+describe("/usage page - bucket densification", () => {
   it("fills yesterday as the full local calendar day", async () => {
     vi.spyOn(Date, "now").mockReturnValue(
       new Date("2026-04-27T05:30:00.000Z").getTime(),
@@ -145,7 +145,7 @@ describe("/_/usage page - bucket densification", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(
@@ -192,7 +192,7 @@ describe("/_/usage page - bucket densification", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(
@@ -216,7 +216,7 @@ describe("/_/usage page - bucket densification", () => {
   });
 });
 
-describe("/_/usage page - error state", () => {
+describe("/usage page - error state", () => {
   it("shows error message when API fails", async () => {
     server.use(
       mockApi(zeroUsageInsightContract.get, ({ respond }) => {
@@ -226,7 +226,7 @@ describe("/_/usage page - error state", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(
@@ -246,7 +246,7 @@ describe("/_/usage page - error state", () => {
   });
 });
 
-describe("/_/usage page - empty state", () => {
+describe("/usage page - empty state", () => {
   it("shows zero credits when no data", async () => {
     server.use(
       mockApi(zeroUsageInsightContract.get, ({ respond }) => {
@@ -268,7 +268,7 @@ describe("/_/usage page - empty state", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(
@@ -288,7 +288,7 @@ describe("/_/usage page - empty state", () => {
   });
 });
 
-describe("/_/usage page - schedule and chat lists", () => {
+describe("/usage page - schedule and chat lists", () => {
   it("shows schedules and chats side-by-side", async () => {
     server.use(
       mockApi(zeroUsageInsightContract.get, ({ respond }) => {
@@ -296,7 +296,7 @@ describe("/_/usage page - schedule and chat lists", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
+++ b/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
@@ -14,7 +14,7 @@ beforeEach(() => {
   resetAllMockHandlers();
 });
 
-describe("/_/usage page", () => {
+describe("/usage page", () => {
   it("renders the page header and usage insight content", async () => {
     server.use(
       mockApi(zeroUsageInsightContract.get, ({ respond }) => {
@@ -22,7 +22,7 @@ describe("/_/usage page", () => {
       }),
     );
 
-    detachedSetupPage({ context, path: "/_/usage" });
+    detachedSetupPage({ context, path: "/usage" });
 
     await waitFor(() => {
       expect(

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -164,7 +164,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Show admin-only daily credits chart and per-run records on Usage page",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.ZeroDebug]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- Enable the usage analytics feature switch for everyone
- Move the Usage page route from the internal `/_/usage` path to `/usage`
- Update usage page and account navigation tests to use the public route

## Tests
- `pnpm exec vitest run src/views/usage-page/__tests__/usage-page.test.tsx src/views/usage-page/__tests__/usage-page-interaction.test.tsx src/views/usage-page/__tests__/usage-insight-components.test.tsx src/signals/zero-page/__tests__/zero-nav.test.ts` in `turbo/apps/platform`
- `pnpm check-types` in `turbo/apps/platform`
- `pnpm check-types` in `turbo/packages/core`
- `pnpm lint` in `turbo/apps/platform`
- `pnpm lint` in `turbo/packages/core`
- `git diff --check`