### PR TITLE
docs(runner): document resource budget accessors

### DIFF
--- a/crates/runner/src/resource_budget.rs
+++ b/crates/runner/src/resource_budget.rs
@@ -57,10 +57,12 @@ impl BudgetLease {
         }
     }
 
+    /// Returns the vCPU reservation held by this lease.
     pub fn vcpu(&self) -> u32 {
         self.vcpu
     }
 
+    /// Returns the memory reservation, in MiB, held by this lease.
     pub fn memory_mb(&self) -> u32 {
         self.memory_mb
     }
@@ -174,14 +176,17 @@ impl ResourceBudget {
         vcpu_ok && mem_ok && count_ok
     }
 
+    /// Returns the vCPU admission budget after applying the concurrency factor.
     pub fn effective_vcpu(&self) -> u32 {
         self.effective_vcpu
     }
 
+    /// Returns the memory admission budget, in MiB, after applying the concurrency factor.
     pub fn effective_memory_mb(&self) -> u32 {
         self.effective_memory_mb
     }
 
+    /// Returns the configured concurrent job cap; `0` means no job-count cap.
     pub fn max_concurrent(&self) -> usize {
         self.max_concurrent
     }


### PR DESCRIPTION
## Summary
- add doc comments for BudgetLease vCPU/memory accessors
- add doc comments for ResourceBudget effective budget and max concurrency accessors

## Testing
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p runner resource_budget
- lefthook pre-commit: cargo-fmt, cargo-clippy

Closes #11322