### PR TITLE
feat(insights): collapse daily diary into one row per day

### DIFF
--- a/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
@@ -146,6 +146,30 @@ export const reloadInsights$ = command(({ set }) => {
 });
 
 // ---------------------------------------------------------------------------
+// Day-level expand/collapse for the daily diary
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-date user choice to expand (true) or collapse (false) the day's masonry.
+ * Dates not in the map fall back to the page-level default (newest day is
+ * expanded, others collapsed).
+ */
+const internalDayExpansion$ = state<Map<string, boolean>>(new Map());
+
+export const dayExpansion$ = computed((get) => {
+  return get(internalDayExpansion$);
+});
+
+export const setDayExpansion$ = command(
+  ({ get, set }, dayDate: string, expanded: boolean) => {
+    const current = get(internalDayExpansion$);
+    const next = new Map(current);
+    next.set(dayDate, expanded);
+    set(internalDayExpansion$, next);
+  },
+);
+
+// ---------------------------------------------------------------------------
 // "Load more" toggle for allowed-permissions card (keyed by day date)
 // ---------------------------------------------------------------------------
 

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
@@ -158,8 +158,9 @@ describe("network insights page - data rendering", () => {
 
     detachedSetupPage({ context, path: "/insights" });
 
+    // Top agent appears in both the digest line and the masonry → multiple matches
     await waitFor(() => {
-      expect(screen.getByText("Alpha Bot")).toBeInTheDocument();
+      expect(screen.getAllByText("Alpha Bot").length).toBeGreaterThanOrEqual(1);
     });
     expect(screen.getByText("Beta Bot")).toBeInTheDocument();
   });
@@ -340,7 +341,7 @@ describe("network insights page - data rendering", () => {
     });
   });
 
