### PR TITLE
fix: soften chat thread running indicator

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -115,6 +115,45 @@
   }
 }
 
+/* Chat thread list: synchronized running-state ripple indicator */
+.zero-running-indicator {
+  position: relative;
+  display: inline-flex;
+  width: 0.86rem;
+  height: 0.86rem;
+  border-radius: 9999px;
+}
+.zero-running-indicator::before {
+  content: "";
+  position: absolute;
+  inset: 2.5px;
+  border-radius: inherit;
+  background: currentColor;
+  opacity: var(--zero-running-indicator-center-opacity, 0.34);
+  transform: scale(var(--zero-running-indicator-center-scale, 0.64));
+  transform-origin: center;
+}
+.zero-running-indicator::after {
+  content: "";
+  position: absolute;
+  inset: 1.5px;
+  border-radius: inherit;
+  border: 1px solid currentColor;
+  opacity: var(--zero-running-indicator-ripple-opacity, 0);
+  transform: scale(var(--zero-running-indicator-ripple-scale, 0.82));
+  transform-origin: center;
+}
+@media (prefers-reduced-motion: reduce) {
+  .zero-running-indicator::before {
+    opacity: 0.28;
+    transform: scale(0.62);
+  }
+  .zero-running-indicator::after {
+    opacity: 0.18;
+    transform: scale(1);
+  }
+}
+
 /* Zero app: inherits global cool gray tokens; only card-specific tokens defined here */
 .zero-app {
   --zero-card-radius: 1rem;

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import {
   useGet,
   useSet,
@@ -11,7 +12,6 @@ import {
   IconChevronRight,
   IconTrash,
   IconPencil,
-  IconLoader2,
 } from "@tabler/icons-react";
 import type { ChatThreadListItem } from "@vm0/api-contracts/contracts/chat-threads";
 import { useChatThreadsTitleLabels } from "./zero-sidebar-shared.tsx";
@@ -65,17 +65,76 @@ import { Link } from "../router/link.tsx";
 
 type IndicatorState = "running" | "unread" | "draft";
 type ChatThreadPaneIndicator = "main" | "sidebar";
+const RUNNING_INDICATOR_ANIMATION_MS = 2400;
+let runningIndicatorConsumers = 0;
+let runningIndicatorFrame: number | null = null;
+
+function setRunningIndicatorFrame(now: number): void {
+  const phase =
+    (now % RUNNING_INDICATOR_ANIMATION_MS) / RUNNING_INDICATOR_ANIMATION_MS;
+  const rippleStart = 0.52;
+  const smooth = (value: number): number => {
+    return value * value * (3 - 2 * value);
+  };
+  const centerProgress = smooth(Math.min(phase / rippleStart, 1));
+  const rippleProgress =
+    phase < rippleStart ? 0 : smooth((phase - rippleStart) / (1 - rippleStart));
+  const centerBaseScale = 0.64;
+  const centerScaleRange = 0.24;
+  const rippleOpacity =
+    phase < rippleStart ? 0 : Math.pow(1 - rippleProgress, 1.35) * 0.34;
+  const rootStyle = document.documentElement.style;
+  rootStyle.setProperty(
+    "--zero-running-indicator-center-scale",
+    (
+      centerBaseScale +
+      centerProgress * centerScaleRange -
+      rippleProgress * centerScaleRange
+    ).toFixed(3),
+  );
+  rootStyle.setProperty(
+    "--zero-running-indicator-center-opacity",
+    (0.34 + centerProgress * 0.18 - rippleProgress * 0.18).toFixed(3),
+  );
+  rootStyle.setProperty(
+    "--zero-running-indicator-ripple-scale",
+    (0.8 + rippleProgress * 0.76).toFixed(3),
+  );
+  rootStyle.setProperty(
+    "--zero-running-indicator-ripple-opacity",
+    rippleOpacity.toFixed(3),
+  );
+}
+
+function tickRunningIndicator(now: number): void {
+  setRunningIndicatorFrame(now);
+  runningIndicatorFrame = window.requestAnimationFrame(tickRunningIndicator);
+}
+
+function useSyncedRunningIndicator(enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled || typeof window === "undefined") {
+      return;
+    }
+    runningIndicatorConsumers += 1;
+    if (runningIndicatorConsumers === 1) {
+      tickRunningIndicator(window.performance.now());
+    }
+    return () => {
+      runningIndicatorConsumers -= 1;
+      if (runningIndicatorConsumers === 0 && runningIndicatorFrame !== null) {
+        window.cancelAnimationFrame(runningIndicatorFrame);
+        runningIndicatorFrame = null;
+      }
+    };
+  }, [enabled]);
+}
 
 function SessionStateIndicator({ state }: { state: IndicatorState }) {
+  useSyncedRunningIndicator(state === "running");
+
   if (state === "running") {
-    return (
-      <IconLoader2
-        aria-label="Running"
-        size={16}
-        stroke={2}
-        className="animate-spin text-sky-600"
-      />
-    );
+    return <span aria-label="Running" className="zero-running-indicator" />;
   }
   if (state === "unread") {
     return (

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import {
   useGet,
   useSet,
@@ -66,8 +65,8 @@ import { Link } from "../router/link.tsx";
 type IndicatorState = "running" | "unread" | "draft";
 type ChatThreadPaneIndicator = "main" | "sidebar";
 const RUNNING_INDICATOR_ANIMATION_MS = 2400;
-let runningIndicatorConsumers = 0;
-let runningIndicatorFrame: number | null = null;
+const RUNNING_INDICATOR_CONSUMERS_KEY = "zeroRunningIndicatorConsumers";
+const RUNNING_INDICATOR_FRAME_KEY = "zeroRunningIndicatorFrame";
 
 function setRunningIndicatorFrame(now: number): void {
   const phase =
@@ -108,33 +107,94 @@ function setRunningIndicatorFrame(now: number): void {
 
 function tickRunningIndicator(now: number): void {
   setRunningIndicatorFrame(now);
-  runningIndicatorFrame = window.requestAnimationFrame(tickRunningIndicator);
+  setRunningIndicatorFrameId(
+    window.requestAnimationFrame(tickRunningIndicator),
+  );
 }
 
-function useSyncedRunningIndicator(enabled: boolean): void {
-  useEffect(() => {
-    if (!enabled || typeof window === "undefined") {
+function getRunningIndicatorRoot(): HTMLElement {
+  return document.documentElement;
+}
+
+function getRunningIndicatorConsumerCount(): number {
+  const value =
+    getRunningIndicatorRoot().dataset[RUNNING_INDICATOR_CONSUMERS_KEY];
+  const count = value ? Number(value) : 0;
+  return Number.isFinite(count) && count > 0 ? count : 0;
+}
+
+function setRunningIndicatorConsumerCount(count: number): void {
+  const root = getRunningIndicatorRoot();
+  if (count > 0) {
+    root.dataset[RUNNING_INDICATOR_CONSUMERS_KEY] = String(count);
+    return;
+  }
+  delete root.dataset[RUNNING_INDICATOR_CONSUMERS_KEY];
+}
+
+function getRunningIndicatorFrameId(): number | null {
+  const value = getRunningIndicatorRoot().dataset[RUNNING_INDICATOR_FRAME_KEY];
+  if (!value) {
+    return null;
+  }
+  const frame = Number(value);
+  return Number.isFinite(frame) ? frame : null;
+}
+
+function setRunningIndicatorFrameId(frame: number | null): void {
+  const root = getRunningIndicatorRoot();
+  if (frame !== null) {
+    root.dataset[RUNNING_INDICATOR_FRAME_KEY] = String(frame);
+    return;
+  }
+  delete root.dataset[RUNNING_INDICATOR_FRAME_KEY];
+}
+
+function registerRunningIndicator(): void {
+  const consumerCount = getRunningIndicatorConsumerCount();
+  setRunningIndicatorConsumerCount(consumerCount + 1);
+  if (consumerCount === 0 && getRunningIndicatorFrameId() === null) {
+    tickRunningIndicator(window.performance.now());
+  }
+}
+
+function unregisterRunningIndicator(): void {
+  const consumerCount = Math.max(0, getRunningIndicatorConsumerCount() - 1);
+  setRunningIndicatorConsumerCount(consumerCount);
+  if (consumerCount === 0) {
+    const frame = getRunningIndicatorFrameId();
+    if (frame !== null) {
+      window.cancelAnimationFrame(frame);
+      setRunningIndicatorFrameId(null);
+    }
+  }
+}
+
+function createRunningIndicatorRef(): (node: HTMLSpanElement | null) => void {
+  let currentNode: HTMLSpanElement | null = null;
+  return (node) => {
+    if (currentNode === node) {
       return;
     }
-    runningIndicatorConsumers += 1;
-    if (runningIndicatorConsumers === 1) {
-      tickRunningIndicator(window.performance.now());
+    if (currentNode !== null && currentNode !== node) {
+      unregisterRunningIndicator();
     }
-    return () => {
-      runningIndicatorConsumers -= 1;
-      if (runningIndicatorConsumers === 0 && runningIndicatorFrame !== null) {
-        window.cancelAnimationFrame(runningIndicatorFrame);
-        runningIndicatorFrame = null;
-      }
-    };
-  }, [enabled]);
+    currentNode = node;
+    if (node !== null) {
+      registerRunningIndicator();
+    }
+  };
 }
 
 function SessionStateIndicator({ state }: { state: IndicatorState }) {
-  useSyncedRunningIndicator(state === "running");
-
   if (state === "running") {
-    return <span aria-label="Running" className="zero-running-indicator" />;
+    return (
+      <span
+        ref={createRunningIndicatorRef()}
+        aria-label="Running"
+        className="zero-running-indicator"
+      />
+    );
   }
   if (state === "unread") {
     return (


### PR DESCRIPTION
## Summary
- replace the chat thread list running spinner with a softer breathing indicator
- drive all running indicators from a shared animation frame so multiple active chats stay in sync
- use neutral theme tokens for a calmer loading state

## Verification
- pnpm --filter @vm0/app check-types
- pnpm test src/views/zero-page/__tests__/sidebar-running-indicator.test.tsx --no-file-parallelism --maxWorkers 1
- pre-commit full check-types