### PR TITLE
feat(ui): add wall-clock-synced RunningIndicator component

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -11,7 +11,6 @@ import {
   IconChevronRight,
   IconTrash,
   IconPencil,
-  IconLoader2,
 } from "@tabler/icons-react";
 import type { ChatThreadListItem } from "@vm0/api-contracts/contracts/chat-threads";
 import { useChatThreadsTitleLabels } from "./zero-sidebar-shared.tsx";
@@ -21,6 +20,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
   Button,
+  RunningIndicator,
 } from "@vm0/ui";
 import {
   Dialog,
@@ -69,14 +69,7 @@ type ChatThreadPaneIndicator = "main" | "sidebar";
 
 function SessionStateIndicator({ state }: { state: IndicatorState }) {
   if (state === "running") {
-    return (
-      <IconLoader2
-        aria-label="Running"
-        size={16}
-        stroke={2}
-        className="animate-spin text-sky-600"
-      />
-    );
+    return <RunningIndicator />;
   }
   if (state === "unread") {
     return (

--- a/turbo/packages/ui/src/components/ui/running-indicator.tsx
+++ b/turbo/packages/ui/src/components/ui/running-indicator.tsx
@@ -1,0 +1,42 @@
+import {
+  useLayoutEffect,
+  useRef,
+  type HTMLAttributes,
+} from "react";
+import { cn } from "../../lib/utils";
+
+const RUNNING_INDICATOR_DURATION_MS = 2400;
+
+interface RunningIndicatorProps extends HTMLAttributes<HTMLSpanElement> {
+  label?: string;
+}
+
+function RunningIndicator({
+  className,
+  label = "Running",
+  ...rest
+}: RunningIndicatorProps) {
+  const ref = useRef<HTMLSpanElement | null>(null);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+    // Anchor every indicator's animation phase to wall-clock time, so
+    // instances mounted at different moments stay visually synchronized.
+    const phase = Date.now() % RUNNING_INDICATOR_DURATION_MS;
+    for (const animation of el.getAnimations({ subtree: true })) {
+      animation.currentTime = phase;
+    }
+  }, []);
+  return (
+    <span
+      ref={ref}
+      aria-label={label}
+      className={cn("running-indicator", className)}
+      {...rest}
+    />
+  );
+}
+
+export { RunningIndicator, type RunningIndicatorProps };

--- a/turbo/packages/ui/src/components/ui/running-indicator.tsx
+++ b/turbo/packages/ui/src/components/ui/running-indicator.tsx
@@ -15,7 +15,9 @@ function RunningIndicator({
   const ref = useRef<HTMLSpanElement | null>(null);
   useLayoutEffect(() => {
     const el = ref.current;
-    if (!el) {
+    // getAnimations is unavailable in some non-browser test DOMs (e.g.
+    // happy-dom); skip phase syncing there.
+    if (!el || typeof el.getAnimations !== "function") {
       return;
     }
     // Anchor every indicator's animation phase to wall-clock time, so

--- a/turbo/packages/ui/src/components/ui/running-indicator.tsx
+++ b/turbo/packages/ui/src/components/ui/running-indicator.tsx
@@ -1,8 +1,4 @@
-import {
-  useLayoutEffect,
-  useRef,
-  type HTMLAttributes,
-} from "react";
+import { useLayoutEffect, useRef, type HTMLAttributes } from "react";
 import { cn } from "../../lib/utils";
 
 const RUNNING_INDICATOR_DURATION_MS = 2400;

--- a/turbo/packages/ui/src/index.ts
+++ b/turbo/packages/ui/src/index.ts
@@ -73,6 +73,10 @@ export {
   SheetTitle,
   SheetDescription,
 } from "./components/ui/sheet";
+export {
+  RunningIndicator,
+  type RunningIndicatorProps,
+} from "./components/ui/running-indicator";
 export { Skeleton } from "./components/ui/skeleton";
 export { Switch } from "./components/ui/switch";
 export {

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -395,4 +395,79 @@
   .dialog-scrollable::-webkit-scrollbar-thumb:hover {
     background-color: rgba(128, 128, 128, 0.5);
   }
+
+  /*
+   * Running indicator — synchronized breathing dot for "in progress" state.
+   * Phase is anchored to wall-clock time by <RunningIndicator/> via the Web
+   * Animations API (Animation.currentTime), so multiple instances mounted at
+   * different moments stay visually in sync.
+   */
+  .running-indicator {
+    position: relative;
+    display: inline-flex;
+    width: 0.86rem;
+    height: 0.86rem;
+    border-radius: 9999px;
+    color: var(--color-sky-600, #0284c7);
+  }
+  .running-indicator::before {
+    content: "";
+    position: absolute;
+    inset: 2.5px;
+    border-radius: inherit;
+    background: currentColor;
+    transform-origin: center;
+    animation: running-indicator-center 2400ms cubic-bezier(0.33, 0, 0.66, 1)
+      infinite;
+  }
+  .running-indicator::after {
+    content: "";
+    position: absolute;
+    inset: 1.5px;
+    border-radius: inherit;
+    border: 1px solid currentColor;
+    transform-origin: center;
+    animation: running-indicator-ripple 2400ms ease-out infinite;
+  }
+}
+
+@keyframes running-indicator-center {
+  0%,
+  100% {
+    transform: scale(0.64);
+    opacity: 0.34;
+  }
+  52% {
+    transform: scale(0.88);
+    opacity: 0.52;
+  }
+}
+
+@keyframes running-indicator-ripple {
+  0%,
+  45% {
+    transform: scale(0.8);
+    opacity: 0;
+  }
+  52% {
+    transform: scale(0.8);
+    opacity: 0.34;
+  }
+  100% {
+    transform: scale(1.56);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .running-indicator::before {
+    animation: none;
+    opacity: 0.28;
+    transform: scale(0.62);
+  }
+  .running-indicator::after {
+    animation: none;
+    opacity: 0.18;
+    transform: scale(1);
+  }
 }


### PR DESCRIPTION
## Summary
- Introduce a shared `<RunningIndicator />` in `@vm0/ui` that anchors animation phase to wall-clock time via the Web Animations API (`Animation.currentTime`), so multiple instances mounted at different moments stay visually in sync.
- Switch the chat sidebar's running session indicator over to the new component (replacing the `IconLoader2` spinner left as a stopgap after #11579 reverted #11523).
- Supersedes #11583 — the pure-CSS keyframes approach had no cross-instance sync (newcomers always started from phase 0).

## Why the previous attempts drifted
- **#11523** (reverted in #11579): used a JS `requestAnimationFrame` loop that wrote frame ids into `<html>` `dataset` every tick — caused 60fps DOM attribute mutations and Safari devtools showed `data-zero-running-indicator-frame` rapidly increasing.
- **#11583** (pure CSS keyframes): each indicator's animation started at its own DOM-attach time, so any newly mounted indicator was visibly out of phase with existing ones.

## How this approach syncs
- CSS animations run at fixed `2400ms` per cycle.
- On mount, `useLayoutEffect` (synchronous after DOM commit, before paint) reads each animation via `el.getAnimations({ subtree: true })` and sets `currentTime = Date.now() % 2400`.
- Every indicator — regardless of mount time — jumps to the same wall-clock-anchored phase before its first paint, so there's no flicker and they stay in sync forever.

## Test plan
- [ ] Open the platform app in Safari and Chrome, trigger multiple running threads in the chat sidebar at different times, confirm all indicators pulse in unison.
- [ ] Confirm `<html>` no longer carries any `data-zero-running-indicator-*` attributes.
- [ ] Verify `prefers-reduced-motion: reduce` shows a static dot instead of the animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)