### PR TITLE
[codex] reset chat composer model selection

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/agent-chat-page-setup.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/agent-chat-page-setup.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, it } from "vitest";
 import { waitFor } from "@testing-library/react";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  setupPage,
+} from "../../../__tests__/page-helper.ts";
+import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
+import { server } from "../../../mocks/server.ts";
+import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
+import { setMockOrgModelProviders } from "../../../mocks/handlers/api-org-model-providers.ts";
 import { pathname, search } from "../../location.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
+import {
+  chatPageModelSelection$,
+  setChatPageModelSelection$,
+} from "../zero-chat-page.ts";
 
 const context = testContext();
+const mockApi = createMockApi(context);
 
 describe("agent chat page setup", () => {
   it("redirects unknown route agents to the default agent chat", async () => {
@@ -32,6 +44,85 @@ describe("agent chat page setup", () => {
         "/agents/c0000000-0000-4000-a000-000000000001/chat",
       );
       expect(search()).toBe("?prompt=hello");
+    });
+  });
+
+  it("resets landing page model override on entry", async () => {
+    const agentId = "c0000000-0000-4000-a000-000000000001";
+    const defaultProviderId = "00000000-0000-4000-a000-000000000001";
+
+    setMockTeam([
+      {
+        id: agentId,
+        displayName: "Zero",
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+    setMockOrgModelProviders([
+      {
+        id: defaultProviderId,
+        type: "anthropic-api-key",
+        framework: "claude-code",
+        secretName: "ANTHROPIC_API_KEY",
+        authMethod: null,
+        secretNames: null,
+        isDefault: true,
+        selectedModel: "claude-sonnet-4-6",
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: "00000000-0000-4000-a000-000000000002",
+        type: "zai-api-key",
+        framework: "claude-code",
+        secretName: "ZAI_API_KEY",
+        authMethod: null,
+        secretNames: null,
+        isDefault: false,
+        selectedModel: "glm-5.1",
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+    server.use(
+      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          agentId,
+          ownerId: "test-user-123",
+          description: null,
+          displayName: "Zero",
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: null,
+          customSkills: [],
+          modelProviderId: null,
+          selectedModel: null,
+        });
+      }),
+    );
+
+    context.store.set(setChatPageModelSelection$, {
+      modelProviderId: "00000000-0000-4000-a000-000000000002",
+      selectedModel: "glm-5.1",
+    });
+
+    await setupPage({
+      context,
+      path: `/agents/${agentId}/chat`,
+      withoutRender: true,
+    });
+
+    await waitFor(async () => {
+      await expect(
+        context.store.get(chatPageModelSelection$),
+      ).resolves.toStrictEqual({
+        modelProviderId: defaultProviderId,
+        selectedModel: "claude-sonnet-4-6",
+      });
     });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
@@ -18,7 +18,10 @@ import {
 import { setChatAgentId$ } from "../agent-chat.ts";
 import { talkDraft$ } from "./chat-draft.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
-import { reloadTagline$ } from "./zero-chat-page.ts";
+import {
+  reloadTagline$,
+  resetChatPageModelSelection$,
+} from "./zero-chat-page.ts";
 import { setupAgentChatPageKeyboard$ } from "./agent-chat-keyboard.ts";
 import { openQueueDrawer$ } from "../queue-page/queue-drawer-state.ts";
 
@@ -31,6 +34,7 @@ export const setupAgentChatPage$ = command(
 
     // Reset the talk draft on entrance
     set(get(talkDraft$).clear$);
+    set(resetChatPageModelSelection$);
 
     // Read agent ID from URL immediately (synchronous) and update sidebar
     // highlight early so the UI responds without waiting for async data.

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -83,3 +83,7 @@ export const setChatPageModelSelection$ = command(
     set(internalChatPageUserOverride$, { kind: "set", value });
   },
 );
+
+export const resetChatPageModelSelection$ = command(({ set }) => {
+  set(internalChatPageUserOverride$, { kind: "unset" });
+});

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -55,6 +55,7 @@ import {
   chatPageModelSelection$,
   setChatPageInput$,
   setChatPageModelSelection$,
+  resetChatPageModelSelection$,
   chatPageTaglineIndex$,
   suggestedPrompts$,
 } from "../../signals/zero-page/zero-chat-page.ts";
@@ -470,6 +471,7 @@ export function AgentChatPage() {
   const orgProviders = useLastResolved(orgModelProviders$);
   const modelSelection = useLastResolved(chatPageModelSelection$) ?? null;
   const setModelSelection = useSet(setChatPageModelSelection$);
+  const resetModelSelection = useSet(resetChatPageModelSelection$);
   const currentAgent = useLastResolved(currentChatAgent$);
   const agentModelDefault =
     currentAgent?.modelProviderId && currentAgent?.selectedModel
@@ -518,6 +520,7 @@ export function AgentChatPage() {
     startTiming();
     setInput("");
     handleSendMessage(text);
+    resetModelSelection();
   };
 
   return (


### PR DESCRIPTION
## Summary

- Reset the `/agents/:id/chat` landing composer model selection when entering the page.
- Reset the same selection after sending a new chat, so the next landing composer render re-resolves agent/workspace defaults.
- Add regression coverage for stale landing-page model overrides.

## Why

The landing composer kept its last explicit model selection in ccstate. Leaving and re-entering an agent chat could show the previously picked provider instead of recomputing from the active agent or workspace default.

## Validation

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- Commit hook: `pnpm knip` and cached `pnpm check-types`

Not run: `pnpm vitest` full suite; skipped per request after starting it.
