### PR TITLE
feat(api-contracts): add openai-api-key provider type with codex model passthrough

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-icons.tsx
@@ -8,6 +8,7 @@ import claudeCodeIcon from "./icons/claude-code.svg";
 import deepseekIcon from "./icons/deepseek.svg";
 import kimiIcon from "./icons/kimi.svg";
 import minimaxIcon from "./icons/minimax.svg";
+import openaiIcon from "./icons/openai.svg";
 import openrouterIcon from "./icons/openrouter.svg";
 import vercelIcon from "./icons/vercel.svg";
 import vm0Icon from "./icons/vm0.svg";
@@ -22,6 +23,7 @@ const PROVIDER_ICONS: Readonly<Record<ModelProviderType, string>> =
     "zai-api-key": chatglmIcon,
     "moonshot-api-key": kimiIcon,
     "vercel-ai-gateway": vercelIcon,
+    "openai-api-key": openaiIcon,
     "azure-foundry": azureIcon,
     "aws-bedrock": bedrockIcon,
     vm0: vm0Icon,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -6,10 +6,13 @@ import {
   getModels,
   getDefaultModel,
   getEnvironmentMapping,
+  getFrameworkForType,
   getVm0VisibleModels,
   normalizeVm0ModelId,
   VM0_MODEL_TO_PROVIDER,
   MODEL_PROVIDER_FIREWALL_CONFIGS,
+  modelProviderTypeSchema,
+  modelProviderFrameworkSchema,
   type ModelProviderType,
 } from "../model-providers";
 
@@ -19,6 +22,7 @@ describe("getProviderBaseUrl", () => {
     "anthropic-api-key",
     "azure-foundry",
     "aws-bedrock",
+    "openai-api-key",
   ] as ModelProviderType[])("returns null for %s", (type) => {
     expect(getProviderBaseUrl(type)).toBeNull();
   });
