### PR TITLE
feat: add model usage ranking

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -42,6 +42,7 @@
     "posthog-js": "^1.372.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "recharts": "^3.8.1",
     "signal-timers": "^1.0.4",
     "yaml": "^2.7.1"
   },

--- a/turbo/apps/platform/src/mocks/handlers/api-usage.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-usage.ts
@@ -2,6 +2,11 @@ import {
   zeroUsageMembersContract,
   type UsageMembersResponse,
 } from "@vm0/api-contracts/contracts/zero-usage";
+import {
+  zeroModelUsageRankingContract,
+  type ModelUsageRankingItem,
+  type ModelUsageRankingRange,
+} from "@vm0/api-contracts/contracts/zero-model-usage-ranking";
 import { zeroMemberCreditCapContract } from "@vm0/api-contracts/contracts/zero-member-credit-cap";
 import { mockApi } from "../msw-contract.ts";
 
@@ -9,6 +14,44 @@ let mockUsageMembersResponse: UsageMembersResponse = {
   period: null,
   members: [],
 };
+
+const defaultModelUsageRankingModels: ModelUsageRankingItem[] = [
+  {
+    model: "claude-sonnet-4-6",
+    inputTokens: 850_000,
+    outputTokens: 310_000,
+    cacheTokens: 120_000,
+    totalTokens: 1_280_000,
+    credits: 12_400,
+    previousCredits: 9000,
+    changePercent: 0.3778,
+    share: 0.6,
+  },
+  {
+    model: "kimi-k2.6",
+    inputTokens: 420_000,
+    outputTokens: 180_000,
+    cacheTokens: 60_000,
+    totalTokens: 660_000,
+    credits: 4900,
+    previousCredits: 3600,
+    changePercent: 0.3611,
+    share: 0.24,
+  },
+  {
+    model: "deepseek-v4-pro",
+    inputTokens: 240_000,
+    outputTokens: 170_000,
+    cacheTokens: 30_000,
+    totalTokens: 440_000,
+    credits: 3200,
+    previousCredits: 0,
+    changePercent: null,
+    share: 0.16,
+  },
+];
+
+let mockModelUsageRankingModels = defaultModelUsageRankingModels;
 
 const mockCreditCaps = new Map<
   string,
@@ -25,6 +68,16 @@ export function resetMockUsageMembers(): void {
   mockUsageMembersResponse = { period: null, members: [] };
 }
 
