### PR TITLE
fix(runner): drain network logs before source release

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -27,7 +27,8 @@ use crate::idle_pool::{
 };
 use crate::kmsg_log;
 use crate::lock;
-use crate::network_log_manager::NetworkLogManager;
+use crate::network_log_drain::NetworkLogDrainCoordinator;
+use crate::network_log_manager::{NetworkLogManager, NetworkLogSession};
 use crate::network_logs;
 use crate::paths::{HomePaths, LogPaths, RunnerPaths, touch_mtime};
 use crate::prefetch;
@@ -239,6 +240,10 @@ pub async fn run_start(
     let dns_handle = dns::start(network_log_manager.clone())
         .await
         .map_err(|e| RunnerError::Internal(format!("dns proxy: {e}")))?;
+    let network_log_drain = NetworkLogDrainCoordinator::new(vec![
+        kmsg_handle.drain_producer(),
+        dns_handle.drain_producer(),
+    ]);
 
     // Resource budget from host resources + config.
     let config::SandboxConfig {
@@ -345,6 +350,7 @@ pub async fn run_start(
         http,
         log_paths,
         network_log_manager,
+        network_log_drain,
         home: home.clone(),
     });
 
@@ -1286,12 +1292,14 @@ struct FinalizeContext {
     session_id: Option<String>,
     guest_session_id: Option<String>,
     source_ip: String,
+    network_log_session: Option<NetworkLogSession>,
     storage_fingerprints: StorageFingerprints,
     factory: Arc<Box<dyn SandboxFactory>>,
     idle_pool: SharedIdlePool,
     status: Arc<StatusTracker>,
     park_notify: Arc<tokio::sync::Notify>,
     parking_gate: ParkingGate,
+    network_log_drain: NetworkLogDrainCoordinator,
     exit_code: i32,
     cancel: CancellationToken,
     cleanup_state: RunCleanupState,
@@ -1316,12 +1324,14 @@ async fn finalize_sandbox_for_completion(
         session_id,
         guest_session_id,
         source_ip,
+        mut network_log_session,
         storage_fingerprints,
         factory,
         idle_pool,
         status,
         park_notify,
         parking_gate,
+        network_log_drain,
         exit_code,
         cancel,
         cleanup_state,
@@ -1361,6 +1371,8 @@ async fn finalize_sandbox_for_completion(
                     profile_name: &profile_name,
                     session_id: Some(&session_id),
                     reason: "park_failed",
+                    network_log_session: network_log_session.take(),
+                    network_log_drain: network_log_drain.clone(),
                 },
             )
             .await;
@@ -1375,6 +1387,7 @@ async fn finalize_sandbox_for_completion(
             );
             BudgetOwnership::active(active_lease)
         } else if cancel.is_cancelled() {
+            close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
             info!(
                 run_id = %run_id,
                 session_id,
@@ -1389,6 +1402,8 @@ async fn finalize_sandbox_for_completion(
                     profile_name: &profile_name,
                     session_id: Some(&session_id),
                     reason: "cancelled",
+                    network_log_session: None,
+                    network_log_drain: network_log_drain.clone(),
                 },
             )
             .await;
@@ -1403,6 +1418,7 @@ async fn finalize_sandbox_for_completion(
             );
             BudgetOwnership::active(active_lease)
         } else {
+            close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
             let mut pool = idle_pool.lock().await;
             if cancel.is_cancelled() {
                 info!(
@@ -1420,6 +1436,8 @@ async fn finalize_sandbox_for_completion(
                         profile_name: &profile_name,
                         session_id: Some(&session_id),
                         reason: "cancelled",
+                        network_log_session: None,
+                        network_log_drain: network_log_drain.clone(),
                     },
                 )
                 .await;
@@ -1532,6 +1550,8 @@ async fn finalize_sandbox_for_completion(
                     session_id.as_deref(),
                     guest_session_id.as_deref(),
                 ),
+                network_log_session: network_log_session.take(),
+                network_log_drain: network_log_drain.clone(),
             },
         )
         .await;
@@ -1548,6 +1568,16 @@ async fn finalize_sandbox_for_completion(
     };
 
     CompletionReady::new(completion_payload, budget)
+}
+
+async fn close_network_log_session(
+    run_id: RunId,
+    session: Option<NetworkLogSession>,
+    drain: &NetworkLogDrainCoordinator,
+) {
+    if let Some(session) = session {
+        session.close_for_upload(run_id, drain).await;
+    }
 }
 
 /// Spawn a job executor task.
@@ -1645,42 +1675,51 @@ fn spawn_job(
                 }
             });
 
-            let (exit_code, err, sandbox, source_ip, guest_session_id, telemetry) =
-                match inner.await {
-                    Ok((outcome, telemetry)) => {
-                        let err = if job_cancel.is_cancelled() {
-                            Some("cancelled by user".to_string())
-                        } else {
-                            outcome.error
-                        };
-                        (
-                            outcome.exit_code,
-                            err,
-                            outcome.sandbox,
-                            outcome.source_ip,
-                            outcome.guest_session_id,
-                            telemetry,
-                        )
-                    }
-                    Err(e) => {
-                        // Panic lost the in-flight telemetry buffer; substitute an
-                        // empty collector so the post-complete flush path stays
-                        // unconditional. `flush` early-returns on empty pending_ops.
-                        let empty_telemetry = JobTelemetry::new(
-                            exec_config_for_deferred.http.clone(),
-                            run_id,
-                            sandbox_token.clone(),
-                        );
-                        (
-                            1,
-                            Some(format!("executor task panicked: {e}")),
-                            None,
-                            String::new(),
-                            None,
-                            empty_telemetry,
-                        )
-                    }
-                };
+            let (
+                exit_code,
+                err,
+                sandbox,
+                source_ip,
+                network_log_session,
+                guest_session_id,
+                telemetry,
+            ) = match inner.await {
+                Ok((outcome, telemetry)) => {
+                    let err = if job_cancel.is_cancelled() {
+                        Some("cancelled by user".to_string())
+                    } else {
+                        outcome.error
+                    };
+                    (
+                        outcome.exit_code,
+                        err,
+                        outcome.sandbox,
+                        outcome.source_ip,
+                        outcome.network_log_session,
+                        outcome.guest_session_id,
+                        telemetry,
+                    )
+                }
+                Err(e) => {
+                    // Panic lost the in-flight telemetry buffer; substitute an
+                    // empty collector so the post-complete flush path stays
+                    // unconditional. `flush` early-returns on empty pending_ops.
+                    let empty_telemetry = JobTelemetry::new(
+                        exec_config_for_deferred.http.clone(),
+                        run_id,
+                        sandbox_token.clone(),
+                    );
+                    (
+                        1,
+                        Some(format!("executor task panicked: {e}")),
+                        None,
+                        String::new(),
+                        None,
+                        None,
+                        empty_telemetry,
+                    )
+                }
+            };
 
             // Single sink for any claimed job's terminal state. Cancellation gets
             // its own info marker; everything else with `err` set is a failure