@@ -177,6 +181,52 @@ describe("normalizeVm0ModelId", () => {
 
   it("keeps unknown model ids unchanged", () => {
     expect(normalizeVm0ModelId("custom/model")).toBe("custom/model");
+  });
+});
+
+describe("openai-api-key codex provider", () => {
+  it("declares codex framework", () => {
+    expect(getFrameworkForType("openai-api-key")).toBe("codex");
+  });
+
+  it("maps OPENAI_API_KEY and OPENAI_MODEL via environment mapping", () => {
+    const mapping = getEnvironmentMapping("openai-api-key");
+    expect(mapping).toBeDefined();
+    expect(mapping!["OPENAI_API_KEY"]).toBe("$secret");
+    expect(mapping!["OPENAI_MODEL"]).toBe("$model");
+  });
+
+  it("offers codex-compatible models with gpt-5.5 default", () => {
+    const models = getModels("openai-api-key");
+    expect(models).toContain("gpt-5.5");
+    expect(models).toContain("gpt-5.4");
+    expect(models).toContain("gpt-5.4-mini");
+    expect(models).toContain("gpt-5.3-codex");
+    expect(models).toContain("gpt-5.2");
+    expect(getDefaultModel("openai-api-key")).toBe("gpt-5.5");
+  });
+
+  it("supports model selection", () => {
+    expect(hasModelSelection("openai-api-key")).toBe(true);
+  });
+
+  it("firewall scopes to OpenAI Responses API", () => {
+    const config = MODEL_PROVIDER_FIREWALL_CONFIGS["openai-api-key"];
+    expect(config.apis).toHaveLength(1);
+    expect(config.apis[0]!.base).toBe("https://api.openai.com/v1/responses");
+    expect(config.apis[0]!.auth.headers).toEqual({
+      Authorization: "Bearer ${{ secrets.OPENAI_API_KEY }}",
+    });
+  });
+
+  it("modelProviderTypeSchema accepts openai-api-key", () => {
+    expect(modelProviderTypeSchema.safeParse("openai-api-key").success).toBe(
+      true,
+    );
+  });
+
+  it("modelProviderFrameworkSchema accepts codex", () => {
+    expect(modelProviderFrameworkSchema.safeParse("codex").success).toBe(true);
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -326,6 +326,25 @@ export const MODEL_PROVIDER_TYPES = {
     ] as string[],
     defaultModel: "anthropic/claude-sonnet-4.6",
   },
+  "openai-api-key": {
+    framework: "codex" as const,
+    secretName: "OPENAI_API_KEY",
+    label: "OpenAI",
+    secretLabel: "API key",
+    helpText: "Get your API key at: https://platform.openai.com/api-keys",
+    environmentMapping: {
+      OPENAI_API_KEY: "$secret",
+      OPENAI_MODEL: "$model",
+    } as Record<string, string>,
+    models: [
+      "gpt-5.5",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+      "gpt-5.3-codex",
+      "gpt-5.2",
+    ] as string[],
+    defaultModel: "gpt-5.5",
+  },
   "azure-foundry": {
     framework: "claude-code" as const,
     label: "Azure Foundry",
@@ -437,7 +456,7 @@ export const MODEL_PROVIDER_TYPES = {
 } as const;
 
 export type ModelProviderType = keyof typeof MODEL_PROVIDER_TYPES;
-export type ModelProviderFramework = "claude-code";
+export type ModelProviderFramework = "claude-code" | "codex";
 
 /**
  * Provider types hidden from user-facing selection UI.
@@ -488,6 +507,12 @@ export function getSelectableProviderTypes(): ModelProviderType[] {
 const ANTHROPIC_API_BASE = "https://api.anthropic.com";
 
 function getFirewallBaseUrl(type: ModelProviderType): string {
+  // Codex providers use OpenAI's Responses API — the only inference endpoint
+  // codex hits today. Scoping to /v1/responses keeps token replacement narrow
+  // (admin endpoints like /v1/files don't see the placeholder swap).
+  if (getFrameworkForType(type) === "codex") {
+    return "https://api.openai.com/v1/responses";
+  }
   const base = (
     getEnvironmentMapping(type)?.ANTHROPIC_BASE_URL ?? ANTHROPIC_API_BASE
   ).replace(/\/+$/, "");
@@ -595,6 +620,13 @@ export const MODEL_PROVIDER_FIREWALL_CONFIGS: Record<
     { name: "Authorization", valuePrefix: "Bearer" },
     "sk-CoffeeSafeLocalCoffeeSafeLocalCo",
   ),
+  // Placeholder: sk-proj-{156 chars}T3BlbkFJ{156 chars} (typical project key shape)
+  // Source: matches turbo/packages/connectors/src/firewalls/openai.generated.ts
+  "openai-api-key": mpFirewall(
+    "openai-api-key",
+    { name: "Authorization", valuePrefix: "Bearer" },
+    "sk-proj-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocaT3BlbkFJCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLoca",
+  ),
 };
 
 /**
@@ -624,12 +656,13 @@ export const modelProviderTypeSchema = z.enum([
   "deepseek-api-key",
   "zai-api-key",
   "vercel-ai-gateway",
+  "openai-api-key",
   "azure-foundry",
   "aws-bedrock",
   "vm0",
 ]);
 
-export const modelProviderFrameworkSchema = z.enum(["claude-code"]);
+export const modelProviderFrameworkSchema = z.enum(["claude-code", "codex"]);
 
 /**
  * Get the concrete provider type for a VM0 managed model.


### PR DESCRIPTION
## Summary

Closes #11527 (sub-issue 2 of epic #11520).

Registers the first non-`claude-code` model provider in `MODEL_PROVIDER_TYPES`: `openai-api-key`, declared as `framework: \"codex\"`. This unlocks BYOK OpenAI for the codex framework — no schema extension needed because vm0's runner already converts `OPENAI_MODEL` env var to a `codex exec -m <model>` flag.

- Widens `ModelProviderFramework` and its zod schema to include `\"codex\"`.
- Registers `openai-api-key` with environment mapping `{ OPENAI_API_KEY: \"$secret\", OPENAI_MODEL: \"$model\" }` and codex-compatible models (`gpt-5.5` default plus `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.2`).
- Generalizes `getFirewallBaseUrl` to branch on the codex framework, scoping the firewall to `https://api.openai.com/v1/responses` (the only inference endpoint codex hits today).
- Adds the corresponding entry to `MODEL_PROVIDER_FIREWALL_CONFIGS` with the standard `Authorization: Bearer …` header and an `sk-proj-…` placeholder.
- Wires the OpenAI icon into `provider-icons.tsx` (the `Record<ModelProviderType, string>` is exhaustive).

## Codex passthrough mechanism

This was the issue's primary verification ask. Mechanism is **end-to-end already wired** in vm0's runner:

1. `environmentMapping.OPENAI_MODEL = \"$model\"` substitutes the selected model into the compose env.
2. Guest-agent reads `OPENAI_MODEL` (`crates/guest-agent/src/env.rs:89`).
3. Guest-agent appends `-m <model>` to `codex exec` if the value is non-empty (`crates/guest-agent/src/cli.rs:152-184`).
4. The `codex` CLI documents `-m / --model <name>` for `codex exec`.

So contracts-side: an `environmentMapping` with `OPENAI_MODEL: \"$model\"` is sufficient — no per-provider model-passthrough field needed. Future model-provider authors: env-var → runner → flag is the lever.

## Picker visibility window — coordinated merge preferred

The codex-beta feature switch and picker filter live in #11529. Until #11529 lands, this entry is included in `getSelectableProviderTypes()` and the OpenAI tile is visible to all users. Functional behavior is correct under the suggested merge order (#11526 → #11527 → #11529): users who create a provider during the window pay OpenAI directly with their own key (BYOK), no vm0 cost. **Reviewer: prefer a coordinated merge with #11529 to minimize the exposure window.** I did not pollute `HIDDEN_PROVIDER_LIST` for temporary gating because doing so would also drop the entry from `FirewallSupportedProvider` and lose token-replacement protection — worse than the UX exposure.

## Out of scope

- Resolver/policy decoupling (the `framework !== \"claude-code\"` short-circuits in `resolve-model-provider.ts:289` and `zero-run-policy.ts:176`) — that's #11526. Until #11526 merges, this entry is inert at runtime.
- Beta gating + provider-create gate + UI description override — that's #11529.
- E2E coverage for codex BYOK — that's #11530.
- DB migration: not needed (`modelProviders.type` is `varchar(50)`).

## Test plan

- [x] `pnpm -F @vm0/api-contracts exec vitest run` — new \`describe(\"openai-api-key codex provider\", …)\` block plus existing tests pass (111/111)
- [x] `pnpm turbo run lint` — 0 warnings
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — no diffs
- [x] `pnpm knip` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)