### PR TITLE
perf: warm runner rootfs cache before fan-out

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -295,7 +295,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: "3.12"
 
       # Needed for the classifier↔firewall consistency check in
       # tests/test_x_billing.py: the check reads
@@ -308,7 +308,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: 'pnpm'
+          cache: "pnpm"
           cache-dependency-path: turbo/pnpm-lock.yaml
       - name: Install turbo deps (triggers firewalls-generator postinstall)
         run: cd turbo && pnpm install --frozen-lockfile
@@ -516,8 +516,8 @@ jobs:
             R2_SECRET_ACCESS_KEY='${R2_SECRET_ACCESS_KEY}' \
             R2_USER_STORAGES_BUCKET_NAME='${R2_USER_STORAGES_BUCKET_NAME}' \
             ${BIN_DIR}/runner build --profile vm0/default" | tee "$BUILD_LOG_DEFAULT"
-          DEFAULT_ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG_DEFAULT" | cut -d= -f2)
-          DEFAULT_SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG_DEFAULT" | cut -d= -f2)
+          DEFAULT_ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG_DEFAULT" | tail -n1 | cut -d= -f2 || true)
+          DEFAULT_SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG_DEFAULT" | tail -n1 | cut -d= -f2 || true)
           rm -f "$BUILD_LOG_DEFAULT"
 
           if [ -z "$DEFAULT_ROOTFS_HASH" ] || [ -z "$DEFAULT_SNAPSHOT_HASH" ]; then

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1541,24 +1541,32 @@ jobs:
 
             # Clean previous run artifacts and upload runner (guests are embedded)
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "sudo rm -rf ${BIN_DIR} ${RUNNER_DIR} && sudo mkdir -p ${BIN_DIR}"
+            if ! ssh "$REMOTE" "sudo rm -rf ${BIN_DIR} ${RUNNER_DIR} && sudo mkdir -p ${BIN_DIR}"; then
+              return 1
+            fi
             # shellcheck disable=SC2029
-            < "${TARGET_DIR}/runner" ssh "$REMOTE" "sudo install -m 755 /dev/stdin ${BIN_DIR}/runner"
+            if ! < "${TARGET_DIR}/runner" ssh "$REMOTE" "sudo install -m 755 /dev/stdin ${BIN_DIR}/runner"; then
+              return 1
+            fi
 
             # Clean up old rootfs/snapshots, keep the 6 most recent (3 deploys × 2 profiles).
             # R2_* env vars are inlined so `runner gc` can also sweep stale R2 image
             # objects — without them, R2-side cleanup is silently skipped.
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "sudo \
+            if ! ssh "$REMOTE" "sudo \
               R2_ACCOUNT_ID='${R2_ACCOUNT_ID}' \
               R2_ACCESS_KEY_ID='${R2_ACCESS_KEY_ID}' \
               R2_SECRET_ACCESS_KEY='${R2_SECRET_ACCESS_KEY}' \
               R2_USER_STORAGES_BUCKET_NAME='${R2_USER_STORAGES_BUCKET_NAME}' \
-              ${BIN_DIR}/runner gc --keep-latest 6"
+              ${BIN_DIR}/runner gc --keep-latest 6"; then
+              return 1
+            fi
 
             # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "sudo ${BIN_DIR}/runner setup"
+            if ! ssh "$REMOTE" "sudo ${BIN_DIR}/runner setup"; then
+              return 1
+            fi
             echo "=== Done preparing ${HOST} ==="
           }
 
@@ -1571,12 +1579,14 @@ jobs:
             # prevents every metal host from racing into the slow local rootfs
             # build path when a PR introduces a new rootfs_hash.
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "sudo \
+            if ! ssh "$REMOTE" "sudo \
               R2_ACCOUNT_ID='${R2_ACCOUNT_ID}' \
               R2_ACCESS_KEY_ID='${R2_ACCESS_KEY_ID}' \
               R2_SECRET_ACCESS_KEY='${R2_SECRET_ACCESS_KEY}' \
               R2_USER_STORAGES_BUCKET_NAME='${R2_USER_STORAGES_BUCKET_NAME}' \
-              ${BIN_DIR}/runner build --profile vm0/default --warm-rootfs-cache"
+              ${BIN_DIR}/runner build --profile vm0/default --warm-rootfs-cache"; then
+              return 1
+            fi
             echo "=== Done warming shared rootfs cache on ${HOST} ==="
           }
 
@@ -1589,12 +1599,14 @@ jobs:
             # R2_* env vars are inlined after `sudo` so they reach the runner
             # process — sudo's default `env_reset` would otherwise strip them.
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "sudo \
+            if ! ssh "$REMOTE" "sudo \
               R2_ACCOUNT_ID='${R2_ACCOUNT_ID}' \
               R2_ACCESS_KEY_ID='${R2_ACCESS_KEY_ID}' \
               R2_SECRET_ACCESS_KEY='${R2_SECRET_ACCESS_KEY}' \
               R2_USER_STORAGES_BUCKET_NAME='${R2_USER_STORAGES_BUCKET_NAME}' \
-              ${BIN_DIR}/runner build --profile vm0/default"
+              ${BIN_DIR}/runner build --profile vm0/default"; then
+              return 1
+            fi
             echo "=== Done building rootfs/snapshot on ${HOST} ==="
           }
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1384,7 +1384,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
     needs: [prepare]
-    timeout-minutes: 20
+    timeout-minutes: 40
     env:
       TARGET_TRIPLE: aarch64-unknown-linux-musl
     if: |
@@ -1625,13 +1625,11 @@ jobs:
 
           WARM_HOST="${HOSTS[0]}"
           WARM_LOG="${LOG_DIR}/warm-rootfs-cache.log"
-          if ! warm_rootfs_cache "$WARM_HOST" > "$WARM_LOG" 2>&1; then
+          if ! warm_rootfs_cache "$WARM_HOST" 2>&1 | tee "$WARM_LOG"; then
             echo "::error::Shared rootfs cache warm failed on ${WARM_HOST}"
-            cat "$WARM_LOG"
             rm -rf "$LOG_DIR"
             exit 1
           fi
-          cat "$WARM_LOG"
 
           PIDS=()
           for HOST in "${HOSTS[@]}"; do

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1670,8 +1670,8 @@ jobs:
           ROOTFS_MAP=$(jq -n '{}')
           SNAPSHOT_MAP=$(jq -n '{}')
           for HOST in "${HOSTS[@]}"; do
-            ROOTFS_HASH=$(grep '^rootfs_hash=' "${LOG_DIR}/${HOST}.build.log" | tail -n1 | cut -d= -f2)
-            SNAPSHOT_HASH=$(grep '^snapshot_hash=' "${LOG_DIR}/${HOST}.build.log" | tail -n1 | cut -d= -f2)
+            ROOTFS_HASH=$(grep '^rootfs_hash=' "${LOG_DIR}/${HOST}.build.log" | tail -n1 | cut -d= -f2 || true)
+            SNAPSHOT_HASH=$(grep '^snapshot_hash=' "${LOG_DIR}/${HOST}.build.log" | tail -n1 | cut -d= -f2 || true)
             if [ -z "$ROOTFS_HASH" ] || [ -z "$SNAPSHOT_HASH" ]; then
               echo "::error::Failed to extract rootfs/snapshot hash from ${HOST} log"
               rm -rf "$LOG_DIR"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1623,19 +1623,15 @@ jobs:
             exit 1
           fi
 
-          if [ -n "${R2_ACCOUNT_ID}" ] && [ -n "${R2_ACCESS_KEY_ID}" ] && [ -n "${R2_SECRET_ACCESS_KEY}" ] && [ -n "${R2_USER_STORAGES_BUCKET_NAME}" ]; then
-            WARM_HOST="${HOSTS[0]}"
-            WARM_LOG="${LOG_DIR}/warm-rootfs-cache.log"
-            if ! warm_rootfs_cache "$WARM_HOST" > "$WARM_LOG" 2>&1; then
-              echo "::error::Shared rootfs cache warm failed on ${WARM_HOST}"
-              cat "$WARM_LOG"
-              rm -rf "$LOG_DIR"
-              exit 1
-            fi
+          WARM_HOST="${HOSTS[0]}"
+          WARM_LOG="${LOG_DIR}/warm-rootfs-cache.log"
+          if ! warm_rootfs_cache "$WARM_HOST" > "$WARM_LOG" 2>&1; then
+            echo "::error::Shared rootfs cache warm failed on ${WARM_HOST}"
             cat "$WARM_LOG"
-          else
-            echo "::warning::Skipping shared rootfs cache warm because R2 image cache credentials are incomplete"
+            rm -rf "$LOG_DIR"
+            exit 1
           fi
+          cat "$WARM_LOG"
 
           PIDS=()
           for HOST in "${HOSTS[@]}"; do

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1532,12 +1532,12 @@ jobs:
         run: |
           TARGET_DIR="crates/target/${TARGET_TRIPLE}/ci"
 
