### PR TITLE
fix(insights): populate schedules + chats in daily snapshot

### DIFF
--- a/turbo/apps/web/app/api/cron/aggregate-insights/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/aggregate-insights/__tests__/route.test.ts
@@ -14,8 +14,17 @@ import {
   seedUserCacheEntry,
   setOrgCredits,
 } from "../../../../../src/__tests__/api-test-helpers";
-import { createTestZeroAgent } from "../../../../../src/__tests__/db-test-seeders/agents";
-import { seedCompletedTestRun } from "../../../../../src/__tests__/db-test-seeders/runs";
+import {
+  createTestZeroAgent,
+  insertTestChatThread,
+} from "../../../../../src/__tests__/db-test-seeders/agents";
+import {
+  insertTestZeroRun,
+  linkRunToChatThread,
+  linkRunToSchedule,
+  seedCompletedTestRun,
+} from "../../../../../src/__tests__/db-test-seeders/runs";
+import { seedTestSchedule } from "../../../../../src/__tests__/db-test-seeders/schedules";
 import { reloadEnv } from "../../../../../src/env";
 
 vi.hoisted(() => {
@@ -57,6 +66,7 @@ function todayDateStr(): string {
 
 describe("GET /api/cron/aggregate-insights", () => {
   let composeVersionId: string;
+  let composeId: string;
   let composeName: string;
   let userId: string;
   let orgId: string;
@@ -68,10 +78,11 @@ describe("GET /api/cron/aggregate-insights", () => {
     const user = await context.setupUser();
     userId = user.userId;
     orgId = user.orgId;
-    const { versionId, name } = await createTestCompose(
+    const { versionId, name, agentId } = await createTestCompose(
       uniqueId("insights-agent"),
     );
     composeVersionId = versionId;
+    composeId = agentId;
     composeName = name;
 
     // Ensure org has metadata row for credit balance lookup
@@ -770,6 +781,97 @@ describe("GET /api/cron/aggregate-insights", () => {
     }>;
     expect(teamUsage).toHaveLength(1);
     expect(teamUsage[0]!.name).toBe("bob");
+  });
+
+  it("should aggregate schedules and chats with credits", async () => {
+    const { date } = recentDate();
+
+    // ── Schedule-triggered run with credits ────────────────────────────
+    const scheduleId = await seedTestSchedule({
+      agentId: composeId,
+      userId,
+      orgId,
+      name: "Daily digest",
+      description: "Sends a daily summary",
+    });
+    const scheduleRunId = await seedCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: date,
+      startedAt: date,
+      completedAt: date,
+    });
+    await insertTestZeroRun(scheduleRunId, { triggerSource: "schedule" });
+    await linkRunToSchedule(scheduleRunId, scheduleId);
+    await seedCreditUsageRecord({
+      runId: scheduleRunId,
+      orgId,
+      userId,
+      creditsCharged: 800,
+      createdAt: date,
+    });
+
+    // ── Chat-triggered run with credits ────────────────────────────────
+    const threadId = await insertTestChatThread(
+      userId,
+      composeId,
+      "Investigate billing",
+    );
+    const chatRunId = await seedCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: date,
+      startedAt: date,
+      completedAt: date,
+    });
+    await insertTestZeroRun(chatRunId, { triggerSource: "web" });
+    await linkRunToChatThread(chatRunId, threadId);
+    await seedCreditUsageRecord({
+      runId: chatRunId,
+      orgId,
+      userId,
+      creditsCharged: 250,
+      createdAt: date,
+    });
+
+    await seedUserCacheEntry(userId, "test@example.com");
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeDefined();
+
+    const data = row!.data as {
+      schedules: Array<{
+        scheduleId: string;
+        scheduleName: string;
+        scheduleDescription: string | null;
+        credits: number;
+        tokens: number;
+      }>;
+      chats: Array<{
+        threadId: string;
+        threadTitle: string | null;
+        credits: number;
+        tokens: number;
+      }>;
+    };
+
+    expect(data.schedules).toHaveLength(1);
+    expect(data.schedules[0]).toMatchObject({
+      scheduleId,
+      scheduleName: "Daily digest",
+      scheduleDescription: "Sends a daily summary",
+      credits: 800,
+    });
+
+    expect(data.chats).toHaveLength(1);
+    expect(data.chats[0]).toMatchObject({
+      threadId,
+      threadTitle: "Investigate billing",
+      credits: 250,
+    });
   });
 
   it("should be idempotent on rerun", async () => {

--- a/turbo/apps/web/app/api/cron/aggregate-insights/route.ts
+++ b/turbo/apps/web/app/api/cron/aggregate-insights/route.ts
@@ -18,6 +18,11 @@ import {
   DATASETS,
 } from "../../../../src/lib/shared/axiom";
 import {
+  queryUsageInsightTopSchedules,
+  queryUsageInsightTopChats,
+  type UsageInsightSqlParams,
+} from "../../../../src/lib/zero/billing/usage-insight-ledger";
+import {
   getConnectorFirewall,
   isFirewallConnectorType,
 } from "@vm0/connectors/firewalls";
@@ -126,6 +131,14 @@ function getLocalToday(
 
 function normalizeDbDate(value: Date | string): Date {
   return value instanceof Date ? value : new Date(value);
+}
+
+/**
+ * Escape a string value as a PostgreSQL single-quoted literal.
+ * Doubles any single quotes inside to prevent injection.
+ */
+function pgLit(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
 }
 
 // ---------------------------------------------------------------------------
@@ -332,6 +345,19 @@ interface InsightData {
     denied: number;
     agentNames: string[];
   }[];
+  schedules: {
+    scheduleId: string;
+    scheduleName: string;
+    scheduleDescription: string | null;
+    credits: number;
+    tokens: number;
+  }[];
+  chats: {
+    threadId: string;
+    threadTitle: string | null;
+    credits: number;
+    tokens: number;
+  }[];
   axiomDegraded?: boolean;
 }
 
@@ -347,6 +373,8 @@ function buildUserInsight(
     agentNames: string[];
     agentCredits: Record<string, number>;
   }>,
+  schedules: InsightData["schedules"],
+  chats: InsightData["chats"],
   axiomDegraded?: boolean,
 ): InsightData {
   const services = networkData
@@ -399,6 +427,8 @@ function buildUserInsight(
     topTask,
     services,
     permissions,
+    schedules,
+    chats,
     ...(axiomDegraded ? { axiomDegraded: true } : {}),
   };
 }
@@ -998,12 +1028,27 @@ async function processWindowGroup(
     const orgCredits = orgCreditsMap.get(orgId);
     const networkData = userNetworkMap.get(key);
 
+    const ledgerParams: UsageInsightSqlParams = {
+      userIdLit: pgLit(userId),
+      orgIdLit: pgLit(orgId),
+      startTsLit: pgLit(dayStart.toISOString()),
+      endTsLit: pgLit(dayEnd.toISOString()),
+      truncLit: pgLit("day"),
+      tzLit: pgLit("UTC"),
+    };
+    const [{ schedules }, { chats }] = await Promise.all([
+      queryUsageInsightTopSchedules(db, ledgerParams),
+      queryUsageInsightTopChats(db, ledgerParams),
+    ]);
+
     const data = buildUserInsight(
       networkData,
       agents,
       orgCredits?.creditsUsed ?? 0,
       orgBalanceMap.get(orgId) ?? 0,
       orgCredits?.teamUsage ?? [],
+      schedules,
+      chats,
       axiomDegraded,
     );
 

--- a/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
@@ -765,6 +765,23 @@ export async function linkRunToSchedule(
 }
 
 /**
+ * Link an existing run to a chat thread by setting its chatThreadId.
+ *
+ * @why-db-direct Sets chatThreadId on zero_runs; no API for run-thread
+ * linking — this is set during web chat dispatch.
+ */
+export async function linkRunToChatThread(
+  runId: string,
+  chatThreadId: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(zeroRuns)
+    .set({ chatThreadId })
+    .where(eq(zeroRuns.id, runId));
+}
+
+/**
  * Insert a test conversation record.
  *
  * @why-db-direct Creates conversation record; conversations are created by


### PR DESCRIPTION
## Summary

PR #11444 added `DaySchedulesCard` and `DayChatsCard` to the Daily breakdown tab on `/insights`, but the per-day cards never render: both cards early-return `null` on empty input, and the cron aggregator (`/api/cron/aggregate-insights`) never wrote the `schedules` / `chats` fields into the `insights_daily.data` JSON. The `/api/zero/insights` reader falls back to `[]`, so the cards are always empty.

This PR wires the existing `queryUsageInsightTopSchedules` / `queryUsageInsightTopChats` helpers (already powering the Time-range tab) into `processWindowGroup` per user, scoped to that user's local-day window. The snapshot now carries the same shape the frontend already expects.

### Why this is the right fix

- The queries already exist and are user-scoped (`UsageInsightSqlParams` takes `userIdLit` / `orgIdLit`), so reuse is direct
- The aggregator already runs once per active user per day and resolves per-user timezones, so the existing window grouping gives us the correct date boundaries for free
- No frontend or contract changes — the existing `DayInsight.schedules` / `.chats` types from #11444 line up exactly with the query output shape
- Old snapshots will fill in on the next cron run when an active user produces new activity

### What changed

- `aggregate-insights/route.ts`: extend `InsightData` to include `schedules` and `chats`; call the two ledger queries per (orgId, userId) inside `processWindowGroup` with the group's `dayStart` / `dayEnd`; pass them through `buildUserInsight` into the snapshot
- `db-test-seeders/runs.ts`: add `linkRunToChatThread` mirroring the existing `linkRunToSchedule`
- New test: seeds a schedule-triggered run and a chat-triggered run with credit usage, asserts the snapshot's `schedules` and `chats` arrays match

## Test plan
- [x] \`pnpm vitest run app/api/cron/aggregate-insights/\` — 20 pass (19 existing + 1 new)
- [x] \`pnpm vitest run app/api/zero/insights/\` — 15 pass
- [x] \`pnpm check-types\`
- [x] \`pnpm lint\`
- [ ] Manual: after this lands, the next cron tick should backfill today's snapshot; verify schedules/chats cards appear under days where the user actually scheduled or chatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)