### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -135,7 +135,7 @@ ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the rootfs cache via script hash)
 GO_VERSION="1.26.2"
-CLAUDE_CODE_VERSION="2.1.121"
+CLAUDE_CODE_VERSION="2.1.123"
 CODEX_CLI_VERSION="0.125.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Summary

Bump pinned tool versions in `crates/runner/scripts/build-rootfs.sh` to the latest upstream releases.

| Package | Old | New |
|---|---|---|
| @anthropic-ai/claude-code | 2.1.121 | 2.1.123 |

Other pinned versions (Go 1.26.2, @openai/codex 0.125.0, @googleworkspace/cli 0.22.5, @xdevplatform/xurl 1.0.3, agent-browser 0.26.0) are already at their latest upstream releases.

## Test plan
- [ ] CI builds rootfs successfully with the new pins