### PR TITLE
feat(model-picker): collapse VM0 dropdown to four primary models

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/model-picker-ui.ts
+++ b/turbo/apps/platform/src/signals/zero-page/model-picker-ui.ts
@@ -1,0 +1,14 @@
+import { command, computed, state } from "ccstate";
+
+// VM0 model dropdown collapse state. Module-scoped so the toggle persists
+// across opens within a session and stays consistent between picker
+// instances (composer, schedule dialog, settings).
+const internalShowAllVm0Models$ = state(false);
+
+export const showAllVm0Models$ = computed((get) => {
+  return get(internalShowAllVm0Models$);
+});
+
+export const toggleShowAllVm0Models$ = command(({ get, set }) => {
+  set(internalShowAllVm0Models$, !get(internalShowAllVm0Models$));
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/model-provider-picker-show-more.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/model-provider-picker-show-more.test.tsx
@@ -31,21 +31,6 @@ const context = testContext();
 const THREAD_ID = "thread-test-show-more";
 const PROVIDER_ID = "00000000-0000-4000-a000-000000000099";
 
-const PRIMARY_LABELS = [
-  "Claude Opus 4.7",
-  "Claude Opus 4.6",
-  "Claude Sonnet 4.6",
-  "DeepSeek V4 Pro",
-];
-const SECONDARY_LABELS = [
-  "GLM-5.1",
-  "Claude Haiku 4.5",
-  "Kimi K2.6",
-  "Kimi K2.5",
-  "MiniMax M2.7",
-  "DeepSeek V4 Flash",
-];
-
 function setupVm0Provider(selectedModel: string): void {
   setMockFeatureSwitches({});
   setMockOrgModelProviders([
@@ -82,9 +67,13 @@ async function openPicker(user: ReturnType<typeof userEvent.setup>) {
   });
 }
 
-function optionLabels(): string[] {
-  return screen.getAllByRole("option").map((el) => {
-    return el.textContent ?? "";
+function listboxText(): string {
+  return screen.getByRole("listbox").textContent ?? "";
+}
+
+function findToggleButton(matcher: RegExp): HTMLElement | undefined {
+  return screen.getAllByRole("button").find((el) => {
+    return matcher.test(el.textContent ?? "");
   });
 }
 
@@ -102,17 +91,19 @@ describe("model-provider-picker — VM0 show more", () => {
 
     await openPicker(user);
 
-    const labels = optionLabels();
-    for (const primary of PRIMARY_LABELS) {
-      expect(labels.some((l) => l.includes(primary))).toBe(true);
-    }
-    for (const secondary of SECONDARY_LABELS) {
-      expect(labels.some((l) => l.includes(secondary))).toBe(false);
-    }
+    const text = listboxText();
+    expect(text).toContain("Claude Opus 4.7");
+    expect(text).toContain("Claude Opus 4.6");
+    expect(text).toContain("Claude Sonnet 4.6");
+    expect(text).toContain("DeepSeek V4 Pro");
+    expect(text).not.toContain("GLM-5.1");
+    expect(text).not.toContain("Claude Haiku 4.5");
+    expect(text).not.toContain("Kimi K2.6");
+    expect(text).not.toContain("Kimi K2.5");
+    expect(text).not.toContain("MiniMax M2.7");
+    expect(text).not.toContain("DeepSeek V4 Flash");
 
-    expect(
-      screen.getByRole("button", { name: /show all models/i }),
-    ).toBeInTheDocument();
+    expect(findToggleButton(/show all models/i)).toBeDefined();
   });
 
   // MPKR-SM-002: Clicking "Show all models" reveals the full list and the
@@ -123,16 +114,20 @@ describe("model-provider-picker — VM0 show more", () => {
 
     await openPicker(user);
 
-    await user.click(screen.getByRole("button", { name: /show all models/i }));
+    const showAll = findToggleButton(/show all models/i);
+    expect(showAll).toBeDefined();
+    await user.click(showAll!);
 
-    const labels = optionLabels();
-    for (const label of [...PRIMARY_LABELS, ...SECONDARY_LABELS]) {
-      expect(labels.some((l) => l.includes(label))).toBe(true);
-    }
+    const text = listboxText();
+    expect(text).toContain("Claude Opus 4.7");
+    expect(text).toContain("GLM-5.1");
+    expect(text).toContain("Claude Haiku 4.5");
+    expect(text).toContain("Kimi K2.6");
+    expect(text).toContain("Kimi K2.5");
+    expect(text).toContain("MiniMax M2.7");
+    expect(text).toContain("DeepSeek V4 Flash");
 
-    expect(
-      screen.getByRole("button", { name: /show fewer models/i }),
-    ).toBeInTheDocument();
+    expect(findToggleButton(/show fewer models/i)).toBeDefined();
   });
 
   // MPKR-SM-003: When the active selection is a non-primary model, it stays
@@ -143,11 +138,11 @@ describe("model-provider-picker — VM0 show more", () => {
 
     await openPicker(user);
 
-    const labels = optionLabels();
-    expect(labels.some((l) => l.includes("Kimi K2.5"))).toBe(true);
+    const text = listboxText();
+    expect(text).toContain("Kimi K2.5");
     // Other secondary models remain hidden — only the active one leaks
     // through.
-    expect(labels.some((l) => l.includes("MiniMax M2.7"))).toBe(false);
-    expect(labels.some((l) => l.includes("DeepSeek V4 Flash"))).toBe(false);
+    expect(text).not.toContain("MiniMax M2.7");
+    expect(text).not.toContain("DeepSeek V4 Flash");
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/model-provider-picker-show-more.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/model-provider-picker-show-more.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Tests for the VM0 model dropdown's "Show all models" collapse.
+ *
+ * The VM0 group lists 10+ models, which made the chat composer dropdown too
+ * tall. The picker now collapses the VM0 group to a primary set (Opus 4.7,
+ * Opus 4.6, Sonnet 4.6, DeepSeek V4 Pro) and exposes a Show all / Show fewer
+ * toggle. The currently selected model stays visible even when collapsed so
+ * the user can always see the highlighted row.
+ *
+ * Entry point: chat thread page, which embeds the picker via the composer.
+ * Mock (external): Web API via MSW (feature switch + org providers + thread).
+ * Real (internal): chat composer signals, ModelProviderPicker, Radix Select.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  setMockOrgModelProviders,
+  resetMockOrgModelProviders,
+} from "../../../mocks/handlers/api-org-model-providers.ts";
+import {
+  setMockFeatureSwitches,
+  resetMockFeatureSwitches,
+} from "../../../mocks/handlers/api-feature-switches.ts";
+import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
+
+const context = testContext();
+const THREAD_ID = "thread-test-show-more";
+const PROVIDER_ID = "00000000-0000-4000-a000-000000000099";
+
+const PRIMARY_LABELS = [
+  "Claude Opus 4.7",
+  "Claude Opus 4.6",
+  "Claude Sonnet 4.6",
+  "DeepSeek V4 Pro",
+];
+const SECONDARY_LABELS = [
+  "GLM-5.1",
+  "Claude Haiku 4.5",
+  "Kimi K2.6",
+  "Kimi K2.5",
+  "MiniMax M2.7",
+  "DeepSeek V4 Flash",
+];
+
+function setupVm0Provider(selectedModel: string): void {
+  setMockFeatureSwitches({});
+  setMockOrgModelProviders([
+    {
+      id: PROVIDER_ID,
+      type: "vm0",
+      framework: "claude-code",
+      secretName: null,
+      authMethod: null,
+      secretNames: null,
+      isDefault: true,
+      selectedModel,
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  ]);
+}
+
+async function openPicker(user: ReturnType<typeof userEvent.setup>) {
+  mockChatLifecycle({ threadId: THREAD_ID });
+  detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+  await waitFor(() => {
+    return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+  });
+
+  const trigger = await waitFor(() => {
+    return screen.getByRole("combobox");
+  });
+  await user.click(trigger);
+
+  await waitFor(() => {
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+  });
+}
+
+function optionLabels(): string[] {
+  return screen.getAllByRole("option").map((el) => {
+    return el.textContent ?? "";
+  });
+}
+
+describe("model-provider-picker — VM0 show more", () => {
+  beforeEach(() => {
+    resetMockOrgModelProviders();
+    resetMockFeatureSwitches();
+  });
+
+  // MPKR-SM-001: Collapsed state shows only the four primary models plus the
+  // Show all toggle row.
+  it("shows only primary VM0 models by default (MPKR-SM-001)", async () => {
+    const user = userEvent.setup();
+    setupVm0Provider("claude-sonnet-4-6");
+
+    await openPicker(user);
+
+    const labels = optionLabels();
+    for (const primary of PRIMARY_LABELS) {
+      expect(labels.some((l) => l.includes(primary))).toBe(true);
+    }
+    for (const secondary of SECONDARY_LABELS) {
+      expect(labels.some((l) => l.includes(secondary))).toBe(false);
+    }
+
+    expect(
+      screen.getByRole("button", { name: /show all models/i }),
+    ).toBeInTheDocument();
+  });
+
+  // MPKR-SM-002: Clicking "Show all models" reveals the full list and the
+  // toggle flips to "Show fewer models".
+  it("expands to all VM0 models when toggled (MPKR-SM-002)", async () => {
+    const user = userEvent.setup();
+    setupVm0Provider("claude-sonnet-4-6");
+
+    await openPicker(user);
+
+    await user.click(screen.getByRole("button", { name: /show all models/i }));
+
+    const labels = optionLabels();
+    for (const label of [...PRIMARY_LABELS, ...SECONDARY_LABELS]) {
+      expect(labels.some((l) => l.includes(label))).toBe(true);
+    }
+
+    expect(
+      screen.getByRole("button", { name: /show fewer models/i }),
+    ).toBeInTheDocument();
+  });
+
+  // MPKR-SM-003: When the active selection is a non-primary model, it stays
+  // visible in the collapsed list so the user can see the highlighted row.
+  it("keeps the active selection visible when collapsed (MPKR-SM-003)", async () => {
+    const user = userEvent.setup();
+    setupVm0Provider("kimi-k2.5");
+
+    await openPicker(user);
+
+    const labels = optionLabels();
+    expect(labels.some((l) => l.includes("Kimi K2.5"))).toBe(true);
+    // Other secondary models remain hidden — only the active one leaks
+    // through.
+    expect(labels.some((l) => l.includes("MiniMax M2.7"))).toBe(false);
+    expect(labels.some((l) => l.includes("DeepSeek V4 Flash"))).toBe(false);
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -1,6 +1,6 @@
 import type { MouseEvent, ReactNode } from "react";
 import { useGet, useSet } from "ccstate-react";
-import { IconChevronDown, IconChevronUp, IconCpu } from "@tabler/icons-react";
+import { IconCpu } from "@tabler/icons-react";
 import {
   Select,
   SelectContent,
@@ -120,9 +120,7 @@ function MultiplierBadge({ multiplier }: { multiplier: number }) {
     <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
-          {/* `bg-card` (instead of bg-muted/50) keeps the badge visible when
-              the row turns accent on hover/highlight. */}
-          <span className="shrink-0 rounded border border-border bg-card px-1 py-px text-[11px] font-medium tabular-nums text-muted-foreground">
+          <span className="shrink-0 cursor-help text-xs tabular-nums text-muted-foreground underline decoration-dotted decoration-muted-foreground/50 underline-offset-2 hover:text-foreground hover:decoration-muted-foreground">
             {formatMultiplier(multiplier)}
           </span>
         </TooltipTrigger>
@@ -490,7 +488,7 @@ function ShowMoreToggleRow({
       role="button"
       tabIndex={0}
       aria-expanded={expanded}
-      className="flex items-center justify-between gap-3 rounded-md px-2 py-1.5 text-sm cursor-pointer hover:bg-accent transition-colors"
+      className="rounded-md px-2 py-1.5 text-sm text-muted-foreground cursor-pointer hover:bg-accent transition-colors"
       onClick={(e) => {
         e.preventDefault();
         onToggle();
@@ -502,14 +500,7 @@ function ShowMoreToggleRow({
         }
       }}
     >
-      <span className="text-muted-foreground">
-        {expanded ? "Show fewer models" : `Show all models (+${hiddenCount})`}
-      </span>
-      {expanded ? (
-        <IconChevronUp size={14} className="text-muted-foreground" />
-      ) : (
-        <IconChevronDown size={14} className="text-muted-foreground" />
-      )}
+      {expanded ? "Show fewer models" : `Show all models (+${hiddenCount})`}
     </div>
   );
 }
@@ -555,13 +546,13 @@ function renderProviderGroup(
             key={`${group.provider.id}::${model}`}
             value={`${group.provider.id}::${model}`}
             disabled={group.incompatible}
-            endSlot={
-              multiplier !== undefined ? (
-                <MultiplierBadge multiplier={multiplier} />
-              ) : undefined
-            }
           >
-            {getModelDisplayName(model)}
+            <span className="inline-flex items-baseline gap-1.5">
+              <span>{getModelDisplayName(model)}</span>
+              {multiplier !== undefined && (
+                <MultiplierBadge multiplier={multiplier} />
+              )}
+            </span>
           </SelectItem>
         );
       })}

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -1,4 +1,5 @@
-import { useState, type MouseEvent, type ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
+import { useGet, useSet } from "ccstate-react";
 import { IconChevronDown, IconChevronUp, IconCpu } from "@tabler/icons-react";
 import {
   Select,
@@ -26,6 +27,10 @@ import {
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { getModelDisplayName } from "@vm0/core/model-display-name";
+import {
+  showAllVm0Models$,
+  toggleShowAllVm0Models$,
+} from "../../../signals/zero-page/model-picker-ui";
 import {
   getUILabel,
   getVm0ModelMultiplier,
@@ -507,14 +512,19 @@ function ShowMoreToggleRow({
   );
 }
 
+interface RenderProviderGroupContext {
+  idx: number;
+  last: number;
+  selectedModel: string | null;
+  showAll: boolean;
+  onToggleShowAll: () => void;
+}
+
 function renderProviderGroup(
   group: ProviderGroup,
-  idx: number,
-  last: number,
-  selectedModel: string | null,
-  showAll: boolean,
-  onToggleShowAll: () => void,
+  ctx: RenderProviderGroupContext,
 ): ReactNode[] {
+  const { idx, last, selectedModel, showAll, onToggleShowAll } = ctx;
   // Only the VM0 group is collapsible — BYOK groups list a handful of models.
   const collapsible = group.isVm0;
   const visibleModels =
@@ -602,7 +612,8 @@ function ModelSelectDropdown({
     ? getModelDisplayName(resolved.selectedModel)
     : placeholder;
   const lastGroupIdx = groups.length - 1;
-  const [showAll, setShowAll] = useState(false);
+  const showAll = useGet(showAllVm0Models$);
+  const toggleShowAll = useSet(toggleShowAllVm0Models$);
   return (
     <Select
       value={encodeValue(value)}
@@ -653,18 +664,13 @@ function ModelSelectDropdown({
         )}
         {(!showUseDefault || value !== null) &&
           groups.flatMap((group, idx) => {
-            return renderProviderGroup(
-              group,
+            return renderProviderGroup(group, {
               idx,
-              lastGroupIdx,
-              resolved?.selectedModel ?? null,
+              last: lastGroupIdx,
+              selectedModel: resolved?.selectedModel ?? null,
               showAll,
-              () => {
-                setShowAll((s) => {
-                  return !s;
-                });
-              },
-            );
+              onToggleShowAll: toggleShowAll,
+            });
           })}
       </SelectContent>
     </Select>

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -555,13 +555,13 @@ function renderProviderGroup(
             key={`${group.provider.id}::${model}`}
             value={`${group.provider.id}::${model}`}
             disabled={group.incompatible}
+            endSlot={
+              multiplier !== undefined ? (
+                <MultiplierBadge multiplier={multiplier} />
+              ) : undefined
+            }
           >
-            <span className="truncate min-w-0 flex-1">
-              {getModelDisplayName(model)}
-            </span>
-            {multiplier !== undefined && (
-              <MultiplierBadge multiplier={multiplier} />
-            )}
+            {getModelDisplayName(model)}
           </SelectItem>
         );
       })}

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -556,14 +556,12 @@ function renderProviderGroup(
             value={`${group.provider.id}::${model}`}
             disabled={group.incompatible}
           >
-            <span className="flex items-center gap-2 w-full">
-              <span className="truncate min-w-0 flex-1">
-                {getModelDisplayName(model)}
-              </span>
-              {multiplier !== undefined && (
-                <MultiplierBadge multiplier={multiplier} />
-              )}
+            <span className="truncate min-w-0 flex-1">
+              {getModelDisplayName(model)}
             </span>
+            {multiplier !== undefined && (
+              <MultiplierBadge multiplier={multiplier} />
+            )}
           </SelectItem>
         );
       })}

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -121,10 +121,8 @@ function MultiplierBadge({ multiplier }: { multiplier: number }) {
       <Tooltip>
         <TooltipTrigger asChild>
           {/* `bg-card` (instead of bg-muted/50) keeps the badge visible when
-              the row turns accent on hover/highlight; `min-w-[2.75rem]` and
-              `text-center` lock it into a fixed column so multipliers across
-              rows stay aligned regardless of model-name length. */}
-          <span className="shrink-0 inline-flex min-w-[2.75rem] justify-center rounded border border-border bg-card px-1.5 py-px text-[11px] font-medium tabular-nums text-muted-foreground">
+              the row turns accent on hover/highlight. */}
+          <span className="shrink-0 rounded border border-border bg-card px-1 py-px text-[11px] font-medium tabular-nums text-muted-foreground">
             {formatMultiplier(multiplier)}
           </span>
         </TooltipTrigger>
@@ -559,7 +557,7 @@ function renderProviderGroup(
             disabled={group.incompatible}
           >
             <span className="flex items-center gap-2 w-full">
-              <span className="truncate flex-1">
+              <span className="truncate min-w-0 flex-1">
                 {getModelDisplayName(model)}
               </span>
               {multiplier !== undefined && (

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -120,7 +120,11 @@ function MultiplierBadge({ multiplier }: { multiplier: number }) {
     <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="shrink-0 rounded border border-border/60 bg-muted/50 px-1.5 py-px text-[11px] font-medium tabular-nums text-muted-foreground">
+          {/* `bg-card` (instead of bg-muted/50) keeps the badge visible when
+              the row turns accent on hover/highlight; `min-w-[2.75rem]` and
+              `text-center` lock it into a fixed column so multipliers across
+              rows stay aligned regardless of model-name length. */}
+          <span className="shrink-0 inline-flex min-w-[2.75rem] justify-center rounded border border-border bg-card px-1.5 py-px text-[11px] font-medium tabular-nums text-muted-foreground">
             {formatMultiplier(multiplier)}
           </span>
         </TooltipTrigger>
@@ -554,8 +558,10 @@ function renderProviderGroup(
             value={`${group.provider.id}::${model}`}
             disabled={group.incompatible}
           >
-            <span className="flex items-center gap-3 w-full">
-              <span className="truncate">{getModelDisplayName(model)}</span>
+            <span className="flex items-center gap-2 w-full">
+              <span className="truncate flex-1">
+                {getModelDisplayName(model)}
+              </span>
               {multiplier !== undefined && (
                 <MultiplierBadge multiplier={multiplier} />
               )}

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -1,5 +1,5 @@
-import type { MouseEvent, ReactNode } from "react";
-import { IconCpu } from "@tabler/icons-react";
+import { useState, type MouseEvent, type ReactNode } from "react";
+import { IconChevronDown, IconChevronUp, IconCpu } from "@tabler/icons-react";
 import {
   Select,
   SelectContent,
@@ -29,6 +29,7 @@ import { getModelDisplayName } from "@vm0/core/model-display-name";
 import {
   getUILabel,
   getVm0ModelMultiplier,
+  isVm0PrimaryModel,
 } from "./settings/provider-ui-config";
 import { ProviderIcon } from "./settings/provider-icons";
 
@@ -468,11 +469,61 @@ function buildProviderGroups(
     });
 }
 
+function ShowMoreToggleRow({
+  expanded,
+  hiddenCount,
+  onToggle,
+}: {
+  expanded: boolean;
+  hiddenCount: number;
+  onToggle: () => void;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-expanded={expanded}
+      className="flex items-center justify-between gap-3 rounded-md px-2 py-1.5 text-sm cursor-pointer hover:bg-accent transition-colors"
+      onClick={(e) => {
+        e.preventDefault();
+        onToggle();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onToggle();
+        }
+      }}
+    >
+      <span className="text-muted-foreground">
+        {expanded ? "Show fewer models" : `Show all models (+${hiddenCount})`}
+      </span>
+      {expanded ? (
+        <IconChevronUp size={14} className="text-muted-foreground" />
+      ) : (
+        <IconChevronDown size={14} className="text-muted-foreground" />
+      )}
+    </div>
+  );
+}
+
 function renderProviderGroup(
   group: ProviderGroup,
   idx: number,
   last: number,
+  selectedModel: string | null,
+  showAll: boolean,
+  onToggleShowAll: () => void,
 ): ReactNode[] {
+  // Only the VM0 group is collapsible — BYOK groups list a handful of models.
+  const collapsible = group.isVm0;
+  const visibleModels =
+    collapsible && !showAll
+      ? group.models.filter((m) => {
+          return isVm0PrimaryModel(m) || m === selectedModel;
+        })
+      : group.models;
+  const hiddenCount = group.models.length - visibleModels.length;
   const rendered: ReactNode[] = [
     <SelectGroup key={group.provider.id}>
       <SelectLabel className="pl-2 pr-8 py-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/60">
@@ -483,7 +534,7 @@ function renderProviderGroup(
           </span>
         )}
       </SelectLabel>
-      {group.models.map((model) => {
+      {visibleModels.map((model) => {
         const multiplier = group.isVm0
           ? getVm0ModelMultiplier(model)
           : undefined;
@@ -502,6 +553,13 @@ function renderProviderGroup(
           </SelectItem>
         );
       })}
+      {collapsible && (showAll || hiddenCount > 0) && (
+        <ShowMoreToggleRow
+          expanded={showAll}
+          hiddenCount={hiddenCount}
+          onToggle={onToggleShowAll}
+        />
+      )}
     </SelectGroup>,
   ];
   if (idx < last) {
@@ -544,6 +602,7 @@ function ModelSelectDropdown({
     ? getModelDisplayName(resolved.selectedModel)
     : placeholder;
   const lastGroupIdx = groups.length - 1;
+  const [showAll, setShowAll] = useState(false);
   return (
     <Select
       value={encodeValue(value)}
@@ -594,7 +653,18 @@ function ModelSelectDropdown({
         )}
         {(!showUseDefault || value !== null) &&
           groups.flatMap((group, idx) => {
-            return renderProviderGroup(group, idx, lastGroupIdx);
+            return renderProviderGroup(
+              group,
+              idx,
+              lastGroupIdx,
+              resolved?.selectedModel ?? null,
+              showAll,
+              () => {
+                setShowAll((s) => {
+                  return !s;
+                });
+              },
+            );
           })}
       </SelectContent>
     </Select>

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -627,7 +627,7 @@ function ModelSelectDropdown({
           />
         </SelectValue>
       </SelectTrigger>
-      <SelectContent className="max-h-[280px]">
+      <SelectContent className="max-h-[280px] min-w-[260px]">
         {showUseDefault && (
           <InheritToggleRow
             effectiveDefault={effectiveDefault}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -232,13 +232,11 @@ export function getVm0ModelMultiplier(model: string): number | undefined {
 // The VM0 model dropdown shows the full list (10+ entries) which is too long
 // for the chat composer. Collapse to these flagship/budget picks by default;
 // the "Show all models" toggle reveals the rest.
-export const VM0_PRIMARY_MODELS: ReadonlySet<string> = new Set([
-  "claude-opus-4-7",
-  "claude-opus-4-6",
-  "claude-sonnet-4-6",
-  "deepseek-v4-pro",
-]);
-
 export function isVm0PrimaryModel(model: string): boolean {
-  return VM0_PRIMARY_MODELS.has(model);
+  return (
+    model === "claude-opus-4-7" ||
+    model === "claude-opus-4-6" ||
+    model === "claude-sonnet-4-6" ||
+    model === "deepseek-v4-pro"
+  );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -228,3 +228,17 @@ const VM0_MODEL_CREDIT_MULTIPLIER = Object.freeze<Record<string, number>>({
 export function getVm0ModelMultiplier(model: string): number | undefined {
   return VM0_MODEL_CREDIT_MULTIPLIER[model];
 }
+
+// The VM0 model dropdown shows the full list (10+ entries) which is too long
+// for the chat composer. Collapse to these flagship/budget picks by default;
+// the "Show all models" toggle reveals the rest.
+export const VM0_PRIMARY_MODELS: ReadonlySet<string> = new Set([
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+  "deepseek-v4-pro",
+]);
+
+export function isVm0PrimaryModel(model: string): boolean {
+  return VM0_PRIMARY_MODELS.has(model);
+}

--- a/turbo/packages/ui/src/components/ui/select.tsx
+++ b/turbo/packages/ui/src/components/ui/select.tsx
@@ -139,7 +139,7 @@ const SelectItem = React.forwardRef<
       )}
       {...props}
     >
-      <SelectPrimitive.ItemText className="flex-1">
+      <SelectPrimitive.ItemText className="flex-1 min-w-0">
         {children}
       </SelectPrimitive.ItemText>
       <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">

--- a/turbo/packages/ui/src/components/ui/select.tsx
+++ b/turbo/packages/ui/src/components/ui/select.tsx
@@ -128,22 +128,8 @@ SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
 const SelectItem = React.forwardRef<
   React.ComponentRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
-    /**
-     * Optional element rendered at the row's right edge, before the check
-     * indicator. Useful for badges, multipliers, or other trailing metadata
-     * that should align in a column across rows.
-     *
-     * Why a dedicated prop instead of styling the children: Radix's
-     * `Select.ItemText` strips `className` from its props before rendering,
-     * so it's impossible to put flex/grow/truncate styling on the text
-     * wrapper itself. With an `endSlot`, this component owns the layout
-     * (flex container, grow on text, shrink-0 on slot) so callers can't
-     * accidentally land in a content-width-only state.
-     */
-    endSlot?: React.ReactNode;
-  }
->(({ className, children, endSlot, ...props }, ref) => {
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => {
   return (
     <SelectPrimitive.Item
       ref={ref}
@@ -153,16 +139,7 @@ const SelectItem = React.forwardRef<
       )}
       {...props}
     >
-      {endSlot !== undefined ? (
-        <span className="flex min-w-0 flex-1 items-center gap-2">
-          <span className="min-w-0 flex-1 truncate">
-            <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-          </span>
-          {endSlot}
-        </span>
-      ) : (
-        <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-      )}
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
       <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
         <SelectPrimitive.ItemIndicator>
           <IconCheck className="h-4 w-4" />

--- a/turbo/packages/ui/src/components/ui/select.tsx
+++ b/turbo/packages/ui/src/components/ui/select.tsx
@@ -128,8 +128,22 @@ SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
 const SelectItem = React.forwardRef<
   React.ComponentRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => {
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
+    /**
+     * Optional element rendered at the row's right edge, before the check
+     * indicator. Useful for badges, multipliers, or other trailing metadata
+     * that should align in a column across rows.
+     *
+     * Why a dedicated prop instead of styling the children: Radix's
+     * `Select.ItemText` strips `className` from its props before rendering,
+     * so it's impossible to put flex/grow/truncate styling on the text
+     * wrapper itself. With an `endSlot`, this component owns the layout
+     * (flex container, grow on text, shrink-0 on slot) so callers can't
+     * accidentally land in a content-width-only state.
+     */
+    endSlot?: React.ReactNode;
+  }
+>(({ className, children, endSlot, ...props }, ref) => {
   return (
     <SelectPrimitive.Item
       ref={ref}
@@ -139,9 +153,16 @@ const SelectItem = React.forwardRef<
       )}
       {...props}
     >
-      <SelectPrimitive.ItemText className="flex flex-1 min-w-0 items-center gap-2">
-        {children}
-      </SelectPrimitive.ItemText>
+      {endSlot !== undefined ? (
+        <span className="flex min-w-0 flex-1 items-center gap-2">
+          <span className="min-w-0 flex-1 truncate">
+            <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+          </span>
+          {endSlot}
+        </span>
+      ) : (
+        <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+      )}
       <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
         <SelectPrimitive.ItemIndicator>
           <IconCheck className="h-4 w-4" />

--- a/turbo/packages/ui/src/components/ui/select.tsx
+++ b/turbo/packages/ui/src/components/ui/select.tsx
@@ -139,7 +139,7 @@ const SelectItem = React.forwardRef<
       )}
       {...props}
     >
-      <SelectPrimitive.ItemText className="flex-1 min-w-0">
+      <SelectPrimitive.ItemText className="flex flex-1 min-w-0 items-center gap-2">
         {children}
       </SelectPrimitive.ItemText>
       <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">


### PR DESCRIPTION
## Summary
- The Built-in model dropdown lists 10+ models, making the chat composer dropdown too tall.
- Default the VM0 group to **Claude Opus 4.7, Opus 4.6, Sonnet 4.6, DeepSeek V4 Pro** with a "Show all models (+N)" toggle revealing the rest.
- The currently selected model stays visible even when collapsed, so the user always sees the active row.
- Only the VM0 group collapses — BYOK provider groups (Anthropic, Moonshot, etc.) already list a small handful of models.

The primary set lives in `provider-ui-config.ts` (`VM0_PRIMARY_MODELS`), co-located with the credit multiplier table.

## Test plan
- [x] Added `model-provider-picker-show-more.test.tsx` covering the three behaviors (default-collapsed, expand toggles, selected model leaks through when collapsed).
- [x] All existing model-picker tests still pass: `model-provider-picker-display`, `model-provider-picker-agent-default`, `chat-composer-model-picker-shortcut`, `chat-composer-model-selection-send`.
- [ ] Manual sanity-check the dropdown in the chat composer, schedule dialog, and settings tab — the toggle should appear in all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)