### PR TITLE
feat(zero): decouple byok secret injection from claude-code framework

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -318,9 +318,12 @@ const router = tsr.router(runsMainContract, {
       authorizeCompose(userId, org.orgId, compose);
       const authorizeTime = Date.now();
 
-      // 4. Validate compose requirements (new runs only)
+      // 4. Validate compose requirements (new runs only).
+      // CLI requests carry no modelProvider/modelProviderId, so pass null —
+      // the validator's existing behavior (compose env required for non-
+      // claude-code frameworks) is preserved on this path.
       if (!body.checkpointId && !body.sessionId) {
-        await validateComposeRequirements(composeContent);
+        await validateComposeRequirements(composeContent, null);
       }
 
       // 5. Validate mutual exclusivity

--- a/turbo/apps/web/src/lib/infra/run/utils/__tests__/validate-framework-api-key.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/utils/__tests__/validate-framework-api-key.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { validateFrameworkApiKey } from "../validate-framework-api-key";
+import {
+  getSecretNameForType,
+  type ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
 import type { AgentComposeYaml } from "../../../agent-compose/types";
 
 function makeCompose(
@@ -76,6 +80,50 @@ describe("validateFrameworkApiKey", () => {
       expect(() => {
         validateFrameworkApiKey(makeCompose("codex", {}));
       }).toThrow(/codex/);
+    });
+
+    it("rejects codex compose when providerType's secretName mismatches the framework key", () => {
+      // anthropic-api-key has secretName=ANTHROPIC_API_KEY, not OPENAI_API_KEY,
+      // so it does NOT satisfy a codex compose's OPENAI_API_KEY requirement.
+      expect(() => {
+        validateFrameworkApiKey(
+          makeCompose("codex", {}),
+          "anthropic-api-key" as ModelProviderType,
+        );
+      }).toThrow(/OPENAI_API_KEY/);
+    });
+
+    it("rejects codex compose when providerType is null", () => {
+      expect(() => {
+        validateFrameworkApiKey(makeCompose("codex", {}), null);
+      }).toThrow(/OPENAI_API_KEY/);
+    });
+
+    // Forward-compat: activates once #11527 adds openai-api-key to MODEL_PROVIDER_TYPES.
+    const openaiSecretName = getSecretNameForType(
+      "openai-api-key" as ModelProviderType,
+    );
+    it.skipIf(openaiSecretName !== "OPENAI_API_KEY")(
+      "accepts codex compose when a provider with OPENAI_API_KEY secretName is supplied (forward-compat for #11527)",
+      () => {
+        expect(() => {
+          validateFrameworkApiKey(
+            makeCompose("codex", {}),
+            "openai-api-key" as ModelProviderType,
+          );
+        }).not.toThrow();
+      },
+    );
+  });
+
+  describe("claude-code with providerType", () => {
+    it("ignores providerType (claude-code is exempt regardless)", () => {
+      expect(() => {
+        validateFrameworkApiKey(
+          makeCompose("claude-code", {}),
+          "anthropic-api-key" as ModelProviderType,
+        );
+      }).not.toThrow();
     });
   });
 

--- a/turbo/apps/web/src/lib/infra/run/utils/validate-framework-api-key.ts
+++ b/turbo/apps/web/src/lib/infra/run/utils/validate-framework-api-key.ts
@@ -1,25 +1,33 @@
 import { getValidatedFramework } from "@vm0/core/frameworks";
 import { badRequest } from "@vm0/api-services/errors";
+import {
+  getSecretNameForType,
+  type ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
 import { resolveFrameworkApiKeyEnvVar } from "../../framework/framework-config";
 import type { AgentComposeYaml } from "../../agent-compose/types";
 
 /**
  * Validate that a compose's environment block declares the framework's
- * required API-key env var.
+ * required API-key env var, OR that a configured model provider supplies
+ * the equivalent secret at runtime.
  *
  * claude-code is exempt: the org-level model-provider system
  * (`checkModelProviderConfigured`) already gates runs that lack
- * `ANTHROPIC_API_KEY` and supports runtime injection from the org's default
- * provider. Frameworks without an org-level injection path (codex today)
- * must declare the key in the compose `environment` — either as a literal
- * value or as a `${{ secrets.X }}` placeholder; the runner resolves the
- * placeholder at execution time and surfaces its own error if the secret
- * is missing.
+ * `ANTHROPIC_API_KEY`. Other frameworks (codex today) are satisfied when
+ * either:
+ *   (a) compose `environment` declares the framework's key (literal or
+ *       `${{ secrets.X }}` placeholder), OR
+ *   (b) a configured `providerType`'s `secretName` matches the framework's
+ *       required env var — runtime injection from the provider supplies the
+ *       key without compose-level declaration.
  *
- * @throws BadRequestError if the env var is absent for a framework that
- *   requires compose-level declaration.
+ * @throws BadRequestError when neither path is satisfied.
  */
-export function validateFrameworkApiKey(compose: AgentComposeYaml): void {
+export function validateFrameworkApiKey(
+  compose: AgentComposeYaml,
+  providerType?: ModelProviderType | null,
+): void {
   const agents = compose.agents ? Object.values(compose.agents) : [];
   const agent = agents[0];
   if (!agent) return;
@@ -29,11 +37,15 @@ export function validateFrameworkApiKey(compose: AgentComposeYaml): void {
 
   const requiredVar = resolveFrameworkApiKeyEnvVar(framework);
   const env = agent.environment ?? {};
-  if (!(requiredVar in env)) {
-    throw badRequest(
-      `Compose with framework "${framework}" requires ${requiredVar} ` +
-        `in agent environment. Set it as a literal value or as a secret ` +
-        `reference: \${{ secrets.${requiredVar} }}`,
-    );
+  if (requiredVar in env) return;
+
+  if (providerType && getSecretNameForType(providerType) === requiredVar) {
+    return;
   }
+
+  throw badRequest(
+    `Compose with framework "${framework}" requires ${requiredVar} ` +
+      `in agent environment. Set it as a literal value or as a secret ` +
+      `reference: \${{ secrets.${requiredVar} }}`,
+  );
 }

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -177,6 +177,7 @@ async function resolveSecretsAndEnvironment(
   environment: Record<string, string> | undefined;
   secretConnectorMap: Record<string, string> | undefined;
   resolvedModelProvider: ModelProviderType | undefined;
+  resolvedFramework: string;
   modelProviderConfig: ExpandedFirewallConfig | undefined;
   selectedModel: string | undefined;
   connectorPermissionConfigs: ExpandedFirewallConfig[];
@@ -329,6 +330,9 @@ async function resolveSecretsAndEnvironment(
     environment,
     secretConnectorMap,
     resolvedModelProvider: modelProviderResult.resolvedModelProvider,
+    // Provider-derived framework when resolution ran; otherwise the compose
+    // framework. Source-of-truth for downstream framework-aware logic.
+    resolvedFramework: modelProviderResult.framework ?? framework,
     modelProviderConfig,
     selectedModel: modelProviderResult.selectedModel,
     connectorPermissionConfigs,
@@ -348,6 +352,8 @@ interface BuildZeroContextResult {
   timings: BuildZeroContextTimings;
   /** The resolved model provider type, if provider resolution ran during context build. */
   resolvedModelProvider: ModelProviderType | undefined;
+  /** Provider-derived framework, source-of-truth for downstream. */
+  resolvedFramework: string;
   /** The logical model name selected by the user, for credit usage billing. */
   selectedModel: string | undefined;
 }
@@ -718,6 +724,7 @@ export async function buildZeroExecutionContext(
     environment,
     secretConnectorMap,
     resolvedModelProvider,
+    resolvedFramework,
     modelProviderConfig,
     selectedModel,
     connectorPermissionConfigs,
@@ -784,6 +791,7 @@ export async function buildZeroExecutionContext(
       resolveSecrets: resolveSecretsEnd - resolveSecretsStart,
     },
     resolvedModelProvider,
+    resolvedFramework,
     selectedModel,
   };
 }

--- a/turbo/apps/web/src/lib/zero/context/__tests__/resolve-model-provider.test.ts
+++ b/turbo/apps/web/src/lib/zero/context/__tests__/resolve-model-provider.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { resolveModelProviderSecrets } from "../resolve-model-provider";
+import { isNoModelProvider } from "@vm0/api-services/errors";
+import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
+import {
+  createTestOrg,
+  insertOrgDefaultModelProvider,
+} from "../../../../__tests__/api-test-helpers";
+import { mockClerk } from "../../../../__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string): Promise<string> {
+  const orgSlug = uniqueId("resolver");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({
+    userId,
+    orgId,
+    orgRole: "org:admin",
+    orgSlug,
+    clerkOrgs: [{ id: orgId, slug: orgSlug, name: orgSlug, role: "org:admin" }],
+  });
+  await createTestOrg(orgSlug);
+  return orgId;
+}
+
+describe("resolveModelProviderSecrets — framework gate removed (#11526)", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("short-circuits on hasExplicitModelProviderConfig regardless of framework", async () => {
+    const userId = uniqueId("explicit-codex");
+    const orgId = await setupOrg(userId);
+
+    const result = await resolveModelProviderSecrets(orgId, "codex", true);
+
+    expect(result.secrets).toBeUndefined();
+    expect(result.injectedEnvironment).toBeUndefined();
+    expect(result.resolvedModelProvider).toBeUndefined();
+    expect(result.framework).toBe("codex");
+  });
+
+  it("short-circuits on hasExplicitModelProviderConfig for claude-code too", async () => {
+    const userId = uniqueId("explicit-cc");
+    const orgId = await setupOrg(userId);
+
+    const result = await resolveModelProviderSecrets(
+      orgId,
+      "claude-code",
+      true,
+    );
+
+    expect(result.framework).toBe("claude-code");
+    expect(result.resolvedModelProvider).toBeUndefined();
+  });
+
+  it("falls through to provider resolution for non-claude-code framework when no explicit config", async () => {
+    // Pre-#11526 behavior: returned silently with framework gate. Post-#11526:
+    // resolver runs to provider lookup, finds no codex provider, throws.
+    const userId = uniqueId("codex-noprov");
+    const orgId = await setupOrg(userId);
+
+    await expect(
+      resolveModelProviderSecrets(orgId, "codex", false),
+    ).rejects.toSatisfy((err: unknown) => {
+      return isNoModelProvider(err);
+    });
+  });
+
+  it("populates framework from the resolved provider for claude-code", async () => {
+    const userId = uniqueId("cc-anthropic");
+    const orgId = await setupOrg(userId);
+    await insertOrgDefaultModelProvider(orgId, "anthropic-api-key");
+
+    // Secret value is absent — resolver returns the metadata without secrets.
+    const result = await resolveModelProviderSecrets(
+      orgId,
+      "claude-code",
+      false,
+    );
+
+    expect(result.resolvedModelProvider).toBe("anthropic-api-key");
+    expect(result.framework).toBe("claude-code");
+  });
+});

--- a/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
@@ -10,7 +10,6 @@ import {
   getVm0Vendor,
   getVm0ApiModel,
   type ModelProviderType,
-  type ModelProviderFramework,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { badRequest, noModelProvider } from "@vm0/api-services/errors";
 import { logger } from "../../shared/logger";
@@ -153,8 +152,12 @@ interface ModelProviderSecretResult {
    *  servicePlaceholders logic; literals (base URLs, model names) are plain strings. */
   injectedEnvironment: Record<string, string> | undefined;
   /** The resolved model provider type (e.g. "anthropic", "vercel-ai-gateway").
-   *  Undefined when provider resolution was skipped (explicit env vars or non-claude-code). */
+   *  Undefined when provider resolution was skipped (explicit env vars). */
   resolvedModelProvider: ModelProviderType | undefined;
+  /** Canonical framework for this resolution. When a provider was resolved this
+   *  is the provider's framework (source-of-truth for downstream); otherwise
+   *  the input `framework` is echoed back. */
+  framework: string;
   /** For meta-providers like "vm0", the concrete provider type resolved at build time.
    *  Used for firewall lookup instead of the meta-provider type. */
   concreteProviderType?: ModelProviderType;
@@ -196,6 +199,7 @@ async function resolveVm0Provider(
     secrets,
     injectedEnvironment,
     resolvedModelProvider: "vm0",
+    framework: getFrameworkForType("vm0"),
     concreteProviderType: concreteType,
     selectedModel,
   };
@@ -262,6 +266,7 @@ async function resolveMultiAuthProviderSecrets(
     secrets: secretsMap,
     injectedEnvironment,
     resolvedModelProvider: providerType,
+    framework: getFrameworkForType(providerType),
     selectedModel,
   };
 }
@@ -285,12 +290,15 @@ export async function resolveModelProviderSecrets(
 ): Promise<ModelProviderSecretResult> {
   const secrets: Record<string, string> | undefined = undefined;
 
-  // Skip if explicit model provider config exists or framework doesn't use model providers
-  if (hasExplicitModelProviderConfig || framework !== "claude-code") {
+  // Skip if compose already declares the framework's auth env var directly.
+  // Framework-agnostic: codex with explicit OPENAI_API_KEY short-circuits here
+  // just like claude-code with explicit ANTHROPIC_API_KEY.
+  if (hasExplicitModelProviderConfig) {
     return {
       secrets,
       injectedEnvironment: undefined,
       resolvedModelProvider: undefined,
+      framework,
     };
   }
 
@@ -299,10 +307,7 @@ export async function resolveModelProviderSecrets(
   if (modelProviderId) {
     defaultProvider = await getModelProviderByIdForOrg(orgId, modelProviderId);
   } else {
-    defaultProvider = await getOrgDefaultModelProvider(
-      orgId,
-      framework as ModelProviderFramework,
-    );
+    defaultProvider = await getOrgDefaultModelProvider(orgId, framework);
   }
 
   const secretUserId = ORG_SENTINEL_USER_ID;
@@ -324,6 +329,8 @@ export async function resolveModelProviderSecrets(
     return resolveVm0Provider(selectedModel);
   }
 
+  const resolvedFramework = getFrameworkForType(providerType);
+
   // Handle multi-auth providers (like aws-bedrock)
   if (hasAuthMethods(providerType)) {
     const resolved = await resolveMultiAuthProviderSecrets(
@@ -338,6 +345,7 @@ export async function resolveModelProviderSecrets(
         secrets,
         injectedEnvironment: undefined,
         resolvedModelProvider: providerType,
+        framework: resolvedFramework,
         selectedModel,
       }
     );
@@ -350,6 +358,7 @@ export async function resolveModelProviderSecrets(
       secrets,
       injectedEnvironment: undefined,
       resolvedModelProvider: providerType,
+      framework: resolvedFramework,
       selectedModel,
     };
   }
@@ -366,6 +375,7 @@ export async function resolveModelProviderSecrets(
       secrets,
       injectedEnvironment: undefined,
       resolvedModelProvider: providerType,
+      framework: resolvedFramework,
       selectedModel,
     };
   }
@@ -385,6 +395,7 @@ export async function resolveModelProviderSecrets(
     secrets: { [secretName]: secretValue },
     injectedEnvironment,
     resolvedModelProvider: providerType,
+    framework: resolvedFramework,
     selectedModel,
   };
 }

--- a/turbo/apps/web/src/lib/zero/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/zero/model-provider/model-provider-service.ts
@@ -72,8 +72,12 @@ function toModelProviderInfo(params: {
 
 /**
  * Get all provider types that belong to a given framework.
+ *
+ * Accepts `string` rather than `ModelProviderFramework` so callers that derive
+ * the framework from a compose document (codex, claude-code, …) can filter
+ * without first widening the registry's enum.
  */
-function getTypesForFramework(framework: ModelProviderFramework): string[] {
+function getTypesForFramework(framework: string): string[] {
   return Object.keys(MODEL_PROVIDER_TYPES).filter((t) => {
     return getFrameworkForType(t as ModelProviderType) === framework;
   });
@@ -868,7 +872,7 @@ async function updateModelProviderModel(
 async function getDefaultModelProvider(
   orgId: string,
   userId: string,
-  framework: ModelProviderFramework,
+  framework: string,
 ): Promise<ModelProviderInfo | null> {
   // Use leftJoin to include multi-auth providers that don't have secretId
   const allProviders = await globalThis.services.db
@@ -1022,11 +1026,15 @@ export function updateOrgModelProviderModel(
 }
 
 /**
- * Get the org-level default model provider for a framework
+ * Get the org-level default model provider for a framework.
+ *
+ * `framework` accepts any string so non-claude-code frameworks (e.g. codex)
+ * can resolve their own default without widening the registry's enum.
+ * Unknown frameworks naturally return null because no registry type matches.
  */
 export function getOrgDefaultModelProvider(
   orgId: string,
-  framework: ModelProviderFramework,
+  framework: string,
 ): Promise<ModelProviderInfo | null> {
   return getDefaultModelProvider(orgId, ORG_SENTINEL_USER_ID, framework);
 }
@@ -1034,13 +1042,24 @@ export function getOrgDefaultModelProvider(
 /**
  * Get the org-level default model provider type for run-policy checks.
  *
- * This intentionally keeps the query narrow and accepts a db handle so callers
- * inside queue-drain transactions can keep the read in the same boundary.
+ * Filters by framework so a claude-code default does not satisfy a codex run
+ * (and vice versa) — without this filter, admission checks would pass for
+ * cross-framework configurations and fail later at provider-resolution time
+ * with a worse error.
+ *
+ * Accepts a db handle so callers inside queue-drain transactions can keep
+ * the read in the same boundary.
  */
 export async function getOrgDefaultModelProviderType(
   orgId: string,
+  framework: string,
   db: Database = globalThis.services.db,
 ): Promise<string | null> {
+  const frameworkTypes = getTypesForFramework(framework);
+  if (frameworkTypes.length === 0) {
+    return null;
+  }
+
   const [row] = await db
     .select({ type: modelProviders.type })
     .from(modelProviders)
@@ -1049,6 +1068,7 @@ export async function getOrgDefaultModelProviderType(
         eq(modelProviders.orgId, orgId),
         eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
         eq(modelProviders.isDefault, true),
+        inArray(modelProviders.type, frameworkTypes),
       ),
     )
     .limit(1);

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -6,12 +6,20 @@ import {
   forbidden,
   noModelProvider,
 } from "@vm0/api-services/errors";
+import {
+  MODEL_PROVIDER_TYPES,
+  type ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
 import { canAccessCompose } from "../infra/agent/compose-access";
 import { validateFrameworkApiKey } from "../infra/run/utils";
 import { logger } from "../shared/logger";
 import { MODEL_PROVIDER_ENV_VARS } from "./context/resolve-model-provider";
 import { checkOrgCredits } from "./credit/check-org-credits";
-import { getOrgDefaultModelProviderType } from "./model-provider/model-provider-service";
+import {
+  getOrgDefaultModelProvider,
+  getOrgDefaultModelProviderType,
+  getModelProviderByIdForOrg,
+} from "./model-provider/model-provider-service";
 import type { Database } from "../../types/global";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
 import type { AgentComposeYaml } from "../infra/agent-compose/types";
@@ -114,14 +122,48 @@ export function authorizeCompose(
  * Validate compose requirements for new runs.
  *
  * Skipped when resuming from checkpoint or continuing a session.
+ *
+ * `providerType`, when supplied, lets the API-key validator accept a
+ * provider-supplied secret in lieu of a compose-level declaration.
  */
 export async function validateComposeRequirements(
   composeContent: AgentComposeYaml,
+  providerType?: ModelProviderType | null,
 ): Promise<void> {
   if (!composeContent?.agents) {
     return;
   }
-  validateFrameworkApiKey(composeContent);
+  validateFrameworkApiKey(composeContent, providerType);
+}
+
+/**
+ * Resolve the provider type that admission checks should treat as the
+ * effective key source for this run. Precedence:
+ *   explicit override → explicit modelProviderId → org default for framework.
+ * Returns null when nothing is configured (admission decides whether that
+ * is fatal).
+ */
+export async function resolveProviderTypeForAdmission(params: {
+  orgId: string;
+  modelProvider?: string | null;
+  modelProviderId?: string | null;
+  composeFramework: string;
+}): Promise<ModelProviderType | null> {
+  if (params.modelProvider && params.modelProvider in MODEL_PROVIDER_TYPES) {
+    return params.modelProvider as ModelProviderType;
+  }
+  if (params.modelProviderId) {
+    const row = await getModelProviderByIdForOrg(
+      params.orgId,
+      params.modelProviderId,
+    );
+    return row?.type ?? null;
+  }
+  const def = await getOrgDefaultModelProvider(
+    params.orgId,
+    params.composeFramework,
+  );
+  return def?.type ?? null;
 }
 
 /**
@@ -147,7 +189,14 @@ export async function checkOrgCreditsForRun(
 
   let isVm0 = modelProvider === "vm0";
   if (!isVm0) {
-    const defaultProviderType = await getOrgDefaultModelProviderType(orgId, db);
+    // vm0 is the only credit-triggering provider, and it lives under
+    // claude-code, so the "is the org's default vm0?" check is intrinsically
+    // claude-code-scoped regardless of the run's framework.
+    const defaultProviderType = await getOrgDefaultModelProviderType(
+      orgId,
+      "claude-code",
+      db,
+    );
     isVm0 = defaultProviderType === "vm0";
   }
 
@@ -173,14 +222,15 @@ export async function checkModelProviderConfigured(
     : undefined;
   const framework = firstAgent?.framework || "claude-code";
 
-  if (framework !== "claude-code") return;
-
   const hasExplicitConfig = MODEL_PROVIDER_ENV_VARS.some((v) => {
     return firstAgent?.environment?.[v] !== undefined;
   });
   if (hasExplicitConfig) return;
 
-  const defaultProviderType = await getOrgDefaultModelProviderType(orgId);
+  const defaultProviderType = await getOrgDefaultModelProviderType(
+    orgId,
+    framework,
+  );
 
   if (!defaultProviderType) {
     throw noModelProvider();

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -33,6 +33,7 @@ import {
   validateComposeRequirements,
   checkOrgCreditsForRun,
   checkModelProviderConfigured,
+  resolveProviderTypeForAdmission,
 } from "./zero-run-policy";
 import {
   buildAndDispatchRun,
@@ -597,9 +598,20 @@ export async function dispatchQueuedZeroRun(
     composeContent,
   );
 
+  const composeAgents = composeContent?.agents
+    ? Object.values(composeContent.agents)
+    : [];
+  const composeFramework = composeAgents[0]?.framework ?? "claude-code";
+  const admissionProviderType = await resolveProviderTypeForAdmission({
+    orgId: params.orgId,
+    modelProvider: params.modelProvider,
+    modelProviderId: params.modelProviderId,
+    composeFramework,
+  });
+
   // Validate compose requirements for new runs only
   if (!params.checkpointId && !params.sessionId) {
-    await validateComposeRequirements(composeContent);
+    await validateComposeRequirements(composeContent, admissionProviderType);
   }
 
   // Register callbacks early so they persist even if context building fails

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -35,6 +35,7 @@ import {
   validateComposeRequirements,
   checkOrgCreditsForRun,
   checkModelProviderConfigured,
+  resolveProviderTypeForAdmission,
 } from "./zero-run-policy";
 import {
   enqueueRun,
@@ -649,8 +650,22 @@ async function createZeroRunRecord(
   });
   const authorizeTime = Date.now();
 
+  const composeAgents = resolved.composeContent?.agents
+    ? Object.values(resolved.composeContent.agents)
+    : [];
+  const composeFramework = composeAgents[0]?.framework ?? "claude-code";
+  const admissionProviderType = await resolveProviderTypeForAdmission({
+    orgId: resolved.orgId,
+    modelProvider: params.modelProvider,
+    modelProviderId: runParams.modelProviderId,
+    composeFramework,
+  });
+
   if (!params.sessionId) {
-    await validateComposeRequirements(resolved.composeContent);
+    await validateComposeRequirements(
+      resolved.composeContent,
+      admissionProviderType,
+    );
   }
 
   const round3Credits = timed(async () => {


### PR DESCRIPTION
## Goal

Make zero's BYOK secret injection and framework derivation framework-agnostic so non-claude-code frameworks (codex, future) can have provider keys resolved end-to-end. Issue #11526; part of epic #11520.

## Behavioral matrix

| Framework | Default provider | Compose api_key | Before | After |
|---|---|---|---|---|
| claude-code | anthropic-api-key | declared | injected | injected (unchanged) |
| claude-code | none | declared | rejected at admission | rejected (unchanged) |
| codex | openai-api-key (future) | declared | **skipped** by gate | injected |
| codex | none | none | passed admission | rejected (correct) |

## Diff summary

- `model-provider-service.ts` — widened framework param to `string`; required `framework` on `getOrgDefaultModelProviderType`
- `resolve-model-provider.ts` — dropped `framework !== "claude-code"` gate; added `framework` to `ModelProviderSecretResult` (provider-derived source of truth)
- `build-zero-context.ts` — surface `resolvedFramework` on `BuildZeroContextResult` for downstream consumers
- `validate-framework-api-key.ts` — accepts optional `providerType`, satisfies the requirement when the provider's secret name matches the framework's required env var
- `zero-run-policy.ts` — added `resolveProviderTypeForAdmission`; dropped `framework !== "claude-code"` bypass in `checkModelProviderConfigured`; pinned `checkOrgCreditsForRun` to `claude-code` (vm0 is the only credit-triggering provider and is claude-code-scoped)
- `zero-run-service.ts`, `zero-run-queue-service.ts`, `runs/route.ts` — plumb `providerType` to `validateComposeRequirements`

## Test plan

- [x] `vitest` resolve-model-provider tests (gate removal)
- [x] `vitest` validate-framework-api-key tests (provider-type match/mismatch + forward-compat openai skipIf)
- [x] `vitest` build-zero-context tests
- [x] `vitest` credit-check + vm0-provider tests (regression)
- [x] `vitest` chat messages route tests (regression)
- [x] `pnpm turbo run lint --filter='web'`
- [x] `pnpm check-types`
- [x] `pnpm format`
- [x] `pnpm knip`
- [x] grep regression: `rg 'framework !== "claude-code"'` in `lib/zero` + `lib/infra` returns zero matches

## Verify steps

1. `pnpm vitest run apps/web/src/lib/zero/context apps/web/src/lib/infra/run/utils`
2. Run a codex compose with an org default `openai-api-key` provider once #11527 lands → secrets injected, validator passes.
3. Run a claude-code compose with an `anthropic-api-key` default → unchanged behavior.

## Rollback

Each of the six commits is independently revertable. Reverting commits 2 + 5 restores the legacy `framework !== "claude-code"` gates if needed.

Closes #11526