### PR TITLE
[codex] allow direct bb0 device code entry

### DIFF
--- a/turbo/apps/platform/src/signals/device-bb0-page/bb0-device-onboarding.ts
+++ b/turbo/apps/platform/src/signals/device-bb0-page/bb0-device-onboarding.ts
@@ -183,7 +183,6 @@ export const bb0CanConfirmCode$ = computed((get) => {
   const stateValue = get(internalProvisioningState$);
   const deviceCode = normalizeDeviceCode(get(internalDeviceCodeInput$));
   return (
-    stateValue.wifiSent &&
     stateValue.operationStatus !== "confirmed" &&
     BB0_DEVICE_CODE_PATTERN.test(deviceCode)
   );

--- a/turbo/apps/platform/src/views/device-bb0/__tests__/bb0-device-page.test.tsx
+++ b/turbo/apps/platform/src/views/device-bb0/__tests__/bb0-device-page.test.tsx
@@ -1,9 +1,58 @@
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
+
+function defineWindowProperty(
+  target: object,
+  property: string,
+  value: unknown,
+): PropertyDescriptor | undefined {
+  const descriptor = Object.getOwnPropertyDescriptor(target, property);
+  Object.defineProperty(target, property, {
+    configurable: true,
+    value,
+  });
+  return descriptor;
+}
+
+function restoreWindowProperty(
+  target: object,
+  property: string,
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) {
+    Object.defineProperty(target, property, descriptor);
+    return;
+  }
+  Reflect.deleteProperty(target, property);
+}
+
+function mockSupportedWebBluetooth(signal: AbortSignal): void {
+  const secureContextDescriptor = defineWindowProperty(
+    window,
+    "isSecureContext",
+    true,
+  );
+  const userAgentDataDescriptor = defineWindowProperty(
+    navigator,
+    "userAgentData",
+    { brands: [{ brand: "Chromium", version: "120" }] },
+  );
+  const bluetoothDescriptor = defineWindowProperty(navigator, "bluetooth", {
+    requestDevice: () => {
+      return Promise.reject(new Error("Bluetooth selection is not used."));
+    },
+  });
+
+  signal.addEventListener("abort", () => {
+    restoreWindowProperty(window, "isSecureContext", secureContextDescriptor);
+    restoreWindowProperty(navigator, "userAgentData", userAgentDataDescriptor);
+    restoreWindowProperty(navigator, "bluetooth", bluetoothDescriptor);
+  });
+}
 
 describe("bb0 device page", () => {
   it("blocks browsers without supported Web Bluetooth", async () => {
@@ -21,5 +70,25 @@ describe("bb0 device page", () => {
     expect(
       screen.getByText(/Open this page in a Chromium-based browser/i),
     ).toBeInTheDocument();
+  });
+
+  it("allows entering a device code before Wi-Fi is sent from the page", async () => {
+    mockSupportedWebBluetooth(context.signal);
+
+    detachedSetupPage({
+      context,
+      path: "/device/bb0",
+    });
+
+    const deviceCodeInput = await screen.findByLabelText("Device code");
+    const confirmButton = screen.getByText("Confirm code");
+
+    expect(deviceCodeInput).toBeEnabled();
+    expect(confirmButton).toBeDisabled();
+
+    await fill(deviceCodeInput, "abcd2345");
+
+    expect(deviceCodeInput).toHaveValue("ABCD-2345");
+    expect(confirmButton).toBeEnabled();
   });
 });

--- a/turbo/apps/platform/src/views/device-bb0/bb0-device-page.tsx
+++ b/turbo/apps/platform/src/views/device-bb0/bb0-device-page.tsx
@@ -329,7 +329,7 @@ function DeviceCodeStep() {
         Device code
         <Input
           value={deviceCode}
-          disabled={!state.wifiSent || confirming || confirmed}
+          disabled={confirming || confirmed}
           placeholder="ABCD-2345"
           inputMode="text"
           autoCapitalize="characters"


### PR DESCRIPTION
## Summary

- Allow the bb0 device code input to be used before Wi-Fi credentials are sent from the page.
- Let the confirm action depend on code format and confirmation state instead of the page-local Wi-Fi sent flag.
- Add a page test for users who already completed provisioning and only need to enter the device code.

## Root Cause

The device code step was coupled to the local `wifiSent` state, which blocked users who had already completed Wi-Fi provisioning outside this page session.

## Validation

- `pnpm -F @vm0/app exec vitest run src/views/device-bb0/__tests__/bb0-device-page.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- pre-commit: prettier, knip, full `pnpm check-types`