+export function setMockModelUsageRanking(
+  models: ModelUsageRankingItem[],
+): void {
+  mockModelUsageRankingModels = models;
+}
+
+export function resetMockModelUsageRanking(): void {
+  mockModelUsageRankingModels = defaultModelUsageRankingModels;
+}
+
 export function setMockMemberCreditCap(
   userId: string,
   creditCap: number | null,
@@ -37,9 +90,64 @@ export function resetMockMemberCreditCaps(): void {
   mockCreditCaps.clear();
 }
 
+function makeMockModelUsageDaily(
+  models: ModelUsageRankingItem[],
+  range: ModelUsageRankingRange,
+) {
+  const dayCount = range === "1d" ? 1 : range === "7d" ? 7 : 30;
+  const today = new Date("2026-04-29T00:00:00.000Z");
+  return Array.from({ length: dayCount }, (_, index) => {
+    const date = new Date(today.getTime() - (dayCount - 1 - index) * 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+    const progress = dayCount === 1 ? 1 : (index + 1) / dayCount;
+    const dailyModels = models.map((item, modelIndex) => {
+      const weight = 0.5 + progress * (0.7 + modelIndex * 0.12);
+      return {
+        model: item.model,
+        credits: Math.round((item.credits / dayCount) * weight),
+        totalTokens: Math.round((item.totalTokens / dayCount) * weight),
+      };
+    });
+    return {
+      date,
+      totalCredits: dailyModels.reduce((sum, item) => {
+        return sum + item.credits;
+      }, 0),
+      totalTokens: dailyModels.reduce((sum, item) => {
+        return sum + item.totalTokens;
+      }, 0),
+      models: dailyModels,
+    };
+  });
+}
+
 export const apiUsageHandlers = [
   mockApi(zeroUsageMembersContract.get, ({ respond }) => {
     return respond(200, mockUsageMembersResponse);
+  }),
+
+  mockApi(zeroModelUsageRankingContract.get, ({ query, respond }) => {
+    const grandTotalTokens = mockModelUsageRankingModels.reduce((sum, item) => {
+      return sum + item.totalTokens;
+    }, 0);
+    const grandTotalCredits = mockModelUsageRankingModels.reduce(
+      (sum, item) => {
+        return sum + item.credits;
+      },
+      0,
+    );
+    return respond(200, {
+      range: query.range as ModelUsageRankingRange,
+      generatedAt: "2026-04-29T00:00:00.000Z",
+      grandTotalTokens,
+      grandTotalCredits,
+      models: mockModelUsageRankingModels,
+      daily: makeMockModelUsageDaily(
+        mockModelUsageRankingModels,
+        query.range as ModelUsageRankingRange,
+      ),
+    });
   }),
 
   mockApi(zeroMemberCreditCapContract.get, ({ query, respond }) => {

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -22,6 +22,7 @@ import {
   apiUsageHandlers,
   resetMockUsageMembers,
   resetMockMemberCreditCaps,
+  resetMockModelUsageRanking,
 } from "./api-usage.ts";
 import {
   apiUsageInsightHandlers,
@@ -130,6 +131,7 @@ export function resetAllMockHandlers(): void {
   resetMockOrgDomains();
   resetMockUsageMembers();
   resetMockMemberCreditCaps();
+  resetMockModelUsageRanking();
   resetMockUsageInsight();
   resetMockSchedules();
   resetMockTeam();

--- a/turbo/apps/platform/src/signals/model-usage-ranking.ts
+++ b/turbo/apps/platform/src/signals/model-usage-ranking.ts
@@ -1,0 +1,50 @@
+import { command, computed, state } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import {
+  zeroModelUsageRankingContract,
+  type ModelUsageRankingRange,
+} from "@vm0/api-contracts/contracts/zero-model-usage-ranking";
+import { zeroClient$ } from "./api-client.ts";
+import { accept } from "../lib/accept.ts";
+import { featureSwitch$ } from "./external/feature-switch.ts";
+
+const internalModelUsageRankingRange$ = state<ModelUsageRankingRange>("7d");
+const internalModelUsageRankingOpen$ = state(false);
+
+export const modelUsageRankingRange$ = computed((get) => {
+  return get(internalModelUsageRankingRange$);
+});
+
+export const modelUsageRankingOpen$ = computed((get) => {
+  return get(internalModelUsageRankingOpen$);
+});
+
+export const modelUsageRankingEnabled$ = computed(async (get) => {
+  const features = await get(featureSwitch$);
+  return features[FeatureSwitchKey.ModelUsageRanking] ?? false;
+});
+
+export const setModelUsageRankingRange$ = command(
+  ({ set }, range: ModelUsageRankingRange) => {
+    set(internalModelUsageRankingRange$, range);
+  },
+);
+
+export const setModelUsageRankingOpen$ = command(({ set }, open: boolean) => {
+  set(internalModelUsageRankingOpen$, open);
+});
+
+export const modelUsageRankingAsync$ = computed(async (get) => {
+  const open = get(internalModelUsageRankingOpen$);
+  const enabled = await get(modelUsageRankingEnabled$);
+  const range = get(modelUsageRankingRange$);
+  if (!open || !enabled) {
+    return null;
+  }
+  const createClient = get(zeroClient$);
+  const client = createClient(zeroModelUsageRankingContract);
+  const result = await accept(client.get({ query: { range } }), [200], {
+    toast: false,
+  });
+  return result.body;
+});

--- a/turbo/apps/platform/src/views/org/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-providers-tab.test.tsx
@@ -12,6 +12,7 @@ import {
   type ModelProviderResponse,
   MODEL_PROVIDER_TYPES,
 } from "@vm0/api-contracts/contracts/model-providers";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   zeroModelProvidersDefaultContract,
   zeroModelProvidersByTypeContract,
@@ -25,6 +26,7 @@ import {
   setMockOrgModelProviders,
   resetMockOrgModelProviders,
 } from "../../../mocks/handlers/api-org-model-providers.ts";
+import { setMockModelUsageRanking } from "../../../mocks/handlers/api-usage.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 
 const context = testContext();
@@ -63,8 +65,14 @@ function mockAPIs(options?: {
   setMockOrgModelProviders(options?.providers ?? []);
 }
 
-async function openProvidersPage() {
-  detachedSetupPage({ context, path: "/?settings=providers" });
+async function openProvidersPage(options?: {
+  featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>;
+}) {
+  detachedSetupPage({
+    context,
+    path: "/?settings=providers",
+    featureSwitches: options?.featureSwitches,
+  });
   await waitFor(() => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
@@ -119,6 +127,69 @@ describe("org providers tab - display", () => {
     await openProvidersPage();
     await waitFor(() => {
       expect(screen.getByText("No providers configured")).toBeInTheDocument();
+    });
+  });
+
+  it("shows VM0 model popularity ranking in place of the provider list", async () => {
+    mockAPIs({
+      providers: [makeProvider("anthropic-api-key", { isDefault: true })],
+    });
+    setMockModelUsageRanking([
+      {
+        model: "claude-sonnet-4-6",
+        inputTokens: 900_000,
+        outputTokens: 250_000,
+        cacheTokens: 50_000,
+        totalTokens: 1_200_000,
+        credits: 11_000,
+        previousCredits: 8000,
+        changePercent: 0.375,
+        share: 0.75,
+      },
+      {
+        model: "kimi-k2.6",
+        inputTokens: 200_000,
+        outputTokens: 150_000,
+        cacheTokens: 50_000,
+        totalTokens: 400_000,
+        credits: 3000,
+        previousCredits: 0,
+        changePercent: null,
+        share: 0.25,
+      },
+    ]);
+
+    await openProvidersPage({
+      featureSwitches: { [FeatureSwitchKey.ModelUsageRanking]: true },
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Open VM0 model popularity ranking"),
+      ).toBeInTheDocument();
+    });
+    click(screen.getByLabelText("Open VM0 model popularity ranking"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Model Popularity")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(
+        "Ranking of the most popular models on VM0, based on platform-wide credits.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Default provider")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Claude Sonnet 4.6").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Kimi/i)).toBeInTheDocument();
+    expect(screen.getByText("LLM Leaderboard")).toBeInTheDocument();
+
+    const backButton = screen.getAllByRole("button").find((el) => {
+      return el.textContent?.includes("Model providers");
+    });
+    expect(backButton).toBeDefined();
+    click(backButton!);
+
+    await waitFor(() => {
+      expect(screen.getByText("Configured")).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
@@ -16,6 +16,7 @@ import {
 } from "@vm0/ui";
 import {
   IconBuilding,
+  IconChartBar,
   IconCpu,
   IconUsers,
   IconCreditCard,
@@ -38,6 +39,11 @@ import {
   billingSubPage$,
   type OrgManageTab,
 } from "../../../../signals/zero-page/settings/org-manage-tabs-state.ts";
+import {
+  modelUsageRankingEnabled$,
+  modelUsageRankingOpen$,
+  setModelUsageRankingOpen$,
+} from "../../../../signals/model-usage-ranking.ts";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 
@@ -152,6 +158,13 @@ function TabContent({ tab }: { tab: OrgManageTab }) {
 export function OrgManageDialog({ open, onOpenChange }: OrgManageDialogProps) {
   const activeTab = useGet(orgManageTab$);
   const setActiveTab = useSet(setActiveOrgManageTab$);
+  const rankingOpen = useGet(modelUsageRankingOpen$);
+  const setRankingOpen = useSet(setModelUsageRankingOpen$);
+  const rankingEnabledLoadable = useLoadable(modelUsageRankingEnabled$);
+  const rankingEnabled =
+    rankingEnabledLoadable.state === "hasData"
+      ? rankingEnabledLoadable.data
+      : false;
 
   const isAdminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin =
@@ -167,9 +180,31 @@ export function OrgManageDialog({ open, onOpenChange }: OrgManageDialogProps) {
   const meta = TAB_META[activeTab];
   const isBillingSubPage = useGet(billingSubPage$);
   const hideHeader = activeTab === "billing" && isBillingSubPage;
+  const showRankingButton =
+    rankingEnabled && activeTab === "providers" && !rankingOpen;
+  const title =
+    activeTab === "providers" && rankingOpen ? "Model Popularity" : meta.title;
+  const description =
+    activeTab === "providers" && rankingOpen
+      ? "Ranking of the most popular models on VM0, based on platform-wide credits."
+      : meta.description;
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setRankingOpen(false);
+    }
+    return onOpenChange(nextOpen);
+  };
+
+  const handleTabChange = (tab: OrgManageTab) => {
+    if (tab !== "providers") {
+      setRankingOpen(false);
+    }
+    return setActiveTab(tab);
+  };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="zero-app flex flex-col w-[calc(100vw-2rem)] max-w-[1200px] h-[92dvh] sm:h-[85vh] p-0 gap-0 overflow-hidden zero-border rounded-xl bg-card">
         <DialogTitle className="sr-only">Workspace settings</DialogTitle>
         <DialogDescription className="sr-only">
@@ -187,7 +222,7 @@ export function OrgManageDialog({ open, onOpenChange }: OrgManageDialogProps) {
             <Select
               value={activeTab}
               onValueChange={(v) => {
-                return setActiveTab(v as OrgManageTab);
+                return handleTabChange(v as OrgManageTab);
               }}
             >
               <SelectTrigger className="h-9 w-full">
@@ -231,7 +266,7 @@ export function OrgManageDialog({ open, onOpenChange }: OrgManageDialogProps) {
                           key={item.id}
                           type="button"
                           onClick={() => {
-                            return setActiveTab(item.id);
+                            return handleTabChange(item.id);
                           }}
                           className={cn(
                             "flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200",
@@ -270,14 +305,28 @@ export function OrgManageDialog({ open, onOpenChange }: OrgManageDialogProps) {
           >
             {!hideHeader && (
               <header className="shrink-0 px-4 sm:px-10 pt-6 sm:pt-8 pb-1">
-                <h2 className="hidden sm:block text-xl font-semibold tracking-tight text-foreground">
-                  {meta.title}
-                </h2>
+                <div className="hidden sm:flex min-h-7 items-center gap-2">
+                  <h2 className="flex h-7 items-center text-xl font-semibold tracking-tight text-foreground">
+                    {title}
+                  </h2>
+                  {showRankingButton && (
+                    <button
+                      type="button"
+                      aria-label="Open VM0 model popularity ranking"
+                      className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      onClick={() => {
+                        return setRankingOpen(true);
+                      }}
+                    >
+                      <IconChartBar size={15} stroke={1.75} />
+                    </button>
+                  )}
+                </div>
                 <p
-                  className="text-sm text-muted-foreground mt-1"
+                  className="mt-1 truncate whitespace-nowrap text-sm text-muted-foreground"
                   data-testid="tab-description"
                 >
-                  {meta.description}
+                  {description}
                 </p>
               </header>
             )}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
@@ -305,8 +305,8 @@ export function OrgManageDialog({ open, onOpenChange }: OrgManageDialogProps) {
           >
             {!hideHeader && (
               <header className="shrink-0 px-4 sm:px-10 pt-6 sm:pt-8 pb-1">
-                <div className="hidden sm:flex min-h-7 items-center gap-2">
-                  <h2 className="flex h-7 items-center text-xl font-semibold tracking-tight text-foreground">
+                <div className="flex min-h-7 items-center gap-2">
+                  <h2 className="hidden h-7 items-center text-xl font-semibold tracking-tight text-foreground sm:flex">
                     {title}
                   </h2>
                   {showRankingButton && (

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
@@ -1,11 +1,35 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
+import type { ReactNode } from "react";
 import { useGet, useSet, useLoadable } from "ccstate-react";
-import { IconPlus, IconDotsVertical } from "@tabler/icons-react";
+import {
+  IconArrowLeft,
+  IconCpu,
+  IconDotsVertical,
+  IconPlus,
+} from "@tabler/icons-react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+  type TooltipContentProps,
+} from "recharts";
 import {
   MODEL_PROVIDER_TYPES,
+  VM0_MODEL_TO_PROVIDER,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
+import type {
+  ModelUsageRankingDailyBucket,
+  ModelUsageRankingItem,
+  ModelUsageRankingRange,
+  ModelUsageRankingResponse,
+} from "@vm0/api-contracts/contracts/zero-model-usage-ranking";
+import { getModelDisplayName } from "@vm0/core/model-display-name";
 import {
   cn,
   Button,
@@ -18,7 +42,18 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  Tabs,
+  TabsList,
+  TabsTrigger,
 } from "@vm0/ui";
+import {
+  modelUsageRankingEnabled$,
+  modelUsageRankingAsync$,
+  modelUsageRankingOpen$,
+  modelUsageRankingRange$,
+  setModelUsageRankingOpen$,
+  setModelUsageRankingRange$,
+} from "../../../../signals/model-usage-ranking.ts";
 import {
   orgAddProviderDialogOpen$,
   setOrgAddProviderDialogOpen$,
@@ -41,6 +76,23 @@ export function OrgProvidersTab() {
   const isAdminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin =
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
+  const rankingOpen = useGet(modelUsageRankingOpen$);
+  const setRankingOpen = useSet(setModelUsageRankingOpen$);
+  const rankingEnabledLoadable = useLoadable(modelUsageRankingEnabled$);
+  const rankingEnabled =
+    rankingEnabledLoadable.state === "hasData"
+      ? rankingEnabledLoadable.data
+      : false;
+
+  if (rankingOpen && rankingEnabled) {
+    return (
+      <ModelUsageRankingSection
+        onBack={() => {
+          return setRankingOpen(false);
+        }}
+      />
+    );
+  }
 
   return (
     <div className="flex flex-col gap-8">
@@ -291,6 +343,466 @@ function ProviderListSection({ isAdmin }: { isAdmin: boolean }) {
       )}
     </div>
   );
+}
+
+function ModelUsageRankingSection({ onBack }: { onBack: () => void }) {
+  const range = useGet(modelUsageRankingRange$);
+  const setRange = useSet(setModelUsageRankingRange$);
+  const rankingLoadable = useLoadable(modelUsageRankingAsync$);
+  const data =
+    rankingLoadable.state === "hasData" ? rankingLoadable.data : null;
+  const models = data?.models ?? [];
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="-ml-2 h-8 gap-1.5 rounded-lg px-2 text-muted-foreground hover:text-foreground"
+          onClick={onBack}
+        >
+          <IconArrowLeft size={14} stroke={1.5} />
+          Model providers
+        </Button>
+        <Tabs
+          value={range}
+          onValueChange={(value) => {
+            return setRange(value as ModelUsageRankingRange);
+          }}
+        >
+          <TabsList className="zero-tabs h-8 gap-1 px-1 py-1">
+            <TabsTrigger value="1d" className="h-6 px-2.5 text-xs">
+              1D
+            </TabsTrigger>
+            <TabsTrigger value="7d" className="h-6 px-2.5 text-xs">
+              7D
+            </TabsTrigger>
+            <TabsTrigger value="30d" className="h-6 px-2.5 text-xs">
+              30D
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
+
+      {rankingLoadable.state === "loading" && <RankingSkeleton />}
+
+      {rankingLoadable.state === "hasError" && (
+        <RankingStatePanel>
+          <p className="px-5 py-10 text-center text-sm text-muted-foreground">
+            Could not load model ranking.
+          </p>
+        </RankingStatePanel>
+      )}
+
+      {rankingLoadable.state === "hasData" && models.length === 0 && (
+        <RankingStatePanel>
+          <p className="px-5 py-10 text-center text-sm text-muted-foreground">
+            No model usage yet.
+          </p>
+        </RankingStatePanel>
+      )}
+
+      {rankingLoadable.state === "hasData" && data && models.length > 0 && (
+        <ModelPopularityDashboard data={data} />
+      )}
+    </section>
+  );
+}
+
+interface TrendSeries {
+  key: string;
+  model: string;
+  color: string;
+}
+
+type TrendDatum = {
+  date: string;
+  label: string;
+} & Record<string, number | string>;
+
+function ModelPopularityDashboard({
+  data,
+}: {
+  data: ModelUsageRankingResponse;
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.9fr)]">
+      <TopModelsTrendPanel data={data} />
+      <ModelLeaderboardPanel models={data.models} />
+    </div>
+  );
+}
+
+function TopModelsTrendPanel({ data }: { data: ModelUsageRankingResponse }) {
+  const { rows, series } = buildTrendChartData(data.daily, data.models);
+  return (
+    <section
+      className="min-w-0 rounded-xl bg-card p-5"
+      style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+    >
+      <div className="min-w-0">
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold text-foreground">Top Models</h3>
+          <p className="mt-1 truncate whitespace-nowrap text-[13px] text-muted-foreground">
+            Daily model popularity across VM0
+          </p>
+        </div>
+      </div>
+
+      <div
+        className="mt-5 h-[300px] min-w-0 [&_.recharts-surface]:outline-none [&_.recharts-surface:focus]:outline-none [&_.recharts-surface:focus-visible]:outline-none [&_.recharts-wrapper]:outline-none [&_.recharts-wrapper:focus]:outline-none"
+        onMouseDown={(event) => {
+          event.preventDefault();
+        }}
+      >
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart
+            data={rows}
+            accessibilityLayer={false}
+            margin={{ top: 12, right: 16, bottom: 4, left: 4 }}
+          >
+            <CartesianGrid
+              vertical={false}
+              stroke="hsl(var(--border))"
+              strokeDasharray="3 3"
+              opacity={0.75}
+            />
+            <XAxis
+              dataKey="label"
+              minTickGap={28}
+              axisLine={false}
+              tickLine={false}
+              tick={{
+                fill: "hsl(var(--muted-foreground))",
+                fontSize: 11,
+                fontWeight: 500,
+              }}
+              tickMargin={10}
+            />
+            <YAxis
+              width={52}
+              axisLine={false}
+              tickLine={false}
+              tickFormatter={formatRankingCredits}
+              tick={{
+                fill: "hsl(var(--muted-foreground))",
+                fontSize: 11,
+                fontWeight: 500,
+              }}
+              tickMargin={8}
+            />
+            <RechartsTooltip
+              cursor={{
+                stroke: "hsl(var(--muted-foreground) / 0.35)",
+                strokeDasharray: "4 4",
+              }}
+              content={renderTrendTooltip}
+            />
+            {series.map((item) => {
+              return (
+                <Line
+                  key={item.key}
+                  type="monotone"
+                  dataKey={item.key}
+                  name={getModelDisplayName(item.model)}
+                  stroke={item.color}
+                  strokeWidth={2.25}
+                  dot={data.daily.length <= 1 ? { r: 3 } : false}
+                  activeDot={{ r: 4 }}
+                  isAnimationActive={false}
+                />
+              );
+            })}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  );
+}
+
+function ModelLeaderboardPanel({
+  models,
+}: {
+  models: ModelUsageRankingItem[];
+}) {
+  return (
+    <section
+      className="min-w-0 overflow-hidden rounded-xl bg-card"
+      style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+    >
+      <div className="px-5 py-4">
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold text-foreground">
+            LLM Leaderboard
+          </h3>
+          <p className="mt-1 truncate whitespace-nowrap text-[13px] text-muted-foreground">
+            Compare the most popular models on VM0
+          </p>
+        </div>
+      </div>
+      <ol className="divide-y divide-border/60">
+        {models.map((item, index) => {
+          return (
+            <LeaderboardRow key={item.model} item={item} rank={index + 1} />
+          );
+        })}
+      </ol>
+    </section>
+  );
+}
+
+function LeaderboardRow({
+  item,
+  rank,
+}: {
+  item: ModelUsageRankingItem;
+  rank: number;
+}) {
+  const providerType = resolveRankingProviderType(item.model);
+  return (
+    <li className="grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-3 px-5 py-3.5">
+      <span className="text-sm font-semibold tabular-nums text-muted-foreground">
+        {rank}.
+      </span>
+      <div className="flex min-w-0 items-center gap-3">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted/60">
+          {providerType ? (
+            <ProviderIcon type={providerType} size={22} />
+          ) : (
+            <IconCpu size={17} stroke={1.5} className="text-muted-foreground" />
+          )}
+        </span>
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium text-foreground">
+            {getModelDisplayName(item.model)}
+          </div>
+          <div className="truncate text-xs text-muted-foreground">
+            by {getRankingVendorLabel(item.model)}
+          </div>
+        </div>
+      </div>
+      <div className="min-w-[5.5rem] text-right">
+        <div className="text-sm font-semibold tabular-nums text-foreground">
+          {formatRankingCredits(item.credits)}
+        </div>
+        <div className="mt-0.5 flex items-center justify-end text-xs">
+          <RankingChangeBadge item={item} />
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function RankingChangeBadge({ item }: { item: ModelUsageRankingItem }) {
+  if (item.changePercent === null) {
+    return (
+      <span className="rounded-full bg-emerald-500/10 px-1.5 py-0.5 font-medium text-emerald-600">
+        new
+      </span>
+    );
+  }
+  const isPositive = item.changePercent > 0;
+  const isNegative = item.changePercent < 0;
+  return (
+    <span
+      className={cn(
+        "rounded-full px-1.5 py-0.5 font-medium tabular-nums",
+        isPositive && "bg-emerald-500/10 text-emerald-600",
+        isNegative && "bg-destructive/10 text-destructive",
+        !isPositive && !isNegative && "bg-muted text-muted-foreground",
+      )}
+    >
+      {isPositive ? "+" : ""}
+      {formatRankingPercent(item.changePercent)}
+    </span>
+  );
+}
+
+function renderTrendTooltip(props: TooltipContentProps) {
+  return <TrendTooltip {...props} />;
+}
+
+function TrendTooltip({ active, payload, label }: TooltipContentProps) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+  const rows = payload
+    .map((entry) => {
+      return {
+        name: String(entry.name ?? ""),
+        color: entry.color,
+        value: Number(entry.value ?? 0),
+      };
+    })
+    .filter((entry) => {
+      return entry.value > 0;
+    });
+  if (rows.length === 0) {
+    return null;
+  }
+  return (
+    <div className="rounded-lg border border-border bg-popover px-3 py-2 text-xs shadow-md">
+      <div className="font-medium text-foreground">{String(label)}</div>
+      <div className="mt-1.5 space-y-1">
+        {rows.map((entry) => {
+          return (
+            <div
+              key={entry.name}
+              className="flex min-w-44 items-center justify-between gap-4"
+            >
+              <span className="flex min-w-0 items-center gap-2 text-muted-foreground">
+                <span
+                  className="h-2 w-2 shrink-0 rounded-full"
+                  style={{ backgroundColor: entry.color }}
+                />
+                <span className="truncate">{entry.name}</span>
+              </span>
+              <span className="font-medium tabular-nums text-foreground">
+                {formatRankingCredits(entry.value)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function buildTrendChartData(
+  daily: ModelUsageRankingDailyBucket[],
+  models: ModelUsageRankingItem[],
+): { rows: TrendDatum[]; series: TrendSeries[] } {
+  const series = models.slice(0, 5).map((item, index) => {
+    return {
+      key: `model_${index}`,
+      model: item.model,
+      color: rankingBarColor(index),
+    };
+  });
+  const rows = daily.map((bucket) => {
+    const row: TrendDatum = {
+      date: bucket.date,
+      label: formatDailyTick(bucket.date),
+    };
+    for (const item of series) {
+      const model = bucket.models.find((entry) => {
+        return entry.model === item.model;
+      });
+      row[item.key] = model?.credits ?? 0;
+    }
+    return row;
+  });
+  return { rows, series };
+}
+
+function RankingSkeleton() {
+  return (
+    <RankingStatePanel>
+      <div className="divide-y divide-border/60">
+        <div className="px-4 py-3.5">
+          <RankingSkeletonRow widthClassName="w-4/5" />
+        </div>
+        <div className="px-4 py-3.5">
+          <RankingSkeletonRow widthClassName="w-3/5" />
+        </div>
+        <div className="px-4 py-3.5">
+          <RankingSkeletonRow widthClassName="w-2/5" />
+        </div>
+      </div>
+    </RankingStatePanel>
+  );
+}
+
+function RankingStatePanel({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="overflow-hidden rounded-xl bg-card"
+      style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function RankingSkeletonRow({ widthClassName }: { widthClassName: string }) {
+  return (
+    <div className="flex items-center gap-3 animate-pulse">
+      <span className="h-4 w-6 rounded bg-muted/60" />
+      <span className="h-9 w-9 rounded-lg bg-muted/60" />
+      <div className="min-w-0 flex-1 space-y-2">
+        <span className="block h-4 w-36 rounded bg-muted/60" />
+        <span
+          className={cn("block h-2 rounded-full bg-muted", widthClassName)}
+        />
+      </div>
+      <span className="h-4 w-12 rounded bg-muted/60" />
+    </div>
+  );
+}
+
+function resolveRankingProviderType(
+  model: string,
+): ModelProviderType | undefined {
+  const entry = VM0_MODEL_TO_PROVIDER[model];
+  return entry?.concreteType as ModelProviderType | undefined;
+}
+
+function getRankingVendorLabel(model: string): string {
+  const entry = VM0_MODEL_TO_PROVIDER[model];
+  if (entry?.vendor) {
+    return entry.vendor;
+  }
+  if (model.includes("/")) {
+    return model.split("/")[0] ?? "vm0";
+  }
+  return "vm0";
+}
+
+function formatDailyTick(date: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${date}T00:00:00.000Z`));
+}
+
+function rankingBarColor(index: number): string {
+  switch (index % 6) {
+    case 0: {
+      return "hsl(var(--primary))";
+    }
+    case 1: {
+      return "hsl(var(--chart-2, 173 58% 39%))";
+    }
+    case 2: {
+      return "hsl(var(--chart-3, 197 37% 24%))";
+    }
+    case 3: {
+      return "hsl(var(--chart-4, 43 74% 66%))";
+    }
+    case 4: {
+      return "hsl(var(--chart-5, 27 87% 67%))";
+    }
+    default: {
+      return "hsl(var(--muted-foreground))";
+    }
+  }
+}
+
+function formatRankingCredits(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: value >= 1_000_000 ? 1 : 0,
+  }).format(value);
+}
+
+function formatRankingPercent(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "percent",
+    maximumFractionDigits: 0,
+  }).format(value);
 }
 
 function ProviderSkeleton() {

--- a/turbo/apps/web/app/api/zero/model-usage-ranking/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/model-usage-ranking/__tests__/route.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import {
+  createTestRequest,
+  deleteTestUsageEventsByProvider,
+  insertTestUsageEvent,
+  seedUserFeatureSwitches,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import type { ModelUsageRankingResponse } from "@vm0/api-contracts/contracts/zero-model-usage-ranking";
+
+import { GET } from "../route";
+
+const context = testContext();
+let user: UserContext;
+
+function makeRequest(range = "7d") {
+  return createTestRequest(
+    `http://localhost:3000/api/zero/model-usage-ranking?range=${range}`,
+  );
+}
+
+describe("GET /api/zero/model-usage-ranking", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(makeRequest());
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 when model usage ranking is disabled", async () => {
+    const response = await GET(makeRequest());
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns platform-wide model credit ranking without org or user details", async () => {
+    await seedUserFeatureSwitches(user.orgId, user.userId, {
+      [FeatureSwitchKey.ModelUsageRanking]: true,
+    });
+
+    const now = new Date();
+    const old = new Date(now.getTime() - 31 * 86_400_000);
+    const modelA = `test-model-a-${Date.now()}`;
+    const modelB = `test-model-b-${Date.now()}`;
+    const pendingModel = `test-model-pending-${Date.now()}`;
+    const oldModel = `test-model-old-${Date.now()}`;
+    const insertedModels = [modelA, modelB, pendingModel, oldModel];
+
+    try {
+      await insertTestUsageEvent("org-a", {
+        userId: "user-a",
+        kind: "model",
+        provider: modelA,
+        category: "tokens.input",
+        quantity: 20_000_000,
+        status: "processed",
+        creditsCharged: 10_000_000,
+        createdAt: now,
+      });
+      await insertTestUsageEvent("org-b", {
+        userId: "user-b",
+        kind: "model",
+        provider: modelA,
+        category: "tokens.output",
+        quantity: 10_000_000,
+        status: "processed",
+        creditsCharged: 20_000_000,
+        createdAt: now,
+      });
+      await insertTestUsageEvent("org-c", {
+        userId: "user-c",
+        kind: "model",
+        provider: modelB,
+        category: "tokens.input",
+        quantity: 15_000_000,
+        status: "processed",
+        creditsCharged: 50_000_000,
+        createdAt: now,
+      });
+      await insertTestUsageEvent("org-d", {
+        userId: "user-d",
+        kind: "model",
+        provider: pendingModel,
+        category: "tokens.input",
+        quantity: 100_000_000,
+        status: "pending",
+        createdAt: now,
+      });
+      await insertTestUsageEvent("org-e", {
+        userId: "user-e",
+        kind: "model",
+        provider: oldModel,
+        category: "tokens.input",
+        quantity: 100_000_000,
+        status: "processed",
+        createdAt: old,
+        processedAt: old,
+      });
+
+      const response = await GET(makeRequest("30d"));
+
+      expect(response.status).toBe(200);
+      const data = (await response.json()) as ModelUsageRankingResponse;
+      const modelARow = data.models.find((row) => {
+        return row.model === modelA;
+      });
+      const modelBRow = data.models.find((row) => {
+        return row.model === modelB;
+      });
+      const modelAIndex = data.models.findIndex((row) => {
+        return row.model === modelA;
+      });
+      const modelBIndex = data.models.findIndex((row) => {
+        return row.model === modelB;
+      });
+      expect(data.range).toBe("30d");
+      expect(data.grandTotalTokens).toBeGreaterThanOrEqual(45_000_000);
+      expect(data.grandTotalCredits).toBeGreaterThanOrEqual(80_000_000);
+      expect(modelBIndex).toBeGreaterThanOrEqual(0);
+      expect(modelAIndex).toBeGreaterThanOrEqual(0);
+      expect(modelBIndex).toBeLessThan(modelAIndex);
+      expect(modelARow).toMatchObject({
+        model: modelA,
+        inputTokens: 20_000_000,
+        outputTokens: 10_000_000,
+        cacheTokens: 0,
+        totalTokens: 30_000_000,
+        credits: 30_000_000,
+        previousCredits: 0,
+        changePercent: null,
+      });
+      expect(modelBRow).toMatchObject({
+        model: modelB,
+        inputTokens: 15_000_000,
+        outputTokens: 0,
+        cacheTokens: 0,
+        totalTokens: 15_000_000,
+        credits: 50_000_000,
+        previousCredits: 0,
+        changePercent: null,
+      });
+      expect(data.daily).toHaveLength(30);
+      const today = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+      )
+        .toISOString()
+        .slice(0, 10);
+      const todayBucket = data.daily.find((bucket) => {
+        return bucket.date === today;
+      });
+      expect(todayBucket?.models).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            model: modelA,
+            credits: 30_000_000,
+            totalTokens: 30_000_000,
+          }),
+          expect.objectContaining({
+            model: modelB,
+            credits: 50_000_000,
+            totalTokens: 15_000_000,
+          }),
+        ]),
+      );
+      expect(
+        data.models.some((row) => {
+          return row.model === pendingModel;
+        }),
+      ).toBe(false);
+      expect(
+        data.models.some((row) => {
+          return row.model === oldModel;
+        }),
+      ).toBe(false);
+      expect(JSON.stringify(data)).not.toContain("org-a");
+      expect(JSON.stringify(data)).not.toContain("user-a");
+    } finally {
+      await deleteTestUsageEventsByProvider(insertedModels);
+    }
+  });
+});

--- a/turbo/apps/web/app/api/zero/model-usage-ranking/route.ts
+++ b/turbo/apps/web/app/api/zero/model-usage-ranking/route.ts
@@ -1,0 +1,46 @@
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
+import { zeroModelUsageRankingContract } from "@vm0/api-contracts/contracts/zero-model-usage-ranking";
+import { initServices } from "../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../src/lib/auth/require-auth";
+import { getModelUsageRanking } from "../../../../src/lib/zero/billing/model-usage-ranking-service";
+import { loadFeatureSwitchOverrides } from "../../../../src/lib/zero/user/feature-switches-service";
+
+const router = tsr.router(zeroModelUsageRankingContract, {
+  get: async ({ query, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    const overrides = await loadFeatureSwitchOverrides(
+      authCtx.orgId,
+      authCtx.userId,
+    );
+    const enabled = isFeatureEnabled(FeatureSwitchKey.ModelUsageRanking, {
+      orgId: authCtx.orgId,
+      userId: authCtx.userId,
+      overrides,
+    });
+    if (!enabled) {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Model usage ranking is not enabled",
+      );
+    }
+
+    const result = await getModelUsageRanking(query.range);
+    return { status: 200 as const, body: result };
+  },
+});
+
+const handler = createHandler(zeroModelUsageRankingContract, router, {
+  routeName: "zero.model-usage-ranking",
+});
+
+export { handler as GET };

--- a/turbo/apps/web/src/__tests__/api-test-helpers/credits.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/credits.ts
@@ -18,6 +18,7 @@ export {
   insertTestUsagePricing,
   deleteTestUsagePricing,
   insertTestUsageEvent,
+  deleteTestUsageEventsByProvider,
   setTestCreditUsageCreatedAt,
   seedCreditUsageRecord,
   seedInsightsDaily,

--- a/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
@@ -175,6 +175,7 @@ export {
   insertTestUsagePricing,
   deleteTestUsagePricing,
   insertTestUsageEvent,
+  deleteTestUsageEventsByProvider,
   setTestCreditUsageCreatedAt,
   seedCreditUsageRecord,
   seedInsightsDaily,
@@ -227,3 +228,4 @@ export {
   findTestRunnerJobEntry,
 } from "./runner";
 export { insertTestExportJob, findTestExportJobById } from "./export";
+export { seedUserFeatureSwitches } from "../db-test-seeders/feature-switches";

--- a/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { randomBytes, randomUUID } from "crypto";
 import { initServices } from "../../lib/init-services";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
@@ -315,6 +315,22 @@ export async function insertTestUsageEvent(
     })
     .returning({ id: usageEvent.id });
   return record!.id;
+}
+
+/**
+ * Delete usage_event records by provider for tests that use platform-wide
+ * queries and cannot rely on org/user scoping for isolation.
+ */
+export async function deleteTestUsageEventsByProvider(
+  providers: string[],
+): Promise<void> {
+  if (providers.length === 0) {
+    return;
+  }
+  initServices();
+  await globalThis.services.db
+    .delete(usageEvent)
+    .where(inArray(usageEvent.provider, providers));
 }
 
 /**

--- a/turbo/apps/web/src/__tests__/db-test-seeders/feature-switches.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/feature-switches.ts
@@ -1,4 +1,5 @@
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { initServices } from "../../lib/init-services";
 
 /**
  * Seed user feature switch overrides for testing.
@@ -10,6 +11,7 @@ export async function seedUserFeatureSwitches(
   userId: string,
   switches: Record<string, boolean>,
 ): Promise<void> {
+  initServices();
   await globalThis.services.db
     .insert(userFeatureSwitches)
     .values({ orgId, userId, switches, updatedAt: new Date() })

--- a/turbo/apps/web/src/lib/zero/billing/model-usage-ranking-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/model-usage-ranking-service.ts
@@ -1,0 +1,386 @@
+import { and, eq, gte, inArray, lt, sql } from "drizzle-orm";
+import { creditUsage } from "@vm0/db/schema/credit-usage";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import type {
+  ModelUsageRankingRange,
+  ModelUsageRankingResponse,
+} from "@vm0/api-contracts/contracts/zero-model-usage-ranking";
+import type { Database } from "../../../types/global";
+import {
+  MODEL_TOKEN_CATEGORIES,
+  MODEL_USAGE_KIND,
+  TOKEN_CATEGORY_CACHE_CREATION,
+  TOKEN_CATEGORY_CACHE_READ,
+  TOKEN_CATEGORY_INPUT,
+  TOKEN_CATEGORY_OUTPUT,
+} from "./model-usage-categories";
+
+const DAY_MS = 86_400_000;
+const MODEL_USAGE_RANKING_LIMIT = 10;
+
+interface ModelUsageAggregateRow {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheTokens: number;
+  credits: number;
+}
+
+interface ModelUsageRowWithTotal extends ModelUsageAggregateRow {
+  totalTokens: number;
+}
+
+interface ModelUsageDailyAggregateRow {
+  date: string;
+  model: string;
+  credits: number;
+  totalTokens: number;
+}
+
+function getRangeDays(range: ModelUsageRankingRange): number {
+  return range === "1d" ? 1 : range === "7d" ? 7 : 30;
+}
+
+function floorUtcDay(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+}
+
+function getRangeStart(range: ModelUsageRankingRange, now: Date): Date {
+  const days = getRangeDays(range);
+  return new Date(floorUtcDay(now).getTime() - (days - 1) * DAY_MS);
+}
+
+function getDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function getDateKeys(start: Date, days: number): string[] {
+  return Array.from({ length: days }, (_, index) => {
+    return getDateKey(new Date(start.getTime() + index * DAY_MS));
+  });
+}
+
+function usageEventTokenSum(category: string, alias: string) {
+  return sql<number>`COALESCE(SUM(CASE WHEN ${usageEvent.category} = ${category} THEN ${usageEvent.quantity} ELSE 0 END), 0)::bigint`.as(
+    alias,
+  );
+}
+
+async function queryUsageEventDailyRows(
+  db: Database,
+  start: Date,
+  end: Date,
+): Promise<ModelUsageDailyAggregateRow[]> {
+  const dateExpr = sql<string>`to_char(date_trunc('day', ${usageEvent.processedAt}), 'YYYY-MM-DD')`;
+  const rows = await db
+    .select({
+      date: dateExpr.as("date"),
+      model: usageEvent.provider,
+      credits:
+        sql<number>`COALESCE(SUM(${usageEvent.creditsCharged}), 0)::bigint`.as(
+          "credits",
+        ),
+      totalTokens:
+        sql<number>`COALESCE(SUM(${usageEvent.quantity}), 0)::bigint`.as(
+          "total_tokens",
+        ),
+    })
+    .from(usageEvent)
+    .where(
+      and(
+        eq(usageEvent.kind, MODEL_USAGE_KIND),
+        eq(usageEvent.status, "processed"),
+        inArray(usageEvent.category, MODEL_TOKEN_CATEGORIES),
+        gte(usageEvent.processedAt, start),
+        lt(usageEvent.processedAt, end),
+      ),
+    )
+    .groupBy(dateExpr, usageEvent.provider);
+
+  return rows.map((row) => {
+    return {
+      date: row.date,
+      model: row.model,
+      credits: Number(row.credits),
+      totalTokens: Number(row.totalTokens),
+    };
+  });
+}
+
+async function queryLegacyCreditUsageDailyRows(
+  db: Database,
+  start: Date,
+  end: Date,
+): Promise<ModelUsageDailyAggregateRow[]> {
+  const dateExpr = sql<string>`to_char(date_trunc('day', ${creditUsage.processedAt}), 'YYYY-MM-DD')`;
+  const rows = await db
+    .select({
+      date: dateExpr.as("date"),
+      model: creditUsage.model,
+      credits:
+        sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
+          "credits",
+        ),
+      totalTokens:
+        sql<number>`COALESCE(SUM(${creditUsage.inputTokens} + ${creditUsage.outputTokens} + ${creditUsage.cacheReadInputTokens} + ${creditUsage.cacheCreationInputTokens}), 0)::bigint`.as(
+          "total_tokens",
+        ),
+    })
+    .from(creditUsage)
+    .where(
+      and(
+        eq(creditUsage.status, "processed"),
+        gte(creditUsage.processedAt, start),
+        lt(creditUsage.processedAt, end),
+      ),
+    )
+    .groupBy(dateExpr, creditUsage.model);
+
+  return rows.map((row) => {
+    return {
+      date: row.date,
+      model: row.model,
+      credits: Number(row.credits),
+      totalTokens: Number(row.totalTokens),
+    };
+  });
+}
+
+async function queryUsageEventModelRows(
+  db: Database,
+  start: Date,
+  end: Date,
+): Promise<ModelUsageAggregateRow[]> {
+  const rows = await db
+    .select({
+      model: usageEvent.provider,
+      inputTokens: usageEventTokenSum(TOKEN_CATEGORY_INPUT, "input_tokens"),
+      outputTokens: usageEventTokenSum(TOKEN_CATEGORY_OUTPUT, "output_tokens"),
+      cacheTokens:
+        sql<number>`COALESCE(SUM(CASE WHEN ${usageEvent.category} IN (${TOKEN_CATEGORY_CACHE_READ}, ${TOKEN_CATEGORY_CACHE_CREATION}) THEN ${usageEvent.quantity} ELSE 0 END), 0)::bigint`.as(
+          "cache_tokens",
+        ),
+      credits:
+        sql<number>`COALESCE(SUM(${usageEvent.creditsCharged}), 0)::bigint`.as(
+          "credits",
+        ),
+    })
+    .from(usageEvent)
+    .where(
+      and(
+        eq(usageEvent.kind, MODEL_USAGE_KIND),
+        eq(usageEvent.status, "processed"),
+        inArray(usageEvent.category, MODEL_TOKEN_CATEGORIES),
+        gte(usageEvent.processedAt, start),
+        lt(usageEvent.processedAt, end),
+      ),
+    )
+    .groupBy(usageEvent.provider);
+
+  return rows.map((row) => {
+    return {
+      model: row.model,
+      inputTokens: Number(row.inputTokens),
+      outputTokens: Number(row.outputTokens),
+      cacheTokens: Number(row.cacheTokens),
+      credits: Number(row.credits),
+    };
+  });
+}
+
+async function queryLegacyCreditUsageModelRows(
+  db: Database,
+  start: Date,
+  end: Date,
+): Promise<ModelUsageAggregateRow[]> {
+  const rows = await db
+    .select({
+      model: creditUsage.model,
+      inputTokens:
+        sql<number>`COALESCE(SUM(${creditUsage.inputTokens}), 0)::bigint`.as(
+          "input_tokens",
+        ),
+      outputTokens:
+        sql<number>`COALESCE(SUM(${creditUsage.outputTokens}), 0)::bigint`.as(
+          "output_tokens",
+        ),
+      cacheTokens:
+        sql<number>`COALESCE(SUM(${creditUsage.cacheReadInputTokens} + ${creditUsage.cacheCreationInputTokens}), 0)::bigint`.as(
+          "cache_tokens",
+        ),
+      credits:
+        sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
+          "credits",
+        ),
+    })
+    .from(creditUsage)
+    .where(
+      and(
+        eq(creditUsage.status, "processed"),
+        gte(creditUsage.processedAt, start),
+        lt(creditUsage.processedAt, end),
+      ),
+    )
+    .groupBy(creditUsage.model);
+
+  return rows.map((row) => {
+    return {
+      model: row.model,
+      inputTokens: Number(row.inputTokens),
+      outputTokens: Number(row.outputTokens),
+      cacheTokens: Number(row.cacheTokens),
+      credits: Number(row.credits),
+    };
+  });
+}
+
+function mergeRows(rows: ModelUsageAggregateRow[]): ModelUsageAggregateRow[] {
+  const byModel = new Map<string, ModelUsageAggregateRow>();
+  for (const row of rows) {
+    const current = byModel.get(row.model);
+    if (!current) {
+      byModel.set(row.model, { ...row });
+      continue;
+    }
+    current.inputTokens += row.inputTokens;
+    current.outputTokens += row.outputTokens;
+    current.cacheTokens += row.cacheTokens;
+    current.credits += row.credits;
+  }
+  return [...byModel.values()];
+}
+
+function mergeDailyRows(
+  rows: ModelUsageDailyAggregateRow[],
+): ModelUsageDailyAggregateRow[] {
+  const byDateAndModel = new Map<string, ModelUsageDailyAggregateRow>();
+  for (const row of rows) {
+    const key = `${row.date}:${row.model}`;
+    const current = byDateAndModel.get(key);
+    if (!current) {
+      byDateAndModel.set(key, { ...row });
+      continue;
+    }
+    current.credits += row.credits;
+    current.totalTokens += row.totalTokens;
+  }
+  return [...byDateAndModel.values()];
+}
+
+function withTotalTokens(
+  rows: ModelUsageAggregateRow[],
+): ModelUsageRowWithTotal[] {
+  return rows.map((row) => {
+    return {
+      ...row,
+      totalTokens: row.inputTokens + row.outputTokens + row.cacheTokens,
+    };
+  });
+}
+
+export async function getModelUsageRanking(
+  range: ModelUsageRankingRange,
+  options: { now?: Date } = {},
+): Promise<ModelUsageRankingResponse> {
+  const now = options.now ?? new Date();
+  const start = getRangeStart(range, now);
+  const days = getRangeDays(range);
+  const previousStart = new Date(start.getTime() - days * DAY_MS);
+  const db = globalThis.services.db;
+
+  const [
+    eventRows,
+    legacyRows,
+    previousEventRows,
+    previousLegacyRows,
+    dailyEventRows,
+    dailyLegacyRows,
+  ] = await Promise.all([
+    queryUsageEventModelRows(db, start, now),
+    queryLegacyCreditUsageModelRows(db, start, now),
+    queryUsageEventModelRows(db, previousStart, start),
+    queryLegacyCreditUsageModelRows(db, previousStart, start),
+    queryUsageEventDailyRows(db, start, now),
+    queryLegacyCreditUsageDailyRows(db, start, now),
+  ]);
+  const rows = withTotalTokens(mergeRows([...eventRows, ...legacyRows]));
+  const previousRows = mergeRows([...previousEventRows, ...previousLegacyRows]);
+  const previousCreditsByModel = new Map(
+    previousRows.map((row) => {
+      return [row.model, row.credits] as const;
+    }),
+  );
+
+  const grandTotalTokens = rows.reduce((sum, row) => {
+    return sum + row.totalTokens;
+  }, 0);
+  const grandTotalCredits = rows.reduce((sum, row) => {
+    return sum + row.credits;
+  }, 0);
+
+  const models = rows
+    .filter((row) => {
+      return row.credits > 0;
+    })
+    .sort((a, b) => {
+      return b.credits - a.credits;
+    })
+    .slice(0, MODEL_USAGE_RANKING_LIMIT)
+    .map((row) => {
+      const previousCredits = previousCreditsByModel.get(row.model) ?? 0;
+      return {
+        model: row.model,
+        inputTokens: row.inputTokens,
+        outputTokens: row.outputTokens,
+        cacheTokens: row.cacheTokens,
+        totalTokens: row.totalTokens,
+        credits: row.credits,
+        previousCredits,
+        changePercent:
+          previousCredits > 0
+            ? (row.credits - previousCredits) / previousCredits
+            : null,
+        share: grandTotalCredits > 0 ? row.credits / grandTotalCredits : 0,
+      };
+    });
+  const rankedModels = models.map((row) => {
+    return row.model;
+  });
+  const dailyRows = mergeDailyRows([...dailyEventRows, ...dailyLegacyRows]);
+  const dailyRowsByDateAndModel = new Map(
+    dailyRows.map((row) => {
+      return [`${row.date}:${row.model}`, row] as const;
+    }),
+  );
+  const daily = getDateKeys(start, days).map((date) => {
+    const dailyModels = rankedModels.map((model) => {
+      const row = dailyRowsByDateAndModel.get(`${date}:${model}`);
+      return {
+        model,
+        credits: row?.credits ?? 0,
+        totalTokens: row?.totalTokens ?? 0,
+      };
+    });
+    return {
+      date,
+      totalCredits: dailyModels.reduce((sum, row) => {
+        return sum + row.credits;
+      }, 0),
+      totalTokens: dailyModels.reduce((sum, row) => {
+        return sum + row.totalTokens;
+      }, 0),
+      models: dailyModels,
+    };
+  });
+
+  return {
+    range,
+    generatedAt: now.toISOString(),
+    grandTotalTokens,
+    grandTotalCredits,
+    models,
+    daily,
+  };
+}

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -883,6 +883,14 @@ export {
   type UsageInsightChatRow,
 } from "./zero-usage-insight";
 export {
+  zeroModelUsageRankingContract,
+  modelUsageRankingRangeSchema,
+  type ZeroModelUsageRankingContract,
+  type ModelUsageRankingRange,
+  type ModelUsageRankingItem,
+  type ModelUsageRankingResponse,
+} from "./zero-model-usage-ranking";
+export {
   zeroTeamContract,
   teamComposeItemSchema,
   type ZeroTeamContract,

--- a/turbo/packages/api-contracts/src/contracts/zero-model-usage-ranking.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-model-usage-ranking.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const modelUsageRankingRangeSchema = z.enum(["1d", "7d", "30d"]);
+
+const modelUsageRankingItemSchema = z.object({
+  model: z.string(),
+  inputTokens: z.number(),
+  outputTokens: z.number(),
+  cacheTokens: z.number(),
+  totalTokens: z.number(),
+  credits: z.number(),
+  previousCredits: z.number(),
+  changePercent: z.number().nullable(),
+  share: z.number(),
+});
+
+const modelUsageRankingDailyModelSchema = z.object({
+  model: z.string(),
+  credits: z.number(),
+  totalTokens: z.number(),
+});
+
+const modelUsageRankingDailyBucketSchema = z.object({
+  date: z.string(),
+  totalCredits: z.number(),
+  totalTokens: z.number(),
+  models: z.array(modelUsageRankingDailyModelSchema),
+});
+
+const modelUsageRankingResponseSchema = z.object({
+  range: modelUsageRankingRangeSchema,
+  generatedAt: z.string(),
+  grandTotalTokens: z.number(),
+  grandTotalCredits: z.number(),
+  models: z.array(modelUsageRankingItemSchema),
+  daily: z.array(modelUsageRankingDailyBucketSchema),
+});
+
+export const zeroModelUsageRankingContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/model-usage-ranking",
+    headers: authHeadersSchema,
+    query: z.object({
+      range: modelUsageRankingRangeSchema,
+    }),
+    responses: {
+      200: modelUsageRankingResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get anonymous VM0 model popularity ranking",
+  },
+});
+
+export type ModelUsageRankingRange = z.infer<
+  typeof modelUsageRankingRangeSchema
+>;
+export type ModelUsageRankingItem = z.infer<typeof modelUsageRankingItemSchema>;
+export type ModelUsageRankingDailyBucket = z.infer<
+  typeof modelUsageRankingDailyBucketSchema
+>;
+export type ModelUsageRankingResponse = z.infer<
+  typeof modelUsageRankingResponseSchema
+>;
+export type ZeroModelUsageRankingContract =
+  typeof zeroModelUsageRankingContract;

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -30,6 +30,7 @@ export enum FeatureSwitchKey {
   DataExport = "dataExport",
   SpotifyConnector = "spotifyConnector",
   UsageAnalytics = "usageAnalytics",
+  ModelUsageRanking = "modelUsageRanking",
   ZeroDebug = "zeroDebug",
   ComputerUse = "computerUse",
   Lab = "lab",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -166,6 +166,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Show admin-only daily credits chart and per-run records on Usage page",
     enabled: true,
   },
+  [FeatureSwitchKey.ModelUsageRanking]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Show the VM0 model popularity ranking in workspace model provider settings.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ZeroDebug]: {
     maintainer: "ethan@vm0.ai",
     description:

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -263,7 +263,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^5.125.9
-        version: 5.125.9(@types/react@19.2.14)(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
+        version: 5.125.9(@types/react@19.2.14)(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
       '@clerk/clerk-react':
         specifier: ^5.61.5
         version: 5.61.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -345,6 +345,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.4(react@19.2.4)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1)
       signal-timers:
         specifier: ^1.0.4
         version: 1.0.4
@@ -3723,6 +3726,17 @@ packages:
     peerDependencies:
       react-native: ^0.0.0-0 || >=0.60 <1.0
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
@@ -4609,6 +4623,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@stripe/stripe-js@5.6.0':
     resolution: {integrity: sha512-w8CEY73X/7tw2KKlL3iOk679V9bWseE4GzNz3zlaYxcTjmcmWOathRb0emgo/QQ3eoNzmq68+2Y2gxluAv3xGw==}
     engines: {node: '>=12.16'}
@@ -5117,6 +5134,33 @@ packages:
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -6010,6 +6054,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -6038,6 +6126,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -6316,6 +6407,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.46.0:
+    resolution: {integrity: sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -6856,6 +6950,12 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -6898,6 +6998,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   intl-messageformat@11.2.0:
     resolution: {integrity: sha512-IhghAA8n4KSlXuWKzYsWyWb82JoYTzShfyvdSF85oJPnNOjvv4kAo7S7Jtkm3/vJ53C7dQNRO+Gpnj3iWgTjBQ==}
@@ -8152,6 +8256,18 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -8204,9 +8320,25 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -8282,6 +8414,9 @@ packages:
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resend@6.9.4:
     resolution: {integrity: sha512-/M3dsJzu5OgozqVsA4Psd/1L7EdePgOIIxClas453GOQYFG3VHc2ZyCHZFlvqsc9aZCCd2BJRRqZgWC8D9c7/g==}
@@ -8663,6 +8798,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -8918,6 +9056,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   viem@2.47.6:
     resolution: {integrity: sha512-zExmbI99NGvMdYa7fmqSTLgkwh48dmhgEqFrUgkpL4kfG4XkVefZ8dZqIKVUhZo6Uhf0FrrEXOsHm9LUyIvI2Q==}
@@ -9833,7 +9974,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-org/account@2.0.1(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)':
+  '@base-org/account@2.0.1(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
@@ -9842,7 +9983,7 @@ snapshots:
       ox: 0.6.9(typescript@5.9.3)(zod@4.3.6)
       preact: 10.24.2
       viem: 2.47.6(typescript@5.9.3)(zod@4.3.6)
-      zustand: 5.0.3(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+      zustand: 5.0.3(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -9877,9 +10018,9 @@ snapshots:
       - react
       - react-dom
 
-  '@clerk/clerk-js@5.125.9(@types/react@19.2.14)(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)':
+  '@clerk/clerk-js@5.125.9(@types/react@19.2.14)(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)':
     dependencies:
-      '@base-org/account': 2.0.1(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
+      '@base-org/account': 2.0.1(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
       '@clerk/localizations': 3.37.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@clerk/shared': 3.47.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@coinbase/wallet-sdk': 4.3.0
@@ -12157,6 +12298,18 @@ snapshots:
       merge-options: 3.0.4
     optional: true
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.4
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+
   '@remirror/core-constants@3.0.0': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
@@ -13191,6 +13344,8 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@standard-schema/utils@0.3.0': {}
+
   '@stripe/stripe-js@5.6.0': {}
 
   '@swc/core-darwin-arm64@1.15.21':
@@ -13656,6 +13811,30 @@ snapshots:
     dependencies:
       '@types/node': 24.3.0
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -14014,9 +14193,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/browser': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -14072,7 +14251,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -14682,6 +14861,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   data-uri-to-buffer@4.0.1: {}
 
   data-view-buffer@1.0.2:
@@ -14707,6 +14924,8 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -14972,6 +15191,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.46.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -15688,6 +15909,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -15729,6 +15954,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   intl-messageformat@11.2.0:
     dependencies:
@@ -17247,6 +17474,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -17304,10 +17540,36 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.46.0
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 17.0.2
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -17451,6 +17713,8 @@ snapshots:
       - supports-color
 
   require-main-filename@2.0.0: {}
+
+  reselect@5.1.1: {}
 
   resend@6.9.4(@react-email/render@2.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
@@ -17952,6 +18216,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -18240,6 +18506,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
+
   viem@2.47.6(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.9.1
@@ -18501,9 +18784,10 @@ snapshots:
 
   zod@4.3.6: {}
 
-  zustand@5.0.3(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+  zustand@5.0.3(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
     optionalDependencies:
       '@types/react': 19.2.14
+      immer: 11.1.4
       react: 19.2.4
       use-sync-external-store: 1.6.0(react@19.2.4)
 

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/api:
     dependencies:
@@ -172,7 +172,7 @@ importers:
         version: 8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/cli:
     dependencies:
@@ -251,7 +251,7 @@ importers:
         version: 6.24.1
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -429,7 +429,7 @@ importers:
         version: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/web:
     dependencies:
@@ -670,7 +670,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/api-contracts:
     dependencies:
@@ -710,7 +710,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/api-services:
     devDependencies:
@@ -734,7 +734,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/connectors:
     dependencies:
@@ -765,7 +765,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/core:
     dependencies:
@@ -799,7 +799,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/db:
     dependencies:
@@ -836,7 +836,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/eslint-config:
     devDependencies:
@@ -890,7 +890,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -1000,7 +1000,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -9170,6 +9170,7 @@ packages:
       '@vitest/ui': 4.1.5
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -14125,7 +14126,7 @@ snapshots:
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14139,7 +14140,7 @@ snapshots:
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14155,7 +14156,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -14173,7 +14174,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -14193,9 +14194,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/browser': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -14251,7 +14252,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -18573,7 +18574,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -18603,18 +18604,39 @@ snapshots:
       '@vitest/ui': 4.1.5(vitest@4.1.5)
       happy-dom: 20.9.0
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
+
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.3.0
+      '@vitest/browser-playwright': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/coverage-v8': 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
+      '@vitest/ui': 4.1.5(vitest@4.1.5)
+      happy-dom: 20.9.0
+    transitivePeerDependencies:
+      - msw
 
   vscode-languageserver-textdocument@1.0.12: {}
 


### PR DESCRIPTION
## Summary
- add a feature-gated VM0 model popularity ranking in org model provider settings
- add a platform-wide model usage ranking API with daily trend buckets and leaderboard deltas
- add tests and cleanup for platform-wide usage ranking fixtures

## Verification
- pnpm --filter @vm0/api-contracts check-types
- pnpm --filter @vm0/core check-types
- pnpm --filter @vm0/connectors check-types
- pnpm --filter @vm0/app check-types
- pnpm --filter web check-types
- pnpm --filter @vm0/app lint
- pnpm --filter web lint
- pnpm test src/views/org/__tests__/org-providers-tab.test.tsx --no-file-parallelism --maxWorkers 1
- pnpm test app/api/zero/model-usage-ranking/__tests__/route.test.ts --no-file-parallelism --maxWorkers 1
- pre-commit: pnpm check-types