### PR TITLE
fix: add min pool connection to api db to eliminate cold-start latency

### DIFF
--- a/turbo/apps/api/src/lib/db.ts
+++ b/turbo/apps/api/src/lib/db.ts
@@ -139,6 +139,7 @@ const pool = lazySingleton((): Pool => {
     new Pool({
       allowExitOnIdle: true,
       connectionString: env("DATABASE_URL"),
+      min: 1,
       max: 5,
     }),
   );


### PR DESCRIPTION
## Summary
- The `apps/api` DB pool had `max: 5` but no `min`, defaulting to 0 connections between requests
- Combined with `allowExitOnIdle: true`, every call more than 10s apart paid a full TCP+TLS handshake (200-500ms)
- `SELECT org_members_cache` spans showed P50=450ms on an 86-row indexed table — the span captured connection establishment, not query execution
- Adding `min: 1` keeps one connection warm, eliminating the handshake from query spans

## Before/After
- Before: `/health/auth` → `getMemberRole()` → `SELECT org_members_cache` P50=450ms, P99=498ms
- After (expected): same query <5ms (connection already warm, indexed PK lookup)

## Test plan
- [ ] Deploy preview: verify `SELECT org_members_cache` spans in Axiom drop to <10ms P50
- [ ] Verify no connection leak: check `pg_stat_activity` count stable after deployment
- [ ] Verify `/health/auth` P99 drops proportionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)