### PR TITLE
refactor: extract mitm response streaming state

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -2,8 +2,8 @@
 
 Exports:
 
-- ``STREAM_BUFFER_LIMIT`` — 64 KB cap used by the streaming buffer in
-  ``mitm_addon.responseheaders`` and by the decompression safety cap.
+- ``STREAM_BUFFER_LIMIT`` — 64 KB cap used by the responseheaders streaming
+  buffer and by the decompression safety cap.
 - Streaming / one-shot decompression for gzip, deflate, br, zstd.
 - UTF-8-safe truncation, text/binary content detection and encoding.
 - Header redaction for sensitive names (auth, token, cookie, …).

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -21,14 +21,15 @@ from mitmproxy.addonmanager import Loader
 
 # --- Sub-module imports ---
 #
-# Usage/body_utils are imported by module (not selective `from X import ...`)
+# Usage/body_utils/response_streaming are imported by module (not selective `from X import ...`)
 # so that:
-#   1. Cross-module calls read as ``usage.X(...)`` / ``body_utils.X(...)``,
+#   1. Cross-module calls read as ``usage.X(...)`` / ``body_utils.X(...)`` /
+#      ``response_streaming.X(...)``,
 #      making the module boundary visible at call sites.
-#   2. Tests can patch ``usage.name`` / ``body_utils.name`` in one place and
-#      it affects both direct callers in those modules and handler callers
-#      here — no mock-placement pitfalls.
+#   2. Tests can patch names on the owning module object and affect all
+#      callers — no mock-placement pitfalls from copied function bindings.
 import body_utils
