### PR TITLE
refactor(sandbox-fc): introduce netns lease ownership

### DIFF
--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -1369,7 +1369,7 @@ mod tests {
         LeakedResources {
             sandbox_id: sandbox_id.into(),
             cow_device: None,
-            network: Some(test_network()),
+            network: None,
             sock_dir: PathBuf::from("/nonexistent"),
             workspace: PathBuf::from("/nonexistent"),
         }
@@ -1602,7 +1602,9 @@ mod tests {
 
         assert_eq!(resources.sandbox_paths.workspace(), workspace.as_path());
         assert_eq!(resources.sock_paths.dir(), sock_dir.as_path());
-        assert_eq!(resources.network.name(), "test-ns");
+        let network = resources.network;
+        assert_eq!(network.name(), "test-ns");
+        let _ = network.into_info_for_test();
         assert!(workspace.exists());
         assert!(sock_dir.exists());
     }
@@ -1657,6 +1659,11 @@ mod tests {
         tx.track_sock_dir(sock_dir.clone());
         tx.track_network(test_network());
 
+        assert!(!tx.send_async_leaked_resources());
+        let network = tx.network.take().unwrap();
+        assert_eq!(network.name(), "test-ns");
+        let _ = network.into_info_for_test();
+
         drop(tx);
 
         assert!(!workspace.exists());
@@ -1680,7 +1687,9 @@ mod tests {
 
         drop(tx);
 
-        assert_eq!(leak_rx.recv().await.unwrap().sandbox_id, "queued");
+        let queued = leak_rx.recv().await.unwrap();
+        assert_eq!(queued.sandbox_id, "queued");
+        assert!(queued.network.is_none());
         let mut leaked = leak_rx.recv().await.unwrap();
         assert_eq!(leaked.sandbox_id, "sandbox");
         let network = leaked.network.take().unwrap();
@@ -1763,9 +1772,12 @@ mod tests {
         })
         .unwrap();
 
-        let leaked = rx.recv().await.unwrap();
+        let mut leaked = rx.recv().await.unwrap();
         assert_eq!(leaked.sandbox_id, "test-sandbox");
         assert!(leaked.cow_device.is_none());
+        let network = leaked.network.take().unwrap();
+        assert_eq!(network.name(), "test-ns");
+        let _ = network.into_info_for_test();
     }
 
     #[test]
@@ -1781,8 +1793,11 @@ mod tests {
             workspace: PathBuf::from("/nonexistent"),
         };
 
-        // Should not panic — just returns Err.
-        assert!(tx.send(resources).is_err());
+        // Should not panic — just returns Err with the original payload.
+        let mut resources = tx.send(resources).unwrap_err().0;
+        let network = resources.network.take().unwrap();
+        assert_eq!(network.name(), "test-ns");
+        let _ = network.into_info_for_test();
     }
 
     #[test]

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -44,6 +44,7 @@ pub(crate) struct LeakedResources {
     pub(crate) network: Option<NetnsLease>,
     pub(crate) sock_dir: PathBuf,
     pub(crate) workspace: PathBuf,
+    pub(crate) delete_workspace: bool,
 }
 
 /// Owns the leaked-resource cleanup channel and its background drain task.
@@ -191,6 +192,7 @@ struct SandboxCreateTransaction {
     network: Option<NetnsLease>,
     cow_device: Option<PooledNbdCowDevice>,
     leak_tx: Option<tokio::sync::mpsc::UnboundedSender<LeakedResources>>,
+    delete_workspace_on_leak_cleanup: bool,
 }
 
 impl SandboxCreateTransaction {
@@ -211,6 +213,7 @@ impl SandboxCreateTransaction {
             network: None,
             cow_device: None,
             leak_tx,
+            delete_workspace_on_leak_cleanup: true,
         }
     }
 
@@ -323,6 +326,9 @@ impl SandboxCreateTransaction {
         } else {
             false
         };
