### PR TITLE
feat: add credit addition records

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-billing.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-billing.ts
@@ -39,6 +39,17 @@ function defaultBillingStatus(): BillingStatusResponse {
     creditBreakdown: [
       { category: "free", label: "Free plan", credits: 10_000 },
     ],
+    creditGrants: [
+      {
+        id: "starter-grant",
+        source: "starter_grant",
+        label: "Free plan",
+        amount: 10_000,
+        remaining: 10_000,
+        createdAt: "2098-12-01T00:00:00.000Z",
+        expiresAt: MOCK_STARTER_GRANT_EXPIRY,
+      },
+    ],
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -466,6 +466,7 @@ describe("org billing tab - auto-recharge section", () => {
           autoRecharge: { enabled, threshold: 2000, amount: 10_000 },
           creditExpiry: { expiringNextCycle: 0, nextExpiryDate: null },
           creditBreakdown: [],
+          creditGrants: [],
         });
       }),
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-manage-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-manage-dialog.test.tsx
@@ -41,6 +41,7 @@ describe("org manage dialog - display", () => {
 
     // Admin-visible tabs
     expect(screen.getByText(/Model Providers/i)).toBeInTheDocument();
+    expect(screen.getByText("Credit balance")).toBeInTheDocument();
   });
 
   it("shows the active tab heading on initial load", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
+import userEvent, {
+  PointerEventsCheckLevel,
+} from "@testing-library/user-event";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
@@ -110,6 +113,116 @@ describe("org usage tab - credit balance display", () => {
     await waitFor(() => {
       const info = screen.getByTestId("credit-balance-info");
       expect(info).toHaveTextContent("15,000");
+    });
+  });
+
+  it("should show credit addition records with expiry on hover", async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    });
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 35_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      creditBreakdown: [
+        { category: "plan", label: "Pro plan", credits: 15_000, tier: "pro" },
+        { category: "payAsYouGo", label: "Pay as you go", credits: 20_000 },
+      ],
+      creditGrants: [
+        {
+          id: "grant-pro",
+          source: "subscription_renewal",
+          label: "Pro plan",
+          amount: 20_000,
+          remaining: 15_000,
+          createdAt: "2026-03-20T00:00:00.000Z",
+          expiresAt: "2026-04-20T00:00:00.000Z",
+        },
+        {
+          id: "grant-payg",
+          source: "auto_recharge",
+          label: "Pay as you go",
+          amount: 20_000,
+          remaining: 20_000,
+          createdAt: "2026-03-25T00:00:00.000Z",
+          expiresAt: "2999-12-31T00:00:00.000Z",
+        },
+      ],
+    });
+
+    setupMockAPIs([]);
+
+    await openUsageTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Credit additions")).toBeInTheDocument();
+      expect(screen.getByTestId("credit-grants-section")).not.toHaveAttribute(
+        "open",
+      );
+    });
+
+    await user.click(screen.getByTestId("credit-grants-toggle"));
+    expect(screen.getByTestId("credit-grants-section")).toHaveAttribute("open");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("credit-grant-grant-pro")).toHaveTextContent(
+        "Pro plan",
+      );
+      expect(screen.getByTestId("credit-grant-grant-pro")).toHaveTextContent(
+        "15,000 left",
+      );
+    });
+
+    await user.hover(screen.getByTestId("credit-grant-grant-pro"));
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Expires Apr 20, 2026").length,
+      ).toBeGreaterThan(0);
+    });
+
+    await user.click(screen.getByTestId("credit-grants-toggle"));
+    expect(screen.getByTestId("credit-grants-section")).not.toHaveAttribute(
+      "open",
+    );
+  });
+
+  it("should show non-expiring credit additions on hover", async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    });
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      creditBreakdown: [
+        { category: "payAsYouGo", label: "Pay as you go", credits: 20_000 },
+      ],
+      creditGrants: [
+        {
+          id: "grant-payg",
+          source: "auto_recharge",
+          label: "Pay as you go",
+          amount: 20_000,
+          remaining: 20_000,
+          createdAt: "2026-03-25T00:00:00.000Z",
+          expiresAt: "2999-12-31T00:00:00.000Z",
+        },
+      ],
+    });
+
+    setupMockAPIs([]);
+
+    await openUsageTab();
+
+    await user.click(screen.getByTestId("credit-grants-toggle"));
+    expect(screen.getByTestId("credit-grant-grant-payg")).toHaveTextContent(
+      "Added Mar 25, 2026",
+    );
+    await user.hover(screen.getByTestId("credit-grant-grant-payg"));
+    await waitFor(() => {
+      expect(screen.getAllByText("Never expires").length).toBeGreaterThan(0);
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
@@ -69,7 +69,7 @@ const TAB_META = {
     description: "Manage your plan and payment method.",
   },
   usage: {
-    title: "Usage",
+    title: "Credit balance",
     description:
       "Credit balance and per-member credit consumption this billing period.",
   },
@@ -88,7 +88,7 @@ const BILLING_GROUP = {
   label: "Billing & pricing",
   items: [
     { id: "billing", label: "Billing", icon: IconCreditCard as NavIcon },
-    { id: "usage", label: "Usage", icon: IconCoins as NavIcon },
+    { id: "usage", label: "Credit balance", icon: IconCoins as NavIcon },
     { id: "invoices", label: "Invoices", icon: IconFileInvoice as NavIcon },
   ],
 } as const satisfies SidebarGroup;

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -3,7 +3,7 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import type { OrgMember } from "@vm0/api-contracts/contracts/org-members";
 import type { BillingStatusResponse } from "@vm0/api-contracts/contracts/zero-billing";
 import type { MemberUsage } from "@vm0/api-contracts/contracts/zero-usage";
-import { IconUsers } from "@tabler/icons-react";
+import { IconChevronRight, IconUsers } from "@tabler/icons-react";
 import { Input } from "@vm0/ui";
 import {
   Tooltip,
@@ -86,6 +86,8 @@ function segmentKey(seg: CreditSegment): string {
   return seg.tier ? `${seg.category}:${seg.tier}` : seg.category;
 }
 
+type CreditGrant = BillingStatusResponse["creditGrants"][number];
+
 function descriptionForSegment(
   seg: CreditSegment,
   currentTier: string,
@@ -97,6 +99,102 @@ function descriptionForSegment(
     return "Monthly plan credits, resets each billing cycle";
   }
   return "Leftover credits from previous plan";
+}
+
+function formatCreditDate(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value));
+}
+
+function expiresLabel(grant: CreditGrant): string {
+  if (grant.source === "auto_recharge") {
+    return "Never expires";
+  }
+  return `Expires ${formatCreditDate(grant.expiresAt)}`;
+}
+
+function CreditGrantRow({ grant }: { grant: CreditGrant }) {
+  const hasPartialBalance = grant.remaining !== grant.amount;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          tabIndex={0}
+          data-testid={`credit-grant-${grant.id}`}
+          className="flex min-w-0 cursor-default items-center justify-between gap-3 rounded-md px-2 py-1.5 outline-none transition-colors hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <div className="min-w-0">
+            <div className="truncate text-[13px] font-medium text-foreground">
+              {grant.label}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              Added {formatCreditDate(grant.createdAt)}
+            </div>
+          </div>
+          <div className="shrink-0 text-right">
+            <div className="text-[13px] font-medium tabular-nums text-foreground">
+              {grant.amount.toLocaleString()}
+            </div>
+            {hasPartialBalance ? (
+              <div className="text-xs tabular-nums text-muted-foreground">
+                {grant.remaining.toLocaleString()} left
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent
+        side="top"
+        sideOffset={8}
+        style={{ backgroundColor: "white", color: "inherit" }}
+        className="border shadow-md"
+      >
+        <div className="font-medium text-foreground">{expiresLabel(grant)}</div>
+        <div className="mt-0.5 text-muted-foreground">
+          {grant.remaining.toLocaleString()} credits remaining
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function CreditGrantList({ grants }: { grants: CreditGrant[] }) {
+  if (grants.length === 0) {
+    return null;
+  }
+
+  return (
+    <details
+      data-testid="credit-grants-section"
+      className="group mt-4 border-t border-border/50 pt-3"
+    >
+      <summary
+        data-testid="credit-grants-toggle"
+        className="mb-1 cursor-pointer list-none px-2"
+      >
+        <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <IconChevronRight
+            size={13}
+            stroke={2}
+            className="shrink-0 transition-transform group-open:rotate-90"
+          />
+          <span>Credit additions</span>
+          <span className="tabular-nums">({grants.length})</span>
+        </div>
+      </summary>
+      <TooltipProvider delayDuration={100}>
+        <div className="flex flex-col">
+          {grants.map((grant) => {
+            return <CreditGrantRow key={grant.id} grant={grant} />;
+          })}
+        </div>
+      </TooltipProvider>
+    </details>
+  );
 }
 
 function CreditBalanceChart({ billing }: { billing: BillingStatusResponse }) {
@@ -168,6 +266,7 @@ function CreditBalanceChart({ billing }: { billing: BillingStatusResponse }) {
           </div>
         </div>
       )}
+      <CreditGrantList grants={billing.creditGrants} />
     </div>
   );
 }
@@ -299,9 +398,7 @@ function OverviewSection() {
 
   return (
     <div className="flex flex-col gap-8">
-      {/* Credit balance */}
       <section className="flex flex-col gap-3">
-        <h3 className="text-sm font-medium text-foreground">Credit balance</h3>
         <div className="overflow-hidden rounded-xl bg-card zero-border">
           {billingLoading && !billing ? (
             <div className="px-5 py-4 space-y-2">

--- a/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
@@ -184,6 +184,15 @@ describe("GET /api/zero/billing/status", () => {
     const data = await response.json();
     expect(data.creditExpiry.expiringNextCycle).toBe(15000);
     expect(data.creditExpiry.nextExpiryDate).toBe(expiryDate.toISOString());
+    expect(data.creditGrants).toEqual([
+      expect.objectContaining({
+        source: "subscription_renewal",
+        label: "Pro plan",
+        amount: 20000,
+        remaining: 15000,
+        expiresAt: expiryDate.toISOString(),
+      }),
+    ]);
   });
 
   it("returns zero creditExpiry for free org", async () => {
@@ -281,6 +290,11 @@ describe("GET /api/zero/billing/status", () => {
       label: "Pay as you go",
       credits: 20_000,
     });
+    expect(
+      data.creditGrants.filter((grant: { source: string }) => {
+        return grant.source === "auto_recharge";
+      }),
+    ).toHaveLength(2);
   });
 
   it("maps subscription_renewal at Pro amount to Pro plan segment", async () => {
@@ -506,6 +520,11 @@ describe("GET /api/zero/billing/status", () => {
         credits: 5_000,
       },
     ]);
+    expect(
+      data.creditGrants.some((grant: { source: string }) => {
+        return grant.source === "auto_recharge";
+      }),
+    ).toBe(false);
   });
 
   it("merges untracked balance on free tier into Free plan segment", async () => {

--- a/turbo/apps/web/app/api/zero/billing/status/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/route.ts
@@ -29,6 +29,13 @@ const router = tsr.router(zeroBillingStatusContract, {
           nextExpiryDate:
             status.creditExpiry.nextExpiryDate?.toISOString() ?? null,
         },
+        creditGrants: status.creditGrants.map((record) => {
+          return {
+            ...record,
+            createdAt: record.createdAt.toISOString(),
+            expiresAt: record.expiresAt.toISOString(),
+          };
+        }),
       },
     };
   },

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -859,13 +859,55 @@ export async function getOrgInvoices(orgId: string): Promise<{
 }
 
 type CreditBreakdownCategory = "plan" | "free" | "promotional" | "payAsYouGo";
+type PlanCreditTier = "pro" | "team";
 
 interface CreditBreakdownSegment {
   category: CreditBreakdownCategory;
   label: string;
   credits: number;
   /** Only set on `plan` segments. */
-  tier?: "pro" | "team";
+  tier?: PlanCreditTier;
+}
+
+interface ActiveCreditRecord {
+  id: string;
+  source: string;
+  amount: number;
+  remaining: number;
+  expiresAt: Date;
+  createdAt: Date;
+}
+
+interface CreditGrant {
+  id: string;
+  source: string;
+  label: string;
+  amount: number;
+  remaining: number;
+  expiresAt: Date;
+  createdAt: Date;
+}
+
+// Returns `null` when the amount doesn't match any known tier.
+function planTierFromAmount(amount: number): PlanCreditTier | null {
+  if (amount === TIER_MONTHLY_CREDITS.team) return "team";
+  if (amount === TIER_MONTHLY_CREDITS.pro) return "pro";
+  return null;
+}
+
+function labelForCreditRecord(
+  record: Pick<ActiveCreditRecord, "source" | "amount">,
+): string {
+  if (record.source === "subscription_renewal") {
+    const planTier = planTierFromAmount(record.amount);
+    if (planTier === "team") return "Team plan";
+    if (planTier === "pro") return "Pro plan";
+    return "Plan credits";
+  }
+  if (record.source === "starter_grant") return "Free plan";
+  if (record.source === "one_time_purchase") return "Promotional";
+  if (record.source === "auto_recharge") return "Pay as you go";
+  return "Credits";
 }
 
 /**
@@ -889,17 +931,9 @@ function buildCreditBreakdown(args: {
   orgId: string;
   tier: string;
   displayedCredits: number;
-  records: Array<{ source: string; amount: number; remaining: number }>;
+  records: ActiveCreditRecord[];
 }): CreditBreakdownSegment[] {
   const { orgId, tier, displayedCredits, records } = args;
-
-  // Returns `null` when the amount doesn't match any known tier — caller will
-  // skip emitting a plan segment for such a record, avoiding a fabricated tier.
-  const planTierFromAmount = (amount: number): "pro" | "team" | null => {
-    if (amount === TIER_MONTHLY_CREDITS.team) return "team";
-    if (amount === TIER_MONTHLY_CREDITS.pro) return "pro";
-    return null;
-  };
 
   const segmentKey = (category: CreditBreakdownCategory, tierKey?: string) => {
     return tierKey ? `${category}:${tierKey}` : category;
@@ -990,13 +1024,37 @@ function buildCreditBreakdown(args: {
     "promotional",
     "payAsYouGo",
   ];
+  const planTierOrder: Record<PlanCreditTier, number> = {
+    pro: 0,
+    team: 1,
+  };
   const segments = Array.from(byKey.values());
   segments.sort((a, b) => {
-    return (
-      categoryOrder.indexOf(a.category) - categoryOrder.indexOf(b.category)
-    );
+    const categoryDelta =
+      categoryOrder.indexOf(a.category) - categoryOrder.indexOf(b.category);
+    if (categoryDelta !== 0) {
+      return categoryDelta;
+    }
+    if (a.category === "plan" && b.category === "plan") {
+      return planTierOrder[a.tier ?? "team"] - planTierOrder[b.tier ?? "team"];
+    }
+    return 0;
   });
   return segments;
+}
+
+function buildCreditGrants(records: ActiveCreditRecord[]): CreditGrant[] {
+  return records.map((record) => {
+    return {
+      id: record.id,
+      source: record.source,
+      label: labelForCreditRecord(record),
+      amount: record.amount,
+      remaining: record.remaining,
+      expiresAt: record.expiresAt,
+      createdAt: record.createdAt,
+    };
+  });
 }
 
 /**
@@ -1019,6 +1077,7 @@ export async function getBillingStatus(orgId: string): Promise<{
     nextExpiryDate: Date | null;
   };
   creditBreakdown: CreditBreakdownSegment[];
+  creditGrants: CreditGrant[];
 }> {
   const db = globalThis.services.db;
   const [org] = await db
@@ -1068,5 +1127,6 @@ export async function getBillingStatus(orgId: string): Promise<{
     },
     creditExpiry: expirySummary,
     creditBreakdown: breakdown,
+    creditGrants: buildCreditGrants(records),
   };
 }

--- a/turbo/apps/web/src/lib/zero/credit/credit-expires-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/credit-expires-service.ts
@@ -1,4 +1,4 @@
-import { eq, and, gt, lte, asc, sql } from "drizzle-orm";
+import { eq, and, gt, lte, asc, desc, sql } from "drizzle-orm";
 import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { logger } from "../../shared/logger";
@@ -225,16 +225,26 @@ export async function getExpiresRecordsSummary(orgId: string): Promise<{
  * rows so callers can distinguish subscription_renewal records from different
  * tiers (e.g. pro=20k vs team=120k).
  */
-export async function getCreditBreakdownRecords(
-  orgId: string,
-): Promise<Array<{ source: string; amount: number; remaining: number }>> {
+export async function getCreditBreakdownRecords(orgId: string): Promise<
+  Array<{
+    id: string;
+    source: string;
+    amount: number;
+    remaining: number;
+    expiresAt: Date;
+    createdAt: Date;
+  }>
+> {
   const db = globalThis.services.db;
 
   return db
     .select({
+      id: creditExpiresRecord.id,
       source: creditExpiresRecord.source,
       amount: creditExpiresRecord.amount,
       remaining: creditExpiresRecord.remaining,
+      expiresAt: creditExpiresRecord.expiresAt,
+      createdAt: creditExpiresRecord.createdAt,
     })
     .from(creditExpiresRecord)
     .where(
@@ -243,5 +253,6 @@ export async function getCreditBreakdownRecords(
         gt(creditExpiresRecord.remaining, 0),
         gt(creditExpiresRecord.expiresAt, new Date()),
       ),
-    );
+    )
+    .orderBy(desc(creditExpiresRecord.createdAt));
 }

--- a/turbo/packages/api-contracts/src/contracts/zero-billing.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-billing.ts
@@ -29,6 +29,16 @@ const creditBreakdownSegmentSchema = z.object({
   tier: z.enum(["pro", "team"]).optional(),
 });
 
+const creditGrantSchema = z.object({
+  id: z.string(),
+  source: z.string(),
+  label: z.string(),
+  amount: z.number(),
+  remaining: z.number(),
+  createdAt: z.string(),
+  expiresAt: z.string(),
+});
+
 const billingStatusResponseSchema = z.object({
   tier: z.string(),
   credits: z.number(),
@@ -39,6 +49,7 @@ const billingStatusResponseSchema = z.object({
   autoRecharge: autoRechargeSchema,
   creditExpiry: creditExpirySchema,
   creditBreakdown: z.array(creditBreakdownSegmentSchema),
+  creditGrants: z.array(creditGrantSchema),
 });
 
 const checkoutResponseSchema = z.object({


### PR DESCRIPTION
## Summary
- add creditGrants to billing status from active credit expiry records
- show a default-collapsed Credit additions section in Credit balance
- show expiry details on hover, with auto-recharge credits marked as never expiring

## Tests
- pnpm test app/api/zero/billing/status/__tests__/route.test.ts --no-file-parallelism --maxWorkers 1
- pnpm test src/views/zero-page/__tests__/org-usage-tab.test.tsx --no-file-parallelism --maxWorkers 1
- pnpm lint / pnpm check-types for platform, web, and api-contracts
- pre-commit turbo check-types