### PR TITLE
perf: add bounded selective json extraction for billing

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -30,11 +30,10 @@ _UTF8_LEAD_MAX_1BYTE = 0x80  # ASCII: 0xxxxxxx
 _UTF8_LEAD_MAX_2BYTE = 0xE0  # 2-byte lead: 110xxxxx
 _UTF8_LEAD_MAX_3BYTE = 0xF0  # 3-byte lead: 1110xxxx
 
-# Decompression cap for response bodies that need full parsing for usage
-# extraction (model-provider non-SSE JSON, billable-connector JSON).  Larger
-# than STREAM_BUFFER_LIMIT (which guards capture-mode body logging) so large
-# search/timeline payloads decompress fully.  Still bounded so a malicious
-# upstream cannot exhaust memory via a decompression bomb.
+# Decompression cap for legacy/test one-shot usage extraction fallbacks.
+# Production billable JSON paths use streaming decompression plus selective
+# extraction; this remains larger than STREAM_BUFFER_LIMIT for direct helper
+# calls while still bounding decompression bombs.
 LARGE_RESPONSE_DECOMPRESS_LIMIT = 5 * 1024 * 1024  # 5 MB
 
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -363,20 +363,24 @@ def responseheaders(flow: http.HTTPFlow) -> None:
         return
 
     buf = bytearray()
-    state = {"truncated": False}
+    state = {"truncated": False, "total_bytes": 0}
 
-    # Set up usage extraction only for billable model-provider responses.
-    # For non-SSE billable model-provider responses, disable buffer truncation
-    # so the full JSON body is available for usage extraction in response().
+    # Set up usage extraction for billable response classes that need body
+    # inspection. The forensic stream_buffer remains capped; billing parsers
+    # consume chunks separately so a large response cannot grow that buffer.
     sse_parser = None
     sse_decompressor = None
+    model_json_parser = None
+    model_json_decompressor = None
     ndjson_parser = None
     ndjson_decompressor = None
+    x_json_parser = None
+    x_json_decompressor = None
     firewall_name = flow.metadata.get("firewall_name", "")
     is_model_provider = firewall_name.startswith("model-provider:")
     # Platform-billable firewall flag, sourced from vm_info["billableFirewalls"]
     # via auth.handle_firewall_request.  Gates report_connector_usage (in response())
-    # and the full-body response buffering that billing payload extraction needs.
+    # and the incremental response parsers used for billing payload extraction.
     is_billable_flow = flow.metadata.get("firewall_billable", False)
     is_billable_model_provider = is_model_provider and is_billable_flow
     # X-specific NDJSON stream classification — tied to the x firewall itself,
@@ -390,10 +394,9 @@ def responseheaders(flow: http.HTTPFlow) -> None:
     # later in response() by report_connector_usage.
     #
     # Gated on 2xx status so error responses (4xx/5xx on stream endpoints
-    # return JSON, not NDJSON) fall through to the existing unbounded-buffer
-    # path and preserve the full error body for forensic inspection in
-    # network logs.  report_connector_usage already skips non-2xx responses
-    # so no billing record is affected either way.
+    # return JSON, not NDJSON) skip the billing parser and only use the capped
+    # forensic stream buffer.  report_connector_usage already skips non-2xx
+    # responses so no billing record is affected either way.
     #
     # Reads ``original_url`` with no fallback — kept consistent with
     # :func:`usage._parse_x_request_metadata` so the log entry's
@@ -412,6 +415,11 @@ def responseheaders(flow: http.HTTPFlow) -> None:
             sse_parser = parser_fn
             flow.metadata["model_provider_usage"] = usage_dict
             sse_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
+        else:
+            extractor = usage.create_model_json_usage_extractor()
+            model_json_parser = extractor.feed
+            flow.metadata["model_json_usage_finish"] = extractor.finish
+            model_json_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
     elif is_x_stream:
         parser_fn, ndjson_state = usage.x.create_ndjson_extractor()
         ndjson_parser = parser_fn
@@ -420,36 +428,88 @@ def responseheaders(flow: http.HTTPFlow) -> None:
         # x_ndjson_state is only consumed by report_connector_usage.
         flow.metadata["x_ndjson_state"] = ndjson_state
         ndjson_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
+    elif (
+        is_x_flow
+        and is_billable_flow
+        and _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN
+    ):
+        extractor = usage.x.create_json_response_extractor()
+        x_json_parser = extractor.feed
+        flow.metadata["x_json_response_finish"] = extractor.finish
+        x_json_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
 
     # Buffer cap policy:
-    # - Billable flows keep the full body for billing extraction.
-    # - X stream endpoints are the exception: the incremental parser handles
-    #   bytes as they arrive, so the buffer is only for forensic logging.
-    # - Everything else uses STREAM_BUFFER_LIMIT (default 64 KB).
-    buf_limit = None if is_billable_flow and not is_x_stream else body_utils.STREAM_BUFFER_LIMIT
+    # - stream_buffer is only for forensic logging / capture and is always
+    #   capped at STREAM_BUFFER_LIMIT.
+    # - Billing extraction uses the incremental parsers above.
+    buf_limit = body_utils.STREAM_BUFFER_LIMIT
 
     def stream_and_buffer(chunk: bytes) -> bytes:
+        state["total_bytes"] += len(chunk)
         if not state["truncated"]:
-            if buf_limit is None:
+            remaining = buf_limit - len(buf)
+            if len(chunk) <= remaining:
                 buf.extend(chunk)
             else:
-                remaining = buf_limit - len(buf)
-                if len(chunk) <= remaining:
-                    buf.extend(chunk)
-                else:
-                    buf.extend(chunk[:remaining])
-                    state["truncated"] = True
+                buf.extend(chunk[:remaining])
+                state["truncated"] = True
         if sse_parser is not None:
             plaintext = sse_decompressor(chunk) if sse_decompressor else chunk
             sse_parser(plaintext)
+        elif model_json_parser is not None:
+            plaintext = model_json_decompressor(chunk) if model_json_decompressor else chunk
+            model_json_parser(plaintext)
         elif ndjson_parser is not None:
             plaintext = ndjson_decompressor(chunk) if ndjson_decompressor else chunk
             ndjson_parser(plaintext)
+        elif x_json_parser is not None:
+            plaintext = x_json_decompressor(chunk) if x_json_decompressor else chunk
+            x_json_parser(plaintext)
         return chunk
 
     flow.response.stream = stream_and_buffer
     flow.metadata["stream_buffer"] = buf
     flow.metadata["stream_buffer_state"] = state
+    flow.metadata["_vm0_response_stream_callback"] = stream_and_buffer
+
+
+def _finalize_model_json_usage(flow: http.HTTPFlow, proxy_log_path: str) -> None:
+    finish = flow.metadata.pop("model_json_usage_finish", None)
+    if finish is None:
+        return
+    flow.metadata["_model_json_usage_finalized"] = True
+    usage_result, error = finish()
+    if usage_result:
+        flow.metadata["model_provider_usage"] = usage_result
+        return
+    if error:
+        log_proxy_entry(
+            proxy_log_path,
+            "warn",
+            "Model provider JSON usage extraction failed",
+            type="usage_event",
+            error=error,
+        )
+
+
+def _finalize_x_json_state(flow: http.HTTPFlow) -> None:
+    finish = flow.metadata.pop("x_json_response_finish", None)
+    if finish is None:
+        return
+    state, error = finish()
+    if error:
+        state["parse_error"] = error
+    flow.metadata["x_json_state"] = state
+
+
+def _release_response_stream_state(flow: http.HTTPFlow) -> None:
+    stream_callback = flow.metadata.pop("_vm0_response_stream_callback", None)
+    flow.metadata.pop("stream_buffer", None)
+    flow.metadata.pop("stream_buffer_state", None)
+    flow.metadata.pop("model_json_usage_finish", None)
+    flow.metadata.pop("x_json_response_finish", None)
+    if stream_callback is not None and flow.response and flow.response.stream is stream_callback:
+        flow.response.stream = False
 
 
 def _track_usage_flow(fn):
@@ -465,6 +525,7 @@ def _track_usage_flow(fn):
         try:
             return fn(flow, *args, **kwargs)
         finally:
+            _release_response_stream_state(flow)
             _release_tracked_usage_flow(flow)
 
     return wrapper
@@ -496,7 +557,9 @@ def response(flow: http.HTTPFlow) -> None:
     # Use buffered body length when complete; fall back to Content-Length header.
     stream_buf = flow.metadata.get("stream_buffer")
     stream_state = flow.metadata.get("stream_buffer_state")
-    if stream_buf is not None and stream_state and not stream_state["truncated"]:
+    if stream_buf is not None and stream_state and "total_bytes" in stream_state:
+        response_size = int(stream_state["total_bytes"])
+    elif stream_buf is not None and stream_state and not stream_state["truncated"]:
         response_size = len(stream_buf)
     elif flow.response:
         response_size = int(flow.response.headers.get("content-length", 0))
@@ -544,10 +607,17 @@ def response(flow: http.HTTPFlow) -> None:
 
         log_network_entry(network_log_path, log_entry)
 
+    _finalize_model_json_usage(flow, proxy_log_path)
+
     # Report proxy-extracted usage for model provider responses.
     # For non-streaming responses, fall back to extracting usage from the
