### PR TITLE
refactor: split runner storage manifest boundaries

### DIFF
--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -68,7 +68,8 @@ fn ancestors_within_target(path: &Path, target: &Path) -> bool {
 
 const LOG_TAG: &str = "sandbox:download";
 
-/// Storage manifest format (matches TypeScript StorageManifest).
+/// Guest-download manifest format written by the runner after reuse/cache
+/// decisions have been applied.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct Manifest {

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -26,8 +26,8 @@ use crate::paths::{HomePaths, LogPaths, guest};
 use crate::proxy::{self, ProxyRegistryHandle};
 use crate::telemetry::JobTelemetry;
 use crate::types::{
-    ArtifactEntry, ExecutionContext, ResumeSession, SandboxReuseResult, StorageEntry,
-    StorageManifest,
+    ExecutionContext, GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry,
+    ResumeSession, SandboxReuseResult,
 };
 
 /// Shared configuration for all executions (profile-independent).
@@ -443,9 +443,10 @@ async fn run_in_sandbox(
 
     // 3. Download storages (skipping entries unchanged since the previous turn)
     if let Some(manifest) = &context.storage_manifest {
-        let mut effective: StorageManifest = match start.prev_storage {
-            Some(prev) => filter_unchanged_storages(manifest, prev),
-            None => manifest.clone(),
+        let guest_manifest = GuestDownloadManifest::from(manifest);
+        let mut effective: GuestDownloadManifest = match start.prev_storage {
+            Some(prev) => filter_unchanged_storages(&guest_manifest, prev),
+            None => guest_manifest,
         };
         // Short-circuit: skip the vsock exec if every entry was filtered out
         // and there are no paths to clean up.
@@ -962,38 +963,33 @@ async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &ExecutionContext) 
 /// version matches the previous turn's fingerprints. `guest-download`
 /// skips entries without a valid URL, so unchanged storages stay on disk.
 fn filter_unchanged_storages(
-    manifest: &StorageManifest,
+    manifest: &GuestDownloadManifest,
     prev: &crate::idle_pool::StorageFingerprints,
-) -> StorageManifest {
+) -> GuestDownloadManifest {
     let mut skipped: usize = 0;
     let mut cleanup_paths: Vec<String> = Vec::new();
 
-    let storages: Vec<StorageEntry> = manifest
+    let storages: Vec<GuestDownloadStorageEntry> = manifest
         .storages
         .iter()
         .map(|s| {
-            let unchanged = match (&s.vas_storage_name, &s.vas_version_id) {
-                (Some(name), Some(ver)) => prev
-                    .storages
-                    .get(&s.mount_path)
-                    .is_some_and(|(pn, pv)| pn == name && pv == ver),
-                _ => false, // no version info → always download
-            };
+            let unchanged = prev
+                .storages
+                .get(&s.mount_path)
+                .is_some_and(|(pn, pv)| pn == &s.vas_storage_name && pv == &s.vas_version_id);
             if unchanged {
                 skipped += 1;
             } else {
                 cleanup_paths.push(s.mount_path.clone());
             }
-            StorageEntry {
-                mount_path: s.mount_path.clone(),
+            GuestDownloadStorageEntry {
                 archive_url: if unchanged {
                     None
                 } else {
                     s.archive_url.clone()
                 },
                 cached: unchanged,
-                vas_storage_name: s.vas_storage_name.clone(),
-                vas_version_id: s.vas_version_id.clone(),
+                ..s.clone()
             }
         })
         .collect();
@@ -1010,7 +1006,7 @@ fn filter_unchanged_storages(
         }
     }
 
-    let filter_artifact = |a: &ArtifactEntry,
+    let filter_artifact = |a: &GuestDownloadArtifactEntry,
                            prev_ver: &Option<(String, String)>,
                            skipped: &mut usize,
                            cleanup: &mut Vec<String>| {
@@ -1022,14 +1018,14 @@ fn filter_unchanged_storages(
         } else {
             cleanup.push(a.mount_path.clone());
         }
-        ArtifactEntry {
+        GuestDownloadArtifactEntry {
             archive_url: if same { None } else { a.archive_url.clone() },
             cached: same,
             ..a.clone()
         }
     };
 
-    let artifacts: Vec<ArtifactEntry> = manifest
+    let artifacts: Vec<GuestDownloadArtifactEntry> = manifest
         .artifacts
         .iter()
         .map(|a| {
@@ -1060,7 +1056,7 @@ fn filter_unchanged_storages(
         );
     }
 
-    StorageManifest {
+    GuestDownloadManifest {
         storages,
         artifacts,
         cleanup_paths,
@@ -1079,7 +1075,7 @@ fn guest_download_env(run_id: &str) -> [(&'static str, &str); 1] {
 async fn download_storages(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
-    manifest: &StorageManifest,
+    manifest: &GuestDownloadManifest,
 ) -> RunnerResult<()> {
     let manifest_json = serde_json::to_vec(manifest)
         .map_err(|e| RunnerError::Internal(format!("manifest json: {e}")))?;
@@ -1414,10 +1410,40 @@ fn build_env_json(
 mod tests {
     use super::*;
     use crate::ids::RunId;
-    use crate::types::{ArtifactEntry, ResumeSession, StorageEntry, StorageManifest};
+    use crate::types::{
+        ArtifactEntry, GuestDownloadArtifactEntry, GuestDownloadManifest,
+        GuestDownloadStorageEntry, ResumeSession, StorageEntry, StorageManifest,
+    };
     use async_trait::async_trait;
     use sandbox_mock::MockSandboxFactory;
     use std::sync::Arc;
+
+    fn api_storage(name: &str, mount_path: &str, version: &str, archive_url: &str) -> StorageEntry {
+        StorageEntry {
+            name: name.into(),
+            mount_path: mount_path.into(),
+            archive_url: archive_url.into(),
+            vas_storage_name: name.into(),
+            vas_version_id: version.into(),
+        }
+    }
+
+    fn api_artifact(
+        name: &str,
+        mount_path: &str,
+        storage_id: &str,
+        version: &str,
+        archive_url: &str,
+    ) -> ArtifactEntry {
+        ArtifactEntry {
+            mount_path: mount_path.into(),
+            archive_url: archive_url.into(),
+            vas_storage_name: name.into(),
+            vas_storage_id: storage_id.into(),
+            vas_version_id: version.into(),
+            manifest_url: None,
+        }
+    }
 
     struct DestroyPanicFactory {
         inner: MockSandboxFactory,
@@ -1546,22 +1572,19 @@ mod tests {
     fn build_env_json_with_single_artifact() {
         let mut ctx = minimal_context();
         ctx.storage_manifest = Some(StorageManifest {
-            storages: vec![StorageEntry {
-                mount_path: "/data".into(),
-                archive_url: None,
-                cached: false,
-                vas_storage_name: None,
-                vas_version_id: None,
-            }],
-            artifacts: vec![ArtifactEntry {
-                mount_path: "/artifacts".into(),
-                archive_url: None,
-                cached: false,
-                vas_storage_name: "my-vol".into(),
-                vas_storage_id: "sid-1".into(),
-                vas_version_id: "v1".into(),
-            }],
-            cleanup_paths: vec![],
+            storages: vec![api_storage(
+                "data",
+                "/data",
+                "v1",
+                "https://example.com/data.tar.gz",
+            )],
+            artifacts: vec![api_artifact(
+                "my-vol",
+                "/artifacts",
+                "sid-1",
+                "v1",
+                "https://example.com/artifacts.tar.gz",
+            )],
         });
 
         let env = build_env_for_test(&ctx, "http://localhost");
@@ -1585,24 +1608,21 @@ mod tests {
         ctx.storage_manifest = Some(StorageManifest {
             storages: vec![],
             artifacts: vec![
-                ArtifactEntry {
-                    mount_path: "/workspace".into(),
-                    archive_url: None,
-                    cached: false,
-                    vas_storage_name: "art-a".into(),
-                    vas_storage_id: "sid-a".into(),
-                    vas_version_id: "v1".into(),
-                },
-                ArtifactEntry {
-                    mount_path: "/data".into(),
-                    archive_url: None,
-                    cached: false,
-                    vas_storage_name: "art-b".into(),
-                    vas_storage_id: "sid-b".into(),
-                    vas_version_id: "v2".into(),
-                },
+                api_artifact(
+                    "art-a",
+                    "/workspace",
+                    "sid-a",
+                    "v1",
+                    "https://example.com/art-a.tar.gz",
+                ),
+                api_artifact(
+                    "art-b",
+                    "/data",
+                    "sid-b",
+                    "v2",
+                    "https://example.com/art-b.tar.gz",
+                ),
             ],
-            cleanup_paths: vec![],
         });
 
         let env = build_env_for_test(&ctx, "http://localhost");
@@ -1623,7 +1643,6 @@ mod tests {
         ctx.storage_manifest = Some(StorageManifest {
             storages: vec![],
             artifacts: vec![],
-            cleanup_paths: vec![],
         });
 
         let env = build_env_for_test(&ctx, "http://localhost");
@@ -2300,14 +2319,13 @@ mod tests {
         let sandbox = MockSandbox::new("test");
         // write_file succeeds by default, exec returns exit 0 by default.
         let ctx = minimal_context();
-        let manifest = StorageManifest {
-            storages: vec![StorageEntry {
-                mount_path: "/data".into(),
-                archive_url: Some("https://s3/archive.tar.gz".into()),
-                cached: false,
-                vas_storage_name: None,
-                vas_version_id: None,
-            }],
+        let manifest = GuestDownloadManifest {
+            storages: vec![guest_storage(
+                "/data",
+                "data",
+                "v1",
+                Some("https://s3/archive.tar.gz"),
+            )],
             artifacts: vec![],
             cleanup_paths: vec![],
         };
@@ -2347,7 +2365,7 @@ mod tests {
             stderr: b"download failed".to_vec(),
         }));
         let ctx = minimal_context();
-        let manifest = StorageManifest {
+        let manifest = GuestDownloadManifest {
             storages: vec![],
             artifacts: vec![],
             cleanup_paths: vec![],
@@ -2458,15 +2476,13 @@ mod tests {
         let mut ctx = minimal_context();
         ctx.storage_manifest = Some(StorageManifest {
             storages: vec![],
-            artifacts: vec![ArtifactEntry {
-                mount_path: "/memory".into(),
-                archive_url: None,
-                cached: false,
-                vas_storage_name: "memory".into(),
-                vas_storage_id: String::new(),
-                vas_version_id: "v2".into(),
-            }],
-            cleanup_paths: vec![],
+            artifacts: vec![api_artifact(
+                "memory",
+                "/memory",
+                "",
+                "v2",
+                "https://example.com/memory.tar.gz",
+            )],
         });
         let env = build_env_for_test(&ctx, "http://localhost");
         assert!(!env.contains_key("VM0_MEMORY_DRIVER"));
@@ -2616,7 +2632,7 @@ mod tests {
         let sandbox = MockSandbox::new("test");
         sandbox.push_write_file_result(Err(sandbox_write_file_error("vsock write failed")));
         let ctx = minimal_context();
-        let manifest = StorageManifest {
+        let manifest = GuestDownloadManifest {
             storages: vec![],
             artifacts: vec![],
             cleanup_paths: vec![],
@@ -2825,15 +2841,13 @@ mod tests {
 
         let mut ctx = minimal_context();
         ctx.storage_manifest = Some(StorageManifest {
-            storages: vec![StorageEntry {
-                mount_path: "/data".into(),
-                archive_url: Some("https://example.com/data.tar.gz".into()),
-                cached: false,
-                vas_storage_name: None,
-                vas_version_id: None,
-            }],
+            storages: vec![api_storage(
+                "data",
+                "/data",
+                "v1",
+                "https://example.com/data.tar.gz",
+            )],
             artifacts: vec![],
-            cleanup_paths: vec![],
         });
         let (exit_code, _) = run_execute_inner(&factory, &ctx, &config, &default_params())
             .await
@@ -3291,13 +3305,28 @@ mod tests {
     // filter_unchanged_storages tests
     // -----------------------------------------------------------------------
 
-    fn art(name: &str, ver: &str, url: &str) -> ArtifactEntry {
-        ArtifactEntry {
+    fn guest_art(name: &str, ver: &str, url: Option<&str>) -> GuestDownloadArtifactEntry {
+        GuestDownloadArtifactEntry {
             mount_path: "/workspace".into(),
-            archive_url: Some(url.into()),
+            archive_url: url.map(str::to_string),
             cached: false,
             vas_storage_name: name.into(),
             vas_storage_id: String::new(),
+            vas_version_id: ver.into(),
+        }
+    }
+
+    fn guest_storage(
+        mount_path: &str,
+        name: &str,
+        ver: &str,
+        url: Option<&str>,
+    ) -> GuestDownloadStorageEntry {
+        GuestDownloadStorageEntry {
+            mount_path: mount_path.into(),
+            archive_url: url.map(str::to_string),
+            cached: false,
+            vas_storage_name: name.into(),
             vas_version_id: ver.into(),
         }
     }
@@ -3310,9 +3339,9 @@ mod tests {
 
     #[test]
     fn filter_same_artifact_version_nulls_url() {
-        let manifest = StorageManifest {
+        let manifest = GuestDownloadManifest {
             storages: vec![],
-            artifacts: vec![art("my-art", "v1", "https://s3/v1")],
+            artifacts: vec![guest_art("my-art", "v1", Some("https://s3/v1"))],
             cleanup_paths: vec![],
         };
         let prev = crate::idle_pool::StorageFingerprints {
@@ -3325,9 +3354,9 @@ mod tests {
 
     #[test]
     fn filter_different_artifact_version_keeps_url() {
-        let manifest = StorageManifest {
+        let manifest = GuestDownloadManifest {
             storages: vec![],
-            artifacts: vec![art("my-art", "v2", "https://s3/v2")],
+            artifacts: vec![guest_art("my-art", "v2", Some("https://s3/v2"))],
             cleanup_paths: vec![],
         };
         let prev = crate::idle_pool::StorageFingerprints {
@@ -3343,9 +3372,9 @@ mod tests {
 
     #[test]
     fn filter_different_artifact_name_keeps_url() {
-        let manifest = StorageManifest {
+        let manifest = GuestDownloadManifest {
             storages: vec![],
-            artifacts: vec![art("other-art", "v1", "https://s3/v1")],
+            artifacts: vec![guest_art("other-art", "v1", Some("https://s3/v1"))],
             cleanup_paths: vec![],
         };
         let prev = crate::idle_pool::StorageFingerprints {
@@ -3358,9 +3387,9 @@ mod tests {
 
     #[test]
     fn filter_new_artifact_not_in_prev_keeps_url() {
-        let manifest = StorageManifest {
+        let manifest = GuestDownloadManifest {
             storages: vec![],
-            artifacts: vec![art("my-art", "v1", "https://s3/v1")],
+            artifacts: vec![guest_art("my-art", "v1", Some("https://s3/v1"))],
             cleanup_paths: vec![],
         };
         let prev = crate::idle_pool::StorageFingerprints::default();
@@ -3370,15 +3399,14 @@ mod tests {
 
     #[test]
     fn filter_empty_prev_downloads_everything() {
-        let manifest = StorageManifest {
-            storages: vec![StorageEntry {
-                mount_path: "/data".into(),
-                archive_url: Some("https://s3/data".into()),
-                cached: false,
-                vas_storage_name: Some("vol-1".into()),
-                vas_version_id: Some("v1".into()),
-            }],
-            artifacts: vec![art("my-art", "v1", "https://s3/v1")],
+        let manifest = GuestDownloadManifest {
+            storages: vec![guest_storage(
+                "/data",
+                "vol-1",
+                "v1",
+                Some("https://s3/data"),
+            )],
+            artifacts: vec![guest_art("my-art", "v1", Some("https://s3/v1"))],
             cleanup_paths: vec![],
         };
         let prev = crate::idle_pool::StorageFingerprints::default();
@@ -3389,15 +3417,14 @@ mod tests {
 
     #[test]
     fn filter_all_unchanged_nulls_all_urls() {
-        let manifest = StorageManifest {
-            storages: vec![StorageEntry {
-                mount_path: "/data".into(),
-                archive_url: Some("https://s3/same-url".into()),
-                cached: false,
-                vas_storage_name: Some("vol-1".into()),
-                vas_version_id: Some("v1".into()),
-            }],
-            artifacts: vec![art("my-art", "v1", "https://s3/v1")],
+        let manifest = GuestDownloadManifest {
+            storages: vec![guest_storage(
+                "/data",
+                "vol-1",
+                "v1",
+                Some("https://s3/same-url"),
+            )],
+            artifacts: vec![guest_art("my-art", "v1", Some("https://s3/v1"))],
             cleanup_paths: vec![],
         };
         let mut storages = HashMap::new();
@@ -3415,7 +3442,7 @@ mod tests {
 
     #[test]
     fn filter_two_artifacts_at_different_mount_paths() {
-        let art_a = ArtifactEntry {
+        let art_a = GuestDownloadArtifactEntry {
             mount_path: "/workspace".into(),
             archive_url: Some("https://s3/a-v2".into()),
             cached: false,
@@ -3423,7 +3450,7 @@ mod tests {
             vas_storage_id: String::new(),
             vas_version_id: "v2".into(),
         };
-        let art_b = ArtifactEntry {
+        let art_b = GuestDownloadArtifactEntry {
             mount_path: "/data".into(),
             archive_url: Some("https://s3/b-v1".into()),
             cached: false,
@@ -3431,7 +3458,7 @@ mod tests {
             vas_storage_id: String::new(),
             vas_version_id: "v1".into(),
         };
-        let manifest = StorageManifest {
+        let manifest = GuestDownloadManifest {
             storages: vec![],
             artifacts: vec![art_a, art_b],
             cleanup_paths: vec![],
@@ -3458,9 +3485,9 @@ mod tests {
     #[test]
     fn filter_detects_removed_artifacts() {
         // Current manifest has only one artifact; previous had two.
-        let manifest = StorageManifest {
+        let manifest = GuestDownloadManifest {
             storages: vec![],
-            artifacts: vec![art("kept", "v1", "https://s3/kept")],
+            artifacts: vec![guest_art("kept", "v1", Some("https://s3/kept"))],
             cleanup_paths: vec![],
         };
         let mut artifacts = HashMap::new();
@@ -3477,22 +3504,20 @@ mod tests {
 
     #[test]
     fn filter_computes_cleanup_for_changed_storages() {
-        let manifest = StorageManifest {
+        let manifest = GuestDownloadManifest {
             storages: vec![
-                StorageEntry {
-                    mount_path: "/home/user/.claude".into(),
-                    archive_url: Some("https://s3/instructions".into()),
-                    cached: false,
-                    vas_storage_name: Some("instructions".into()),
-                    vas_version_id: Some("v2".into()),
-                },
-                StorageEntry {
-                    mount_path: "/home/user/.claude/skills/foo".into(),
-                    archive_url: Some("https://s3/foo".into()),
-                    cached: false,
-                    vas_storage_name: Some("skill-foo".into()),
-                    vas_version_id: Some("v1".into()),
-                },
+                guest_storage(
+                    "/home/user/.claude",
+                    "instructions",
+                    "v2",
+                    Some("https://s3/instructions"),
+                ),
+                guest_storage(
+                    "/home/user/.claude/skills/foo",
+                    "skill-foo",
+                    "v1",
+                    Some("https://s3/foo"),
+                ),
             ],
             artifacts: vec![],
             cleanup_paths: vec![],
@@ -3522,14 +3547,13 @@ mod tests {
 
     #[test]
     fn filter_detects_removed_storages() {
-        let manifest = StorageManifest {
-            storages: vec![StorageEntry {
-                mount_path: "/home/user/.claude".into(),
-                archive_url: Some("https://s3/instructions".into()),
-                cached: false,
-                vas_storage_name: Some("instructions".into()),
-                vas_version_id: Some("v1".into()),
-            }],
+        let manifest = GuestDownloadManifest {
+            storages: vec![guest_storage(
+                "/home/user/.claude",
+                "instructions",
+                "v1",
+                Some("https://s3/instructions"),
+            )],
             artifacts: vec![],
             cleanup_paths: vec![],
         };
@@ -3558,9 +3582,9 @@ mod tests {
 
     #[test]
     fn filter_changed_artifact_adds_cleanup_path() {
-        let manifest = StorageManifest {
+        let manifest = GuestDownloadManifest {
             storages: vec![],
-            artifacts: vec![art("my-art", "v2", "https://s3/v2")],
+            artifacts: vec![guest_art("my-art", "v2", Some("https://s3/v2"))],
             cleanup_paths: vec![],
         };
         let prev = crate::idle_pool::StorageFingerprints {
@@ -3578,16 +3602,9 @@ mod tests {
 
     #[test]
     fn filter_changed_artifact_with_null_url_adds_cleanup_path() {
-        let manifest = StorageManifest {
+        let manifest = GuestDownloadManifest {
             storages: vec![],
-            artifacts: vec![ArtifactEntry {
-                mount_path: "/workspace".into(),
-                archive_url: None, // API returned null
-                cached: false,
-                vas_storage_name: "my-art".into(),
-                vas_storage_id: String::new(),
-                vas_version_id: "v2".into(),
-            }],
+            artifacts: vec![guest_art("my-art", "v2", None)],
             cleanup_paths: vec![],
         };
         let prev = crate::idle_pool::StorageFingerprints {
@@ -3595,21 +3612,15 @@ mod tests {
             artifacts: art_fp("/workspace", "my-art", "v1"),
         };
         let result = filter_unchanged_storages(&manifest, &prev);
-        // Version changed → must be in cleanup_paths even though URL is null.
+        // Version changed → must be in cleanup_paths even though URL is absent.
         assert!(result.cleanup_paths.contains(&"/workspace".to_string()));
         assert!(!result.artifacts[0].cached);
     }
 
     #[test]
     fn filter_changed_storage_with_null_url_adds_cleanup_path() {
-        let manifest = StorageManifest {
-            storages: vec![StorageEntry {
-                mount_path: "/data".into(),
-                archive_url: None, // API returned null
-                cached: false,
-                vas_storage_name: Some("vol-1".into()),
-                vas_version_id: Some("v2".into()),
-            }],
+        let manifest = GuestDownloadManifest {
+            storages: vec![guest_storage("/data", "vol-1", "v2", None)],
             artifacts: vec![],
             cleanup_paths: vec![],
         };
@@ -3620,21 +3631,20 @@ mod tests {
             artifacts: HashMap::new(),
         };
         let result = filter_unchanged_storages(&manifest, &prev);
-        // Version changed → must be in cleanup_paths even though URL is null.
+        // Version changed → must be in cleanup_paths even though URL is absent.
         assert!(result.cleanup_paths.contains(&"/data".to_string()));
         assert!(!result.storages[0].cached);
     }
 
     #[test]
     fn filter_unchanged_storage_sets_cached_true() {
-        let manifest = StorageManifest {
-            storages: vec![StorageEntry {
-                mount_path: "/data".into(),
-                archive_url: Some("https://s3/data".into()),
-                cached: false,
-                vas_storage_name: Some("vol-1".into()),
-                vas_version_id: Some("v1".into()),
-            }],
+        let manifest = GuestDownloadManifest {
+            storages: vec![guest_storage(
+                "/data",
+                "vol-1",
+                "v1",
+                Some("https://s3/data"),
+            )],
             artifacts: vec![],
             cleanup_paths: vec![],
         };

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -37,9 +37,10 @@ impl StorageFingerprints {
     pub fn from_manifest(manifest: &StorageManifest) -> Self {
         let mut storages = HashMap::new();
         for s in &manifest.storages {
-            if let (Some(name), Some(ver)) = (&s.vas_storage_name, &s.vas_version_id) {
-                storages.insert(s.mount_path.clone(), (name.clone(), ver.clone()));
-            }
+            storages.insert(
+                s.mount_path.clone(),
+                (s.vas_storage_name.clone(), s.vas_version_id.clone()),
+            );
         }
         let mut artifacts = HashMap::new();
         for a in &manifest.artifacts {

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -23,8 +23,6 @@ pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 1800;
 /// Used to skip re-downloading unchanged storages on VM reuse.
 ///
 /// All comparisons use `(vas_storage_name, vas_version_id)` tuples.
-/// For regular storages without version fields, the entry is omitted
-/// from the map and will always be re-downloaded.
 #[derive(Clone, Debug, Default)]
 pub struct StorageFingerprints {
     /// mount_path → (vas_storage_name, vas_version_id) for regular storages.

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -516,25 +516,45 @@ async fn write_to_cache(cache_dir: &Path, bytes: &[u8]) -> RunnerResult<()> {
         .map_err(|e| RunnerError::Internal(format!("create staging {}: {e}", staging.display())))?;
 
     let archive_staging = staging.join("archive.tar.gz");
-    fs::write(&archive_staging, bytes)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("write {}: {e}", archive_staging.display())))?;
+    if let Err(e) = fs::write(&archive_staging, bytes).await {
+        let _ = fs::remove_dir_all(&staging).await;
+        return Err(RunnerError::Internal(format!(
+            "write {}: {e}",
+            archive_staging.display()
+        )));
+    }
 
     // fsync the archive so a crash between rename and next sync cannot
     // leave a zero-byte or torn file visible at the final path.
-    let f = fs::File::open(&archive_staging).await.map_err(|e| {
-        RunnerError::Internal(format!("open for fsync {}: {e}", archive_staging.display()))
-    })?;
-    f.sync_all()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("fsync {}: {e}", archive_staging.display())))?;
+    let f = match fs::File::open(&archive_staging).await {
+        Ok(f) => f,
+        Err(e) => {
+            let _ = fs::remove_dir_all(&staging).await;
+            return Err(RunnerError::Internal(format!(
+                "open for fsync {}: {e}",
+                archive_staging.display()
+            )));
+        }
+    };
+    if let Err(e) = f.sync_all().await {
+        drop(f);
+        let _ = fs::remove_dir_all(&staging).await;
+        return Err(RunnerError::Internal(format!(
+            "fsync {}: {e}",
+            archive_staging.display()
+        )));
+    }
     drop(f);
 
     // Ensure the `<name>/` parent exists so the rename below has a target.
-    if let Some(parent) = cache_dir.parent() {
-        fs::create_dir_all(parent).await.map_err(|e| {
-            RunnerError::Internal(format!("create cache parent {}: {e}", parent.display()))
-        })?;
+    if let Some(parent) = cache_dir.parent()
+        && let Err(e) = fs::create_dir_all(parent).await
+    {
+        let _ = fs::remove_dir_all(&staging).await;
+        return Err(RunnerError::Internal(format!(
+            "create cache parent {}: {e}",
+            parent.display()
+        )));
     }
 
     if let Err(e) = fs::rename(&staging, cache_dir).await {

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -112,7 +112,7 @@ enum DownloadBody {
 /// pushed into the guest over vsock.
 ///
 /// Invariant: only touches entries where `cached == false`, `archive_url.is_some()`,
-/// and both `vas_storage_name` and `vas_version_id` are set. Entries that
+/// and both `vas_storage_name` and `vas_version_id` are non-empty. Entries that
 /// `filter_unchanged_storages` marked as reuse-in-place (`archive_url = None`)
 /// are left untouched.
 pub async fn populate_cache(

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -1284,6 +1284,28 @@ mod tests {
         assert_eq!(s.parent(), d.parent());
     }
 
+    #[tokio::test]
+    async fn write_to_cache_rename_error_cleans_staging() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir = temp.path().join("storages").join("name").join("version");
+        let parent = cache_dir.parent().unwrap();
+        fs::create_dir_all(parent).await.unwrap();
+        fs::write(&cache_dir, b"not-a-cache-dir").await.unwrap();
+
+        let staging = staging_dir(&cache_dir);
+
+        let err = write_to_cache(&cache_dir, b"archive bytes")
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("rename"), "got: {err}");
+        assert!(
+            !staging.exists(),
+            "failed cache write must not leave staging dir"
+        );
+        assert_eq!(fs::read(&cache_dir).await.unwrap(), b"not-a-cache-dir");
+    }
+
     #[test]
     fn limited_body_allows_exact_limit() {
         let mut bytes = Vec::new();

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -39,7 +39,7 @@ use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
 use crate::paths::{HomePaths, short_digest, touch_mtime};
 use crate::telemetry::JobTelemetry;
-use crate::types::StorageManifest;
+use crate::types::GuestDownloadManifest;
 
 /// Archive sizes strictly larger than this are passthrough.
 const CACHE_MAX_SIZE: u64 = 8 * 1024 * 1024;
@@ -116,7 +116,7 @@ enum DownloadBody {
 /// `filter_unchanged_storages` marked as reuse-in-place (`archive_url = None`)
 /// are left untouched.
 pub async fn populate_cache(
-    manifest: &mut StorageManifest,
+    manifest: &mut GuestDownloadManifest,
     sandbox: &dyn Sandbox,
     home: &HomePaths,
     telemetry: &mut JobTelemetry,
@@ -159,7 +159,7 @@ pub async fn populate_cache(
     Ok(())
 }
 
-fn collect_targets(manifest: &StorageManifest) -> Vec<CacheTarget> {
+fn collect_targets(manifest: &GuestDownloadManifest) -> Vec<CacheTarget> {
     let mut out = Vec::new();
     for (i, s) in manifest.storages.iter().enumerate() {
         if s.cached {
@@ -168,12 +168,8 @@ fn collect_targets(manifest: &StorageManifest) -> Vec<CacheTarget> {
         let Some(url) = s.archive_url.as_deref() else {
             continue;
         };
-        let Some(name) = s.vas_storage_name.as_deref() else {
-            continue;
-        };
-        let Some(version) = s.vas_version_id.as_deref() else {
-            continue;
-        };
+        let name = s.vas_storage_name.as_str();
+        let version = s.vas_version_id.as_str();
         // Empty components would hash to the same fixed digest as every
         // other empty component, collapsing distinct manifest entries into
         // a shared cache slot. Treat them like missing keys: passthrough.
@@ -586,7 +582,7 @@ fn staging_dir(final_dir: &Path) -> PathBuf {
 }
 
 fn apply_outcome(
-    manifest: &mut StorageManifest,
+    manifest: &mut GuestDownloadManifest,
     target: &CacheTarget,
     outcome: &TargetOutcome,
     telemetry: &mut JobTelemetry,
@@ -627,7 +623,7 @@ fn apply_outcome(
 /// any future parallel mutation at this pipeline stage. A mismatch is not
 /// a hard error (the caller made the right conservative choice) but is
 /// logged so a regression that breaks the invariant is visible.
-fn rewrite_url(manifest: &mut StorageManifest, target: &CacheTarget) {
+fn rewrite_url(manifest: &mut GuestDownloadManifest, target: &CacheTarget) {
     let new_url = format!(
         "file://{}",
         guest_archive_path(&target.name, &target.version)
@@ -636,8 +632,8 @@ fn rewrite_url(manifest: &mut StorageManifest, target: &CacheTarget) {
     match target.kind {
         TargetKind::Storage => {
             if let Some(entry) = manifest.storages.get_mut(target.index)
-                && entry.vas_storage_name.as_deref() == Some(target.name.as_str())
-                && entry.vas_version_id.as_deref() == Some(target.version.as_str())
+                && entry.vas_storage_name == target.name
+                && entry.vas_version_id == target.version
             {
                 entry.archive_url = Some(new_url);
                 applied = true;
@@ -676,7 +672,9 @@ mod tests {
 
     use crate::http::HttpClient;
     use crate::ids::RunId;
-    use crate::types::{ArtifactEntry, StorageEntry};
+    use crate::types::{
+        GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry,
+    };
 
     fn new_telemetry() -> JobTelemetry {
         let http = HttpClient::new("http://localhost:0".to_string()).unwrap();
@@ -687,14 +685,14 @@ mod tests {
         HomePaths::with_root(temp.path().to_path_buf())
     }
 
-    fn manifest_single_storage(url: String, name: &str, version: &str) -> StorageManifest {
-        StorageManifest {
-            storages: vec![StorageEntry {
+    fn manifest_single_storage(url: String, name: &str, version: &str) -> GuestDownloadManifest {
+        GuestDownloadManifest {
+            storages: vec![GuestDownloadStorageEntry {
                 mount_path: format!("/mnt/{name}"),
                 archive_url: Some(url),
                 cached: false,
-                vas_storage_name: Some(name.to_string()),
-                vas_version_id: Some(version.to_string()),
+                vas_storage_name: name.to_string(),
+                vas_version_id: version.to_string(),
             }],
             artifacts: Vec::new(),
             cleanup_paths: Vec::new(),
@@ -940,13 +938,13 @@ mod tests {
         let mut telemetry = new_telemetry();
 
         // Entry the filter has already marked reuse-in-place: archive_url = None, cached = true.
-        let mut manifest = StorageManifest {
-            storages: vec![StorageEntry {
+        let mut manifest = GuestDownloadManifest {
+            storages: vec![GuestDownloadStorageEntry {
                 mount_path: "/mnt/foo".into(),
                 archive_url: None,
                 cached: true,
-                vas_storage_name: Some("foo".into()),
-                vas_version_id: Some("v1".into()),
+                vas_storage_name: "foo".into(),
+                vas_version_id: "v1".into(),
             }],
             artifacts: Vec::new(),
             cleanup_paths: Vec::new(),
@@ -970,14 +968,14 @@ mod tests {
         let sandbox = MockSandbox::new("test");
         let mut telemetry = new_telemetry();
 
-        // Entry without vas_storage_name / vas_version_id — pre-epic schema.
-        let mut manifest = StorageManifest {
-            storages: vec![StorageEntry {
+        // Entry without usable vas_storage_name / vas_version_id passes through.
+        let mut manifest = GuestDownloadManifest {
+            storages: vec![GuestDownloadStorageEntry {
                 mount_path: "/mnt/legacy".into(),
                 archive_url: Some("https://r2.example.com/legacy.tar.gz".into()),
                 cached: false,
-                vas_storage_name: None,
-                vas_version_id: None,
+                vas_storage_name: String::new(),
+                vas_version_id: String::new(),
             }],
             artifacts: Vec::new(),
             cleanup_paths: Vec::new(),
@@ -1108,9 +1106,9 @@ mod tests {
         std::fs::create_dir_all(&cache_dir).unwrap();
         std::fs::write(cache_dir.join("archive.tar.gz"), tarball_bytes()).unwrap();
 
-        let mut manifest = StorageManifest {
+        let mut manifest = GuestDownloadManifest {
             storages: Vec::new(),
-            artifacts: vec![ArtifactEntry {
+            artifacts: vec![GuestDownloadArtifactEntry {
                 mount_path: "/mnt/artifact".into(),
                 archive_url: Some("https://r2.example.com/ignored.tar.gz".into()),
                 cached: false,
@@ -1387,21 +1385,21 @@ mod tests {
             std::fs::write(cache_dir.join("archive.tar.gz"), tarball_bytes()).unwrap();
         }
 
-        let mut manifest = StorageManifest {
+        let mut manifest = GuestDownloadManifest {
             storages: vec![
-                StorageEntry {
+                GuestDownloadStorageEntry {
                     mount_path: format!("/mnt/{name_a}"),
                     archive_url: Some("https://r2.example.com/ignored.tar.gz".into()),
                     cached: false,
-                    vas_storage_name: Some(name_a.to_string()),
-                    vas_version_id: Some(version.to_string()),
+                    vas_storage_name: name_a.to_string(),
+                    vas_version_id: version.to_string(),
                 },
-                StorageEntry {
+                GuestDownloadStorageEntry {
                     mount_path: format!("/mnt/{name_b}"),
                     archive_url: Some("https://r2.example.com/ignored.tar.gz".into()),
                     cached: false,
-                    vas_storage_name: Some(name_b.to_string()),
-                    vas_version_id: Some(version.to_string()),
+                    vas_storage_name: name_b.to_string(),
+                    vas_version_id: version.to_string(),
                 },
             ],
             artifacts: Vec::new(),
@@ -1441,9 +1439,9 @@ mod tests {
         let mut telemetry = new_telemetry();
 
         let original = "https://r2.example.com/nameless.tar.gz".to_string();
-        let mut manifest = StorageManifest {
+        let mut manifest = GuestDownloadManifest {
             storages: Vec::new(),
-            artifacts: vec![ArtifactEntry {
+            artifacts: vec![GuestDownloadArtifactEntry {
                 mount_path: "/mnt/nameless".into(),
                 archive_url: Some(original.clone()),
                 cached: false,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -165,6 +165,46 @@ pub struct StorageManifest {
     pub storages: Vec<StorageEntry>,
     #[serde(default)]
     pub artifacts: Vec<ArtifactEntry>,
+}
+
+/// API/wire storage entry from the web claim response.
+///
+/// Runner-derived guest-download state such as `cached` does not belong here.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageEntry {
+    pub name: String,
+    pub mount_path: String,
+    pub archive_url: String,
+    pub vas_storage_name: String,
+    pub vas_version_id: String,
+}
+
+/// API/wire artifact entry from the web claim response.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactEntry {
+    pub mount_path: String,
+    pub archive_url: String,
+    pub vas_storage_name: String,
+    /// Storage UUID, used guest-side to locally recompute the content hash
+    /// and skip VAS calls when an artifact is unchanged since mount.
+    pub vas_storage_id: String,
+    pub vas_version_id: String,
+    #[serde(default)]
+    pub manifest_url: Option<String>,
+}
+
+/// Runner-derived manifest written to `guest-download`.
+///
+/// This is intentionally separate from the API `StorageManifest`: `cached`,
+/// nullable `archive_url`, and `cleanup_paths` are computed by the runner.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GuestDownloadManifest {
+    pub storages: Vec<GuestDownloadStorageEntry>,
+    #[serde(default)]
+    pub artifacts: Vec<GuestDownloadArtifactEntry>,
     /// Paths to clean before downloading (computed from previous fingerprints).
     /// Used on VM reuse to remove stale files from changed/removed storages.
     #[serde(default)]
@@ -173,35 +213,89 @@ pub struct StorageManifest {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct StorageEntry {
+pub struct GuestDownloadStorageEntry {
     pub mount_path: String,
-    #[serde(default)]
     pub archive_url: Option<String>,
     /// Whether this entry is cached from a previous turn (fingerprint matched).
     /// When true, `archive_url` is intentionally `None` — the guest should
     /// preserve existing files at this mount path during cleanup.
-    #[serde(default)]
     pub cached: bool,
-    #[serde(default)]
-    pub vas_storage_name: Option<String>,
-    #[serde(default)]
-    pub vas_version_id: Option<String>,
+    pub vas_storage_name: String,
+    pub vas_version_id: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ArtifactEntry {
+pub struct GuestDownloadArtifactEntry {
     pub mount_path: String,
-    #[serde(default)]
     pub archive_url: Option<String>,
     /// Whether this entry is cached from a previous turn (fingerprint matched).
-    #[serde(default)]
     pub cached: bool,
     pub vas_storage_name: String,
-    /// Storage UUID, used guest-side to locally recompute the content hash
-    /// and skip VAS calls when an artifact is unchanged since mount.
     pub vas_storage_id: String,
     pub vas_version_id: String,
+}
+
+impl From<&StorageManifest> for GuestDownloadManifest {
+    fn from(manifest: &StorageManifest) -> Self {
+        Self {
+            storages: manifest
+                .storages
+                .iter()
+                .map(|storage| GuestDownloadStorageEntry {
+                    mount_path: storage.mount_path.clone(),
+                    archive_url: Some(storage.archive_url.clone()),
+                    cached: false,
+                    vas_storage_name: storage.vas_storage_name.clone(),
+                    vas_version_id: storage.vas_version_id.clone(),
+                })
+                .collect(),
+            artifacts: manifest
+                .artifacts
+                .iter()
+                .map(|artifact| GuestDownloadArtifactEntry {
+                    mount_path: artifact.mount_path.clone(),
+                    archive_url: Some(artifact.archive_url.clone()),
+                    cached: false,
+                    vas_storage_name: artifact.vas_storage_name.clone(),
+                    vas_storage_id: artifact.vas_storage_id.clone(),
+                    vas_version_id: artifact.vas_version_id.clone(),
+                })
+                .collect(),
+            cleanup_paths: Vec::new(),
+        }
+    }
+}
+
+impl From<StorageManifest> for GuestDownloadManifest {
+    fn from(manifest: StorageManifest) -> Self {
+        Self {
+            storages: manifest
+                .storages
+                .into_iter()
+                .map(|storage| GuestDownloadStorageEntry {
+                    mount_path: storage.mount_path,
+                    archive_url: Some(storage.archive_url),
+                    cached: false,
+                    vas_storage_name: storage.vas_storage_name,
+                    vas_version_id: storage.vas_version_id,
+                })
+                .collect(),
+            artifacts: manifest
+                .artifacts
+                .into_iter()
+                .map(|artifact| GuestDownloadArtifactEntry {
+                    mount_path: artifact.mount_path,
+                    archive_url: Some(artifact.archive_url),
+                    cached: false,
+                    vas_storage_name: artifact.vas_storage_name,
+                    vas_storage_id: artifact.vas_storage_id,
+                    vas_version_id: artifact.vas_version_id,
+                })
+                .collect(),
+            cleanup_paths: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -370,12 +464,20 @@ mod tests {
             "vars": {"API_KEY": "secret"},
             "checkpointId": "660e8400-e29b-41d4-a716-446655440000",
             "storageManifest": {
-                "storages": [{"mountPath": "/data", "archiveUrl": "https://s3/archive.tar.gz"}],
-                "artifact": {
+                "storages": [{
+                    "name": "data",
+                    "mountPath": "/data",
+                    "vasStorageName": "data",
+                    "vasVersionId": "v1",
+                    "archiveUrl": "https://s3/archive.tar.gz"
+                }],
+                "artifacts": [{
                     "mountPath": "/artifacts",
+                    "archiveUrl": "https://s3/artifact.tar.gz",
                     "vasStorageName": "art-1",
+                    "vasStorageId": "sid-1",
                     "vasVersionId": "v1"
-                }
+                }]
             },
             "environment": {"NODE_ENV": "production"},
             "resumeSession": {"sessionId": "sess-1", "sessionHistory": "/tmp/history"},
@@ -593,18 +695,31 @@ mod tests {
     #[test]
     fn storage_manifest_camel_case() {
         let json = json!({
-            "storages": [{"mountPath": "/workspace"}],
+            "storages": [{
+                "name": "workspace",
+                "mountPath": "/workspace",
+                "archiveUrl": "https://example.com/workspace.tar.gz",
+                "vasStorageName": "workspace",
+                "vasVersionId": "v1"
+            }],
             "artifacts": [{
                 "mountPath": "/artifacts",
+                "archiveUrl": "https://example.com/artifacts.tar.gz",
                 "vasStorageName": "my-artifact",
                 "vasStorageId": "sid-1",
-                "vasVersionId": "v1"
+                "vasVersionId": "v1",
+                "manifestUrl": "https://example.com/manifest.json"
             }]
         });
         let manifest: StorageManifest = serde_json::from_value(json).unwrap();
         assert_eq!(manifest.storages[0].mount_path, "/workspace");
+        assert_eq!(manifest.storages[0].name, "workspace");
         assert_eq!(manifest.artifacts.len(), 1);
         assert_eq!(manifest.artifacts[0].vas_storage_name, "my-artifact");
+        assert_eq!(
+            manifest.artifacts[0].manifest_url.as_deref(),
+            Some("https://example.com/manifest.json")
+        );
     }
 
     #[test]
@@ -614,12 +729,14 @@ mod tests {
             "artifacts": [
                 {
                     "mountPath": "/workspace",
+                    "archiveUrl": "https://example.com/a.tar.gz",
                     "vasStorageName": "art-a",
                     "vasStorageId": "sid-a",
                     "vasVersionId": "v1"
                 },
                 {
                     "mountPath": "/data",
+                    "archiveUrl": "https://example.com/b.tar.gz",
                     "vasStorageName": "art-b",
                     "vasStorageId": "sid-b",
                     "vasVersionId": "v2"
@@ -639,6 +756,70 @@ mod tests {
         });
         let manifest: StorageManifest = serde_json::from_value(json).unwrap();
         assert!(manifest.artifacts.is_empty());
+    }
+
+    #[test]
+    fn storage_manifest_conversion_initializes_guest_download_fields() {
+        let manifest = StorageManifest {
+            storages: vec![StorageEntry {
+                name: "workspace".into(),
+                mount_path: "/workspace".into(),
+                archive_url: "https://example.com/workspace.tar.gz".into(),
+                vas_storage_name: "workspace".into(),
+                vas_version_id: "v1".into(),
+            }],
+            artifacts: vec![ArtifactEntry {
+                mount_path: "/artifacts".into(),
+                archive_url: "https://example.com/artifact.tar.gz".into(),
+                vas_storage_name: "memory".into(),
+                vas_storage_id: "sid-1".into(),
+                vas_version_id: "v2".into(),
+                manifest_url: Some("https://example.com/manifest.json".into()),
+            }],
+        };
+
+        let guest_manifest = GuestDownloadManifest::from(&manifest);
+
+        assert!(guest_manifest.cleanup_paths.is_empty());
+        assert!(!guest_manifest.storages[0].cached);
+        assert_eq!(
+            guest_manifest.storages[0].archive_url.as_deref(),
+            Some("https://example.com/workspace.tar.gz")
+        );
+        assert!(!guest_manifest.artifacts[0].cached);
+        assert_eq!(
+            guest_manifest.artifacts[0].archive_url.as_deref(),
+            Some("https://example.com/artifact.tar.gz")
+        );
+    }
+
+    #[test]
+    fn guest_download_manifest_serialization_omits_api_only_fields() {
+        let manifest = StorageManifest {
+            storages: vec![StorageEntry {
+                name: "workspace".into(),
+                mount_path: "/workspace".into(),
+                archive_url: "https://example.com/workspace.tar.gz".into(),
+                vas_storage_name: "workspace".into(),
+                vas_version_id: "v1".into(),
+            }],
+            artifacts: vec![ArtifactEntry {
+                mount_path: "/artifacts".into(),
+                archive_url: "https://example.com/artifact.tar.gz".into(),
+                vas_storage_name: "memory".into(),
+                vas_storage_id: "sid-1".into(),
+                vas_version_id: "v2".into(),
+                manifest_url: Some("https://example.com/manifest.json".into()),
+            }],
+        };
+
+        let value = serde_json::to_value(GuestDownloadManifest::from(&manifest)).unwrap();
+
+        assert!(value["cleanupPaths"].is_array());
+        assert_eq!(value["storages"][0]["cached"], false);
+        assert!(value["storages"][0].get("name").is_none());
+        assert_eq!(value["artifacts"][0]["cached"], false);
+        assert!(value["artifacts"][0].get("manifestUrl").is_none());
     }
 
     #[test]

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { storageManifestSchema } from "../runners";
+
+describe("runner storage manifest contract", () => {
+  it("accepts the web-produced claim manifest shape", () => {
+    expect(
+      storageManifestSchema.parse({
+        storages: [
+          {
+            name: "workspace",
+            mountPath: "/workspace",
+            vasStorageName: "workspace-volume",
+            vasVersionId: "version-1",
+            archiveUrl: "https://storage.example/archive.tar.gz",
+          },
+        ],
+        artifacts: [
+          {
+            mountPath: "/home/user/.claude/projects/project",
+            vasStorageName: "memory",
+            vasStorageId: "storage-id-1",
+            vasVersionId: "version-2",
+            archiveUrl: "https://storage.example/artifact.tar.gz",
+            manifestUrl: "https://storage.example/manifest.json",
+          },
+        ],
+      }),
+    ).toEqual({
+      storages: [
+        {
+          name: "workspace",
+          mountPath: "/workspace",
+          vasStorageName: "workspace-volume",
+          vasVersionId: "version-1",
+          archiveUrl: "https://storage.example/archive.tar.gz",
+        },
+      ],
+      artifacts: [
+        {
+          mountPath: "/home/user/.claude/projects/project",
+          vasStorageName: "memory",
+          vasStorageId: "storage-id-1",
+          vasVersionId: "version-2",
+          archiveUrl: "https://storage.example/artifact.tar.gz",
+          manifestUrl: "https://storage.example/manifest.json",
+        },
+      ],
+    });
+  });
+
+  it("rejects guest-download-only nullable archive urls", () => {
+    const result = storageManifestSchema.safeParse({
+      storages: [
+        {
+          name: "workspace",
+          mountPath: "/workspace",
+          vasStorageName: "workspace-volume",
+          vasVersionId: "version-1",
+          archiveUrl: null,
+        },
+      ],
+      artifacts: [],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("strips runner-derived guest-download fields", () => {
+    const manifest = storageManifestSchema.parse({
+      storages: [
+        {
+          name: "workspace",
+          mountPath: "/workspace",
+          vasStorageName: "workspace-volume",
+          vasVersionId: "version-1",
+          archiveUrl: "https://storage.example/archive.tar.gz",
+          cached: true,
+        },
+      ],
+      artifacts: [],
+      cleanupPaths: ["/workspace"],
+    });
+
+    expect(manifest).toEqual({
+      storages: [
+        {
+          name: "workspace",
+          mountPath: "/workspace",
+          vasStorageName: "workspace-volume",
+          vasVersionId: "version-1",
+          archiveUrl: "https://storage.example/archive.tar.gz",
+        },
+      ],
+      artifacts: [],
+    });
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -70,8 +70,11 @@ export const runnersPollContract = c.router({
  * Storage entry in manifest
  */
 export const storageEntrySchema = z.object({
+  name: z.string(),
   mountPath: z.string(),
-  archiveUrl: z.string().nullable(),
+  vasStorageName: z.string(),
+  vasVersionId: z.string(),
+  archiveUrl: z.string(),
 });
 
 /**
@@ -79,9 +82,11 @@ export const storageEntrySchema = z.object({
  */
 export const artifactEntrySchema = z.object({
   mountPath: z.string(),
-  archiveUrl: z.string().nullable(),
   vasStorageName: z.string(),
+  vasStorageId: z.string(),
   vasVersionId: z.string(),
+  archiveUrl: z.string(),
+  manifestUrl: z.string().optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Keep `StorageManifest` as the web-to-runner API manifest type and remove runner-derived fields from it.
- Add `GuestDownloadManifest` for the runner-to-guest `guest-download` payload and convert explicitly before reuse filtering/cache rewrite.
- Align the TypeScript runner storage manifest contract with the web-produced claim payload and add contract coverage.

## Tests

- `cargo test -p runner --bin runner --manifest-path crates/Cargo.toml`
- `cargo test -p guest-download --lib --manifest-path crates/Cargo.toml`
- `pnpm -F @vm0/api-contracts test`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts run generate:rust && git diff --exit-code -- crates/api-contracts/src/generated`
- `git diff --check`

Closes #11466
