### PR TITLE
fix(api): stop @sentry/node from emitting duplicate spans

### DIFF
--- a/turbo/apps/api/src/__tests__/instrument.test.ts
+++ b/turbo/apps/api/src/__tests__/instrument.test.ts
@@ -66,10 +66,24 @@ describe("instrument", () => {
           app: "api",
         },
       },
+      integrations: [
+        { name: "Http", options: { spans: false, tracePropagation: false } },
+        { name: "NodeFetch", options: { tracePropagation: false } },
+      ],
       release: "abc123",
       sendDefaultPii: false,
       shutdownTimeout: 500,
+      skipOpenTelemetrySetup: true,
       tracesSampleRate: 0,
+    });
+    expect(context.mocks.sentry.httpIntegration).toHaveBeenCalledWith({
+      spans: false,
+      tracePropagation: false,
+    });
+    expect(
+      context.mocks.sentry.nativeNodeFetchIntegration,
+    ).toHaveBeenCalledWith({
+      tracePropagation: false,
     });
   });
 });

--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -15,7 +15,9 @@ export interface ApiTestMocks {
   };
   readonly sentry: {
     readonly captureException: SyncMock;
+    readonly httpIntegration: Mock<(...args: unknown[]) => unknown>;
     readonly init: SyncMock;
+    readonly nativeNodeFetchIntegration: Mock<(...args: unknown[]) => unknown>;
   };
 }
 
@@ -35,7 +37,15 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
     },
     sentry: {
       captureException: vi.fn<(...args: unknown[]) => void>(),
+      httpIntegration: vi.fn<(...args: unknown[]) => unknown>((options) => {
+        return { name: "Http", options };
+      }),
       init: vi.fn<(...args: unknown[]) => void>(),
+      nativeNodeFetchIntegration: vi.fn<(...args: unknown[]) => unknown>(
+        (options) => {
+          return { name: "NodeFetch", options };
+        },
+      ),
     },
   };
 });
@@ -65,5 +75,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.clerk.users.getOrganizationMembershipList.mockReset();
   apiTestMocks.otel.registerOTel.mockReset();
   apiTestMocks.sentry.captureException.mockReset();
+  apiTestMocks.sentry.httpIntegration.mockClear();
   apiTestMocks.sentry.init.mockReset();
+  apiTestMocks.sentry.nativeNodeFetchIntegration.mockClear();
 }

--- a/turbo/apps/api/src/instrument.ts
+++ b/turbo/apps/api/src/instrument.ts
@@ -2,7 +2,11 @@ import { propagation } from "@opentelemetry/api";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { PgInstrumentation } from "@opentelemetry/instrumentation-pg";
 import { ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
-import { init } from "@sentry/node";
+import {
+  httpIntegration,
+  init,
+  nativeNodeFetchIntegration,
+} from "@sentry/node";
 import { registerOTel } from "@vercel/otel";
 
 import { env } from "./lib/env";
@@ -85,6 +89,23 @@ function setupSentry() {
     return;
   }
 
+  // We run our own OTel pipeline (@vercel/otel + @hono/otel + PgInstrumentation
+  // exporting to Axiom). @sentry/node v10 layers Sentry's own instrumentations
+  // on top of whatever tracer it sees, so without these opt-outs every request
+  // got a duplicate SERVER span and every outgoing request received both
+  // Sentry's `sentry-trace`/`baggage` and OTel's `traceparent` headers. The
+  // configuration below matches Sentry's "Using Your Existing OpenTelemetry
+  // Setup" guide:
+  //   - `skipOpenTelemetrySetup: true` — don't let Sentry init its own OTel
+  //     SDK; @vercel/otel already provides the tracer/exporter.
+  //   - `httpIntegration({ spans: false, tracePropagation: false })` — keep
+  //     Sentry's request isolation but stop it from creating SERVER spans or
+  //     injecting Sentry trace headers on incoming requests.
+  //   - `nativeNodeFetchIntegration({ tracePropagation: false })` — stop
+  //     Sentry from injecting trace headers on outgoing fetch; span emission
+  //     is already off because skipOpenTelemetrySetup flips its default.
+  // Sentry error capture (`captureException`) is unaffected by any of these.
+  // Reference: https://docs.sentry.io/platforms/javascript/guides/hono/opentelemetry/custom-setup/
   init({
     dsn,
     environment: env("VERCEL_ENV"),
@@ -93,9 +114,14 @@ function setupSentry() {
         app: "api",
       },
     },
+    integrations: [
+      httpIntegration({ spans: false, tracePropagation: false }),
+      nativeNodeFetchIntegration({ tracePropagation: false }),
+    ],
     release,
     sendDefaultPii: false,
     shutdownTimeout: 500,
+    skipOpenTelemetrySetup: true,
     tracesSampleRate: 0,
   });
 }

