### PR TITLE
fix(api): include cron definitions in build output

### DIFF
--- a/turbo/apps/api/vite.config.ts
+++ b/turbo/apps/api/vite.config.ts
@@ -1,6 +1,8 @@
 import build from "@hono/vite-build/vercel";
 import { defineConfig } from "vite";
 
+import vercelConfig from "./vercel.json";
+
 export default defineConfig({
   build: {
     copyPublicDir: false,
@@ -9,6 +11,11 @@ export default defineConfig({
     build({
       emptyOutDir: true,
       entry: "./src/index.ts",
+      vercel: {
+        config: {
+          crons: vercelConfig.crons,
+        },
+      },
     }),
   ],
 });


### PR DESCRIPTION
## Summary

- Include the API app's `vercel.json` cron definitions in the Hono/Vite Vercel Build Output config.
- Keeps the existing API prebuilt deployment path (`pnpm --dir turbo/apps/api build` then `vercel deploy --prebuilt`) while ensuring `.vercel/output/config.json` contains `crons`.

## Root Cause

The API production deployment uses prebuilt artifacts generated by `@hono/vite-build/vercel`, not Vercel's native `vercel build` path used by the web app. The generated `.vercel/output/config.json` previously contained only `version` and `routes`, so Vercel had no cron definitions to register for the production deployment.

## Validation

- `pnpm --dir turbo/apps/api build`
- Verified `turbo/apps/api/.vercel/output/config.json` contains `crons` with `/api/internal/cron/aggregate-model-stats`
- `pnpm --dir turbo/apps/api check-types`
- `pnpm --dir turbo/apps/api lint`
- `pnpm --dir turbo exec prettier --check apps/api/vite.config.ts`
- `pnpm --dir turbo/apps/api test`

## Notes

The local pre-commit hook's repo-wide `knip --cache` step failed on the fresh `origin/main` worktree with existing unused-file/export reports unrelated to this one-file API config change. The API-specific build, typecheck, lint, format, and tests passed.