-    # buffered JSON body (buffer is never truncated for billable model providers).
-    if not flow.metadata.get("model_provider_usage") and stream_buf:
+    # buffered JSON body only for legacy/test flows that did not pass through
+    # responseheaders() and therefore have no incremental extractor.
+    if (
+        not flow.metadata.get("_model_json_usage_finalized")
+        and not flow.metadata.get("model_provider_usage")
+        and stream_buf
+    ):
         firewall_name = flow.metadata.get("firewall_name", "")
         if firewall_name.startswith("model-provider:") and flow.metadata.get(
             "firewall_billable", False
@@ -561,6 +631,7 @@ def response(flow: http.HTTPFlow) -> None:
     usage.report_model_provider_usage(flow, run_id)
 
     # Billable connector usage observation (issue #9504, stage 0).
+    _finalize_x_json_state(flow)
     usage.report_connector_usage(flow, run_id)
 
     # Invalidate firewall header cache on 401 so next request gets fresh headers.
@@ -652,10 +723,11 @@ def error(flow: http.HTTPFlow) -> None:
     # Billable connector usage for X NDJSON streams that crash mid-flight
     # (issue #9534): the incremental parser populated x_ndjson_state during
     # chunks; log what was observed so partial streams aren't silently
-    # dropped from billing.  report_connector_usage no-ops when there's no
-    # response or the status is non-2xx, so normal model-provider errors
-    # are unaffected.
-    usage.report_connector_usage(flow, run_id)
+    # dropped from billing.  Do not run the generic connector fallback for
+    # non-streaming JSON errors: partial bodies could otherwise be treated
+    # as unparseable successes and billed from request-side hints.
+    if flow.metadata.get("x_ndjson_state") is not None:
+        usage.report_connector_usage(flow, run_id)
 
     log_proxy_entry(
         proxy_log_path,

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -20,11 +20,16 @@ patches can't reach.
 
 from . import webhook
 from .counters import decrement_flows, increment_flows, set_pending_path
-from .extract import create_sse_usage_extractor, extract_usage_from_json
+from .extract import (
+    create_model_json_usage_extractor,
+    create_sse_usage_extractor,
+    extract_usage_from_json,
+)
 from .providers.connectors import report_connector_usage, x
 from .providers.model_provider import report_model_provider_usage
 
 __all__ = [
+    "create_model_json_usage_extractor",
     "create_sse_usage_extractor",
     "decrement_flows",
     "extract_usage_from_json",

--- a/crates/runner/mitm-addon/src/usage/extract.py
+++ b/crates/runner/mitm-addon/src/usage/extract.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 
 import body_utils
 
+from .json_selective import JsonSelectiveExtractor, ScalarField
 from .model_tokens import ANTHROPIC_USAGE_FIELD_CATEGORIES
 
 # SSE event boundaries we scan for.  When no boundary is found we keep
@@ -17,6 +18,15 @@ from .model_tokens import ANTHROPIC_USAGE_FIELD_CATEGORIES
 # adding a longer separator here updates the tail automatically.
 _SSE_SEPARATORS: tuple[bytes, ...] = (b"\r\n\r\n", b"\n\n")
 _MAX_SEPARATOR_LEN = max(len(s) for s in _SSE_SEPARATORS)
+
+_MODEL_JSON_SCALAR_FIELDS = {
+    ("id",): ScalarField("string", max_bytes=1024),
+    ("model",): ScalarField("string", max_bytes=1024),
+    **{
+        ("usage", field): ScalarField("int", max_bytes=64)
+        for field in ANTHROPIC_USAGE_FIELD_CATEGORIES
+    },
+}
 
 
 def _extract_billing_usage(raw_usage, target: dict) -> None:
@@ -141,6 +151,39 @@ def create_sse_usage_extractor() -> tuple[Callable[[bytes], None], dict]:
     return parse_chunk, usage
 
 
+class ModelJsonUsageExtractor:
+    """Incrementally extract model usage from non-streaming JSON responses."""
+
+    def __init__(self) -> None:
+        self._extractor = JsonSelectiveExtractor(scalar_fields=_MODEL_JSON_SCALAR_FIELDS)
+
+    def feed(self, chunk: bytes) -> None:
+        self._extractor.feed(chunk)
+
+    def finish(self) -> tuple[dict | None, str | None]:
+        result = self._extractor.finish()
+        if not result.complete:
+            return None, result.error
+        usage: dict = {}
+        model = result.values.get(("model",))
+        if isinstance(model, str) and model:
+            usage["model"] = model
+        for raw_field, category in ANTHROPIC_USAGE_FIELD_CATEGORIES.items():
+            value = result.values.get(("usage", raw_field))
+            if _is_usage_quantity(value) and (value > 0 or category not in usage):
+                usage[category] = value
+        if not usage:
+            return None, None
+        message_id = result.values.get(("id",))
+        if isinstance(message_id, str) and message_id:
+            usage["message_id"] = message_id
+        return usage, None
+
+
+def create_model_json_usage_extractor() -> ModelJsonUsageExtractor:
+    return ModelJsonUsageExtractor()
+
+
 def extract_usage_from_json(body: bytes, headers) -> dict | None:
     """Extract usage from a non-streaming Anthropic API JSON response.
 
@@ -151,20 +194,7 @@ def extract_usage_from_json(body: bytes, headers) -> dict | None:
         body = body_utils.decompress_body(
             body, headers, max_output=body_utils.LARGE_RESPONSE_DECOMPRESS_LIMIT
         )
-    try:
-        data = json.loads(body)
-    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
-        return None
-    if not isinstance(data, dict):
-        return None
-    usage: dict = {}
-    model = data.get("model")
-    if model:
-        usage["model"] = model
-    _extract_billing_usage(data.get("usage"), usage)
-    if not usage:
-        return None
-    message_id = data.get("id")
-    if message_id:
-        usage["message_id"] = message_id
+    extractor = create_model_json_usage_extractor()
+    extractor.feed(body)
+    usage, _error = extractor.finish()
     return usage

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -1,0 +1,724 @@
+"""Bounded selective JSON extraction.
+
+This module intentionally does not wrap vendored ijson: its pure-Python
+lexer materializes full string lexemes before emitting events.  The scanner
+below keeps only selected scalars and object keys needed to resolve selected
+paths, while skipping unselected values by JSON syntax.
+"""
+
+import json
+from dataclasses import dataclass, field
+from typing import Literal
+
+Path = tuple[str, ...]
+WildcardPath = tuple[str, ...]
+ScalarKind = Literal["string", "int"]
+_UNKNOWN_KEY = "\0__vm0_json_unknown_key__"
+_ARRAY_ELEMENT = "\0__vm0_json_array_element__"
+_INTERNAL_PATH_MARKERS = frozenset((_UNKNOWN_KEY, _ARRAY_ELEMENT))
+_JSON_CONTROL_CHAR_MAX = 0x20
+_UTF8_ONE_BYTE_MAX = 0x80
+_UTF8_CONT_MIN = 0x80
+_UTF8_CONT_MAX = 0xBF
+_UTF8_TWO_BYTE_MIN = 0xC2
+_UTF8_TWO_BYTE_MAX = 0xDF
+_UTF8_THREE_BYTE_MIN = 0xE0
+_UTF8_THREE_BYTE_MAX = 0xEF
+_UTF8_FOUR_BYTE_MIN = 0xF0
+_UTF8_FOUR_BYTE_MAX = 0xF4
+_UTF8_MIN_TWO_BYTE_CODEPOINT = 0x80
+_UTF8_MIN_THREE_BYTE_CODEPOINT = 0x800
+_UTF8_MIN_FOUR_BYTE_CODEPOINT = 0x10000
+_UTF8_MAX_CODEPOINT = 0x10FFFF
+_UTF8_SURROGATE_MIN = 0xD800
+_UTF8_SURROGATE_MAX = 0xDFFF
+
+
+@dataclass(frozen=True)
+class ScalarField:
+    kind: ScalarKind
+    max_bytes: int = 4096
+
+
+@dataclass
+class JsonExtractionResult:
+    complete: bool
+    values: dict[Path, object] = field(default_factory=dict)
+    array_counts: dict[Path, int] = field(default_factory=dict)
+    wildcard_array_counts: dict[WildcardPath, dict[str, int]] = field(default_factory=dict)
+    object_present: set[Path] = field(default_factory=set)
+    error: str | None = None
+
+
+@dataclass
+class _Frame:
+    kind: Literal["object", "array"]
+    path: Path
+    state: str
+    pending_key: str | None = None
+    count_path: Path | None = None
+    wildcard_counts: list[tuple[WildcardPath, str]] = field(default_factory=list)
+
+
+@dataclass
+class _StringState:
+    role: Literal["key", "selected", "skip"]
+    path: Path | None
+    max_bytes: int
+    raw: bytearray | None
+    escape: bool = False
+    unicode_remaining: int = 0
+    utf8_remaining: int = 0
+    utf8_codepoint: int = 0
+    utf8_min_codepoint: int = 0
+
+
+@dataclass
+class _NumberState:
+    path: Path
+    selected: bool
+    raw: bytearray | None
+    max_bytes: int
+    phase: str = "start"
+
+
+@dataclass
+class _LiteralState:
+    literal: bytes
+    offset: int = 0
+
+
+class JsonSelectiveExtractor:
+    def __init__(
+        self,
+        *,
+        scalar_fields: dict[Path, ScalarField] | None = None,
+        array_count_paths: set[Path] | None = None,
+        wildcard_array_count_paths: set[WildcardPath] | None = None,
+        object_presence_paths: set[Path] | None = None,
+        max_depth: int = 256,
+        max_key_bytes: int = 1024,
+        max_number_bytes: int = 128,
+        max_wildcard_keys: int = 256,
+    ) -> None:
+        self.scalar_fields = scalar_fields or {}
+        self.array_count_paths = array_count_paths or set()
+        self.wildcard_array_count_paths = wildcard_array_count_paths or set()
+        for pattern in self.wildcard_array_count_paths:
+            if pattern.count("*") != 1:
+                raise ValueError("wildcard array count paths must contain exactly one '*'")
+        self.object_presence_paths = object_presence_paths or set()
+        self.max_depth = max_depth
+        self.max_key_bytes = max_key_bytes
+        self.max_number_bytes = max_number_bytes
+        self.max_wildcard_keys = max_wildcard_keys
+        self.key_collection_paths = _build_key_collection_paths(
+            set(self.scalar_fields)
+            | self.array_count_paths
+            | self.wildcard_array_count_paths
+            | self.object_presence_paths
+        )
+
+        self.values: dict[Path, object] = {}
+        self.array_counts: dict[Path, int] = {}
+        self.wildcard_array_counts: dict[WildcardPath, dict[str, int]] = {}
+        self.object_present: set[Path] = set()
+
+        self._stack: list[_Frame] = []
+        self._root_done = False
+        self._error: str | None = None
+        self._string: _StringState | None = None
+        self._number: _NumberState | None = None
+        self._literal: _LiteralState | None = None
+
+    def feed(self, chunk: bytes) -> None:
+        if self._error:
+            return
+        i = 0
+        while i < len(chunk) and not self._error:
+            if self._string is not None:
+                i = self._consume_string(chunk, i)
+            elif self._number is not None:
+                i = self._consume_number(chunk, i)
+            elif self._literal is not None:
+                i = self._consume_literal(chunk, i)
+            else:
+                i = self._consume_main(chunk, i)
+
+    def finish(self) -> JsonExtractionResult:
+        if not self._error and self._number is not None:
+            self._finish_number()
+
+        if not self._error:
+            if self._literal is not None:
+                self._error = "incomplete literal"
+            elif self._string is not None:
+                self._error = "incomplete string"
+            elif self._stack or not self._root_done:
+                self._error = "incomplete json"
+
+        complete = self._error is None and self._root_done and not self._stack
+        return JsonExtractionResult(
+            complete=complete,
+            values=dict(self.values) if complete else {},
+            array_counts=dict(self.array_counts) if complete else {},
+            wildcard_array_counts={
+                pattern: dict(counts) for pattern, counts in self.wildcard_array_counts.items()
+            }
+            if complete
+            else {},
+            object_present=set(self.object_present) if complete else set(),
+            error=self._error,
+        )
+
+    def _consume_main(self, chunk: bytes, i: int) -> int:
+        b = chunk[i]
+        if b in b" \t\r\n":
+            return i + 1
+
+        if self._root_done:
+            self._error = "trailing data after root value"
+            return i + 1
+
+        if not self._stack:
+            return self._start_value((), chunk, i)
+
+        frame = self._stack[-1]
+        if frame.kind == "object":
+            return self._consume_object(frame, chunk, i)
+        return self._consume_array(frame, chunk, i)
+
+    def _consume_object(self, frame: _Frame, chunk: bytes, i: int) -> int:
+        b = chunk[i]
+        if frame.state == "key_or_end":
+            if b == ord("}"):
+                return self._end_container(i)
+            if b != ord('"'):
+                self._error = "expected object key or end"
+                return i + 1
+            collect_key = _matches_any_path_pattern(self.key_collection_paths, frame.path)
+            self._string = _StringState(
+                role="key",
+                path=None,
+                max_bytes=self.max_key_bytes,
+                raw=bytearray() if collect_key else None,
+            )
+            return i + 1
+
+        if frame.state == "colon":
+            if b != ord(":"):
+                self._error = "expected colon"
+            else:
+                frame.state = "value"
+            return i + 1
+
+        if frame.state == "value":
+            if frame.pending_key is None:
+                self._error = "missing object key"
+                return i + 1
+            value_path = (*frame.path, frame.pending_key)
+            self._clear_observations_for_path(value_path)
+            return self._start_value(value_path, chunk, i)
+
+        if frame.state == "comma_or_end":
+            if b == ord(","):
+                frame.pending_key = None
+                frame.state = "key_or_end"
+            elif b == ord("}"):
+                return self._end_container(i)
+            else:
+                self._error = "expected object comma or end"
+            return i + 1
+
+        self._error = "invalid object parser state"
+        return i + 1
+
+    def _consume_array(self, frame: _Frame, chunk: bytes, i: int) -> int:
+        b = chunk[i]
+        if frame.state == "value_or_end":
+            if b == ord("]"):
+                return self._end_container(i)
+            self._count_array_element(frame)
+            return self._start_value((*frame.path, _ARRAY_ELEMENT), chunk, i, from_array=True)
+
+        if frame.state == "comma_or_end":
+            if b == ord(","):
+                frame.state = "value_or_end"
+            elif b == ord("]"):
+                return self._end_container(i)
+            else:
+                self._error = "expected array comma or end"
+            return i + 1
+
+        self._error = "invalid array parser state"
+        return i + 1
+
+    def _start_value(self, path: Path, chunk: bytes, i: int, *, from_array: bool = False) -> int:
+        b = chunk[i]
+        if b == ord("{"):
+            self._start_object(path, from_array=from_array)
+            return i + 1
+        if b == ord("["):
+            self._start_array(path)
+            return i + 1
+        if b == ord('"'):
+            field = self.scalar_fields.get(path)
+            if field and field.kind == "string":
+                self._string = _StringState(
+                    role="selected",
+                    path=path,
+                    max_bytes=field.max_bytes,
+                    raw=bytearray(),
+                )
+            else:
+                self._string = _StringState(
+                    role="skip",
+                    path=path,
+                    max_bytes=0,
+                    raw=None,
+                )
+            return i + 1
+        if b == ord("-") or ord("0") <= b <= ord("9"):
+            field = self.scalar_fields.get(path, None)
+            selected = bool(field and field.kind == "int")
+            self._number = _NumberState(
+                path=path,
+                selected=selected,
+                raw=bytearray() if selected else None,
+                max_bytes=min(self.max_number_bytes, field.max_bytes)
+                if selected and field
+                else self.max_number_bytes,
+            )
+            return self._consume_number(chunk, i)
+        if b == ord("t"):
+            self._literal = _LiteralState(b"true")
+            return self._consume_literal(chunk, i)
+        if b == ord("f"):
+            self._literal = _LiteralState(b"false")
+            return self._consume_literal(chunk, i)
+        if b == ord("n"):
+            self._literal = _LiteralState(b"null")
+            return self._consume_literal(chunk, i)
+        self._error = "expected json value"
+        return i + 1
+
+    def _start_object(self, path: Path, *, from_array: bool = False) -> None:
+        if len(self._stack) >= self.max_depth:
+            self._error = "max depth exceeded"
+            return
+        if not from_array and path in self.object_presence_paths:
+            self.object_present.add(path)
+        self._stack.append(_Frame(kind="object", path=path, state="key_or_end"))
+
+    def _start_array(self, path: Path) -> None:
+        if len(self._stack) >= self.max_depth:
+            self._error = "max depth exceeded"
+            return
+
+        count_path = path if path in self.array_count_paths else None
+        if count_path is not None:
+            self.array_counts[count_path] = 0
+        wildcard_counts = self._wildcard_matches(path)
+        if self._error:
+            return
+        self._stack.append(
+            _Frame(
+                kind="array",
+                path=path,
+                state="value_or_end",
+                count_path=count_path,
+                wildcard_counts=wildcard_counts,
+            )
+        )
+
+    def _wildcard_matches(self, path: Path) -> list[tuple[WildcardPath, str]]:
+        matches = []
+        for pattern in self.wildcard_array_count_paths:
+            if not _path_matches_pattern(pattern, path):
+                continue
+            wildcard_index = pattern.index("*")
+            key = path[wildcard_index]
+            counts = self.wildcard_array_counts.setdefault(pattern, {})
+            if key not in counts and len(counts) >= self.max_wildcard_keys:
+                self._error = "max wildcard keys exceeded"
+                return matches
+            counts[key] = 0
+            matches.append((pattern, key))
+        return matches
+
+    def _clear_observations_for_path(self, path: Path) -> None:
+        self.values = {
+            observed_path: value
+            for observed_path, value in self.values.items()
+            if not _is_path_prefix(path, observed_path)
+        }
+        self.array_counts = {
+            observed_path: count
+            for observed_path, count in self.array_counts.items()
+            if not _is_path_prefix(path, observed_path)
+        }
+        self.object_present = {
+            observed_path
+            for observed_path in self.object_present
+            if not _is_path_prefix(path, observed_path)
+        }
+        for pattern, counts in list(self.wildcard_array_counts.items()):
+            self._clear_wildcard_observations_for_path(pattern, counts, path)
+            if not counts:
+                self.wildcard_array_counts.pop(pattern, None)
+
+    def _clear_wildcard_observations_for_path(
+        self, pattern: WildcardPath, counts: dict[str, int], path: Path
+    ) -> None:
+        if len(path) > len(pattern):
+            return
+        try:
+            wildcard_index = pattern.index("*")
+        except ValueError:
+            counts.clear()
+            return
+
+        if not _path_prefix_matches_pattern(pattern, path):
+            return
+
+        if len(path) <= wildcard_index:
+            counts.clear()
+            return
+        counts.pop(path[wildcard_index], None)
+
+    def _count_array_element(self, frame: _Frame) -> None:
+        if frame.count_path is not None:
+            self.array_counts[frame.count_path] = self.array_counts.get(frame.count_path, 0) + 1
+        for pattern, key in frame.wildcard_counts:
+            counts = self.wildcard_array_counts.setdefault(pattern, {})
+            counts[key] = counts.get(key, 0) + 1
+
+    def _end_container(self, i: int) -> int:
+        if not self._stack:
+            self._error = "unexpected container end"
+            return i + 1
+        self._stack.pop()
+        self._value_complete()
+        return i + 1
+
+    def _value_complete(self) -> None:
+        if not self._stack:
+            self._root_done = True
+            return
+        parent = self._stack[-1]
+        if (parent.kind == "object" and parent.state == "value") or (
+            parent.kind == "array" and parent.state == "value_or_end"
+        ):
+            parent.state = "comma_or_end"
+        else:
+            self._error = "value completed in invalid parser state"
+
+    def _consume_string(self, chunk: bytes, i: int) -> int:
+        state = self._string
+        if state is None:
+            self._error = "missing string parser state"
+            return i
+        while i < len(chunk):
+            b = chunk[i]
+            i += 1
+
+            if state.unicode_remaining:
+                if not _is_hex_byte(b):
+                    self._error = "invalid unicode escape"
+                    return i
+                self._append_string_byte(state, b)
+                if self._error:
+                    return i
+                state.unicode_remaining -= 1
+                continue
+
+            if state.escape:
+                if b not in b'"\\/bfnrtu':
+                    self._error = "invalid string escape"
+                    return i
+                self._append_string_byte(state, b)
+                if self._error:
+                    return i
+                state.escape = False
+                if b == ord("u"):
+                    state.unicode_remaining = 4
+                continue
+
+            if b == ord("\\"):
+                self._accept_string_byte(state, b)
+                if self._error:
+                    return i
+                state.escape = True
+                continue
+
+            if b == ord('"'):
+                self._finish_string(state)
+                self._string = None
+                return i
+
+            if b < _JSON_CONTROL_CHAR_MAX:
+                self._error = "control character in string"
+                return i
+            self._accept_string_byte(state, b)
+            if self._error:
+                return i
+
+        return i
+
+    def _accept_string_byte(self, state: _StringState, b: int) -> None:
+        self._validate_string_byte(state, b)
+        if not self._error:
+            self._append_string_byte(state, b)
+
+    def _validate_string_byte(self, state: _StringState, b: int) -> None:
+        if state.utf8_remaining:
+            if not _is_utf8_continuation(b):
+                self._error = "invalid string"
+                return
+            state.utf8_codepoint = (state.utf8_codepoint << 6) | (b & 0x3F)
+            state.utf8_remaining -= 1
+            if state.utf8_remaining == 0 and not _is_valid_utf8_codepoint(
+                state.utf8_codepoint, state.utf8_min_codepoint
+            ):
+                self._error = "invalid string"
+            return
+
+        if b < _UTF8_ONE_BYTE_MAX:
+            return
+        if _UTF8_TWO_BYTE_MIN <= b <= _UTF8_TWO_BYTE_MAX:
+            state.utf8_remaining = 1
+            state.utf8_codepoint = b & 0x1F
+            state.utf8_min_codepoint = _UTF8_MIN_TWO_BYTE_CODEPOINT
+            return
+        if _UTF8_THREE_BYTE_MIN <= b <= _UTF8_THREE_BYTE_MAX:
+            state.utf8_remaining = 2
+            state.utf8_codepoint = b & 0x0F
+            state.utf8_min_codepoint = _UTF8_MIN_THREE_BYTE_CODEPOINT
+            return
+        if _UTF8_FOUR_BYTE_MIN <= b <= _UTF8_FOUR_BYTE_MAX:
+            state.utf8_remaining = 3
+            state.utf8_codepoint = b & 0x07
+            state.utf8_min_codepoint = _UTF8_MIN_FOUR_BYTE_CODEPOINT
+            return
+        self._error = "invalid string"
+
+    def _append_string_byte(self, state: _StringState, b: int) -> None:
+        if state.raw is None:
+            return
+        state.raw.append(b)
+        if len(state.raw) > state.max_bytes:
+            if state.role == "key":
+                state.raw = None
+                return
+            self._error = "string limit exceeded"
+
+    def _finish_string(self, state: _StringState) -> None:
+        if state.utf8_remaining:
+            self._error = "invalid string"
+            return
+        try:
+            value = (
+                _UNKNOWN_KEY if state.raw is None else json.loads(b'"' + bytes(state.raw) + b'"')
+            )
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            self._error = "invalid string"
+            return
+        if state.role == "key":
+            if _contains_surrogate(value):
+                value = _UNKNOWN_KEY
+            if not self._stack or self._stack[-1].kind != "object":
+                self._error = "object key outside object"
+                return
+            frame = self._stack[-1]
+            frame.pending_key = value
+            frame.state = "colon"
+            return
+        if state.path is None:
+            self._error = "missing selected string path"
+            return
+        if state.raw is None:
+            self._value_complete()
+            return
+        if _contains_surrogate(value):
+            self._value_complete()
+            return
+        self.values[state.path] = value
+        self._value_complete()
+
+    def _consume_number(self, chunk: bytes, i: int) -> int:
+        state = self._number
+        if state is None:
+            self._error = "missing number parser state"
+            return i
+        while i < len(chunk):
+            b = chunk[i]
+            if b in b" \t\r\n,]}":
+                self._finish_number()
+                return i
+            self._accept_number_byte(state, b)
+            if self._error:
+                return i + 1
+            i += 1
+        return i
+
+    def _accept_number_byte(self, state: _NumberState, b: int) -> None:
+        phase = state.phase
+        if phase == "start":
+            if b == ord("-"):
+                state.phase = "after_minus"
+            elif b == ord("0"):
+                state.phase = "zero"
+            elif ord("1") <= b <= ord("9"):
+                state.phase = "int"
+            else:
+                self._error = "invalid number"
+                return
+        elif phase == "after_minus":
+            if b == ord("0"):
+                state.phase = "zero"
+            elif ord("1") <= b <= ord("9"):
+                state.phase = "int"
+            else:
+                self._error = "invalid number"
+                return
+        elif phase == "zero":
+            if b == ord("."):
+                state.phase = "dot"
+            elif b in b"eE":
+                state.phase = "exp"
+            else:
+                self._error = "invalid number"
+                return
+        elif phase == "int":
+            if ord("0") <= b <= ord("9"):
+                pass
+            elif b == ord("."):
+                state.phase = "dot"
+            elif b in b"eE":
+                state.phase = "exp"
+            else:
+                self._error = "invalid number"
+                return
+        elif phase == "dot":
+            if ord("0") <= b <= ord("9"):
+                state.phase = "frac"
+            else:
+                self._error = "invalid number"
+                return
+        elif phase == "frac":
+            if ord("0") <= b <= ord("9"):
+                pass
+            elif b in b"eE":
+                state.phase = "exp"
+            else:
+                self._error = "invalid number"
+                return
+        elif phase == "exp":
+            if b in b"+-":
+                state.phase = "exp_sign"
+            elif ord("0") <= b <= ord("9"):
+                state.phase = "exp_digits"
+            else:
+                self._error = "invalid number"
+                return
+        elif phase == "exp_sign":
+            if ord("0") <= b <= ord("9"):
+                state.phase = "exp_digits"
+            else:
+                self._error = "invalid number"
+                return
+        elif phase == "exp_digits":
+            if not ord("0") <= b <= ord("9"):
+                self._error = "invalid number"
+                return
+        else:
+            self._error = "invalid number"
+            return
+
+        if state.raw is not None:
+            state.raw.append(b)
+            if len(state.raw) > state.max_bytes:
+                self._error = "number limit exceeded"
+
+    def _finish_number(self) -> None:
+        state = self._number
+        if state is None:
+            return
+        self._number = None
+        if state.phase not in ("zero", "int", "frac", "exp_digits"):
+            self._error = "invalid number"
+            return
+        if not state.selected:
+            self._value_complete()
+            return
+        try:
+            token = bytes(state.raw or b"").decode("ascii")
+            value = json.loads(token)
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+            self._error = "invalid number"
+            return
+        if state.selected and isinstance(value, int) and not isinstance(value, bool):
+            self.values[state.path] = value
+        self._value_complete()
+
+    def _consume_literal(self, chunk: bytes, i: int) -> int:
+        state = self._literal
+        if state is None:
+            self._error = "missing literal parser state"
+            return i
+        while i < len(chunk) and state.offset < len(state.literal):
+            if chunk[i] != state.literal[state.offset]:
+                self._error = "invalid literal"
+                return i + 1
+            i += 1
+            state.offset += 1
+        if state.offset == len(state.literal):
+            self._literal = None
+            self._value_complete()
+        return i
+
+
+def _is_hex_byte(b: int) -> bool:
+    return ord("0") <= b <= ord("9") or ord("a") <= b <= ord("f") or ord("A") <= b <= ord("F")
+
+
+def _is_utf8_continuation(b: int) -> bool:
+    return _UTF8_CONT_MIN <= b <= _UTF8_CONT_MAX
+
+
+def _is_valid_utf8_codepoint(codepoint: int, min_codepoint: int) -> bool:
+    return (
+        min_codepoint <= codepoint <= _UTF8_MAX_CODEPOINT
+        and not _UTF8_SURROGATE_MIN <= codepoint <= _UTF8_SURROGATE_MAX
+    )
+
+
+def _contains_surrogate(value: object) -> bool:
+    return isinstance(value, str) and any(
+        _UTF8_SURROGATE_MIN <= ord(ch) <= _UTF8_SURROGATE_MAX for ch in value
+    )
+
+
+def _matches_any_path_pattern(patterns: set[Path], path: Path) -> bool:
+    return any(_path_matches_pattern(pattern, path) for pattern in patterns)
+
+
+def _path_matches_pattern(pattern: Path, path: Path) -> bool:
+    return len(pattern) == len(path) and _path_prefix_matches_pattern(pattern, path)
+
+
+def _path_prefix_matches_pattern(pattern: Path, path: Path) -> bool:
+    if len(path) > len(pattern):
+        return False
+    return all(
+        (expected == "*" and actual not in _INTERNAL_PATH_MARKERS) or expected == actual
+        for expected, actual in zip(pattern, path, strict=False)
+    )
+
+
+def _is_path_prefix(prefix: Path, path: Path) -> bool:
+    return len(prefix) <= len(path) and path[: len(prefix)] == prefix
+
+
+def _build_key_collection_paths(paths: set[Path]) -> set[Path]:
+    return {path[:idx] for path in paths for idx in range(len(path))}

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -18,6 +18,7 @@ import body_utils
 from auth import get_api_url
 from logging_utils import log_proxy_entry
 
+from ...json_selective import JsonSelectiveExtractor, ScalarField
 from ...namespaces import USAGE_EVENT_NAMESPACE_CONNECTOR
 from ...webhook import _enqueue_webhook
 from .x_billing import (
@@ -64,8 +65,13 @@ def is_stream_path(path: str) -> bool:
 # ``body_utils.py``.  A real X tweet line (``data`` + ``includes`` +
 # ``matching_rules`` with full expansion) should never approach this size;
 # exceeding it indicates malformed or hostile upstream data, so the parser
-# drops ``line_buf`` to protect memory.
+# discards that row through its terminating newline to protect memory.
 MAX_NDJSON_LINE_BYTES = 5 * 1024 * 1024  # 5 MB
+
+_X_JSON_RESULT_COUNT_FIELDS = {
+    ("meta", "result_count"): ScalarField("int", max_bytes=64),
+    ("meta", "total_tweet_count"): ScalarField("int", max_bytes=64),
+}
 
 
 class NdjsonState(TypedDict):
@@ -83,7 +89,7 @@ class NdjsonState(TypedDict):
     lines_parsed: int
     """JSON-parseable non-blank lines."""
     lines_failed: int
-    """Lines that failed JSON decoding."""
+    """Lines that failed JSON decoding or exceeded the single-line safety cap."""
 
 
 def create_ndjson_extractor() -> tuple[Callable[[bytes], None], NdjsonState]:
@@ -105,13 +111,15 @@ def create_ndjson_extractor() -> tuple[Callable[[bytes], None], NdjsonState]:
     - ``includes``: dict[str, int] — running sum across all lines of
       ``len(includes.<key>)`` for each expansion resource key.
     - ``lines_parsed``: int — JSON-parseable non-blank lines.
-    - ``lines_failed``: int — lines that failed JSON decoding.
+    - ``lines_failed``: int — lines that failed JSON decoding or exceeded
+      the single-line safety cap.
 
     The parser keeps a ``line_buf`` holding the in-flight partial line
     across chunk boundaries.  If a single line ever exceeds
-    :data:`MAX_NDJSON_LINE_BYTES` the buffer is reset (malformed / hostile
-    upstream).  A truncated trailing line at connection close (no final
-    ``\\n``) stays in the buffer uncounted — worst-case under-count is 1.
+    :data:`MAX_NDJSON_LINE_BYTES` the whole line is discarded until its
+    terminating newline (malformed / hostile upstream).  A truncated
+    trailing line at connection close (no final ``\\n``) stays in the buffer
+    uncounted — worst-case under-count is 1.
     """
     state: NdjsonState = {
         "data_count": 0,
@@ -123,22 +131,51 @@ def create_ndjson_extractor() -> tuple[Callable[[bytes], None], NdjsonState]:
     # ``parse_chunk`` — captured by the closure.  Rebinding via
     # ``line_buf = ...`` would create a new local and lose cross-call state.
     line_buf = bytearray()
+    discarding_overlong_line = False
 
     def parse_chunk(chunk: bytes) -> None:
-        line_buf.extend(chunk)
-        while b"\n" in line_buf:
-            raw, _, rest = line_buf.partition(b"\n")
-            line_buf[:] = rest
-            line = raw.rstrip(b"\r")
+        nonlocal discarding_overlong_line
+
+        start = 0
+        while start < len(chunk):
+            newline = chunk.find(b"\n", start)
+            end = len(chunk) if newline == -1 else newline
+            fragment_len = end - start
+
+            if discarding_overlong_line:
+                if newline == -1:
+                    return
+                discarding_overlong_line = False
+                start = newline + 1
+                continue
+
+            if len(line_buf) + fragment_len > MAX_NDJSON_LINE_BYTES:
+                line_buf[:] = b""
+                state["lines_failed"] += 1
+                if newline == -1:
+                    discarding_overlong_line = True
+                    return
+                start = newline + 1
+                continue
+
+            line_buf.extend(chunk[start:end])
+            if newline == -1:
+                return
+
+            line = bytes(line_buf).rstrip(b"\r")
+            line_buf[:] = b""
             if not line:
+                start = newline + 1
                 continue  # keep-alive blank line
             try:
                 obj = json.loads(line)
             except (json.JSONDecodeError, UnicodeDecodeError):
                 state["lines_failed"] += 1
+                start = newline + 1
                 continue
             state["lines_parsed"] += 1
             if not isinstance(obj, dict):
+                start = newline + 1
                 continue
             if isinstance(obj.get("data"), dict):
                 state["data_count"] += 1
@@ -147,13 +184,61 @@ def create_ndjson_extractor() -> tuple[Callable[[bytes], None], NdjsonState]:
                 for k, v in inc.items():
                     if isinstance(v, list):
                         state["includes"][k] = state["includes"].get(k, 0) + len(v)
-        # Defense: if a single line exceeds MAX_NDJSON_LINE_BYTES (malformed
-        # or hostile upstream) reset line_buf so we don't hold unbounded
-        # memory.  Subsequent lines parse normally.
-        if len(line_buf) > MAX_NDJSON_LINE_BYTES:
-            line_buf[:] = b""
+            start = newline + 1
 
     return parse_chunk, state
+
+
+class XJsonResponseExtractor:
+    """Incrementally extract billing metadata from non-streaming X JSON."""
+
+    def __init__(self) -> None:
+        self._extractor = JsonSelectiveExtractor(
+            scalar_fields=_X_JSON_RESULT_COUNT_FIELDS,
+            array_count_paths={("data",), ("errors",)},
+            wildcard_array_count_paths={("includes", "*")},
+            object_presence_paths={(), ("data",)},
+        )
+
+    def feed(self, chunk: bytes) -> None:
+        self._extractor.feed(chunk)
+
+    def finish(self) -> tuple[dict, str | None]:
+        result: dict = {"body_parsed": False, "body_truncated": False}
+        extracted = self._extractor.finish()
+        if not extracted.complete:
+            return result, extracted.error
+        if () not in extracted.object_present:
+            return result, None
+
+        result["body_parsed"] = True
+        data_count = extracted.array_counts.get(("data",))
+        if data_count is not None:
+            result["response_data_count"] = data_count
+        elif ("data",) in extracted.object_present:
+            result["response_data_count"] = 1
+
+        errors_count = extracted.array_counts.get(("errors",), 0)
+        if errors_count:
+            result["response_errors_count"] = errors_count
+
+        includes = extracted.wildcard_array_counts.get(("includes", "*"), {})
+        if includes:
+            result["response_includes"] = dict(includes)
+
+        rcs = [
+            value
+            for path in (("meta", "result_count"), ("meta", "total_tweet_count"))
+            if isinstance((value := extracted.values.get(path)), int)
+        ]
+        if rcs:
+            result["response_result_count"] = max(rcs)
+
+        return result, None
+
+
+def create_json_response_extractor() -> XJsonResponseExtractor:
+    return XJsonResponseExtractor()
 
 
 def _parse_request_metadata(flow: http.HTTPFlow) -> dict:
@@ -214,8 +299,8 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
     incremental parser that populates ``flow.metadata["x_ndjson_state"]``
     as response bytes arrive.  When that state is present we return its
     accumulated counters directly (``body_format: "ndjson"``) and skip
-    the full-body ``json.loads`` path, since stream buffers are capped
-    at ``STREAM_BUFFER_LIMIT`` and don't contain the full response.
+    the legacy buffered ``json.loads`` fallback, since stream buffers are
+    capped at ``STREAM_BUFFER_LIMIT`` and don't contain the full response.
     For streams ``body_truncated`` is always ``False`` — the incremental
     parser saw every byte even if the forensic ``stream_buffer`` filled up.
 
@@ -247,6 +332,10 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
         result["ndjson_lines_parsed"] = ndjson_state["lines_parsed"]
         result["ndjson_lines_failed"] = ndjson_state["lines_failed"]
         return result
+
+    json_state = flow.metadata.get("x_json_state")
+    if isinstance(json_state, dict):
+        return {**result, **json_state}
 
     buf = flow.metadata.get("stream_buffer")
     if not buf:

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -823,6 +823,23 @@ class TestStreamDecompressor:
         assert decomp is not None
         assert decomp(zstandard.ZstdCompressor().compress(b"hello world")) == b"hello world"
 
+    def test_supported_encodings_across_small_chunks(self, headers):
+        plaintext = b'{"model":"claude-sonnet-4-6","usage":{"input_tokens":42}}'
+        compressed_by_encoding = {
+            "gzip": gzip.compress(plaintext),
+            "deflate": zlib.compress(plaintext),
+            "br": brotli.compress(plaintext),
+            "zstd": zstandard.ZstdCompressor().compress(plaintext),
+        }
+
+        for encoding, compressed in compressed_by_encoding.items():
+            decomp = create_stream_decompressor(headers(("Content-Encoding", encoding)))
+            assert decomp is not None
+            out = bytearray()
+            for idx in range(0, len(compressed), 3):
+                out.extend(decomp(compressed[idx : idx + 3]))
+            assert bytes(out) == plaintext, encoding
+
     def test_no_encoding_returns_none(self, headers):
         assert create_stream_decompressor(headers()) is None
 

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1178,8 +1178,8 @@ class TestResponseHeadersHandler:
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
         assert flow.metadata["x_ndjson_state"]["data_count"] == 1
 
-    def test_x_non_stream_endpoint_keeps_unbounded_buffer(self, real_flow, headers):
-        """Non-stream X requests still need full body for json.loads."""
+    def test_x_non_stream_endpoint_uses_bounded_buffer_and_json_extractor(self, real_flow, headers):
+        """Non-stream X requests parse billing JSON without unbounded buffering."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/users/by")
         flow.metadata["firewall_name"] = "x"
         flow.metadata["firewall_billable"] = True
@@ -1191,10 +1191,17 @@ class TestResponseHeadersHandler:
         mitm_addon.responseheaders(flow)
 
         callback = flow.response.stream
+        callback(b'{"data":[{"id":"1","text":"')
         callback(b"x" * (200 * 1024))
-        assert len(flow.metadata["stream_buffer"]) == 200 * 1024
-        assert flow.metadata["stream_buffer_state"]["truncated"] is False
+        callback(b'"}],"includes":{"users":[{"id":"u1"}]}}')
+        assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
+        assert flow.metadata["stream_buffer_state"]["truncated"] is True
         assert "x_ndjson_state" not in flow.metadata
+        state, error = flow.metadata["x_json_response_finish"]()
+        assert error is None
+        assert state["body_parsed"] is True
+        assert state["response_data_count"] == 1
+        assert state["response_includes"] == {"users": 1}
 
     def test_x_stream_rules_is_not_registered_as_stream(self, real_flow, headers):
         """/2/tweets/search/stream/rules is rules mgmt, not a stream — no NDJSON parser."""
@@ -1209,15 +1216,15 @@ class TestResponseHeadersHandler:
 
         mitm_addon.responseheaders(flow)
 
-        # No NDJSON state registered; regular unbounded X buffer path
+        # No NDJSON state registered; this endpoint is ordinary JSON, not a stream.
         assert "x_ndjson_state" not in flow.metadata
 
-    def test_x_stream_error_response_keeps_unbounded_buffer(self, real_flow, headers):
-        """4xx/5xx on stream endpoints must preserve full error body (no NDJSON parser).
+    def test_x_stream_error_response_uses_bounded_forensic_buffer(self, real_flow, headers):
+        """4xx/5xx on stream endpoints does not register NDJSON or JSON billing parser.
 
         Error responses on stream endpoints return a single JSON error object,
-        not NDJSON.  The NDJSON parser gate on 2xx prevents the stream buffer
-        from being capped at 64 KB so forensic logging sees the full body.
+        not NDJSON.  They are not billable, so the response body is only kept
+        in the capped forensic buffer.
         """
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/search/stream")
         flow.metadata["firewall_name"] = "x"
@@ -1231,12 +1238,12 @@ class TestResponseHeadersHandler:
 
         # No NDJSON parser — error body would fail NDJSON parsing anyway.
         assert "x_ndjson_state" not in flow.metadata
+        assert "x_json_response_finish" not in flow.metadata
         callback = flow.response.stream
-        # Unbounded X buffer retains the full error body for forensic logging.
         error_body = b'{"title":"Unauthorized","detail":"' + b"x" * (200 * 1024) + b'"}'
         callback(error_body)
-        assert len(flow.metadata["stream_buffer"]) == len(error_body)
-        assert flow.metadata["stream_buffer_state"]["truncated"] is False
+        assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
+        assert flow.metadata["stream_buffer_state"]["truncated"] is True
 
     def test_x_stream_gzip_compressed_body(self, real_flow, headers):
         """Gzip-encoded NDJSON stream: decompressor + parser wire up correctly."""
@@ -1270,6 +1277,63 @@ class TestResponseHeadersHandler:
         state = flow.metadata["x_ndjson_state"]
         assert state["data_count"] == 3
         assert state["includes"] == {"users": 3}
+
+    def test_model_provider_gzip_json_extractor(self, real_flow, headers):
+        """Gzip-encoded non-streaming model JSON feeds the selective extractor."""
+        body = json.dumps(
+            {
+                "id": "msg_1",
+                "model": "claude-sonnet-4-6",
+                "usage": {"input_tokens": 10, "output_tokens": 20},
+            }
+        ).encode()
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(
+                **{"content-type": "application/json", "content-encoding": "gzip"}
+            ),
+        )
+
+        mitm_addon.responseheaders(flow)
+
+        flow.response.stream(gzip.compress(body))
+        usage_result, error = flow.metadata["model_json_usage_finish"]()
+        assert error is None
+        assert usage_result["message_id"] == "msg_1"
+        assert usage_result["tokens.input"] == 10
+        assert usage_result["tokens.output"] == 20
+
+    def test_x_non_stream_gzip_json_extractor(self, real_flow, headers):
+        """Gzip-encoded X JSON feeds the selective extractor."""
+        body = json.dumps(
+            {
+                "data": [{"id": "1"}, {"id": "2"}],
+                "includes": {"users": [{"id": "u1"}]},
+                "meta": {"result_count": 2},
+            }
+        ).encode()
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(
+                **{"content-type": "application/json", "content-encoding": "gzip"}
+            ),
+        )
+
+        mitm_addon.responseheaders(flow)
+
+        flow.response.stream(gzip.compress(body))
+        json_state, error = flow.metadata["x_json_response_finish"]()
+        assert error is None
+        assert json_state["response_data_count"] == 2
+        assert json_state["response_includes"] == {"users": 1}
+        assert json_state["response_result_count"] == 2
 
 
 class TestResponseHandler:
@@ -1374,6 +1438,35 @@ class TestResponseHandler:
         lines = Path(log_path).read_text().splitlines()
         entry = json.loads(lines[0])
         assert entry["response_size"] == 50000  # from Content-Length header
+
+    def test_response_size_tracks_streamed_bytes_when_buffer_truncated_without_length(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        """response_size should not become 0 for chunked large streamed responses."""
+        flow = real_flow(with_response=False, host="api.example.com")
+        log_path = str(tmp_path / "network.jsonl")
+        body = b"x" * (body_utils.STREAM_BUFFER_LIMIT + 4096)
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        flow.response.stream(body[:123])
+        flow.response.stream(body[123:])
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        lines = Path(log_path).read_text().splitlines()
+        entry = json.loads(lines[0])
+        assert entry["response_size"] == len(body)
 
     def test_401_firewall_cache_invalidation(self, real_flow, mitm_ctx, headers):
         """401 response with firewall_base pops the cache entry and marks force-refresh (#9860)."""
@@ -1827,10 +1920,33 @@ class TestNdjsonExtractor:
         parse, state = usage.x.create_ndjson_extractor()
         big = b"x" * (usage.x.MAX_NDJSON_LINE_BYTES + 1024)
         parse(big)
-        # line_buf should have been reset
+        parse(b"\n")
         parse(b'{"data":{"id":"after"}}\n')
         assert state["data_count"] == 1
         assert state["lines_parsed"] == 1
+        assert state["lines_failed"] == 1
+
+    def test_oversized_line_discards_until_newline(self):
+        """A valid-looking tail of an overlong line must not be counted as its own row."""
+        parse, state = usage.x.create_ndjson_extractor()
+        big = b"x" * (usage.x.MAX_NDJSON_LINE_BYTES + 1024)
+        parse(big)
+        parse(b'{"data":{"id":"tail"}}\n')
+        parse(b'{"data":{"id":"next"}}\n')
+
+        assert state["data_count"] == 1
+        assert state["lines_parsed"] == 1
+        assert state["lines_failed"] == 1
+
+    def test_oversized_line_with_newline_continues_in_same_chunk(self):
+        """Dropping an overlong row should not discard valid later rows in the same chunk."""
+        parse, state = usage.x.create_ndjson_extractor()
+        big = b"x" * (usage.x.MAX_NDJSON_LINE_BYTES + 1024)
+        parse(big + b'\n{"data":{"id":"after"}}\n')
+
+        assert state["data_count"] == 1
+        assert state["lines_parsed"] == 1
+        assert state["lines_failed"] == 1
 
     def test_includes_multiple_keys(self):
         parse, state = usage.x.create_ndjson_extractor()
@@ -2015,8 +2131,271 @@ class TestResponseUsageReporting:
         assert extracted["tokens.input"] == 50
         assert extracted["tokens.output"] == 200
 
-    def test_model_provider_buffer_not_truncated(self, real_flow, headers):
-        """Billable model provider responses should buffer without truncation."""
+    def test_full_pipeline_large_model_json_uses_bounded_buffer(
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+    ):
+        """responseheaders + response report model usage without full-body buffering."""
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        callback = flow.response.stream
+        callback(b'{"id":"msg_1","model":"claude-sonnet-4-6","content":[{"text":"')
+        callback(b"x" * (body_utils.STREAM_BUFFER_LIMIT + 4096))
+        callback(b'"}],"usage":{"input_tokens":50,"output_tokens":200}}')
+        assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
+        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert by_category == {"tokens.input": 50, "tokens.output": 200}
+
+    def test_full_pipeline_incomplete_model_json_does_not_report_partial_usage(
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+    ):
+        """Fields seen before EOF are ignored unless the JSON document completes."""
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        flow.response.stream(
+            b'{"id":"msg_1","model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":50,"output_tokens":200}'
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+        assert "Model provider JSON usage extraction failed" in proxy_log.read_text()
+
+    def test_full_pipeline_corrupt_model_json_encoding_does_not_fallback_to_raw_buffer(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """A bad Content-Encoding must not parse raw stream_buffer and bill usage."""
+        raw_json = json.dumps(
+            {
+                "id": "msg_1",
+                "model": "claude-sonnet-4-6",
+                "usage": {"input_tokens": 50, "output_tokens": 200},
+            }
+        ).encode()
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(
+                **{"content-type": "application/json", "content-encoding": "gzip"}
+            ),
+        )
+
+        mitm_addon.responseheaders(flow)
+        flow.response.stream(raw_json)
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+        assert "model_provider_usage" not in flow.metadata
+        assert "stream_buffer" not in flow.metadata
+
+    def test_full_pipeline_model_json_ignores_usage_array_shape(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """usage fields inside array elements must not be treated as usage object fields."""
+        body = json.dumps(
+            {
+                "id": "msg_1",
+                "model": "claude-sonnet-4-6",
+                "usage": [{"input_tokens": 50, "output_tokens": 200}],
+            }
+        ).encode()
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        flow.response.stream(body)
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        mock_opener.open.assert_not_called()
+
+    def test_response_releases_streaming_state(self, tmp_path, real_flow, mitm_ctx):
+        """The completed response hook must not retain parser/buffer closures."""
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        flow.response.stream(b'{"model":"claude-sonnet-4-6"}')
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        assert flow.response.stream is False
+        assert "stream_buffer" not in flow.metadata
+        assert "stream_buffer_state" not in flow.metadata
+        assert "model_json_usage_finish" not in flow.metadata
+
+    def test_response_without_run_id_releases_x_json_streaming_state(self, real_flow):
+        """Even early-returning flows should not retain response parser closures."""
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        flow.response.stream(b'{"data":[{"id":"1"}]}')
+        assert "x_json_response_finish" in flow.metadata
+
+        mitm_addon.response(flow)
+
+        assert flow.response.stream is False
+        assert "stream_buffer" not in flow.metadata
+        assert "stream_buffer_state" not in flow.metadata
+        assert "x_json_response_finish" not in flow.metadata
+
+    def test_response_does_not_clear_external_stream_callback(self, tmp_path, real_flow, mitm_ctx):
+        """Cleanup should only reset the stream callback installed by this addon."""
+        flow = real_flow(with_response=False, host="api.example.com")
+        log_path = str(tmp_path / "network.jsonl")
+
+        def external_stream(chunk):
+            return chunk
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.response = tutils.tresp(status_code=200)
+        flow.response.stream = external_stream
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        assert flow.response.stream is external_stream
+
+    def test_response_does_not_clear_replaced_stream_callback(self, tmp_path, real_flow, mitm_ctx):
+        """Cleanup should not clear a callback that replaced ours after responseheaders."""
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+
+        def external_stream(chunk):
+            return chunk
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        vm0_stream = flow.response.stream
+        vm0_stream(b'{"model":"claude-sonnet-4-6"}')
+        flow.response.stream = external_stream
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        assert flow.response.stream is external_stream
+        assert "stream_buffer" not in flow.metadata
+        assert "model_json_usage_finish" not in flow.metadata
+
+    def test_model_provider_uses_bounded_buffer_and_json_extractor(self, real_flow, headers):
+        """Billable model provider JSON should parse usage without unbounded buffering."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.response = tutils.tresp(
             status_code=200, headers=http.Headers(**{"content-type": "application/json"})
@@ -2027,14 +2406,20 @@ class TestResponseUsageReporting:
         mitm_addon.responseheaders(flow)
 
         callback = flow.response.stream
-        # Feed data exceeding STREAM_BUFFER_LIMIT (64KB)
-        large_chunk = b"x" * (body_utils.STREAM_BUFFER_LIMIT + 1000)
-        callback(large_chunk)
+        callback(b'{"id":"msg_1","model":"claude-sonnet-4-6","content":[{"text":"')
+        callback(b"x" * (body_utils.STREAM_BUFFER_LIMIT + 1000))
+        callback(b'"}],"usage":{"input_tokens":50,"output_tokens":100}}')
 
         buf = flow.metadata["stream_buffer"]
         state = flow.metadata["stream_buffer_state"]
-        assert len(buf) == len(large_chunk)
-        assert not state["truncated"]
+        assert len(buf) == body_utils.STREAM_BUFFER_LIMIT
+        assert state["truncated"]
+        usage_result, error = flow.metadata["model_json_usage_finish"]()
+        assert error is None
+        assert usage_result["model"] == "claude-sonnet-4-6"
+        assert usage_result["message_id"] == "msg_1"
+        assert usage_result["tokens.input"] == 50
+        assert usage_result["tokens.output"] == 100
 
     def test_non_billable_model_provider_buffer_truncated(self, real_flow, headers):
         """Non-billable model providers should use the normal bounded buffer."""
@@ -2075,33 +2460,34 @@ class TestResponseUsageReporting:
         assert len(buf) == body_utils.STREAM_BUFFER_LIMIT
         assert state["truncated"]
 
-    def test_billable_connector_buffer_not_truncated(self, real_flow, headers):
-        """Billable connector responses should buffer the full body (no 64KB cap)."""
+    def test_billable_x_connector_uses_bounded_buffer_and_json_extractor(self, real_flow, headers):
+        """Billable X connector responses should not buffer the full body."""
         flow = real_flow(with_response=False, host="api.x.com")
         flow.response = tutils.tresp(
             status_code=200, headers=http.Headers(**{"content-type": "application/json"})
         )
         flow.metadata["firewall_name"] = "x"
         flow.metadata["firewall_billable"] = True
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets"
 
         mitm_addon.responseheaders(flow)
 
         callback = flow.response.stream
-        large_chunk = b"x" * (body_utils.STREAM_BUFFER_LIMIT + 1000)
-        callback(large_chunk)
+        callback(b'{"data":[{"id":"1","text":"')
+        callback(b"x" * (body_utils.STREAM_BUFFER_LIMIT + 1000))
+        callback(b'"}],"meta":{"result_count":1}}')
 
         buf = flow.metadata["stream_buffer"]
         state = flow.metadata["stream_buffer_state"]
-        assert len(buf) == len(large_chunk)
-        assert not state["truncated"]
+        assert len(buf) == body_utils.STREAM_BUFFER_LIMIT
+        assert state["truncated"]
+        json_state, error = flow.metadata["x_json_response_finish"]()
+        assert error is None
+        assert json_state["response_data_count"] == 1
+        assert json_state["response_result_count"] == 1
 
-    def test_non_x_billable_connector_keeps_unbounded_buffer(self, real_flow, headers):
-        """Buffer policy gates on firewall_billable (not firewall_name == 'x').
-
-        When BILLABLE_CONNECTORS grows past ['x'], responseheaders must
-        keep the body unbounded for the new connector too — its future
-        log_*_connector_usage handler will need json.loads on the full body.
-        """
+    def test_non_x_billable_connector_uses_bounded_forensic_buffer(self, real_flow, headers):
+        """Future billable connectors must not get unbounded buffers by default."""
         flow = real_flow(with_response=False, host="api.gamma.example")
         flow.response = tutils.tresp(
             status_code=200, headers=http.Headers(**{"content-type": "application/json"})
@@ -2117,10 +2503,11 @@ class TestResponseUsageReporting:
 
         buf = flow.metadata["stream_buffer"]
         state = flow.metadata["stream_buffer_state"]
-        assert len(buf) == len(large_chunk)
-        assert not state["truncated"]
+        assert len(buf) == body_utils.STREAM_BUFFER_LIMIT
+        assert state["truncated"]
         # And no X-specific state gets attached to a non-x flow.
         assert "x_ndjson_state" not in flow.metadata
+        assert "x_json_response_finish" not in flow.metadata
 
     def test_no_usage_report_for_non_model_provider(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
@@ -2343,6 +2730,70 @@ class TestErrorHandler:
             mitm_addon.error(flow)
 
         assert "flow-err-1" not in mitm_addon._request_start_times
+
+    def test_error_releases_unfinished_json_streaming_state(self, tmp_path, real_flow, mitm_ctx):
+        """Connection errors should drop unfinished JSON parser closures."""
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "net.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        flow.response.stream(b'{"model":"claude-sonnet-4-6","usage":')
+        flow.error = Error("connection reset")
+
+        with mitm_ctx():
+            mitm_addon.error(flow)
+
+        assert flow.response.stream is False
+        assert "stream_buffer" not in flow.metadata
+        assert "stream_buffer_state" not in flow.metadata
+        assert "model_json_usage_finish" not in flow.metadata
+        assert "model_provider_usage" not in flow.metadata
+
+    def test_error_does_not_bill_partial_x_json_response(
+        self, tmp_path, real_flow, mitm_ctx, sync_usage_executor
+    ):
+        """Interrupted non-stream JSON must not be billed via request-hint fallback."""
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets?ids=1,2,3")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "net.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["vm_sandbox_token"] = "test-token"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets?ids=1,2,3"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["firewall_permission"] = "tweet.read"
+        flow.metadata["firewall_rule_match"] = "GET /2/tweets"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        flow.response.stream(b'{"data":[{"id":"1"}')
+        flow.error = Error("connection reset")
+
+        with (
+            mitm_ctx(api_url="https://app.test"),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.error(flow)
+
+        mock_opener.open.assert_not_called()
+        assert flow.response.stream is False
+        assert "stream_buffer" not in flow.metadata
+        assert "x_json_response_finish" not in flow.metadata
 
     def test_skips_log_when_no_metadata(self, real_flow, mitm_ctx):
         flow = real_flow(with_response=False)
@@ -3160,6 +3611,178 @@ class TestReportConnectorUsage:
         assert p["category"] == "posts.read"
         assert p["quantity"] == 1
 
+    def test_full_response_pipeline_large_x_json_uses_bounded_buffer(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        """responseheaders + response bill X JSON without full-body buffering."""
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["vm_sandbox_token"] = "test-token"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets?expansions=author_id"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["firewall_permission"] = "tweet.read"
+        flow.metadata["firewall_rule_match"] = "GET /2/tweets"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        callback = flow.response.stream
+        callback(b'{"data":[{"id":"1","text":"')
+        callback(b"x" * (body_utils.STREAM_BUFFER_LIMIT + 4096))
+        callback(b'"}],"includes":{"users":[{"id":"u1"}]},"meta":{"result_count":1}}')
+        assert len(flow.metadata["stream_buffer"]) == body_utils.STREAM_BUFFER_LIMIT
+        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(
+                usage.providers.connectors.x, "get_api_url", return_value="https://app.test"
+            ),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+
+        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert by_category == {"posts.read": 1, "user.read": 1}
+
+    def test_full_response_pipeline_x_data_object_bills_single_resource(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        """Selective X JSON extraction must count a top-level data object as one resource."""
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets/1")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["vm_sandbox_token"] = "test-token"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets/1"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["firewall_permission"] = "tweet.read"
+        flow.metadata["firewall_rule_match"] = "GET /2/tweets/{id}"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        flow.response.stream(b'{"data":{"id":"1","text":"hello"}}')
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(
+                usage.providers.connectors.x, "get_api_url", return_value="https://app.test"
+            ),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+
+        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        assert len(events) == 1
+        assert events[0]["category"] == "posts.read"
+        assert events[0]["quantity"] == 1
+
+    def test_full_response_pipeline_x_soft_error_ignores_request_hints(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        """Parsed X soft errors must not fall back to URL hints and bill missing resources."""
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["vm_sandbox_token"] = "test-token"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets?ids=1,2,3"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["firewall_permission"] = "tweet.read"
+        flow.metadata["firewall_rule_match"] = "GET /2/tweets"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        flow.response.stream(
+            json.dumps(
+                {
+                    "errors": [
+                        {
+                            "title": "Not Found Error",
+                            "detail": "Could not find tweets for ids: [1, 2, 3].",
+                        }
+                    ]
+                }
+            ).encode()
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(
+                usage.providers.connectors.x, "get_api_url", return_value="https://app.test"
+            ),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+
+        mock_opener.open.assert_not_called()
+
+    def test_full_response_pipeline_x_root_array_uses_request_hints(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        """Non-object JSON roots stay unparsed so request-side hints still bill."""
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets?ids=1,2,3")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["vm_sandbox_token"] = "test-token"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets?ids=1,2,3"
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["firewall_permission"] = "tweet.read"
+        flow.metadata["firewall_rule_match"] = "GET /2/tweets"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        flow.response.stream(b'[{"id":"1"}]')
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(
+                usage.providers.connectors.x, "get_api_url", return_value="https://app.test"
+            ),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+
+        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        assert len(events) == 1
+        assert events[0]["category"] == "posts.read"
+        assert events[0]["quantity"] == 3
+
     def test_logs_write_operation_charges_one(self, tmp_path, real_flow):
         """POST /2/tweets (no request body parsed) -> stay on the expensive
         with_url bucket, quantity=1."""
@@ -3450,6 +4073,23 @@ class TestReportConnectorUsage:
     def test_invalid_json_with_no_hints_skips_billing(self, tmp_path, real_flow):
         """Malformed body + no URL hints → skip emission (see above)."""
         flow = self._make_x_flow(real_flow, tmp_path, body=b"not json")
+        assert self._call_and_get_billing(flow) == []
+
+    def test_non_dict_json_with_no_hints_skips_billing(self, tmp_path, real_flow):
+        """A valid non-object JSON response preserves the old unparseable fallback."""
+        flow = self._make_x_flow(real_flow, tmp_path, body=b"[1,2,3]")
+        assert self._call_and_get_billing(flow) == []
+
+    def test_array_element_fields_do_not_drive_x_billing(self, tmp_path, real_flow):
+        """Fields under array elements must not masquerade as top-level X metadata."""
+        body = json.dumps(
+            {
+                "data": [],
+                "includes": [{"users": [{"id": "u1"}]}],
+                "meta": [{"result_count": 5}],
+            }
+        ).encode()
+        flow = self._make_x_flow(real_flow, tmp_path, body=body)
         assert self._call_and_get_billing(flow) == []
 
     def test_unparseable_no_hints_writes_error_to_proxy_log(self, tmp_path, real_flow):

--- a/crates/runner/mitm-addon/tests/test_json_selective.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective.py
@@ -1,0 +1,835 @@
+"""Tests for bounded selective JSON extraction."""
+
+import json
+
+import pytest
+
+from usage.json_selective import JsonSelectiveExtractor, ScalarField
+
+
+def _finish(extractor: JsonSelectiveExtractor):
+    return extractor.finish()
+
+
+_COMMON_SCALAR_FIELDS = {
+    ("id",): ScalarField("string"),
+    ("model",): ScalarField("string"),
+    ("usage", "input_tokens"): ScalarField("int"),
+    ("usage", "output_tokens"): ScalarField("int"),
+    ("meta", "result_count"): ScalarField("int"),
+    ("meta", "total_tweet_count"): ScalarField("int"),
+}
+_COMMON_ARRAY_COUNT_PATHS = {("data",), ("errors",)}
+_COMMON_WILDCARD_ARRAY_COUNT_PATHS = {("includes", "*")}
+_COMMON_OBJECT_PRESENCE_PATHS = {(), ("data",)}
+
+
+def _get_path(data: object, path: tuple[str, ...]) -> tuple[object, bool]:
+    cur = data
+    for key in path:
+        if not isinstance(cur, dict) or key not in cur:
+            return None, False
+        cur = cur[key]
+    return cur, True
+
+
+def _expected_common_extraction(data: object):
+    values = {}
+    for path, field in _COMMON_SCALAR_FIELDS.items():
+        value, found = _get_path(data, path)
+        if not found:
+            continue
+        if (field.kind == "string" and isinstance(value, str)) or (
+            field.kind == "int" and isinstance(value, int) and not isinstance(value, bool)
+        ):
+            values[path] = value
+
+    array_counts = {}
+    for path in _COMMON_ARRAY_COUNT_PATHS:
+        value, found = _get_path(data, path)
+        if found and isinstance(value, list):
+            array_counts[path] = len(value)
+
+    wildcard_array_counts = {}
+    includes = data.get("includes") if isinstance(data, dict) else None
+    if isinstance(includes, dict):
+        counts = {
+            key: len(value)
+            for key, value in includes.items()
+            if isinstance(key, str)
+            and isinstance(value, list)
+            and not key.startswith("\0__vm0_json_")
+        }
+        if counts:
+            wildcard_array_counts[("includes", "*")] = counts
+
+    object_present = set()
+    if isinstance(data, dict):
+        object_present.add(())
+        if isinstance(data.get("data"), dict):
+            object_present.add(("data",))
+
+    return values, array_counts, wildcard_array_counts, object_present
+
+
+def _common_extractor() -> JsonSelectiveExtractor:
+    return JsonSelectiveExtractor(
+        scalar_fields=_COMMON_SCALAR_FIELDS,
+        array_count_paths=_COMMON_ARRAY_COUNT_PATHS,
+        wildcard_array_count_paths=_COMMON_WILDCARD_ARRAY_COUNT_PATHS,
+        object_presence_paths=_COMMON_OBJECT_PRESENCE_PATHS,
+    )
+
+
+def test_common_extraction_matches_json_loads_across_chunk_sizes():
+    payloads = [
+        (
+            b'{"id":"msg_1","model":"claude\\n\\u2603",'
+            b'"content":[{"text":"ignored"}],'
+            b'"usage":{"input_tokens":10,"output_tokens":5},'
+            b'"data":[{"id":"1"},{"id":"2"}],"errors":[{"title":"bad"}],'
+            b'"includes":{"users":[{"id":"u1"},{"id":"u2"}],"tweets":[{"id":"t1"}]},'
+            b'"meta":{"result_count":3}}'
+        ),
+        (
+            b'{"id":"msg_2","data":{"id":"1"},'
+            b'"usage":{"input_tokens":0,"output_tokens":7},'
+            b'"meta":{"total_tweet_count":9}}'
+        ),
+    ]
+
+    for payload in payloads:
+        expected = _expected_common_extraction(json.loads(payload))
+        for chunk_size in (1, 2, 3, 5, 8, 13):
+            extractor = _common_extractor()
+            for idx in range(0, len(payload), chunk_size):
+                extractor.feed(payload[idx : idx + chunk_size])
+            result = _finish(extractor)
+
+            assert result.complete is True
+            assert (
+                result.values,
+                result.array_counts,
+                result.wildcard_array_counts,
+                result.object_present,
+            ) == expected
+
+
+def test_extracts_selected_scalars_across_chunks():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={
+            ("model",): ScalarField("string"),
+            ("usage", "input_tokens"): ScalarField("int"),
+        }
+    )
+
+    extractor.feed(b'{"mo')
+    extractor.feed(b'del":"claude","usage":{"input_')
+    extractor.feed(b'tokens":42}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {
+        ("model",): "claude",
+        ("usage", "input_tokens"): 42,
+    }
+
+
+def test_decodes_selected_escaped_strings():
+    extractor = JsonSelectiveExtractor(scalar_fields={("model",): ScalarField("string")})
+
+    extractor.feed(b'{"model":"claude\\n\\u2603"}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values[("model",)] == "claude\n\u2603"
+
+
+def test_decodes_selected_escaped_strings_across_chunks():
+    extractor = JsonSelectiveExtractor(scalar_fields={("model",): ScalarField("string")})
+
+    extractor.feed(b'{"model":"claude\\')
+    extractor.feed(b"n\\u")
+    extractor.feed(b'2603"}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values[("model",)] == "claude\n\u2603"
+
+
+def test_decodes_selected_surrogate_pair_escape():
+    extractor = JsonSelectiveExtractor(scalar_fields={("model",): ScalarField("string")})
+
+    extractor.feed(b'{"model":"claude\\ud83d\\ude00"}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("model",): "claude\U0001f600"}
+
+
+def test_ignores_selected_lone_surrogate_escape():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={
+            ("id",): ScalarField("string"),
+            ("usage", "input_tokens"): ScalarField("int"),
+        }
+    )
+
+    extractor.feed(b'{"id":"\\ud800","usage":{"input_tokens":7}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 7}
+
+
+def test_decodes_escaped_object_keys_for_path_matching():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"us\\u0061ge":{"input_tokens":5}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 5}
+
+
+def test_decodes_escaped_object_keys_across_chunks():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"us\\u')
+    extractor.feed(b'0061ge":{"input_tokens":5}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 5}
+
+
+def test_lone_surrogate_key_does_not_abort_later_selected_fields():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"\\ud800":{"input_tokens":99},"usage":{"input_tokens":7}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 7}
+
+
+def test_skips_large_unselected_string_without_storing_value():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+    large_text = b"x" * (512 * 1024)
+
+    extractor.feed(b'{"content":[{"text":"')
+    extractor.feed(large_text)
+    extractor.feed(b'"}],"usage":{"input_tokens":7}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 7}
+
+
+def test_accepts_multibyte_unselected_string_across_chunks():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"content":"\xe2')
+    extractor.feed(b'\x98\x83","usage":{"input_tokens":9}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 9}
+
+
+def test_rejects_invalid_utf8_in_unselected_string():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"content":"\xff","usage":{"input_tokens":7}}')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "invalid string"
+    assert result.values == {}
+
+
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        (b'{"content":"\xe2\x98"}', "invalid string"),
+        (b'{"content":"\xed\xa0\x80"}', "invalid string"),
+        (b'{"content":"abc\x01"}', "control character in string"),
+        (b'{"content":"\\x"}', "invalid string escape"),
+        (b'{"content":"\\u12xz"}', "invalid unicode escape"),
+    ],
+)
+def test_rejects_invalid_string_forms(payload, error):
+    extractor = JsonSelectiveExtractor()
+
+    extractor.feed(payload)
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == error
+    assert result.values == {}
+
+
+def test_accepts_selected_string_at_exact_limit():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("model",): ScalarField("string", max_bytes=3)}
+    )
+
+    extractor.feed(b'{"model":"abc"}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("model",): "abc"}
+
+
+def test_rejects_oversized_selected_string():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("model",): ScalarField("string", max_bytes=3)}
+    )
+
+    extractor.feed(b'{"model":"abcd"}')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "string limit exceeded"
+    assert result.values == {}
+
+
+def test_selected_string_limit_stops_collecting_current_chunk():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("model",): ScalarField("string", max_bytes=3)}
+    )
+
+    extractor.feed(b'{"model":"' + b"x" * (64 * 1024))
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "string limit exceeded"
+    assert result.values == {}
+
+
+def test_skips_oversized_unmatched_object_key():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")},
+        max_key_bytes=32,
+    )
+
+    extractor.feed(b'{"long_unmatched_key":{"input_tokens":99},"usage":{"input_tokens":7}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 7}
+
+
+def test_skips_long_uninteresting_key_inside_unselected_subtree():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")},
+        max_key_bytes=32,
+    )
+
+    extractor.feed(b'{"content":[{"input":{"')
+    extractor.feed(b"a" * 4096)
+    extractor.feed(b'":1}}],"usage":{"input_tokens":7}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 7}
+
+
+def test_wildcard_count_skips_oversized_key_and_keeps_later_keys():
+    extractor = JsonSelectiveExtractor(
+        wildcard_array_count_paths={("includes", "*")},
+        max_key_bytes=32,
+    )
+
+    extractor.feed(b'{"includes":{"')
+    extractor.feed(b"a" * 4096)
+    extractor.feed(b'":[{"id":"ignored"}],"users":[{"id":"u1"},{"id":"u2"}]}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.wildcard_array_counts == {("includes", "*"): {"users": 2}}
+
+
+def test_wildcard_count_skips_internal_marker_key():
+    extractor = JsonSelectiveExtractor(wildcard_array_count_paths={("includes", "*")})
+
+    extractor.feed(
+        b'{"includes":{"\\u0000__vm0_json_array_element__":[{"id":"internal"}],'
+        b'"users":[{"id":"u1"}]}}'
+    )
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.wildcard_array_counts == {("includes", "*"): {"users": 1}}
+
+
+def test_wildcard_count_skips_unknown_internal_marker_key():
+    extractor = JsonSelectiveExtractor(wildcard_array_count_paths={("includes", "*")})
+
+    extractor.feed(
+        b'{"includes":{"\\u0000__vm0_json_unknown_key__":[{"id":"internal"}],'
+        b'"users":[{"id":"u1"}]}}'
+    )
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.wildcard_array_counts == {("includes", "*"): {"users": 1}}
+
+
+def test_rejects_oversized_number():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")},
+        max_number_bytes=3,
+    )
+
+    extractor.feed(b'{"usage":{"input_tokens":1234}}')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "number limit exceeded"
+
+
+def test_rejects_oversized_number_with_field_limit():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int", max_bytes=3)},
+        max_number_bytes=128,
+    )
+
+    extractor.feed(b'{"usage":{"input_tokens":1234}}')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "number limit exceeded"
+
+
+def test_skips_oversized_unselected_number_without_storing_value():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")},
+        max_number_bytes=3,
+    )
+
+    extractor.feed(b'{"content":{"score":1234567890},"usage":{"input_tokens":7}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 7}
+
+
+def test_rejects_invalid_unselected_number():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"content":{"score":01},"usage":{"input_tokens":7}}')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "invalid number"
+
+
+def test_extracts_root_number_at_eof():
+    extractor = JsonSelectiveExtractor(scalar_fields={(): ScalarField("int")})
+
+    extractor.feed(b"42")
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {(): 42}
+
+
+def test_finishes_selected_number_when_delimiter_arrives_next_chunk():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"usage":{"input_tokens":42')
+    extractor.feed(b"}}")
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 42}
+
+
+def test_selected_float_is_valid_json_but_not_an_int_value():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"usage":{"input_tokens":1.5}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {}
+
+
+def test_rejects_invalid_json_number():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"usage":{"input_tokens":01}}')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "invalid number"
+
+
+def test_incomplete_json_discards_seen_values():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"usage":{"input_tokens":42}')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.values == {}
+
+
+def test_incomplete_json_after_number_reports_error():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"usage":{"input_tokens":42')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "incomplete json"
+    assert result.values == {}
+
+
+def test_incomplete_literal_reports_error():
+    extractor = JsonSelectiveExtractor()
+
+    extractor.feed(b'{"ok":tru')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "incomplete literal"
+
+
+def test_split_literals_continue_to_later_selected_fields():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"ok":tr')
+    extractor.feed(b'ue,"missing":nul')
+    extractor.feed(b'l,"off":fal')
+    extractor.feed(b'se,"usage":{"input_tokens":7}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 7}
+
+
+def test_counts_arrays_and_wildcard_child_arrays():
+    extractor = JsonSelectiveExtractor(
+        array_count_paths={("data",), ("errors",)},
+        wildcard_array_count_paths={("includes", "*")},
+    )
+
+    extractor.feed(
+        b'{"data":[{"id":"1"},{"id":"2"}],'
+        b'"errors":[{"title":"bad"}],'
+        b'"includes":{"users":[{"id":"u1"}],"tweets":[{"id":"t1"},{"id":"t2"}]}}'
+    )
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.array_counts == {("data",): 2, ("errors",): 1}
+    assert result.wildcard_array_counts == {("includes", "*"): {"users": 1, "tweets": 2}}
+
+
+def test_counts_all_matching_wildcard_patterns():
+    extractor = JsonSelectiveExtractor(
+        wildcard_array_count_paths={("a", "*"), ("*", "b")},
+    )
+
+    extractor.feed(b'{"a":{"b":[{"id":"1"},{"id":"2"}]}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.wildcard_array_counts == {
+        ("a", "*"): {"b": 2},
+        ("*", "b"): {"a": 2},
+    }
+
+
+def test_wildcard_pattern_collects_keys_after_wildcard_segment():
+    extractor = JsonSelectiveExtractor(wildcard_array_count_paths={("*", "items")})
+
+    extractor.feed(b'{"a":{"items":[1,2]},"b":{"items":[3]}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.wildcard_array_counts == {("*", "items"): {"a": 2, "b": 1}}
+
+
+def test_leading_wildcard_does_not_match_array_element_marker():
+    extractor = JsonSelectiveExtractor(wildcard_array_count_paths={("*", "items")})
+
+    extractor.feed(b'[{"items":[1,2]}]')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.wildcard_array_counts == {}
+
+
+def test_rejects_wildcard_pattern_without_exactly_one_wildcard():
+    with pytest.raises(ValueError, match="exactly one"):
+        JsonSelectiveExtractor(wildcard_array_count_paths={("includes",)})
+
+    with pytest.raises(ValueError, match="exactly one"):
+        JsonSelectiveExtractor(wildcard_array_count_paths={("*", "*")})
+
+
+def test_counts_empty_arrays_as_zero():
+    extractor = JsonSelectiveExtractor(array_count_paths={("data",), ("errors",)})
+
+    extractor.feed(b'{"data":[],"errors":[]}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.array_counts == {("data",): 0, ("errors",): 0}
+
+
+def test_array_element_object_does_not_record_parent_object_presence():
+    extractor = JsonSelectiveExtractor(
+        array_count_paths={("data",)},
+        object_presence_paths={(), ("data",)},
+    )
+
+    extractor.feed(b'{"data":[{"id":"1"}]}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.array_counts == {("data",): 1}
+    assert result.object_present == {()}
+
+
+def test_array_element_object_fields_do_not_match_object_paths():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={
+            ("model",): ScalarField("string"),
+            ("usage", "input_tokens"): ScalarField("int"),
+        },
+        wildcard_array_count_paths={("includes", "*")},
+    )
+
+    extractor.feed(
+        b'[{"model":"claude","usage":{"input_tokens":7},"includes":{"users":[{"id":"u1"}]}}]'
+    )
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {}
+    assert result.wildcard_array_counts == {}
+
+
+def test_array_value_fields_do_not_match_object_paths():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={
+            ("model",): ScalarField("string"),
+            ("usage", "input_tokens"): ScalarField("int"),
+        }
+    )
+
+    extractor.feed(b'{"model":"claude","usage":[{"input_tokens":7}]}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("model",): "claude"}
+
+
+def test_root_array_object_does_not_record_root_object_presence():
+    extractor = JsonSelectiveExtractor(object_presence_paths={()})
+
+    extractor.feed(b'[{"id":"1"}]')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.object_present == set()
+
+
+def test_duplicate_scalar_parent_uses_last_value():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"usage":{"input_tokens":7},"usage":{}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {}
+
+
+def test_duplicate_array_path_uses_last_value_kind():
+    extractor = JsonSelectiveExtractor(
+        array_count_paths={("data",)},
+        object_presence_paths={("data",)},
+    )
+
+    extractor.feed(b'{"data":[{"id":"1"},{"id":"2"}],"data":{"id":"3"}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.array_counts == {}
+    assert result.object_present == {("data",)}
+
+
+def test_duplicate_object_path_replaced_by_array_clears_presence():
+    extractor = JsonSelectiveExtractor(
+        array_count_paths={("data",)},
+        object_presence_paths={("data",)},
+    )
+
+    extractor.feed(b'{"data":{"id":"1"},"data":[]}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.array_counts == {("data",): 0}
+    assert result.object_present == set()
+
+
+def test_duplicate_wildcard_parent_clears_previous_counts():
+    extractor = JsonSelectiveExtractor(wildcard_array_count_paths={("includes", "*")})
+
+    extractor.feed(b'{"includes":{"users":[{"id":"1"},{"id":"2"}]},"includes":{}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.wildcard_array_counts == {}
+
+
+def test_duplicate_wildcard_child_uses_last_array_count():
+    extractor = JsonSelectiveExtractor(wildcard_array_count_paths={("includes", "*")})
+
+    extractor.feed(b'{"includes":{"users":[{"id":"1"},{"id":"2"}],"users":[]}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.wildcard_array_counts == {("includes", "*"): {"users": 0}}
+
+
+def test_duplicate_wildcard_prefix_keeps_unrelated_keys():
+    extractor = JsonSelectiveExtractor(wildcard_array_count_paths={("*", "items")})
+
+    extractor.feed(b'{"a":{"items":[1,2]},"b":{"items":[3]},"b":{}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.wildcard_array_counts == {("*", "items"): {"a": 2}}
+
+
+def test_records_object_presence():
+    extractor = JsonSelectiveExtractor(object_presence_paths={("data",)})
+
+    extractor.feed(b'{"data":{"id":"1"}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.object_present == {("data",)}
+
+
+def test_rejects_excessive_depth():
+    extractor = JsonSelectiveExtractor(max_depth=2)
+
+    extractor.feed(b'{"a":{"b":{"c":1}}}')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "max depth exceeded"
+
+
+def test_default_depth_allows_deep_unselected_subtree():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+    depth = 80
+
+    extractor.feed(b'{"content":')
+    extractor.feed(b'{"x":' * depth)
+    extractor.feed(b"0")
+    extractor.feed(b"}" * depth)
+    extractor.feed(b',"usage":{"input_tokens":7}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 7}
+
+
+def test_rejects_too_many_wildcard_keys():
+    extractor = JsonSelectiveExtractor(
+        wildcard_array_count_paths={("includes", "*")},
+        max_wildcard_keys=1,
+    )
+
+    extractor.feed(b'{"includes":{"users":[],"tweets":[]}}')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "max wildcard keys exceeded"
+
+
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        (b'{"model" "claude"}', "expected colon"),
+        (b'{"a":1 "b":2}', "expected object comma or end"),
+        (b'{"data":[{}{}]}', "expected array comma or end"),
+    ],
+)
+def test_rejects_missing_separators(payload, error):
+    extractor = JsonSelectiveExtractor()
+
+    extractor.feed(payload)
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == error
+
+
+def test_rejects_trailing_data():
+    extractor = JsonSelectiveExtractor()
+
+    extractor.feed(b"{}{}")
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "trailing data after root value"
+
+
+def test_allows_trailing_whitespace_after_root():
+    extractor = JsonSelectiveExtractor(scalar_fields={("model",): ScalarField("string")})
+
+    extractor.feed(b'{"model":"claude"} \n\t\r')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("model",): "claude"}
+
+
+def test_feed_after_error_does_not_recover():
+    extractor = JsonSelectiveExtractor(scalar_fields={("model",): ScalarField("string")})
+
+    extractor.feed(b'{"model":@')
+    extractor.feed(b'"claude"}')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "expected json value"
+    assert result.values == {}


### PR DESCRIPTION
## Summary
- add a bounded selective JSON extractor for billable model-provider and X JSON responses
- keep forensic stream buffers capped while billing parsers consume chunks incrementally
- cover parser edge cases, corrupted encodings, response cleanup, and X fallback behavior

## Tests
- python3 -m pytest tests
- python3 -m ruff check .
- python3 -m ruff format --check .

Closes #11401