-          deploy_to_host() {
+          prepare_host() {
             local HOST=$1
             local HOST_INDEX=$2
             local RUNNER_NAME="${JOB_REF}-${HOST_INDEX}"
             local REMOTE="${METAL_USER}@${HOST}"
-            echo "=== Deploying to ${HOST} (runner: ${RUNNER_NAME}) ==="
+            echo "=== Preparing ${HOST} (runner: ${RUNNER_NAME}) ==="
 
             # Clean previous run artifacts and upload runner (guests are embedded)
             # shellcheck disable=SC2029
@@ -1559,6 +1559,31 @@ jobs:
             # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
             # shellcheck disable=SC2029
             ssh "$REMOTE" "sudo ${BIN_DIR}/runner setup"
+            echo "=== Done preparing ${HOST} ==="
+          }
+
+          warm_rootfs_cache() {
+            local HOST=$1
+            local REMOTE="${METAL_USER}@${HOST}"
+            echo "=== Warming shared rootfs cache on ${HOST} ==="
+
+            # Warm exactly once before the per-host snapshot build fan-out. This
+            # prevents every metal host from racing into the slow local rootfs
+            # build path when a PR introduces a new rootfs_hash.
+            # shellcheck disable=SC2029
+            ssh "$REMOTE" "sudo \
+              R2_ACCOUNT_ID='${R2_ACCOUNT_ID}' \
+              R2_ACCESS_KEY_ID='${R2_ACCESS_KEY_ID}' \
+              R2_SECRET_ACCESS_KEY='${R2_SECRET_ACCESS_KEY}' \
+              R2_USER_STORAGES_BUCKET_NAME='${R2_USER_STORAGES_BUCKET_NAME}' \
+              ${BIN_DIR}/runner build --profile vm0/default --warm-rootfs-cache"
+            echo "=== Done warming shared rootfs cache on ${HOST} ==="
+          }
+
+          build_snapshot_on_host() {
+            local HOST=$1
+            local REMOTE="${METAL_USER}@${HOST}"
+            echo "=== Building rootfs/snapshot on ${HOST} ==="
 
             # Run build to create rootfs + snapshot (outputs hashes to stdout).
             # R2_* env vars are inlined after `sudo` so they reach the runner
@@ -1570,7 +1595,7 @@ jobs:
               R2_SECRET_ACCESS_KEY='${R2_SECRET_ACCESS_KEY}' \
               R2_USER_STORAGES_BUCKET_NAME='${R2_USER_STORAGES_BUCKET_NAME}' \
               ${BIN_DIR}/runner build --profile vm0/default"
-            echo "=== Done deploying to ${HOST} ==="
+            echo "=== Done building rootfs/snapshot on ${HOST} ==="
           }
 
           LOG_DIR=$(mktemp -d)
@@ -1579,7 +1604,7 @@ jobs:
           HOST_INDEX=0
           for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
             HOST_INDEX=$((HOST_INDEX + 1))
-            deploy_to_host "$HOST" "$HOST_INDEX" > "${LOG_DIR}/${HOST}.log" 2>&1 &
+            prepare_host "$HOST" "$HOST_INDEX" > "${LOG_DIR}/${HOST}.prepare.log" 2>&1 &
             PIDS+=($!)
             HOSTS+=("$HOST")
           done
@@ -1588,10 +1613,44 @@ jobs:
           for i in "${!PIDS[@]}"; do
             if ! wait "${PIDS[$i]}"; then
               FAILED=1
-              echo "::error::Deployment failed on ${HOSTS[$i]}"
+              echo "::error::Runner preparation failed on ${HOSTS[$i]}"
             fi
-            echo "=== ${HOSTS[$i]} ==="
-            cat "${LOG_DIR}/${HOSTS[$i]}.log"
+            echo "=== ${HOSTS[$i]} prepare ==="
+            cat "${LOG_DIR}/${HOSTS[$i]}.prepare.log"
+          done
+          if [ "$FAILED" -ne 0 ]; then
+            rm -rf "$LOG_DIR"
+            exit 1
+          fi
+
+          if [ -n "${R2_ACCOUNT_ID}" ] && [ -n "${R2_ACCESS_KEY_ID}" ] && [ -n "${R2_SECRET_ACCESS_KEY}" ] && [ -n "${R2_USER_STORAGES_BUCKET_NAME}" ]; then
+            WARM_HOST="${HOSTS[0]}"
+            WARM_LOG="${LOG_DIR}/warm-rootfs-cache.log"
+            if ! warm_rootfs_cache "$WARM_HOST" > "$WARM_LOG" 2>&1; then
+              echo "::error::Shared rootfs cache warm failed on ${WARM_HOST}"
+              cat "$WARM_LOG"
+              rm -rf "$LOG_DIR"
+              exit 1
+            fi
+            cat "$WARM_LOG"
+          else
+            echo "::warning::Skipping shared rootfs cache warm because R2 image cache credentials are incomplete"
+          fi
+
+          PIDS=()
+          for HOST in "${HOSTS[@]}"; do
+            build_snapshot_on_host "$HOST" > "${LOG_DIR}/${HOST}.build.log" 2>&1 &
+            PIDS+=($!)
+          done
+
+          FAILED=0
+          for i in "${!PIDS[@]}"; do
+            if ! wait "${PIDS[$i]}"; then
+              FAILED=1
+              echo "::error::Runner image build failed on ${HOSTS[$i]}"
+            fi
+            echo "=== ${HOSTS[$i]} build ==="
+            cat "${LOG_DIR}/${HOSTS[$i]}.build.log"
           done
           if [ "$FAILED" -ne 0 ]; then
             rm -rf "$LOG_DIR"
@@ -1603,8 +1662,8 @@ jobs:
           ROOTFS_MAP=$(jq -n '{}')
           SNAPSHOT_MAP=$(jq -n '{}')
           for HOST in "${HOSTS[@]}"; do
-            ROOTFS_HASH=$(grep '^rootfs_hash=' "${LOG_DIR}/${HOST}.log" | cut -d= -f2)
-            SNAPSHOT_HASH=$(grep '^snapshot_hash=' "${LOG_DIR}/${HOST}.log" | cut -d= -f2)
+            ROOTFS_HASH=$(grep '^rootfs_hash=' "${LOG_DIR}/${HOST}.build.log" | tail -n1 | cut -d= -f2)
+            SNAPSHOT_HASH=$(grep '^snapshot_hash=' "${LOG_DIR}/${HOST}.build.log" | tail -n1 | cut -d= -f2)
             if [ -z "$ROOTFS_HASH" ] || [ -z "$SNAPSHOT_HASH" ]; then
               echo "::error::Failed to extract rootfs/snapshot hash from ${HOST} log"
               rm -rf "$LOG_DIR"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1384,7 +1384,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260419
     needs: [prepare]
-    timeout-minutes: 40
+    timeout-minutes: 20
     env:
       TARGET_TRIPLE: aarch64-unknown-linux-musl
     if: |

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1530,6 +1530,8 @@ jobs:
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_USER_STORAGES_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
         run: |
+          set -euo pipefail
+
           TARGET_DIR="crates/target/${TARGET_TRIPLE}/ci"
 
           prepare_host() {
@@ -1545,7 +1547,7 @@ jobs:
               return 1
             fi
             # shellcheck disable=SC2029
-            if ! < "${TARGET_DIR}/runner" ssh "$REMOTE" "sudo install -m 755 /dev/stdin ${BIN_DIR}/runner"; then
+            if ! ssh "$REMOTE" "sudo install -m 755 /dev/stdin ${BIN_DIR}/runner" < "${TARGET_DIR}/runner"; then
               return 1
             fi
 

--- a/ansible/playbooks/build-runner.yml
+++ b/ansible/playbooks/build-runner.yml
@@ -15,12 +15,20 @@
 #     -e "ansible_user=ubuntu" \
 #     -e "official_runner_secret=xxx" \
 #     -e "api_url=https://www.vm0.ai" \
-#     -e "runner_version=0.3.0"
+#     -e "runner_version=0.3.0" \
+#     -e "r2_account_id=xxx" \
+#     -e "r2_access_key_id=xxx" \
+#     -e "r2_secret_access_key=xxx" \
+#     -e "r2_bucket=xxx"
 #
 # Required Variables:
 #   - runner_version: Semantic version of the runner being built
 #   - official_runner_secret: Runner authentication secret (baked into config)
 #   - api_url: vm0 API URL (baked into config)
+#   - r2_account_id / r2_access_key_id / r2_secret_access_key / r2_bucket:
+#       Shared rootfs image cache credentials. Required so the pre-fan-out
+#       warm step can fail visibly instead of allowing every host to rebuild
+#       the same rootfs locally.
 
 - name: Build VM0 Runner
   hosts: all
@@ -54,6 +62,22 @@
     # ========================================
     - name: Download dependencies (Firecracker, kernel, mitmproxy)
       command: "{{ bin_dir }}/runner setup"
+
+    - name: Warm shared rootfs cache
+      run_once: true
+      command: >
+        {{ bin_dir }}/runner build
+        --profile vm0/default
+        --warm-rootfs-cache
+      environment:
+        # Fail visibly if the shared R2 cache cannot be warmed. This prevents
+        # every production host from stampeding into the slow local rootfs
+        # build path during a new rootfs_hash deploy.
+        R2_ACCOUNT_ID: "{{ r2_account_id | default('') }}"
+        R2_ACCESS_KEY_ID: "{{ r2_access_key_id | default('') }}"
+        R2_SECRET_ACCESS_KEY: "{{ r2_secret_access_key | default('') }}"
+        R2_USER_STORAGES_BUCKET_NAME: "{{ r2_bucket | default('') }}"
+      register: default_rootfs_warm_output
 
     - name: Build default rootfs and snapshot
       command: >

--- a/ansible/playbooks/build-runner.yml
+++ b/ansible/playbooks/build-runner.yml
@@ -84,12 +84,11 @@
         {{ bin_dir }}/runner build
         --profile vm0/default
       environment:
-        # R2 credentials so `runner build` can pull the rootfs.ext4 from the
-        # shared image cache instead of rebuilding it from scratch (~3-5 min
-        # saved per deploy).  Only rootfs is cached; the snapshot is always
-        # created locally because it contains host-specific state.  Host CA
-        # is swapped in via inject-ca.sh after download.  Without these, R2
-        # download is skipped and the local build path runs unchanged.
+        # R2 credentials so `runner build` can pull the rootfs.ext4 warmed
+        # above instead of rebuilding it from scratch. Only rootfs is cached;
+        # the snapshot is always created locally because it contains
+        # host-specific state. Host CA is swapped in via inject-ca.sh after
+        # download.
         R2_ACCOUNT_ID: "{{ r2_account_id | default('') }}"
         R2_ACCESS_KEY_ID: "{{ r2_access_key_id | default('') }}"
         R2_SECRET_ACCESS_KEY: "{{ r2_secret_access_key | default('') }}"

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -59,10 +59,10 @@
 # Optional Variables:
 #   - sentry_dsn: Forwarded to the systemd unit as SENTRY_DSN
 #   - r2_account_id / r2_access_key_id / r2_secret_access_key / r2_bucket:
-#       If all are provided on the install path, rollback warms the shared
-#       rootfs cache once before per-host rebuilds. If omitted, rollback keeps
-#       its offline-capable local rebuild behavior. Also passed to `runner gc`
-#       for best-effort R2-side cleanup.
+#       Passed to `runner build` for best-effort rootfs cache download/upload
+#       and to `runner gc` for best-effort R2-side cleanup. Rollback does not
+#       run the newer `--warm-rootfs-cache` path because the target rollback
+#       binary may predate that flag.
 
 - name: Rollback VM0 Runner
   hosts: all
@@ -337,34 +337,12 @@
       when: not (skip_install | default(false))
       command: "{{ bin_dir }}/runner setup"
 
-    - name: Warm shared rootfs cache when R2 credentials are available
-      when:
-        - not (skip_install | default(false))
-        - r2_account_id is defined and r2_account_id | length > 0
-        - r2_access_key_id is defined and r2_access_key_id | length > 0
-        - r2_secret_access_key is defined and r2_secret_access_key | length > 0
-        - r2_bucket is defined and r2_bucket | length > 0
-      run_once: true
-      command: >
-        {{ bin_dir }}/runner build
-        --profile vm0/default
-        --warm-rootfs-cache
-      environment:
-        # Fail visibly if the shared R2 cache cannot be warmed. This prevents
-        # every rollback install target from stampeding into the slow local
-        # rootfs build path when the target rootfs_hash is not already cached.
-        R2_ACCOUNT_ID: "{{ r2_account_id | default('') }}"
-        R2_ACCESS_KEY_ID: "{{ r2_access_key_id | default('') }}"
-        R2_SECRET_ACCESS_KEY: "{{ r2_secret_access_key | default('') }}"
-        R2_USER_STORAGES_BUCKET_NAME: "{{ r2_bucket | default('') }}"
-      register: default_rootfs_warm_output
-
     # Always runs on install path. Content-addressed by hash of embedded
     # guests + recipe; if target's rootfs/snapshot are already on disk at
-    # the matching hash path, this returns in ~1s. When R2 credentials were
-    # provided, the warm step above ensures remote cache can satisfy a local
-    # rootfs miss in seconds instead of rebuilding. Without R2 credentials,
-    # rollback intentionally preserves the old offline-capable local path.
+    # the matching hash path, this returns in ~1s. When R2 credentials are
+    # provided, the build can best-effort download/upload rootfs through the
+    # shared cache. Without R2 credentials, rollback intentionally preserves
+    # the old offline-capable local path.
     - name: Rebuild default rootfs and snapshot
       when: not (skip_install | default(false))
       command: >

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -59,9 +59,9 @@
 # Optional Variables:
 #   - sentry_dsn: Forwarded to the systemd unit as SENTRY_DSN
 #   - r2_account_id / r2_access_key_id / r2_secret_access_key / r2_bucket:
-#       Passed to `runner build` (speeds up rootfs cache hit on fresh hosts)
-#       and to `runner gc` (R2-side cache cleanup). If omitted, local-only
-#       behavior is used in both cases.
+#       Required on the install path for the pre-fan-out rootfs cache warm
+#       step, and passed to `runner gc` for R2-side cleanup. If `skip_install`
+#       is true, only the GC use remains best-effort.
 
 - name: Rollback VM0 Runner
   hosts: all
@@ -335,6 +335,23 @@
     - name: Download runner dependencies
       when: not (skip_install | default(false))
       command: "{{ bin_dir }}/runner setup"
+
+    - name: Warm shared rootfs cache
+      when: not (skip_install | default(false))
+      run_once: true
+      command: >
+        {{ bin_dir }}/runner build
+        --profile vm0/default
+        --warm-rootfs-cache
+      environment:
+        # Fail visibly if the shared R2 cache cannot be warmed. This prevents
+        # every rollback install target from stampeding into the slow local
+        # rootfs build path when the target rootfs_hash is not already cached.
+        R2_ACCOUNT_ID: "{{ r2_account_id | default('') }}"
+        R2_ACCESS_KEY_ID: "{{ r2_access_key_id | default('') }}"
+        R2_SECRET_ACCESS_KEY: "{{ r2_secret_access_key | default('') }}"
+        R2_USER_STORAGES_BUCKET_NAME: "{{ r2_bucket | default('') }}"
+      register: default_rootfs_warm_output
 
     # Always runs on install path. Content-addressed by hash of embedded
     # guests + recipe; if target's rootfs/snapshot are already on disk at

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -59,9 +59,10 @@
 # Optional Variables:
 #   - sentry_dsn: Forwarded to the systemd unit as SENTRY_DSN
 #   - r2_account_id / r2_access_key_id / r2_secret_access_key / r2_bucket:
-#       Required on the install path for the pre-fan-out rootfs cache warm
-#       step, and passed to `runner gc` for R2-side cleanup. If `skip_install`
-#       is true, only the GC use remains best-effort.
+#       If all are provided on the install path, rollback warms the shared
+#       rootfs cache once before per-host rebuilds. If omitted, rollback keeps
+#       its offline-capable local rebuild behavior. Also passed to `runner gc`
+#       for best-effort R2-side cleanup.
 
 - name: Rollback VM0 Runner
   hosts: all
@@ -336,8 +337,13 @@
       when: not (skip_install | default(false))
       command: "{{ bin_dir }}/runner setup"
 
-    - name: Warm shared rootfs cache
-      when: not (skip_install | default(false))
+    - name: Warm shared rootfs cache when R2 credentials are available
+      when:
+        - not (skip_install | default(false))
+        - r2_account_id is defined and r2_account_id | length > 0
+        - r2_access_key_id is defined and r2_access_key_id | length > 0
+        - r2_secret_access_key is defined and r2_secret_access_key | length > 0
+        - r2_bucket is defined and r2_bucket | length > 0
       run_once: true
       command: >
         {{ bin_dir }}/runner build
@@ -355,9 +361,10 @@
 
     # Always runs on install path. Content-addressed by hash of embedded
     # guests + recipe; if target's rootfs/snapshot are already on disk at
-    # the matching hash path, this returns in ~1s. The warm step above
-    # ensures remote cache can satisfy a local rootfs miss in seconds
-    # instead of rebuilding.
+    # the matching hash path, this returns in ~1s. When R2 credentials were
+    # provided, the warm step above ensures remote cache can satisfy a local
+    # rootfs miss in seconds instead of rebuilding. Without R2 credentials,
+    # rollback intentionally preserves the old offline-capable local path.
     - name: Rebuild default rootfs and snapshot
       when: not (skip_install | default(false))
       command: >

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -355,8 +355,9 @@
 
     # Always runs on install path. Content-addressed by hash of embedded
     # guests + recipe; if target's rootfs/snapshot are already on disk at
-    # the matching hash path, this returns in ~1s. If R2 creds are passed,
-    # remote cache can satisfy a local miss in seconds instead of rebuilding.
+    # the matching hash path, this returns in ~1s. The warm step above
+    # ensures remote cache can satisfy a local rootfs miss in seconds
+    # instead of rebuilding.
     - name: Rebuild default rootfs and snapshot
       when: not (skip_install | default(false))
       command: >

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -429,12 +429,20 @@ async fn ensure_rootfs_under_lock(input: RootfsBuildInput<'_>) -> RunnerResult<(
                     tracing::info!("R2 cache miss for {} — building locally", input.rootfs_hash)
                 }
                 Err(e) => {
-                    if input.policy.is_strict() {
+                    if e.is_invalid_object() {
+                        tracing::warn!(
+                            "R2 object for {} is invalid ({e}) — \
+                             rebuilding locally and force-overwriting the bad object",
+                            input.rootfs_hash
+                        );
+                        force_reupload = true;
+                    } else if input.policy.is_strict() {
                         return Err(RunnerError::Internal(format!(
                             "R2 download failed while warming rootfs cache: {e}"
                         )));
+                    } else {
+                        tracing::warn!("R2 download failed: {e} — falling back to local build");
                     }
-                    tracing::warn!("R2 download failed: {e} — falling back to local build");
                 }
             }
         }

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -122,6 +122,36 @@ pub struct BuildArgs {
     /// Compute and print the image hash without building
     #[arg(long)]
     pub dry_run: bool,
+    /// Build or upload only the shared R2 rootfs cache, without creating a snapshot
+    #[arg(long)]
+    pub warm_rootfs_cache: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RootfsCachePolicy {
+    BestEffort,
+    StrictWarm,
+}
+
+impl RootfsCachePolicy {
+    fn is_strict(self) -> bool {
+        matches!(self, Self::StrictWarm)
+    }
+}
+
+struct RootfsBuildInput<'a> {
+    paths: &'a HomePaths,
+    rootfs_hash: &'a str,
+    rootfs_paths: &'a RootfsPaths,
+    r2: Option<&'a R2ImageCache>,
+    policy: RootfsCachePolicy,
+    disk_mb: u32,
+    guest_agent: &'a Path,
+    guest_download: &'a Path,
+    guest_init: &'a Path,
+    guest_mock_claude: &'a Path,
+    guest_mock_codex: &'a Path,
+    guest_reseed: &'a Path,
 }
 
 /// Resolve a guest binary path: CLI arg takes priority, then bundled binary
@@ -158,6 +188,7 @@ async fn resolve_guest(
 pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> RunnerResult<()> {
     let def = profile::get(&args.profile)?;
     let dry_run = args.dry_run;
+    let warm_rootfs_cache = args.warm_rootfs_cache;
 
     // Create temp dir for any bundled guest binaries that need extracting.
     // IMPORTANT: tmp_dir must outlive build script execution — dropping it deletes extracted guests.
@@ -221,7 +252,8 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
     let snapshot_dir = snapshot_paths.dir();
 
     // Fast path: both rootfs and snapshot already present.
-    if is_rootfs_present(&rootfs_paths).await?
+    if !warm_rootfs_cache
+        && is_rootfs_present(&rootfs_paths).await?
         && provider.is_complete(snapshot_dir).await.unwrap_or(false)
     {
         tracing::info!("[OK] image already built: rootfs={rootfs_hash}, snapshot={snapshot_hash}");
@@ -236,16 +268,28 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         .await
         .map_err(|e| RunnerError::Internal(format!("R2 cache init: {e}")))?;
     if r2.is_none() {
+        if warm_rootfs_cache {
+            return Err(RunnerError::Internal(
+                "--warm-rootfs-cache requires all R2_* image cache environment variables".into(),
+            ));
+        }
         // Info, not warn — dev environments routinely run without R2 configured.
         tracing::info!("R2 cache disabled (R2_* env vars not set) — skipping download and upload");
     }
 
-    // Acquire exclusive locks to prevent concurrent builds and block GC.
+    // Acquire the rootfs lock before any rootfs mutation. Full builds keep it
+    // through snapshot creation so GC cannot reap the rootfs while the snapshot
+    // provider is reading it.
     let _rootfs_lock = lock::acquire(paths.rootfs_lock(&rootfs_hash)).await?;
-    let _snapshot_lock = lock::acquire(paths.snapshot_lock(&snapshot_hash)).await?;
+    let _snapshot_lock = if warm_rootfs_cache {
+        None
+    } else {
+        Some(lock::acquire(paths.snapshot_lock(&snapshot_hash)).await?)
+    };
 
     // Re-check after acquiring lock — another process may have completed the build.
-    if is_rootfs_present(&rootfs_paths).await?
+    if !warm_rootfs_cache
+        && is_rootfs_present(&rootfs_paths).await?
         && provider.is_complete(snapshot_dir).await.unwrap_or(false)
     {
         tracing::info!("[OK] image already built: rootfs={rootfs_hash}, snapshot={snapshot_hash}");
@@ -254,218 +298,30 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         return Ok(());
     }
 
-    // Clear any `rootfs.ext4.staging` residue from a previous crashed or
-    // failed build. Holding the rootfs flock means the previous writer has
-    // already exited (kernel releases flocks on process death), so any
-    // staging file on disk is guaranteed to be stale — never a concurrent
-    // writer's work-in-progress. This is the recovery arm of the
-    // staging-rename contract; see `RootfsPaths::rootfs_staging`.
-    clear_rootfs_staging(&rootfs_paths).await;
-
-    // Write scripts to a temp directory (needed for both R2 and local paths).
-    let work_dir =
-        tempfile::tempdir().map_err(|e| RunnerError::Internal(format!("create temp dir: {e}")))?;
-    tokio::fs::write(work_dir.path().join("build-rootfs.sh"), BUILD_SCRIPT)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("write build script: {e}")))?;
-    tokio::fs::write(work_dir.path().join("verify-rootfs.sh"), VERIFY_SCRIPT)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("write verify script: {e}")))?;
-    tokio::fs::write(work_dir.path().join("inject-ca.sh"), INJECT_CA_SCRIPT)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("write inject-ca script: {e}")))?;
-
-    let ca_dir = paths.ca_dir();
-
-    // --- Phase 1: Obtain rootfs ---
-    //
-    // R2 caches only rootfs.ext4. Snapshots are always created locally
-    // because they contain host-specific state (page cache, kernel metadata).
-    // Multiple snapshot variants can share one rootfs.
-
-    let mut force_reupload = false;
-    let mut rootfs_from_r2 = false;
-
-    let need_rootfs = !is_rootfs_present(&rootfs_paths).await?;
-
-    if need_rootfs {
-        // Try R2 download (rootfs only). try_download manages its own staging
-        // directory and atomic rename, so rootfs_dir stays absent on failure.
-        if let Some(cache) = &r2 {
-            match cache.try_download(&rootfs_hash, rootfs_dir).await {
-                Ok(true) => {
-                    if tokio::fs::try_exists(rootfs_paths.rootfs())
-                        .await
-                        .unwrap_or(false)
-                    {
-                        // Remove any non-rootfs files from the download (e.g. stale
-                        // snapshot artifacts from an old archive format).
-                        remove_all_except_rootfs(&rootfs_paths).await;
-                        tracing::info!("[OK] rootfs downloaded from R2: {}", rootfs_dir.display());
-                        // Demote the downloaded image to staging before CA
-                        // injection runs. The R2-cached rootfs carries the
-                        // build host's CA; Phase 1.5 replaces it. Keeping
-                        // the file at the committed `rootfs.ext4` path
-                        // during injection would let a mid-script crash
-                        // leave a rootfs whose CA file no longer matches
-                        // its system bundle, permanently poisoning the
-                        // Fast-path reuse check.
-                        demote_to_staging(&rootfs_paths).await?;
-                        rootfs_from_r2 = true;
-                    } else {
-                        tracing::warn!(
-                            "R2 download for {rootfs_hash} succeeded but rootfs missing — \
-                             will rebuild locally and force-overwrite the bad object"
-                        );
-                        force_reupload = true;
-                        if let Err(e) = tokio::fs::remove_dir_all(rootfs_dir).await {
-                            tracing::warn!(
-                                "failed to clean bad R2 download at {}: {e}",
-                                rootfs_dir.display()
-                            );
-                        }
-                    }
-                }
-                Ok(false) => {
-                    tracing::info!("R2 cache miss for {rootfs_hash} — building locally")
-                }
-                Err(e) => {
-                    tracing::warn!("R2 download failed: {e} — falling back to local build")
-                }
-            }
-        }
-
-        if !rootfs_from_r2 {
-            // Create rootfs_dir for local build (R2 path creates it via rename).
-            tokio::fs::create_dir_all(rootfs_dir).await.map_err(|e| {
-                RunnerError::Internal(format!("create {}: {e}", rootfs_dir.display()))
-            })?;
-
-            // Local rootfs build — the slow path (debootstrap + apt install).
-            let rootfs_dir_str = rootfs_dir.to_string_lossy();
-            let guest_agent_str = guest_agent.to_string_lossy();
-            let guest_download_str = guest_download.to_string_lossy();
-            let guest_init_str = guest_init.to_string_lossy();
-            let guest_mock_claude_str = guest_mock_claude.to_string_lossy();
-            let guest_mock_codex_str = guest_mock_codex.to_string_lossy();
-            let guest_reseed_str = guest_reseed.to_string_lossy();
-            let ca_dir_str = ca_dir.to_string_lossy();
-            let debootstrap_dir = paths.debootstrap_dir();
-            tokio::fs::create_dir_all(&debootstrap_dir)
-                .await
-                .map_err(|e| {
-                    RunnerError::Internal(format!("create {}: {e}", debootstrap_dir.display()))
-                })?;
-            let debootstrap_dir_str = debootstrap_dir.to_string_lossy();
-            let disk_mb_str = def.disk_mb.to_string();
-
-            let status = tokio::process::Command::new("bash")
-                .arg(work_dir.path().join("build-rootfs.sh"))
-                .args([
-                    "--output-dir",
-                    &rootfs_dir_str,
-                    "--ca-dir",
-                    &ca_dir_str,
-                    "--debootstrap-dir",
-                    &debootstrap_dir_str,
-                    "--hash",
-                    &rootfs_hash,
-                    "--disk-mb",
-                    &disk_mb_str,
-                    "--guest-agent",
-                    &guest_agent_str,
-                    "--guest-download",
-                    &guest_download_str,
-                    "--guest-init",
-                    &guest_init_str,
-                    "--guest-mock-claude",
-                    &guest_mock_claude_str,
-                    "--guest-mock-codex",
-                    &guest_mock_codex_str,
-                    "--guest-reseed",
-                    &guest_reseed_str,
-                    "--dns-nameserver",
-                    "8.8.8.8",
-                ])
-                .stdin(std::process::Stdio::null())
-                .status()
-                .await
-                .map_err(|e| RunnerError::Internal(format!("spawn build script: {e}")))?;
-
-            if !status.success() {
-                return Err(RunnerError::Internal(format!(
-                    "build-rootfs.sh failed with {status}"
-                )));
-            }
-
-            let rootfs_str = rootfs_paths.rootfs().to_string_lossy().into_owned();
-            let status = tokio::process::Command::new("bash")
-                .arg(work_dir.path().join("verify-rootfs.sh"))
-                .args(["--rootfs", &rootfs_str])
-                .stdin(std::process::Stdio::null())
-                .status()
-                .await
-                .map_err(|e| RunnerError::Internal(format!("spawn verify script: {e}")))?;
-
-            if !status.success() {
-                return Err(RunnerError::Internal(format!(
-                    "verify-rootfs.sh failed with {status}"
-                )));
-            }
-
-            let rootfs_sz = file_sizes(&rootfs_paths.rootfs()).await;
-            tracing::info!(
-                rootfs_logical = %rootfs_sz.0,
-                rootfs_disk = %rootfs_sz.1,
-                "rootfs creation complete"
-            );
-
-            // Upload rootfs to R2 BEFORE CA injection — the cached rootfs should
-            // be generic (build host's CA) so other hosts can download and inject
-            // their own CA.
-            if let Some(cache) = &r2 {
-                let files = vec![rootfs_paths.rootfs()];
-                match cache.upload(&rootfs_hash, &files, force_reupload).await {
-                    Ok(()) => tracing::info!("uploaded rootfs to R2: {rootfs_hash}"),
-                    Err(e) => tracing::warn!("R2 upload failed: {e} — rootfs is on local disk"),
-                }
-            }
-        }
+    let policy = if warm_rootfs_cache {
+        RootfsCachePolicy::StrictWarm
     } else {
-        tracing::info!("[OK] rootfs already present: {}", rootfs_dir.display());
-    }
+        RootfsCachePolicy::BestEffort
+    };
+    ensure_rootfs_under_lock(RootfsBuildInput {
+        paths: &paths,
+        rootfs_hash: &rootfs_hash,
+        rootfs_paths: &rootfs_paths,
+        r2: r2.as_ref(),
+        policy,
+        disk_mb: def.disk_mb,
+        guest_agent: &guest_agent,
+        guest_download: &guest_download,
+        guest_init: &guest_init,
+        guest_mock_claude: &guest_mock_claude,
+        guest_mock_codex: &guest_mock_codex,
+        guest_reseed: &guest_reseed,
+    })
+    .await?;
 
