### PR TITLE
docs(sandbox-fc): document snapshot error variants

### DIFF
--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -26,19 +26,59 @@ const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 use crate::factory::{DESTROY_RETRIES, DESTROY_RETRY_DELAY};
 
-/// Errors that can occur during snapshot creation.
+/// Errors that can occur during Firecracker snapshot creation.
+///
+/// These are the backend-specific errors returned by direct calls to
+/// [`create_snapshot`]. When snapshotting is invoked through
+/// [`FirecrackerSnapshotProvider`], they are converted into the provider-neutral
+/// `sandbox::SnapshotError` categories.
+///
+/// A failed attempt should be treated as not producing a usable snapshot.
+/// Cleanup is best-effort on most failure paths: stale output artifacts are
+/// removed at the start of the next attempt where possible, while some backend
+/// resources may need the runner garbage collector or operator inspection.
 #[derive(Debug, thiserror::Error)]
 pub enum SnapshotError {
+    /// Host or guest setup failed before a valid snapshot was finalized.
+    ///
+    /// This includes prerequisite checks, output/work/socket path setup, COW
+    /// file and NBD device preparation, network namespace setup/acquisition,
+    /// and guest pre-warm command execution. Retry is meaningful after fixing
+    /// the reported prerequisite/configuration issue or after a transient
+    /// resource failure clears.
     #[error("setup failed: {0}")]
     Setup(String),
+    /// The Firecracker launch path failed at the process boundary.
+    ///
+    /// This includes failing to spawn the `unshare`/network-namespace
+    /// Firecracker command and cases where that launch chain exits early and an
+    /// API timeout is reclassified with the captured process stderr. The
+    /// snapshot output is not valid.
     #[error("firecracker process failed: {0}")]
     Process(String),
+    /// Snapshot resource teardown failed after the workflow had otherwise
+    /// reached the finalization phase.
+    ///
+    /// Currently this is used when `destroy_keep_cow` exhausts its retries.
+    /// The NBD device is abandoned for later garbage collection and the
+    /// snapshot is aborted rather than publishing a COW file without a trusted
+    /// bitmap sidecar.
     #[error("teardown failed: {0}")]
     Teardown(String),
+    /// The Firecracker API failed while waiting for readiness, configuring the
+    /// VM, starting the instance, pausing it, or asking Firecracker to write
+    /// snapshot state and memory files.
     #[error("api error: {0}")]
     Api(#[from] ApiError),
+    /// The guest did not establish the expected vsock readiness connection, or
+    /// the listener task failed while waiting for it.
+    ///
+    /// Firecracker may already be running when this happens, but the snapshot
+    /// workflow has not reached the pre-warm, pause, or snapshot stages.
     #[error("vsock connection failed: {0}")]
     Vsock(String),
+    /// A host filesystem I/O operation failed while creating directories,
+    /// moving finalized COW artifacts, or syncing the output directory.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 }

--- a/crates/sandbox/src/snapshot.rs
+++ b/crates/sandbox/src/snapshot.rs
@@ -33,18 +33,50 @@ pub struct SnapshotOutput {
 }
 
 /// Errors that can occur during snapshot operations.
+///
+/// These variants describe provider-neutral failure categories returned by
+/// [`SnapshotProvider::create_snapshot`]. A failed snapshot attempt should be
+/// treated as incomplete: callers should not reuse output artifacts from the
+/// failed attempt unless the concrete provider documents a stronger guarantee.
 #[derive(Debug, thiserror::Error)]
 pub enum SnapshotError {
+    /// The provider could not prepare host resources, validate inputs, or
+    /// finish provider-specific setup needed before the snapshot can complete.
+    ///
+    /// Retry is usually only useful after fixing the reported prerequisite,
+    /// configuration, or transient resource-allocation failure.
     #[error("setup failed: {0}")]
     Setup(String),
+    /// The sandbox backend process or its launch chain failed while creating
+    /// the snapshot.
+    ///
+    /// This includes failures to spawn the backend and cases where the backend
+    /// exits before the provider can complete the snapshot workflow.
     #[error("process failed: {0}")]
     Process(String),
+    /// The provider failed while releasing or finalizing snapshot resources.
+    ///
+    /// The output should be treated as invalid. Retry may require operator
+    /// cleanup or the provider's garbage-collection path, depending on the
+    /// concrete backend.
     #[error("teardown failed: {0}")]
     Teardown(String),
+    /// The backend API reported an error while configuring, starting, pausing,
+    /// or snapshotting the sandbox.
+    ///
+    /// Retry depends on whether the API failure was caused by transient backend
+    /// state or by an invalid snapshot configuration.
     #[error("backend api error: {0}")]
     Api(String),
+    /// The provider could not establish or observe the guest readiness
+    /// connection required for snapshot creation.
+    ///
+    /// The backend may have started, but the snapshot workflow did not reach a
+    /// complete state.
     #[error("vsock connection failed: {0}")]
     Vsock(String),
+    /// A host I/O operation failed while preparing, finalizing, or checking
+    /// snapshot artifacts.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 }

--- a/crates/sandbox/src/snapshot.rs
+++ b/crates/sandbox/src/snapshot.rs
@@ -35,9 +35,9 @@ pub struct SnapshotOutput {
 /// Errors that can occur during snapshot operations.
 ///
 /// These variants describe provider-neutral failure categories returned by
-/// [`SnapshotProvider::create_snapshot`]. A failed snapshot attempt should be
-/// treated as incomplete: callers should not reuse output artifacts from the
-/// failed attempt unless the concrete provider documents a stronger guarantee.
+/// [`SnapshotProvider`] operations. A failed snapshot attempt should be treated
+/// as incomplete: callers should not reuse output artifacts from the failed
+/// attempt unless the concrete provider documents a stronger guarantee.
 #[derive(Debug, thiserror::Error)]
 pub enum SnapshotError {
     /// The provider could not prepare host resources, validate inputs, or


### PR DESCRIPTION
## Summary
- Document provider-neutral `sandbox::SnapshotError` categories used by `SnapshotProvider`
- Document Firecracker-specific `SnapshotError` variants, output validity, cleanup, and retry semantics

## Testing
- `cargo check --manifest-path crates/Cargo.toml -p sandbox -p sandbox-fc`
- pre-commit `cargo-fmt` and `cargo-clippy`

Closes #11477