### PR TITLE
fix: estimate WAV duration from byte size instead of chunk-walk parsing

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-io/speech/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/speech/__tests__/route.test.ts
@@ -92,6 +92,44 @@ function createWavBytes(durationSeconds: number): Uint8Array {
   return bytes;
 }
 
+function createWavBytesWithJunkAndOversizedDataChunk(
+  durationSeconds: number,
+): Uint8Array {
+  const sampleRate = 16000;
+  const numChannels = 1;
+  const bitsPerSample = 16;
+  const bytesPerSample = (numChannels * bitsPerSample) / 8;
+  const dataSize = durationSeconds * sampleRate * bytesPerSample;
+  const junkSize = 4;
+  const dataOffset = 56;
+  const bytes = new Uint8Array(dataOffset + dataSize);
+  const view = new DataView(bytes.buffer);
+
+  const writeStr = (offset: number, value: string) => {
+    for (let i = 0; i < value.length; i++) {
+      view.setUint8(offset + i, value.charCodeAt(i));
+    }
+  };
+
+  writeStr(0, "RIFF");
+  view.setUint32(4, bytes.byteLength - 8, true);
+  writeStr(8, "WAVE");
+  writeStr(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, numChannels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * bytesPerSample, true);
+  view.setUint16(32, bytesPerSample, true);
+  view.setUint16(34, bitsPerSample, true);
+  writeStr(36, "JUNK");
+  view.setUint32(40, junkSize, true);
+  writeStr(48, "data");
+  view.setUint32(52, dataSize + 10_000, true);
+
+  return bytes;
+}
+
 async function seedSpeechPricing() {
   await insertTestUsagePricing({
     kind: "audio",
@@ -245,6 +283,38 @@ describe("POST /api/zero/voice-io/speech", () => {
     expect(uploadedBytes.equals(Buffer.from(wavBytes))).toBe(true);
     expect(contentType).toBe("audio/wav");
 
+    expect(await getOrgCredits(orgId)).toBe(996);
+    expect(await findTestUsageEventsByRunId(runId)).toEqual([]);
+  });
+
+  it("estimates WAV duration from actual data bytes when data chunk size is oversized", async () => {
+    const userId = uniqueId("speech-oversized-data");
+    const { orgId } = await setupOrg(userId);
+    const runId = randomUUID();
+    const token = await generateZeroToken(userId, runId, orgId);
+    await setOrgCredits(orgId, 1000);
+    await seedSpeechPricing();
+    const wavBytes = createWavBytesWithJunkAndOversizedDataChunk(10);
+
+    server.use(
+      http.post(OPENAI_SPEECH_URL, () => {
+        return new HttpResponse(wavBytes, {
+          headers: { "Content-Type": "audio/wav" },
+        });
+      }),
+    );
+
+    const response = await POST(
+      speechRequest(
+        { text: "hello world", voice: "nova" },
+        { Authorization: `Bearer ${token}` },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as SpeechResponse;
+    expect(body.durationSeconds).toBe(10);
+    expect(body.creditsCharged).toBe(4);
     expect(await getOrgCredits(orgId)).toBe(996);
     expect(await findTestUsageEventsByRunId(runId)).toEqual([]);
   });

--- a/turbo/apps/web/app/api/zero/voice-io/speech/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/speech/route.ts
@@ -60,16 +60,49 @@ function readAscii(bytes: Uint8Array, offset: number, length: number): string {
   return text;
 }
 
+function isRiffWav(bytes: Uint8Array): boolean {
+  return readAscii(bytes, 0, 4) === "RIFF" && readAscii(bytes, 8, 4) === "WAVE";
+}
+
+type WavFormat = {
+  channels: number;
+  sampleRate: number;
+  bitsPerSample: number;
+};
+
+function readWavFormat(
+  view: DataView,
+  chunkStart: number,
+  byteLength: number,
+): WavFormat | null {
+  if (chunkStart + 16 > byteLength) return null;
+  return {
+    channels: view.getUint16(chunkStart + 2, true),
+    sampleRate: view.getUint32(chunkStart + 4, true),
+    bitsPerSample: view.getUint16(chunkStart + 14, true),
+  };
+}
+
+function readStandardWavFormat(view: DataView): WavFormat {
+  return {
+    channels: view.getUint16(22, true),
+    sampleRate: view.getUint32(24, true),
+    bitsPerSample: view.getUint16(34, true),
+  };
+}
+
+function hasUsableWavFormat(format: WavFormat): boolean {
+  return (
+    format.channels > 0 && format.sampleRate > 0 && format.bitsPerSample > 0
+  );
+}
+
 function parseWavDurationSeconds(bytes: Uint8Array): number | null {
   if (bytes.byteLength < 44) return null;
-  if (readAscii(bytes, 0, 4) !== "RIFF" || readAscii(bytes, 8, 4) !== "WAVE") {
-    return null;
-  }
+  if (!isRiffWav(bytes)) return null;
 
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-  let channels: number | null = null;
-  let sampleRate: number | null = null;
-  let bitsPerSample: number | null = null;
+  let format: WavFormat | null = null;
   let dataOffset: number | null = null;
 
   // Walk chunks to find fmt info and the start of the data chunk
@@ -78,29 +111,23 @@ function parseWavDurationSeconds(bytes: Uint8Array): number | null {
     const chunkId = readAscii(bytes, offset, 4);
     const chunkSize = view.getUint32(offset + 4, true);
     const chunkStart = offset + 8;
-
-    if (chunkStart + chunkSize > bytes.byteLength) break;
+    const chunkEnd = chunkStart + chunkSize;
 
     if (chunkId === "fmt " && chunkSize >= 16) {
-      channels = view.getUint16(chunkStart + 2, true);
-      sampleRate = view.getUint32(chunkStart + 4, true);
-      bitsPerSample = view.getUint16(chunkStart + 14, true);
+      format = readWavFormat(view, chunkStart, bytes.byteLength) ?? format;
     } else if (chunkId === "data") {
       dataOffset = chunkStart;
     }
 
-    offset = chunkStart + chunkSize + (chunkSize % 2);
+    if (chunkEnd > bytes.byteLength) break;
+
+    offset = chunkEnd + (chunkSize % 2);
   }
 
   // If we couldn't find fmt chunk via walking, try standard WAV header position
   // (24 kHz, 16-bit, mono is what gpt-4o-mini-tts outputs)
-  if (!channels || !sampleRate || !bitsPerSample) {
-    channels = channels ?? view.getUint16(22, true);
-    sampleRate = sampleRate ?? view.getUint32(24, true);
-    bitsPerSample = bitsPerSample ?? view.getUint16(34, true);
-  }
-
-  if (!channels || !sampleRate || !bitsPerSample) return null;
+  format = format ?? readStandardWavFormat(view);
+  if (!hasUsableWavFormat(format)) return null;
 
   // Estimate audio data size from total bytes rather than trusting the data chunk header.
   // If we found the data chunk, use bytes after it; otherwise subtract the standard 44-byte header.
@@ -109,7 +136,8 @@ function parseWavDurationSeconds(bytes: Uint8Array): number | null {
 
   if (audioBytes <= 0) return null;
 
-  const bytesPerSecond = sampleRate * channels * (bitsPerSample / 8);
+  const bytesPerSecond =
+    format.sampleRate * format.channels * (format.bitsPerSample / 8);
   if (!Number.isFinite(bytesPerSecond) || bytesPerSecond <= 0) return null;
   return Math.max(1, Math.ceil(audioBytes / bytesPerSecond));
 }

--- a/turbo/apps/web/app/api/zero/voice-io/speech/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/speech/route.ts
@@ -67,36 +67,51 @@ function parseWavDurationSeconds(bytes: Uint8Array): number | null {
   }
 
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-  let offset = 12;
   let channels: number | null = null;
   let sampleRate: number | null = null;
   let bitsPerSample: number | null = null;
-  let dataBytes: number | null = null;
+  let dataOffset: number | null = null;
 
+  // Walk chunks to find fmt info and the start of the data chunk
+  let offset = 12;
   while (offset + 8 <= bytes.byteLength) {
     const chunkId = readAscii(bytes, offset, 4);
     const chunkSize = view.getUint32(offset + 4, true);
     const chunkStart = offset + 8;
-    if (chunkStart + chunkSize > bytes.byteLength) return null;
+
+    if (chunkStart + chunkSize > bytes.byteLength) break;
 
     if (chunkId === "fmt " && chunkSize >= 16) {
       channels = view.getUint16(chunkStart + 2, true);
       sampleRate = view.getUint32(chunkStart + 4, true);
       bitsPerSample = view.getUint16(chunkStart + 14, true);
     } else if (chunkId === "data") {
-      dataBytes = chunkSize;
+      dataOffset = chunkStart;
     }
 
     offset = chunkStart + chunkSize + (chunkSize % 2);
   }
 
-  if (!channels || !sampleRate || !bitsPerSample || dataBytes === null) {
-    return null;
+  // If we couldn't find fmt chunk via walking, try standard WAV header position
+  // (24 kHz, 16-bit, mono is what gpt-4o-mini-tts outputs)
+  if (!channels || !sampleRate || !bitsPerSample) {
+    channels = channels ?? view.getUint16(22, true);
+    sampleRate = sampleRate ?? view.getUint32(24, true);
+    bitsPerSample = bitsPerSample ?? view.getUint16(34, true);
   }
+
+  if (!channels || !sampleRate || !bitsPerSample) return null;
+
+  // Estimate audio data size from total bytes rather than trusting the data chunk header.
+  // If we found the data chunk, use bytes after it; otherwise subtract the standard 44-byte header.
+  const audioBytes =
+    dataOffset !== null ? bytes.byteLength - dataOffset : bytes.byteLength - 44;
+
+  if (audioBytes <= 0) return null;
 
   const bytesPerSecond = sampleRate * channels * (bitsPerSample / 8);
   if (!Number.isFinite(bytesPerSecond) || bytesPerSecond <= 0) return null;
-  return Math.max(1, Math.ceil(dataBytes / bytesPerSecond));
+  return Math.max(1, Math.ceil(audioBytes / bytesPerSecond));
 }
 
 async function loadSpeechPricing() {


### PR DESCRIPTION
## Summary
- Fixes 502 "Could not determine generated audio duration" error from `/api/zero/voice-io/speech`
- Replaces the strict chunk-walking WAV parser with a lenient byte-size estimation approach
- Adds fallback to standard WAV header fields when chunk walking fails to find format info

## Root Cause
`parseWavDurationSeconds()` walked WAV chunks to find `fmt` and `data`, but returned `null` for non-standard chunk layouts returned by OpenAI TTS. The OpenAI `gpt-4o-mini-tts` model generates valid WAV audio but with chunk structures that differ from what the parser expected.

## Fix
Three changes to `parseWavDurationSeconds()`:
1. **Lenient overflow**: `break` on chunks that exceed buffer bounds instead of `return null`
2. **Byte-size estimation**: `duration = (totalBytes - dataOffset) / bytesPerSecond` instead of trusting the data chunk's self-reported size
3. **Fallback header parsing**: If chunk walking fails to find fmt info, read it from the standard WAV header position (bytes 20-36)

## Test Plan
- [x] Type check passes
- [x] Format check passes
- [ ] Existing integration tests pass in CI
- [ ] Manual `zero web voice --text "test" --voice nova` returns audio successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)