### PR TITLE
fix(api): buffer upstream body in proxyToWeb to prevent ReadableStream loss

### DIFF
--- a/turbo/apps/api/src/app-factory.ts
+++ b/turbo/apps/api/src/app-factory.ts
@@ -87,7 +87,10 @@ async function proxyToWeb(context: Context, webUrl: string): Promise<Response> {
   for (const cookie of upstream.headers.getSetCookie()) {
     headers.append("set-cookie", cookie);
   }
-  return new Response(upstream.body, {
+  // Buffer the upstream body to avoid losing it when the undici ReadableStream
+  // is re-wrapped in a new Response (streams >1 chunk are silently dropped).
+  const body = await upstream.arrayBuffer();
+  return new Response(body, {
     status: upstream.status,
     statusText: upstream.statusText,
     headers,


### PR DESCRIPTION
## Summary

`proxyToWeb` in `app-factory.ts` wraps upstream `fetch()` response body (`ReadableStream`) directly in `new Response(upstream.body, ...)`. In the Vercel Node.js runtime (undici + Hono), this silently drops the body for any response spanning more than one chunk.

All small JSON error responses (<~100 bytes) appeared to work because they're fully buffered in the first undici chunk. But any proxied response with a larger body — including Next.js HTML pages, 404 pages, and authenticated API responses — returned headers correctly but 0 bytes of body.

## Fix

Read the upstream body with `arrayBuffer()` before constructing the proxy Response. This avoids the undici ReadableStream re-wrap issue.

- Before: `new Response(upstream.body, ...)` → body lost for multi-chunk responses
- After: `const body = await upstream.arrayBuffer(); new Response(body, ...)` → body buffered then sent

## Test plan

- [ ] Verify `GET /` via `api.vm0.ai` returns full HTML body (not 0 bytes)
- [ ] Verify `POST /api/zero/realtime/token` via `api.vm0.ai` returns proper response
- [ ] Verify proxied headers (set-cookie, CSP, CORS) still pass through correctly

## Affected routes

All requests hitting `api.vm0.ai` that don't match a registered route in vm0-api fall through to `app.notFound` → `proxyToWeb`. This covers the majority of API endpoints until migration is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)