### PR TITLE
fix: adapt connector category menu layout

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -111,10 +111,10 @@ function ConnectorCategoryMenu({
   }
 
   return (
-    <aside className="pointer-events-none absolute bottom-0 left-full top-[60px] ml-16 hidden w-44 xl:block">
+    <aside className="pointer-events-none absolute bottom-0 top-[60px] hidden w-44 min-[1184px]:left-[960px] min-[1184px]:block 2xl:left-full 2xl:ml-16">
       <nav
         aria-label="Connector categories"
-        className="group pointer-events-auto sticky top-[28vh] flex flex-col gap-3 pb-3 pl-5"
+        className="group pointer-events-auto sticky top-[28vh] flex max-h-[68vh] flex-col gap-3 overflow-y-auto pb-3 pl-5"
       >
         {groups.flatMap((group) => {
           if (group.kind === "group") {
@@ -723,15 +723,14 @@ export function ZeroConnectorsPage() {
     renderCard,
     search,
   });
-
   return (
     <div
       ref={scrollContainerRef}
       className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]"
     >
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-3 md:pt-10 pb-0 md:pb-3">
-        <div className="mx-auto max-w-[960px]">
-          <div className="flex flex-wrap items-end justify-between gap-4">
+        <div className="mx-auto w-full max-w-[960px] min-[1184px]:max-w-[1136px] 2xl:max-w-[960px]">
+          <div className="flex w-full max-w-[960px] flex-wrap items-end justify-between gap-4">
             <div className="min-w-0 hidden md:block">
               <h1 className="text-lg font-semibold tracking-tight text-foreground">
                 Connectors
@@ -761,7 +760,7 @@ export function ZeroConnectorsPage() {
       </header>
 
       <main className="flex-1 px-4 sm:px-6 pt-3 pb-16">
-        <div className="relative mx-auto w-full max-w-[960px]">
+        <div className="relative mx-auto w-full max-w-[960px] min-[1184px]:max-w-[1136px] 2xl:max-w-[960px]">
           {activeTab === "builtin" &&
             allTypesLoadable.state === "hasData" &&
             showConnectorCategories && (
@@ -771,7 +770,7 @@ export function ZeroConnectorsPage() {
               />
             )}
 
-          <div className="min-w-0 flex flex-col gap-6">
+          <div className="min-w-0 flex w-full max-w-[960px] flex-col gap-6">
             <div className="flex items-center justify-between">
               <Tabs
                 value={activeTab}


### PR DESCRIPTION
## Summary
- make the connector category menu render as a sticky horizontal scroller below 2xl
- keep the compact right-side category index on 2xl+ with constrained height and scrolling
- preserve the existing category scroll targeting and active states

## Tests
- pnpm vitest run src/views/zero-page/__tests__/zero-connectors-page-display.test.tsx src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm --filter @vm0/app lint
- pnpm --filter @vm0/app check-types
- git diff --check

## Note
- Full pre-commit hook `pnpm check-types` failed in `web#check-types` due an unrelated Next 16.1.7/16.2.3 typegen mismatch in `apps/web/.next/dev/types/validator.ts`; no web files were changed.