### PR TITLE
refactor(nbd-cow): tie device pool leases to COW lifecycle

### DIFF
--- a/crates/nbd-cow/src/bin/bench.rs
+++ b/crates/nbd-cow/src/bin/bench.rs
@@ -8,7 +8,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use nbd_cow::NbdCowDevice;
+use nbd_cow::{DestroyRetryPolicy, pool::DevicePoolHandle};
 
 #[tokio::main]
 async fn main() {
@@ -214,34 +214,34 @@ async fn run_nbd_cow_bench(
 
     eprintln!("  NBD module loaded, setting up NBD COW device...");
 
-    let device_pool = tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
-        nbd_cow::pool::DevicePoolConfig::default(),
-    ));
-    device_pool.lock().await.warmup().await;
+    let device_pool = DevicePoolHandle::new(nbd_cow::pool::DevicePoolConfig::default());
+    device_pool.warmup().await;
 
     for wl in workloads {
         let cow_path = work_dir.join("nbd-cow.img");
 
-        let mut device = NbdCowDevice::create(base_path, &cow_path, base_size, &device_pool)
+        let device = device_pool
+            .create_cow_device(base_path, &cow_path, base_size)
             .await
             .map_err(|e| format!("failed to create NBD COW device: {e}"))?;
 
         let dev_path = device.device_path().to_string_lossy().to_string();
-        let device_index = device.device_index();
         eprintln!("  Running fio ({}) on {dev_path}...", wl.name);
 
         let result = run_fio_with_iostat(&dev_path, wl, host_disk)?;
         results.push(result);
 
         device
-            .destroy()
+            .destroy_with_retries(DestroyRetryPolicy {
+                attempts: 1,
+                delay: std::time::Duration::ZERO,
+            })
             .await
             .map_err(|e| format!("failed to destroy NBD device: {e}"))?;
-        device_pool.lock().await.release(device_index);
         let _ = std::fs::remove_file(&cow_path);
     }
 
-    device_pool.lock().await.cleanup().await;
+    device_pool.cleanup().await;
     Ok(results)
 }
 

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -504,12 +504,17 @@ impl PooledNbdCowDevice {
     }
 
     /// Destroy the device, removing the COW file and bitmap.
