### PR TITLE
fix: preserve cancelled run chat error

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
@@ -817,6 +817,34 @@ describe("POST /api/internal/callbacks/chat", () => {
       expect(errorMsg?.content).toBe(actionableError);
     });
 
+    it("should preserve user-cancelled run errors", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread({
+        status: "failed",
+      });
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "failed",
+            error: "Run cancelled",
+            payload: { threadId, agentId },
+          },
+          secret,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+
+      const chatMessages = await getTestChatMessagesByThread(threadId);
+      const errorMsg = chatMessages.find((message) => {
+        return message.role === "assistant" && message.error !== null;
+      });
+      expect(errorMsg?.error).toBe("Run cancelled");
+      expect(errorMsg?.content).toBe("Run cancelled");
+    });
+
     it("should not derive sessionId on failed run without agentSessionId", async () => {
       const { threadId, runId, secret } = await setupRunAndThread({
         status: "failed",

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-run-error-message.ts
@@ -15,6 +15,7 @@ const ACTIONABLE_ERROR_SNIPPETS = [
   }),
   "Cannot continue session",
   "Invalid signature in thinking block",
+  "Run cancelled",
 ] as const;
 
 function isActionableRunError(errorMessage: string): boolean {


### PR DESCRIPTION
## Summary
- Treat `Run cancelled` as an actionable chat run error so user-initiated cancels are shown directly.
- Add chat callback coverage for cancelled run error preservation.

## Verification
- `pnpm test app/api/internal/callbacks/chat/__tests__/route.test.ts --no-file-parallelism --maxWorkers 1`
- pre-commit: prettier, knip, check-types