### PR TITLE
chore(crates): enforce rustdoc checks

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -236,6 +236,11 @@ jobs:
           cd crates
           cargo clippy --all-targets --all-features
 
+      - name: Build documentation
+        run: |
+          cd crates
+          cargo doc --workspace --all-features --no-deps
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -97,6 +97,15 @@ codegen-units = 4
 [workspace.lints.rust]
 warnings = "deny"
 
+[workspace.lints.rustdoc]
+bare_urls = "deny"
+broken_intra_doc_links = "deny"
+invalid_codeblock_attributes = "deny"
+invalid_html_tags = "deny"
+invalid_rust_codeblocks = "deny"
+private_intra_doc_links = "deny"
+redundant_explicit_links = "deny"
+
 # See clippy.toml for test-specific overrides (allow-unwrap-in-tests etc.)
 [workspace.lints.clippy]
 all = "deny"

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -274,7 +274,7 @@ impl http_body::Body for SizedBody {
 /// PUT a file to a presigned S3 URL by streaming from disk.
 ///
 /// Unlike [`put_presigned`], this avoids loading the entire file into memory.
-/// A [`SizedBody`] streams bounded chunks and reports the file size via
+/// A `SizedBody` streams bounded chunks and reports the file size via
 /// `size_hint`, so hyper sets `Content-Length` automatically.
 /// On each retry the original file handle is cloned, producing a fresh body
 /// with stable file identity and length.

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -1,7 +1,7 @@
 //! Telemetry uploader — single-writer ownership of position files.
 //!
 //! All reads of the log files and writes to the `*_pos.txt` files happen
-//! on one tokio task ([`run`]). The periodic tick and any caller-driven
+//! on one tokio task (`run`). The periodic tick and any caller-driven
 //! flushes both flow through the same `tokio::select!`, so uploads are
 //! serialized — eliminating the tick-vs-final race that used to regress
 //! the position file (#11008).
@@ -219,7 +219,7 @@ impl Telemetry {
     ///
     /// Spawn **at most one instance per process.** The pos files
     /// (`paths::telemetry_*_pos_file`) are process-global; two uploader
-    /// tasks would each call [`upload_telemetry`] on the same files,
+    /// tasks would each call `upload_telemetry` on the same files,
     /// reintroducing the multi-writer race that the channel was built
     /// to eliminate (#11008). The type system can't enforce this — the
     /// constraint is the shared pos paths, not the channel.

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -9,10 +9,12 @@
 //! in the consumer.
 //!
 //! Usage (mirrors real Codex CLI):
+//! ```text
 //!   guest-mock-codex exec [--json] [--sandbox <mode>] [--skip-git-repo-check]
 //!                          [-C <dir>] [-m <model>] [--append-system-prompt <s>]
 //!                          [--last] [-- <prompt>]
 //!   guest-mock-codex exec resume <thread_id> [-- <prompt>]
+//! ```
 //!
 //! Fixture mode: when `MOCK_CODEX_FIXTURE=<name>` is set in the env, the
 //! synthetic 3-event sequence is replaced with a baked JSONL fixture by

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -27,7 +27,7 @@ pub struct ConfigArgs {
     /// Runner logical name
     #[arg(long)]
     name: String,
-    /// Runner group in vm0/<name> format (e.g. "vm0/production")
+    /// Runner group in `vm0/<name>` format (e.g. "vm0/production")
     #[arg(long)]
     group: String,
     /// Runner directory name (under /var/lib/vm0-runner/runners/)

--- a/crates/runner/src/network_logs.rs
+++ b/crates/runner/src/network_logs.rs
@@ -9,7 +9,7 @@ use crate::ids::RunId;
 
 /// Network log entry from the per-run JSONL file.
 ///
-/// [NETWORK_LOG_FIELDS] — shared schema boundary is api-contracts; producers
+/// `NETWORK_LOG_FIELDS` — shared schema boundary is api-contracts; producers
 /// include mitmproxy plus Rust-side DNS/kmsg logging.
 /// Uses a transparent `serde_json::Value` wrapper so all fields pass through
 /// to Axiom without needing a struct field for each one. This avoids silently

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -69,7 +69,7 @@ fn parse_runner_cmdline(argv: &[String]) -> Option<(PathBuf, String)> {
 
 /// Check if an argv belongs to a firecracker process.
 ///
-/// Looks at the binary name (argv[0]) — the run ID and base directory
+/// Looks at the binary name (`argv[0]`) — the run ID and base directory
 /// are resolved from `/proc/{pid}/cwd` instead of argument parsing,
 /// since our sandbox always sets `current_dir` to the workspace.
 fn is_firecracker_cmdline(argv: &[String]) -> bool {

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -299,7 +299,7 @@ impl MitmProxy {
     /// clean slate and will detect real crashes.
     ///
     /// The caller should spawn the mitmdump process (potentially in a
-    /// background task) and then call [`complete_restart`] with the result.
+    /// background task) and then call `complete_restart` with the result.
     pub async fn begin_restart(&mut self) -> MitmRestartParams {
         // Silence the old monitor permanently: after this call, no one
         // else holds a handle that could reset its `Arc<AtomicBool>`

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -660,7 +660,7 @@ impl InvariantConfig {
 /// SHA-256 fingerprint of all sandbox-fc internal configuration that affects
 /// snapshot output.
 ///
-/// Derived from [`InvariantConfig`] serialization — adding a field to that
+/// Derived from `InvariantConfig` serialization — adding a field to that
 /// struct automatically changes this hash.
 ///
 /// This is the backing implementation for [`SandboxFactory::config_hash`].

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -97,7 +97,7 @@ pub struct PooledNetns {
 /// Configuration for creating a [`NetnsPool`].
 ///
 /// When `proxy_port` is set, the pool maintains **two** queues
-/// (plain + proxy), each buffering [`BUFFER_SIZE`] namespaces.
+/// (plain + proxy), each buffering `BUFFER_SIZE` namespaces.
 pub struct NetnsPoolConfig {
     /// Proxy port for HTTP/HTTPS redirect (only adds redirect rules when set).
     pub proxy_port: Option<u16>,
@@ -663,7 +663,7 @@ fn acquire_pool_lock(locks: &LockPaths) -> Result<(u32, Flock<File>)> {
 
 /// Pre-warmed pool of network namespaces for Firecracker VMs.
 ///
-/// Maintains a buffer of [`BUFFER_SIZE`] ready namespaces per queue.
+/// Maintains a buffer of `BUFFER_SIZE` ready namespaces per queue.
 /// After each [`acquire`](Self::acquire), the pool spawns a background
 /// task to replenish the buffer. Namespaces returned via
 /// [`release`](Self::release) are recycled back into the queue.
@@ -687,7 +687,7 @@ pub struct NetnsPool {
 impl NetnsPool {
     /// Create a new pool with a small pre-warmed buffer.
     ///
-    /// Pre-warms [`BUFFER_SIZE`] namespaces per queue at startup.
+    /// Pre-warms `BUFFER_SIZE` namespaces per queue at startup.
     /// After each [`acquire`](Self::acquire), the pool replenishes to
     /// maintain the buffer level. Namespaces returned via
     /// [`release`](Self::release) are recycled back into the queue.
@@ -817,7 +817,7 @@ impl NetnsPool {
     /// 3. Create on-demand as fallback
     ///
     /// After acquisition, spawns a background replenishment task if the
-    /// buffer is below [`BUFFER_SIZE`].
+    /// buffer is below `BUFFER_SIZE`.
     ///
     /// When `proxy_port` is configured, acquires from the proxy queue
     /// (namespaces with iptables REDIRECT rules). Otherwise acquires from
@@ -1002,7 +1002,7 @@ impl NetnsPool {
     /// Return a namespace to the pool, or delete it if the pool is inactive.
     ///
     /// When `proxy_port` is configured, the namespace is returned to
-    /// [`Self::proxy_queue`] so its REDIRECT rules are reused.
+    /// the proxy queue so its REDIRECT rules are reused.
     pub async fn release(&mut self, ns: PooledNetns) -> Result<()> {
         if !self.active {
             delete_namespace_resources(&ns.name, &ns.host_device).await;

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -191,8 +191,8 @@ pub trait Sandbox: Send + Sync + Any {
     /// supervision via [`wait_exit`](Self::wait_exit).
     ///
     /// `output` controls whether stdout is buffered into the final
-    /// [`ProcessExit`](crate::ProcessExit) or streamed in real time through
-    /// [`SpawnHandle::stdout_rx`](crate::SpawnHandle::stdout_rx), optionally
+    /// [`ProcessExit`] or streamed in real time through
+    /// [`SpawnHandle::stdout_rx`], optionally
     /// teeing streamed chunks into a guest-side file.
     async fn spawn_watch(
         &self,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -43,6 +43,10 @@ pre-commit:
             run: cargo clippy --all-targets --all-features
             root: crates/
             glob: "crates/**/*.{rs,toml}"
+          - name: cargo-doc
+            run: cargo doc --workspace --all-features --no-deps
+            root: crates/
+            glob: "crates/**/*.{rs,toml}"
           - name: ruff-fmt
             run: ruff format .
             root: crates/runner/mitm-addon/


### PR DESCRIPTION
## Summary
- add workspace rustdoc lint denies in `crates/Cargo.toml` so cargo doc fails on broken public docs without requiring `RUSTDOCFLAGS`
- add `cargo doc --workspace --all-features --no-deps` to the crates CI check job and Rust pre-commit hook
- clean existing rustdoc warnings in crate documentation

## Testing
- `cargo doc --workspace --all-features --no-deps`
- pre-commit `cargo-doc`, `cargo-fmt`, and `cargo-clippy`

Closes #11537