-  it("should render multiple days", async () => {
+  it("should render a digest row per day with only the newest auto-expanded", async () => {
     mockInsightsAPI([
       sampleDay(day1Ago),
       sampleDay(day2Ago, {
@@ -353,9 +354,27 @@ describe("network insights page - data rendering", () => {
     detachedSetupPage({ context, path: "/insights" });
 
     await waitFor(() => {
-      expect(screen.getByText("Alpha Bot")).toBeInTheDocument();
+      expect(screen.getByText("Yesterday")).toBeInTheDocument();
     });
-    expect(screen.getByText("Gamma Bot")).toBeInTheDocument();
+    // Two digest rows render — older day's row contains an h2 inside the button
+    const digestButtons = screen.getAllByRole("button").filter((b) => {
+      return b.querySelector("h2") !== null;
+    });
+    expect(digestButtons).toHaveLength(2);
+    // Newest is auto-expanded; older is collapsed
+    expect(
+      digestButtons.filter((b) => {
+        return b.getAttribute("aria-expanded") === "true";
+      }),
+    ).toHaveLength(1);
+    expect(
+      digestButtons.filter((b) => {
+        return b.getAttribute("aria-expanded") === "false";
+      }),
+    ).toHaveLength(1);
+    // Older day's masonry-only artifact (PermissionsAllowedCard heading) absent
+    // because the older day is collapsed; the expanded newest day still shows it.
+    expect(screen.getAllByText("Allowed")).toHaveLength(1);
   });
 });
 
@@ -400,7 +419,7 @@ describe("network insights page - date range filter", () => {
     });
   });
 
-  it("should switch to Last 30 Days range", async () => {
+  it("should switch to Last 30 Days range and surface older day's digest row", async () => {
     mockInsightsAPI([
       sampleDay(day1Ago),
       sampleDay(day25Ago, {
@@ -412,21 +431,38 @@ describe("network insights page - date range filter", () => {
 
     detachedSetupPage({ context, path: "/insights" });
 
-    // Default is "Last 7 Days" — OldBot not visible
+    // Default is "Last 7 Days" — OldBot's day filtered out entirely
     await waitFor(() => {
       expect(screen.getByText("Last 7 Days")).toBeInTheDocument();
     });
     expect(screen.queryByText("OldBot")).not.toBeInTheDocument();
 
-    // Open dropdown and select "Last 30 Days"
     click(screen.getByText("Last 7 Days"));
     await waitFor(() => {
       expect(screen.getByText("Last 30 Days")).toBeInTheDocument();
     });
     click(screen.getByText("Last 30 Days"));
 
+    // Older day's digest row appears but content stays collapsed by default —
+    // expand it to reveal OldBot.
     await waitFor(() => {
-      expect(screen.getByText("OldBot")).toBeInTheDocument();
+      const collapsed = screen
+        .getAllByRole("button", { expanded: false })
+        .find((b) => {
+          return b.querySelector("h2") !== null;
+        });
+      expect(collapsed).toBeDefined();
+    });
+    const collapsedDigest = screen
+      .getAllByRole("button", { expanded: false })
+      .find((b) => {
+        return b.querySelector("h2") !== null;
+      })!;
+    click(collapsedDigest);
+
+    // OldBot now appears in both the digest line and the masonry
+    await waitFor(() => {
+      expect(screen.getAllByText("OldBot").length).toBeGreaterThanOrEqual(2);
     });
   });
 });
@@ -516,9 +552,12 @@ describe("network insights page - data refetch", () => {
     detachedSetupPage({ context, path: "/insights" });
 
     // The page setup calls reloadInsights$ which triggers a second fetch,
-    // so the UI should eventually show the refreshed data.
+    // so the UI should eventually show the refreshed data. RefreshedBot is
+    // the top agent → appears in both the digest line and the masonry.
     await waitFor(() => {
-      expect(screen.getByText("RefreshedBot")).toBeInTheDocument();
+      expect(
+        screen.getAllByText("RefreshedBot").length,
+      ).toBeGreaterThanOrEqual(1);
     });
     expect(callCount).toBeGreaterThanOrEqual(2);
   });
@@ -798,5 +837,165 @@ describe("network insights page - allowed card layout", () => {
     expect(
       screen.getByText(/calls made within 1 granted permission/),
     ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Daily diary — collapse/expand
+// ---------------------------------------------------------------------------
+
+describe("network insights page - daily diary", () => {
+  it("should auto-expand only the most recent day", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago),
+      sampleDay(day2Ago, {
+        agents: [
+          { agentName: "Older Bot", agentId: "a-old", runs: 2, credits: 30 },
+        ],
+      }),
+    ]);
+
+    detachedSetupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Yesterday")).toBeInTheDocument();
+    });
+    // The masonry's PermissionsAllowedCard heading is unique to the expanded
+    // day's content — exactly one "Allowed" means exactly one day expanded.
+    expect(screen.getAllByText("Allowed")).toHaveLength(1);
+  });
+
+  it("should reveal an older day's masonry on expand", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago),
+      sampleDay(day2Ago, {
+        agents: [
+          { agentName: "Older Bot", agentId: "a-old", runs: 2, credits: 30 },
+        ],
+      }),
+    ]);
+
+    detachedSetupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Yesterday")).toBeInTheDocument();
+    });
+    // Before expand: Older Bot only in collapsed digest (1 occurrence)
+    expect(screen.getAllByText("Older Bot")).toHaveLength(1);
+
+    const collapsedDigest = screen
+      .getAllByRole("button", { expanded: false })
+      .find((b) => {
+        return b.querySelector("h2") !== null;
+      })!;
+    click(collapsedDigest);
+
+    // After expand: Older Bot appears in both digest line and masonry
+    await waitFor(() => {
+      expect(screen.getAllByText("Older Bot").length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it("should collapse an expanded day on second click", async () => {
+    mockInsightsAPI([sampleDay(day1Ago)]);
+
+    detachedSetupPage({ context, path: "/insights" });
+
+    // Newest day auto-expanded → masonry "Allowed" heading visible
+    await waitFor(() => {
+      expect(screen.getByText("Allowed")).toBeInTheDocument();
+    });
+
+    const expandedDigest = screen
+      .getAllByRole("button", { expanded: true })
+      .find((b) => {
+        return b.querySelector("h2") !== null;
+      })!;
+    click(expandedDigest);
+
+    // After collapse: masonry artifacts gone
+    await waitFor(() => {
+      expect(screen.queryByText("Allowed")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should display credits and runs in the digest line", async () => {
+    mockInsightsAPI([sampleDay(day1Ago)]);
+
+    detachedSetupPage({ context, path: "/insights" });
+
+    // sampleDay totals: 200 credits, 5+3=8 runs
+    await waitFor(() => {
+      expect(screen.getByText("Yesterday")).toBeInTheDocument();
+    });
+    // Credits and runs appear in the digest header
+    const digestRow = screen
+      .getAllByRole("button", { expanded: true })
+      .find((b) => {
+        return b.querySelector("h2") !== null;
+      })!;
+    expect(digestRow.textContent).toContain("200");
+    expect(digestRow.textContent).toContain("8 runs");
+  });
+
+  it("should show top agent in the digest line", async () => {
+    mockInsightsAPI([sampleDay(day1Ago)]);
+
+    detachedSetupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Yesterday")).toBeInTheDocument();
+    });
+    // Alpha Bot has 120 credits vs Beta Bot's 80 → Alpha Bot is top
+    const digestRow = screen
+      .getAllByRole("button", { expanded: true })
+      .find((b) => {
+        return b.querySelector("h2") !== null;
+      })!;
+    expect(digestRow.textContent).toContain("Alpha Bot");
+  });
+
+  it("should show blocked badge in digest line when denials exist", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago, {
+        permissions: [
+          {
+            label: "stripe:charge",
+            connectorType: "stripe",
+            allowed: 0,
+            denied: 4,
+            agentNames: ["Alpha Bot"],
+          },
+        ],
+      }),
+    ]);
+
+    detachedSetupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("4 blocked")).toBeInTheDocument();
+    });
+  });
+
+  it("should not show blocked badge when no denials", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago, {
+        permissions: [
+          {
+            label: "chat:write",
+            allowed: 10,
+            denied: 0,
+            agentNames: ["Alpha Bot"],
+          },
+        ],
+      }),
+    ]);
+
+    detachedSetupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Yesterday")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/\d+ blocked$/)).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -30,6 +30,8 @@ import {
   setInsightsHoveredAgent$,
   expandedAllowedDays$,
   toggleExpandedAllowed$,
