### PR TITLE
[codex] forward bb0 device code routes to api

### DIFF
--- a/turbo/apps/web/app/api/device-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/device-token/__tests__/route.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { HttpResponse } from "msw";
+
+import { POST as createDeviceToken } from "../route";
+import { POST as pollDeviceToken } from "../poll/route";
+import { server } from "../../../../src/mocks/server";
+import { http } from "../../../../src/__tests__/msw";
+
+describe("POST /api/device-token", () => {
+  it("forwards device code creation to the api backend", async () => {
+    const forwardedBodies: unknown[] = [];
+    const handler = http.post(
+      "http://localhost:3001/api/device-token",
+      async ({ request }) => {
+        forwardedBodies.push(await request.json());
+        return HttpResponse.json({
+          device_code: "ABCD-2345",
+          expires_in: 600,
+          interval: 3,
+          poll_token: "poll_token_123456789012345678901234567890",
+        });
+      },
+    );
+    server.use(handler.handler);
+
+    const response = await createDeviceToken(
+      new Request("http://localhost:3000/api/device-token", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          device_type: "bb0",
+          ble_session_nonce: "bb0-session-nonce-1234",
+        }),
+      }),
+    );
+
+    await expect(response.json()).resolves.toStrictEqual({
+      device_code: "ABCD-2345",
+      expires_in: 600,
+      interval: 3,
+      poll_token: "poll_token_123456789012345678901234567890",
+    });
+    expect(response.status).toBe(200);
+    expect(forwardedBodies).toStrictEqual([
+      {
+        device_type: "bb0",
+        ble_session_nonce: "bb0-session-nonce-1234",
+      },
+    ]);
+  });
+});
+
+describe("POST /api/device-token/poll", () => {
+  it("forwards device code polling to the api backend", async () => {
+    const forwardedBodies: unknown[] = [];
+    const handler = http.post(
+      "http://localhost:3001/api/device-token/poll",
+      async ({ request }) => {
+        forwardedBodies.push(await request.json());
+        return HttpResponse.json(
+          {
+            status: "pending",
+            interval: 3,
+          },
+          { status: 202 },
+        );
+      },
+    );
+    server.use(handler.handler);
+
+    const response = await pollDeviceToken(
+      new Request("http://localhost:3000/api/device-token/poll", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          device_code: "ABCD-2345",
+          poll_token: "poll_token_123456789012345678901234567890",
+        }),
+      }),
+    );
+
+    await expect(response.json()).resolves.toStrictEqual({
+      status: "pending",
+      interval: 3,
+    });
+    expect(response.status).toBe(202);
+    expect(forwardedBodies).toStrictEqual([
+      {
+        device_code: "ABCD-2345",
+        poll_token: "poll_token_123456789012345678901234567890",
+      },
+    ]);
+  });
+});

--- a/turbo/apps/web/app/api/device-token/poll/route.ts
+++ b/turbo/apps/web/app/api/device-token/poll/route.ts
@@ -1,0 +1,5 @@
+import { proxyToApiBackend } from "../../../../src/lib/api-backend-proxy";
+
+export async function POST(request: Request): Promise<Response> {
+  return proxyToApiBackend(request);
+}

--- a/turbo/apps/web/app/api/device-token/route.ts
+++ b/turbo/apps/web/app/api/device-token/route.ts
@@ -1,0 +1,5 @@
+import { proxyToApiBackend } from "../../../src/lib/api-backend-proxy";
+
+export async function POST(request: Request): Promise<Response> {
+  return proxyToApiBackend(request);
+}

--- a/turbo/apps/web/app/api/zero/devices/bb0/confirm/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/devices/bb0/confirm/__tests__/route.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { HttpResponse } from "msw";
+
+import { POST } from "../route";
+import { server } from "../../../../../../../src/mocks/server";
+import { http } from "../../../../../../../src/__tests__/msw";
+
+describe("POST /api/zero/devices/bb0/confirm", () => {
+  it("forwards the confirmation request to the api backend", async () => {
+    const forwardedBodies: unknown[] = [];
+    const forwardedHeaders: Headers[] = [];
+    const handler = http.post(
+      "http://localhost:3001/api/zero/devices/bb0/confirm",
+      async ({ request }) => {
+        forwardedBodies.push(await request.json());
+        forwardedHeaders.push(request.headers);
+        return HttpResponse.json(
+          { status: "approved" },
+          {
+            status: 200,
+            headers: {
+              "x-api-service": "api",
+            },
+          },
+        );
+      },
+    );
+    server.use(handler.handler);
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/zero/devices/bb0/confirm", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer clerk-session",
+          cookie: "__session=session-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ device_code: "ABCD-2345" }),
+      }),
+    );
+
+    await expect(response.json()).resolves.toStrictEqual({
+      status: "approved",
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-api-service")).toBe("api");
+    expect(forwardedBodies).toStrictEqual([{ device_code: "ABCD-2345" }]);
+    expect(forwardedHeaders[0]?.get("authorization")).toBe(
+      "Bearer clerk-session",
+    );
+    expect(forwardedHeaders[0]?.get("cookie")).toBe("__session=session-token");
+  });
+
+  it("preserves the upstream status and body", async () => {
+    const handler = http.post(
+      "http://localhost:3001/api/zero/devices/bb0/confirm",
+      () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Device code not found or expired",
+              code: "NOT_FOUND",
+            },
+          },
+          { status: 404 },
+        );
+      },
+    );
+    server.use(handler.handler);
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/zero/devices/bb0/confirm", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ device_code: "ABCD-2345" }),
+      }),
+    );
+
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Device code not found or expired",
+        code: "NOT_FOUND",
+      },
+    });
+    expect(response.status).toBe(404);
+  });
+});

