### PR TITLE
feat: add artifact google drive sync

### DIFF
--- a/turbo/apps/platform/src/lib/zip.ts
+++ b/turbo/apps/platform/src/lib/zip.ts
@@ -1,0 +1,187 @@
+const ZIP_LOCAL_FILE_HEADER_SIGNATURE = 0x04_03_4b_50;
+const ZIP_CENTRAL_DIRECTORY_SIGNATURE = 0x02_01_4b_50;
+const ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06_05_4b_50;
+const ZIP_VERSION_NEEDED = 20;
+const ZIP_STORE_METHOD = 0;
+const ZIP_MAX_UINT32 = 0xff_ff_ff_ff;
+
+type ZipFileEntry = {
+  readonly filename: string;
+  readonly data: ArrayBuffer | Uint8Array;
+  readonly modifiedAt?: Date;
+};
+
+type PreparedZipEntry = {
+  readonly filenameBytes: Uint8Array;
+  readonly data: Uint8Array;
+  readonly crc32: number;
+  readonly dosDate: number;
+  readonly dosTime: number;
+  readonly localHeaderOffset: number;
+};
+
+export function createZipBlob(entries: readonly ZipFileEntry[]): Blob {
+  let offset = 0;
+  const crc32Table = createCrc32Table();
+  const preparedEntries = entries.map((entry) => {
+    const data = toUint8Array(entry.data);
+    const filenameBytes = new TextEncoder().encode(normalizeZipFilename(entry));
+    assertZipEntrySize(data.byteLength);
+    const dosDateTime = toDosDateTime(entry.modifiedAt ?? new Date());
+    const prepared: PreparedZipEntry = {
+      filenameBytes,
+      data,
+      crc32: crc32(data, crc32Table),
+      dosDate: dosDateTime.date,
+      dosTime: dosDateTime.time,
+      localHeaderOffset: offset,
+    };
+    offset += ZIP_LOCAL_FILE_HEADER_SIZE + filenameBytes.byteLength;
+    offset += data.byteLength;
+    return prepared;
+  });
+
+  const localParts = preparedEntries.flatMap((entry) => {
+    return [createLocalFileHeader(entry), entry.data];
+  });
+  const centralDirectoryOffset = offset;
+  const centralDirectoryParts = preparedEntries.map((entry) => {
+    const header = createCentralDirectoryHeader(entry);
+    offset += header.byteLength;
+    return header;
+  });
+  const centralDirectorySize = offset - centralDirectoryOffset;
+  const endRecord = createEndOfCentralDirectoryRecord({
+    entryCount: preparedEntries.length,
+    centralDirectorySize,
+    centralDirectoryOffset,
+  });
+
+  return new Blob(
+    [...localParts, ...centralDirectoryParts, endRecord].map(toArrayBuffer),
+    { type: "application/zip" },
+  );
+}
+
+const ZIP_LOCAL_FILE_HEADER_SIZE = 30;
+const ZIP_CENTRAL_DIRECTORY_HEADER_SIZE = 46;
+const ZIP_END_OF_CENTRAL_DIRECTORY_SIZE = 22;
+
+function normalizeZipFilename(entry: ZipFileEntry): string {
+  const filename = entry.filename.split(/[\\/]/).pop()?.trim();
+  return filename && filename.length > 0 ? filename : "artifact";
+}
+
+function toUint8Array(data: ArrayBuffer | Uint8Array): Uint8Array {
+  return data instanceof Uint8Array ? data : new Uint8Array(data);
+}
+
+function toArrayBuffer(data: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(data.byteLength);
+  copy.set(data);
+  return copy.buffer;
+}
+
+function assertZipEntrySize(size: number): void {
+  if (size > ZIP_MAX_UINT32) {
+    throw new Error("Artifact is too large to include in a zip download");
+  }
+}
+
+function createLocalFileHeader(entry: PreparedZipEntry): Uint8Array {
+  const header = new Uint8Array(
+    ZIP_LOCAL_FILE_HEADER_SIZE + entry.filenameBytes.byteLength,
+  );
+  const view = new DataView(header.buffer);
+  view.setUint32(0, ZIP_LOCAL_FILE_HEADER_SIGNATURE, true);
+  view.setUint16(4, ZIP_VERSION_NEEDED, true);
+  view.setUint16(6, 0, true);
+  view.setUint16(8, ZIP_STORE_METHOD, true);
+  view.setUint16(10, entry.dosTime, true);
+  view.setUint16(12, entry.dosDate, true);
+  view.setUint32(14, entry.crc32, true);
+  view.setUint32(18, entry.data.byteLength, true);
+  view.setUint32(22, entry.data.byteLength, true);
+  view.setUint16(26, entry.filenameBytes.byteLength, true);
+  view.setUint16(28, 0, true);
+  header.set(entry.filenameBytes, ZIP_LOCAL_FILE_HEADER_SIZE);
+  return header;
+}
+
+function createCentralDirectoryHeader(entry: PreparedZipEntry): Uint8Array {
+  const header = new Uint8Array(
+    ZIP_CENTRAL_DIRECTORY_HEADER_SIZE + entry.filenameBytes.byteLength,
+  );
+  const view = new DataView(header.buffer);
+  view.setUint32(0, ZIP_CENTRAL_DIRECTORY_SIGNATURE, true);
+  view.setUint16(4, ZIP_VERSION_NEEDED, true);
+  view.setUint16(6, ZIP_VERSION_NEEDED, true);
+  view.setUint16(8, 0, true);
+  view.setUint16(10, ZIP_STORE_METHOD, true);
+  view.setUint16(12, entry.dosTime, true);
+  view.setUint16(14, entry.dosDate, true);
+  view.setUint32(16, entry.crc32, true);
+  view.setUint32(20, entry.data.byteLength, true);
+  view.setUint32(24, entry.data.byteLength, true);
+  view.setUint16(28, entry.filenameBytes.byteLength, true);
+  view.setUint16(30, 0, true);
+  view.setUint16(32, 0, true);
+  view.setUint16(34, 0, true);
+  view.setUint16(36, 0, true);
+  view.setUint32(38, 0, true);
+  view.setUint32(42, entry.localHeaderOffset, true);
+  header.set(entry.filenameBytes, ZIP_CENTRAL_DIRECTORY_HEADER_SIZE);
+  return header;
+}
+
+function createEndOfCentralDirectoryRecord(params: {
+  readonly entryCount: number;
+  readonly centralDirectorySize: number;
+  readonly centralDirectoryOffset: number;
+}): Uint8Array {
+  const header = new Uint8Array(ZIP_END_OF_CENTRAL_DIRECTORY_SIZE);
+  const view = new DataView(header.buffer);
+  view.setUint32(0, ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE, true);
+  view.setUint16(4, 0, true);
+  view.setUint16(6, 0, true);
+  view.setUint16(8, params.entryCount, true);
+  view.setUint16(10, params.entryCount, true);
+  view.setUint32(12, params.centralDirectorySize, true);
+  view.setUint32(16, params.centralDirectoryOffset, true);
+  view.setUint16(20, 0, true);
+  return header;
+}
+
+function toDosDateTime(date: Date): {
+  readonly date: number;
+  readonly time: number;
+} {
+  const year = Math.max(date.getFullYear(), 1980);
+  return {
+    date: ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate(),
+    time:
+      (date.getHours() << 11) |
+      (date.getMinutes() << 5) |
+      Math.floor(date.getSeconds() / 2),
+  };
+}
+
+function createCrc32Table(): Uint32Array {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < table.length; i += 1) {
+    let value = i;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = (value & 1) === 1 ? 0xed_b8_83_20 ^ (value >>> 1) : value >>> 1;
+    }
+    table[i] = value >>> 0;
+  }
+  return table;
+}
+
+function crc32(data: Uint8Array, table: Uint32Array): number {
+  let crc = 0xff_ff_ff_ff;
+  for (const byte of data) {
+    crc = table[(crc ^ byte) & 0xff]! ^ (crc >>> 8);
+  }
+  return (crc ^ 0xff_ff_ff_ff) >>> 0;
+}

