### PR TITLE
refactor(api): convert route test db helpers to commands

### DIFF
--- a/turbo/apps/api/custom-eslint/__tests__/no-store-in-params.test.ts
+++ b/turbo/apps/api/custom-eslint/__tests__/no-store-in-params.test.ts
@@ -1,0 +1,50 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "vitest";
+
+import { noStoreInParams } from "../rules/no-store-in-params.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-store-in-params", noStoreInParams, {
+  valid: [
+    { code: "function helper(value: string) { }" },
+    {
+      code: "function setupRouter(store: Store) { }",
+      options: [{ allowedFunctions: ["setupRouter"] }],
+    },
+    {
+      code: "const setupRouter = (store: Store) => { }",
+      options: [{ allowedFunctions: ["setupRouter"] }],
+    },
+    { code: "function init() { }" },
+    { code: "function init(store: lib.Store) { }" },
+    { code: "type TestStore = Store; function init(store: TestStore) { }" },
+    { code: "function init(store) { }" },
+  ],
+  invalid: [
+    {
+      code: "function helper(store: Store) { }",
+      errors: [{ messageId: "noStoreInParams" }],
+    },
+    {
+      code: "const helper = (store: Store) => { }",
+      errors: [{ messageId: "noStoreInParams" }],
+    },
+    {
+      code: "function helper(options: { store: Store }) { }",
+      errors: [{ messageId: "noStoreInObjectParams" }],
+    },
+    {
+      code: "function helper(stores: Array<Store>) { }",
+      errors: [{ messageId: "noStoreInParams" }],
+    },
+    {
+      code: "class Helper { cleanup(store: Store) { } }",
+      errors: [{ messageId: "noStoreInParams" }],
+    },
+  ],
+});

--- a/turbo/apps/api/custom-eslint/index.ts
+++ b/turbo/apps/api/custom-eslint/index.ts
@@ -3,6 +3,7 @@ import { noFnDollarSuffix } from "./rules/no-fn-dollar-suffix.ts";
 import { noGetterSetterParams } from "./rules/no-getter-setter-params.ts";
 import { noLoggerInfo } from "./rules/no-logger-info.ts";
 import { noPackageVariable } from "./rules/no-package-variable.ts";
+import { noStoreInParams } from "./rules/no-store-in-params.ts";
 import { noTestViMocks } from "./rules/no-test-vi-mocks.ts";
 import { signalCheckAwait } from "./rules/signal-check-await.ts";
 
@@ -17,6 +18,7 @@ export const apiLintPlugin = {
     "no-getter-setter-params": noGetterSetterParams,
     "no-logger-info": noLoggerInfo,
     "no-package-variable": noPackageVariable,
+    "no-store-in-params": noStoreInParams,
     "no-test-vi-mocks": noTestViMocks,
     "signal-check-await": signalCheckAwait,
   },

