### PR TITLE
ci: smoke test release migrations on neon branch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -113,10 +113,75 @@ jobs:
         id: timer
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
+      - name: Create Production Migration Smoke Branch
+        id: create-migration-smoke-branch
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+          BRANCH_NAME: release-smoke/production-migration
+        run: |
+          if neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -e --arg name "$BRANCH_NAME" '.[] | select(.name == $name)' > /dev/null; then
+            echo "Smoke branch $BRANCH_NAME already exists, resetting..."
+            neonctl branches reset "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --parent
+          else
+            echo "Creating smoke branch $BRANCH_NAME from production"
+            neonctl branches create --name "$BRANCH_NAME" --parent production --project-id "$NEON_PROJECT_ID"
+          fi
+
+          echo "Waiting for smoke branch $BRANCH_NAME to become ready"
+          CURRENT_STATE=""
+          for i in $(seq 1 30); do
+            CURRENT_STATE=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -r --arg name "$BRANCH_NAME" '.[] | select(.name == $name) | .current_state')
+            if [ "$CURRENT_STATE" = "ready" ]; then
+              echo "Smoke branch ready"
+              break
+            fi
+            echo "Smoke branch state: ${CURRENT_STATE:-missing} (attempt $i/30)"
+            sleep 2
+          done
+
+          if [ "$CURRENT_STATE" != "ready" ]; then
+            echo "::error::Smoke branch $BRANCH_NAME not ready after 60 seconds (state: ${CURRENT_STATE:-missing})"
+            exit 1
+          fi
+
+      - name: Run Production Migration Smoke Test
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+          BRANCH_NAME: release-smoke/production-migration
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
+        run: |
+          echo "Getting pooled database URL for smoke branch $BRANCH_NAME"
+          DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --pooled)
+
+          echo "Running production migration smoke test on $BRANCH_NAME"
+          cd turbo
+          DATABASE_URL="$DATABASE_URL" pnpm -F web db:migrate
+          echo "Production migration smoke test completed"
+
+      - name: Delete Production Migration Smoke Branch
+        if: ${{ always() && steps.create-migration-smoke-branch.outcome != 'skipped' }}
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+          BRANCH_NAME: release-smoke/production-migration
+        run: |
+          echo "Cleaning up smoke branch $BRANCH_NAME"
+          BRANCHES_JSON=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json)
+
+          if echo "$BRANCHES_JSON" | jq -e --arg name "$BRANCH_NAME" '.[] | select(.name == $name)' > /dev/null; then
+            neonctl branches delete "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID"
+            echo "Smoke branch $BRANCH_NAME deleted"
+          else
+            echo "Smoke branch $BRANCH_NAME does not exist; cleanup skipped"
+          fi
+
       - name: Get Production Database URL
         id: get-db-url
         run: |
-          # Get the main branch database URL (production)
+          # Get the production branch database URL.
           DATABASE_URL=$(neonctl connection-string production --project-id ${{ vars.NEON_PROJECT_ID }} --database-name neondb --pooled)
           echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
         env:
@@ -124,6 +189,7 @@ jobs:
 
       - name: Run Production Migrations
         run: |
+          echo "Running production migrations on production"
           cd turbo && pnpm -F web db:migrate
         env:
           DATABASE_URL: ${{ steps.get-db-url.outputs.database-url }}


### PR DESCRIPTION
## Summary

- add a release migration smoke step before production DB migrations
- use fixed Neon branch `release-smoke/production-migration`, resetting it when present and creating it from `production` when absent
- run the same `pnpm -F web db:migrate` command against the smoke branch using pooled connection strings, then always clean up the smoke branch before production migration

Closes #11576

## Verification

- actionlint `.github/workflows/release-please.yml`
- `pnpm exec prettier --check ../.github/workflows/release-please.yml` from `turbo/`
- `git diff --check`