@@ -1711,12 +1750,14 @@ fn spawn_job(
                     session_id,
                     guest_session_id,
                     source_ip,
+                    network_log_session,
                     storage_fingerprints,
                     factory: factory_for_cleanup,
                     idle_pool,
                     status: Arc::clone(&status),
                     park_notify,
                     parking_gate,
+                    network_log_drain: exec_config_for_deferred.network_log_drain.clone(),
                     exit_code,
                     cancel: job_cancel,
                     cleanup_state: cleanup_state_for_body.clone(),
@@ -1735,9 +1776,10 @@ fn spawn_job(
             // user-visible run-complete signal isn't blocked on these uploads.
             // They're still awaited (not spawned) so the surrounding `jobs`
             // JoinSet drains them on graceful shutdown — no data loss on SIGTERM.
-            // Telemetry flush runs concurrently with network-log drain + upload.
-            // Network-log upload must wait for accepted Rust-side DNS/kmsg writes
-            // before reading the per-run JSONL snapshot.
+            // Telemetry flush runs concurrently with best-effort network-log upload.
+            // The job finalizer already closed the local Rust-side DNS/kmsg
+            // session before sandbox reuse/release. Keep this flush as a
+            // defensive no-op for any accepted writes still finishing.
             let network_log_path = exec_config_for_deferred.log_paths.network_log(run_id);
             let network_log_upload = async {
                 exec_config_for_deferred
@@ -2179,20 +2221,21 @@ async fn destroy_idle_payload_and_wait(
     }
 }
 
-#[derive(Clone, Copy)]
 struct ActiveCleanupContext<'a> {
     run_id: RunId,
     sandbox_id: SandboxId,
     profile_name: &'a str,
     session_id: Option<&'a str>,
     reason: &'static str,
+    network_log_session: Option<NetworkLogSession>,
+    network_log_drain: NetworkLogDrainCoordinator,
 }
 
 /// Stop a sandbox and destroy it via its factory.
 async fn stop_and_destroy_sandbox(
     mut sandbox: Box<dyn Sandbox>,
     factory: &dyn SandboxFactory,
-    context: ActiveCleanupContext<'_>,
+    mut context: ActiveCleanupContext<'_>,
 ) -> DestroyOutcome {
     let mut uncertain = false;
     match AssertUnwindSafe(sandbox.stop()).catch_unwind().await {
@@ -2218,6 +2261,12 @@ async fn stop_and_destroy_sandbox(
             uncertain = true;
         }
     }
+    close_network_log_session(
+        context.run_id,
+        context.network_log_session.take(),
+        &context.network_log_drain,
+    )
+    .await;
     if AssertUnwindSafe(factory.destroy(sandbox))
         .catch_unwind()
         .await
@@ -3729,6 +3778,7 @@ mod tests {
                 http: crate::http::HttpClient::new(api_url.to_string()).unwrap(),
                 log_paths: crate::paths::LogPaths::new(log_dir),
                 network_log_manager: NetworkLogManager::new(),
+                network_log_drain: NetworkLogDrainCoordinator::noop(),
                 home,
             }),
             firecracker: config::FirecrackerConfig {
@@ -3938,7 +3988,7 @@ mod tests {
             ),
         )
         .unwrap();
-        network_log_manager
+        let _network_log_session = network_log_manager
             .register_source_ip("10.200.0.200", network_log_path.clone())
             .await;
         assert!(
@@ -3959,12 +4009,16 @@ mod tests {
         let run_handle = tokio::spawn(run(config));
         push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
 
+        // The finalizer now closes Rust-side network-log attribution before
+        // completing the job, so release the accepted write before waiting for
+        // completion. The upload itself is still deferred until after the
+        // completion request below.
+        release_write.add_permits(1);
         let completion = env
             .handle
             .wait_completion(run_id, Duration::from_secs(5))
             .await;
         assert!(completion.is_some(), "job should complete");
-        release_write.add_permits(1);
 
         // Drain shutdown — must block on each `spawn_job` closure's deferred
         // `tokio::join!(flush, upload)` via the outer `jobs` JoinSet.

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -2651,6 +2651,142 @@ mod tests {
         assert_eq!(budget.allocated().2, 0);
     }
 
+    #[tokio::test]
+    async fn finalizer_closes_network_log_session_before_parking() {
+        let (_budget, lease) = test_budget_lease();
+        let dir = tempfile::tempdir().unwrap();
+        let status = Arc::new(StatusTracker::new(
+            dir.path().join("status.json"),
+            4,
+            None,
+            None,
+        ));
+        status.write_initial().await;
+        let parking_gate = ParkingGate::new_open();
+        let idle_pool: SharedIdlePool =
+            Arc::new(tokio::sync::Mutex::new(IdlePool::new_with_parking_gate(
+                IdlePoolConfig {
+                    default_timeout: Duration::from_secs(300),
+                    max_idle: 10,
+                },
+                parking_gate.clone(),
+            )));
+        let network_log_manager = NetworkLogManager::new();
+        let network_log_path = dir.path().join("network.jsonl");
+        let network_log_session = network_log_manager
+            .register_source_ip("10.0.0.1", network_log_path)
+            .await;
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+
+        let _completion_ready = finalize_sandbox_for_completion(
+            Some(Box::new(MockSandbox::new("network-log-park"))),
+            ActiveBudgetLease::new(lease),
+            CompletionPayload::new(run_id, 0, None, sandbox_id, SandboxReuseResult::PoolMiss),
+            FinalizeContext {
+                run_id,
+                sandbox_id,
+                profile_name: "vm0/default".into(),
+                session_id: Some("sess-network-log-park".into()),
+                guest_session_id: None,
+                source_ip: "10.0.0.1".into(),
+                network_log_session: Some(network_log_session),
+                storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+                factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+                idle_pool: Arc::clone(&idle_pool),
+                status,
+                park_notify: Arc::new(tokio::sync::Notify::new()),
+                parking_gate,
+                network_log_drain: NetworkLogDrainCoordinator::noop(),
+                exit_code: 0,
+                cancel: CancellationToken::new(),
+                cleanup_state: RunCleanupState::new(),
+                outer_job_panic: None,
+            },
+        )
+        .await;
+
+        assert_eq!(idle_pool.lock().await.len(), 1);
+        assert!(
+            !network_log_manager
+                .append_for_ip(
+                    "10.0.0.1",
+                    serde_json::json!({"type":"dns","host":"after-park.test"})
+                )
+                .await,
+            "parked sandbox must not retain the previous run's network-log attribution",
+        );
+    }
+
+    #[tokio::test]
+    async fn finalizer_closes_network_log_session_before_cancel_destroy() {
+        let (_budget, lease) = test_budget_lease();
+        let dir = tempfile::tempdir().unwrap();
+        let status = Arc::new(StatusTracker::new(
+            dir.path().join("status.json"),
+            4,
+            None,
+            None,
+        ));
+        status.write_initial().await;
+        let parking_gate = ParkingGate::new_open();
+        let idle_pool: SharedIdlePool =
+            Arc::new(tokio::sync::Mutex::new(IdlePool::new_with_parking_gate(
+                IdlePoolConfig {
+                    default_timeout: Duration::from_secs(300),
+                    max_idle: 10,
+                },
+                parking_gate.clone(),
+            )));
+        let network_log_manager = NetworkLogManager::new();
+        let network_log_path = dir.path().join("network.jsonl");
+        let network_log_session = network_log_manager
+            .register_source_ip("10.0.0.1", network_log_path)
+            .await;
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+
+        let _completion_ready = finalize_sandbox_for_completion(
+            Some(Box::new(MockSandbox::new("network-log-cancel"))),
+            ActiveBudgetLease::new(lease),
+            CompletionPayload::new(run_id, 0, None, sandbox_id, SandboxReuseResult::PoolMiss),
+            FinalizeContext {
+                run_id,
+                sandbox_id,
+                profile_name: "vm0/default".into(),
+                session_id: Some("sess-network-log-cancel".into()),
+                guest_session_id: None,
+                source_ip: "10.0.0.1".into(),
+                network_log_session: Some(network_log_session),
+                storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+                factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+                idle_pool: Arc::clone(&idle_pool),
+                status,
+                park_notify: Arc::new(tokio::sync::Notify::new()),
+                parking_gate,
+                network_log_drain: NetworkLogDrainCoordinator::noop(),
+                exit_code: 0,
+                cancel,
+                cleanup_state: RunCleanupState::new(),
+                outer_job_panic: None,
+            },
+        )
+        .await;
+
+        assert_eq!(idle_pool.lock().await.len(), 0);
+        assert!(
+            !network_log_manager
+                .append_for_ip(
+                    "10.0.0.1",
+                    serde_json::json!({"type":"dns","host":"after-destroy.test"})
+                )
+                .await,
+            "cancelled destroyed sandbox must not retain network-log attribution",
+        );
+    }
+
     #[test]
     fn active_budget_drop_releases_budget_as_raii_fallback() {
         let (budget, lease) = test_budget_lease();

--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -18,10 +18,14 @@
 use std::process::Stdio;
 
 use chrono::{DateTime, Utc};
-use tokio::io::AsyncBufReadExt;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt};
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use crate::network_log_drain::{
+    NetworkLogDrainProducer, NetworkLogDrainRequest, ReadyLine, poll_next_line_ready,
+};
 use crate::network_log_manager::NetworkLogManager;
 
 /// Handle to the dnsmasq process and its log monitor.
@@ -29,6 +33,7 @@ pub struct DnsProxy {
     cancel: CancellationToken,
     task: tokio::task::JoinHandle<()>,
     child: Option<tokio::process::Child>,
+    drain: NetworkLogDrainProducer,
     port: u16,
 }
 
@@ -49,15 +54,33 @@ impl DnsProxy {
         self.port
     }
 
+    pub fn drain_producer(&self) -> NetworkLogDrainProducer {
+        self.drain.clone()
+    }
+
     /// Create a noop handle for testing. No `dnsmasq` process is spawned.
     #[cfg(test)]
     pub fn noop() -> Self {
         let cancel = CancellationToken::new();
         let token = cancel.clone();
+        let (drain, mut drain_rx) = NetworkLogDrainProducer::channel("dns");
         Self {
             cancel,
-            task: tokio::spawn(async move { token.cancelled().await }),
+            task: tokio::spawn(async move {
+                loop {
+                    tokio::select! {
+                        _ = token.cancelled() => break,
+                        request = drain_rx.recv() => {
+                            let Some(request) = request else {
+                                break;
+                            };
+                            request.ack();
+                        }
+                    }
+                }
+            }),
             child: None,
+            drain,
             port: 0,
         }
     }
@@ -192,8 +215,9 @@ async fn try_start(port: u16, network_log_manager: NetworkLogManager) -> std::io
 
     let cancel = CancellationToken::new();
     let token = cancel.clone();
+    let (drain, drain_rx) = NetworkLogDrainProducer::channel("dns");
     let task = tokio::spawn(async move {
-        if let Err(e) = tail_stderr(stderr, network_log_manager, token).await {
+        if let Err(e) = tail_stderr(stderr, network_log_manager, token, drain_rx).await {
             warn!(error = %e, "dns log monitor exited");
         }
     });
@@ -203,6 +227,7 @@ async fn try_start(port: u16, network_log_manager: NetworkLogManager) -> std::io
         cancel,
         task,
         child: Some(child),
+        drain,
         port,
     })
 }
@@ -223,11 +248,41 @@ async fn tail_stderr(
     stderr: tokio::process::ChildStderr,
     network_log_manager: NetworkLogManager,
     cancel: CancellationToken,
+    drain_rx: mpsc::Receiver<NetworkLogDrainRequest>,
 ) -> std::io::Result<()> {
-    let mut lines = tokio::io::BufReader::new(stderr).lines();
+    tail_reader(
+        tokio::io::BufReader::new(stderr),
+        network_log_manager,
+        cancel,
+        drain_rx,
+    )
+    .await
+}
+
+async fn tail_reader<R>(
+    reader: R,
+    network_log_manager: NetworkLogManager,
+    cancel: CancellationToken,
+    mut drain_rx: mpsc::Receiver<NetworkLogDrainRequest>,
+) -> std::io::Result<()>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut lines = reader.lines();
     loop {
         tokio::select! {
             _ = cancel.cancelled() => break,
+            request = drain_rx.recv() => {
+                let Some(request) = request else {
+                    break;
+                };
+                let outcome = drain_ready_lines(&mut lines, &network_log_manager).await;
+                request.ack();
+                if let DrainOutcome::Stop(result) = outcome {
+                    result?;
+                    break;
+                }
+            }
             result = lines.next_line() => {
                 let line = match result {
                     Ok(Some(l)) => l,
@@ -243,16 +298,42 @@ async fn tail_stderr(
                     }
                 };
 
-                if let Some(entry) = parse_dns_line(&line) {
-                    // Capture the timestamp before handing the row to the manager so
-                    // it reflects DNS observation time, not delayed write time.
-                    let timestamp = Utc::now();
-                    append_dns_entry(&network_log_manager, &entry, timestamp).await;
-                }
+                handle_dns_line(&network_log_manager, &line).await;
             }
         }
     }
     Ok(())
+}
+
+enum DrainOutcome {
+    Continue,
+    Stop(std::io::Result<()>),
+}
+
+async fn drain_ready_lines<R>(
+    lines: &mut tokio::io::Lines<R>,
+    network_log_manager: &NetworkLogManager,
+) -> DrainOutcome
+where
+    R: AsyncBufRead + Unpin,
+{
+    loop {
+        match poll_next_line_ready(lines) {
+            Ok(ReadyLine::Line(line)) => handle_dns_line(network_log_manager, &line).await,
+            Ok(ReadyLine::Pending) => return DrainOutcome::Continue,
+            Ok(ReadyLine::Eof) => return DrainOutcome::Stop(Ok(())),
+            Err(e) => return DrainOutcome::Stop(Err(e)),
+        }
+    }
+}
+
+async fn handle_dns_line(network_log_manager: &NetworkLogManager, line: &str) {
+    if let Some(entry) = parse_dns_line(line) {
+        // Capture the timestamp before handing the row to the manager so
+        // it reflects DNS observation time, not delayed write time.
+        let timestamp = Utc::now();
+        append_dns_entry(network_log_manager, &entry, timestamp).await;
+    }
 }
 
 /// Parsed DNS log entry.
