### PR TITLE
feat: add split chat thread sidebar

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -1,103 +1,72 @@
 import { command } from "ccstate";
-import { matchShortcut, isEditableTarget } from "@vm0/ui";
 import { chatThreads$, currentChatThreadId$ } from "../agent-chat.ts";
-import { navigateToChat$ } from "../zero-page/zero-nav.ts";
+import {
+  chatSidebarThreadId$,
+  navigateMainChatPreservingSidebar$,
+  openChatSidebar$,
+} from "./chat-sidebar.ts";
 import { detachedNavigateTo$ } from "../route.ts";
-import { onDomEventFn } from "../utils.ts";
 import type { ChatThreadSignals } from "./create-chat-thread.ts";
-import { setChatShortcutHelpOpen$ } from "./chat-shortcut-help.ts";
 
-const navigateToAdjacentThread$ = command(
+export const navigateToAdjacentThread$ = command(
   async (
     { get, set },
-    direction: "prev" | "next",
+    args: {
+      currentThreadId: string;
+      direction: "prev" | "next";
+    },
     signal: AbortSignal,
   ): Promise<void> => {
-    const currentId = get(currentChatThreadId$);
-    if (!currentId) {
+    const mainThreadId = get(currentChatThreadId$);
+    const sidebarThreadId = get(chatSidebarThreadId$);
+    const inMainPane = args.currentThreadId === mainThreadId;
+    const inSidebarPane = args.currentThreadId === sidebarThreadId;
+    if (!inMainPane && !inSidebarPane) {
       return;
     }
+
     const threads = await get(chatThreads$);
     signal.throwIfAborted();
-    const idx = threads.findIndex((t) => {
-      return t.id === currentId;
+    const excludedThreadId = inMainPane ? sidebarThreadId : mainThreadId;
+    const availableThreads = threads.filter((thread) => {
+      return thread.id !== excludedThreadId;
+    });
+    const idx = availableThreads.findIndex((t) => {
+      return t.id === args.currentThreadId;
     });
     if (idx === -1) {
       return;
     }
-    if (direction === "prev" && idx === 0) {
+    if (args.direction === "prev" && idx === 0) {
       // Escape upwards from the first thread to the agent chat page.
-      const agentId = threads[0]!.agent.id;
+      if (inSidebarPane) {
+        return;
+      }
+      const agentId = availableThreads[0]!.agent.id;
       set(detachedNavigateTo$, "/agents/:agentId/chat", {
         pathParams: { agentId },
       });
       return;
     }
-    const targetIdx = direction === "prev" ? idx - 1 : idx + 1;
-    if (targetIdx < 0 || targetIdx >= threads.length) {
+    const targetIdx = args.direction === "prev" ? idx - 1 : idx + 1;
+    if (targetIdx < 0 || targetIdx >= availableThreads.length) {
       return;
     }
-    set(navigateToChat$, threads[targetIdx]!.id);
+    const targetThreadId = availableThreads[targetIdx]!.id;
+    if (inMainPane) {
+      set(navigateMainChatPreservingSidebar$, targetThreadId);
+    } else {
+      set(openChatSidebar$, targetThreadId);
+    }
   },
 );
 
-const scrollCurrentThread$ = command(
+export const scrollCurrentThread$ = command(
   ({ set }, thread: ChatThreadSignals, position: "top" | "bottom") => {
     if (position === "top") {
       set(thread.scrollToTop$);
     } else {
       set(thread.scrollToBottom$);
     }
-  },
-);
-
-// Keyboard shortcuts for the chat thread page.
-//
-// These run even while focus is in the composer textarea, so we attach the
-// listener directly to `document` instead of going through setupGlobalShortcut
-// (which filters out editable targets). Shortcuts whose key would collide
-// with plain typing (e.g. shift+/ → "?") explicitly skip editable targets.
-//
-// - mod+up / mod+down        → scroll messages to top / bottom
-// - mod+shift+up / shift+down → jump to previous / next thread in the list
-//   (mod+shift+up on the first thread escapes to /agents/:agentId/chat;
-//    mod+shift+down on the last thread is a no-op)
-// - shift+/                   → open keyboard shortcut help (non-editable only)
-export const setupChatPageKeyboard$ = command(
-  ({ set }, thread: ChatThreadSignals, signal: AbortSignal) => {
-    document.addEventListener(
-      "keydown",
-      onDomEventFn(async (e: KeyboardEvent) => {
-        if (e.defaultPrevented) {
-          return;
-        }
-        if (matchShortcut("mod+arrowup", e)) {
-          e.preventDefault();
-          set(scrollCurrentThread$, thread, "top");
-          return;
-        }
-        if (matchShortcut("mod+arrowdown", e)) {
-          e.preventDefault();
-          set(scrollCurrentThread$, thread, "bottom");
-          return;
-        }
-        if (matchShortcut("mod+shift+arrowup", e)) {
-          e.preventDefault();
-          await set(navigateToAdjacentThread$, "prev", signal);
-          return;
-        }
-        if (matchShortcut("mod+shift+arrowdown", e)) {
-          e.preventDefault();
-          await set(navigateToAdjacentThread$, "next", signal);
-          return;
-        }
-        if (matchShortcut("shift+/", e) && !isEditableTarget(e.target)) {
-          e.preventDefault();
-          set(setChatShortcutHelpOpen$, true);
-          return;
-        }
-      }),
-      { signal },
-    );
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -14,7 +14,6 @@ import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import { createChatThreadSignals, ensureDraft$ } from "./create-chat-thread.ts";
 import { createRestoredAttachment } from "../zero-page/chat-draft.ts";
-import { setupChatPageKeyboard$ } from "./chat-keyboard.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import {
   clearMatchingOptimisticChatThread$,
@@ -42,7 +41,6 @@ export const setupChatPage$ = command(
 
     const { draft, isNew } = set(ensureDraft$, threadId);
     const thread = createChatThreadSignals(threadId, draft);
-    set(setupChatPageKeyboard$, thread, signal);
 
     const optimisticThread = get(optimisticChatThread$);
     const matchingOptimisticThread =

--- a/turbo/apps/platform/src/signals/chat-page/chat-sidebar.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-sidebar.ts
@@ -1,0 +1,75 @@
+import { command, computed } from "ccstate";
+import { currentChatThreadId$ } from "../agent-chat.ts";
+import {
+  detachedNavigateTo$,
+  searchParams$,
+  updateSearchParams$,
+} from "../route.ts";
+import {
+  createChatThreadSignals,
+  type ChatThreadSignals,
+} from "./create-chat-thread.ts";
+import { createDraftSignals } from "../zero-page/chat-draft.ts";
+
+const SIDEBAR_PARAM = "sidebar";
+
+export const chatSidebarThreadId$ = computed((get): string | null => {
+  const currentThreadId = get(currentChatThreadId$);
+  if (!currentThreadId) {
+    return null;
+  }
+
+  const sidebarThreadId = get(searchParams$).get(SIDEBAR_PARAM);
+  if (!sidebarThreadId || sidebarThreadId === currentThreadId) {
+    return null;
+  }
+
+  return sidebarThreadId;
+});
+
+export const chatSidebarThread$ = computed((get): ChatThreadSignals | null => {
+  const sidebarThreadId = get(chatSidebarThreadId$);
+  if (!sidebarThreadId) {
+    return null;
+  }
+
+  return createChatThreadSignals(sidebarThreadId, createDraftSignals());
+});
+
+export const openChatSidebar$ = command(({ get, set }, threadId: string) => {
+  const currentThreadId = get(currentChatThreadId$);
+  const currentSidebarThreadId = get(chatSidebarThreadId$);
+  if (!currentThreadId) {
+    return;
+  }
+  if (threadId === currentThreadId) {
+    return;
+  }
+  if (threadId === currentSidebarThreadId) {
+    set(closeChatSidebar$);
+    return;
+  }
+
+  const next = new URLSearchParams(get(searchParams$));
+  next.set(SIDEBAR_PARAM, threadId);
+  set(updateSearchParams$, next);
+});
+
+const closeChatSidebar$ = command(({ get, set }) => {
+  const next = new URLSearchParams(get(searchParams$));
+  next.delete(SIDEBAR_PARAM);
+  set(updateSearchParams$, next);
+});
+
+export const navigateMainChatPreservingSidebar$ = command(
+  ({ get, set }, threadId: string) => {
+    const next = new URLSearchParams(get(searchParams$));
+    if (next.get(SIDEBAR_PARAM) === threadId) {
+      next.delete(SIDEBAR_PARAM);
+    }
+    set(detachedNavigateTo$, "/chats/:threadId", {
+      pathParams: { threadId },
+      searchParams: next,
+    });
+  },
+);

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -135,6 +135,7 @@ function formatDonePhrase(lastMsg: PagedChatMessage | undefined): string {
 // ---------------------------------------------------------------------------
 
 export interface ChatThreadSignals {
+  threadId: string;
   // ── Data signals ──────────────────────────────────────────────────────────
   threadData$: Computed<Promise<ChatThread | null>>;
   // ── Composer model override ──────────────────────────────────────────────
@@ -179,6 +180,7 @@ export interface ChatThreadSignals {
   // ── Focus ─────────────────────────────────────────────────────────────────
   setInputRef$: Command<(() => void) | undefined, [HTMLElement | null]>;
   focusInput$: Command<void, []>;
+  setRuntimeRef$: Command<(() => void) | undefined, [HTMLElement | null]>;
   // ── Draft sync ────────────────────────────────────────────────────────────
   scheduleDraftSync$: Command<Promise<void>, [AbortSignal]>;
   // ── Paged messages (sole rendering path) ─────────────────────────────────
@@ -991,6 +993,68 @@ function createInputRef() {
   return { setInputRef$, focusInput$ };
 }
 
+function createRuntimeRef({
+  threadData$,
+  groupedChatMessages$,
+  hideSkeleton$,
+  scrollToBottom$,
+  runPhraseLoop$,
+  loadPagedMessages$,
+}: {
+  threadData$: Computed<Promise<ChatThread | null>>;
+  groupedChatMessages$: Computed<Promise<GroupedChatMessageGroup[]>>;
+  hideSkeleton$: Command<void, []>;
+  scrollToBottom$: Command<void, []>;
+  runPhraseLoop$: Command<Promise<void>, [AbortSignal]>;
+  loadPagedMessages$: Command<Promise<void>, [AbortSignal]>;
+}) {
+  return onRef(
+    command(async ({ get, set }, _el: HTMLElement, signal: AbortSignal) => {
+      const threadData = await get(threadData$);
+      signal.throwIfAborted();
+      if (!threadData) {
+        set(hideSkeleton$);
+        return;
+      }
+
+      await get(groupedChatMessages$);
+      signal.throwIfAborted();
+
+      animationFrame(
+        () => {
+          set(scrollToBottom$);
+          set(hideSkeleton$);
+        },
+        { signal },
+      );
+
+      await Promise.all([
+        set(runPhraseLoop$, signal),
+        set(loadPagedMessages$, signal),
+      ]);
+    }),
+  );
+}
+
+function createLatestRunStatus(
+  threadData$: Computed<Promise<ChatThread | null>>,
+) {
+  return computed(async (get): Promise<string | null> => {
+    const thread = await get(threadData$);
+    return thread?.activeRuns[0]?.status ?? null;
+  });
+}
+
+function createLoadHistoryWithPrependScroll(
+  recordScrollHeightForPrepend$: Command<void, []>,
+  loadPagedHistory$: Command<Promise<void>, [AbortSignal]>,
+) {
+  return command(async ({ set }, signal: AbortSignal): Promise<void> => {
+    set(recordScrollHeightForPrepend$);
+    await set(loadPagedHistory$, signal);
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Factory: createRunTracking
 // ---------------------------------------------------------------------------
@@ -1400,13 +1464,9 @@ export function createChatThreadSignals(
     insertOptimisticMessage$,
   } = createPagedMessages(threadId, threadData$, options);
 
-  // Anchor the scroll viewport to current content before the prepend so the
-  // ResizeObserver compensation keeps the user reading the same spot.
-  const loadHistory$: Command<Promise<void>, [AbortSignal]> = command(
-    async ({ set }, signal: AbortSignal): Promise<void> => {
-      set(recordScrollHeightForPrepend$);
-      await set(loadPagedHistory$, signal);
-    },
+  const loadHistory$ = createLoadHistoryWithPrependScroll(
+    recordScrollHeightForPrepend$,
+    loadPagedHistory$,
   );
 
   const { scheduleDraftSync$, cancelDraftSync$, flushDraftClear$ } =
@@ -1443,16 +1503,18 @@ export function createChatThreadSignals(
     setArtifactPreviewKey$,
   } = createArtifacts(threadId, groupedChatMessages$);
 
-  // Status of the currently-active run, sourced from threadData$.activeRuns.
-  // `chatThreadRunUpdated` Ably events trigger reloadThread$, so this signal
-  // flips from "queued" → "running" as soon as the run is dispatched. Null
-  // once the run enters a terminal state and drops out of activeRuns.
-  const latestRunStatus$ = computed(async (get): Promise<string | null> => {
-    const thread = await get(threadData$);
-    return thread?.activeRuns[0]?.status ?? null;
+  const latestRunStatus$ = createLatestRunStatus(threadData$);
+  const setRuntimeRef$ = createRuntimeRef({
+    threadData$,
+    groupedChatMessages$,
+    hideSkeleton$,
+    scrollToBottom$,
+    runPhraseLoop$,
+    loadPagedMessages$,
   });
 
   return {
+    threadId,
     threadData$,
     modelSelection$,
     setModelSelection$,
@@ -1477,6 +1539,7 @@ export function createChatThreadSignals(
     copyMessage$,
     setInputRef$,
     focusInput$,
+    setRuntimeRef$,
     scheduleDraftSync$,
     earliestChatMessageId$,
     latestChatMessageId$,

--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-keyboard.ts
@@ -18,7 +18,7 @@ const navigateToFirstThread$ = command(
 // Keyboard shortcuts for the agent chat landing page (/agents/:agentId/chat).
 //
 // Listener is attached to `document` so it fires even while focus is inside
-// the composer textarea, mirroring setupChatPageKeyboard$ on the thread page.
+// the landing-page composer textarea.
 //
 // - mod+shift+down → jump into the first thread in the list (no-op when empty)
 export const setupAgentChatPageKeyboard$ = command(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -17,6 +16,25 @@ const context = testContext();
 const mockApi = createMockApi(context);
 
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+function mainChatPane(): HTMLElement {
+  const element = document.querySelector<HTMLElement>(
+    "[data-chat-thread-container-id]",
+  );
+  expect(element).not.toBeNull();
+  return element!;
+}
+
+function fireMainShortcut(
+  key: "ArrowUp" | "ArrowDown",
+  options?: { shiftKey?: boolean },
+): void {
+  fireEvent.keyDown(mainChatPane(), {
+    key,
+    ctrlKey: true,
+    shiftKey: options?.shiftKey ?? false,
+  });
+}
 
 function mockEmptyMessages(threadId: string) {
   server.use(
@@ -63,7 +81,6 @@ function mockThreadList(threads: { id: string; title: string }[]) {
 
 describe("chat page keyboard shortcuts", () => {
   it("mod+shift+down navigates to the next thread", async () => {
-    const user = userEvent.setup();
     mockThreadList([
       { id: "thread-1", title: "First" },
       { id: "thread-2", title: "Second" },
@@ -81,7 +98,7 @@ describe("chat page keyboard shortcuts", () => {
       ).toBeInTheDocument();
     });
 
-    await user.keyboard("{Control>}{Shift>}{ArrowDown}{/Shift}{/Control}");
+    fireMainShortcut("ArrowDown", { shiftKey: true });
 
     await waitFor(() => {
       expect(pathname()).toBe("/chats/thread-2");
@@ -89,7 +106,6 @@ describe("chat page keyboard shortcuts", () => {
   });
 
   it("mod+shift+up navigates to the previous thread", async () => {
-    const user = userEvent.setup();
     mockThreadList([
       { id: "thread-1", title: "First" },
       { id: "thread-2", title: "Second" },
@@ -107,7 +123,7 @@ describe("chat page keyboard shortcuts", () => {
       ).toBeInTheDocument();
     });
 
-    await user.keyboard("{Control>}{Shift>}{ArrowUp}{/Shift}{/Control}");
+    fireMainShortcut("ArrowUp", { shiftKey: true });
 
     await waitFor(() => {
       expect(pathname()).toBe("/chats/thread-1");
@@ -115,7 +131,6 @@ describe("chat page keyboard shortcuts", () => {
   });
 
   it("mod+shift+up on the first thread escapes to the agent chat page", async () => {
-    const user = userEvent.setup();
     mockThreadList([
       { id: "thread-1", title: "First" },
       { id: "thread-2", title: "Second" },
@@ -131,7 +146,7 @@ describe("chat page keyboard shortcuts", () => {
       ).toBeInTheDocument();
     });
 
-    await user.keyboard("{Control>}{Shift>}{ArrowUp}{/Shift}{/Control}");
+    fireMainShortcut("ArrowUp", { shiftKey: true });
 
     await waitFor(() => {
       expect(pathname()).toBe(`/agents/${AGENT_ID}/chat`);
@@ -139,7 +154,6 @@ describe("chat page keyboard shortcuts", () => {
   });
 
   it("mod+shift+up on the first thread uses the list item's agent.id", async () => {
-    const user = userEvent.setup();
     // The escape navigation must use agent.id, not agentId.
     const AGENT_ID_FROM_OBJECT = "a2222222-0000-4000-a000-000000000002";
     // Include the thread's agent in the team so the chat page setup does not
@@ -208,7 +222,7 @@ describe("chat page keyboard shortcuts", () => {
       ).toBeInTheDocument();
     });
 
-    await user.keyboard("{Control>}{Shift>}{ArrowUp}{/Shift}{/Control}");
+    fireMainShortcut("ArrowUp", { shiftKey: true });
 
     await waitFor(() => {
       expect(pathname()).toBe(`/agents/${AGENT_ID_FROM_OBJECT}/chat`);
@@ -216,7 +230,6 @@ describe("chat page keyboard shortcuts", () => {
   });
 
   it("mod+shift+down is a no-op on the last thread", async () => {
-    const user = userEvent.setup();
     mockThreadList([
       { id: "thread-1", title: "First" },
       { id: "thread-2", title: "Second" },
@@ -236,8 +249,8 @@ describe("chat page keyboard shortcuts", () => {
     // mod+shift+up which is expected to navigate to thread-1. If the first
     // shortcut had incorrectly navigated, the second navigation would end up
     // somewhere other than thread-1.
-    await user.keyboard("{Control>}{Shift>}{ArrowDown}{/Shift}{/Control}");
-    await user.keyboard("{Control>}{Shift>}{ArrowUp}{/Shift}{/Control}");
+    fireMainShortcut("ArrowDown", { shiftKey: true });
+    fireMainShortcut("ArrowUp", { shiftKey: true });
 
     await waitFor(() => {
       expect(pathname()).toBe("/chats/thread-1");
@@ -245,7 +258,6 @@ describe("chat page keyboard shortcuts", () => {
   });
 
   it("mod+down scrolls the message list to the bottom", async () => {
-    const user = userEvent.setup();
     mockThreadList([{ id: "thread-scroll", title: "Scroll test" }]);
     server.use(
       mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {
@@ -299,7 +311,7 @@ describe("chat page keyboard shortcuts", () => {
       configurable: true,
     });
     scrollContainer!.scrollTop = 0;
-    await user.keyboard("{Control>}{ArrowDown}{/Control}");
+    fireMainShortcut("ArrowDown");
 
     await waitFor(() => {
       expect(scrollContainer!.scrollTop).toBe(1200);
@@ -307,7 +319,6 @@ describe("chat page keyboard shortcuts", () => {
   });
 
   it("mod+up scrolls the message list to the top", async () => {
-    const user = userEvent.setup();
     mockThreadList([{ id: "thread-scroll-top", title: "Scroll top test" }]);
     server.use(
       mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {
@@ -353,7 +364,7 @@ describe("chat page keyboard shortcuts", () => {
     expect(scrollContainer).not.toBeNull();
 
     scrollContainer!.scrollTop = 500;
-    await user.keyboard("{Control>}{ArrowUp}{/Control}");
+    fireMainShortcut("ArrowUp");
 
     await waitFor(() => {
       expect(scrollContainer!.scrollTop).toBe(0);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-sidebar.test.tsx
@@ -1,0 +1,421 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { pathname, search } from "../../../signals/location.ts";
+import { createMockApi } from "../../../mocks/msw-contract.ts";
+import {
+  chatThreadByIdContract,
+  chatThreadMarkReadContract,
+  chatThreadMessagesContract,
+  chatThreadsContract,
+} from "@vm0/api-contracts/contracts/chat-threads";
+
+const context = testContext();
+const mockApi = createMockApi(context);
+
+const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+const threadTitles = {
+  "thread-main": "Main conversation",
+  "thread-sidebar": "Sidebar conversation",
+  "thread-third": "Third conversation",
+  "thread-fourth": "Fourth conversation",
+} as const;
+
+const threadMessages = {
+  "thread-main": "Primary thread answer",
+  "thread-sidebar": "Sidebar thread answer",
+  "thread-third": "Third thread answer",
+  "thread-fourth": "Fourth thread answer",
+} as const;
+
+type ThreadId = keyof typeof threadTitles;
+
+function isThreadId(value: string): value is ThreadId {
+  return value in threadTitles;
+}
+
+function mockChatSidebarApis(): void {
+  server.use(
+    mockApi(chatThreadsContract.list, ({ respond }) => {
+      return respond(200, {
+        threads: Object.entries(threadTitles).map(([id, title]) => {
+          return {
+            id,
+            title,
+            agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
+            createdAt: "2026-03-10T00:00:00Z",
+            updatedAt: "2026-03-10T00:00:00Z",
+            isRead: false,
+            isArchived: false,
+            running: false,
+          };
+        }),
+      });
+    }),
+    mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
+      const id = String(params.id);
+      if (!isThreadId(id)) {
+        return respond(404, {
+          error: { message: "Not found", code: "NOT_FOUND" },
+        });
+      }
+      return respond(200, {
+        id,
+        title: threadTitles[id],
+        agentId: DEFAULT_AGENT_ID,
+        chatMessages: [],
+        latestSessionId: null,
+        lastReadMessageId: null,
+        activeRunIds: [],
+        activeRuns: [],
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+        draftContent: null,
+        draftAttachments: null,
+      });
+    }),
+    mockApi(chatThreadMessagesContract.list, ({ params, query, respond }) => {
+      const id = String(params.threadId);
+      if (!isThreadId(id)) {
+        return respond(404, {
+          error: { message: "Not found", code: "NOT_FOUND" },
+        });
+      }
+      if (query.sinceId) {
+        return respond(200, { messages: [], hasHistoryBefore: false });
+      }
+      return respond(200, {
+        messages: [
+          {
+            id: `${id}-message`,
+            role: "assistant",
+            content: threadMessages[id],
+            createdAt: "2026-03-10T00:00:00Z",
+          },
+        ],
+        hasHistoryBefore: false,
+      });
+    }),
+    mockApi(chatThreadMarkReadContract.markRead, ({ respond }) => {
+      return respond(200, { lastReadMessageId: null, changed: false });
+    }),
+  );
+}
+
+function chatThreadLink(title: string): HTMLAnchorElement {
+  const threadId = Object.entries(threadTitles).find(([, value]) => {
+    return value === title;
+  })?.[0];
+  expect(threadId).toBeDefined();
+  const link = document.querySelector<HTMLAnchorElement>(
+    `a[data-chat-thread-id="${threadId}"]`,
+  );
+  expect(link).not.toBeNull();
+  return link!;
+}
+
+function chatThreadContainer(threadId: string): HTMLElement {
+  const element = document.querySelector<HTMLElement>(
+    `[data-chat-thread-container-id="${threadId}"]`,
+  );
+  expect(element).not.toBeNull();
+  return element!;
+}
+
+function fireModShiftArrow(
+  threadId: string,
+  key: "ArrowUp" | "ArrowDown",
+): void {
+  fireEvent.keyDown(chatThreadContainer(threadId), {
+    key,
+    ctrlKey: true,
+    shiftKey: true,
+  });
+}
+
+describe("chat sidebar", () => {
+  it("uses normal clicks for the main chat and keeps the sidebar open", async () => {
+    mockChatSidebarApis();
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-main?sidebar=thread-sidebar",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Primary thread answer")).toBeInTheDocument();
+      expect(screen.getByText("Sidebar thread answer")).toBeInTheDocument();
+    });
+
+    fireEvent.click(chatThreadLink("Third conversation"));
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-third");
+      expect(search()).toBe("?sidebar=thread-sidebar");
+      expect(screen.getByText("Third thread answer")).toBeInTheDocument();
+      expect(screen.getByText("Sidebar thread answer")).toBeInTheDocument();
+    });
+  });
+
+  it("opens a chat sidebar on option-click without changing the main chat path", async () => {
+    mockChatSidebarApis();
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => {
+      return null;
+    });
+
+    detachedSetupPage({ context, path: "/chats/thread-main" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Primary thread answer")).toBeInTheDocument();
+    });
+
+    fireEvent.click(chatThreadLink("Sidebar conversation"), { altKey: true });
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-main");
+      expect(search()).toBe("?sidebar=thread-sidebar");
+      expect(chatThreadContainer("thread-sidebar")).toBeInTheDocument();
+      expect(screen.getByText("Sidebar thread answer")).toBeInTheDocument();
+    });
+    expect(openSpy).not.toHaveBeenCalled();
+
+    fireEvent.click(chatThreadLink("Sidebar conversation"), { altKey: true });
+
+    await waitFor(() => {
+      expect(search()).toBe("");
+      expect(
+        document.querySelector(
+          '[data-chat-thread-container-id="thread-sidebar"]',
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows pane icons in highlighted sidebar chat titles only while two chats are open", async () => {
+    mockChatSidebarApis();
+
+    detachedSetupPage({ context, path: "/chats/thread-main" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Primary thread answer")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("chat-thread-list-pane-icon-main"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("chat-thread-list-pane-icon-sidebar"),
+      ).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(chatThreadLink("Sidebar conversation"), { altKey: true });
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-main");
+      expect(search()).toBe("?sidebar=thread-sidebar");
+      expect(
+        within(chatThreadLink("Main conversation")).getByTestId(
+          "chat-thread-list-pane-icon-main",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        within(chatThreadLink("Sidebar conversation")).getByTestId(
+          "chat-thread-list-pane-icon-sidebar",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows thread titles after the agent name in chat headers while two chats are open", async () => {
+    mockChatSidebarApis();
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-main?sidebar=thread-sidebar",
+    });
+
+    await waitFor(() => {
+      expect(
+        within(chatThreadContainer("thread-main")).getByText(
+          "Main conversation",
+        ),
+      ).toHaveClass("truncate");
+      expect(
+        within(chatThreadContainer("thread-sidebar")).getByText(
+          "Sidebar conversation",
+        ),
+      ).toHaveClass("truncate");
+    });
+  });
+
+  it("does nothing when option-clicking the currently open main chat", async () => {
+    mockChatSidebarApis();
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-main?sidebar=thread-sidebar",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Primary thread answer")).toBeInTheDocument();
+      expect(screen.getByText("Sidebar thread answer")).toBeInTheDocument();
+    });
+
+    fireEvent.click(chatThreadLink("Main conversation"), { altKey: true });
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-main");
+      expect(search()).toBe("?sidebar=thread-sidebar");
+      expect(chatThreadContainer("thread-main")).toBeInTheDocument();
+      expect(chatThreadContainer("thread-sidebar")).toBeInTheDocument();
+      expect(screen.getByText("Primary thread answer")).toBeInTheDocument();
+      expect(screen.getByText("Sidebar thread answer")).toBeInTheDocument();
+    });
+  });
+
+  it("highlights the sidebar query thread and ignores normal clicks on highlighted chats", async () => {
+    mockChatSidebarApis();
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-main?sidebar=thread-sidebar",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Primary thread answer")).toBeInTheDocument();
+      expect(screen.getByText("Sidebar thread answer")).toBeInTheDocument();
+      expect(chatThreadLink("Main conversation")).toHaveClass("bg-gray-200");
+      expect(chatThreadLink("Sidebar conversation")).toHaveClass("bg-gray-200");
+    });
+
+    fireEvent.click(chatThreadLink("Sidebar conversation"));
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-main");
+      expect(search()).toBe("?sidebar=thread-sidebar");
+      expect(chatThreadContainer("thread-main")).toBeInTheDocument();
+      expect(chatThreadContainer("thread-sidebar")).toBeInTheDocument();
+    });
+
+    fireEvent.click(chatThreadLink("Main conversation"));
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-main");
+      expect(search()).toBe("?sidebar=thread-sidebar");
+      expect(chatThreadContainer("thread-main")).toBeInTheDocument();
+      expect(chatThreadContainer("thread-sidebar")).toBeInTheDocument();
+    });
+  });
+
+  it("switches and closes the existing sidebar with option-click", async () => {
+    mockChatSidebarApis();
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-main?sidebar=thread-sidebar",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Sidebar thread answer")).toBeInTheDocument();
+    });
+
+    fireEvent.click(chatThreadLink("Third conversation"), { altKey: true });
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-main");
+      expect(search()).toBe("?sidebar=thread-third");
+      expect(screen.getByText("Third thread answer")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Sidebar thread answer"),
+      ).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(chatThreadLink("Third conversation"), { altKey: true });
+
+    await waitFor(() => {
+      expect(search()).toBe("");
+      expect(
+        document.querySelector(
+          '[data-chat-thread-container-id="thread-third"]',
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("restores the chat sidebar from the sidebar query param", async () => {
+    mockChatSidebarApis();
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-main?sidebar=thread-sidebar",
+    });
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-main");
+      expect(search()).toBe("?sidebar=thread-sidebar");
+      expect(chatThreadContainer("thread-sidebar")).toBeInTheDocument();
+      expect(screen.getByText("Sidebar thread answer")).toBeInTheDocument();
+    });
+  });
+
+  it("uses main-pane shortcuts to switch the main thread while skipping the sidebar thread", async () => {
+    mockChatSidebarApis();
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-main?sidebar=thread-sidebar",
+    });
+
+    await waitFor(() => {
+      expect(chatThreadContainer("thread-main")).toBeInTheDocument();
+      expect(chatThreadContainer("thread-sidebar")).toBeInTheDocument();
+    });
+
+    fireModShiftArrow("thread-main", "ArrowDown");
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-third");
+      expect(search()).toBe("?sidebar=thread-sidebar");
+      expect(screen.getByText("Third thread answer")).toBeInTheDocument();
+    });
+
+    fireModShiftArrow("thread-third", "ArrowUp");
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-main");
+      expect(search()).toBe("?sidebar=thread-sidebar");
+      expect(screen.getByText("Primary thread answer")).toBeInTheDocument();
+    });
+  });
+
+  it("uses sidebar-pane shortcuts to switch the sidebar while skipping the main thread", async () => {
+    mockChatSidebarApis();
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-sidebar?sidebar=thread-third",
+    });
+
+    await waitFor(() => {
+      expect(chatThreadContainer("thread-sidebar")).toBeInTheDocument();
+      expect(chatThreadContainer("thread-third")).toBeInTheDocument();
+    });
+
+    fireModShiftArrow("thread-third", "ArrowUp");
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-sidebar");
+      expect(search()).toBe("?sidebar=thread-main");
+      expect(screen.getByText("Primary thread answer")).toBeInTheDocument();
+    });
+
+    fireModShiftArrow("thread-main", "ArrowDown");
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-sidebar");
+      expect(search()).toBe("?sidebar=thread-third");
+      expect(screen.getByText("Third thread answer")).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -39,6 +39,11 @@ import {
   deleteChatThread$,
 } from "../../signals/chat-page/chat-message.ts";
 import {
+  chatSidebarThreadId$,
+  navigateMainChatPreservingSidebar$,
+  openChatSidebar$,
+} from "../../signals/chat-page/chat-sidebar.ts";
+import {
   createNewChatThreadOptimistically$,
   optimisticChatThread$,
   pendingOptimisticChatThreads$,
@@ -59,6 +64,7 @@ import {
 import { Link } from "../router/link.tsx";
 
 type IndicatorState = "running" | "unread" | "draft";
+type ChatThreadPaneIndicator = "main" | "sidebar";
 
 function SessionStateIndicator({ state }: { state: IndicatorState }) {
   if (state === "running") {
@@ -86,29 +92,122 @@ function SessionStateIndicator({ state }: { state: IndicatorState }) {
   );
 }
 
-function ChatThreadItem({
-  session,
-  isSelected,
-  onSelect,
-}: {
-  session: ChatThreadListItem;
-  isSelected: boolean;
-  onSelect?: () => void;
-}) {
-  const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
-  const isRunning = session.running;
-  const isUnread = !session.isRead && !isSelected;
-  const hasDraft = (session.hasDraft ?? false) && !isSelected;
+function ChatThreadListPaneIcon({ pane }: { pane: ChatThreadPaneIndicator }) {
+  return (
+    <span
+      aria-hidden="true"
+      data-testid={`chat-thread-list-pane-icon-${pane}`}
+      className="grid h-3 w-4 shrink-0 grid-cols-2 overflow-hidden rounded-[2px] border border-current"
+    >
+      <span className={pane === "main" ? "bg-current" : "bg-transparent"} />
+      <span className={pane === "sidebar" ? "bg-current" : "bg-transparent"} />
+    </span>
+  );
+}
 
-  // Priority: running > unread > draft. Only one indicator occupies the
-  // right slot at a time; on hover the slot swaps to the delete button.
-  const indicatorState: IndicatorState | null = isRunning
-    ? "running"
-    : isUnread
-      ? "unread"
-      : hasDraft
-        ? "draft"
-        : null;
+function getChatThreadPaneIndicator({
+  isCurrentPage,
+  sidebarThreadId,
+  threadId,
+}: {
+  isCurrentPage: boolean;
+  sidebarThreadId: string | null;
+  threadId: string;
+}): ChatThreadPaneIndicator | null {
+  if (!sidebarThreadId) {
+    return null;
+  }
+  if (isCurrentPage) {
+    return "main";
+  }
+  return sidebarThreadId === threadId ? "sidebar" : null;
+}
+
+function getIndicatorState({
+  hasDraft,
+  isRunning,
+  isUnread,
+}: {
+  hasDraft: boolean;
+  isRunning: boolean;
+  isUnread: boolean;
+}): IndicatorState | null {
+  if (isRunning) {
+    return "running";
+  }
+  if (isUnread) {
+    return "unread";
+  }
+  return hasDraft ? "draft" : null;
+}
+
+function handleChatThreadClick(
+  e: React.MouseEvent<HTMLAnchorElement>,
+  {
+    canOpenSidebar,
+    closeSidebarOnSelect,
+    isHighlighted,
+    navigateMainChatPreservingSidebar,
+    openChatSidebar,
+    threadId,
+  }: {
+    canOpenSidebar: boolean;
+    closeSidebarOnSelect: () => void;
+    isHighlighted: boolean;
+    navigateMainChatPreservingSidebar: (threadId: string) => void;
+    openChatSidebar: (threadId: string) => void;
+    threadId: string;
+  },
+) {
+  if (e.altKey && canOpenSidebar) {
+    e.preventDefault();
+    openChatSidebar(threadId);
+    if (!isHighlighted) {
+      closeSidebarOnSelect();
+    }
+    return;
+  }
+  if (e.metaKey || e.ctrlKey || e.shiftKey) {
+    return;
+  }
+  if (isHighlighted) {
+    e.preventDefault();
+    return;
+  }
+  if (canOpenSidebar) {
+    e.preventDefault();
+    navigateMainChatPreservingSidebar(threadId);
+  }
+  closeSidebarOnSelect();
+}
+
+function ChatThreadItem({ session }: { session: ChatThreadListItem }) {
+  const pathParams = useGet(pathParams$);
+  const selectedThreadId =
+    typeof pathParams?.threadId === "string" ? pathParams.threadId : null;
+  const sidebarThreadId = useGet(chatSidebarThreadId$);
+  const setSidebarExpanded = useSet(setSidebarExpanded$);
+  const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
+  const openChatSidebar = useSet(openChatSidebar$);
+  const navigateMainChatPreservingSidebar = useSet(
+    navigateMainChatPreservingSidebar$,
+  );
+  const isCurrentPage = selectedThreadId === session.id;
+  const isHighlighted = isCurrentPage || sidebarThreadId === session.id;
+  const paneIndicator = getChatThreadPaneIndicator({
+    isCurrentPage,
+    sidebarThreadId,
+    threadId: session.id,
+  });
+  const canOpenSidebar = selectedThreadId !== null;
+  const isRunning = session.running;
+  const isUnread = !session.isRead && !isHighlighted;
+  const hasDraft = (session.hasDraft ?? false) && !isHighlighted;
+  const indicatorState = getIndicatorState({
+    hasDraft,
+    isRunning,
+    isUnread,
+  });
 
   function handleDeleteClick(e: React.MouseEvent) {
     e.preventDefault();
@@ -116,29 +215,40 @@ function ChatThreadItem({
     setPendingDeleteThreadId(session.id);
   }
 
+  function closeSidebarOnSelect() {
+    setSidebarExpanded(false);
+  }
+
   return (
     <div className="group relative">
       <Link
         pathname="/chats/:threadId"
         options={{ pathParams: { threadId: session.id } }}
-        aria-current={isSelected ? "page" : undefined}
+        aria-current={isCurrentPage ? "page" : undefined}
         data-chat-thread-id={session.id}
         onClick={(e) => {
-          if (e.metaKey || e.ctrlKey || e.shiftKey) {
-            return;
-          }
-          onSelect?.();
+          handleChatThreadClick(e, {
+            canOpenSidebar,
+            closeSidebarOnSelect,
+            isHighlighted,
+            navigateMainChatPreservingSidebar,
+            openChatSidebar,
+            threadId: session.id,
+          });
         }}
         className={`flex h-8 items-center gap-2 rounded-lg py-2 pl-2 pr-8 text-left text-sm leading-5 transition-colors ${
-          isSelected
+          isHighlighted
             ? "bg-gray-200 text-gray-900 font-medium"
             : isUnread
               ? "text-sidebar-foreground font-medium hover:bg-sidebar-accent"
               : "text-sidebar-foreground hover:bg-sidebar-accent"
         }`}
       >
-        <span className="truncate min-w-0 flex-1">
-          {session.title ?? "New chat"}
+        <span className="flex min-w-0 flex-1 items-center gap-2">
+          {paneIndicator && <ChatThreadListPaneIcon pane={paneIndicator} />}
+          <span className="min-w-0 truncate">
+            {session.title ?? "New chat"}
+          </span>
         </span>
       </Link>
       <div className="pointer-events-none absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
@@ -159,7 +269,7 @@ function ChatThreadItem({
                   type="button"
                   onClick={handleDeleteClick}
                   className={`pointer-events-auto absolute top-1 left-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-md invisible group-hover:visible transition-opacity duration-150 ${
-                    isSelected
+                    isHighlighted
                       ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-300))]"
                       : "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-200))]"
                   }`}
@@ -180,10 +290,6 @@ function ChatThreadItem({
 }
 
 function ChatThreads() {
-  const pathParams = useGet(pathParams$);
-  const selectedThreadId =
-    typeof pathParams?.threadId === "string" ? pathParams.threadId : null;
-  const setSidebarExpanded = useSet(setSidebarExpanded$);
   const pendingDeleteThreadId = useGet(pendingDeleteThreadId$);
   const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
   const deleteChatThread = useSet(deleteChatThread$);
@@ -204,10 +310,6 @@ function ChatThreads() {
         return (s.title ?? "").toLowerCase().includes(trimmedTerm);
       })
     : optimisticChatThreads;
-
-  const onRecentSelect = () => {
-    setSidebarExpanded(false);
-  };
 
   function confirmDelete() {
     if (!pendingDeleteThreadId) {
@@ -233,24 +335,10 @@ function ChatThreads() {
   return (
     <>
       {filteredOptimisticChatThreads.map((session) => {
-        return (
-          <ChatThreadItem
-            key={session.id}
-            session={session}
-            isSelected={selectedThreadId === session.id}
-            onSelect={onRecentSelect}
-          />
-        );
+        return <ChatThreadItem key={session.id} session={session} />;
       })}
       {filteredChatThreads.map((session) => {
-        return (
-          <ChatThreadItem
-            key={session.id}
-            session={session}
-            isSelected={selectedThreadId === session.id}
-            onSelect={onRecentSelect}
-          />
-        );
+        return <ChatThreadItem key={session.id} session={session} />;
       })}
       <Dialog
         open={pendingDeleteThreadId !== null}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import type { CSSProperties, KeyboardEvent as ReactKeyboardEvent } from "react";
 import {
   useGet,
   useSet,
@@ -28,6 +28,8 @@ import {
 } from "@tabler/icons-react";
 import {
   cn,
+  isEditableTarget,
+  matchShortcut,
   Sheet,
   SheetContent,
   SheetDescription,
@@ -107,6 +109,14 @@ import {
   imageLoadStatusRef$,
   setImageLoadStatus$,
 } from "../../signals/view-component-state.ts";
+import {
+  chatSidebarThread$,
+  chatSidebarThreadId$,
+} from "../../signals/chat-page/chat-sidebar.ts";
+import {
+  navigateToAdjacentThread$,
+  scrollCurrentThread$,
+} from "../../signals/chat-page/chat-keyboard.ts";
 
 const CHAT_SHORTCUT_SECTIONS = [
   {
@@ -249,10 +259,14 @@ function ArtifactsButtonInner({ thread }: { thread: ChatThreadSignals }) {
 
 function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
   const displayName = useLastResolved(thread.agentDisplayName$);
+  const threadData = useLastResolved(thread.threadData$);
+  const sidebarThreadId = useGet(chatSidebarThreadId$);
   const autoRead = useGet(autoReadEnabled$);
   const toggleAutoReadFn = useSet(toggleAutoRead$);
   const features = useLastResolved(featureSwitch$);
   const audioOutputEnabled = features?.[FeatureSwitchKey.AudioOutput] ?? false;
+  const threadTitle = threadData?.title?.trim() ?? "";
+  const showThreadTitle = sidebarThreadId !== null && threadTitle.length > 0;
 
   return (
     <header className="hidden sm:flex shrink-0 bg-transparent px-6 py-3 items-center justify-between">
@@ -261,11 +275,20 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
           <HeaderAgentAvatar thread={thread} />
           <PinPillButton thread={thread} />
         </div>
-        {displayName ? (
-          <span className="font-semibold text-foreground">{displayName}</span>
-        ) : (
-          <Skeleton className="h-5 w-32 rounded" />
-        )}
+        <span className="flex min-w-0 items-baseline gap-2">
+          {displayName ? (
+            <span className="shrink-0 font-semibold text-foreground">
+              {displayName}
+            </span>
+          ) : (
+            <Skeleton className="h-5 w-32 shrink-0 rounded" />
+          )}
+          {showThreadTitle && (
+            <span className="min-w-0 truncate text-sm font-medium text-muted-foreground">
+              {threadTitle}
+            </span>
+          )}
+        </span>
       </div>
       <div className="hidden sm:flex items-center gap-0.5">
         <ArtifactsButton thread={thread} />
@@ -944,14 +967,49 @@ function ChatArtifactsDrawer({ thread }: { thread: ChatThreadSignals }) {
 // ZeroSessionChatPage — real conversation backed by agent runs
 // ---------------------------------------------------------------------------
 
+function ChatThread({ thread }: { thread: ChatThreadSignals }) {
+  const setRuntimeRef = useSet(thread.setRuntimeRef$);
+  const onKeyDown = useChatThreadKeyDown(thread);
+
+  return (
+    <section
+      ref={setRuntimeRef}
+      aria-label="Chat thread"
+      className="flex min-w-0 basis-0 flex-1 flex-col min-h-0 bg-transparent focus:outline-none"
+      data-chat-thread-container-id={thread.threadId}
+      onKeyDown={onKeyDown}
+      tabIndex={-1}
+    >
+      <ChatThreadContent thread={thread} />
+    </section>
+  );
+}
+
 export function ZeroChatThreadPage({ thread }: ZeroChatThreadPageProps) {
   const shortcutHelpOpen = useGet(chatShortcutHelpOpen$);
   const setShortcutHelpOpen = useSet(setChatShortcutHelpOpen$);
+  const sidebarThread = useGet(chatSidebarThread$);
+  const lightboxUrl = useGet(attachmentLightboxUrl$);
 
   return (
     <>
-      <ZeroChatThreadPageInner thread={thread} />
+      <div className="flex flex-1 min-h-0 bg-transparent">
+        <ChatThread key={thread.threadId} thread={thread} />
+        {sidebarThread && (
+          <>
+            <div className="w-px shrink-0 bg-border/60" aria-hidden="true" />
+            <ChatThread key={sidebarThread.threadId} thread={sidebarThread} />
+          </>
+        )}
+      </div>
       <ChatArtifactsDrawer thread={thread} />
+      {sidebarThread && (
+        <ChatArtifactsDrawer
+          key={sidebarThread.threadId}
+          thread={sidebarThread}
+        />
+      )}
+      {lightboxUrl && <AttachmentLightbox />}
       <ShortcutHelpDialog
         open={shortcutHelpOpen}
         onOpenChange={setShortcutHelpOpen}
@@ -981,16 +1039,71 @@ function resolveSessionError(
       ? groupsLoadable.error.message
       : "Failed to load messages";
   }
+  if (
+    threadDataLoadable.state === "hasData" &&
+    threadDataLoadable.data === null
+  ) {
+    return "Chat not found";
+  }
   return null;
 }
 
-function ZeroChatThreadPageInner({
-  thread,
-  autoFocus = true,
-}: {
-  thread: ChatThreadSignals;
-  autoFocus?: boolean;
-}) {
+function useChatThreadKeyDown(thread: ChatThreadSignals) {
+  const pageSignal = useGet(pageSignal$);
+  const scrollCurrentThread = useSet(scrollCurrentThread$);
+  const navigateToAdjacentThread = useSet(navigateToAdjacentThread$);
+  const setShortcutHelpOpen = useSet(setChatShortcutHelpOpen$);
+
+  return (event: ReactKeyboardEvent<HTMLElement>) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+    if (matchShortcut("mod+arrowup", event)) {
+      event.preventDefault();
+      scrollCurrentThread(thread, "top");
+      return;
+    }
+    if (matchShortcut("mod+arrowdown", event)) {
+      event.preventDefault();
+      scrollCurrentThread(thread, "bottom");
+      return;
+    }
+    if (matchShortcut("mod+shift+arrowup", event)) {
+      event.preventDefault();
+      detach(
+        navigateToAdjacentThread(
+          {
+            currentThreadId: thread.threadId,
+            direction: "prev",
+          },
+          pageSignal,
+        ),
+        Reason.DomCallback,
+      );
+      return;
+    }
+    if (matchShortcut("mod+shift+arrowdown", event)) {
+      event.preventDefault();
+      detach(
+        navigateToAdjacentThread(
+          {
+            currentThreadId: thread.threadId,
+            direction: "next",
+          },
+          pageSignal,
+        ),
+        Reason.DomCallback,
+      );
+      return;
+    }
+    if (matchShortcut("shift+/", event) && !isEditableTarget(event.target)) {
+      event.preventDefault();
+      setShortcutHelpOpen(true);
+    }
+  };
+}
+
+function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
   const features = useLastResolved(featureSwitch$);
   const groupsLoadable = useLastLoadable(thread.groupedChatMessages$);
   const hasOlderHistory = useLastResolved(thread.hasOlderHistory$) ?? false;
@@ -1003,7 +1116,6 @@ function ZeroChatThreadPageInner({
   const groups = groupsLoadable.state === "hasData" ? groupsLoadable.data : [];
   const setScrollContainer = useSet(thread.setScrollContainer$);
   const skeletonVisible = useGet(thread.skeletonVisible$);
-  const lightboxUrl = useGet(attachmentLightboxUrl$);
   const manualHistoryEnabled =
     features?.[FeatureSwitchKey.ChatManualHistory] ?? false;
   const loadingHistory = loadHistoryLoadable.state === "loading";
@@ -1013,7 +1125,7 @@ function ZeroChatThreadPageInner({
   });
 
   return (
-    <div className="flex flex-1 flex-col min-h-0 bg-transparent">
+    <>
       <ChatThreadHeader thread={thread} />
 
       <div className="flex-1 min-h-0 relative isolate">
@@ -1095,9 +1207,8 @@ function ZeroChatThreadPageInner({
         )}
       </div>
 
-      <ChatThreadComposer thread={thread} autoFocus={autoFocus} />
-      {lightboxUrl && <AttachmentLightbox />}
-    </div>
+      <ChatThreadComposer thread={thread} />
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add URL-persisted split chat sidebar support via opt-click on chat threads
- render main and sidebar panes with the same ChatThread component and equal widths
- move pane indicators/highlighting into sidebar thread rows and keep keyboard navigation pane-scoped

## Testing
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/chat-sidebar.test.tsx src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx --run
- pnpm -F web exec vitest app/api/telegram/setup-status/__tests__/route.test.ts app/api/zero/integrations/telegram/download-file/__tests__/route.test.ts app/api/zero/integrations/telegram/bots/__tests__/route.test.ts app/api/zero/integrations/telegram/upload-file/complete/__tests__/route.test.ts --run
- git diff --check

## Notes
- Full `pnpm vitest` was started after clearing stale local Telegram test data, but was stopped per user request to open the PR directly.
