### PR TITLE
fix(model-picker): drop help cursor on multiplier hover

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -120,7 +120,7 @@ function MultiplierBadge({ multiplier }: { multiplier: number }) {
     <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="shrink-0 cursor-help text-xs tabular-nums text-muted-foreground underline decoration-dotted decoration-muted-foreground/50 underline-offset-2 hover:text-foreground hover:decoration-muted-foreground">
+          <span className="shrink-0 text-xs tabular-nums text-muted-foreground underline decoration-dotted decoration-muted-foreground/50 underline-offset-2 hover:text-foreground hover:decoration-muted-foreground">
             {formatMultiplier(multiplier)}
           </span>
         </TooltipTrigger>


### PR DESCRIPTION
## Summary
- Remove the `cursor-help` (question-mark cursor) from the multiplier text in the model picker.
- Stacked on top of #11455 — the multiplier-as-text affordance was introduced there.

The dotted underline already conveys "hover for tooltip"; the question-mark cursor felt heavy on a passive metadata element.

## Test plan
- [x] Lint passes
- [ ] Verify on the preview that hovering the ×0.06 / ×1.7 text no longer shows the help cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)