@@ -447,6 +528,9 @@ fn network_log_row(entry: &DnsLogEntry, timestamp: DateTime<Utc>) -> serde_json:
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ids::RunId;
+    use crate::network_log_drain::NetworkLogDrainContext;
+    use tokio::io::AsyncWriteExt;
 
     fn assert_query_event(entry: &DnsLogEntry, expected_query_type: &str) {
         assert_eq!(entry.event.name(), "query");
@@ -644,7 +728,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("dns.jsonl");
         let manager = NetworkLogManager::new();
-        manager.register_source_ip("10.200.0.2", path.clone()).await;
+        let _session = manager.register_source_ip("10.200.0.2", path.clone()).await;
         let entry = DnsLogEntry {
             source_ip: "10.200.0.2".to_string(),
             domain: "api.github.com".to_string(),
@@ -673,7 +757,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("dns.jsonl");
         let manager = NetworkLogManager::new();
-        manager.register_source_ip("10.0.0.1", path.clone()).await;
+        let _session = manager.register_source_ip("10.0.0.1", path.clone()).await;
         for domain in ["a.com", "b.com", "c.com"] {
             assert!(
                 append_dns_entry(
@@ -717,7 +801,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("dns.jsonl");
         let manager = NetworkLogManager::new();
-        manager.register_source_ip("10.0.0.1", path.clone()).await;
+        let _session = manager.register_source_ip("10.0.0.1", path.clone()).await;
 
         for result in ["140.82.121.3", "140.82.121.4"] {
             assert!(
@@ -777,6 +861,51 @@ mod tests {
         );
         manager.flush_path(&path).await;
         assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn drain_barrier_processes_queued_dns_line_before_ack() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dns.jsonl");
+        let manager = NetworkLogManager::new();
+        let _session = manager.register_source_ip("10.0.0.1", path.clone()).await;
+        let cancel = CancellationToken::new();
+        let (producer, drain_rx) = NetworkLogDrainProducer::channel("dns-test");
+        let (mut writer, reader) = tokio::io::duplex(1024);
+        let task = tokio::spawn(tail_reader(
+            tokio::io::BufReader::new(reader),
+            manager.clone(),
+            cancel.clone(),
+            drain_rx,
+        ));
+
+        writer
+            .write_all(b"dnsmasq[1234]: 42 10.0.0.1/54321 query[A] example.com from 10.0.0.1\n")
+            .await
+            .unwrap();
+
+        producer
+            .drain(
+                NetworkLogDrainContext {
+                    run_id: RunId::nil(),
+                    source_ip: "10.0.0.1",
+                    path: &path,
+                    generation: 1,
+                },
+                std::time::Duration::from_secs(1),
+            )
+            .await;
+        manager.flush_path(&path).await;
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(parsed["type"], "dns");
+        assert_eq!(parsed["host"], "example.com");
+        assert_eq!(parsed["dns_event"], "query");
+
+        cancel.cancel();
+        drop(writer);
+        task.await.unwrap().unwrap();
     }
 
     #[test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -21,7 +21,9 @@ const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
 use crate::idle_pool::ReusableIdleSandbox;
+use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_log_manager::NetworkLogManager;
+use crate::network_log_manager::NetworkLogSession;
 use crate::paths::{HomePaths, LogPaths, guest};
 use crate::proxy::{self, ProxyRegistryHandle};
 use crate::telemetry::JobTelemetry;
@@ -37,6 +39,7 @@ pub struct ExecutorConfig {
     pub http: HttpClient,
     pub log_paths: LogPaths,
     pub network_log_manager: NetworkLogManager,
+    pub network_log_drain: NetworkLogDrainCoordinator,
     pub home: HomePaths,
 }
 
@@ -56,6 +59,7 @@ pub struct ExecuteOutcome {
     /// during create/start (sandbox was destroyed inline).
     pub sandbox: Option<Box<dyn Sandbox>>,
     pub source_ip: String,
+    pub network_log_session: Option<NetworkLogSession>,
     /// CLI-generated session ID read from the guest after execution.
     /// Used for first-run VM parking when `resume_session` is absent.
     pub guest_session_id: Option<String>,
@@ -101,6 +105,7 @@ pub async fn execute_job(
             error: Some(e.to_string()),
             sandbox: None,
             source_ip: String::new(),
+            network_log_session: None,
             guest_session_id: None,
         },
     };
@@ -229,11 +234,14 @@ async fn execute_new_sandbox(
     let source_ip = sandbox.source_ip().to_string();
 
     // Register VM in proxy registry BEFORE starting the sandbox.
-    register_proxy(config, context, &source_ip).await;
+    let network_log_session = register_proxy(config, context, &source_ip).await;
 
     if let Err(e) = sandbox.start().await {
         telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
-        unregister_proxy(config, context, &source_ip).await;
+        unregister_proxy_registry(config, context, &source_ip).await;
+        network_log_session
+            .close_for_upload(context.run_id, &config.network_log_drain)
+            .await;
         destroy_sandbox_panic_safe(factory, sandbox).await;
         return Err(e.into());
     }
@@ -254,7 +262,7 @@ async fn execute_new_sandbox(
     )
     .await;
 
-    // Post-job: copy logs + unregister proxy (sandbox stays alive for possible reuse)
+    // Post-job: copy logs + unregister proxy registry (sandbox stays alive for possible reuse)
     post_job_cleanup(sandbox.as_ref(), config, context, &source_ip).await;
 
     let (exit_code, error) = match result {
@@ -279,6 +287,7 @@ async fn execute_new_sandbox(
         error,
         sandbox: Some(sandbox),
         source_ip,
+        network_log_session: Some(network_log_session),
         guest_session_id,
     })
 }
@@ -312,7 +321,7 @@ async fn execute_reused_sandbox(
     );
 
     // Re-register proxy with new run credentials
-    register_proxy(config, context, source_ip).await;
+    let network_log_session = register_proxy(config, context, source_ip).await;
 
     // Run job — clock/entropy fixed inside run_in_sandbox (always needed after idle).
     let result = run_in_sandbox(
@@ -329,7 +338,7 @@ async fn execute_reused_sandbox(
     )
     .await;
 
-    // Post-job cleanup (copy logs to host, unregister proxy, upload network logs)
+    // Post-job cleanup (copy logs to host, unregister proxy registry)
     post_job_cleanup(sandbox.as_ref(), config, context, source_ip).await;
 
     let (exit_code, error) = match result {
@@ -353,12 +362,17 @@ async fn execute_reused_sandbox(
         error,
         sandbox: Some(sandbox),
         source_ip: source_ip.to_string(),
+        network_log_session: Some(network_log_session),
         guest_session_id,
     }
 }
 
 /// Register a VM in the proxy registry and network log manager.
-async fn register_proxy(config: &ExecutorConfig, context: &ExecutionContext, source_ip: &str) {
+async fn register_proxy(
+    config: &ExecutorConfig,
+    context: &ExecutionContext,
+    source_ip: &str,
+) -> NetworkLogSession {
     let network_log_path = config.log_paths.network_log(context.run_id);
     let proxy_log_path = config.log_paths.proxy_log(context.run_id);
     let run_id_str = context.run_id.to_string();
@@ -385,24 +399,24 @@ async fn register_proxy(config: &ExecutorConfig, context: &ExecutionContext, sou
         .await
 }
 
-/// Unregister a VM from the proxy registry and network log manager.
-async fn unregister_proxy(config: &ExecutorConfig, context: &ExecutionContext, source_ip: &str) {
+/// Unregister a VM from the proxy registry.
+async fn unregister_proxy_registry(
+    config: &ExecutorConfig,
+    context: &ExecutionContext,
+    source_ip: &str,
+) {
     if let Err(e) = config.registry.unregister_vm(source_ip).await {
         warn!(run_id = %context.run_id, error = %e, "failed to unregister VM from proxy");
     }
-    config
-        .network_log_manager
-        .unregister_source_ip(source_ip)
-        .await;
 }
 
-/// Post-job cleanup: copy logs, unregister proxy.
+/// Post-job cleanup: copy logs, unregister proxy registry.
 ///
 /// Called after `run_in_sandbox` completes, whether the sandbox will be
-/// parked (keep-alive) or destroyed. The network-log upload is deliberately
-/// **not** done here — `spawn_job` (in `cmd/start.rs`) runs it after
-/// `provider.complete` so the user-visible run-complete signal isn't blocked
-/// on the best-effort upload (~1.6 s saved per job).
+/// parked (keep-alive) or destroyed. Rust-side network-log attribution stays
+/// open until `cmd/start.rs` quiesces the sandbox and closes the returned
+/// `NetworkLogSession`; the HTTP upload remains deferred after
+/// `provider.complete`.
 async fn post_job_cleanup(
     sandbox: &dyn Sandbox,
     config: &ExecutorConfig,
@@ -410,7 +424,7 @@ async fn post_job_cleanup(
     source_ip: &str,
 ) {
     copy_guest_logs(sandbox, context, &config.log_paths).await;
-    unregister_proxy(config, context, source_ip).await;
+    unregister_proxy_registry(config, context, source_ip).await;
 }
 
 /// How this run is entering its sandbox. Each field feeds a distinct step:
@@ -2693,6 +2707,7 @@ mod tests {
             http: crate::http::HttpClient::new("http://localhost:9999".into()).unwrap(),
             log_paths: LogPaths::new(log_dir),
             network_log_manager: NetworkLogManager::new(),
+            network_log_drain: NetworkLogDrainCoordinator::noop(),
             home: HomePaths::with_root(dir.to_path_buf()),
         }
     }

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -9,10 +9,14 @@
 use std::process::Stdio;
 
 use chrono::{DateTime, Utc};
-use tokio::io::AsyncBufReadExt;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt};
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use crate::network_log_drain::{
+    NetworkLogDrainProducer, NetworkLogDrainRequest, ReadyLine, poll_next_line_ready,
+};
 use crate::network_log_manager::NetworkLogManager;
 
 /// Prefix used in iptables `--log-prefix` to identify our log lines.
@@ -24,6 +28,7 @@ pub struct KmsgHandle {
     cancel: CancellationToken,
     task: tokio::task::JoinHandle<()>,
     child: Option<tokio::process::Child>,
+    drain: NetworkLogDrainProducer,
 }
 
 impl KmsgHandle {
@@ -43,11 +48,29 @@ impl KmsgHandle {
     pub fn noop() -> Self {
         let cancel = CancellationToken::new();
         let token = cancel.clone();
+        let (drain, mut drain_rx) = NetworkLogDrainProducer::channel("kmsg");
         Self {
             cancel,
-            task: tokio::spawn(async move { token.cancelled().await }),
+            task: tokio::spawn(async move {
+                loop {
+                    tokio::select! {
+                        _ = token.cancelled() => break,
+                        request = drain_rx.recv() => {
+                            let Some(request) = request else {
+                                break;
+                            };
+                            request.ack();
+                        }
+                    }
+                }
+            }),
             child: None,
+            drain,
         }
+    }
+
+    pub fn drain_producer(&self) -> NetworkLogDrainProducer {
+        self.drain.clone()
     }
 }
 
@@ -83,6 +106,7 @@ pub fn spawn(network_log_manager: NetworkLogManager) -> std::io::Result<KmsgHand
 
     let cancel = CancellationToken::new();
     let token = cancel.clone();
+    let (drain, drain_rx) = NetworkLogDrainProducer::channel("kmsg");
 
     // Log stderr in a background task so dmesg errors are visible.
     // Shares the cancel token so the task exits promptly on shutdown.
@@ -108,12 +132,13 @@ pub fn spawn(network_log_manager: NetworkLogManager) -> std::io::Result<KmsgHand
     }
 
     let task = tokio::spawn(async move {
-        run_loop(network_log_manager, token, stdout).await;
+        run_loop(network_log_manager, token, stdout, drain_rx).await;
     });
     Ok(KmsgHandle {
         cancel,
         task,
         child: Some(child),
+        drain,
     })
 }
 
@@ -123,11 +148,39 @@ async fn run_loop(
     network_log_manager: NetworkLogManager,
     cancel: CancellationToken,
     stdout: tokio::process::ChildStdout,
+    drain_rx: mpsc::Receiver<NetworkLogDrainRequest>,
 ) {
-    let mut lines = tokio::io::BufReader::new(stdout).lines();
+    run_reader(
+        network_log_manager,
+        cancel,
+        tokio::io::BufReader::new(stdout),
+        drain_rx,
+    )
+    .await;
+}
+
+async fn run_reader<R>(
+    network_log_manager: NetworkLogManager,
+    cancel: CancellationToken,
+    reader: R,
+    mut drain_rx: mpsc::Receiver<NetworkLogDrainRequest>,
+) where
+    R: AsyncBufRead + Unpin,
+{
+    let mut lines = reader.lines();
     loop {
         tokio::select! {
             _ = cancel.cancelled() => break,
+            request = drain_rx.recv() => {
+                let Some(request) = request else {
+                    break;
+                };
+                let stop = drain_ready_lines(&mut lines, &network_log_manager).await;
+                request.ack();
+                if stop {
+                    break;
+                }
+            }
             result = lines.next_line() => {
                 let line = match result {
                     Ok(Some(l)) => l,
@@ -139,14 +192,39 @@ async fn run_loop(
                     continue;
                 }
 
-                if let Some(entry) = parse_log_message(&line) {
-                    // Capture the timestamp before handing the row to the manager so
-                    // it reflects observation time, not delayed write time.
-                    let timestamp = Utc::now();
-                    append_log_entry(&network_log_manager, &entry, timestamp).await;
-                }
+                handle_kmsg_line(&network_log_manager, &line).await;
             }
         }
+    }
+}
+
+async fn drain_ready_lines<R>(
+    lines: &mut tokio::io::Lines<R>,
+    network_log_manager: &NetworkLogManager,
+) -> bool
+where
+    R: AsyncBufRead + Unpin,
+{
+    loop {
+        match poll_next_line_ready(lines) {
+            Ok(ReadyLine::Line(line)) => handle_kmsg_line(network_log_manager, &line).await,
+            Ok(ReadyLine::Pending) => return false,
+            Ok(ReadyLine::Eof) | Err(_) => return true,
+        }
+    }
+}
+
+async fn handle_kmsg_line(network_log_manager: &NetworkLogManager, line: &str) {
+    // Fast check before acquiring lock.
+    if !line.contains(LOG_PREFIX) {
+        return;
+    }
+
+    if let Some(entry) = parse_log_message(line) {
+        // Capture the timestamp before handing the row to the manager so
+        // it reflects observation time, not delayed write time.
+        let timestamp = Utc::now();
+        append_log_entry(network_log_manager, &entry, timestamp).await;
     }
 }
 
@@ -236,6 +314,9 @@ fn network_log_row(entry: &LogEntry, timestamp: DateTime<Utc>) -> serde_json::Va
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ids::RunId;
+    use crate::network_log_drain::NetworkLogDrainContext;
+    use tokio::io::AsyncWriteExt;
 
     #[test]
     fn parse_udp_log_message() {
@@ -358,7 +439,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.jsonl");
         let manager = NetworkLogManager::new();
-        manager.register_source_ip("10.200.0.2", path.clone()).await;
+        let _session = manager.register_source_ip("10.200.0.2", path.clone()).await;
         let entry = LogEntry {
             source_ip: "10.200.0.2".to_string(),
             dst_ip: "8.8.8.8".to_string(),
@@ -398,7 +479,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("multi.jsonl");
         let manager = NetworkLogManager::new();
-        manager.register_source_ip("10.0.0.1", path.clone()).await;
+        let _session = manager.register_source_ip("10.0.0.1", path.clone()).await;
         for dst in ["8.8.8.8", "1.1.1.1", "9.9.9.9"] {
             assert!(
                 append_log_entry(
@@ -457,6 +538,53 @@ mod tests {
         );
         manager.flush_path(&path).await;
         assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn drain_barrier_processes_queued_kmsg_line_before_ack() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("kmsg.jsonl");
+        let manager = NetworkLogManager::new();
+        let _session = manager.register_source_ip("10.0.0.1", path.clone()).await;
+        let cancel = CancellationToken::new();
+        let (producer, drain_rx) = NetworkLogDrainProducer::channel("kmsg-test");
+        let (mut writer, reader) = tokio::io::duplex(1024);
+        let task = tokio::spawn(run_reader(
+            manager.clone(),
+            cancel.clone(),
+            tokio::io::BufReader::new(reader),
+            drain_rx,
+        ));
+
+        writer
+            .write_all(
+                b"[12345.678901] VM0:10.0.0.1:IN=vm0-ve OUT=ens5 SRC=10.0.0.1 DST=8.8.8.8 LEN=64 PROTO=UDP SPT=45678 DPT=53\n",
+            )
+            .await
+            .unwrap();
+
+        producer
+            .drain(
+                NetworkLogDrainContext {
+                    run_id: RunId::nil(),
+                    source_ip: "10.0.0.1",
+                    path: &path,
+                    generation: 1,
+                },
+                std::time::Duration::from_secs(1),
+            )
+            .await;
+        manager.flush_path(&path).await;
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(parsed["type"], "udp");
+        assert_eq!(parsed["host"], "8.8.8.8");
+        assert_eq!(parsed["port"], 53);
+
+        cancel.cancel();
+        drop(writer);
+        task.await.unwrap();
     }
 
     #[test]

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -14,6 +14,7 @@ mod ids;
 mod image_hash;
 mod kmsg_log;
 mod lock;
+mod network_log_drain;
 mod network_log_manager;
 mod network_logs;
 mod paths;

--- a/crates/runner/src/network_log_drain.rs
+++ b/crates/runner/src/network_log_drain.rs
@@ -1,0 +1,169 @@
+use std::future::Future;
+use std::path::Path;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use futures_util::future::join_all;
+use futures_util::task::noop_waker_ref;
+use tokio::io::{AsyncBufRead, Lines};
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::timeout;
+use tracing::warn;
+
+use crate::ids::RunId;
+
+const DEFAULT_DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
+
+#[derive(Clone)]
+pub struct NetworkLogDrainCoordinator {
+    producers: Arc<Vec<NetworkLogDrainProducer>>,
+    timeout: Duration,
+}
+
+impl Default for NetworkLogDrainCoordinator {
+    fn default() -> Self {
+        Self::noop()
+    }
+}
+
+impl NetworkLogDrainCoordinator {
+    pub fn new(producers: Vec<NetworkLogDrainProducer>) -> Self {
+        Self {
+            producers: Arc::new(producers),
+            timeout: DEFAULT_DRAIN_TIMEOUT,
+        }
+    }
+
+    pub fn noop() -> Self {
+        Self::new(Vec::new())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_timeout_for_test(
+        producers: Vec<NetworkLogDrainProducer>,
+        timeout: Duration,
+    ) -> Self {
+        Self {
+            producers: Arc::new(producers),
+            timeout,
+        }
+    }
+
+    pub async fn drain(&self, context: NetworkLogDrainContext<'_>) {
+        join_all(
+            self.producers
+                .iter()
+                .map(|producer| producer.drain(context, self.timeout)),
+        )
+        .await;
+    }
+}
+
+#[derive(Clone)]
+pub struct NetworkLogDrainProducer {
+    name: &'static str,
+    tx: mpsc::Sender<NetworkLogDrainRequest>,
+}
+
+impl NetworkLogDrainProducer {
+    pub fn channel(name: &'static str) -> (Self, mpsc::Receiver<NetworkLogDrainRequest>) {
+        let (tx, rx) = mpsc::channel(64);
+        (Self { name, tx }, rx)
+    }
+
+    pub(crate) async fn drain(&self, context: NetworkLogDrainContext<'_>, wait: Duration) {
+        let (ack_tx, ack_rx) = oneshot::channel();
+        match timeout(wait, self.tx.send(NetworkLogDrainRequest { ack: ack_tx })).await {
+            Ok(Ok(())) => {}
+            Ok(Err(_)) => {
+                warn!(
+                    run_id = %context.run_id,
+                    source_ip = context.source_ip,
+                    path = %context.path.display(),
+                    generation = context.generation,
+                    producer = self.name,
+                    "network log drain producer unavailable"
+                );
+                return;
+            }
+            Err(_) => {
+                warn!(
+                    run_id = %context.run_id,
+                    source_ip = context.source_ip,
+                    path = %context.path.display(),
+                    generation = context.generation,
+                    producer = self.name,
+                    timeout_ms = wait.as_millis(),
+                    "network log drain request timed out"
+                );
+                return;
+            }
+        }
+
+        match timeout(wait, ack_rx).await {
+            Ok(Ok(())) => {}
+            Ok(Err(_)) => warn!(
+                run_id = %context.run_id,
+                source_ip = context.source_ip,
+                path = %context.path.display(),
+                generation = context.generation,
+                producer = self.name,
+                "network log drain producer dropped ack"
+            ),
+            Err(_) => warn!(
+                run_id = %context.run_id,
+                source_ip = context.source_ip,
+                path = %context.path.display(),
+                generation = context.generation,
+                producer = self.name,
+                timeout_ms = wait.as_millis(),
+                "network log drain producer timed out"
+            ),
+        }
+    }
+}
+
+pub(crate) struct NetworkLogDrainRequest {
+    ack: oneshot::Sender<()>,
+}
+
+impl NetworkLogDrainRequest {
+    pub(crate) fn ack(self) {
+        let _ = self.ack.send(());
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct NetworkLogDrainContext<'a> {
+    pub run_id: RunId,
+    pub source_ip: &'a str,
+    pub path: &'a Path,
+    pub generation: u64,
+}
+
+pub(crate) enum ReadyLine {
+    Line(String),
+    Eof,
+    Pending,
+}
+
+/// Poll `Lines::next_line` once without waiting for future readiness.
+///
+/// `Lines::next_line` is cancellation-safe; when the poll returns `Pending`,
+/// dropping the future preserves the reader state for the normal loop. This is
+/// the producer-owned barrier used to drain complete lines that are immediately
+/// observable to the runner reader task without sleeping.
+pub(crate) fn poll_next_line_ready<R>(lines: &mut Lines<R>) -> std::io::Result<ReadyLine>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut next = std::pin::pin!(lines.next_line());
+    let mut cx = Context::from_waker(noop_waker_ref());
+    match Future::poll(next.as_mut(), &mut cx) {
+        Poll::Ready(Ok(Some(line))) => Ok(ReadyLine::Line(line)),
+        Poll::Ready(Ok(None)) => Ok(ReadyLine::Eof),
+        Poll::Ready(Err(e)) => Err(e),
+        Poll::Pending => Ok(ReadyLine::Pending),
+    }
+}

--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -356,6 +356,30 @@ mod tests {
             .collect()
     }
 
+    async fn source_ip_registered(manager: &NetworkLogManager, source_ip: &str) -> bool {
+        manager
+            .inner
+            .state
+            .lock()
+            .await
+            .source_paths
+            .contains_key(source_ip)
+    }
+
+    async fn wait_source_ip_unregistered(manager: &NetworkLogManager, source_ip: &str) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            if !source_ip_registered(manager, source_ip).await {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "source IP {source_ip} stayed registered after session drop",
+            );
+            tokio::task::yield_now().await;
+        }
+    }
+
     #[tokio::test]
     async fn append_for_ip_writes_json_line_to_registered_path() {
         let dir = tempfile::tempdir().unwrap();
@@ -681,6 +705,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dropped_unclosed_session_finalizes_mapping() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let manager = NetworkLogManager::new();
+        let session = manager.register_source_ip("10.200.0.2", path.clone()).await;
+        assert!(source_ip_registered(&manager, "10.200.0.2").await);
+
+        drop(session);
+        wait_source_ip_unregistered(&manager, "10.200.0.2").await;
+
+        assert!(
+            !manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"after-drop.test"}))
+                .await
+        );
+        manager.flush_path(&path).await;
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
     async fn close_for_upload_waits_for_barrier_and_flushes_late_rows() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("network.jsonl");
@@ -709,6 +753,56 @@ mod tests {
         let lines = read_json_lines(&path);
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0]["host"], "during-drain.test");
+        assert!(
+            !manager
+                .append_for_ip(
+                    "10.200.0.2",
+                    json!({"type":"dns","host":"after-close.test"})
+                )
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn close_for_upload_with_unavailable_producer_finalizes_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let manager = NetworkLogManager::new();
+        let session = manager.register_source_ip("10.200.0.2", path.clone()).await;
+        let (producer, drain_rx) = NetworkLogDrainProducer::channel("closed");
+        drop(drain_rx);
+        let drain = NetworkLogDrainCoordinator::new(vec![producer]);
+
+        session.close_for_upload(RunId::nil(), &drain).await;
+
+        assert!(!source_ip_registered(&manager, "10.200.0.2").await);
+        assert!(
+            !manager
+                .append_for_ip(
+                    "10.200.0.2",
+                    json!({"type":"dns","host":"after-close.test"})
+                )
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn close_for_upload_with_dropped_ack_finalizes_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let manager = NetworkLogManager::new();
+        let session = manager.register_source_ip("10.200.0.2", path.clone()).await;
+        let (producer, mut drain_rx) = NetworkLogDrainProducer::channel("dropped-ack");
+        let drain = NetworkLogDrainCoordinator::new(vec![producer]);
+        let receiver = tokio::spawn(async move {
+            let request = drain_rx.recv().await.expect("drain request");
+            drop(request);
+        });
+
+        session.close_for_upload(RunId::nil(), &drain).await;
+        receiver.await.unwrap();
+
+        assert!(!source_ip_registered(&manager, "10.200.0.2").await);
         assert!(
             !manager
                 .append_for_ip(

--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -79,6 +79,12 @@ struct WriteGate {
     release: Arc<Semaphore>,
 }
 
+/// Owns a source-IP network-log attribution for one runner job.
+///
+/// Keep this value alive until the sandbox is parked or stopped, then call
+/// [`NetworkLogSession::close_for_upload`] before reading/uploading the job's
+/// network log. Dropping it is only a best-effort cleanup fallback.
+#[must_use = "dropping a NetworkLogSession immediately closes network-log attribution"]
 pub struct NetworkLogSession {
     manager: NetworkLogManager,
     source_ip: String,

--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -9,6 +9,9 @@ use tokio::sync::Semaphore;
 use tokio::sync::{Mutex, Notify};
 use tracing::{debug, warn};
 
+use crate::ids::RunId;
+use crate::network_log_drain::{NetworkLogDrainContext, NetworkLogDrainCoordinator};
+
 /// Coordinates Rust-side DNS/kmsg network log attribution and file writes.
 ///
 /// Source-IP lookup and pending-write registration happen under the same lock,
@@ -27,8 +30,32 @@ struct Inner {
 
 #[derive(Default)]
 struct State {
-    source_paths: HashMap<String, PathBuf>,
+    source_paths: HashMap<String, SourceState>,
     pending_paths: HashMap<PathBuf, PathState>,
+    next_generation: u64,
+}
+
+enum SourceState {
+    Active { path: PathBuf, generation: u64 },
+    Draining { path: PathBuf, generation: u64 },
+}
+
+impl SourceState {
+    fn path(&self) -> &PathBuf {
+        match self {
+            Self::Active { path, .. } | Self::Draining { path, .. } => path,
+        }
+    }
+
+    fn generation(&self) -> u64 {
+        match self {
+            Self::Active { generation, .. } | Self::Draining { generation, .. } => *generation,
+        }
+    }
+
+    fn matches(&self, path: &Path, generation: u64) -> bool {
+        self.generation() == generation && self.path() == path
+    }
 }
 
 struct PathState {
@@ -52,6 +79,63 @@ struct WriteGate {
     release: Arc<Semaphore>,
 }
 
+pub struct NetworkLogSession {
+    manager: NetworkLogManager,
+    source_ip: String,
+    path: PathBuf,
+    generation: u64,
+    closed: bool,
+}
+
+impl NetworkLogSession {
+    /// Close local Rust-side network logs for this run before upload reads the file.
+    ///
+    /// The barrier only covers rows observable to the runner reader tasks. It
+    /// cannot prove delivery for data still buffered inside dnsmasq, `dmesg`,
+    /// or the kernel before those producers emit to their monitored streams.
+    pub async fn close_for_upload(mut self, run_id: RunId, drain: &NetworkLogDrainCoordinator) {
+        let current = self
+            .manager
+            .begin_session_drain(&self.source_ip, &self.path, self.generation)
+            .await;
+        if current {
+            drain
+                .drain(NetworkLogDrainContext {
+                    run_id,
+                    source_ip: &self.source_ip,
+                    path: &self.path,
+                    generation: self.generation,
+                })
+                .await;
+        }
+        self.manager.flush_path(&self.path).await;
+        self.manager
+            .finalize_session(&self.source_ip, &self.path, self.generation)
+            .await;
+        self.closed = true;
+    }
+}
+
+impl Drop for NetworkLogSession {
+    fn drop(&mut self) {
+        if self.closed {
+            return;
+        }
+
+        let manager = self.manager.clone();
+        let source_ip = self.source_ip.clone();
+        let path = self.path.clone();
+        let generation = self.generation;
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            std::mem::drop(handle.spawn(async move {
+                manager
+                    .finalize_session(&source_ip, &path, generation)
+                    .await;
+            }));
+        }
+    }
+}
+
 impl NetworkLogManager {
     pub fn new() -> Self {
         Self::default()
@@ -67,11 +151,33 @@ impl NetworkLogManager {
         }
     }
 
-    pub async fn register_source_ip(&self, source_ip: impl Into<String>, path: PathBuf) {
+    pub async fn register_source_ip(
+        &self,
+        source_ip: impl Into<String>,
+        path: PathBuf,
+    ) -> NetworkLogSession {
+        let source_ip = source_ip.into();
         let mut state = self.inner.state.lock().await;
-        state.source_paths.insert(source_ip.into(), path);
+        state.next_generation += 1;
+        let generation = state.next_generation;
+        state.source_paths.insert(
+            source_ip.clone(),
+            SourceState::Active {
+                path: path.clone(),
+                generation,
+            },
+        );
+        NetworkLogSession {
+            manager: self.clone(),
+            source_ip,
+            path,
+            generation,
+            closed: false,
+        }
     }
 
+    /// Remove a source mapping immediately.
+    #[cfg(test)]
     pub async fn unregister_source_ip(&self, source_ip: &str) {
         let mut state = self.inner.state.lock().await;
         state.source_paths.remove(source_ip);
@@ -96,7 +202,12 @@ impl NetworkLogManager {
 
         let path = {
             let mut state = self.inner.state.lock().await;
-            let Some(path) = state.source_paths.get(source_ip).cloned() else {
+            let Some(path) = state
+                .source_paths
+                .get(source_ip)
+                .map(SourceState::path)
+                .cloned()
+            else {
                 return false;
             };
             let path_state = state
@@ -109,6 +220,34 @@ impl NetworkLogManager {
 
         self.spawn_append(path, line);
         true
+    }
+
+    async fn begin_session_drain(&self, source_ip: &str, path: &Path, generation: u64) -> bool {
+        let mut state = self.inner.state.lock().await;
+        let Some(source_state) = state.source_paths.get(source_ip) else {
+            return false;
+        };
+        if !source_state.matches(path, generation) {
+            return false;
+        }
+        state.source_paths.insert(
+            source_ip.to_string(),
+            SourceState::Draining {
+                path: path.to_path_buf(),
+                generation,
+            },
+        );
+        true
+    }
+
+    async fn finalize_session(&self, source_ip: &str, path: &Path, generation: u64) {
+        let mut state = self.inner.state.lock().await;
+        let Some(source_state) = state.source_paths.get(source_ip) else {
+            return;
+        };
+        if source_state.matches(path, generation) {
+            state.source_paths.remove(source_ip);
+        }
     }
 
     /// Wait until all currently accepted Rust-side writes for `path` finish.
@@ -194,8 +333,12 @@ fn append_line(path: &Path, line: &str) -> std::io::Result<()> {
 mod tests {
     use std::future::{Future, poll_fn};
     use std::task::Poll;
+    use std::time::Duration;
 
     use serde_json::json;
+
+    use crate::ids::RunId;
+    use crate::network_log_drain::{NetworkLogDrainCoordinator, NetworkLogDrainProducer};
 
     use super::*;
 
@@ -213,7 +356,7 @@ mod tests {
         let path = dir.path().join("network.jsonl");
         let manager = NetworkLogManager::new();
 
-        manager.register_source_ip("10.200.0.2", path.clone()).await;
+        let _session = manager.register_source_ip("10.200.0.2", path.clone()).await;
         assert!(
             manager
                 .append_for_ip(
@@ -240,7 +383,7 @@ mod tests {
         let release = Arc::new(Semaphore::new(0));
         let manager = NetworkLogManager::new_with_write_gate(started.clone(), release.clone());
 
-        manager.register_source_ip("10.200.0.2", path.clone()).await;
+        let _session = manager.register_source_ip("10.200.0.2", path.clone()).await;
         assert!(
             manager
                 .append_for_ip("10.200.0.2", json!({"type":"dns","host":"held.test"}))
@@ -275,8 +418,8 @@ mod tests {
         let release = Arc::new(Semaphore::new(0));
         let manager = NetworkLogManager::new_with_write_gate(started.clone(), release.clone());
 
-        manager.register_source_ip("10.200.0.2", path.clone()).await;
-        manager.register_source_ip("10.200.0.3", path.clone()).await;
+        let _session_a = manager.register_source_ip("10.200.0.2", path.clone()).await;
+        let _session_b = manager.register_source_ip("10.200.0.3", path.clone()).await;
 
         let first_started = started.notified();
         assert!(
@@ -339,7 +482,7 @@ mod tests {
         let path = dir.path().join("missing").join("network.jsonl");
         let manager = NetworkLogManager::new();
 
-        manager.register_source_ip("10.200.0.2", path.clone()).await;
+        let _session = manager.register_source_ip("10.200.0.2", path.clone()).await;
         assert!(
             manager
                 .append_for_ip("10.200.0.2", json!({"type":"dns","host":"bad-path.test"}))
@@ -356,7 +499,7 @@ mod tests {
         let path = dir.path().join("network.jsonl");
         let manager = NetworkLogManager::new();
 
-        manager.register_source_ip("10.200.0.2", path.clone()).await;
+        let _session = manager.register_source_ip("10.200.0.2", path.clone()).await;
         manager.unregister_source_ip("10.200.0.2").await;
 
         assert!(
@@ -377,7 +520,7 @@ mod tests {
         let release = Arc::new(Semaphore::new(0));
         let manager = NetworkLogManager::new_with_write_gate(started.clone(), release.clone());
 
-        manager.register_source_ip("10.200.0.2", path.clone()).await;
+        let _session = manager.register_source_ip("10.200.0.2", path.clone()).await;
         assert!(
             manager
                 .append_for_ip("10.200.0.2", json!({"type":"dns","host":"accepted.test"}))
@@ -403,7 +546,7 @@ mod tests {
         let release = Arc::new(Semaphore::new(0));
         let manager = NetworkLogManager::new_with_write_gate(started.clone(), release.clone());
 
-        manager
+        let _old_session = manager
             .register_source_ip("10.200.0.2", old_path.clone())
             .await;
         let old_started = started.notified();
@@ -415,7 +558,7 @@ mod tests {
         old_started.await;
 
         manager.unregister_source_ip("10.200.0.2").await;
-        manager
+        let _new_session = manager
             .register_source_ip("10.200.0.2", new_path.clone())
             .await;
         let new_started = started.notified();
@@ -446,11 +589,11 @@ mod tests {
         let new_path = dir.path().join("new.jsonl");
         let manager = NetworkLogManager::new();
 
-        manager
+        let _old_session = manager
             .register_source_ip("10.200.0.2", old_path.clone())
             .await;
         manager.unregister_source_ip("10.200.0.2").await;
-        manager
+        let _new_session = manager
             .register_source_ip("10.200.0.2", new_path.clone())
             .await;
 
@@ -465,5 +608,140 @@ mod tests {
         let lines = read_json_lines(&new_path);
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0]["host"], "new.test");
+    }
+
+    #[tokio::test]
+    async fn draining_session_accepts_late_rows_until_finalized() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let manager = NetworkLogManager::new();
+        let session = manager.register_source_ip("10.200.0.2", path.clone()).await;
+
+        manager
+            .begin_session_drain(&session.source_ip, &session.path, session.generation)
+            .await;
+        assert!(
+            manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"late.test"}))
+                .await
+        );
+        manager.flush_path(&path).await;
+
+        let lines = read_json_lines(&path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["host"], "late.test");
+
+        manager
+            .finalize_session(&session.source_ip, &session.path, session.generation)
+            .await;
+        assert!(
+            !manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"closed.test"}))
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn old_session_finalize_does_not_remove_new_registration() {
+        let dir = tempfile::tempdir().unwrap();
+        let old_path = dir.path().join("old.jsonl");
+        let new_path = dir.path().join("new.jsonl");
+        let manager = NetworkLogManager::new();
+        let old = manager
+            .register_source_ip("10.200.0.2", old_path.clone())
+            .await;
+
+        manager
+            .begin_session_drain(&old.source_ip, &old.path, old.generation)
+            .await;
+        let _new_session = manager
+            .register_source_ip("10.200.0.2", new_path.clone())
+            .await;
+        manager
+            .finalize_session(&old.source_ip, &old.path, old.generation)
+            .await;
+
+        assert!(
+            manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"new.test"}))
+                .await
+        );
+        manager.flush_path(&new_path).await;
+
+        assert!(!old_path.exists());
+        let lines = read_json_lines(&new_path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["host"], "new.test");
+    }
+
+    #[tokio::test]
+    async fn close_for_upload_waits_for_barrier_and_flushes_late_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let manager = NetworkLogManager::new();
+        let session = manager.register_source_ip("10.200.0.2", path.clone()).await;
+        let (producer, mut drain_rx) = NetworkLogDrainProducer::channel("test");
+        let drain = NetworkLogDrainCoordinator::new(vec![producer]);
+
+        let manager_for_barrier = manager.clone();
+        let barrier = tokio::spawn(async move {
+            let request = drain_rx.recv().await.expect("drain request");
+            assert!(
+                manager_for_barrier
+                    .append_for_ip(
+                        "10.200.0.2",
+                        json!({"type":"dns","host":"during-drain.test"}),
+                    )
+                    .await
+            );
+            request.ack();
+        });
+
+        session.close_for_upload(RunId::nil(), &drain).await;
+        barrier.await.unwrap();
+
+        let lines = read_json_lines(&path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["host"], "during-drain.test");
+        assert!(
+            !manager
+                .append_for_ip(
+                    "10.200.0.2",
+                    json!({"type":"dns","host":"after-close.test"})
+                )
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn close_for_upload_timeout_still_flushes_accepted_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let manager = NetworkLogManager::new();
+        let session = manager.register_source_ip("10.200.0.2", path.clone()).await;
+        assert!(
+            manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"accepted.test"}),)
+                .await
+        );
+        let (producer, _drain_rx) = NetworkLogDrainProducer::channel("held");
+        let drain = NetworkLogDrainCoordinator::new_with_timeout_for_test(
+            vec![producer],
+            Duration::from_millis(1),
+        );
+
+        session.close_for_upload(RunId::nil(), &drain).await;
+
+        let lines = read_json_lines(&path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["host"], "accepted.test");
+        assert!(
+            !manager
+                .append_for_ip(
+                    "10.200.0.2",
+                    json!({"type":"dns","host":"after-timeout.test"})
+                )
+                .await
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add a runner-side network log drain coordinator for DNS and kmsg producers
- keep network log source attribution open until sandbox park/stop quiesces, then close by generation before upload
- cover late rows, reused source IP generations, producer drain barriers, and graceful shutdown upload behavior

Fixes #11341

## Tests
- cargo check --manifest-path crates/Cargo.toml -p runner
- cargo test --manifest-path crates/Cargo.toml -p runner network_log_manager
- cargo test --manifest-path crates/Cargo.toml -p runner drain_barrier_processes_queued
- cargo test --manifest-path crates/Cargo.toml -p runner
- pre-commit cargo fmt/clippy via git commit