--- a/turbo/apps/api/custom-eslint/rules/no-store-in-params.ts
+++ b/turbo/apps/api/custom-eslint/rules/no-store-in-params.ts
@@ -1,0 +1,201 @@
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+import { createRule } from "../utils.ts";
+
+export interface NoStoreInParamsOptions {
+  readonly allowedFunctions?: readonly string[];
+}
+
+export type NoStoreInParamsMessageIds =
+  | "noStoreInParams"
+  | "noStoreInObjectParams";
+
+function findStorePath(
+  typeNode: TSESTree.TypeNode,
+  path: readonly string[] = [],
+  depth = 0,
+): readonly string[] | null {
+  if (depth > 3) {
+    return null;
+  }
+
+  switch (typeNode.type) {
+    case AST_NODE_TYPES.TSTypeReference: {
+      const { typeName } = typeNode;
+      if (
+        typeName.type === AST_NODE_TYPES.Identifier &&
+        typeName.name === "Store"
+      ) {
+        return path;
+      }
+
+      if (typeNode.typeArguments) {
+        for (const arg of typeNode.typeArguments.params) {
+          const found = findStorePath(arg, path, depth + 1);
+          if (found !== null) {
+            return found;
+          }
+        }
+      }
+      return null;
+    }
+
+    case AST_NODE_TYPES.TSUnionType:
+    case AST_NODE_TYPES.TSIntersectionType: {
+      for (const memberType of typeNode.types) {
+        const found = findStorePath(memberType, path, depth + 1);
+        if (found !== null) {
+          return found;
+        }
+      }
+      return null;
+    }
+
+    case AST_NODE_TYPES.TSArrayType: {
+      return findStorePath(typeNode.elementType, [...path, "[]"], depth + 1);
+    }
+
+    case AST_NODE_TYPES.TSTypeLiteral: {
+      for (const member of typeNode.members) {
+        if (
+          member.type !== AST_NODE_TYPES.TSPropertySignature ||
+          !member.typeAnnotation
+        ) {
+          continue;
+        }
+
+        const propertyName =
+          member.key.type === AST_NODE_TYPES.Identifier ? member.key.name : "?";
+        const found = findStorePath(
+          member.typeAnnotation.typeAnnotation,
+          [...path, propertyName],
+          depth + 1,
+        );
+        if (found !== null) {
+          return found;
+        }
+      }
+      return null;
+    }
+
+    default: {
+      return null;
+    }
+  }
+}
+
+export const noStoreInParams = createRule<
+  [NoStoreInParamsOptions?],
+  NoStoreInParamsMessageIds
+>({
+  name: "no-store-in-params",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Prevent Store type in function parameters",
+      requiresTypeChecking: false,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowedFunctions: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noStoreInParams:
+        "Function parameters should not accept Store type: {{param}}",
+      noStoreInObjectParams:
+        "Function parameters should not contain Store type in object properties: {{param}}.{{property}}",
+    },
+  },
+  create(context) {
+    const options = context.options[0] ?? {};
+    const allowedFunctions = new Set(options.allowedFunctions ?? []);
+
+    function checkParameter(param: TSESTree.Parameter): void {
+      if (param.type !== AST_NODE_TYPES.Identifier) {
+        return;
+      }
+
+      const annotation = param.typeAnnotation?.typeAnnotation;
+      if (!annotation) {
+        return;
+      }
+
+      const storePath = findStorePath(annotation);
+      if (storePath === null) {
+        return;
+      }
+
+      if (storePath.length === 0) {
+        context.report({
+          node: param,
+          messageId: "noStoreInParams",
+          data: { param: param.name },
+        });
+        return;
+      }
+
+      context.report({
+        node: param,
+        messageId: "noStoreInObjectParams",
+        data: { param: param.name, property: storePath.join(".") },
+      });
+    }
+
+    function functionName(
+      node:
+        | TSESTree.FunctionDeclaration
+        | TSESTree.ArrowFunctionExpression
+        | TSESTree.FunctionExpression,
+    ): string | undefined {
+      if (node.type === AST_NODE_TYPES.FunctionDeclaration) {
+        return node.id?.name;
+      }
+
+      if (
+        node.parent?.type === AST_NODE_TYPES.VariableDeclarator &&
+        node.parent.id.type === AST_NODE_TYPES.Identifier
+      ) {
+        return node.parent.id.name;
+      }
+
+      return undefined;
+    }
+
+    function checkFunction(
+      node:
+        | TSESTree.FunctionDeclaration
+        | TSESTree.ArrowFunctionExpression
+        | TSESTree.FunctionExpression,
+    ): void {
+      const name = functionName(node);
+      if (name !== undefined && allowedFunctions.has(name)) {
+        return;
+      }
+
+      for (const param of node.params) {
+        checkParameter(param);
+      }
+    }
+
+    return {
+      FunctionDeclaration: checkFunction,
+      ArrowFunctionExpression: checkFunction,
+      "FunctionExpression:not(MethodDefinition > FunctionExpression)":
+        checkFunction,
+      MethodDefinition(node: TSESTree.MethodDefinition): void {
+        if (node.value.type === AST_NODE_TYPES.FunctionExpression) {
+          checkFunction(node.value);
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -63,6 +63,7 @@ export default [
       "api/no-fn-dollar-suffix": "error",
       "api/no-getter-setter-params": "error",
       "api/no-logger-info": "error",
+      "api/no-store-in-params": "error",
       "api/signal-check-await": "error",
     },
   },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-api-keys.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-api-keys.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { Store } from "ccstate";
+import { command } from "ccstate";
 import { cliTokens } from "@vm0/db/schema/cli-tokens";
 import { eq } from "drizzle-orm";
 
@@ -18,36 +18,44 @@ interface ApiKeySeedValues {
   readonly lastUsedAt?: Date | null;
 }
 
-export async function seedApiKeys(
-  store: Store,
-  rows: readonly ApiKeySeedValues[],
-): Promise<ApiKeysFixture> {
-  const fixture = { userId: `user_${randomUUID()}` };
-  const writeDb = store.set(writeDb$);
+export const seedApiKeys$ = command(
+  async (
+    { set },
+    rows: readonly ApiKeySeedValues[],
+    signal: AbortSignal,
+  ): Promise<ApiKeysFixture> => {
+    const fixture = { userId: `user_${randomUUID()}` };
+    const writeDb = set(writeDb$);
 
-  if (rows.length > 0) {
-    await writeDb.insert(cliTokens).values(
-      rows.map((row) => {
-        return {
-          id: randomUUID(),
-          userId: fixture.userId,
-          name: row.name,
-          token: row.token,
-          createdAt: row.createdAt,
-          expiresAt: row.expiresAt,
-          lastUsedAt: row.lastUsedAt ?? null,
-        };
-      }),
-    );
-  }
+    if (rows.length > 0) {
+      await writeDb.insert(cliTokens).values(
+        rows.map((row) => {
+          return {
+            id: randomUUID(),
+            userId: fixture.userId,
+            name: row.name,
+            token: row.token,
+            createdAt: row.createdAt,
+            expiresAt: row.expiresAt,
+            lastUsedAt: row.lastUsedAt ?? null,
+          };
+        }),
+      );
+      signal.throwIfAborted();
+    }
 
-  return fixture;
-}
+    return fixture;
+  },
+);
 
-export async function deleteApiKeys(
-  store: Store,
-  fixture: ApiKeysFixture,
-): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb.delete(cliTokens).where(eq(cliTokens.userId, fixture.userId));
-}
+export const deleteApiKeys$ = command(
+  async (
+    { set },
+    fixture: ApiKeysFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb.delete(cliTokens).where(eq(cliTokens.userId, fixture.userId));
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-billing-auto-recharge.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-billing-auto-recharge.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { Store } from "ccstate";
+import { command } from "ccstate";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { eq } from "drizzle-orm";
 
@@ -17,28 +17,38 @@ interface AutoRechargeSeedValues {
   readonly amount?: number | null;
 }
 
-export async function seedAutoRechargeOrg(
-  store: Store,
-  values: AutoRechargeSeedValues = {},
-): Promise<AutoRechargeOrgFixture> {
-  const orgId = `org_${randomUUID()}`;
-  const userId = `user_${randomUUID()}`;
-  const writeDb = store.set(writeDb$);
+export const seedAutoRechargeOrg$ = command(
+  async (
+    { set },
+    values: AutoRechargeSeedValues,
+    signal: AbortSignal,
+  ): Promise<AutoRechargeOrgFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const writeDb = set(writeDb$);
 
-  await writeDb.insert(orgMetadata).values({
-    orgId,
-    autoRechargeEnabled: values.enabled ?? false,
-    autoRechargeThreshold: values.threshold ?? null,
-    autoRechargeAmount: values.amount ?? null,
-  });
+    await writeDb.insert(orgMetadata).values({
+      orgId,
+      autoRechargeEnabled: values.enabled ?? false,
+      autoRechargeThreshold: values.threshold ?? null,
+      autoRechargeAmount: values.amount ?? null,
+    });
+    signal.throwIfAborted();
 
-  return { orgId, userId };
-}
+    return { orgId, userId };
+  },
+);
 
-export async function deleteAutoRechargeOrg(
-  store: Store,
-  fixture: AutoRechargeOrgFixture,
-): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
-}
+export const deleteAutoRechargeOrg$ = command(
+  async (
+    { set },
+    fixture: AutoRechargeOrgFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-chat-threads.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { Store } from "ccstate";
+import { command } from "ccstate";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
@@ -22,42 +22,54 @@ interface SeedChatThreadOptions {
   readonly title?: string | null;
 }
 
-export async function seedZeroChatThread(
-  store: Store,
-  options: SeedChatThreadOptions = {},
-): Promise<ZeroChatThreadFixture> {
-  const userId = options.userId ?? `user_${randomUUID()}`;
-  const orgId = options.orgId ?? `org_${randomUUID()}`;
-  const composeId = randomUUID();
-  const threadId = randomUUID();
-  const writeDb = store.set(writeDb$);
+export const seedZeroChatThread$ = command(
+  async (
+    { set },
+    options: SeedChatThreadOptions,
+    signal: AbortSignal,
+  ): Promise<ZeroChatThreadFixture> => {
+    const userId = options.userId ?? `user_${randomUUID()}`;
+    const orgId = options.orgId ?? `org_${randomUUID()}`;
+    const composeId = randomUUID();
+    const threadId = randomUUID();
+    const writeDb = set(writeDb$);
 
-  await writeDb.insert(agentComposes).values({
-    id: composeId,
-    userId,
-    orgId,
-    name: `compose-${composeId.slice(0, 8)}`,
-  });
-  await writeDb.insert(chatThreads).values({
-    id: threadId,
-    userId,
-    agentComposeId: composeId,
-    title: options.title ?? "chat thread",
-  });
+    await writeDb.insert(agentComposes).values({
+      id: composeId,
+      userId,
+      orgId,
+      name: `compose-${composeId.slice(0, 8)}`,
+    });
+    signal.throwIfAborted();
+    await writeDb.insert(chatThreads).values({
+      id: threadId,
+      userId,
+      agentComposeId: composeId,
+      title: options.title ?? "chat thread",
+    });
+    signal.throwIfAborted();
 
-  return { userId, orgId, composeId, threadId };
-}
+    return { userId, orgId, composeId, threadId };
+  },
+);
 
-export async function deleteZeroChatThread(
-  store: Store,
-  fixture: ZeroChatThreadFixture,
-): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb.delete(chatThreads).where(eq(chatThreads.id, fixture.threadId));
-  await writeDb
-    .delete(agentComposes)
-    .where(eq(agentComposes.id, fixture.composeId));
-}
+export const deleteZeroChatThread$ = command(
+  async (
+    { set },
+    fixture: ZeroChatThreadFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(chatThreads)
+      .where(eq(chatThreads.id, fixture.threadId));
+    signal.throwIfAborted();
+    await writeDb
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, fixture.composeId));
+    signal.throwIfAborted();
+  },
+);
 
 interface SeedChatMessageOptions {
   readonly role: "user" | "assistant";
@@ -67,21 +79,25 @@ interface SeedChatMessageOptions {
   readonly sequenceNumber?: number | null;
 }
 
-export async function seedZeroChatMessage(
-  store: Store,
-  fixture: ZeroChatThreadFixture,
-  options: SeedChatMessageOptions,
-): Promise<string> {
-  const id = randomUUID();
-  const writeDb = store.set(writeDb$);
-  await writeDb.insert(chatMessages).values({
-    id,
-    chatThreadId: fixture.threadId,
-    role: options.role,
-    content: options.content,
-    attachFiles: options.attachFiles ? [...options.attachFiles] : null,
-    sequenceNumber: options.sequenceNumber ?? null,
-    createdAt: options.createdAt ?? nowDate(),
-  });
-  return id;
-}
+export const seedZeroChatMessage$ = command(
+  async (
+    { set },
+    fixture: ZeroChatThreadFixture,
+    options: SeedChatMessageOptions,
+    signal: AbortSignal,
+  ): Promise<string> => {
+    const id = randomUUID();
+    const writeDb = set(writeDb$);
+    await writeDb.insert(chatMessages).values({
+      id,
+      chatThreadId: fixture.threadId,
+      role: options.role,
+      content: options.content,
+      attachFiles: options.attachFiles ? [...options.attachFiles] : null,
+      sequenceNumber: options.sequenceNumber ?? null,
+      createdAt: options.createdAt ?? nowDate(),
+    });
+    signal.throwIfAborted();
+    return id;
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-feature-switches.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { Store } from "ccstate";
+import { command } from "ccstate";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { and, eq } from "drizzle-orm";
 
@@ -11,34 +11,42 @@ export interface FeatureSwitchesFixture {
   readonly userId: string;
 }
 
-export async function seedFeatureSwitches(
-  store: Store,
-  switches: Record<string, boolean>,
-): Promise<FeatureSwitchesFixture> {
-  const orgId = `org_${randomUUID()}`;
-  const userId = `user_${randomUUID()}`;
-  const writeDb = store.set(writeDb$);
+export const seedFeatureSwitches$ = command(
+  async (
+    { set },
+    switches: Record<string, boolean>,
+    signal: AbortSignal,
+  ): Promise<FeatureSwitchesFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const writeDb = set(writeDb$);
 
-  await writeDb.insert(userFeatureSwitches).values({
-    orgId,
-    userId,
-    switches,
-  });
+    await writeDb.insert(userFeatureSwitches).values({
+      orgId,
+      userId,
+      switches,
+    });
+    signal.throwIfAborted();
 
-  return { orgId, userId };
-}
+    return { orgId, userId };
+  },
+);
 
-export async function deleteFeatureSwitches(
-  store: Store,
-  fixture: FeatureSwitchesFixture,
-): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb
-    .delete(userFeatureSwitches)
-    .where(
-      and(
-        eq(userFeatureSwitches.orgId, fixture.orgId),
-        eq(userFeatureSwitches.userId, fixture.userId),
-      ),
-    );
-}
+export const deleteFeatureSwitches$ = command(
+  async (
+    { set },
+    fixture: FeatureSwitchesFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(userFeatureSwitches)
+      .where(
+        and(
+          eq(userFeatureSwitches.orgId, fixture.orgId),
+          eq(userFeatureSwitches.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-onboarding-status.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-onboarding-status.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { Store } from "ccstate";
+import { command } from "ccstate";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
@@ -26,70 +26,86 @@ export interface OnboardingStatusFixture {
   readonly composeId: string | null;
 }
 
-export async function seedOnboardingStatusOrg(
-  store: Store,
-  values: OnboardingSeedValues = {},
-): Promise<OnboardingStatusFixture> {
-  const orgId = `org_${randomUUID()}`;
-  const userId = `user_${randomUUID()}`;
-  const writeDb = store.set(writeDb$);
-  const composeId = values.defaultAgent ? randomUUID() : null;
+export const seedOnboardingStatusOrg$ = command(
+  async (
+    { set },
+    values: OnboardingSeedValues,
+    signal: AbortSignal,
+  ): Promise<OnboardingStatusFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const writeDb = set(writeDb$);
+    const composeId = values.defaultAgent ? randomUUID() : null;
 
-  if (composeId) {
-    await writeDb.insert(agentComposes).values({
-      id: composeId,
-      userId,
+    if (composeId) {
+      await writeDb.insert(agentComposes).values({
+        id: composeId,
+        userId,
+        orgId,
+        name: `agent-${composeId.slice(0, 8)}`,
+      });
+      signal.throwIfAborted();
+      await writeDb.insert(zeroAgents).values({
+        id: composeId,
+        orgId,
+        owner: userId,
+        name: `agent-${composeId.slice(0, 8)}`,
+        displayName: values.defaultAgent?.displayName ?? null,
+        description: values.defaultAgent?.description ?? null,
+        sound: values.defaultAgent?.sound ?? null,
+      });
+      signal.throwIfAborted();
+    }
+
+    await writeDb.insert(orgMetadata).values({
       orgId,
-      name: `agent-${composeId.slice(0, 8)}`,
+      defaultAgentId: composeId,
     });
-    await writeDb.insert(zeroAgents).values({
-      id: composeId,
-      orgId,
-      owner: userId,
-      name: `agent-${composeId.slice(0, 8)}`,
-      displayName: values.defaultAgent?.displayName ?? null,
-      description: values.defaultAgent?.description ?? null,
-      sound: values.defaultAgent?.sound ?? null,
-    });
-  }
+    signal.throwIfAborted();
 
-  await writeDb.insert(orgMetadata).values({
-    orgId,
-    defaultAgentId: composeId,
-  });
+    if (values.onboardingDone !== undefined) {
+      await writeDb.insert(orgMembersMetadata).values({
+        orgId,
+        userId,
+        onboardingDone: values.onboardingDone,
+      });
+      signal.throwIfAborted();
+    }
 
-  if (values.onboardingDone !== undefined) {
-    await writeDb.insert(orgMembersMetadata).values({
-      orgId,
-      userId,
-      onboardingDone: values.onboardingDone,
-    });
-  }
+    return { orgId, userId, composeId };
+  },
+);
 
-  return { orgId, userId, composeId };
-}
-
-export async function deleteOnboardingStatusOrg(
-  store: Store,
-  fixture: OnboardingStatusFixture,
-): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb
-    .delete(orgMembersMetadata)
-    .where(
-      and(
-        eq(orgMembersMetadata.orgId, fixture.orgId),
-        eq(orgMembersMetadata.userId, fixture.userId),
-      ),
-    );
-  await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
-
-  if (fixture.composeId) {
+export const deleteOnboardingStatusOrg$ = command(
+  async (
+    { set },
+    fixture: OnboardingStatusFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
     await writeDb
-      .delete(zeroAgents)
-      .where(eq(zeroAgents.id, fixture.composeId));
+      .delete(orgMembersMetadata)
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, fixture.orgId),
+          eq(orgMembersMetadata.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
     await writeDb
-      .delete(agentComposes)
-      .where(eq(agentComposes.id, fixture.composeId));
-  }
-}
+      .delete(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
+
+    if (fixture.composeId) {
+      await writeDb
+        .delete(zeroAgents)
+        .where(eq(zeroAgents.id, fixture.composeId));
+      signal.throwIfAborted();
+      await writeDb
+        .delete(agentComposes)
+        .where(eq(agentComposes.id, fixture.composeId));
+      signal.throwIfAborted();
+    }
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-queue-position.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-queue-position.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { Store } from "ccstate";
+import { command } from "ccstate";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
@@ -23,109 +23,135 @@ interface QueuePositionSeedValues {
   readonly unqueuedRuns?: number;
 }
 
-async function seedRun(
-  store: Store,
-  values: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly composeId: string;
-    readonly status: string;
+const seedRun$ = command(
+  async (
+    { set },
+    values: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly composeId: string;
+      readonly status: string;
+    },
+    signal: AbortSignal,
+  ): Promise<string> => {
+    const writeDb = set(writeDb$);
+    const runId = randomUUID();
+    const sessionId = randomUUID();
+
+    await writeDb.insert(agentSessions).values({
+      id: sessionId,
+      userId: values.userId,
+      orgId: values.orgId,
+      agentComposeId: values.composeId,
+    });
+    signal.throwIfAborted();
+    await writeDb.insert(agentRuns).values({
+      id: runId,
+      userId: values.userId,
+      orgId: values.orgId,
+      sessionId,
+      status: values.status,
+      prompt: "test prompt",
+    });
+    signal.throwIfAborted();
+
+    return runId;
   },
-): Promise<string> {
-  const writeDb = store.set(writeDb$);
-  const runId = randomUUID();
-  const sessionId = randomUUID();
+);
 
-  await writeDb.insert(agentSessions).values({
-    id: sessionId,
-    userId: values.userId,
-    orgId: values.orgId,
-    agentComposeId: values.composeId,
-  });
-  await writeDb.insert(agentRuns).values({
-    id: runId,
-    userId: values.userId,
-    orgId: values.orgId,
-    sessionId,
-    status: values.status,
-    prompt: "test prompt",
-  });
+export const seedQueuePositionRuns$ = command(
+  async (
+    { set },
+    values: QueuePositionSeedValues,
+    signal: AbortSignal,
+  ): Promise<QueuePositionFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const composeId = randomUUID();
+    const queuedRuns = values.queuedRuns ?? 0;
+    const unqueuedRuns = values.unqueuedRuns ?? 0;
+    const queuedRunIds: string[] = [];
+    const unqueuedRunIds: string[] = [];
+    const writeDb = set(writeDb$);
 
-  return runId;
-}
+    await writeDb.insert(agentComposes).values({
+      id: composeId,
+      userId,
+      orgId,
+      name: `agent-${composeId.slice(0, 8)}`,
+    });
+    signal.throwIfAborted();
 
-export async function seedQueuePositionRuns(
-  store: Store,
-  values: QueuePositionSeedValues = {},
-): Promise<QueuePositionFixture> {
-  const orgId = `org_${randomUUID()}`;
-  const userId = `user_${randomUUID()}`;
-  const composeId = randomUUID();
-  const queuedRuns = values.queuedRuns ?? 0;
-  const unqueuedRuns = values.unqueuedRuns ?? 0;
-  const queuedRunIds: string[] = [];
-  const unqueuedRunIds: string[] = [];
-  const writeDb = store.set(writeDb$);
+    const baseTime = now();
+    for (let index = 0; index < queuedRuns; index++) {
+      const runId = await set(
+        seedRun$,
+        {
+          orgId,
+          userId,
+          composeId,
+          status: "queued",
+        },
+        signal,
+      );
+      const createdAt = new Date(baseTime + index * 1000);
+      await writeDb.insert(agentRunQueue).values({
+        runId,
+        userId,
+        orgId,
+        createdAt,
+        expiresAt: new Date(createdAt.getTime() + 60 * 60 * 1000),
+      });
+      signal.throwIfAborted();
 
-  await writeDb.insert(agentComposes).values({
-    id: composeId,
-    userId,
-    orgId,
-    name: `agent-${composeId.slice(0, 8)}`,
-  });
+      queuedRunIds.push(runId);
+    }
 
-  const baseTime = now();
-  for (let index = 0; index < queuedRuns; index++) {
-    const runId = await seedRun(store, {
+    for (let index = 0; index < unqueuedRuns; index++) {
+      const runId = await set(
+        seedRun$,
+        {
+          orgId,
+          userId,
+          composeId,
+          status: "running",
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+      unqueuedRunIds.push(runId);
+    }
+
+    return {
       orgId,
       userId,
       composeId,
-      status: "queued",
-    });
-    const createdAt = new Date(baseTime + index * 1000);
-    await writeDb.insert(agentRunQueue).values({
-      runId,
-      userId,
-      orgId,
-      createdAt,
-      expiresAt: new Date(createdAt.getTime() + 60 * 60 * 1000),
-    });
+      queuedRunIds,
+      unqueuedRunIds,
+    };
+  },
+);
 
-    queuedRunIds.push(runId);
-  }
-
-  for (let index = 0; index < unqueuedRuns; index++) {
-    const runId = await seedRun(store, {
-      orgId,
-      userId,
-      composeId,
-      status: "running",
-    });
-    unqueuedRunIds.push(runId);
-  }
-
-  return {
-    orgId,
-    userId,
-    composeId,
-    queuedRunIds,
-    unqueuedRunIds,
-  };
-}
-
-export async function deleteQueuePositionRuns(
-  store: Store,
-  fixture: QueuePositionFixture,
-): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb
-    .delete(agentRunQueue)
-    .where(eq(agentRunQueue.orgId, fixture.orgId));
-  await writeDb.delete(agentRuns).where(eq(agentRuns.orgId, fixture.orgId));
-  await writeDb
-    .delete(agentSessions)
-    .where(eq(agentSessions.orgId, fixture.orgId));
-  await writeDb
-    .delete(agentComposes)
-    .where(eq(agentComposes.id, fixture.composeId));
-}
+export const deleteQueuePositionRuns$ = command(
+  async (
+    { set },
+    fixture: QueuePositionFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(agentRunQueue)
+      .where(eq(agentRunQueue.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await writeDb.delete(agentRuns).where(eq(agentRuns.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await writeDb
+      .delete(agentSessions)
+      .where(eq(agentSessions.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await writeDb
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, fixture.composeId));
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-user-data.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-user-data.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from "node:crypto";
 
-import type { Store } from "ccstate";
 import type { SendMode } from "@vm0/api-contracts/contracts/zero-user-preferences";
 import type { SecretType } from "@vm0/api-contracts/contracts/secrets";
+import { command } from "ccstate";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
@@ -45,117 +45,143 @@ function createUserDataFixture(): UserDataFixture {
   };
 }
 
-export async function seedUserPreferences(
-  store: Store,
-  values: UserPreferencesSeedValues = {},
-): Promise<UserDataFixture> {
-  const fixture = createUserDataFixture();
-  const writeDb = store.set(writeDb$);
+export const seedUserPreferences$ = command(
+  async (
+    { set },
+    values: UserPreferencesSeedValues,
+    signal: AbortSignal,
+  ): Promise<UserDataFixture> => {
+    const fixture = createUserDataFixture();
+    const writeDb = set(writeDb$);
 
-  await writeDb.insert(orgMembersMetadata).values({
-    orgId: fixture.orgId,
-    userId: fixture.userId,
-    timezone: values.timezone ?? null,
-    pinnedAgentIds: [...(values.pinnedAgentIds ?? [])],
-    sendMode: values.sendMode ?? "enter",
-    captureNetworkBodiesRemaining: values.captureNetworkBodiesRemaining ?? 0,
-  });
+    await writeDb.insert(orgMembersMetadata).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      timezone: values.timezone ?? null,
+      pinnedAgentIds: [...(values.pinnedAgentIds ?? [])],
+      sendMode: values.sendMode ?? "enter",
+      captureNetworkBodiesRemaining: values.captureNetworkBodiesRemaining ?? 0,
+    });
+    signal.throwIfAborted();
 
-  return fixture;
-}
+    return fixture;
+  },
+);
 
-export async function seedVariables(
-  store: Store,
-  rows: readonly VariableSeedValues[],
-): Promise<UserDataFixture> {
-  const fixture = createUserDataFixture();
-  const writeDb = store.set(writeDb$);
+export const seedVariables$ = command(
+  async (
+    { set },
+    rows: readonly VariableSeedValues[],
+    signal: AbortSignal,
+  ): Promise<UserDataFixture> => {
+    const fixture = createUserDataFixture();
+    const writeDb = set(writeDb$);
 
-  if (rows.length > 0) {
-    await writeDb.insert(variables).values(
-      rows.map((row) => {
-        return {
-          orgId: fixture.orgId,
-          userId: fixture.userId,
-          name: row.name,
-          value: row.value,
-          description: row.description ?? null,
-          createdAt: row.createdAt,
-          updatedAt: row.updatedAt,
-        };
-      }),
-    );
-  }
+    if (rows.length > 0) {
+      await writeDb.insert(variables).values(
+        rows.map((row) => {
+          return {
+            orgId: fixture.orgId,
+            userId: fixture.userId,
+            name: row.name,
+            value: row.value,
+            description: row.description ?? null,
+            createdAt: row.createdAt,
+            updatedAt: row.updatedAt,
+          };
+        }),
+      );
+      signal.throwIfAborted();
+    }
 
-  return fixture;
-}
+    return fixture;
+  },
+);
 
-export async function seedSecrets(
-  store: Store,
-  rows: readonly SecretSeedValues[],
-): Promise<UserDataFixture> {
-  const fixture = createUserDataFixture();
-  const writeDb = store.set(writeDb$);
+export const seedSecrets$ = command(
+  async (
+    { set },
+    rows: readonly SecretSeedValues[],
+    signal: AbortSignal,
+  ): Promise<UserDataFixture> => {
+    const fixture = createUserDataFixture();
+    const writeDb = set(writeDb$);
 
-  if (rows.length > 0) {
-    await writeDb.insert(secrets).values(
-      rows.map((row) => {
-        return {
-          orgId: fixture.orgId,
-          userId: fixture.userId,
-          name: row.name,
-          encryptedValue: `encrypted_${row.name}`,
-          description: row.description ?? null,
-          type: row.type ?? "user",
-          createdAt: row.createdAt,
-          updatedAt: row.updatedAt,
-        };
-      }),
-    );
-  }
+    if (rows.length > 0) {
+      await writeDb.insert(secrets).values(
+        rows.map((row) => {
+          return {
+            orgId: fixture.orgId,
+            userId: fixture.userId,
+            name: row.name,
+            encryptedValue: `encrypted_${row.name}`,
+            description: row.description ?? null,
+            type: row.type ?? "user",
+            createdAt: row.createdAt,
+            updatedAt: row.updatedAt,
+          };
+        }),
+      );
+      signal.throwIfAborted();
+    }
 
-  return fixture;
-}
+    return fixture;
+  },
+);
 
-export async function seedOtherVariable(
-  store: Store,
-  fixture: UserDataFixture,
-): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb.insert(variables).values({
-    orgId: fixture.orgId,
-    userId: `user_${randomUUID()}`,
-    name: "OTHER_USER_VAR",
-    value: "other-user",
-  });
-}
+export const seedOtherVariable$ = command(
+  async (
+    { set },
+    fixture: UserDataFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb.insert(variables).values({
+      orgId: fixture.orgId,
+      userId: `user_${randomUUID()}`,
+      name: "OTHER_USER_VAR",
+      value: "other-user",
+    });
+    signal.throwIfAborted();
+  },
+);
 
-export async function seedOtherSecret(
-  store: Store,
-  fixture: UserDataFixture,
-): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb.insert(secrets).values({
-    orgId: fixture.orgId,
-    userId: `user_${randomUUID()}`,
-    name: "OTHER_USER_SECRET",
-    encryptedValue: "encrypted_other_user",
-  });
-}
+export const seedOtherSecret$ = command(
+  async (
+    { set },
+    fixture: UserDataFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb.insert(secrets).values({
+      orgId: fixture.orgId,
+      userId: `user_${randomUUID()}`,
+      name: "OTHER_USER_SECRET",
+      encryptedValue: "encrypted_other_user",
+    });
+    signal.throwIfAborted();
+  },
+);
 
-export async function deleteUserData(
-  store: Store,
-  fixture: UserDataFixture,
-): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb
-    .delete(orgMembersMetadata)
-    .where(
-      and(
-        eq(orgMembersMetadata.orgId, fixture.orgId),
-        eq(orgMembersMetadata.userId, fixture.userId),
-      ),
-    );
-  await writeDb.delete(variables).where(eq(variables.orgId, fixture.orgId));
-  await writeDb.delete(secrets).where(eq(secrets.orgId, fixture.orgId));
-}
+export const deleteUserData$ = command(
+  async (
+    { set },
+    fixture: UserDataFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(orgMembersMetadata)
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, fixture.orgId),
+          eq(orgMembersMetadata.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+    await writeDb.delete(variables).where(eq(variables.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await writeDb.delete(secrets).where(eq(secrets.orgId, fixture.orgId));
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-voice-io-quota.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-voice-io-quota.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
-import type { Store } from "ccstate";
+import { command } from "ccstate";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { userBehaviorCount } from "@vm0/db/schema/user-behavior-count";
 import { and, eq } from "drizzle-orm";
@@ -20,45 +20,57 @@ interface VoiceIoQuotaSeedValues {
   readonly count?: number;
 }
 
-export async function seedVoiceIoQuotaOrg(
-  store: Store,
-  values: VoiceIoQuotaSeedValues = {},
-): Promise<VoiceIoQuotaFixture> {
-  const orgId = `org_${randomUUID()}`;
-  const userId = `user_${randomUUID()}`;
-  const writeDb = store.set(writeDb$);
+export const seedVoiceIoQuotaOrg$ = command(
+  async (
+    { set },
+    values: VoiceIoQuotaSeedValues,
+    signal: AbortSignal,
+  ): Promise<VoiceIoQuotaFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const writeDb = set(writeDb$);
 
-  if (values.tier) {
-    await writeDb.insert(orgMetadata).values({
-      orgId,
-      tier: values.tier,
-    });
-  }
+    if (values.tier) {
+      await writeDb.insert(orgMetadata).values({
+        orgId,
+        tier: values.tier,
+      });
+      signal.throwIfAborted();
+    }
 
-  if (values.count !== undefined) {
-    await writeDb.insert(userBehaviorCount).values({
-      orgId,
-      userId,
-      behaviorKey: AUDIO_INPUT_BEHAVIOR_KEY,
-      count: values.count,
-    });
-  }
+    if (values.count !== undefined) {
+      await writeDb.insert(userBehaviorCount).values({
+        orgId,
+        userId,
+        behaviorKey: AUDIO_INPUT_BEHAVIOR_KEY,
+        count: values.count,
+      });
+      signal.throwIfAborted();
+    }
 
-  return { orgId, userId };
-}
+    return { orgId, userId };
+  },
+);
 
-export async function deleteVoiceIoQuotaOrg(
-  store: Store,
-  fixture: VoiceIoQuotaFixture,
-): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb
-    .delete(userBehaviorCount)
-    .where(
-      and(
-        eq(userBehaviorCount.orgId, fixture.orgId),
-        eq(userBehaviorCount.userId, fixture.userId),
-      ),
-    );
-  await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
-}
+export const deleteVoiceIoQuotaOrg$ = command(
+  async (
+    { set },
+    fixture: VoiceIoQuotaFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(userBehaviorCount)
+      .where(
+        and(
+          eq(userBehaviorCount.orgId, fixture.orgId),
+          eq(userBehaviorCount.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+    await writeDb
+      .delete(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-api-keys.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-api-keys.test.ts
@@ -8,8 +8,8 @@ import {
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
 import {
-  deleteApiKeys,
-  seedApiKeys,
+  deleteApiKeys$,
+  seedApiKeys$,
   type ApiKeysFixture,
 } from "./helpers/zero-api-keys";
 
@@ -19,36 +19,44 @@ const mocks = createZeroRouteMocks(context);
 
 describe("GET /api/zero/api-keys", () => {
   const track = createFixtureTracker<ApiKeysFixture>((fixture) => {
-    return deleteApiKeys(store, fixture);
+    return store.set(deleteApiKeys$, fixture, context.signal);
   });
 
   it("returns the current user's API keys sorted by creation time", async () => {
     const fixture = await track(
-      seedApiKeys(store, [
-        {
-          name: "Older",
-          token: "vm0_pat_older_token",
-          createdAt: new Date("2026-03-01T00:00:00.000Z"),
-          expiresAt: new Date("2026-04-01T00:00:00.000Z"),
-        },
-        {
-          name: "Newer",
-          token: "vm0_pat_newer_token",
-          createdAt: new Date("2026-03-02T00:00:00.000Z"),
-          expiresAt: new Date("2026-04-02T00:00:00.000Z"),
-          lastUsedAt: new Date("2026-03-03T00:00:00.000Z"),
-        },
-      ]),
+      store.set(
+        seedApiKeys$,
+        [
+          {
+            name: "Older",
+            token: "vm0_pat_older_token",
+            createdAt: new Date("2026-03-01T00:00:00.000Z"),
+            expiresAt: new Date("2026-04-01T00:00:00.000Z"),
+          },
+          {
+            name: "Newer",
+            token: "vm0_pat_newer_token",
+            createdAt: new Date("2026-03-02T00:00:00.000Z"),
+            expiresAt: new Date("2026-04-02T00:00:00.000Z"),
+            lastUsedAt: new Date("2026-03-03T00:00:00.000Z"),
+          },
+        ],
+        context.signal,
+      ),
     );
     await track(
-      seedApiKeys(store, [
-        {
-          name: "Other user",
-          token: "vm0_pat_other_token",
-          createdAt: new Date("2026-03-03T00:00:00.000Z"),
-          expiresAt: new Date("2026-04-03T00:00:00.000Z"),
-        },
-      ]),
+      store.set(
+        seedApiKeys$,
+        [
+          {
+            name: "Other user",
+            token: "vm0_pat_other_token",
+            createdAt: new Date("2026-03-03T00:00:00.000Z"),
+            expiresAt: new Date("2026-04-03T00:00:00.000Z"),
+          },
+        ],
+        context.signal,
+      ),
     );
     mocks.clerk.session(fixture.userId, null);
     mockApiShadowCompareRoutes([apiKeysContract.list]);
@@ -82,7 +90,7 @@ describe("GET /api/zero/api-keys", () => {
   });
 
   it("returns an empty list when the user has no API keys", async () => {
-    const fixture = await track(seedApiKeys(store, []));
+    const fixture = await track(store.set(seedApiKeys$, [], context.signal));
     mocks.clerk.session(fixture.userId, null);
     mockApiShadowCompareRoutes([apiKeysContract.list]);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts
@@ -6,8 +6,8 @@ import { createStore } from "ccstate";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import {
-  deleteAutoRechargeOrg,
-  seedAutoRechargeOrg,
+  deleteAutoRechargeOrg$,
+  seedAutoRechargeOrg$,
   type AutoRechargeOrgFixture,
 } from "./helpers/zero-billing-auto-recharge";
 import {
@@ -21,16 +21,20 @@ const mocks = createZeroRouteMocks(context);
 
 describe("GET /api/zero/billing/auto-recharge", () => {
   const track = createFixtureTracker<AutoRechargeOrgFixture>((fixture) => {
-    return deleteAutoRechargeOrg(store, fixture);
+    return store.set(deleteAutoRechargeOrg$, fixture, context.signal);
   });
 
   it("returns the org auto-recharge config from the api implementation", async () => {
     const fixture = await track(
-      seedAutoRechargeOrg(store, {
-        enabled: true,
-        threshold: 500,
-        amount: 5000,
-      }),
+      store.set(
+        seedAutoRechargeOrg$,
+        {
+          enabled: true,
+          threshold: 500,
+          amount: 5000,
+        },
+        context.signal,
+      ),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mockApiShadowCompareRoutes([zeroBillingAutoRechargeContract.get]);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
@@ -7,9 +7,9 @@ import {
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import {
-  deleteZeroChatThread,
-  seedZeroChatMessage,
-  seedZeroChatThread,
+  deleteZeroChatThread$,
+  seedZeroChatMessage$,
+  seedZeroChatThread$,
   type ZeroChatThreadFixture,
 } from "./helpers/zero-chat-threads";
 import {
@@ -23,19 +23,24 @@ const mocks = createZeroRouteMocks(context);
 
 describe("GET /api/zero/chat-threads/:id", () => {
   const track = createFixtureTracker<ZeroChatThreadFixture>((fixture) => {
-    return deleteZeroChatThread(store, fixture);
+    return store.set(deleteZeroChatThread$, fixture, context.signal);
   });
 
   it("returns thread detail with S3-backed attachment metadata", async () => {
     const fixture = await track(
-      seedZeroChatThread(store, { title: "Uploads" }),
+      store.set(seedZeroChatThread$, { title: "Uploads" }, context.signal),
     );
-    await seedZeroChatMessage(store, fixture, {
-      role: "user",
-      content: "see attached file",
-      attachFiles: ["file_123"],
-      createdAt: new Date("2025-01-01T00:00:00.000Z"),
-    });
+    await store.set(
+      seedZeroChatMessage$,
+      fixture,
+      {
+        role: "user",
+        content: "see attached file",
+        attachFiles: ["file_123"],
+        createdAt: new Date("2025-01-01T00:00:00.000Z"),
+      },
+      context.signal,
+    );
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mocks.s3.listObjects([
       {
@@ -90,17 +95,24 @@ describe("GET /api/zero/chat-threads/:id", () => {
 
 describe("GET /api/zero/chat-threads/:threadId/messages", () => {
   const track = createFixtureTracker<ZeroChatThreadFixture>((fixture) => {
-    return deleteZeroChatThread(store, fixture);
+    return store.set(deleteZeroChatThread$, fixture, context.signal);
   });
 
   it("returns paged messages with S3-backed attachment metadata", async () => {
-    const fixture = await track(seedZeroChatThread(store));
-    await seedZeroChatMessage(store, fixture, {
-      role: "assistant",
-      content: "uploaded",
-      attachFiles: ["image_file"],
-      createdAt: new Date("2025-01-01T00:00:00.000Z"),
-    });
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    await store.set(
+      seedZeroChatMessage$,
+      fixture,
+      {
+        role: "assistant",
+        content: "uploaded",
+        attachFiles: ["image_file"],
+        createdAt: new Date("2025-01-01T00:00:00.000Z"),
+      },
+      context.signal,
+    );
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mocks.s3.listObjects([
       {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -6,8 +6,8 @@ import { createStore } from "ccstate";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import {
-  deleteFeatureSwitches,
-  seedFeatureSwitches,
+  deleteFeatureSwitches$,
+  seedFeatureSwitches$,
   type FeatureSwitchesFixture,
 } from "./helpers/zero-feature-switches";
 import {
@@ -21,15 +21,19 @@ const mocks = createZeroRouteMocks(context);
 
 describe("GET /api/zero/feature-switches", () => {
   const track = createFixtureTracker<FeatureSwitchesFixture>((fixture) => {
-    return deleteFeatureSwitches(store, fixture);
+    return store.set(deleteFeatureSwitches$, fixture, context.signal);
   });
 
   it("returns persisted feature switch overrides", async () => {
     const fixture = await track(
-      seedFeatureSwitches(store, {
-        apiBackend: true,
-        audioInput: false,
-      }),
+      store.set(
+        seedFeatureSwitches$,
+        {
+          apiBackend: true,
+          audioInput: false,
+        },
+        context.signal,
+      ),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mockApiShadowCompareRoutes([zeroFeatureSwitchesContract.get]);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-status.test.ts
@@ -6,8 +6,8 @@ import { createStore } from "ccstate";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import {
-  deleteOnboardingStatusOrg,
-  seedOnboardingStatusOrg,
+  deleteOnboardingStatusOrg$,
+  seedOnboardingStatusOrg$,
   type OnboardingStatusFixture,
 } from "./helpers/zero-onboarding-status";
 import {
@@ -21,7 +21,7 @@ const mocks = createZeroRouteMocks(context);
 
 describe("GET /api/zero/onboarding/status", () => {
   const track = createFixtureTracker<OnboardingStatusFixture>((fixture) => {
-    return deleteOnboardingStatusOrg(store, fixture);
+    return store.set(deleteOnboardingStatusOrg$, fixture, context.signal);
   });
 
   it("returns onboarding required when the session has no active org", async () => {
@@ -48,7 +48,9 @@ describe("GET /api/zero/onboarding/status", () => {
   });
 
   it("requires admin onboarding when the org has no default agent", async () => {
-    const fixture = await track(seedOnboardingStatusOrg(store));
+    const fixture = await track(
+      store.set(seedOnboardingStatusOrg$, {}, context.signal),
+    );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     mockApiShadowCompareRoutes([onboardingStatusContract.getStatus]);
 
@@ -73,13 +75,17 @@ describe("GET /api/zero/onboarding/status", () => {
 
   it("returns completed onboarding with default agent metadata", async () => {
     const fixture = await track(
-      seedOnboardingStatusOrg(store, {
-        defaultAgent: {
-          displayName: "Support",
-          description: "Handles customer questions",
+      store.set(
+        seedOnboardingStatusOrg$,
+        {
+          defaultAgent: {
+            displayName: "Support",
+            description: "Handles customer questions",
+          },
+          onboardingDone: true,
         },
-        onboardingDone: true,
-      }),
+        context.signal,
+      ),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
     mockApiShadowCompareRoutes([onboardingStatusContract.getStatus]);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-queue-position.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-queue-position.test.ts
@@ -7,8 +7,8 @@ import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import {
-  deleteQueuePositionRuns,
-  seedQueuePositionRuns,
+  deleteQueuePositionRuns$,
+  seedQueuePositionRuns$,
   type QueuePositionFixture,
 } from "./helpers/zero-queue-position";
 import {
@@ -22,12 +22,12 @@ const mocks = createZeroRouteMocks(context);
 
 describe("GET /api/zero/queue-position", () => {
   const track = createFixtureTracker<QueuePositionFixture>((fixture) => {
-    return deleteQueuePositionRuns(store, fixture);
+    return store.set(deleteQueuePositionRuns$, fixture, context.signal);
   });
 
   it("returns the queued run position within the org queue", async () => {
     const fixture = await track(
-      seedQueuePositionRuns(store, { queuedRuns: 2 }),
+      store.set(seedQueuePositionRuns$, { queuedRuns: 2 }, context.signal),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
     const runId = fixture.queuedRunIds[1];
@@ -54,7 +54,7 @@ describe("GET /api/zero/queue-position", () => {
 
   it("returns zero position for an owned run that is not queued", async () => {
     const fixture = await track(
-      seedQueuePositionRuns(store, { unqueuedRuns: 1 }),
+      store.set(seedQueuePositionRuns$, { unqueuedRuns: 1 }, context.signal),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
     const runId = fixture.unqueuedRunIds[0];
@@ -81,7 +81,7 @@ describe("GET /api/zero/queue-position", () => {
 
   it("returns 404 for a run owned by another user", async () => {
     const fixture = await track(
-      seedQueuePositionRuns(store, { queuedRuns: 1 }),
+      store.set(seedQueuePositionRuns$, { queuedRuns: 1 }, context.signal),
     );
     mocks.clerk.session(`user_${randomUUID()}`, fixture.orgId);
     const runId = fixture.queuedRunIds[0];

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-secrets.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-secrets.test.ts
@@ -8,9 +8,9 @@ import {
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
 import {
-  deleteUserData,
-  seedOtherSecret,
-  seedSecrets,
+  deleteUserData$,
+  seedOtherSecret$,
+  seedSecrets$,
   type UserDataFixture,
 } from "./helpers/zero-user-data";
 
@@ -20,31 +20,35 @@ const mocks = createZeroRouteMocks(context);
 
 describe("GET /api/zero/secrets", () => {
   const track = createFixtureTracker<UserDataFixture>((fixture) => {
-    return deleteUserData(store, fixture);
+    return store.set(deleteUserData$, fixture, context.signal);
   });
 
   it("returns current user secret metadata sorted by name", async () => {
     const createdAt = new Date("2026-01-02T03:04:05.000Z");
     const updatedAt = new Date("2026-01-03T03:04:05.000Z");
     const fixture = await track(
-      seedSecrets(store, [
-        {
-          name: "Z_TOKEN",
-          description: null,
-          type: "connector",
-          createdAt,
-          updatedAt,
-        },
-        {
-          name: "A_TOKEN",
-          description: "alpha",
-          type: "user",
-          createdAt,
-          updatedAt,
-        },
-      ]),
+      store.set(
+        seedSecrets$,
+        [
+          {
+            name: "Z_TOKEN",
+            description: null,
+            type: "connector",
+            createdAt,
+            updatedAt,
+          },
+          {
+            name: "A_TOKEN",
+            description: "alpha",
+            type: "user",
+            createdAt,
+            updatedAt,
+          },
+        ],
+        context.signal,
+      ),
     );
-    await seedOtherSecret(store, fixture);
+    await store.set(seedOtherSecret$, fixture, context.signal);
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mockApiShadowCompareRoutes([zeroSecretsContract.list]);
 
@@ -77,7 +81,7 @@ describe("GET /api/zero/secrets", () => {
   });
 
   it("returns an empty list when the user has no secrets", async () => {
-    const fixture = await track(seedSecrets(store, []));
+    const fixture = await track(store.set(seedSecrets$, [], context.signal));
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mockApiShadowCompareRoutes([zeroSecretsContract.list]);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-preferences.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-preferences.test.ts
@@ -10,8 +10,8 @@ import {
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
 import {
-  deleteUserData,
-  seedUserPreferences,
+  deleteUserData$,
+  seedUserPreferences$,
   type UserDataFixture,
 } from "./helpers/zero-user-data";
 
@@ -21,17 +21,21 @@ const mocks = createZeroRouteMocks(context);
 
 describe("GET /api/zero/user-preferences", () => {
   const track = createFixtureTracker<UserDataFixture>((fixture) => {
-    return deleteUserData(store, fixture);
+    return store.set(deleteUserData$, fixture, context.signal);
   });
 
   it("returns the persisted preferences for the current org member", async () => {
     const fixture = await track(
-      seedUserPreferences(store, {
-        timezone: "America/Los_Angeles",
-        pinnedAgentIds: ["agent_b", "agent_a"],
-        sendMode: "cmd-enter",
-        captureNetworkBodiesRemaining: 3,
-      }),
+      store.set(
+        seedUserPreferences$,
+        {
+          timezone: "America/Los_Angeles",
+          pinnedAgentIds: ["agent_b", "agent_a"],
+          sendMode: "cmd-enter",
+          captureNetworkBodiesRemaining: 3,
+        },
+        context.signal,
+      ),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mockApiShadowCompareRoutes([zeroUserPreferencesContract.get]);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-variables.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-variables.test.ts
@@ -8,9 +8,9 @@ import {
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
 import {
-  deleteUserData,
-  seedOtherVariable,
-  seedVariables,
+  deleteUserData$,
+  seedOtherVariable$,
+  seedVariables$,
   type UserDataFixture,
 } from "./helpers/zero-user-data";
 
@@ -20,31 +20,35 @@ const mocks = createZeroRouteMocks(context);
 
 describe("GET /api/zero/variables", () => {
   const track = createFixtureTracker<UserDataFixture>((fixture) => {
-    return deleteUserData(store, fixture);
+    return store.set(deleteUserData$, fixture, context.signal);
   });
 
   it("returns current user variables sorted by name", async () => {
     const createdAt = new Date("2026-02-02T03:04:05.000Z");
     const updatedAt = new Date("2026-02-03T03:04:05.000Z");
     const fixture = await track(
-      seedVariables(store, [
-        {
-          name: "Z_REGION",
-          value: "us-west-2",
-          description: null,
-          createdAt,
-          updatedAt,
-        },
-        {
-          name: "A_ENDPOINT",
-          value: "https://api.example.test",
-          description: "endpoint",
-          createdAt,
-          updatedAt,
-        },
-      ]),
+      store.set(
+        seedVariables$,
+        [
+          {
+            name: "Z_REGION",
+            value: "us-west-2",
+            description: null,
+            createdAt,
+            updatedAt,
+          },
+          {
+            name: "A_ENDPOINT",
+            value: "https://api.example.test",
+            description: "endpoint",
+            createdAt,
+            updatedAt,
+          },
+        ],
+        context.signal,
+      ),
     );
-    await seedOtherVariable(store, fixture);
+    await store.set(seedOtherVariable$, fixture, context.signal);
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mockApiShadowCompareRoutes([zeroVariablesContract.list]);
 
@@ -77,7 +81,7 @@ describe("GET /api/zero/variables", () => {
   });
 
   it("returns an empty list when the user has no variables", async () => {
-    const fixture = await track(seedVariables(store, []));
+    const fixture = await track(store.set(seedVariables$, [], context.signal));
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mockApiShadowCompareRoutes([zeroVariablesContract.list]);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-quota.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-quota.test.ts
@@ -4,8 +4,8 @@ import { createStore } from "ccstate";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import {
-  deleteVoiceIoQuotaOrg,
-  seedVoiceIoQuotaOrg,
+  deleteVoiceIoQuotaOrg$,
+  seedVoiceIoQuotaOrg$,
   type VoiceIoQuotaFixture,
 } from "./helpers/zero-voice-io-quota";
 import {
@@ -19,11 +19,13 @@ const mocks = createZeroRouteMocks(context);
 
 describe("GET /api/zero/voice-io/quota", () => {
   const track = createFixtureTracker<VoiceIoQuotaFixture>((fixture) => {
-    return deleteVoiceIoQuotaOrg(store, fixture);
+    return store.set(deleteVoiceIoQuotaOrg$, fixture, context.signal);
   });
 
   it("defaults a missing org metadata row to the free quota", async () => {
-    const fixture = await track(seedVoiceIoQuotaOrg(store));
+    const fixture = await track(
+      store.set(seedVoiceIoQuotaOrg$, {}, context.signal),
+    );
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mockApiShadowCompareRoutes([zeroVoiceIoQuotaContract.get]);
 
@@ -44,7 +46,9 @@ describe("GET /api/zero/voice-io/quota", () => {
   });
 
   it("blocks free tier users at the lifetime audio input quota", async () => {
-    const fixture = await track(seedVoiceIoQuotaOrg(store, { count: 10 }));
+    const fixture = await track(
+      store.set(seedVoiceIoQuotaOrg$, { count: 10 }, context.signal),
+    );
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mockApiShadowCompareRoutes([zeroVoiceIoQuotaContract.get]);
 
@@ -66,10 +70,14 @@ describe("GET /api/zero/voice-io/quota", () => {
 
   it("does not apply the free quota to paid tiers", async () => {
     const fixture = await track(
-      seedVoiceIoQuotaOrg(store, {
-        tier: "pro",
-        count: 10,
-      }),
+      store.set(
+        seedVoiceIoQuotaOrg$,
+        {
+          tier: "pro",
+          count: 10,
+        },
+        context.signal,
+      ),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
     mockApiShadowCompareRoutes([zeroVoiceIoQuotaContract.get]);


### PR DESCRIPTION
## Summary

- Add an API custom ESLint rule that rejects `Store` in function parameters.
- Refactor affected API route test DB fixture helpers into ccstate `command()` helpers.
- Update route tests to call fixture commands with `context.signal`.

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F api exec vitest run custom-eslint/__tests__/no-store-in-params.test.ts src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts src/signals/routes/__tests__/zero-chat-threads.test.ts src/signals/routes/__tests__/zero-feature-switches.test.ts src/signals/routes/__tests__/zero-onboarding-status.test.ts src/signals/routes/__tests__/zero-queue-position.test.ts src/signals/routes/__tests__/zero-voice-io-quota.test.ts`
- pre-commit hook: `pnpm check-types` via lefthook