### PR TITLE
fix: remove visibility gate before markThreadReadIfNeeded on chat open

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -7,11 +7,7 @@ import {
   type State,
 } from "ccstate";
 import { animationFrame, delay } from "signal-timers";
-import {
-  onRef,
-  resetSignal,
-  setLoop,
-} from "../utils.ts";
+import { onRef, resetSignal, setLoop } from "../utils.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { createScrollSignals } from "../auto-scroll.ts";
 import {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1168,7 +1168,7 @@ function createRunTracking({
       if (document.visibilityState !== "visible") {
         const visibleDeferred = createDeferredPromise<void>(signal);
         const handler = () => {
-          if (document.visibilityState === "visible") {
+          if (document.visibilityState === "visible" && !visibleDeferred.settled()) {
             visibleDeferred.resolve();
           }
         };

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -8,7 +8,6 @@ import {
 } from "ccstate";
 import { animationFrame, delay } from "signal-timers";
 import {
-  createDeferredPromise,
   onRef,
   resetSignal,
   setLoop,
@@ -1164,20 +1163,6 @@ function createRunTracking({
         return;
       }
 
-      // Mark thread as read on open (focus-gated)
-      if (document.visibilityState !== "visible") {
-        const visibleDeferred = createDeferredPromise<void>(signal);
-        const handler = () => {
-          if (document.visibilityState === "visible" && !visibleDeferred.settled()) {
-            visibleDeferred.resolve();
-          }
-        };
-        document.addEventListener("visibilitychange", handler, {
-          signal,
-        });
-        await visibleDeferred.promise;
-        signal.throwIfAborted();
-      }
       await set(markThreadReadIfNeeded$, signal);
 
       const onMessageCreated$ = command(async ({ set }, sig: AbortSignal) => {


### PR DESCRIPTION
## Problem

Sentry: **Error: Deferred promise already settled** — 27 occurrences, all on Mobile Safari (iPhone, iOS 18.7), all on `/chats/<thread-id>`.

When a chat thread opened while the document was hidden (PWA in background), the code waited for `visibilitychange` before calling `markThreadReadIfNeeded$`:

```ts
if (document.visibilityState !== "visible") {
  const visibleDeferred = createDeferredPromise<void>(signal);
  const handler = () => {
    if (document.visibilityState === "visible") {
      visibleDeferred.resolve(); // iOS fires this multiple times → throws on 2nd call
    }
  };
  document.addEventListener("visibilitychange", handler, { signal });
  await visibleDeferred.promise;
}
await set(markThreadReadIfNeeded$, signal);
```

On iOS, `visibilitychange` fires multiple times in quick succession with `"visible"` during tab restore. `createDeferredPromise` throws `"Deferred promise already settled"` on the second `resolve()`, crashing the chat thread signal (white screen, no back navigation).

## Fix

Remove the visibility gate entirely — mark the thread as read immediately on open:

```ts
await set(markThreadReadIfNeeded$, signal);
```

Also removes the now-unused `createDeferredPromise` import.