### PR TITLE
refactor: extract mitm registry cache

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -331,7 +331,7 @@ async def get_firewall_headers(
     (run_id, api_id) coalesce into a single HTTP fetch.
 
     Cache is evicted when:
-    - The run is removed from the registry (see load_registry)
+    - The run is removed from the registry (see registry.load_registry)
     - A 401 response is received (see response handler)
     - The expiresAt timestamp from the auth endpoint has passed
     """

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -21,20 +21,21 @@ from mitmproxy.addonmanager import Loader
 
 # --- Sub-module imports ---
 #
-# Usage/body_utils/response_streaming are imported by module (not selective `from X import ...`)
+# Usage/body_utils/registry/response_streaming are imported by module
+# (not selective `from X import ...`)
 # so that:
 #   1. Cross-module calls read as ``usage.X(...)`` / ``body_utils.X(...)`` /
-#      ``response_streaming.X(...)``,
+#      ``registry.X(...)`` / ``response_streaming.X(...)``,
 #      making the module boundary visible at call sites.
 #   2. Tests can patch names on the owning module object and affect all
 #      callers — no mock-placement pitfalls from copied function bindings.
 import body_utils
+import registry
 import response_streaming
 import usage
 import vendor_check
 from auth import (
     _firewall_header_cache,
-    evict_stale_cache_keys,
     handle_firewall_request,
     request_force_refresh,
 )
@@ -104,66 +105,8 @@ def get_registry_path() -> str:
     return ctx.options.vm0_proxy_registry_path
 
 
-# ============================================================================
-# Registry & VM Lookup
-# ============================================================================
-
-# Cache for proxy registry (invalidated by file stat change)
-_registry_cache: dict = {}
-_registry_cache_key: tuple[int, int] = (0, 0)
-# One-shot guard for stat-path failures: no cache key is available in that
-# branch, so we fall back to a flag (mirrors counters.py:_pending_write_error_logged).
-# Parse-path failures use the cache key itself — recording the bad file's
-# (mtime_ns, size) as already-processed prevents re-parsing the same bytes
-# on every request and re-warning about them.
-_registry_load_error_logged = False
-
 # Track request start times for latency calculation
 _request_start_times: dict = {}
-
-
-def load_registry() -> dict:
-    """Load the proxy registry from file, with stat-based cache invalidation."""
-    global _registry_cache, _registry_cache_key, _registry_load_error_logged
-
-    try:
-        registry_path = Path(get_registry_path())
-        st = registry_path.stat()
-    except OSError as e:
-        if not _registry_load_error_logged:
-            _registry_load_error_logged = True
-            ctx.log.warn(f"Failed to stat proxy registry: {e}")
-        return _registry_cache
-
-    key = (st.st_mtime_ns, st.st_size)
-    if key == _registry_cache_key:
-        return _registry_cache
-
-    try:
-        with registry_path.open() as f:
-            new_registry = json.load(f).get("vms", {})
-
-        # Evict cache entries for runs no longer in the registry
-        active_run_ids = {vm.get("runId") for vm in new_registry.values()}
-        evict_stale_cache_keys(active_run_ids)
-
-        _registry_cache = new_registry
-        _registry_load_error_logged = False
-    except Exception as e:
-        if not _registry_load_error_logged:
-            _registry_load_error_logged = True
-            ctx.log.warn(f"Failed to parse proxy registry: {e}")
-
-    # Record this file state as already processed — success or parse failure —
-    # so subsequent requests on the same bytes short-circuit at the key check.
-    _registry_cache_key = key
-    return _registry_cache
-
-
-def get_vm_info(client_ip: str) -> dict | None:
-    """Look up VM info by client IP address."""
-    registry = load_registry()
-    return registry.get(client_ip)
 
 
 # ============================================================================
@@ -181,7 +124,7 @@ def tls_clienthello(data: tls.ClientHelloData) -> None:
     if not client_ip:
         return
 
-    vm_info = get_vm_info(client_ip)
+    vm_info = registry.get_vm_info(client_ip, get_registry_path())
     if not vm_info:
         # Not a registered VM - pass through without MITM interception
         # This is critical for CIDR-based rules where all VM traffic is redirected
@@ -212,7 +155,7 @@ async def request(flow: http.HTTPFlow) -> None:
         return
 
     # Look up VM info from registry
-    vm_info = get_vm_info(client_ip)
+    vm_info = registry.get_vm_info(client_ip, get_registry_path())
 
     if not vm_info:
         # Not a registered VM, pass through without proxying
@@ -603,7 +546,7 @@ def tcp_start(flow: tcp.TCPFlow) -> None:
     if not client_ip:
         return
 
-    vm_info = get_vm_info(client_ip)
+    vm_info = registry.get_vm_info(client_ip, get_registry_path())
     if not vm_info:
         return
 

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -1,0 +1,69 @@
+"""Proxy registry loading and VM lookup cache."""
+
+import json
+from pathlib import Path
+
+from mitmproxy import ctx
+
+from auth import evict_stale_cache_keys
+
+# Cache for proxy registry (invalidated by file stat change).
+_registry_cache: dict = {}
+_registry_cache_key: tuple[int, int] = (0, 0)
+# One-shot guard for stat-path failures: no cache key is available in that
+# branch, so we fall back to a flag (mirrors counters.py:_pending_write_error_logged).
+# Parse-path failures use the cache key itself — recording the bad file's
+# (mtime_ns, size) as already-processed prevents re-parsing the same bytes
+# on every request and re-warning about them.
+_registry_load_error_logged = False
+
+
+def reset_cache_for_tests() -> None:
+    """Reset module cache state between tests."""
+    global _registry_cache, _registry_cache_key, _registry_load_error_logged
+    _registry_cache = {}
+    _registry_cache_key = (0, 0)
+    _registry_load_error_logged = False
+
+
+def load_registry(registry_path: str) -> dict:
+    """Load the proxy registry from file, with stat-based cache invalidation."""
+    global _registry_cache, _registry_cache_key, _registry_load_error_logged
+
+    path = Path(registry_path)
+    try:
+        st = path.stat()
+    except OSError as e:
+        if not _registry_load_error_logged:
+            _registry_load_error_logged = True
+            ctx.log.warn(f"Failed to stat proxy registry: {e}")
+        return _registry_cache
+
+    key = (st.st_mtime_ns, st.st_size)
+    if key == _registry_cache_key:
+        return _registry_cache
+
+    try:
+        with path.open() as f:
+            new_registry = json.load(f).get("vms", {})
+
+        # Evict cache entries for runs no longer in the registry.
+        active_run_ids = {run_id for vm in new_registry.values() if (run_id := vm.get("runId"))}
+        evict_stale_cache_keys(active_run_ids)
+
+        _registry_cache = new_registry
+        _registry_load_error_logged = False
+    except Exception as e:
+        if not _registry_load_error_logged:
+            _registry_load_error_logged = True
+            ctx.log.warn(f"Failed to parse proxy registry: {e}")
+
+    # Record this file state as already processed — success or parse failure —
+    # so subsequent requests on the same bytes short-circuit at the key check.
+    _registry_cache_key = key
+    return _registry_cache
+
+
+def get_vm_info(client_ip: str, registry_path: str) -> dict | None:
+    """Look up VM info by client IP address."""
+    return load_registry(registry_path).get(client_ip)

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -26,6 +26,7 @@ from mitmproxy.test import tflow, tutils
 
 import auth
 import mitm_addon
+import registry
 import usage
 from usage.providers import connectors as _usage_connectors
 
@@ -34,7 +35,7 @@ from usage.providers import connectors as _usage_connectors
 def _reset_module_state() -> None:
     """Clear cached singletons between tests.
 
-    ``mitm_addon`` and ``auth`` cache registry data and firewall header
+    ``registry`` and ``auth`` cache registry data and firewall header
     lookups in module-level dicts.  Without a reset, earlier tests leak
     entries that change later tests' behaviour (e.g. a request from IP X
     in test A primes ``_request_start_times`` seen by test B).
