### PR TITLE
refactor(api): convert body validation to computed and drop barrel reexports

### DIFF
--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -6,7 +6,7 @@ import {
 } from "@vm0/api-contracts/contracts/composes";
 import { z } from "zod";
 
-import { env } from "../external/env";
+import { env } from "../../lib/env";
 import { lazySingleton } from "../external/lazy-singleton";
 import { now } from "../external/time";
 import { safeJsonParse } from "../utils";

--- a/turbo/apps/api/src/signals/context/request.ts
+++ b/turbo/apps/api/src/signals/context/request.ts
@@ -1,5 +1,5 @@
 import type { AppRoute } from "@ts-rest/core";
-import { command, computed, type Command, type Computed } from "ccstate";
+import { computed, type Computed } from "ccstate";
 import type { z } from "zod";
 
 import { badRequest, badRequestMessage } from "../../lib/error";
@@ -116,31 +116,36 @@ export function queryOf<T>(_route: RouteWithQuery<T>): Computed<T> {
   return validatedQuery$ as Computed<T>;
 }
 
+const bodyResult$ = computed(async (get): Promise<BodyResult<unknown>> => {
+  const text = await get(request$).text();
+
+  const parsed = text.length === 0 ? {} : safeJsonParse(text);
+  if (parsed === undefined) {
+    return {
+      ok: false,
+      response: badRequestMessage("Invalid JSON in request body"),
+    };
+  }
+
+  const route = get(route$);
+  const schema = "body" in route ? route.body : undefined;
+  if (!isZodLikeSchema(schema)) {
+    return { ok: true, data: parsed };
+  }
+
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    return {
+      ok: false,
+      response: badRequest(result.error?.issues[0] ?? FALLBACK_ISSUE),
+    };
+  }
+
+  return { ok: true, data: result.data };
+});
+
 export function bodyResultOf<T>(
-  route: RouteWithBody<T>,
-): Command<Promise<BodyResult<T>>, [AbortSignal]> {
-  return command(
-    async ({ get }, signal: AbortSignal): Promise<BodyResult<T>> => {
-      const text = await get(request$).text();
-      signal.throwIfAborted();
-
-      const parsed = text.length === 0 ? {} : safeJsonParse(text);
-      if (parsed === undefined) {
-        return {
-          ok: false,
-          response: badRequestMessage("Invalid JSON in request body"),
-        };
-      }
-
-      const result = route.body.safeParse(parsed);
-      if (!result.success) {
-        return {
-          ok: false,
-          response: badRequest(result.error.issues[0] ?? FALLBACK_ISSUE),
-        };
-      }
-
-      return { ok: true, data: result.data };
-    },
-  );
+  _route: RouteWithBody<T>,
+): Computed<Promise<BodyResult<T>>> {
+  return bodyResult$ as Computed<Promise<BodyResult<T>>>;
 }

--- a/turbo/apps/api/src/signals/external/env.ts
+++ b/turbo/apps/api/src/signals/external/env.ts
@@ -2,8 +2,6 @@ import { computed, type Computed } from "ccstate";
 
 import { env, type EnvKey } from "../../lib/env";
 
-export { env, type EnvKey } from "../../lib/env";
-
 function envComputed<K extends EnvKey>(
   name: K,
 ): Computed<ReturnType<typeof env<K>>> {

--- a/turbo/apps/api/src/signals/external/log.ts
+++ b/turbo/apps/api/src/signals/external/log.ts
@@ -1,1 +1,0 @@
-export { logger } from "../../lib/log";

--- a/turbo/apps/api/src/signals/routes/device-token.ts
+++ b/turbo/apps/api/src/signals/routes/device-token.ts
@@ -19,26 +19,30 @@ const createBody$ = bodyResultOf(deviceTokenContract.create);
 const pollBody$ = bodyResultOf(deviceTokenContract.poll);
 const confirmBody$ = bodyResultOf(bb0DeviceConfirmContract.confirm);
 
-const createDeviceToken$ = command(async ({ set }, signal: AbortSignal) => {
-  const body = await set(createBody$, signal);
-  if (!body.ok) {
-    return body.response;
-  }
+const createDeviceToken$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const body = await get(createBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
 
-  const result = await set(
-    createBb0DeviceCode$,
-    body.data.ble_session_nonce,
-    signal,
-  );
+    const result = await set(
+      createBb0DeviceCode$,
+      body.data.ble_session_nonce,
+      signal,
+    );
 
-  return {
-    status: 200 as const,
-    body: result,
-  };
-});
+    return {
+      status: 200 as const,
+      body: result,
+    };
+  },
+);
 
-const pollDeviceToken$ = command(async ({ set }, signal: AbortSignal) => {
-  const body = await set(pollBody$, signal);
+const pollDeviceToken$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const body = await get(pollBody$);
+  signal.throwIfAborted();
   if (!body.ok) {
     return body.response;
   }
@@ -81,7 +85,8 @@ const pollDeviceToken$ = command(async ({ set }, signal: AbortSignal) => {
 
 const confirmBb0DeviceInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const body = await set(confirmBody$, signal);
+    const body = await get(confirmBody$);
+    signal.throwIfAborted();
     if (!body.ok) {
       return body.response;
     }

--- a/turbo/apps/api/src/signals/utils.ts
+++ b/turbo/apps/api/src/signals/utils.ts
@@ -1,6 +1,6 @@
-import { env } from "./external/env";
+import { env } from "../lib/env";
+import { logger } from "../lib/log";
 import { lazySingleton } from "./external/lazy-singleton";
-import { logger } from "./external/log";
 
 export enum Mechanism {
   WaitUntil = "wait_until",


### PR DESCRIPTION
## Summary

- Migrate `bodyResultOf` from a per-route `command` factory to a single shared `computed` that reads the body schema from `route$`, mirroring `queryOf` / `pathParamsOf`. Body parsing is now memoized per request, and all `bodyResultOf(...)` calls return the same underlying computed (typed via a phantom-type wrapper).
- Drop the unused barrel re-export in `signals/external/env.ts` and remove the single-line re-export file `signals/external/log.ts`. Consumers (`signals/utils.ts`, `signals/auth/tokens.ts`) now import `lib/env` and `lib/log` directly.
- Update `device-token.ts` route handlers to read body via `await get(...)` instead of `await set(..., signal)`, with required `signal.throwIfAborted()` after each await per the `signal-check-await` lint rule.

## Test plan

- [x] `pnpm -F api exec eslint` clean on changed files
- [x] `pnpm -F api check-types` passes
- [x] `pnpm -F api exec vitest run src/signals/routes` — 74/74 pass
- [ ] CI: lint / test / deploy / cli-e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)