### PR TITLE
feat(zero): codex-beta feature switch with provider-create gate and picker filter

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
@@ -11,10 +11,12 @@ import {
   getSelectableProviderTypes,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   orgConfiguredProviders$,
   orgOpenAddDialog$,
 } from "../../../../signals/zero-page/settings/org-model-providers.ts";
+import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import { getUILabel, getUIDescription } from "./provider-ui-config.ts";
 import { ProviderIcon } from "./provider-icons.tsx";
 
@@ -70,6 +72,8 @@ export function OrgAddProviderDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const configuredProviders = useLastResolved(orgConfiguredProviders$);
+  const features = useLastResolved(featureSwitch$);
+  const codexBetaEnabled = features?.[FeatureSwitchKey.CodexBeta] ?? false;
   const openAdd = useSet(orgOpenAddDialog$);
   const configuredSet = new Set(
     configuredProviders?.map((p) => {
@@ -82,7 +86,13 @@ export function OrgAddProviderDialog({
   };
 
   const availableTypes = getProviderTypes().filter((type) => {
-    return !configuredSet.has(type);
+    if (configuredSet.has(type)) {
+      return false;
+    }
+    if (type === "openai-api-key" && !codexBetaEnabled) {
+      return false;
+    }
+    return true;
   });
 
   return (

--- a/turbo/apps/web/app/api/zero/model-providers/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/__tests__/route.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { GET, POST } from "../route";
 import { DELETE } from "../[type]/route";
 import { POST as setDefaultPOST } from "../[type]/default/route";
@@ -8,6 +9,18 @@ import {
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import type { ModelProviderType } from "@vm0/api-contracts/contracts/model-providers";
+
+vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@vm0/core/feature-switch")>();
+  return {
+    ...actual,
+    isFeatureEnabled: vi.fn().mockReturnValue(true),
+  };
+});
+
+const { isFeatureEnabled } = await import("@vm0/core/feature-switch");
+const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
 
 const context = testContext();
 
@@ -295,6 +308,56 @@ describe("Org-level model provider routes", () => {
       });
       expect(anthropic!.isDefault).toBe(false);
       expect(oauth!.isDefault).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // codex-beta gate on POST /api/zero/model-providers
+  // ---------------------------------------------------------------------------
+
+  describe("openai-api-key codex-beta gate", () => {
+    beforeEach(() => {
+      mockIsFeatureEnabled.mockImplementation(() => {
+        return true;
+      });
+    });
+
+    it("creates openai-api-key provider when codex-beta is enabled", async () => {
+      mockIsFeatureEnabled.mockImplementation((key) => {
+        return key === FeatureSwitchKey.CodexBeta;
+      });
+
+      const response = await createProvider(
+        "openai-api-key",
+        "sk-proj-test",
+        "gpt-5.5",
+      );
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.provider.type).toBe("openai-api-key");
+      expect(data.provider.framework).toBe("codex");
+    });
+
+    it("returns 404 when codex-beta is disabled", async () => {
+      mockIsFeatureEnabled.mockImplementation((key) => {
+        return key !== FeatureSwitchKey.CodexBeta;
+      });
+
+      const response = await createProvider(
+        "openai-api-key",
+        "sk-proj-test",
+        "gpt-5.5",
+      );
+      expect(response.status).toBe(404);
+    });
+
+    it("does not gate other provider types when codex-beta is disabled", async () => {
+      mockIsFeatureEnabled.mockImplementation((key) => {
+        return key !== FeatureSwitchKey.CodexBeta;
+      });
+
+      const response = await createProvider("anthropic-api-key", "sk-ant-test");
+      expect(response.status).toBe(201);
     });
   });
 });

--- a/turbo/apps/web/app/api/zero/model-providers/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/route.ts
@@ -2,6 +2,8 @@ import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
 import { hasAuthMethods } from "@vm0/api-contracts/contracts/model-providers";
 import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { initServices } from "../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -14,6 +16,7 @@ import {
   upsertOrgMultiAuthModelProvider,
   upsertOrgNoSecretModelProvider,
 } from "../../../../src/lib/zero/model-provider/model-provider-service";
+import { loadFeatureSwitchOverrides } from "../../../../src/lib/zero/user/feature-switches-service";
 import { logger } from "../../../../src/lib/shared/logger";
 import { isBadRequest } from "@vm0/api-services/errors";
 
@@ -66,6 +69,21 @@ const router = tsr.router(zeroModelProvidersMainContract, {
     }
 
     const { type, secret, authMethod, secrets, selectedModel } = body;
+
+    if (type === "openai-api-key") {
+      const overrides = await loadFeatureSwitchOverrides(
+        org.orgId,
+        authCtx.userId,
+      );
+      const codexBetaEnabled = isFeatureEnabled(FeatureSwitchKey.CodexBeta, {
+        userId: authCtx.userId,
+        orgId: org.orgId,
+        overrides,
+      });
+      if (!codexBetaEnabled) {
+        return createErrorResponse("NOT_FOUND", `Provider "${type}" not found`);
+      }
+    }
 
     log.debug("upserting org model provider", {
       orgId: org.orgId,

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -53,4 +53,5 @@ export enum FeatureSwitchKey {
   Trinity = "trinity",
   ZapierConnector = "zapierConnector",
   GumroadConnector = "gumroadConnector",
+  CodexBeta = "codexBeta",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -294,6 +294,16 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable the Gumroad creator commerce connector (api-token + OAuth).",
     enabled: true,
   },
+  [FeatureSwitchKey.CodexBeta]: {
+    maintainer: "lancy@vm0.ai",
+    description:
+      "Gate the codex framework via BYOK OpenAI provider in zero web. " +
+      "When off, the openai-api-key tile is hidden in the add-provider " +
+      "dialog and POST /api/zero/model-providers with type=openai-api-key " +
+      "returns 404. Staff-only during rollout; per-user toggle via Lab.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary

- Add `FeatureSwitchKey.CodexBeta` with staff-org default via `STAFF_ORG_ID_HASHES` and per-user Lab override
- Gate `POST /api/zero/model-providers` when `type === "openai-api-key"` (returns `404 NOT_FOUND` to match `PlatformConnectors` precedent)
- Filter the `openai-api-key` tile from `OrgAddProviderDialog` when flag is off
- Pre-existing `openai-api-key` rows are grandfathered (gate is create-only, list/delete/setDefault unaffected)

Closes #11529
Refs #11520 (parent epic)

## Test plan

- [x] `vitest` — new gate tests in `app/api/zero/model-providers/__tests__/route.test.ts`:
  - creates `openai-api-key` provider when `CodexBeta` is enabled (201)
  - returns 404 when `CodexBeta` is disabled
  - does not gate other provider types when `CodexBeta` is disabled
- [x] `lint`, `format`, `check-types`, `knip` all green
- [x] Existing 18 tests in the same file still pass (no regressions)

## Notes on plan divergence (pre-approved)

- Issue body referenced singular path `/api/zero/model-provider/` — actual is plural `model-providers/`, handler key is `upsert`
- Issue body suggested 403 — used 404 to match `PlatformConnectors` pattern (don't reveal gated provider exists)
- Issue body referenced `model-provider-picker.tsx` (chat composer) — actual filter point is `OrgAddProviderDialog` (settings page entry)
- Issue body's gate omitted `loadFeatureSwitchOverrides` — added it so per-user Lab toggle works

🤖 Generated with [Claude Code](https://claude.com/claude-code)