--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -22,6 +22,8 @@ ABLY_API_KEY=op://Development/ably/ABLY_API_KEY
 AXIOM_TOKEN_SESSIONS=op://Development/axiom/AXIOM_TOKEN_SESSIONS
 AXIOM_TOKEN_TELEMETRY=op://Development/axiom/AXIOM_TOKEN_TELEMETRY
 AXIOM_DATASET_SUFFIX=dev
+# api/instrument.ts gates OTel on this — set any non-empty value so local dev emits spans
+VERCEL_GIT_COMMIT_SHA=local-dev
 
 SECRETS_ENCRYPTION_KEY=op://Development/vm0/SECRETS_ENCRYPTION_KEY
 


### PR DESCRIPTION
## Summary

We run our own OTel pipeline (`@vercel/otel` + `@hono/otel` + `PgInstrumentation` exporting to Axiom). `@sentry/node` v10 layers its own instrumentations on top of whatever tracer it sees, so without opt-outs every request got a duplicate SERVER span on `vm0-traces-{dev,prod}` and every outgoing request received both Sentry's `sentry-trace`/`baggage` and OTel's `traceparent` headers.

Adopt [Sentry's "Using Your Existing OpenTelemetry Setup" guide](https://docs.sentry.io/platforms/javascript/guides/hono/opentelemetry/custom-setup/) verbatim:

```ts
init({
  ...,
  skipOpenTelemetrySetup: true,
  integrations: [
    httpIntegration({ spans: false, tracePropagation: false }),
    nativeNodeFetchIntegration({ tracePropagation: false }),
  ],
  tracesSampleRate: 0,
});
```

Each flag in plain English:
- `skipOpenTelemetrySetup: true` — Sentry doesn't init its own OTel SDK; @vercel/otel provides the tracer/exporter. Also flips `nativeNodeFetchIntegration` `spans` default to `false`.
- `httpIntegration({ spans: false, tracePropagation: false })` — keep Sentry's per-request isolation, stop SERVER span creation, stop `sentry-trace`/`baggage` header injection. `spans: true` is the default even with skipOpenTelemetrySetup, so it has to be explicit.
- `nativeNodeFetchIntegration({ tracePropagation: false })` — stop `sentry-trace`/`baggage` injection on outgoing fetch; OTel's propagator handles W3C `traceparent`.

`Sentry.captureException` is unaffected.

Also seeds `VERCEL_GIT_COMMIT_SHA=local-dev` in the web env template so `pnpm dev` actually emits spans (the OTel setup gates on a non-empty value).

## Evidence

24h sample on `vm0-traces-dev` before this change:

| scope.name | kind | count |
| --- | --- | --- |
| `@sentry/node` | server | 520 |
| `@hono/otel` | server | 289 |
| `@sentry/instrumentation-undici` | client | 113 |
| `@opentelemetry/instrumentation-pg` | client | 14 |

Local verification (10 hono requests + 5 db hits, dummy `SENTRY_DSN`):

| config | hono server | sentry server | pg client | undici client |
| --- | --- | --- | --- | --- |
| baseline (no opt-outs) | 11 | **11** | 15 | 0 |
| only `skipOpenTelemetrySetup` | 11 | **11** | 15 | 0 |
| skip + `httpIntegration(spans:false)` | 11 | **0** ✓ | 15 | 0 |
| skip + httpIntegration + nativeNodeFetch (final) | 11 | **0** ✓ | 15 | 0 |

`tracePropagation: false` is invisible to span counts (only affects outbound header injection), but matches the official guide and avoids dual-injection of trace headers downstream.

## Test plan

- [x] Local: emit 10 SERVER + 5 CLIENT spans via `@hono/otel` + PgInstrumentation; confirm zero `@sentry/node` spans on `vm0-traces-dev`.
- [ ] After merge: re-query `vm0-traces-dev` over a 24h window and confirm `@sentry/node` server count drops to ~0 while `@hono/otel` count stays steady.
- [ ] Confirm Sentry continues to receive captured exceptions (trigger an unhandled 5xx and check the Sentry project's Issues tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)