+import response_streaming
 import usage
 import vendor_check
 from auth import (
@@ -47,11 +48,7 @@ from url_utils import get_original_url
 # starts shadowing our vendored copy; see vendor_check.py for the playbook.
 vendor_check.verify()
 
-# HTTP status boundaries used in response-phase classification.  Also defined
-# in ``usage.py`` for the same reason; kept local because they're RFC-fixed
-# (never drift) and factoring them out for two callers adds no value.
-_HTTP_STATUS_OK_MIN = 200  # inclusive: start of 2xx success range
-_HTTP_STATUS_REDIRECT_MIN = 300  # start of 3xx — doubles as the 2xx exclusive upper bound
+# HTTP status boundaries used in response-phase classification.
 _HTTP_STATUS_UNAUTHORIZED = 401
 _HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
 
@@ -350,166 +347,8 @@ def _release_tracked_usage_flow(flow: http.HTTPFlow) -> None:
 
 
 def responseheaders(flow: http.HTTPFlow) -> None:
-    """
-    Enable response streaming with body buffering.
-
-    Uses a callback to stream response data to the client immediately
-    while accumulating a copy in memory (up to ``STREAM_BUFFER_LIMIT``).
-    Once the limit is exceeded, buffering stops but streaming continues
-    uninterrupted.  The buffered body is available in the ``response()``
-    hook via ``flow.metadata["stream_buffer"]``.
-    """
-    if not flow.response:
-        return
-
-    buf = bytearray()
-    state = {"truncated": False, "total_bytes": 0}
-
-    # Set up usage extraction for billable response classes that need body
-    # inspection. The forensic stream_buffer remains capped; billing parsers
-    # consume chunks separately so a large response cannot grow that buffer.
-    sse_parser = None
-    sse_decompressor = None
-    model_json_parser = None
-    model_json_decompressor = None
-    ndjson_parser = None
-    ndjson_decompressor = None
-    x_json_parser = None
-    x_json_decompressor = None
-    firewall_name = flow.metadata.get("firewall_name", "")
-    is_model_provider = firewall_name.startswith("model-provider:")
-    # Platform-billable firewall flag, sourced from vm_info["billableFirewalls"]
-    # via auth.handle_firewall_request.  Gates report_connector_usage (in response())
-    # and the incremental response parsers used for billing payload extraction.
-    is_billable_flow = flow.metadata.get("firewall_billable", False)
-    is_billable_model_provider = is_model_provider and is_billable_flow
-    # X-specific NDJSON stream classification — tied to the x firewall itself,
-    # not to billing.  Kept separate so a future non-x billable connector
-    # doesn't accidentally inherit X stream parsing.
-    is_x_flow = firewall_name == "x"
-
-    # Classify X NDJSON streams early so we can register an incremental parser
-    # and avoid buffering the (potentially multi-GB) stream body.  Only a
-    # cheap path-only check happens here — full request metadata is parsed
-    # later in response() by report_connector_usage.
-    #
-    # Gated on 2xx status so error responses (4xx/5xx on stream endpoints
-    # return JSON, not NDJSON) skip the billing parser and only use the capped
-    # forensic stream buffer.  report_connector_usage already skips non-2xx
-    # responses so no billing record is affected either way.
-    #
-    # Reads ``original_url`` with no fallback — kept consistent with
-    # :func:`usage._parse_x_request_metadata` so the log entry's
-    # ``is_stream`` field cannot diverge from the parser registration
-    # decision.  For any x firewall flow, ``request()`` has already
-    # populated ``original_url`` before ``responseheaders`` fires.
-    is_x_stream = False
-    if is_x_flow and _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN:
-        stream_path = urllib.parse.urlparse(flow.metadata.get("original_url", "")).path
-        is_x_stream = usage.x.is_stream_path(stream_path)
-
-    if is_billable_model_provider:
-        content_type = flow.response.headers.get("content-type", "")
-        if "text/event-stream" in content_type:
-            parser_fn, usage_dict = usage.create_sse_usage_extractor()
-            sse_parser = parser_fn
-            flow.metadata["model_provider_usage"] = usage_dict
-            sse_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
-        else:
-            extractor = usage.create_model_json_usage_extractor()
-            model_json_parser = extractor.feed
-            flow.metadata["model_json_usage_finish"] = extractor.finish
-            model_json_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
-    elif is_x_stream:
-        parser_fn, ndjson_state = usage.x.create_ndjson_extractor()
-        ndjson_parser = parser_fn
-        # Deliberately NOT "model_provider_usage" — that key would route through
-        # report_model_provider_usage and trigger the model-provider webhook.
-        # x_ndjson_state is only consumed by report_connector_usage.
-        flow.metadata["x_ndjson_state"] = ndjson_state
-        ndjson_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
-    elif (
-        is_x_flow
-        and is_billable_flow
-        and _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN
-    ):
-        extractor = usage.x.create_json_response_extractor()
-        x_json_parser = extractor.feed
-        flow.metadata["x_json_response_finish"] = extractor.finish
-        x_json_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
-
-    # Buffer cap policy:
-    # - stream_buffer is only for forensic logging / capture and is always
-    #   capped at STREAM_BUFFER_LIMIT.
-    # - Billing extraction uses the incremental parsers above.
-    buf_limit = body_utils.STREAM_BUFFER_LIMIT
-
-    def stream_and_buffer(chunk: bytes) -> bytes:
-        state["total_bytes"] += len(chunk)
-        if not state["truncated"]:
-            remaining = buf_limit - len(buf)
-            if len(chunk) <= remaining:
-                buf.extend(chunk)
-            else:
-                buf.extend(chunk[:remaining])
-                state["truncated"] = True
-        if sse_parser is not None:
-            plaintext = sse_decompressor(chunk) if sse_decompressor else chunk
-            sse_parser(plaintext)
-        elif model_json_parser is not None:
-            plaintext = model_json_decompressor(chunk) if model_json_decompressor else chunk
-            model_json_parser(plaintext)
-        elif ndjson_parser is not None:
-            plaintext = ndjson_decompressor(chunk) if ndjson_decompressor else chunk
-            ndjson_parser(plaintext)
-        elif x_json_parser is not None:
-            plaintext = x_json_decompressor(chunk) if x_json_decompressor else chunk
-            x_json_parser(plaintext)
-        return chunk
-
-    flow.response.stream = stream_and_buffer
-    flow.metadata["stream_buffer"] = buf
-    flow.metadata["stream_buffer_state"] = state
-    flow.metadata["_vm0_response_stream_callback"] = stream_and_buffer
-
-
-def _finalize_model_json_usage(flow: http.HTTPFlow, proxy_log_path: str) -> None:
-    finish = flow.metadata.pop("model_json_usage_finish", None)
-    if finish is None:
-        return
-    flow.metadata["_model_json_usage_finalized"] = True
-    usage_result, error = finish()
-    if usage_result:
-        flow.metadata["model_provider_usage"] = usage_result
-        return
-    if error:
-        log_proxy_entry(
-            proxy_log_path,
-            "warn",
-            "Model provider JSON usage extraction failed",
-            type="usage_event",
-            error=error,
-        )
-
-
-def _finalize_x_json_state(flow: http.HTTPFlow) -> None:
-    finish = flow.metadata.pop("x_json_response_finish", None)
-    if finish is None:
-        return
-    state, error = finish()
-    if error:
-        state["parse_error"] = error
-    flow.metadata["x_json_state"] = state
-
-
-def _release_response_stream_state(flow: http.HTTPFlow) -> None:
-    stream_callback = flow.metadata.pop("_vm0_response_stream_callback", None)
-    flow.metadata.pop("stream_buffer", None)
-    flow.metadata.pop("stream_buffer_state", None)
-    flow.metadata.pop("model_json_usage_finish", None)
-    flow.metadata.pop("x_json_response_finish", None)
-    if stream_callback is not None and flow.response and flow.response.stream is stream_callback:
-        flow.response.stream = False
+    """Install response stream buffering and incremental body parsers."""
+    response_streaming.configure_response_stream(flow)
 
 
 def _track_usage_flow(fn):
@@ -525,7 +364,7 @@ def _track_usage_flow(fn):
         try:
             return fn(flow, *args, **kwargs)
         finally:
-            _release_response_stream_state(flow)
+            response_streaming.release_response_stream_state(flow)
             _release_tracked_usage_flow(flow)
 
     return wrapper
@@ -607,7 +446,7 @@ def response(flow: http.HTTPFlow) -> None:
 
         log_network_entry(network_log_path, log_entry)
 
-    _finalize_model_json_usage(flow, proxy_log_path)
+    response_streaming.finalize_model_json_usage(flow, proxy_log_path)
 
     # Report proxy-extracted usage for model provider responses.
     # For non-streaming responses, fall back to extracting usage from the
@@ -631,7 +470,7 @@ def response(flow: http.HTTPFlow) -> None:
     usage.report_model_provider_usage(flow, run_id)
 
     # Billable connector usage observation (issue #9504, stage 0).
-    _finalize_x_json_state(flow)
+    response_streaming.finalize_x_json_state(flow)
     usage.report_connector_usage(flow, run_id)
 
     # Invalidate firewall header cache on 401 so next request gets fresh headers.

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -1,0 +1,182 @@
+"""Response streaming setup and parser state for the mitmproxy addon."""
+
+import urllib.parse
+
+from mitmproxy import http
+
+import body_utils
+import usage
+from logging_utils import log_proxy_entry
+
+# HTTP 2xx success range (RFC 9110).  Also defined in
+# ``usage.providers.connectors.x`` for local response-phase classification.
+_HTTP_STATUS_OK_MIN = 200
+_HTTP_STATUS_REDIRECT_MIN = 300
+
+_MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
+_MODEL_JSON_USAGE_FINALIZED = "_model_json_usage_finalized"
+_RESPONSE_STREAM_CALLBACK = "_vm0_response_stream_callback"
+_X_JSON_RESPONSE_FINISH = "x_json_response_finish"
+
+
+def configure_response_stream(flow: http.HTTPFlow) -> None:
+    """
+    Enable response streaming with body buffering.
+
+    Uses a callback to stream response data to the client immediately
+    while accumulating a copy in memory (up to ``STREAM_BUFFER_LIMIT``).
+    Once the limit is exceeded, buffering stops but streaming continues
+    uninterrupted.  The buffered body is available in the ``response()``
+    hook via ``flow.metadata["stream_buffer"]``.
+    """
+    if not flow.response:
+        return
+
+    buf = bytearray()
+    state = {"truncated": False, "total_bytes": 0}
+
+    # Set up usage extraction for billable response classes that need body
+    # inspection. The forensic stream_buffer remains capped; billing parsers
+    # consume chunks separately so a large response cannot grow that buffer.
+    sse_parser = None
+    sse_decompressor = None
+    model_json_parser = None
+    model_json_decompressor = None
+    ndjson_parser = None
+    ndjson_decompressor = None
+    x_json_parser = None
+    x_json_decompressor = None
+    firewall_name = flow.metadata.get("firewall_name", "")
+    is_model_provider = firewall_name.startswith("model-provider:")
+    # Platform-billable firewall flag, sourced from vm_info["billableFirewalls"]
+    # via auth.handle_firewall_request.  Gates report_connector_usage (in response())
+    # and the incremental response parsers used for billing payload extraction.
+    is_billable_flow = flow.metadata.get("firewall_billable", False)
+    is_billable_model_provider = is_model_provider and is_billable_flow
+    # X-specific NDJSON stream classification — tied to the x firewall itself,
+    # not to billing.  Kept separate so a future non-x billable connector
+    # doesn't accidentally inherit X stream parsing.
+    is_x_flow = firewall_name == "x"
+
+    # Classify X NDJSON streams early so we can register an incremental parser
+    # and avoid buffering the (potentially multi-GB) stream body.  Only a
+    # cheap path-only check happens here — full request metadata is parsed
+    # later in response() by report_connector_usage.
+    #
+    # Gated on 2xx status so error responses (4xx/5xx on stream endpoints
+    # return JSON, not NDJSON) skip the billing parser and only use the capped
+    # forensic stream buffer.  report_connector_usage already skips non-2xx
+    # responses so no billing record is affected either way.
+    #
+    # Reads ``original_url`` with no fallback — kept consistent with
+    # :func:`usage.x._parse_request_metadata` so the log entry's
+    # ``is_stream`` field cannot diverge from the parser registration
+    # decision.  For any x firewall flow, ``request()`` has already
+    # populated ``original_url`` before ``responseheaders`` fires.
+    is_x_stream = False
+    if is_x_flow and _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN:
+        stream_path = urllib.parse.urlparse(flow.metadata.get("original_url", "")).path
+        is_x_stream = usage.x.is_stream_path(stream_path)
+
+    if is_billable_model_provider:
+        content_type = flow.response.headers.get("content-type", "")
+        if "text/event-stream" in content_type:
+            parser_fn, usage_dict = usage.create_sse_usage_extractor()
+            sse_parser = parser_fn
+            flow.metadata["model_provider_usage"] = usage_dict
+            sse_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
+        else:
+            extractor = usage.create_model_json_usage_extractor()
+            model_json_parser = extractor.feed
+            flow.metadata[_MODEL_JSON_USAGE_FINISH] = extractor.finish
+            model_json_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
+    elif is_x_stream:
+        parser_fn, ndjson_state = usage.x.create_ndjson_extractor()
+        ndjson_parser = parser_fn
+        # Deliberately NOT "model_provider_usage" — that key would route through
+        # report_model_provider_usage and trigger the model-provider webhook.
+        # x_ndjson_state is only consumed by report_connector_usage.
+        flow.metadata["x_ndjson_state"] = ndjson_state
+        ndjson_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
+    elif (
+        is_x_flow
+        and is_billable_flow
+        and _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN
+    ):
+        extractor = usage.x.create_json_response_extractor()
+        x_json_parser = extractor.feed
+        flow.metadata[_X_JSON_RESPONSE_FINISH] = extractor.finish
+        x_json_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
+
+    # Buffer cap policy:
+    # - stream_buffer is only for forensic logging / capture and is always
+    #   capped at STREAM_BUFFER_LIMIT.
+    # - Billing extraction uses the incremental parsers above.
+    buf_limit = body_utils.STREAM_BUFFER_LIMIT
+
+    def stream_and_buffer(chunk: bytes) -> bytes:
+        state["total_bytes"] += len(chunk)
+        if not state["truncated"]:
+            remaining = buf_limit - len(buf)
+            if len(chunk) <= remaining:
+                buf.extend(chunk)
+            else:
+                buf.extend(chunk[:remaining])
+                state["truncated"] = True
+        if sse_parser is not None:
+            plaintext = sse_decompressor(chunk) if sse_decompressor else chunk
+            sse_parser(plaintext)
+        elif model_json_parser is not None:
+            plaintext = model_json_decompressor(chunk) if model_json_decompressor else chunk
+            model_json_parser(plaintext)
+        elif ndjson_parser is not None:
+            plaintext = ndjson_decompressor(chunk) if ndjson_decompressor else chunk
+            ndjson_parser(plaintext)
+        elif x_json_parser is not None:
+            plaintext = x_json_decompressor(chunk) if x_json_decompressor else chunk
+            x_json_parser(plaintext)
+        return chunk
+
+    flow.response.stream = stream_and_buffer
+    flow.metadata["stream_buffer"] = buf
+    flow.metadata["stream_buffer_state"] = state
+    flow.metadata[_RESPONSE_STREAM_CALLBACK] = stream_and_buffer
+
+
+def finalize_model_json_usage(flow: http.HTTPFlow, proxy_log_path: str) -> None:
+    finish = flow.metadata.pop(_MODEL_JSON_USAGE_FINISH, None)
+    if finish is None:
+        return
+    flow.metadata[_MODEL_JSON_USAGE_FINALIZED] = True
+    usage_result, error = finish()
+    if usage_result:
+        flow.metadata["model_provider_usage"] = usage_result
+        return
+    if error:
+        log_proxy_entry(
+            proxy_log_path,
+            "warn",
+            "Model provider JSON usage extraction failed",
+            type="usage_event",
+            error=error,
+        )
+
+
+def finalize_x_json_state(flow: http.HTTPFlow) -> None:
+    finish = flow.metadata.pop(_X_JSON_RESPONSE_FINISH, None)
+    if finish is None:
+        return
+    state, error = finish()
+    if error:
+        state["parse_error"] = error
+    flow.metadata["x_json_state"] = state
+
+
+def release_response_stream_state(flow: http.HTTPFlow) -> None:
+    stream_callback = flow.metadata.pop(_RESPONSE_STREAM_CALLBACK, None)
+    flow.metadata.pop("stream_buffer", None)
+    flow.metadata.pop("stream_buffer_state", None)
+    flow.metadata.pop(_MODEL_JSON_USAGE_FINISH, None)
+    flow.metadata.pop(_X_JSON_RESPONSE_FINISH, None)
+    if stream_callback is not None and flow.response and flow.response.stream is stream_callback:
+        flow.response.stream = False

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -27,8 +27,8 @@ from .x_billing import (
     refine_bucket_with_body,
 )
 
-# HTTP 2xx success range (RFC 9110).  Also defined in ``mitm_addon.py``; kept
-# local to avoid introducing a constants module for two callers.  The upper
+# HTTP 2xx success range (RFC 9110).  Also defined in ``response_streaming.py``;
+# kept local to avoid introducing a constants module for two callers.  The upper
 # bound is ``REDIRECT_MIN`` (300) because 300 is the first 3xx status — using
 # ``status < _HTTP_STATUS_REDIRECT_MIN`` reads as "still in 2xx" without the
 # ambiguity of an ``OK_MAX`` that is itself excluded from the OK range.
@@ -38,8 +38,8 @@ _USAGE_EVENT_BATCH_SIZE = 100
 
 # X v2 NDJSON streaming endpoint paths (exact match — ``/2/tweets/search/stream/rules``
 # is a regular request/response endpoint for rules management, NOT a stream).
-# Streams deliver one JSON object per line, possibly for hours; responseheaders
-# registers an incremental NDJSON parser as the stream callback so we never
+# Streams deliver one JSON object per line, possibly for hours; the responseheaders
+# hook registers an incremental NDJSON parser as the stream callback so we never
 # buffer the response body.
 _STREAM_ENDPOINTS = frozenset(
     {
@@ -295,7 +295,7 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
         ``meta``).  Both fields are alternative spellings of the same
         billing dimension, so we collapse them into one log key.
 
-    For X NDJSON streaming endpoints, ``responseheaders`` registers an
+    For X NDJSON streaming endpoints, the responseheaders hook registers an
     incremental parser that populates ``flow.metadata["x_ndjson_state"]``
     as response bytes arrive.  When that state is present we return its
     accumulated counters directly (``body_format: "ndjson"``) and skip

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -2759,6 +2759,30 @@ class TestErrorHandler:
         assert "model_json_usage_finish" not in flow.metadata
         assert "model_provider_usage" not in flow.metadata
 
+    def test_error_without_run_id_releases_streaming_state(self, real_flow, mitm_ctx):
+        """Early-returning error flows should still drop response parser closures."""
+        flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
+        flow.metadata["firewall_name"] = "x"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["original_url"] = "https://api.x.com/2/tweets"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        flow.response.stream(b'{"data":[{"id":"1"}')
+        assert "x_json_response_finish" in flow.metadata
+        flow.error = Error("connection reset")
+
+        with mitm_ctx():
+            mitm_addon.error(flow)
+
+        assert flow.response.stream is False
+        assert "stream_buffer" not in flow.metadata
+        assert "stream_buffer_state" not in flow.metadata
+        assert "x_json_response_finish" not in flow.metadata
+
     def test_error_does_not_bill_partial_x_json_response(
         self, tmp_path, real_flow, mitm_ctx, sync_usage_executor
     ):

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -887,6 +887,7 @@ PY
             "auth.py",
             "body_utils.py",
             "matching.py",
+            "response_streaming.py",
             "url_utils.py",
             "logging_utils.py",
             "usage/__init__.py",


### PR DESCRIPTION
## Summary
- Extract mitm response streaming setup/finalization/cleanup into response_streaming.py
- Keep mitm_addon.py focused on hook orchestration and network/usage reporting
- Embed the new addon module in the runner script bundle

Fixes #11483

## Tests
- cd crates/runner/mitm-addon && python3 -m ruff check .
- cd crates/runner/mitm-addon && python3 -m ruff format --check .
- cd crates/runner/mitm-addon && python3 -m pytest tests/test_handlers.py -q
- cd crates/runner/mitm-addon && python3 -m pytest tests -q
- cargo test -p runner addon_scripts_are_embedded