-    // --- Phase 1.5: Replace CA cert (R2-downloaded rootfs only) ---
-    //
-    // Operates on `rootfs.ext4.staging` (not `rootfs.ext4`). On non-zero
-    // exit we leave the staging file in place — the next build's
-    // `clear_rootfs_staging` step above deletes it. We deliberately do
-    // NOT remove `rootfs_dir`: snapshots for other snapshot_hashes (same
-    // rootfs_hash, different vcpu/memory profile) live under
-    // `<rootfs_dir>/snapshots/` and would be collateral damage.
-    if rootfs_from_r2 {
-        let staging = rootfs_paths.rootfs_staging();
-        let staging_str = staging.to_string_lossy().into_owned();
-        let ca_dir_str = ca_dir.to_string_lossy().into_owned();
-        let status = tokio::process::Command::new("bash")
-            .arg(work_dir.path().join("inject-ca.sh"))
-            .args(["--rootfs", &staging_str, "--ca-dir", &ca_dir_str])
-            .stdin(std::process::Stdio::null())
-            .status()
-            .await
-            .map_err(|e| RunnerError::Internal(format!("spawn inject-ca script: {e}")))?;
-
-        if !status.success() {
-            return Err(RunnerError::Internal(format!(
-                "inject-ca.sh failed with {status}"
-            )));
-        }
-        // Commit the rootfs. Same-filesystem rename is POSIX-atomic, so
-        // `rootfs.ext4` only becomes visible once CA injection has fully
-        // succeeded — future `is_rootfs_present` / Fast-path checks can
-        // now trust its presence as "assembly pipeline completed".
-        commit_staging(&rootfs_paths).await?;
-        tracing::info!("CA cert replaced in R2-downloaded rootfs");
+    if warm_rootfs_cache {
+        tracing::info!("rootfs cache warm complete: rootfs={rootfs_hash}");
+        return Ok(());
     }
 
     // --- Phase 2: Build snapshot ---
@@ -505,6 +361,274 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
     );
 
     tracing::info!("image creation complete: rootfs={rootfs_hash}, snapshot={snapshot_hash}");