-    pub async fn destroy_with_retries(self, policy: DestroyRetryPolicy) -> Result<()> {
+    pub fn destroy_with_retries(
+        self,
+        policy: DestroyRetryPolicy,
+    ) -> impl std::future::Future<Output = Result<()>> + Send + 'static {
         // Once finalization starts, let it run to completion even if the caller's
         // future is cancelled. Otherwise dropping the owned device mid-finalizer
         // can disconnect best-effort but leave the pool lease in flight.
-        let handle = tokio::spawn(async move { self.destroy_with_retries_inner(policy).await });
-        Self::await_finalizer(handle).await
+        //
+        // This must spawn before returning the Future: an `async fn` body would
+        // not run if the returned future was dropped before its first poll.
+        Self::run_finalizer(async move { self.destroy_with_retries_inner(policy).await })
     }
 
     async fn destroy_with_retries_inner(self, policy: DestroyRetryPolicy) -> Result<()> {
@@ -545,15 +550,13 @@ impl PooledNbdCowDevice {
     }
 
     /// Destroy the device while preserving COW data for snapshot persistence.
-    pub async fn destroy_keep_cow_with_retries(
+    pub fn destroy_keep_cow_with_retries(
         self,
         policy: DestroyRetryPolicy,
-    ) -> Result<KeptCow> {
+    ) -> impl std::future::Future<Output = Result<KeptCow>> + Send + 'static {
         // See destroy_with_retries(): the COW file must either be finalized or
         // abandoned with the lease retired even if the awaiting task is dropped.
-        let handle =
-            tokio::spawn(async move { self.destroy_keep_cow_with_retries_inner(policy).await });
-        Self::await_finalizer(handle).await
+        Self::run_finalizer(async move { self.destroy_keep_cow_with_retries_inner(policy).await })
     }
 
     async fn destroy_keep_cow_with_retries_inner(
@@ -600,10 +603,12 @@ impl PooledNbdCowDevice {
     }
 
     /// Mark the device as abandoned and retire the pool lease as uncertain.
-    pub async fn abandon(self) {
+    pub fn abandon(self) -> impl std::future::Future<Output = ()> + Send + 'static {
         let handle = tokio::spawn(async move { self.abandon_inner().await });
-        if let Err(e) = handle.await {
-            tracing::warn!(error = %e, "pooled NBD COW abandon task failed");
+        async move {
+            if let Err(e) = handle.await {
+                tracing::warn!(error = %e, "pooled NBD COW abandon task failed");
+            }
         }
     }
 
@@ -615,6 +620,16 @@ impl PooledNbdCowDevice {
         } = self;
         device.abandon();
         Self::retire_uncertain(&pool, &mut lease).await;
+    }
+
+    fn run_finalizer<T>(
+        future: impl std::future::Future<Output = Result<T>> + Send + 'static,
+    ) -> impl std::future::Future<Output = Result<T>> + Send + 'static
+    where
+        T: Send + 'static,
+    {
+        let handle = tokio::spawn(future);
+        async move { Self::await_finalizer(handle).await }
     }
 
     async fn await_finalizer<T>(handle: JoinHandle<Result<T>>) -> Result<T> {
@@ -685,6 +700,33 @@ impl Drop for NbdCowDevice {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn pooled_finalizer_starts_before_returned_future_is_polled() {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+
+        let finalizer = PooledNbdCowDevice::run_finalizer(async move {
+            let _ = started_tx.send(());
+            finish_rx.await.map_err(|e| {
+                error::NbdCowError::Io(std::io::Error::other(format!(
+                    "test finalizer release dropped: {e}"
+                )))
+            })?;
+            let _ = done_tx.send(());
+            Ok(())
+        });
+
+        started_rx.await.unwrap();
+        drop(finalizer);
+        finish_tx.send(()).unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), done_rx)
+            .await
+            .unwrap()
+            .unwrap();
+    }
 
     /// Verify is_our_thread correctly identifies the main thread (TID == TGID).
     #[test]

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -176,9 +176,7 @@ impl NbdCowDevice {
                 })();
                 if let Err(e) = setup_err {
                     shutdown.cancel();
-                    for handle in server_handles {
-                        handle.abort();
-                    }
+                    abort_server_handles(server_handles).await;
                     // Release device back — connect was never attempted, device
                     // is still free in kernel. No cooldown needed but release()
                     // adds one defensively.
@@ -201,9 +199,7 @@ impl NbdCowDevice {
                             "EBUSY on connect, trying next device"
                         );
                         shutdown.cancel();
-                        for handle in server_handles {
-                            handle.abort();
-                        }
+                        abort_server_handles(server_handles).await;
                         if ebusy_count > MAX_EBUSY_RETRIES {
                             device_pool.discard(lease).await;
                             return Err(error::NbdCowError::NoFreeDevice);
@@ -216,9 +212,7 @@ impl NbdCowDevice {
                     }
                     Err(e) => {
                         shutdown.cancel();
-                        for handle in server_handles {
-                            handle.abort();
-                        }
+                        abort_server_handles(server_handles).await;
                         // Connect failed with non-EBUSY error. Device may be in
                         // an unknown kernel state — retire with cooldown so it
                         // gets re-validated before reuse.
@@ -253,14 +247,12 @@ impl NbdCowDevice {
                 attempt = size_attempt + 1,
                 "device size 0 after connect, disconnecting and retrying"
             );
+            shutdown.cancel();
+            abort_server_handles(server_handles).await;
             if netlink::disconnect(device_index).is_ok() {
                 device_pool.release_clean(lease).await;
             } else {
                 device_pool.retire_uncertain(lease).await;
-            }
-            shutdown.cancel();
-            for handle in server_handles {
-                handle.abort();
             }
             last_err_idx = device_index;
 
@@ -444,9 +436,16 @@ impl pool::DevicePoolHandle {
         let (device, lease) = NbdCowDevice::create_inner(base_image, cow_file, size, self).await?;
         Ok(PooledNbdCowDevice {
             device,
-            lease: LeaseGuard::new(lease),
+            lease: LeaseGuard::new(lease, self.clone()),
             pool: self.clone(),
         })
+    }
+}
+
+async fn abort_server_handles(handles: Vec<JoinHandle<()>>) {
+    for handle in handles {
+        handle.abort();
+        let _ = handle.await;
     }
 }
 
@@ -459,11 +458,15 @@ pub struct PooledNbdCowDevice {
 
 struct LeaseGuard {
     lease: Option<pool::DeviceLease>,
+    pool: pool::DevicePoolHandle,
 }
 
 impl LeaseGuard {
-    fn new(lease: pool::DeviceLease) -> Self {
-        Self { lease: Some(lease) }
+    fn new(lease: pool::DeviceLease, pool: pool::DevicePoolHandle) -> Self {
+        Self {
+            lease: Some(lease),
+            pool,
+        }
     }
 
     fn take(&mut self) -> Option<pool::DeviceLease> {
@@ -473,11 +476,13 @@ impl LeaseGuard {
 
 impl Drop for LeaseGuard {
     fn drop(&mut self) {
-        if let Some(lease) = self.lease.as_ref() {
+        if let Some(lease) = self.lease.take() {
+            let device_index = lease.index();
             tracing::warn!(
-                device_index = lease.index(),
-                "pooled NBD COW device dropped without finalizer; pool lease will require cleanup"
+                device_index,
+                "pooled NBD COW device dropped without finalizer; retiring pool lease as uncertain"
             );
+            self.pool.retire_uncertain_detached(lease);
         }
     }
 }
@@ -723,6 +728,35 @@ mod tests {
         finish_tx.send(()).unwrap();
 
         tokio::time::timeout(std::time::Duration::from_secs(1), done_rx)
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn abort_server_handles_waits_for_task_cleanup() {
+        struct DropNotify(Option<tokio::sync::oneshot::Sender<()>>);
+
+        impl Drop for DropNotify {
+            fn drop(&mut self) {
+                if let Some(tx) = self.0.take() {
+                    let _ = tx.send(());
+                }
+            }
+        }
+
+        let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(async move {
+            let _notify = DropNotify(Some(dropped_tx));
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+        });
+
+        started_rx.await.unwrap();
+        abort_server_handles(vec![handle]).await;
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), dropped_rx)
             .await
             .unwrap()
             .unwrap();

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -195,7 +195,7 @@ impl NbdCowDevice {
                     }
                     Err(error::NbdCowError::NetlinkErrno { errno, .. }) if errno == libc::EBUSY => {
                         ebusy_count += 1;
-                        tracing::debug!(
+                        tracing::info!(
                             device_index,
                             ebusy_count,
                             "EBUSY on connect, trying next device"
@@ -248,7 +248,7 @@ impl NbdCowDevice {
             }
 
             // Size is wrong — disconnect, release with cooldown, and retry.
-            tracing::debug!(
+            tracing::info!(
                 device_index,
                 attempt = size_attempt + 1,
                 "device size 0 after connect, disconnecting and retrying"

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -505,6 +505,14 @@ impl PooledNbdCowDevice {
 
     /// Destroy the device, removing the COW file and bitmap.
     pub async fn destroy_with_retries(self, policy: DestroyRetryPolicy) -> Result<()> {
+        // Once finalization starts, let it run to completion even if the caller's
+        // future is cancelled. Otherwise dropping the owned device mid-finalizer
+        // can disconnect best-effort but leave the pool lease in flight.
+        let handle = tokio::spawn(async move { self.destroy_with_retries_inner(policy).await });
+        Self::await_finalizer(handle).await
+    }
+
+    async fn destroy_with_retries_inner(self, policy: DestroyRetryPolicy) -> Result<()> {
         let Self {
             mut device,
             mut lease,
@@ -538,6 +546,17 @@ impl PooledNbdCowDevice {
 
     /// Destroy the device while preserving COW data for snapshot persistence.
     pub async fn destroy_keep_cow_with_retries(
+        self,
+        policy: DestroyRetryPolicy,
+    ) -> Result<KeptCow> {
+        // See destroy_with_retries(): the COW file must either be finalized or
+        // abandoned with the lease retired even if the awaiting task is dropped.
+        let handle =
+            tokio::spawn(async move { self.destroy_keep_cow_with_retries_inner(policy).await });
+        Self::await_finalizer(handle).await
+    }
+
+    async fn destroy_keep_cow_with_retries_inner(
         self,
         policy: DestroyRetryPolicy,
     ) -> Result<KeptCow> {
@@ -582,6 +601,13 @@ impl PooledNbdCowDevice {
 
     /// Mark the device as abandoned and retire the pool lease as uncertain.
     pub async fn abandon(self) {
+        let handle = tokio::spawn(async move { self.abandon_inner().await });
+        if let Err(e) = handle.await {
+            tracing::warn!(error = %e, "pooled NBD COW abandon task failed");
+        }
+    }
+
+    async fn abandon_inner(self) {
         let Self {
             mut device,
             mut lease,
@@ -589,6 +615,15 @@ impl PooledNbdCowDevice {
         } = self;
         device.abandon();
         Self::retire_uncertain(&pool, &mut lease).await;
+    }
+
+    async fn await_finalizer<T>(handle: JoinHandle<Result<T>>) -> Result<T> {
+        match handle.await {
+            Ok(result) => result,
+            Err(e) => Err(error::NbdCowError::Io(std::io::Error::other(format!(
+                "pooled NBD COW finalizer task failed: {e}"
+            )))),
+        }
     }
 
     async fn release_clean(pool: &pool::DevicePoolHandle, lease: &mut LeaseGuard) {

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -81,6 +81,150 @@ enum DeviceOwnership {
     Unknown(std::io::Error),
 }
 
+#[derive(Clone, Copy)]
+struct ConnectedDevice {
+    index: u32,
+    connect_tid: u32,
+}
+
+struct CreateAttemptGuard {
+    pool: pool::DevicePoolHandle,
+    device_index: u32,
+    lease: Option<pool::DeviceLease>,
+    shutdown: CancellationToken,
+    server_handles: Vec<JoinHandle<()>>,
+    connected: Option<ConnectedDevice>,
+}
+
+impl CreateAttemptGuard {
+    fn new(pool: pool::DevicePoolHandle, lease: pool::DeviceLease) -> Self {
+        let device_index = lease.index();
+        Self {
+            pool,
+            device_index,
+            lease: Some(lease),
+            shutdown: CancellationToken::new(),
+            server_handles: Vec::with_capacity(NUM_CONNECTIONS),
+            connected: None,
+        }
+    }
+
+    fn device_index(&self) -> u32 {
+        self.device_index
+    }
+
+    fn shutdown_token(&self) -> CancellationToken {
+        self.shutdown.clone()
+    }
+
+    fn push_server_handle(&mut self, handle: JoinHandle<()>) {
+        self.server_handles.push(handle);
+    }
+
+    fn mark_connected(&mut self, connect_tid: u32) {
+        self.connected = Some(ConnectedDevice {
+            index: self.device_index(),
+            connect_tid,
+        });
+    }
+
+    async fn abort_servers(&mut self) {
+        self.shutdown.cancel();
+        abort_server_handles(std::mem::take(&mut self.server_handles)).await;
+    }
+
+    async fn release_clean(mut self) {
+        self.abort_servers().await;
+        if let Some(lease) = self.lease.take() {
+            self.pool.release_clean(lease).await;
+        }
+    }
+
+    async fn discard(mut self) {
+        self.abort_servers().await;
+        if let Some(lease) = self.lease.take() {
+            self.pool.discard(lease).await;
+        }
+    }
+
+    async fn retire_uncertain(mut self) {
+        self.abort_servers().await;
+        if let Some(lease) = self.lease.take() {
+            self.pool.retire_uncertain(lease).await;
+        }
+    }
+
+    async fn disconnect_and_release(mut self) -> bool {
+        self.abort_servers().await;
+        let disconnected = self
+            .connected
+            .take()
+            .is_some_and(|connected| netlink::disconnect(connected.index).is_ok());
+        if let Some(lease) = self.lease.take() {
+            if disconnected {
+                self.pool.release_clean(lease).await;
+            } else {
+                self.pool.retire_uncertain(lease).await;
+            }
+        }
+        disconnected
+    }
+
+    fn into_device(
+        mut self,
+        cow_file: &Path,
+        cow_layer: Arc<RwLock<cow::CowLayer>>,
+    ) -> Result<(NbdCowDevice, pool::DeviceLease)> {
+        let Some(connected) = self.connected else {
+            return Err(error::NbdCowError::Io(std::io::Error::other(
+                "connected device missing during NBD COW create",
+            )));
+        };
+        let Some(lease) = self.lease.take() else {
+            return Err(error::NbdCowError::Io(std::io::Error::other(
+                "pool lease missing during NBD COW create",
+            )));
+        };
+        self.connected = None;
+        let shutdown = std::mem::replace(&mut self.shutdown, CancellationToken::new());
+        let server_handles = std::mem::take(&mut self.server_handles);
+
+        Ok((
+            NbdCowDevice {
+                device_index: connected.index,
+                device_path: PathBuf::from(format!("/dev/nbd{}", connected.index)),
+                cow_file: cow_file.to_path_buf(),
+                cow: cow_layer,
+                server_handles,
+                shutdown,
+                disconnected: false,
+                connect_tid: connected.connect_tid,
+            },
+            lease,
+        ))
+    }
+}
+
+impl Drop for CreateAttemptGuard {
+    fn drop(&mut self) {
+        self.shutdown.cancel();
+        for handle in self.server_handles.drain(..) {
+            handle.abort();
+        }
+        if let Some(connected) = self.connected.take() {
+            disconnect_connected_if_owned(connected);
+        }
+        if let Some(lease) = self.lease.take() {
+            let device_index = lease.index();
+            tracing::warn!(
+                device_index,
+                "NBD COW create attempt dropped before completion; retiring pool lease as uncertain"
+            );
+            self.pool.retire_uncertain_detached(lease);
+        }
+    }
+}
+
 /// An NBD COW block device backed by a base image and sparse COW file.
 ///
 /// The device appears as `/dev/nbdN` and can be used as a Firecracker rootfs.
@@ -149,14 +293,13 @@ impl NbdCowDevice {
             // Inner loop: acquire from pool and try to connect.
             // EBUSY retries get a fresh device without consuming the outer budget.
             let mut ebusy_count: u32 = 0;
-            let (lease, shutdown, server_handles, connect_tid) = loop {
+            let attempt = loop {
                 let lease = device_pool.acquire().await?;
-                let device_index = lease.index();
+                let mut attempt = CreateAttemptGuard::new(device_pool.clone(), lease);
+                let device_index = attempt.device_index();
 
                 // Fresh shutdown token and socketpairs for each attempt
-                let shutdown = CancellationToken::new();
                 let mut client_fds = Vec::with_capacity(NUM_CONNECTIONS);
-                let mut server_handles = Vec::with_capacity(NUM_CONNECTIONS);
 
                 let setup_err = (|| -> Result<()> {
                     for _ in 0..NUM_CONNECTIONS {
@@ -164,23 +307,21 @@ impl NbdCowDevice {
                         client_fds.push(client_fd);
 
                         let cow = cow_layer.clone();
-                        let token = shutdown.clone();
+                        let token = attempt.shutdown_token();
                         let handle = tokio::spawn(async move {
                             if let Err(e) = server::dispatch(server_fd, cow, token).await {
                                 tracing::error!("NBD dispatch error: {e}");
                             }
                         });
-                        server_handles.push(handle);
+                        attempt.push_server_handle(handle);
                     }
                     Ok(())
                 })();
                 if let Err(e) = setup_err {
-                    shutdown.cancel();
-                    abort_server_handles(server_handles).await;
                     // Release device back — connect was never attempted, device
                     // is still free in kernel. No cooldown needed but release()
                     // adds one defensively.
-                    device_pool.release_clean(lease).await;
+                    attempt.release_clean().await;
                     return Err(e);
                 }
 
@@ -189,7 +330,8 @@ impl NbdCowDevice {
                         // Record the TID of the thread that connected — the kernel
                         // stores this in /sys/block/nbdN/pid via task_pid_nr().
                         let tid = unsafe { libc::gettid() } as u32;
-                        break (lease, shutdown, server_handles, tid);
+                        attempt.mark_connected(tid);
+                        break attempt;
                     }
                     Err(error::NbdCowError::NetlinkErrno { errno, .. }) if errno == libc::EBUSY => {
                         ebusy_count += 1;
@@ -198,47 +340,30 @@ impl NbdCowDevice {
                             ebusy_count,
                             "EBUSY on connect, trying next device"
                         );
-                        shutdown.cancel();
-                        abort_server_handles(server_handles).await;
                         if ebusy_count > MAX_EBUSY_RETRIES {
-                            device_pool.discard(lease).await;
+                            attempt.discard().await;
                             return Err(error::NbdCowError::NoFreeDevice);
                         }
                         // Device is owned by another process — stop tracking
                         // without cooldown. Background scan will rediscover
                         // if it frees.
-                        device_pool.discard(lease).await;
+                        attempt.discard().await;
                         continue;
                     }
                     Err(e) => {
-                        shutdown.cancel();
-                        abort_server_handles(server_handles).await;
                         // Connect failed with non-EBUSY error. Device may be in
                         // an unknown kernel state — retire with cooldown so it
                         // gets re-validated before reuse.
-                        device_pool.retire_uncertain(lease).await;
+                        attempt.retire_uncertain().await;
                         return Err(e);
                     }
                 }
             };
-            let device_index = lease.index();
+            let device_index = attempt.device_index();
 
             // Verify the device got the correct size via sysfs.
             if netlink::verify_device_size(device_index, size).await {
-                let device_path = PathBuf::from(format!("/dev/nbd{device_index}"));
-                return Ok((
-                    Self {
-                        device_index,
-                        device_path,
-                        cow_file: cow_file.to_path_buf(),
-                        cow: cow_layer,
-                        server_handles,
-                        shutdown,
-                        disconnected: false,
-                        connect_tid,
-                    },
-                    lease,
-                ));
+                return attempt.into_device(cow_file, cow_layer);
             }
 
             // Size is wrong — disconnect, release with cooldown, and retry.
@@ -247,13 +372,7 @@ impl NbdCowDevice {
                 attempt = size_attempt + 1,
                 "device size 0 after connect, disconnecting and retrying"
             );
-            shutdown.cancel();
-            abort_server_handles(server_handles).await;
-            if netlink::disconnect(device_index).is_ok() {
-                device_pool.release_clean(lease).await;
-            } else {
-                device_pool.retire_uncertain(lease).await;
-            }
+            attempt.disconnect_and_release().await;
             last_err_idx = device_index;
 
             if size_attempt < MAX_SIZE_RETRIES {
@@ -406,22 +525,54 @@ impl NbdCowDevice {
     /// `is_our_thread()` check return false and skip disconnect — leaking the
     /// device.
     fn device_ownership(&self) -> DeviceOwnership {
-        let pid_path = format!("/sys/block/nbd{}/pid", self.device_index);
-        match std::fs::read_to_string(&pid_path) {
-            Ok(contents) => {
-                let tid: u32 = contents.trim().parse().unwrap_or(0);
-                if tid == self.connect_tid {
-                    DeviceOwnership::Ours
-                } else {
-                    DeviceOwnership::Foreign(tid)
-                }
-            }
-            Err(e) => DeviceOwnership::Unknown(e),
-        }
+        device_ownership(self.device_index, self.connect_tid)
     }
 
     fn bitmap_path(&self) -> PathBuf {
         cow::bitmap_path_for(&self.cow_file)
+    }
+}
+
+fn device_ownership(device_index: u32, connect_tid: u32) -> DeviceOwnership {
+    let pid_path = format!("/sys/block/nbd{device_index}/pid");
+    match std::fs::read_to_string(&pid_path) {
+        Ok(contents) => {
+            let tid: u32 = contents.trim().parse().unwrap_or(0);
+            if tid == connect_tid {
+                DeviceOwnership::Ours
+            } else {
+                DeviceOwnership::Foreign(tid)
+            }
+        }
+        Err(e) => DeviceOwnership::Unknown(e),
+    }
+}
+
+fn disconnect_connected_if_owned(connected: ConnectedDevice) {
+    match device_ownership(connected.index, connected.connect_tid) {
+        DeviceOwnership::Ours => {
+            if let Err(e) = netlink::disconnect(connected.index) {
+                tracing::warn!(
+                    device_index = connected.index,
+                    error = %e,
+                    "NBD disconnect failed during cancelled create"
+                );
+            }
+        }
+        DeviceOwnership::Foreign(pid) => {
+            tracing::warn!(
+                device_index = connected.index,
+                foreign_pid = pid,
+                "skipping cancelled-create disconnect: device recycled by another process"
+            );
+        }
+        DeviceOwnership::Unknown(err) => {
+            tracing::warn!(
+                device_index = connected.index,
+                error = %err,
+                "skipping cancelled-create disconnect: cannot read device pid"
+            );
+        }
     }
 }
 
@@ -443,8 +594,10 @@ impl pool::DevicePoolHandle {
 }
 
 async fn abort_server_handles(handles: Vec<JoinHandle<()>>) {
-    for handle in handles {
+    for handle in &handles {
         handle.abort();
+    }
+    for handle in handles {
         let _ = handle.await;
     }
 }
@@ -760,6 +913,40 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn create_attempt_guard_drop_aborts_dispatch_task() {
+        struct DropNotify(Option<tokio::sync::oneshot::Sender<()>>);
+
+        impl Drop for DropNotify {
+            fn drop(&mut self) {
+                if let Some(tx) = self.0.take() {
+                    let _ = tx.send(());
+                }
+            }
+        }
+
+        let pool = pool::DevicePoolHandle::new(pool::DevicePoolConfig::default());
+        let mut guard = CreateAttemptGuard::new(pool.clone(), pool::DeviceLease::new_for_test(3));
+        let token = guard.shutdown_token();
+        let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        guard.push_server_handle(tokio::spawn(async move {
+            let _notify = DropNotify(Some(dropped_tx));
+            let _ = started_tx.send(());
+            token.cancelled().await;
+        }));
+
+        started_rx.await.unwrap();
+        drop(guard);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), dropped_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        pool.cleanup().await;
     }
 
     /// Verify is_our_thread correctly identifies the main thread (TID == TGID).

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -29,8 +29,11 @@ pub mod pool;
 pub mod protocol;
 pub mod server;
 
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use error::Result;
@@ -69,6 +72,86 @@ pub struct KeptCow {
     pub cow_file: PathBuf,
     /// Persisted dirty bitmap sidecar path.
     pub bitmap_file: PathBuf,
+}
+
+struct PooledCowFinalizer<T: Send + 'static> {
+    handle: Option<JoinHandle<Result<T>>>,
+}
+
+impl<T: Send + 'static> PooledCowFinalizer<T> {
+    fn new(handle: JoinHandle<Result<T>>) -> Self {
+        Self {
+            handle: Some(handle),
+        }
+    }
+}
+
+impl<T: Send + 'static> Future for PooledCowFinalizer<T> {
+    type Output = Result<T>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let Some(handle) = this.handle.as_mut() else {
+            return Poll::Ready(Err(error::NbdCowError::Io(std::io::Error::other(
+                "pooled NBD COW finalizer polled after completion",
+            ))));
+        };
+
+        match Pin::new(handle).poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(result) => {
+                this.handle.take();
+                Poll::Ready(finish_finalizer_join(result))
+            }
+        }
+    }
+}
+
+impl<T: Send + 'static> Drop for PooledCowFinalizer<T> {
+    fn drop(&mut self) {
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+
+        match tokio::runtime::Handle::try_current() {
+            Ok(runtime) => {
+                runtime.spawn(observe_detached_finalizer(handle));
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "pooled NBD COW finalizer future dropped outside Tokio runtime; continuing without observer"
+                );
+            }
+        }
+    }
+}
+
+fn finish_finalizer_join<T>(
+    result: std::result::Result<Result<T>, tokio::task::JoinError>,
+) -> Result<T> {
+    match result {
+        Ok(result) => result,
+        Err(e) if e.is_panic() => std::panic::resume_unwind(e.into_panic()),
+        Err(e) => Err(error::NbdCowError::Io(std::io::Error::other(format!(
+            "pooled NBD COW finalizer task was cancelled: {e}"
+        )))),
+    }
+}
+
+async fn observe_detached_finalizer<T: Send + 'static>(handle: JoinHandle<Result<T>>) {
+    match handle.await {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "detached pooled NBD COW finalizer failed");
+        }
+        Err(e) if e.is_panic() => {
+            tracing::error!(error = %e, "detached pooled NBD COW finalizer panicked");
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "detached pooled NBD COW finalizer task was cancelled");
+        }
+    }
 }
 
 /// Result of checking NBD device ownership via sysfs PID.
@@ -762,10 +845,13 @@ impl PooledNbdCowDevice {
 
     /// Mark the device as abandoned and retire the pool lease as uncertain.
     pub fn abandon(self) -> impl std::future::Future<Output = ()> + Send + 'static {
-        let handle = tokio::spawn(async move { self.abandon_inner().await });
+        let finalizer = Self::run_finalizer(async move {
+            self.abandon_inner().await;
+            Ok(())
+        });
         async move {
-            if let Err(e) = handle.await {
-                tracing::warn!(error = %e, "pooled NBD COW abandon task failed");
+            if let Err(e) = finalizer.await {
+                tracing::warn!(error = %e, "pooled NBD COW abandon finalizer failed");
             }
         }
     }
@@ -782,21 +868,11 @@ impl PooledNbdCowDevice {
 
     fn run_finalizer<T>(
         future: impl std::future::Future<Output = Result<T>> + Send + 'static,
-    ) -> impl std::future::Future<Output = Result<T>> + Send + 'static
+    ) -> PooledCowFinalizer<T>
     where
         T: Send + 'static,
     {
-        let handle = tokio::spawn(future);
-        async move { Self::await_finalizer(handle).await }
-    }
-
-    async fn await_finalizer<T>(handle: JoinHandle<Result<T>>) -> Result<T> {
-        match handle.await {
-            Ok(result) => result,
-            Err(e) => Err(error::NbdCowError::Io(std::io::Error::other(format!(
-                "pooled NBD COW finalizer task failed: {e}"
-            )))),
-        }
+        PooledCowFinalizer::new(tokio::spawn(future))
     }
 
     async fn release_clean(pool: &pool::DevicePoolHandle, lease: &mut LeaseGuard) {
@@ -884,6 +960,18 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "pooled finalizer panic")]
+    async fn pooled_finalizer_propagates_panic_when_awaited() {
+        let finalizer = PooledNbdCowDevice::run_finalizer(async move {
+            panic!("pooled finalizer panic");
+            #[allow(unreachable_code)]
+            Ok::<(), error::NbdCowError>(())
+        });
+
+        let _ = finalizer.await;
     }
 
     #[tokio::test]

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -745,6 +745,9 @@ impl PooledNbdCowDevice {
     }
 
     /// Destroy the device, removing the COW file and bitmap.
+    ///
+    /// Finalization starts immediately. Dropping the returned future does not
+    /// cancel cleanup; it continues in the background and logs its result.
     pub fn destroy_with_retries(
         self,
         policy: DestroyRetryPolicy,
@@ -791,6 +794,9 @@ impl PooledNbdCowDevice {
     }
 
     /// Destroy the device while preserving COW data for snapshot persistence.
+    ///
+    /// Finalization starts immediately. Dropping the returned future does not
+    /// cancel cleanup; it continues in the background and logs its result.
     pub fn destroy_keep_cow_with_retries(
         self,
         policy: DestroyRetryPolicy,
@@ -965,11 +971,10 @@ mod tests {
     #[tokio::test]
     #[should_panic(expected = "pooled finalizer panic")]
     async fn pooled_finalizer_propagates_panic_when_awaited() {
-        let finalizer = PooledNbdCowDevice::run_finalizer(async move {
-            panic!("pooled finalizer panic");
-            #[allow(unreachable_code)]
-            Ok::<(), error::NbdCowError>(())
-        });
+        let finalizer =
+            PooledNbdCowDevice::run_finalizer::<()>(
+                async move { panic!("pooled finalizer panic") },
+            );
 
         let _ = finalizer.await;
     }

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -1,7 +1,8 @@
 //! In-process NBD copy-on-write block devices.
 //!
 //! This crate exposes a Linux NBD device backed by a read-only base image and a
-//! sparse copy-on-write (COW) file. [`NbdCowDevice::create`] connects the device,
+//! sparse copy-on-write (COW) file. [`pool::DevicePoolHandle::create_cow_device`]
+//! connects the device,
 //! starts the request dispatch tasks, and serves reads from pending writes, the
 //! COW file, then the base image. Writes are buffered in memory and flushed to
 //! the sparse COW file according to [`DEFAULT_FLUSH_THRESHOLD`].
@@ -17,9 +18,9 @@
 //! - [`protocol`] for NBD transmission protocol parsing and serialization.
 //! - [`error`] for crate error and result types.
 //!
-//! Call [`NbdCowDevice::destroy`] or [`NbdCowDevice::destroy_keep_cow`] when the
-//! device should be shut down cleanly. Dropping a device only performs
-//! best-effort cleanup and may discard buffered writes that were not flushed.
+//! Call pooled-device finalizers when the device should be shut down cleanly.
+//! Dropping a device only performs best-effort cleanup and may discard buffered
+//! writes that were not flushed.
 
 pub mod cow;
 pub mod error;
@@ -30,9 +31,10 @@ pub mod server;
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use error::Result;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -44,6 +46,30 @@ pub const NUM_CONNECTIONS: usize = 4;
 
 /// Default write buffer flush threshold: 4MB.
 pub const DEFAULT_FLUSH_THRESHOLD: usize = 4 * 1024 * 1024;
+
+/// Retry policy for clean COW device finalization.
+#[derive(Clone, Copy, Debug)]
+pub struct DestroyRetryPolicy {
+    /// Number of destroy attempts. Values below 1 are treated as 1 attempt.
+    pub attempts: u32,
+    /// Delay between attempts.
+    pub delay: Duration,
+}
+
+impl DestroyRetryPolicy {
+    fn attempts(self) -> u32 {
+        self.attempts.max(1)
+    }
+}
+
+/// Paths produced by a successful keep-COW finalizer.
+#[derive(Debug)]
+pub struct KeptCow {
+    /// Preserved COW file path.
+    pub cow_file: PathBuf,
+    /// Persisted dirty bitmap sidecar path.
+    pub bitmap_file: PathBuf,
+}
 
 /// Result of checking NBD device ownership via sysfs PID.
 enum DeviceOwnership {
@@ -97,12 +123,12 @@ impl NbdCowDevice {
     /// - **Outer (size-stuck-at-0):** If the kernel hasn't finished tearing down
     ///   a previous connection, disconnect, release with cooldown, and retry
     ///   with fresh sockets. Up to 5 retries with 200ms sleep between attempts.
-    pub async fn create(
+    async fn create_inner(
         base_image: &Path,
         cow_file: &Path,
         size: u64,
-        device_pool: &Mutex<pool::DevicePool>,
-    ) -> Result<Self> {
+        device_pool: &pool::DevicePoolHandle,
+    ) -> Result<(Self, pool::DeviceLease)> {
         // Create COW layer
         let cow_layer = cow::CowLayer::new(
             base_image,
@@ -123,8 +149,9 @@ impl NbdCowDevice {
             // Inner loop: acquire from pool and try to connect.
             // EBUSY retries get a fresh device without consuming the outer budget.
             let mut ebusy_count: u32 = 0;
-            let (device_index, shutdown, server_handles, connect_tid) = loop {
-                let device_index = device_pool.lock().await.acquire().await?;
+            let (lease, shutdown, server_handles, connect_tid) = loop {
+                let lease = device_pool.acquire().await?;
+                let device_index = lease.index();
 
                 // Fresh shutdown token and socketpairs for each attempt
                 let shutdown = CancellationToken::new();
@@ -155,7 +182,7 @@ impl NbdCowDevice {
                     // Release device back — connect was never attempted, device
                     // is still free in kernel. No cooldown needed but release()
                     // adds one defensively.
-                    device_pool.lock().await.release(device_index);
+                    device_pool.release_clean(lease).await;
                     return Err(e);
                 }
 
@@ -164,7 +191,7 @@ impl NbdCowDevice {
                         // Record the TID of the thread that connected — the kernel
                         // stores this in /sys/block/nbdN/pid via task_pid_nr().
                         let tid = unsafe { libc::gettid() } as u32;
-                        break (device_index, shutdown, server_handles, tid);
+                        break (lease, shutdown, server_handles, tid);
                     }
                     Err(error::NbdCowError::NetlinkErrno { errno, .. }) if errno == libc::EBUSY => {
                         ebusy_count += 1;
@@ -178,13 +205,13 @@ impl NbdCowDevice {
                             handle.abort();
                         }
                         if ebusy_count > MAX_EBUSY_RETRIES {
-                            device_pool.lock().await.discard(device_index);
+                            device_pool.discard(lease).await;
                             return Err(error::NbdCowError::NoFreeDevice);
                         }
                         // Device is owned by another process — stop tracking
                         // without cooldown. Background scan will rediscover
                         // if it frees.
-                        device_pool.lock().await.discard(device_index);
+                        device_pool.discard(lease).await;
                         continue;
                     }
                     Err(e) => {
@@ -193,27 +220,31 @@ impl NbdCowDevice {
                             handle.abort();
                         }
                         // Connect failed with non-EBUSY error. Device may be in
-                        // an unknown kernel state — release with cooldown so it
+                        // an unknown kernel state — retire with cooldown so it
                         // gets re-validated before reuse.
-                        device_pool.lock().await.release(device_index);
+                        device_pool.retire_uncertain(lease).await;
                         return Err(e);
                     }
                 }
             };
+            let device_index = lease.index();
 
             // Verify the device got the correct size via sysfs.
             if netlink::verify_device_size(device_index, size).await {
                 let device_path = PathBuf::from(format!("/dev/nbd{device_index}"));
-                return Ok(Self {
-                    device_index,
-                    device_path,
-                    cow_file: cow_file.to_path_buf(),
-                    cow: cow_layer,
-                    server_handles,
-                    shutdown,
-                    disconnected: false,
-                    connect_tid,
-                });
+                return Ok((
+                    Self {
+                        device_index,
+                        device_path,
+                        cow_file: cow_file.to_path_buf(),
+                        cow: cow_layer,
+                        server_handles,
+                        shutdown,
+                        disconnected: false,
+                        connect_tid,
+                    },
+                    lease,
+                ));
             }
 
             // Size is wrong — disconnect, release with cooldown, and retry.
@@ -222,8 +253,11 @@ impl NbdCowDevice {
                 attempt = size_attempt + 1,
                 "device size 0 after connect, disconnecting and retrying"
             );
-            let _ = netlink::disconnect(device_index);
-            device_pool.lock().await.release(device_index);
+            if netlink::disconnect(device_index).is_ok() {
+                device_pool.release_clean(lease).await;
+            } else {
+                device_pool.retire_uncertain(lease).await;
+            }
             shutdown.cancel();
             for handle in server_handles {
                 handle.abort();
@@ -396,6 +430,177 @@ impl NbdCowDevice {
 
     fn bitmap_path(&self) -> PathBuf {
         cow::bitmap_path_for(&self.cow_file)
+    }
+}
+
+impl pool::DevicePoolHandle {
+    /// Create a pooled NBD COW device.
+    pub async fn create_cow_device(
+        &self,
+        base_image: &Path,
+        cow_file: &Path,
+        size: u64,
+    ) -> Result<PooledNbdCowDevice> {
+        let (device, lease) = NbdCowDevice::create_inner(base_image, cow_file, size, self).await?;
+        Ok(PooledNbdCowDevice {
+            device,
+            lease: LeaseGuard::new(lease),
+            pool: self.clone(),
+        })
+    }
+}
+
+/// A COW device whose NBD pool ownership is tied to the device lifecycle.
+pub struct PooledNbdCowDevice {
+    device: NbdCowDevice,
+    lease: LeaseGuard,
+    pool: pool::DevicePoolHandle,
+}
+
+struct LeaseGuard {
+    lease: Option<pool::DeviceLease>,
+}
+
+impl LeaseGuard {
+    fn new(lease: pool::DeviceLease) -> Self {
+        Self { lease: Some(lease) }
+    }
+
+    fn take(&mut self) -> Option<pool::DeviceLease> {
+        self.lease.take()
+    }
+}
+
+impl Drop for LeaseGuard {
+    fn drop(&mut self) {
+        if let Some(lease) = self.lease.as_ref() {
+            tracing::warn!(
+                device_index = lease.index(),
+                "pooled NBD COW device dropped without finalizer; pool lease will require cleanup"
+            );
+        }
+    }
+}
+
+impl PooledNbdCowDevice {
+    /// NBD device index (N in `/dev/nbdN`), for diagnostics only.
+    pub fn device_index(&self) -> u32 {
+        self.device.device_index()
+    }
+
+    /// Path to the block device (e.g., `/dev/nbd0`).
+    pub fn device_path(&self) -> &Path {
+        self.device.device_path()
+    }
+
+    /// Path to the sparse COW file.
+    pub fn cow_file(&self) -> &Path {
+        self.device.cow_file()
+    }
+
+    /// Log COW device status for debugging.
+    pub async fn log_status(&self) {
+        self.device.log_status().await;
+    }
+
+    /// Destroy the device, removing the COW file and bitmap.
+    pub async fn destroy_with_retries(self, policy: DestroyRetryPolicy) -> Result<()> {
+        let Self {
+            mut device,
+            mut lease,
+            pool,
+        } = self;
+        let attempts = policy.attempts();
+
+        match device.destroy().await {
+            Ok(()) => {
+                Self::release_clean(&pool, &mut lease).await;
+                Ok(())
+            }
+            Err(mut last_err) => {
+                for _ in 1..attempts {
+                    tokio::time::sleep(policy.delay).await;
+                    match device.destroy().await {
+                        Ok(()) => {
+                            Self::release_clean(&pool, &mut lease).await;
+                            return Ok(());
+                        }
+                        Err(e) => last_err = e,
+                    }
+                }
+
+                device.abandon();
+                Self::retire_uncertain(&pool, &mut lease).await;
+                Err(last_err)
+            }
+        }
+    }
+
+    /// Destroy the device while preserving COW data for snapshot persistence.
+    pub async fn destroy_keep_cow_with_retries(
+        self,
+        policy: DestroyRetryPolicy,
+    ) -> Result<KeptCow> {
+        let Self {
+            mut device,
+            mut lease,
+            pool,
+        } = self;
+        let cow_file = device.cow_file().to_path_buf();
+        let bitmap_file = device.bitmap_path();
+        let attempts = policy.attempts();
+
+        match device.destroy_keep_cow().await {
+            Ok(()) => {
+                Self::release_clean(&pool, &mut lease).await;
+                Ok(KeptCow {
+                    cow_file,
+                    bitmap_file,
+                })
+            }
+            Err(mut last_err) => {
+                for _ in 1..attempts {
+                    tokio::time::sleep(policy.delay).await;
+                    match device.destroy_keep_cow().await {
+                        Ok(()) => {
+                            Self::release_clean(&pool, &mut lease).await;
+                            return Ok(KeptCow {
+                                cow_file,
+                                bitmap_file,
+                            });
+                        }
+                        Err(e) => last_err = e,
+                    }
+                }
+
+                device.abandon();
+                Self::retire_uncertain(&pool, &mut lease).await;
+                Err(last_err)
+            }
+        }
+    }
+
+    /// Mark the device as abandoned and retire the pool lease as uncertain.
+    pub async fn abandon(self) {
+        let Self {
+            mut device,
+            mut lease,
+            pool,
+        } = self;
+        device.abandon();
+        Self::retire_uncertain(&pool, &mut lease).await;
+    }
+
+    async fn release_clean(pool: &pool::DevicePoolHandle, lease: &mut LeaseGuard) {
+        if let Some(lease) = lease.take() {
+            pool.release_clean(lease).await;
+        }
+    }
+
+    async fn retire_uncertain(pool: &pool::DevicePoolHandle, lease: &mut LeaseGuard) {
+        if let Some(lease) = lease.take() {
+            pool.retire_uncertain(lease).await;
+        }
     }
 }
 

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -748,6 +748,7 @@ impl PooledNbdCowDevice {
     ///
     /// Finalization starts immediately. Dropping the returned future does not
     /// cancel cleanup; it continues in the background and logs its result.
+    /// Must be called from a Tokio runtime.
     pub fn destroy_with_retries(
         self,
         policy: DestroyRetryPolicy,
@@ -797,6 +798,7 @@ impl PooledNbdCowDevice {
     ///
     /// Finalization starts immediately. Dropping the returned future does not
     /// cancel cleanup; it continues in the background and logs its result.
+    /// Must be called from a Tokio runtime.
     pub fn destroy_keep_cow_with_retries(
         self,
         policy: DestroyRetryPolicy,
@@ -850,6 +852,8 @@ impl PooledNbdCowDevice {
     }
 
     /// Mark the device as abandoned and retire the pool lease as uncertain.
+    ///
+    /// Must be called from a Tokio runtime.
     pub fn abandon(self) -> impl std::future::Future<Output = ()> + Send + 'static {
         let finalizer = Self::run_finalizer(async move {
             self.abandon_inner().await;

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -1,12 +1,13 @@
 //! Device pool for pre-validated NBD device indices.
 //!
-//! Instead of scanning sysfs on every `NbdCowDevice::create()`, this pool
+//! Instead of scanning sysfs on every pooled COW device creation, this pool
 //! maintains a queue of pre-validated device indices ready for immediate use.
 //! Released devices enter a cooldown period before becoming available again,
 //! preventing the "size stuck at 0" flake caused by reusing a device before
 //! the kernel finishes cleanup.
 
 use std::collections::{HashSet, VecDeque};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::error::{NbdCowError, Result};
@@ -27,6 +28,25 @@ struct CooldownSlot {
     released_at: Instant,
 }
 
+/// Owned authority for a checked-out NBD device index.
+///
+/// This intentionally does not implement `Clone` or `Copy`: returning an index
+/// to the pool must consume the lease, not copied diagnostic metadata.
+pub struct DeviceLease {
+    index: u32,
+}
+
+impl DeviceLease {
+    fn new(index: u32) -> Self {
+        Self { index }
+    }
+
+    /// NBD device index (N in `/dev/nbdN`).
+    pub fn index(&self) -> u32 {
+        self.index
+    }
+}
+
 /// Configuration for the device pool.
 pub struct DevicePoolConfig {
     /// Cooldown period before a released device can be reused.
@@ -41,10 +61,59 @@ impl Default for DevicePoolConfig {
     }
 }
 
+/// Cloneable handle to the shared NBD device pool.
+#[derive(Clone)]
+pub struct DevicePoolHandle {
+    inner: Arc<tokio::sync::Mutex<DevicePool>>,
+}
+
+impl DevicePoolHandle {
+    /// Create a new shared device pool handle.
+    pub fn new(config: DevicePoolConfig) -> Self {
+        Self {
+            inner: Arc::new(tokio::sync::Mutex::new(DevicePool::new(config))),
+        }
+    }
+
+    /// Wrap an existing pool.
+    pub fn from_pool(pool: DevicePool) -> Self {
+        Self {
+            inner: Arc::new(tokio::sync::Mutex::new(pool)),
+        }
+    }
+
+    /// Pre-warm the underlying pool.
+    pub async fn warmup(&self) {
+        self.inner.lock().await.warmup().await;
+    }
+
+    /// Clean up the underlying pool.
+    pub async fn cleanup(&self) {
+        self.inner.lock().await.cleanup().await;
+    }
+
+    pub(crate) async fn acquire(&self) -> Result<DeviceLease> {
+        self.inner.lock().await.acquire().await
+    }
+
+    pub(crate) async fn release_clean(&self, lease: DeviceLease) {
+        self.inner.lock().await.release(lease);
+    }
+
+    pub(crate) async fn discard(&self, lease: DeviceLease) {
+        self.inner.lock().await.discard(lease);
+    }
+
+    pub(crate) async fn retire_uncertain(&self, lease: DeviceLease) {
+        self.inner.lock().await.retire_uncertain(lease);
+    }
+}
+
 /// Pre-validated NBD device index pool.
 ///
-/// Manages device indices as a host-level resource shared across factories
-/// via `Arc<Mutex<DevicePool>>`, following the same pattern as `NetnsPool`.
+/// Manages device indices as a host-level resource. Production callers should
+/// share it through [`DevicePoolHandle`] so pool release authority stays tied to
+/// owned device leases.
 pub struct DevicePool {
     active: bool,
     /// Validated free device indices ready for immediate acquire.
@@ -115,7 +184,7 @@ impl DevicePool {
     /// 1. Pop from ready queue (instant)
     /// 2. Await a pending background validation
     /// 3. Synchronous on-demand scan (fallback)
-    pub async fn acquire(&mut self) -> Result<u32> {
+    pub(crate) async fn acquire(&mut self) -> Result<DeviceLease> {
         if !self.active {
             return Err(NbdCowError::NoFreeDevice);
         }
@@ -129,7 +198,7 @@ impl DevicePool {
         if let Some(index) = self.ready.pop_front() {
             self.in_flight.insert(index);
             self.maybe_replenish();
-            return Ok(index);
+            return Ok(DeviceLease::new(index));
         }
 
         // Tier 2: await pending background validation
@@ -138,7 +207,7 @@ impl DevicePool {
                 Ok(Ok(index)) => {
                     self.in_flight.insert(index);
                     self.maybe_replenish();
-                    return Ok(index);
+                    return Ok(DeviceLease::new(index));
                 }
                 Ok(Err(_)) | Err(_) => continue,
             }
@@ -155,14 +224,15 @@ impl DevicePool {
 
         self.in_flight.insert(index);
         self.maybe_replenish();
-        Ok(index)
+        Ok(DeviceLease::new(index))
     }
 
     /// Release a device index back to the pool after disconnect.
     ///
     /// The device enters a cooldown period before it can be reused,
     /// giving the kernel time to finish teardown.
-    pub fn release(&mut self, index: u32) {
+    pub(crate) fn release(&mut self, lease: DeviceLease) {
+        let index = lease.index;
         if !self.active {
             return;
         }
@@ -185,13 +255,28 @@ impl DevicePool {
     /// Used when `connect_device` fails with EBUSY — the device belongs to
     /// another process and should not enter cooldown. Background scans will
     /// rediscover it later if it becomes free.
-    pub fn discard(&mut self, index: u32) {
+    pub(crate) fn discard(&mut self, lease: DeviceLease) {
+        let index = lease.index;
         self.in_flight.remove(&index);
+    }
+
+    /// Retire a device whose post-owner state is uncertain.
+    ///
+    /// This is intentionally conservative: the index must still pass through
+    /// cooldown and sysfs validation before it can become ready again.
+    pub(crate) fn retire_uncertain(&mut self, lease: DeviceLease) {
+        self.release(lease);
     }
 
     /// Clean up the pool: cancel pending tasks and clear queues.
     pub async fn cleanup(&mut self) {
         self.active = false;
+        if !self.in_flight.is_empty() {
+            tracing::warn!(
+                in_flight = self.in_flight.len(),
+                "device pool cleanup with outstanding leases"
+            );
+        }
         self.pending.abort_all();
         while self.pending.join_next().await.is_some() {}
         self.ready.clear();
@@ -322,14 +407,34 @@ mod tests {
     }
 
     #[test]
-    fn release_ignores_duplicate_index() {
+    fn release_consumes_lease_and_enters_cooldown() {
         let mut pool = test_pool_with_in_flight(3);
 
-        pool.release(3);
-        pool.release(3);
+        pool.release(DeviceLease::new(3));
 
         assert_eq!(pool.cooldown.len(), 1);
         assert_eq!(pool.cooldown.front().map(|slot| slot.index), Some(3));
+        assert!(pool.in_flight.is_empty());
+    }
+
+    #[test]
+    fn retire_uncertain_enters_cooldown() {
+        let mut pool = test_pool_with_in_flight(3);
+
+        pool.retire_uncertain(DeviceLease::new(3));
+
+        assert_eq!(pool.cooldown.len(), 1);
+        assert_eq!(pool.cooldown.front().map(|slot| slot.index), Some(3));
+        assert!(pool.in_flight.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cleanup_with_outstanding_lease_does_not_panic() {
+        let mut pool = test_pool_with_in_flight(3);
+
+        pool.cleanup().await;
+
+        assert!(!pool.active);
         assert!(pool.in_flight.is_empty());
     }
 }

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -34,11 +34,22 @@ struct CooldownSlot {
 /// to the pool must consume the lease, not copied diagnostic metadata.
 pub struct DeviceLease {
     index: u32,
+    return_to: Option<mpsc::UnboundedSender<DevicePoolCommand>>,
 }
 
 impl DeviceLease {
     fn new(index: u32) -> Self {
-        Self { index }
+        Self {
+            index,
+            return_to: None,
+        }
+    }
+
+    fn with_return(index: u32, return_to: mpsc::UnboundedSender<DevicePoolCommand>) -> Self {
+        Self {
+            index,
+            return_to: Some(return_to),
+        }
     }
 
     #[cfg(test)]
@@ -49,6 +60,32 @@ impl DeviceLease {
     /// NBD device index (N in `/dev/nbdN`).
     pub fn index(&self) -> u32 {
         self.index
+    }
+
+    fn into_index(mut self) -> u32 {
+        self.return_to.take();
+        self.index
+    }
+}
+
+impl Drop for DeviceLease {
+    fn drop(&mut self) {
+        let Some(return_to) = self.return_to.take() else {
+            return;
+        };
+        let (done, _done_rx) = oneshot::channel();
+        if return_to
+            .send(DevicePoolCommand::RetireUncertain {
+                index: self.index,
+                done,
+            })
+            .is_err()
+        {
+            tracing::warn!(
+                device_index = self.index,
+                "device pool actor stopped before dropped lease could be retired"
+            );
+        }
     }
 }
 
@@ -80,15 +117,15 @@ enum DevicePoolCommand {
         respond_to: oneshot::Sender<Result<DeviceLease>>,
     },
     ReleaseClean {
-        lease: DeviceLease,
+        index: u32,
         done: oneshot::Sender<()>,
     },
     Discard {
-        lease: DeviceLease,
+        index: u32,
         done: oneshot::Sender<()>,
     },
     RetireUncertain {
-        lease: DeviceLease,
+        index: u32,
         done: oneshot::Sender<()>,
     },
     Cleanup {
@@ -134,8 +171,9 @@ impl DevicePoolHandle {
         Self::from_pool(DevicePool::new(config))
     }
 
-    fn from_pool(pool: DevicePool) -> Self {
+    fn from_pool(mut pool: DevicePool) -> Self {
         let (commands, command_rx) = mpsc::unbounded_channel();
+        pool.set_lease_return(commands.clone());
         tokio::spawn(
             DevicePoolActor {
                 pool,
@@ -183,10 +221,11 @@ impl DevicePoolHandle {
     }
 
     pub(crate) async fn release_clean(&self, lease: DeviceLease) {
+        let index = lease.into_index();
         let (done, done_rx) = oneshot::channel();
         if self
             .commands
-            .send(DevicePoolCommand::ReleaseClean { lease, done })
+            .send(DevicePoolCommand::ReleaseClean { index, done })
             .is_err()
         {
             tracing::warn!("device pool actor stopped before clean release");
@@ -196,10 +235,11 @@ impl DevicePoolHandle {
     }
 
     pub(crate) async fn discard(&self, lease: DeviceLease) {
+        let index = lease.into_index();
         let (done, done_rx) = oneshot::channel();
         if self
             .commands
-            .send(DevicePoolCommand::Discard { lease, done })
+            .send(DevicePoolCommand::Discard { index, done })
             .is_err()
         {
             tracing::warn!("device pool actor stopped before discard");
@@ -209,10 +249,11 @@ impl DevicePoolHandle {
     }
 
     pub(crate) async fn retire_uncertain(&self, lease: DeviceLease) {
+        let index = lease.into_index();
         let (done, done_rx) = oneshot::channel();
         if self
             .commands
-            .send(DevicePoolCommand::RetireUncertain { lease, done })
+            .send(DevicePoolCommand::RetireUncertain { index, done })
             .is_err()
         {
             tracing::warn!("device pool actor stopped before uncertain retire");
@@ -222,10 +263,11 @@ impl DevicePoolHandle {
     }
 
     pub(crate) fn retire_uncertain_detached(&self, lease: DeviceLease) {
+        let index = lease.into_index();
         let (done, _done_rx) = oneshot::channel();
         if self
             .commands
-            .send(DevicePoolCommand::RetireUncertain { lease, done })
+            .send(DevicePoolCommand::RetireUncertain { index, done })
             .is_err()
         {
             tracing::warn!("device pool actor stopped before detached uncertain retire");
@@ -279,21 +321,21 @@ impl DevicePoolActor {
             DevicePoolCommand::Acquire { respond_to } => {
                 self.pool.handle_acquire(respond_to);
             }
-            DevicePoolCommand::ReleaseClean { lease, done } => {
-                self.pool.release(lease);
+            DevicePoolCommand::ReleaseClean { index, done } => {
+                self.pool.release_index(index);
                 self.pool.ensure_waiting_progress();
                 if self.pool.waiting_acquires.is_empty() {
                     self.pool.maybe_replenish();
                 }
                 let _ = done.send(());
             }
-            DevicePoolCommand::Discard { lease, done } => {
-                self.pool.discard(lease);
+            DevicePoolCommand::Discard { index, done } => {
+                self.pool.discard_index(index);
                 self.pool.ensure_waiting_progress();
                 let _ = done.send(());
             }
-            DevicePoolCommand::RetireUncertain { lease, done } => {
-                self.pool.retire_uncertain(lease);
+            DevicePoolCommand::RetireUncertain { index, done } => {
+                self.pool.retire_uncertain_index(index);
                 self.pool.ensure_waiting_progress();
                 if self.pool.waiting_acquires.is_empty() {
                     self.pool.maybe_replenish();
@@ -325,6 +367,8 @@ pub struct DevicePool {
     cooldown: VecDeque<CooldownSlot>,
     /// Background sysfs validation tasks.
     pending: tokio::task::JoinSet<ValidationResult>,
+    /// Sender embedded in assigned leases so dropping a lease still returns it.
+    lease_return: Option<mpsc::UnboundedSender<DevicePoolCommand>>,
     /// Acquire errors that raced with still-pending validation tasks.
     deferred_acquire_errors: VecDeque<NbdCowError>,
     /// Acquire requests waiting for validation or a released device.
@@ -351,11 +395,23 @@ impl DevicePool {
             ready: VecDeque::with_capacity(BUFFER_SIZE),
             cooldown: VecDeque::new(),
             pending: tokio::task::JoinSet::new(),
+            lease_return: None,
             deferred_acquire_errors: VecDeque::new(),
             waiting_acquires: VecDeque::new(),
             max_devices,
             config,
             in_flight: HashSet::new(),
+        }
+    }
+
+    fn set_lease_return(&mut self, return_to: mpsc::UnboundedSender<DevicePoolCommand>) {
+        self.lease_return = Some(return_to);
+    }
+
+    fn lease_for(&self, index: u32) -> DeviceLease {
+        match &self.lease_return {
+            Some(return_to) => DeviceLease::with_return(index, return_to.clone()),
+            None => DeviceLease::new(index),
         }
     }
 
@@ -389,11 +445,17 @@ impl DevicePool {
 
         self.promote_cooled_down();
         if let Some(index) = self.ready.pop_front() {
-            if respond_to.send(Ok(DeviceLease::new(index))).is_ok() {
-                self.in_flight.insert(index);
-                self.maybe_replenish();
-            } else {
-                self.ready.push_front(index);
+            match respond_to.send(Ok(self.lease_for(index))) {
+                Ok(()) => {
+                    self.in_flight.insert(index);
+                    self.maybe_replenish();
+                }
+                Err(Ok(lease)) => {
+                    self.ready.push_front(lease.into_index());
+                }
+                Err(Err(_)) => {
+                    self.ready.push_front(index);
+                }
             }
             return;
         }
@@ -484,11 +546,17 @@ impl DevicePool {
                 break;
             };
 
-            if respond_to.send(Ok(DeviceLease::new(index))).is_ok() {
-                self.in_flight.insert(index);
-                assigned = true;
-            } else {
-                self.ready.push_front(index);
+            match respond_to.send(Ok(self.lease_for(index))) {
+                Ok(()) => {
+                    self.in_flight.insert(index);
+                    assigned = true;
+                }
+                Err(Ok(lease)) => {
+                    self.ready.push_front(lease.into_index());
+                }
+                Err(Err(_)) => {
+                    self.ready.push_front(index);
+                }
             }
         }
         assigned
@@ -499,10 +567,17 @@ impl DevicePool {
             return false;
         }
 
+        let mut index = index;
         while let Some(respond_to) = self.waiting_acquires.pop_front() {
-            if respond_to.send(Ok(DeviceLease::new(index))).is_ok() {
-                self.in_flight.insert(index);
-                return true;
+            match respond_to.send(Ok(self.lease_for(index))) {
+                Ok(()) => {
+                    self.in_flight.insert(index);
+                    return true;
+                }
+                Err(Ok(lease)) => {
+                    index = lease.into_index();
+                }
+                Err(Err(_)) => {}
             }
         }
 
@@ -516,7 +591,7 @@ impl DevicePool {
                 Ok(()) => return true,
                 Err(Err(e)) => error = e,
                 Err(Ok(lease)) => {
-                    self.ready.push_front(lease.index);
+                    self.ready.push_front(lease.into_index());
                     return false;
                 }
             }
@@ -553,8 +628,12 @@ impl DevicePool {
     ///
     /// The device enters a cooldown period before it can be reused,
     /// giving the kernel time to finish teardown.
-    pub(crate) fn release(&mut self, lease: DeviceLease) {
-        let index = lease.index;
+    #[cfg(test)]
+    fn release(&mut self, lease: DeviceLease) {
+        self.release_index(lease.into_index());
+    }
+
+    fn release_index(&mut self, index: u32) {
         if !self.active {
             return;
         }
@@ -576,8 +655,7 @@ impl DevicePool {
     /// Used when `connect_device` fails with EBUSY — the device belongs to
     /// another process and should not enter cooldown. Background scans will
     /// rediscover it later if it becomes free.
-    pub(crate) fn discard(&mut self, lease: DeviceLease) {
-        let index = lease.index;
+    fn discard_index(&mut self, index: u32) {
         self.in_flight.remove(&index);
     }
 
@@ -585,8 +663,13 @@ impl DevicePool {
     ///
     /// This is intentionally conservative: the index must still pass through
     /// cooldown and sysfs validation before it can become ready again.
-    pub(crate) fn retire_uncertain(&mut self, lease: DeviceLease) {
-        self.release(lease);
+    #[cfg(test)]
+    fn retire_uncertain(&mut self, lease: DeviceLease) {
+        self.retire_uncertain_index(lease.into_index());
+    }
+
+    fn retire_uncertain_index(&mut self, index: u32) {
+        self.release_index(index);
     }
 
     /// Clean up the pool: cancel pending tasks and clear queues.
@@ -778,6 +861,7 @@ mod tests {
             ready: VecDeque::from([0, 1, 2, 4]),
             cooldown: VecDeque::new(),
             pending: tokio::task::JoinSet::new(),
+            lease_return: None,
             deferred_acquire_errors: VecDeque::new(),
             waiting_acquires: VecDeque::new(),
             max_devices: 8,
@@ -792,6 +876,7 @@ mod tests {
             ready: VecDeque::new(),
             cooldown: VecDeque::new(),
             pending: tokio::task::JoinSet::new(),
+            lease_return: None,
             deferred_acquire_errors: VecDeque::new(),
             waiting_acquires: VecDeque::new(),
             max_devices: 0,
@@ -928,6 +1013,30 @@ mod tests {
         })
         .await
         .expect("detached retire did not reach actor");
+        handle.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn dropped_assigned_lease_retires_to_cooldown() {
+        let mut pool = test_pool_for_pending_scan();
+        pool.ready.push_back(3);
+        let handle = DevicePoolHandle::from_pool(pool);
+
+        let lease = handle.acquire().await.expect("acquire lease");
+        assert_eq!(lease.index(), 3);
+        drop(lease);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let snapshot = handle.snapshot().await;
+                if snapshot.cooldown == vec![3] && !snapshot.in_flight.contains(&3) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropped lease did not return to cooldown");
         handle.cleanup().await;
     }
 

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -41,6 +41,11 @@ impl DeviceLease {
         Self { index }
     }
 
+    #[cfg(test)]
+    pub(crate) fn new_for_test(index: u32) -> Self {
+        Self::new(index)
+    }
+
     /// NBD device index (N in `/dev/nbdN`).
     pub fn index(&self) -> u32 {
         self.index

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -309,6 +309,8 @@ pub struct DevicePool {
     cooldown: VecDeque<CooldownSlot>,
     /// Background sysfs validation tasks.
     pending: tokio::task::JoinSet<ValidationResult>,
+    /// Acquire errors that raced with still-pending validation tasks.
+    deferred_acquire_errors: VecDeque<NbdCowError>,
     /// Acquire requests waiting for validation or a released device.
     waiting_acquires: VecDeque<oneshot::Sender<Result<DeviceLease>>>,
     /// Total number of NBD devices (from sysfs nbds_max).
@@ -333,6 +335,7 @@ impl DevicePool {
             ready: VecDeque::with_capacity(BUFFER_SIZE),
             cooldown: VecDeque::new(),
             pending: tokio::task::JoinSet::new(),
+            deferred_acquire_errors: VecDeque::new(),
             waiting_acquires: VecDeque::new(),
             max_devices,
             config,
@@ -391,9 +394,20 @@ impl DevicePool {
 
         self.promote_cooled_down();
         let assigned = self.satisfy_waiters_from_ready();
-        if !self.waiting_acquires.is_empty() {
+        if self.waiting_acquires.is_empty() {
+            self.deferred_acquire_errors.clear();
+            if assigned {
+                self.maybe_replenish();
+            }
+            return;
+        }
+
+        if self.pending.is_empty() {
+            self.fail_deferred_acquire_errors();
+        }
+        if !self.waiting_acquires.is_empty() && self.deferred_acquire_errors.is_empty() {
             self.spawn_demand_batch();
-        } else if assigned {
+        } else if self.waiting_acquires.is_empty() && assigned {
             self.maybe_replenish();
         }
     }
@@ -426,7 +440,7 @@ impl DevicePool {
                 purpose: ValidationPurpose::Demand,
                 result: Err(e),
             }) => {
-                self.fail_one_waiter(e);
+                self.defer_acquire_error(e);
                 self.ensure_waiting_progress();
             }
             Ok(ValidationResult {
@@ -437,7 +451,7 @@ impl DevicePool {
             }
             Err(e) => {
                 if !self.waiting_acquires.is_empty() {
-                    self.fail_one_waiter(NbdCowError::Io(std::io::Error::other(format!(
+                    self.defer_acquire_error(NbdCowError::Io(std::io::Error::other(format!(
                         "device validation task failed: {e}"
                     ))));
                 }
@@ -492,6 +506,25 @@ impl DevicePool {
             }
         }
         false
+    }
+
+    fn defer_acquire_error(&mut self, error: NbdCowError) {
+        if self.waiting_acquires.is_empty() {
+            return;
+        }
+        self.deferred_acquire_errors.push_back(error);
+    }
+
+    fn fail_deferred_acquire_errors(&mut self) {
+        while !self.waiting_acquires.is_empty() {
+            let Some(error) = self.deferred_acquire_errors.pop_front() else {
+                break;
+            };
+            self.fail_one_waiter(error);
+        }
+        if self.waiting_acquires.is_empty() {
+            self.deferred_acquire_errors.clear();
+        }
     }
 
     fn fail_all_waiters(&mut self) {
@@ -550,6 +583,7 @@ impl DevicePool {
             );
         }
         self.fail_all_waiters();
+        self.deferred_acquire_errors.clear();
         self.abort_pending().await;
         self.ready.clear();
         self.cooldown.clear();
@@ -734,6 +768,7 @@ mod tests {
             ready: VecDeque::from([0, 1, 2, 4]),
             cooldown: VecDeque::new(),
             pending: tokio::task::JoinSet::new(),
+            deferred_acquire_errors: VecDeque::new(),
             waiting_acquires: VecDeque::new(),
             max_devices: 8,
             config: DevicePoolConfig::default(),
@@ -747,6 +782,7 @@ mod tests {
             ready: VecDeque::new(),
             cooldown: VecDeque::new(),
             pending: tokio::task::JoinSet::new(),
+            deferred_acquire_errors: VecDeque::new(),
             waiting_acquires: VecDeque::new(),
             max_devices: 0,
             config: DevicePoolConfig::default(),
@@ -850,6 +886,37 @@ mod tests {
         assert_eq!(pool.waiting_acquires.len(), 1);
         assert_eq!(pool.pending.len(), 1);
         pool.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn demand_error_waits_for_pending_success_before_failing_waiter() {
+        let mut pool = test_pool_for_pending_scan();
+        let complete_validation = queue_controlled_validation(&mut pool);
+        let (first_tx, mut first_rx) = oneshot::channel();
+        let (second_tx, second_rx) = oneshot::channel();
+        pool.waiting_acquires.push_back(first_tx);
+        pool.waiting_acquires.push_back(second_tx);
+
+        pool.handle_validation_join(Ok(ValidationResult {
+            purpose: ValidationPurpose::Demand,
+            result: Err(NbdCowError::NoFreeDevice),
+        }));
+
+        assert!(matches!(
+            first_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+
+        complete_validation.send(Ok(4)).unwrap();
+        let validation = pool.pending.join_next().await.unwrap();
+        pool.handle_validation_join(validation);
+
+        let first_lease = first_rx.await.unwrap().unwrap();
+        assert_eq!(first_lease.index(), 4);
+        assert!(matches!(
+            second_rx.await.unwrap(),
+            Err(NbdCowError::NoFreeDevice)
+        ));
     }
 
     #[tokio::test]

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -309,6 +309,7 @@ impl DevicePoolActor {
             }
         }
 
+        self.pool.active = false;
         self.pool.abort_pending().await;
     }
 

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -837,6 +837,20 @@ mod tests {
         assert!(matches!(result, Err(NbdCowError::NoFreeDevice)));
     }
 
+    #[test]
+    fn cancelled_ready_acquire_returns_index_to_ready() {
+        let mut pool = test_pool_for_pending_scan();
+        pool.ready.push_back(3);
+        let (respond_to, response) = oneshot::channel();
+        drop(response);
+
+        pool.handle_acquire(respond_to);
+
+        assert_eq!(pool.ready.iter().copied().collect::<Vec<_>>(), vec![3]);
+        assert!(pool.in_flight.is_empty());
+        assert!(pool.waiting_acquires.is_empty());
+    }
+
     #[tokio::test]
     async fn warmup_after_cleanup_does_not_restart_pool() {
         let mut pool = test_pool_for_pending_scan();
@@ -967,6 +981,47 @@ mod tests {
         assert_eq!(pool.waiting_acquires.len(), 1);
         assert_eq!(pool.pending.len(), 1);
         pool.cleanup().await;
+    }
+
+    #[test]
+    fn ready_assignment_skips_cancelled_waiter() {
+        let mut pool = test_pool_for_pending_scan();
+        pool.ready.push_back(4);
+        let (cancelled_tx, cancelled_rx) = oneshot::channel();
+        let (active_tx, mut active_rx) = oneshot::channel();
+        drop(cancelled_rx);
+        pool.waiting_acquires.push_back(cancelled_tx);
+        pool.waiting_acquires.push_back(active_tx);
+
+        assert!(pool.satisfy_waiters_from_ready());
+
+        let lease = active_rx.try_recv().unwrap().unwrap();
+        assert_eq!(lease.index(), 4);
+        assert!(pool.waiting_acquires.is_empty());
+        assert!(pool.ready.is_empty());
+        assert!(pool.in_flight.contains(&4));
+    }
+
+    #[test]
+    fn validation_success_skips_cancelled_waiter() {
+        let mut pool = test_pool_for_pending_scan();
+        pool.ready.extend([0, 1, 2, 3]);
+        let (cancelled_tx, cancelled_rx) = oneshot::channel();
+        let (active_tx, mut active_rx) = oneshot::channel();
+        drop(cancelled_rx);
+        pool.waiting_acquires.push_back(cancelled_tx);
+        pool.waiting_acquires.push_back(active_tx);
+
+        pool.handle_validation_join(Ok(ValidationResult {
+            purpose: ValidationPurpose::Demand,
+            result: Ok(4),
+        }));
+
+        let lease = active_rx.try_recv().unwrap().unwrap();
+        assert_eq!(lease.index(), 4);
+        assert!(pool.waiting_acquires.is_empty());
+        assert!(pool.in_flight.contains(&4));
+        assert!(pool.pending.is_empty());
     }
 
     #[tokio::test]

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -472,23 +472,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn acquire_skips_duplicate_pending_validation_result() {
+    async fn acquire_rejects_duplicate_pending_validation_result() {
         let mut pool = test_pool_for_pending_scan();
         pool.in_flight.insert(3);
         pool.pending.spawn(async { Ok(3) });
-        pool.pending.spawn(async {
-            tokio::time::sleep(Duration::from_millis(10)).await;
-            Ok(5)
-        });
 
-        let lease = pool.acquire().await.expect("acquire non-duplicate index");
+        let result = pool.acquire().await;
 
-        assert_eq!(lease.index(), 5);
+        assert!(matches!(result, Err(NbdCowError::NoFreeDevice)));
         assert!(pool.in_flight.contains(&3));
-        assert!(pool.in_flight.contains(&5));
-
-        pool.release(lease);
-        pool.cleanup().await;
+        assert!(pool.ready.is_empty());
     }
 
     #[tokio::test]

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -136,8 +136,7 @@ impl DevicePool {
     ///
     /// Reads `nbds_max` from sysfs to determine the device range.
     /// Call [`warmup()`](Self::warmup) before first use to pre-populate
-    /// the ready queue and avoid a synchronous sysfs scan on the first
-    /// [`acquire()`](Self::acquire).
+    /// the ready queue and avoid a synchronous sysfs scan on first use.
     pub fn new(config: DevicePoolConfig) -> Self {
         let max_devices = netlink::nbds_max();
         Self {
@@ -469,6 +468,16 @@ mod tests {
 
         assert!(!pool.active);
         assert!(pool.in_flight.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cleanup_rejects_acquire() {
+        let mut pool = test_pool_for_pending_scan();
+
+        pool.cleanup().await;
+
+        let result = pool.acquire().await;
+        assert!(matches!(result, Err(NbdCowError::NoFreeDevice)));
     }
 
     #[tokio::test]

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -7,12 +7,11 @@
 //! the kernel finishes cleanup.
 
 use std::collections::{HashSet, VecDeque};
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::error::{NbdCowError, Result};
 use crate::netlink;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, oneshot};
 
 /// Number of pre-validated device indices to maintain in the ready queue.
 const BUFFER_SIZE: usize = 4;
@@ -65,83 +64,237 @@ impl Default for DevicePoolConfig {
 /// Cloneable handle to the shared NBD device pool.
 #[derive(Clone)]
 pub struct DevicePoolHandle {
-    inner: Arc<tokio::sync::Mutex<DevicePool>>,
+    commands: mpsc::UnboundedSender<DevicePoolCommand>,
 }
 
-enum AcquireStep {
-    Ready(DeviceLease),
-    WaitForPending(watch::Receiver<u64>),
-    Scan { max: u32, exclude: Vec<u32> },
+enum DevicePoolCommand {
+    Warmup {
+        done: oneshot::Sender<()>,
+    },
+    Acquire {
+        respond_to: oneshot::Sender<Result<DeviceLease>>,
+    },
+    ReleaseClean {
+        lease: DeviceLease,
+        done: oneshot::Sender<()>,
+    },
+    Discard {
+        lease: DeviceLease,
+        done: oneshot::Sender<()>,
+    },
+    RetireUncertain {
+        lease: DeviceLease,
+        done: oneshot::Sender<()>,
+    },
+    Cleanup {
+        done: oneshot::Sender<()>,
+    },
+    #[cfg(test)]
+    Snapshot {
+        respond_to: oneshot::Sender<DevicePoolSnapshot>,
+    },
+}
+
+struct DevicePoolActor {
+    pool: DevicePool,
+    commands: mpsc::UnboundedReceiver<DevicePoolCommand>,
+}
+
+#[derive(Clone, Copy)]
+enum ValidationPurpose {
+    Background,
+    Demand,
+}
+
+struct ValidationResult {
+    purpose: ValidationPurpose,
+    result: Result<u32>,
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct DevicePoolSnapshot {
+    cooldown: Vec<u32>,
+    waiting_acquires: usize,
 }
 
 impl DevicePoolHandle {
     /// Create a new shared device pool handle.
+    ///
+    /// Must be called from a Tokio runtime: the handle owns a background actor
+    /// task that serializes all pool state transitions.
     pub fn new(config: DevicePoolConfig) -> Self {
-        Self {
-            inner: Arc::new(tokio::sync::Mutex::new(DevicePool::new(config))),
-        }
+        Self::from_pool(DevicePool::new(config))
     }
 
     /// Wrap an existing pool.
+    ///
+    /// Must be called from a Tokio runtime. Intended for tests and for sharing
+    /// a pre-built pool state through the actor-backed handle.
     pub fn from_pool(pool: DevicePool) -> Self {
-        Self {
-            inner: Arc::new(tokio::sync::Mutex::new(pool)),
-        }
+        let (commands, command_rx) = mpsc::unbounded_channel();
+        tokio::spawn(
+            DevicePoolActor {
+                pool,
+                commands: command_rx,
+            }
+            .run(),
+        );
+        Self { commands }
     }
 
     /// Pre-warm the underlying pool.
     pub async fn warmup(&self) {
-        self.inner.lock().await.warmup().await;
+        let (done, done_rx) = oneshot::channel();
+        if self
+            .commands
+            .send(DevicePoolCommand::Warmup { done })
+            .is_ok()
+        {
+            let _ = done_rx.await;
+        }
     }
 
     /// Clean up the underlying pool.
     pub async fn cleanup(&self) {
-        self.inner.lock().await.cleanup().await;
+        let (done, done_rx) = oneshot::channel();
+        if self
+            .commands
+            .send(DevicePoolCommand::Cleanup { done })
+            .is_ok()
+        {
+            let _ = done_rx.await;
+        }
     }
 
     pub(crate) async fn acquire(&self) -> Result<DeviceLease> {
-        loop {
-            let step = {
-                let mut pool = self.inner.lock().await;
-                pool.acquire_step()?
-            };
+        let (respond_to, response) = oneshot::channel();
+        if self
+            .commands
+            .send(DevicePoolCommand::Acquire { respond_to })
+            .is_err()
+        {
+            return Err(actor_stopped_error());
+        }
+        response.await.map_err(|_| actor_stopped_error())?
+    }
 
-            match step {
-                AcquireStep::Ready(lease) => return Ok(lease),
-                AcquireStep::WaitForPending(mut pending_rx) => {
-                    let _ = pending_rx.changed().await;
-                }
-                AcquireStep::Scan { max, exclude } => {
-                    let index =
-                        tokio::task::spawn_blocking(move || scan_free_device(max, &exclude))
-                            .await
-                            .map_err(|e| {
-                                NbdCowError::Io(std::io::Error::other(format!(
-                                    "scan task panicked: {e}"
-                                )))
-                            })??;
-                    if let Some(lease) = self.finish_acquire_candidate(index).await? {
-                        return Ok(lease);
+    pub(crate) async fn release_clean(&self, lease: DeviceLease) {
+        let (done, done_rx) = oneshot::channel();
+        if self
+            .commands
+            .send(DevicePoolCommand::ReleaseClean { lease, done })
+            .is_err()
+        {
+            tracing::warn!("device pool actor stopped before clean release");
+            return;
+        }
+        let _ = done_rx.await;
+    }
+
+    pub(crate) async fn discard(&self, lease: DeviceLease) {
+        let (done, done_rx) = oneshot::channel();
+        if self
+            .commands
+            .send(DevicePoolCommand::Discard { lease, done })
+            .is_err()
+        {
+            tracing::warn!("device pool actor stopped before discard");
+            return;
+        }
+        let _ = done_rx.await;
+    }
+
+    pub(crate) async fn retire_uncertain(&self, lease: DeviceLease) {
+        let (done, done_rx) = oneshot::channel();
+        if self
+            .commands
+            .send(DevicePoolCommand::RetireUncertain { lease, done })
+            .is_err()
+        {
+            tracing::warn!("device pool actor stopped before uncertain retire");
+            return;
+        }
+        let _ = done_rx.await;
+    }
+
+    #[cfg(test)]
+    async fn snapshot(&self) -> DevicePoolSnapshot {
+        let (respond_to, response) = oneshot::channel();
+        self.commands
+            .send(DevicePoolCommand::Snapshot { respond_to })
+            .expect("device pool actor stopped before snapshot");
+        response.await.expect("device pool actor dropped snapshot")
+    }
+}
+
+impl DevicePoolActor {
+    async fn run(mut self) {
+        loop {
+            if self.pool.pending.is_empty() {
+                let Some(command) = self.commands.recv().await else {
+                    break;
+                };
+                self.handle_command(command).await;
+            } else {
+                tokio::select! {
+                    command = self.commands.recv() => {
+                        let Some(command) = command else {
+                            break;
+                        };
+                        self.handle_command(command).await;
+                    }
+                    validation = self.pool.pending.join_next() => {
+                        if let Some(validation) = validation {
+                            self.pool.handle_validation_join(validation);
+                        }
                     }
                 }
             }
         }
+
+        self.pool.abort_pending().await;
     }
 
-    pub(crate) async fn release_clean(&self, lease: DeviceLease) {
-        self.inner.lock().await.release(lease);
-    }
-
-    pub(crate) async fn discard(&self, lease: DeviceLease) {
-        self.inner.lock().await.discard(lease);
-    }
-
-    pub(crate) async fn retire_uncertain(&self, lease: DeviceLease) {
-        self.inner.lock().await.retire_uncertain(lease);
-    }
-
-    async fn finish_acquire_candidate(&self, index: u32) -> Result<Option<DeviceLease>> {
-        self.inner.lock().await.finish_acquire_candidate(index)
+    async fn handle_command(&mut self, command: DevicePoolCommand) {
+        match command {
+            DevicePoolCommand::Warmup { done } => {
+                self.pool.warmup().await;
+                let _ = done.send(());
+            }
+            DevicePoolCommand::Acquire { respond_to } => {
+                self.pool.handle_acquire(respond_to);
+            }
+            DevicePoolCommand::ReleaseClean { lease, done } => {
+                self.pool.release(lease);
+                self.pool.ensure_waiting_progress();
+                if self.pool.waiting_acquires.is_empty() {
+                    self.pool.maybe_replenish();
+                }
+                let _ = done.send(());
+            }
+            DevicePoolCommand::Discard { lease, done } => {
+                self.pool.discard(lease);
+                self.pool.ensure_waiting_progress();
+                let _ = done.send(());
+            }
+            DevicePoolCommand::RetireUncertain { lease, done } => {
+                self.pool.retire_uncertain(lease);
+                self.pool.ensure_waiting_progress();
+                if self.pool.waiting_acquires.is_empty() {
+                    self.pool.maybe_replenish();
+                }
+                let _ = done.send(());
+            }
+            DevicePoolCommand::Cleanup { done } => {
+                self.pool.cleanup().await;
+                let _ = done.send(());
+            }
+            #[cfg(test)]
+            DevicePoolCommand::Snapshot { respond_to } => {
+                let _ = respond_to.send(self.pool.snapshot());
+            }
+        }
     }
 }
 
@@ -157,15 +310,9 @@ pub struct DevicePool {
     /// Recently released devices waiting for cooldown to expire.
     cooldown: VecDeque<CooldownSlot>,
     /// Background sysfs validation tasks.
-    pending: tokio::task::JoinSet<()>,
-    /// Number of validation tasks whose result has not been drained yet.
-    pending_count: usize,
-    /// Completed validation results from background tasks.
-    validation_tx: mpsc::UnboundedSender<Result<u32>>,
-    validation_rx: mpsc::UnboundedReceiver<Result<u32>>,
-    /// Versioned notification for completed validation results.
-    validation_watch_tx: watch::Sender<u64>,
-    validation_watch_rx: watch::Receiver<u64>,
+    pending: tokio::task::JoinSet<ValidationResult>,
+    /// Acquire requests waiting for validation or a released device.
+    waiting_acquires: VecDeque<oneshot::Sender<Result<DeviceLease>>>,
     /// Total number of NBD devices (from sysfs nbds_max).
     max_devices: u32,
     /// Pool configuration.
@@ -183,18 +330,12 @@ impl DevicePool {
     /// the ready queue and avoid a synchronous sysfs scan on first use.
     pub fn new(config: DevicePoolConfig) -> Self {
         let max_devices = netlink::nbds_max();
-        let (validation_tx, validation_rx) = mpsc::unbounded_channel();
-        let (validation_watch_tx, validation_watch_rx) = watch::channel(0);
         Self {
             active: true,
             ready: VecDeque::with_capacity(BUFFER_SIZE),
             cooldown: VecDeque::new(),
             pending: tokio::task::JoinSet::new(),
-            pending_count: 0,
-            validation_tx,
-            validation_rx,
-            validation_watch_tx,
-            validation_watch_rx,
+            waiting_acquires: VecDeque::new(),
             max_devices,
             config,
             in_flight: HashSet::new(),
@@ -203,21 +344,17 @@ impl DevicePool {
 
     /// Pre-warm the pool by scanning for free devices.
     pub async fn warmup(&mut self) {
-        self.spawn_validations();
+        if !self.active {
+            return;
+        }
 
-        // Wait for initial batch to complete
-        loop {
-            self.drain_completed();
-            if self.ready.len() >= BUFFER_SIZE || self.pending_count == 0 {
-                break;
-            }
+        self.spawn_background_batch();
 
-            let mut pending_rx = self.pending_notification();
-            self.drain_completed();
-            if self.ready.len() >= BUFFER_SIZE || self.pending_count == 0 {
+        while self.ready.len() < BUFFER_SIZE {
+            let Some(validation) = self.pending.join_next().await else {
                 break;
-            }
-            let _ = pending_rx.changed().await;
+            };
+            self.handle_validation_join(validation);
         }
 
         tracing::info!(
@@ -236,84 +373,174 @@ impl DevicePool {
     #[cfg(test)]
     pub(crate) async fn acquire(&mut self) -> Result<DeviceLease> {
         loop {
-            match self.acquire_step()? {
-                AcquireStep::Ready(lease) => return Ok(lease),
-                AcquireStep::WaitForPending(mut pending_rx) => {
-                    let _ = pending_rx.changed().await;
-                }
-                AcquireStep::Scan { max, exclude } => {
-                    let index =
-                        tokio::task::spawn_blocking(move || scan_free_device(max, &exclude))
-                            .await
-                            .map_err(|e| {
-                                NbdCowError::Io(std::io::Error::other(format!(
-                                    "scan task panicked: {e}"
-                                )))
-                            })??;
-                    if let Some(lease) = self.finish_acquire_candidate(index)? {
-                        return Ok(lease);
+            if !self.active {
+                return Err(NbdCowError::NoFreeDevice);
+            }
+
+            self.promote_cooled_down();
+            if let Some(index) = self.ready.pop_front() {
+                self.in_flight.insert(index);
+                self.maybe_replenish();
+                return Ok(DeviceLease::new(index));
+            }
+
+            while let Some(validation) = self.pending.join_next().await {
+                match validation {
+                    Ok(ValidationResult {
+                        result: Ok(index), ..
+                    }) if !self.is_tracked(index) => {
+                        self.in_flight.insert(index);
+                        self.maybe_replenish();
+                        return Ok(DeviceLease::new(index));
                     }
+                    Ok(_) | Err(_) => {}
+                }
+            }
+
+            let max = self.max_devices;
+            let exclude = self.tracked_indices();
+            let index = tokio::task::spawn_blocking(move || scan_free_device(max, &exclude))
+                .await
+                .map_err(|e| {
+                    NbdCowError::Io(std::io::Error::other(format!("scan task panicked: {e}")))
+                })??;
+            if !self.is_tracked(index) {
+                self.in_flight.insert(index);
+                self.maybe_replenish();
+                return Ok(DeviceLease::new(index));
+            }
+        }
+    }
+
+    fn handle_acquire(&mut self, respond_to: oneshot::Sender<Result<DeviceLease>>) {
+        if !self.active {
+            let _ = respond_to.send(Err(NbdCowError::NoFreeDevice));
+            return;
+        }
+
+        self.promote_cooled_down();
+        if let Some(index) = self.ready.pop_front() {
+            if respond_to.send(Ok(DeviceLease::new(index))).is_ok() {
+                self.in_flight.insert(index);
+                self.maybe_replenish();
+            } else {
+                self.ready.push_front(index);
+            }
+            return;
+        }
+
+        self.waiting_acquires.push_back(respond_to);
+        self.ensure_waiting_progress();
+    }
+
+    fn ensure_waiting_progress(&mut self) {
+        if !self.active {
+            self.fail_all_waiters();
+            return;
+        }
+
+        self.promote_cooled_down();
+        let assigned = self.satisfy_waiters_from_ready();
+        if !self.waiting_acquires.is_empty() {
+            if self.pending.is_empty() {
+                self.spawn_validation(ValidationPurpose::Demand);
+            }
+        } else if assigned {
+            self.maybe_replenish();
+        }
+    }
+
+    fn handle_validation_join(
+        &mut self,
+        validation: std::result::Result<ValidationResult, tokio::task::JoinError>,
+    ) {
+        match validation {
+            Ok(ValidationResult {
+                purpose: _,
+                result: Ok(index),
+            }) => {
+                let assigned = self.assign_candidate(index);
+                self.ensure_waiting_progress();
+                if assigned && self.waiting_acquires.is_empty() {
+                    self.maybe_replenish();
+                }
+            }
+            Ok(ValidationResult {
+                purpose: ValidationPurpose::Demand,
+                result: Err(e),
+            }) => {
+                self.fail_one_waiter(e);
+                self.ensure_waiting_progress();
+            }
+            Ok(ValidationResult {
+                purpose: ValidationPurpose::Background,
+                result: Err(_),
+            }) => {
+                self.ensure_waiting_progress();
+            }
+            Err(e) => {
+                if !self.waiting_acquires.is_empty() {
+                    self.fail_one_waiter(NbdCowError::Io(std::io::Error::other(format!(
+                        "device validation task failed: {e}"
+                    ))));
+                }
+                self.ensure_waiting_progress();
+            }
+        }
+    }
+
+    fn satisfy_waiters_from_ready(&mut self) -> bool {
+        let mut assigned = false;
+        while let Some(respond_to) = self.waiting_acquires.pop_front() {
+            let Some(index) = self.ready.pop_front() else {
+                self.waiting_acquires.push_front(respond_to);
+                break;
+            };
+
+            if respond_to.send(Ok(DeviceLease::new(index))).is_ok() {
+                self.in_flight.insert(index);
+                assigned = true;
+            } else {
+                self.ready.push_front(index);
+            }
+        }
+        assigned
+    }
+
+    fn assign_candidate(&mut self, index: u32) -> bool {
+        if self.is_tracked(index) {
+            return false;
+        }
+
+        while let Some(respond_to) = self.waiting_acquires.pop_front() {
+            if respond_to.send(Ok(DeviceLease::new(index))).is_ok() {
+                self.in_flight.insert(index);
+                return true;
+            }
+        }
+
+        self.ready.push_back(index);
+        false
+    }
+
+    fn fail_one_waiter(&mut self, mut error: NbdCowError) -> bool {
+        while let Some(respond_to) = self.waiting_acquires.pop_front() {
+            match respond_to.send(Err(error)) {
+                Ok(()) => return true,
+                Err(Err(e)) => error = e,
+                Err(Ok(lease)) => {
+                    self.ready.push_front(lease.index);
+                    return false;
                 }
             }
         }
+        false
     }
 
-    fn acquire_step(&mut self) -> Result<AcquireStep> {
-        if !self.active {
-            return Err(NbdCowError::NoFreeDevice);
+    fn fail_all_waiters(&mut self) {
+        while let Some(respond_to) = self.waiting_acquires.pop_front() {
+            let _ = respond_to.send(Err(NbdCowError::NoFreeDevice));
         }
-
-        // Promote expired cooldown slots to ready queue
-        self.promote_cooled_down();
-        self.drain_completed();
-
-        // Tier 1: instant pop from ready queue
-        if let Some(lease) = self.pop_ready_lease() {
-            return Ok(AcquireStep::Ready(lease));
-        }
-
-        // Tier 2: wait for background validation outside the pool lock.
-        if self.pending_count > 0 {
-            let pending_rx = self.pending_notification();
-            // Close the lost-wakeup gap: if a task completed before we cloned
-            // the watch receiver, its result is now visible on the channel.
-            self.drain_completed();
-            if let Some(lease) = self.pop_ready_lease() {
-                return Ok(AcquireStep::Ready(lease));
-            }
-            if self.pending_count > 0 {
-                return Ok(AcquireStep::WaitForPending(pending_rx));
-            }
-        }
-
-        // Tier 3: synchronous on-demand scan outside the pool lock.
-        Ok(AcquireStep::Scan {
-            max: self.max_devices,
-            exclude: self.tracked_indices(),
-        })
-    }
-
-    fn pop_ready_lease(&mut self) -> Option<DeviceLease> {
-        let index = self.ready.pop_front()?;
-        self.in_flight.insert(index);
-        self.maybe_replenish();
-        Some(DeviceLease::new(index))
-    }
-
-    fn pending_notification(&self) -> watch::Receiver<u64> {
-        self.validation_watch_rx.clone()
-    }
-
-    fn finish_acquire_candidate(&mut self, index: u32) -> Result<Option<DeviceLease>> {
-        if !self.active {
-            return Err(NbdCowError::NoFreeDevice);
-        }
-        if self.is_tracked(index) {
-            return Ok(None);
-        }
-        self.in_flight.insert(index);
-        self.maybe_replenish();
-        Ok(Some(DeviceLease::new(index)))
     }
 
     /// Release a device index back to the pool after disconnect.
@@ -336,7 +563,6 @@ impl DevicePool {
             index,
             released_at: Instant::now(),
         });
-        self.maybe_replenish();
     }
 
     /// Stop tracking an in-flight index without returning it to the pool.
@@ -366,18 +592,17 @@ impl DevicePool {
                 "device pool cleanup with outstanding leases"
             );
         }
-        self.validation_watch_tx
-            .send_modify(|version| *version = version.wrapping_add(1));
-        self.pending.abort_all();
-        while self.pending.join_next().await.is_some() {}
-        self.pending_count = 0;
-        while self.validation_rx.try_recv().is_ok() {
-            // Drop completed validation results after shutdown.
-        }
+        self.fail_all_waiters();
+        self.abort_pending().await;
         self.ready.clear();
         self.cooldown.clear();
         self.in_flight.clear();
         tracing::info!("device pool cleanup complete");
+    }
+
+    async fn abort_pending(&mut self) {
+        self.pending.abort_all();
+        while self.pending.join_next().await.is_some() {}
     }
 
     /// Move expired cooldown slots to the ready queue.
@@ -401,62 +626,38 @@ impl DevicePool {
 
     /// Spawn background validation tasks if the ready queue needs replenishment.
     fn maybe_replenish(&mut self) {
-        self.drain_completed();
-        let total_available = self.ready.len() + self.pending_count;
-        if total_available >= BUFFER_SIZE {
+        if !self.active || !self.waiting_acquires.is_empty() {
+            return;
+        }
+        self.spawn_background_batch();
+    }
+
+    fn spawn_background_batch(&mut self) {
+        if !self.active {
             return;
         }
 
-        self.spawn_validations();
+        while self.pending.len() < MAX_PENDING
+            && self.ready.len() + self.pending.len() < BUFFER_SIZE
+        {
+            self.spawn_validation(ValidationPurpose::Background);
+        }
     }
 
-    /// Spawn background tasks to scan for free devices.
-    fn spawn_validations(&mut self) {
-        while self.pending_count < MAX_PENDING
-            && self.ready.len() + self.pending_count < BUFFER_SIZE
-        {
-            let max = self.max_devices;
-            let exclude = self.tracked_indices();
-            let validation_tx = self.validation_tx.clone();
-            let validation_watch_tx = self.validation_watch_tx.clone();
-            self.pending_count += 1;
-            self.pending.spawn(async move {
-                let result = match tokio::task::spawn_blocking(move || {
-                    scan_free_device(max, &exclude)
-                })
-                .await
-                {
+    /// Spawn a validation task to scan for a free device.
+    fn spawn_validation(&mut self, purpose: ValidationPurpose) {
+        let max = self.max_devices;
+        let exclude = self.tracked_indices();
+        self.pending.spawn(async move {
+            let result =
+                match tokio::task::spawn_blocking(move || scan_free_device(max, &exclude)).await {
                     Ok(result) => result,
                     Err(e) => Err(NbdCowError::Io(std::io::Error::other(format!(
                         "scan task panicked: {e}"
                     )))),
                 };
-                let _ = validation_tx.send(result);
-                validation_watch_tx.send_modify(|version| *version = version.wrapping_add(1));
-            });
-        }
-    }
-
-    /// Drain completed validation results into the ready queue.
-    fn drain_completed(&mut self) {
-        loop {
-            match self.validation_rx.try_recv() {
-                Ok(result) => {
-                    self.pending_count = self.pending_count.saturating_sub(1);
-                    if let Ok(index) = result {
-                        self.push_ready_if_untracked(index);
-                    }
-                }
-                Err(mpsc::error::TryRecvError::Empty) => break,
-                Err(mpsc::error::TryRecvError::Disconnected) => break,
-            }
-        }
-
-        while let Some(result) = self.pending.try_join_next() {
-            if result.is_err() {
-                self.pending_count = self.pending_count.saturating_sub(1);
-            }
-        }
+            ValidationResult { purpose, result }
+        });
     }
 
     /// Collect all indices currently tracked by the pool (ready + cooldown + in-flight)
@@ -483,6 +684,14 @@ impl DevicePool {
         }
         self.ready.push_back(index);
         true
+    }
+
+    #[cfg(test)]
+    fn snapshot(&self) -> DevicePoolSnapshot {
+        DevicePoolSnapshot {
+            cooldown: self.cooldown.iter().map(|slot| slot.index).collect(),
+            waiting_acquires: self.waiting_acquires.len(),
+        }
     }
 }
 
@@ -517,37 +726,38 @@ fn scan_free_device(max_devices: u32, exclude: &[u32]) -> Result<u32> {
     Err(NbdCowError::NoFreeDevice)
 }
 
+fn actor_stopped_error() -> NbdCowError {
+    NbdCowError::Io(std::io::Error::other("device pool actor stopped"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn validation_channel() -> (
-        mpsc::UnboundedSender<Result<u32>>,
-        mpsc::UnboundedReceiver<Result<u32>>,
-    ) {
-        mpsc::unbounded_channel()
-    }
-
     fn queue_validation_result(pool: &mut DevicePool, result: Result<u32>) {
-        pool.pending_count += 1;
-        pool.validation_tx.send(result).unwrap();
-        pool.validation_watch_tx
-            .send_modify(|version| *version = version.wrapping_add(1));
+        pool.pending.spawn(async move {
+            ValidationResult {
+                purpose: ValidationPurpose::Background,
+                result,
+            }
+        });
     }
 
-    fn complete_validation(
-        validation_tx: &mpsc::UnboundedSender<Result<u32>>,
-        validation_watch_tx: &watch::Sender<u64>,
-        result: Result<u32>,
-    ) {
-        validation_tx.send(result).unwrap();
-        validation_watch_tx.send_modify(|version| *version = version.wrapping_add(1));
+    fn queue_controlled_validation(pool: &mut DevicePool) -> oneshot::Sender<Result<u32>> {
+        let (complete, complete_rx) = oneshot::channel();
+        pool.pending.spawn(async move {
+            ValidationResult {
+                purpose: ValidationPurpose::Background,
+                result: complete_rx.await.unwrap_or(Err(NbdCowError::NoFreeDevice)),
+            }
+        });
+        complete
     }
 
-    async fn wait_for_validation_waiter(validation_watch_tx: &watch::Sender<u64>) {
+    async fn wait_for_validation_waiter(handle: &DevicePoolHandle) {
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {
-                if validation_watch_tx.receiver_count() > 1 {
+                if handle.snapshot().await.waiting_acquires > 0 {
                     break;
                 }
                 tokio::task::yield_now().await;
@@ -558,8 +768,6 @@ mod tests {
     }
 
     fn test_pool_with_in_flight(index: u32) -> DevicePool {
-        let (validation_tx, validation_rx) = validation_channel();
-        let (validation_watch_tx, validation_watch_rx) = watch::channel(0);
         DevicePool {
             active: true,
             // Keep the ready queue full so `release()` does not spawn host
@@ -567,11 +775,7 @@ mod tests {
             ready: VecDeque::from([0, 1, 2, 4]),
             cooldown: VecDeque::new(),
             pending: tokio::task::JoinSet::new(),
-            pending_count: 0,
-            validation_tx,
-            validation_rx,
-            validation_watch_tx,
-            validation_watch_rx,
+            waiting_acquires: VecDeque::new(),
             max_devices: 8,
             config: DevicePoolConfig::default(),
             in_flight: HashSet::from([index]),
@@ -579,18 +783,12 @@ mod tests {
     }
 
     fn test_pool_for_pending_scan() -> DevicePool {
-        let (validation_tx, validation_rx) = validation_channel();
-        let (validation_watch_tx, validation_watch_rx) = watch::channel(0);
         DevicePool {
             active: true,
             ready: VecDeque::new(),
             cooldown: VecDeque::new(),
             pending: tokio::task::JoinSet::new(),
-            pending_count: 0,
-            validation_tx,
-            validation_rx,
-            validation_watch_tx,
-            validation_watch_rx,
+            waiting_acquires: VecDeque::new(),
             max_devices: 0,
             config: DevicePoolConfig::default(),
             in_flight: HashSet::new(),
@@ -640,6 +838,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn warmup_after_cleanup_does_not_restart_pool() {
+        let mut pool = test_pool_for_pending_scan();
+
+        pool.cleanup().await;
+        pool.warmup().await;
+
+        assert!(!pool.active);
+        assert!(pool.pending.is_empty());
+        assert!(pool.ready.is_empty());
+    }
+
+    #[tokio::test]
     async fn acquire_rejects_duplicate_pending_validation_result() {
         let mut pool = test_pool_for_pending_scan();
         pool.in_flight.insert(3);
@@ -655,29 +865,24 @@ mod tests {
     #[tokio::test]
     async fn handle_acquire_waiting_for_validation_does_not_block_release() {
         let mut pool = test_pool_for_pending_scan();
-        pool.pending_count = 1;
         pool.in_flight.insert(3);
-        let validation_tx = pool.validation_tx.clone();
-        let validation_watch_tx = pool.validation_watch_tx.clone();
+        let complete_validation = queue_controlled_validation(&mut pool);
         let handle = DevicePoolHandle::from_pool(pool);
         let acquire_task = tokio::spawn({
             let handle = handle.clone();
             async move { handle.acquire().await }
         });
 
-        wait_for_validation_waiter(&validation_watch_tx).await;
+        wait_for_validation_waiter(&handle).await;
         tokio::time::timeout(
             Duration::from_secs(1),
             handle.release_clean(DeviceLease::new(3)),
         )
         .await
         .expect("release blocked behind pending acquire");
-        {
-            let pool = handle.inner.lock().await;
-            assert_eq!(pool.cooldown.front().map(|slot| slot.index), Some(3));
-        }
+        assert_eq!(handle.snapshot().await.cooldown, vec![3]);
 
-        complete_validation(&validation_tx, &validation_watch_tx, Ok(4));
+        complete_validation.send(Ok(4)).unwrap();
         let lease = tokio::time::timeout(Duration::from_secs(1), acquire_task)
             .await
             .expect("acquire did not finish after validation")
@@ -691,15 +896,14 @@ mod tests {
     #[tokio::test]
     async fn cleanup_wakes_handle_acquire_waiting_for_validation() {
         let mut pool = test_pool_for_pending_scan();
-        pool.pending_count = 1;
-        let validation_watch_tx = pool.validation_watch_tx.clone();
+        let _complete_validation = queue_controlled_validation(&mut pool);
         let handle = DevicePoolHandle::from_pool(pool);
         let acquire_task = tokio::spawn({
             let handle = handle.clone();
             async move { handle.acquire().await }
         });
 
-        wait_for_validation_waiter(&validation_watch_tx).await;
+        wait_for_validation_waiter(&handle).await;
         tokio::time::timeout(Duration::from_secs(1), handle.cleanup())
             .await
             .expect("cleanup blocked behind pending acquire");

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -650,14 +650,8 @@ impl DevicePool {
     fn spawn_validation(&mut self, purpose: ValidationPurpose) {
         let max = self.max_devices;
         let exclude = self.tracked_indices();
-        self.pending.spawn(async move {
-            let result =
-                match tokio::task::spawn_blocking(move || scan_free_device(max, &exclude)).await {
-                    Ok(result) => result,
-                    Err(e) => Err(NbdCowError::Io(std::io::Error::other(format!(
-                        "scan task panicked: {e}"
-                    )))),
-                };
+        self.pending.spawn_blocking(move || {
+            let result = scan_free_device(max, &exclude);
             ValidationResult { purpose, result }
         });
     }

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -115,6 +115,8 @@ struct ValidationResult {
 #[derive(Debug)]
 struct DevicePoolSnapshot {
     cooldown: Vec<u32>,
+    ready: Vec<u32>,
+    in_flight: HashSet<u32>,
     waiting_acquires: usize,
 }
 
@@ -127,11 +129,7 @@ impl DevicePoolHandle {
         Self::from_pool(DevicePool::new(config))
     }
 
-    /// Wrap an existing pool.
-    ///
-    /// Must be called from a Tokio runtime. Intended for tests and for sharing
-    /// a pre-built pool state through the actor-backed handle.
-    pub fn from_pool(pool: DevicePool) -> Self {
+    fn from_pool(pool: DevicePool) -> Self {
         let (commands, command_rx) = mpsc::unbounded_channel();
         tokio::spawn(
             DevicePoolActor {
@@ -364,54 +362,6 @@ impl DevicePool {
         );
     }
 
-    /// Acquire a pre-validated device index.
-    ///
-    /// Three-tier strategy:
-    /// 1. Pop from ready queue (instant)
-    /// 2. Await a pending background validation
-    /// 3. Synchronous on-demand scan (fallback)
-    #[cfg(test)]
-    pub(crate) async fn acquire(&mut self) -> Result<DeviceLease> {
-        loop {
-            if !self.active {
-                return Err(NbdCowError::NoFreeDevice);
-            }
-
-            self.promote_cooled_down();
-            if let Some(index) = self.ready.pop_front() {
-                self.in_flight.insert(index);
-                self.maybe_replenish();
-                return Ok(DeviceLease::new(index));
-            }
-
-            while let Some(validation) = self.pending.join_next().await {
-                match validation {
-                    Ok(ValidationResult {
-                        result: Ok(index), ..
-                    }) if !self.is_tracked(index) => {
-                        self.in_flight.insert(index);
-                        self.maybe_replenish();
-                        return Ok(DeviceLease::new(index));
-                    }
-                    Ok(_) | Err(_) => {}
-                }
-            }
-
-            let max = self.max_devices;
-            let exclude = self.tracked_indices();
-            let index = tokio::task::spawn_blocking(move || scan_free_device(max, &exclude))
-                .await
-                .map_err(|e| {
-                    NbdCowError::Io(std::io::Error::other(format!("scan task panicked: {e}")))
-                })??;
-            if !self.is_tracked(index) {
-                self.in_flight.insert(index);
-                self.maybe_replenish();
-                return Ok(DeviceLease::new(index));
-            }
-        }
-    }
-
     fn handle_acquire(&mut self, respond_to: oneshot::Sender<Result<DeviceLease>>) {
         if !self.active {
             let _ = respond_to.send(Err(NbdCowError::NoFreeDevice));
@@ -442,11 +392,18 @@ impl DevicePool {
         self.promote_cooled_down();
         let assigned = self.satisfy_waiters_from_ready();
         if !self.waiting_acquires.is_empty() {
-            if self.pending.is_empty() {
-                self.spawn_validation(ValidationPurpose::Demand);
-            }
+            self.spawn_demand_batch();
         } else if assigned {
             self.maybe_replenish();
+        }
+    }
+
+    fn spawn_demand_batch(&mut self) {
+        while self.active
+            && self.pending.len() < MAX_PENDING
+            && self.pending.len() < self.waiting_acquires.len()
+        {
+            self.spawn_validation(ValidationPurpose::Demand);
         }
     }
 
@@ -690,6 +647,8 @@ impl DevicePool {
     fn snapshot(&self) -> DevicePoolSnapshot {
         DevicePoolSnapshot {
             cooldown: self.cooldown.iter().map(|slot| slot.index).collect(),
+            ready: self.ready.iter().copied().collect(),
+            in_flight: self.in_flight.clone(),
             waiting_acquires: self.waiting_acquires.len(),
         }
     }
@@ -829,11 +788,11 @@ mod tests {
 
     #[tokio::test]
     async fn cleanup_rejects_acquire() {
-        let mut pool = test_pool_for_pending_scan();
+        let handle = DevicePoolHandle::from_pool(test_pool_for_pending_scan());
 
-        pool.cleanup().await;
+        handle.cleanup().await;
 
-        let result = pool.acquire().await;
+        let result = handle.acquire().await;
         assert!(matches!(result, Err(NbdCowError::NoFreeDevice)));
     }
 
@@ -854,12 +813,43 @@ mod tests {
         let mut pool = test_pool_for_pending_scan();
         pool.in_flight.insert(3);
         queue_validation_result(&mut pool, Ok(3));
+        let handle = DevicePoolHandle::from_pool(pool);
 
-        let result = pool.acquire().await;
+        let result = handle.acquire().await;
 
         assert!(matches!(result, Err(NbdCowError::NoFreeDevice)));
-        assert!(pool.in_flight.contains(&3));
-        assert!(pool.ready.is_empty());
+        let snapshot = handle.snapshot().await;
+        assert!(snapshot.in_flight.contains(&3));
+        assert!(snapshot.ready.is_empty());
+        handle.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn waiting_acquires_spawn_demand_validations_up_to_limit() {
+        let mut pool = test_pool_for_pending_scan();
+        let mut responses = Vec::new();
+
+        for _ in 0..(MAX_PENDING + 2) {
+            let (respond_to, response) = oneshot::channel();
+            pool.handle_acquire(respond_to);
+            responses.push(response);
+        }
+
+        assert_eq!(pool.waiting_acquires.len(), MAX_PENDING + 2);
+        assert_eq!(pool.pending.len(), MAX_PENDING);
+        pool.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn single_waiting_acquire_spawns_single_demand_validation() {
+        let mut pool = test_pool_for_pending_scan();
+        let (respond_to, _response) = oneshot::channel();
+
+        pool.handle_acquire(respond_to);
+
+        assert_eq!(pool.waiting_acquires.len(), 1);
+        assert_eq!(pool.pending.len(), 1);
+        pool.cleanup().await;
     }
 
     #[tokio::test]

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -159,9 +159,7 @@ impl DevicePool {
         while let Some(result) = self.pending.join_next().await {
             match result {
                 Ok(Ok(index)) => {
-                    if !self.ready.contains(&index) {
-                        self.ready.push_back(index);
-                    }
+                    self.push_ready_if_untracked(index);
                 }
                 Ok(Err(e)) => tracing::debug!("warmup validation failed: {e}"),
                 Err(e) => tracing::debug!("warmup task panicked: {e}"),
@@ -205,6 +203,13 @@ impl DevicePool {
         while let Some(result) = self.pending.join_next().await {
             match result {
                 Ok(Ok(index)) => {
+                    if self.is_tracked(index) {
+                        tracing::debug!(
+                            device_index = index,
+                            "ignoring duplicate pending device validation result"
+                        );
+                        continue;
+                    }
                     self.in_flight.insert(index);
                     self.maybe_replenish();
                     return Ok(DeviceLease::new(index));
@@ -295,7 +300,7 @@ impl DevicePool {
                 };
                 // Re-validate via sysfs before promoting
                 if netlink::device_appears_free(slot.index) {
-                    self.ready.push_back(slot.index);
+                    self.push_ready_if_untracked(slot.index);
                 }
                 // If not free (recycled by another process), just drop it
             } else {
@@ -313,9 +318,7 @@ impl DevicePool {
         while let Some(Ok(result)) = self.pending.try_join_next() {
             match result {
                 Ok(index) => {
-                    if !self.ready.contains(&index) && !self.in_flight.contains(&index) {
-                        self.ready.push_back(index);
-                    }
+                    self.push_ready_if_untracked(index);
                 }
                 Err(e) => tracing::debug!("background validation failed: {e}"),
             }
@@ -354,6 +357,24 @@ impl DevicePool {
             .chain(self.cooldown.iter().map(|s| s.index))
             .chain(self.in_flight.iter().copied())
             .collect()
+    }
+
+    fn is_tracked(&self, index: u32) -> bool {
+        self.ready.contains(&index)
+            || self.in_flight.contains(&index)
+            || self.cooldown.iter().any(|slot| slot.index == index)
+    }
+
+    fn push_ready_if_untracked(&mut self, index: u32) -> bool {
+        if self.is_tracked(index) {
+            tracing::debug!(
+                device_index = index,
+                "ignoring duplicate ready device candidate"
+            );
+            return false;
+        }
+        self.ready.push_back(index);
+        true
     }
 }
 
@@ -406,6 +427,18 @@ mod tests {
         }
     }
 
+    fn test_pool_for_pending_scan() -> DevicePool {
+        DevicePool {
+            active: true,
+            ready: VecDeque::new(),
+            cooldown: VecDeque::new(),
+            pending: tokio::task::JoinSet::new(),
+            max_devices: 0,
+            config: DevicePoolConfig::default(),
+            in_flight: HashSet::new(),
+        }
+    }
+
     #[test]
     fn release_consumes_lease_and_enters_cooldown() {
         let mut pool = test_pool_with_in_flight(3);
@@ -436,5 +469,47 @@ mod tests {
 
         assert!(!pool.active);
         assert!(pool.in_flight.is_empty());
+    }
+
+    #[tokio::test]
+    async fn acquire_skips_duplicate_pending_validation_result() {
+        let mut pool = test_pool_for_pending_scan();
+        pool.in_flight.insert(3);
+        pool.pending.spawn(async { Ok(3) });
+        pool.pending.spawn(async {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            Ok(5)
+        });
+
+        let lease = pool.acquire().await.expect("acquire non-duplicate index");
+
+        assert_eq!(lease.index(), 5);
+        assert!(pool.in_flight.contains(&3));
+        assert!(pool.in_flight.contains(&5));
+
+        pool.release(lease);
+        pool.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn warmup_skips_already_tracked_validation_results() {
+        let mut pool = test_pool_for_pending_scan();
+        pool.ready.push_back(4);
+        pool.cooldown.push_back(CooldownSlot {
+            index: 5,
+            released_at: Instant::now(),
+        });
+        pool.in_flight.insert(3);
+        pool.pending.spawn(async { Ok(3) });
+        pool.pending.spawn(async { Ok(4) });
+        pool.pending.spawn(async { Ok(5) });
+        pool.pending.spawn(async { Ok(6) });
+
+        pool.warmup().await;
+
+        let ready: Vec<u32> = pool.ready.iter().copied().collect();
+        assert_eq!(ready, vec![4, 6]);
+        assert_eq!(pool.cooldown.front().map(|slot| slot.index), Some(5));
+        assert!(pool.in_flight.contains(&3));
     }
 }

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -173,7 +173,7 @@ impl DevicePoolHandle {
 
     fn from_pool(mut pool: DevicePool) -> Self {
         let (commands, command_rx) = mpsc::unbounded_channel();
-        pool.set_lease_return(commands.clone());
+        pool.set_lease_return(commands.downgrade());
         tokio::spawn(
             DevicePoolActor {
                 pool,
@@ -367,8 +367,8 @@ pub struct DevicePool {
     cooldown: VecDeque<CooldownSlot>,
     /// Background sysfs validation tasks.
     pending: tokio::task::JoinSet<ValidationResult>,
-    /// Sender embedded in assigned leases so dropping a lease still returns it.
-    lease_return: Option<mpsc::UnboundedSender<DevicePoolCommand>>,
+    /// Weak sender used to embed a strong return path in assigned leases.
+    lease_return: Option<mpsc::WeakUnboundedSender<DevicePoolCommand>>,
     /// Acquire errors that raced with still-pending validation tasks.
     deferred_acquire_errors: VecDeque<NbdCowError>,
     /// Acquire requests waiting for validation or a released device.
@@ -404,13 +404,17 @@ impl DevicePool {
         }
     }
 
-    fn set_lease_return(&mut self, return_to: mpsc::UnboundedSender<DevicePoolCommand>) {
+    fn set_lease_return(&mut self, return_to: mpsc::WeakUnboundedSender<DevicePoolCommand>) {
         self.lease_return = Some(return_to);
     }
 
     fn lease_for(&self, index: u32) -> DeviceLease {
-        match &self.lease_return {
-            Some(return_to) => DeviceLease::with_return(index, return_to.clone()),
+        match self
+            .lease_return
+            .as_ref()
+            .and_then(|return_to| return_to.upgrade())
+        {
+            Some(return_to) => DeviceLease::with_return(index, return_to),
             None => DeviceLease::new(index),
         }
     }
@@ -925,6 +929,33 @@ mod tests {
 
         let result = handle.acquire().await;
         assert!(matches!(result, Err(NbdCowError::NoFreeDevice)));
+    }
+
+    #[tokio::test]
+    async fn dropping_last_handle_closes_actor_command_channel() {
+        let handle = DevicePoolHandle::from_pool(test_pool_for_pending_scan());
+        let weak_commands = handle.commands.downgrade();
+
+        assert!(weak_commands.upgrade().is_some());
+        drop(handle);
+        tokio::task::yield_now().await;
+
+        assert!(weak_commands.upgrade().is_none());
+    }
+
+    #[tokio::test]
+    async fn checked_out_lease_keeps_return_channel_until_dropped() {
+        let mut pool = test_pool_for_pending_scan();
+        pool.ready.push_back(3);
+        let handle = DevicePoolHandle::from_pool(pool);
+        let weak_commands = handle.commands.downgrade();
+
+        let lease = handle.acquire().await.expect("acquire lease");
+        drop(handle);
+        assert!(weak_commands.upgrade().is_some());
+
+        drop(lease);
+        assert!(weak_commands.upgrade().is_none());
     }
 
     #[test]

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -535,6 +535,28 @@ mod tests {
             .send_modify(|version| *version = version.wrapping_add(1));
     }
 
+    fn complete_validation(
+        validation_tx: &mpsc::UnboundedSender<Result<u32>>,
+        validation_watch_tx: &watch::Sender<u64>,
+        result: Result<u32>,
+    ) {
+        validation_tx.send(result).unwrap();
+        validation_watch_tx.send_modify(|version| *version = version.wrapping_add(1));
+    }
+
+    async fn wait_for_validation_waiter(validation_watch_tx: &watch::Sender<u64>) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if validation_watch_tx.receiver_count() > 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("acquire did not wait for validation");
+    }
+
     fn test_pool_with_in_flight(index: u32) -> DevicePool {
         let (validation_tx, validation_rx) = validation_channel();
         let (validation_watch_tx, validation_watch_rx) = watch::channel(0);
@@ -628,6 +650,65 @@ mod tests {
         assert!(matches!(result, Err(NbdCowError::NoFreeDevice)));
         assert!(pool.in_flight.contains(&3));
         assert!(pool.ready.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handle_acquire_waiting_for_validation_does_not_block_release() {
+        let mut pool = test_pool_for_pending_scan();
+        pool.pending_count = 1;
+        pool.in_flight.insert(3);
+        let validation_tx = pool.validation_tx.clone();
+        let validation_watch_tx = pool.validation_watch_tx.clone();
+        let handle = DevicePoolHandle::from_pool(pool);
+        let acquire_task = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.acquire().await }
+        });
+
+        wait_for_validation_waiter(&validation_watch_tx).await;
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            handle.release_clean(DeviceLease::new(3)),
+        )
+        .await
+        .expect("release blocked behind pending acquire");
+        {
+            let pool = handle.inner.lock().await;
+            assert_eq!(pool.cooldown.front().map(|slot| slot.index), Some(3));
+        }
+
+        complete_validation(&validation_tx, &validation_watch_tx, Ok(4));
+        let lease = tokio::time::timeout(Duration::from_secs(1), acquire_task)
+            .await
+            .expect("acquire did not finish after validation")
+            .expect("acquire task panicked")
+            .expect("acquire failed");
+        assert_eq!(lease.index(), 4);
+        handle.discard(lease).await;
+        handle.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn cleanup_wakes_handle_acquire_waiting_for_validation() {
+        let mut pool = test_pool_for_pending_scan();
+        pool.pending_count = 1;
+        let validation_watch_tx = pool.validation_watch_tx.clone();
+        let handle = DevicePoolHandle::from_pool(pool);
+        let acquire_task = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.acquire().await }
+        });
+
+        wait_for_validation_waiter(&validation_watch_tx).await;
+        tokio::time::timeout(Duration::from_secs(1), handle.cleanup())
+            .await
+            .expect("cleanup blocked behind pending acquire");
+
+        let result = tokio::time::timeout(Duration::from_secs(1), acquire_task)
+            .await
+            .expect("acquire did not finish after cleanup")
+            .expect("acquire task panicked");
+        assert!(matches!(result, Err(NbdCowError::NoFreeDevice)));
     }
 
     #[tokio::test]

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -216,6 +216,17 @@ impl DevicePoolHandle {
         let _ = done_rx.await;
     }
 
+    pub(crate) fn retire_uncertain_detached(&self, lease: DeviceLease) {
+        let (done, _done_rx) = oneshot::channel();
+        if self
+            .commands
+            .send(DevicePoolCommand::RetireUncertain { lease, done })
+            .is_err()
+        {
+            tracing::warn!("device pool actor stopped before detached uncertain retire");
+        }
+    }
+
     #[cfg(test)]
     async fn snapshot(&self) -> DevicePoolSnapshot {
         let (respond_to, response) = oneshot::channel();
@@ -886,6 +897,25 @@ mod tests {
         assert_eq!(pool.waiting_acquires.len(), 1);
         assert_eq!(pool.pending.len(), 1);
         pool.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn detached_retire_returns_in_flight_lease_to_cooldown() {
+        let handle = DevicePoolHandle::from_pool(test_pool_with_in_flight(3));
+
+        handle.retire_uncertain_detached(DeviceLease::new(3));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if handle.snapshot().await.cooldown == vec![3] {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached retire did not reach actor");
+        handle.cleanup().await;
     }
 
     #[tokio::test]

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -950,6 +950,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn deferred_error_starts_new_demand_scan_for_remaining_waiter() {
+        let mut pool = test_pool_for_pending_scan();
+        let (first_tx, first_rx) = oneshot::channel();
+        let (second_tx, mut second_rx) = oneshot::channel();
+        pool.waiting_acquires.push_back(first_tx);
+        pool.waiting_acquires.push_back(second_tx);
+
+        pool.handle_validation_join(Ok(ValidationResult {
+            purpose: ValidationPurpose::Demand,
+            result: Err(NbdCowError::NoFreeDevice),
+        }));
+
+        assert!(matches!(
+            first_rx.await.unwrap(),
+            Err(NbdCowError::NoFreeDevice)
+        ));
+        assert!(matches!(
+            second_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+        assert_eq!(pool.waiting_acquires.len(), 1);
+        assert_eq!(pool.pending.len(), 1);
+        pool.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn deferred_error_skips_cancelled_waiter() {
+        let mut pool = test_pool_for_pending_scan();
+        let (cancelled_tx, cancelled_rx) = oneshot::channel();
+        let (active_tx, active_rx) = oneshot::channel();
+        drop(cancelled_rx);
+        pool.waiting_acquires.push_back(cancelled_tx);
+        pool.waiting_acquires.push_back(active_tx);
+
+        pool.handle_validation_join(Ok(ValidationResult {
+            purpose: ValidationPurpose::Demand,
+            result: Err(NbdCowError::NoFreeDevice),
+        }));
+
+        assert!(matches!(
+            active_rx.await.unwrap(),
+            Err(NbdCowError::NoFreeDevice)
+        ));
+        assert!(pool.waiting_acquires.is_empty());
+        assert!(pool.deferred_acquire_errors.is_empty());
+    }
+
+    #[tokio::test]
     async fn handle_acquire_waiting_for_validation_does_not_block_release() {
         let mut pool = test_pool_for_pending_scan();
         pool.in_flight.insert(3);

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, Instant};
 
 use crate::error::{NbdCowError, Result};
 use crate::netlink;
+use tokio::sync::{mpsc, watch};
 
 /// Number of pre-validated device indices to maintain in the ready queue.
 const BUFFER_SIZE: usize = 4;
@@ -67,6 +68,12 @@ pub struct DevicePoolHandle {
     inner: Arc<tokio::sync::Mutex<DevicePool>>,
 }
 
+enum AcquireStep {
+    Ready(DeviceLease),
+    WaitForPending(watch::Receiver<u64>),
+    Scan { max: u32, exclude: Vec<u32> },
+}
+
 impl DevicePoolHandle {
     /// Create a new shared device pool handle.
     pub fn new(config: DevicePoolConfig) -> Self {
@@ -93,7 +100,32 @@ impl DevicePoolHandle {
     }
 
     pub(crate) async fn acquire(&self) -> Result<DeviceLease> {
-        self.inner.lock().await.acquire().await
+        loop {
+            let step = {
+                let mut pool = self.inner.lock().await;
+                pool.acquire_step()?
+            };
+
+            match step {
+                AcquireStep::Ready(lease) => return Ok(lease),
+                AcquireStep::WaitForPending(mut pending_rx) => {
+                    let _ = pending_rx.changed().await;
+                }
+                AcquireStep::Scan { max, exclude } => {
+                    let index =
+                        tokio::task::spawn_blocking(move || scan_free_device(max, &exclude))
+                            .await
+                            .map_err(|e| {
+                                NbdCowError::Io(std::io::Error::other(format!(
+                                    "scan task panicked: {e}"
+                                )))
+                            })??;
+                    if let Some(lease) = self.finish_acquire_candidate(index).await? {
+                        return Ok(lease);
+                    }
+                }
+            }
+        }
     }
 
     pub(crate) async fn release_clean(&self, lease: DeviceLease) {
@@ -106,6 +138,10 @@ impl DevicePoolHandle {
 
     pub(crate) async fn retire_uncertain(&self, lease: DeviceLease) {
         self.inner.lock().await.retire_uncertain(lease);
+    }
+
+    async fn finish_acquire_candidate(&self, index: u32) -> Result<Option<DeviceLease>> {
+        self.inner.lock().await.finish_acquire_candidate(index)
     }
 }
 
@@ -121,7 +157,15 @@ pub struct DevicePool {
     /// Recently released devices waiting for cooldown to expire.
     cooldown: VecDeque<CooldownSlot>,
     /// Background sysfs validation tasks.
-    pending: tokio::task::JoinSet<Result<u32>>,
+    pending: tokio::task::JoinSet<()>,
+    /// Number of validation tasks whose result has not been drained yet.
+    pending_count: usize,
+    /// Completed validation results from background tasks.
+    validation_tx: mpsc::UnboundedSender<Result<u32>>,
+    validation_rx: mpsc::UnboundedReceiver<Result<u32>>,
+    /// Versioned notification for completed validation results.
+    validation_watch_tx: watch::Sender<u64>,
+    validation_watch_rx: watch::Receiver<u64>,
     /// Total number of NBD devices (from sysfs nbds_max).
     max_devices: u32,
     /// Pool configuration.
@@ -139,11 +183,18 @@ impl DevicePool {
     /// the ready queue and avoid a synchronous sysfs scan on first use.
     pub fn new(config: DevicePoolConfig) -> Self {
         let max_devices = netlink::nbds_max();
+        let (validation_tx, validation_rx) = mpsc::unbounded_channel();
+        let (validation_watch_tx, validation_watch_rx) = watch::channel(0);
         Self {
             active: true,
             ready: VecDeque::with_capacity(BUFFER_SIZE),
             cooldown: VecDeque::new(),
             pending: tokio::task::JoinSet::new(),
+            pending_count: 0,
+            validation_tx,
+            validation_rx,
+            validation_watch_tx,
+            validation_watch_rx,
             max_devices,
             config,
             in_flight: HashSet::new(),
@@ -155,17 +206,18 @@ impl DevicePool {
         self.spawn_validations();
 
         // Wait for initial batch to complete
-        while let Some(result) = self.pending.join_next().await {
-            match result {
-                Ok(Ok(index)) => {
-                    self.push_ready_if_untracked(index);
-                }
-                Ok(Err(e)) => tracing::debug!("warmup validation failed: {e}"),
-                Err(e) => tracing::debug!("warmup task panicked: {e}"),
-            }
-            if self.ready.len() >= BUFFER_SIZE {
+        loop {
+            self.drain_completed();
+            if self.ready.len() >= BUFFER_SIZE || self.pending_count == 0 {
                 break;
             }
+
+            let mut pending_rx = self.pending_notification();
+            self.drain_completed();
+            if self.ready.len() >= BUFFER_SIZE || self.pending_count == 0 {
+                break;
+            }
+            let _ = pending_rx.changed().await;
         }
 
         tracing::info!(
@@ -181,54 +233,87 @@ impl DevicePool {
     /// 1. Pop from ready queue (instant)
     /// 2. Await a pending background validation
     /// 3. Synchronous on-demand scan (fallback)
+    #[cfg(test)]
     pub(crate) async fn acquire(&mut self) -> Result<DeviceLease> {
+        loop {
+            match self.acquire_step()? {
+                AcquireStep::Ready(lease) => return Ok(lease),
+                AcquireStep::WaitForPending(mut pending_rx) => {
+                    let _ = pending_rx.changed().await;
+                }
+                AcquireStep::Scan { max, exclude } => {
+                    let index =
+                        tokio::task::spawn_blocking(move || scan_free_device(max, &exclude))
+                            .await
+                            .map_err(|e| {
+                                NbdCowError::Io(std::io::Error::other(format!(
+                                    "scan task panicked: {e}"
+                                )))
+                            })??;
+                    if let Some(lease) = self.finish_acquire_candidate(index)? {
+                        return Ok(lease);
+                    }
+                }
+            }
+        }
+    }
+
+    fn acquire_step(&mut self) -> Result<AcquireStep> {
         if !self.active {
             return Err(NbdCowError::NoFreeDevice);
         }
 
         // Promote expired cooldown slots to ready queue
         self.promote_cooled_down();
-        // Drain completed background tasks into ready queue
         self.drain_completed();
 
         // Tier 1: instant pop from ready queue
-        if let Some(index) = self.ready.pop_front() {
-            self.in_flight.insert(index);
-            self.maybe_replenish();
-            return Ok(DeviceLease::new(index));
+        if let Some(lease) = self.pop_ready_lease() {
+            return Ok(AcquireStep::Ready(lease));
         }
 
-        // Tier 2: await pending background validation
-        while let Some(result) = self.pending.join_next().await {
-            match result {
-                Ok(Ok(index)) => {
-                    if self.is_tracked(index) {
-                        tracing::debug!(
-                            device_index = index,
-                            "ignoring duplicate pending device validation result"
-                        );
-                        continue;
-                    }
-                    self.in_flight.insert(index);
-                    self.maybe_replenish();
-                    return Ok(DeviceLease::new(index));
-                }
-                Ok(Err(_)) | Err(_) => continue,
+        // Tier 2: wait for background validation outside the pool lock.
+        if self.pending_count > 0 {
+            let pending_rx = self.pending_notification();
+            // Close the lost-wakeup gap: if a task completed before we cloned
+            // the watch receiver, its result is now visible on the channel.
+            self.drain_completed();
+            if let Some(lease) = self.pop_ready_lease() {
+                return Ok(AcquireStep::Ready(lease));
+            }
+            if self.pending_count > 0 {
+                return Ok(AcquireStep::WaitForPending(pending_rx));
             }
         }
 
-        // Tier 3: synchronous on-demand scan
-        let max = self.max_devices;
-        let tracked_indices = self.tracked_indices();
-        let index = tokio::task::spawn_blocking(move || scan_free_device(max, &tracked_indices))
-            .await
-            .map_err(|e| {
-                NbdCowError::Io(std::io::Error::other(format!("scan task panicked: {e}")))
-            })??;
+        // Tier 3: synchronous on-demand scan outside the pool lock.
+        Ok(AcquireStep::Scan {
+            max: self.max_devices,
+            exclude: self.tracked_indices(),
+        })
+    }
 
+    fn pop_ready_lease(&mut self) -> Option<DeviceLease> {
+        let index = self.ready.pop_front()?;
         self.in_flight.insert(index);
         self.maybe_replenish();
-        Ok(DeviceLease::new(index))
+        Some(DeviceLease::new(index))
+    }
+
+    fn pending_notification(&self) -> watch::Receiver<u64> {
+        self.validation_watch_rx.clone()
+    }
+
+    fn finish_acquire_candidate(&mut self, index: u32) -> Result<Option<DeviceLease>> {
+        if !self.active {
+            return Err(NbdCowError::NoFreeDevice);
+        }
+        if self.is_tracked(index) {
+            return Ok(None);
+        }
+        self.in_flight.insert(index);
+        self.maybe_replenish();
+        Ok(Some(DeviceLease::new(index)))
     }
 
     /// Release a device index back to the pool after disconnect.
@@ -281,8 +366,14 @@ impl DevicePool {
                 "device pool cleanup with outstanding leases"
             );
         }
+        self.validation_watch_tx
+            .send_modify(|version| *version = version.wrapping_add(1));
         self.pending.abort_all();
         while self.pending.join_next().await.is_some() {}
+        self.pending_count = 0;
+        while self.validation_rx.try_recv().is_ok() {
+            // Drop completed validation results after shutdown.
+        }
         self.ready.clear();
         self.cooldown.clear();
         self.in_flight.clear();
@@ -308,25 +399,10 @@ impl DevicePool {
         }
     }
 
-    /// Drain completed pending tasks into the ready queue.
-    ///
-    /// Deduplicates against the ready queue: concurrent `spawn_blocking`
-    /// tasks may discover the same free device index because each task
-    /// snapshots `tracked_indices` at spawn time.
-    fn drain_completed(&mut self) {
-        while let Some(Ok(result)) = self.pending.try_join_next() {
-            match result {
-                Ok(index) => {
-                    self.push_ready_if_untracked(index);
-                }
-                Err(e) => tracing::debug!("background validation failed: {e}"),
-            }
-        }
-    }
-
     /// Spawn background validation tasks if the ready queue needs replenishment.
     fn maybe_replenish(&mut self) {
-        let total_available = self.ready.len() + self.pending.len();
+        self.drain_completed();
+        let total_available = self.ready.len() + self.pending_count;
         if total_available >= BUFFER_SIZE {
             return;
         }
@@ -336,13 +412,50 @@ impl DevicePool {
 
     /// Spawn background tasks to scan for free devices.
     fn spawn_validations(&mut self) {
-        while self.pending.len() < MAX_PENDING
-            && self.ready.len() + self.pending.len() < BUFFER_SIZE
+        while self.pending_count < MAX_PENDING
+            && self.ready.len() + self.pending_count < BUFFER_SIZE
         {
             let max = self.max_devices;
             let exclude = self.tracked_indices();
-            self.pending
-                .spawn_blocking(move || scan_free_device(max, &exclude));
+            let validation_tx = self.validation_tx.clone();
+            let validation_watch_tx = self.validation_watch_tx.clone();
+            self.pending_count += 1;
+            self.pending.spawn(async move {
+                let result = match tokio::task::spawn_blocking(move || {
+                    scan_free_device(max, &exclude)
+                })
+                .await
+                {
+                    Ok(result) => result,
+                    Err(e) => Err(NbdCowError::Io(std::io::Error::other(format!(
+                        "scan task panicked: {e}"
+                    )))),
+                };
+                let _ = validation_tx.send(result);
+                validation_watch_tx.send_modify(|version| *version = version.wrapping_add(1));
+            });
+        }
+    }
+
+    /// Drain completed validation results into the ready queue.
+    fn drain_completed(&mut self) {
+        loop {
+            match self.validation_rx.try_recv() {
+                Ok(result) => {
+                    self.pending_count = self.pending_count.saturating_sub(1);
+                    if let Ok(index) = result {
+                        self.push_ready_if_untracked(index);
+                    }
+                }
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => break,
+            }
+        }
+
+        while let Some(result) = self.pending.try_join_next() {
+            if result.is_err() {
+                self.pending_count = self.pending_count.saturating_sub(1);
+            }
         }
     }
 
@@ -366,10 +479,6 @@ impl DevicePool {
 
     fn push_ready_if_untracked(&mut self, index: u32) -> bool {
         if self.is_tracked(index) {
-            tracing::debug!(
-                device_index = index,
-                "ignoring duplicate ready device candidate"
-            );
             return false;
         }
         self.ready.push_back(index);
@@ -412,7 +521,23 @@ fn scan_free_device(max_devices: u32, exclude: &[u32]) -> Result<u32> {
 mod tests {
     use super::*;
 
+    fn validation_channel() -> (
+        mpsc::UnboundedSender<Result<u32>>,
+        mpsc::UnboundedReceiver<Result<u32>>,
+    ) {
+        mpsc::unbounded_channel()
+    }
+
+    fn queue_validation_result(pool: &mut DevicePool, result: Result<u32>) {
+        pool.pending_count += 1;
+        pool.validation_tx.send(result).unwrap();
+        pool.validation_watch_tx
+            .send_modify(|version| *version = version.wrapping_add(1));
+    }
+
     fn test_pool_with_in_flight(index: u32) -> DevicePool {
+        let (validation_tx, validation_rx) = validation_channel();
+        let (validation_watch_tx, validation_watch_rx) = watch::channel(0);
         DevicePool {
             active: true,
             // Keep the ready queue full so `release()` does not spawn host
@@ -420,6 +545,11 @@ mod tests {
             ready: VecDeque::from([0, 1, 2, 4]),
             cooldown: VecDeque::new(),
             pending: tokio::task::JoinSet::new(),
+            pending_count: 0,
+            validation_tx,
+            validation_rx,
+            validation_watch_tx,
+            validation_watch_rx,
             max_devices: 8,
             config: DevicePoolConfig::default(),
             in_flight: HashSet::from([index]),
@@ -427,11 +557,18 @@ mod tests {
     }
 
     fn test_pool_for_pending_scan() -> DevicePool {
+        let (validation_tx, validation_rx) = validation_channel();
+        let (validation_watch_tx, validation_watch_rx) = watch::channel(0);
         DevicePool {
             active: true,
             ready: VecDeque::new(),
             cooldown: VecDeque::new(),
             pending: tokio::task::JoinSet::new(),
+            pending_count: 0,
+            validation_tx,
+            validation_rx,
+            validation_watch_tx,
+            validation_watch_rx,
             max_devices: 0,
             config: DevicePoolConfig::default(),
             in_flight: HashSet::new(),
@@ -484,7 +621,7 @@ mod tests {
     async fn acquire_rejects_duplicate_pending_validation_result() {
         let mut pool = test_pool_for_pending_scan();
         pool.in_flight.insert(3);
-        pool.pending.spawn(async { Ok(3) });
+        queue_validation_result(&mut pool, Ok(3));
 
         let result = pool.acquire().await;
 
@@ -502,10 +639,10 @@ mod tests {
             released_at: Instant::now(),
         });
         pool.in_flight.insert(3);
-        pool.pending.spawn(async { Ok(3) });
-        pool.pending.spawn(async { Ok(4) });
-        pool.pending.spawn(async { Ok(5) });
-        pool.pending.spawn(async { Ok(6) });
+        queue_validation_result(&mut pool, Ok(3));
+        queue_validation_result(&mut pool, Ok(4));
+        queue_validation_result(&mut pool, Ok(5));
+        queue_validation_result(&mut pool, Ok(6));
 
         pool.warmup().await;
 

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -44,10 +44,19 @@ fn create_test_base_image(path: &Path) {
     f.set_len(64 * 1024 * 1024).expect("truncate base image");
 }
 
-fn test_device_pool() -> tokio::sync::Mutex<nbd_cow::pool::DevicePool> {
-    tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
-        nbd_cow::pool::DevicePoolConfig::default(),
-    ))
+fn test_device_pool() -> nbd_cow::pool::DevicePoolHandle {
+    nbd_cow::pool::DevicePoolHandle::new(nbd_cow::pool::DevicePoolConfig::default())
+}
+
+fn destroy_policy() -> nbd_cow::DestroyRetryPolicy {
+    nbd_cow::DestroyRetryPolicy {
+        attempts: 1,
+        delay: std::time::Duration::ZERO,
+    }
+}
+
+fn keep_cow_policy() -> nbd_cow::DestroyRetryPolicy {
+    destroy_policy()
 }
 
 // ---------------------------------------------------------------------------
@@ -67,7 +76,8 @@ async fn create_and_destroy() {
     let size = 64 * 1024 * 1024;
 
     let pool = test_device_pool();
-    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
+    let device = pool
+        .create_cow_device(&base, &cow, size)
         .await
         .expect("create");
 
@@ -78,7 +88,10 @@ async fn create_and_destroy() {
         "path should be /dev/nbdN"
     );
 
-    device.destroy().await.expect("destroy");
+    device
+        .destroy_with_retries(destroy_policy())
+        .await
+        .expect("destroy");
     // After destroy, the COW file should be removed
     assert!(!cow.exists(), "COW file should be removed after destroy");
 }
@@ -96,7 +109,8 @@ async fn destroy_keep_cow_preserves_file() {
     let size = 64 * 1024 * 1024;
 
     let pool = test_device_pool();
-    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
+    let device = pool
+        .create_cow_device(&base, &cow, size)
         .await
         .expect("create");
 
@@ -119,7 +133,10 @@ async fn destroy_keep_cow_preserves_file() {
     assert!(status.success());
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
-    device.destroy_keep_cow().await.expect("destroy_keep_cow");
+    device
+        .destroy_keep_cow_with_retries(keep_cow_policy())
+        .await
+        .expect("destroy_keep_cow");
     assert!(cow.exists(), "COW file should be preserved");
 }
 
@@ -136,7 +153,8 @@ async fn write_and_read_back_via_block_device() {
     let size = 64 * 1024 * 1024;
 
     let pool = test_device_pool();
-    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
+    let device = pool
+        .create_cow_device(&base, &cow, size)
         .await
         .expect("create");
     let dev_path = device.device_path().to_owned();
@@ -185,7 +203,10 @@ async fn write_and_read_back_via_block_device() {
         "marker should survive write/read"
     );
 
-    device.destroy().await.expect("destroy");
+    device
+        .destroy_with_retries(destroy_policy())
+        .await
+        .expect("destroy");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -201,7 +222,8 @@ async fn cow_file_is_sparse() {
     let size = 64 * 1024 * 1024;
 
     let pool = test_device_pool();
-    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
+    let device = pool
+        .create_cow_device(&base, &cow, size)
         .await
         .expect("create");
 
@@ -226,7 +248,10 @@ async fn cow_file_is_sparse() {
     // Give the flush a moment
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
-    device.destroy_keep_cow().await.expect("destroy");
+    device
+        .destroy_keep_cow_with_retries(keep_cow_policy())
+        .await
+        .expect("destroy");
 
     // Check COW file is sparse — actual disk usage should be much less than 64MB
     let meta = fs::metadata(&cow).expect("metadata");
@@ -250,7 +275,8 @@ async fn device_path_format() {
     let size = 64 * 1024 * 1024;
 
     let pool = test_device_pool();
-    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
+    let device = pool
+        .create_cow_device(&base, &cow, size)
         .await
         .expect("create");
 
@@ -260,7 +286,10 @@ async fn device_path_format() {
         "device path should start with /dev/nbd, got: {path_str}"
     );
 
-    device.destroy().await.expect("destroy");
+    device
+        .destroy_with_retries(destroy_policy())
+        .await
+        .expect("destroy");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -278,10 +307,12 @@ async fn multiple_devices_from_same_base() {
     let cow2 = tmp.path().join("cow2.img");
 
     let pool = test_device_pool();
-    let mut dev1 = nbd_cow::NbdCowDevice::create(&base, &cow1, size, &pool)
+    let dev1 = pool
+        .create_cow_device(&base, &cow1, size)
         .await
         .expect("create 1");
-    let mut dev2 = nbd_cow::NbdCowDevice::create(&base, &cow2, size, &pool)
+    let dev2 = pool
+        .create_cow_device(&base, &cow2, size)
         .await
         .expect("create 2");
 
@@ -289,8 +320,12 @@ async fn multiple_devices_from_same_base() {
     assert!(dev1.device_path().exists());
     assert!(dev2.device_path().exists());
 
-    dev1.destroy().await.expect("destroy 1");
-    dev2.destroy().await.expect("destroy 2");
+    dev1.destroy_with_retries(destroy_policy())
+        .await
+        .expect("destroy 1");
+    dev2.destroy_with_retries(destroy_policy())
+        .await
+        .expect("destroy 2");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -311,7 +346,8 @@ async fn snapshot_restore_round_trip() {
 
     // Phase 1: create device, write data, destroy_keep_cow
     {
-        let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
+        let device = pool
+            .create_cow_device(&base, &cow, size)
             .await
             .expect("create");
 
@@ -347,7 +383,10 @@ async fn snapshot_restore_round_trip() {
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
         device.log_status().await;
-        device.destroy_keep_cow().await.expect("destroy_keep_cow");
+        device
+            .destroy_keep_cow_with_retries(keep_cow_policy())
+            .await
+            .expect("destroy_keep_cow");
     }
 
     // Verify COW file and bitmap exist
@@ -373,7 +412,8 @@ async fn snapshot_restore_round_trip() {
 
     // Phase 2: create new device with same base + COW — data should persist
     {
-        let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
+        let device = pool
+            .create_cow_device(&base, &cow, size)
             .await
             .expect("restore create");
 
@@ -406,7 +446,10 @@ async fn snapshot_restore_round_trip() {
             "marker should survive snapshot restore"
         );
 
-        device.destroy().await.expect("destroy");
+        device
+            .destroy_with_retries(destroy_policy())
+            .await
+            .expect("destroy");
     }
 
     // After destroy, COW and bitmap should both be cleaned up
@@ -434,9 +477,9 @@ async fn connect_device_specific_index() {
     let cow = tmp.path().join("cow.img");
     let size: u64 = 64 * 1024 * 1024;
 
-    // Find a free device via pool, then connect with connect_device directly
-    let pool = test_device_pool();
-    let device_index = pool.lock().await.acquire().await.expect("acquire");
+    let device_index = (0..nbd_cow::netlink::nbds_max())
+        .find(|index| nbd_cow::netlink::device_appears_free(*index))
+        .expect("free NBD device");
 
     let mut client_fds = Vec::new();
     let mut server_handles = Vec::new();
@@ -477,9 +520,6 @@ async fn connect_device_specific_index() {
     }
     drop(client_fds);
     let _ = nbd_cow::netlink::disconnect(device_index);
-
-    pool.lock().await.release(device_index);
-    pool.lock().await.cleanup().await;
 }
 
 /// After destroy + release, the pool should not hand back the same device
@@ -496,25 +536,26 @@ async fn pool_cooldown_prevents_immediate_reuse() {
     let size = 64 * 1024 * 1024;
 
     // Use a long cooldown so the released device can't be reused
-    let pool = tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
-        nbd_cow::pool::DevicePoolConfig {
-            cooldown: std::time::Duration::from_secs(60),
-        },
-    ));
+    let pool = nbd_cow::pool::DevicePoolHandle::new(nbd_cow::pool::DevicePoolConfig {
+        cooldown: std::time::Duration::from_secs(60),
+    });
 
     let cow1 = tmp.path().join("cow1.img");
-    let mut dev1 = nbd_cow::NbdCowDevice::create(&base, &cow1, size, &pool)
+    let dev1 = pool
+        .create_cow_device(&base, &cow1, size)
         .await
         .expect("create 1");
     let idx1 = dev1.device_index();
 
-    dev1.destroy().await.expect("destroy 1");
-    pool.lock().await.release(idx1);
+    dev1.destroy_with_retries(destroy_policy())
+        .await
+        .expect("destroy 1");
 
     // Immediately create another device — should get a DIFFERENT index
     // because idx1 is still in cooldown (60s)
     let cow2 = tmp.path().join("cow2.img");
-    let mut dev2 = nbd_cow::NbdCowDevice::create(&base, &cow2, size, &pool)
+    let dev2 = pool
+        .create_cow_device(&base, &cow2, size)
         .await
         .expect("create 2");
     let idx2 = dev2.device_index();
@@ -524,9 +565,10 @@ async fn pool_cooldown_prevents_immediate_reuse() {
         "pool should not reuse device {idx1} during cooldown"
     );
 
-    dev2.destroy().await.expect("destroy 2");
-    pool.lock().await.release(idx2);
-    pool.lock().await.cleanup().await;
+    dev2.destroy_with_retries(destroy_policy())
+        .await
+        .expect("destroy 2");
+    pool.cleanup().await;
 }
 
 /// After cooldown expires, a released device should become available again.
@@ -542,96 +584,91 @@ async fn pool_release_and_reacquire_after_cooldown() {
     let size = 64 * 1024 * 1024;
 
     // Very short cooldown so we can test re-acquisition
-    let pool = tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
-        nbd_cow::pool::DevicePoolConfig {
-            cooldown: std::time::Duration::from_millis(50),
-        },
-    ));
+    let pool = nbd_cow::pool::DevicePoolHandle::new(nbd_cow::pool::DevicePoolConfig {
+        cooldown: std::time::Duration::from_millis(50),
+    });
 
     let cow = tmp.path().join("cow.img");
-    let mut dev = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
+    let dev = pool
+        .create_cow_device(&base, &cow, size)
         .await
         .expect("create");
-    let idx = dev.device_index();
 
-    dev.destroy().await.expect("destroy");
-    pool.lock().await.release(idx);
+    dev.destroy_with_retries(destroy_policy())
+        .await
+        .expect("destroy");
 
     // Wait for cooldown to expire
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-    // The released device should now be available via acquire
-    let reacquired = pool.lock().await.acquire().await.expect("reacquire");
-
-    // We can't guarantee it's the SAME index (background scan might find
-    // another free device first), but acquire should succeed without error.
-    // Release it back and clean up.
-    pool.lock().await.release(reacquired);
-    pool.lock().await.cleanup().await;
+    let cow2 = tmp.path().join("cow2.img");
+    let dev2 = pool
+        .create_cow_device(&base, &cow2, size)
+        .await
+        .expect("create after cooldown");
+    dev2.destroy_with_retries(destroy_policy())
+        .await
+        .expect("destroy after cooldown");
+    pool.cleanup().await;
 }
 
-/// Pool warmup should populate the ready queue.
+/// Pool warmup should leave the public pooled-device path usable.
 #[tokio::test(flavor = "multi_thread")]
 #[ignore]
-async fn pool_warmup_populates_ready_queue() {
+async fn pool_warmup_allows_pooled_create() {
     require_root!();
     require_nbd!();
 
-    let pool = tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
-        nbd_cow::pool::DevicePoolConfig::default(),
-    ));
-    pool.lock().await.warmup().await;
+    let pool = nbd_cow::pool::DevicePoolHandle::new(nbd_cow::pool::DevicePoolConfig::default());
+    pool.warmup().await;
 
-    // After warmup, acquire should be instant (Tier 1 — from ready queue)
-    let start = std::time::Instant::now();
-    let idx = pool
-        .lock()
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("base.img");
+    create_test_base_image(&base);
+    let cow = tmp.path().join("cow.img");
+    let device = pool
+        .create_cow_device(&base, &cow, 64 * 1024 * 1024)
         .await
-        .acquire()
+        .expect("create after warmup");
+
+    device
+        .destroy_with_retries(destroy_policy())
         .await
-        .expect("acquire after warmup");
-    let elapsed = start.elapsed();
-
-    // Tier 1 acquire should be sub-millisecond (no sysfs scan needed)
-    assert!(
-        elapsed.as_millis() < 50,
-        "acquire after warmup took {elapsed:?}, expected < 50ms (Tier 1)"
-    );
-
-    pool.lock().await.release(idx);
-    pool.lock().await.cleanup().await;
+        .expect("destroy after warmup");
+    pool.cleanup().await;
 }
 
 /// After cleanup(), acquire must return NoFreeDevice immediately.
 /// This is a pure-logic test — no root or nbd module required.
 #[tokio::test(flavor = "multi_thread")]
 async fn pool_cleanup_rejects_acquire() {
-    let pool = tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
-        nbd_cow::pool::DevicePoolConfig::default(),
-    ));
-    pool.lock().await.cleanup().await;
+    let pool = nbd_cow::pool::DevicePoolHandle::new(nbd_cow::pool::DevicePoolConfig::default());
+    pool.cleanup().await;
 
-    let result = pool.lock().await.acquire().await;
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("base.img");
+    create_test_base_image(&base);
+    let cow = tmp.path().join("cow.img");
+    let result = pool.create_cow_device(&base, &cow, 64 * 1024 * 1024).await;
     assert!(result.is_err(), "acquire after cleanup should fail");
 }
 
-/// Calling release() after cleanup() should be a no-op (not panic or corrupt state).
+/// Calling cleanup() twice should be a no-op (not panic or corrupt state).
 /// This is a pure-logic test — no root or nbd module required.
 #[tokio::test(flavor = "multi_thread")]
-async fn pool_release_after_cleanup_is_noop() {
-    let pool = tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
-        nbd_cow::pool::DevicePoolConfig::default(),
-    ));
-    pool.lock().await.cleanup().await;
+async fn pool_cleanup_is_idempotent() {
+    let pool = nbd_cow::pool::DevicePoolHandle::new(nbd_cow::pool::DevicePoolConfig::default());
+    pool.cleanup().await;
+    pool.cleanup().await;
 
-    // release after cleanup should silently do nothing
-    pool.lock().await.release(42);
-
-    // pool should still reject acquire
-    let result = pool.lock().await.acquire().await;
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("base.img");
+    create_test_base_image(&base);
+    let cow = tmp.path().join("cow.img");
+    let result = pool.create_cow_device(&base, &cow, 64 * 1024 * 1024).await;
     assert!(
         result.is_err(),
-        "acquire should still fail after release on cleaned-up pool"
+        "create should still fail after repeated cleanup"
     );
 }
 
@@ -650,7 +687,8 @@ async fn drop_without_destroy_disconnects() {
     let size: u64 = 64 * 1024 * 1024;
 
     let pool = test_device_pool();
-    let device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
+    let device = pool
+        .create_cow_device(&base, &cow, size)
         .await
         .expect("create");
 
@@ -688,5 +726,5 @@ async fn drop_without_destroy_disconnects() {
         );
     }
 
-    pool.lock().await.cleanup().await;
+    pool.cleanup().await;
 }

--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -1,7 +1,7 @@
 //! COW Device Pool for Firecracker VMs
 //!
 //! Pre-warms COW files in the background to reduce sandbox creation latency.
-//! On acquire, only `NbdCowDevice::create()` remains on the hot path (~15ms,
+//! On acquire, only `DevicePoolHandle::create_cow_device()` remains on the hot path (~15ms,
 //! netlink connect — no subprocess calls).
 //!
 //! Follows the [`NetnsPool`](crate::network::NetnsPool) pattern:
@@ -41,7 +41,7 @@ pub(crate) struct CowPoolConfig {
 /// A pre-warmed slot: workspace directory + COW file created.
 ///
 /// The caller must create the NBD device on acquire via
-/// [`NbdCowDevice::create()`](nbd_cow::NbdCowDevice::create).
+/// `DevicePoolHandle::create_cow_device()`.
 pub(crate) struct PrewarmedSlot {
     /// Unique slot ID (UUID). Used as workspace directory name.
     pub id: String,
@@ -85,7 +85,7 @@ pub(crate) enum CowPoolError {
 ///
 /// Maintains a buffer of pre-created COW files. On [`acquire`](Self::acquire),
 /// pops a slot and the caller creates the NBD device with
-/// [`NbdCowDevice::create()`](nbd_cow::NbdCowDevice::create).
+/// `DevicePoolHandle::create_cow_device()`.
 pub(crate) struct CowPool {
     active: bool,
     queue: VecDeque<PrewarmedSlot>,

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -28,8 +28,10 @@ pub(crate) const DESTROY_RETRY_DELAY: std::time::Duration = std::time::Duration:
 ///
 /// Shutdown is the graceful path, so already-queued leak reports should drain
 /// before the pool Arcs are unwrapped. If cleanup gets stuck, fall back to
-/// aborting and let the next `runner gc` clean leftovers.
-const LEAK_CLEANUP_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+/// aborting and let the next `runner gc` clean leftovers. This must exceed the
+/// COW destroy retry budget because leaked sandbox cleanup now owns the pooled
+/// COW device and may need a full finalizer pass before releasing netns/dirs.
+const LEAK_CLEANUP_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Resources that require async cleanup when a sandbox is dropped without
 /// going through `factory.destroy()` or when create is dropped mid-allocation.

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -656,14 +656,6 @@ pub fn config_hash() -> String {
     hex::encode(Sha256::digest(json.as_bytes()))
 }
 
-fn take_owned_netns_pool<T>(netns_pool: &mut Option<T>, owns_netns_pool: bool) -> Option<T> {
-    if owns_netns_pool {
-        netns_pool.take()
-    } else {
-        None
-    }
-}
-
 pub struct FirecrackerFactory {
     config: FirecrackerConfig,
     factory_paths: FactoryPaths,
@@ -1005,7 +997,8 @@ impl SandboxFactory for FirecrackerFactory {
         // Direct factories own their netns pool and must clean it up even when
         // detached destroy tasks still hold Arc clones. Shared runtime pools are
         // cleaned up by FirecrackerRuntime::shutdown().
-        if let Some(netns_pool) = take_owned_netns_pool(&mut self.netns_pool, self.owns_netns_pool)
+        if self.owns_netns_pool
+            && let Some(netns_pool) = self.netns_pool.take()
         {
             let mut pool = netns_pool.lock().await;
             if let Err(e) = pool.cleanup().await {
@@ -1099,28 +1092,30 @@ mod tests {
         assert_eq!(h1.len(), 64); // SHA-256 hex
     }
 
-    #[test]
-    fn take_owned_netns_pool_takes_owned_pool_with_extra_arc_refs() {
-        let pool = Arc::new(());
+    #[tokio::test]
+    async fn shutdown_cleans_owned_netns_pool_with_extra_arc_refs() {
+        let pool = Arc::new(tokio::sync::Mutex::new(NetnsPool::inactive_for_test()));
         let _destroy_task_clone = Arc::clone(&pool);
-        let mut netns_pool = Some(pool);
+        let mut factory = test_factory(true);
+        factory.netns_pool = Some(pool);
+        factory.owns_netns_pool = true;
 
-        let taken = take_owned_netns_pool(&mut netns_pool, true).unwrap();
+        factory.shutdown().await;
 
-        assert!(netns_pool.is_none());
-        assert_eq!(Arc::strong_count(&taken), 2);
+        assert!(factory.netns_pool.is_none());
     }
 
-    #[test]
-    fn take_owned_netns_pool_keeps_shared_pool_for_runtime_shutdown() {
-        let pool = Arc::new(());
-        let mut netns_pool = Some(Arc::clone(&pool));
+    #[tokio::test]
+    async fn shutdown_keeps_shared_netns_pool_for_runtime_shutdown() {
+        let pool = Arc::new(tokio::sync::Mutex::new(NetnsPool::inactive_for_test()));
+        let mut factory = test_factory(true);
+        factory.netns_pool = Some(Arc::clone(&pool));
+        factory.owns_netns_pool = false;
 
-        let taken = take_owned_netns_pool(&mut netns_pool, false);
+        factory.shutdown().await;
 
-        assert!(taken.is_none());
-        assert!(netns_pool.is_some());
-        assert_eq!(Arc::strong_count(netns_pool.as_ref().unwrap()), 2);
+        assert!(factory.netns_pool.is_some());
+        assert_eq!(Arc::strong_count(factory.netns_pool.as_ref().unwrap()), 2);
     }
 
     /// Both supported framework CLIs must be warmed during snapshot creation.

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -954,67 +954,25 @@ impl SandboxFactory for FirecrackerFactory {
     }
 
     async fn destroy(&self, sandbox: Box<dyn Sandbox>) {
-        let mut sandbox = match (sandbox as Box<dyn std::any::Any>).downcast::<FirecrackerSandbox>()
-        {
+        let sandbox = match (sandbox as Box<dyn std::any::Any>).downcast::<FirecrackerSandbox>() {
             Ok(s) => *s,
             Err(_) => {
                 warn!("destroy called with non-firecracker sandbox, ignoring");
                 return;
             }
         };
+        let netns_pool = std::sync::Arc::clone(self.netns_pool());
 
-        // Ensure the sandbox is killed before releasing pool resources.
-        // After kill(), `sandbox.process` is `None`, so the Drop impl's
-        // killpg becomes a no-op when `sandbox` is dropped below.
-        let _ = sandbox.kill().await;
-
-        // Clone lightweight handles before dropping sandbox.
-        let sandbox_id = sandbox.id.clone();
-        let network = sandbox.network.clone();
-        let sock_dir = sandbox.sock_paths.dir().to_owned();
-        let workspace = sandbox.sandbox_paths.workspace().to_owned();
-
-        // Log NBD COW stats before teardown for performance debugging.
-        if let Some(cow_device) = sandbox.cow_device.as_ref() {
-            cow_device.log_status().await;
+        // Move all cleanup-owned resources into a task before the first await.
+        // If the caller drops this destroy future mid-cleanup, the task keeps
+        // running instead of letting FirecrackerSandbox::Drop race the COW
+        // finalizer and directory cleanup.
+        let handle = tokio::spawn(destroy_firecracker_sandbox(sandbox, netns_pool));
+        match handle.await {
+            Ok(()) => {}
+            Err(e) if e.is_panic() => std::panic::resume_unwind(e.into_panic()),
+            Err(e) => warn!(error = %e, "sandbox destroy task was cancelled"),
         }
-
-        // Destroy the NBD COW device (flushes data, disconnects, removes COW file).
-        //
-        // After kill_process_group + child.wait(), the kernel may still be
-        // releasing file descriptors (particularly the NBD device fd).
-        // Retry a few times to let it finish.
-        let cow_destroyed = match sandbox.cow_device.take() {
-            Some(cow_device) => destroy_cow_device_with_retries(&sandbox_id, cow_device).await,
-            None => true,
-        };
-
-        // Return the network namespace to the pool.
-        let mut netns_pool = self.netns_pool().lock().await;
-        if let Err(e) = netns_pool.release(network).await {
-            warn!(id = %sandbox_id, error = %e, "failed to release netns");
-        }
-        drop(netns_pool);
-
-        // Delete the socket directory.
-        if let Err(e) = tokio::fs::remove_dir_all(&sock_dir).await {
-            warn!(id = %sandbox_id, error = %e, "failed to delete sock dir");
-        }
-
-        // Delete the workspace directory only if the COW device was fully torn
-        // down.  When destroy() failed, the NBD device may still reference
-        // the COW file — keep the workspace intact for debugging.
-        if cow_destroyed && let Err(e) = tokio::fs::remove_dir_all(&workspace).await {
-            warn!(id = %sandbox_id, error = %e, "failed to delete workspace");
-        }
-
-        // Mark as destroyed only after all explicit cleanup steps complete.
-        // Until this point, `FirecrackerSandbox::Drop` remains armed as a
-        // panic fallback and sends pool resources to the leak-cleanup task.
-        sandbox.destroyed = true;
-        drop(sandbox);
-
-        info!(id = %sandbox_id, "sandbox destroyed");
     }
 
     async fn shutdown(&mut self) {
@@ -1044,6 +1002,64 @@ impl SandboxFactory for FirecrackerFactory {
         self.started = false;
         info!("factory shutdown complete");
     }
+}
+
+async fn destroy_firecracker_sandbox(
+    mut sandbox: FirecrackerSandbox,
+    netns_pool: std::sync::Arc<tokio::sync::Mutex<NetnsPool>>,
+) {
+    // Ensure the sandbox is killed before releasing pool resources.
+    // After kill(), `sandbox.process` is `None`, so the Drop impl's
+    // killpg becomes a no-op when `sandbox` is dropped below.
+    let _ = sandbox.kill().await;
+
+    // Clone lightweight handles before dropping sandbox.
+    let sandbox_id = sandbox.id.clone();
+    let network = sandbox.network.clone();
+    let sock_dir = sandbox.sock_paths.dir().to_owned();
+    let workspace = sandbox.sandbox_paths.workspace().to_owned();
+
+    // Log NBD COW stats before teardown for performance debugging.
+    if let Some(cow_device) = sandbox.cow_device.as_ref() {
+        cow_device.log_status().await;
+    }
+
+    // Destroy the NBD COW device (flushes data, disconnects, removes COW file).
+    //
+    // After kill_process_group + child.wait(), the kernel may still be
+    // releasing file descriptors (particularly the NBD device fd).
+    // Retry a few times to let it finish.
+    let cow_destroyed = match sandbox.cow_device.take() {
+        Some(cow_device) => destroy_cow_device_with_retries(&sandbox_id, cow_device).await,
+        None => true,
+    };
+
+    // Return the network namespace to the pool.
+    let mut pool = netns_pool.lock().await;
+    if let Err(e) = pool.release(network).await {
+        warn!(id = %sandbox_id, error = %e, "failed to release netns");
+    }
+    drop(pool);
+
+    // Delete the socket directory.
+    if let Err(e) = tokio::fs::remove_dir_all(&sock_dir).await {
+        warn!(id = %sandbox_id, error = %e, "failed to delete sock dir");
+    }
+
+    // Delete the workspace directory only if the COW device was fully torn
+    // down.  When destroy() failed, the NBD device may still reference
+    // the COW file — keep the workspace intact for debugging.
+    if cow_destroyed && let Err(e) = tokio::fs::remove_dir_all(&workspace).await {
+        warn!(id = %sandbox_id, error = %e, "failed to delete workspace");
+    }
+
+    // Mark as destroyed only after all explicit cleanup steps complete.
+    // Until this point, `FirecrackerSandbox::Drop` remains armed as a
+    // panic fallback and sends pool resources to the leak-cleanup task.
+    sandbox.destroyed = true;
+    drop(sandbox);
+
+    info!(id = %sandbox_id, "sandbox destroyed");
 }
 
 impl Drop for FirecrackerFactory {

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -661,6 +661,7 @@ pub struct FirecrackerFactory {
     factory_paths: FactoryPaths,
     runtime_paths: RuntimePaths,
     netns_pool: Option<std::sync::Arc<tokio::sync::Mutex<NetnsPool>>>,
+    owns_netns_pool: bool,
     /// Shared NBD device pool for pre-validated device indices.
     device_pool: nbd_cow::pool::DevicePoolHandle,
     /// Base image path and size (bytes), populated during startup.
@@ -703,12 +704,14 @@ impl FirecrackerFactory {
 
         let factory_paths = FactoryPaths::new(config.base_dir.clone());
         let runtime_paths = RuntimePaths::new();
+        let owns_netns_pool = netns_pool.is_none();
 
         Ok(Self {
             config,
             factory_paths,
             runtime_paths,
             netns_pool,
+            owns_netns_pool,
             device_pool,
             base_image_path: None,
             base_image_size: 0,
@@ -759,6 +762,7 @@ impl SandboxFactory for FirecrackerFactory {
 
         // Create netns pool only if not provided externally (shared pool case).
         if self.netns_pool.is_none() {
+            self.owns_netns_pool = true;
             let t = std::time::Instant::now();
             let netns_config = NetnsPoolConfig {
                 proxy_port: self.config.proxy_port,
@@ -990,12 +994,15 @@ impl SandboxFactory for FirecrackerFactory {
 
         self.base_image_path = None;
 
-        // Clean up netns pool only if we hold the last reference.
-        // When shared across multiple factories, the caller manages cleanup.
-        if let Some(Ok(mutex)) = self.netns_pool.take().map(std::sync::Arc::try_unwrap) {
-            let mut pool = mutex.into_inner();
+        // Direct factories own their netns pool and must clean it up even when
+        // detached destroy tasks still hold Arc clones. Shared runtime pools are
+        // cleaned up by FirecrackerRuntime::shutdown().
+        if self.owns_netns_pool
+            && let Some(netns_pool) = self.netns_pool.take()
+        {
+            let mut pool = netns_pool.lock().await;
             if let Err(e) = pool.cleanup().await {
-                warn!(error = %e, "failed to cleanup netns pool");
+                warn!(error = %e, "failed to cleanup owned netns pool");
             }
         }
 
@@ -1309,6 +1316,7 @@ mod tests {
             factory_paths: FactoryPaths::new(PathBuf::from("/tmp/factory-test")),
             runtime_paths: RuntimePaths::new(),
             netns_pool: None,
+            owns_netns_pool: true,
             device_pool: nbd_cow::pool::DevicePoolHandle::new(
                 nbd_cow::pool::DevicePoolConfig::default(),
             ),

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -656,6 +656,14 @@ pub fn config_hash() -> String {
     hex::encode(Sha256::digest(json.as_bytes()))
 }
 
+fn take_owned_netns_pool<T>(netns_pool: &mut Option<T>, owns_netns_pool: bool) -> Option<T> {
+    if owns_netns_pool {
+        netns_pool.take()
+    } else {
+        None
+    }
+}
+
 pub struct FirecrackerFactory {
     config: FirecrackerConfig,
     factory_paths: FactoryPaths,
@@ -997,8 +1005,7 @@ impl SandboxFactory for FirecrackerFactory {
         // Direct factories own their netns pool and must clean it up even when
         // detached destroy tasks still hold Arc clones. Shared runtime pools are
         // cleaned up by FirecrackerRuntime::shutdown().
-        if self.owns_netns_pool
-            && let Some(netns_pool) = self.netns_pool.take()
+        if let Some(netns_pool) = take_owned_netns_pool(&mut self.netns_pool, self.owns_netns_pool)
         {
             let mut pool = netns_pool.lock().await;
             if let Err(e) = pool.cleanup().await {
@@ -1090,6 +1097,30 @@ mod tests {
         let h2 = config_hash();
         assert_eq!(h1, h2);
         assert_eq!(h1.len(), 64); // SHA-256 hex
+    }
+
+    #[test]
+    fn take_owned_netns_pool_takes_owned_pool_with_extra_arc_refs() {
+        let pool = Arc::new(());
+        let _destroy_task_clone = Arc::clone(&pool);
+        let mut netns_pool = Some(pool);
+
+        let taken = take_owned_netns_pool(&mut netns_pool, true).unwrap();
+
+        assert!(netns_pool.is_none());
+        assert_eq!(Arc::strong_count(&taken), 2);
+    }
+
+    #[test]
+    fn take_owned_netns_pool_keeps_shared_pool_for_runtime_shutdown() {
+        let pool = Arc::new(());
+        let mut netns_pool = Some(Arc::clone(&pool));
+
+        let taken = take_owned_netns_pool(&mut netns_pool, false);
+
+        assert!(taken.is_none());
+        assert!(netns_pool.is_some());
+        assert_eq!(Arc::strong_count(netns_pool.as_ref().unwrap()), 2);
     }
 
     /// Both supported framework CLIs must be warmed during snapshot creation.

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -8,7 +8,7 @@ use sandbox::{
 use sha2::{Digest, Sha256};
 use tracing::{info, warn};
 
-use nbd_cow::NbdCowDevice;
+use nbd_cow::{DestroyRetryPolicy, PooledNbdCowDevice};
 
 use crate::config::FirecrackerConfig;
 use crate::network::{GUEST_NETWORK, NetnsPool, NetnsPoolConfig, PooledNetns, generate_boot_args};
@@ -38,8 +38,7 @@ const LEAK_CLEANUP_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::
 /// drains them asynchronously.
 pub(crate) struct LeakedResources {
     pub(crate) sandbox_id: String,
-    pub(crate) device_index: Option<u32>,
-    pub(crate) cow_device: Option<NbdCowDevice>,
+    pub(crate) cow_device: Option<PooledNbdCowDevice>,
     pub(crate) network: Option<PooledNetns>,
     pub(crate) sock_dir: PathBuf,
     pub(crate) workspace: PathBuf,
@@ -57,21 +56,13 @@ struct LeakCleaner {
 }
 
 impl LeakCleaner {
-    fn spawn(
-        device_pool: std::sync::Arc<tokio::sync::Mutex<nbd_cow::pool::DevicePool>>,
-        netns_pool: std::sync::Arc<tokio::sync::Mutex<NetnsPool>>,
-    ) -> Self {
+    fn spawn(netns_pool: std::sync::Arc<tokio::sync::Mutex<NetnsPool>>) -> Self {
         // Drop cannot await, and losing a leak report can strand host resources.
         // Keep this unbounded: reports only come from exceptional cleanup paths,
         // with runner GC as the final backstop if the cleaner stalls.
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
-        let handle = tokio::spawn(drain_leaked_resources(
-            rx,
-            shutdown_rx,
-            device_pool,
-            netns_pool,
-        ));
+        let handle = tokio::spawn(drain_leaked_resources(rx, shutdown_rx, netns_pool));
         Self {
             tx: Some(tx),
             shutdown_tx: Some(shutdown_tx),
@@ -131,7 +122,7 @@ impl Drop for LeakCleaner {
 
 #[async_trait]
 trait CreateRollbackCleanup {
-    async fn destroy_cow_device(&self, cow_device: NbdCowDevice) -> bool;
+    async fn destroy_cow_device(&self, cow_device: PooledNbdCowDevice) -> bool;
     async fn release_network(&self, network: PooledNetns);
     async fn remove_dir(&self, kind: &'static str, path: PathBuf);
     fn destroy_slot(&self, slot: crate::cow_pool::PrewarmedSlot);
@@ -139,17 +130,13 @@ trait CreateRollbackCleanup {
 
 struct FactoryCreateRollbackCleanup {
     id: String,
-    device_pool: std::sync::Arc<tokio::sync::Mutex<nbd_cow::pool::DevicePool>>,
     netns_pool: std::sync::Arc<tokio::sync::Mutex<NetnsPool>>,
 }
 
 #[async_trait]
 impl CreateRollbackCleanup for FactoryCreateRollbackCleanup {
-    async fn destroy_cow_device(&self, mut cow_device: NbdCowDevice) -> bool {
-        let device_index = cow_device.device_index();
-        let cow_destroyed = destroy_cow_device_with_retries(&self.id, &mut cow_device).await;
-        self.device_pool.lock().await.release(device_index);
-        cow_destroyed
+    async fn destroy_cow_device(&self, cow_device: PooledNbdCowDevice) -> bool {
+        destroy_cow_device_with_retries(&self.id, cow_device).await
     }
 
     async fn release_network(&self, network: PooledNetns) {
@@ -184,7 +171,7 @@ struct SandboxCreateResources {
     sandbox_paths: SandboxPaths,
     sock_paths: SockPaths,
     network: PooledNetns,
-    cow_device: NbdCowDevice,
+    cow_device: PooledNbdCowDevice,
 }
 
 #[cfg(test)]
@@ -200,7 +187,7 @@ struct SandboxCreateTransaction {
     workspace: Option<PathBuf>,
     sock_dir: Option<PathBuf>,
     network: Option<PooledNetns>,
-    cow_device: Option<NbdCowDevice>,
+    cow_device: Option<PooledNbdCowDevice>,
     leak_tx: Option<tokio::sync::mpsc::UnboundedSender<LeakedResources>>,
 }
 
@@ -249,7 +236,7 @@ impl SandboxCreateTransaction {
         self.network = Some(network);
     }
 
-    fn track_cow_device(&mut self, cow_device: NbdCowDevice) {
+    fn track_cow_device(&mut self, cow_device: PooledNbdCowDevice) {
         self.cow_device = Some(cow_device);
     }
 
@@ -382,7 +369,6 @@ impl SandboxCreateTransaction {
 
         let leaked = LeakedResources {
             sandbox_id: self.id.clone(),
-            device_index: None,
             cow_device: self.cow_device.take(),
             network: self.network.take(),
             sock_dir,
@@ -471,23 +457,24 @@ where
     }
 }
 
-async fn destroy_cow_device_with_retries(id: &str, cow_device: &mut NbdCowDevice) -> bool {
-    for attempt in 0..DESTROY_RETRIES {
-        match cow_device.destroy().await {
-            Ok(()) => return true,
-            Err(e) => {
-                if attempt + 1 < DESTROY_RETRIES {
-                    tokio::time::sleep(DESTROY_RETRY_DELAY).await;
-                } else {
-                    // Last resort: abandon the device. It persists in
-                    // the kernel until `runner gc` cleans it up.
-                    warn!(id = %id, error = %e, "destroy failed after retries — abandoning");
-                    cow_device.abandon();
-                }
-            }
+fn cow_destroy_retry_policy() -> DestroyRetryPolicy {
+    DestroyRetryPolicy {
+        attempts: DESTROY_RETRIES,
+        delay: DESTROY_RETRY_DELAY,
+    }
+}
+
+async fn destroy_cow_device_with_retries(id: &str, cow_device: PooledNbdCowDevice) -> bool {
+    match cow_device
+        .destroy_with_retries(cow_destroy_retry_policy())
+        .await
+    {
+        Ok(()) => true,
+        Err(e) => {
+            warn!(id = %id, error = %e, "destroy failed after retries — abandoned device");
+            false
         }
     }
-    false
 }
 
 /// Background task that receives leaked sandbox resources from `Drop`
@@ -495,14 +482,12 @@ async fn destroy_cow_device_with_retries(id: &str, cow_device: &mut NbdCowDevice
 async fn drain_leaked_resources(
     rx: tokio::sync::mpsc::UnboundedReceiver<LeakedResources>,
     shutdown_rx: tokio::sync::oneshot::Receiver<()>,
-    device_pool: std::sync::Arc<tokio::sync::Mutex<nbd_cow::pool::DevicePool>>,
     netns_pool: std::sync::Arc<tokio::sync::Mutex<NetnsPool>>,
 ) {
     drain_leaked_resources_with_cleanup(rx, shutdown_rx, move |leaked| {
-        let device_pool = std::sync::Arc::clone(&device_pool);
         let netns_pool = std::sync::Arc::clone(&netns_pool);
         async move {
-            cleanup_leaked_resource(leaked, &device_pool, &netns_pool).await;
+            cleanup_leaked_resource(leaked, &netns_pool).await;
         }
     })
     .await;
@@ -538,24 +523,18 @@ async fn drain_leaked_resources_with_cleanup<C, Fut>(
 
 async fn cleanup_leaked_resource(
     leaked: LeakedResources,
-    device_pool: &tokio::sync::Mutex<nbd_cow::pool::DevicePool>,
     netns_pool: &tokio::sync::Mutex<NetnsPool>,
 ) {
     warn!(
         id = %leaked.sandbox_id,
-        device_index = ?leaked.device_index,
         has_cow_device = leaked.cow_device.is_some(),
         has_network = leaked.network.is_some(),
         "cleaning up leaked sandbox resources"
     );
 
     let mut cow_destroyed = true;
-    if let Some(mut cow_device) = leaked.cow_device {
-        let device_index = cow_device.device_index();
-        cow_destroyed = destroy_cow_device_with_retries(&leaked.sandbox_id, &mut cow_device).await;
-        device_pool.lock().await.release(device_index);
-    } else if let Some(device_index) = leaked.device_index {
-        device_pool.lock().await.release(device_index);
+    if let Some(cow_device) = leaked.cow_device {
+        cow_destroyed = destroy_cow_device_with_retries(&leaked.sandbox_id, cow_device).await;
     }
 
     if let Some(network) = leaked.network {
@@ -681,7 +660,7 @@ pub struct FirecrackerFactory {
     runtime_paths: RuntimePaths,
     netns_pool: Option<std::sync::Arc<tokio::sync::Mutex<NetnsPool>>>,
     /// Shared NBD device pool for pre-validated device indices.
-    device_pool: std::sync::Arc<tokio::sync::Mutex<nbd_cow::pool::DevicePool>>,
+    device_pool: nbd_cow::pool::DevicePoolHandle,
     /// Base image path and size (bytes), populated during startup.
     base_image_path: Option<std::path::PathBuf>,
     base_image_size: u64,
@@ -701,7 +680,7 @@ impl FirecrackerFactory {
     pub async fn new(
         config: FirecrackerConfig,
         netns_pool: Option<std::sync::Arc<tokio::sync::Mutex<NetnsPool>>>,
-        device_pool: std::sync::Arc<tokio::sync::Mutex<nbd_cow::pool::DevicePool>>,
+        device_pool: nbd_cow::pool::DevicePoolHandle,
     ) -> Result<Self, SandboxError> {
         let t = std::time::Instant::now();
         let mode = match config.snapshot.as_ref() {
@@ -828,10 +807,7 @@ impl SandboxFactory for FirecrackerFactory {
 
         // Spawn background task to clean up resources leaked by sandbox Drop
         // impls that fire without going through factory.destroy().
-        self.leak_cleaner = Some(LeakCleaner::spawn(
-            std::sync::Arc::clone(&self.device_pool),
-            self.netns_pool().clone(),
-        ));
+        self.leak_cleaner = Some(LeakCleaner::spawn(self.netns_pool().clone()));
 
         self.started = true;
 
@@ -857,7 +833,6 @@ impl SandboxFactory for FirecrackerFactory {
         let id = config.id.to_string();
         let rollback_cleanup = FactoryCreateRollbackCleanup {
             id: id.clone(),
-            device_pool: std::sync::Arc::clone(&self.device_pool),
             netns_pool: std::sync::Arc::clone(self.netns_pool()),
         };
         let mut tx = SandboxCreateTransaction::new_with_leak_tx(
@@ -933,17 +908,14 @@ impl SandboxFactory for FirecrackerFactory {
                         state: "started without base image".into(),
                         message: "factory base image path missing".into(),
                     })?;
-            let cow_device = NbdCowDevice::create(
-                base_image,
-                &cow_file,
-                self.base_image_size,
-                &self.device_pool,
-            )
-            .await
-            .map_err(|e| SandboxError::Initialization {
-                phase: SandboxInitializationPhase::SandboxAllocation,
-                message: format!("create NBD COW device: {e}"),
-            })?;
+            let cow_device = self
+                .device_pool
+                .create_cow_device(base_image, &cow_file, self.base_image_size)
+                .await
+                .map_err(|e| SandboxError::Initialization {
+                    phase: SandboxInitializationPhase::SandboxAllocation,
+                    message: format!("create NBD COW device: {e}"),
+                })?;
             tx.track_cow_device(cow_device);
 
             tx.commit()
@@ -994,26 +966,26 @@ impl SandboxFactory for FirecrackerFactory {
         // killpg becomes a no-op when `sandbox` is dropped below.
         let _ = sandbox.kill().await;
 
-        // Clone lightweight handles before dropping sandbox — Drop requires
-        // all fields intact, so we cannot move them out.
+        // Clone lightweight handles before dropping sandbox.
         let sandbox_id = sandbox.id.clone();
         let network = sandbox.network.clone();
         let sock_dir = sandbox.sock_paths.dir().to_owned();
         let workspace = sandbox.sandbox_paths.workspace().to_owned();
 
         // Log NBD COW stats before teardown for performance debugging.
-        sandbox.cow_device.log_status().await;
+        if let Some(cow_device) = sandbox.cow_device.as_ref() {
+            cow_device.log_status().await;
+        }
 
         // Destroy the NBD COW device (flushes data, disconnects, removes COW file).
         //
         // After kill_process_group + child.wait(), the kernel may still be
         // releasing file descriptors (particularly the NBD device fd).
         // Retry a few times to let it finish.
-        let device_index = sandbox.cow_device.device_index();
-        let cow_destroyed =
-            destroy_cow_device_with_retries(&sandbox_id, &mut sandbox.cow_device).await;
-        // Release device index back to pool with cooldown.
-        self.device_pool.lock().await.release(device_index);
+        let cow_destroyed = match sandbox.cow_device.take() {
+            Some(cow_device) => destroy_cow_device_with_retries(&sandbox_id, cow_device).await,
+            None => true,
+        };
 
         // Return the network namespace to the pool.
         let mut netns_pool = self.netns_pool().lock().await;
@@ -1228,7 +1200,7 @@ mod tests {
 
     #[async_trait]
     impl CreateRollbackCleanup for BlockingRemoveDirCleanup {
-        async fn destroy_cow_device(&self, _cow_device: NbdCowDevice) -> bool {
+        async fn destroy_cow_device(&self, _cow_device: PooledNbdCowDevice) -> bool {
             panic!("test cleanup should not receive a real COW device");
         }
 
@@ -1260,7 +1232,7 @@ mod tests {
 
     #[async_trait]
     impl CreateRollbackCleanup for RecordingCreateRollbackCleanup {
-        async fn destroy_cow_device(&self, _cow_device: NbdCowDevice) -> bool {
+        async fn destroy_cow_device(&self, _cow_device: PooledNbdCowDevice) -> bool {
             panic!("test cleanup should not receive a real COW device");
         }
 
@@ -1290,10 +1262,9 @@ mod tests {
         }
     }
 
-    fn test_leaked_resource(sandbox_id: &str, device_index: u32) -> LeakedResources {
+    fn test_leaked_resource(sandbox_id: &str) -> LeakedResources {
         LeakedResources {
             sandbox_id: sandbox_id.into(),
-            device_index: Some(device_index),
             cow_device: None,
             network: Some(test_network()),
             sock_dir: PathBuf::from("/nonexistent"),
@@ -1320,9 +1291,9 @@ mod tests {
             factory_paths: FactoryPaths::new(PathBuf::from("/tmp/factory-test")),
             runtime_paths: RuntimePaths::new(),
             netns_pool: None,
-            device_pool: std::sync::Arc::new(tokio::sync::Mutex::new(
-                nbd_cow::pool::DevicePool::new(nbd_cow::pool::DevicePoolConfig::default()),
-            )),
+            device_pool: nbd_cow::pool::DevicePoolHandle::new(
+                nbd_cow::pool::DevicePoolConfig::default(),
+            ),
             base_image_path: None,
             base_image_size: 0,
             cow_pool: None,
@@ -1566,7 +1537,7 @@ mod tests {
         tokio::fs::create_dir_all(&workspace).await.unwrap();
         tokio::fs::create_dir_all(&sock_dir).await.unwrap();
         let (leak_tx, mut leak_rx) = tokio::sync::mpsc::unbounded_channel();
-        leak_tx.send(test_leaked_resource("queued", 7)).unwrap();
+        leak_tx.send(test_leaked_resource("queued")).unwrap();
 
         let mut tx = SandboxCreateTransaction::new_with_leak_tx("sandbox".into(), Some(leak_tx));
         tx.slot_renamed_to(workspace.clone());
@@ -1601,7 +1572,6 @@ mod tests {
 
         let leaked = leak_rx.recv().await.unwrap();
         assert_eq!(leaked.sandbox_id, "sandbox");
-        assert_eq!(leaked.device_index, None);
         assert!(leaked.cow_device.is_none());
         assert_eq!(leaked.network.unwrap().name, "test-ns");
         assert_eq!(leaked.sock_dir, sock_dir);
@@ -1648,7 +1618,6 @@ mod tests {
 
         tx.send(LeakedResources {
             sandbox_id: "test-sandbox".into(),
-            device_index: Some(42),
             cow_device: None,
             network: Some(test_network()),
             sock_dir: PathBuf::from("/tmp/nonexistent-sock"),
@@ -1658,7 +1627,7 @@ mod tests {
 
         let leaked = rx.recv().await.unwrap();
         assert_eq!(leaked.sandbox_id, "test-sandbox");
-        assert_eq!(leaked.device_index, Some(42));
+        assert!(leaked.cow_device.is_none());
     }
 
     #[test]
@@ -1668,7 +1637,6 @@ mod tests {
 
         let resources = LeakedResources {
             sandbox_id: "test".into(),
-            device_index: Some(0),
             cow_device: None,
             network: Some(test_network()),
             sock_dir: PathBuf::from("/nonexistent"),
@@ -1684,7 +1652,7 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
 
         for index in 0..64 {
-            tx.send(test_leaked_resource(&format!("leaked-{index}"), index))
+            tx.send(test_leaked_resource(&format!("leaked-{index}")))
                 .unwrap();
         }
 
@@ -1700,7 +1668,7 @@ mod tests {
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
 
         for index in 0..64 {
-            tx.send(test_leaked_resource(&format!("leaked-{index}"), index))
+            tx.send(test_leaked_resource(&format!("leaked-{index}")))
                 .unwrap();
         }
 
@@ -1726,7 +1694,7 @@ mod tests {
         let expected: Vec<String> = (0..64).map(|index| format!("leaked-{index}")).collect();
         assert_eq!(*cleaned.lock().await, expected);
         assert!(matches!(
-            live_sender_clone.send(test_leaked_resource("late", 2)),
+            live_sender_clone.send(test_leaked_resource("late")),
             Err(tokio::sync::mpsc::error::SendError(_))
         ));
     }
@@ -1736,8 +1704,8 @@ mod tests {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
         let (_shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
 
-        tx.send(test_leaked_resource("first", 0)).unwrap();
-        tx.send(test_leaked_resource("second", 1)).unwrap();
+        tx.send(test_leaked_resource("first")).unwrap();
+        tx.send(test_leaked_resource("second")).unwrap();
         drop(tx);
 
         let cleaned = Arc::new(tokio::sync::Mutex::new(Vec::new()));

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -1792,6 +1792,18 @@ mod tests {
         assert!(aborted.load(Ordering::SeqCst));
     }
 
+    #[test]
+    fn leak_cleaner_shutdown_timeout_covers_cow_destroy_retry_budget() {
+        let retry_budget = DESTROY_RETRY_DELAY
+            .checked_mul(DESTROY_RETRIES)
+            .expect("destroy retry budget should fit in Duration");
+
+        assert!(
+            LEAK_CLEANUP_SHUTDOWN_TIMEOUT > retry_budget,
+            "leak cleaner shutdown timeout must allow queued COW finalizers to finish"
+        );
+    }
+
     #[tokio::test]
     async fn leak_cleaner_abort_closes_sender_and_aborts_task() {
         struct AbortFlag(Arc<AtomicBool>);

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -685,6 +685,29 @@ pub struct NetnsPool {
 }
 
 impl NetnsPool {
+    #[cfg(test)]
+    pub(crate) fn inactive_for_test() -> Self {
+        let file = tempfile::tempfile().expect("create test netns pool lock file");
+        let lock = match Flock::lock(file, FlockArg::LockExclusiveNonblock) {
+            Ok(lock) => lock,
+            Err((_, errno)) => panic!("lock test netns pool file: {errno}"),
+        };
+
+        Self {
+            active: false,
+            plain_queue: VecDeque::new(),
+            proxy_queue: VecDeque::new(),
+            pending_plain: tokio::task::JoinSet::new(),
+            pending_proxy: tokio::task::JoinSet::new(),
+            next_ns_index: 0,
+            pool_index: 0,
+            proxy_port: None,
+            dns_port: None,
+            default_iface: "test0".into(),
+            _lock: lock,
+        }
+    }
+
     /// Create a new pool with a small pre-warmed buffer.
     ///
     /// Pre-warms `BUFFER_SIZE` namespaces per queue at startup.

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -17,7 +17,7 @@ use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
 
 /// Firecracker-backed sandbox runtime.
 ///
-/// Manages shared resources ([`NetnsPool`], [`DevicePool`]) and creates
+/// Manages shared resources ([`NetnsPool`], [`DevicePoolHandle`]) and creates
 /// [`FirecrackerFactory`] instances that share them.
 pub struct FirecrackerRuntime {
     netns_pool: Arc<tokio::sync::Mutex<NetnsPool>>,

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -8,7 +8,7 @@ use sandbox::{
     SandboxRuntime, SnapshotRef,
 };
 
-use nbd_cow::pool::{DevicePool, DevicePoolConfig};
+use nbd_cow::pool::{DevicePoolConfig, DevicePoolHandle};
 
 use crate::config::{FirecrackerConfig, SnapshotConfig};
 use crate::factory::FirecrackerFactory;
@@ -21,7 +21,7 @@ use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
 /// [`FirecrackerFactory`] instances that share them.
 pub struct FirecrackerRuntime {
     netns_pool: Arc<tokio::sync::Mutex<NetnsPool>>,
-    device_pool: Arc<tokio::sync::Mutex<DevicePool>>,
+    device_pool: DevicePoolHandle,
     proxy_port: Option<u16>,
     dns_port: Option<u16>,
 }
@@ -51,7 +51,7 @@ impl FirecrackerRuntime {
         );
 
         let t = std::time::Instant::now();
-        let mut device_pool = DevicePool::new(DevicePoolConfig::default());
+        let device_pool = DevicePoolHandle::new(DevicePoolConfig::default());
         device_pool.warmup().await;
         info!(
             elapsed_ms = t.elapsed().as_millis() as u64,
@@ -60,7 +60,7 @@ impl FirecrackerRuntime {
 
         Ok(Self {
             netns_pool: Arc::new(tokio::sync::Mutex::new(netns_pool)),
-            device_pool: Arc::new(tokio::sync::Mutex::new(device_pool)),
+            device_pool,
             proxy_port: config.proxy_port,
             dns_port: config.dns_port,
         })
@@ -105,7 +105,7 @@ impl SandboxRuntime for FirecrackerRuntime {
         let mut factory = FirecrackerFactory::new(
             fc_config,
             Some(Arc::clone(&self.netns_pool)),
-            Arc::clone(&self.device_pool),
+            self.device_pool.clone(),
         )
         .await?;
         factory.startup().await?;
@@ -121,7 +121,7 @@ impl SandboxRuntime for FirecrackerRuntime {
         drop(pool);
 
         // Clean up shared device pool.
-        self.device_pool.lock().await.cleanup().await;
+        self.device_pool.cleanup().await;
 
         info!("runtime shutdown complete");
     }

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -19,7 +19,7 @@ use tracing::{info, trace, warn};
 use vsock_host::VsockHost;
 
 use crate::api::ApiError;
-use nbd_cow::NbdCowDevice;
+use nbd_cow::PooledNbdCowDevice;
 
 use crate::api::ApiClient;
 use crate::balloon;
@@ -268,7 +268,7 @@ pub struct FirecrackerSandbox {
     /// Pooled network namespace (returned to pool on destroy).
     pub(crate) network: PooledNetns,
     /// NBD COW device (torn down on destroy).
-    pub(crate) cow_device: NbdCowDevice,
+    pub(crate) cow_device: Option<PooledNbdCowDevice>,
     process_monitor: Option<ProcessMonitorHandle>,
     /// Process-group leader PID for the spawned Firecracker wrapper.
     /// Captured at spawn time for cleanup and best-effort host-side OOM
@@ -314,7 +314,7 @@ impl FirecrackerSandbox {
         sandbox_paths: SandboxPaths,
         sock_paths: SockPaths,
         network: PooledNetns,
-        cow_device: NbdCowDevice,
+        cow_device: PooledNbdCowDevice,
         leak_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::factory::LeakedResources>>,
     ) -> Self {
         let id = config.id.to_string();
@@ -325,7 +325,7 @@ impl FirecrackerSandbox {
             sandbox_paths,
             sock_paths,
             network,
-            cow_device,
+            cow_device: Some(cow_device),
             process_monitor: None,
             process_group_pid: None,
             state: Arc::new(AtomicU8::new(SandboxState::Created as u8)),
@@ -338,6 +338,12 @@ impl FirecrackerSandbox {
             destroyed: false,
             is_parked: false,
         }
+    }
+
+    pub(crate) fn cow_device(&self) -> sandbox::Result<&PooledNbdCowDevice> {
+        self.cow_device.as_ref().ok_or_else(|| SandboxError::Start {
+            message: "COW device missing before sandbox start".into(),
+        })
     }
 
     fn current_state(&self) -> SandboxState {
@@ -428,13 +434,13 @@ impl FirecrackerSandbox {
     }
 
     /// Build the Firecracker JSON configuration for fresh boot.
-    fn build_config(&self) -> serde_json::Value {
+    fn build_config(&self) -> sandbox::Result<serde_json::Value> {
         let inv = InvariantConfig::new();
         let kernel_path = self.factory_config.kernel_path.display().to_string();
-        let cow_device_path = self.cow_device.device_path().display().to_string();
+        let cow_device_path = self.cow_device()?.device_path().display().to_string();
         let vsock_path = self.sock_paths.vsock().display().to_string();
 
-        serde_json::json!({
+        Ok(serde_json::json!({
             "boot-source": {
                 "kernel_image_path": kernel_path,
                 "boot_args": inv.boot_args,
@@ -467,12 +473,12 @@ impl FirecrackerSandbox {
                 "deflate_on_oom": inv.balloon.deflate_on_oom,
                 "stats_polling_interval_s": inv.balloon.stats_polling_interval_s,
             },
-        })
+        }))
     }
 
     /// Start using a fresh boot with `--config-file --api-sock`.
     async fn start_fresh(&mut self, runtime_cancel: CancellationToken) -> sandbox::Result<()> {
-        let config = self.build_config();
+        let config = self.build_config()?;
         let config_json =
             serde_json::to_string_pretty(&config).map_err(|e| SandboxError::Start {
                 message: format!("serialize config: {e}"),
@@ -575,7 +581,7 @@ impl FirecrackerSandbox {
                 message: format!("sock dir missing before spawn: {}", sock_dir.display()),
             });
         }
-        let cow_device_path = self.cow_device.device_path();
+        let cow_device_path = self.cow_device()?.device_path();
         info!(
             id = %self.id,
             api_sock = %api_sock.display(),
@@ -715,15 +721,14 @@ impl Drop for FirecrackerSandbox {
 
         // If factory.destroy() was not called, send pool resources to the
         // async cleanup channel so they can be released without blocking.
-        // NbdCowDevice::Drop handles the kernel-level NBD disconnect; this
-        // covers the pool index, network namespace, and directories.
+        // The owned pooled COW device carries the pool lease; copied device
+        // indices are diagnostics only and are not release authority.
         if !self.destroyed
             && let Some(tx) = self.leak_tx.take()
         {
             let resources = crate::factory::LeakedResources {
                 sandbox_id: self.id.clone(),
-                device_index: Some(self.cow_device.device_index()),
-                cow_device: None,
+                cow_device: self.cow_device.take(),
                 network: Some(self.network.clone()),
                 sock_dir: self.sock_paths.dir().to_owned(),
                 workspace: self.sandbox_paths.workspace().to_owned(),

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use tokio::io::AsyncBufReadExt;
 use tracing::info;
 
-use nbd_cow::NbdCowDevice;
+use nbd_cow::{DestroyRetryPolicy, PooledNbdCowDevice};
 use sandbox::{SnapshotCreateConfig, SnapshotOutput, SnapshotProvider};
 
 use crate::api::{ApiClient, ApiError};
@@ -25,6 +25,13 @@ const API_READY_TIMEOUT: Duration = Duration::from_secs(5);
 const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 use crate::factory::{DESTROY_RETRIES, DESTROY_RETRY_DELAY};
+
+fn cow_destroy_retry_policy() -> DestroyRetryPolicy {
+    DestroyRetryPolicy {
+        attempts: DESTROY_RETRIES,
+        delay: DESTROY_RETRY_DELAY,
+    }
+}
 
 /// Errors that can occur during Firecracker snapshot creation.
 ///
@@ -189,26 +196,30 @@ pub async fn create_snapshot(
             .map_err(|e| SnapshotError::Setup(format!("set COW file size: {e}")))?;
     }
 
-    let device_pool = tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
-        nbd_cow::pool::DevicePoolConfig::default(),
-    ));
-    device_pool.lock().await.warmup().await;
-    let cow_device = NbdCowDevice::create(&config.rootfs_path, &cow_file, base_size, &device_pool)
+    let device_pool =
+        nbd_cow::pool::DevicePoolHandle::new(nbd_cow::pool::DevicePoolConfig::default());
+    device_pool.warmup().await;
+    let cow_device = device_pool
+        .create_cow_device(&config.rootfs_path, &cow_file, base_size)
         .await
         .map_err(|e| SnapshotError::Setup(format!("create NBD COW device: {e}")))?;
 
-    let device_index = cow_device.device_index();
     info!(device = %cow_device.device_path().display(), "NBD COW device created");
 
     // 3. Create network namespace (pool of 1, index auto-allocated via flock).
     let mut netns_pool = match NetnsPool::create_checked(netns_config).await {
         Ok(pool) => pool,
         Err(e) => {
-            drop(cow_device);
-            let mut pool = device_pool.lock().await;
-            pool.release(device_index);
-            pool.cleanup().await;
-            drop(pool);
+            if let Err(cleanup_err) = cow_device
+                .destroy_with_retries(cow_destroy_retry_policy())
+                .await
+            {
+                tracing::warn!(
+                    error = %cleanup_err,
+                    "failed to destroy COW device after netns pool failure"
+                );
+            }
+            device_pool.cleanup().await;
             if let Err(cleanup_err) = tokio::fs::remove_dir_all(&sock_dir).await {
                 tracing::warn!(
                     error = %cleanup_err,
@@ -230,11 +241,7 @@ pub async fn create_snapshot(
     )
     .await;
 
-    // Release device index back to pool before cleanup.
-    let mut pool = device_pool.lock().await;
-    pool.release(device_index);
-    pool.cleanup().await;
-    drop(pool);
+    device_pool.cleanup().await;
     if let Err(e) = netns_pool.cleanup().await {
         tracing::warn!(error = %e, "failed to cleanup netns pool");
     }
@@ -340,7 +347,7 @@ async fn run_snapshot_workflow(
     sock_paths: &SockPaths,
     output: &SnapshotOutputPaths,
     netns_pool: &mut NetnsPool,
-    mut cow_device: NbdCowDevice,
+    cow_device: PooledNbdCowDevice,
 ) -> Result<SnapshotConfig, SnapshotError> {
     // Filesystem pre-requisites that don't require the netns: do these
     // *before* `netns_pool.acquire()` so that a transient fs error
@@ -484,46 +491,20 @@ async fn run_snapshot_workflow(
     // released. The COW-device bind mount lived inside the FC process's
     // private mount namespace and was auto-cleaned when the process exited.
     if result.is_ok() {
-        let mut last_err = None;
-        for attempt in 0..DESTROY_RETRIES {
-            match cow_device.destroy_keep_cow().await {
-                Ok(()) => {
-                    last_err = None;
-                    break;
-                }
-                Err(e) => {
-                    last_err = Some(e);
-                    if attempt + 1 < DESTROY_RETRIES {
-                        tokio::time::sleep(DESTROY_RETRY_DELAY).await;
-                    }
-                }
-            }
-        }
-        if let Some(e) = last_err {
-            // Last resort: abandon the device so Drop is a no-op. It persists
-            // in the kernel until `runner gc` cleans it up; the COW file is
-            // left in the work dir and will be cleaned up by the next
-            // `create_snapshot` run.
-            //
-            // Fail the snapshot instead of finalizing it: without a successful
-            // `destroy_keep_cow` we cannot rely on `save_bitmap` having
-            // persisted the dirty bitmap, and renaming the COW file into the
-            // output dir without a matching bitmap would produce a snapshot
-            // that `is_complete()` reports as valid but silently corrupts
-            // restore reads (dirty blocks shadowed by base image). See #9843.
-            cow_device.abandon();
-            return Err(SnapshotError::Teardown(format!(
-                "destroy_keep_cow exhausted retries; device abandoned, snapshot aborted (last error: {e})"
-            )));
-        }
+        let kept_cow = cow_device
+            .destroy_keep_cow_with_retries(cow_destroy_retry_policy())
+            .await
+            .map_err(|e| {
+                SnapshotError::Teardown(format!(
+                    "destroy_keep_cow exhausted retries; device abandoned, snapshot aborted (last error: {e})"
+                ))
+            })?;
         // destroy_keep_cow succeeded, so save_bitmap succeeded — the bitmap
         // sidecar is on disk. Rename is unconditional: if the sidecar is
         // missing we want to fail loudly, not silently produce a
         // bitmap-less snapshot.
-        let cow_file = cow_device.cow_file();
-        let bitmap_src = nbd_cow::cow::bitmap_path_for(cow_file);
-        tokio::fs::rename(&bitmap_src, &output.cow_bitmap()).await?;
-        tokio::fs::rename(cow_file, &output.cow()).await?;
+        tokio::fs::rename(&kept_cow.bitmap_file, &output.cow_bitmap()).await?;
+        tokio::fs::rename(&kept_cow.cow_file, &output.cow()).await?;
         // Persist the output directory so all four final dir entries
         // (snapshot.bin and memory.bin written by Firecracker via the API,
         // cow.img and cow.img.bitmap just renamed in) are durable. Without
@@ -536,8 +517,12 @@ async fn run_snapshot_workflow(
         // (same failure class as #9794, one layer up).
         let dir = tokio::fs::File::open(output.dir()).await?;
         dir.sync_all().await?;
+    } else if let Err(e) = cow_device
+        .destroy_with_retries(cow_destroy_retry_policy())
+        .await
+    {
+        tracing::warn!(error = %e, "failed to destroy COW device after snapshot error");
     }
-    // On error, cow_device is dropped → Drop calls destroy() (best-effort).
 
     result
 }

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -33,6 +33,19 @@ fn cow_destroy_retry_policy() -> DestroyRetryPolicy {
     }
 }
 
+async fn destroy_snapshot_cow_after_error(context: &'static str, cow_device: PooledNbdCowDevice) {
+    if let Err(e) = cow_device
+        .destroy_with_retries(cow_destroy_retry_policy())
+        .await
+    {
+        tracing::warn!(
+            error = %e,
+            context,
+            "failed to destroy COW device after snapshot setup error"
+        );
+    }
+}
+
 /// Errors that can occur during Firecracker snapshot creation.
 ///
 /// These are the backend-specific errors returned by direct calls to
@@ -358,21 +371,26 @@ async fn run_snapshot_workflow(
     // The empty bind target file is consumed by `mount --bind` inside
     // `unshare --mount` at spawn time; file content is irrelevant
     // because the bind overlay is what FC reads.
-    tokio::fs::create_dir_all(sock_paths.dir())
-        .await
-        .map_err(|e| SnapshotError::Setup(format!("mkdir sock dir: {e}")))?;
+    if let Err(e) = tokio::fs::create_dir_all(sock_paths.dir()).await {
+        destroy_snapshot_cow_after_error("mkdir sock dir", cow_device).await;
+        return Err(SnapshotError::Setup(format!("mkdir sock dir: {e}")));
+    }
     let api_sock = sock_paths.api_sock();
 
     let drive_bind = paths.cow_device_bind();
-    tokio::fs::write(&drive_bind, b"")
-        .await
-        .map_err(|e| SnapshotError::Setup(format!("create bind target: {e}")))?;
+    if let Err(e) = tokio::fs::write(&drive_bind, b"").await {
+        destroy_snapshot_cow_after_error("create bind target", cow_device).await;
+        return Err(SnapshotError::Setup(format!("create bind target: {e}")));
+    }
 
     // 4. Acquire the network namespace and spawn Firecracker into it.
-    let network = netns_pool
-        .acquire()
-        .await
-        .map_err(|e| SnapshotError::Setup(format!("acquire netns: {e}")))?;
+    let network = match netns_pool.acquire().await {
+        Ok(network) => network,
+        Err(e) => {
+            destroy_snapshot_cow_after_error("acquire netns", cow_device).await;
+            return Err(SnapshotError::Setup(format!("acquire netns: {e}")));
+        }
+    };
 
     info!(netns = %network.name, "namespace acquired");
 
@@ -413,6 +431,7 @@ async fn run_snapshot_workflow(
             if let Err(re) = netns_pool.release(network).await {
                 tracing::warn!(error = %re, "failed to release netns after spawn failure");
             }
+            destroy_snapshot_cow_after_error("spawn firecracker", cow_device).await;
             return Err(SnapshotError::Process(format!("spawn firecracker: {e}")));
         }
     };


### PR DESCRIPTION
Closes #11452

## Summary
- introduce non-cloneable NBD device leases and a shared DevicePoolHandle
- add PooledNbdCowDevice finalizers so clean release vs uncertain retirement is decided inside nbd-cow
- migrate sandbox-fc runtime/factory/sandbox/snapshot, nbd-cow tests, and bench away from raw device-index release

## Verification
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow -p sandbox-fc --all-targets -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p nbd-cow
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc