### PR TITLE
feat: enable gumroad connector for all users

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -292,7 +292,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Enable the Gumroad creator commerce connector (api-token + OAuth).",
-    enabled: false,
+    enabled: true,
   },
 };
 


### PR DESCRIPTION
## Summary
- Enable the Gumroad OAuth + api-token connector for all users by setting `GumroadConnector` feature switch to `enabled: true`
- Single-line change in `turbo/packages/core/src/feature-switch.ts`

## Test plan
- [x] Verify feature switch evaluates to true for all users
- [ ] CI passes (lint, type-check, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)