+    Ok(())
+}
+
+async fn ensure_rootfs_under_lock(input: RootfsBuildInput<'_>) -> RunnerResult<()> {
+    let rootfs_dir = input.rootfs_paths.dir();
+
+    // Clear any `rootfs.ext4.staging` residue from a previous crashed or
+    // failed build. Holding the rootfs flock means the previous writer has
+    // already exited (kernel releases flocks on process death), so any
+    // staging file on disk is guaranteed to be stale — never a concurrent
+    // writer's work-in-progress. This is the recovery arm of the
+    // staging-rename contract; see `RootfsPaths::rootfs_staging`.
+    clear_rootfs_staging(input.rootfs_paths).await;
+
+    // --- Phase 1: Obtain rootfs ---
+    //
+    // R2 caches only rootfs.ext4. Snapshots are always created locally
+    // because they contain host-specific state (page cache, kernel metadata).
+    // Multiple snapshot variants can share one rootfs.
+    let mut force_reupload = false;
+    let mut rootfs_from_r2 = false;
+
+    let need_rootfs = !is_rootfs_present(input.rootfs_paths).await?;
+    let mut work_dir = None;
+
+    if need_rootfs {
+        // Try R2 download (rootfs only). try_download manages its own staging
+        // directory and atomic rename, so rootfs_dir stays absent on failure.
+        if let Some(cache) = input.r2 {
+            match cache.try_download(input.rootfs_hash, rootfs_dir).await {
+                Ok(true) => {
+                    if tokio::fs::try_exists(input.rootfs_paths.rootfs())
+                        .await
+                        .unwrap_or(false)
+                    {
+                        // Remove any non-rootfs files from the download (e.g. stale
+                        // snapshot artifacts from an old archive format).
+                        remove_all_except_rootfs(input.rootfs_paths).await;
+                        tracing::info!("[OK] rootfs downloaded from R2: {}", rootfs_dir.display());
+                        // Demote the downloaded image to staging before CA
+                        // injection runs. The R2-cached rootfs carries the
+                        // build host's CA; Phase 1.5 replaces it. Keeping
+                        // the file at the committed `rootfs.ext4` path
+                        // during injection would let a mid-script crash
+                        // leave a rootfs whose CA file no longer matches
+                        // its system bundle, permanently poisoning the
+                        // Fast-path reuse check.
+                        demote_to_staging(input.rootfs_paths).await?;
+                        rootfs_from_r2 = true;
+                    } else {
+                        tracing::warn!(
+                            "R2 download for {} succeeded but rootfs missing — \
+                             will rebuild locally and force-overwrite the bad object",
+                            input.rootfs_hash
+                        );
+                        force_reupload = true;
+                        if let Err(e) = tokio::fs::remove_dir_all(rootfs_dir).await {
+                            tracing::warn!(
+                                "failed to clean bad R2 download at {}: {e}",
+                                rootfs_dir.display()
+                            );
+                        }
+                    }
+                }
+                Ok(false) => {
+                    tracing::info!("R2 cache miss for {} — building locally", input.rootfs_hash)
+                }
+                Err(e) => {
+                    if input.policy.is_strict() {
+                        return Err(RunnerError::Internal(format!(
+                            "R2 download failed while warming rootfs cache: {e}"
+                        )));
+                    }
+                    tracing::warn!("R2 download failed: {e} — falling back to local build");
+                }
+            }
+        }
+
+        if !rootfs_from_r2 {
+            let work_dir_path = work_dir_for_rootfs(&mut work_dir).await?;
+            build_rootfs_locally(&input, &work_dir_path).await?;
+            upload_rootfs_to_r2(&input, force_reupload).await?;
+        }
+    } else {
+        tracing::info!("[OK] rootfs already present: {}", rootfs_dir.display());
+        if input.policy.is_strict() {
+            upload_rootfs_to_r2(&input, false).await?;
+        }
+    }
+
+    // --- Phase 1.5: Replace CA cert (R2-downloaded rootfs only) ---
+    //
+    // Operates on `rootfs.ext4.staging` (not `rootfs.ext4`). On non-zero
+    // exit we leave the staging file in place — the next build's
+    // `clear_rootfs_staging` step above deletes it. We deliberately do
+    // NOT remove `rootfs_dir`: snapshots for other snapshot_hashes (same
+    // rootfs_hash, different vcpu/memory profile) live under
+    // `<rootfs_dir>/snapshots/` and would be collateral damage.
+    if rootfs_from_r2 {
+        let work_dir_path = work_dir_for_rootfs(&mut work_dir).await?;
+        inject_ca_into_staging(&input, &work_dir_path).await?;
+        // Commit the rootfs. Same-filesystem rename is POSIX-atomic, so
+        // `rootfs.ext4` only becomes visible once CA injection has fully
+        // succeeded — future `is_rootfs_present` / Fast-path checks can
+        // now trust its presence as "assembly pipeline completed".
+        commit_staging(input.rootfs_paths).await?;
+        tracing::info!("CA cert replaced in R2-downloaded rootfs");
+    }
+
+    Ok(())
+}
+
+async fn work_dir_for_rootfs(work_dir: &mut Option<tempfile::TempDir>) -> RunnerResult<PathBuf> {
+    if work_dir.is_none() {
+        let dir = tempfile::tempdir()
+            .map_err(|e| RunnerError::Internal(format!("create temp dir: {e}")))?;
+        tokio::fs::write(dir.path().join("build-rootfs.sh"), BUILD_SCRIPT)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("write build script: {e}")))?;
+        tokio::fs::write(dir.path().join("verify-rootfs.sh"), VERIFY_SCRIPT)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("write verify script: {e}")))?;
+        tokio::fs::write(dir.path().join("inject-ca.sh"), INJECT_CA_SCRIPT)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("write inject-ca script: {e}")))?;
+        *work_dir = Some(dir);
+    }
+    match work_dir.as_ref() {
+        Some(dir) => Ok(dir.path().to_path_buf()),
+        None => Err(RunnerError::Internal(
+            "rootfs work dir was not initialized".into(),
+        )),
+    }
+}
+
+async fn build_rootfs_locally(input: &RootfsBuildInput<'_>, work_dir: &Path) -> RunnerResult<()> {
+    let rootfs_dir = input.rootfs_paths.dir();
+    // Create rootfs_dir for local build (R2 path creates it via rename).
+    tokio::fs::create_dir_all(rootfs_dir)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("create {}: {e}", rootfs_dir.display())))?;
+
+    // Local rootfs build — the slow path (debootstrap + apt install).
+    let rootfs_dir_str = rootfs_dir.to_string_lossy();
+    let guest_agent_str = input.guest_agent.to_string_lossy();
+    let guest_download_str = input.guest_download.to_string_lossy();
+    let guest_init_str = input.guest_init.to_string_lossy();
+    let guest_mock_claude_str = input.guest_mock_claude.to_string_lossy();
+    let guest_mock_codex_str = input.guest_mock_codex.to_string_lossy();
+    let guest_reseed_str = input.guest_reseed.to_string_lossy();
+    let ca_dir = input.paths.ca_dir();
+    let ca_dir_str = ca_dir.to_string_lossy();
+    let debootstrap_dir = input.paths.debootstrap_dir();
+    tokio::fs::create_dir_all(&debootstrap_dir)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("create {}: {e}", debootstrap_dir.display())))?;
+    let debootstrap_dir_str = debootstrap_dir.to_string_lossy();
+    let disk_mb_str = input.disk_mb.to_string();
+
+    let status = tokio::process::Command::new("bash")
+        .arg(work_dir.join("build-rootfs.sh"))
+        .args([
+            "--output-dir",
+            &rootfs_dir_str,
+            "--ca-dir",
+            &ca_dir_str,
+            "--debootstrap-dir",
+            &debootstrap_dir_str,
+            "--hash",
+            input.rootfs_hash,
+            "--disk-mb",
+            &disk_mb_str,
+            "--guest-agent",
+            &guest_agent_str,
+            "--guest-download",
+            &guest_download_str,
+            "--guest-init",
+            &guest_init_str,
+            "--guest-mock-claude",
+            &guest_mock_claude_str,
+            "--guest-mock-codex",
+            &guest_mock_codex_str,
+            "--guest-reseed",
+            &guest_reseed_str,
+            "--dns-nameserver",
+            "8.8.8.8",
+        ])
+        .stdin(std::process::Stdio::null())
+        .status()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("spawn build script: {e}")))?;
+
+    if !status.success() {
+        return Err(RunnerError::Internal(format!(
+            "build-rootfs.sh failed with {status}"
+        )));
+    }
+
+    let rootfs_str = input.rootfs_paths.rootfs().to_string_lossy().into_owned();
+    let status = tokio::process::Command::new("bash")
+        .arg(work_dir.join("verify-rootfs.sh"))
+        .args(["--rootfs", &rootfs_str])
+        .stdin(std::process::Stdio::null())
+        .status()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("spawn verify script: {e}")))?;
+
+    if !status.success() {
+        return Err(RunnerError::Internal(format!(
+            "verify-rootfs.sh failed with {status}"
+        )));
+    }
+
+    let rootfs_sz = file_sizes(&input.rootfs_paths.rootfs()).await;
+    tracing::info!(
+        rootfs_logical = %rootfs_sz.0,
+        rootfs_disk = %rootfs_sz.1,
+        "rootfs creation complete"
+    );
+
+    Ok(())
+}
+
+async fn upload_rootfs_to_r2(input: &RootfsBuildInput<'_>, force: bool) -> RunnerResult<()> {
+    let Some(cache) = input.r2 else {
+        if input.policy.is_strict() {
+            return Err(RunnerError::Internal(
+                "--warm-rootfs-cache requires R2 cache configuration".into(),
+            ));
+        }
+        return Ok(());
+    };
+
+    let files = vec![input.rootfs_paths.rootfs()];
+    match cache.upload(input.rootfs_hash, &files, force).await {
+        Ok(()) => {
+            tracing::info!("uploaded rootfs to R2: {}", input.rootfs_hash);
+            Ok(())
+        }
+        Err(e) if input.policy.is_strict() => Err(RunnerError::Internal(format!(
+            "R2 upload failed while warming rootfs cache: {e}"
+        ))),
+        Err(e) => {
+            tracing::warn!("R2 upload failed: {e} — rootfs is on local disk");
+            Ok(())
+        }
+    }
+}
+
+async fn inject_ca_into_staging(input: &RootfsBuildInput<'_>, work_dir: &Path) -> RunnerResult<()> {
+    let staging = input.rootfs_paths.rootfs_staging();
+    let staging_str = staging.to_string_lossy().into_owned();
+    let ca_dir = input.paths.ca_dir();
+    let ca_dir_str = ca_dir.to_string_lossy().into_owned();
+    let status = tokio::process::Command::new("bash")
+        .arg(work_dir.join("inject-ca.sh"))
+        .args(["--rootfs", &staging_str, "--ca-dir", &ca_dir_str])
+        .stdin(std::process::Stdio::null())
+        .status()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("spawn inject-ca script: {e}")))?;
+
+    if !status.success() {
+        return Err(RunnerError::Internal(format!(
+            "inject-ca.sh failed with {status}"
+        )));
+    }
+
     Ok(())
 }
 