--- a/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
@@ -1,0 +1,211 @@
+import { command } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import { accept } from "../../lib/accept.ts";
+import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
+import { connectors$, reloadConnectors$ } from "../external/connectors.ts";
+import { setAblyLoop$ } from "../realtime.ts";
+
+type ArtifactGoogleDriveSyncParams = {
+  readonly agentId?: string;
+  readonly threadId: string;
+} & ArtifactGoogleDriveSyncFile;
+
+export type ArtifactGoogleDriveSyncFile = {
+  readonly runId: string;
+  readonly fileId: string;
+  readonly filename?: string | undefined;
+};
+
+type ArtifactGoogleDriveSyncFilesParams = {
+  readonly agentId?: string;
+  readonly threadId: string;
+  readonly files: readonly ArtifactGoogleDriveSyncFile[];
+};
+
+function googleDriveSyncErrorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : "Failed to sync to Google Drive";
+}
+
+function googleDriveSyncLoadingMessage(
+  files: readonly ArtifactGoogleDriveSyncFile[],
+): string {
+  if (files.length === 1) {
+    const filename = files[0]?.filename;
+    return filename ? `Syncing ${filename}...` : "Syncing artifact...";
+  }
+  return `Syncing ${files.length} files...`;
+}
+
+function googleDriveSyncSuccessMessage(fileCount: number): string {
+  return fileCount === 1
+    ? "Synced to Google Drive"
+    : `Synced ${fileCount} files to Google Drive`;
+}
+
+type ArtifactGoogleDriveSyncResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly message: string };
+
+function isArtifactGoogleDriveSyncFailure(
+  result: ArtifactGoogleDriveSyncResult,
+): result is Extract<ArtifactGoogleDriveSyncResult, { readonly ok: false }> {
+  return !result.ok;
+}
+
+export async function syncArtifactFilesToGoogleDrive(
+  params: ArtifactGoogleDriveSyncFilesParams & {
+    readonly createClient: ZeroClientFactory;
+    readonly signal?: AbortSignal;
+  },
+): Promise<boolean> {
+  if (params.files.length === 0) {
+    toast.error("No artifacts to sync");
+    return false;
+  }
+
+  const toastId = toast.loading(googleDriveSyncLoadingMessage(params.files));
+  const client = params.createClient(chatThreadArtifactsContract);
+  const results: ArtifactGoogleDriveSyncResult[] = await Promise.all(
+    params.files.map((file) => {
+      return accept(
+        client.syncGoogleDrive({
+          params: { threadId: params.threadId },
+          body: {
+            runId: file.runId,
+            fileId: file.fileId,
+          },
+          fetchOptions: params.signal ? { signal: params.signal } : undefined,
+        }),
+        [200],
+        { toast: false },
+      ).then(
+        () => {
+          return { ok: true as const };
+        },
+        (error: unknown) => {
+          return {
+            ok: false as const,
+            message: googleDriveSyncErrorMessage(error),
+          };
+        },
+      );
+    }),
+  );
+  const syncedCount = results.filter((result) => {
+    return result.ok;
+  }).length;
+
+  if (syncedCount === params.files.length) {
+    toast.success(googleDriveSyncSuccessMessage(params.files.length), {
+      id: toastId,
+    });
+    return true;
+  }
+
+  const firstFailure = results.find(isArtifactGoogleDriveSyncFailure);
+  toast.error(
+    syncedCount > 0
+      ? `Synced ${syncedCount} of ${params.files.length} files to Google Drive`
+      : (firstFailure?.message ?? "Failed to sync to Google Drive"),
+    { id: toastId },
+  );
+  return syncedCount > 0;
+}
+
+export async function syncArtifactFileToGoogleDrive(
+  params: ArtifactGoogleDriveSyncParams & {
+    readonly createClient: ZeroClientFactory;
+    readonly signal?: AbortSignal;
+  },
+): Promise<boolean> {
+  return await syncArtifactFilesToGoogleDrive({
+    createClient: params.createClient,
+    threadId: params.threadId,
+    files: [
+      {
+        runId: params.runId,
+        fileId: params.fileId,
+        filename: params.filename,
+      },
+    ],
+    signal: params.signal,
+  });
+}
+
+async function authorizeGoogleDriveForAgent(params: {
+  readonly agentId: string;
+  readonly createClient: ZeroClientFactory;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const client = params.createClient(zeroUserConnectorsContract);
+  const current = await accept(
+    client.get({
+      params: { id: params.agentId },
+      fetchOptions: { signal: params.signal },
+    }),
+    [200],
+  );
+  params.signal.throwIfAborted();
+
+  if (current.body.enabledTypes.includes("google-drive")) {
+    return;
+  }
+
+  await accept(
+    client.update({
+      params: { id: params.agentId },
+      body: { enabledTypes: [...current.body.enabledTypes, "google-drive"] },
+      fetchOptions: { signal: params.signal },
+    }),
+    [200],
+  );
+  params.signal.throwIfAborted();
+}
+
+export const waitForGoogleDriveAndSyncArtifacts$ = command(
+  async (
+    { set },
+    params: ArtifactGoogleDriveSyncFilesParams & { readonly agentId: string },
+    signal: AbortSignal,
+  ) => {
+    const syncWhenConnected$ = command(
+      async ({ get, set }, sig: AbortSignal) => {
+        set(reloadConnectors$);
+        const { connectors } = await get(connectors$);
+        sig.throwIfAborted();
+        const connected = connectors.some((connector) => {
+          return connector.type === "google-drive" && !connector.needsReconnect;
+        });
+        if (!connected) {
+          return false;
+        }
+
+        const createClient = get(zeroClient$);
+        await authorizeGoogleDriveForAgent({
+          agentId: params.agentId,
+          createClient,
+          signal: sig,
+        });
+        sig.throwIfAborted();
+
+        await syncArtifactFilesToGoogleDrive({
+          createClient,
+          threadId: params.threadId,
+          files: params.files,
+          signal: sig,
+        });
+        return true;
+      },
+    );
+
+    if (await set(syncWhenConnected$, signal)) {
+      return;
+    }
+    signal.throwIfAborted();
+    await set(setAblyLoop$, "connector:changed", syncWhenConnected$, signal);
+  },
+);

--- a/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
@@ -1,7 +1,10 @@
 import { command } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
-import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import {
+  zeroUserConnectorsContract,
+  type UserConnectorEnabledTypes,
+} from "@vm0/api-contracts/contracts/user-connectors";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
 import { connectors$, reloadConnectors$ } from "../external/connectors.ts";
@@ -69,32 +72,34 @@ export async function syncArtifactFilesToGoogleDrive(
 
   const toastId = toast.loading(googleDriveSyncLoadingMessage(params.files));
   const client = params.createClient(chatThreadArtifactsContract);
-  const results: ArtifactGoogleDriveSyncResult[] = await Promise.all(
-    params.files.map((file) => {
-      return accept(
-        client.syncGoogleDrive({
-          params: { threadId: params.threadId },
-          body: {
-            runId: file.runId,
-            fileId: file.fileId,
-          },
-          fetchOptions: params.signal ? { signal: params.signal } : undefined,
-        }),
-        [200],
-        { toast: false },
-      ).then(
-        () => {
-          return { ok: true as const };
+  const results: ArtifactGoogleDriveSyncResult[] = [];
+  for (const file of params.files) {
+    params.signal?.throwIfAborted();
+    const result = await accept(
+      client.syncGoogleDrive({
+        params: { threadId: params.threadId },
+        body: {
+          runId: file.runId,
+          fileId: file.fileId,
         },
-        (error: unknown) => {
-          return {
-            ok: false as const,
-            message: googleDriveSyncErrorMessage(error),
-          };
-        },
-      );
-    }),
-  );
+        fetchOptions: params.signal ? { signal: params.signal } : undefined,
+      }),
+      [200],
+      { toast: false },
+    ).then(
+      () => {
+        return { ok: true as const };
+      },
+      (error: unknown) => {
+        params.signal?.throwIfAborted();
+        return {
+          ok: false as const,
+          message: googleDriveSyncErrorMessage(error),
+        };
+      },
+    );
+    results.push(result);
+  }
   const syncedCount = results.filter((result) => {
     return result.ok;
   }).length;
@@ -142,13 +147,13 @@ async function authorizeGoogleDriveForAgent(params: {
   readonly signal: AbortSignal;
 }): Promise<void> {
   const client = params.createClient(zeroUserConnectorsContract);
-  const current = await accept(
+  const current = (await accept(
     client.get({
       params: { id: params.agentId },
       fetchOptions: { signal: params.signal },
     }),
     [200],
-  );
+  )) as { body: UserConnectorEnabledTypes };
   params.signal.throwIfAborted();
 
   if (current.body.enabledTypes.includes("google-drive")) {

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -79,6 +79,7 @@ describe("connectConnector$", () => {
     const connectPromise = context.store.set(
       connectConnector$,
       "github",
+      {},
       context.signal,
     );
 
@@ -146,6 +147,7 @@ describe("connectConnector$", () => {
     const connectPromise = context.store.set(
       connectConnector$,
       "github",
+      {},
       context.signal,
     );
 
@@ -168,7 +170,7 @@ describe("connectConnector$", () => {
     expect(result).toBeTruthy();
     expect(pollCount).toBeGreaterThanOrEqual(3);
     expect(context.store.get(pollingConnectorType$)).toBeNull();
-    expect(context.store.get(permissionDialogType$)).toBe("github");
+    expect(context.store.get(permissionDialogType$)).toBeNull();
   });
 
   it("exits when popup is closed even if connector not found", async () => {
@@ -186,6 +188,7 @@ describe("connectConnector$", () => {
     const connectPromise = context.store.set(
       connectConnector$,
       "github",
+      {},
       context.signal,
     );
 
@@ -203,7 +206,7 @@ describe("connectConnector$", () => {
     expect(context.store.get(pollingConnectorType$)).toBeNull();
   });
 
-  it("sets permissionDialogType$ after connector appears", async () => {
+  it("sets permissionDialogType$ after connector appears when requested", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
 
     const mockWindow = { closed: false, close: vi.fn() };
@@ -218,6 +221,7 @@ describe("connectConnector$", () => {
     const connectPromise = context.store.set(
       connectConnector$,
       "github",
+      { showPermissionDialog: true },
       context.signal,
     );
 
@@ -248,6 +252,7 @@ describe("connectConnector$", () => {
     const connectPromise = context.store.set(
       connectConnector$,
       "github",
+      {},
       context.signal,
     );
 
@@ -277,6 +282,7 @@ describe("connectConnector$", () => {
     const connectPromise = context.store.set(
       connectConnector$,
       "github",
+      {},
       context.signal,
     );
 
@@ -289,7 +295,7 @@ describe("connectConnector$", () => {
 
     expect(result).toBeTruthy();
     expect(context.store.get(pollingConnectorType$)).toBeNull();
-    expect(context.store.get(permissionDialogType$)).toBe("github");
+    expect(context.store.get(permissionDialogType$)).toBeNull();
   });
 
   it("handles multiple fetch cycles in standalone mode", async () => {
@@ -312,6 +318,7 @@ describe("connectConnector$", () => {
     const connectPromise = context.store.set(
       connectConnector$,
       "github",
+      {},
       context.signal,
     );
 
@@ -331,7 +338,7 @@ describe("connectConnector$", () => {
     expect(result).toBeTruthy();
     expect(pollCount).toBeGreaterThanOrEqual(3);
     expect(context.store.get(pollingConnectorType$)).toBeNull();
-    expect(context.store.get(permissionDialogType$)).toBe("github");
+    expect(context.store.get(permissionDialogType$)).toBeNull();
   });
 });
 
@@ -343,6 +350,7 @@ describe("submitApiToken$", () => {
       submitApiToken$,
       "github",
       { GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_test123" },
+      { showPermissionDialog: true },
       context.signal,
     );
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/disconnect-clears-just-connected.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/disconnect-clears-just-connected.test.ts
@@ -30,6 +30,7 @@ describe("deleteConnector$ + justConnectedTypes$", () => {
       submitApiToken$,
       "ahrefs",
       { AHREFS_API_KEY: "test" },
+      {},
       context.signal,
     );
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -39,6 +39,10 @@ const HIDDEN_CONNECTIONS_STORAGE_KEY = "vm0.connections.hiddenTypes";
 const { get$: hiddenConnectorTypesRaw$, set$: setHiddenConnectorTypes$ } =
   localStorageSignals(HIDDEN_CONNECTIONS_STORAGE_KEY);
 
+type PostConnectOptions = {
+  readonly showPermissionDialog?: boolean;
+};
+
 // ---------------------------------------------------------------------------
 // Derived state
 // ---------------------------------------------------------------------------
@@ -291,7 +295,12 @@ export const setTokenFormSubmitting$ = command(
 // ---------------------------------------------------------------------------
 
 export const enablePlatformConnector$ = command(
-  async ({ get, set }, type: ConnectorType, signal: AbortSignal) => {
+  async (
+    { get, set },
+    type: ConnectorType,
+    options: PostConnectOptions,
+    signal: AbortSignal,
+  ) => {
     const createClient = get(zeroClient$);
     const client = createClient(zeroPlatformConnectorContract);
     await accept(
@@ -313,7 +322,9 @@ export const enablePlatformConnector$ = command(
     toast.success(`${CONNECTOR_TYPES[type].label} enabled`, {
       id: `connector-connected-${type}`,
     });
-    set(internalPermissionDialogType$, type);
+    if (options.showPermissionDialog) {
+      set(internalPermissionDialogType$, type);
+    }
   },
 );
 
@@ -326,6 +337,7 @@ export const submitApiToken$ = command(
     { get, set },
     type: ConnectorType,
     inputSecrets: Record<string, string>,
+    options: PostConnectOptions,
     signal: AbortSignal,
   ) => {
     const createClient = get(zeroClient$);
@@ -368,7 +380,9 @@ export const submitApiToken$ = command(
     toast.success(`${CONNECTOR_TYPES[type].label} connected successfully`, {
       id: `connector-connected-${type}`,
     });
-    set(internalPermissionDialogType$, type);
+    if (options.showPermissionDialog) {
+      set(internalPermissionDialogType$, type);
+    }
   },
 );
 
@@ -472,7 +486,12 @@ async function watchPopupClosed(
 // ---------------------------------------------------------------------------
 
 export const connectConnector$ = command(
-  async ({ get, set }, type: ConnectorType, signal: AbortSignal) => {
+  async (
+    { get, set },
+    type: ConnectorType,
+    options: PostConnectOptions,
+    signal: AbortSignal,
+  ) => {
     const baseUrl = await get(apiBaseForNavigation$);
     signal.throwIfAborted();
 
@@ -576,10 +595,13 @@ export const connectConnector$ = command(
     const hidden = new Set(get(hiddenConnectorTypes$));
     hidden.delete(type);
     set(setHiddenConnectorTypes$, JSON.stringify([...hidden]));
-    // Close connect modal on OAuth success and show permission dialog
+    // Close connect modal on OAuth success. Only connectors-page flows should
+    // show the post-connect permission dialog.
     if (isConnected) {
       set(internalSelectedConnectorType$, null);
-      set(internalPermissionDialogType$, type);
+      if (options.showPermissionDialog) {
+        set(internalPermissionDialogType$, type);
+      }
     }
     return isConnected;
   },
@@ -594,9 +616,10 @@ export const connectAndSettle$ = command(
     { set },
     type: ConnectorType,
     onSuccess: () => void | Promise<void>,
+    options: PostConnectOptions,
     signal: AbortSignal,
   ): Promise<void> => {
-    const connected = await set(connectConnector$, type, signal);
+    const connected = await set(connectConnector$, type, options, signal);
     if (connected) {
       await onSuccess();
     }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-connect-permission.test.tsx
@@ -96,9 +96,8 @@ describe("onboarding connector permission dialog suppression", () => {
       }),
     );
 
-    // Click "Connect" on GitHub — this triggers connectConnector$ which
-    // normally sets permissionDialogType$, but the onboarding wrapper
-    // clears it immediately after.
+    // Click "Connect" on GitHub — this triggers connectConnector$ without
+    // opting into the post-connect permission dialog.
     click(screen.getByText("Connect"));
 
     // Wait for the Ably subscription to be registered, then simulate the
@@ -114,9 +113,8 @@ describe("onboarding connector permission dialog suppression", () => {
       expect(screen.getByText("Connected")).toBeInTheDocument();
     });
 
-    // The key assertion: permissionDialogType$ should be null because the
-    // onboarding component clears it after connectConnector$ completes.
-    // Without the fix, this would be "github".
+    // The key assertion: permissionDialogType$ should be null outside the
+    // connectors page.
     await waitFor(() => {
       expect(context.store.get(permissionDialogType$)).toBeNull();
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -1087,6 +1087,151 @@ describe("zero chat thread page display - artifacts drawer", () => {
     });
   });
 
+  it("syncs bulk Google Drive artifacts sequentially", async () => {
+    const user = userEvent.setup();
+    const syncBodies: unknown[] = [];
+    let firstSyncFinished = false;
+    let secondSyncStartedAfterFirst = false;
+    let releaseFirstSync: () => void = () => {
+      throw new Error("First sync has not started");
+    };
+
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: "See attached",
+          runId: "run-artifacts-sequential-sync",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    setMockConnectors([
+      {
+        id: "00000000-0000-4000-8000-000000000000",
+        type: "google-drive",
+        authMethod: "oauth",
+        externalId: "drive-user",
+        externalUsername: "Drive User",
+        externalEmail: "drive@example.com",
+        oauthScopes: ["https://www.googleapis.com/auth/drive"],
+        needsReconnect: false,
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+      },
+    ]);
+    server.use(
+      http.get("https://example.com/first.csv", () => {
+        return new HttpResponse("label,value\nfirst,1\n", {
+          headers: { "Content-Type": "text/csv" },
+        });
+      }),
+      http.get("https://example.com/second.csv", () => {
+        return new HttpResponse("label,value\nsecond,2\n", {
+          headers: { "Content-Type": "text/csv" },
+        });
+      }),
+      mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
+        return respond(200, {
+          runs: [
+            {
+              runId: "run-artifacts-sequential-sync",
+              files: [
+                {
+                  id: "file-1",
+                  filename: "first.csv",
+                  contentType: "text/csv",
+                  size: 1024,
+                  url: "https://example.com/first.csv",
+                  createdAt: "2026-03-10T00:00:00Z",
+                  googleDriveSync: { status: "not_synced" },
+                },
+                {
+                  id: "file-2",
+                  filename: "second.csv",
+                  contentType: "text/csv",
+                  size: 2048,
+                  url: "https://example.com/second.csv",
+                  createdAt: "2026-03-10T00:00:00Z",
+                  googleDriveSync: { status: "not_synced" },
+                },
+              ],
+            },
+          ],
+        });
+      }),
+      mockApi(
+        chatThreadArtifactsContract.syncGoogleDrive,
+        ({ body, respond, deferred }) => {
+          syncBodies.push(body);
+          if (body.fileId === "file-1") {
+            const gate = deferred<void>();
+            releaseFirstSync = () => {
+              firstSyncFinished = true;
+              gate.resolve();
+            };
+            return gate.promise.then(() => {
+              return respond(200, {
+                id: `drive-${body.fileId}`,
+                name: `${body.fileId}.csv`,
+                webViewLink: `https://drive.google.com/file/d/${body.fileId}/view`,
+              });
+            });
+          }
+          if (body.fileId === "file-2") {
+            secondSyncStartedAfterFirst = firstSyncFinished;
+          }
+          return respond(200, {
+            id: `drive-${body.fileId}`,
+            name: `${body.fileId}.csv`,
+            webViewLink: `https://drive.google.com/file/d/${body.fileId}/view`,
+          });
+        },
+      ),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+    });
+
+    const button = await waitFor(() => {
+      return screen.getByLabelText("Open artifacts");
+    });
+    click(button);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("first.csv").length).toBeGreaterThan(0);
+    });
+    await user.click(screen.getByLabelText("More artifact actions"));
+    await user.click(screen.getByText("Sync all to Google Drive"));
+
+    await waitFor(() => {
+      expect(syncBodies).toStrictEqual([
+        {
+          runId: "run-artifacts-sequential-sync",
+          fileId: "file-1",
+        },
+      ]);
+    });
+
+    releaseFirstSync();
+
+    await waitFor(() => {
+      expect(syncBodies).toStrictEqual([
+        {
+          runId: "run-artifacts-sequential-sync",
+          fileId: "file-1",
+        },
+        {
+          runId: "run-artifacts-sequential-sync",
+          fileId: "file-2",
+        },
+      ]);
+    });
+    expect(secondSyncStartedAfterFirst).toBeTruthy();
+  });
+
   it("opens Google Drive OAuth in a new tab and syncs after the connector event", async () => {
     const user = userEvent.setup();
     const fileUrl = "https://example.com/disconnected-chart.png";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -8,9 +8,11 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
 import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
 import { mockApi } from "../../../mocks/msw-contract.ts";
-import { hasSubscription } from "../../../mocks/ably.ts";
+import { hasSubscription, triggerAblyEvent } from "../../../mocks/ably.ts";
 import { updateChatArtifacts } from "../../../mocks/mock-helpers.ts";
 import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
 import {
   mockChatLifecycle,
   mockSubagentThread,
@@ -814,9 +816,12 @@ describe("zero chat thread page display - artifacts drawer", () => {
       .spyOn(URL, "createObjectURL")
       .mockReturnValue("blob:artifact-download");
     vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    let downloadedFilename = "";
     const anchorClickSpy = vi
       .spyOn(HTMLAnchorElement.prototype, "click")
-      .mockImplementation(() => {});
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        downloadedFilename = this.download;
+      });
 
     detachedSetupPage({
       context,
@@ -838,13 +843,22 @@ describe("zero chat thread page display - artifacts drawer", () => {
       document.querySelectorAll('img[src="https://example.com/chart.png"]')
         .length,
     ).toBeGreaterThanOrEqual(3);
-    const downloadButtons = screen.getAllByLabelText("Download chart.png");
-    expect(downloadButtons[0]!.tagName).toBe("BUTTON");
-    await user.click(downloadButtons[0]!);
+    expect(screen.getAllByLabelText("Download chart.png")).toHaveLength(1);
+    await user.click(screen.getByLabelText("More artifact actions"));
+    await user.click(screen.getByText("Download all"));
     await waitFor(() => {
       expect(createObjectURLSpy).toHaveBeenCalledOnce();
       expect(anchorClickSpy).toHaveBeenCalledOnce();
     });
+    expect(downloadedFilename).toBe("vm0-artifact-thread-test-1.zip");
+    const zipBlob = createObjectURLSpy.mock.calls[0]?.[0];
+    expect(zipBlob).toBeInstanceOf(Blob);
+    expect((zipBlob as Blob).type).toBe("application/zip");
+    const zipText = new TextDecoder().decode(
+      await (zipBlob as Blob).arrayBuffer(),
+    );
+    expect(zipText).toContain("chart.png");
+    expect(zipText).toContain("data.csv");
     expect(screen.getAllByText("chart.png").length).toBeGreaterThan(0);
     expect(screen.getByText("data.csv")).toBeInTheDocument();
 
@@ -930,6 +944,265 @@ describe("zero chat thread page display - artifacts drawer", () => {
       expect(screen.getAllByText("artifact.zip").length).toBeGreaterThan(0);
     });
     expect(artifactsRequests).toBeGreaterThanOrEqual(2);
+  });
+
+  it("copies artifact links and syncs to Google Drive when connected", async () => {
+    const user = userEvent.setup();
+    const fileUrl = "https://example.com/chart.png";
+    let artifactsRequests = 0;
+    const syncBodies: unknown[] = [];
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: "See attached",
+          runId: "run-artifacts-actions",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    setMockConnectors([
+      {
+        id: "00000000-0000-4000-8000-000000000000",
+        type: "google-drive",
+        authMethod: "oauth",
+        externalId: "drive-user",
+        externalUsername: "Drive User",
+        externalEmail: "drive@example.com",
+        oauthScopes: ["https://www.googleapis.com/auth/drive"],
+        needsReconnect: false,
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+      },
+    ]);
+    server.use(
+      http.get(fileUrl, () => {
+        return new HttpResponse(new Blob(["img"], { type: "image/png" }), {
+          headers: { "Content-Type": "image/png" },
+        });
+      }),
+      mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
+        artifactsRequests += 1;
+        return respond(200, {
+          runs: [
+            {
+              runId: "run-artifacts-actions",
+              files: [
+                {
+                  id: "file-1",
+                  filename: "chart.png",
+                  contentType: "image/png",
+                  size: 4096,
+                  url: fileUrl,
+                  createdAt: "2026-03-10T00:00:00Z",
+                  googleDriveSync:
+                    artifactsRequests > 1
+                      ? {
+                          status: "synced",
+                          id: "drive-file-id",
+                          name: "chart.png",
+                          webViewLink:
+                            "https://drive.google.com/file/d/drive-file-id/view",
+                        }
+                      : { status: "not_synced" },
+                },
+                {
+                  id: "file-2",
+                  filename: "data.csv",
+                  contentType: "text/csv",
+                  size: 2048,
+                  url: "https://example.com/data.csv",
+                  createdAt: "2026-03-10T00:00:00Z",
+                  googleDriveSync: { status: "not_synced" },
+                },
+              ],
+            },
+          ],
+        });
+      }),
+      mockApi(
+        chatThreadArtifactsContract.syncGoogleDrive,
+        ({ body, respond }) => {
+          syncBodies.push(body);
+          return respond(200, {
+            id: "drive-file-id",
+            name: "chart.png",
+            webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+          });
+        },
+      ),
+    );
+    const writeTextSpy = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+    });
+
+    const button = await waitFor(() => {
+      return screen.getByLabelText("Open artifacts");
+    });
+    click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Copy link for chart.png"),
+      ).toBeInTheDocument();
+    });
+    await user.click(screen.getByLabelText("Copy link for chart.png"));
+    expect(writeTextSpy).toHaveBeenCalledWith(fileUrl);
+
+    await user.click(screen.getByLabelText("Sync chart.png to Google Drive"));
+
+    await waitFor(() => {
+      expect(syncBodies).toStrictEqual([
+        {
+          runId: "run-artifacts-actions",
+          fileId: "file-1",
+        },
+      ]);
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("chart.png is synced to Google Drive"),
+      ).toHaveAttribute("aria-disabled", "true");
+    });
+
+    await user.click(screen.getByLabelText("More artifact actions"));
+    await user.click(screen.getByText("Sync all to Google Drive"));
+
+    await waitFor(() => {
+      expect(syncBodies).toStrictEqual([
+        {
+          runId: "run-artifacts-actions",
+          fileId: "file-1",
+        },
+        {
+          runId: "run-artifacts-actions",
+          fileId: "file-2",
+        },
+      ]);
+    });
+  });
+
+  it("opens Google Drive OAuth in a new tab and syncs after the connector event", async () => {
+    const user = userEvent.setup();
+    const fileUrl = "https://example.com/disconnected-chart.png";
+    let authorizeCalled = false;
+    let syncSawAuthorize = false;
+    let syncBody: unknown;
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockReturnValue({ closed: false } as Window);
+
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: "See attached",
+          runId: "run-artifacts-disconnected-actions",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    setMockConnectors([]);
+    server.use(
+      http.get(fileUrl, () => {
+        return new HttpResponse(new Blob(["img"], { type: "image/png" }), {
+          headers: { "Content-Type": "image/png" },
+        });
+      }),
+      mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
+        return respond(200, {
+          runs: [
+            {
+              runId: "run-artifacts-disconnected-actions",
+              files: [
+                {
+                  id: "file-disconnected",
+                  filename: "disconnected-chart.png",
+                  contentType: "image/png",
+                  size: 4096,
+                  url: fileUrl,
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+              ],
+            },
+          ],
+        });
+      }),
+      mockApi(
+        chatThreadArtifactsContract.syncGoogleDrive,
+        ({ body, respond }) => {
+          syncSawAuthorize = authorizeCalled;
+          syncBody = body;
+          return respond(200, {
+            id: "drive-file-id",
+            name: "disconnected-chart.png",
+            webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+          });
+        },
+      ),
+      mockApi(zeroUserConnectorsContract.get, ({ respond }) => {
+        return respond(200, { enabledTypes: [] });
+      }),
+      mockApi(zeroUserConnectorsContract.update, ({ body, respond }) => {
+        authorizeCalled = body.enabledTypes.includes("google-drive");
+        return respond(200, { enabledTypes: body.enabledTypes });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+    });
+
+    const button = await waitFor(() => {
+      return screen.getByLabelText("Open artifacts");
+    });
+    click(button);
+
+    const syncButton = await waitFor(() => {
+      return screen.getByLabelText(
+        "Sync disconnected-chart.png to Google Drive",
+      );
+    });
+
+    await user.click(syncButton);
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/zero/connectors/google-drive/authorize"),
+        "_blank",
+      );
+      expect(hasSubscription("connector:changed")).toBeTruthy();
+    });
+    expect(syncBody).toBeUndefined();
+
+    setMockConnectors([
+      {
+        id: "00000000-0000-4000-8000-000000000000",
+        type: "google-drive",
+        authMethod: "oauth",
+        externalId: "drive-user",
+        externalUsername: "Drive User",
+        externalEmail: "drive@example.com",
+        oauthScopes: ["https://www.googleapis.com/auth/drive"],
+        needsReconnect: false,
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+      },
+    ]);
+    triggerAblyEvent("connector:changed");
+
+    await waitFor(() => {
+      expect(syncBody).toStrictEqual({
+        runId: "run-artifacts-disconnected-actions",
+        fileId: "file-disconnected",
+      });
+      expect(syncSawAuthorize).toBeTruthy();
+    });
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-disconnect.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page-disconnect.test.tsx
@@ -30,6 +30,7 @@ test("disconnect moves a just-connected connector back to an available card (reg
     submitApiToken$,
     "ahrefs",
     { AHREFS_API_KEY: "test" },
+    {},
     context.signal,
   );
   context.store.set(setPermissionDialogType$, null);

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -85,10 +85,12 @@ function ApiTokenForm({
   type,
   item,
   onSuccess,
+  showPermissionDialogOnConnect,
 }: {
   type: ConnectorType;
   item: ConnectorTypeWithStatus;
   onSuccess: () => void | Promise<void>;
+  showPermissionDialogOnConnect: boolean;
 }) {
   const config = CONNECTOR_TYPES[type];
   const apiTokenConfig = config.authMethods["api-token"];
@@ -117,7 +119,14 @@ function ApiTokenForm({
     setSubmitting(type);
     detach(
       (async () => {
-        await submit(type, secretValues, pageSignal);
+        await submit(
+          type,
+          secretValues,
+          {
+            showPermissionDialog: showPermissionDialogOnConnect,
+          },
+          pageSignal,
+        );
         setSubmitting(null);
         clearForm(type);
         await onSuccess();
@@ -184,9 +193,11 @@ function ApiTokenForm({
 function PlatformConfirmationForm({
   type,
   onSuccess,
+  showPermissionDialogOnConnect,
 }: {
   type: ConnectorType;
   onSuccess: () => void | Promise<void>;
+  showPermissionDialogOnConnect: boolean;
 }) {
   const config = CONNECTOR_TYPES[type];
   const platformConfig = config.authMethods.platform;
@@ -207,7 +218,13 @@ function PlatformConfirmationForm({
     setSubmitting(type);
     detach(
       (async () => {
-        await enable(type, pageSignal);
+        await enable(
+          type,
+          {
+            showPermissionDialog: showPermissionDialogOnConnect,
+          },
+          pageSignal,
+        );
         setSubmitting(null);
         await onSuccess();
       })().catch((error: unknown) => {
@@ -247,9 +264,11 @@ function PlatformConfirmationForm({
 function ConnectModalContent({
   item,
   onSuccess,
+  showPermissionDialogOnConnect,
 }: {
   item: ConnectorTypeWithStatus;
   onSuccess: () => void | Promise<void>;
+  showPermissionDialogOnConnect: boolean;
 }) {
   const [settleLoadable, connectAndSettle] = useLoadableSet(connectAndSettle$);
   const pageSignal = useGet(pageSignal$);
@@ -289,7 +308,14 @@ function ConnectModalContent({
           variant="outline"
           onClick={() => {
             return detach(
-              connectAndSettle(item.type, onSuccess, pageSignal),
+              connectAndSettle(
+                item.type,
+                onSuccess,
+                {
+                  showPermissionDialog: showPermissionDialogOnConnect,
+                },
+                pageSignal,
+              ),
               Reason.DomCallback,
             );
           }}
@@ -311,7 +337,12 @@ function ConnectModalContent({
       )}
 
       {hasApiToken && (
-        <ApiTokenForm type={item.type} item={item} onSuccess={onSuccess} />
+        <ApiTokenForm
+          type={item.type}
+          item={item}
+          onSuccess={onSuccess}
+          showPermissionDialogOnConnect={showPermissionDialogOnConnect}
+        />
       )}
 
       {hasApiToken && hasPlatform && (
@@ -326,7 +357,11 @@ function ConnectModalContent({
       )}
 
       {hasPlatform && (
-        <PlatformConfirmationForm type={item.type} onSuccess={onSuccess} />
+        <PlatformConfirmationForm
+          type={item.type}
+          onSuccess={onSuccess}
+          showPermissionDialogOnConnect={showPermissionDialogOnConnect}
+        />
       )}
     </div>
   );
@@ -339,9 +374,11 @@ function ConnectModalContent({
 export function ConnectModal({
   onClose,
   onSuccess,
+  showPermissionDialogOnConnect = false,
 }: {
   onClose: () => void;
   onSuccess?: () => void | Promise<void>;
+  showPermissionDialogOnConnect?: boolean;
 }) {
   const selectedType = useGet(selectedConnectorType$);
   const connectorTypes = useLastResolved(allConnectorTypes$);
@@ -382,6 +419,7 @@ export function ConnectModal({
 
         <ConnectModalContent
           item={item}
+          showPermissionDialogOnConnect={showPermissionDialogOnConnect}
           onSuccess={async () => {
             await onSuccess?.();
             onClose();

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -115,6 +115,19 @@ function getAttachmentDownloadUrl(url: string): string {
   return parsed.toString();
 }
 
+export function getAttachmentRawUrl(url: string): string {
+  if (!URL.canParse(url, window.location.origin)) {
+    return url;
+  }
+  const parsed = new URL(url, window.location.origin);
+  const isFileRoute = /^\/f\/[^/]+\/[^/]+\/[^/]+$/.test(parsed.pathname);
+  if (isFileRoute) {
+    parsed.searchParams.delete("download");
+    parsed.searchParams.set("raw", "1");
+  }
+  return parsed.toString();
+}
+
 function triggerDirectDownload(url: string, filename: string): void {
   const a = document.createElement("a");
   a.href = getAttachmentDownloadUrl(url);

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1,4 +1,8 @@
-import type { CSSProperties, KeyboardEvent as ReactKeyboardEvent } from "react";
+import type {
+  CSSProperties,
+  KeyboardEvent as ReactKeyboardEvent,
+  ReactNode,
+} from "react";
 import {
   useGet,
   useSet,
@@ -15,13 +19,16 @@ import {
   IconPlayerStop,
   IconCopy,
   IconCheck,
+  IconDots,
   IconPin,
   IconVolume2,
   IconArrowBarToUp,
+  IconBrandGoogleDrive,
   IconDownload,
   IconEye,
   IconFile,
   IconFileMusic,
+  IconLink,
   IconLoader2,
   IconPackage,
   IconVideo,
@@ -36,12 +43,17 @@ import {
   SheetHeader,
   SheetTitle,
   Skeleton,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@vm0/ui";
 import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
+import type { ChatThreadArtifactFile } from "@vm0/api-contracts/contracts/chat-threads";
 import emptyChatImg from "./assets/empty-chat.webp";
 import emptyArtifactImg from "./assets/empty-artifact.webp";
 import docCsvIcon from "./assets/doc-csv.svg";
@@ -63,10 +75,12 @@ import {
 } from "../../signals/voice-io/voice-io-settings.ts";
 import { Markdown } from "../components/markdown.tsx";
 import { detach, Reason, onDomEventFn } from "../../signals/utils.ts";
+import { zeroClient$ } from "../../signals/api-client.ts";
 import {
   AttachmentLightbox,
   downloadAttachmentUrl,
   FileAttachmentChip,
+  getAttachmentRawUrl,
   PreviewableFileAttachmentChip,
 } from "./zero-attachment-chips.tsx";
 import {
@@ -83,6 +97,12 @@ import {
   updatePinnedAgentIds$,
 } from "../../signals/zero-page/zero-pinned-agents.ts";
 import {
+  writeToClipboard,
+  type ChatClipboardAttachment,
+} from "../../signals/zero-page/clipboard.ts";
+import { connectors$ } from "../../signals/external/connectors.ts";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import {
   chatShortcutHelpOpen$,
   setChatShortcutHelpOpen$,
 } from "../../signals/chat-page/chat-shortcut-help.ts";
@@ -93,11 +113,9 @@ import type {
   GroupedChatMessageGroup,
   PagedChatMessage,
 } from "../../signals/chat-page/chat-message.ts";
-import type { ChatThreadArtifactFile } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ChatThreadSignals } from "../../signals/chat-page/create-chat-thread.ts";
 import type { ChatThread } from "../../signals/agent-chat.ts";
 import { ATTACH_ONLY_PLACEHOLDER } from "../../signals/chat-page/resolve-draft-attachments.ts";
-import type { ChatClipboardAttachment } from "../../signals/zero-page/clipboard.ts";
 import { ZeroChatComposer } from "./zero-chat-composer.tsx";
 import { orgModelProviders$ } from "../../signals/external/org-model-providers.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
@@ -117,6 +135,17 @@ import {
   navigateToAdjacentThread$,
   scrollCurrentThread$,
 } from "../../signals/chat-page/chat-keyboard.ts";
+import {
+  type ArtifactGoogleDriveSyncFile,
+  syncArtifactFilesToGoogleDrive,
+  syncArtifactFileToGoogleDrive,
+  waitForGoogleDriveAndSyncArtifacts$,
+} from "../../signals/chat-page/artifact-google-drive-sync.ts";
+import { apiBaseForNavigation$ } from "../../signals/fetch.ts";
+import { createZipBlob } from "../../lib/zip.ts";
+
+const CONNECT_GOOGLE_DRIVE_ARTIFACT_UPLOAD_TOOLTIP =
+  "Connect Google Drive to upload artifacts";
 
 const CHAT_SHORTCUT_SECTIONS = [
   {
@@ -481,30 +510,438 @@ function ArtifactPreviewBadge({ file }: { file: ChatThreadArtifactFile }) {
   return <ArtifactFileIcon file={file} />;
 }
 
-function ArtifactDownloadAction({
-  file,
-  className,
+async function copyArtifactLinkToClipboard(
+  file: ChatThreadArtifactFile,
+): Promise<void> {
+  const copied = await writeToClipboard(file.url);
+  if (copied) {
+    toast.success("Link copied");
+    return;
+  }
+  toast.error("Failed to copy link");
+}
+
+function downloadArtifactItemsAsZip(params: {
+  readonly items: readonly ChatArtifactItem[];
+  readonly signal: AbortSignal;
+  readonly threadId: string;
+}): Promise<void> {
+  const toastId = toast.loading(`Preparing ${params.items.length} files...`);
+  return Promise.all(
+    params.items.map((item) => {
+      return fetchArtifactZipEntry(item, params.signal);
+    }),
+  ).then(
+    (entries) => {
+      const zip = createZipBlob(entries);
+      triggerArtifactZipDownload(zip, `vm0-artifact-${params.threadId}.zip`);
+      toast.success("Downloaded artifacts", { id: toastId });
+    },
+    (error: unknown) => {
+      params.signal.throwIfAborted();
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to prepare artifact download",
+        { id: toastId },
+      );
+    },
+  );
+}
+
+function fetchArtifactZipEntry(
+  item: ChatArtifactItem,
+  signal: AbortSignal,
+): Promise<{
+  readonly filename: string;
+  readonly data: ArrayBuffer;
+  readonly modifiedAt: Date;
+}> {
+  return fetch(getAttachmentRawUrl(item.file.url), {
+    mode: "cors",
+    signal,
+  })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to download ${item.file.filename}`);
+      }
+      return response.arrayBuffer();
+    })
+    .then((data) => {
+      return {
+        filename: item.file.filename,
+        data,
+        modifiedAt: new Date(item.file.createdAt),
+      };
+    });
+}
+
+function triggerArtifactZipDownload(blob: Blob, filename: string): void {
+  const blobUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = blobUrl;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(blobUrl);
+}
+
+function artifactItemsToGoogleDriveFiles(
+  items: readonly ChatArtifactItem[],
+): ArtifactGoogleDriveSyncFile[] {
+  return items.map((item) => {
+    return {
+      runId: item.runId,
+      fileId: item.file.id,
+      filename: item.file.filename,
+    };
+  });
+}
+
+function isArtifactSyncedToGoogleDrive(item: ChatArtifactItem): boolean {
+  return item.file.googleDriveSync?.status === "synced";
+}
+
+type WaitForGoogleDriveAndSyncArtifactsFn = (
+  params: {
+    readonly agentId: string;
+    readonly threadId: string;
+    readonly files: readonly ArtifactGoogleDriveSyncFile[];
+  },
+  signal: AbortSignal,
+) => Promise<unknown>;
+
+function startGoogleDriveConnectAndSync(params: {
+  agentId: string | null | undefined;
+  apiBase: string | null | undefined;
+  files: readonly ArtifactGoogleDriveSyncFile[];
+  pageSignal: AbortSignal;
+  threadId: string;
+  waitForGoogleDriveAndSyncArtifacts: WaitForGoogleDriveAndSyncArtifactsFn;
+  onSyncComplete: () => void;
+}): void {
+  if (params.files.length === 0) {
+    return;
+  }
+  if (!params.agentId) {
+    toast.error("Agent is still loading");
+    return;
+  }
+  if (!params.apiBase) {
+    toast.error("Google Drive connection page is still loading");
+    return;
+  }
+  detach(
+    params
+      .waitForGoogleDriveAndSyncArtifacts(
+        {
+          agentId: params.agentId,
+          threadId: params.threadId,
+          files: params.files,
+        },
+        params.pageSignal,
+      )
+      .then(() => {
+        params.onSyncComplete();
+      }),
+    Reason.DomCallback,
+    "artifact google drive connect sync",
+  );
+  const authWindow = window.open(
+    `${params.apiBase}/api/zero/connectors/google-drive/authorize`,
+    "_blank",
+  );
+  if (!authWindow) {
+    toast.error("Failed to open Google Drive connection page");
+  }
+}
+
+function syncArtifactFilesAndRefresh(params: {
+  sync: Promise<boolean>;
+  onSyncSuccess: () => void;
+  reason: string;
+}): void {
+  detach(
+    params.sync.then((success) => {
+      if (success) {
+        params.onSyncSuccess();
+      }
+    }),
+    Reason.DomCallback,
+    params.reason,
+  );
+}
+
+function ArtifactGoogleDriveConnectMenuItem({
+  agentId,
+  files,
+  label,
+  onSyncComplete,
+  threadId,
 }: {
-  file: ChatThreadArtifactFile;
-  className: string;
+  agentId: string | null | undefined;
+  files: readonly ArtifactGoogleDriveSyncFile[];
+  label: string;
+  onSyncComplete: () => void;
+  threadId: string;
 }) {
+  const waitForGoogleDriveAndSyncArtifacts = useSet(
+    waitForGoogleDriveAndSyncArtifacts$,
+  );
+  const apiBase = useLastResolved(apiBaseForNavigation$);
   const pageSignal = useGet(pageSignal$);
 
   return (
-    <button
-      type="button"
-      onClick={() => {
-        detach(
-          downloadAttachmentUrl(file.url, pageSignal, file.filename),
-          Reason.DomCallback,
-          "artifact download",
-        );
-      }}
-      className={className}
-      aria-label={`Download ${file.filename}`}
-    >
-      <IconDownload size={16} stroke={1.5} />
-    </button>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuItem
+            className="text-muted-foreground"
+            title={CONNECT_GOOGLE_DRIVE_ARTIFACT_UPLOAD_TOOLTIP}
+            onClick={() => {
+              startGoogleDriveConnectAndSync({
+                agentId,
+                apiBase,
+                files,
+                pageSignal,
+                threadId,
+                waitForGoogleDriveAndSyncArtifacts,
+                onSyncComplete,
+              });
+            }}
+          >
+            <IconBrandGoogleDrive size={14} stroke={1.5} />
+            {label}
+          </DropdownMenuItem>
+        </TooltipTrigger>
+        <TooltipContent side="left">
+          {CONNECT_GOOGLE_DRIVE_ARTIFACT_UPLOAD_TOOLTIP}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function ArtifactPreviewIconButton({
+  ariaLabel,
+  children,
+  disabled = false,
+  onClick,
+  tooltip,
+}: {
+  ariaLabel: string;
+  children: ReactNode;
+  disabled?: boolean;
+  onClick: () => void;
+  tooltip: string;
+}) {
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-disabled={disabled}
+            aria-label={ariaLabel}
+            onClick={() => {
+              if (!disabled) {
+                onClick();
+              }
+            }}
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
+              disabled &&
+                "cursor-not-allowed opacity-45 hover:bg-transparent hover:text-muted-foreground",
+            )}
+          >
+            {children}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          <p className="text-xs">{tooltip}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function ArtifactPreviewActions({
+  item,
+  googleDriveConnected,
+  agentId,
+  threadId,
+  onSyncSuccess,
+}: {
+  item: ChatArtifactItem;
+  googleDriveConnected: boolean;
+  agentId: string | null | undefined;
+  threadId: string;
+  onSyncSuccess: () => void;
+}) {
+  const createClient = useGet(zeroClient$);
+  const waitForGoogleDriveAndSyncArtifacts = useSet(
+    waitForGoogleDriveAndSyncArtifacts$,
+  );
+  const apiBase = useLastResolved(apiBaseForNavigation$);
+  const pageSignal = useGet(pageSignal$);
+  const { file } = item;
+  const synced = isArtifactSyncedToGoogleDrive(item);
+  const syncTooltip = synced
+    ? "Synced to Google Drive"
+    : googleDriveConnected
+      ? "Sync to Google Drive"
+      : CONNECT_GOOGLE_DRIVE_ARTIFACT_UPLOAD_TOOLTIP;
+  const syncAriaLabel = synced
+    ? `${file.filename} is synced to Google Drive`
+    : `Sync ${file.filename} to Google Drive`;
+
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      <ArtifactPreviewIconButton
+        ariaLabel={`Copy link for ${file.filename}`}
+        tooltip="Copy link"
+        onClick={() => {
+          detach(
+            copyArtifactLinkToClipboard(file),
+            Reason.DomCallback,
+            "artifact copy link",
+          );
+        }}
+      >
+        <IconLink size={16} stroke={1.5} />
+      </ArtifactPreviewIconButton>
+      <ArtifactPreviewIconButton
+        ariaLabel={`Download ${file.filename}`}
+        tooltip="Download"
+        onClick={() => {
+          detach(
+            downloadAttachmentUrl(file.url, pageSignal, file.filename),
+            Reason.DomCallback,
+            "artifact download",
+          );
+        }}
+      >
+        <IconDownload size={16} stroke={1.5} />
+      </ArtifactPreviewIconButton>
+      <ArtifactPreviewIconButton
+        ariaLabel={syncAriaLabel}
+        disabled={synced}
+        tooltip={syncTooltip}
+        onClick={() => {
+          if (googleDriveConnected) {
+            syncArtifactFilesAndRefresh({
+              sync: syncArtifactFileToGoogleDrive({
+                createClient,
+                threadId,
+                runId: item.runId,
+                fileId: item.file.id,
+                filename: item.file.filename,
+                signal: pageSignal,
+              }),
+              onSyncSuccess,
+              reason: "artifact google drive sync",
+            });
+            return;
+          }
+          startGoogleDriveConnectAndSync({
+            agentId,
+            apiBase,
+            files: artifactItemsToGoogleDriveFiles([item]),
+            pageSignal,
+            threadId,
+            waitForGoogleDriveAndSyncArtifacts,
+            onSyncComplete: onSyncSuccess,
+          });
+        }}
+      >
+        <IconBrandGoogleDrive size={16} stroke={1.5} />
+      </ArtifactPreviewIconButton>
+    </div>
+  );
+}
+
+function ArtifactBulkActionsMenu({
+  items,
+  googleDriveConnected,
+  agentId,
+  onSyncSuccess,
+  threadId,
+}: {
+  items: readonly ChatArtifactItem[];
+  googleDriveConnected: boolean;
+  agentId: string | null | undefined;
+  onSyncSuccess: () => void;
+  threadId: string;
+}) {
+  const createClient = useGet(zeroClient$);
+  const pageSignal = useGet(pageSignal$);
+  const syncableItems = items.filter((item) => {
+    return !isArtifactSyncedToGoogleDrive(item);
+  });
+  const files = artifactItemsToGoogleDriveFiles(syncableItems);
+  const allSynced = items.length > 0 && files.length === 0;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          aria-label="More artifact actions"
+        >
+          <IconDots size={15} stroke={1.5} />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuItem
+          onClick={() => {
+            detach(
+              downloadArtifactItemsAsZip({
+                items,
+                signal: pageSignal,
+                threadId,
+              }),
+              Reason.DomCallback,
+              "artifact download all",
+            );
+          }}
+        >
+          <IconDownload size={14} stroke={1.5} />
+          Download all
+        </DropdownMenuItem>
+        {googleDriveConnected ? (
+          <DropdownMenuItem
+            disabled={allSynced}
+            onClick={() => {
+              syncArtifactFilesAndRefresh({
+                sync: syncArtifactFilesToGoogleDrive({
+                  createClient,
+                  threadId,
+                  files,
+                  signal: pageSignal,
+                }),
+                onSyncSuccess,
+                reason: "artifact google drive sync all",
+              });
+            }}
+          >
+            <IconBrandGoogleDrive size={14} stroke={1.5} />
+            {allSynced
+              ? "Synced all to Google Drive"
+              : "Sync all to Google Drive"}
+          </DropdownMenuItem>
+        ) : (
+          <ArtifactGoogleDriveConnectMenuItem
+            agentId={agentId}
+            files={files}
+            label="Sync all to Google Drive"
+            onSyncComplete={onSyncSuccess}
+            threadId={threadId}
+          />
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -672,10 +1109,20 @@ function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
   );
 }
 
-function ArtifactPreviewPanel({ item }: { item: ChatArtifactItem }) {
+function ArtifactPreviewPanel({
+  item,
+  googleDriveConnected,
+  agentId,
+  onSyncSuccess,
+  threadId,
+}: {
+  item: ChatArtifactItem;
+  googleDriveConnected: boolean;
+  agentId: string | null | undefined;
+  onSyncSuccess: () => void;
+  threadId: string;
+}) {
   const { file } = item;
-  const actionClass =
-    "flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground";
 
   return (
     <div className="overflow-hidden rounded-lg border border-border/70 bg-background shadow-sm">
@@ -697,7 +1144,13 @@ function ArtifactPreviewPanel({ item }: { item: ChatArtifactItem }) {
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
-          <ArtifactDownloadAction file={file} className={actionClass} />
+          <ArtifactPreviewActions
+            item={item}
+            googleDriveConnected={googleDriveConnected}
+            agentId={agentId}
+            threadId={threadId}
+            onSyncSuccess={onSyncSuccess}
+          />
         </div>
       </div>
     </div>
@@ -790,8 +1243,6 @@ function ArtifactFileRow({
   onPreview: () => void;
 }) {
   const { file } = item;
-  const actionClass =
-    "flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground";
 
   return (
     <div
@@ -805,7 +1256,7 @@ function ArtifactFileRow({
       <button
         type="button"
         onClick={onPreview}
-        className="flex min-w-0 flex-1 items-start gap-3 rounded-l-lg px-3 py-2.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        className="flex min-w-0 flex-1 items-start gap-3 rounded-lg px-3 py-2.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         aria-label={`Select ${file.filename}`}
       >
         <ArtifactThumbnail file={file} selected={selected} />
@@ -825,17 +1276,17 @@ function ArtifactFileRow({
           </div>
         </div>
       </button>
-      <div className="flex shrink-0 items-center pr-3">
-        <ArtifactDownloadAction file={file} className={actionClass} />
-      </div>
     </div>
   );
 }
 
 function ChatArtifactsDrawerContent({ thread }: { thread: ChatThreadSignals }) {
   const loadable = useLastLoadable(thread.artifacts$);
+  const connectorList = useLastResolved(connectors$);
+  const agentId = useLastResolved(thread.agentId$);
   const selectedArtifactKey = useGet(thread.artifactPreviewKey$);
   const setSelectedArtifactKey = useSet(thread.setArtifactPreviewKey$);
+  const reloadArtifacts = useSet(thread.setArtifactsDrawerOpen$);
 
   if (loadable.state === "loading") {
     return (
@@ -887,14 +1338,36 @@ function ChatArtifactsDrawerContent({ thread }: { thread: ChatThreadSignals }) {
   }
 
   const selectedKey = selectedItem ? artifactItemKey(selectedItem) : null;
+  const googleDriveConnected =
+    connectorList?.connectors.some((connector) => {
+      return connector.type === "google-drive" && !connector.needsReconnect;
+    }) ?? false;
+  const refreshArtifactSyncStatus = () => {
+    reloadArtifacts(true);
+  };
 
   return (
     <div className="flex flex-col gap-5">
-      {selectedItem && <ArtifactPreviewPanel item={selectedItem} />}
+      {selectedItem && (
+        <ArtifactPreviewPanel
+          item={selectedItem}
+          googleDriveConnected={googleDriveConnected}
+          agentId={agentId}
+          onSyncSuccess={refreshArtifactSyncStatus}
+          threadId={thread.threadId}
+        />
+      )}
       <div className="flex items-center justify-between border-b border-border/60 pb-3 text-xs text-muted-foreground">
         <span>
           {totalFiles} file{totalFiles === 1 ? "" : "s"}
         </span>
+        <ArtifactBulkActionsMenu
+          items={items}
+          googleDriveConnected={googleDriveConnected}
+          agentId={agentId}
+          onSyncSuccess={refreshArtifactSyncStatus}
+          threadId={thread.threadId}
+        />
       </div>
       <div className="flex flex-col gap-2">
         {items.map((item) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -649,7 +649,10 @@ export function ZeroConnectorsPage() {
     ) {
       setSelected(type);
     } else {
-      detach(connect(type, signal), Reason.DomCallback);
+      detach(
+        connect(type, { showPermissionDialog: true }, signal),
+        Reason.DomCallback,
+      );
     }
   };
 
@@ -808,6 +811,7 @@ export function ZeroConnectorsPage() {
           onClose={() => {
             return setSelected(null);
           }}
+          showPermissionDialogOnConnect
           onSuccess={() => {
             const label =
               allConnectors.find((c) => {
@@ -826,7 +830,10 @@ export function ZeroConnectorsPage() {
           }}
           onReconnect={(type) => {
             setScopeReviewType(null);
-            detach(connect(type, signal), Reason.DomCallback);
+            detach(
+              connect(type, { showPermissionDialog: true }, signal),
+              Reason.DomCallback,
+            );
           }}
         />
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -110,7 +110,7 @@ function DirectedAuthorizeCard() {
     } else {
       detach(
         (async () => {
-          await connect(connectorType, signal);
+          await connect(connectorType, {}, signal);
           await authorize(connectorType, agentId, signal);
         })(),
         Reason.DomCallback,

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -41,15 +41,18 @@ import { Vm0LogoLink, GoogleOAuthNotice } from "./zero-directed-shared.tsx";
 function runDirectedConnect(params: {
   authMethods: string[];
   connectorType: ConnectorType;
-  agentId: string | null;
   signal: AbortSignal;
-  connect: (type: ConnectorType, signal: AbortSignal) => Promise<unknown>;
-  enable: (type: ConnectorType, signal: AbortSignal) => Promise<unknown>;
-  authorize: (
+  connect: (
     type: ConnectorType,
-    agentId: string,
+    options: { readonly showPermissionDialog?: boolean },
+    signal: AbortSignal,
+  ) => Promise<boolean>;
+  enable: (
+    type: ConnectorType,
+    options: { readonly showPermissionDialog?: boolean },
     signal: AbortSignal,
   ) => Promise<unknown>;
+  onConnected: () => Promise<void>;
   openTokenDialog: () => void;
 }): void {
   const hasOAuth = params.authMethods.includes("oauth");
@@ -74,17 +77,18 @@ function runDirectedConnect(params: {
   }
   detach(
     (async () => {
+      let connected = true;
       if (hasOAuth) {
-        await params.connect(params.connectorType, params.signal);
-      } else {
-        await params.enable(params.connectorType, params.signal);
-      }
-      if (params.agentId) {
-        await params.authorize(
+        connected = await params.connect(
           params.connectorType,
-          params.agentId,
+          {},
           params.signal,
         );
+      } else {
+        await params.enable(params.connectorType, {}, params.signal);
+      }
+      if (connected) {
+        await params.onConnected();
       }
     })(),
     Reason.DomCallback,
@@ -141,7 +145,7 @@ function ApiTokenForm({
     setSubmitting(type);
     detach(
       (async () => {
-        await submit(type, secretValues, pageSignal);
+        await submit(type, secretValues, {}, pageSignal);
         setSubmitting(null);
         clearForm(type);
         onSuccess();
@@ -300,16 +304,21 @@ function DirectedConnectCard() {
   const isConnected =
     justConnected.has(connectorType) || (item?.connected ?? false);
 
+  const runPostConnectActions = async () => {
+    if (agentId) {
+      await authorize(connectorType, agentId, signal);
+    }
+  };
+
   const handleConnect = () => {
     runDirectedConnect({
       authMethods:
         item?.availableAuthMethods ?? Object.keys(config.authMethods),
       connectorType,
-      agentId,
       signal,
       connect,
       enable,
-      authorize,
+      onConnected: runPostConnectActions,
       openTokenDialog: () => {
         return setTokenDialogOpen(true);
       },
@@ -366,10 +375,7 @@ function DirectedConnectCard() {
         onConnected={
           agentId
             ? () => {
-                detach(
-                  authorize(connectorType, agentId, signal),
-                  Reason.DomCallback,
-                );
+                detach(runPostConnectActions(), Reason.DomCallback);
               }
             : undefined
         }

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -273,11 +273,8 @@ function ConnectStepContent() {
     ) {
       setSelectedConnector(type);
     } else {
-      // During onboarding the backend authorizes connectors for the default
-      // agent at step 4, so suppress the multi-agent permission dialog that
-      // connectConnector$ normally triggers.
       detach(
-        connect(type, pageSignal).then(() => {
+        connect(type, {}, pageSignal).then(() => {
           return clearPermissionDialog(null);
         }),
         Reason.DomCallback,

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { GET } from "../route";
+import { http, HttpResponse } from "msw";
+import { GET, POST as SYNC_POST } from "../route";
 import { POST } from "../../../route";
 import {
   createTestCompose,
@@ -12,7 +13,9 @@ import {
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
+import { insertTestConnectorSecret } from "../../../../../../../src/__tests__/db-test-seeders/connectors";
 import { recordRunUploadedFile } from "../../../../../../../src/lib/zero/uploads/run-uploaded-files";
+import { server } from "../../../../../../../src/mocks/server";
 
 const context = testContext();
 
@@ -89,6 +92,88 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
     expect(data.runs[0].files[0].url).toContain("/f/");
   });
 
+  it("returns Google Drive sync status from the connected Drive account", async () => {
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+    const { runId } = await seedTestRun(testUserId, testComposeId, {
+      status: "completed",
+      prompt: "Use the attached file",
+      chatThreadId: threadId,
+    });
+
+    await context.createConnector(testOrgId, {
+      userId: testUserId,
+      type: "google-drive",
+      authMethod: "oauth",
+    });
+    await insertTestConnectorSecret(
+      testOrgId,
+      testUserId,
+      "GOOGLE_DRIVE_ACCESS_TOKEN",
+      "drive-access-token",
+    );
+    await recordRunUploadedFile({
+      runId,
+      source: "web",
+      externalId: "file-1",
+      userId: testUserId,
+      orgId: testOrgId,
+      filename: "data.csv",
+      contentType: "text/csv",
+      sizeBytes: 2048,
+      url: `http://localhost:3000/f/${testUserId}/file-1/data.csv`,
+    });
+
+    let authHeader: string | null = null;
+    let driveQuery = "";
+    server.use(
+      http.get("https://www.googleapis.com/drive/v3/files", ({ request }) => {
+        const url = new URL(request.url);
+        authHeader = request.headers.get("authorization");
+        driveQuery = url.searchParams.get("q") ?? "";
+        return HttpResponse.json({
+          files: [
+            {
+              id: "drive-file-id",
+              name: "data.csv",
+              webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+              appProperties: {
+                vm0Artifact: "true",
+                vm0ThreadId: threadId,
+                vm0RunId: runId,
+                vm0FileId: "file-1",
+              },
+            },
+          ],
+        });
+      }),
+    );
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}/artifacts`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(authHeader).toBe("Bearer drive-access-token");
+    expect(driveQuery).toContain("appProperties has");
+    expect(driveQuery).toContain(`value='${threadId}'`);
+    expect(data.runs[0].files[0].googleDriveSync).toStrictEqual({
+      status: "synced",
+      id: "drive-file-id",
+      name: "data.csv",
+      webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+    });
+  });
+
   it("uses chat message run ownership when zero run chat thread is missing", async () => {
     const createRes = await POST(
       createTestRequest("http://localhost:3000/api/zero/chat-threads", {
@@ -138,5 +223,175 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
       contentType: "text/html",
       size: 512,
     });
+  });
+
+  it("syncs a thread artifact file to Google Drive", async () => {
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+    const { runId } = await seedTestRun(testUserId, testComposeId, {
+      status: "completed",
+      prompt: "Use the attached file",
+      chatThreadId: threadId,
+    });
+    const s3Key = `uploads/${testUserId}/file-1/data.csv`;
+
+    await context.createConnector(testOrgId, {
+      userId: testUserId,
+      type: "google-drive",
+      authMethod: "oauth",
+    });
+    await insertTestConnectorSecret(
+      testOrgId,
+      testUserId,
+      "GOOGLE_DRIVE_ACCESS_TOKEN",
+      "drive-access-token",
+    );
+    await recordRunUploadedFile({
+      runId,
+      source: "web",
+      externalId: "file-1",
+      userId: testUserId,
+      orgId: testOrgId,
+      filename: "data.csv",
+      contentType: "text/csv",
+      sizeBytes: 2048,
+      url: `http://localhost:3000/f/${testUserId}/file-1/data.csv`,
+      metadata: { s3Key },
+    });
+
+    context.mocks.s3.downloadS3Buffer.mockResolvedValueOnce(
+      Buffer.from("name,value\nalpha,1\n"),
+    );
+
+    let authHeader: string | null = null;
+    let contentType: string | null = null;
+    let uploadType: string | null = null;
+    let uploadBody = "";
+    const folderQueries: string[] = [];
+    const createdFolders: unknown[] = [];
+    server.use(
+      http.get("https://www.googleapis.com/drive/v3/files", ({ request }) => {
+        const url = new URL(request.url);
+        folderQueries.push(url.searchParams.get("q") ?? "");
+        return HttpResponse.json({ files: [] });
+      }),
+      http.post(
+        "https://www.googleapis.com/drive/v3/files",
+        async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>;
+          createdFolders.push(body);
+          return HttpResponse.json({
+            id:
+              createdFolders.length === 1
+                ? "drive-folder-vm0-artifact"
+                : "drive-folder-chat-thread",
+            name: typeof body.name === "string" ? body.name : "folder",
+          });
+        },
+      ),
+      http.post(
+        "https://www.googleapis.com/upload/drive/v3/files",
+        async ({ request }) => {
+          const url = new URL(request.url);
+          authHeader = request.headers.get("authorization");
+          contentType = request.headers.get("content-type");
+          uploadType = url.searchParams.get("uploadType");
+          uploadBody = await request.text();
+          return HttpResponse.json({
+            id: "drive-file-id",
+            name: "data.csv",
+            webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+          });
+        },
+      ),
+    );
+
+    const response = await SYNC_POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}/artifacts`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ runId, fileId: "file-1" }),
+        },
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      id: "drive-file-id",
+      name: "data.csv",
+      webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+    });
+    expect(context.mocks.s3.downloadS3Buffer).toHaveBeenCalledWith(
+      expect.any(String),
+      s3Key,
+    );
+    expect(authHeader).toBe("Bearer drive-access-token");
+    expect(contentType).toContain("multipart/related");
+    expect(uploadType).toBe("multipart");
+    expect(folderQueries).toHaveLength(2);
+    expect(folderQueries[0]).toContain("name = 'vm0-artifact'");
+    expect(folderQueries[0]).toContain("'root' in parents");
+    expect(folderQueries[1]).toContain(`name = 'chat-${threadId}'`);
+    expect(folderQueries[1]).toContain(
+      "'drive-folder-vm0-artifact' in parents",
+    );
+    expect(createdFolders).toStrictEqual([
+      {
+        name: "vm0-artifact",
+        mimeType: "application/vnd.google-apps.folder",
+      },
+      {
+        name: `chat-${threadId}`,
+        mimeType: "application/vnd.google-apps.folder",
+        parents: ["drive-folder-vm0-artifact"],
+      },
+    ]);
+    expect(uploadBody).toContain('"name":"data.csv"');
+    expect(uploadBody).toContain('"parents":["drive-folder-chat-thread"]');
+    expect(uploadBody).toContain('"vm0Artifact":"true"');
+    expect(uploadBody).toContain(`"vm0ThreadId":"${threadId}"`);
+    expect(uploadBody).toContain(`"vm0RunId":"${runId}"`);
+    expect(uploadBody).toContain('"vm0FileId":"file-1"');
+    expect(uploadBody).toContain("Content-Type: text/csv\r\n\r\nname,value");
+  });
+
+  it("requires a connected Google Drive account before syncing", async () => {
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+
+    const response = await SYNC_POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}/artifacts`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            runId: "00000000-0000-4000-8000-000000000001",
+            fileId: "file-1",
+          }),
+        },
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.message).toBe(
+      "Connect Google Drive before syncing artifacts",
+    );
   });
 });

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/route.ts
@@ -4,7 +4,20 @@ import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../../src/lib/auth/get-auth-context";
 import { getChatThreadArtifacts } from "../../../../../../src/lib/zero/chat-thread";
-import { isNotFound } from "@vm0/api-services/errors";
+import {
+  resolveOrg,
+  resolveOrgOrNull,
+} from "../../../../../../src/lib/zero/org/resolve-org";
+import {
+  applyGoogleDriveArtifactSyncStatuses,
+  getGoogleDriveArtifactStatusLookup,
+  syncArtifactToGoogleDrive,
+} from "../../../../../../src/lib/zero/chat-thread/artifact-google-drive-sync";
+import {
+  isBadRequest,
+  isForbidden,
+  isNotFound,
+} from "@vm0/api-services/errors";
 
 const router = tsr.router(chatThreadArtifactsContract, {
   list: async ({ params, headers }) => {
@@ -15,15 +28,69 @@ const router = tsr.router(chatThreadArtifactsContract, {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
 
+    const googleDriveStatusLookup = resolveOrgOrNull(authCtx).then(
+      async (org) => {
+        return org
+          ? await getGoogleDriveArtifactStatusLookup({
+              threadId: params.threadId,
+              orgId: org.orgId,
+              userId: authCtx.userId,
+            })
+          : { type: "disconnected" as const };
+      },
+      () => {
+        return { type: "disconnected" as const };
+      },
+    );
+
     try {
       const runs = await getChatThreadArtifacts(
         params.threadId,
         authCtx.userId,
       );
-      return { status: 200 as const, body: { runs } };
+      return {
+        status: 200 as const,
+        body: {
+          runs: applyGoogleDriveArtifactSyncStatuses(
+            runs,
+            await googleDriveStatusLookup,
+          ),
+        },
+      };
     } catch (error) {
       if (isNotFound(error)) {
         return createErrorResponse("NOT_FOUND", "Chat thread not found");
+      }
+      throw error;
+    }
+  },
+  syncGoogleDrive: async ({ params, body, headers }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+
+    try {
+      const { org } = await resolveOrg(authCtx);
+      const result = await syncArtifactToGoogleDrive({
+        threadId: params.threadId,
+        runId: body.runId,
+        fileId: body.fileId,
+        orgId: org.orgId,
+        userId: authCtx.userId,
+      });
+      return { status: 200 as const, body: result };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return createErrorResponse("NOT_FOUND", error.message);
+      }
+      if (isBadRequest(error)) {
+        return createErrorResponse("BAD_REQUEST", error.message);
+      }
+      if (isForbidden(error)) {
+        return createErrorResponse("FORBIDDEN", error.message);
       }
       throw error;
     }
@@ -34,4 +101,4 @@ const handler = createHandler(chatThreadArtifactsContract, router, {
   routeName: "zero.chat-threads.artifacts",
 });
 
-export { handler as GET };
+export { handler as GET, handler as POST };

--- a/turbo/apps/web/src/lib/zero/chat-thread/artifact-google-drive-sync.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/artifact-google-drive-sync.ts
@@ -1,0 +1,693 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, or, sql } from "drizzle-orm";
+import { z } from "zod";
+import { badRequest, notFound } from "@vm0/api-services/errors";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import type {
+  ChatThreadArtifactGoogleDriveSync,
+  ChatThreadArtifactRun,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { env } from "../../../env";
+import { downloadS3Buffer } from "../../infra/s3/s3-client";
+import { inferMimetype } from "../../shared/mimetype";
+import { logger } from "../../shared/logger";
+import {
+  getConnector,
+  getConnectorAccessToken,
+  getConnectorRefreshToken,
+  refreshConnectorAccessToken,
+} from "../connector/connector-service";
+import { getChatThread } from "./chat-thread-service";
+
+const GOOGLE_DRIVE_UPLOAD_URL =
+  "https://www.googleapis.com/upload/drive/v3/files";
+const GOOGLE_DRIVE_FILES_URL = "https://www.googleapis.com/drive/v3/files";
+const GOOGLE_DRIVE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder";
+const GOOGLE_DRIVE_ARTIFACT_APP_PROPERTY = "vm0Artifact";
+const GOOGLE_DRIVE_THREAD_APP_PROPERTY = "vm0ThreadId";
+const GOOGLE_DRIVE_RUN_APP_PROPERTY = "vm0RunId";
+const GOOGLE_DRIVE_FILE_APP_PROPERTY = "vm0FileId";
+const GOOGLE_DRIVE_STATUS_TIMEOUT_MS = 2_000;
+
+const log = logger("service:artifact-google-drive-sync");
+
+const googleDriveUploadResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  webViewLink: z.string().nullable().optional(),
+});
+
+const googleDriveFolderSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+const googleDriveFolderListSchema = z.object({
+  files: z.array(googleDriveFolderSchema),
+});
+
+const googleDriveArtifactFileSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  webViewLink: z.string().nullable().optional(),
+  appProperties: z.record(z.string(), z.string()).optional(),
+});
+
+const googleDriveArtifactFileListSchema = z.object({
+  files: z.array(googleDriveArtifactFileSchema),
+});
+
+type GoogleDriveTokenResult<T> =
+  | { type: "ok"; value: T }
+  | { type: "unauthorized" };
+
+type ArtifactFileRow = {
+  runId: string;
+  source: string;
+  externalId: string;
+  filename: string | null;
+  contentType: string | null;
+  url: string | null;
+  metadata: Record<string, unknown>;
+};
+
+type GoogleDriveSyncResult = {
+  id: string;
+  name: string;
+  webViewLink: string | null;
+};
+
+type GoogleDriveArtifactStatusLookup =
+  | { type: "ready"; syncedByKey: Map<string, GoogleDriveSyncResult> }
+  | { type: "disconnected" }
+  | { type: "unknown" };
+
+function googleDriveArtifactKey(params: {
+  runId: string;
+  fileId: string;
+}): string {
+  return `${params.runId}:${params.fileId}`;
+}
+
+export function applyGoogleDriveArtifactSyncStatuses(
+  runs: ChatThreadArtifactRun[],
+  lookup: GoogleDriveArtifactStatusLookup,
+): ChatThreadArtifactRun[] {
+  return runs.map((run) => {
+    return {
+      ...run,
+      files: run.files.map((file) => {
+        return {
+          ...file,
+          googleDriveSync: resolveGoogleDriveSyncStatus({
+            lookup,
+            runId: run.runId,
+            fileId: file.id,
+          }),
+        };
+      }),
+    };
+  });
+}
+
+function resolveGoogleDriveSyncStatus(params: {
+  lookup: GoogleDriveArtifactStatusLookup;
+  runId: string;
+  fileId: string;
+}): ChatThreadArtifactGoogleDriveSync {
+  if (params.lookup.type === "disconnected") {
+    return { status: "disconnected" };
+  }
+  if (params.lookup.type === "unknown") {
+    return { status: "unknown" };
+  }
+
+  const synced = params.lookup.syncedByKey.get(
+    googleDriveArtifactKey({
+      runId: params.runId,
+      fileId: params.fileId,
+    }),
+  );
+  return synced ? { status: "synced", ...synced } : { status: "not_synced" };
+}
+
+export async function getGoogleDriveArtifactStatusLookup(params: {
+  threadId: string;
+  orgId: string;
+  userId: string;
+}): Promise<GoogleDriveArtifactStatusLookup> {
+  return await readGoogleDriveArtifactStatusLookup(params).then(
+    (lookup) => {
+      return lookup;
+    },
+    (error: unknown) => {
+      log.warn("failed to read Google Drive artifact sync status", error);
+      return { type: "unknown" as const };
+    },
+  );
+}
+
+async function readGoogleDriveArtifactStatusLookup(params: {
+  threadId: string;
+  orgId: string;
+  userId: string;
+}): Promise<GoogleDriveArtifactStatusLookup> {
+  const connector = await getConnector(
+    params.orgId,
+    params.userId,
+    "google-drive",
+  );
+  if (!connector || connector.needsReconnect) {
+    return { type: "disconnected" };
+  }
+
+  const accessToken = await getConnectorAccessToken(
+    "google-drive",
+    params.orgId,
+    params.userId,
+  );
+  if (!accessToken) {
+    return { type: "disconnected" };
+  }
+
+  const files = await listGoogleDriveArtifactFilesWithRefresh({
+    accessToken,
+    threadId: params.threadId,
+    orgId: params.orgId,
+    userId: params.userId,
+    signal: AbortSignal.timeout(GOOGLE_DRIVE_STATUS_TIMEOUT_MS),
+  });
+  if (files.type === "unauthorized") {
+    return { type: "unknown" };
+  }
+
+  return {
+    type: "ready",
+    syncedByKey: googleDriveArtifactsToStatusMap(files.value),
+  };
+}
+
+export async function syncArtifactToGoogleDrive(params: {
+  threadId: string;
+  runId: string;
+  fileId: string;
+  orgId: string;
+  userId: string;
+}): Promise<GoogleDriveSyncResult> {
+  const connector = await getConnector(
+    params.orgId,
+    params.userId,
+    "google-drive",
+  );
+  if (!connector || connector.needsReconnect) {
+    throw badRequest("Connect Google Drive before syncing artifacts");
+  }
+
+  const accessToken = await getConnectorAccessToken(
+    "google-drive",
+    params.orgId,
+    params.userId,
+  );
+  if (!accessToken) {
+    throw badRequest("Connect Google Drive before syncing artifacts");
+  }
+
+  const artifact = await getThreadArtifactFile(params);
+  const s3Key = resolveArtifactS3Key(artifact, params.userId);
+  if (!s3Key) {
+    throw badRequest("This artifact file cannot be synced to Google Drive");
+  }
+
+  const filename = artifact.filename ?? artifact.externalId;
+  const contentType = artifact.contentType ?? inferMimetype(filename);
+  const file = await downloadS3Buffer(
+    env().R2_USER_STORAGES_BUCKET_NAME,
+    s3Key,
+  );
+
+  let result = await uploadArtifactWithGoogleDriveToken({
+    accessToken,
+    threadId: params.threadId,
+    runId: params.runId,
+    fileId: params.fileId,
+    filename,
+    contentType,
+    file,
+  });
+
+  if (result.type === "unauthorized") {
+    const refreshedToken = await refreshGoogleDriveAccessToken(
+      params.orgId,
+      params.userId,
+    );
+    if (refreshedToken) {
+      result = await uploadArtifactWithGoogleDriveToken({
+        accessToken: refreshedToken,
+        threadId: params.threadId,
+        runId: params.runId,
+        fileId: params.fileId,
+        filename,
+        contentType,
+        file,
+      });
+    }
+  }
+
+  if (result.type === "unauthorized") {
+    throw badRequest("Google Drive upload failed with HTTP 401");
+  }
+
+  return await parseGoogleDriveUploadResponse(result.value);
+}
+
+async function getThreadArtifactFile(params: {
+  threadId: string;
+  runId: string;
+  fileId: string;
+  userId: string;
+}): Promise<ArtifactFileRow> {
+  await getChatThread(params.threadId, params.userId);
+
+  const [row] = await globalThis.services.db
+    .select({
+      runId: runUploadedFiles.runId,
+      source: runUploadedFiles.source,
+      externalId: runUploadedFiles.externalId,
+      filename: runUploadedFiles.filename,
+      contentType: runUploadedFiles.contentType,
+      url: runUploadedFiles.url,
+      metadata: runUploadedFiles.metadata,
+    })
+    .from(runUploadedFiles)
+    .innerJoin(zeroRuns, eq(zeroRuns.id, runUploadedFiles.runId))
+    .where(
+      and(
+        eq(runUploadedFiles.userId, params.userId),
+        eq(runUploadedFiles.runId, params.runId),
+        eq(runUploadedFiles.externalId, params.fileId),
+        or(
+          eq(zeroRuns.chatThreadId, params.threadId),
+          sql`EXISTS (
+            SELECT 1
+            FROM ${chatMessages}
+            WHERE ${chatMessages.runId} = ${runUploadedFiles.runId}
+              AND ${chatMessages.chatThreadId} = ${params.threadId}
+          )`,
+        ),
+      ),
+    )
+    .limit(1);
+
+  if (!row) {
+    throw notFound("Artifact file not found");
+  }
+
+  return row;
+}
+
+function resolveArtifactS3Key(
+  artifact: ArtifactFileRow,
+  userId: string,
+): string | null {
+  const metadataS3Key = artifact.metadata.s3Key;
+  if (
+    typeof metadataS3Key === "string" &&
+    metadataS3Key.startsWith(`uploads/${userId}/`)
+  ) {
+    return metadataS3Key;
+  }
+
+  const urlS3Key = artifact.url
+    ? parseFileUrlS3Key(artifact.url, userId)
+    : null;
+  if (urlS3Key) {
+    return urlS3Key;
+  }
+
+  if (artifact.source === "web" && artifact.filename) {
+    return `uploads/${userId}/${artifact.externalId}/${artifact.filename}`;
+  }
+
+  return null;
+}
+
+function parseFileUrlS3Key(url: string, userId: string): string | null {
+  if (!URL.canParse(url)) {
+    return null;
+  }
+
+  const parsed = new URL(url);
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  if (segments.length < 4 || segments[0] !== "f") {
+    return null;
+  }
+
+  const urlUserId = decodeURIComponent(segments[1]!);
+  if (urlUserId !== userId) {
+    return null;
+  }
+
+  const fileId = segments[2]!;
+  const filename = decodeURIComponent(segments.slice(3).join("/"));
+  return `uploads/${urlUserId}/${fileId}/${filename}`;
+}
+
+async function refreshGoogleDriveAccessToken(
+  orgId: string,
+  userId: string,
+): Promise<string | null> {
+  const refreshToken = await getConnectorRefreshToken(
+    "google-drive",
+    orgId,
+    userId,
+  );
+  if (!refreshToken) {
+    return null;
+  }
+
+  return await refreshConnectorAccessToken("google-drive", orgId, userId, {
+    [refreshToken.secretName]: refreshToken.token,
+  });
+}
+
+async function uploadArtifactWithGoogleDriveToken(params: {
+  accessToken: string;
+  threadId: string;
+  runId: string;
+  fileId: string;
+  filename: string;
+  contentType: string;
+  file: Buffer;
+}): Promise<GoogleDriveTokenResult<Response>> {
+  const folderId = await ensureGoogleDriveArtifactFolder({
+    accessToken: params.accessToken,
+    threadId: params.threadId,
+  });
+  if (folderId.type === "unauthorized") {
+    return folderId;
+  }
+
+  const response = await uploadGoogleDriveFile({
+    accessToken: params.accessToken,
+    parentFolderId: folderId.value,
+    filename: params.filename,
+    threadId: params.threadId,
+    runId: params.runId,
+    fileId: params.fileId,
+    contentType: params.contentType,
+    file: params.file,
+  });
+
+  if (response.status === 401) {
+    return { type: "unauthorized" };
+  }
+
+  return { type: "ok", value: response };
+}
+
+async function ensureGoogleDriveArtifactFolder(params: {
+  accessToken: string;
+  threadId: string;
+}): Promise<GoogleDriveTokenResult<string>> {
+  let parentFolderId: string | null = null;
+  for (const name of ["vm0-artifact", `chat-${params.threadId}`]) {
+    const folder = await ensureGoogleDriveFolder({
+      accessToken: params.accessToken,
+      parentFolderId,
+      name,
+    });
+    if (folder.type === "unauthorized") {
+      return folder;
+    }
+    parentFolderId = folder.value.id;
+  }
+
+  if (!parentFolderId) {
+    throw badRequest("Google Drive artifact folder could not be resolved");
+  }
+
+  return { type: "ok", value: parentFolderId };
+}
+
+async function ensureGoogleDriveFolder(params: {
+  accessToken: string;
+  parentFolderId: string | null;
+  name: string;
+}): Promise<GoogleDriveTokenResult<z.infer<typeof googleDriveFolderSchema>>> {
+  const existingFolder = await findGoogleDriveFolder(params);
+  if (existingFolder.type === "unauthorized") {
+    return existingFolder;
+  }
+  if (existingFolder.value) {
+    return { type: "ok", value: existingFolder.value };
+  }
+
+  return await createGoogleDriveFolder(params);
+}
+
+async function findGoogleDriveFolder(params: {
+  accessToken: string;
+  parentFolderId: string | null;
+  name: string;
+}): Promise<
+  GoogleDriveTokenResult<z.infer<typeof googleDriveFolderSchema> | null>
+> {
+  const url = new URL(GOOGLE_DRIVE_FILES_URL);
+  url.searchParams.set(
+    "q",
+    [
+      `mimeType = '${GOOGLE_DRIVE_FOLDER_MIME_TYPE}'`,
+      `name = '${escapeGoogleDriveQueryString(params.name)}'`,
+      "trashed = false",
+      params.parentFolderId
+        ? `'${escapeGoogleDriveQueryString(params.parentFolderId)}' in parents`
+        : "'root' in parents",
+    ].join(" and "),
+  );
+  url.searchParams.set("fields", "files(id,name)");
+  url.searchParams.set("pageSize", "1");
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${params.accessToken}`,
+    },
+  });
+
+  if (response.status === 401) {
+    return { type: "unauthorized" };
+  }
+  if (!response.ok) {
+    throw badRequest(
+      `Google Drive folder lookup failed with HTTP ${response.status}`,
+    );
+  }
+
+  const parsed = googleDriveFolderListSchema.parse(await response.json());
+  return { type: "ok", value: parsed.files[0] ?? null };
+}
+
+async function createGoogleDriveFolder(params: {
+  accessToken: string;
+  parentFolderId: string | null;
+  name: string;
+}): Promise<GoogleDriveTokenResult<z.infer<typeof googleDriveFolderSchema>>> {
+  const url = new URL(GOOGLE_DRIVE_FILES_URL);
+  url.searchParams.set("fields", "id,name");
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${params.accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      name: params.name,
+      mimeType: GOOGLE_DRIVE_FOLDER_MIME_TYPE,
+      ...(params.parentFolderId ? { parents: [params.parentFolderId] } : {}),
+    }),
+  });
+
+  if (response.status === 401) {
+    return { type: "unauthorized" };
+  }
+  if (!response.ok) {
+    throw badRequest(
+      `Google Drive folder creation failed with HTTP ${response.status}`,
+    );
+  }
+
+  return {
+    type: "ok",
+    value: googleDriveFolderSchema.parse(await response.json()),
+  };
+}
+
+function escapeGoogleDriveQueryString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+async function listGoogleDriveArtifactFilesWithRefresh(params: {
+  accessToken: string;
+  threadId: string;
+  orgId: string;
+  userId: string;
+  signal?: AbortSignal;
+}): Promise<
+  GoogleDriveTokenResult<z.infer<typeof googleDriveArtifactFileSchema>[]>
+> {
+  let result = await listGoogleDriveArtifactFiles(params);
+  if (result.type !== "unauthorized") {
+    return result;
+  }
+
+  const refreshedToken = await refreshGoogleDriveAccessToken(
+    params.orgId,
+    params.userId,
+  );
+  if (!refreshedToken) {
+    return result;
+  }
+
+  result = await listGoogleDriveArtifactFiles({
+    accessToken: refreshedToken,
+    threadId: params.threadId,
+    signal: params.signal,
+  });
+  return result;
+}
+
+async function listGoogleDriveArtifactFiles(params: {
+  accessToken: string;
+  threadId: string;
+  signal?: AbortSignal;
+}): Promise<
+  GoogleDriveTokenResult<z.infer<typeof googleDriveArtifactFileSchema>[]>
+> {
+  const url = new URL(GOOGLE_DRIVE_FILES_URL);
+  url.searchParams.set(
+    "q",
+    [
+      `appProperties has { key='${GOOGLE_DRIVE_ARTIFACT_APP_PROPERTY}' and value='true' }`,
+      `appProperties has { key='${GOOGLE_DRIVE_THREAD_APP_PROPERTY}' and value='${escapeGoogleDriveQueryString(
+        params.threadId,
+      )}' }`,
+      "trashed = false",
+    ].join(" and "),
+  );
+  url.searchParams.set("fields", "files(id,name,webViewLink,appProperties)");
+  url.searchParams.set("pageSize", "1000");
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${params.accessToken}`,
+    },
+    signal: params.signal,
+  });
+
+  if (response.status === 401) {
+    return { type: "unauthorized" };
+  }
+  if (!response.ok) {
+    throw badRequest(
+      `Google Drive artifact lookup failed with HTTP ${response.status}`,
+    );
+  }
+
+  const parsed = googleDriveArtifactFileListSchema.parse(await response.json());
+  return { type: "ok", value: parsed.files };
+}
+
+function googleDriveArtifactsToStatusMap(
+  files: z.infer<typeof googleDriveArtifactFileSchema>[],
+): Map<string, GoogleDriveSyncResult> {
+  const map = new Map<string, GoogleDriveSyncResult>();
+  for (const file of files) {
+    const runId = file.appProperties?.[GOOGLE_DRIVE_RUN_APP_PROPERTY];
+    const fileId = file.appProperties?.[GOOGLE_DRIVE_FILE_APP_PROPERTY];
+    if (!runId || !fileId) {
+      continue;
+    }
+    map.set(googleDriveArtifactKey({ runId, fileId }), {
+      id: file.id,
+      name: file.name,
+      webViewLink: file.webViewLink ?? null,
+    });
+  }
+  return map;
+}
+
+async function uploadGoogleDriveFile(params: {
+  accessToken: string;
+  parentFolderId: string;
+  filename: string;
+  threadId: string;
+  runId: string;
+  fileId: string;
+  contentType: string;
+  file: Buffer;
+}): Promise<Response> {
+  const boundary = `vm0-${randomUUID()}`;
+  const metadata = JSON.stringify({
+    name: params.filename,
+    mimeType: params.contentType,
+    parents: [params.parentFolderId],
+    appProperties: {
+      [GOOGLE_DRIVE_ARTIFACT_APP_PROPERTY]: "true",
+      [GOOGLE_DRIVE_THREAD_APP_PROPERTY]: params.threadId,
+      [GOOGLE_DRIVE_RUN_APP_PROPERTY]: params.runId,
+      [GOOGLE_DRIVE_FILE_APP_PROPERTY]: params.fileId,
+    },
+  });
+  const body = Buffer.concat([
+    Buffer.from(
+      [
+        `--${boundary}`,
+        "Content-Type: application/json; charset=UTF-8",
+        "",
+        metadata,
+        `--${boundary}`,
+        `Content-Type: ${params.contentType}`,
+        "",
+        "",
+      ].join("\r\n"),
+      "utf8",
+    ),
+    params.file,
+    Buffer.from(`\r\n--${boundary}--\r\n`, "utf8"),
+  ]);
+
+  const uploadUrl = new URL(GOOGLE_DRIVE_UPLOAD_URL);
+  uploadUrl.searchParams.set("uploadType", "multipart");
+  uploadUrl.searchParams.set("fields", "id,name,webViewLink");
+
+  return await fetch(uploadUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${params.accessToken}`,
+      "Content-Type": `multipart/related; boundary=${boundary}`,
+      "Content-Length": String(body.length),
+    },
+    body,
+  });
+}
+
+async function parseGoogleDriveUploadResponse(
+  response: Response,
+): Promise<GoogleDriveSyncResult> {
+  if (!response.ok) {
+    throw badRequest(readGoogleDriveError(response));
+  }
+
+  const parsed = googleDriveUploadResponseSchema.parse(await response.json());
+  return {
+    id: parsed.id,
+    name: parsed.name,
+    webViewLink: parsed.webViewLink ?? null,
+  };
+}
+
+function readGoogleDriveError(response: Response): string {
+  return `Google Drive upload failed with HTTP ${response.status}`;
+}

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -28,8 +28,21 @@ const resolvedAttachFileSchema = attachFileSchema.extend({
   url: z.string(),
 });
 
+const chatThreadArtifactGoogleDriveSyncSchema = z.discriminatedUnion("status", [
+  z.object({
+    status: z.literal("synced"),
+    id: z.string(),
+    name: z.string(),
+    webViewLink: z.string().nullable(),
+  }),
+  z.object({ status: z.literal("not_synced") }),
+  z.object({ status: z.literal("disconnected") }),
+  z.object({ status: z.literal("unknown") }),
+]);
+
 const chatThreadArtifactFileSchema = resolvedAttachFileSchema.extend({
   createdAt: z.string(),
+  googleDriveSync: chatThreadArtifactGoogleDriveSyncSchema.optional(),
 });
 
 const chatThreadArtifactRunSchema = z.object({
@@ -452,6 +465,29 @@ export const chatThreadArtifactsContract = c.router({
     },
     summary: "List uploaded files associated with every run in a chat thread",
   },
+  syncGoogleDrive: {
+    method: "POST",
+    path: "/api/zero/chat-threads/:threadId/artifacts",
+    headers: authHeadersSchema,
+    pathParams: z.object({ threadId: z.string() }),
+    body: z.object({
+      runId: z.string(),
+      fileId: z.string(),
+    }),
+    responses: {
+      200: z.object({
+        id: z.string(),
+        name: z.string(),
+        webViewLink: z.string().nullable(),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Sync a chat artifact file to the user's connected Google Drive",
+  },
 });
 
 export type ChatThreadsContract = typeof chatThreadsContract;
@@ -475,6 +511,7 @@ export {
   attachFileSchema,
   resolvedAttachFileSchema,
   chatThreadArtifactFileSchema,
+  chatThreadArtifactGoogleDriveSyncSchema,
   chatThreadArtifactRunSchema,
 };
 
@@ -489,5 +526,8 @@ export type AttachFile = z.infer<typeof attachFileSchema>;
 export type ResolvedAttachFile = z.infer<typeof resolvedAttachFileSchema>;
 export type ChatThreadArtifactFile = z.infer<
   typeof chatThreadArtifactFileSchema
+>;
+export type ChatThreadArtifactGoogleDriveSync = z.infer<
+  typeof chatThreadArtifactGoogleDriveSyncSchema
 >;
 export type ChatThreadArtifactRun = z.infer<typeof chatThreadArtifactRunSchema>;


### PR DESCRIPTION
## Summary
- Add artifact preview actions for copy link, download, and Google Drive sync with synced-state refresh.
- Add artifact bulk menu for zip download all and sync all to Google Drive.
- Add server-side Google Drive sync status lookup and upload metadata/pathing for artifacts.

## Testing
- pnpm --filter @vm0/api-contracts check-types
- pnpm --filter @vm0/app check-types
- pnpm --filter web check-types
- pnpm exec vitest run app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts --reporter=verbose
- pnpm exec vitest run src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx -t "artifacts drawer" --reporter=verbose
- pnpm knip --cache
- git diff --check