### PR TITLE
refactor: extract org default provider type lookup

### DIFF
--- a/turbo/apps/web/src/lib/zero/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/zero/model-provider/model-provider-service.ts
@@ -16,6 +16,7 @@ import { encryptSecretValue } from "../../shared/crypto";
 import { badRequest, notFound } from "@vm0/api-services/errors";
 import { logger } from "../../shared/logger";
 import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
+import type { Database } from "../../../types/global";
 
 const log = logger("service:model-provider");
 
@@ -1028,6 +1029,31 @@ export function getOrgDefaultModelProvider(
   framework: ModelProviderFramework,
 ): Promise<ModelProviderInfo | null> {
   return getDefaultModelProvider(orgId, ORG_SENTINEL_USER_ID, framework);
+}
+
+/**
+ * Get the org-level default model provider type for run-policy checks.
+ *
+ * This intentionally keeps the query narrow and accepts a db handle so callers
+ * inside queue-drain transactions can keep the read in the same boundary.
+ */
+export async function getOrgDefaultModelProviderType(
+  orgId: string,
+  db: Database = globalThis.services.db,
+): Promise<string | null> {
+  const [row] = await db
+    .select({ type: modelProviders.type })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.orgId, orgId),
+        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+        eq(modelProviders.isDefault, true),
+      ),
+    )
+    .limit(1);
+
+  return row?.type ?? null;
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -9,10 +9,9 @@ import {
 import { canAccessCompose } from "../infra/agent/compose-access";
 import { validateFrameworkApiKey } from "../infra/run/utils";
 import { logger } from "../shared/logger";
-import { modelProviders } from "@vm0/db/schema/model-provider";
-import { ORG_SENTINEL_USER_ID } from "./org/org-sentinel";
 import { MODEL_PROVIDER_ENV_VARS } from "./context/resolve-model-provider";
 import { checkOrgCredits } from "./credit/check-org-credits";
+import { getOrgDefaultModelProviderType } from "./model-provider/model-provider-service";
 import type { Database } from "../../types/global";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
 import type { AgentComposeYaml } from "../infra/agent-compose/types";
@@ -148,18 +147,8 @@ export async function checkOrgCreditsForRun(
 
   let isVm0 = modelProvider === "vm0";
   if (!isVm0) {
-    const [defaultProvider] = await db
-      .select({ type: modelProviders.type })
-      .from(modelProviders)
-      .where(
-        and(
-          eq(modelProviders.orgId, orgId),
-          eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
-          eq(modelProviders.isDefault, true),
-        ),
-      )
-      .limit(1);
-    isVm0 = defaultProvider?.type === "vm0";
+    const defaultProviderType = await getOrgDefaultModelProviderType(orgId, db);
+    isVm0 = defaultProviderType === "vm0";
   }
 
   if (!isVm0) return;
@@ -191,19 +180,9 @@ export async function checkModelProviderConfigured(
   });
   if (hasExplicitConfig) return;
 
-  const [defaultProvider] = await globalThis.services.db
-    .select({ type: modelProviders.type })
-    .from(modelProviders)
-    .where(
-      and(
-        eq(modelProviders.orgId, orgId),
-        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
-        eq(modelProviders.isDefault, true),
-      ),
-    )
-    .limit(1);
+  const defaultProviderType = await getOrgDefaultModelProviderType(orgId);
 
-  if (!defaultProvider) {
+  if (!defaultProviderType) {
     throw noModelProvider();
   }
 }


### PR DESCRIPTION
## Summary

- add a narrow `getOrgDefaultModelProviderType(orgId, db?)` helper for run-policy checks
- replace duplicated org default-provider type queries in `zero-run-policy.ts`
- keep the queue-drain transaction path intact by passing through the existing db/tx handle

Closes #10997

## Testing

- `pnpm -C turbo exec vitest --run apps/web/src/lib/zero/__tests__/credit-check.test.ts`
- `pnpm -C turbo --filter web lint`
- `pnpm -C turbo --filter web check-types` *(fails locally due existing Next 16.1.7/16.2.3 `NextRequest` type mismatch in `.next/dev/types`, unrelated to this change)*