@@ -762,6 +886,112 @@ fn human_bytes(bytes: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(clap::Parser)]
+    struct TestBuildCli {
+        #[command(flatten)]
+        args: BuildArgs,
+    }
+
+    fn build_args() -> [&'static str; 15] {
+        [
+            "runner-build",
+            "--guest-agent",
+            "/tmp/guest-agent",
+            "--guest-download",
+            "/tmp/guest-download",
+            "--guest-init",
+            "/tmp/guest-init",
+            "--guest-mock-claude",
+            "/tmp/guest-mock-claude",
+            "--guest-mock-codex",
+            "/tmp/guest-mock-codex",
+            "--guest-reseed",
+            "/tmp/guest-reseed",
+            "--profile",
+            "vm0/default",
+        ]
+    }
+
+    #[test]
+    fn build_args_parse_warm_rootfs_cache_flag() {
+        let mut args = build_args().to_vec();
+        args.push("--warm-rootfs-cache");
+
+        let cli = <TestBuildCli as clap::Parser>::try_parse_from(args).unwrap();
+
+        assert!(cli.args.warm_rootfs_cache);
+        assert!(!cli.args.dry_run);
+    }
+
+    #[test]
+    fn rootfs_cache_policy_marks_only_warm_as_strict() {
+        assert!(!RootfsCachePolicy::BestEffort.is_strict());
+        assert!(RootfsCachePolicy::StrictWarm.is_strict());
+    }
+
+    #[tokio::test]
+    async fn work_dir_for_rootfs_writes_embedded_scripts_once() {
+        let mut work_dir = None;
+
+        let first = work_dir_for_rootfs(&mut work_dir).await.unwrap();
+        let second = work_dir_for_rootfs(&mut work_dir).await.unwrap();
+
+        assert_eq!(first, second);
+        assert!(first.join("build-rootfs.sh").exists());
+        assert!(first.join("verify-rootfs.sh").exists());
+        assert!(first.join("inject-ca.sh").exists());
+    }
+
+    #[tokio::test]
+    async fn strict_upload_requires_r2_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
+        let rootfs = RootfsPaths::new(&home, "strict-hash");
+        let guest = dir.path().join("guest");
+        let input = RootfsBuildInput {
+            paths: &home,
+            rootfs_hash: "strict-hash",
+            rootfs_paths: &rootfs,
+            r2: None,
+            policy: RootfsCachePolicy::StrictWarm,
+            disk_mb: 16384,
+            guest_agent: &guest,
+            guest_download: &guest,
+            guest_init: &guest,
+            guest_mock_claude: &guest,
+            guest_mock_codex: &guest,
+            guest_reseed: &guest,
+        };
+
+        let err = upload_rootfs_to_r2(&input, false).await.unwrap_err();
+
+        assert!(err.to_string().contains("--warm-rootfs-cache requires R2"));
+    }
+
+    #[tokio::test]
+    async fn best_effort_upload_allows_missing_r2_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
+        let rootfs = RootfsPaths::new(&home, "best-effort-hash");
+        let guest = dir.path().join("guest");
+        let input = RootfsBuildInput {
+            paths: &home,
+            rootfs_hash: "best-effort-hash",
+            rootfs_paths: &rootfs,
+            r2: None,
+            policy: RootfsCachePolicy::BestEffort,
+            disk_mb: 16384,
+            guest_agent: &guest,
+            guest_download: &guest,
+            guest_init: &guest,
+            guest_mock_claude: &guest,
+            guest_mock_codex: &guest,
+            guest_reseed: &guest,
+        };
+
+        upload_rootfs_to_r2(&input, false).await.unwrap();
+    }
 
     #[test]
     fn human_bytes_formatting() {

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -1393,6 +1393,13 @@ mod tests {
             .await
             .unwrap();
 
+        // Create a stale directory that should also be removed
+        let stale_dir = rootfs.dir().join("stale-dir");
+        tokio::fs::create_dir_all(&stale_dir).await.unwrap();
+        tokio::fs::write(stale_dir.join("old.bin"), b"old")
+            .await
+            .unwrap();
+
         remove_all_except_rootfs(&rootfs).await;
 
         assert!(rootfs.rootfs().exists(), "rootfs.ext4 must survive");
@@ -1404,6 +1411,7 @@ mod tests {
             !rootfs.dir().join("stale.txt").exists(),
             "stale file must be removed"
         );
+        assert!(!stale_dir.exists(), "stale directory must be removed");
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -913,6 +913,29 @@ mod tests {
         ]
     }
 
+    fn rootfs_input<'a>(
+        home: &'a HomePaths,
+        rootfs: &'a RootfsPaths,
+        guest: &'a Path,
+        policy: RootfsCachePolicy,
+        r2: Option<&'a R2ImageCache>,
+    ) -> RootfsBuildInput<'a> {
+        RootfsBuildInput {
+            paths: home,
+            rootfs_hash: "test-hash",
+            rootfs_paths: rootfs,
+            r2,
+            policy,
+            disk_mb: 16384,
+            guest_agent: guest,
+            guest_download: guest,
+            guest_init: guest,
+            guest_mock_claude: guest,
+            guest_mock_codex: guest,
+            guest_reseed: guest,
+        }
+    }
+
     #[test]
     fn build_args_parse_warm_rootfs_cache_flag() {
         let mut args = build_args().to_vec();
@@ -949,20 +972,7 @@ mod tests {
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
         let rootfs = RootfsPaths::new(&home, "strict-hash");
         let guest = dir.path().join("guest");
-        let input = RootfsBuildInput {
-            paths: &home,
-            rootfs_hash: "strict-hash",
-            rootfs_paths: &rootfs,
-            r2: None,
-            policy: RootfsCachePolicy::StrictWarm,
-            disk_mb: 16384,
-            guest_agent: &guest,
-            guest_download: &guest,
-            guest_init: &guest,
-            guest_mock_claude: &guest,
-            guest_mock_codex: &guest,
-            guest_reseed: &guest,
-        };
+        let input = rootfs_input(&home, &rootfs, &guest, RootfsCachePolicy::StrictWarm, None);
 
         let err = upload_rootfs_to_r2(&input, false).await.unwrap_err();
 
@@ -975,22 +985,47 @@ mod tests {
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
         let rootfs = RootfsPaths::new(&home, "best-effort-hash");
         let guest = dir.path().join("guest");
-        let input = RootfsBuildInput {
-            paths: &home,
-            rootfs_hash: "best-effort-hash",
-            rootfs_paths: &rootfs,
-            r2: None,
-            policy: RootfsCachePolicy::BestEffort,
-            disk_mb: 16384,
-            guest_agent: &guest,
-            guest_download: &guest,
-            guest_init: &guest,
-            guest_mock_claude: &guest,
-            guest_mock_codex: &guest,
-            guest_reseed: &guest,
-        };
+        let input = rootfs_input(&home, &rootfs, &guest, RootfsCachePolicy::BestEffort, None);
 
         upload_rootfs_to_r2(&input, false).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn strict_warm_existing_rootfs_still_requires_r2_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
+        let rootfs = RootfsPaths::new(&home, "strict-local-hash");
+        tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
+        tokio::fs::write(rootfs.rootfs(), b"local-rootfs")
+            .await
+            .unwrap();
+        let guest = dir.path().join("guest");
+        let input = rootfs_input(&home, &rootfs, &guest, RootfsCachePolicy::StrictWarm, None);
+
+        let err = ensure_rootfs_under_lock(input).await.unwrap_err();
+
+        assert!(err.to_string().contains("--warm-rootfs-cache requires R2"));
+        assert!(
+            rootfs.rootfs().exists(),
+            "strict warm must not remove a valid local rootfs when R2 is missing"
+        );
+    }
+
+    #[tokio::test]
+    async fn best_effort_existing_rootfs_allows_missing_r2_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
+        let rootfs = RootfsPaths::new(&home, "best-effort-local-hash");
+        tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
+        tokio::fs::write(rootfs.rootfs(), b"local-rootfs")
+            .await
+            .unwrap();
+        let guest = dir.path().join("guest");
+        let input = rootfs_input(&home, &rootfs, &guest, RootfsCachePolicy::BestEffort, None);
+
+        ensure_rootfs_under_lock(input).await.unwrap();
+
+        assert!(rootfs.rootfs().exists());
     }
 
     #[test]

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -686,11 +686,11 @@ async fn is_rootfs_present(rootfs: &RootfsPaths) -> RunnerResult<bool> {
 
 /// Delete any `rootfs.ext4.staging` left behind by a previous build.
 ///
-/// Called under the rootfs flock, after the re-check has confirmed there
-/// is no committed `rootfs.ext4` we could reuse. Because holding the
-/// flock implies the previous writer has exited (the kernel releases
-/// flocks on process death), any staging file we see here is guaranteed
-/// to be crash residue — not a live writer's in-progress file.
+/// Called under the rootfs flock before rootfs work continues. Because
+/// holding the flock implies the previous writer has exited (the kernel
+/// releases flocks on process death), any staging file we see here is
+/// guaranteed to be crash residue — not a live writer's in-progress file.
+/// A committed `rootfs.ext4`, if present, is left untouched.
 ///
 /// Non-existence is the common case and not logged. Removal is best
 /// effort: an error here just means the next step (writing new staging)

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -277,33 +277,12 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         tracing::info!("R2 cache disabled (R2_* env vars not set) — skipping download and upload");
     }
 
-    // Acquire the rootfs lock before any rootfs mutation. Full builds keep it
-    // through snapshot creation so GC cannot reap the rootfs while the snapshot
-    // provider is reading it.
-    let _rootfs_lock = lock::acquire(paths.rootfs_lock(&rootfs_hash)).await?;
-    let _snapshot_lock = if warm_rootfs_cache {
-        None
-    } else {
-        Some(lock::acquire(paths.snapshot_lock(&snapshot_hash)).await?)
-    };
-
-    // Re-check after acquiring lock — another process may have completed the build.
-    if !warm_rootfs_cache
-        && is_rootfs_present(&rootfs_paths).await?
-        && provider.is_complete(snapshot_dir).await.unwrap_or(false)
-    {
-        tracing::info!("[OK] image already built: rootfs={rootfs_hash}, snapshot={snapshot_hash}");
-        touch_mtime(rootfs_dir);
-        touch_mtime(snapshot_dir);
-        return Ok(());
-    }
-
     let policy = if warm_rootfs_cache {
         RootfsCachePolicy::StrictWarm
     } else {
         RootfsCachePolicy::BestEffort
     };
-    ensure_rootfs_under_lock(RootfsBuildInput {
+    let input = RootfsBuildInput {
         paths: &paths,
         rootfs_hash: &rootfs_hash,
         rootfs_paths: &rootfs_paths,
@@ -316,13 +295,49 @@ pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> Runn
         guest_mock_claude: &guest_mock_claude,
         guest_mock_codex: &guest_mock_codex,
         guest_reseed: &guest_reseed,
-    })
-    .await?;
+    };
 
     if warm_rootfs_cache {
+        if upload_existing_rootfs_for_warm_if_present(&input, paths.rootfs_lock(&rootfs_hash))
+            .await?
+        {
+            tracing::info!("rootfs cache warm complete: rootfs={rootfs_hash}");
+            return Ok(());
+        }
+
+        let rootfs_lock_path = paths.rootfs_lock(&rootfs_hash);
+        tracing::info!(
+            "acquiring exclusive rootfs lock for warm build: {}",
+            rootfs_lock_path.display()
+        );
+        let _rootfs_lock = lock::acquire(rootfs_lock_path).await?;
+        ensure_rootfs_under_lock(input).await?;
         tracing::info!("rootfs cache warm complete: rootfs={rootfs_hash}");
         return Ok(());
     }
+
+    // Acquire the rootfs lock before any rootfs mutation. Full builds keep it
+    // through snapshot creation so GC cannot reap the rootfs while the snapshot
+    // provider is reading it.
+    let rootfs_lock_path = paths.rootfs_lock(&rootfs_hash);
+    tracing::info!(
+        "acquiring exclusive rootfs lock for image build: {}",
+        rootfs_lock_path.display()
+    );
+    let _rootfs_lock = lock::acquire(rootfs_lock_path).await?;
+    let _snapshot_lock = lock::acquire(paths.snapshot_lock(&snapshot_hash)).await?;
+
+    // Re-check after acquiring lock — another process may have completed the build.
+    if is_rootfs_present(&rootfs_paths).await?
+        && provider.is_complete(snapshot_dir).await.unwrap_or(false)
+    {
+        tracing::info!("[OK] image already built: rootfs={rootfs_hash}, snapshot={snapshot_hash}");
+        touch_mtime(rootfs_dir);
+        touch_mtime(snapshot_dir);
+        return Ok(());
+    }
+
+    ensure_rootfs_under_lock(input).await?;
 
     // --- Phase 2: Build snapshot ---
     //
@@ -479,6 +494,28 @@ async fn ensure_rootfs_under_lock(input: RootfsBuildInput<'_>) -> RunnerResult<(
     }
 
     Ok(())
+}
+
+async fn upload_existing_rootfs_for_warm_if_present(
+    input: &RootfsBuildInput<'_>,
+    rootfs_lock_path: PathBuf,
+) -> RunnerResult<bool> {
+    if !is_rootfs_present(input.rootfs_paths).await? {
+        return Ok(false);
+    }
+
+    tracing::info!(
+        "rootfs already present; acquiring shared rootfs lock for warm upload: {}",
+        rootfs_lock_path.display()
+    );
+    let _rootfs_lock = lock::acquire_shared(rootfs_lock_path).await?;
+    if !is_rootfs_present(input.rootfs_paths).await? {
+        tracing::info!("rootfs disappeared while waiting for shared lock; rebuilding for warm");
+        return Ok(false);
+    }
+
+    upload_rootfs_to_r2(input, false).await?;
+    Ok(true)
 }
 
 async fn work_dir_for_rootfs(work_dir: &mut Option<tempfile::TempDir>) -> RunnerResult<PathBuf> {
@@ -1017,6 +1054,33 @@ mod tests {
             rootfs.rootfs().exists(),
             "strict warm must not remove a valid local rootfs when R2 is missing"
         );
+    }
+
+    #[tokio::test]
+    async fn warm_existing_rootfs_upload_does_not_block_on_shared_rootfs_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
+        let rootfs = RootfsPaths::new(&home, "warm-shared-lock-hash");
+        tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
+        tokio::fs::write(rootfs.rootfs(), b"local-rootfs")
+            .await
+            .unwrap();
+        let guest = dir.path().join("guest");
+        let input = rootfs_input(&home, &rootfs, &guest, RootfsCachePolicy::StrictWarm, None);
+        let rootfs_lock_path = home.rootfs_lock("warm-shared-lock-hash");
+        let _existing_reader = lock::acquire_shared(rootfs_lock_path.clone())
+            .await
+            .unwrap();
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            upload_existing_rootfs_for_warm_if_present(&input, rootfs_lock_path),
+        )
+        .await
+        .expect("warm upload should share the rootfs lock with active runners");
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("--warm-rootfs-cache requires R2"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -89,11 +89,11 @@
 //! dedup-skips → the bad object stays, forever.
 //!
 //! `cmd::build::run_build` defends by passing `force = true` to `upload`
-//! whenever it observes "download Ok(true) but rootfs missing". That
-//! bypasses the dedup check and atomically overwrites the bad object in
-//! a single PUT — robust against `s3:DeleteObject` permission being
-//! revoked or transiently failing (which a `delete + retry-upload`
-//! sequence would not be).
+//! whenever it observes "download Ok(true) but rootfs missing" or a
+//! successfully-fetched object that cannot be unpacked. That bypasses the
+//! dedup check and atomically overwrites the bad object in a single PUT —
+//! robust against `s3:DeleteObject` permission being revoked or transiently
+//! failing (which a `delete + retry-upload` sequence would not be).
 //!
 //! ## Tar entry security
 //!
@@ -117,10 +117,10 @@
 //!    regular file.)
 //!
 //! **Maintenance note**: the caller (`cmd::build::run_build`) checks
-//! rootfs presence after download and sets `force_reupload = true` if it
-//! is missing. If you add a new file to the R2 archive, you MUST extend
-//! that check accordingly — otherwise an attacker-controlled tar that
-//! omits the new file would go undetected.
+//! rootfs presence after a structurally-valid download and sets
+//! `force_reupload = true` if it is missing. If you add a new file to the
+//! R2 archive, you MUST extend that check accordingly — otherwise an
+//! attacker-controlled tar that omits the new file would go undetected.
 
 use std::path::{Path, PathBuf};
 
@@ -158,6 +158,22 @@ pub enum R2Error {
     S3(String),
     #[error("io: {0}")]
     Io(#[from] std::io::Error),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum R2DownloadError {
+    #[error("request failed: {0}")]
+    Request(#[source] R2Error),
+    #[error("invalid cache object: {0}")]
+    InvalidObject(#[source] R2Error),
+    #[error("local filesystem failed: {0}")]
+    Local(#[source] R2Error),
+}
+
+impl R2DownloadError {
+    pub fn is_invalid_object(&self) -> bool {
+        matches!(self, Self::InvalidObject(_))
+    }
 }
 
 impl<E, R> From<SdkError<E, R>> for R2Error
@@ -263,7 +279,11 @@ impl R2ImageCache {
     ///
     /// Network hangs are bounded by the AWS SDK's own per-operation timeouts;
     /// outer call sites (CI/systemd) bound total wall time.
-    pub async fn try_download(&self, hash: &str, final_dir: &Path) -> Result<bool, R2Error> {
+    pub async fn try_download(
+        &self,
+        hash: &str,
+        final_dir: &Path,
+    ) -> Result<bool, R2DownloadError> {
         let key = key_for_hash(hash);
         let resp = match self
             .client
@@ -282,7 +302,11 @@ impl R2ImageCache {
             {
                 return Ok(false);
             }
-            Err(e) => return Err(R2Error::S3(format!("get_object: {e:?}"))),
+            Err(e) => {
+                return Err(R2DownloadError::Request(R2Error::S3(format!(
+                    "get_object: {e:?}"
+                ))));
+            }
         };
 
         // Atomic via staging dir + rename. Cleanup-on-error covers the entire
@@ -291,17 +315,23 @@ impl R2ImageCache {
         // followed by a local build could fill the disk before GC catches up.
         let staging = staging_dir(final_dir);
         let body_reader = resp.body.into_async_read();
-        let outcome = async {
+
+        let _ = tokio::fs::remove_dir_all(&staging).await;
+        if let Err(e) = tokio::fs::create_dir_all(&staging).await {
             let _ = tokio::fs::remove_dir_all(&staging).await;
-            tokio::fs::create_dir_all(&staging).await?;
-            unpack_into_staging(body_reader, &staging).await?;
-            finalize_staging(&staging, final_dir).await
+            return Err(R2DownloadError::Local(R2Error::Io(e)));
         }
-        .await;
-        if outcome.is_err() {
+
+        if let Err(e) = unpack_into_staging(body_reader, &staging).await {
             let _ = tokio::fs::remove_dir_all(&staging).await;
+            return Err(R2DownloadError::InvalidObject(e));
         }
-        outcome?;
+
+        if let Err(e) = finalize_staging(&staging, final_dir).await {
+            let _ = tokio::fs::remove_dir_all(&staging).await;
+            return Err(R2DownloadError::Local(e));
+        }
+
         Ok(true)
     }
 
@@ -1791,11 +1821,54 @@ mod tests {
         let final_dir = dst.path().join("hash");
         let result = cache.try_download("hash", &final_dir).await;
 
-        assert!(result.is_err(), "bad body → Err");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, R2DownloadError::InvalidObject(_)),
+            "bad body must be classified as invalid cache object, got {err:?}"
+        );
         assert!(!final_dir.exists(), "final_dir MUST remain absent");
         assert!(
             !staging_dir(&final_dir).exists(),
             "staging MUST be wiped — this is the disk-leak guard"
+        );
+    }
+
+    /// Local filesystem failures after a valid download must not be
+    /// classified as invalid R2 objects. The caller should not force-overwrite
+    /// a healthy cache key when the local target path is the problem.
+    #[tokio::test]
+    async fn try_download_classifies_finalize_failure_as_local() {
+        use std::sync::Arc;
+
+        use aws_sdk_s3::Client;
+        use aws_sdk_s3::operation::get_object::GetObjectOutput;
+        use aws_sdk_s3::primitives::ByteStream;
+
+        let archive = Arc::new(build_test_archive_bytes().await);
+        let archive_for_closure = Arc::clone(&archive);
+        let get = mock!(Client::get_object).then_output(move || {
+            GetObjectOutput::builder()
+                .body(ByteStream::from((*archive_for_closure).clone()))
+                .build()
+        });
+        let cache = mock_cache("test-bucket", &[&get]);
+
+        let dst = tempfile::tempdir().unwrap();
+        let final_dir = dst.path().join("hash");
+        tokio::fs::write(&final_dir, b"not a directory")
+            .await
+            .unwrap();
+
+        let err = cache.try_download("hash", &final_dir).await.unwrap_err();
+
+        assert!(
+            matches!(err, R2DownloadError::Local(_)),
+            "target path failure must be local, got {err:?}"
+        );
+        assert!(final_dir.is_file(), "local target file should remain");
+        assert!(
+            !staging_dir(&final_dir).exists(),
+            "staging MUST be wiped after finalize failure"
         );
     }
 


### PR DESCRIPTION
## Summary
- add a strict `runner build --warm-rootfs-cache` mode that prepares only the shared R2 rootfs cache
- keep normal `runner build` snapshot behavior and best-effort R2 fallback semantics unchanged
- warm the rootfs cache once before PR CI and production build fan-out
- keep rollback on the older best-effort `runner build` path so rollback can target binaries that predate `--warm-rootfs-cache`

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::build`
- `cargo check --manifest-path crates/Cargo.toml -p runner --bin runner`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --bin runner --all-targets --all-features -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `ansible-playbook --syntax-check ansible/playbooks/build-runner.yml`
- `ansible-playbook --syntax-check ansible/playbooks/rollback-runner.yml`

Closes #11500