### PR TITLE
fix: strip forwarded headers from api fallback proxy

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -168,6 +168,113 @@ describe("createApp", () => {
       expect(observedBody).toBe('{"hello":"world"}');
     });
 
+    it("proxies realtime token requests without stale forwarded host metadata", async () => {
+      mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
+      const captured: {
+        urls: string[];
+        authorization: string[];
+        origins: string[];
+        bodies: string[];
+        forwarded: (string | null)[];
+        forwardedHost: (string | null)[];
+        forwardedPort: (string | null)[];
+        forwardedProto: (string | null)[];
+      } = {
+        urls: [],
+        authorization: [],
+        origins: [],
+        bodies: [],
+        forwarded: [],
+        forwardedHost: [],
+        forwardedPort: [],
+        forwardedProto: [],
+      };
+      server.use(
+        http.post(
+          "https://www.vm0.ai/api/zero/realtime/token",
+          async ({ request }) => {
+            captured.urls.push(request.url);
+            captured.authorization.push(
+              request.headers.get("authorization") ?? "",
+            );
+            captured.origins.push(request.headers.get("origin") ?? "");
+            captured.bodies.push(await request.text());
+            captured.forwarded.push(request.headers.get("forwarded"));
+            captured.forwardedHost.push(
+              request.headers.get("x-forwarded-host"),
+            );
+            captured.forwardedPort.push(
+              request.headers.get("x-forwarded-port"),
+            );
+            captured.forwardedProto.push(
+              request.headers.get("x-forwarded-proto"),
+            );
+            return HttpResponse.json({ token: "proxied" });
+          },
+        ),
+      );
+
+      const app = createApp({ signal: context.signal });
+      const response = await app.request("/api/zero/realtime/token", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer clerk-session",
+          "content-type": "application/json",
+          forwarded: "host=api.vm0.ai;proto=https",
+          origin: "https://app.vm0.ai",
+          "x-forwarded-host": "api.vm0.ai",
+          "x-forwarded-port": "443",
+          "x-forwarded-proto": "https",
+        },
+        body: "{}",
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toStrictEqual({
+        token: "proxied",
+      });
+      expect(captured.urls).toStrictEqual([
+        "https://www.vm0.ai/api/zero/realtime/token",
+      ]);
+      expect(captured.authorization).toStrictEqual(["Bearer clerk-session"]);
+      expect(captured.origins).toStrictEqual(["https://app.vm0.ai"]);
+      expect(captured.bodies).toStrictEqual(["{}"]);
+      expect(captured.forwarded).toStrictEqual([null]);
+      expect(captured.forwardedHost).toStrictEqual([null]);
+      expect(captured.forwardedPort).toStrictEqual([null]);
+      expect(captured.forwardedProto).toStrictEqual([null]);
+    });
+
+    it("preserves multiple set-cookie response headers", async () => {
+      mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
+      server.use(
+        http.get("https://www.vm0.ai/api/connectors/github/authorize", () => {
+          return new HttpResponse(null, {
+            status: 302,
+            headers: [
+              ["location", "https://github.com/login/oauth/authorize"],
+              ["set-cookie", "oauth_state=abc; Path=/; HttpOnly"],
+              ["set-cookie", "oauth_pkce=def; Path=/; HttpOnly"],
+            ],
+          });
+        }),
+      );
+
+      const app = createApp({ signal: context.signal });
+      const response = await app.request("/api/connectors/github/authorize", {
+        method: "GET",
+      });
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe(
+        "https://github.com/login/oauth/authorize",
+      );
+      expect(response.headers.getSetCookie()).toStrictEqual([
+        "oauth_state=abc; Path=/; HttpOnly",
+        "oauth_pkce=def; Path=/; HttpOnly",
+      ]);
+    });
+
     it("returns 404 when VM0_WEB_URL is not configured", async () => {
       // No msw handler registered — if the proxy tried to fetch, msw would
       // throw on the unhandled request. The 404 path must short-circuit.

--- a/turbo/apps/api/src/app-factory.ts
+++ b/turbo/apps/api/src/app-factory.ts
@@ -30,8 +30,19 @@ const HOP_BY_HOP_HEADERS: Readonly<Record<string, true>> = {
   upgrade: true,
 };
 
+const PROXY_REQUEST_HEADERS: Readonly<Record<string, true>> = {
+  forwarded: true,
+  "x-forwarded-host": true,
+  "x-forwarded-port": true,
+  "x-forwarded-proto": true,
+};
+
 function isHopByHop(name: string): boolean {
   return Object.hasOwn(HOP_BY_HOP_HEADERS, name.toLowerCase());
+}
+
+function isProxyRequestHeader(name: string): boolean {
+  return Object.hasOwn(PROXY_REQUEST_HEADERS, name.toLowerCase());
 }
 
 function buildProxyRequest(context: Context, webUrl: string): Request {
@@ -40,7 +51,7 @@ function buildProxyRequest(context: Context, webUrl: string): Request {
 
   const headers = new Headers();
   for (const [key, value] of context.req.raw.headers) {
-    if (!isHopByHop(key)) {
+    if (!isHopByHop(key) && !isProxyRequestHeader(key)) {
       headers.set(key, value);
     }
   }
@@ -69,9 +80,12 @@ async function proxyToWeb(context: Context, webUrl: string): Promise<Response> {
   // can set its own Content-Length / Transfer-Encoding for our reply.
   const headers = new Headers();
   for (const [key, value] of upstream.headers) {
-    if (!isHopByHop(key)) {
+    if (!isHopByHop(key) && key.toLowerCase() !== "set-cookie") {
       headers.set(key, value);
     }
+  }
+  for (const cookie of upstream.headers.getSetCookie()) {
+    headers.append("set-cookie", cookie);
   }
   return new Response(upstream.body, {
     status: upstream.status,

--- a/turbo/packages/proxy/Caddyfile
+++ b/turbo/packages/proxy/Caddyfile
@@ -1,44 +1,56 @@
 {
-  http_port 8080
-  https_port 8443
-  storage file_system {
-    root /home/vscode/.local/certs/caddy
-  }
+	http_port 8080
+	https_port 8443
+	storage file_system {
+		root /home/vscode/.local/certs/caddy
+	}
 }
 
 # Main domain redirect to www
 vm7.ai:8443 {
-  tls {
-    dns cloudflare {env.CF_DNS_AND_TUNNEL_API_TOKEN}
-  }
-  redir https://www.vm7.ai:8443{uri} permanent
+	tls {
+		dns cloudflare {env.CF_DNS_AND_TUNNEL_API_TOKEN}
+	}
+	redir https://www.vm7.ai:8443{uri} permanent
 }
 
 # Web application
 www.vm7.ai:8443 {
-  tls {
-    dns cloudflare {env.CF_DNS_AND_TUNNEL_API_TOKEN}
-  }
-  reverse_proxy localhost:3000
+	tls {
+		dns cloudflare {env.CF_DNS_AND_TUNNEL_API_TOKEN}
+	}
+	reverse_proxy localhost:3000
 }
 
 # App application
 app.vm7.ai:8443 {
-  tls {
-    dns cloudflare {env.CF_DNS_AND_TUNNEL_API_TOKEN}
-  }
-  reverse_proxy localhost:3002
+	tls {
+		dns cloudflare {env.CF_DNS_AND_TUNNEL_API_TOKEN}
+	}
+	reverse_proxy localhost:3002
+}
+
+# API application
+api.vm7.ai:8443 {
+	tls {
+		dns cloudflare {env.CF_DNS_AND_TUNNEL_API_TOKEN}
+	}
+	reverse_proxy localhost:3001
 }
 
 # HTTP redirects to HTTPS
 http://vm7.ai:8080 {
-  redir https://www.vm7.ai:8443{uri} permanent
+	redir https://www.vm7.ai:8443{uri} permanent
 }
 
 http://www.vm7.ai:8080 {
-  redir https://www.vm7.ai:8443{uri} permanent
+	redir https://www.vm7.ai:8443{uri} permanent
 }
 
 http://app.vm7.ai:8080 {
-  redir https://app.vm7.ai:8443{uri} permanent
+	redir https://app.vm7.ai:8443{uri} permanent
+}
+
+http://api.vm7.ai:8080 {
+	redir https://api.vm7.ai:8443{uri} permanent
 }

--- a/turbo/packages/proxy/README.md
+++ b/turbo/packages/proxy/README.md
@@ -9,7 +9,7 @@ This package provides a Caddy-based reverse proxy that enables HTTPS for local d
 ## Features
 
 - **Automatic HTTPS** via Let's Encrypt (no manual certificate management)
-- **Multiple domains**: www.vm7.ai, app.vm7.ai
+- **Multiple domains**: www.vm7.ai, app.vm7.ai, api.vm7.ai
 - **Automatic HTTP to HTTPS redirect**
 - **WebSocket support** for hot module replacement
 - **Shared certificate cache** across devcontainers via Docker volume
@@ -20,9 +20,9 @@ This package provides a Caddy-based reverse proxy that enables HTTPS for local d
 Browser
   ↓
 Caddy Proxy (HTTPS: 8443, HTTP: 8080)
-  ↓              ↓
-Web App        App
-(port 3000)    (port 3002)
+  ↓              ↓              ↓
+Web App        App            API
+(port 3000)    (port 3002)    (port 3001)
 ```
 
 ## Quick Start
@@ -57,11 +57,13 @@ On first start, Caddy will automatically obtain a Let's Encrypt certificate (~30
 
 - Web: https://www.vm7.ai:8443
 - App: https://app.vm7.ai:8443
+- API: https://api.vm7.ai:8443
 
 Direct access (HTTP only):
 
 - Web: http://localhost:3000
 - App: http://localhost:3002
+- API: http://localhost:3001
 
 ## Configuration
 
@@ -80,6 +82,7 @@ The `Caddyfile` defines:
 | --------------- | ---- | ---------------------------- |
 | www.vm7.ai:8443 | 8443 | localhost:3000 (Next.js web) |
 | app.vm7.ai:8443 | 8443 | localhost:3002 (Vite app)    |
+| api.vm7.ai:8443 | 8443 | localhost:3001 (Hono API)    |
 | vm7.ai:8443     | 8443 | Redirect to www.vm7.ai:8443  |
 
 ## Scripts
@@ -105,7 +108,7 @@ pkill -f caddy
 In DevContainer, this should be automatic. If not:
 
 ```bash
-echo "127.0.0.1 vm7.ai www.vm7.ai app.vm7.ai" | sudo tee -a /etc/hosts
+echo "127.0.0.1 vm7.ai www.vm7.ai app.vm7.ai api.vm7.ai" | sudo tee -a /etc/hosts
 ```
 
 ## File Structure

--- a/turbo/packages/proxy/scripts/start-caddy.js
+++ b/turbo/packages/proxy/scripts/start-caddy.js
@@ -73,9 +73,11 @@ setTimeout(() => {
   console.log("\n📱 Available at:");
   console.log("   Web:       https://www.vm7.ai:8443");
   console.log("   App:       https://app.vm7.ai:8443");
+  console.log("   API:       https://api.vm7.ai:8443");
   console.log("\n💡 Make sure your applications are running:");
   console.log("   Web:       pnpm --filter web dev (port 3000)");
   console.log("   App:       pnpm --filter @vm0/app dev (port 3002)");
+  console.log("   API:       pnpm --filter api dev (port 3001)");
   console.log(
     "\n🔐 Certificates are provisioned automatically via Let's Encrypt.",
   );

--- a/turbo/scripts/dev-server-check.sh
+++ b/turbo/scripts/dev-server-check.sh
@@ -20,3 +20,4 @@ check_port() {
 
 check_port "Web:      https://www.vm7.ai:8443"      "https://www.vm7.ai:8443/"
 check_port "App:      https://app.vm7.ai:8443"  "https://app.vm7.ai:8443/"
+check_port "API:      https://api.vm7.ai:8443"  "https://api.vm7.ai:8443/health"


### PR DESCRIPTION
## Summary
- strip stale Forwarded/X-Forwarded-* metadata before the API fallback proxy forwards unmatched requests to web
- preserve multiple Set-Cookie headers from proxied web responses
- add local api.vm7.ai Caddy vhost and dev server health check coverage for browser validation

## Testing
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm vitest (passed after resetting the local test DB to clear stale fixed-id Telegram rows)
- pnpm knip
- CF_DNS_AND_TUNNEL_API_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa caddy validate --config turbo/packages/proxy/Caddyfile
- git diff --check
- browser: app.vm7.ai login session fetch to api.vm7.ai and www.vm7.ai /api/zero/realtime/token returned 200 with matching response fields

## Notes
- Reverting the proxy header stripping makes the MSW regression test observe stale forwarded host metadata on the web fallback request.
- The browser repro did not reproduce the production 401 locally on either old or fixed code, but the fallback proxy request shape is now verified at the HTTP boundary.