--- a/turbo/apps/web/app/api/zero/devices/bb0/confirm/route.ts
+++ b/turbo/apps/web/app/api/zero/devices/bb0/confirm/route.ts
@@ -1,0 +1,5 @@
+import { proxyToApiBackend } from "../../../../../../src/lib/api-backend-proxy";
+
+export async function POST(request: Request): Promise<Response> {
+  return proxyToApiBackend(request);
+}

--- a/turbo/apps/web/src/lib/api-backend-proxy.ts
+++ b/turbo/apps/web/src/lib/api-backend-proxy.ts
@@ -1,0 +1,78 @@
+import { env } from "../env";
+
+const HOP_BY_HOP_HEADERS: Readonly<Record<string, true>> = {
+  connection: true,
+  "content-length": true,
+  host: true,
+  "keep-alive": true,
+  "proxy-authenticate": true,
+  "proxy-authorization": true,
+  te: true,
+  trailer: true,
+  "transfer-encoding": true,
+  upgrade: true,
+};
+
+function isHopByHopHeader(name: string): boolean {
+  return Object.hasOwn(HOP_BY_HOP_HEADERS, name.toLowerCase());
+}
+
+function buildProxyHeaders(request: Request): Headers {
+  const headers = new Headers();
+  for (const [key, value] of request.headers) {
+    if (!isHopByHopHeader(key)) {
+      headers.set(key, value);
+    }
+  }
+  return headers;
+}
+
+function buildProxyResponse(response: Response): Response {
+  const headers = new Headers();
+  for (const [key, value] of response.headers) {
+    if (!isHopByHopHeader(key)) {
+      headers.set(key, value);
+    }
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export async function proxyToApiBackend(request: Request): Promise<Response> {
+  const requestUrl = new URL(request.url);
+  const apiBackendUrl = env().VM0_API_BACKEND_URL;
+  if (!apiBackendUrl) {
+    return Response.json(
+      {
+        error: {
+          message: "API backend is not configured",
+          code: "BAD_GATEWAY",
+        },
+      },
+      { status: 502 },
+    );
+  }
+
+  const target = new URL(
+    `${requestUrl.pathname}${requestUrl.search}`,
+    apiBackendUrl,
+  );
+
+  const init: RequestInit & { duplex?: "half" } = {
+    method: request.method,
+    headers: buildProxyHeaders(request),
+    redirect: "manual",
+    signal: request.signal,
+  };
+
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    init.body = request.body;
+    init.duplex = "half";
+  }
+
+  const response = await fetch(target, init);
+  return buildProxyResponse(response);
+}


### PR DESCRIPTION
## Summary

- Add web route handlers for the bb0 device code flow: `/api/device-token`, `/api/device-token/poll`, and `/api/zero/devices/bb0/confirm`.
- Route those requests server-side to `VM0_API_BACKEND_URL` so the API service owns bb0 device code creation, polling, and confirmation.
- Share a small `proxyToApiBackend` helper that preserves request bodies, cookies, authorization headers, and upstream response status/body while stripping hop-by-hop headers.
- Add route integration tests covering create, poll, confirm, auth/header forwarding, and upstream status passthrough.

## Validation

- `pnpm -F web exec vitest run app/api/device-token/__tests__/route.test.ts app/api/zero/devices/bb0/confirm/__tests__/route.test.ts`
- `pnpm -F web exec oxlint src/lib/api-backend-proxy.ts app/api/device-token/route.ts app/api/device-token/poll/route.ts app/api/device-token/__tests__/route.test.ts app/api/zero/devices/bb0/confirm/route.ts app/api/zero/devices/bb0/confirm/__tests__/route.test.ts`
- `pnpm -F web exec eslint src/lib/api-backend-proxy.ts app/api/device-token/route.ts app/api/device-token/poll/route.ts app/api/device-token/__tests__/route.test.ts app/api/zero/devices/bb0/confirm/route.ts app/api/zero/devices/bb0/confirm/__tests__/route.test.ts --max-warnings 0`
- `pnpm -F web exec prettier --check src/lib/api-backend-proxy.ts app/api/device-token/route.ts app/api/device-token/poll/route.ts app/api/device-token/__tests__/route.test.ts app/api/zero/devices/bb0/confirm/route.ts app/api/zero/devices/bb0/confirm/__tests__/route.test.ts`

## Notes

- Full `pnpm -F web check-types` and the pre-commit hook currently fail on existing web type-check issues unrelated to this diff: Next 16.1.7/16.2.3 `NextRequest` type conflicts in existing routes/tests and `src/lib/zero/billing/model-usage-event-adapter.ts` failing to resolve `uuid` types. The check-types log did not include the new bb0 proxy files.