### PR TITLE
feat: add promo credits messaging to homepage hero

### DIFF
--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -942,6 +942,9 @@ export function LandingPage({ initialIsSignedIn = false }: LandingPageProps) {
               />
               <AddToSlackButton />
             </div>
+            <p className="text-sm text-[hsl(var(--muted-foreground))]">
+              {t("hero.ctaSubtext")}
+            </p>
           </div>
         </section>
 

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -4700,6 +4700,7 @@
       "subtitle": "Zero connects to 100+ tools and does the work. Reports, triage, outreach, research. In Slack or on the web.",
       "ctaGetStarted": "Get started",
       "ctaOpenApp": "Open app",
+      "ctaSubtext": "Free to start. Redeem up to $100 in bonus credits.",
       "seedBanner": "Check out our $14M seed round fundraising blog."
     },
     "worksForYou": {
@@ -4808,7 +4809,7 @@
     },
     "cta": {
       "title": "You decide what matters. Zero handles the rest.",
-      "subtitle": "Start free. Use it in Slack or on the web. No credit card required."
+      "subtitle": "Start free with credits. Redeem up to $100 more. No credit card required."
     }
   },
   "securityPage": {


### PR DESCRIPTION
## Summary
- Add "Free to start. Redeem up to $100 in bonus credits." subtext under the hero CTA buttons
- Update bottom CTA subtitle to "Start free with credits. Redeem up to $100 more. No credit card required."
- New translation key: `landing.hero.ctaSubtext`

## Context
The ZERO100 campaign already exists in the platform at `/redeem/ZERO100` (100,000 bonus credits, 30-day expiry). This PR surfaces that value proposition on the homepage so visitors see the offer before clicking through.

## Changes
- `LandingPage.tsx` — one `<p>` tag under the hero CTA button group
- `en.json` — one new key + one updated subtitle string

## Test plan
- [ ] Verify hero CTA subtext renders on `/en` (signed-out)
- [ ] Verify bottom CTA subtitle reflects credit messaging
- [ ] Verify `/redeem/ZERO100` flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)