@@ -43,9 +44,7 @@ def _reset_module_state() -> None:
     cleanup, so we use ``return``-style (not ``yield``) per PT022.
     """
     mitm_addon._request_start_times.clear()
-    mitm_addon._registry_cache = {}
-    mitm_addon._registry_cache_key = (0, 0)
-    mitm_addon._registry_load_error_logged = False
+    registry.reset_cache_for_tests()
     auth._firewall_header_cache.clear()
     auth._cache_locks.clear()
     auth._force_refresh_markers.clear()

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -18,6 +18,7 @@ from mitmproxy.test import tutils
 import auth
 import body_utils
 import mitm_addon
+import registry as registry_cache
 import usage
 from usage import create_sse_usage_extractor
 from usage.namespaces import USAGE_EVENT_NAMESPACE_MODEL
@@ -4770,8 +4771,8 @@ class TestFirewallHeaderCache:
         with (
             mitm_ctx(registry_path=str(reg_path)),
         ):
-            mitm_addon._registry_cache_key = (0, 0)
-            mitm_addon.load_registry()
+            registry_cache.reset_cache_for_tests()
+            registry_cache.load_registry(str(reg_path))
 
         assert ("run-old", "api-1") not in auth._firewall_header_cache
         assert ("run-old", "api-1") not in auth._cache_locks

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -63,6 +63,22 @@ class TestLoadRegistry:
         assert log.warn.call_count == 1
         assert "Failed to stat" in log.warn.call_args_list[0].args[0]
 
+    def test_missing_file_after_success_returns_cached_registry(self, registry_file):
+        """A transiently missing registry file should not drop the last valid cache."""
+        cached = registry.load_registry(str(registry_file))
+        registry_file.unlink()
+
+        log = MagicMock()
+        with patch.object(registry.ctx, "log", log, create=True):
+            result1 = registry.load_registry(str(registry_file))
+            result2 = registry.load_registry(str(registry_file))
+
+        assert result1 is cached
+        assert result2 is cached
+        assert result1["10.200.0.1"]["runId"] == "run-abc-123"
+        assert log.warn.call_count == 1
+        assert "Failed to stat" in log.warn.call_args_list[0].args[0]
+
     def test_parse_failure_logs_once_and_does_not_reparse(self, tmp_path):
         """Parse failure on a fixed file: key match short-circuits re-parse."""
         bad = tmp_path / "bad.json"
@@ -75,6 +91,26 @@ class TestLoadRegistry:
             for _ in range(5):
                 assert registry.load_registry(str(bad)) == {}
 
+        assert spy.call_count == 1
+        assert log.warn.call_count == 1
+        assert "Failed to parse" in log.warn.call_args_list[0].args[0]
+
+    def test_parse_failure_after_success_returns_cached_registry(self, registry_file):
+        """A transient parse failure should preserve the last valid registry cache."""
+        cached = registry.load_registry(str(registry_file))
+        registry_file.write_text("{ not valid json after success")
+
+        log = MagicMock()
+        with (
+            patch.object(registry.ctx, "log", log, create=True),
+            patch.object(registry.json, "load", wraps=registry.json.load) as spy,
+        ):
+            result1 = registry.load_registry(str(registry_file))
+            result2 = registry.load_registry(str(registry_file))
+
+        assert result1 is cached
+        assert result2 is cached
+        assert result1["10.200.0.1"]["runId"] == "run-abc-123"
         assert spy.call_count == 1
         assert log.warn.call_count == 1
         assert "Failed to parse" in log.warn.call_args_list[0].args[0]
@@ -137,6 +173,64 @@ class TestLoadRegistry:
         assert ("run-other", "api-0") in auth._cache_locks
         assert ("run-other", "api-0") in auth._force_refresh_markers
         assert ("run-other", "api-0") in auth._last_force_refresh_at
+
+    def test_parse_failure_does_not_evict_header_cache(self, registry_file):
+        """Auth cache eviction only runs after a successfully parsed registry reload."""
+        registry.load_registry(str(registry_file))
+
+        auth._firewall_header_cache[("run-abc-123", "api-0")] = {
+            "headers": {"Authorization": "Bearer tok"},
+        }
+        auth._cache_locks[("run-abc-123", "api-0")] = asyncio.Lock()
+        auth._force_refresh_markers.add(("run-abc-123", "api-0"))
+        auth._last_force_refresh_at[("run-abc-123", "api-0")] = 100.0
+
+        registry_file.write_text("{ broken while preserving cache")
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            registry.load_registry(str(registry_file))
+
+        assert ("run-abc-123", "api-0") in auth._firewall_header_cache
+        assert ("run-abc-123", "api-0") in auth._cache_locks
+        assert ("run-abc-123", "api-0") in auth._force_refresh_markers
+        assert ("run-abc-123", "api-0") in auth._last_force_refresh_at
+
+    def test_registry_entries_without_run_id_do_not_keep_header_cache(self, registry_file):
+        """Registry entries with missing/empty runId are not active cache owners."""
+        registry.load_registry(str(registry_file))
+
+        auth._firewall_header_cache[("", "api-0")] = {"headers": {}}
+        auth._cache_locks[("", "api-0")] = asyncio.Lock()
+        auth._force_refresh_markers.add(("", "api-0"))
+        auth._last_force_refresh_at[("", "api-0")] = 100.0
+        auth._firewall_header_cache[("run-active", "api-0")] = {"headers": {}}
+        auth._cache_locks[("run-active", "api-0")] = asyncio.Lock()
+        auth._force_refresh_markers.add(("run-active", "api-0"))
+        auth._last_force_refresh_at[("run-active", "api-0")] = 200.0
+
+        registry_file.write_text(
+            json.dumps(
+                {
+                    "vms": {
+                        "10.200.0.1": {"runId": ""},
+                        "10.200.0.2": {},
+                        "10.200.0.3": {"runId": "run-active"},
+                    },
+                    "updatedAt": 0,
+                }
+            )
+        )
+
+        registry.load_registry(str(registry_file))
+
+        assert ("", "api-0") not in auth._firewall_header_cache
+        assert ("", "api-0") not in auth._cache_locks
+        assert ("", "api-0") not in auth._force_refresh_markers
+        assert ("", "api-0") not in auth._last_force_refresh_at
+        assert ("run-active", "api-0") in auth._firewall_header_cache
+        assert ("run-active", "api-0") in auth._cache_locks
+        assert ("run-active", "api-0") in auth._force_refresh_markers
+        assert ("run-active", "api-0") in auth._last_force_refresh_at
 
 
 class TestGetVmInfo:

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -6,14 +6,13 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import auth
-import mitm_addon
+import logging_utils
+import registry
 
 
 def _reset_cache():
     """Reset the module-level registry cache between tests."""
-    mitm_addon._registry_cache = {}
-    mitm_addon._registry_cache_key = (0, 0)
-    mitm_addon._registry_load_error_logged = False
+    registry.reset_cache_for_tests()
     auth._firewall_header_cache.clear()
     auth._cache_locks.clear()
 
@@ -23,52 +22,43 @@ class TestLoadRegistry:
         _reset_cache()
 
     def test_loads_valid_registry(self, registry_file):
-        with patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)):
-            result = mitm_addon.load_registry()
+        result = registry.load_registry(str(registry_file))
 
         assert "10.200.0.1" in result
         assert result["10.200.0.1"]["runId"] == "run-abc-123"
 
     def test_missing_file_returns_empty(self, tmp_path):
         missing = str(tmp_path / "nonexistent.json")
-        with (
-            patch.object(mitm_addon, "get_registry_path", return_value=missing),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-        ):
-            result = mitm_addon.load_registry()
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            result = registry.load_registry(missing)
 
         assert result == {}
 
     def test_cache_returns_same_on_unchanged(self, registry_file):
-        with patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)):
-            result1 = mitm_addon.load_registry()
-            result2 = mitm_addon.load_registry()
+        result1 = registry.load_registry(str(registry_file))
+        result2 = registry.load_registry(str(registry_file))
 
         assert result1 is result2
 
     def test_cache_invalidated_on_change(self, registry_file):
-        with patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)):
-            result1 = mitm_addon.load_registry()
-            assert "10.200.0.1" in result1
+        result1 = registry.load_registry(str(registry_file))
+        assert "10.200.0.1" in result1
 
-            # Modify the file
-            new_data = {"vms": {"10.200.0.99": {"runId": "new-run"}}, "updatedAt": 0}
-            registry_file.write_text(json.dumps(new_data))
+        # Modify the file
+        new_data = {"vms": {"10.200.0.99": {"runId": "new-run"}}, "updatedAt": 0}
+        registry_file.write_text(json.dumps(new_data))
 
-            result2 = mitm_addon.load_registry()
-            assert "10.200.0.99" in result2
-            assert "10.200.0.1" not in result2
+        result2 = registry.load_registry(str(registry_file))
+        assert "10.200.0.99" in result2
+        assert "10.200.0.1" not in result2
 
     def test_missing_file_logs_once_across_calls(self, tmp_path):
         """Stat-path failures repeated across requests emit at most one warn."""
         missing = str(tmp_path / "nonexistent.json")
         log = MagicMock()
-        with (
-            patch.object(mitm_addon, "get_registry_path", return_value=missing),
-            patch.object(mitm_addon.ctx, "log", log, create=True),
-        ):
+        with patch.object(registry.ctx, "log", log, create=True):
             for _ in range(5):
-                assert mitm_addon.load_registry() == {}
+                assert registry.load_registry(missing) == {}
 
         assert log.warn.call_count == 1
         assert "Failed to stat" in log.warn.call_args_list[0].args[0]
@@ -79,12 +69,11 @@ class TestLoadRegistry:
         bad.write_text("{ not valid json")
         log = MagicMock()
         with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(bad)),
-            patch.object(mitm_addon.ctx, "log", log, create=True),
-            patch.object(mitm_addon.json, "load", wraps=mitm_addon.json.load) as spy,
+            patch.object(registry.ctx, "log", log, create=True),
+            patch.object(registry.json, "load", wraps=registry.json.load) as spy,
         ):
             for _ in range(5):
-                assert mitm_addon.load_registry() == {}
+                assert registry.load_registry(str(bad)) == {}
 
         assert spy.call_count == 1
         assert log.warn.call_count == 1
@@ -95,16 +84,13 @@ class TestLoadRegistry:
         path = tmp_path / "registry.json"
         path.write_text("{ broken")
         log = MagicMock()
-        with (
-            patch.object(mitm_addon, "get_registry_path", return_value=str(path)),
-            patch.object(mitm_addon.ctx, "log", log, create=True),
-        ):
-            mitm_addon.load_registry()  # parse fails → warn #1
+        with patch.object(registry.ctx, "log", log, create=True):
+            registry.load_registry(str(path))  # parse fails → warn #1
             assert log.warn.call_count == 1
 
             # File becomes valid → successful load clears the flag.
             path.write_text(json.dumps({"vms": {"10.0.0.1": {"runId": "r1"}}}))
-            result = mitm_addon.load_registry()
+            result = registry.load_registry(str(path))
             assert "10.0.0.1" in result
             assert log.warn.call_count == 1  # no new warn on success
 
@@ -112,35 +98,34 @@ class TestLoadRegistry:
             # busts the cache key so the parse re-runs; the successful load
             # reset the flag, so this failure warns again.
             path.write_text("{ broken again, different size")
-            mitm_addon.load_registry()
+            registry.load_registry(str(path))
             assert log.warn.call_count == 2
 
     def test_evicts_header_cache_on_run_removal(self, registry_file):
         """When a run disappears from registry, its header cache entries are evicted."""
-        with patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)):
-            mitm_addon.load_registry()  # initial load (has run-abc-123)
+        registry.load_registry(str(registry_file))  # initial load (has run-abc-123)
 
-            # Simulate cached headers, locks, markers, and refresh timestamps
-            # for run-abc-123
-            auth._firewall_header_cache[("run-abc-123", "api-0")] = {
-                "headers": {"Authorization": "Bearer tok"},
-            }
-            auth._cache_locks[("run-abc-123", "api-0")] = asyncio.Lock()
-            auth._force_refresh_markers.add(("run-abc-123", "api-0"))
-            auth._last_force_refresh_at[("run-abc-123", "api-0")] = 100.0
-            # Also cache for run-other (will appear in new registry)
-            auth._firewall_header_cache[("run-other", "api-0")] = {
-                "headers": {"Authorization": "Bearer other"},
-            }
-            auth._cache_locks[("run-other", "api-0")] = asyncio.Lock()
-            auth._force_refresh_markers.add(("run-other", "api-0"))
-            auth._last_force_refresh_at[("run-other", "api-0")] = 200.0
+        # Simulate cached headers, locks, markers, and refresh timestamps
+        # for run-abc-123
+        auth._firewall_header_cache[("run-abc-123", "api-0")] = {
+            "headers": {"Authorization": "Bearer tok"},
+        }
+        auth._cache_locks[("run-abc-123", "api-0")] = asyncio.Lock()
+        auth._force_refresh_markers.add(("run-abc-123", "api-0"))
+        auth._last_force_refresh_at[("run-abc-123", "api-0")] = 100.0
+        # Also cache for run-other (will appear in new registry)
+        auth._firewall_header_cache[("run-other", "api-0")] = {
+            "headers": {"Authorization": "Bearer other"},
+        }
+        auth._cache_locks[("run-other", "api-0")] = asyncio.Lock()
+        auth._force_refresh_markers.add(("run-other", "api-0"))
+        auth._last_force_refresh_at[("run-other", "api-0")] = 200.0
 
-            # Update registry: remove run-abc-123, add run-other
-            new_data = {"vms": {"10.200.0.99": {"runId": "run-other"}}, "updatedAt": 0}
-            registry_file.write_text(json.dumps(new_data))
+        # Update registry: remove run-abc-123, add run-other
+        new_data = {"vms": {"10.200.0.99": {"runId": "run-other"}}, "updatedAt": 0}
+        registry_file.write_text(json.dumps(new_data))
 
-            mitm_addon.load_registry()  # reload triggers eviction
+        registry.load_registry(str(registry_file))  # reload triggers eviction
 
         # run-abc-123 state should be evicted (no longer in registry)
         assert ("run-abc-123", "api-0") not in auth._firewall_header_cache
@@ -159,15 +144,13 @@ class TestGetVmInfo:
         _reset_cache()
 
     def test_known_ip(self, registry_file):
-        with patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)):
-            info = mitm_addon.get_vm_info("10.200.0.1")
+        info = registry.get_vm_info("10.200.0.1", str(registry_file))
 
         assert info is not None
         assert info["runId"] == "run-abc-123"
 
     def test_unknown_ip(self, registry_file):
-        with patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)):
-            info = mitm_addon.get_vm_info("192.168.1.1")
+        info = registry.get_vm_info("192.168.1.1", str(registry_file))
 
         assert info is None
 
@@ -177,8 +160,8 @@ class TestLogNetworkEntry:
         log_path = str(tmp_path / "net.jsonl")
         entry = {"action": "ALLOW", "host": "example.com"}
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
-            mitm_addon.log_network_entry(log_path, entry)
+        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
+            logging_utils.log_network_entry(log_path, entry)
 
         lines = Path(log_path).read_text().splitlines()
         assert len(lines) == 1
@@ -189,13 +172,13 @@ class TestLogNetworkEntry:
     def test_appends_multiple(self, tmp_path):
         log_path = str(tmp_path / "net.jsonl")
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
-            mitm_addon.log_network_entry(log_path, {"n": 1})
-            mitm_addon.log_network_entry(log_path, {"n": 2})
+        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
+            logging_utils.log_network_entry(log_path, {"n": 1})
+            logging_utils.log_network_entry(log_path, {"n": 2})
 
         lines = Path(log_path).read_text().splitlines()
         assert len(lines) == 2
 
     def test_no_path_is_noop(self):
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
-            mitm_addon.log_network_entry("", {"action": "ALLOW"})
+        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
+            logging_utils.log_network_entry("", {"action": "ALLOW"})

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -887,6 +887,7 @@ PY
             "auth.py",
             "body_utils.py",
             "matching.py",
+            "registry.py",
             "response_streaming.py",
             "url_utils.py",
             "logging_utils.py",

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -82,10 +82,11 @@ def _make_http_flow(client_ip="10.200.0.1", host="example.com", port=443, path="
 The addon uses module-level caches. Reset between tests:
 
 ```python
+import registry
+
 def _reset():
     mitm_addon._request_start_times.clear()
-    mitm_addon._registry_cache = {}
-    mitm_addon._registry_cache_key = (0, 0)
+    registry.reset_cache_for_tests()
 
 class TestRequestHandler:
     def setup_method(self):


### PR DESCRIPTION
Fixes #11482

## Summary
- move mitm proxy registry cache and VM lookup into `registry.py`
- update addon hook call sites and tests to use the owning registry module
- include `registry.py` in the runner addon embed guard

## Tests
- `python3 -m compileall -q src tests`
- `python3 -m ruff check .`
- `python3 -m ruff format --check .`
- `python3 -m pytest tests/test_registry.py -q`
- `python3 -m pytest tests/test_handlers.py -q -k 'tls_clienthello or TcpStart or registry_eviction'`\n- `python3 -m pytest tests -q`\n- `CARGO_BUILD_JOBS=1 cargo test -p runner addon_scripts_are_embedded`