### PR TITLE
revert: soften chat thread running indicator (#11523)

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -115,45 +115,6 @@
   }
 }
 
-/* Chat thread list: synchronized running-state ripple indicator */
-.zero-running-indicator {
-  position: relative;
-  display: inline-flex;
-  width: 0.86rem;
-  height: 0.86rem;
-  border-radius: 9999px;
-}
-.zero-running-indicator::before {
-  content: "";
-  position: absolute;
-  inset: 2.5px;
-  border-radius: inherit;
-  background: currentColor;
-  opacity: var(--zero-running-indicator-center-opacity, 0.34);
-  transform: scale(var(--zero-running-indicator-center-scale, 0.64));
-  transform-origin: center;
-}
-.zero-running-indicator::after {
-  content: "";
-  position: absolute;
-  inset: 1.5px;
-  border-radius: inherit;
-  border: 1px solid currentColor;
-  opacity: var(--zero-running-indicator-ripple-opacity, 0);
-  transform: scale(var(--zero-running-indicator-ripple-scale, 0.82));
-  transform-origin: center;
-}
-@media (prefers-reduced-motion: reduce) {
-  .zero-running-indicator::before {
-    opacity: 0.28;
-    transform: scale(0.62);
-  }
-  .zero-running-indicator::after {
-    opacity: 0.18;
-    transform: scale(1);
-  }
-}
-
 /* Zero app: inherits global cool gray tokens; only card-specific tokens defined here */
 .zero-app {
   --zero-card-radius: 1rem;

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -11,6 +11,7 @@ import {
   IconChevronRight,
   IconTrash,
   IconPencil,
+  IconLoader2,
 } from "@tabler/icons-react";
 import type { ChatThreadListItem } from "@vm0/api-contracts/contracts/chat-threads";
 import { useChatThreadsTitleLabels } from "./zero-sidebar-shared.tsx";
@@ -65,135 +66,15 @@ import { Link } from "../router/link.tsx";
 
 type IndicatorState = "running" | "unread" | "draft";
 type ChatThreadPaneIndicator = "main" | "sidebar";
-const RUNNING_INDICATOR_ANIMATION_MS = 2400;
-const RUNNING_INDICATOR_CONSUMERS_KEY = "zeroRunningIndicatorConsumers";
-const RUNNING_INDICATOR_FRAME_KEY = "zeroRunningIndicatorFrame";
-
-function setRunningIndicatorFrame(now: number): void {
-  const phase =
-    (now % RUNNING_INDICATOR_ANIMATION_MS) / RUNNING_INDICATOR_ANIMATION_MS;
-  const rippleStart = 0.52;
-  const smooth = (value: number): number => {
-    return value * value * (3 - 2 * value);
-  };
-  const centerProgress = smooth(Math.min(phase / rippleStart, 1));
-  const rippleProgress =
-    phase < rippleStart ? 0 : smooth((phase - rippleStart) / (1 - rippleStart));
-  const centerBaseScale = 0.64;
-  const centerScaleRange = 0.24;
-  const rippleOpacity =
-    phase < rippleStart ? 0 : Math.pow(1 - rippleProgress, 1.35) * 0.34;
-  const rootStyle = document.documentElement.style;
-  rootStyle.setProperty(
-    "--zero-running-indicator-center-scale",
-    (
-      centerBaseScale +
-      centerProgress * centerScaleRange -
-      rippleProgress * centerScaleRange
-    ).toFixed(3),
-  );
-  rootStyle.setProperty(
-    "--zero-running-indicator-center-opacity",
-    (0.34 + centerProgress * 0.18 - rippleProgress * 0.18).toFixed(3),
-  );
-  rootStyle.setProperty(
-    "--zero-running-indicator-ripple-scale",
-    (0.8 + rippleProgress * 0.76).toFixed(3),
-  );
-  rootStyle.setProperty(
-    "--zero-running-indicator-ripple-opacity",
-    rippleOpacity.toFixed(3),
-  );
-}
-
-function tickRunningIndicator(now: number): void {
-  setRunningIndicatorFrame(now);
-  setRunningIndicatorFrameId(
-    window.requestAnimationFrame(tickRunningIndicator),
-  );
-}
-
-function getRunningIndicatorRoot(): HTMLElement {
-  return document.documentElement;
-}
-
-function getRunningIndicatorConsumerCount(): number {
-  const value =
-    getRunningIndicatorRoot().dataset[RUNNING_INDICATOR_CONSUMERS_KEY];
-  const count = value ? Number(value) : 0;
-  return Number.isFinite(count) && count > 0 ? count : 0;
-}
-
-function setRunningIndicatorConsumerCount(count: number): void {
-  const root = getRunningIndicatorRoot();
-  if (count > 0) {
-    root.dataset[RUNNING_INDICATOR_CONSUMERS_KEY] = String(count);
-    return;
-  }
-  delete root.dataset[RUNNING_INDICATOR_CONSUMERS_KEY];
-}
-
-function getRunningIndicatorFrameId(): number | null {
-  const value = getRunningIndicatorRoot().dataset[RUNNING_INDICATOR_FRAME_KEY];
-  if (!value) {
-    return null;
-  }
-  const frame = Number(value);
-  return Number.isFinite(frame) ? frame : null;
-}
-
-function setRunningIndicatorFrameId(frame: number | null): void {
-  const root = getRunningIndicatorRoot();
-  if (frame !== null) {
-    root.dataset[RUNNING_INDICATOR_FRAME_KEY] = String(frame);
-    return;
-  }
-  delete root.dataset[RUNNING_INDICATOR_FRAME_KEY];
-}
-
-function registerRunningIndicator(): void {
-  const consumerCount = getRunningIndicatorConsumerCount();
-  setRunningIndicatorConsumerCount(consumerCount + 1);
-  if (consumerCount === 0 && getRunningIndicatorFrameId() === null) {
-    tickRunningIndicator(window.performance.now());
-  }
-}
-
-function unregisterRunningIndicator(): void {
-  const consumerCount = Math.max(0, getRunningIndicatorConsumerCount() - 1);
-  setRunningIndicatorConsumerCount(consumerCount);
-  if (consumerCount === 0) {
-    const frame = getRunningIndicatorFrameId();
-    if (frame !== null) {
-      window.cancelAnimationFrame(frame);
-      setRunningIndicatorFrameId(null);
-    }
-  }
-}
-
-function createRunningIndicatorRef(): (node: HTMLSpanElement | null) => void {
-  let currentNode: HTMLSpanElement | null = null;
-  return (node) => {
-    if (currentNode === node) {
-      return;
-    }
-    if (currentNode !== null && currentNode !== node) {
-      unregisterRunningIndicator();
-    }
-    currentNode = node;
-    if (node !== null) {
-      registerRunningIndicator();
-    }
-  };
-}
 
 function SessionStateIndicator({ state }: { state: IndicatorState }) {
   if (state === "running") {
     return (
-      <span
-        ref={createRunningIndicatorRef()}
+      <IconLoader2
         aria-label="Running"
-        className="zero-running-indicator"
+        size={16}
+        stroke={2}
+        className="animate-spin text-sky-600"
       />
     );
   }


### PR DESCRIPTION
## Summary
- Revert #11523 ("fix: soften chat thread running indicator").
- The replacement indicator runs a `requestAnimationFrame` loop that writes the frame id and consumer count into `<html>` dataset attributes on every tick. In Safari the `data-zero-running-indicator-frame` attribute is observed increasing rapidly in the inspector, and every page load produces 60fps DOM attribute mutations regardless of whether any thread is running.
- Restores the original `IconLoader2` spinner while we redesign the animation without per-frame DOM writes.

## Test plan
- [ ] Open the app in Safari and confirm the `<html>` element no longer carries `data-zero-running-indicator-*` attributes.
- [ ] Verify a running thread in the sidebar shows the spinner indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)