### PR TITLE
fix(api): emit pg client spans by wrapping the pool instance

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -18,7 +18,6 @@
     "@hono/otel": "^1.1.1",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
-    "@opentelemetry/instrumentation-pg": "^0.67.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@sentry/node": "^10.50.0",
     "@t3-oss/env-core": "^0.13.11",

--- a/turbo/apps/api/src/app-factory.ts
+++ b/turbo/apps/api/src/app-factory.ts
@@ -83,8 +83,8 @@ async function proxyToWeb(context: Context, webUrl: string): Promise<Response> {
 // Stamp the matched route template into OTel baggage so child spans (db
 // queries, outbound fetches) can carry `http.route` without reaching back
 // into the parent SERVER span. Any code further down the call tree —
-// including PgInstrumentation's requestHook in instrument.ts — reads it
-// from `propagation.getActiveBaggage()`.
+// including the pg pool wrapper in `lib/db.ts` — reads it from
+// `propagation.getActiveBaggage()`.
 //
 // `c.req.routePath` reflects the *current* middleware's pattern (here `"*"`)
 // until next() returns, but we need the matched route *before* next() so the

--- a/turbo/apps/api/src/instrument.ts
+++ b/turbo/apps/api/src/instrument.ts
@@ -1,6 +1,4 @@
-import { propagation } from "@opentelemetry/api";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
-import { PgInstrumentation } from "@opentelemetry/instrumentation-pg";
 import { ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
 import {
   httpIntegration,
@@ -12,27 +10,6 @@ import { registerOTel } from "@vercel/otel";
 import { env } from "./lib/env";
 
 const OTEL_SERVICE_NAME = "vm0-api";
-
-const HTTP_ROUTE_BAGGAGE_KEY = "http.route";
-
-// PgInstrumentation defaults the span name to "pg.query:SELECT <db>" — too
-// generic to slice on. Pull the operation + first referenced table out of
-// the parameterized SQL so RED metrics can group by a readable label.
-// `db.statement` still carries the full parameterized SQL for cases where
-// the exact template matters.
-function deriveSqlSpanName(sql: string): string | null {
-  const trimmed = sql.trim();
-  const opMatch = /^(SELECT|INSERT|UPDATE|DELETE|WITH|MERGE)/i.exec(trimmed);
-  if (!opMatch?.[1]) {
-    return null;
-  }
-  const op = opMatch[1].toUpperCase();
-  const tableMatch =
-    /\b(?:FROM|INTO|UPDATE|JOIN)\s+(?:ONLY\s+)?"?([a-zA-Z_][a-zA-Z0-9_]*)"?/i.exec(
-      trimmed,
-    );
-  return tableMatch ? `${op} ${tableMatch[1]}` : op;
-}
 
 function buildAxiomTraceExporter(): OTLPTraceExporter {
   return new OTLPTraceExporter({
@@ -48,35 +25,19 @@ function setupOpenTelemetry() {
   // OTel only runs in deployed environments — VERCEL_GIT_COMMIT_SHA is
   // injected by Vercel and absent during `pnpm dev` / vitest. Without it
   // we don't have a useful service.version anyway.
+  //
+  // pg CLIENT spans are emitted by the in-process pool wrapper in
+  // `lib/db.ts`, not by `@opentelemetry/instrumentation-pg`. The auto
+  // instrumentation relies on `require-in-the-middle`, which doesn't fire
+  // once `vercel deploy --prebuilt` bundles pg into the function.
   const serviceVersion = env("VERCEL_GIT_COMMIT_SHA");
   if (!serviceVersion) {
     return;
   }
 
-  // Copy the matched route template from baggage onto every db span the
-  // hono request triggers, and rename the span to <op> <table> so RED
-  // dashboards group on something readable. The full parameterized SQL
-  // is still on `db.statement` for fine-grained slicing.
-  const pgInstrumentation = new PgInstrumentation({
-    ignoreConnectSpans: true,
-    requestHook: (span, info) => {
-      const route = propagation
-        .getActiveBaggage()
-        ?.getEntry(HTTP_ROUTE_BAGGAGE_KEY)?.value;
-      if (route) {
-        span.setAttribute("http.route", route);
-      }
-      const derived = deriveSqlSpanName(info.query.text);
-      if (derived) {
-        span.updateName(derived);
-      }
-    },
-  });
-
   registerOTel({
     serviceName: OTEL_SERVICE_NAME,
     attributes: { [ATTR_SERVICE_VERSION]: serviceVersion },
-    instrumentations: [pgInstrumentation],
     traceExporter: buildAxiomTraceExporter(),
   });
 }

--- a/turbo/apps/api/src/lib/__tests__/sql-span-name.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/sql-span-name.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveSqlSpanName } from "../sql-span-name";
+
+// Inputs are parameterized SQL templates as produced by drizzle (the same
+// strings we set on `db.statement`). drizzle quotes identifiers and uses
+// `$N` placeholders, so the cases here mirror real-world payloads.
+describe("deriveSqlSpanName", () => {
+  describe("supported DML keywords with a quoted target table", () => {
+    it('select … from "table"', () => {
+      const sql =
+        'select "id", "token" from "cli_tokens" where "cli_tokens"."id" = $1 limit $2';
+      expect(deriveSqlSpanName(sql)).toBe("SELECT cli_tokens");
+    });
+
+    it('insert into "table" … returning', () => {
+      const sql =
+        'insert into "model_stats" ("model", "count") values ($1, $2) returning "id"';
+      expect(deriveSqlSpanName(sql)).toBe("INSERT model_stats");
+    });
+
+    it('update "table" set …', () => {
+      const sql =
+        'update "cli_tokens" set "last_used_at" = $1 where "cli_tokens"."id" = $2';
+      expect(deriveSqlSpanName(sql)).toBe("UPDATE cli_tokens");
+    });
+
+    it('delete from "table"', () => {
+      const sql =
+        'delete from "device_codes" where "device_codes"."expires_at" < $1';
+      expect(deriveSqlSpanName(sql)).toBe("DELETE device_codes");
+    });
+
+    it('merge into "table" (postgres 15+)', () => {
+      const sql =
+        'merge into "model_stats" using "staging" on "model_stats"."id" = "staging"."id" when matched then update set "count" = "staging"."count"';
+      expect(deriveSqlSpanName(sql)).toBe("MERGE model_stats");
+    });
+  });
+
+  describe("multi-table or sub-select queries pick the first from/into/update/join target", () => {
+    it("select joining two tables uses the from table", () => {
+      const sql =
+        'select "u"."id", "o"."role" from "users" "u" inner join "org_members" "o" on "u"."id" = "o"."user_id"';
+      expect(deriveSqlSpanName(sql)).toBe("SELECT users");
+    });
+
+    it("insert into … select from other_table uses the into table", () => {
+      const sql =
+        'insert into "model_stats_daily" ("model", "count") select "model", count(*) from "model_stats" group by "model"';
+      expect(deriveSqlSpanName(sql)).toBe("INSERT model_stats_daily");
+    });
+
+    it("with cte as (…) … takes the first from inside the cte", () => {
+      const sql =
+        'with "stale" as (select "id" from "cli_tokens" where "expires_at" < $1) delete from "cli_tokens" using "stale"';
+      expect(deriveSqlSpanName(sql)).toBe("WITH cli_tokens");
+    });
+  });
+
+  describe("postgres-specific syntax", () => {
+    it('delete from only "table" (table inheritance) strips only', () => {
+      const sql = 'delete from only "audit_log" where "id" < $1';
+      expect(deriveSqlSpanName(sql)).toBe("DELETE audit_log");
+    });
+
+    it("unquoted system catalog name (drizzle.execute raw sql)", () => {
+      expect(
+        deriveSqlSpanName("select datname from pg_database where datname = $1"),
+      ).toBe("SELECT pg_database");
+    });
+  });
+
+  describe("operation without a target table", () => {
+    it("select 1 has no from, return the operation alone", () => {
+      expect(deriveSqlSpanName("select 1")).toBe("SELECT");
+    });
+
+    it("select now() has no from either", () => {
+      expect(deriveSqlSpanName("select now()")).toBe("SELECT");
+    });
+  });
+
+  describe("input variations", () => {
+    it("is case-insensitive on the leading keyword", () => {
+      expect(deriveSqlSpanName('SELECT 1 FROM "users"')).toBe("SELECT users");
+      expect(deriveSqlSpanName('Select 1 from "users"')).toBe("SELECT users");
+    });
+
+    it("tolerates leading/trailing whitespace", () => {
+      expect(deriveSqlSpanName('   select * from "users"   ')).toBe(
+        "SELECT users",
+      );
+    });
+  });
+
+  describe("returns null when there is no recognised dml keyword", () => {
+    it("empty string", () => {
+      expect(deriveSqlSpanName("")).toBeNull();
+    });
+
+    it("explain analyze select … (does not start with a dml verb)", () => {
+      expect(
+        deriveSqlSpanName('explain analyze select 1 from "users"'),
+      ).toBeNull();
+    });
+
+    it("show search_path", () => {
+      expect(deriveSqlSpanName("show search_path")).toBeNull();
+    });
+
+    it("begin / commit control statements", () => {
+      expect(deriveSqlSpanName("begin")).toBeNull();
+      expect(deriveSqlSpanName("commit")).toBeNull();
+    });
+  });
+});

--- a/turbo/apps/api/src/lib/db.ts
+++ b/turbo/apps/api/src/lib/db.ts
@@ -1,16 +1,147 @@
+import {
+  propagation,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+} from "@opentelemetry/api";
 import { schema } from "@vm0/db";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
-import { Pool } from "pg";
+import { Pool, type PoolClient, type QueryConfig } from "pg";
 
 import { env } from "./env";
 import { lazySingleton } from "./lazy-singleton";
+import { deriveSqlSpanName } from "./sql-span-name";
+
+const HTTP_ROUTE_BAGGAGE_KEY = "http.route";
 
 const pool = lazySingleton((): Pool => {
-  return new Pool({
-    allowExitOnIdle: true,
-    connectionString: env("DATABASE_URL"),
-    max: 5,
-  });
+  // `@opentelemetry/instrumentation-pg` would normally hook `pg.Pool` via
+  // `require-in-the-middle`, but `vercel deploy --prebuilt --archive=tgz`
+  // bundles the api into a single `index.js` so the require hook never fires.
+  // Hook the `Pool` instance ourselves at lazy-init time — bundle-safe and
+  // covers every code path because every drizzle/pg call funnels through this
+  // singleton. `tracer.startActiveSpan` is a no-op when no provider is
+  // registered (i.e. `pnpm dev` / vitest without VERCEL_GIT_COMMIT_SHA), so the
+  // wrap stays cheap when OTel is off.
+  const tracer = trace.getTracer("vm0-api/pg");
+
+  type AnyArgs = readonly unknown[];
+  type PgQuery = (...args: AnyArgs) => unknown;
+
+  function extractSql(args: AnyArgs): string {
+    const first = args[0];
+    if (typeof first === "string") {
+      return first;
+    }
+    if (first && typeof first === "object" && "text" in first) {
+      const config = first as QueryConfig;
+      return config.text;
+    }
+    return "pg.query";
+  }
+
+  function instrumentQuery(target: object, original: PgQuery): PgQuery {
+    return function instrumentedQuery(
+      this: unknown,
+      ...args: AnyArgs
+    ): unknown {
+      // pg's `query()` is overloaded: when the caller passes a trailing
+      // callback (`pool.query` itself does this internally to drive
+      // `client.query`) the result is `undefined` and the user's callback is
+      // the only completion signal. We can't wrap that into a Promise without
+      // intercepting the callback, and pool.query above already produced a
+      // span for the outer call — so just pass it straight through.
+      if (typeof args[args.length - 1] === "function") {
+        return Reflect.apply(original, target, args);
+      }
+
+      const sql = extractSql(args);
+      const spanName = deriveSqlSpanName(sql) ?? "pg.query";
+      return tracer.startActiveSpan(
+        spanName,
+        {
+          kind: SpanKind.CLIENT,
+          attributes: {
+            "db.system": "postgresql",
+            "db.statement": sql,
+          },
+        },
+        (span) => {
+          const route = propagation
+            .getActiveBaggage()
+            ?.getEntry(HTTP_ROUTE_BAGGAGE_KEY)?.value;
+          if (route) {
+            span.setAttribute("http.route", route);
+          }
+          // Promise chain instead of try/catch so this file doesn't have to
+          // opt out of `no-restricted-syntax` (the api package centralises
+          // guarded operations). `.then(onOk, onErr)` covers both branches in
+          // a single pass; `.finally(span.end)` runs whichever branch fired.
+          return (Reflect.apply(original, target, args) as Promise<unknown>)
+            .then(
+              (result) => {
+                span.setStatus({ code: SpanStatusCode.OK });
+                return result;
+              },
+              (error: unknown) => {
+                span.setStatus({
+                  code: SpanStatusCode.ERROR,
+                  message:
+                    error instanceof Error ? error.message : String(error),
+                });
+                span.recordException(error as Error);
+                throw error;
+              },
+            )
+            .finally(() => {
+              span.end();
+            });
+        },
+      );
+    } as PgQuery;
+  }
+
+  function instrumentPool(target: Pool): Pool {
+    const originalQuery = target.query.bind(target) as PgQuery;
+    target.query = instrumentQuery(target, originalQuery) as Pool["query"];
+
+    // pg-pool's `pool.query()` internally calls `pool.connect(callback)` to
+    // acquire a client — that path is already covered by the wrapped
+    // `pool.query` above, so leave callback-style connect alone (replacing
+    // the callback would double-wrap and the callback would never fire).
+    // Promise-style `pool.connect()` is what drizzle uses for transactions —
+    // patch the returned client's `query` so the BEGIN/COMMIT plus every
+    // statement inside the transaction emit CLIENT spans too.
+    const originalConnect = target.connect.bind(target);
+    target.connect = function patchedConnect(...args: AnyArgs) {
+      if (typeof args[args.length - 1] === "function") {
+        return Reflect.apply(originalConnect, target, args);
+      }
+      const promise = Reflect.apply(
+        originalConnect,
+        target,
+        args,
+      ) as Promise<PoolClient>;
+      return promise.then((client) => {
+        const clientQuery = client.query.bind(client) as PgQuery;
+        client.query = instrumentQuery(
+          client,
+          clientQuery,
+        ) as PoolClient["query"];
+        return client;
+      });
+    } as Pool["connect"];
+
+    return target;
+  }
+
+  return instrumentPool(
+    new Pool({
+      allowExitOnIdle: true,
+      connectionString: env("DATABASE_URL"),
+      max: 5,
+    }),
+  );
 });
 
 export const db = lazySingleton((): NodePgDatabase<typeof schema> => {

--- a/turbo/apps/api/src/lib/sql-span-name.ts
+++ b/turbo/apps/api/src/lib/sql-span-name.ts
@@ -1,0 +1,17 @@
+// pg's default span name is "pg.query:SELECT <db>" — too generic to slice on.
+// Pull the operation + first referenced table out of the parameterized SQL so
+// RED metrics can group by a readable label. `db.statement` still carries the
+// full parameterized SQL when the exact template matters.
+export function deriveSqlSpanName(sql: string): string | null {
+  const trimmed = sql.trim();
+  const opMatch = /^(SELECT|INSERT|UPDATE|DELETE|WITH|MERGE)/i.exec(trimmed);
+  if (!opMatch?.[1]) {
+    return null;
+  }
+  const op = opMatch[1].toUpperCase();
+  const tableMatch =
+    /\b(?:FROM|INTO|UPDATE|JOIN)\s+(?:ONLY\s+)?"?([a-zA-Z_][a-zA-Z0-9_]*)"?/i.exec(
+      trimmed,
+    );
+  return tableMatch ? `${op} ${tableMatch[1]}` : op;
+}

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/api:
     dependencies:
@@ -85,9 +85,6 @@ importers:
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.215.0
         version: 0.215.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-pg':
-        specifier: ^0.67.0
-        version: 0.67.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions':
         specifier: ^1.40.0
         version: 1.40.0
@@ -172,7 +169,7 @@ importers:
         version: 8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/cli:
     dependencies:
@@ -251,7 +248,7 @@ importers:
         version: 6.24.1
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -426,7 +423,7 @@ importers:
         version: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/web:
     dependencies:
@@ -667,7 +664,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/api-contracts:
     dependencies:
@@ -707,7 +704,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/api-services:
     devDependencies:
@@ -731,7 +728,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/connectors:
     dependencies:
@@ -762,7 +759,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/core:
     dependencies:
@@ -796,7 +793,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/db:
     dependencies:
@@ -833,7 +830,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/eslint-config:
     devDependencies:
@@ -887,7 +884,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -997,7 +994,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -2648,12 +2645,6 @@ packages:
 
   '@opentelemetry/instrumentation-pg@0.66.0':
     resolution: {integrity: sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-pg@0.67.0':
-    resolution: {integrity: sha512-1b1o/9nelDwoE3+EucZ9eHZsdUgji799C94lX1ZPy6O0EVjdTj3HczLL6z3GqPGZHmV4OpmJjGz8kuLtuPjCGA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -9029,6 +9020,7 @@ packages:
       '@vitest/ui': 4.1.5
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -11217,18 +11209,6 @@ snapshots:
       - supports-color
 
   '@opentelemetry/instrumentation-pg@0.66.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.215.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
-      '@types/pg': 8.15.6
-      '@types/pg-pool': 2.0.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-pg@0.67.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
@@ -13946,7 +13926,7 @@ snapshots:
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -13960,7 +13940,7 @@ snapshots:
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -13976,7 +13956,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -13994,7 +13974,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -14014,7 +13994,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       '@vitest/browser': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
 
@@ -14072,7 +14052,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -18290,7 +18270,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -18320,18 +18300,39 @@ snapshots:
       '@vitest/ui': 4.1.5(vitest@4.1.5)
       happy-dom: 20.9.0
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
+
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.3.0
+      '@vitest/browser-playwright': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/coverage-v8': 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
+      '@vitest/ui': 4.1.5(vitest@4.1.5)
+      happy-dom: 20.9.0
+    transitivePeerDependencies:
+      - msw
 
   vscode-languageserver-textdocument@1.0.12: {}
 


### PR DESCRIPTION
## Summary

`@opentelemetry/instrumentation-pg` hooks `pg.Pool` via `require-in-the-middle`. `vercel deploy --prebuilt --archive=tgz` bundles the api into one `index.js`, so the require hook never fires once the function ships, and pg auto-instrumentation produces **zero CLIENT spans on `vm0-traces-prod`** (24h baseline: 14k+ hono server spans, 0 pg client spans). RED dashboards over SQL aren't possible until this is fixed.

Replace the auto-instrumentation with an **in-process wrapper applied at the `Pool` instance during lazy-init in `lib/db.ts`**. Every drizzle/pg call in this app funnels through `pool()` singleton, so hooking the instance is a single-point fix that stays bundle-safe and doesn't depend on the loader patching `pg`.

## What's wrapped

- **`pool.query()`** — drizzle's normal query path. Wrapped directly.
- **`pool.connect()`** (promise form) — drizzle uses this for transactions. The returned `PoolClient`'s `query` is wrapped on the way out so `BEGIN`/`COMMIT` plus every statement inside the transaction emit CLIENT spans too.
- **`pool.connect(callback)`** (callback form) is intentionally left alone — pg-pool's own `pool.query()` calls it internally, and the `pool.query` wrap above already covers that path. Replacing the callback would deadlock pool.query and double-wrap.

## Span shape (matches old PgInstrumentation)

| field | value |
| --- | --- |
| `name` | `<OP> <table>` via `deriveSqlSpanName` (e.g. `SELECT cli_tokens`) |
| `kind` | CLIENT |
| `scope.name` | `vm0-api/pg` |
| `attributes.db.system` | `postgresql` |
| `attributes.db.statement` | full parameterized SQL |
| `attributes.http.route` | copied from baggage so RED dashboards slice "SQL P99 by URL template" |
| `status` | OK / ERROR with message + `recordException` event |

`tracer.startActiveSpan` is a NoopTracer when no provider is registered (`pnpm dev` / vitest without `VERCEL_GIT_COMMIT_SHA`), so the wrap is cheap when OTel is off.

## Cleanup

- Drop `@opentelemetry/instrumentation-pg` dependency.
- Remove `PgInstrumentation` + `requestHook` plumbing from `instrument.ts`.
- Extract `deriveSqlSpanName` to `lib/sql-span-name.ts`.
- Update an `app-factory.ts` comment that referenced the now-removed PgInstrumentation requestHook.

## Verification

Local end-to-end against `vm0-traces-dev` with `service.version=local-pg-pool-wrap`:

```
kind   scope.name                       count
server @hono/otel                       11
client vm0-api/pg                        5
```

The 5 client spans were `SELECT cli_tokens` from the PAT auth lookup; carry `http.route=/health/auth`, `db.system=postgresql`, full `db.statement`; status flips to ERROR with the UUID parse exception event when the test PAT's tokenId fails to parse; `parent_span_id` correctly links to the `@hono/otel` SERVER span.

## Test plan

- [x] `pnpm -F api exec vitest run` — 143 tests pass
- [x] Local: hit api with bearer PAT, confirm pg client spans land on `vm0-traces-dev` with correct attributes (above)
- [ ] After merge: re-query `vm0-traces-prod` over 24h and confirm `@opentelemetry/instrumentation-pg` count of 0 is replaced by `vm0-api/pg` client spans for every db-touching route

🤖 Generated with [Claude Code](https://claude.com/claude-code)