### PR TITLE
[codex] preserve chat sidebar on new thread

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -131,9 +131,9 @@ export const apiAgentsHandlers = [
   }),
 
   // POST /api/zero/chat-threads (create new thread)
-  mockApi(chatThreadsContract.create, ({ respond }) => {
+  mockApi(chatThreadsContract.create, ({ body, respond }) => {
     return respond(201, {
-      id: "b0000000-0000-4000-a000-000000000001",
+      id: body.clientThreadId ?? "b0000000-0000-4000-a000-000000000001",
       title: null,
       createdAt: "2026-03-10T00:00:00Z",
     });

--- a/turbo/apps/platform/src/signals/chat-page/chat-sidebar.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-sidebar.ts
@@ -10,6 +10,7 @@ import {
   type ChatThreadSignals,
 } from "./create-chat-thread.ts";
 import { createDraftSignals } from "../zero-page/chat-draft.ts";
+import { sidebarOptimisticChatThread$ } from "./optimistic-chat-thread-page.ts";
 
 const SIDEBAR_PARAM = "sidebar";
 
@@ -31,6 +32,11 @@ export const chatSidebarThread$ = computed((get): ChatThreadSignals | null => {
   const sidebarThreadId = get(chatSidebarThreadId$);
   if (!sidebarThreadId) {
     return null;
+  }
+
+  const optimisticThread = get(sidebarOptimisticChatThread$);
+  if (optimisticThread?.threadId === sidebarThreadId) {
+    return optimisticThread.pendingThread;
   }
 
   return createChatThreadSignals(sidebarThreadId, createDraftSignals());

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -14,7 +14,12 @@ import {
   currentChatThreadId$,
   reloadChatThreads$,
 } from "../agent-chat.ts";
-import { detachedNavigateTo$ } from "../route.ts";
+import {
+  detachedNavigateTo$,
+  replaceSearchParams$,
+  searchParams$,
+  updateSearchParams$,
+} from "../route.ts";
 import { talkDraft$ } from "../zero-page/chat-draft.ts";
 import { zeroOnboardingStatus$ } from "../zero-page/zero-onboarding.ts";
 import {
@@ -24,13 +29,22 @@ import {
 } from "./create-chat-thread.ts";
 import { prepareUserMessageFromDraft$ } from "./resolve-draft-attachments.ts";
 
+const SIDEBAR_PARAM = "sidebar";
+
+export type OptimisticChatPane = "main" | "sidebar";
+
+interface SettledChatThread {
+  threadId: string;
+}
+
 interface PendingChatThread {
+  pane: OptimisticChatPane;
   threadId: string;
   agentId: string;
   createdAt: string;
   running: boolean;
   pendingThread: ReturnType<typeof createChatThreadSignals>;
-  settleResult: Promise<void>;
+  settleResult: Promise<SettledChatThread>;
 }
 
 interface SendNewThreadMessageRequest {
@@ -48,17 +62,111 @@ interface SendNewThreadMessagePending extends PendingChatThread {
   sendResult: Promise<SendNewThreadMessageResult>;
 }
 
-const internalOptimisticChatThread$ = state<PendingChatThread | null>(null);
+interface OptimisticChatThreads {
+  main: PendingChatThread | null;
+  sidebar: PendingChatThread | null;
+}
+
+const internalOptimisticChatThreads$ = state<OptimisticChatThreads>({
+  main: null,
+  sidebar: null,
+});
 
 export const optimisticChatThread$ = computed((get) => {
-  return get(internalOptimisticChatThread$);
+  return get(internalOptimisticChatThreads$).main;
+});
+
+export const sidebarOptimisticChatThread$ = computed((get) => {
+  return get(internalOptimisticChatThreads$).sidebar;
 });
 
 export const clearMatchingOptimisticChatThread$ = command(
   ({ set }, pending: PendingChatThread) => {
-    set(internalOptimisticChatThread$, (current) => {
-      return current === pending ? null : current;
+    set(internalOptimisticChatThreads$, (current) => {
+      if (current[pending.pane] !== pending) {
+        return current;
+      }
+      return { ...current, [pending.pane]: null };
     });
+  },
+);
+
+function settledThreadId(
+  pending: PendingChatThread,
+  settled: SettledChatThread,
+): string {
+  return settled.threadId || pending.threadId;
+}
+
+const routeMainOptimisticChatThread$ = command(
+  ({ get, set }, pending: PendingChatThread) => {
+    const next = new URLSearchParams(get(searchParams$));
+    if (next.get(SIDEBAR_PARAM) === pending.threadId) {
+      next.delete(SIDEBAR_PARAM);
+    }
+    set(detachedNavigateTo$, "/chats/:threadId", {
+      pathParams: { threadId: pending.threadId },
+      searchParams: next,
+    });
+  },
+);
+
+const routeSidebarOptimisticChatThread$ = command(
+  ({ get, set }, pending: PendingChatThread) => {
+    if (!get(currentChatThreadId$)) {
+      return;
+    }
+
+    const next = new URLSearchParams(get(searchParams$));
+    next.set(SIDEBAR_PARAM, pending.threadId);
+    set(updateSearchParams$, next);
+  },
+);
+
+const rerouteSettledOptimisticChatThread$ = command(
+  ({ get, set }, pending: PendingChatThread, settled: SettledChatThread) => {
+    const nextThreadId = settledThreadId(pending, settled);
+    if (nextThreadId === pending.threadId) {
+      return;
+    }
+
+    if (pending.pane === "main") {
+      if (get(currentChatThreadId$) !== pending.threadId) {
+        return;
+      }
+      set(detachedNavigateTo$, "/chats/:threadId", {
+        pathParams: { threadId: nextThreadId },
+        searchParams: new URLSearchParams(get(searchParams$)),
+        replace: true,
+      });
+      return;
+    }
+
+    const next = new URLSearchParams(get(searchParams$));
+    if (next.get(SIDEBAR_PARAM) !== pending.threadId) {
+      return;
+    }
+    if (get(currentChatThreadId$) === nextThreadId) {
+      next.delete(SIDEBAR_PARAM);
+    } else {
+      next.set(SIDEBAR_PARAM, nextThreadId);
+    }
+    set(replaceSearchParams$, next);
+  },
+);
+
+const showExistingOptimisticChatThread$ = command(
+  ({ get, set }, pending: PendingChatThread) => {
+    if (pending.pane === "main") {
+      if (get(currentChatThreadId$) !== pending.threadId) {
+        set(routeMainOptimisticChatThread$, pending);
+      }
+      return;
+    }
+
+    if (get(searchParams$).get(SIDEBAR_PARAM) !== pending.threadId) {
+      set(routeSidebarOptimisticChatThread$, pending);
+    }
   },
 );
 
@@ -69,19 +177,30 @@ const routeOptimisticChatThread$ = command(
     signal.addEventListener("abort", () => {
       set(clearMatchingOptimisticChatThread$, pending);
     });
-    set(internalOptimisticChatThread$, pending);
-
-    set(detachedNavigateTo$, "/chats/:threadId", {
-      pathParams: { threadId: pending.threadId },
+    set(internalOptimisticChatThreads$, (current) => {
+      return { ...current, [pending.pane]: pending };
     });
 
-    await pending.settleResult.catch((error: unknown) => {
+    if (pending.pane === "main") {
+      set(routeMainOptimisticChatThread$, pending);
+    } else {
+      set(routeSidebarOptimisticChatThread$, pending);
+    }
+
+    const settled = await pending.settleResult.catch((error: unknown) => {
       set(clearMatchingOptimisticChatThread$, pending);
       throw error;
     });
     signal.throwIfAborted();
 
-    if (get(currentChatThreadId$) !== pending.threadId) {
+    set(rerouteSettledOptimisticChatThread$, pending, settled);
+    const nextThreadId = settledThreadId(pending, settled);
+
+    if (
+      pending.pane === "sidebar" ||
+      nextThreadId !== pending.threadId ||
+      get(currentChatThreadId$) !== pending.threadId
+    ) {
       set(clearMatchingOptimisticChatThread$, pending);
     }
   },
@@ -113,6 +232,7 @@ const createNewChatThread$ = command(
   async (
     { get, set },
     agentComposeId: string | null,
+    pane: OptimisticChatPane,
     signal: AbortSignal,
   ): Promise<PendingChatThread | null> => {
     const resolvedComposeId =
@@ -153,7 +273,7 @@ const createNewChatThread$ = command(
     set(localThread.hideSkeleton$);
 
     const createClient = get(zeroClient$);
-    const settleResult = (async () => {
+    const settleResult = (async (): Promise<SettledChatThread> => {
       const thread = await createChatThread(
         createClient,
         resolvedComposeId,
@@ -162,16 +282,11 @@ const createNewChatThread$ = command(
         threadId,
       );
       signal.throwIfAborted();
-
-      if (thread.id !== threadId) {
-        set(detachedNavigateTo$, "/chats/:threadId", {
-          pathParams: { threadId: thread.id },
-          replace: true,
-        });
-      }
+      return { threadId: thread.id };
     })();
 
     return {
+      pane,
       threadId,
       agentId: resolvedComposeId,
       createdAt,
@@ -183,18 +298,26 @@ const createNewChatThread$ = command(
 );
 
 export const createNewChatThreadOptimistically$ = command(
-  async ({ get, set }, agentComposeId: string | null, signal: AbortSignal) => {
-    const optimisticThread = get(optimisticChatThread$);
+  async (
+    { get, set },
+    agentComposeId: string | null,
+    pane: OptimisticChatPane,
+    signal: AbortSignal,
+  ) => {
+    const targetPane =
+      pane === "sidebar" && get(currentChatThreadId$) ? "sidebar" : "main";
+    const optimisticThread = get(internalOptimisticChatThreads$)[targetPane];
     if (optimisticThread) {
-      if (get(currentChatThreadId$) !== optimisticThread.threadId) {
-        set(detachedNavigateTo$, "/chats/:threadId", {
-          pathParams: { threadId: optimisticThread.threadId },
-        });
-      }
+      set(showExistingOptimisticChatThread$, optimisticThread);
       return;
     }
 
-    const result = await set(createNewChatThread$, agentComposeId, signal);
+    const result = await set(
+      createNewChatThread$,
+      agentComposeId,
+      targetPane,
+      signal,
+    );
     if (!result) {
       return;
     }
@@ -205,37 +328,46 @@ export const createNewChatThreadOptimistically$ = command(
 
 export const pendingOptimisticChatThreads$ = computed(
   async (get): Promise<ChatThreadListItem[]> => {
-    const optimisticThread = get(optimisticChatThread$);
-    if (!optimisticThread) {
+    const optimisticThreads = Object.values(
+      get(internalOptimisticChatThreads$),
+    ).filter((thread): thread is PendingChatThread => {
+      return thread !== null;
+    });
+    if (optimisticThreads.length === 0) {
       return [];
     }
 
     const currentAgentId = await get(currentChatAgentId$);
-    if (!currentAgentId || optimisticThread.agentId !== currentAgentId) {
+    if (!currentAgentId) {
       return [];
     }
 
     const persistedThreads = await get(chatThreads$);
-    if (
-      persistedThreads.some((thread) => {
-        return thread.id === optimisticThread.threadId;
-      })
-    ) {
-      return [];
-    }
+    const persistedThreadIds = new Set(
+      persistedThreads.map((thread) => {
+        return thread.id;
+      }),
+    );
 
-    return [
-      {
-        id: optimisticThread.threadId,
-        title: null,
-        agent: { id: optimisticThread.agentId, avatarUrl: null },
-        createdAt: optimisticThread.createdAt,
-        updatedAt: optimisticThread.createdAt,
-        isRead: true,
-        isArchived: false,
-        running: optimisticThread.running,
-      },
-    ];
+    return optimisticThreads
+      .filter((thread) => {
+        return (
+          thread.agentId === currentAgentId &&
+          !persistedThreadIds.has(thread.threadId)
+        );
+      })
+      .map((thread) => {
+        return {
+          id: thread.threadId,
+          title: null,
+          agent: { id: thread.agentId, avatarUrl: null },
+          createdAt: thread.createdAt,
+          updatedAt: thread.createdAt,
+          isRead: true,
+          isArchived: false,
+          running: thread.running,
+        };
+      });
   },
 );
 
@@ -319,13 +451,16 @@ const sendNewThreadMessage$ = command(
     })();
 
     return {
+      pane: "main",
       threadId,
       agentId,
       createdAt,
       running: true,
       pendingThread: localThread,
       sendResult,
-      settleResult: sendResult.then(() => {}),
+      settleResult: sendResult.then((result) => {
+        return { threadId: result.threadId };
+      }),
     };
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -16,7 +16,6 @@ import {
 } from "../agent-chat.ts";
 import {
   detachedNavigateTo$,
-  replaceSearchParams$,
   searchParams$,
   updateSearchParams$,
 } from "../route.ts";
@@ -33,10 +32,6 @@ const SIDEBAR_PARAM = "sidebar";
 
 export type OptimisticChatPane = "main" | "sidebar";
 
-interface SettledChatThread {
-  threadId: string;
-}
-
 interface PendingChatThread {
   pane: OptimisticChatPane;
   threadId: string;
@@ -44,7 +39,7 @@ interface PendingChatThread {
   createdAt: string;
   running: boolean;
   pendingThread: ReturnType<typeof createChatThreadSignals>;
-  settleResult: Promise<SettledChatThread>;
+  settleResult: Promise<void>;
 }
 
 interface SendNewThreadMessageRequest {
@@ -91,13 +86,6 @@ export const clearMatchingOptimisticChatThread$ = command(
   },
 );
 
-function settledThreadId(
-  pending: PendingChatThread,
-  settled: SettledChatThread,
-): string {
-  return settled.threadId || pending.threadId;
-}
-
 const routeMainOptimisticChatThread$ = command(
   ({ get, set }, pending: PendingChatThread) => {
     const next = new URLSearchParams(get(searchParams$));
@@ -120,38 +108,6 @@ const routeSidebarOptimisticChatThread$ = command(
     const next = new URLSearchParams(get(searchParams$));
     next.set(SIDEBAR_PARAM, pending.threadId);
     set(updateSearchParams$, next);
-  },
-);
-
-const rerouteSettledOptimisticChatThread$ = command(
-  ({ get, set }, pending: PendingChatThread, settled: SettledChatThread) => {
-    const nextThreadId = settledThreadId(pending, settled);
-    if (nextThreadId === pending.threadId) {
-      return;
-    }
-
-    if (pending.pane === "main") {
-      if (get(currentChatThreadId$) !== pending.threadId) {
-        return;
-      }
-      set(detachedNavigateTo$, "/chats/:threadId", {
-        pathParams: { threadId: nextThreadId },
-        searchParams: new URLSearchParams(get(searchParams$)),
-        replace: true,
-      });
-      return;
-    }
-
-    const next = new URLSearchParams(get(searchParams$));
-    if (next.get(SIDEBAR_PARAM) !== pending.threadId) {
-      return;
-    }
-    if (get(currentChatThreadId$) === nextThreadId) {
-      next.delete(SIDEBAR_PARAM);
-    } else {
-      next.set(SIDEBAR_PARAM, nextThreadId);
-    }
-    set(replaceSearchParams$, next);
   },
 );
 
@@ -187,18 +143,14 @@ const routeOptimisticChatThread$ = command(
       set(routeSidebarOptimisticChatThread$, pending);
     }
 
-    const settled = await pending.settleResult.catch((error: unknown) => {
+    await pending.settleResult.catch((error: unknown) => {
       set(clearMatchingOptimisticChatThread$, pending);
       throw error;
     });
     signal.throwIfAborted();
 
-    set(rerouteSettledOptimisticChatThread$, pending, settled);
-    const nextThreadId = settledThreadId(pending, settled);
-
     if (
       pending.pane === "sidebar" ||
-      nextThreadId !== pending.threadId ||
       get(currentChatThreadId$) !== pending.threadId
     ) {
       set(clearMatchingOptimisticChatThread$, pending);
@@ -212,9 +164,9 @@ async function createChatThread(
   signal: AbortSignal,
   title: string | undefined,
   clientThreadId: string,
-): Promise<{ id: string; title: string | null }> {
+): Promise<void> {
   const client = createClient(chatThreadsContract);
-  const result = await accept(
+  await accept(
     client.create({
       body: {
         agentId,
@@ -225,7 +177,6 @@ async function createChatThread(
     }),
     [201],
   );
-  return { id: result.body.id, title: result.body.title };
 }
 
 const createNewChatThread$ = command(
@@ -273,8 +224,8 @@ const createNewChatThread$ = command(
     set(localThread.hideSkeleton$);
 
     const createClient = get(zeroClient$);
-    const settleResult = (async (): Promise<SettledChatThread> => {
-      const thread = await createChatThread(
+    const settleResult = (async (): Promise<void> => {
+      await createChatThread(
         createClient,
         resolvedComposeId,
         signal,
@@ -282,7 +233,6 @@ const createNewChatThread$ = command(
         threadId,
       );
       signal.throwIfAborted();
-      return { threadId: thread.id };
     })();
 
     return {
@@ -458,9 +408,7 @@ const sendNewThreadMessage$ = command(
       running: true,
       pendingThread: localThread,
       sendResult,
-      settleResult: sendResult.then((result) => {
-        return { threadId: result.threadId };
-      }),
+      settleResult: sendResult.then(() => {}),
     };
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-sidebar.test.tsx
@@ -4,6 +4,7 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { pathname, search } from "../../../signals/location.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import {
   chatThreadByIdContract,
@@ -37,26 +38,83 @@ function isThreadId(value: string): value is ThreadId {
   return value in threadTitles;
 }
 
-function mockChatSidebarApis(): void {
+function mockChatSidebarApis(): {
+  createdThreadIds: string[];
+  createdThreads: Map<string, { agentId: string; title: string | null }>;
+  recordCreatedThread: (
+    id: string,
+    agentId: string,
+    title: string | null,
+  ) => void;
+} {
+  const createdThreadIds: string[] = [];
+  const createdThreads = new Map<
+    string,
+    { agentId: string; title: string | null }
+  >();
+  const recordCreatedThread = (
+    id: string,
+    agentId: string,
+    title: string | null,
+  ) => {
+    createdThreadIds.unshift(id);
+    createdThreads.set(id, { agentId, title });
+  };
+
   server.use(
     mockApi(chatThreadsContract.list, ({ respond }) => {
       return respond(200, {
-        threads: Object.entries(threadTitles).map(([id, title]) => {
-          return {
-            id,
-            title,
-            agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
-            createdAt: "2026-03-10T00:00:00Z",
-            updatedAt: "2026-03-10T00:00:00Z",
-            isRead: false,
-            isArchived: false,
-            running: false,
-          };
-        }),
+        threads: [
+          ...createdThreadIds.map((id) => {
+            const thread = createdThreads.get(id);
+            return {
+              id,
+              title: thread?.title ?? null,
+              agent: {
+                id: thread?.agentId ?? DEFAULT_AGENT_ID,
+                avatarUrl: null,
+              },
+              createdAt: "2026-03-10T00:00:01Z",
+              updatedAt: "2026-03-10T00:00:01Z",
+              isRead: true,
+              isArchived: false,
+              running: false,
+            };
+          }),
+          ...Object.entries(threadTitles).map(([id, title]) => {
+            return {
+              id,
+              title,
+              agent: { id: DEFAULT_AGENT_ID, avatarUrl: null },
+              createdAt: "2026-03-10T00:00:00Z",
+              updatedAt: "2026-03-10T00:00:00Z",
+              isRead: false,
+              isArchived: false,
+              running: false,
+            };
+          }),
+        ],
       });
     }),
     mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
       const id = String(params.id);
+      const createdThread = createdThreads.get(id);
+      if (createdThread) {
+        return respond(200, {
+          id,
+          title: createdThread.title,
+          agentId: createdThread.agentId,
+          chatMessages: [],
+          latestSessionId: null,
+          lastReadMessageId: null,
+          activeRunIds: [],
+          activeRuns: [],
+          createdAt: "2026-03-10T00:00:01Z",
+          updatedAt: "2026-03-10T00:00:01Z",
+          draftContent: null,
+          draftAttachments: null,
+        });
+      }
       if (!isThreadId(id)) {
         return respond(404, {
           error: { message: "Not found", code: "NOT_FOUND" },
@@ -79,6 +137,9 @@ function mockChatSidebarApis(): void {
     }),
     mockApi(chatThreadMessagesContract.list, ({ params, query, respond }) => {
       const id = String(params.threadId);
+      if (createdThreads.has(id)) {
+        return respond(200, { messages: [], hasHistoryBefore: false });
+      }
       if (!isThreadId(id)) {
         return respond(404, {
           error: { message: "Not found", code: "NOT_FOUND" },
@@ -99,10 +160,22 @@ function mockChatSidebarApis(): void {
         hasHistoryBefore: false,
       });
     }),
+    mockApi(chatThreadsContract.create, ({ body, respond }) => {
+      const id =
+        body.clientThreadId ?? `created-thread-${createdThreadIds.length + 1}`;
+      recordCreatedThread(id, body.agentId, body.title ?? null);
+      return respond(201, {
+        id,
+        title: body.title ?? null,
+        createdAt: "2026-03-10T00:00:01Z",
+      });
+    }),
     mockApi(chatThreadMarkReadContract.markRead, ({ respond }) => {
       return respond(200, { lastReadMessageId: null, changed: false });
     }),
   );
+
+  return { createdThreadIds, createdThreads, recordCreatedThread };
 }
 
 function chatThreadLink(title: string): HTMLAnchorElement {
@@ -123,6 +196,12 @@ function chatThreadContainer(threadId: string): HTMLElement {
   );
   expect(element).not.toBeNull();
   return element!;
+}
+
+function sidebarNewChatButton(): HTMLElement {
+  return within(
+    screen.getByRole("navigation", { name: "Sidebar" }),
+  ).getByLabelText(/^New chat/);
 }
 
 function fireModShiftArrow(
@@ -192,6 +271,112 @@ describe("chat sidebar", () => {
         ),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("keeps the sidebar open when directly creating a new main chat", async () => {
+    const { createdThreadIds } = mockChatSidebarApis();
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-main?sidebar=thread-sidebar",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Primary thread answer")).toBeInTheDocument();
+      expect(screen.getByText("Sidebar thread answer")).toBeInTheDocument();
+    });
+
+    fireEvent.click(sidebarNewChatButton());
+
+    await waitFor(() => {
+      expect(createdThreadIds).toHaveLength(1);
+    });
+    const createdThreadId = createdThreadIds[0]!;
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/chats/${createdThreadId}`);
+      expect(search()).toBe("?sidebar=thread-sidebar");
+      expect(chatThreadContainer(createdThreadId)).toBeInTheDocument();
+      expect(chatThreadContainer("thread-sidebar")).toBeInTheDocument();
+    });
+  });
+
+  it("creates a new sidebar chat on option-clicking the new chat button", async () => {
+    const { createdThreadIds } = mockChatSidebarApis();
+
+    detachedSetupPage({ context, path: "/chats/thread-main" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Primary thread answer")).toBeInTheDocument();
+    });
+
+    fireEvent.click(sidebarNewChatButton(), { altKey: true });
+
+    await waitFor(() => {
+      expect(createdThreadIds).toHaveLength(1);
+    });
+    const createdThreadId = createdThreadIds[0]!;
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-main");
+      expect(search()).toBe(`?sidebar=${createdThreadId}`);
+      expect(chatThreadContainer("thread-main")).toBeInTheDocument();
+      expect(
+        within(chatThreadContainer(createdThreadId)).getByText(
+          "Send a message to start the conversation",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders the option-clicked new sidebar chat optimistically before create settles", async () => {
+    const { createdThreadIds, createdThreads } = mockChatSidebarApis();
+    const createDeferred = createDeferredPromise<void>(context.signal);
+
+    server.use(
+      mockApi(chatThreadsContract.create, async ({ body, respond }) => {
+        const id =
+          body.clientThreadId ??
+          `created-thread-${createdThreadIds.length + 1}`;
+        createdThreadIds.unshift(id);
+        await createDeferred.promise;
+        createdThreads.set(id, {
+          agentId: body.agentId,
+          title: body.title ?? null,
+        });
+        return respond(201, {
+          id,
+          title: body.title ?? null,
+          createdAt: "2026-03-10T00:00:01Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-main" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Primary thread answer")).toBeInTheDocument();
+    });
+
+    fireEvent.click(sidebarNewChatButton(), { altKey: true });
+
+    await waitFor(() => {
+      expect(createdThreadIds).toHaveLength(1);
+    });
+    const createdThreadId = createdThreadIds[0]!;
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-main");
+      expect(search()).toBe(`?sidebar=${createdThreadId}`);
+      expect(chatThreadContainer("thread-main")).toBeInTheDocument();
+      expect(
+        within(chatThreadContainer(createdThreadId)).getByText(
+          "Send a message to start the conversation",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    createDeferred.resolve();
   });
 
   it("shows pane icons in highlighted sidebar chat titles only while two chats are open", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -358,7 +358,8 @@ export function mockChatLifecycle(options?: {
     mockApi(chatThreadsContract.list, ({ respond }) => {
       return respond(200, { threads: threadList });
     }),
-    mockApi(chatThreadsContract.create, ({ respond }) => {
+    mockApi(chatThreadsContract.create, ({ body, respond }) => {
+      threadId = body.clientThreadId ?? threadId;
       return respond(201, {
         id: threadId,
         title: null,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
@@ -200,6 +200,7 @@ describe("sidebar chat delete", () => {
     await context.store.set(
       createNewChatThreadOptimistically$,
       AGENT_ID,
+      "main",
       context.signal,
     );
     const createdId = getLastCreatedId();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
@@ -21,6 +21,7 @@ const mockApi = createMockApi(context);
 
 function mockSubagentAPIs() {
   // Stateful thread store — POST adds threads, GET returns them
+  const createdThreadIds: string[] = [];
   const threads: {
     id: string;
     title: string | null;
@@ -117,7 +118,24 @@ function mockSubagentAPIs() {
     mockApi(chatThreadsContract.list, ({ respond }) => {
       return respond(200, { threads });
     }),
-    mockApi(chatThreadByIdContract.get, ({ respond }) => {
+    mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
+      if (params.id !== "thread-sub-1") {
+        const thread = threads.find((item) => {
+          return item.id === params.id;
+        });
+        return respond(200, {
+          id: params.id,
+          title: thread?.title ?? null,
+          agentId: thread?.agent.id ?? "c0000000-0000-4000-a000-000000000001",
+          chatMessages: [],
+          latestSessionId: null,
+          activeRunIds: [],
+          draftContent: null,
+          draftAttachments: null,
+          createdAt: thread?.createdAt ?? "2026-03-10T00:00:00Z",
+          updatedAt: thread?.updatedAt ?? "2026-03-10T00:00:00Z",
+        });
+      }
       return respond(200, {
         id: "thread-sub-1",
         title: "Subagent thread",
@@ -144,8 +162,10 @@ function mockSubagentAPIs() {
     }),
     mockApi(chatThreadsContract.create, ({ body, respond }) => {
       const now = new Date().toISOString();
+      const id = body.clientThreadId ?? "new-thread-id";
+      createdThreadIds.unshift(id);
       const newThread = {
-        id: "new-thread-id",
+        id,
         title: body.title ?? null,
         agent: { id: body.agentId, avatarUrl: null },
         createdAt: now,
@@ -162,11 +182,13 @@ function mockSubagentAPIs() {
       });
     }),
   );
+
+  return { createdThreadIds };
 }
 
 describe("sidebar new chat navigation", () => {
   it("should create thread and navigate to /chat/:threadId when clicking new chat for default agent", async () => {
-    mockSubagentAPIs();
+    const { createdThreadIds } = mockSubagentAPIs();
 
     // Start on the default agent chat page — this synchronously sets currentChatAgentId$
     // so ChatThreadsSection doesn't remount between waitFor and click
@@ -185,12 +207,13 @@ describe("sidebar new chat navigation", () => {
 
     // Verify navigation to /chat/:threadId
     await waitFor(() => {
-      expect(pathname()).toBe("/chats/new-thread-id");
+      expect(createdThreadIds).toHaveLength(1);
+      expect(pathname()).toBe(`/chats/${createdThreadIds[0]!}`);
     });
   });
 
   it("should create thread and navigate to /chat/:threadId when clicking new chat for a subagent", async () => {
-    mockSubagentAPIs();
+    const { createdThreadIds } = mockSubagentAPIs();
 
     detachedSetupPage({
       context,
@@ -207,7 +230,8 @@ describe("sidebar new chat navigation", () => {
 
     // Verify navigation to /chat/:threadId
     await waitFor(() => {
-      expect(pathname()).toBe("/chats/new-thread-id");
+      expect(createdThreadIds).toHaveLength(1);
+      expect(pathname()).toBe(`/chats/${createdThreadIds[0]!}`);
     });
   });
 
@@ -215,11 +239,13 @@ describe("sidebar new chat navigation", () => {
     mockSubagentAPIs();
     // Override POST with deferred so we can control when the response arrives
     const createDeferred = createDeferredPromise<void>(context.signal);
+    let clientThreadId: string | null = null;
     server.use(
-      mockApi(chatThreadsContract.create, async ({ respond }) => {
+      mockApi(chatThreadsContract.create, async ({ body, respond }) => {
+        clientThreadId = body.clientThreadId ?? null;
         await createDeferred.promise;
         return respond(201, {
-          id: "delayed-thread-id",
+          id: body.clientThreadId ?? "delayed-thread-id",
           title: null,
           createdAt: "2026-03-10T00:00:00Z",
         });
@@ -251,48 +277,23 @@ describe("sidebar new chat navigation", () => {
 
     // After creation completes, button should be re-enabled
     await waitFor(() => {
-      expect(pathname()).toBe("/chats/delayed-thread-id");
+      expect(clientThreadId).not.toBeNull();
+      expect(pathname()).toBe(`/chats/${clientThreadId}`);
     });
   });
 
   it("should show new chat entry in sidebar and focus textarea after creating new chat", async () => {
     mockSubagentAPIs();
-
-    // Override list and detail endpoints to include the newly created thread.
-    // fetchZeroSessionList$ is always called after navigation so the list must
-    // include the new thread (title: null) for "New chat" to appear in the sidebar.
+    const createDeferred = createDeferredPromise<void>(context.signal);
+    let createdThreadId: string | null = null;
     server.use(
-      mockApi(chatThreadsContract.list, ({ respond }) => {
-        return respond(200, {
-          threads: [
-            {
-              id: "new-thread-id",
-              title: null,
-              agent: {
-                id: "c0000000-0000-4000-a000-000000000001",
-                avatarUrl: null,
-              },
-              createdAt: "2026-03-10T00:00:00Z",
-              updatedAt: "2026-03-10T00:00:00Z",
-              isRead: false,
-              isArchived: false,
-              running: false,
-            },
-          ],
-        });
-      }),
-      mockApi(chatThreadByIdContract.get, ({ respond }) => {
-        return respond(200, {
-          id: "new-thread-id",
+      mockApi(chatThreadsContract.create, async ({ body, respond }) => {
+        createdThreadId = body.clientThreadId ?? "created-thread-id";
+        await createDeferred.promise;
+        return respond(201, {
+          id: createdThreadId,
           title: null,
-          agentId: "c0000000-0000-4000-a000-000000000001",
-          chatMessages: [],
-          latestSessionId: "session-new-1",
-          activeRunIds: [],
-          draftContent: null,
-          draftAttachments: null,
           createdAt: "2026-03-10T00:00:00Z",
-          updatedAt: "2026-03-10T00:00:00Z",
         });
       }),
     );
@@ -304,25 +305,28 @@ describe("sidebar new chat navigation", () => {
       path: "/agents/c0000000-0000-4000-a000-000000000001/chat",
     });
 
-    // Wait for thread list to load — the thread row for the not-yet-named
-    // thread is identifiable by its link href.
     const newChatButton = await waitFor(() => {
-      expect(
-        document.querySelector(`a[href="/chats/new-thread-id"]`),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Subagent thread")).toBeInTheDocument();
       return screen.getByLabelText(/^New chat/);
     });
 
     click(newChatButton);
+    await waitFor(() => {
+      expect(createdThreadId).not.toBeNull();
+    });
+    const threadId = createdThreadId;
+    if (!threadId) {
+      throw new Error("Expected created thread id");
+    }
 
     // 1. Verify navigation (URL-based selection confirmation)
     await waitFor(() => {
-      expect(pathname()).toBe("/chats/new-thread-id");
+      expect(pathname()).toBe(`/chats/${threadId}`);
     });
 
     // 2. Verify sidebar row falls back to "New chat" for a null title.
     await waitFor(() => {
-      const link = document.querySelector(`a[href="/chats/new-thread-id"]`);
+      const link = document.querySelector(`a[href="/chats/${threadId}"]`);
       expect(link).toBeInTheDocument();
       expect(within(link as HTMLElement).getByText("New chat")).toBeDefined();
     });
@@ -331,6 +335,8 @@ describe("sidebar new chat navigation", () => {
     await waitFor(() => {
       expect(screen.getByRole("textbox")).toHaveFocus();
     });
+
+    createDeferred.resolve();
   });
 
   it("should reuse an existing optimistic new chat when creating again", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
@@ -373,6 +373,7 @@ describe("sidebar new chat navigation", () => {
     await context.store.set(
       createNewChatThreadOptimistically$,
       "c0000000-0000-4000-a000-000000000001",
+      "main",
       context.signal,
     );
     expect(createCount).toBe(1);
@@ -390,6 +391,7 @@ describe("sidebar new chat navigation", () => {
     await context.store.set(
       createNewChatThreadOptimistically$,
       "c0000000-0000-4000-a000-000000000001",
+      "main",
       context.signal,
     );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
@@ -22,9 +22,18 @@ import {
 const context = testContext();
 const mockApi = createMockApi(context);
 
+function expectCreatedThreadRoute(getCreatedThreadId: () => string | null) {
+  const createdThreadId = getCreatedThreadId();
+  if (createdThreadId === null) {
+    throw new Error("expected a thread to be created");
+  }
+  expect(pathname()).toBe(`/chats/${createdThreadId}`);
+}
+
 function mockAPIsWithSubagents({
   pinnedAgentIds = ["pinned-agent-id"],
 }: { pinnedAgentIds?: string[] } = {}) {
+  let createdThreadId: string | null = null;
   setMockTeam([
     {
       id: "c0000000-0000-4000-a000-000000000001",
@@ -59,9 +68,9 @@ function mockAPIsWithSubagents({
     mockApi(chatThreadsContract.list, ({ respond }) => {
       return respond(200, { threads: [] });
     }),
-    mockApi(chatThreadByIdContract.get, ({ respond }) => {
+    mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
       return respond(200, {
-        id: "new-thread-from-dialog",
+        id: params.id,
         title: null,
         agentId: "c0000000-0000-4000-a000-000000000001",
         chatMessages: [],
@@ -73,14 +82,21 @@ function mockAPIsWithSubagents({
         updatedAt: "2026-03-10T00:00:00Z",
       });
     }),
-    mockApi(chatThreadsContract.create, ({ respond }) => {
+    mockApi(chatThreadsContract.create, ({ body, respond }) => {
+      createdThreadId = body.clientThreadId ?? "new-thread-from-dialog";
       return respond(201, {
-        id: "new-thread-from-dialog",
+        id: createdThreadId,
         title: null,
         createdAt: "2026-03-10T00:00:00Z",
       });
     }),
   );
+
+  return {
+    getCreatedThreadId: () => {
+      return createdThreadId;
+    },
+  };
 }
 
 async function openChatListDialog() {
@@ -100,7 +116,7 @@ function openManagePinnedDialog() {
 
 describe("chatListDialog", () => {
   it("should navigate to chat when clicking a pinned agent", async () => {
-    mockAPIsWithSubagents();
+    const { getCreatedThreadId } = mockAPIsWithSubagents();
     detachedSetupPage({ context, path: "/agents" });
 
     await openChatListDialog();
@@ -118,14 +134,13 @@ describe("chatListDialog", () => {
 
     click(pinnedAgentButton);
 
-    // Should navigate to /chat/:threadId
     await waitFor(() => {
-      expect(pathname()).toBe("/chats/new-thread-from-dialog");
+      expectCreatedThreadRoute(getCreatedThreadId);
     });
   });
 
   it("should navigate to chat when clicking an unpinned agent", async () => {
-    mockAPIsWithSubagents();
+    const { getCreatedThreadId } = mockAPIsWithSubagents();
     detachedSetupPage({ context, path: "/agents" });
 
     await openChatListDialog();
@@ -145,7 +160,7 @@ describe("chatListDialog", () => {
     click(unpinnedAgentButton);
 
     await waitFor(() => {
-      expect(pathname()).toBe("/chats/new-thread-from-dialog");
+      expectCreatedThreadRoute(getCreatedThreadId);
     });
   });
 
@@ -169,7 +184,7 @@ describe("chatListDialog", () => {
   });
 
   it("should navigate to chat when clicking the lead agent", async () => {
-    mockAPIsWithSubagents();
+    const { getCreatedThreadId } = mockAPIsWithSubagents();
     detachedSetupPage({ context, path: "/agents" });
 
     await openChatListDialog();
@@ -184,7 +199,7 @@ describe("chatListDialog", () => {
     click(leadButton);
 
     await waitFor(() => {
-      expect(pathname()).toBe("/chats/new-thread-from-dialog");
+      expectCreatedThreadRoute(getCreatedThreadId);
     });
   });
 });
@@ -404,7 +419,7 @@ describe("managePinnedAgentsDialog - pin button adds agent to pinned (SIDEBAR-D-
 
 describe("chatListDialog - agent list item opens chat on click (SIDEBAR-D-036)", () => {
   it("opens a chat session when a pinned agent is clicked in the dialog", async () => {
-    mockAPIsWithSubagents();
+    const { getCreatedThreadId } = mockAPIsWithSubagents();
     detachedSetupPage({ context, path: "/agents" });
     await openChatListDialog();
 
@@ -420,7 +435,7 @@ describe("chatListDialog - agent list item opens chat on click (SIDEBAR-D-036)",
     click(pinnedAgentBtn);
 
     await waitFor(() => {
-      expect(pathname()).toBe("/chats/new-thread-from-dialog");
+      expectCreatedThreadRoute(getCreatedThreadId);
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
@@ -398,10 +398,10 @@ describe("zero sidebar - new chat button enabled/disabled state (SIDEBAR-D-010)"
 
     mockBaseAPIs();
     server.use(
-      mockApi(chatThreadsContract.create, async ({ respond }) => {
+      mockApi(chatThreadsContract.create, async ({ body, respond }) => {
         await deferred.promise;
         return respond(201, {
-          id: "new-thread",
+          id: body.clientThreadId ?? "new-thread",
           title: null,
           createdAt: "2026-03-10T00:00:00Z",
         });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -305,18 +305,20 @@ describe("zero sidebar - clear search button resets search (SIDEBAR-D-016)", () 
 describe("zero sidebar - new chat button creates session (SIDEBAR-D-017)", () => {
   it("creates a new chat session and navigates to it", async () => {
     mockBaseAPIs();
+    let createdThreadId: string | null = null;
 
     server.use(
-      mockApi(chatThreadsContract.create, ({ respond }) => {
+      mockApi(chatThreadsContract.create, ({ body, respond }) => {
+        createdThreadId = body.clientThreadId ?? "new-thread-id";
         return respond(201, {
-          id: "new-thread-id",
+          id: createdThreadId,
           title: null,
           createdAt: "2026-03-10T00:00:00Z",
         });
       }),
-      mockApi(chatThreadByIdContract.get, ({ respond }) => {
+      mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
         return respond(200, {
-          id: "new-thread-id",
+          id: params.id,
           title: null,
           agentId: DEFAULT_AGENT_ID,
           chatMessages: [],
@@ -348,7 +350,10 @@ describe("zero sidebar - new chat button creates session (SIDEBAR-D-017)", () =>
     click(newChatButton);
 
     await waitFor(() => {
-      expect(pathname()).toBe("/chats/new-thread-id");
+      if (createdThreadId === null) {
+        throw new Error("expected a thread to be created");
+      }
+      expect(pathname()).toBe(`/chats/${createdThreadId}`);
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -69,6 +69,7 @@ import {
   createNewChatThreadOptimistically$,
   optimisticChatThread$,
   sendNewThreadOptimistically$,
+  type OptimisticChatPane,
 } from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 import { voiceChatStatus$ } from "../../signals/voice-chat/voice-chat-session.ts";
 import { startChatNavigationTiming$ } from "../../lib/posthog.ts";
@@ -180,9 +181,9 @@ function NewChatButton() {
   const creating = useGet(optimisticChatThread$) !== null;
   const { signal: rootSignal } = useGet(rootSignal$);
 
-  const handleNewChat = () => {
+  const handleNewChat = (pane: OptimisticChatPane) => {
     detach(
-      createNewChat(currentChatAgentId ?? null, rootSignal),
+      createNewChat(currentChatAgentId ?? null, pane, rootSignal),
       Reason.DomCallback,
     );
   };
@@ -191,7 +192,9 @@ function NewChatButton() {
     <Button
       variant="outline"
       size="sm"
-      onClick={handleNewChat}
+      onClick={(event) => {
+        handleNewChat(event.altKey ? "sidebar" : "main");
+      }}
       disabled={creating}
       className="zero-btn-morandi gap-1.5"
       data-testid="chat-header-new-button"

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -24,6 +24,7 @@ import {
 import {
   createNewChatThreadOptimistically$,
   optimisticChatThread$,
+  type OptimisticChatPane,
 } from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 import { AvatarFromUrl } from "./zero-sidebar-shared.tsx";
 import { QueueDrawer } from "../queue-page/queue-drawer.tsx";
@@ -153,9 +154,9 @@ function NewOrUnreadChatButtonLeaf() {
     );
   }
 
-  const handleNewChat = () => {
+  const handleNewChat = (pane: OptimisticChatPane) => {
     detach(
-      createNewChat(currentChatAgentId ?? null, rootSignal),
+      createNewChat(currentChatAgentId ?? null, pane, rootSignal),
       Reason.DomCallback,
     );
   };
@@ -163,7 +164,9 @@ function NewOrUnreadChatButtonLeaf() {
   return (
     <button
       type="button"
-      onClick={handleNewChat}
+      onClick={(event) => {
+        handleNewChat(event.altKey ? "sidebar" : "main");
+      }}
       disabled={creating}
       className="flex items-center gap-1.5 h-8 px-3 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0 disabled:opacity-50"
     >

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -46,6 +46,7 @@ import {
 import {
   createNewChatThreadOptimistically$,
   optimisticChatThread$,
+  type OptimisticChatPane,
   pendingOptimisticChatThreads$,
 } from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 import { currentChatAgentId$ } from "../../signals/agent-chat.ts";
@@ -383,8 +384,11 @@ function ChatThreadsTitle() {
   const { titleLabel, searchPlaceholder, newChatAriaLabel } =
     useChatThreadsTitleLabels();
   const newChatDisabled = useGet(optimisticChatThread$) !== null;
-  const onNewChat = () => {
-    detach(createNewChat(currentChatAgentId, rootSignal), Reason.DomCallback);
+  const onNewChat = (pane: OptimisticChatPane) => {
+    detach(
+      createNewChat(currentChatAgentId, pane, rootSignal),
+      Reason.DomCallback,
+    );
     setExpanded(false);
   };
   const searchOpen = useGet(threadSearchOpen$);
@@ -471,7 +475,7 @@ function ChatThreadsTitle() {
                 type="button"
                 onClick={(e) => {
                   e.stopPropagation();
-                  onNewChat();
+                  onNewChat(e.altKey ? "sidebar" : "main");
                 }}
                 disabled={newChatDisabled}
                 className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-[hsl(var(--gray-200))] transition-colors disabled:opacity-50"

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
@@ -25,6 +25,7 @@ import {
 import {
   createNewChatThreadOptimistically$,
   optimisticChatThread$,
+  type OptimisticChatPane,
 } from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 import { navigateToChat$ } from "../../signals/zero-page/zero-nav.ts";
 import {
@@ -76,9 +77,9 @@ export function ZeroChatListPage() {
       })
     : recentSessions;
 
-  const onNewChat = () => {
+  const onNewChat = (pane: OptimisticChatPane) => {
     detach(
-      createNewChat(currentChatAgentId ?? null, rootSignal),
+      createNewChat(currentChatAgentId ?? null, pane, rootSignal),
       Reason.DomCallback,
     );
   };
@@ -130,7 +131,9 @@ export function ZeroChatListPage() {
       <div className="shrink-0 px-4 py-2">
         <button
           type="button"
-          onClick={onNewChat}
+          onClick={(event) => {
+            onNewChat(event.altKey ? "sidebar" : "main");
+          }}
           disabled={creating}
           className="flex w-full h-10 items-center justify-center gap-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
         >

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -104,7 +104,7 @@ function AgentListDialogContainer() {
   const setExpanded = useSet(setSidebarExpanded$);
   const { signal: rootSignal } = useGet(rootSignal$);
   const onNewChat = (agentId: string | null) => {
-    detach(createNewChat(agentId, rootSignal), Reason.DomCallback);
+    detach(createNewChat(agentId, "main", rootSignal), Reason.DomCallback);
     setExpanded(false);
   };
   return (


### PR DESCRIPTION
## Summary

Fix new chat creation so the existing split chat sidebar is preserved and Option-clicking New opens the new chat in the sidebar pane instead of replacing the main pane.

## Root cause

New chat optimistic state was a single global pending thread. `routeOptimisticChatThread$` always navigated the main route to `/chats/:threadId` without preserving or distinguishing the sidebar query param, so creating a new chat could wipe an already-open `?sidebar=...` pane.

## What changed

- Split optimistic new-thread state by pane: `main` and `sidebar`.
- Direct New clicks route the new optimistic thread into the main pane while carrying forward the current `?sidebar=...` search param.
- Option-clicking New routes the new optimistic thread into `?sidebar=<newThreadId>` without changing the main chat path.
- The sidebar computed thread now returns the matching optimistic thread signals when the `sidebar` query param points at a pending new thread.
- New-thread buttons now pass the intended pane based on `event.altKey`.
- Removed the defensive settled-id replacement path because the backend contract preserves `clientThreadId` as the persisted thread id.

## Setup page flow impact

No direct edits were made to `setupChatPage$`, but the flow around it changed:

- Main-pane new chat still uses `detachedNavigateTo$`, so normal chat route setup runs for the new main `/chats/:threadId` route. The difference is that it now passes the current `searchParams`, preserving an already-open sidebar.
- Sidebar-pane new chat uses `updateSearchParams$` to mutate only `?sidebar=...`. That recomputes `searchParams$` and `chatSidebarThread$`, but does not invoke a full page route setup or abort/recreate the main page signal.
- While the create request is pending, `chatSidebarThread$` resolves `?sidebar=<newThreadId>` to the sidebar optimistic `pendingThread`, so the right pane renders immediately before the server response settles.
- On create success, the flow trusts the `clientThreadId` already used by the optimistic route/sidebar param. Failure still clears the matching optimistic pending state.

## Validation

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-sidebar.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-sidebar.test.tsx src/views/zero-page/__tests__/sidebar-navigation.test.tsx src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- pre-commit hook also ran prettier, knip, full `turbo run check-types --concurrency=1`, and commitlint