### PR TITLE
test(web): add usage-event validation edge cases

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/usage-event/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/usage-event/__tests__/route.test.ts
@@ -366,6 +366,36 @@ describe("POST /api/webhooks/agent/usage-event", () => {
       expect(response.status).toBe(400);
     });
 
+    it.each([
+      {
+        name: "non-integer quantity",
+        body: () => {
+          return validBody({ ...validEvent(), quantity: 1.5 });
+        },
+      },
+      {
+        name: "unknown kind",
+        body: () => {
+          return validBody({ ...validEvent(), kind: "external-api" });
+        },
+      },
+      {
+        name: "unexpected event field",
+        body: () => {
+          return validBody({ ...validEvent(), unexpected: true });
+        },
+      },
+      {
+        name: "unexpected top-level field",
+        body: () => {
+          return { ...validBody(), unexpected: true };
+        },
+      },
+    ])("rejects $name", async ({ body }) => {
+      const response = await POST(makeRequest(body(), testToken));
+      expect(response.status).toBe(400);
+    });
+
     it("rejects empty provider", async () => {
       const body = validBody({ ...validEvent(), provider: "" });
       const response = await POST(makeRequest(body, testToken));


### PR DESCRIPTION
## Summary
- add route integration coverage for usage-event schema validation edge cases
- cover non-integer quantities, unknown event kinds, and strict extra-field rejection

Closes #11491

## Testing
- pnpm -F web test app/api/webhooks/agent/usage-event/__tests__/route.test.ts
- pnpm -F web lint
- pnpm -F web check-types
- pre-commit: pnpm knip --cache
- pre-commit: turbo run check-types --concurrency=1
