### PR TITLE
fix: eliminate 1px sub-pixel gap between composer gradient and footer

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1280,7 +1280,7 @@ function ChatThreadComposer({
       className="relative shrink-0 bg-[hsl(var(--background))]"
       style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}
     >
-      <div className="pointer-events-none absolute inset-x-0 -top-5 h-5 bg-gradient-to-t from-[hsl(var(--background))] to-transparent" />
+      <div className="pointer-events-none absolute inset-x-0 -top-5 h-[21px] bg-gradient-to-t from-[hsl(var(--background))] to-transparent" />
       <div className="overflow-y-auto [scrollbar-gutter:stable] px-4 sm:px-6 pt-3 pb-2">
         <div className="mx-auto max-w-[900px]">
           <ZeroChatComposer


### PR DESCRIPTION
## Summary
- Extends the composer gradient overlay height from `h-5` (20px) to `h-[21px]` so its bottom edge overlaps the footer background by 1px
- Prevents a visible anti-aliasing seam at the gradient/footer boundary

## Root cause
The gradient strip is absolutely positioned at `-top-5 h-5`, placing its bottom edge exactly at the footer's top boundary. Although both use `hsl(var(--background))`, the browser renders each element's edge independently — sub-pixel anti-aliasing creates a ~1px visible seam between them.

This became noticeable after [#11029](https://github.com/vm0-ai/vm0/pull/11029) unblocked the gradient (it was previously clipped by `overflow-y-auto` on the footer).

## Test plan
- [x] Visual check: chat thread page — no visible gap between gradient fade and composer card
- [x] Visual check: light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)