+  dayExpansion$,
+  setDayExpansion$,
   type DayInsight,
   type NetworkInsightsData,
 } from "../../signals/network-insights/network-insights-signals.ts";
@@ -978,7 +980,7 @@ function formatDate(iso: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Day section — masonry of cards (dim approach for hover)
+// Day section — masonry of cards (rendered inside DayDigestRow when expanded)
 // ---------------------------------------------------------------------------
 
 function DaySection({
@@ -998,39 +1000,121 @@ function DaySection({
   };
 
   return (
-    <section className="flex flex-col gap-3">
-      <h2 className="text-lg font-semibold text-foreground sticky top-0 bg-background/80 backdrop-blur-sm py-2 z-10">
-        {formatDate(day.date)}
-      </h2>
-      <div className="columns-1 sm:columns-2 lg:columns-3 gap-3">
-        <SummaryCard day={day} />
-        {isAdmin && (
-          <TeamCreditUsageCard
-            day={day}
-            colorIndex={1}
-            hoveredAgent={hoveredAgent}
-          />
-        )}
-        <YourCreditUsageCard
+    <div className="columns-1 sm:columns-2 lg:columns-3 gap-3">
+      <SummaryCard day={day} />
+      {isAdmin && (
+        <TeamCreditUsageCard
           day={day}
           colorIndex={1}
-          userId={userId}
           hoveredAgent={hoveredAgent}
         />
-        <AgentsCard
-          day={day}
-          colorIndex={0}
-          hoveredAgent={hoveredAgent}
-          onHoverAgent={handleHoverAgent}
+      )}
+      <YourCreditUsageCard
+        day={day}
+        colorIndex={1}
+        userId={userId}
+        hoveredAgent={hoveredAgent}
+      />
+      <AgentsCard
+        day={day}
+        colorIndex={0}
+        hoveredAgent={hoveredAgent}
+        onHoverAgent={handleHoverAgent}
+      />
+      <ServicesCard day={day} colorIndex={2} hoveredAgent={hoveredAgent} />
+      <PermissionsAllowedCard
+        day={day}
+        colorIndex={5}
+        hoveredAgent={hoveredAgent}
+      />
+      <PermissionsBlockedCard day={day} hoveredAgent={hoveredAgent} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Day digest row — single-line summary, expands to show DaySection on click
+// ---------------------------------------------------------------------------
+
+function DayDigestRow({
+  day,
+  isAdmin,
+  userId,
+  defaultExpanded,
+}: {
+  day: DayInsight;
+  isAdmin: boolean;
+  userId: string | null;
+  defaultExpanded: boolean;
+}) {
+  const expansion = useGet(dayExpansion$);
+  const setExpansion = useSet(setDayExpansion$);
+  const userChoice = expansion.get(day.date);
+  const isExpanded = userChoice ?? defaultExpanded;
+
+  const totalRuns = day.agents.reduce((s, a) => {
+    return s + a.runs;
+  }, 0);
+  const topAgent = [...day.agents].sort((a, b) => {
+    return b.credits - a.credits;
+  })[0];
+  const blocked = day.permissions.reduce((s, p) => {
+    return s + p.denied;
+  }, 0);
+
+  return (
+    <section className="flex flex-col gap-3">
+      <button
+        type="button"
+        onClick={() => {
+          setExpansion(day.date, !isExpanded);
+        }}
+        aria-expanded={isExpanded}
+        className="group flex items-center gap-3 w-full text-left rounded-[14px] border border-border bg-card px-4 py-3 hover:border-foreground/20 transition-colors"
+      >
+        <IconChevronDown
+          size={16}
+          className={`text-muted-foreground transition-transform ${
+            isExpanded ? "" : "-rotate-90"
+          }`}
         />
-        <ServicesCard day={day} colorIndex={2} hoveredAgent={hoveredAgent} />
-        <PermissionsAllowedCard
-          day={day}
-          colorIndex={5}
-          hoveredAgent={hoveredAgent}
-        />
-        <PermissionsBlockedCard day={day} hoveredAgent={hoveredAgent} />
-      </div>
+        <h2 className="text-base font-semibold text-foreground">
+          {formatDate(day.date)}
+        </h2>
+        <span className="text-xs text-muted-foreground">·</span>
+        <span
+          className="text-sm font-medium text-foreground"
+          title={day.creditsUsed.toLocaleString()}
+        >
+          {formatCredits(day.creditsUsed)}
+        </span>
+        <span className="text-xs text-muted-foreground">credits</span>
+        {totalRuns > 0 && (
+          <>
+            <span className="text-xs text-muted-foreground">·</span>
+            <span className="text-sm text-foreground">
+              {totalRuns} {totalRuns === 1 ? "run" : "runs"}
+            </span>
+          </>
+        )}
+        {topAgent && (
+          <>
+            <span className="text-xs text-muted-foreground">·</span>
+            <span className="text-xs text-muted-foreground">top:</span>
+            <span className="text-sm text-foreground truncate max-w-[180px]">
+              {topAgent.agentName}
+            </span>
+          </>
+        )}
+        {blocked > 0 && (
+          <span className="ml-auto inline-flex items-center gap-1 rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+            {blocked} blocked
+          </span>
+        )}
+      </button>
+      {isExpanded && (
+        <DaySection day={day} isAdmin={isAdmin} userId={userId} />
+      )}
     </section>
   );
 }
@@ -1118,13 +1202,14 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
             </p>
           </div>
         ) : (
-          filtered.map((day) => {
+          filtered.map((day, idx) => {
             return (
-              <DaySection
+              <DayDigestRow
                 key={day.date}
                 day={day}
                 isAdmin={isAdmin}
                 userId={userId}
+                defaultExpanded={idx === 0}
               />
             );
           })


### PR DESCRIPTION
## Summary

The Insights page today renders 7 cards per day × N days. On a 28-day window that's ~196 card instances stacked vertically — visually overwhelming and most of the per-day detail goes unread.

This PR wraps each \`DaySection\` in a \`DayDigestRow\` that condenses the day into a single line:

\`\`\`
▼  Yesterday  ·  12.4 K credits  ·  8 runs  ·  top: Alpha Bot         2 blocked
   ┌── Summary ──┬── Team Credit ──┬── Your Credit ──┐
   │   ...       │    ...          │    ...          │   ← masonry below when expanded
   └─────────────┴─────────────────┴─────────────────┘
\`\`\`

- **Newest day is auto-expanded** so the page is immediately useful on first visit
- **Older days collapse by default** — click a row to expand its full 7-card masonry
- User toggles persist in a new \`dayExpansion$\` signal, indexed by date
- Existing \`DaySection\` masonry preserved as-is — only the surrounding wrapper changed
- Sticky \`h2\` removed from \`DaySection\` since the digest row now owns the day header

## Why this design

Three layers of information map to three different user questions:
1. Period overview (top of page) — *"How are things this period?"*
2. Daily diary (this PR) — *"Show me each day at a glance"*
3. Day detail (expand on click) — *"Drill into a specific day"*

This PR ships layer 2. Layer 1 (period rollup) is a follow-up that will use the existing \`days[]\` data client-side.

## Test plan
- [x] \`pnpm vitest run src/views/network-insights/\` — 43 pass (36 existing + 7 new for digest row behavior)
- [x] \`pnpm check-types\`
- [x] \`pnpm lint\`
- [ ] Manual: visit \`/insights\` with multi-day data, verify only newest expanded; click an older row, verify masonry appears; click again, verify it collapses

🤖 Generated with [Claude Code](https://claude.com/claude-code)