### PR TITLE
refactor: generate runner storage manifest types

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -2,6 +2,39 @@
 // Do not edit by hand.
 // Regenerate with: cd turbo && pnpm -F @vm0/api-contracts generate:rust
 
+pub mod runners {
+    pub mod storage {
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct ArtifactEntry {
+            pub mount_path: String,
+            pub vas_storage_name: String,
+            pub vas_storage_id: String,
+            pub vas_version_id: String,
+            pub archive_url: String,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub manifest_url: Option<String>,
+        }
+
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct StorageEntry {
+            pub name: String,
+            pub mount_path: String,
+            pub vas_storage_name: String,
+            pub vas_version_id: String,
+            pub archive_url: String,
+        }
+
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct StorageManifest {
+            pub storages: Vec<StorageEntry>,
+            pub artifacts: Vec<ArtifactEntry>,
+        }
+    }
+}
+
 pub mod webhooks {
     pub mod agent {
         pub mod storages {

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -1,4 +1,7 @@
-use api_contracts::generated::types::webhooks::agent::storages::{commit, prepare};
+use api_contracts::generated::types::{
+    runners::storage as runner_storage,
+    webhooks::agent::storages::{commit, prepare},
+};
 use serde_json::json;
 
 #[test]
@@ -177,4 +180,112 @@ fn generated_commit_response_deserializes_success_shape() {
     assert_eq!(response.size, 42.0);
     assert_eq!(response.file_count, 3.0);
     assert_eq!(response.deduplicated, Some(true));
+}
+
+#[test]
+fn generated_storage_manifest_deserializes_web_claim_shape() {
+    let manifest: runner_storage::StorageManifest = serde_json::from_value(json!({
+        "storages": [{
+            "name": "workspace",
+            "mountPath": "/workspace",
+            "vasStorageName": "workspace-volume",
+            "vasVersionId": "version-1",
+            "archiveUrl": "https://storage.example/workspace.tar.gz",
+        }],
+        "artifacts": [{
+            "mountPath": "/home/user/.claude/projects/project",
+            "vasStorageName": "memory",
+            "vasStorageId": "storage-id-1",
+            "vasVersionId": "version-2",
+            "archiveUrl": "https://storage.example/artifact.tar.gz",
+            "manifestUrl": "https://storage.example/manifest.json",
+        }],
+    }))
+    .unwrap();
+
+    assert_eq!(manifest.storages[0].name, "workspace");
+    assert_eq!(manifest.storages[0].mount_path, "/workspace");
+    assert_eq!(manifest.storages[0].vas_storage_name, "workspace-volume");
+    assert_eq!(manifest.artifacts[0].vas_storage_id, "storage-id-1");
+    assert_eq!(
+        manifest.artifacts[0].manifest_url.as_deref(),
+        Some("https://storage.example/manifest.json")
+    );
+}
+
+#[test]
+fn generated_storage_manifest_serializes_without_absent_manifest_url() {
+    let manifest = runner_storage::StorageManifest {
+        storages: vec![runner_storage::StorageEntry {
+            name: "workspace".to_string(),
+            mount_path: "/workspace".to_string(),
+            vas_storage_name: "workspace-volume".to_string(),
+            vas_version_id: "version-1".to_string(),
+            archive_url: "https://storage.example/workspace.tar.gz".to_string(),
+        }],
+        artifacts: vec![runner_storage::ArtifactEntry {
+            mount_path: "/home/user/.claude/projects/project".to_string(),
+            vas_storage_name: "memory".to_string(),
+            vas_storage_id: "storage-id-1".to_string(),
+            vas_version_id: "version-2".to_string(),
+            archive_url: "https://storage.example/artifact.tar.gz".to_string(),
+            manifest_url: None,
+        }],
+    };
+
+    let value = serde_json::to_value(manifest).unwrap();
+
+    assert_eq!(
+        value,
+        json!({
+            "storages": [{
+                "name": "workspace",
+                "mountPath": "/workspace",
+                "vasStorageName": "workspace-volume",
+                "vasVersionId": "version-1",
+                "archiveUrl": "https://storage.example/workspace.tar.gz",
+            }],
+            "artifacts": [{
+                "mountPath": "/home/user/.claude/projects/project",
+                "vasStorageName": "memory",
+                "vasStorageId": "storage-id-1",
+                "vasVersionId": "version-2",
+                "archiveUrl": "https://storage.example/artifact.tar.gz",
+            }],
+        })
+    );
+}
+
+#[test]
+fn generated_storage_manifest_serializes_empty_artifacts() {
+    let manifest = runner_storage::StorageManifest {
+        storages: vec![],
+        artifacts: vec![],
+    };
+
+    let value = serde_json::to_value(manifest).unwrap();
+
+    assert_eq!(
+        value,
+        json!({
+            "storages": [],
+            "artifacts": [],
+        })
+    );
+}
+
+#[test]
+fn generated_storage_manifest_rejects_guest_download_null_archive_url() {
+    let result = serde_json::from_value::<runner_storage::StorageManifest>(json!({
+        "storages": [{
+            "name": "workspace",
+            "mountPath": "/workspace",
+            "vasStorageName": "workspace-volume",
+            "vasVersionId": "version-1",
+            "archiveUrl": null,
+        }],
+        "artifacts": [],
+    }));
+
+    assert!(result.is_err());
 }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1411,8 +1411,10 @@ mod tests {
     use super::*;
     use crate::ids::RunId;
     use crate::types::{
-        ArtifactEntry, GuestDownloadArtifactEntry, GuestDownloadManifest,
-        GuestDownloadStorageEntry, ResumeSession, StorageEntry, StorageManifest,
+        GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry, ResumeSession,
+    };
+    use api_contracts::generated::types::runners::storage::{
+        ArtifactEntry, StorageEntry, StorageManifest,
     };
     use async_trait::async_trait;
     use sandbox_mock::MockSandboxFactory;

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -6,12 +6,12 @@ use std::sync::{
 };
 use std::time::{Duration, Instant};
 
+use api_contracts::generated::types::runners::storage::StorageManifest;
 use futures_util::FutureExt;
 use sandbox::{Sandbox, SandboxFactory, SandboxId};
 
 use crate::resource_budget::BudgetLease;
 use crate::status::IdleVm;
-use crate::types::StorageManifest;
 
 /// Default idle timeout for kept-alive VMs (30 minutes).
 ///

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -4,6 +4,8 @@ use sandbox::SandboxId;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use api_contracts::generated::types::runners::storage::StorageManifest;
+
 use crate::ids::RunId;
 
 // ---------------------------------------------------------------------------
@@ -157,42 +159,6 @@ pub struct NetworkPolicy {
     /// Policy for requests not matching any known permission rule.
     /// Values: "allow", "deny", "ask"
     pub unknown_policy: String,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StorageManifest {
-    pub storages: Vec<StorageEntry>,
-    #[serde(default)]
-    pub artifacts: Vec<ArtifactEntry>,
-}
-
-/// API/wire storage entry from the web claim response.
-///
-/// Runner-derived guest-download state such as `cached` does not belong here.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StorageEntry {
-    pub name: String,
-    pub mount_path: String,
-    pub archive_url: String,
-    pub vas_storage_name: String,
-    pub vas_version_id: String,
-}
-
-/// API/wire artifact entry from the web claim response.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ArtifactEntry {
-    pub mount_path: String,
-    pub archive_url: String,
-    pub vas_storage_name: String,
-    /// Storage UUID, used guest-side to locally recompute the content hash
-    /// and skip VAS calls when an artifact is unchanged since mount.
-    pub vas_storage_id: String,
-    pub vas_version_id: String,
-    #[serde(default)]
-    pub manifest_url: Option<String>,
 }
 
 /// Runner-derived manifest written to `guest-download`.
@@ -391,6 +357,7 @@ impl SandboxReuseResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use api_contracts::generated::types::runners::storage::{ArtifactEntry, StorageEntry};
     use serde_json::json;
 
     #[test]
@@ -750,12 +717,11 @@ mod tests {
     }
 
     #[test]
-    fn storage_manifest_empty_artifacts_defaults() {
+    fn storage_manifest_requires_artifacts_field() {
         let json = json!({
             "storages": []
         });
-        let manifest: StorageManifest = serde_json::from_value(json).unwrap();
-        assert!(manifest.artifacts.is_empty());
+        assert!(serde_json::from_value::<StorageManifest>(json).is_err());
     }
 
     #[test]

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -5,8 +5,28 @@ import {
   type NormalizedTypeBinding,
 } from "../generate";
 import { type RustTypeBinding, rustTypeBindings } from "../types";
+import {
+  artifactEntrySchema,
+  storageEntrySchema,
+  storageManifestSchema,
+} from "../../contracts/runners";
 
 const expectedBindings = [
+  {
+    rustModulePath: ["runners", "storage"],
+    rustTypeName: "ArtifactEntry",
+    direction: "response",
+  },
+  {
+    rustModulePath: ["runners", "storage"],
+    rustTypeName: "StorageEntry",
+    direction: "response",
+  },
+  {
+    rustModulePath: ["runners", "storage"],
+    rustTypeName: "StorageManifest",
+    direction: "response",
+  },
   {
     rustModulePath: ["webhooks", "agent", "storages", "prepare"],
     rustTypeName: "Request",
@@ -81,6 +101,31 @@ describe("Rust type bindings", () => {
     expect(firstRender).toContain("pub struct Response {");
     expect(firstRender).toContain("pub files: Vec<RequestFile>,");
     expect(firstRender).toContain("pub uploads: Option<ResponseUploads>,");
+    expect(firstRender).toContain("pub struct StorageManifest {");
+    expect(firstRender).toContain("pub storages: Vec<StorageEntry>,");
+    expect(firstRender).toContain("pub artifacts: Vec<ArtifactEntry>,");
+  });
+
+  it("keeps storage manifest field overrides aligned with entry schemas", () => {
+    const manifestSchema = z.toJSONSchema(storageManifestSchema);
+    const storageSchema = { ...z.toJSONSchema(storageEntrySchema) };
+    const artifactSchema = { ...z.toJSONSchema(artifactEntrySchema) };
+    delete storageSchema.$schema;
+    delete artifactSchema.$schema;
+
+    expect(manifestSchema).toMatchObject({
+      required: ["storages", "artifacts"],
+      properties: {
+        storages: {
+          type: "array",
+          items: storageSchema,
+        },
+        artifacts: {
+          type: "array",
+          items: artifactSchema,
+        },
+      },
+    });
   });
 
   it("renders common JSON schema shapes", () => {

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -1,5 +1,10 @@
 import type { z } from "zod";
 import {
+  artifactEntrySchema,
+  storageEntrySchema,
+  storageManifestSchema,
+} from "../contracts/runners";
+import {
   webhookStoragesCommitContract,
   webhookStoragesPrepareContract,
 } from "../contracts/webhooks";
@@ -13,6 +18,28 @@ export interface RustTypeBinding {
 }
 
 export const rustTypeBindings = [
+  {
+    schema: artifactEntrySchema,
+    rustModulePath: ["runners", "storage"],
+    rustTypeName: "ArtifactEntry",
+    direction: "response",
+  },
+  {
+    schema: storageEntrySchema,
+    rustModulePath: ["runners", "storage"],
+    rustTypeName: "StorageEntry",
+    direction: "response",
+  },
+  {
+    schema: storageManifestSchema,
+    rustModulePath: ["runners", "storage"],
+    rustTypeName: "StorageManifest",
+    direction: "response",
+    fieldTypeOverrides: {
+      storages: "Vec<StorageEntry>",
+      artifacts: "Vec<ArtifactEntry>",
+    },
+  },
   {
     schema: webhookStoragesPrepareContract.prepare.body,
     rustModulePath: ["webhooks", "agent", "storages", "prepare"],


### PR DESCRIPTION
## Summary
- generate runner storage manifest DTOs from the api-contracts Rust binding registry
- switch runner storage manifest consumers to the generated API type while keeping guest-download state local
- add TS/Rust coverage for web claim shape, optional manifestUrl, empty artifacts, and guest-download-only null archiveUrl rejection

## Tests
- pnpm -F @vm0/api-contracts test -- src/rust-bindings/__tests__/types.test.ts src/contracts/__tests__/runners.test.ts
- pnpm -F @vm0/api-contracts lint
- cargo test --manifest-path crates/Cargo.toml -p api-contracts
- cargo check --manifest-path crates/Cargo.toml -p runner --bin runner
- cargo test --manifest-path crates/Cargo.toml -p runner --bin runner storage_manifest
- cd crates && cargo fmt --all -- --check
- git diff --check
- pnpm -F @vm0/api-contracts generate:rust && git diff --exit-code -- crates/api-contracts/src/generated
- pre-commit hook: cargo-clippy, prettier, knip, check-types

Note: generated the local ignored gumroad firewall file so the existing check-types hook could resolve ./gumroad.generated; it is not part of this PR.