### PR TITLE
feat: add generation connector doctor

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/generate.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/generate.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import chalk from "chalk";
+import { server } from "../../../../mocks/server";
+import { generateCommand } from "../generate";
+
+const AGENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+function connector(
+  type: string,
+  externalUsername: string | null = `${type}-user`,
+) {
+  return {
+    id: null,
+    type,
+    authMethod: "api-token",
+    externalId: `${type}-external-id`,
+    externalUsername,
+    externalEmail: null,
+    oauthScopes: null,
+    needsReconnect: false,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+function stubConnectors(connectors: Array<Record<string, unknown>>) {
+  return http.get("http://localhost:3000/api/zero/connectors", () => {
+    return HttpResponse.json({
+      connectors,
+      configuredTypes: ["fal", "luma", "openai", "replicate", "runway"],
+      connectorProvidedSecretNames: [],
+    });
+  });
+}
+
+function stubUserConnectors(enabledTypes: string[]) {
+  return http.get(
+    `http://localhost:3000/api/zero/agents/${AGENT_ID}/user-connectors`,
+    () => {
+      return HttpResponse.json({ enabledTypes });
+    },
+  );
+}
+
+describe("zero doctor generate command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    vi.stubEnv("ZERO_AGENT_ID", AGENT_ID);
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  function output(): string {
+    return mockConsoleLog.mock.calls.flat().join("\n");
+  }
+
+  function errors(): string {
+    return mockConsoleError.mock.calls.flat().join("\n");
+  }
+
+  it("lists ready image generation connectors for the current agent", async () => {
+    server.use(
+      stubConnectors([
+        connector("fal", "fal-user"),
+        connector("openai", "openai-user"),
+        connector("replicate", "replicate-user"),
+      ]),
+      stubUserConnectors(["fal", "openai"]),
+    );
+
+    await generateCommand.parseAsync(["node", "cli", "image"]);
+
+    const text = output();
+    expect(text).toContain("Image generation choices for current agent");
+    expect(text).toContain(`Agent:    ${AGENT_ID}`);
+    expect(text).toContain("fal");
+    expect(text).toContain("fal.ai");
+    expect(text).toContain("@fal-user");
+    expect(text).toContain("openai");
+    expect(text).toContain("OpenAI");
+    expect(text).not.toContain("replicate-user");
+    expect(text).toContain(
+      "Use --all to see every image generation candidate.",
+    );
+  });
+
+  it("shows not-ready candidates and action links with --all", async () => {
+    server.use(
+      stubConnectors([
+        connector("fal", "fal-user"),
+        connector("replicate", "replicate-user"),
+        { ...connector("openai", "openai-user"), needsReconnect: true },
+      ]),
+      stubUserConnectors(["fal"]),
+    );
+
+    await generateCommand.parseAsync(["node", "cli", "image", "--all"]);
+
+    const text = output();
+    expect(text).toContain("Other image generation connectors");
+    expect(text).toContain("Replicate");
+    expect(text).toContain("connected, not authorized for current agent");
+    expect(text).toContain("Luma AI");
+    expect(text).toContain("not connected or authorized for current agent");
+    expect(text).toContain("OpenAI");
+    expect(text).toContain("connected, reconnect required");
+    expect(text).toContain(
+      `[Authorize Replicate](http://localhost:3000/connectors/replicate/authorize?agentId=${AGENT_ID})`,
+    );
+    expect(text).toContain(
+      `[Connect and authorize Luma AI](http://localhost:3000/connectors/luma/authorize?agentId=${AGENT_ID})`,
+    );
+    expect(text).toContain(
+      "[Reconnect OpenAI](http://localhost:3000/connectors)",
+    );
+  });
+
+  it("outputs machine-readable JSON", async () => {
+    server.use(
+      stubConnectors([connector("fal", "fal-user"), connector("replicate")]),
+      stubUserConnectors(["fal"]),
+    );
+
+    await generateCommand.parseAsync(["node", "cli", "image", "--json"]);
+
+    const json = JSON.parse(output()) as {
+      generationType: string;
+      agentId: string;
+      choices: Array<{ type: string; status: string }>;
+      otherCandidates: Array<{ type: string; status: string }>;
+    };
+    expect(json.generationType).toBe("image");
+    expect(json.agentId).toBe(AGENT_ID);
+    expect(json.choices).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "fal", status: "ready" }),
+      ]),
+    );
+    expect(json.otherCandidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "replicate",
+          status: "not-authorized",
+        }),
+      ]),
+    );
+  });
+
+  it("rejects unknown generation types with available type guidance", async () => {
+    await expect(
+      generateCommand.parseAsync(["node", "cli", "spaceship"]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(errors()).toContain("Unknown generation type: spaceship");
+    expect(errors()).toContain("Available types:");
+    expect(errors()).toContain("image");
+    expect(errors()).toContain("video");
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/doctor/generate.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/generate.ts
@@ -1,0 +1,362 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorConfig,
+  type ConnectorGenerationType,
+  type ConnectorType,
+} from "@vm0/connectors/connectors";
+import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connector-schemas";
+import { getZeroAgentUserConnectors } from "../../../lib/api/domains/zero-agents";
+import { listZeroConnectors } from "../../../lib/api/domains/zero-connectors";
+import { withErrorHandler } from "../../../lib/command";
+import { getPlatformOrigin } from "./platform-url";
+
+const GENERATION_TYPE_ORDER: readonly ConnectorGenerationType[] = [
+  "image",
+  "video",
+  "audio",
+  "text",
+  "code",
+  "document",
+  "presentation",
+  "website",
+];
+
+const GENERATION_TYPE_LABELS: Record<ConnectorGenerationType, string> = {
+  audio: "Audio",
+  code: "Code",
+  document: "Document",
+  image: "Image",
+  presentation: "Presentation",
+  text: "Text",
+  video: "Video",
+  website: "Website",
+};
+
+type ConnectedConnector = ConnectorListResponse["connectors"][number];
+
+type CandidateStatus =
+  | "ready"
+  | "needs-reconnect"
+  | "not-authorized"
+  | "not-connected"
+  | "not-available";
+
+interface GenerateOptions {
+  all?: boolean;
+  json?: boolean;
+}
+
+interface GenerationCandidate {
+  type: ConnectorType;
+  label: string;
+  status: CandidateStatus;
+  reason: string;
+  account?: string;
+  authMethod?: string;
+  actionLabel?: string;
+  actionUrl?: string;
+}
+
+function getAvailableGenerationTypes(): ConnectorGenerationType[] {
+  const available = new Set<ConnectorGenerationType>();
+  for (const config of Object.values(CONNECTOR_TYPES)) {
+    for (const generationType of config.generation ?? []) {
+      available.add(generationType);
+    }
+  }
+
+  return GENERATION_TYPE_ORDER.filter((type) => {
+    return available.has(type);
+  });
+}
+
+function parseGenerationType(value: string): ConnectorGenerationType {
+  const availableTypes = getAvailableGenerationTypes();
+  if (availableTypes.includes(value as ConnectorGenerationType)) {
+    return value as ConnectorGenerationType;
+  }
+
+  throw new Error(`Unknown generation type: ${value}`, {
+    cause: new Error(`Available types: ${availableTypes.join(", ")}`),
+  });
+}
+
+function getGenerationConnectors(
+  generationType: ConnectorGenerationType,
+): Array<[ConnectorType, ConnectorConfig]> {
+  return (
+    Object.entries(CONNECTOR_TYPES) as Array<[ConnectorType, ConnectorConfig]>
+  )
+    .filter(([, config]) => {
+      return config.generation?.includes(generationType) === true;
+    })
+    .sort(([a], [b]) => {
+      return a.localeCompare(b);
+    });
+}
+
+function formatAccount(connector: ConnectedConnector): string | undefined {
+  if (connector.externalUsername) return `@${connector.externalUsername}`;
+  if (connector.externalEmail) return connector.externalEmail;
+  if (connector.externalId) return connector.externalId;
+  return undefined;
+}
+
+function getAction(
+  status: CandidateStatus,
+  type: ConnectorType,
+  label: string,
+  agentId: string | undefined,
+  platformOrigin: string,
+): { actionLabel?: string; actionUrl?: string } {
+  if (status === "needs-reconnect") {
+    return {
+      actionLabel: `Reconnect ${label}`,
+      actionUrl: `${platformOrigin}/connectors`,
+    };
+  }
+
+  if (status === "not-authorized" && agentId) {
+    return {
+      actionLabel: `Authorize ${label}`,
+      actionUrl: `${platformOrigin}/connectors/${type}/authorize?agentId=${agentId}`,
+    };
+  }
+
+  if (status === "not-connected") {
+    if (agentId) {
+      return {
+        actionLabel: `Connect and authorize ${label}`,
+        actionUrl: `${platformOrigin}/connectors/${type}/authorize?agentId=${agentId}`,
+      };
+    }
+
+    return {
+      actionLabel: `Connect ${label}`,
+      actionUrl: `${platformOrigin}/connectors/${type}/connect`,
+    };
+  }
+
+  return {};
+}
+
+function toCandidate(params: {
+  type: ConnectorType;
+  config: ConnectorConfig;
+  connector: ConnectedConnector | undefined;
+  configuredTypes: Set<ConnectorType>;
+  authorizedTypes: Set<string> | null;
+  agentId: string | undefined;
+  platformOrigin: string;
+}): GenerationCandidate {
+  const {
+    type,
+    config,
+    connector,
+    configuredTypes,
+    authorizedTypes,
+    agentId,
+    platformOrigin,
+  } = params;
+
+  let status: CandidateStatus;
+  let reason: string;
+
+  if (connector?.needsReconnect) {
+    status = "needs-reconnect";
+    reason = "connected, reconnect required";
+  } else if (!connector) {
+    status = configuredTypes.has(type) ? "not-connected" : "not-available";
+    reason =
+      status === "not-connected"
+        ? agentId
+          ? "not connected or authorized for current agent"
+          : "not connected"
+        : "not available in this environment";
+  } else if (authorizedTypes && !authorizedTypes.has(type)) {
+    status = "not-authorized";
+    reason = "connected, not authorized for current agent";
+  } else {
+    status = "ready";
+    reason = agentId
+      ? "connected and authorized for current agent"
+      : "connected; agent authorization was not checked";
+  }
+
+  return {
+    type,
+    label: config.label,
+    status,
+    reason,
+    account: connector ? formatAccount(connector) : undefined,
+    authMethod: connector?.authMethod,
+    ...getAction(status, type, config.label, agentId, platformOrigin),
+  };
+}
+
+function pad(value: string, width: number): string {
+  return value.padEnd(width);
+}
+
+function renderRows(candidates: GenerationCandidate[]): void {
+  const typeWidth = Math.max(
+    4,
+    ...candidates.map((candidate) => {
+      return candidate.type.length;
+    }),
+  );
+  const labelWidth = Math.max(
+    5,
+    ...candidates.map((candidate) => {
+      return candidate.label.length;
+    }),
+  );
+
+  for (const candidate of candidates) {
+    const suffix =
+      candidate.status === "ready"
+        ? (candidate.account ?? candidate.authMethod ?? "")
+        : candidate.reason;
+    console.log(
+      `  ${pad(candidate.type, typeWidth)}  ${pad(candidate.label, labelWidth)}  ${suffix}`,
+    );
+  }
+}
+
+function renderActions(candidates: GenerationCandidate[]): void {
+  const actionable = candidates.filter((candidate) => {
+    return candidate.actionLabel && candidate.actionUrl;
+  });
+  if (actionable.length === 0) return;
+
+  console.log("");
+  console.log("Next actions:");
+  for (const candidate of actionable) {
+    console.log(`  [${candidate.actionLabel}](${candidate.actionUrl})`);
+  }
+}
+
+function renderText(params: {
+  generationType: ConnectorGenerationType;
+  agentId: string | undefined;
+  ready: GenerationCandidate[];
+  other: GenerationCandidate[];
+  showAll: boolean;
+}): void {
+  const { generationType, agentId, ready, other, showAll } = params;
+  const label = GENERATION_TYPE_LABELS[generationType];
+  const scope = agentId ? "for current agent" : "(connected connectors)";
+
+  console.log(`${label} generation choices ${scope}`);
+  console.log("");
+
+  if (agentId) {
+    console.log(`${"Agent:".padEnd(10)}${agentId}`);
+    console.log("");
+  } else {
+    console.log(
+      "ZERO_AGENT_ID is not set, so agent authorization could not be checked.",
+    );
+    console.log("");
+  }
+
+  if (ready.length > 0) {
+    renderRows(ready);
+  } else {
+    console.log(`No ready ${generationType} generation connectors found.`);
+  }
+
+  if (showAll && other.length > 0) {
+    console.log("");
+    console.log(`Other ${generationType} generation connectors`);
+    console.log("");
+    renderRows(other);
+  }
+
+  if (ready.length === 0 || showAll) {
+    renderActions(other);
+  }
+}
+
+export const generateCommand = new Command()
+  .name("generate")
+  .description("Show generation connector choices for the current agent")
+  .argument(
+    "<type>",
+    `Generation type (${getAvailableGenerationTypes().join(", ")})`,
+  )
+  .option("--all", "Also show unavailable or not-yet-authorized connectors")
+  .option("--json", "Output machine-readable JSON")
+  .action(
+    withErrorHandler(async (type: string, options: GenerateOptions) => {
+      const generationType = parseGenerationType(type);
+      const agentId = process.env.ZERO_AGENT_ID;
+      const [connectorList, enabledTypes, platformOrigin] = await Promise.all([
+        listZeroConnectors(),
+        agentId ? getZeroAgentUserConnectors(agentId) : Promise.resolve(null),
+        getPlatformOrigin(),
+      ]);
+      const connectedMap = new Map(
+        connectorList.connectors.map((connector) => {
+          return [connector.type, connector];
+        }),
+      );
+      const configuredTypes = new Set(connectorList.configuredTypes);
+      const authorizedTypes = enabledTypes ? new Set(enabledTypes) : null;
+      const candidates = getGenerationConnectors(generationType).map(
+        ([connectorType, config]) => {
+          return toCandidate({
+            type: connectorType,
+            config,
+            connector: connectedMap.get(connectorType),
+            configuredTypes,
+            authorizedTypes,
+            agentId,
+            platformOrigin,
+          });
+        },
+      );
+      const ready = candidates.filter((candidate) => {
+        return candidate.status === "ready";
+      });
+      const other = candidates.filter((candidate) => {
+        return candidate.status !== "ready";
+      });
+
+      if (options.json) {
+        console.log(
+          JSON.stringify(
+            {
+              generationType,
+              availableTypes: getAvailableGenerationTypes(),
+              agentId: agentId ?? null,
+              choices: ready,
+              otherCandidates: other,
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+
+      renderText({
+        generationType,
+        agentId,
+        ready,
+        other,
+        showAll: options.all === true,
+      });
+
+      if (!options.all && other.length > 0) {
+        console.log("");
+        console.log(
+          chalk.dim(
+            `Use --all to see every ${generationType} generation candidate.`,
+          ),
+        );
+      }
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/doctor/index.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/index.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { checkConnectorCommand } from "./check-connector";
+import { generateCommand } from "./generate";
 import { permissionDenyCommand } from "./permission-deny";
 import { permissionChangeCommand } from "./permission-change";
 
@@ -7,6 +8,7 @@ export const zeroDoctorCommand = new Command()
   .name("doctor")
   .description("Diagnose runtime issues (connector health, permission denials)")
   .addCommand(checkConnectorCommand)
+  .addCommand(generateCommand)
   .addCommand(permissionDenyCommand)
   .addCommand(permissionChangeCommand)
   .addHelpText(
@@ -15,6 +17,7 @@ export const zeroDoctorCommand = new Command()
 Examples:
   Check a connector?     zero doctor check-connector --env-name GITHUB_TOKEN
   Check a URL?           zero doctor check-connector --url https://api.github.com/repos/owner/repo
+  Generate with image?   zero doctor generate image
   Check with permission? zero doctor check-connector --env-name SLACK_TOKEN --check-permission chat:write
   Permission denied?     zero doctor permission-deny github --method GET --path /repos/owner/repo
   Change a permission?   zero doctor permission-change github --permission contents:read --enable

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -243,6 +243,16 @@ export type ConnectorDisplayCategory =
 
 export type ConnectorDisplayCategoryGroup = "ai";
 
+export type ConnectorGenerationType =
+  | "audio"
+  | "code"
+  | "document"
+  | "image"
+  | "presentation"
+  | "text"
+  | "video"
+  | "website";
+
 export const CONNECTOR_DISPLAY_CATEGORY_GROUPS: Record<
   ConnectorDisplayCategoryGroup,
   { label: string; menuLabel: string }
@@ -345,6 +355,11 @@ export interface ConnectorConfig {
   readonly oauth?: ConnectorOAuthConfig;
   /** Environment mapping declaring which env vars this connector provides. */
   readonly environmentMapping: Record<string, string>;
+  /**
+   * Output categories this connector skill can generate. This is product
+   * metadata for discovery and routing, not a permission/capability grant.
+   */
+  readonly generation?: readonly ConnectorGenerationType[];
   /**
    * Optional concept words and common-guess aliases used by connector search.
    * Lowercase only. Avoid duplicating content already in `label`,

--- a/turbo/packages/connectors/src/connectors/browserless.ts
+++ b/turbo/packages/connectors/src/connectors/browserless.ts
@@ -4,6 +4,7 @@ export const browserless = {
   browserless: {
     label: "Browserless",
     category: "data-automation-infrastructure",
+    generation: ["document", "image"],
     environmentMapping: {
       BROWSERLESS_TOKEN: "$secrets.BROWSERLESS_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/deepseek.ts
+++ b/turbo/packages/connectors/src/connectors/deepseek.ts
@@ -4,6 +4,7 @@ export const deepseek = {
   deepseek: {
     label: "DeepSeek",
     category: "ai-general-models",
+    generation: ["code", "text"],
     environmentMapping: {
       DEEPSEEK_TOKEN: "$secrets.DEEPSEEK_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/dify.ts
+++ b/turbo/packages/connectors/src/connectors/dify.ts
@@ -4,6 +4,7 @@ export const dify = {
   dify: {
     label: "Dify",
     category: "ai-agent-apps",
+    generation: ["text"],
     environmentMapping: {
       DIFY_TOKEN: "$secrets.DIFY_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/elevenlabs.ts
+++ b/turbo/packages/connectors/src/connectors/elevenlabs.ts
@@ -4,6 +4,7 @@ export const elevenlabs = {
   elevenlabs: {
     label: "ElevenLabs",
     category: "ai-voice-audio",
+    generation: ["audio"],
     environmentMapping: {
       ELEVENLABS_TOKEN: "$secrets.ELEVENLABS_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/fal.ts
+++ b/turbo/packages/connectors/src/connectors/fal.ts
@@ -4,6 +4,7 @@ export const fal = {
   fal: {
     label: "fal.ai",
     category: "ai-image-video",
+    generation: ["image", "video"],
     environmentMapping: {
       FAL_TOKEN: "$secrets.FAL_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/gamma.ts
+++ b/turbo/packages/connectors/src/connectors/gamma.ts
@@ -4,6 +4,7 @@ export const gamma = {
   gamma: {
     label: "Gamma",
     category: "marketing-content-growth",
+    generation: ["document", "presentation", "website"],
     environmentMapping: {
       GAMMA_TOKEN: "$secrets.GAMMA_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/groq.ts
+++ b/turbo/packages/connectors/src/connectors/groq.ts
@@ -4,6 +4,7 @@ export const groq = {
   groq: {
     label: "Groq",
     category: "ai-general-models",
+    generation: ["text"],
     tags: ["llm", "ai", "llama", "inference"],
     environmentMapping: {
       GROQ_TOKEN: "$secrets.GROQ_TOKEN",

--- a/turbo/packages/connectors/src/connectors/heygen.ts
+++ b/turbo/packages/connectors/src/connectors/heygen.ts
@@ -4,6 +4,7 @@ export const heygen = {
   heygen: {
     label: "HeyGen",
     category: "marketing-content-growth",
+    generation: ["video"],
     environmentMapping: {
       HEYGEN_TOKEN: "$secrets.HEYGEN_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/htmlcsstoimage.ts
+++ b/turbo/packages/connectors/src/connectors/htmlcsstoimage.ts
@@ -4,6 +4,7 @@ export const htmlcsstoimage = {
   htmlcsstoimage: {
     label: "HTML/CSS to Image",
     category: "marketing-content-growth",
+    generation: ["image"],
     environmentMapping: {
       HCTI_API_KEY: "$secrets.HCTI_API_KEY",
       HCTI_USER_ID: "$vars.HCTI_USER_ID",

--- a/turbo/packages/connectors/src/connectors/hugging-face.ts
+++ b/turbo/packages/connectors/src/connectors/hugging-face.ts
@@ -4,6 +4,7 @@ export const huggingFace = {
   "hugging-face": {
     label: "Hugging Face",
     category: "ai-general-models",
+    generation: ["image", "text"],
     environmentMapping: {
       HUGGING_FACE_TOKEN: "$secrets.HUGGING_FACE_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/hume.ts
+++ b/turbo/packages/connectors/src/connectors/hume.ts
@@ -4,6 +4,7 @@ export const hume = {
   hume: {
     label: "Hume",
     category: "ai-voice-audio",
+    generation: ["audio"],
     environmentMapping: {
       HUME_TOKEN: "$secrets.HUME_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/luma.ts
+++ b/turbo/packages/connectors/src/connectors/luma.ts
@@ -4,6 +4,7 @@ export const luma = {
   luma: {
     label: "Luma AI",
     category: "ai-image-video",
+    generation: ["image", "video"],
     environmentMapping: {
       LUMA_TOKEN: "$secrets.LUMA_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/minimax.ts
+++ b/turbo/packages/connectors/src/connectors/minimax.ts
@@ -4,6 +4,7 @@ export const minimax = {
   minimax: {
     label: "MiniMax",
     category: "ai-general-models",
+    generation: ["audio", "text", "video"],
     environmentMapping: {
       MINIMAX_TOKEN: "$secrets.MINIMAX_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/nano-banana.ts
+++ b/turbo/packages/connectors/src/connectors/nano-banana.ts
@@ -5,6 +5,7 @@ export const nanoBanana = {
   "nano-banana": {
     label: "Nano Banana",
     category: "ai-image-video",
+    generation: ["image"],
     environmentMapping: {},
     helpText: "Google Gemini image generation, billed to your org credits",
     featureFlag: FeatureSwitchKey.PlatformConnectors,

--- a/turbo/packages/connectors/src/connectors/openai.ts
+++ b/turbo/packages/connectors/src/connectors/openai.ts
@@ -4,6 +4,7 @@ export const openai = {
   openai: {
     label: "OpenAI",
     category: "ai-general-models",
+    generation: ["audio", "image", "text"],
     tags: ["llm", "ai", "gpt", "chatgpt"],
     environmentMapping: {
       OPENAI_TOKEN: "$secrets.OPENAI_TOKEN",

--- a/turbo/packages/connectors/src/connectors/pdf4me.ts
+++ b/turbo/packages/connectors/src/connectors/pdf4me.ts
@@ -4,6 +4,7 @@ export const pdf4me = {
   pdf4me: {
     label: "PDF4me",
     category: "data-automation-infrastructure",
+    generation: ["document"],
     environmentMapping: {
       PDF4ME_TOKEN: "$secrets.PDF4ME_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/pdfco.ts
+++ b/turbo/packages/connectors/src/connectors/pdfco.ts
@@ -4,6 +4,7 @@ export const pdfco = {
   pdfco: {
     label: "PDF.co",
     category: "data-automation-infrastructure",
+    generation: ["document"],
     environmentMapping: {
       PDFCO_TOKEN: "$secrets.PDFCO_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/pdforge.ts
+++ b/turbo/packages/connectors/src/connectors/pdforge.ts
@@ -4,6 +4,7 @@ export const pdforge = {
   pdforge: {
     label: "PDForge",
     category: "data-automation-infrastructure",
+    generation: ["document"],
     environmentMapping: {
       PDFORGE_API_KEY: "$secrets.PDFORGE_API_KEY",
     },

--- a/turbo/packages/connectors/src/connectors/perplexity.ts
+++ b/turbo/packages/connectors/src/connectors/perplexity.ts
@@ -4,6 +4,7 @@ export const perplexity = {
   perplexity: {
     label: "Perplexity",
     category: "data-automation-infrastructure",
+    generation: ["text"],
     environmentMapping: {
       PERPLEXITY_TOKEN: "$secrets.PERPLEXITY_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/replicate.ts
+++ b/turbo/packages/connectors/src/connectors/replicate.ts
@@ -4,6 +4,7 @@ export const replicate = {
   replicate: {
     label: "Replicate",
     category: "ai-image-video",
+    generation: ["image", "text"],
     environmentMapping: {
       REPLICATE_TOKEN: "$secrets.REPLICATE_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/runway.ts
+++ b/turbo/packages/connectors/src/connectors/runway.ts
@@ -4,6 +4,7 @@ export const runway = {
   runway: {
     label: "Runway",
     category: "ai-image-video",
+    generation: ["video"],
     environmentMapping: {
       RUNWAY_TOKEN: "$secrets.RUNWAY_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/stability-ai.ts
+++ b/turbo/packages/connectors/src/connectors/stability-ai.ts
@@ -5,6 +5,7 @@ export const stabilityAi = {
   "stability-ai": {
     label: "Stability AI",
     category: "ai-image-video",
+    generation: ["image"],
     environmentMapping: {
       STABILITY_TOKEN: "$secrets.STABILITY_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/together.ts
+++ b/turbo/packages/connectors/src/connectors/together.ts
@@ -4,6 +4,7 @@ export const together = {
   together: {
     label: "Together AI",
     category: "ai-general-models",
+    generation: ["image", "text"],
     environmentMapping: {
       TOGETHER_TOKEN: "$secrets.TOGETHER_TOKEN",
     },

--- a/turbo/packages/connectors/src/connectors/v0.ts
+++ b/turbo/packages/connectors/src/connectors/v0.ts
@@ -4,6 +4,7 @@ export const v0 = {
   v0: {
     label: "v0",
     category: "ai-agent-apps",
+    generation: ["code", "website"],
     environmentMapping: {
       V0_TOKEN: "$secrets.V0_TOKEN",
     },


### PR DESCRIPTION
## Summary
- add connector `generation` metadata for generation-capable skills
- add `zero doctor generate <type>` to list usable generation connectors for `ZERO_AGENT_ID`
- add command tests for ready choices, `--all`, JSON output, and invalid type guidance

## Tests
- `pnpm --filter @vm0/cli test -- src/commands/zero/doctor/__tests__/generate.test.ts`
- `pnpm --filter @vm0/connectors check-types`
- `pnpm --filter @vm0/cli check-types`
- `pnpm --filter @vm0/connectors lint`
- `pnpm --filter @vm0/cli lint`

## Notes
- pre-commit full workspace `pnpm check-types` is currently blocked by existing `apps/platform` errors in `org-providers-tab.tsx` (`recharts` module missing and implicit `any` parameters); the focused connector/CLI checks above pass.