### PR TITLE
feat(zero): wire codex item.completed events into chat thread persistence

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
@@ -398,6 +398,88 @@ describe("POST /api/internal/callbacks/chat", () => {
       expect(resultMsg!.sequenceNumber).toBe(2);
     });
 
+    it("should persist codex item.completed agent_message in final sweep", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread();
+
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        {
+          sequenceNumber: 0,
+          eventType: "item.completed",
+          eventData: {
+            type: "item.completed",
+            item: {
+              id: "item_1",
+              type: "agent_message",
+              text: "Codex final sweep text",
+            },
+          },
+        },
+      ]);
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "completed",
+            payload: { threadId, agentId },
+          },
+          secret,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+
+      const messages = await getTestChatMessagesByThread(threadId);
+      expect(messages).toHaveLength(2);
+      const assistant = messages.find((m) => {
+        return m.role === "assistant" && m.sequenceNumber !== null;
+      });
+      expect(assistant).toBeDefined();
+      expect(assistant!.content).toBe("Codex final sweep text");
+      expect(assistant!.runId).toBe(runId);
+    });
+
+    it("should skip non-agent_message codex item.completed events in final sweep", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread();
+
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        {
+          sequenceNumber: 0,
+          eventType: "item.completed",
+          eventData: {
+            type: "item.completed",
+            item: {
+              id: "cmd_1",
+              type: "command_execution",
+              command: "ls",
+              exit_code: 0,
+              output: "README.md",
+            },
+          },
+        },
+      ]);
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "completed",
+            payload: { threadId, agentId },
+          },
+          secret,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const messages = await getTestChatMessagesByThread(threadId);
+      const assistantRows = messages.filter((m) => {
+        return m.role === "assistant";
+      });
+      expect(assistantRows).toHaveLength(0);
+    });
+
     it("should read result fallback sequence from eventData when needed", async () => {
       const { threadId, runId, secret } = await setupRunAndThread();
 

--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -46,11 +46,17 @@ interface ContentBlock {
   text?: string;
 }
 
+interface CodexItem {
+  type?: string;
+  text?: string;
+}
+
 interface AxiomChatOutputEvent {
   eventType?: string;
   sequenceNumber?: number;
   eventData?: {
     message?: { content?: ContentBlock[] };
+    item?: CodexItem;
     result?: string;
     sequenceNumber?: number;
   };
@@ -78,7 +84,7 @@ async function queryChatOutputEvents(runId: string): Promise<{
   const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
   const apl = `['${dataset}']
 | where runId == "${runId}"
-| where eventType == "assistant" or eventType == "result"
+| where eventType == "assistant" or eventType == "result" or eventType == "item.completed"
 | order by sequenceNumber asc
 | limit 200`;
 
@@ -90,33 +96,63 @@ async function queryChatOutputEvents(runId: string): Promise<{
     const seq = e.sequenceNumber ?? e.eventData?.sequenceNumber;
     if (typeof seq !== "number") continue;
 
-    const content = e.eventData?.message?.content;
-    if (content) {
-      const parts: string[] = [];
-      for (const block of content) {
-        if (block.type === "text" && typeof block.text === "string") {
-          parts.push(block.text);
-        }
-      }
-      if (parts.length > 0) {
-        assistantItems.push({
-          sequenceNumber: seq,
-          content: parts.length === 1 ? parts[0]! : parts.join("\n\n"),
-        });
-      }
+    const assistant = extractAssistantContent(e);
+    if (assistant !== null) {
+      assistantItems.push({ sequenceNumber: seq, content: assistant });
       continue;
     }
 
-    const result = e.eventData?.result;
-    if (typeof result !== "string") continue;
-    const trimmed = result.trim();
-    if (!trimmed) continue;
-    resultFallback = {
-      sequenceNumber: seq,
-      content: result,
-    };
+    const fallback = extractResultFallback(seq, e);
+    if (fallback !== null) {
+      resultFallback = fallback;
+    }
   }
   return { assistantItems, resultFallback };
+}
+
+function extractAnthropicContent(blocks: ContentBlock[]): string | null {
+  const parts: string[] = [];
+  for (const block of blocks) {
+    if (block.type === "text" && typeof block.text === "string") {
+      parts.push(block.text);
+    }
+  }
+  if (parts.length === 0) return null;
+  return parts.length === 1 ? parts[0]! : parts.join("\n\n");
+}
+
+function extractCodexAgentMessageContent(item: CodexItem): string | null {
+  if (
+    item.type !== "agent_message" ||
+    typeof item.text !== "string" ||
+    item.text.length === 0
+  ) {
+    return null;
+  }
+  return item.text;
+}
+
+function extractAssistantContent(e: AxiomChatOutputEvent): string | null {
+  const content = e.eventData?.message?.content;
+  if (content) {
+    return extractAnthropicContent(content);
+  }
+  const item = e.eventData?.item;
+  if (item) {
+    return extractCodexAgentMessageContent(item);
+  }
+  return null;
+}
+
+function extractResultFallback(
+  seq: number,
+  e: AxiomChatOutputEvent,
+): ResultEventItem | null {
+  const result = e.eventData?.result;
+  if (typeof result !== "string") return null;
+  const trimmed = result.trim();
+  if (!trimmed) return null;
+  return { sequenceNumber: seq, content: result };
 }
 
 async function latestEventBackedAssistantMessage(

--- a/turbo/apps/web/app/api/internal/event-consumers/chat-assistant/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/event-consumers/chat-assistant/__tests__/route.test.ts
@@ -46,6 +46,37 @@ function buildToolUseEvent(sequenceNumber: number): Record<string, unknown> {
   };
 }
 
+function buildCodexAgentMessageEvent(
+  sequenceNumber: number,
+  text: string,
+): Record<string, unknown> {
+  return {
+    type: "item.completed",
+    sequenceNumber,
+    item: {
+      id: `item_${sequenceNumber}`,
+      type: "agent_message",
+      text,
+    },
+  };
+}
+
+function buildCodexCommandExecutionEvent(
+  sequenceNumber: number,
+): Record<string, unknown> {
+  return {
+    type: "item.completed",
+    sequenceNumber,
+    item: {
+      id: `cmd_${sequenceNumber}`,
+      type: "command_execution",
+      command: "ls",
+      exit_code: 0,
+      output: "README.md",
+    },
+  };
+}
+
 const context = testContext();
 
 describe("POST /api/internal/event-consumers/chat-assistant", () => {
@@ -142,5 +173,54 @@ describe("POST /api/internal/event-consumers/chat-assistant", () => {
       `chatThreadMessageCreated:${threadId}`,
       null,
     );
+  });
+
+  it("should persist codex agent_message text from item.completed events", async () => {
+    const { runId } = await seedTestRun(user.userId, agentComposeId);
+    const threadId = await insertTestChatThread(
+      user.userId,
+      agentComposeId,
+      "test thread",
+    );
+    await addTestRunToThread(threadId, runId, user.userId);
+
+    const request = createEventConsumerRequest({
+      runId,
+      events: [buildCodexAgentMessageEvent(1, "Codex says hi")],
+      context: { userId: user.userId, orgId: user.orgId },
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.processed).toBe(1);
+
+    expect(mockAblyPublish).toHaveBeenCalledWith(
+      `chatThreadMessageCreated:${threadId}`,
+      null,
+    );
+  });
+
+  it("should ignore non-agent_message codex item.completed events", async () => {
+    const { runId } = await seedTestRun(user.userId, agentComposeId);
+    const threadId = await insertTestChatThread(
+      user.userId,
+      agentComposeId,
+      "test thread",
+    );
+    await addTestRunToThread(threadId, runId, user.userId);
+
+    const request = createEventConsumerRequest({
+      runId,
+      events: [buildCodexCommandExecutionEvent(1)],
+      context: { userId: user.userId, orgId: user.orgId },
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.processed).toBe(0);
+
+    expect(mockAblyPublish).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/web/app/api/internal/event-consumers/chat-assistant/route.ts
+++ b/turbo/apps/web/app/api/internal/event-consumers/chat-assistant/route.ts
@@ -11,13 +11,7 @@ import { logger } from "../../../../../src/lib/shared/logger";
 
 const log = logger("event-consumer:chat-assistant");
 
-/**
- * Concatenate all text blocks in a single assistant event into one string.
- * Assistant events usually carry a single text block, but may carry several
- * interleaved with tool_use blocks. Tool_use blocks are ignored here —
- * activity summaries are rendered live from the telemetry endpoint.
- */
-function eventText(event: AgentEvent): string | null {
+function anthropicMessageText(event: AgentEvent): string | null {
   const msg = event.message;
   if (
     typeof msg !== "object" ||
@@ -44,18 +38,55 @@ function eventText(event: AgentEvent): string | null {
   return parts.length === 1 ? parts[0]! : parts.join("\n\n");
 }
 
+function codexAgentMessageText(event: AgentEvent): string | null {
+  if (event.type !== "item.completed") return null;
+  const item = event.item;
+  if (
+    typeof item !== "object" ||
+    item === null ||
+    !("type" in item) ||
+    item.type !== "agent_message" ||
+    !("text" in item) ||
+    typeof item.text !== "string" ||
+    item.text.length === 0
+  ) {
+    return null;
+  }
+  return item.text;
+}
+
 /**
- * Extract the Anthropic message ID from an assistant event.
- * Real Claude Code events include message.id (e.g. "msg_01abc...").
- * Returns undefined for mock/test events that lack this field.
+ * Extract user-facing assistant text from a single agent event. Two shapes
+ * are supported: Anthropic `assistant` events with `message.content[]` text
+ * blocks, and codex `item.completed` events whose item is an `agent_message`.
+ * Tool-call / command / reasoning items return null — activity summaries are
+ * rendered live from the telemetry endpoint, not chat persistence.
+ */
+function eventText(event: AgentEvent): string | null {
+  const fromMessage = anthropicMessageText(event);
+  if (fromMessage !== null) return fromMessage;
+  return codexAgentMessageText(event);
+}
+
+/**
+ * Extract the upstream message ID from an event for run_event_id dedup.
+ * Anthropic events expose `message.id` (e.g. "msg_01abc..."); codex
+ * `item.completed` events expose `item.id` (e.g. "item_1").
  */
 function eventMessageId(event: AgentEvent): string | undefined {
   const msg = event.message;
-  if (typeof msg !== "object" || msg === null || !("id" in msg)) {
-    return undefined;
+  if (typeof msg === "object" && msg !== null && "id" in msg) {
+    const id = (msg as { id: unknown }).id;
+    if (typeof id === "string") return id;
   }
-  const id = (msg as { id: unknown }).id;
-  return typeof id === "string" ? id : undefined;
+
+  const item = event.item;
+  if (typeof item === "object" && item !== null && "id" in item) {
+    const id = (item as { id: unknown }).id;
+    if (typeof id === "string") return id;
+  }
+
+  return undefined;
 }
 
 /**

--- a/turbo/apps/web/src/lib/infra/event-consumer/registry.ts
+++ b/turbo/apps/web/src/lib/infra/event-consumer/registry.ts
@@ -15,7 +15,7 @@ export const eventConsumers: EventConsumerConfig[] = [
   {
     name: "chat-assistant",
     path: "/api/internal/event-consumers/chat-assistant",
-    eventTypes: ["assistant"],
+    eventTypes: ["assistant", "item.completed"],
   },
   {
     name: "telegram-typing",


### PR DESCRIPTION
## Summary

Closes #11559. Refs #11520.

Closes the gap discovered by PR #11550's e2e validator: codex CAN run via BYOK, but its output never reached chat threads because chat persistence was hardcoded to the anthropic event shape. This PR makes both chat persistence paths codex-aware so codex `item.completed` agent_message events produce `chat_messages` rows.

### Changes
- **Registry filter** — `chat-assistant` consumer now subscribes to both `assistant` and `item.completed` event types.
- **Live consumer** (`chat-assistant/route.ts`) — `eventText` / `eventMessageId` recognise codex `item.completed` agent_message items in addition to anthropic `message.content[]` text blocks. Tool / command / reasoning items still return `null`.
- **Final-sweep callback** (`callbacks/chat/route.ts`) — APL `where` clause expanded to include `item.completed`, and the per-event extractor delegates to `extractAnthropicContent` or `extractCodexAgentMessageContent` based on shape.
- **Per-message row semantics retained** — one `chat_messages` row per agent_message item; idempotency stays anchored on `(run_id, sequence_number)`.
- **Voice-chat consumer left untouched** — voice path is out of scope for this issue.

### Design decisions (per leader feedback on #11559)
1. **Both paths fixed** — live consumer + final sweep — keeping current dual-write idempotent model.
2. **Translation lives at the read site** (consumer + sweep callback), not at axiom ingest — preserves Axiom as a verbatim event log.
3. **Per-message rows** (one row per `agent_message`), not aggregate-per-turn — matches existing per-event-row symmetry and keeps the consumer stateless.

Full deep-dive (research/innovate/plan) is posted on #11559.

## Test plan
- [x] `chat-assistant` consumer: persists codex agent_message text from `item.completed` (1 row, signal published)
- [x] `chat-assistant` consumer: ignores non-agent_message codex `item.completed` (e.g. `command_execution`)
- [x] `chat-assistant` consumer: existing anthropic `assistant`-event tests still pass
- [x] `callbacks/chat` final sweep: persists codex `item.completed` agent_message
- [x] `callbacks/chat` final sweep: skips non-agent_message codex `item.completed`
- [x] `pnpm turbo run lint`, `pnpm format`, `pnpm check-types`, `pnpm knip` all green
- [x] Existing 38 callbacks/chat tests + 6 chat-assistant tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)