+        if keep_workspace {
+            self.delete_workspace_on_leak_cleanup = false;
+        }
         if let Some(network) = self.network.take() {
             self.network = Some(network);
             cleanup.release_network(&mut self.network).await;
@@ -383,6 +389,7 @@ impl SandboxCreateTransaction {
             network: self.network.take(),
             sock_dir,
             workspace,
+            delete_workspace: self.delete_workspace_on_leak_cleanup,
         };
 
         match leak_tx.send(leaked) {
@@ -424,7 +431,15 @@ impl Drop for SandboxCreateTransaction {
             let _ = std::fs::remove_dir_all(sock_dir);
         }
         if let Some(workspace) = self.workspace.take() {
-            let _ = std::fs::remove_dir_all(workspace);
+            if self.delete_workspace_on_leak_cleanup {
+                let _ = std::fs::remove_dir_all(workspace);
+            } else {
+                warn!(
+                    id = %self.id,
+                    path = %workspace.display(),
+                    "preserving workspace after failed COW cleanup"
+                );
+            }
         }
         if self.cow_device.is_some() {
             warn!(
@@ -557,7 +572,10 @@ async fn cleanup_leaked_resource(
     if let Err(e) = tokio::fs::remove_dir_all(&leaked.sock_dir).await {
         warn!(id = %leaked.sandbox_id, error = %e, "failed to delete leaked sock dir");
     }
-    if cow_destroyed && let Err(e) = tokio::fs::remove_dir_all(&leaked.workspace).await {
+    if cow_destroyed
+        && leaked.delete_workspace
+        && let Err(e) = tokio::fs::remove_dir_all(&leaked.workspace).await
+    {
         warn!(id = %leaked.sandbox_id, error = %e, "failed to delete leaked workspace");
     }
     info!(id = %leaked.sandbox_id, "leaked sandbox resources cleaned up");
@@ -1048,6 +1066,9 @@ async fn destroy_firecracker_sandbox(
         Some(cow_device) => destroy_cow_device_with_retries(&sandbox_id, cow_device).await,
         None => true,
     };
+    if !cow_destroyed {
+        sandbox.preserve_workspace_on_leak_cleanup();
+    }
 
     // Return the network namespace to the pool.
     let mut pool = netns_pool.lock().await;
@@ -1372,6 +1393,7 @@ mod tests {
             network: None,
             sock_dir: PathBuf::from("/nonexistent"),
             workspace: PathBuf::from("/nonexistent"),
+            delete_workspace: true,
         }
     }
 
@@ -1671,6 +1693,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_transaction_drop_sync_fallback_respects_workspace_preservation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        let sock_dir = tmp.path().join("sock");
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::create_dir_all(&sock_dir).await.unwrap();
+
+        let mut tx = SandboxCreateTransaction::new("sandbox".into());
+        tx.slot_renamed_to(workspace.clone());
+        tx.track_sock_dir(sock_dir.clone());
+        tx.delete_workspace_on_leak_cleanup = false;
+
+        drop(tx);
+
+        assert!(workspace.exists());
+        assert!(!sock_dir.exists());
+    }
+
+    #[tokio::test]
     async fn create_transaction_drop_does_not_drop_queued_leak_cleanup_work() {
         let tmp = tempfile::tempdir().unwrap();
         let workspace = tmp.path().join("workspace");
@@ -1769,6 +1810,7 @@ mod tests {
             network: Some(test_network()),
             sock_dir: PathBuf::from("/tmp/nonexistent-sock"),
             workspace: PathBuf::from("/tmp/nonexistent-ws"),
+            delete_workspace: true,
         })
         .unwrap();
 
@@ -1791,6 +1833,7 @@ mod tests {
             network: Some(test_network()),
             sock_dir: PathBuf::from("/nonexistent"),
             workspace: PathBuf::from("/nonexistent"),
+            delete_workspace: true,
         };
 
         // Should not panic — just returns Err with the original payload.
@@ -1798,6 +1841,32 @@ mod tests {
         let network = resources.network.take().unwrap();
         assert_eq!(network.name(), "test-ns");
         let _ = network.into_info_for_test();
+    }
+
+    #[tokio::test]
+    async fn cleanup_leaked_resource_respects_workspace_preservation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock_dir = tmp.path().join("sock");
+        let workspace = tmp.path().join("workspace");
+        tokio::fs::create_dir_all(&sock_dir).await.unwrap();
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        let netns_pool = tokio::sync::Mutex::new(NetnsPool::inactive_for_test());
+
+        cleanup_leaked_resource(
+            LeakedResources {
+                sandbox_id: "sandbox".into(),
+                cow_device: None,
+                network: None,
+                sock_dir: sock_dir.clone(),
+                workspace: workspace.clone(),
+                delete_workspace: false,
+            },
+            &netns_pool,
+        )
+        .await;
+
+        assert!(!sock_dir.exists());
+        assert!(workspace.exists());
     }
 
     #[test]

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -11,7 +11,7 @@ use tracing::{info, warn};
 use nbd_cow::{DestroyRetryPolicy, PooledNbdCowDevice};
 
 use crate::config::FirecrackerConfig;
-use crate::network::{GUEST_NETWORK, NetnsPool, NetnsPoolConfig, PooledNetns, generate_boot_args};
+use crate::network::{GUEST_NETWORK, NetnsLease, NetnsPool, NetnsPoolConfig, generate_boot_args};
 use crate::paths::{FactoryPaths, RuntimePaths, SandboxPaths, SockPaths};
 use crate::prerequisites;
 use crate::sandbox::FirecrackerSandbox;
@@ -41,7 +41,7 @@ const LEAK_CLEANUP_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::
 pub(crate) struct LeakedResources {
     pub(crate) sandbox_id: String,
     pub(crate) cow_device: Option<PooledNbdCowDevice>,
-    pub(crate) network: Option<PooledNetns>,
+    pub(crate) network: Option<NetnsLease>,
     pub(crate) sock_dir: PathBuf,
     pub(crate) workspace: PathBuf,
 }
@@ -125,7 +125,7 @@ impl Drop for LeakCleaner {
 #[async_trait]
 trait CreateRollbackCleanup {
     async fn destroy_cow_device(&self, cow_device: PooledNbdCowDevice) -> bool;
-    async fn release_network(&self, network: PooledNetns);
+    async fn release_network(&self, network: &mut Option<NetnsLease>);
     async fn remove_dir(&self, kind: &'static str, path: PathBuf);
     fn destroy_slot(&self, slot: crate::cow_pool::PrewarmedSlot);
 }
@@ -141,7 +141,7 @@ impl CreateRollbackCleanup for FactoryCreateRollbackCleanup {
         destroy_cow_device_with_retries(&self.id, cow_device).await
     }
 
-    async fn release_network(&self, network: PooledNetns) {
+    async fn release_network(&self, network: &mut Option<NetnsLease>) {
         let mut netns_pool = self.netns_pool.lock().await;
         if let Err(e) = netns_pool.release(network).await {
             warn!(id = %self.id, error = %e, "failed to release netns during rollback");
@@ -172,7 +172,7 @@ impl CreateRollbackCleanup for FactoryCreateRollbackCleanup {
 struct SandboxCreateResources {
     sandbox_paths: SandboxPaths,
     sock_paths: SockPaths,
-    network: PooledNetns,
+    network: NetnsLease,
     cow_device: PooledNbdCowDevice,
 }
 
@@ -180,7 +180,7 @@ struct SandboxCreateResources {
 struct SandboxCreateResourcesWithoutCow {
     sandbox_paths: SandboxPaths,
     sock_paths: SockPaths,
-    network: PooledNetns,
+    network: NetnsLease,
 }
 
 struct SandboxCreateTransaction {
@@ -188,7 +188,7 @@ struct SandboxCreateTransaction {
     slot: Option<crate::cow_pool::PrewarmedSlot>,
     workspace: Option<PathBuf>,
     sock_dir: Option<PathBuf>,
-    network: Option<PooledNetns>,
+    network: Option<NetnsLease>,
     cow_device: Option<PooledNbdCowDevice>,
     leak_tx: Option<tokio::sync::mpsc::UnboundedSender<LeakedResources>>,
 }
@@ -234,7 +234,7 @@ impl SandboxCreateTransaction {
         self.sock_dir = Some(sock_dir);
     }
 
-    fn track_network(&mut self, network: PooledNetns) {
+    fn track_network(&mut self, network: NetnsLease) {
         self.network = Some(network);
     }
 
@@ -299,7 +299,7 @@ impl SandboxCreateTransaction {
 
     fn take_base_resources_after_validation(
         &mut self,
-    ) -> sandbox::Result<(PathBuf, PathBuf, PooledNetns)> {
+    ) -> sandbox::Result<(PathBuf, PathBuf, NetnsLease)> {
         let workspace = self.workspace.take().ok_or_else(|| {
             create_transaction_invalid_state("missing workspace after validation")
         })?;
@@ -324,7 +324,15 @@ impl SandboxCreateTransaction {
             false
         };
         if let Some(network) = self.network.take() {
-            cleanup.release_network(network).await;
+            self.network = Some(network);
+            cleanup.release_network(&mut self.network).await;
+        }
+        if self.network.is_some() {
+            warn!(
+                id = %self.id,
+                "keeping create rollback directories so Drop can hand unreleased netns to leak cleaner"
+            );
+            return;
         }
         if let Some(sock_dir) = self.sock_dir.take() {
             cleanup.remove_dir("sock", sock_dir).await;
@@ -540,8 +548,9 @@ async fn cleanup_leaked_resource(
     }
 
     if let Some(network) = leaked.network {
+        let mut network = Some(network);
         let mut pool = netns_pool.lock().await;
-        if let Err(e) = pool.release(network).await {
+        if let Err(e) = pool.release(&mut network).await {
             warn!(id = %leaked.sandbox_id, error = %e, "failed to release leaked netns");
         }
     }
@@ -1022,7 +1031,6 @@ async fn destroy_firecracker_sandbox(
 
     // Clone lightweight handles before dropping sandbox.
     let sandbox_id = sandbox.id.clone();
-    let network = sandbox.network.clone();
     let sock_dir = sandbox.sock_paths.dir().to_owned();
     let workspace = sandbox.sandbox_paths.workspace().to_owned();
 
@@ -1043,7 +1051,7 @@ async fn destroy_firecracker_sandbox(
 
     // Return the network namespace to the pool.
     let mut pool = netns_pool.lock().await;
-    if let Err(e) = pool.release(network).await {
+    if let Err(e) = pool.release(sandbox.network.lease_mut()).await {
         warn!(id = %sandbox_id, error = %e, "failed to release netns");
     }
     drop(pool);
@@ -1063,7 +1071,9 @@ async fn destroy_firecracker_sandbox(
     // Mark as destroyed only after all explicit cleanup steps complete.
     // Until this point, `FirecrackerSandbox::Drop` remains armed as a
     // panic fallback and sends pool resources to the leak-cleanup task.
-    sandbox.destroyed = true;
+    if !sandbox.network.has_lease() {
+        sandbox.destroyed = true;
+    }
     drop(sandbox);
 
     info!(id = %sandbox_id, "sandbox destroyed");
@@ -1170,12 +1180,8 @@ mod tests {
         assert_eq!(trait_hash, direct_hash);
     }
 
-    fn test_network() -> PooledNetns {
-        PooledNetns {
-            name: "test-ns".into(),
-            host_device: "test-ve".into(),
-            peer_ip: "10.200.0.2".into(),
-        }
+    fn test_network() -> NetnsLease {
+        NetnsLease::new_for_test("test-ns")
     }
 
     #[derive(Default)]
@@ -1184,6 +1190,21 @@ mod tests {
     }
 
     impl RecordingCreateRollbackCleanup {
+        fn events(&self) -> Vec<String> {
+            self.events.lock().unwrap().clone()
+        }
+
+        fn record(&self, event: String) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
+    #[derive(Default)]
+    struct FailingNetworkReleaseCleanup {
+        events: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl FailingNetworkReleaseCleanup {
         fn events(&self) -> Vec<String> {
             self.events.lock().unwrap().clone()
         }
@@ -1255,8 +1276,10 @@ mod tests {
             panic!("test cleanup should not receive a real COW device");
         }
 
-        async fn release_network(&self, network: PooledNetns) {
-            self.record(format!("release_network:{}", network.name));
+        async fn release_network(&self, network: &mut Option<NetnsLease>) {
+            let network = network.take().expect("test network lease");
+            self.record(format!("release_network:{}", network.name()));
+            let _ = network.into_info_for_test();
         }
 
         async fn remove_dir(&self, kind: &'static str, path: PathBuf) {
@@ -1282,13 +1305,42 @@ mod tests {
     }
 
     #[async_trait]
+    impl CreateRollbackCleanup for FailingNetworkReleaseCleanup {
+        async fn destroy_cow_device(&self, _cow_device: PooledNbdCowDevice) -> bool {
+            panic!("test cleanup should not receive a real COW device");
+        }
+
+        async fn release_network(&self, network: &mut Option<NetnsLease>) {
+            self.record(format!(
+                "release_network:{}",
+                network.as_ref().expect("test network lease").name()
+            ));
+        }
+
+        async fn remove_dir(&self, kind: &'static str, path: PathBuf) {
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("<unknown>");
+            self.record(format!("remove_dir:{kind}:{name}"));
+        }
+
+        fn destroy_slot(&self, slot: crate::cow_pool::PrewarmedSlot) {
+            self.record(format!("destroy_slot:{}", slot.id));
+            crate::cow_pool::destroy_slot(slot);
+        }
+    }
+
+    #[async_trait]
     impl CreateRollbackCleanup for RecordingCreateRollbackCleanup {
         async fn destroy_cow_device(&self, _cow_device: PooledNbdCowDevice) -> bool {
             panic!("test cleanup should not receive a real COW device");
         }
 
-        async fn release_network(&self, network: PooledNetns) {
-            self.record(format!("release_network:{}", network.name));
+        async fn release_network(&self, network: &mut Option<NetnsLease>) {
+            let network = network.take().expect("test network lease");
+            self.record(format!("release_network:{}", network.name()));
+            let _ = network.into_info_for_test();
         }
 
         async fn remove_dir(&self, kind: &'static str, path: PathBuf) {
@@ -1503,6 +1555,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_transaction_rollback_keeps_dirs_when_network_release_fails() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        let sock_dir = tmp.path().join("sock");
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::create_dir_all(&sock_dir).await.unwrap();
+
+        let (leak_tx, mut leak_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut tx = SandboxCreateTransaction::new_with_leak_tx("sandbox".into(), Some(leak_tx));
+        tx.slot_renamed_to(workspace.clone());
+        tx.track_sock_dir(sock_dir.clone());
+        tx.track_network(test_network());
+        let cleanup = FailingNetworkReleaseCleanup::default();
+
+        tx.rollback(&cleanup).await;
+
+        assert!(workspace.exists());
+        assert!(sock_dir.exists());
+        assert_eq!(cleanup.events(), vec!["release_network:test-ns"]);
+
+        drop(tx);
+        let mut leaked = leak_rx.recv().await.unwrap();
+        let network = leaked.network.take().unwrap();
+        assert_eq!(network.name(), "test-ns");
+        let _ = network.into_info_for_test();
+        assert_eq!(leaked.sock_dir, sock_dir);
+        assert_eq!(leaked.workspace, workspace);
+    }
+
+    #[tokio::test]
     async fn create_transaction_commit_disarms_rollback() {
         let tmp = tempfile::tempdir().unwrap();
         let workspace = tmp.path().join("workspace");
@@ -1520,7 +1602,7 @@ mod tests {
 
         assert_eq!(resources.sandbox_paths.workspace(), workspace.as_path());
         assert_eq!(resources.sock_paths.dir(), sock_dir.as_path());
-        assert_eq!(resources.network.name, "test-ns");
+        assert_eq!(resources.network.name(), "test-ns");
         assert!(workspace.exists());
         assert!(sock_dir.exists());
     }
@@ -1599,9 +1681,11 @@ mod tests {
         drop(tx);
 
         assert_eq!(leak_rx.recv().await.unwrap().sandbox_id, "queued");
-        let leaked = leak_rx.recv().await.unwrap();
+        let mut leaked = leak_rx.recv().await.unwrap();
         assert_eq!(leaked.sandbox_id, "sandbox");
-        assert_eq!(leaked.network.unwrap().name, "test-ns");
+        let network = leaked.network.take().unwrap();
+        assert_eq!(network.name(), "test-ns");
+        let _ = network.into_info_for_test();
         assert_eq!(leaked.sock_dir, sock_dir);
         assert_eq!(leaked.workspace, workspace);
     }
@@ -1622,10 +1706,12 @@ mod tests {
 
         drop(tx);
 
-        let leaked = leak_rx.recv().await.unwrap();
+        let mut leaked = leak_rx.recv().await.unwrap();
         assert_eq!(leaked.sandbox_id, "sandbox");
         assert!(leaked.cow_device.is_none());
-        assert_eq!(leaked.network.unwrap().name, "test-ns");
+        let network = leaked.network.take().unwrap();
+        assert_eq!(network.name(), "test-ns");
+        let _ = network.into_info_for_test();
         assert_eq!(leaked.sock_dir, sock_dir);
         assert_eq!(leaked.workspace, workspace);
     }

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -17,7 +17,7 @@ pub use api::{ApiClient, ApiError, BalloonStatistics};
 pub use config::{FirecrackerConfig, SnapshotConfig};
 pub use control::FirecrackerControl;
 pub use factory::{FirecrackerFactory, PREWARM_SCRIPT, config_hash};
-pub use network::{NetnsPool, NetnsPoolConfig};
+pub use network::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig};
 pub use paths::{
     FactoryPaths, LockPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths,
 };

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -17,7 +17,8 @@ pub use api::{ApiClient, ApiError, BalloonStatistics};
 pub use config::{FirecrackerConfig, SnapshotConfig};
 pub use control::FirecrackerControl;
 pub use factory::{FirecrackerFactory, PREWARM_SCRIPT, config_hash};
-pub use network::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig};
+#[allow(deprecated)]
+pub use network::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, PooledNetns};
 pub use paths::{
     FactoryPaths, LockPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths,
 };

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -17,8 +17,7 @@ pub use api::{ApiClient, ApiError, BalloonStatistics};
 pub use config::{FirecrackerConfig, SnapshotConfig};
 pub use control::FirecrackerControl;
 pub use factory::{FirecrackerFactory, PREWARM_SCRIPT, config_hash};
-#[allow(deprecated)]
-pub use network::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, PooledNetns};
+pub use network::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig};
 pub use paths::{
     FactoryPaths, LockPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths,
 };

--- a/crates/sandbox-fc/src/network/error.rs
+++ b/crates/sandbox-fc/src/network/error.rs
@@ -21,4 +21,7 @@ pub enum NetworkError {
 
     #[error("prerequisite check failed: {0}")]
     Prerequisite(String),
+
+    #[error("invalid namespace lease: {0}")]
+    InvalidLease(String),
 }

--- a/crates/sandbox-fc/src/network/error.rs
+++ b/crates/sandbox-fc/src/network/error.rs
@@ -13,6 +13,9 @@ pub enum NetworkError {
     #[error("namespace limit reached: max {max} namespaces allowed")]
     NamespaceLimitReached { max: u32 },
 
+    #[error("pool is not active")]
+    PoolNotActive,
+
     #[error("failed to detect default network interface from: {0}")]
     NoDefaultInterface(String),
 

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -4,4 +4,5 @@ mod pool;
 
 pub use guest::generate_boot_args;
 pub use guest::{GUEST_NETWORK, GuestNetwork};
-pub use pool::{NetnsPool, NetnsPoolConfig, PooledNetns};
+pub(crate) use pool::{NetnsInfo, NetnsLease};
+pub use pool::{NetnsPool, NetnsPoolConfig};

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -4,5 +4,4 @@ mod pool;
 
 pub use guest::generate_boot_args;
 pub use guest::{GUEST_NETWORK, GuestNetwork};
-pub(crate) use pool::{NetnsInfo, NetnsLease};
-pub use pool::{NetnsPool, NetnsPoolConfig};
+pub use pool::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig};

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -4,4 +4,5 @@ mod pool;
 
 pub use guest::generate_boot_args;
 pub use guest::{GUEST_NETWORK, GuestNetwork};
-pub use pool::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig};
+#[allow(deprecated)]
+pub use pool::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, PooledNetns};

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -4,5 +4,4 @@ mod pool;
 
 pub use guest::generate_boot_args;
 pub use guest::{GUEST_NETWORK, GuestNetwork};
-#[allow(deprecated)]
-pub use pool::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, PooledNetns};
+pub use pool::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig};

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -128,6 +128,9 @@ impl NetnsInfo {
 }
 
 /// Non-cloneable release authority for a checked-out namespace.
+///
+/// Dropping a live lease only emits a warning. Call [`NetnsPool::release`] so
+/// the namespace is either recycled into the pool or deleted during shutdown.
 #[derive(Debug)]
 #[must_use]
 pub struct NetnsLease {
@@ -973,16 +976,18 @@ impl NetnsPool {
                 remaining = self.plain_queue.len(),
                 "acquired namespace"
             );
+            let lease = self.checkout_or_requeue(pooled, false)?;
             self.maybe_replenish_plain();
-            return self.checkout_or_requeue(pooled, false);
+            return Ok(lease);
         }
         // Tier 2: await in-flight background task.
         while let Some(result) = self.pending_plain.join_next().await {
             match result {
                 Ok(Ok(ns)) => {
                     info!(name = %ns.name, "acquired namespace from pending");
+                    let lease = self.checkout_or_requeue(ns, false)?;
                     self.maybe_replenish_plain();
-                    return self.checkout_or_requeue(ns, false);
+                    return Ok(lease);
                 }
                 Ok(Err(e)) => error!(error = %e, "pending namespace creation failed"),
                 Err(e) => error!(error = %e, "pending namespace task panicked"),
@@ -991,8 +996,9 @@ impl NetnsPool {
         // Tier 3: on-demand.
         info!("pool exhausted, creating namespace on-demand");
         let ns = self.create_on_demand(None, None).await?;
+        let lease = self.checkout_or_requeue(ns, false)?;
         self.maybe_replenish_plain();
-        self.checkout_or_requeue(ns, false)
+        Ok(lease)
     }
 
     /// Acquire from the proxy queue.
@@ -1007,16 +1013,18 @@ impl NetnsPool {
                 remaining = self.proxy_queue.len(),
                 "acquired namespace (proxy)"
             );
+            let lease = self.checkout_or_requeue(pooled, true)?;
             self.maybe_replenish_proxy();
-            return self.checkout_or_requeue(pooled, true);
+            return Ok(lease);
         }
         // Tier 2: await in-flight background task.
         while let Some(result) = self.pending_proxy.join_next().await {
             match result {
                 Ok(Ok(ns)) => {
                     info!(name = %ns.name, "acquired namespace (proxy) from pending");
+                    let lease = self.checkout_or_requeue(ns, true)?;
                     self.maybe_replenish_proxy();
-                    return self.checkout_or_requeue(ns, true);
+                    return Ok(lease);
                 }
                 Ok(Err(e)) => error!(error = %e, "pending proxy namespace creation failed"),
                 Err(e) => error!(error = %e, "pending proxy namespace task panicked"),
@@ -1027,8 +1035,9 @@ impl NetnsPool {
         let ns = self
             .create_on_demand(self.proxy_port, self.dns_port)
             .await?;
+        let lease = self.checkout_or_requeue(ns, true)?;
         self.maybe_replenish_proxy();
-        self.checkout_or_requeue(ns, true)
+        Ok(lease)
     }
 
     /// Create a new namespace on-demand, allocating the next index.
@@ -1760,6 +1769,8 @@ mod tests {
         assert!(matches!(err, NetworkError::InvalidLease(_)));
         assert_eq!(pool.plain_queue.len(), 1);
         assert_eq!(pool.plain_queue.front().unwrap().name(), "test-ns");
+        assert!(pool.pending_plain.is_empty());
+        assert_eq!(pool.next_ns_index, 0);
 
         pool.in_flight.clear();
         pool.cleanup().await.unwrap();
@@ -1770,7 +1781,6 @@ mod tests {
         let mut pool = NetnsPool::inactive_for_test();
         pool.active = true;
         pool.proxy_port = Some(8080);
-        pool.next_ns_index = MAX_NAMESPACES;
         pool.in_flight.insert("test-ns".into());
         pool.proxy_queue.push_back(test_info("test-ns"));
 
@@ -1780,6 +1790,8 @@ mod tests {
         assert!(pool.plain_queue.is_empty());
         assert_eq!(pool.proxy_queue.len(), 1);
         assert_eq!(pool.proxy_queue.front().unwrap().name(), "test-ns");
+        assert!(pool.pending_proxy.is_empty());
+        assert_eq!(pool.next_ns_index, 0);
 
         pool.in_flight.clear();
         pool.proxy_queue.clear();

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -30,8 +30,10 @@
 //! Design:
 //! - Pool lazily pre-warms a small number of namespaces at init, then
 //!   replenishes in the background on each [`NetnsPool::acquire`]
-//! - [`NetnsPool::acquire`] returns a namespace from pool, or creates on-demand as fallback
-//! - [`NetnsPool::release`] returns the namespace to the pool
+//! - [`NetnsPool::acquire`] returns a non-cloneable [`NetnsLease`] from the
+//!   pool, or creates one on-demand as fallback
+//! - [`NetnsPool::release`] takes `&mut Option<NetnsLease>` so cancellation
+//!   before the final commit point leaves cleanup ownership with the caller
 //! - Pool index (0–63) is auto-allocated via flock on `/var/lock`
 //! - Orphans from abnormally-exited prior runners (SIGKILL, panic, OOM,
 //!   power loss, aborted in-flight creation tasks) are reconciled at
@@ -195,14 +197,26 @@ impl Drop for NetnsLease {
     }
 }
 
+/// Backward-compatible name for a checked-out namespace lease.
+///
+/// The old `PooledNetns` metadata struct was cloneable, which made namespace
+/// release authority ambiguous. New code should keep the lease in an
+/// `Option<NetnsLease>` and pass it to [`NetnsPool::release`].
+#[deprecated(
+    since = "0.28.0",
+    note = "use NetnsLease and release it with NetnsPool::release(&mut Option<NetnsLease>)"
+)]
+pub type PooledNetns = NetnsLease;
+
 /// Configuration for creating a [`NetnsPool`].
 ///
-/// When `proxy_port` is set, the pool maintains **two** queues
-/// (plain + proxy), each buffering `BUFFER_SIZE` namespaces.
+/// When `proxy_port` is set, the pool pre-warms and acquires from the proxy
+/// queue only. Without `proxy_port`, it pre-warms and acquires from the plain
+/// queue. This avoids keeping an unreachable plain queue alive in proxy mode.
 pub struct NetnsPoolConfig {
     /// Proxy port for HTTP/HTTPS redirect (only adds redirect rules when set).
     pub proxy_port: Option<u16>,
-    /// DNS proxy port for DNS query redirect (only adds redirect rules when set).
+    /// DNS proxy port for DNS query redirect. Only meaningful with `proxy_port`.
     pub dns_port: Option<u16>,
 }
 

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -1273,8 +1273,8 @@ impl NetnsPool {
         }
     }
 
-    /// Delete all namespaces currently in the pool queue and cancel
-    /// in-flight background creation tasks.
+    /// Delete all namespaces currently in the pool queue and wait for
+    /// in-flight background creation tasks so their resources can be deleted.
     ///
     /// Namespaces that have been acquired but not yet released are **not**
     /// cleaned up here — they will be caught by orphan cleanup on the next
@@ -1340,10 +1340,14 @@ impl NetnsPool {
 
 impl Drop for NetnsPool {
     fn drop(&mut self) {
-        if self.active {
+        let queued = self.plain_queue.len() + self.proxy_queue.len();
+        let pending = self.pending_plain.len() + self.pending_proxy.len();
+        if self.active || queued != 0 || pending != 0 || !self.in_flight.is_empty() {
             warn!(
-                queued = self.plain_queue.len() + self.proxy_queue.len(),
-                pending = self.pending_plain.len() + self.pending_proxy.len(),
+                active = self.active,
+                queued,
+                pending,
+                in_flight = self.in_flight.len(),
                 "NetnsPool dropped without calling cleanup()"
             );
         }

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -1832,6 +1832,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cleanup_retries_when_pool_is_inactive_but_not_drained() {
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.plain_queue.push_back(test_info("test-ns"));
+
+        pool.cleanup().await.unwrap();
+
+        assert!(!pool.active);
+        assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
     async fn acquire_requeues_namespace_when_checkout_detects_in_flight_duplicate() {
         let mut pool = NetnsPool::inactive_for_test();
         pool.active = true;

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -1280,7 +1280,12 @@ impl NetnsPool {
     /// cleaned up here — they will be caught by orphan cleanup on the next
     /// [`NetnsPool::create`] call with the same index.
     pub async fn cleanup(&mut self) -> Result<()> {
-        if !self.active {
+        if !self.active
+            && self.plain_queue.is_empty()
+            && self.proxy_queue.is_empty()
+            && self.pending_plain.is_empty()
+            && self.pending_proxy.is_empty()
+        {
             return Ok(());
         }
         self.active = false;
@@ -1291,11 +1296,8 @@ impl NetnsPool {
             );
         }
 
-        // Cancel in-flight background creation tasks.
-        self.pending_plain.abort_all();
-        self.pending_proxy.abort_all();
-
-        // Drain any tasks that completed before abort into queues for cleanup.
+        // Let in-flight creation finish instead of aborting it. Aborting can
+        // leave partially-created kernel resources with no NetnsInfo to retry.
         while let Some(result) = self.pending_plain.join_next().await {
             if let Ok(Ok(ns)) = result {
                 self.plain_queue.push_back(ns);
@@ -1310,27 +1312,29 @@ impl NetnsPool {
         let count = self.plain_queue.len() + self.proxy_queue.len();
         info!(count, "cleaning up namespace pool");
 
-        let to_delete: Vec<NetnsInfo> = self
-            .plain_queue
-            .drain(..)
-            .chain(self.proxy_queue.drain(..))
-            .collect();
-
-        // Delete namespaces in parallel
-        let mut set = tokio::task::JoinSet::new();
-        for ns in to_delete {
-            set.spawn(async move {
-                delete_namespace_resources(&ns.name, &ns.host_device).await;
-            });
-        }
-        while let Some(result) = set.join_next().await {
-            if let Err(e) = result {
-                error!(error = %e, "namespace deletion task panicked");
-            }
-        }
+        Self::delete_queued_namespaces(&mut self.plain_queue).await;
+        Self::delete_queued_namespaces(&mut self.proxy_queue).await;
 
         info!("namespace pool cleanup complete");
         Ok(())
+    }
+
+    async fn delete_queued_namespaces(queue: &mut VecDeque<NetnsInfo>) {
+        Self::delete_queued_namespaces_with(queue, |ns| async move {
+            delete_namespace_resources(&ns.name, &ns.host_device).await;
+        })
+        .await;
+    }
+
+    async fn delete_queued_namespaces_with<F, Fut>(queue: &mut VecDeque<NetnsInfo>, mut delete: F)
+    where
+        F: FnMut(NetnsInfo) -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        while let Some(ns) = queue.front().cloned() {
+            delete(ns).await;
+            queue.pop_front();
+        }
     }
 }
 
@@ -1755,6 +1759,76 @@ mod tests {
         assert_eq!(pool.plain_queue.front().unwrap().name(), "test-ns");
 
         pool.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cleanup_retry_drains_pending_creation_after_cancel() {
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let entered = std::sync::Arc::new(tokio::sync::Notify::new());
+        let release = std::sync::Arc::new(tokio::sync::Notify::new());
+        let entered_task = std::sync::Arc::clone(&entered);
+        let release_task = std::sync::Arc::clone(&release);
+        pool.pending_plain.spawn(async move {
+            entered_task.notify_one();
+            release_task.notified().await;
+            Ok(test_info("test-ns"))
+        });
+
+        {
+            let cleanup = pool.cleanup();
+            tokio::pin!(cleanup);
+            tokio::select! {
+                result = &mut cleanup => panic!("cleanup completed before pending task was released: {result:?}"),
+                _ = entered.notified() => {}
+            }
+        }
+
+        assert!(!pool.active);
+        assert_eq!(pool.pending_plain.len(), 1);
+
+        release.notify_one();
+        pool.cleanup().await.unwrap();
+
+        assert!(!pool.active);
+        assert!(pool.pending_plain.is_empty());
+        assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_queued_namespaces_keeps_front_entry_when_cancelled() {
+        let mut queue = VecDeque::from([test_info("test-ns")]);
+        let entered = std::sync::Arc::new(tokio::sync::Notify::new());
+        let release = std::sync::Arc::new(tokio::sync::Notify::new());
+
+        let delete = {
+            let entered = std::sync::Arc::clone(&entered);
+            let release = std::sync::Arc::clone(&release);
+            move |ns: NetnsInfo| {
+                assert_eq!(ns.name(), "test-ns");
+                let entered = std::sync::Arc::clone(&entered);
+                let release = std::sync::Arc::clone(&release);
+                async move {
+                    entered.notify_one();
+                    release.notified().await;
+                }
+            }
+        };
+        {
+            let deletion = NetnsPool::delete_queued_namespaces_with(&mut queue, delete);
+            tokio::pin!(deletion);
+            tokio::select! {
+                _ = &mut deletion => panic!("delete completed before test released it"),
+                _ = entered.notified() => {}
+            }
+        }
+
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue.front().unwrap().name(), "test-ns");
+
+        release.notify_one();
+        NetnsPool::delete_queued_namespaces_with(&mut queue, |_| async {}).await;
+        assert!(queue.is_empty());
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -38,8 +38,9 @@
 //!   startup via flock-based liveness probe — see
 //!   [`reconcile_orphan_namespaces`]
 
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::fs::File;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use nix::fcntl::{Flock, FlockArg};
 use sandbox::SandboxError;
@@ -81,17 +82,114 @@ const _: () = assert!(MAX_POOLS * MAX_NAMESPACES * 4 <= 65536);
 // Public types
 // ---------------------------------------------------------------------------
 
-/// A pooled network namespace resource.
+/// Monotonic in-process identity for [`NetnsPool`] instances.
+static NEXT_NETNS_POOL_INSTANCE_ID: AtomicU64 = AtomicU64::new(1);
+
+fn next_pool_instance_id() -> u64 {
+    NEXT_NETNS_POOL_INSTANCE_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Cloneable metadata for a network namespace.
+///
+/// Cloning this does not grant release authority. Checked-out ownership is held
+/// by [`NetnsLease`].
 #[derive(Debug, Clone)]
 #[must_use]
-pub struct PooledNetns {
+pub struct NetnsInfo {
     /// Namespace name (e.g. `vm0-ns-00-00`).
-    pub name: String,
+    name: String,
     /// Host-side veth device name (e.g. `vm0-ve-00-00`).
-    pub host_device: String,
+    host_device: String,
     /// Veth namespace-side IP (e.g. `10.200.0.2`). This is the source IP
     /// that the proxy sees after NAT, used as the VM registry key.
-    pub peer_ip: String,
+    peer_ip: String,
+}
+
+impl NetnsInfo {
+    fn new(name: String, host_device: String, peer_ip: String) -> Self {
+        Self {
+            name,
+            host_device,
+            peer_ip,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn host_device(&self) -> &str {
+        &self.host_device
+    }
+
+    pub fn peer_ip(&self) -> &str {
+        &self.peer_ip
+    }
+}
+
+/// Non-cloneable release authority for a checked-out namespace.
+#[derive(Debug)]
+#[must_use]
+pub struct NetnsLease {
+    info: NetnsInfo,
+    pool_instance_id: u64,
+    active: bool,
+}
+
+impl NetnsLease {
+    fn new(info: NetnsInfo, pool_instance_id: u64) -> Self {
+        Self {
+            info,
+            pool_instance_id,
+            active: true,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test(name: &str) -> Self {
+        Self::new(
+            NetnsInfo::new(name.into(), "test-ve".into(), "10.200.0.2".into()),
+            0,
+        )
+    }
+
+    pub fn info(&self) -> &NetnsInfo {
+        &self.info
+    }
+
+    pub fn name(&self) -> &str {
+        self.info.name()
+    }
+
+    pub fn peer_ip(&self) -> &str {
+        self.info.peer_ip()
+    }
+
+    fn pool_instance_id(&self) -> u64 {
+        self.pool_instance_id
+    }
+
+    fn into_info(mut self) -> NetnsInfo {
+        self.active = false;
+        self.info.clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn into_info_for_test(self) -> NetnsInfo {
+        self.into_info()
+    }
+}
+
+impl Drop for NetnsLease {
+    fn drop(&mut self) {
+        if self.active {
+            warn!(
+                name = %self.info.name,
+                pool_instance_id = self.pool_instance_id,
+                "netns lease dropped without explicit release"
+            );
+        }
+    }
 }
 
 /// Configuration for creating a [`NetnsPool`].
@@ -669,12 +767,15 @@ fn acquire_pool_lock(locks: &LockPaths) -> Result<(u32, Flock<File>)> {
 /// [`release`](Self::release) are recycled back into the queue.
 pub struct NetnsPool {
     active: bool,
-    plain_queue: VecDeque<PooledNetns>,
-    proxy_queue: VecDeque<PooledNetns>,
+    plain_queue: VecDeque<NetnsInfo>,
+    proxy_queue: VecDeque<NetnsInfo>,
     /// In-flight background namespace creation tasks (plain).
-    pending_plain: tokio::task::JoinSet<Result<PooledNetns>>,
+    pending_plain: tokio::task::JoinSet<Result<NetnsInfo>>,
     /// In-flight background namespace creation tasks (proxy).
-    pending_proxy: tokio::task::JoinSet<Result<PooledNetns>>,
+    pending_proxy: tokio::task::JoinSet<Result<NetnsInfo>>,
+    /// Namespaces checked out from this pool instance.
+    in_flight: HashSet<String>,
+    instance_id: u64,
     next_ns_index: u32,
     pool_index: u32,
     proxy_port: Option<u16>,
@@ -699,6 +800,8 @@ impl NetnsPool {
             proxy_queue: VecDeque::new(),
             pending_plain: tokio::task::JoinSet::new(),
             pending_proxy: tokio::task::JoinSet::new(),
+            in_flight: HashSet::new(),
+            instance_id: next_pool_instance_id(),
             next_ns_index: 0,
             pool_index: 0,
             proxy_port: None,
@@ -753,6 +856,8 @@ impl NetnsPool {
             }),
             pending_plain: tokio::task::JoinSet::new(),
             pending_proxy: tokio::task::JoinSet::new(),
+            in_flight: HashSet::new(),
+            instance_id: next_pool_instance_id(),
             next_ns_index: 0,
             pool_index: index,
             proxy_port: config.proxy_port,
@@ -845,7 +950,7 @@ impl NetnsPool {
     /// When `proxy_port` is configured, acquires from the proxy queue
     /// (namespaces with iptables REDIRECT rules). Otherwise acquires from
     /// the plain queue.
-    pub async fn acquire(&mut self) -> Result<PooledNetns> {
+    pub async fn acquire(&mut self) -> Result<NetnsLease> {
         // Move completed background tasks into queues before checking.
         self.drain_completed();
 
@@ -860,7 +965,7 @@ impl NetnsPool {
     ///
     /// Tries three tiers: queue → pending → on-demand.
     /// Spawns a background replenishment task after success.
-    async fn acquire_plain(&mut self) -> Result<PooledNetns> {
+    async fn acquire_plain(&mut self) -> Result<NetnsLease> {
         // Tier 1: pre-warmed queue.
         if let Some(pooled) = self.plain_queue.pop_front() {
             info!(
@@ -869,7 +974,7 @@ impl NetnsPool {
                 "acquired namespace"
             );
             self.maybe_replenish_plain();
-            return Ok(pooled);
+            return self.checkout(pooled);
         }
         // Tier 2: await in-flight background task.
         while let Some(result) = self.pending_plain.join_next().await {
@@ -877,7 +982,7 @@ impl NetnsPool {
                 Ok(Ok(ns)) => {
                     info!(name = %ns.name, "acquired namespace from pending");
                     self.maybe_replenish_plain();
-                    return Ok(ns);
+                    return self.checkout(ns);
                 }
                 Ok(Err(e)) => error!(error = %e, "pending namespace creation failed"),
                 Err(e) => error!(error = %e, "pending namespace task panicked"),
@@ -887,14 +992,14 @@ impl NetnsPool {
         info!("pool exhausted, creating namespace on-demand");
         let ns = self.create_on_demand(None, None).await?;
         self.maybe_replenish_plain();
-        Ok(ns)
+        self.checkout(ns)
     }
 
     /// Acquire from the proxy queue.
     ///
     /// Tries three tiers: queue → pending → on-demand.
     /// Spawns a background replenishment task after success.
-    async fn acquire_proxy(&mut self) -> Result<PooledNetns> {
+    async fn acquire_proxy(&mut self) -> Result<NetnsLease> {
         // Tier 1: pre-warmed queue.
         if let Some(pooled) = self.proxy_queue.pop_front() {
             info!(
@@ -903,7 +1008,7 @@ impl NetnsPool {
                 "acquired namespace (proxy)"
             );
             self.maybe_replenish_proxy();
-            return Ok(pooled);
+            return self.checkout(pooled);
         }
         // Tier 2: await in-flight background task.
         while let Some(result) = self.pending_proxy.join_next().await {
@@ -911,7 +1016,7 @@ impl NetnsPool {
                 Ok(Ok(ns)) => {
                     info!(name = %ns.name, "acquired namespace (proxy) from pending");
                     self.maybe_replenish_proxy();
-                    return Ok(ns);
+                    return self.checkout(ns);
                 }
                 Ok(Err(e)) => error!(error = %e, "pending proxy namespace creation failed"),
                 Err(e) => error!(error = %e, "pending proxy namespace task panicked"),
@@ -923,7 +1028,7 @@ impl NetnsPool {
             .create_on_demand(self.proxy_port, self.dns_port)
             .await?;
         self.maybe_replenish_proxy();
-        Ok(ns)
+        self.checkout(ns)
     }
 
     /// Create a new namespace on-demand, allocating the next index.
@@ -931,7 +1036,7 @@ impl NetnsPool {
         &mut self,
         proxy_port: Option<u16>,
         dns_port: Option<u16>,
-    ) -> Result<PooledNetns> {
+    ) -> Result<NetnsInfo> {
         let ns_index = self.next_ns_index;
         if ns_index >= MAX_NAMESPACES {
             return Err(NetworkError::NamespaceLimitReached {
@@ -947,6 +1052,16 @@ impl NetnsPool {
             dns_port,
         )
         .await
+    }
+
+    fn checkout(&mut self, info: NetnsInfo) -> Result<NetnsLease> {
+        if !self.in_flight.insert(info.name.clone()) {
+            return Err(NetworkError::InvalidLease(format!(
+                "namespace {} is already checked out",
+                info.name
+            )));
+        }
+        Ok(NetnsLease::new(info, self.instance_id))
     }
 
     /// Move completed background tasks into their respective queues.
@@ -1026,27 +1141,82 @@ impl NetnsPool {
     ///
     /// When `proxy_port` is configured, the namespace is returned to
     /// the proxy queue so its REDIRECT rules are reused.
-    pub async fn release(&mut self, ns: PooledNetns) -> Result<()> {
+    pub async fn release(&mut self, lease: &mut Option<NetnsLease>) -> Result<()> {
+        let Some(active_lease) = lease.as_ref() else {
+            return Err(NetworkError::InvalidLease("missing netns lease".into()));
+        };
+        if active_lease.pool_instance_id() != self.instance_id {
+            warn!(
+                name = %active_lease.name(),
+                lease_pool_instance_id = active_lease.pool_instance_id(),
+                pool_instance_id = self.instance_id,
+                "refusing to release netns lease from a different pool instance"
+            );
+            return Err(NetworkError::InvalidLease(format!(
+                "namespace {} belongs to pool instance {}, not {}",
+                active_lease.name(),
+                active_lease.pool_instance_id(),
+                self.instance_id
+            )));
+        }
+        if !self.in_flight.contains(active_lease.name()) {
+            warn!(
+                name = %active_lease.name(),
+                pool_instance_id = self.instance_id,
+                "refusing to release netns lease that is not in flight"
+            );
+            return Err(NetworkError::InvalidLease(format!(
+                "namespace {} is not checked out",
+                active_lease.name()
+            )));
+        }
+
         if !self.active {
-            delete_namespace_resources(&ns.name, &ns.host_device).await;
+            delete_namespace_resources(active_lease.name(), active_lease.info().host_device())
+                .await;
+            let Some(lease) = lease.take() else {
+                return Err(NetworkError::InvalidLease(
+                    "validated netns lease disappeared".into(),
+                ));
+            };
+            self.in_flight.remove(lease.name());
+            let _ = lease.into_info();
             return Ok(());
         }
 
         let has_proxy = self.proxy_port.is_some();
+        if self
+            .target_queue(has_proxy)
+            .iter()
+            .any(|r| r.name == active_lease.name())
+        {
+            warn!(
+                name = %active_lease.name(),
+                "refusing to release netns lease already queued in pool"
+            );
+            return Err(NetworkError::InvalidLease(format!(
+                "namespace {} is already queued",
+                active_lease.name()
+            )));
+        }
+
+        // Flush stale conntrack entries so the next VM using this namespace
+        // does not inherit connection tracking state from the previous VM.
+        flush_conntrack(active_lease.peer_ip()).await;
+
+        let Some(lease) = lease.take() else {
+            return Err(NetworkError::InvalidLease(
+                "validated netns lease disappeared".into(),
+            ));
+        };
+        self.in_flight.remove(lease.name());
+        let ns = lease.into_info();
+
         let target_queue = if has_proxy {
             &mut self.proxy_queue
         } else {
             &mut self.plain_queue
         };
-
-        if target_queue.iter().any(|r| r.name == ns.name) {
-            info!(name = %ns.name, "namespace already in pool, ignoring");
-            return Ok(());
-        }
-
-        // Flush stale conntrack entries so the next VM using this namespace
-        // does not inherit connection tracking state from the previous VM.
-        flush_conntrack(&ns.peer_ip).await;
 
         info!(
             name = %ns.name,
@@ -1056,6 +1226,14 @@ impl NetnsPool {
         );
         target_queue.push_back(ns);
         Ok(())
+    }
+
+    fn target_queue(&self, has_proxy: bool) -> &VecDeque<NetnsInfo> {
+        if has_proxy {
+            &self.proxy_queue
+        } else {
+            &self.plain_queue
+        }
     }
 
     /// Delete all namespaces currently in the pool queue and cancel
@@ -1069,6 +1247,12 @@ impl NetnsPool {
             return Ok(());
         }
         self.active = false;
+        if !self.in_flight.is_empty() {
+            warn!(
+                in_flight = self.in_flight.len(),
+                "namespace pool cleanup with outstanding leases"
+            );
+        }
 
         // Cancel in-flight background creation tasks.
         self.pending_plain.abort_all();
@@ -1089,7 +1273,7 @@ impl NetnsPool {
         let count = self.plain_queue.len() + self.proxy_queue.len();
         info!(count, "cleaning up namespace pool");
 
-        let to_delete: Vec<PooledNetns> = self
+        let to_delete: Vec<NetnsInfo> = self
             .plain_queue
             .drain(..)
             .chain(self.proxy_queue.drain(..))
@@ -1139,7 +1323,7 @@ async fn create_single_namespace(
     default_iface: String,
     proxy_port: Option<u16>,
     dns_port: Option<u16>,
-) -> Result<PooledNetns> {
+) -> Result<NetnsInfo> {
     if ns_index >= MAX_NAMESPACES {
         return Err(NetworkError::NamespaceLimitReached {
             max: MAX_NAMESPACES,
@@ -1192,11 +1376,7 @@ async fn create_single_namespace(
                 }
             }
             info!(name = %ns_name, "namespace created");
-            Ok(PooledNetns {
-                name: ns_name,
-                host_device,
-                peer_ip,
-            })
+            Ok(NetnsInfo::new(ns_name, host_device, peer_ip))
         }
         Err(e) => {
             error!(name = %ns_name, error = %e, "failed to create namespace, cleaning up");
@@ -1517,6 +1697,59 @@ mod tests {
     #[test]
     fn parse_ns_name_bare_prefix() {
         assert_eq!(parse_ns_name("vm0-ns-"), None);
+    }
+
+    fn test_info(name: &str) -> NetnsInfo {
+        NetnsInfo::new(name.into(), "test-ve".into(), "10.200.0.2".into())
+    }
+
+    #[tokio::test]
+    async fn release_disarms_lease_and_returns_info_to_queue() {
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let info = test_info("test-ns");
+        let mut lease = Some(pool.checkout(info).unwrap());
+
+        pool.release(&mut lease).await.unwrap();
+
+        assert!(lease.is_none());
+        assert!(pool.in_flight.is_empty());
+        assert_eq!(pool.plain_queue.len(), 1);
+        assert_eq!(pool.plain_queue.front().unwrap().name(), "test-ns");
+
+        pool.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn release_keeps_lease_on_wrong_pool_instance() {
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let info = test_info("test-ns");
+        let mut lease = Some(NetnsLease::new(info, pool.instance_id + 1));
+
+        let err = pool.release(&mut lease).await.unwrap_err();
+
+        assert!(matches!(err, NetworkError::InvalidLease(_)));
+        assert!(lease.is_some());
+        let _ = lease.take().unwrap().into_info_for_test();
+
+        pool.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn release_keeps_lease_when_not_in_flight() {
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let info = test_info("test-ns");
+        let mut lease = Some(NetnsLease::new(info, pool.instance_id));
+
+        let err = pool.release(&mut lease).await.unwrap_err();
+
+        assert!(matches!(err, NetworkError::InvalidLease(_)));
+        assert!(lease.is_some());
+        let _ = lease.take().unwrap().into_info_for_test();
+
+        pool.cleanup().await.unwrap();
     }
 
     #[test]

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -197,11 +197,13 @@ impl Drop for NetnsLease {
     }
 }
 
-/// Backward-compatible name for a checked-out namespace lease.
+/// Deprecated name retained for callers that refer to the old type name.
 ///
 /// The old `PooledNetns` metadata struct was cloneable, which made namespace
-/// release authority ambiguous. New code should keep the lease in an
-/// `Option<NetnsLease>` and pass it to [`NetnsPool::release`].
+/// release authority ambiguous. This alias is not source-compatible with the
+/// old public-field metadata struct: it names a non-cloneable [`NetnsLease`].
+/// New code should keep the lease in an `Option<NetnsLease>` and pass it to
+/// [`NetnsPool::release`].
 #[deprecated(
     since = "0.28.0",
     note = "use NetnsLease and release it with NetnsPool::release(&mut Option<NetnsLease>)"

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -968,6 +968,10 @@ impl NetnsPool {
     /// (namespaces with iptables REDIRECT rules). Otherwise acquires from
     /// the plain queue.
     pub async fn acquire(&mut self) -> Result<NetnsLease> {
+        if !self.active {
+            return Err(NetworkError::PoolNotActive);
+        }
+
         // Move completed background tasks into queues before checking.
         self.drain_completed();
 
@@ -1932,6 +1936,19 @@ mod tests {
 
         assert!(!pool.active);
         assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_inactive_pool() {
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.plain_queue.push_back(test_info("test-ns"));
+
+        let err = pool.acquire().await.unwrap_err();
+
+        assert!(matches!(err, NetworkError::PoolNotActive));
+        assert_eq!(pool.plain_queue.len(), 1);
+        assert!(pool.in_flight.is_empty());
+        pool.cleanup().await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -1141,6 +1141,11 @@ impl NetnsPool {
     ///
     /// When `proxy_port` is configured, the namespace is returned to
     /// the proxy queue so its REDIRECT rules are reused.
+    ///
+    /// The caller keeps the lease in `Some` while this future awaits. Release
+    /// only takes and disarms the lease at the final no-await commit point, so
+    /// cancelling this future before success leaves cleanup ownership with the
+    /// caller.
     pub async fn release(&mut self, lease: &mut Option<NetnsLease>) -> Result<()> {
         let Some(active_lease) = lease.as_ref() else {
             return Err(NetworkError::InvalidLease("missing netns lease".into()));

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -1824,6 +1824,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn release_after_cleanup_deletes_outstanding_lease_without_requeueing() {
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let info = test_info("test-ns");
+        let mut lease = Some(pool.checkout(info).unwrap());
+
+        pool.cleanup().await.unwrap();
+
+        assert!(!pool.active);
+        assert!(lease.is_some());
+        assert!(pool.in_flight.contains("test-ns"));
+
+        pool.release(&mut lease).await.unwrap();
+
+        assert!(lease.is_none());
+        assert!(pool.in_flight.is_empty());
+        assert!(pool.plain_queue.is_empty());
+        assert!(pool.proxy_queue.is_empty());
+        pool.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn cleanup_retry_drains_pending_creation_after_cancel() {
         let mut pool = NetnsPool::inactive_for_test();
         pool.active = true;

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -197,19 +197,6 @@ impl Drop for NetnsLease {
     }
 }
 
-/// Deprecated name retained for callers that refer to the old type name.
-///
-/// The old `PooledNetns` metadata struct was cloneable, which made namespace
-/// release authority ambiguous. This alias is not source-compatible with the
-/// old public-field metadata struct: it names a non-cloneable [`NetnsLease`].
-/// New code should keep the lease in an `Option<NetnsLease>` and pass it to
-/// [`NetnsPool::release`].
-#[deprecated(
-    since = "0.28.0",
-    note = "use NetnsLease and release it with NetnsPool::release(&mut Option<NetnsLease>)"
-)]
-pub type PooledNetns = NetnsLease;
-
 /// Configuration for creating a [`NetnsPool`].
 ///
 /// When `proxy_port` is set, the pool pre-warms and acquires from the proxy

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -1766,6 +1766,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn proxy_acquire_requeues_namespace_when_checkout_detects_in_flight_duplicate() {
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        pool.proxy_port = Some(8080);
+        pool.next_ns_index = MAX_NAMESPACES;
+        pool.in_flight.insert("test-ns".into());
+        pool.proxy_queue.push_back(test_info("test-ns"));
+
+        let err = pool.acquire().await.unwrap_err();
+
+        assert!(matches!(err, NetworkError::InvalidLease(_)));
+        assert!(pool.plain_queue.is_empty());
+        assert_eq!(pool.proxy_queue.len(), 1);
+        assert_eq!(pool.proxy_queue.front().unwrap().name(), "test-ns");
+
+        pool.in_flight.clear();
+        pool.proxy_queue.clear();
+        pool.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn release_keeps_lease_when_namespace_already_queued() {
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let info = test_info("test-ns");
+        let mut lease = Some(pool.checkout(info.clone()).unwrap());
+        pool.plain_queue.push_back(info);
+
+        let err = pool.release(&mut lease).await.unwrap_err();
+
+        assert!(matches!(err, NetworkError::InvalidLease(_)));
+        assert!(lease.is_some());
+        assert_eq!(pool.plain_queue.len(), 1);
+        assert_eq!(pool.plain_queue.front().unwrap().name(), "test-ns");
+
+        let _ = lease.take().unwrap().into_info_for_test();
+        pool.in_flight.clear();
+        pool.plain_queue.clear();
+        pool.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn release_keeps_lease_on_wrong_pool_instance() {
         let mut pool = NetnsPool::inactive_for_test();
         pool.active = true;

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -974,7 +974,7 @@ impl NetnsPool {
                 "acquired namespace"
             );
             self.maybe_replenish_plain();
-            return self.checkout(pooled);
+            return self.checkout_or_requeue(pooled, false);
         }
         // Tier 2: await in-flight background task.
         while let Some(result) = self.pending_plain.join_next().await {
@@ -982,7 +982,7 @@ impl NetnsPool {
                 Ok(Ok(ns)) => {
                     info!(name = %ns.name, "acquired namespace from pending");
                     self.maybe_replenish_plain();
-                    return self.checkout(ns);
+                    return self.checkout_or_requeue(ns, false);
                 }
                 Ok(Err(e)) => error!(error = %e, "pending namespace creation failed"),
                 Err(e) => error!(error = %e, "pending namespace task panicked"),
@@ -992,7 +992,7 @@ impl NetnsPool {
         info!("pool exhausted, creating namespace on-demand");
         let ns = self.create_on_demand(None, None).await?;
         self.maybe_replenish_plain();
-        self.checkout(ns)
+        self.checkout_or_requeue(ns, false)
     }
 
     /// Acquire from the proxy queue.
@@ -1008,7 +1008,7 @@ impl NetnsPool {
                 "acquired namespace (proxy)"
             );
             self.maybe_replenish_proxy();
-            return self.checkout(pooled);
+            return self.checkout_or_requeue(pooled, true);
         }
         // Tier 2: await in-flight background task.
         while let Some(result) = self.pending_proxy.join_next().await {
@@ -1016,7 +1016,7 @@ impl NetnsPool {
                 Ok(Ok(ns)) => {
                     info!(name = %ns.name, "acquired namespace (proxy) from pending");
                     self.maybe_replenish_proxy();
-                    return self.checkout(ns);
+                    return self.checkout_or_requeue(ns, true);
                 }
                 Ok(Err(e)) => error!(error = %e, "pending proxy namespace creation failed"),
                 Err(e) => error!(error = %e, "pending proxy namespace task panicked"),
@@ -1028,7 +1028,7 @@ impl NetnsPool {
             .create_on_demand(self.proxy_port, self.dns_port)
             .await?;
         self.maybe_replenish_proxy();
-        self.checkout(ns)
+        self.checkout_or_requeue(ns, true)
     }
 
     /// Create a new namespace on-demand, allocating the next index.
@@ -1054,12 +1054,27 @@ impl NetnsPool {
         .await
     }
 
-    fn checkout(&mut self, info: NetnsInfo) -> Result<NetnsLease> {
+    fn checkout_or_requeue(&mut self, info: NetnsInfo, has_proxy: bool) -> Result<NetnsLease> {
+        let name = info.name.clone();
+        match self.checkout(info) {
+            Ok(lease) => Ok(lease),
+            Err(info) => {
+                warn!(
+                    name = %name,
+                    has_proxy,
+                    "namespace is already checked out; returning metadata to queue"
+                );
+                self.target_queue_mut(has_proxy).push_front(info);
+                Err(NetworkError::InvalidLease(format!(
+                    "namespace {name} is already checked out"
+                )))
+            }
+        }
+    }
+
+    fn checkout(&mut self, info: NetnsInfo) -> std::result::Result<NetnsLease, NetnsInfo> {
         if !self.in_flight.insert(info.name.clone()) {
-            return Err(NetworkError::InvalidLease(format!(
-                "namespace {} is already checked out",
-                info.name
-            )));
+            return Err(info);
         }
         Ok(NetnsLease::new(info, self.instance_id))
     }
@@ -1238,6 +1253,14 @@ impl NetnsPool {
             &self.proxy_queue
         } else {
             &self.plain_queue
+        }
+    }
+
+    fn target_queue_mut(&mut self, has_proxy: bool) -> &mut VecDeque<NetnsInfo> {
+        if has_proxy {
+            &mut self.proxy_queue
+        } else {
+            &mut self.plain_queue
         }
     }
 
@@ -1722,6 +1745,23 @@ mod tests {
         assert_eq!(pool.plain_queue.len(), 1);
         assert_eq!(pool.plain_queue.front().unwrap().name(), "test-ns");
 
+        pool.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn acquire_requeues_namespace_when_checkout_detects_in_flight_duplicate() {
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        pool.in_flight.insert("test-ns".into());
+        pool.plain_queue.push_back(test_info("test-ns"));
+
+        let err = pool.acquire().await.unwrap_err();
+
+        assert!(matches!(err, NetworkError::InvalidLease(_)));
+        assert_eq!(pool.plain_queue.len(), 1);
+        assert_eq!(pool.plain_queue.front().unwrap().name(), "test-ns");
+
+        pool.in_flight.clear();
         pool.cleanup().await.unwrap();
     }
 

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -995,7 +995,10 @@ impl NetnsPool {
         }
         // Tier 3: on-demand.
         info!("pool exhausted, creating namespace on-demand");
-        let ns = self.create_on_demand(None, None).await?;
+        // Spawn into the pool-owned JoinSet before awaiting so cancellation
+        // leaves the creation task reachable for later acquire/cleanup.
+        self.spawn_plain_creation()?;
+        let ns = self.await_on_demand_plain().await?;
         let lease = self.checkout_or_requeue(ns, false)?;
         self.maybe_replenish_plain();
         Ok(lease)
@@ -1032,20 +1035,16 @@ impl NetnsPool {
         }
         // Tier 3: on-demand.
         info!("proxy pool exhausted, creating namespace on-demand");
-        let ns = self
-            .create_on_demand(self.proxy_port, self.dns_port)
-            .await?;
+        // Spawn into the pool-owned JoinSet before awaiting so cancellation
+        // leaves the creation task reachable for later acquire/cleanup.
+        self.spawn_proxy_creation()?;
+        let ns = self.await_on_demand_proxy().await?;
         let lease = self.checkout_or_requeue(ns, true)?;
         self.maybe_replenish_proxy();
         Ok(lease)
     }
 
-    /// Create a new namespace on-demand, allocating the next index.
-    async fn create_on_demand(
-        &mut self,
-        proxy_port: Option<u16>,
-        dns_port: Option<u16>,
-    ) -> Result<NetnsInfo> {
+    fn reserve_ns_index(&mut self) -> Result<u32> {
         let ns_index = self.next_ns_index;
         if ns_index >= MAX_NAMESPACES {
             return Err(NetworkError::NamespaceLimitReached {
@@ -1053,14 +1052,76 @@ impl NetnsPool {
             });
         }
         self.next_ns_index += 1;
-        create_single_namespace(
-            self.pool_index,
+        Ok(ns_index)
+    }
+
+    fn spawn_plain_creation(&mut self) -> Result<()> {
+        let ns_index = self.reserve_ns_index()?;
+        let pool_index = self.pool_index;
+        let default_iface = self.default_iface.clone();
+        self.pending_plain.spawn(create_single_namespace(
+            pool_index,
             ns_index,
-            self.default_iface.clone(),
-            proxy_port,
+            default_iface,
+            None,
+            None,
+        ));
+        Ok(())
+    }
+
+    fn spawn_proxy_creation(&mut self) -> Result<()> {
+        let Some(proxy_port) = self.proxy_port else {
+            return Err(NetworkError::Prerequisite(
+                "proxy namespace requested without proxy port".into(),
+            ));
+        };
+        let ns_index = self.reserve_ns_index()?;
+        let pool_index = self.pool_index;
+        let default_iface = self.default_iface.clone();
+        let dns_port = self.dns_port;
+        self.pending_proxy.spawn(create_single_namespace(
+            pool_index,
+            ns_index,
+            default_iface,
+            Some(proxy_port),
             dns_port,
-        )
-        .await
+        ));
+        Ok(())
+    }
+
+    async fn await_on_demand_plain(&mut self) -> Result<NetnsInfo> {
+        match self.pending_plain.join_next().await {
+            Some(Ok(Ok(ns))) => Ok(ns),
+            Some(Ok(Err(e))) => Err(e),
+            Some(Err(e)) => Err(Self::join_error_to_network_error(
+                e,
+                "on-demand namespace creation task",
+            )),
+            None => Err(NetworkError::Prerequisite(
+                "on-demand namespace creation task disappeared".into(),
+            )),
+        }
+    }
+
+    async fn await_on_demand_proxy(&mut self) -> Result<NetnsInfo> {
+        match self.pending_proxy.join_next().await {
+            Some(Ok(Ok(ns))) => Ok(ns),
+            Some(Ok(Err(e))) => Err(e),
+            Some(Err(e)) => Err(Self::join_error_to_network_error(
+                e,
+                "on-demand proxy namespace creation task",
+            )),
+            None => Err(NetworkError::Prerequisite(
+                "on-demand proxy namespace creation task disappeared".into(),
+            )),
+        }
+    }
+
+    fn join_error_to_network_error(e: tokio::task::JoinError, context: &str) -> NetworkError {
+        if e.is_panic() {
+            std::panic::resume_unwind(e.into_panic());
+        }
+        NetworkError::Prerequisite(format!("{context} cancelled: {e}"))
     }
 
     fn checkout_or_requeue(&mut self, info: NetnsInfo, has_proxy: bool) -> Result<NetnsLease> {
@@ -1120,17 +1181,7 @@ impl NetnsPool {
         {
             return;
         }
-        let ns_index = self.next_ns_index;
-        self.next_ns_index += 1;
-        let pool_index = self.pool_index;
-        let default_iface = self.default_iface.clone();
-        self.pending_plain.spawn(create_single_namespace(
-            pool_index,
-            ns_index,
-            default_iface,
-            None,
-            None,
-        ));
+        let _ = self.spawn_plain_creation();
     }
 
     /// Spawn a background proxy namespace creation task if needed.
@@ -1138,27 +1189,16 @@ impl NetnsPool {
     /// Skips if: no proxy port configured, buffer is full, a task is
     /// already in-flight, or namespace index limit reached.
     fn maybe_replenish_proxy(&mut self) {
-        let Some(proxy_port) = self.proxy_port else {
+        if self.proxy_port.is_none() {
             return;
-        };
+        }
         if self.proxy_queue.len() + self.pending_proxy.len() >= BUFFER_SIZE
             || !self.pending_proxy.is_empty()
             || self.next_ns_index >= MAX_NAMESPACES
         {
             return;
         }
-        let ns_index = self.next_ns_index;
-        self.next_ns_index += 1;
-        let pool_index = self.pool_index;
-        let default_iface = self.default_iface.clone();
-        let dns_port = self.dns_port;
-        self.pending_proxy.spawn(create_single_namespace(
-            pool_index,
-            ns_index,
-            default_iface,
-            Some(proxy_port),
-            dns_port,
-        ));
+        let _ = self.spawn_proxy_creation();
     }
 
     /// Return a namespace to the pool, or delete it if the pool is inactive.
@@ -1789,6 +1829,40 @@ mod tests {
         }
 
         assert!(!pool.active);
+        assert_eq!(pool.pending_plain.len(), 1);
+
+        release.notify_one();
+        pool.cleanup().await.unwrap();
+
+        assert!(!pool.active);
+        assert!(pool.pending_plain.is_empty());
+        assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn acquire_cancellation_keeps_pending_creation_for_cleanup() {
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let entered = std::sync::Arc::new(tokio::sync::Notify::new());
+        let release = std::sync::Arc::new(tokio::sync::Notify::new());
+        let entered_task = std::sync::Arc::clone(&entered);
+        let release_task = std::sync::Arc::clone(&release);
+        pool.pending_plain.spawn(async move {
+            entered_task.notify_one();
+            release_task.notified().await;
+            Ok(test_info("test-ns"))
+        });
+
+        {
+            let acquire = pool.acquire();
+            tokio::pin!(acquire);
+            tokio::select! {
+                result = &mut acquire => panic!("acquire completed before pending task was released: {result:?}"),
+                _ = entered.notified() => {}
+            }
+        }
+
+        assert!(pool.in_flight.is_empty());
         assert_eq!(pool.pending_plain.len(), 1);
 
         release.notify_one();

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -26,7 +26,7 @@ use crate::balloon;
 use crate::config::FirecrackerConfig;
 use crate::control;
 use crate::factory::InvariantConfig;
-use crate::network::PooledNetns;
+use crate::network::{NetnsInfo, NetnsLease};
 use crate::paths::{SandboxPaths, SockPaths};
 use crate::process::{kill_process_group, kill_process_group_by_pid};
 
@@ -265,8 +265,8 @@ pub struct FirecrackerSandbox {
     pub(crate) sandbox_paths: SandboxPaths,
     /// Runtime socket paths (api.sock, vsock).
     pub(crate) sock_paths: SockPaths,
-    /// Pooled network namespace (returned to pool on destroy).
-    pub(crate) network: PooledNetns,
+    /// Pooled network namespace metadata plus cleanup ownership.
+    pub(crate) network: SandboxNetwork,
     /// NBD COW device (torn down on destroy).
     pub(crate) cow_device: Option<PooledNbdCowDevice>,
     process_monitor: Option<ProcessMonitorHandle>,
@@ -307,13 +307,47 @@ pub struct FirecrackerSandbox {
     is_parked: bool,
 }
 
+pub(crate) struct SandboxNetwork {
+    info: NetnsInfo,
+    lease: Option<NetnsLease>,
+}
+
+impl SandboxNetwork {
+    fn from_lease(lease: NetnsLease) -> Self {
+        Self {
+            info: lease.info().clone(),
+            lease: Some(lease),
+        }
+    }
+
+    fn name(&self) -> &str {
+        self.info.name()
+    }
+
+    fn peer_ip(&self) -> &str {
+        self.info.peer_ip()
+    }
+
+    pub(crate) fn lease_mut(&mut self) -> &mut Option<NetnsLease> {
+        &mut self.lease
+    }
+
+    pub(crate) fn take_lease(&mut self) -> Option<NetnsLease> {
+        self.lease.take()
+    }
+
+    pub(crate) fn has_lease(&self) -> bool {
+        self.lease.is_some()
+    }
+}
+
 impl FirecrackerSandbox {
     pub(crate) fn new(
         config: SandboxConfig,
         factory_config: FirecrackerConfig,
         sandbox_paths: SandboxPaths,
         sock_paths: SockPaths,
-        network: PooledNetns,
+        network: NetnsLease,
         cow_device: PooledNbdCowDevice,
         leak_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::factory::LeakedResources>>,
     ) -> Self {
@@ -324,7 +358,7 @@ impl FirecrackerSandbox {
             id,
             sandbox_paths,
             sock_paths,
-            network,
+            network: SandboxNetwork::from_lease(network),
             cow_device: Some(cow_device),
             process_monitor: None,
             process_group_pid: None,
@@ -494,7 +528,7 @@ impl FirecrackerSandbox {
 
         let child = tokio::process::Command::new("ip")
             .args(["netns", "exec"])
-            .arg(&self.network.name)
+            .arg(self.network.name())
             .arg(&self.factory_config.binary_path)
             .args(["--config-file"])
             .arg(self.sandbox_paths.config())
@@ -587,7 +621,7 @@ impl FirecrackerSandbox {
             api_sock = %api_sock.display(),
             sock_dir = %sock_dir.display(),
             cow_device = %cow_device_path.display(),
-            netns = %self.network.name,
+            netns = %self.network.name(),
             binary = %self.factory_config.binary_path.display(),
             "spawning firecracker (snapshot restore)"
         );
@@ -614,7 +648,7 @@ impl FirecrackerSandbox {
             .arg(&snapshot.vsock_bind_dir) // $2
             .arg(cow_device_path) // $3
             .arg(&snapshot.drive_bind_path) // $4
-            .arg(&self.network.name) // $5
+            .arg(self.network.name()) // $5
             .arg(&self.factory_config.binary_path) // $6
             .arg(&api_sock) // $7
             .current_dir(self.sandbox_paths.workspace())
@@ -729,7 +763,7 @@ impl Drop for FirecrackerSandbox {
             let resources = crate::factory::LeakedResources {
                 sandbox_id: self.id.clone(),
                 cow_device: self.cow_device.take(),
-                network: Some(self.network.clone()),
+                network: self.network.take_lease(),
                 sock_dir: self.sock_paths.dir().to_owned(),
                 workspace: self.sandbox_paths.workspace().to_owned(),
             };
@@ -917,7 +951,7 @@ impl Sandbox for FirecrackerSandbox {
     }
 
     fn source_ip(&self) -> &str {
-        &self.network.peer_ip
+        self.network.peer_ip()
     }
 
     fn process_pid(&self) -> Option<u32> {

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -296,6 +296,7 @@ pub struct FirecrackerSandbox {
     /// Sender for leaked resource cleanup. When Drop fires without prior
     /// `factory.destroy()`, pool resources are sent here for async cleanup.
     leak_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::factory::LeakedResources>>,
+    delete_workspace_on_leak_cleanup: bool,
     /// Set to `true` by `factory.destroy()` to suppress Drop-based leak recovery.
     pub(crate) destroyed: bool,
     /// Tracks whether the sandbox is currently in the idle/parked state.
@@ -369,6 +370,7 @@ impl FirecrackerSandbox {
             control_server: None,
             balloon_controller: None,
             leak_tx,
+            delete_workspace_on_leak_cleanup: true,
             destroyed: false,
             is_parked: false,
         }
@@ -378,6 +380,10 @@ impl FirecrackerSandbox {
         self.cow_device.as_ref().ok_or_else(|| SandboxError::Start {
             message: "COW device missing before sandbox start".into(),
         })
+    }
+
+    pub(crate) fn preserve_workspace_on_leak_cleanup(&mut self) {
+        self.delete_workspace_on_leak_cleanup = false;
     }
 
     fn current_state(&self) -> SandboxState {
@@ -766,6 +772,7 @@ impl Drop for FirecrackerSandbox {
                 network: self.network.take_lease(),
                 sock_dir: self.sock_paths.dir().to_owned(),
                 workspace: self.sandbox_paths.workspace().to_owned(),
+                delete_workspace: self.delete_workspace_on_leak_cleanup,
             };
             if tx.send(resources).is_err() {
                 tracing::warn!(

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -364,8 +364,8 @@ async fn run_snapshot_workflow(
 ) -> Result<SnapshotConfig, SnapshotError> {
     // Filesystem pre-requisites that don't require the netns: do these
     // *before* `netns_pool.acquire()` so that a transient fs error
-    // (mkdir, write) doesn't leak an acquired netns. `PooledNetns` has
-    // no Drop impl — release must be explicit, and `netns_pool.cleanup()`
+    // (mkdir, write) doesn't leak an acquired netns. A checked-out netns lease
+    // requires explicit release, and `netns_pool.cleanup()`
     // only drains queued (not acquired) entries.
     //
     // The empty bind target file is consumed by `mount --bind` inside
@@ -392,10 +392,12 @@ async fn run_snapshot_workflow(
         }
     };
 
-    info!(netns = %network.name, "namespace acquired");
+    let network_info = network.info().clone();
+
+    info!(netns = %network_info.name(), "namespace acquired");
 
     info!(
-        netns = %network.name,
+        netns = %network_info.name(),
         binary = %config.binary_path.display(),
         api_sock = %api_sock.display(),
         "spawning firecracker"
@@ -411,7 +413,7 @@ async fn run_snapshot_workflow(
         .args(["bash", "-c", SPAWN_INNER_CMD, "_"])
         .arg(&cow_device_path) // $1
         .arg(&drive_bind) // $2
-        .arg(&network.name) // $3
+        .arg(network_info.name()) // $3
         .arg(&config.binary_path) // $4
         .arg(&api_sock) // $5
         .current_dir(paths.workspace())
@@ -424,11 +426,11 @@ async fn run_snapshot_workflow(
     let mut child = match spawn_result {
         Ok(c) => c,
         Err(e) => {
-            // Release the netns before returning — `PooledNetns` has no
-            // Drop impl, and `netns_pool.cleanup()` (called by the outer
-            // `create_snapshot`) only drains queued entries, not
-            // already-acquired ones.
-            if let Err(re) = netns_pool.release(network).await {
+            // Release the checked-out netns before returning —
+            // `netns_pool.cleanup()` (called by the outer `create_snapshot`)
+            // only drains queued entries, not already-acquired ones.
+            let mut network = Some(network);
+            if let Err(re) = netns_pool.release(&mut network).await {
                 tracing::warn!(error = %re, "failed to release netns after spawn failure");
             }
             destroy_snapshot_cow_after_error("spawn firecracker", cow_device).await;
@@ -499,7 +501,8 @@ async fn run_snapshot_workflow(
     // Release network namespace back to the pool before teardown.
     // Without this, the namespace resources (veth, iptables) leak
     // because cleanup() only drains queued (unused) namespaces.
-    if let Err(e) = netns_pool.release(network).await {
+    let mut network = Some(network);
+    if let Err(e) = netns_pool.release(&mut network).await {
         tracing::warn!(error = %e, "failed to release netns");
     }
 

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -500,7 +500,8 @@ async fn run_snapshot_workflow(
 
     // Release network namespace back to the pool before teardown.
     // Without this, the namespace resources (veth, iptables) leak
-    // because cleanup() only drains queued (unused) namespaces.
+    // because cleanup() only drains pool-owned namespaces, not checked-out
+    // leases.
     let mut network = Some(network);
     if let Err(e) = netns_pool.release(&mut network).await {
         tracing::warn!(error = %e, "failed to release netns");


### PR DESCRIPTION
## Summary
- split network namespace metadata into cloneable `NetnsInfo` and non-cloneable `NetnsLease`
- make pool release mutate the owner `Option<NetnsLease>` only after awaited cleanup succeeds
- update sandbox destroy/drop, create rollback, leak cleanup, and snapshot release paths to preserve fallback ownership
- add pool instance + in-flight validation and ownership-focused tests

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`

Fixes #11453
