### PR TITLE
fix: aggregate model rankings by model name

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/model-stats.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-stats.test.ts
@@ -42,6 +42,7 @@ describe("GET /api/internal/cron/aggregate-model-stats", () => {
   it("aggregates hourly model usage and excludes connector usage", async () => {
     const db = store.set(writeDb$);
     const model = "claude-sonnet-4-6";
+    const modelAlias = "anthropic/claude-sonnet-4.6";
     const unknownModel = `unknown-model-${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
@@ -70,6 +71,20 @@ describe("GET /api/internal/cron/aggregate-model-stats", () => {
         cacheReadInputTokens: 10,
         cacheCreationInputTokens: 5,
         creditsCharged: 12,
+        status: "processed",
+        createdAt,
+        processedAt: createdAt,
+      },
+      {
+        orgId,
+        userId,
+        model: modelAlias,
+        modelProvider: "openrouter-api-key",
+        inputTokens: 50,
+        outputTokens: 5,
+        cacheReadInputTokens: 2,
+        cacheCreationInputTokens: 3,
+        creditsCharged: 2,
         status: "processed",
         createdAt,
         processedAt: createdAt,
@@ -135,6 +150,19 @@ describe("GET /api/internal/cron/aggregate-model-stats", () => {
         orgId,
         userId,
         kind: "model",
+        provider: modelAlias,
+        category: "tokens.input",
+        quantity: 25,
+        creditsCharged: 1,
+        status: "processed",
+        createdAt,
+        processedAt: createdAt,
+      },
+      {
+        idempotencyKey: randomUUID(),
+        orgId,
+        userId,
+        kind: "model",
         provider: unknownModel,
         category: "tokens.input",
         quantity: 300_000,
@@ -168,13 +196,14 @@ describe("GET /api/internal/cron/aggregate-model-stats", () => {
 
     expect(row).toMatchObject({
       hourStart: expectedHourStart,
-      inputTokens: 400,
-      outputTokens: 240,
-      cacheReadInputTokens: 10,
-      cacheCreationInputTokens: 5,
-      totalTokens: 655,
-      creditsCharged: 19,
-      requestCount: 3,
+      modelProvider: "",
+      inputTokens: 475,
+      outputTokens: 245,
+      cacheReadInputTokens: 12,
+      cacheCreationInputTokens: 8,
+      totalTokens: 740,
+      creditsCharged: 22,
+      requestCount: 5,
       orgCount: 1,
       userCount: 1,
     });
@@ -207,7 +236,7 @@ describe("GET /api/internal/cron/aggregate-model-stats", () => {
       )
       .limit(1);
 
-    expect(updatedRow?.creditsCharged).toBe(23);
+    expect(updatedRow?.creditsCharged).toBe(26);
 
     const [connectorRow] = await db
       .select()

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -3,9 +3,12 @@ import { sql } from "drizzle-orm";
 import { creditUsage } from "@vm0/db/schema/credit-usage";
 import { modelStat } from "@vm0/db/schema/model-stat";
 import { usageEvent } from "@vm0/db/schema/usage-event";
-import { VM0_MODEL_TO_PROVIDER } from "@vm0/api-contracts/contracts/model-providers";
+import {
+  VM0_MODEL_ALIAS_TO_MODEL,
+  VM0_MODEL_TO_PROVIDER,
+} from "@vm0/api-contracts/contracts/model-providers";
 
-import { writeDb$ } from "../external/db";
+import { type Db, writeDb$ } from "../external/db";
 import { nowDate } from "../external/time";
 
 const HOUR_MS = 60 * 60_000;
@@ -16,13 +19,22 @@ const TOKEN_CATEGORY_INPUT = "tokens.input";
 const TOKEN_CATEGORY_OUTPUT = "tokens.output";
 const TOKEN_CATEGORY_CACHE_READ = "tokens.cache_read";
 const TOKEN_CATEGORY_CACHE_CREATION = "tokens.cache_creation";
-const MODEL_STATS_MODEL_IDS = Object.keys(VM0_MODEL_TO_PROVIDER);
-const MODEL_STATS_MODEL_ID_SQL = sql.join(
-  MODEL_STATS_MODEL_IDS.map((model) => {
-    return sql`${model}`;
-  }),
-  sql`, `,
-);
+
+function getModelAliasEntries() {
+  return Object.entries(VM0_MODEL_ALIAS_TO_MODEL);
+}
+
+function getModelStatsModelIdSql() {
+  return sql.join(
+    [
+      ...Object.keys(VM0_MODEL_TO_PROVIDER),
+      ...Object.keys(VM0_MODEL_ALIAS_TO_MODEL),
+    ].map((model) => {
+      return sql`${model}`;
+    }),
+    sql`, `,
+  );
+}
 
 interface ModelStatsAggregationResult {
   readonly windowStart: Date;
@@ -41,23 +53,48 @@ function utcHourStart(date: Date): Date {
   );
 }
 
-export const aggregateModelStats$ = command(
-  async (
-    { set },
-    hours: number,
-    signal: AbortSignal,
-  ): Promise<ModelStatsAggregationResult> => {
-    const db = set(writeDb$);
-    const windowEnd = utcHourStart(nowDate());
-    const windowStart = new Date(windowEnd.getTime() - hours * HOUR_MS);
+function creditUsageModelExpression() {
+  const modelColumn = sql.raw('"credit_usage"."model"');
+  return sql<string>`CASE ${sql.join(
+    getModelAliasEntries().map(([alias, model]) => {
+      return sql`WHEN ${modelColumn} = ${alias} THEN ${model}`;
+    }),
+    sql` `,
+  )} ELSE ${modelColumn} END`;
+}
 
-    signal.throwIfAborted();
-    const result = await db.execute(sql`
+function usageEventModelExpression() {
+  const providerColumn = sql.raw('"usage_event"."provider"');
+  return sql<string>`CASE ${sql.join(
+    getModelAliasEntries().map(([alias, model]) => {
+      return sql`WHEN ${providerColumn} = ${alias} THEN ${model}`;
+    }),
+    sql` `,
+  )} ELSE ${providerColumn} END`;
+}
+
+async function replaceModelStats(
+  db: Db,
+  windowStart: Date,
+  windowEnd: Date,
+): Promise<number> {
+  const creditUsageModelExpr = creditUsageModelExpression();
+  const usageEventModelExpr = usageEventModelExpression();
+  const modelStatsModelIdSql = getModelStatsModelIdSql();
+
+  const result = await db.transaction(async (tx) => {
+    await tx.execute(sql`
+      DELETE FROM ${modelStat}
+      WHERE ${modelStat.hourStart} >= ${windowStart}
+        AND ${modelStat.hourStart} < ${windowEnd}
+        AND ${modelStat.model} IN (${modelStatsModelIdSql})
+    `);
+
+    return tx.execute(sql`
       WITH usage_rows AS (
         SELECT
           date_trunc('hour', ${creditUsage.createdAt})::timestamp AS hour_start,
-          ${creditUsage.model} AS model,
-          ${creditUsage.modelProvider} AS model_provider,
+          ${creditUsageModelExpr} AS model,
           ${creditUsage.orgId} AS org_id,
           ${creditUsage.userId} AS user_id,
           COALESCE(${creditUsage.runId}::text, ${creditUsage.id}::text) AS request_key,
@@ -69,14 +106,13 @@ export const aggregateModelStats$ = command(
         FROM ${creditUsage}
         WHERE ${creditUsage.createdAt} >= ${windowStart}
           AND ${creditUsage.createdAt} < ${windowEnd}
-          AND ${creditUsage.model} IN (${MODEL_STATS_MODEL_ID_SQL})
+          AND ${creditUsage.model} IN (${modelStatsModelIdSql})
 
         UNION ALL
 
         SELECT
           date_trunc('hour', ${usageEvent.createdAt})::timestamp AS hour_start,
-          ${usageEvent.provider} AS model,
-          ''::varchar(100) AS model_provider,
+          ${usageEventModelExpr} AS model,
           ${usageEvent.orgId} AS org_id,
           ${usageEvent.userId} AS user_id,
           COALESCE(${usageEvent.runId}::text, ${usageEvent.idempotencyKey}::text) AS request_key,
@@ -93,13 +129,12 @@ export const aggregateModelStats$ = command(
         WHERE ${usageEvent.createdAt} >= ${windowStart}
           AND ${usageEvent.createdAt} < ${windowEnd}
           AND ${usageEvent.kind} = ${MODEL_USAGE_KIND}
-          AND ${usageEvent.provider} IN (${MODEL_STATS_MODEL_ID_SQL})
+          AND ${usageEvent.provider} IN (${modelStatsModelIdSql})
       ),
       aggregated AS (
         SELECT
           hour_start,
           model,
-          model_provider,
           COUNT(DISTINCT request_key)::bigint AS request_count,
           COUNT(DISTINCT org_id)::int AS org_count,
           COUNT(DISTINCT user_id)::int AS user_count,
@@ -116,7 +151,7 @@ export const aggregateModelStats$ = command(
           COALESCE(SUM(credits_charged), 0)::bigint AS credits_charged
         FROM usage_rows
         WHERE model <> ''
-        GROUP BY hour_start, model, model_provider
+        GROUP BY hour_start, model
       )
       INSERT INTO ${modelStat} (
         "hour_start",
@@ -135,7 +170,7 @@ export const aggregateModelStats$ = command(
       SELECT
         hour_start,
         model,
-        model_provider,
+        ''::varchar(100) AS model_provider,
         request_count,
         org_count,
         user_count,
@@ -159,12 +194,29 @@ export const aggregateModelStats$ = command(
         updated_at = NOW()
       RETURNING id
     `);
+  });
+
+  return result.rowCount ?? 0;
+}
+
+export const aggregateModelStats$ = command(
+  async (
+    { set },
+    hours: number,
+    signal: AbortSignal,
+  ): Promise<ModelStatsAggregationResult> => {
+    const db = set(writeDb$);
+    const windowEnd = utcHourStart(nowDate());
+    const windowStart = new Date(windowEnd.getTime() - hours * HOUR_MS);
+
+    signal.throwIfAborted();
+    const aggregated = await replaceModelStats(db, windowStart, windowEnd);
     signal.throwIfAborted();
 
     return {
       windowStart,
       windowEnd,
-      aggregated: result.rowCount ?? 0,
+      aggregated,
     };
   },
 );

--- a/turbo/apps/platform/src/mocks/handlers/api-usage.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-usage.ts
@@ -22,8 +22,7 @@ const defaultModelUsageRankingModels: ModelUsageRankingItem[] = [
     outputTokens: 310_000,
     cacheTokens: 120_000,
     totalTokens: 1_280_000,
-    credits: 12_400,
-    previousCredits: 9000,
+    previousTotalTokens: 929_000,
     changePercent: 0.3778,
     share: 0.6,
   },
@@ -33,8 +32,7 @@ const defaultModelUsageRankingModels: ModelUsageRankingItem[] = [
     outputTokens: 180_000,
     cacheTokens: 60_000,
     totalTokens: 660_000,
-    credits: 4900,
-    previousCredits: 3600,
+    previousTotalTokens: 485_000,
     changePercent: 0.3611,
     share: 0.24,
   },
@@ -44,8 +42,7 @@ const defaultModelUsageRankingModels: ModelUsageRankingItem[] = [
     outputTokens: 170_000,
     cacheTokens: 30_000,
     totalTokens: 440_000,
-    credits: 3200,
-    previousCredits: 0,
+    previousTotalTokens: 0,
     changePercent: null,
     share: 0.16,
   },
@@ -105,15 +102,11 @@ function makeMockModelUsageDaily(
       const weight = 0.5 + progress * (0.7 + modelIndex * 0.12);
       return {
         model: item.model,
-        credits: Math.round((item.credits / dayCount) * weight),
         totalTokens: Math.round((item.totalTokens / dayCount) * weight),
       };
     });
     return {
       date,
-      totalCredits: dailyModels.reduce((sum, item) => {
-        return sum + item.credits;
-      }, 0),
       totalTokens: dailyModels.reduce((sum, item) => {
         return sum + item.totalTokens;
       }, 0),
@@ -131,17 +124,10 @@ export const apiUsageHandlers = [
     const grandTotalTokens = mockModelUsageRankingModels.reduce((sum, item) => {
       return sum + item.totalTokens;
     }, 0);
-    const grandTotalCredits = mockModelUsageRankingModels.reduce(
-      (sum, item) => {
-        return sum + item.credits;
-      },
-      0,
-    );
     return respond(200, {
       range: query.range as ModelUsageRankingRange,
       generatedAt: "2026-04-29T00:00:00.000Z",
       grandTotalTokens,
-      grandTotalCredits,
       models: mockModelUsageRankingModels,
       daily: makeMockModelUsageDaily(
         mockModelUsageRankingModels,

--- a/turbo/apps/platform/src/views/org/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-providers-tab.test.tsx
@@ -141,8 +141,7 @@ describe("org providers tab - display", () => {
         outputTokens: 250_000,
         cacheTokens: 50_000,
         totalTokens: 1_200_000,
-        credits: 11_000,
-        previousCredits: 8000,
+        previousTotalTokens: 872_727,
         changePercent: 0.375,
         share: 0.75,
       },
@@ -152,8 +151,7 @@ describe("org providers tab - display", () => {
         outputTokens: 150_000,
         cacheTokens: 50_000,
         totalTokens: 400_000,
-        credits: 3000,
-        previousCredits: 0,
+        previousTotalTokens: 0,
         changePercent: null,
         share: 0.25,
       },
@@ -174,7 +172,7 @@ describe("org providers tab - display", () => {
     });
     expect(
       screen.getByText(
-        "Ranking of the most popular models on VM0, based on platform-wide credits.",
+        "Ranking of the most popular models on VM0, based on platform-wide tokens.",
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText("Default provider")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
@@ -186,7 +186,7 @@ export function OrgManageDialog({ open, onOpenChange }: OrgManageDialogProps) {
     activeTab === "providers" && rankingOpen ? "Model Popularity" : meta.title;
   const description =
     activeTab === "providers" && rankingOpen
-      ? "Ranking of the most popular models on VM0, based on platform-wide credits."
+      ? "Ranking of the most popular models on VM0, based on platform-wide tokens."
       : meta.description;
 
   const handleOpenChange = (nextOpen: boolean) => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
@@ -485,7 +485,7 @@ function TopModelsTrendPanel({ data }: { data: ModelUsageRankingResponse }) {
               width={52}
               axisLine={false}
               tickLine={false}
-              tickFormatter={formatRankingCredits}
+              tickFormatter={formatRankingTokens}
               tick={{
                 fill: "hsl(var(--muted-foreground))",
                 fontSize: 11,
@@ -585,7 +585,7 @@ function LeaderboardRow({
       </div>
       <div className="min-w-[5.5rem] text-right">
         <div className="text-sm font-semibold tabular-nums text-foreground">
-          {formatRankingCredits(item.credits)}
+          {formatRankingTokens(item.totalTokens)}
         </div>
         <div className="mt-0.5 flex items-center justify-end text-xs">
           <RankingChangeBadge item={item} />
@@ -660,7 +660,7 @@ function TrendTooltip({ active, payload, label }: TooltipContentProps) {
                 <span className="truncate">{entry.name}</span>
               </span>
               <span className="font-medium tabular-nums text-foreground">
-                {formatRankingCredits(entry.value)}
+                {formatRankingTokens(entry.value)}
               </span>
             </div>
           );
@@ -690,7 +690,7 @@ function buildTrendChartData(
       const model = bucket.models.find((entry) => {
         return entry.model === item.model;
       });
-      row[item.key] = model?.credits ?? 0;
+      row[item.key] = model?.totalTokens ?? 0;
     }
     return row;
   });
@@ -791,7 +791,7 @@ function rankingBarColor(index: number): string {
   }
 }
 
-function formatRankingCredits(value: number): string {
+function formatRankingTokens(value: number): string {
   return new Intl.NumberFormat("en-US", {
     notation: "compact",
     maximumFractionDigits: value >= 1_000_000 ? 1 : 0,

--- a/turbo/apps/web/app/[locale]/rankings/page.tsx
+++ b/turbo/apps/web/app/[locale]/rankings/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next";
 import { sql } from "drizzle-orm";
 import { modelStat } from "@vm0/db/schema/model-stat";
+import {
+  VM0_MODEL_ALIAS_TO_MODEL,
+  normalizeVm0ModelId,
+} from "@vm0/api-contracts/contracts/model-providers";
 
 import { type Locale } from "../../../i18n";
 import { buildLocaleAlternates } from "../../lib/seo/alternates";
@@ -32,26 +36,20 @@ interface RankingRow {
   readonly name: string;
   readonly vendor: string;
   readonly iconPath: string | null;
-  readonly providers: string;
-  readonly requestCount: number;
   readonly inputTokens: number;
   readonly outputTokens: number;
   readonly cacheTokens: number;
   readonly totalTokens: number;
-  readonly creditsCharged: number;
   readonly previousTotalTokens: number;
   readonly share: number;
 }
 
 interface RawRankingRow {
   readonly model: unknown;
-  readonly providers: unknown;
-  readonly request_count: unknown;
   readonly input_tokens: unknown;
   readonly output_tokens: unknown;
   readonly cache_tokens: unknown;
   readonly total_tokens: unknown;
-  readonly credits_charged: unknown;
   readonly previous_total_tokens: unknown;
 }
 
@@ -65,6 +63,10 @@ const MODELS_BY_ID = new Map(
     ] as const;
   }),
 );
+
+function getModelAliasEntries() {
+  return Object.entries(VM0_MODEL_ALIAS_TO_MODEL);
+}
 
 export async function generateMetadata({
   params,
@@ -162,13 +164,6 @@ function toNumber(value: unknown): number {
   return 0;
 }
 
-function formatCompact(value: number): string {
-  return new Intl.NumberFormat("en", {
-    notation: "compact",
-    maximumFractionDigits: value >= 1_000_000 ? 1 : 0,
-  }).format(value);
-}
-
 function formatTokens(value: number): string {
   if (value >= 1_000_000_000_000) {
     return `${(value / 1_000_000_000_000).toFixed(2)}T`;
@@ -217,13 +212,24 @@ function formatChange(
 }
 
 function resolveModel(modelId: string): ModelEntry | undefined {
-  const direct = MODELS_BY_ID.get(modelId.toLowerCase());
+  const normalizedModelId = normalizeVm0ModelId(modelId);
+  const direct = MODELS_BY_ID.get(normalizedModelId.toLowerCase());
   if (direct) return direct;
 
-  const [, suffix] = modelId.split("/");
+  const [, suffix] = normalizedModelId.split("/");
   if (!suffix) return undefined;
 
   return MODELS_BY_ID.get(suffix.toLowerCase());
+}
+
+function modelStatModelExpression() {
+  const modelColumn = sql.raw('"model_stat"."model"');
+  return sql<string>`CASE ${sql.join(
+    getModelAliasEntries().map(([alias, model]) => {
+      return sql`WHEN ${modelColumn} = ${alias} THEN ${model}`;
+    }),
+    sql` `,
+  )} ELSE ${modelColumn} END`;
 }
 
 async function getRankings(period: PeriodKey): Promise<{
@@ -238,41 +244,36 @@ async function getRankings(period: PeriodKey): Promise<{
   const duration = Math.max(window.end.getTime() - window.start.getTime(), 0);
   const previousEnd = window.start;
   const previousStart = new Date(previousEnd.getTime() - duration);
+  const modelExpr = modelStatModelExpression();
 
   const result = await globalThis.services.db.execute(sql`
     WITH current_period AS (
       SELECT
-        ${modelStat.model} AS model,
-        COALESCE(string_agg(DISTINCT NULLIF(${modelStat.modelProvider}, ''), ', '), '') AS providers,
-        COALESCE(SUM(${modelStat.requestCount}), 0)::bigint AS request_count,
+        ${modelExpr} AS model,
         COALESCE(SUM(${modelStat.inputTokens}), 0)::bigint AS input_tokens,
         COALESCE(SUM(${modelStat.outputTokens}), 0)::bigint AS output_tokens,
         COALESCE(SUM(${modelStat.cacheReadInputTokens} + ${modelStat.cacheCreationInputTokens}), 0)::bigint AS cache_tokens,
-        COALESCE(SUM(${modelStat.totalTokens}), 0)::bigint AS total_tokens,
-        COALESCE(SUM(${modelStat.creditsCharged}), 0)::bigint AS credits_charged
+        COALESCE(SUM(${modelStat.totalTokens}), 0)::bigint AS total_tokens
       FROM ${modelStat}
       WHERE ${modelStat.hourStart} >= ${window.start}
         AND ${modelStat.hourStart} < ${window.end}
-      GROUP BY ${modelStat.model}
+      GROUP BY 1
     ),
     previous_period AS (
       SELECT
-        ${modelStat.model} AS model,
+        ${modelExpr} AS model,
         COALESCE(SUM(${modelStat.totalTokens}), 0)::bigint AS previous_total_tokens
       FROM ${modelStat}
       WHERE ${modelStat.hourStart} >= ${previousStart}
         AND ${modelStat.hourStart} < ${previousEnd}
-      GROUP BY ${modelStat.model}
+      GROUP BY 1
     )
     SELECT
       current_period.model,
-      current_period.providers,
-      current_period.request_count,
       current_period.input_tokens,
       current_period.output_tokens,
       current_period.cache_tokens,
       current_period.total_tokens,
-      current_period.credits_charged,
       COALESCE(previous_period.previous_total_tokens, 0)::bigint AS previous_total_tokens
     FROM current_period
     LEFT JOIN previous_period ON previous_period.model = current_period.model
@@ -316,13 +317,10 @@ async function getRankings(period: PeriodKey): Promise<{
         name: item.modelEntry.name,
         vendor: item.modelEntry.vendor,
         iconPath: vendorIconPath(item.modelEntry.vendor),
-        providers: String(item.row.providers ?? ""),
-        requestCount: toNumber(item.row.request_count),
         inputTokens: toNumber(item.row.input_tokens),
         outputTokens: toNumber(item.row.output_tokens),
         cacheTokens: toNumber(item.row.cache_tokens),
         totalTokens: item.totalTokens,
-        creditsCharged: toNumber(item.row.credits_charged),
         previousTotalTokens: toNumber(item.row.previous_total_tokens),
         share: totalTokens > 0 ? (item.totalTokens / totalTokens) * 100 : 0,
       };
@@ -396,7 +394,7 @@ function RankingTable({
 
   return (
     <div className="overflow-x-auto border-y border-[hsl(var(--gray-200))]">
-      <table className="w-full min-w-[760px] border-collapse text-left">
+      <table className="w-full min-w-[640px] border-collapse text-left">
         <thead>
           <tr className="border-b border-[hsl(var(--gray-200))] text-[12px] uppercase text-[hsl(var(--muted-foreground))]">
             <th className="w-[64px] px-3 py-3 font-medium">Rank</th>
@@ -404,13 +402,10 @@ function RankingTable({
             <th className="px-3 py-3 text-right font-medium">Tokens</th>
             <th className="px-3 py-3 text-right font-medium">Share</th>
             <th className="px-3 py-3 text-right font-medium">Change</th>
-            <th className="px-3 py-3 text-right font-medium">Requests</th>
-            <th className="px-3 py-3 text-right font-medium">Credits</th>
           </tr>
         </thead>
         <tbody>
           {rows.map((row) => {
-            const provider = row.providers || row.vendor;
             return (
               <tr
                 key={row.model}
@@ -442,7 +437,7 @@ function RankingTable({
                         {row.name}
                       </div>
                       <div className="truncate text-[12px] text-[hsl(var(--muted-foreground))]">
-                        {provider}
+                        {row.vendor}
                       </div>
                     </div>
                   </div>
@@ -464,12 +459,6 @@ function RankingTable({
                     current={row.totalTokens}
                     previous={row.previousTotalTokens}
                   />
-                </td>
-                <td className="px-3 py-4 text-right text-[14px] text-[hsl(var(--foreground))]">
-                  {formatCompact(row.requestCount)}
-                </td>
-                <td className="px-3 py-4 text-right text-[14px] text-[hsl(var(--foreground))]">
-                  {formatCompact(row.creditsCharged)}
                 </td>
               </tr>
             );

--- a/turbo/apps/web/app/api/zero/model-usage-ranking/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/model-usage-ranking/__tests__/route.test.ts
@@ -44,7 +44,7 @@ describe("GET /api/zero/model-usage-ranking", () => {
     expect(response.status).toBe(403);
   });
 
-  it("returns platform-wide model credit ranking without org or user details", async () => {
+  it("returns platform-wide model token ranking without org or user details", async () => {
     await seedUserFeatureSwitches(user.orgId, user.userId, {
       [FeatureSwitchKey.ModelUsageRanking]: true,
     });
@@ -55,7 +55,15 @@ describe("GET /api/zero/model-usage-ranking", () => {
     const modelB = `test-model-b-${Date.now()}`;
     const pendingModel = `test-model-pending-${Date.now()}`;
     const oldModel = `test-model-old-${Date.now()}`;
-    const insertedModels = [modelA, modelB, pendingModel, oldModel];
+    const sonnetAlias = "anthropic/claude-sonnet-4.6";
+    const sonnetModel = "claude-sonnet-4-6";
+    const insertedModels = [
+      modelA,
+      modelB,
+      pendingModel,
+      oldModel,
+      sonnetAlias,
+    ];
 
     try {
       await insertTestUsageEvent("org-a", {
@@ -88,6 +96,16 @@ describe("GET /api/zero/model-usage-ranking", () => {
         creditsCharged: 50_000_000,
         createdAt: now,
       });
+      await insertTestUsageEvent("org-sonnet", {
+        userId: "user-sonnet",
+        kind: "model",
+        provider: sonnetAlias,
+        category: "tokens.input",
+        quantity: 90_000_000,
+        status: "processed",
+        creditsCharged: 1,
+        createdAt: now,
+      });
       await insertTestUsageEvent("org-d", {
         userId: "user-d",
         kind: "model",
@@ -118,6 +136,9 @@ describe("GET /api/zero/model-usage-ranking", () => {
       const modelBRow = data.models.find((row) => {
         return row.model === modelB;
       });
+      const sonnetRow = data.models.find((row) => {
+        return row.model === sonnetModel;
+      });
       const modelAIndex = data.models.findIndex((row) => {
         return row.model === modelA;
       });
@@ -125,19 +146,17 @@ describe("GET /api/zero/model-usage-ranking", () => {
         return row.model === modelB;
       });
       expect(data.range).toBe("30d");
-      expect(data.grandTotalTokens).toBeGreaterThanOrEqual(45_000_000);
-      expect(data.grandTotalCredits).toBeGreaterThanOrEqual(80_000_000);
+      expect(data.grandTotalTokens).toBeGreaterThanOrEqual(135_000_000);
       expect(modelBIndex).toBeGreaterThanOrEqual(0);
       expect(modelAIndex).toBeGreaterThanOrEqual(0);
-      expect(modelBIndex).toBeLessThan(modelAIndex);
+      expect(modelAIndex).toBeLessThan(modelBIndex);
       expect(modelARow).toMatchObject({
         model: modelA,
         inputTokens: 20_000_000,
         outputTokens: 10_000_000,
         cacheTokens: 0,
         totalTokens: 30_000_000,
-        credits: 30_000_000,
-        previousCredits: 0,
+        previousTotalTokens: 0,
         changePercent: null,
       });
       expect(modelBRow).toMatchObject({
@@ -146,10 +165,15 @@ describe("GET /api/zero/model-usage-ranking", () => {
         outputTokens: 0,
         cacheTokens: 0,
         totalTokens: 15_000_000,
-        credits: 50_000_000,
-        previousCredits: 0,
+        previousTotalTokens: 0,
         changePercent: null,
       });
+      expect(sonnetRow).toMatchObject({
+        model: sonnetModel,
+        inputTokens: expect.any(Number),
+        totalTokens: expect.any(Number),
+      });
+      expect(sonnetRow?.inputTokens).toBeGreaterThanOrEqual(90_000_000);
       expect(data.daily).toHaveLength(30);
       const today = new Date(
         Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
@@ -163,12 +187,10 @@ describe("GET /api/zero/model-usage-ranking", () => {
         expect.arrayContaining([
           expect.objectContaining({
             model: modelA,
-            credits: 30_000_000,
             totalTokens: 30_000_000,
           }),
           expect.objectContaining({
             model: modelB,
-            credits: 50_000_000,
             totalTokens: 15_000_000,
           }),
         ]),
@@ -183,8 +205,15 @@ describe("GET /api/zero/model-usage-ranking", () => {
           return row.model === oldModel;
         }),
       ).toBe(false);
+      expect(
+        data.models.some((row) => {
+          return row.model === sonnetAlias;
+        }),
+      ).toBe(false);
       expect(JSON.stringify(data)).not.toContain("org-a");
       expect(JSON.stringify(data)).not.toContain("user-a");
+      expect(JSON.stringify(data)).not.toContain("credits");
+      expect(JSON.stringify(data)).not.toContain("request");
     } finally {
       await deleteTestUsageEventsByProvider(insertedModels);
     }

--- a/turbo/apps/web/src/lib/zero/billing/model-usage-ranking-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/model-usage-ranking-service.ts
@@ -5,6 +5,7 @@ import type {
   ModelUsageRankingRange,
   ModelUsageRankingResponse,
 } from "@vm0/api-contracts/contracts/zero-model-usage-ranking";
+import { VM0_MODEL_ALIAS_TO_MODEL } from "@vm0/api-contracts/contracts/model-providers";
 import type { Database } from "../../../types/global";
 import {
   MODEL_TOKEN_CATEGORIES,
@@ -23,7 +24,6 @@ interface ModelUsageAggregateRow {
   inputTokens: number;
   outputTokens: number;
   cacheTokens: number;
-  credits: number;
 }
 
 interface ModelUsageRowWithTotal extends ModelUsageAggregateRow {
@@ -33,8 +33,11 @@ interface ModelUsageRowWithTotal extends ModelUsageAggregateRow {
 interface ModelUsageDailyAggregateRow {
   date: string;
   model: string;
-  credits: number;
   totalTokens: number;
+}
+
+function getModelAliasEntries() {
+  return Object.entries(VM0_MODEL_ALIAS_TO_MODEL);
 }
 
 function getRangeDays(range: ModelUsageRankingRange): number {
@@ -68,20 +71,37 @@ function usageEventTokenSum(category: string, alias: string) {
   );
 }
 
+function usageEventModelExpression() {
+  const providerColumn = sql.raw('"usage_event"."provider"');
+  return sql<string>`CASE ${sql.join(
+    getModelAliasEntries().map(([alias, model]) => {
+      return sql`WHEN ${providerColumn} = ${alias} THEN ${model}`;
+    }),
+    sql` `,
+  )} ELSE ${providerColumn} END`;
+}
+
+function creditUsageModelExpression() {
+  const modelColumn = sql.raw('"credit_usage"."model"');
+  return sql<string>`CASE ${sql.join(
+    getModelAliasEntries().map(([alias, model]) => {
+      return sql`WHEN ${modelColumn} = ${alias} THEN ${model}`;
+    }),
+    sql` `,
+  )} ELSE ${modelColumn} END`;
+}
+
 async function queryUsageEventDailyRows(
   db: Database,
   start: Date,
   end: Date,
 ): Promise<ModelUsageDailyAggregateRow[]> {
   const dateExpr = sql<string>`to_char(date_trunc('day', ${usageEvent.processedAt}), 'YYYY-MM-DD')`;
+  const modelExpr = usageEventModelExpression();
   const rows = await db
     .select({
       date: dateExpr.as("date"),
-      model: usageEvent.provider,
-      credits:
-        sql<number>`COALESCE(SUM(${usageEvent.creditsCharged}), 0)::bigint`.as(
-          "credits",
-        ),
+      model: modelExpr.as("model"),
       totalTokens:
         sql<number>`COALESCE(SUM(${usageEvent.quantity}), 0)::bigint`.as(
           "total_tokens",
@@ -97,13 +117,12 @@ async function queryUsageEventDailyRows(
         lt(usageEvent.processedAt, end),
       ),
     )
-    .groupBy(dateExpr, usageEvent.provider);
+    .groupBy(sql.raw("1"), sql.raw("2"));
 
   return rows.map((row) => {
     return {
       date: row.date,
       model: row.model,
-      credits: Number(row.credits),
       totalTokens: Number(row.totalTokens),
     };
   });
@@ -115,14 +134,11 @@ async function queryLegacyCreditUsageDailyRows(
   end: Date,
 ): Promise<ModelUsageDailyAggregateRow[]> {
   const dateExpr = sql<string>`to_char(date_trunc('day', ${creditUsage.processedAt}), 'YYYY-MM-DD')`;
+  const modelExpr = creditUsageModelExpression();
   const rows = await db
     .select({
       date: dateExpr.as("date"),
-      model: creditUsage.model,
-      credits:
-        sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
-          "credits",
-        ),
+      model: modelExpr.as("model"),
       totalTokens:
         sql<number>`COALESCE(SUM(${creditUsage.inputTokens} + ${creditUsage.outputTokens} + ${creditUsage.cacheReadInputTokens} + ${creditUsage.cacheCreationInputTokens}), 0)::bigint`.as(
           "total_tokens",
@@ -136,13 +152,12 @@ async function queryLegacyCreditUsageDailyRows(
         lt(creditUsage.processedAt, end),
       ),
     )
-    .groupBy(dateExpr, creditUsage.model);
+    .groupBy(sql.raw("1"), sql.raw("2"));
 
   return rows.map((row) => {
     return {
       date: row.date,
       model: row.model,
-      credits: Number(row.credits),
       totalTokens: Number(row.totalTokens),
     };
   });
@@ -153,18 +168,15 @@ async function queryUsageEventModelRows(
   start: Date,
   end: Date,
 ): Promise<ModelUsageAggregateRow[]> {
+  const modelExpr = usageEventModelExpression();
   const rows = await db
     .select({
-      model: usageEvent.provider,
+      model: modelExpr.as("model"),
       inputTokens: usageEventTokenSum(TOKEN_CATEGORY_INPUT, "input_tokens"),
       outputTokens: usageEventTokenSum(TOKEN_CATEGORY_OUTPUT, "output_tokens"),
       cacheTokens:
         sql<number>`COALESCE(SUM(CASE WHEN ${usageEvent.category} IN (${TOKEN_CATEGORY_CACHE_READ}, ${TOKEN_CATEGORY_CACHE_CREATION}) THEN ${usageEvent.quantity} ELSE 0 END), 0)::bigint`.as(
           "cache_tokens",
-        ),
-      credits:
-        sql<number>`COALESCE(SUM(${usageEvent.creditsCharged}), 0)::bigint`.as(
-          "credits",
         ),
     })
     .from(usageEvent)
@@ -177,7 +189,7 @@ async function queryUsageEventModelRows(
         lt(usageEvent.processedAt, end),
       ),
     )
-    .groupBy(usageEvent.provider);
+    .groupBy(sql.raw("1"));
 
   return rows.map((row) => {
     return {
@@ -185,7 +197,6 @@ async function queryUsageEventModelRows(
       inputTokens: Number(row.inputTokens),
       outputTokens: Number(row.outputTokens),
       cacheTokens: Number(row.cacheTokens),
-      credits: Number(row.credits),
     };
   });
 }
@@ -195,9 +206,10 @@ async function queryLegacyCreditUsageModelRows(
   start: Date,
   end: Date,
 ): Promise<ModelUsageAggregateRow[]> {
+  const modelExpr = creditUsageModelExpression();
   const rows = await db
     .select({
-      model: creditUsage.model,
+      model: modelExpr.as("model"),
       inputTokens:
         sql<number>`COALESCE(SUM(${creditUsage.inputTokens}), 0)::bigint`.as(
           "input_tokens",
@@ -210,10 +222,6 @@ async function queryLegacyCreditUsageModelRows(
         sql<number>`COALESCE(SUM(${creditUsage.cacheReadInputTokens} + ${creditUsage.cacheCreationInputTokens}), 0)::bigint`.as(
           "cache_tokens",
         ),
-      credits:
-        sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
-          "credits",
-        ),
     })
     .from(creditUsage)
     .where(
@@ -223,7 +231,7 @@ async function queryLegacyCreditUsageModelRows(
         lt(creditUsage.processedAt, end),
       ),
     )
-    .groupBy(creditUsage.model);
+    .groupBy(sql.raw("1"));
 
   return rows.map((row) => {
     return {
@@ -231,7 +239,6 @@ async function queryLegacyCreditUsageModelRows(
       inputTokens: Number(row.inputTokens),
       outputTokens: Number(row.outputTokens),
       cacheTokens: Number(row.cacheTokens),
-      credits: Number(row.credits),
     };
   });
 }
@@ -247,7 +254,6 @@ function mergeRows(rows: ModelUsageAggregateRow[]): ModelUsageAggregateRow[] {
     current.inputTokens += row.inputTokens;
     current.outputTokens += row.outputTokens;
     current.cacheTokens += row.cacheTokens;
-    current.credits += row.credits;
   }
   return [...byModel.values()];
 }
@@ -263,7 +269,6 @@ function mergeDailyRows(
       byDateAndModel.set(key, { ...row });
       continue;
     }
-    current.credits += row.credits;
     current.totalTokens += row.totalTokens;
   }
   return [...byDateAndModel.values()];
@@ -306,43 +311,41 @@ export async function getModelUsageRanking(
     queryLegacyCreditUsageDailyRows(db, start, now),
   ]);
   const rows = withTotalTokens(mergeRows([...eventRows, ...legacyRows]));
-  const previousRows = mergeRows([...previousEventRows, ...previousLegacyRows]);
-  const previousCreditsByModel = new Map(
+  const previousRows = withTotalTokens(
+    mergeRows([...previousEventRows, ...previousLegacyRows]),
+  );
+  const previousTotalTokensByModel = new Map(
     previousRows.map((row) => {
-      return [row.model, row.credits] as const;
+      return [row.model, row.totalTokens] as const;
     }),
   );
 
   const grandTotalTokens = rows.reduce((sum, row) => {
     return sum + row.totalTokens;
   }, 0);
-  const grandTotalCredits = rows.reduce((sum, row) => {
-    return sum + row.credits;
-  }, 0);
-
   const models = rows
     .filter((row) => {
-      return row.credits > 0;
+      return row.totalTokens > 0;
     })
     .sort((a, b) => {
-      return b.credits - a.credits;
+      return b.totalTokens - a.totalTokens;
     })
     .slice(0, MODEL_USAGE_RANKING_LIMIT)
     .map((row) => {
-      const previousCredits = previousCreditsByModel.get(row.model) ?? 0;
+      const previousTotalTokens =
+        previousTotalTokensByModel.get(row.model) ?? 0;
       return {
         model: row.model,
         inputTokens: row.inputTokens,
         outputTokens: row.outputTokens,
         cacheTokens: row.cacheTokens,
         totalTokens: row.totalTokens,
-        credits: row.credits,
-        previousCredits,
+        previousTotalTokens,
         changePercent:
-          previousCredits > 0
-            ? (row.credits - previousCredits) / previousCredits
+          previousTotalTokens > 0
+            ? (row.totalTokens - previousTotalTokens) / previousTotalTokens
             : null,
-        share: grandTotalCredits > 0 ? row.credits / grandTotalCredits : 0,
+        share: grandTotalTokens > 0 ? row.totalTokens / grandTotalTokens : 0,
       };
     });
   const rankedModels = models.map((row) => {
@@ -359,15 +362,11 @@ export async function getModelUsageRanking(
       const row = dailyRowsByDateAndModel.get(`${date}:${model}`);
       return {
         model,
-        credits: row?.credits ?? 0,
         totalTokens: row?.totalTokens ?? 0,
       };
     });
     return {
       date,
-      totalCredits: dailyModels.reduce((sum, row) => {
-        return sum + row.credits;
-      }, 0),
       totalTokens: dailyModels.reduce((sum, row) => {
         return sum + row.totalTokens;
       }, 0),
@@ -379,7 +378,6 @@ export async function getModelUsageRanking(
     range,
     generatedAt: now.toISOString(),
     grandTotalTokens,
-    grandTotalCredits,
     models,
     daily,
   };

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -7,6 +7,7 @@ import {
   getDefaultModel,
   getEnvironmentMapping,
   getVm0VisibleModels,
+  normalizeVm0ModelId,
   VM0_MODEL_TO_PROVIDER,
   MODEL_PROVIDER_FIREWALL_CONFIGS,
   type ModelProviderType,
@@ -160,6 +161,22 @@ describe("getVm0VisibleModels", () => {
     const models = getVm0VisibleModels({});
     expect(models).toContain("deepseek-v4-pro");
     expect(models).toContain("deepseek-v4-flash");
+  });
+});
+
+describe("normalizeVm0ModelId", () => {
+  it.each([
+    ["anthropic/claude-sonnet-4.6", "claude-sonnet-4-6"],
+    ["deepseek/deepseek-v4-pro", "deepseek-v4-pro"],
+    ["z-ai/glm-5.1", "glm-5.1"],
+    ["moonshotai/kimi-k2.6", "kimi-k2.6"],
+    ["minimax/minimax-m2.7", "MiniMax-M2.7"],
+  ])("normalizes %s to %s", (model, expected) => {
+    expect(normalizeVm0ModelId(model)).toBe(expected);
+  });
+
+  it("keeps unknown model ids unchanged", () => {
+    expect(normalizeVm0ModelId("custom/model")).toBe("custom/model");
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -276,10 +276,12 @@ export {
   // VM0 managed provider
   VM0_ORG_SLUG,
   VM0_MODEL_TO_PROVIDER,
+  VM0_MODEL_ALIAS_TO_MODEL,
   getVm0ConcreteProviderType,
   getVm0Vendor,
   getVm0ApiModel,
   getVm0VisibleModels,
+  normalizeVm0ModelId,
 } from "./model-providers";
 export {
   sessionsByIdContract,

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -92,6 +92,26 @@ export const VM0_MODEL_TO_PROVIDER: Record<string, Vm0ModelConfig> = {
   },
 };
 
+export const VM0_MODEL_ALIAS_TO_MODEL = {
+  "anthropic/claude-opus-4.7": "claude-opus-4-7",
+  "anthropic/claude-opus-4.6": "claude-opus-4-6",
+  "anthropic/claude-sonnet-4.6": "claude-sonnet-4-6",
+  "anthropic/claude-haiku-4.5": "claude-haiku-4-5",
+  "z-ai/glm-5.1": "glm-5.1",
+  "deepseek/deepseek-v4-pro": "deepseek-v4-pro",
+  "deepseek/deepseek-v4-flash": "deepseek-v4-flash",
+  "moonshotai/kimi-k2.6": "kimi-k2.6",
+  "moonshotai/kimi-k2.5": "kimi-k2.5",
+  "minimax/minimax-m2.7": "MiniMax-M2.7",
+} as const satisfies Record<string, keyof typeof VM0_MODEL_TO_PROVIDER>;
+
+const VM0_MODEL_ALIAS_LOOKUP: Readonly<Record<string, string>> =
+  VM0_MODEL_ALIAS_TO_MODEL;
+
+export function normalizeVm0ModelId(model: string): string {
+  return VM0_MODEL_ALIAS_LOOKUP[model] ?? model;
+}
+
 /**
  * Return the VM0 managed models visible to the caller, filtered by feature
  * switches. Models without a featureFlag are always visible; models with a

--- a/turbo/packages/api-contracts/src/contracts/zero-model-usage-ranking.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-model-usage-ranking.ts
@@ -12,21 +12,18 @@ const modelUsageRankingItemSchema = z.object({
   outputTokens: z.number(),
   cacheTokens: z.number(),
   totalTokens: z.number(),
-  credits: z.number(),
-  previousCredits: z.number(),
+  previousTotalTokens: z.number(),
   changePercent: z.number().nullable(),
   share: z.number(),
 });
 
 const modelUsageRankingDailyModelSchema = z.object({
   model: z.string(),
-  credits: z.number(),
   totalTokens: z.number(),
 });
 
 const modelUsageRankingDailyBucketSchema = z.object({
   date: z.string(),
-  totalCredits: z.number(),
   totalTokens: z.number(),
   models: z.array(modelUsageRankingDailyModelSchema),
 });
@@ -35,7 +32,6 @@ const modelUsageRankingResponseSchema = z.object({
   range: modelUsageRankingRangeSchema,
   generatedAt: z.string(),
   grandTotalTokens: z.number(),
-  grandTotalCredits: z.number(),
   models: z.array(modelUsageRankingItemSchema),
   daily: z.array(modelUsageRankingDailyBucketSchema),
 });


### PR DESCRIPTION
## Summary
- remove requests and credits from model ranking UI/API surfaces
- normalize provider-specific model IDs before ranking aggregation
- aggregate model stats by canonical model name instead of provider

## Tests
- pnpm format
- pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/model-stats.test.ts
- pnpm -F web exec vitest run app/api/zero/model-usage-ranking/__tests__/route.test.ts
- pnpm -F @vm0/app exec vitest run src/views/org/__tests__/org-providers-tab.test.tsx
- pnpm -F @vm0/api-contracts check-types
- pnpm -F api check-types
- pnpm -F web check-types
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/api-contracts lint
- pnpm -F api lint
- pnpm -F web lint
- pnpm -F @vm0/app lint
- git diff --check
- pre-commit hook: pnpm knip; turbo run check-types --concurrency=1