### PR TITLE
refactor(sandbox-fc): avoid shared netns pool lock waits

### DIFF
--- a/crates/sandbox-fc/src/command.rs
+++ b/crates/sandbox-fc/src/command.rs
@@ -60,34 +60,6 @@ fn format_command_display(program: &str, args: &[&str]) -> String {
     parts.join(" ")
 }
 
-/// Execute a command.
-///
-/// Invokes the program binary directly with the given arguments.
-/// Returns trimmed stdout on success.
-#[cfg_attr(not(test), allow(dead_code))]
-pub async fn exec(program: &str, args: &[&str]) -> Result<String, CommandError> {
-    let cmd_display = format_command_display(program, args);
-    trace!(command = %cmd_display, "exec");
-
-    let output = Command::new(program).args(args).output().await;
-
-    let output = output.map_err(|e| CommandError {
-        command: cmd_display.clone(),
-        detail: e.to_string(),
-    })?;
-
-    if output.status.success() {
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        Ok(stdout)
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        Err(CommandError {
-            command: cmd_display,
-            detail: stderr,
-        })
-    }
-}
-
 /// Execute a command with a bounded runtime.
 ///
 /// This helper is intended for host lifecycle operations where an unbounded
@@ -119,26 +91,6 @@ pub async fn exec_with_timeout(
             command: cmd_display,
             detail: stderr,
         })
-    }
-}
-
-/// Execute a command, ignoring any errors.
-#[cfg_attr(not(test), allow(dead_code))]
-pub async fn exec_ignore_errors(program: &str, args: &[&str]) {
-    let cmd_display = format_command_display(program, args);
-    trace!(command = %cmd_display, "exec_ignore_errors");
-
-    let output = Command::new(program).args(args).output().await;
-
-    match output {
-        Ok(o) if !o.status.success() => {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            trace!(command = %cmd_display, stderr = %stderr.trim(), "command failed (ignored)");
-        }
-        Err(e) => {
-            trace!(command = %cmd_display, error = %e, "command failed to spawn (ignored)");
-        }
-        _ => {}
     }
 }
 
@@ -410,20 +362,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn exec_returns_trimmed_stdout() {
-        let output = exec("echo", &["hello"]).await.unwrap();
+    async fn exec_with_timeout_returns_trimmed_stdout() {
+        let output = exec_with_timeout("echo", &["hello"], Duration::from_secs(1))
+            .await
+            .unwrap();
         assert_eq!(output, "hello");
     }
 
     #[tokio::test]
-    async fn exec_captures_multiline_output() {
-        let output = exec("printf", &["a\\nb\\nc"]).await.unwrap();
+    async fn exec_with_timeout_captures_multiline_output() {
+        let output = exec_with_timeout("printf", &["a\\nb\\nc"], Duration::from_secs(1))
+            .await
+            .unwrap();
         assert_eq!(output, "a\nb\nc");
     }
 
     #[tokio::test]
-    async fn exec_returns_error_on_failure() {
-        let err = exec("false", &[]).await.unwrap_err();
+    async fn exec_with_timeout_returns_error_on_failure() {
+        let err = exec_with_timeout("false", &[], Duration::from_secs(1))
+            .await
+            .unwrap_err();
         assert!(
             err.command.contains("false"),
             "command was: {}",
@@ -432,27 +390,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn exec_error_contains_stderr() {
-        let err = exec("bash", &["-c", "echo oops >&2; exit 1"])
-            .await
-            .unwrap_err();
+    async fn exec_with_timeout_error_contains_stderr() {
+        let err = exec_with_timeout(
+            "bash",
+            &["-c", "echo oops >&2; exit 1"],
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_err();
         assert!(err.detail.contains("oops"), "detail was: {}", err.detail);
     }
 
     #[tokio::test]
-    async fn exec_passes_multiple_args() {
-        let output = exec("printf", &["%s-%s", "a", "b"]).await.unwrap();
+    async fn exec_with_timeout_passes_multiple_args() {
+        let output = exec_with_timeout("printf", &["%s-%s", "a", "b"], Duration::from_secs(1))
+            .await
+            .unwrap();
         assert_eq!(output, "a-b");
     }
 
     #[tokio::test]
-    async fn exec_ignore_errors_does_not_panic_on_failure() {
-        exec_ignore_errors("false", &[]).await;
+    async fn exec_ignore_errors_with_timeout_reports_nonzero() {
+        let outcome = exec_ignore_errors_with_timeout("false", &[], Duration::from_secs(1)).await;
+        assert_eq!(outcome, IgnoredCommandOutcome::NonZero);
     }
 
     #[tokio::test]
-    async fn exec_ignore_errors_does_not_panic_on_success() {
-        exec_ignore_errors("true", &[]).await;
+    async fn exec_ignore_errors_with_timeout_reports_success() {
+        let outcome = exec_ignore_errors_with_timeout("true", &[], Duration::from_secs(1)).await;
+        assert_eq!(outcome, IgnoredCommandOutcome::Success);
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/command.rs
+++ b/crates/sandbox-fc/src/command.rs
@@ -412,53 +412,123 @@ mod tests {
     #[tokio::test]
     async fn exec_with_timeout_kills_child_process_group() {
         let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("pid");
         let marker = dir.path().join("marker");
+        let pid_file = pid_file.to_str().unwrap();
         let marker = marker.to_str().unwrap();
 
-        let _ = exec_ignore_errors_with_timeout(
+        let outcome = exec_ignore_errors_with_timeout(
             "sh",
-            &["-c", "(sleep 0.2; touch \"$1\") & wait", "_", marker],
-            Duration::from_millis(50),
+            &[
+                "-c",
+                "(sleep 5; touch \"$2\") & echo $! > \"$1\"; wait",
+                "_",
+                pid_file,
+                marker,
+            ],
+            Duration::from_millis(250),
         )
         .await;
 
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        assert_eq!(outcome, IgnoredCommandOutcome::Timeout);
+        let pid = read_pid_file(pid_file).await;
+        assert_pid_exits(pid).await;
         assert!(!std::path::Path::new(marker).exists());
     }
 
     #[tokio::test]
     async fn exec_with_timeout_bounds_pipe_drain_after_parent_exits() {
         let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("pid");
         let marker = dir.path().join("marker");
+        let pid_file = pid_file.to_str().unwrap();
         let marker = marker.to_str().unwrap();
 
         let outcome = exec_ignore_errors_with_timeout(
             "sh",
-            &["-c", "(sleep 0.2; touch \"$1\") &", "_", marker],
-            Duration::from_millis(50),
+            &[
+                "-c",
+                "(sleep 5; touch \"$2\") & echo $! > \"$1\"",
+                "_",
+                pid_file,
+                marker,
+            ],
+            Duration::from_millis(250),
         )
         .await;
 
         assert_eq!(outcome, IgnoredCommandOutcome::Timeout);
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        let pid = read_pid_file(pid_file).await;
+        assert_pid_exits(pid).await;
         assert!(!std::path::Path::new(marker).exists());
     }
 
     #[tokio::test]
     async fn exec_with_timeout_aborts_only_remaining_pipe_reader() {
         let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("pid");
         let marker = dir.path().join("marker");
+        let pid_file = pid_file.to_str().unwrap();
         let marker = marker.to_str().unwrap();
 
         let outcome = exec_ignore_errors_with_timeout(
             "sh",
-            &["-c", "(exec 1>&-; sleep 0.2; touch \"$1\") &", "_", marker],
-            Duration::from_millis(50),
+            &[
+                "-c",
+                "(exec 1>&-; sleep 5; touch \"$2\") & echo $! > \"$1\"",
+                "_",
+                pid_file,
+                marker,
+            ],
+            Duration::from_millis(250),
         )
         .await;
 
         assert_eq!(outcome, IgnoredCommandOutcome::Timeout);
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        let pid = read_pid_file(pid_file).await;
+        assert_pid_exits(pid).await;
         assert!(!std::path::Path::new(marker).exists());
+    }
+
+    async fn read_pid_file(path: &str) -> u32 {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+        loop {
+            match std::fs::read_to_string(path) {
+                Ok(pid) => return pid.trim().parse().expect("pid file contains pid"),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => panic!("read pid file {path}: {e}"),
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "pid file was not written: {path}"
+            );
+            tokio::task::yield_now().await;
+        }
+    }
+
+    async fn assert_pid_exits(pid: u32) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        while process_exists(pid) {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "process {pid} was not killed by command timeout"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[cfg(unix)]
+    fn process_exists(pid: u32) -> bool {
+        let pid = nix::unistd::Pid::from_raw(i32::try_from(pid).expect("pid fits in i32"));
+        match nix::sys::signal::kill(pid, None) {
+            Ok(()) => true,
+            Err(nix::errno::Errno::ESRCH) => false,
+            Err(_) => true,
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn process_exists(_pid: u32) -> bool {
+        false
     }
 }

--- a/crates/sandbox-fc/src/command.rs
+++ b/crates/sandbox-fc/src/command.rs
@@ -255,32 +255,31 @@ async fn collect_pipes_with_deadline(
     timeout: Duration,
     child_pid: Option<u32>,
 ) -> std::result::Result<(Vec<u8>, Vec<u8>), CommandRunError> {
-    let mut stdout = None;
-    let mut stderr = None;
-    let sleep = tokio::time::sleep_until(deadline);
-    tokio::pin!(sleep);
-
-    loop {
-        tokio::select! {
-            result = &mut stdout_task, if stdout.is_none() => {
-                stdout = Some(collect_pipe_result(result)?);
+    let stdout = match tokio::time::timeout_at(deadline, &mut stdout_task).await {
+        Ok(result) => match collect_pipe_result(result) {
+            Ok(stdout) => stdout,
+            Err(e) => {
+                abort_pipe_task(stderr_task).await;
+                return Err(e);
             }
-            result = &mut stderr_task, if stderr.is_none() => {
-                stderr = Some(collect_pipe_result(result)?);
-            }
-            () = &mut sleep => {
-                kill_process_group_by_optional_pid(child_pid);
-                abort_pipe_tasks(stdout_task, stderr_task).await;
-                return Err(CommandRunError::Timeout(timeout.as_millis()));
-            }
+        },
+        Err(_) => {
+            kill_process_group_by_optional_pid(child_pid);
+            abort_pipe_tasks(stdout_task, stderr_task).await;
+            return Err(CommandRunError::Timeout(timeout.as_millis()));
         }
+    };
 
-        if stdout.is_some() && stderr.is_some() {
-            let stdout = stdout.ok_or(CommandRunError::PipeUnavailable("stdout"))?;
-            let stderr = stderr.ok_or(CommandRunError::PipeUnavailable("stderr"))?;
-            return Ok((stdout, stderr));
+    let stderr = match tokio::time::timeout_at(deadline, &mut stderr_task).await {
+        Ok(result) => collect_pipe_result(result)?,
+        Err(_) => {
+            kill_process_group_by_optional_pid(child_pid);
+            abort_pipe_task(stderr_task).await;
+            return Err(CommandRunError::Timeout(timeout.as_millis()));
         }
-    }
+    };
+
+    Ok((stdout, stderr))
 }
 
 fn collect_pipe_result(
@@ -311,10 +310,13 @@ async fn abort_pipe_tasks(
     stdout_task: JoinHandle<std::io::Result<Vec<u8>>>,
     stderr_task: JoinHandle<std::io::Result<Vec<u8>>>,
 ) {
-    stdout_task.abort();
-    stderr_task.abort();
-    let _ = stdout_task.await;
-    let _ = stderr_task.await;
+    abort_pipe_task(stdout_task).await;
+    abort_pipe_task(stderr_task).await;
+}
+
+async fn abort_pipe_task(task: JoinHandle<std::io::Result<Vec<u8>>>) {
+    task.abort();
+    let _ = task.await;
 }
 
 #[cfg(test)]
@@ -433,6 +435,24 @@ mod tests {
         let outcome = exec_ignore_errors_with_timeout(
             "sh",
             &["-c", "(sleep 0.2; touch \"$1\") &", "_", marker],
+            Duration::from_millis(50),
+        )
+        .await;
+
+        assert_eq!(outcome, IgnoredCommandOutcome::Timeout);
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        assert!(!std::path::Path::new(marker).exists());
+    }
+
+    #[tokio::test]
+    async fn exec_with_timeout_aborts_only_remaining_pipe_reader() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("marker");
+        let marker = marker.to_str().unwrap();
+
+        let outcome = exec_ignore_errors_with_timeout(
+            "sh",
+            &["-c", "(exec 1>&-; sleep 0.2; touch \"$1\") &", "_", marker],
             Duration::from_millis(50),
         )
         .await;

--- a/crates/sandbox-fc/src/command.rs
+++ b/crates/sandbox-fc/src/command.rs
@@ -2,7 +2,7 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use tokio::io::AsyncReadExt;
-use tokio::process::Command;
+use tokio::process::{Child, Command};
 use tracing::trace;
 
 /// Error from a failed command.
@@ -14,14 +14,16 @@ pub struct CommandError {
 }
 
 /// Outcome for best-effort commands where callers intentionally ignore
-/// non-zero exits but still need to know whether cleanup timed out or failed to
-/// spawn.
+/// non-zero exits but still need coarse failure classification for cleanup
+/// safety decisions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IgnoredCommandOutcome {
     Success,
     NonZero,
+    NotFound,
     SpawnError,
     WaitError,
+    PipeError,
     Timeout,
 }
 
@@ -29,6 +31,22 @@ impl IgnoredCommandOutcome {
     pub fn completed_without_timeout(self) -> bool {
         matches!(self, Self::Success | Self::NonZero)
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum CommandRunError {
+    #[error("spawn failed: {0}")]
+    Spawn(std::io::Error),
+    #[error("wait failed: {0}")]
+    Wait(std::io::Error),
+    #[error("pipe read task failed: {0}")]
+    PipeTask(tokio::task::JoinError),
+    #[error("pipe read failed: {0}")]
+    PipeRead(std::io::Error),
+    #[error("{0} pipe unavailable")]
+    PipeUnavailable(&'static str),
+    #[error("timed out after {0}ms")]
+    Timeout(u128),
 }
 
 /// Format a human-readable display string for a command invocation.
@@ -71,7 +89,8 @@ pub async fn exec(program: &str, args: &[&str]) -> Result<String, CommandError> 
 ///
 /// This helper is intended for host lifecycle operations where an unbounded
 /// subprocess can block resource cleanup. On timeout the child is killed and
-/// waited before returning.
+/// waited before returning. On Unix, the subprocess runs in its own process
+/// group so timeout cleanup also kills grandchildren.
 pub async fn exec_with_timeout(
     program: &str,
     args: &[&str],
@@ -82,9 +101,9 @@ pub async fn exec_with_timeout(
 
     let output = command_output_with_timeout(program, args, timeout)
         .await
-        .map_err(|detail| CommandError {
+        .map_err(|e| CommandError {
             command: cmd_display.clone(),
-            detail,
+            detail: e.to_string(),
         })?;
 
     if output.status.success() {
@@ -135,16 +154,32 @@ pub async fn exec_ignore_errors_with_timeout(
             trace!(command = %cmd_display, stderr = %stderr.trim(), "command failed (ignored)");
             IgnoredCommandOutcome::NonZero
         }
-        Err(detail) if detail.starts_with("timed out ") => {
-            trace!(command = %cmd_display, detail, "command timed out (ignored)");
+        Err(CommandRunError::Timeout(ms)) => {
+            trace!(command = %cmd_display, timeout_ms = ms as u64, "command timed out (ignored)");
             IgnoredCommandOutcome::Timeout
         }
-        Err(detail) if detail.starts_with("wait failed: ") => {
-            trace!(command = %cmd_display, detail, "command wait failed (ignored)");
+        Err(CommandRunError::Wait(e)) => {
+            trace!(command = %cmd_display, error = %e, "command wait failed (ignored)");
             IgnoredCommandOutcome::WaitError
         }
-        Err(detail) => {
-            trace!(command = %cmd_display, detail, "command failed to spawn (ignored)");
+        Err(CommandRunError::PipeTask(e)) => {
+            trace!(command = %cmd_display, error = %e, "command pipe task failed (ignored)");
+            IgnoredCommandOutcome::PipeError
+        }
+        Err(CommandRunError::PipeRead(e)) => {
+            trace!(command = %cmd_display, error = %e, "command pipe read failed (ignored)");
+            IgnoredCommandOutcome::PipeError
+        }
+        Err(CommandRunError::PipeUnavailable(pipe)) => {
+            trace!(command = %cmd_display, pipe, "command pipe unavailable (ignored)");
+            IgnoredCommandOutcome::PipeError
+        }
+        Err(CommandRunError::Spawn(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+            trace!(command = %cmd_display, error = %e, "command not found (ignored)");
+            IgnoredCommandOutcome::NotFound
+        }
+        Err(CommandRunError::Spawn(e)) => {
+            trace!(command = %cmd_display, error = %e, "command failed to spawn (ignored)");
             IgnoredCommandOutcome::SpawnError
         }
     }
@@ -154,23 +189,25 @@ async fn command_output_with_timeout(
     program: &str,
     args: &[&str],
     timeout: Duration,
-) -> std::result::Result<std::process::Output, String> {
-    let mut child = Command::new(program)
+) -> std::result::Result<std::process::Output, CommandRunError> {
+    let mut command = Command::new(program);
+    command
         .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()
-        .map_err(|e| e.to_string())?;
+        .kill_on_drop(true);
+    #[cfg(unix)]
+    command.process_group(0);
+    let mut child = command.spawn().map_err(CommandRunError::Spawn)?;
 
     let stdout = child
         .stdout
         .take()
-        .ok_or_else(|| "stdout pipe unavailable".to_string())?;
+        .ok_or(CommandRunError::PipeUnavailable("stdout"))?;
     let stderr = child
         .stderr
         .take()
-        .ok_or_else(|| "stderr pipe unavailable".to_string())?;
+        .ok_or(CommandRunError::PipeUnavailable("stderr"))?;
 
     let stdout_task = tokio::spawn(read_pipe(stdout));
     let stderr_task = tokio::spawn(read_pipe(stderr));
@@ -178,14 +215,14 @@ async fn command_output_with_timeout(
     let status = match tokio::time::timeout(timeout, child.wait()).await {
         Ok(Ok(status)) => status,
         Ok(Err(e)) => {
+            kill_child_tree(&mut child).await;
             abort_pipe_tasks(stdout_task, stderr_task).await;
-            return Err(format!("wait failed: {e}"));
+            return Err(CommandRunError::Wait(e));
         }
         Err(_) => {
-            let _ = child.kill().await;
-            let _ = child.wait().await;
+            kill_child_tree(&mut child).await;
             abort_pipe_tasks(stdout_task, stderr_task).await;
-            return Err(format!("timed out after {}ms", timeout.as_millis()));
+            return Err(CommandRunError::Timeout(timeout.as_millis()));
         }
     };
 
@@ -209,10 +246,17 @@ where
 
 async fn collect_pipe(
     task: tokio::task::JoinHandle<std::io::Result<Vec<u8>>>,
-) -> std::result::Result<Vec<u8>, String> {
+) -> std::result::Result<Vec<u8>, CommandRunError> {
     task.await
-        .map_err(|e| format!("pipe read task failed: {e}"))?
-        .map_err(|e| format!("pipe read failed: {e}"))
+        .map_err(CommandRunError::PipeTask)?
+        .map_err(CommandRunError::PipeRead)
+}
+
+async fn kill_child_tree(child: &mut Child) {
+    #[cfg(unix)]
+    crate::process::kill_process_group(child);
+    let _ = child.start_kill();
+    let _ = child.wait().await;
 }
 
 async fn abort_pipe_tasks(
@@ -304,15 +348,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn exec_with_timeout_kills_child_before_followup_command() {
+    async fn exec_ignore_errors_with_timeout_reports_not_found() {
+        let outcome = exec_ignore_errors_with_timeout(
+            "vm0-definitely-missing-command-for-timeout-test",
+            &[],
+            Duration::from_millis(50),
+        )
+        .await;
+
+        assert_eq!(outcome, IgnoredCommandOutcome::NotFound);
+    }
+
+    #[tokio::test]
+    async fn exec_with_timeout_kills_child_process_group() {
         let dir = tempfile::tempdir().unwrap();
         let marker = dir.path().join("marker");
-        let script = format!("sleep 1; touch {}", marker.display());
+        let marker = marker.to_str().unwrap();
 
-        let _ = exec_ignore_errors_with_timeout("sh", &["-c", &script], Duration::from_millis(50))
-            .await;
+        let _ = exec_ignore_errors_with_timeout(
+            "sh",
+            &["-c", "(sleep 0.2; touch \"$1\") & wait", "_", marker],
+            Duration::from_millis(50),
+        )
+        .await;
 
-        tokio::time::sleep(Duration::from_millis(1200)).await;
-        assert!(!marker.exists());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        assert!(!std::path::Path::new(marker).exists());
     }
 }

--- a/crates/sandbox-fc/src/command.rs
+++ b/crates/sandbox-fc/src/command.rs
@@ -6,6 +6,8 @@ use tokio::process::{Child, Command};
 use tokio::task::JoinHandle;
 use tracing::trace;
 
+type PipeReadTask = JoinHandle<std::io::Result<Vec<u8>>>;
+
 /// Error from a failed command.
 #[derive(Debug, thiserror::Error)]
 #[error("command failed: {command}\n{detail}")]
@@ -202,6 +204,7 @@ async fn command_output_with_timeout(
     command.process_group(0);
     let mut child = command.spawn().map_err(CommandRunError::Spawn)?;
     let child_pid = child.id();
+    let mut kill_guard = ProcessGroupKillGuard::new(child_pid);
 
     let stdout = child
         .stdout
@@ -212,26 +215,30 @@ async fn command_output_with_timeout(
         .take()
         .ok_or(CommandRunError::PipeUnavailable("stderr"))?;
 
-    let stdout_task = tokio::spawn(read_pipe(stdout));
-    let stderr_task = tokio::spawn(read_pipe(stderr));
+    let mut pipe_tasks = PipeTasks::new(
+        tokio::spawn(read_pipe(stdout)),
+        tokio::spawn(read_pipe(stderr)),
+    );
     let deadline = tokio::time::Instant::now() + timeout;
 
     let status = match tokio::time::timeout_at(deadline, child.wait()).await {
         Ok(Ok(status)) => status,
         Ok(Err(e)) => {
             kill_child_tree(&mut child).await;
-            abort_pipe_tasks(stdout_task, stderr_task).await;
+            pipe_tasks.abort_all().await;
             return Err(CommandRunError::Wait(e));
         }
         Err(_) => {
             kill_child_tree(&mut child).await;
-            abort_pipe_tasks(stdout_task, stderr_task).await;
+            pipe_tasks.abort_all().await;
             return Err(CommandRunError::Timeout(timeout.as_millis()));
         }
     };
 
-    let (stdout, stderr) =
-        collect_pipes_with_deadline(stdout_task, stderr_task, deadline, timeout, child_pid).await?;
+    let (stdout, stderr) = pipe_tasks
+        .collect_with_deadline(deadline, timeout, child_pid)
+        .await?;
+    kill_guard.disarm();
     Ok(std::process::Output {
         status,
         stdout,
@@ -248,38 +255,119 @@ where
     Ok(output)
 }
 
-async fn collect_pipes_with_deadline(
-    mut stdout_task: JoinHandle<std::io::Result<Vec<u8>>>,
-    mut stderr_task: JoinHandle<std::io::Result<Vec<u8>>>,
-    deadline: tokio::time::Instant,
-    timeout: Duration,
-    child_pid: Option<u32>,
-) -> std::result::Result<(Vec<u8>, Vec<u8>), CommandRunError> {
-    let stdout = match tokio::time::timeout_at(deadline, &mut stdout_task).await {
-        Ok(result) => match collect_pipe_result(result) {
-            Ok(stdout) => stdout,
-            Err(e) => {
-                abort_pipe_task(stderr_task).await;
-                return Err(e);
+struct ProcessGroupKillGuard {
+    pid: Option<u32>,
+}
+
+impl ProcessGroupKillGuard {
+    fn new(pid: Option<u32>) -> Self {
+        Self { pid }
+    }
+
+    fn disarm(&mut self) {
+        self.pid = None;
+    }
+}
+
+impl Drop for ProcessGroupKillGuard {
+    fn drop(&mut self) {
+        kill_process_group_by_optional_pid(self.pid);
+    }
+}
+
+struct PipeTasks {
+    stdout: Option<PipeReadTask>,
+    stderr: Option<PipeReadTask>,
+}
+
+impl PipeTasks {
+    fn new(stdout: PipeReadTask, stderr: PipeReadTask) -> Self {
+        Self {
+            stdout: Some(stdout),
+            stderr: Some(stderr),
+        }
+    }
+
+    async fn collect_with_deadline(
+        &mut self,
+        deadline: tokio::time::Instant,
+        timeout: Duration,
+        child_pid: Option<u32>,
+    ) -> std::result::Result<(Vec<u8>, Vec<u8>), CommandRunError> {
+        let stdout = match tokio::time::timeout_at(
+            deadline,
+            self.stdout
+                .as_mut()
+                .ok_or(CommandRunError::PipeUnavailable("stdout"))?,
+        )
+        .await
+        {
+            Ok(result) => {
+                self.stdout.take();
+                match collect_pipe_result(result) {
+                    Ok(stdout) => stdout,
+                    Err(e) => {
+                        self.abort_stderr().await;
+                        return Err(e);
+                    }
+                }
             }
-        },
-        Err(_) => {
-            kill_process_group_by_optional_pid(child_pid);
-            abort_pipe_tasks(stdout_task, stderr_task).await;
-            return Err(CommandRunError::Timeout(timeout.as_millis()));
-        }
-    };
+            Err(_) => {
+                kill_process_group_by_optional_pid(child_pid);
+                self.abort_all().await;
+                return Err(CommandRunError::Timeout(timeout.as_millis()));
+            }
+        };
 
-    let stderr = match tokio::time::timeout_at(deadline, &mut stderr_task).await {
-        Ok(result) => collect_pipe_result(result)?,
-        Err(_) => {
-            kill_process_group_by_optional_pid(child_pid);
-            abort_pipe_task(stderr_task).await;
-            return Err(CommandRunError::Timeout(timeout.as_millis()));
-        }
-    };
+        let stderr = match tokio::time::timeout_at(
+            deadline,
+            self.stderr
+                .as_mut()
+                .ok_or(CommandRunError::PipeUnavailable("stderr"))?,
+        )
+        .await
+        {
+            Ok(result) => {
+                self.stderr.take();
+                collect_pipe_result(result)?
+            }
+            Err(_) => {
+                kill_process_group_by_optional_pid(child_pid);
+                self.abort_stderr().await;
+                return Err(CommandRunError::Timeout(timeout.as_millis()));
+            }
+        };
 
-    Ok((stdout, stderr))
+        Ok((stdout, stderr))
+    }
+
+    async fn abort_all(&mut self) {
+        self.abort_stdout().await;
+        self.abort_stderr().await;
+    }
+
+    async fn abort_stdout(&mut self) {
+        if let Some(task) = self.stdout.take() {
+            abort_pipe_task(task).await;
+        }
+    }
+
+    async fn abort_stderr(&mut self) {
+        if let Some(task) = self.stderr.take() {
+            abort_pipe_task(task).await;
+        }
+    }
+}
+
+impl Drop for PipeTasks {
+    fn drop(&mut self) {
+        if let Some(task) = self.stdout.take() {
+            task.abort();
+        }
+        if let Some(task) = self.stderr.take() {
+            task.abort();
+        }
+    }
 }
 
 fn collect_pipe_result(
@@ -306,15 +394,7 @@ fn kill_process_group_by_optional_pid(pid: Option<u32>) {
     let _ = pid;
 }
 
-async fn abort_pipe_tasks(
-    stdout_task: JoinHandle<std::io::Result<Vec<u8>>>,
-    stderr_task: JoinHandle<std::io::Result<Vec<u8>>>,
-) {
-    abort_pipe_task(stdout_task).await;
-    abort_pipe_task(stderr_task).await;
-}
-
-async fn abort_pipe_task(task: JoinHandle<std::io::Result<Vec<u8>>>) {
+async fn abort_pipe_task(task: PipeReadTask) {
     task.abort();
     let _ = task.await;
 }
@@ -490,11 +570,50 @@ mod tests {
         assert!(!std::path::Path::new(marker).exists());
     }
 
+    #[tokio::test]
+    async fn exec_with_timeout_cancel_kills_child_process_group() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("pid");
+        let marker = dir.path().join("marker");
+        let pid_file = pid_file.to_str().unwrap().to_string();
+        let marker = marker.to_str().unwrap().to_string();
+
+        let command = tokio::spawn({
+            let pid_file = pid_file.clone();
+            let marker = marker.clone();
+            async move {
+                exec_ignore_errors_with_timeout(
+                    "sh",
+                    &[
+                        "-c",
+                        "(sleep 5; touch \"$2\") & echo $! > \"$1\"; wait",
+                        "_",
+                        &pid_file,
+                        &marker,
+                    ],
+                    Duration::from_secs(10),
+                )
+                .await
+            }
+        });
+
+        let pid = read_pid_file(&pid_file).await;
+        command.abort();
+        let _ = command.await;
+
+        assert_pid_exits(pid).await;
+        assert!(!std::path::Path::new(&marker).exists());
+    }
+
     async fn read_pid_file(path: &str) -> u32 {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
         loop {
             match std::fs::read_to_string(path) {
-                Ok(pid) => return pid.trim().parse().expect("pid file contains pid"),
+                Ok(pid) => match pid.trim().parse() {
+                    Ok(pid) => return pid,
+                    Err(_) if pid.trim().is_empty() => {}
+                    Err(e) => panic!("pid file {path} contains invalid pid: {e}"),
+                },
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
                 Err(e) => panic!("read pid file {path}: {e}"),
             }

--- a/crates/sandbox-fc/src/command.rs
+++ b/crates/sandbox-fc/src/command.rs
@@ -1,3 +1,7 @@
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 use tracing::trace;
 
@@ -7,6 +11,24 @@ use tracing::trace;
 pub struct CommandError {
     pub command: String,
     pub detail: String,
+}
+
+/// Outcome for best-effort commands where callers intentionally ignore
+/// non-zero exits but still need to know whether cleanup timed out or failed to
+/// spawn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IgnoredCommandOutcome {
+    Success,
+    NonZero,
+    SpawnError,
+    WaitError,
+    Timeout,
+}
+
+impl IgnoredCommandOutcome {
+    pub fn completed_without_timeout(self) -> bool {
+        matches!(self, Self::Success | Self::NonZero)
+    }
 }
 
 /// Format a human-readable display string for a command invocation.
@@ -21,6 +43,7 @@ fn format_command_display(program: &str, args: &[&str]) -> String {
 ///
 /// Invokes the program binary directly with the given arguments.
 /// Returns trimmed stdout on success.
+#[cfg_attr(not(test), allow(dead_code))]
 pub async fn exec(program: &str, args: &[&str]) -> Result<String, CommandError> {
     let cmd_display = format_command_display(program, args);
     trace!(command = %cmd_display, "exec");
@@ -44,7 +67,40 @@ pub async fn exec(program: &str, args: &[&str]) -> Result<String, CommandError> 
     }
 }
 
+/// Execute a command with a bounded runtime.
+///
+/// This helper is intended for host lifecycle operations where an unbounded
+/// subprocess can block resource cleanup. On timeout the child is killed and
+/// waited before returning.
+pub async fn exec_with_timeout(
+    program: &str,
+    args: &[&str],
+    timeout: Duration,
+) -> Result<String, CommandError> {
+    let cmd_display = format_command_display(program, args);
+    trace!(command = %cmd_display, timeout_ms = timeout.as_millis() as u64, "exec_with_timeout");
+
+    let output = command_output_with_timeout(program, args, timeout)
+        .await
+        .map_err(|detail| CommandError {
+            command: cmd_display.clone(),
+            detail,
+        })?;
+
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        Ok(stdout)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        Err(CommandError {
+            command: cmd_display,
+            detail: stderr,
+        })
+    }
+}
+
 /// Execute a command, ignoring any errors.
+#[cfg_attr(not(test), allow(dead_code))]
 pub async fn exec_ignore_errors(program: &str, args: &[&str]) {
     let cmd_display = format_command_display(program, args);
     trace!(command = %cmd_display, "exec_ignore_errors");
@@ -61,6 +117,112 @@ pub async fn exec_ignore_errors(program: &str, args: &[&str]) {
         }
         _ => {}
     }
+}
+
+/// Execute a best-effort command with a bounded runtime.
+pub async fn exec_ignore_errors_with_timeout(
+    program: &str,
+    args: &[&str],
+    timeout: Duration,
+) -> IgnoredCommandOutcome {
+    let cmd_display = format_command_display(program, args);
+    trace!(command = %cmd_display, timeout_ms = timeout.as_millis() as u64, "exec_ignore_errors_with_timeout");
+
+    match command_output_with_timeout(program, args, timeout).await {
+        Ok(o) if o.status.success() => IgnoredCommandOutcome::Success,
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            trace!(command = %cmd_display, stderr = %stderr.trim(), "command failed (ignored)");
+            IgnoredCommandOutcome::NonZero
+        }
+        Err(detail) if detail.starts_with("timed out ") => {
+            trace!(command = %cmd_display, detail, "command timed out (ignored)");
+            IgnoredCommandOutcome::Timeout
+        }
+        Err(detail) if detail.starts_with("wait failed: ") => {
+            trace!(command = %cmd_display, detail, "command wait failed (ignored)");
+            IgnoredCommandOutcome::WaitError
+        }
+        Err(detail) => {
+            trace!(command = %cmd_display, detail, "command failed to spawn (ignored)");
+            IgnoredCommandOutcome::SpawnError
+        }
+    }
+}
+
+async fn command_output_with_timeout(
+    program: &str,
+    args: &[&str],
+    timeout: Duration,
+) -> std::result::Result<std::process::Output, String> {
+    let mut child = Command::new(program)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| e.to_string())?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "stdout pipe unavailable".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "stderr pipe unavailable".to_string())?;
+
+    let stdout_task = tokio::spawn(read_pipe(stdout));
+    let stderr_task = tokio::spawn(read_pipe(stderr));
+
+    let status = match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(Ok(status)) => status,
+        Ok(Err(e)) => {
+            abort_pipe_tasks(stdout_task, stderr_task).await;
+            return Err(format!("wait failed: {e}"));
+        }
+        Err(_) => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            abort_pipe_tasks(stdout_task, stderr_task).await;
+            return Err(format!("timed out after {}ms", timeout.as_millis()));
+        }
+    };
+
+    let stdout = collect_pipe(stdout_task).await?;
+    let stderr = collect_pipe(stderr_task).await?;
+    Ok(std::process::Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+async fn read_pipe<R>(mut pipe: R) -> std::io::Result<Vec<u8>>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut output = Vec::new();
+    pipe.read_to_end(&mut output).await?;
+    Ok(output)
+}
+
+async fn collect_pipe(
+    task: tokio::task::JoinHandle<std::io::Result<Vec<u8>>>,
+) -> std::result::Result<Vec<u8>, String> {
+    task.await
+        .map_err(|e| format!("pipe read task failed: {e}"))?
+        .map_err(|e| format!("pipe read failed: {e}"))
+}
+
+async fn abort_pipe_tasks(
+    stdout_task: tokio::task::JoinHandle<std::io::Result<Vec<u8>>>,
+    stderr_task: tokio::task::JoinHandle<std::io::Result<Vec<u8>>>,
+) {
+    stdout_task.abort();
+    stderr_task.abort();
+    let _ = stdout_task.await;
+    let _ = stderr_task.await;
 }
 
 #[cfg(test)]
@@ -117,5 +279,40 @@ mod tests {
     #[tokio::test]
     async fn exec_ignore_errors_does_not_panic_on_success() {
         exec_ignore_errors("true", &[]).await;
+    }
+
+    #[tokio::test]
+    async fn exec_with_timeout_returns_timeout() {
+        let err = exec_with_timeout("sh", &["-c", "sleep 2"], Duration::from_millis(50))
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.detail.contains("timed out"),
+            "detail was: {}",
+            err.detail
+        );
+    }
+
+    #[tokio::test]
+    async fn exec_ignore_errors_with_timeout_reports_timeout() {
+        let outcome =
+            exec_ignore_errors_with_timeout("sh", &["-c", "sleep 2"], Duration::from_millis(50))
+                .await;
+
+        assert_eq!(outcome, IgnoredCommandOutcome::Timeout);
+    }
+
+    #[tokio::test]
+    async fn exec_with_timeout_kills_child_before_followup_command() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("marker");
+        let script = format!("sleep 1; touch {}", marker.display());
+
+        let _ = exec_ignore_errors_with_timeout("sh", &["-c", &script], Duration::from_millis(50))
+            .await;
+
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+        assert!(!marker.exists());
     }
 }

--- a/crates/sandbox-fc/src/command.rs
+++ b/crates/sandbox-fc/src/command.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use tokio::io::AsyncReadExt;
 use tokio::process::{Child, Command};
+use tokio::task::JoinHandle;
 use tracing::trace;
 
 /// Error from a failed command.
@@ -90,7 +91,8 @@ pub async fn exec(program: &str, args: &[&str]) -> Result<String, CommandError> 
 /// This helper is intended for host lifecycle operations where an unbounded
 /// subprocess can block resource cleanup. On timeout the child is killed and
 /// waited before returning. On Unix, the subprocess runs in its own process
-/// group so timeout cleanup also kills grandchildren.
+/// group so timeout cleanup also kills grandchildren. The timeout bounds both
+/// child exit and stdout/stderr pipe draining.
 pub async fn exec_with_timeout(
     program: &str,
     args: &[&str],
@@ -199,6 +201,7 @@ async fn command_output_with_timeout(
     #[cfg(unix)]
     command.process_group(0);
     let mut child = command.spawn().map_err(CommandRunError::Spawn)?;
+    let child_pid = child.id();
 
     let stdout = child
         .stdout
@@ -211,8 +214,9 @@ async fn command_output_with_timeout(
 
     let stdout_task = tokio::spawn(read_pipe(stdout));
     let stderr_task = tokio::spawn(read_pipe(stderr));
+    let deadline = tokio::time::Instant::now() + timeout;
 
-    let status = match tokio::time::timeout(timeout, child.wait()).await {
+    let status = match tokio::time::timeout_at(deadline, child.wait()).await {
         Ok(Ok(status)) => status,
         Ok(Err(e)) => {
             kill_child_tree(&mut child).await;
@@ -226,8 +230,8 @@ async fn command_output_with_timeout(
         }
     };
 
-    let stdout = collect_pipe(stdout_task).await?;
-    let stderr = collect_pipe(stderr_task).await?;
+    let (stdout, stderr) =
+        collect_pipes_with_deadline(stdout_task, stderr_task, deadline, timeout, child_pid).await?;
     Ok(std::process::Output {
         status,
         stdout,
@@ -244,10 +248,45 @@ where
     Ok(output)
 }
 
-async fn collect_pipe(
-    task: tokio::task::JoinHandle<std::io::Result<Vec<u8>>>,
+async fn collect_pipes_with_deadline(
+    mut stdout_task: JoinHandle<std::io::Result<Vec<u8>>>,
+    mut stderr_task: JoinHandle<std::io::Result<Vec<u8>>>,
+    deadline: tokio::time::Instant,
+    timeout: Duration,
+    child_pid: Option<u32>,
+) -> std::result::Result<(Vec<u8>, Vec<u8>), CommandRunError> {
+    let mut stdout = None;
+    let mut stderr = None;
+    let sleep = tokio::time::sleep_until(deadline);
+    tokio::pin!(sleep);
+
+    loop {
+        tokio::select! {
+            result = &mut stdout_task, if stdout.is_none() => {
+                stdout = Some(collect_pipe_result(result)?);
+            }
+            result = &mut stderr_task, if stderr.is_none() => {
+                stderr = Some(collect_pipe_result(result)?);
+            }
+            () = &mut sleep => {
+                kill_process_group_by_optional_pid(child_pid);
+                abort_pipe_tasks(stdout_task, stderr_task).await;
+                return Err(CommandRunError::Timeout(timeout.as_millis()));
+            }
+        }
+
+        if stdout.is_some() && stderr.is_some() {
+            let stdout = stdout.ok_or(CommandRunError::PipeUnavailable("stdout"))?;
+            let stderr = stderr.ok_or(CommandRunError::PipeUnavailable("stderr"))?;
+            return Ok((stdout, stderr));
+        }
+    }
+}
+
+fn collect_pipe_result(
+    result: std::result::Result<std::io::Result<Vec<u8>>, tokio::task::JoinError>,
 ) -> std::result::Result<Vec<u8>, CommandRunError> {
-    task.await
+    result
         .map_err(CommandRunError::PipeTask)?
         .map_err(CommandRunError::PipeRead)
 }
@@ -259,9 +298,18 @@ async fn kill_child_tree(child: &mut Child) {
     let _ = child.wait().await;
 }
 
+fn kill_process_group_by_optional_pid(pid: Option<u32>) {
+    #[cfg(unix)]
+    if let Some(pid) = pid {
+        crate::process::kill_process_group_by_pid(pid);
+    }
+    #[cfg(not(unix))]
+    let _ = pid;
+}
+
 async fn abort_pipe_tasks(
-    stdout_task: tokio::task::JoinHandle<std::io::Result<Vec<u8>>>,
-    stderr_task: tokio::task::JoinHandle<std::io::Result<Vec<u8>>>,
+    stdout_task: JoinHandle<std::io::Result<Vec<u8>>>,
+    stderr_task: JoinHandle<std::io::Result<Vec<u8>>>,
 ) {
     stdout_task.abort();
     stderr_task.abort();
@@ -372,6 +420,24 @@ mod tests {
         )
         .await;
 
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        assert!(!std::path::Path::new(marker).exists());
+    }
+
+    #[tokio::test]
+    async fn exec_with_timeout_bounds_pipe_drain_after_parent_exits() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("marker");
+        let marker = marker.to_str().unwrap();
+
+        let outcome = exec_ignore_errors_with_timeout(
+            "sh",
+            &["-c", "(sleep 0.2; touch \"$1\") &", "_", marker],
+            Duration::from_millis(50),
+        )
+        .await;
+
+        assert_eq!(outcome, IgnoredCommandOutcome::Timeout);
         tokio::time::sleep(Duration::from_millis(500)).await;
         assert!(!std::path::Path::new(marker).exists());
     }

--- a/crates/sandbox-fc/src/command.rs
+++ b/crates/sandbox-fc/src/command.rs
@@ -478,7 +478,7 @@ mod tests {
 
         assert_eq!(outcome, IgnoredCommandOutcome::Timeout);
         let pid = read_pid_file(pid_file).await;
-        assert_pid_exits(pid).await;
+        assert_pid_not_running(pid).await;
         assert!(!std::path::Path::new(marker).exists());
     }
 
@@ -505,7 +505,7 @@ mod tests {
 
         assert_eq!(outcome, IgnoredCommandOutcome::Timeout);
         let pid = read_pid_file(pid_file).await;
-        assert_pid_exits(pid).await;
+        assert_pid_not_running(pid).await;
         assert!(!std::path::Path::new(marker).exists());
     }
 
@@ -532,7 +532,7 @@ mod tests {
 
         assert_eq!(outcome, IgnoredCommandOutcome::Timeout);
         let pid = read_pid_file(pid_file).await;
-        assert_pid_exits(pid).await;
+        assert_pid_not_running(pid).await;
         assert!(!std::path::Path::new(marker).exists());
     }
 
@@ -567,7 +567,7 @@ mod tests {
         command.abort();
         let _ = command.await;
 
-        assert_pid_exits(pid).await;
+        assert_pid_not_running(pid).await;
         assert!(!std::path::Path::new(&marker).exists());
     }
 
@@ -591,19 +591,30 @@ mod tests {
         }
     }
 
-    async fn assert_pid_exits(pid: u32) {
+    async fn assert_pid_not_running(pid: u32) {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
-        while process_exists(pid) {
+        while process_is_running(pid) {
             assert!(
                 tokio::time::Instant::now() < deadline,
-                "process {pid} was not killed by command timeout"
+                "process {pid} was still running after command timeout"
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
     }
 
-    #[cfg(unix)]
-    fn process_exists(pid: u32) -> bool {
+    #[cfg(target_os = "linux")]
+    fn process_is_running(pid: u32) -> bool {
+        let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+            return false;
+        };
+        let Some((_, after_comm)) = stat.rsplit_once(") ") else {
+            return false;
+        };
+        !after_comm.starts_with('Z')
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
+    fn process_is_running(pid: u32) -> bool {
         let pid = nix::unistd::Pid::from_raw(i32::try_from(pid).expect("pid fits in i32"));
         match nix::sys::signal::kill(pid, None) {
             Ok(()) => true,
@@ -613,7 +624,7 @@ mod tests {
     }
 
     #[cfg(not(unix))]
-    fn process_exists(_pid: u32) -> bool {
+    fn process_is_running(_pid: u32) -> bool {
         false
     }
 }

--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -148,16 +148,13 @@ impl CowPool {
     /// but do not prevent the pool from operating (acquire falls back to
     /// on-demand creation).
     pub async fn warmup(&mut self) {
-        let mut set = tokio::task::JoinSet::new();
-        for _ in 0..BUFFER_SIZE {
-            if self.next_slot_idx >= MAX_SLOTS {
+        let missing = BUFFER_SIZE.saturating_sub(self.queue.len() + self.pending.len());
+        for _ in 0..missing {
+            if !self.spawn_slot_creation() {
                 break;
             }
-            self.next_slot_idx += 1;
-            let config = self.config.clone();
-            set.spawn_blocking(move || create_slot(&config));
         }
-        while let Some(result) = set.join_next().await {
+        while let Some(result) = self.pending.join_next().await {
             match result {
                 Ok(Ok(slot)) => self.queue.push_back(slot),
                 Ok(Err(e)) => {
@@ -243,7 +240,7 @@ impl CowPool {
 
     /// Shut down the pool: wait for pending tasks, destroy all queued slots.
     pub async fn cleanup(&mut self) {
-        if !self.active {
+        if !self.active && self.pending.is_empty() && self.queue.is_empty() {
             return;
         }
         self.active = false;
@@ -299,12 +296,17 @@ impl CowPool {
 
     /// Spawn one background replenishment task if the queue is below threshold.
     fn maybe_replenish(&mut self) {
+        self.spawn_slot_creation();
+    }
+
+    fn spawn_slot_creation(&mut self) -> bool {
         if self.queue.len() + self.pending.len() >= BUFFER_SIZE || self.next_slot_idx >= MAX_SLOTS {
-            return;
+            return false;
         }
         self.next_slot_idx += 1;
         let config = self.config.clone();
         self.pending.spawn_blocking(move || create_slot(&config));
+        true
     }
 }
 
@@ -419,6 +421,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelled_cleanup_can_retry_after_pool_marked_inactive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path());
+        let ws = tmp.path().join("cleanup-retry-slot");
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let mut pool = CowPool::new(config);
+        pool.next_slot_idx = 1;
+        pool.pending.spawn_blocking({
+            let ws = ws.clone();
+            move || {
+                std::fs::create_dir_all(&ws).unwrap();
+                std::fs::write(ws.join("cow.img"), b"cow").unwrap();
+                entered_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                Ok(PrewarmedSlot {
+                    id: "pending".into(),
+                    workspace: ws,
+                })
+            }
+        });
+
+        {
+            let cleanup = pool.cleanup();
+            tokio::pin!(cleanup);
+            tokio::select! {
+                result = &mut cleanup => panic!("cleanup completed before pending slot was released: {result:?}"),
+                result = entered_rx => result.expect("pending slot creation should enter"),
+            }
+        }
+
+        assert!(!pool.active);
+        assert_eq!(
+            pool.pending.len(),
+            1,
+            "cancelled cleanup must leave pending slot owned by the pool"
+        );
+        release_tx.send(()).unwrap();
+        pool.cleanup().await;
+
+        assert_eq!(pool.next_slot_idx, 0);
+        assert!(pool.pending.is_empty());
+        assert!(pool.queue.is_empty());
+        assert!(!ws.exists(), "retried cleanup should remove pending slot");
+    }
+
+    #[tokio::test]
     async fn warmup_with_bad_config_does_not_panic() {
         // Point to a nonexistent golden COW file — all pre-warm tasks will
         // fail, but warmup must handle errors gracefully.
@@ -434,6 +483,60 @@ mod tests {
         assert_eq!(pool.queue.len(), 0);
         // next_slot_idx should be reclaimed after failures.
         assert_eq!(pool.next_slot_idx, 0);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cancelled_warmup_keeps_pending_slots_for_cleanup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspaces = tmp.path().join("workspaces");
+        let fifo = tmp.path().join("golden.fifo");
+        nix::unistd::mkfifo(
+            &fifo,
+            nix::sys::stat::Mode::S_IRUSR | nix::sys::stat::Mode::S_IWUSR,
+        )
+        .unwrap();
+        let config = CowPoolConfig {
+            workspaces_dir: workspaces.clone(),
+            base_size: 64 * 1024 * 1024,
+            golden_cow: Some(fifo.clone()),
+        };
+        let mut pool = CowPool::new(config);
+        pool.next_slot_idx = MAX_SLOTS - 1;
+
+        {
+            let warmup = pool.warmup();
+            tokio::pin!(warmup);
+            tokio::select! {
+                result = &mut warmup => panic!("warmup completed before cancellation: {result:?}"),
+                () = wait_for_workspace_entry(&workspaces) => {}
+            }
+        }
+
+        assert!(
+            !pool.pending.is_empty(),
+            "cancelled warmup must leave pending slots owned by the pool"
+        );
+        assert_eq!(pool.next_slot_idx, MAX_SLOTS);
+
+        let writer = tokio::task::spawn_blocking(move || {
+            use std::io::Write;
+
+            let mut fifo = std::fs::OpenOptions::new().write(true).open(fifo).unwrap();
+            fifo.write_all(b"cow").unwrap();
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(1), writer)
+            .await
+            .expect("fifo writer should not block forever")
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), pool.cleanup())
+            .await
+            .expect("cleanup should drain cancelled warmup slots");
+
+        assert_eq!(pool.next_slot_idx, MAX_SLOTS - 1);
+        assert!(pool.pending.is_empty());
+        assert!(pool.queue.is_empty());
+        assert!(!workspace_entry_exists(&workspaces));
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -83,6 +83,23 @@ impl std::fmt::Debug for PrewarmedSlot {
     }
 }
 
+struct SlotCapacityGuard<'a> {
+    next_slot_idx: &'a mut u32,
+}
+
+impl<'a> SlotCapacityGuard<'a> {
+    fn reserve(next_slot_idx: &'a mut u32) -> Self {
+        *next_slot_idx += 1;
+        Self { next_slot_idx }
+    }
+}
+
+impl Drop for SlotCapacityGuard<'_> {
+    fn drop(&mut self) {
+        *self.next_slot_idx = self.next_slot_idx.saturating_sub(1);
+    }
+}
+
 /// Pool error type.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum CowPoolError {
@@ -210,22 +227,17 @@ impl CowPool {
         if self.next_slot_idx >= MAX_SLOTS {
             return Err(CowPoolError::SlotLimitReached { max: MAX_SLOTS });
         }
-        self.next_slot_idx += 1;
         let config = self.config.clone();
-        match tokio::task::spawn_blocking(move || create_slot(&config)).await {
+        let reservation = SlotCapacityGuard::reserve(&mut self.next_slot_idx);
+        let result = tokio::task::spawn_blocking(move || create_slot(&config)).await;
+        drop(reservation);
+        match result {
             Ok(Ok(slot)) => {
-                self.next_slot_idx = self.next_slot_idx.saturating_sub(1);
                 self.maybe_replenish();
                 Ok(slot)
             }
-            Ok(Err(e)) => {
-                self.next_slot_idx = self.next_slot_idx.saturating_sub(1);
-                Err(e)
-            }
-            Err(e) => {
-                self.next_slot_idx = self.next_slot_idx.saturating_sub(1);
-                Err(CowPoolError::CowFileCreation(format!("join: {e}")))
-            }
+            Ok(Err(e)) => Err(e),
+            Err(e) => Err(CowPoolError::CowFileCreation(format!("join: {e}"))),
         }
     }
 
@@ -438,6 +450,60 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cancelled_on_demand_acquire_reclaims_slot_capacity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspaces = tmp.path().join("workspaces");
+        let fifo = tmp.path().join("golden.fifo");
+        nix::unistd::mkfifo(
+            &fifo,
+            nix::sys::stat::Mode::S_IRUSR | nix::sys::stat::Mode::S_IWUSR,
+        )
+        .unwrap();
+        let config = CowPoolConfig {
+            workspaces_dir: workspaces.clone(),
+            base_size: 64 * 1024 * 1024,
+            golden_cow: Some(fifo.clone()),
+        };
+        let mut pool = CowPool::new(config);
+        pool.next_slot_idx = MAX_SLOTS - 1;
+
+        {
+            let acquire = pool.acquire();
+            tokio::pin!(acquire);
+            tokio::select! {
+                result = &mut acquire => panic!("on-demand acquire completed before cancellation: {result:?}"),
+                () = wait_for_workspace_entry(&workspaces) => {}
+            }
+        }
+
+        assert_eq!(
+            pool.next_slot_idx,
+            MAX_SLOTS - 1,
+            "cancelled on-demand acquire must reclaim reserved capacity"
+        );
+
+        let writer = tokio::task::spawn_blocking(move || {
+            use std::io::Write;
+
+            let mut fifo = std::fs::OpenOptions::new().write(true).open(fifo).unwrap();
+            fifo.write_all(b"cow").unwrap();
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(1), writer)
+            .await
+            .expect("fifo writer should not block forever")
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while workspace_entry_exists(&workspaces) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached on-demand slot should be dropped after creation");
+    }
+
     #[tokio::test]
     async fn slot_limit_enforced() {
         let tmp = tempfile::tempdir().unwrap();
@@ -520,6 +586,26 @@ mod tests {
         drop(pool);
 
         assert!(!ws.exists(), "queued slot should be removed on pool drop");
+    }
+
+    fn workspace_entry_exists(path: &Path) -> bool {
+        match std::fs::read_dir(path) {
+            Ok(mut entries) => entries.next().is_some(),
+            Err(e) if e.kind() == ErrorKind::NotFound => false,
+            Err(e) => panic!("read workspace dir {}: {e}", path.display()),
+        }
+    }
+
+    async fn wait_for_workspace_entry(path: &Path) {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+        while !workspace_entry_exists(path) {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "workspace entry was not created under {}",
+                path.display()
+            );
+            tokio::task::yield_now().await;
+        }
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -505,6 +505,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelled_pending_acquire_keeps_slot_for_cleanup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path());
+        let ws = tmp.path().join("pending-acquire-slot");
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let mut pool = CowPool::new(config);
+        pool.next_slot_idx = 1;
+        pool.pending.spawn_blocking({
+            let ws = ws.clone();
+            move || {
+                std::fs::create_dir_all(&ws).unwrap();
+                std::fs::write(ws.join("cow.img"), b"cow").unwrap();
+                entered_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                Ok(PrewarmedSlot {
+                    id: "pending".into(),
+                    workspace: ws,
+                })
+            }
+        });
+
+        {
+            let acquire = pool.acquire();
+            tokio::pin!(acquire);
+            tokio::select! {
+                result = &mut acquire => panic!("pending acquire completed before cancellation: {result:?}"),
+                result = entered_rx => result.expect("pending slot creation should enter"),
+            }
+        }
+
+        assert_eq!(
+            pool.pending.len(),
+            1,
+            "cancelled join_next must leave pending slot owned by the pool"
+        );
+        release_tx.send(()).unwrap();
+        pool.cleanup().await;
+
+        assert_eq!(pool.next_slot_idx, 0);
+        assert!(pool.pending.is_empty());
+        assert!(pool.queue.is_empty());
+        assert!(!ws.exists(), "cleanup should remove pending acquire slot");
+    }
+
+    #[tokio::test]
     async fn slot_limit_enforced() {
         let tmp = tempfile::tempdir().unwrap();
         let mut pool = CowPool::new(test_config(tmp.path()));

--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -11,6 +11,7 @@
 //! - No recycling (COW files have dirty data after VM use)
 
 use std::collections::VecDeque;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use tracing::{error, info, warn};
@@ -54,6 +55,22 @@ impl PrewarmedSlot {
     #[cfg(test)]
     fn cow_file(&self) -> PathBuf {
         self.workspace.join("cow.img")
+    }
+
+    fn remove_workspace(&self) {
+        match std::fs::remove_dir_all(&self.workspace) {
+            Ok(()) => {}
+            Err(e) if e.kind() == ErrorKind::NotFound => {}
+            Err(e) => {
+                warn!(id = %self.id, error = %e, "failed to delete pool workspace dir");
+            }
+        }
+    }
+}
+
+impl Drop for PrewarmedSlot {
+    fn drop(&mut self) {
+        self.remove_workspace();
     }
 }
 
@@ -346,9 +363,7 @@ fn sparse_copy(src: &Path, dst: &Path) -> Result<(), CowPoolError> {
 ///
 /// Removes the workspace directory (which contains the COW file).
 pub(crate) fn destroy_slot(slot: PrewarmedSlot) {
-    if let Err(e) = std::fs::remove_dir_all(&slot.workspace) {
-        warn!(id = %slot.id, error = %e, "failed to delete pool workspace dir");
-    }
+    drop(slot);
 }
 
 // ---------------------------------------------------------------------------
@@ -479,5 +494,31 @@ mod tests {
         assert!(ws.exists());
         destroy_slot(slot);
         assert!(!ws.exists(), "workspace should be removed");
+    }
+
+    #[test]
+    fn dropped_slot_removes_workspace() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path());
+        let slot = create_slot(&config).unwrap();
+        let ws = slot.workspace.clone();
+        assert!(ws.exists());
+        drop(slot);
+        assert!(!ws.exists(), "workspace should be removed on slot drop");
+    }
+
+    #[test]
+    fn dropped_pool_removes_queued_slots() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path());
+        let slot = create_slot(&config).unwrap();
+        let ws = slot.workspace.clone();
+        assert!(ws.exists());
+
+        let mut pool = CowPool::new(config);
+        pool.queue.push_back(slot);
+        drop(pool);
+
+        assert!(!ws.exists(), "queued slot should be removed on pool drop");
     }
 }

--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -521,4 +521,43 @@ mod tests {
 
         assert!(!ws.exists(), "queued slot should be removed on pool drop");
     }
+
+    #[tokio::test]
+    async fn dropped_pool_removes_late_pending_slot() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path());
+        let ws = tmp.path().join("pending-slot");
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let mut pool = CowPool::new(config);
+
+        pool.pending.spawn_blocking({
+            let ws = ws.clone();
+            move || {
+                std::fs::create_dir_all(&ws).unwrap();
+                std::fs::write(ws.join("cow.img"), b"cow").unwrap();
+                entered_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                Ok(PrewarmedSlot {
+                    id: "pending".into(),
+                    workspace: ws,
+                })
+            }
+        });
+
+        entered_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+        assert!(ws.exists());
+        drop(pool);
+        release_tx.send(()).unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while ws.exists() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("late pending slot workspace should be removed after pool drop");
+    }
 }

--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -527,7 +527,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let config = test_config(tmp.path());
         let ws = tmp.path().join("pending-slot");
-        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
         let (release_tx, release_rx) = std::sync::mpsc::channel();
         let mut pool = CowPool::new(config);
 
@@ -545,8 +545,9 @@ mod tests {
             }
         });
 
-        entered_rx
-            .recv_timeout(std::time::Duration::from_secs(1))
+        tokio::time::timeout(std::time::Duration::from_secs(1), entered_rx)
+            .await
+            .expect("pending slot creation should enter")
             .unwrap();
         assert!(ws.exists());
         drop(pool);

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -11,7 +11,9 @@ use tracing::{info, warn};
 use nbd_cow::{DestroyRetryPolicy, PooledNbdCowDevice};
 
 use crate::config::FirecrackerConfig;
-use crate::network::{GUEST_NETWORK, NetnsLease, NetnsPool, NetnsPoolConfig, generate_boot_args};
+use crate::network::{
+    GUEST_NETWORK, NetnsLease, NetnsPoolConfig, NetnsPoolHandle, generate_boot_args,
+};
 use crate::paths::{FactoryPaths, RuntimePaths, SandboxPaths, SockPaths};
 use crate::prerequisites;
 use crate::sandbox::FirecrackerSandbox;
@@ -59,7 +61,7 @@ struct LeakCleaner {
 }
 
 impl LeakCleaner {
-    fn spawn(netns_pool: std::sync::Arc<tokio::sync::Mutex<NetnsPool>>) -> Self {
+    fn spawn(netns_pool: NetnsPoolHandle) -> Self {
         // Drop cannot await, and losing a leak report can strand host resources.
         // Keep this unbounded: reports only come from exceptional cleanup paths,
         // with runner GC as the final backstop if the cleaner stalls.
@@ -133,7 +135,7 @@ trait CreateRollbackCleanup {
 
 struct FactoryCreateRollbackCleanup {
     id: String,
-    netns_pool: std::sync::Arc<tokio::sync::Mutex<NetnsPool>>,
+    netns_pool: NetnsPoolHandle,
 }
 
 #[async_trait]
@@ -143,9 +145,9 @@ impl CreateRollbackCleanup for FactoryCreateRollbackCleanup {
     }
 
     async fn release_network(&self, network: &mut Option<NetnsLease>) {
-        let mut netns_pool = self.netns_pool.lock().await;
-        if let Err(e) = netns_pool.release(network).await {
-            warn!(id = %self.id, error = %e, "failed to release netns during rollback");
+        let outcome = self.netns_pool.release(network).await;
+        if let Some(message) = outcome.invalid_message() {
+            warn!(id = %self.id, error = %message, "failed to release netns during rollback");
         }
     }
 
@@ -507,10 +509,10 @@ async fn destroy_cow_device_with_retries(id: &str, cow_device: PooledNbdCowDevic
 async fn drain_leaked_resources(
     rx: tokio::sync::mpsc::UnboundedReceiver<LeakedResources>,
     shutdown_rx: tokio::sync::oneshot::Receiver<()>,
-    netns_pool: std::sync::Arc<tokio::sync::Mutex<NetnsPool>>,
+    netns_pool: NetnsPoolHandle,
 ) {
     drain_leaked_resources_with_cleanup(rx, shutdown_rx, move |leaked| {
-        let netns_pool = std::sync::Arc::clone(&netns_pool);
+        let netns_pool = netns_pool.clone();
         async move {
             cleanup_leaked_resource(leaked, &netns_pool).await;
         }
@@ -546,10 +548,7 @@ async fn drain_leaked_resources_with_cleanup<C, Fut>(
     }
 }
 
-async fn cleanup_leaked_resource(
-    leaked: LeakedResources,
-    netns_pool: &tokio::sync::Mutex<NetnsPool>,
-) {
+async fn cleanup_leaked_resource(leaked: LeakedResources, netns_pool: &NetnsPoolHandle) {
     warn!(
         id = %leaked.sandbox_id,
         has_cow_device = leaked.cow_device.is_some(),
@@ -564,9 +563,9 @@ async fn cleanup_leaked_resource(
 
     if let Some(network) = leaked.network {
         let mut network = Some(network);
-        let mut pool = netns_pool.lock().await;
-        if let Err(e) = pool.release(&mut network).await {
-            warn!(id = %leaked.sandbox_id, error = %e, "failed to release leaked netns");
+        let outcome = netns_pool.release(&mut network).await;
+        if let Some(message) = outcome.invalid_message() {
+            warn!(id = %leaked.sandbox_id, error = %message, "failed to release leaked netns");
         }
     }
     if let Err(e) = tokio::fs::remove_dir_all(&leaked.sock_dir).await {
@@ -687,7 +686,7 @@ pub struct FirecrackerFactory {
     config: FirecrackerConfig,
     factory_paths: FactoryPaths,
     runtime_paths: RuntimePaths,
-    netns_pool: Option<std::sync::Arc<tokio::sync::Mutex<NetnsPool>>>,
+    netns_pool: Option<NetnsPoolHandle>,
     owns_netns_pool: bool,
     /// Shared NBD device pool for pre-validated device indices.
     device_pool: nbd_cow::pool::DevicePoolHandle,
@@ -709,7 +708,7 @@ impl FirecrackerFactory {
     /// creating a new one in `startup()` (used for multi-profile runners).
     pub async fn new(
         config: FirecrackerConfig,
-        netns_pool: Option<std::sync::Arc<tokio::sync::Mutex<NetnsPool>>>,
+        netns_pool: Option<NetnsPoolHandle>,
         device_pool: nbd_cow::pool::DevicePoolHandle,
     ) -> Result<Self, SandboxError> {
         let t = std::time::Instant::now();
@@ -756,7 +755,7 @@ impl FirecrackerFactory {
     /// # Panics
     /// Panics if called before `startup()` — this is a programming error.
     #[allow(clippy::expect_used)]
-    fn netns_pool(&self) -> &std::sync::Arc<tokio::sync::Mutex<NetnsPool>> {
+    fn netns_pool(&self) -> &NetnsPoolHandle {
         self.netns_pool.as_ref().expect("factory not started")
     }
 
@@ -796,17 +795,17 @@ impl SandboxFactory for FirecrackerFactory {
                 dns_port: self.config.dns_port,
             }
             .into_checked()?;
-            let netns_pool = NetnsPool::create_checked(netns_config).await.map_err(|e| {
-                SandboxError::Initialization {
+            let netns_pool = NetnsPoolHandle::create_checked(netns_config)
+                .await
+                .map_err(|e| SandboxError::Initialization {
                     phase: SandboxInitializationPhase::Factory,
                     message: format!("netns pool: {e}"),
-                }
-            })?;
+                })?;
             info!(
                 elapsed_ms = t.elapsed().as_millis() as u64,
                 "netns pool created"
             );
-            self.netns_pool = Some(std::sync::Arc::new(tokio::sync::Mutex::new(netns_pool)));
+            self.netns_pool = Some(netns_pool);
         }
 
         // Determine base image size from file metadata.
@@ -866,94 +865,91 @@ impl SandboxFactory for FirecrackerFactory {
         let id = config.id.to_string();
         let rollback_cleanup = FactoryCreateRollbackCleanup {
             id: id.clone(),
-            netns_pool: std::sync::Arc::clone(self.netns_pool()),
+            netns_pool: self.netns_pool().clone(),
         };
         let mut tx = SandboxCreateTransaction::new_with_leak_tx(
             id.clone(),
             self.leak_cleaner.as_ref().and_then(LeakCleaner::sender),
         );
 
-        let create_result: sandbox::Result<SandboxCreateResources> = async {
-            // Acquire a pre-warmed COW slot from the pool.
-            // The slot provides: workspace dir (already created) and cow file.
-            let slot = self.cow_pool().lock().await.acquire().await.map_err(|e| {
-                SandboxError::Initialization {
-                    phase: SandboxInitializationPhase::SandboxAllocation,
-                    message: format!("acquire COW slot: {e}"),
+        let create_result: sandbox::Result<SandboxCreateResources> =
+            async {
+                // Acquire a pre-warmed COW slot from the pool.
+                // The slot provides: workspace dir (already created) and cow file.
+                let slot = self.cow_pool().lock().await.acquire().await.map_err(|e| {
+                    SandboxError::Initialization {
+                        phase: SandboxInitializationPhase::SandboxAllocation,
+                        message: format!("acquire COW slot: {e}"),
+                    }
+                })?;
+                tx.track_slot(slot);
+
+                // The slot workspace is {workspaces_dir}/{slot_uuid}/.
+                // Rename to {workspaces_dir}/{sandbox_id}/ for doctor correlation.
+                let target_workspace = self.factory_paths.workspace(&id);
+                if target_workspace.exists()
+                    && let Err(e) = tokio::fs::remove_dir_all(&target_workspace).await
+                {
+                    warn!(id = %id, error = %e, "failed to clean stale workspace dir");
                 }
-            })?;
-            tx.track_slot(slot);
+                let slot_workspace = tx.slot_workspace()?;
+                if let Err(e) = tokio::fs::rename(&slot_workspace, &target_workspace).await {
+                    return Err(SandboxError::Initialization {
+                        phase: SandboxInitializationPhase::SandboxAllocation,
+                        message: format!("rename workspace: {e}"),
+                    });
+                }
+                tx.slot_renamed_to(target_workspace.clone());
 
-            // The slot workspace is {workspaces_dir}/{slot_uuid}/.
-            // Rename to {workspaces_dir}/{sandbox_id}/ for doctor correlation.
-            let target_workspace = self.factory_paths.workspace(&id);
-            if target_workspace.exists()
-                && let Err(e) = tokio::fs::remove_dir_all(&target_workspace).await
-            {
-                warn!(id = %id, error = %e, "failed to clean stale workspace dir");
-            }
-            let slot_workspace = tx.slot_workspace()?;
-            if let Err(e) = tokio::fs::rename(&slot_workspace, &target_workspace).await {
-                return Err(SandboxError::Initialization {
-                    phase: SandboxInitializationPhase::SandboxAllocation,
-                    message: format!("rename workspace: {e}"),
-                });
-            }
-            tx.slot_renamed_to(target_workspace.clone());
+                // Recompute cow_file path after rename (the slot path no longer exists).
+                let cow_file = target_workspace.join("cow.img");
 
-            // Recompute cow_file path after rename (the slot path no longer exists).
-            let cow_file = target_workspace.join("cow.img");
+                // Clean stale sock dir and create vsock directory.
+                let sock_paths = SockPaths::new(self.runtime_paths.sock_dir(&id));
+                if sock_paths.dir().exists()
+                    && let Err(e) = tokio::fs::remove_dir_all(sock_paths.dir()).await
+                {
+                    warn!(id = %id, error = %e, "failed to clean stale sock dir");
+                }
+                tx.track_sock_dir(sock_paths.dir().to_owned());
+                if let Err(e) = tokio::fs::create_dir_all(sock_paths.vsock_dir()).await {
+                    return Err(SandboxError::Initialization {
+                        phase: SandboxInitializationPhase::SandboxAllocation,
+                        message: format!("mkdir vsock dir: {e}"),
+                    });
+                }
 
-            // Clean stale sock dir and create vsock directory.
-            let sock_paths = SockPaths::new(self.runtime_paths.sock_dir(&id));
-            if sock_paths.dir().exists()
-                && let Err(e) = tokio::fs::remove_dir_all(sock_paths.dir()).await
-            {
-                warn!(id = %id, error = %e, "failed to clean stale sock dir");
-            }
-            tx.track_sock_dir(sock_paths.dir().to_owned());
-            if let Err(e) = tokio::fs::create_dir_all(sock_paths.vsock_dir()).await {
-                return Err(SandboxError::Initialization {
-                    phase: SandboxInitializationPhase::SandboxAllocation,
-                    message: format!("mkdir vsock dir: {e}"),
-                });
-            }
-
-            // Acquire a network namespace from the pool.
-            let network = self
-                .netns_pool()
-                .lock()
-                .await
-                .acquire()
-                .await
-                .map_err(|e| SandboxError::Initialization {
-                    phase: SandboxInitializationPhase::SandboxAllocation,
-                    message: format!("acquire netns: {e}"),
+                // Acquire a network namespace from the pool.
+                let network = self.netns_pool().acquire().await.map_err(|e| {
+                    SandboxError::Initialization {
+                        phase: SandboxInitializationPhase::SandboxAllocation,
+                        message: format!("acquire netns: {e}"),
+                    }
                 })?;
-            tx.track_network(network);
+                tx.track_network(network);
 
-            // Create NBD COW device (~15ms via netlink, no subprocess).
-            let base_image =
-                self.base_image_path
-                    .as_ref()
-                    .ok_or_else(|| SandboxError::InvalidState {
-                        context: SandboxInvalidStateContext::Factory,
-                        state: "started without base image".into(),
-                        message: "factory base image path missing".into(),
+                // Create NBD COW device (~15ms via netlink, no subprocess).
+                let base_image =
+                    self.base_image_path
+                        .as_ref()
+                        .ok_or_else(|| SandboxError::InvalidState {
+                            context: SandboxInvalidStateContext::Factory,
+                            state: "started without base image".into(),
+                            message: "factory base image path missing".into(),
+                        })?;
+                let cow_device = self
+                    .device_pool
+                    .create_cow_device(base_image, &cow_file, self.base_image_size)
+                    .await
+                    .map_err(|e| SandboxError::Initialization {
+                        phase: SandboxInitializationPhase::SandboxAllocation,
+                        message: format!("create NBD COW device: {e}"),
                     })?;
-            let cow_device = self
-                .device_pool
-                .create_cow_device(base_image, &cow_file, self.base_image_size)
-                .await
-                .map_err(|e| SandboxError::Initialization {
-                    phase: SandboxInitializationPhase::SandboxAllocation,
-                    message: format!("create NBD COW device: {e}"),
-                })?;
-            tx.track_cow_device(cow_device);
+                tx.track_cow_device(cow_device);
 
-            tx.commit()
-        }
-        .await;
+                tx.commit()
+            }
+            .await;
 
         let resources = match create_result {
             Ok(resources) => resources,
@@ -992,7 +988,7 @@ impl SandboxFactory for FirecrackerFactory {
                 return;
             }
         };
-        let netns_pool = std::sync::Arc::clone(self.netns_pool());
+        let netns_pool = self.netns_pool().clone();
 
         // Move all cleanup-owned resources into a task before the first await.
         // If the caller drops this destroy future mid-cleanup, the task keeps
@@ -1026,11 +1022,9 @@ impl SandboxFactory for FirecrackerFactory {
         // cleaned up by FirecrackerRuntime::shutdown().
         if self.owns_netns_pool
             && let Some(netns_pool) = self.netns_pool.take()
+            && let Err(e) = netns_pool.cleanup().await
         {
-            let mut pool = netns_pool.lock().await;
-            if let Err(e) = pool.cleanup().await {
-                warn!(error = %e, "failed to cleanup owned netns pool");
-            }
+            warn!(error = %e, "failed to cleanup owned netns pool");
         }
 
         self.started = false;
@@ -1038,10 +1032,7 @@ impl SandboxFactory for FirecrackerFactory {
     }
 }
 
-async fn destroy_firecracker_sandbox(
-    mut sandbox: FirecrackerSandbox,
-    netns_pool: std::sync::Arc<tokio::sync::Mutex<NetnsPool>>,
-) {
+async fn destroy_firecracker_sandbox(mut sandbox: FirecrackerSandbox, netns_pool: NetnsPoolHandle) {
     // Ensure the sandbox is killed before releasing pool resources.
     // After kill(), `sandbox.process` is `None`, so the Drop impl's
     // killpg becomes a no-op when `sandbox` is dropped below.
@@ -1071,11 +1062,10 @@ async fn destroy_firecracker_sandbox(
     }
 
     // Return the network namespace to the pool.
-    let mut pool = netns_pool.lock().await;
-    if let Err(e) = pool.release(sandbox.network.lease_mut()).await {
-        warn!(id = %sandbox_id, error = %e, "failed to release netns");
+    let outcome = netns_pool.release(sandbox.network.lease_mut()).await;
+    if let Some(message) = outcome.invalid_message() {
+        warn!(id = %sandbox_id, error = %message, "failed to release netns");
     }
-    drop(pool);
 
     // Delete the socket directory.
     if let Err(e) = tokio::fs::remove_dir_all(&sock_dir).await {
@@ -1110,6 +1100,7 @@ impl Drop for FirecrackerFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::network::NetnsPool;
     use std::sync::{
         Arc, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -1125,8 +1116,8 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_cleans_owned_netns_pool_with_extra_arc_refs() {
-        let pool = Arc::new(tokio::sync::Mutex::new(NetnsPool::inactive_for_test()));
-        let _destroy_task_clone = Arc::clone(&pool);
+        let pool = NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test());
+        let _destroy_task_clone = pool.clone();
         let mut factory = test_factory(true);
         factory.netns_pool = Some(pool);
         factory.owns_netns_pool = true;
@@ -1138,15 +1129,18 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_keeps_shared_netns_pool_for_runtime_shutdown() {
-        let pool = Arc::new(tokio::sync::Mutex::new(NetnsPool::inactive_for_test()));
+        let pool = NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test());
         let mut factory = test_factory(true);
-        factory.netns_pool = Some(Arc::clone(&pool));
+        factory.netns_pool = Some(pool.clone());
         factory.owns_netns_pool = false;
 
         factory.shutdown().await;
 
         assert!(factory.netns_pool.is_some());
-        assert_eq!(Arc::strong_count(factory.netns_pool.as_ref().unwrap()), 2);
+        assert_eq!(
+            factory.netns_pool.as_ref().unwrap().strong_count_for_test(),
+            2
+        );
     }
 
     /// Both supported framework CLIs must be warmed during snapshot creation.
@@ -1850,7 +1844,7 @@ mod tests {
         let workspace = tmp.path().join("workspace");
         tokio::fs::create_dir_all(&sock_dir).await.unwrap();
         tokio::fs::create_dir_all(&workspace).await.unwrap();
-        let netns_pool = tokio::sync::Mutex::new(NetnsPool::inactive_for_test());
+        let netns_pool = NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test());
 
         cleanup_leaked_resource(
             LeakedResources {

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -2020,18 +2020,21 @@ mod tests {
 
     #[tokio::test]
     async fn leak_cleaner_drop_signals_shutdown_and_detaches_drain() {
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
         let live_sender_clone = tx.clone();
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
         let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let cleaned = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let cleaned_clone = Arc::clone(&cleaned);
         let handle = tokio::spawn(async move {
-            shutdown_rx.await.unwrap();
-            rx.close();
-            let mut drained = Vec::new();
-            while let Some(leaked) = rx.recv().await {
-                drained.push(leaked.sandbox_id);
-            }
-            done_tx.send(drained).unwrap();
+            drain_leaked_resources_with_cleanup(rx, shutdown_rx, move |leaked| {
+                let cleaned = Arc::clone(&cleaned_clone);
+                async move {
+                    cleaned.lock().await.push(leaked.sandbox_id);
+                }
+            })
+            .await;
+            done_tx.send(()).unwrap();
         });
         let cleaner = LeakCleaner {
             tx: Some(tx),
@@ -2044,11 +2047,11 @@ mod tests {
             .unwrap();
         drop(cleaner);
 
-        let drained = tokio::time::timeout(std::time::Duration::from_secs(1), done_rx)
+        tokio::time::timeout(std::time::Duration::from_secs(1), done_rx)
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(drained, vec!["queued".to_string()]);
+        assert_eq!(*cleaned.lock().await, vec!["queued".to_string()]);
         assert!(matches!(
             live_sender_clone.send(test_leaked_resource("late")),
             Err(tokio::sync::mpsc::error::SendError(_))

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -52,8 +52,8 @@ pub(crate) struct LeakedResources {
 /// Owns the leaked-resource cleanup channel and its background drain task.
 ///
 /// Normal factory shutdown signals the drain task to close the receiver, drain
-/// already-queued resources, and finish. `Drop` cannot await, so it aborts as a
-/// best-effort fallback.
+/// already-queued resources, and finish. `Drop` cannot await, so it signals
+/// shutdown and detaches the task as a best-effort fallback.
 struct LeakCleaner {
     tx: Option<tokio::sync::mpsc::UnboundedSender<LeakedResources>>,
     shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
@@ -109,6 +109,7 @@ impl LeakCleaner {
         }
     }
 
+    #[cfg(test)]
     fn abort(&mut self) {
         // Drop handles first, then abort immediately as a synchronous Drop backstop.
         self.tx.take();
@@ -117,11 +118,22 @@ impl LeakCleaner {
             handle.abort();
         }
     }
+
+    fn detach_shutdown(&mut self) {
+        self.tx.take();
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+        // Dropping JoinHandle detaches the task. If the runtime is still
+        // alive, the drain loop can finish queued cleanup without blocking
+        // this synchronous Drop path.
+        self.handle.take();
+    }
 }
 
 impl Drop for LeakCleaner {
     fn drop(&mut self) {
-        self.abort();
+        self.detach_shutdown();
     }
 }
 
@@ -2004,6 +2016,43 @@ mod tests {
         shutdown.await;
 
         assert!(aborted.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn leak_cleaner_drop_signals_shutdown_and_detaches_drain() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
+        let live_sender_clone = tx.clone();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(async move {
+            shutdown_rx.await.unwrap();
+            rx.close();
+            let mut drained = Vec::new();
+            while let Some(leaked) = rx.recv().await {
+                drained.push(leaked.sandbox_id);
+            }
+            done_tx.send(drained).unwrap();
+        });
+        let cleaner = LeakCleaner {
+            tx: Some(tx),
+            shutdown_tx: Some(shutdown_tx),
+            handle: Some(handle),
+        };
+
+        live_sender_clone
+            .send(test_leaked_resource("queued"))
+            .unwrap();
+        drop(cleaner);
+
+        let drained = tokio::time::timeout(std::time::Duration::from_secs(1), done_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(drained, vec!["queued".to_string()]);
+        assert!(matches!(
+            live_sender_clone.send(test_leaked_resource("late")),
+            Err(tokio::sync::mpsc::error::SendError(_))
+        ));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -52,8 +52,9 @@ pub(crate) struct LeakedResources {
 /// Owns the leaked-resource cleanup channel and its background drain task.
 ///
 /// Normal factory shutdown signals the drain task to close the receiver, drain
-/// already-queued resources, and finish. `Drop` cannot await, so it signals
-/// shutdown and detaches the task as a best-effort fallback.
+/// already-queued resources, and finish. `Drop` cannot await, so it only
+/// detaches the task; live sandbox sender clones can still report leaked
+/// resources before the channel naturally closes.
 struct LeakCleaner {
     tx: Option<tokio::sync::mpsc::UnboundedSender<LeakedResources>>,
     shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
@@ -119,21 +120,19 @@ impl LeakCleaner {
         }
     }
 
-    fn detach_shutdown(&mut self) {
+    fn detach_for_drop(&mut self) {
         self.tx.take();
-        if let Some(shutdown_tx) = self.shutdown_tx.take() {
-            let _ = shutdown_tx.send(());
-        }
-        // Dropping JoinHandle detaches the task. If the runtime is still
-        // alive, the drain loop can finish queued cleanup without blocking
-        // this synchronous Drop path.
+        self.shutdown_tx.take();
+        // Dropping JoinHandle detaches the task. If the runtime is still alive,
+        // the drain loop can finish queued cleanup and accept leak reports from
+        // live sandbox sender clones without blocking this synchronous Drop path.
         self.handle.take();
     }
 }
 
 impl Drop for LeakCleaner {
     fn drop(&mut self) {
-        self.detach_shutdown();
+        self.detach_for_drop();
     }
 }
 
@@ -534,21 +533,24 @@ async fn drain_leaked_resources(
 
 async fn drain_leaked_resources_with_cleanup<C, Fut>(
     mut rx: tokio::sync::mpsc::UnboundedReceiver<LeakedResources>,
-    mut shutdown_rx: tokio::sync::oneshot::Receiver<()>,
+    shutdown_rx: tokio::sync::oneshot::Receiver<()>,
     mut cleanup: C,
 ) where
     C: FnMut(LeakedResources) -> Fut,
     Fut: std::future::Future<Output = ()>,
 {
+    let mut shutdown_rx = Some(shutdown_rx);
     loop {
         tokio::select! {
             biased;
-            _ = &mut shutdown_rx => {
-                rx.close();
-                while let Some(leaked) = rx.recv().await {
-                    cleanup(leaked).await;
+            shutdown = wait_for_leak_cleaner_shutdown(&mut shutdown_rx) => {
+                if shutdown {
+                    rx.close();
+                    while let Some(leaked) = rx.recv().await {
+                        cleanup(leaked).await;
+                    }
+                    break;
                 }
-                break;
             }
             maybe_leaked = rx.recv() => {
                 let Some(leaked) = maybe_leaked else {
@@ -556,6 +558,22 @@ async fn drain_leaked_resources_with_cleanup<C, Fut>(
                 };
                 cleanup(leaked).await;
             }
+        }
+    }
+}
+
+async fn wait_for_leak_cleaner_shutdown(
+    shutdown_rx: &mut Option<tokio::sync::oneshot::Receiver<()>>,
+) -> bool {
+    let Some(rx) = shutdown_rx.as_mut() else {
+        return std::future::pending::<bool>().await;
+    };
+
+    match rx.await {
+        Ok(()) => true,
+        Err(_) => {
+            *shutdown_rx = None;
+            false
         }
     }
 }
@@ -2019,7 +2037,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn leak_cleaner_drop_signals_shutdown_and_detaches_drain() {
+    async fn leak_cleaner_drop_detaches_drain_and_keeps_live_senders_usable() {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
         let live_sender_clone = tx.clone();
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
@@ -2046,16 +2064,19 @@ mod tests {
             .send(test_leaked_resource("queued"))
             .unwrap();
         drop(cleaner);
+        live_sender_clone
+            .send(test_leaked_resource("late"))
+            .unwrap();
+        drop(live_sender_clone);
 
         tokio::time::timeout(std::time::Duration::from_secs(1), done_rx)
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(*cleaned.lock().await, vec!["queued".to_string()]);
-        assert!(matches!(
-            live_sender_clone.send(test_leaked_resource("late")),
-            Err(tokio::sync::mpsc::error::SendError(_))
-        ));
+        assert_eq!(
+            *cleaned.lock().await,
+            vec!["queued".to_string(), "late".to_string()]
+        );
     }
 
     #[test]

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -2079,6 +2079,38 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn leak_cleaner_drop_without_sender_clones_lets_drain_exit() {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let cleaned = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let cleaned_clone = Arc::clone(&cleaned);
+        let handle = tokio::spawn(async move {
+            drain_leaked_resources_with_cleanup(rx, shutdown_rx, move |leaked| {
+                let cleaned = Arc::clone(&cleaned_clone);
+                async move {
+                    cleaned.lock().await.push(leaked.sandbox_id);
+                }
+            })
+            .await;
+            done_tx.send(()).unwrap();
+        });
+        let cleaner = LeakCleaner {
+            tx: Some(tx),
+            shutdown_tx: Some(shutdown_tx),
+            handle: Some(handle),
+        };
+
+        drop(cleaner);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), done_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(cleaned.lock().await.is_empty());
+    }
+
     #[test]
     fn leak_cleaner_shutdown_timeout_covers_cow_destroy_retry_budget() {
         let retry_budget = DESTROY_RETRY_DELAY

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -4,4 +4,4 @@ mod pool;
 
 pub use guest::generate_boot_args;
 pub use guest::{GUEST_NETWORK, GuestNetwork};
-pub use pool::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig};
+pub use pool::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, NetnsPoolHandle};

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -42,13 +42,18 @@
 
 use std::collections::{HashSet, VecDeque};
 use std::fs::File;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use nix::fcntl::{Flock, FlockArg};
 use sandbox::SandboxError;
-use tracing::{error, info, trace, warn};
+use tokio::sync::{mpsc, watch};
+use tracing::{error, info, warn};
 
-use crate::command::{exec, exec_ignore_errors};
+use crate::command::{IgnoredCommandOutcome, exec_ignore_errors_with_timeout, exec_with_timeout};
 use crate::paths::LockPaths;
 
 use super::GUEST_NETWORK;
@@ -75,6 +80,8 @@ const MAX_NAMESPACES: u32 = 256;
 /// The pool pre-warms this many at startup and replenishes to
 /// maintain this level after each acquire.
 const BUFFER_SIZE: usize = 4;
+/// Maximum time for host commands that create, reset, or delete netns state.
+const NETNS_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 
 // Compile-time check: all /30 subnets fit within `10.200.0.0/16`.
 // 64 pools × 256 ns × 4 addresses per /30 = 65536 = exactly 2^16.
@@ -222,6 +229,165 @@ impl NetnsPoolConfig {
     }
 }
 
+type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+
+#[derive(Clone)]
+struct NetnsLifecycleOps {
+    flush_conntrack: Arc<dyn Fn(String) -> BoxFuture<ConntrackFlushOutcome> + Send + Sync>,
+    delete_namespace: Arc<dyn Fn(NetnsInfo) -> BoxFuture<NamespaceDeleteOutcome> + Send + Sync>,
+}
+
+impl Default for NetnsLifecycleOps {
+    fn default() -> Self {
+        Self {
+            flush_conntrack: Arc::new(|peer_ip| {
+                Box::pin(async move { flush_conntrack(&peer_ip).await })
+            }),
+            delete_namespace: Arc::new(|ns| {
+                Box::pin(async move { delete_namespace_resources(&ns.name, &ns.host_device).await })
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+impl NetnsLifecycleOps {
+    fn trusted_for_test() -> Self {
+        Self {
+            flush_conntrack: Arc::new(|_| Box::pin(async { ConntrackFlushOutcome::Trusted })),
+            delete_namespace: Arc::new(|_| Box::pin(async { NamespaceDeleteOutcome::Deleted })),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConntrackFlushOutcome {
+    Trusted,
+    Untrusted,
+}
+
+impl ConntrackFlushOutcome {
+    fn is_trusted(self) -> bool {
+        matches!(self, Self::Trusted)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NamespaceDeleteOutcome {
+    Deleted,
+    Abandoned,
+}
+
+impl NamespaceDeleteOutcome {
+    fn from_best_effort(outcomes: impl IntoIterator<Item = IgnoredCommandOutcome>) -> Self {
+        if outcomes
+            .into_iter()
+            .all(|outcome| outcome.completed_without_timeout())
+        {
+            Self::Deleted
+        } else {
+            Self::Abandoned
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NetnsReleaseOutcome {
+    Released,
+    Deleted,
+    Abandoned,
+    InvalidLease(String),
+}
+
+impl NetnsReleaseOutcome {
+    pub(crate) fn invalid_message(&self) -> Option<&str> {
+        match self {
+            Self::InvalidLease(message) => Some(message),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct PendingId(u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingKind {
+    Plain,
+    Proxy,
+}
+
+struct CreationCompletion {
+    id: PendingId,
+    kind: PendingKind,
+    result: Result<NetnsInfo>,
+}
+
+#[derive(Clone)]
+struct CreationNotifier {
+    tx: mpsc::UnboundedSender<CreationCompletion>,
+    generation: Arc<AtomicU64>,
+    wake_tx: watch::Sender<u64>,
+    ops: NetnsLifecycleOps,
+}
+
+impl CreationNotifier {
+    async fn send(self, completion: CreationCompletion) {
+        match self.tx.send(completion) {
+            Ok(()) => self.wake(),
+            Err(err) => {
+                let completion = err.0;
+                if let Ok(ns) = completion.result {
+                    warn!(
+                        name = %ns.name,
+                        host_device = %ns.host_device,
+                        "namespace creation completed after pool receiver dropped; deleting"
+                    );
+                    let outcome = (self.ops.delete_namespace)(ns.clone()).await;
+                    if matches!(outcome, NamespaceDeleteOutcome::Abandoned) {
+                        warn!(
+                            name = %ns.name,
+                            host_device = %ns.host_device,
+                            "failed to delete namespace after completion delivery failed; startup orphan reconciliation will retry"
+                        );
+                    }
+                }
+                self.wake();
+            }
+        }
+    }
+
+    fn wake(&self) {
+        let generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        let _ = self.wake_tx.send(generation);
+    }
+}
+
+#[derive(Clone)]
+pub struct NetnsPoolHandle {
+    inner: Arc<tokio::sync::Mutex<NetnsPool>>,
+}
+
+enum AcquirePlan {
+    Ready(NetnsLease),
+    Delete(Vec<NetnsInfo>, NetnsLifecycleOps),
+    Wait(watch::Receiver<u64>),
+}
+
+struct ReleasePlan {
+    info: NetnsInfo,
+    has_proxy: bool,
+    active_at_prepare: bool,
+    ops: NetnsLifecycleOps,
+}
+
+struct CleanupPlan {
+    namespaces: Vec<NetnsInfo>,
+    ops: NetnsLifecycleOps,
+    wait_for_pending: Option<watch::Receiver<u64>>,
+    done: bool,
+}
+
 // ---------------------------------------------------------------------------
 // Naming & IP helpers (pure functions)
 // ---------------------------------------------------------------------------
@@ -291,13 +457,13 @@ fn is_hex2(s: &str) -> bool {
 
 /// Shorthand: run `ip <args>`, discard stdout.
 async fn exec_ip(args: &[&str]) -> Result<()> {
-    exec("ip", args).await?;
+    exec_with_timeout("ip", args, NETNS_COMMAND_TIMEOUT).await?;
     Ok(())
 }
 
 /// Shorthand: run `iptables <args>`, discard stdout.
 async fn exec_iptables(args: &[&str]) -> Result<()> {
-    exec("iptables", args).await?;
+    exec_with_timeout("iptables", args, NETNS_COMMAND_TIMEOUT).await?;
     Ok(())
 }
 
@@ -644,7 +810,8 @@ async fn add_dns_drop_rules(name: &str, peer_ip: &str) -> Result<()> {
 }
 
 async fn get_default_interface() -> Result<String> {
-    let result = exec("ip", &["route", "get", "8.8.8.8"]).await?;
+    let result =
+        exec_with_timeout("ip", &["route", "get", "8.8.8.8"], NETNS_COMMAND_TIMEOUT).await?;
     let iface = result
         .split_whitespace()
         .skip_while(|&w| w != "dev")
@@ -655,26 +822,35 @@ async fn get_default_interface() -> Result<String> {
 }
 
 /// Delete iptables rules that contain `comment` in nat and filter tables.
-async fn delete_iptables_rules_by_comment(comment: &str) {
-    let ((), ()) = tokio::join!(
+async fn delete_iptables_rules_by_comment(comment: &str) -> NamespaceDeleteOutcome {
+    let (nat, filter) = tokio::join!(
         delete_iptables_from_table("nat", comment),
         delete_iptables_from_table("filter", comment),
     );
+    if matches!(nat, NamespaceDeleteOutcome::Deleted)
+        && matches!(filter, NamespaceDeleteOutcome::Deleted)
+    {
+        NamespaceDeleteOutcome::Deleted
+    } else {
+        NamespaceDeleteOutcome::Abandoned
+    }
 }
 
-async fn delete_iptables_from_table(table: &str, comment: &str) {
-    let output = match exec("iptables-save", &["-t", table]).await {
-        Ok(output) => output,
-        Err(e) => {
-            trace!(table, error = %e, "failed to read iptables rules, skipping cleanup");
-            return;
-        }
-    };
+async fn delete_iptables_from_table(table: &str, comment: &str) -> NamespaceDeleteOutcome {
+    let output =
+        match exec_with_timeout("iptables-save", &["-t", table], NETNS_COMMAND_TIMEOUT).await {
+            Ok(output) => output,
+            Err(e) => {
+                warn!(table, error = %e, "failed to read iptables rules, skipping cleanup");
+                return NamespaceDeleteOutcome::Abandoned;
+            }
+        };
     // Sequential: xtables lock serializes writes to the same table anyway.
     // Note: split_whitespace + trim_matches('"') is safe because namespace
     // comment values (e.g. "vm0-ns-00-0a") never contain spaces. If they
     // did, iptables-save would quote them as `--comment "foo bar"` and the
     // split would incorrectly break the value into separate arguments.
+    let mut outcomes = Vec::new();
     for line in output
         .lines()
         .filter(|line| line.starts_with("-A ") && line.contains(comment))
@@ -682,21 +858,36 @@ async fn delete_iptables_from_table(table: &str, comment: &str) {
         let rule = line.replacen("-A ", "-D ", 1);
         let mut args: Vec<&str> = vec!["-t", table];
         args.extend(rule.split_whitespace().map(|t| t.trim_matches('"')));
-        exec_ignore_errors("iptables", &args).await;
+        outcomes
+            .push(exec_ignore_errors_with_timeout("iptables", &args, NETNS_COMMAND_TIMEOUT).await);
     }
+    NamespaceDeleteOutcome::from_best_effort(outcomes)
 }
 
 /// Delete a namespace's network resources (iptables, veth, netns).
-async fn delete_namespace_resources(ns_name: &str, host_device: &str) {
+async fn delete_namespace_resources(ns_name: &str, host_device: &str) -> NamespaceDeleteOutcome {
     info!(name = %ns_name, "deleting namespace");
-    delete_iptables_rules_by_comment(ns_name).await;
+    let iptables = delete_iptables_rules_by_comment(ns_name).await;
     let del_link_args = ["link", "del", host_device];
     let del_ns_args = ["netns", "del", ns_name];
-    tokio::join!(
-        exec_ignore_errors("ip", &del_link_args),
-        exec_ignore_errors("ip", &del_ns_args),
+    let (link, netns) = tokio::join!(
+        exec_ignore_errors_with_timeout("ip", &del_link_args, NETNS_COMMAND_TIMEOUT),
+        exec_ignore_errors_with_timeout("ip", &del_ns_args, NETNS_COMMAND_TIMEOUT),
     );
-    info!(name = %ns_name, "namespace deleted");
+    let outcome = NamespaceDeleteOutcome::from_best_effort([link, netns]);
+    if matches!(iptables, NamespaceDeleteOutcome::Deleted)
+        && matches!(outcome, NamespaceDeleteOutcome::Deleted)
+    {
+        info!(name = %ns_name, "namespace deleted");
+        NamespaceDeleteOutcome::Deleted
+    } else {
+        warn!(
+            name = %ns_name,
+            host_device,
+            "namespace cleanup did not complete cleanly; startup orphan reconciliation will retry"
+        );
+        NamespaceDeleteOutcome::Abandoned
+    }
 }
 
 /// Flush conntrack entries for a given IP address.
@@ -705,13 +896,24 @@ async fn delete_namespace_resources(ns_name: &str, host_device: &str) {
 /// flushing, stale conntrack entries from a previous VM can cause the
 /// stateful iptables rule (`-m state --state RELATED,ESTABLISHED`) to
 /// misroute or silently drop return packets for a new VM.
-async fn flush_conntrack(peer_ip: &str) {
+async fn flush_conntrack(peer_ip: &str) -> ConntrackFlushOutcome {
     let src_args = ["-D", "-s", peer_ip];
     let dst_args = ["-D", "-d", peer_ip];
-    tokio::join!(
-        exec_ignore_errors("conntrack", &src_args),
-        exec_ignore_errors("conntrack", &dst_args),
+    let (src, dst) = tokio::join!(
+        exec_ignore_errors_with_timeout("conntrack", &src_args, NETNS_COMMAND_TIMEOUT),
+        exec_ignore_errors_with_timeout("conntrack", &dst_args, NETNS_COMMAND_TIMEOUT),
     );
+    if src.completed_without_timeout() && dst.completed_without_timeout() {
+        ConntrackFlushOutcome::Trusted
+    } else {
+        warn!(
+            peer_ip,
+            src = ?src,
+            dst = ?dst,
+            "conntrack flush failed or timed out; namespace will not be reused"
+        );
+        ConntrackFlushOutcome::Untrusted
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -776,22 +978,49 @@ pub struct NetnsPool {
     plain_queue: VecDeque<NetnsInfo>,
     proxy_queue: VecDeque<NetnsInfo>,
     /// In-flight background namespace creation tasks (plain).
-    pending_plain: tokio::task::JoinSet<Result<NetnsInfo>>,
+    pending_plain: HashSet<PendingId>,
     /// In-flight background namespace creation tasks (proxy).
-    pending_proxy: tokio::task::JoinSet<Result<NetnsInfo>>,
+    pending_proxy: HashSet<PendingId>,
+    completion_tx: mpsc::UnboundedSender<CreationCompletion>,
+    completion_rx: mpsc::UnboundedReceiver<CreationCompletion>,
+    completion_generation: Arc<AtomicU64>,
+    completion_wake_tx: watch::Sender<u64>,
     /// Namespaces checked out from this pool instance.
     in_flight: HashSet<String>,
+    /// In-flight namespaces that must be deleted instead of reused.
+    non_reusable: HashSet<String>,
     instance_id: u64,
+    next_pending_id: u64,
     next_ns_index: u32,
     pool_index: u32,
     proxy_port: Option<u16>,
     dns_port: Option<u16>,
     default_iface: String,
+    ops: NetnsLifecycleOps,
+    #[cfg(test)]
+    acquire_waiting_notify: Option<Arc<tokio::sync::Notify>>,
     /// Held for the lifetime of the pool to reserve the pool index.
     _lock: Flock<File>,
 }
 
 impl NetnsPool {
+    fn completion_state() -> (
+        mpsc::UnboundedSender<CreationCompletion>,
+        mpsc::UnboundedReceiver<CreationCompletion>,
+        Arc<AtomicU64>,
+        watch::Sender<u64>,
+    ) {
+        let (completion_tx, completion_rx) = mpsc::unbounded_channel();
+        let completion_generation = Arc::new(AtomicU64::new(0));
+        let (completion_wake_tx, _) = watch::channel(0);
+        (
+            completion_tx,
+            completion_rx,
+            completion_generation,
+            completion_wake_tx,
+        )
+    }
+
     #[cfg(test)]
     pub(crate) fn inactive_for_test() -> Self {
         let file = tempfile::tempfile().expect("create test netns pool lock file");
@@ -799,20 +1028,30 @@ impl NetnsPool {
             Ok(lock) => lock,
             Err((_, errno)) => panic!("lock test netns pool file: {errno}"),
         };
+        let (completion_tx, completion_rx, completion_generation, completion_wake_tx) =
+            Self::completion_state();
 
         Self {
             active: false,
             plain_queue: VecDeque::new(),
             proxy_queue: VecDeque::new(),
-            pending_plain: tokio::task::JoinSet::new(),
-            pending_proxy: tokio::task::JoinSet::new(),
+            pending_plain: HashSet::new(),
+            pending_proxy: HashSet::new(),
+            completion_tx,
+            completion_rx,
+            completion_generation,
+            completion_wake_tx,
             in_flight: HashSet::new(),
+            non_reusable: HashSet::new(),
             instance_id: next_pool_instance_id(),
+            next_pending_id: 0,
             next_ns_index: 0,
             pool_index: 0,
             proxy_port: None,
             dns_port: None,
             default_iface: "test0".into(),
+            ops: NetnsLifecycleOps::trusted_for_test(),
+            acquire_waiting_notify: None,
             _lock: lock,
         }
     }
@@ -842,7 +1081,12 @@ impl NetnsPool {
         info!(index, buffer = BUFFER_SIZE, "initializing namespace pool");
 
         // Enable host-level IP forwarding (idempotent, needed once per host).
-        exec("sysctl", &["-w", "net.ipv4.ip_forward=1"]).await?;
+        exec_with_timeout(
+            "sysctl",
+            &["-w", "net.ipv4.ip_forward=1"],
+            NETNS_COMMAND_TIMEOUT,
+        )
+        .await?;
 
         // Reconcile orphans from our own index and any idle pool index.
         // This is the correctness guarantee for kernel-side cleanup —
@@ -851,6 +1095,8 @@ impl NetnsPool {
         reconcile_orphan_namespaces(&lock_paths, index, &lock).await;
 
         let default_iface = get_default_interface().await?;
+        let (completion_tx, completion_rx, completion_generation, completion_wake_tx) =
+            Self::completion_state();
 
         let mut pool = Self {
             active: true,
@@ -860,15 +1106,24 @@ impl NetnsPool {
             } else {
                 0
             }),
-            pending_plain: tokio::task::JoinSet::new(),
-            pending_proxy: tokio::task::JoinSet::new(),
+            pending_plain: HashSet::new(),
+            pending_proxy: HashSet::new(),
+            completion_tx,
+            completion_rx,
+            completion_generation,
+            completion_wake_tx,
             in_flight: HashSet::new(),
+            non_reusable: HashSet::new(),
             instance_id: next_pool_instance_id(),
+            next_pending_id: 0,
             next_ns_index: 0,
             pool_index: index,
             proxy_port: config.proxy_port,
             dns_port: config.dns_port,
             default_iface,
+            ops: NetnsLifecycleOps::default(),
+            #[cfg(test)]
+            acquire_waiting_notify: None,
             _lock: lock,
         };
 
@@ -945,110 +1200,25 @@ impl NetnsPool {
 
     /// Acquire a namespace from the pool, or create one on-demand if empty.
     ///
-    /// Uses a three-tier strategy:
-    /// 1. Pop from pre-warmed queue (instant)
-    /// 2. Await in-flight background creation (if any)
-    /// 3. Create on-demand as fallback
-    ///
-    /// After acquisition, spawns a background replenishment task if the
-    /// buffer is below `BUFFER_SIZE`.
-    ///
-    /// When `proxy_port` is configured, acquires from the proxy queue
-    /// (namespaces with iptables REDIRECT rules). Otherwise acquires from
-    /// the plain queue.
+    /// The direct API is kept for one-shot local users. Shared users should use
+    /// `NetnsPoolHandle::acquire` so the mutex is not held while waiting for
+    /// namespace creation.
     pub async fn acquire(&mut self) -> Result<NetnsLease> {
-        if !self.active {
-            return Err(NetworkError::PoolNotActive);
-        }
-
-        // Move completed background tasks into queues before checking.
-        self.drain_completed();
-
-        if self.proxy_port.is_some() {
-            self.acquire_proxy().await
-        } else {
-            self.acquire_plain().await
-        }
-    }
-
-    /// Acquire from the plain (non-proxy) queue.
-    ///
-    /// Tries three tiers: queue → pending → on-demand.
-    /// Spawns a background replenishment task after success.
-    async fn acquire_plain(&mut self) -> Result<NetnsLease> {
-        // Tier 1: pre-warmed queue.
-        if let Some(pooled) = self.plain_queue.pop_front() {
-            info!(
-                name = %pooled.name,
-                remaining = self.plain_queue.len(),
-                "acquired namespace"
-            );
-            let lease = self.checkout_or_requeue(pooled, false)?;
-            self.maybe_replenish_plain();
-            return Ok(lease);
-        }
-        // Tier 2: await in-flight background task.
-        while let Some(result) = self.pending_plain.join_next().await {
-            match result {
-                Ok(Ok(ns)) => {
-                    info!(name = %ns.name, "acquired namespace from pending");
-                    let lease = self.checkout_or_requeue(ns, false)?;
-                    self.maybe_replenish_plain();
-                    return Ok(lease);
+        loop {
+            match self.prepare_acquire()? {
+                AcquirePlan::Ready(lease) => return Ok(lease),
+                AcquirePlan::Delete(namespaces, ops) => {
+                    delete_namespaces_with_ops(ops, namespaces).await;
                 }
-                Ok(Err(e)) => error!(error = %e, "pending namespace creation failed"),
-                Err(e) => error!(error = %e, "pending namespace task panicked"),
+                AcquirePlan::Wait(mut waiter) => {
+                    if waiter.changed().await.is_err() {
+                        return Err(NetworkError::Prerequisite(
+                            "namespace creation notifier closed".into(),
+                        ));
+                    }
+                }
             }
         }
-        // Tier 3: on-demand.
-        info!("pool exhausted, creating namespace on-demand");
-        // Spawn into the pool-owned JoinSet before awaiting so cancellation
-        // leaves the creation task reachable for later acquire/cleanup.
-        self.spawn_plain_creation()?;
-        let ns = self.await_on_demand_plain().await?;
-        let lease = self.checkout_or_requeue(ns, false)?;
-        self.maybe_replenish_plain();
-        Ok(lease)
-    }
-
-    /// Acquire from the proxy queue.
-    ///
-    /// Tries three tiers: queue → pending → on-demand.
-    /// Spawns a background replenishment task after success.
-    async fn acquire_proxy(&mut self) -> Result<NetnsLease> {
-        // Tier 1: pre-warmed queue.
-        if let Some(pooled) = self.proxy_queue.pop_front() {
-            info!(
-                name = %pooled.name,
-                remaining = self.proxy_queue.len(),
-                "acquired namespace (proxy)"
-            );
-            let lease = self.checkout_or_requeue(pooled, true)?;
-            self.maybe_replenish_proxy();
-            return Ok(lease);
-        }
-        // Tier 2: await in-flight background task.
-        while let Some(result) = self.pending_proxy.join_next().await {
-            match result {
-                Ok(Ok(ns)) => {
-                    info!(name = %ns.name, "acquired namespace (proxy) from pending");
-                    let lease = self.checkout_or_requeue(ns, true)?;
-                    self.maybe_replenish_proxy();
-                    return Ok(lease);
-                }
-                Ok(Err(e)) => error!(error = %e, "pending proxy namespace creation failed"),
-                Err(e) => error!(error = %e, "pending proxy namespace task panicked"),
-            }
-        }
-        // Tier 3: on-demand.
-        info!("proxy pool exhausted, creating namespace on-demand");
-        // Spawn into the pool-owned JoinSet before awaiting so cancellation
-        // leaves the creation task reachable for later acquire/cleanup.
-        self.spawn_proxy_creation()?;
-        let ns = self.await_on_demand_proxy().await?;
-        let lease = self.checkout_or_requeue(ns, true)?;
-        self.maybe_replenish_proxy();
-        Ok(lease)
     }
 
     fn reserve_ns_index(&mut self) -> Result<u32> {
@@ -1062,73 +1232,63 @@ impl NetnsPool {
         Ok(ns_index)
     }
 
+    fn reserve_pending_id(&mut self) -> PendingId {
+        let id = PendingId(self.next_pending_id);
+        self.next_pending_id += 1;
+        id
+    }
+
+    fn creation_notifier(&self) -> CreationNotifier {
+        CreationNotifier {
+            tx: self.completion_tx.clone(),
+            generation: Arc::clone(&self.completion_generation),
+            wake_tx: self.completion_wake_tx.clone(),
+            ops: self.ops.clone(),
+        }
+    }
+
     fn spawn_plain_creation(&mut self) -> Result<()> {
-        let ns_index = self.reserve_ns_index()?;
-        let pool_index = self.pool_index;
-        let default_iface = self.default_iface.clone();
-        self.pending_plain.spawn(create_single_namespace(
-            pool_index,
-            ns_index,
-            default_iface,
-            None,
-            None,
-        ));
-        Ok(())
+        self.spawn_creation(PendingKind::Plain)
     }
 
     fn spawn_proxy_creation(&mut self) -> Result<()> {
-        let Some(proxy_port) = self.proxy_port else {
-            return Err(NetworkError::Prerequisite(
-                "proxy namespace requested without proxy port".into(),
-            ));
-        };
+        self.spawn_creation(PendingKind::Proxy)
+    }
+
+    fn spawn_creation(&mut self, kind: PendingKind) -> Result<()> {
         let ns_index = self.reserve_ns_index()?;
         let pool_index = self.pool_index;
         let default_iface = self.default_iface.clone();
-        let dns_port = self.dns_port;
-        self.pending_proxy.spawn(create_single_namespace(
-            pool_index,
-            ns_index,
-            default_iface,
-            Some(proxy_port),
-            dns_port,
-        ));
+        let (proxy_port, dns_port) = match kind {
+            PendingKind::Plain => (None, None),
+            PendingKind::Proxy => {
+                let Some(proxy_port) = self.proxy_port else {
+                    return Err(NetworkError::Prerequisite(
+                        "proxy namespace requested without proxy port".into(),
+                    ));
+                };
+                (Some(proxy_port), self.dns_port)
+            }
+        };
+        let id = self.reserve_pending_id();
+        self.pending_set_mut(kind).insert(id);
+        spawn_creation_worker(
+            id,
+            kind,
+            self.creation_notifier(),
+            create_single_namespace(pool_index, ns_index, default_iface, proxy_port, dns_port),
+        );
         Ok(())
     }
 
-    async fn await_on_demand_plain(&mut self) -> Result<NetnsInfo> {
-        match self.pending_plain.join_next().await {
-            Some(Ok(Ok(ns))) => Ok(ns),
-            Some(Ok(Err(e))) => Err(e),
-            Some(Err(e)) => Err(Self::join_error_to_network_error(
-                e,
-                "on-demand namespace creation task",
-            )),
-            None => Err(NetworkError::Prerequisite(
-                "on-demand namespace creation task disappeared".into(),
-            )),
-        }
-    }
-
-    async fn await_on_demand_proxy(&mut self) -> Result<NetnsInfo> {
-        match self.pending_proxy.join_next().await {
-            Some(Ok(Ok(ns))) => Ok(ns),
-            Some(Ok(Err(e))) => Err(e),
-            Some(Err(e)) => Err(Self::join_error_to_network_error(
-                e,
-                "on-demand proxy namespace creation task",
-            )),
-            None => Err(NetworkError::Prerequisite(
-                "on-demand proxy namespace creation task disappeared".into(),
-            )),
-        }
-    }
-
-    fn join_error_to_network_error(e: tokio::task::JoinError, context: &str) -> NetworkError {
-        if e.is_panic() {
-            std::panic::resume_unwind(e.into_panic());
-        }
-        NetworkError::Prerequisite(format!("{context} cancelled: {e}"))
+    #[cfg(test)]
+    fn spawn_plain_creation_for_test<F>(&mut self, future: F)
+    where
+        F: Future<Output = Result<NetnsInfo>> + Send + 'static,
+    {
+        let id = self.reserve_pending_id();
+        self.pending_plain.insert(id);
+        spawn_creation_worker(id, PendingKind::Plain, self.creation_notifier(), future);
     }
 
     fn checkout_or_requeue(&mut self, info: NetnsInfo, has_proxy: bool) -> Result<NetnsLease> {
@@ -1156,56 +1316,146 @@ impl NetnsPool {
         Ok(NetnsLease::new(info, self.instance_id))
     }
 
-    /// Move completed background tasks into their respective queues.
-    ///
-    /// Uses `try_join_next()` to avoid blocking — only drains tasks that
-    /// have already finished.
-    fn drain_completed(&mut self) {
-        while let Some(result) = self.pending_plain.try_join_next() {
-            match result {
-                Ok(Ok(ns)) => self.plain_queue.push_back(ns),
-                Ok(Err(e)) => error!(error = %e, "background namespace creation failed"),
-                Err(e) => error!(error = %e, "background namespace creation panicked"),
-            }
+    fn drain_completed(&mut self, queue_when_inactive: bool) -> Vec<NetnsInfo> {
+        let mut delete = Vec::new();
+        while let Ok(completion) = self.completion_rx.try_recv() {
+            self.apply_completion(completion, queue_when_inactive, &mut delete);
         }
-        while let Some(result) = self.pending_proxy.try_join_next() {
-            match result {
-                Ok(Ok(ns)) => self.proxy_queue.push_back(ns),
-                Ok(Err(e)) => error!(error = %e, "background proxy namespace creation failed"),
-                Err(e) => error!(error = %e, "background proxy namespace creation panicked"),
+        delete
+    }
+
+    fn apply_completion(
+        &mut self,
+        completion: CreationCompletion,
+        queue_when_inactive: bool,
+        delete: &mut Vec<NetnsInfo>,
+    ) {
+        if !self.pending_set_mut(completion.kind).remove(&completion.id) {
+            warn!(
+                id = completion.id.0,
+                kind = ?completion.kind,
+                "ignoring completion for unknown namespace creation task"
+            );
+            if let Ok(ns) = completion.result {
+                delete.push(ns);
+            }
+            return;
+        }
+
+        match completion.result {
+            Ok(ns) if self.active || queue_when_inactive => {
+                self.target_queue_for_kind_mut(completion.kind)
+                    .push_back(ns);
+            }
+            Ok(ns) => delete.push(ns),
+            Err(e) => {
+                error!(
+                    id = completion.id.0,
+                    kind = ?completion.kind,
+                    error = %e,
+                    "background namespace creation failed"
+                );
             }
         }
     }
 
-    /// Spawn a background plain namespace creation task if needed.
-    ///
-    /// Skips if: buffer is full, a task is already in-flight, or
-    /// namespace index limit reached.
-    fn maybe_replenish_plain(&mut self) {
-        if self.plain_queue.len() + self.pending_plain.len() >= BUFFER_SIZE
-            || !self.pending_plain.is_empty()
-            || self.next_ns_index >= MAX_NAMESPACES
-        {
-            return;
+    fn prepare_acquire(&mut self) -> Result<AcquirePlan> {
+        loop {
+            if !self.active {
+                return Err(NetworkError::PoolNotActive);
+            }
+            let delete = self.drain_completed(false);
+            if !delete.is_empty() {
+                return Ok(AcquirePlan::Delete(delete, self.ops.clone()));
+            }
+            if let Some(lease) = self.try_checkout_ready()? {
+                return Ok(AcquirePlan::Ready(lease));
+            }
+
+            let kind = self.acquire_kind();
+            if self.pending_set(kind).is_empty() {
+                self.spawn_creation(kind)?;
+            }
+
+            let waiter = self.completion_wake_tx.subscribe();
+
+            // Subscribe before the re-check to avoid missing a completion
+            // between the decision to wait and dropping the outer mutex.
+            let delete = self.drain_completed(false);
+            if !delete.is_empty() {
+                return Ok(AcquirePlan::Delete(delete, self.ops.clone()));
+            }
+            if !self.active {
+                return Err(NetworkError::PoolNotActive);
+            }
+            if let Some(lease) = self.try_checkout_ready()? {
+                return Ok(AcquirePlan::Ready(lease));
+            }
+            if self.pending_set(kind).is_empty() {
+                continue;
+            }
+
+            #[cfg(test)]
+            if let Some(notify) = &self.acquire_waiting_notify {
+                notify.notify_one();
+            }
+
+            return Ok(AcquirePlan::Wait(waiter));
         }
-        let _ = self.spawn_plain_creation();
     }
 
-    /// Spawn a background proxy namespace creation task if needed.
-    ///
-    /// Skips if: no proxy port configured, buffer is full, a task is
-    /// already in-flight, or namespace index limit reached.
-    fn maybe_replenish_proxy(&mut self) {
-        if self.proxy_port.is_none() {
+    fn try_checkout_ready(&mut self) -> Result<Option<NetnsLease>> {
+        let has_proxy = self.proxy_port.is_some();
+        let queue_len_after_pop;
+        let pooled = if has_proxy {
+            let pooled = self.proxy_queue.pop_front();
+            queue_len_after_pop = self.proxy_queue.len();
+            pooled
+        } else {
+            let pooled = self.plain_queue.pop_front();
+            queue_len_after_pop = self.plain_queue.len();
+            pooled
+        };
+        let Some(pooled) = pooled else {
+            return Ok(None);
+        };
+
+        info!(
+            name = %pooled.name,
+            remaining = queue_len_after_pop,
+            has_proxy,
+            "acquired namespace"
+        );
+        let lease = self.checkout_or_requeue(pooled, has_proxy)?;
+        self.maybe_replenish_kind(self.acquire_kind());
+        Ok(Some(lease))
+    }
+
+    fn acquire_kind(&self) -> PendingKind {
+        if self.proxy_port.is_some() {
+            PendingKind::Proxy
+        } else {
+            PendingKind::Plain
+        }
+    }
+
+    fn maybe_replenish_kind(&mut self, kind: PendingKind) {
+        if matches!(kind, PendingKind::Proxy) && self.proxy_port.is_none() {
             return;
         }
-        if self.proxy_queue.len() + self.pending_proxy.len() >= BUFFER_SIZE
-            || !self.pending_proxy.is_empty()
+        if self.target_queue_for_kind(kind).len() + self.pending_set(kind).len() >= BUFFER_SIZE
+            || !self.pending_set(kind).is_empty()
             || self.next_ns_index >= MAX_NAMESPACES
         {
             return;
         }
-        let _ = self.spawn_proxy_creation();
+        let result = match kind {
+            PendingKind::Plain => self.spawn_plain_creation(),
+            PendingKind::Proxy => self.spawn_proxy_creation(),
+        };
+        if let Err(e) = result {
+            warn!(kind = ?kind, error = %e, "failed to replenish namespace pool");
+        }
     }
 
     /// Return a namespace to the pool, or delete it if the pool is inactive.
@@ -1218,8 +1468,45 @@ impl NetnsPool {
     /// cancelling this future before success leaves cleanup ownership with the
     /// caller.
     pub async fn release(&mut self, lease: &mut Option<NetnsLease>) -> Result<()> {
+        match self.release_outcome(lease).await {
+            NetnsReleaseOutcome::Released
+            | NetnsReleaseOutcome::Deleted
+            | NetnsReleaseOutcome::Abandoned => Ok(()),
+            NetnsReleaseOutcome::InvalidLease(message) => Err(NetworkError::InvalidLease(message)),
+        }
+    }
+
+    async fn release_outcome(&mut self, lease: &mut Option<NetnsLease>) -> NetnsReleaseOutcome {
+        let plan = match self.prepare_release(lease) {
+            Ok(plan) => plan,
+            Err(message) => return NetnsReleaseOutcome::InvalidLease(message),
+        };
+
+        let can_requeue = if plan.active_at_prepare {
+            (plan.ops.flush_conntrack)(plan.info.peer_ip.clone())
+                .await
+                .is_trusted()
+        } else {
+            false
+        };
+
+        if can_requeue && self.active {
+            return self.commit_release_requeue(lease, &plan);
+        }
+        if plan.active_at_prepare {
+            self.mark_non_reusable(&plan);
+        }
+
+        let delete = (plan.ops.delete_namespace)(plan.info.clone()).await;
+        self.commit_release_delete(lease, &plan, delete)
+    }
+
+    fn prepare_release(
+        &self,
+        lease: &Option<NetnsLease>,
+    ) -> std::result::Result<ReleasePlan, String> {
         let Some(active_lease) = lease.as_ref() else {
-            return Err(NetworkError::InvalidLease("missing netns lease".into()));
+            return Err("missing netns lease".into());
         };
         if active_lease.pool_instance_id() != self.instance_id {
             warn!(
@@ -1228,12 +1515,12 @@ impl NetnsPool {
                 pool_instance_id = self.instance_id,
                 "refusing to release netns lease from a different pool instance"
             );
-            return Err(NetworkError::InvalidLease(format!(
+            return Err(format!(
                 "namespace {} belongs to pool instance {}, not {}",
                 active_lease.name(),
                 active_lease.pool_instance_id(),
                 self.instance_id
-            )));
+            ));
         }
         if !self.in_flight.contains(active_lease.name()) {
             warn!(
@@ -1241,54 +1528,57 @@ impl NetnsPool {
                 pool_instance_id = self.instance_id,
                 "refusing to release netns lease that is not in flight"
             );
-            return Err(NetworkError::InvalidLease(format!(
+            return Err(format!(
                 "namespace {} is not checked out",
                 active_lease.name()
-            )));
-        }
-
-        if !self.active {
-            delete_namespace_resources(active_lease.name(), active_lease.info().host_device())
-                .await;
-            let Some(lease) = lease.take() else {
-                return Err(NetworkError::InvalidLease(
-                    "validated netns lease disappeared".into(),
-                ));
-            };
-            self.in_flight.remove(lease.name());
-            let _ = lease.into_info();
-            return Ok(());
+            ));
         }
 
         let has_proxy = self.proxy_port.is_some();
-        if self
-            .target_queue(has_proxy)
-            .iter()
-            .any(|r| r.name == active_lease.name())
+        let reusable = self.active && !self.non_reusable.contains(active_lease.name());
+        if reusable
+            && self
+                .target_queue(has_proxy)
+                .iter()
+                .any(|r| r.name == active_lease.name())
         {
             warn!(
                 name = %active_lease.name(),
                 "refusing to release netns lease already queued in pool"
             );
-            return Err(NetworkError::InvalidLease(format!(
+            return Err(format!(
                 "namespace {} is already queued",
                 active_lease.name()
-            )));
+            ));
         }
 
-        // Flush stale conntrack entries so the next VM using this namespace
-        // does not inherit connection tracking state from the previous VM.
-        flush_conntrack(active_lease.peer_ip()).await;
+        Ok(ReleasePlan {
+            info: active_lease.info().clone(),
+            has_proxy,
+            active_at_prepare: reusable,
+            ops: self.ops.clone(),
+        })
+    }
 
+    fn mark_non_reusable(&mut self, plan: &ReleasePlan) {
+        if self.in_flight.contains(&plan.info.name) {
+            self.non_reusable.insert(plan.info.name.clone());
+        }
+    }
+
+    fn commit_release_requeue(
+        &mut self,
+        lease: &mut Option<NetnsLease>,
+        plan: &ReleasePlan,
+    ) -> NetnsReleaseOutcome {
         let Some(lease) = lease.take() else {
-            return Err(NetworkError::InvalidLease(
-                "validated netns lease disappeared".into(),
-            ));
+            return NetnsReleaseOutcome::InvalidLease("validated netns lease disappeared".into());
         };
         self.in_flight.remove(lease.name());
+        self.non_reusable.remove(lease.name());
         let ns = lease.into_info();
 
-        let target_queue = if has_proxy {
+        let target_queue = if plan.has_proxy {
             &mut self.proxy_queue
         } else {
             &mut self.plain_queue
@@ -1297,11 +1587,39 @@ impl NetnsPool {
         info!(
             name = %ns.name,
             available = target_queue.len() + 1,
-            has_proxy,
+            has_proxy = plan.has_proxy,
             "namespace released"
         );
         target_queue.push_back(ns);
-        Ok(())
+        NetnsReleaseOutcome::Released
+    }
+
+    fn commit_release_delete(
+        &mut self,
+        lease: &mut Option<NetnsLease>,
+        _plan: &ReleasePlan,
+        delete: NamespaceDeleteOutcome,
+    ) -> NetnsReleaseOutcome {
+        let Some(lease) = lease.take() else {
+            return NetnsReleaseOutcome::InvalidLease("validated netns lease disappeared".into());
+        };
+        self.in_flight.remove(lease.name());
+        self.non_reusable.remove(lease.name());
+        let ns = lease.into_info();
+        match delete {
+            NamespaceDeleteOutcome::Deleted => {
+                info!(name = %ns.name, "namespace lease deleted instead of requeued");
+                NetnsReleaseOutcome::Deleted
+            }
+            NamespaceDeleteOutcome::Abandoned => {
+                warn!(
+                    name = %ns.name,
+                    host_device = %ns.host_device,
+                    "namespace release abandoned after cleanup failure; startup orphan reconciliation will retry"
+                );
+                NetnsReleaseOutcome::Abandoned
+            }
+        }
     }
 
     fn target_queue(&self, has_proxy: bool) -> &VecDeque<NetnsInfo> {
@@ -1320,6 +1638,34 @@ impl NetnsPool {
         }
     }
 
+    fn target_queue_for_kind(&self, kind: PendingKind) -> &VecDeque<NetnsInfo> {
+        match kind {
+            PendingKind::Plain => &self.plain_queue,
+            PendingKind::Proxy => &self.proxy_queue,
+        }
+    }
+
+    fn target_queue_for_kind_mut(&mut self, kind: PendingKind) -> &mut VecDeque<NetnsInfo> {
+        match kind {
+            PendingKind::Plain => &mut self.plain_queue,
+            PendingKind::Proxy => &mut self.proxy_queue,
+        }
+    }
+
+    fn pending_set(&self, kind: PendingKind) -> &HashSet<PendingId> {
+        match kind {
+            PendingKind::Plain => &self.pending_plain,
+            PendingKind::Proxy => &self.pending_proxy,
+        }
+    }
+
+    fn pending_set_mut(&mut self, kind: PendingKind) -> &mut HashSet<PendingId> {
+        match kind {
+            PendingKind::Plain => &mut self.pending_plain,
+            PendingKind::Proxy => &mut self.pending_proxy,
+        }
+    }
+
     /// Delete all namespaces currently in the pool queue and wait for
     /// in-flight background creation tasks so their resources can be deleted.
     ///
@@ -1327,14 +1673,28 @@ impl NetnsPool {
     /// cleaned up here — they will be caught by orphan cleanup on the next
     /// [`NetnsPool::create`] call with the same index.
     pub async fn cleanup(&mut self) -> Result<()> {
-        if !self.active
-            && self.plain_queue.is_empty()
-            && self.proxy_queue.is_empty()
-            && self.pending_plain.is_empty()
-            && self.pending_proxy.is_empty()
-        {
-            return Ok(());
+        loop {
+            let plan = self.prepare_cleanup();
+            if plan.done {
+                info!("namespace pool cleanup complete");
+                return Ok(());
+            }
+
+            let names = cleanup_namespace_names(&plan.namespaces);
+            delete_namespaces_with_ops(plan.ops, plan.namespaces).await;
+            self.remove_queued_namespaces(&names);
+
+            if let Some(mut waiter) = plan.wait_for_pending
+                && waiter.changed().await.is_err()
+            {
+                return Err(NetworkError::Prerequisite(
+                    "namespace creation notifier closed".into(),
+                ));
+            }
         }
+    }
+
+    fn prepare_cleanup(&mut self) -> CleanupPlan {
         self.active = false;
         if !self.in_flight.is_empty() {
             warn!(
@@ -1343,36 +1703,38 @@ impl NetnsPool {
             );
         }
 
-        // Let in-flight creation finish instead of aborting it. Aborting can
-        // leave partially-created kernel resources with no NetnsInfo to retry.
-        while let Some(result) = self.pending_plain.join_next().await {
-            if let Ok(Ok(ns)) = result {
-                self.plain_queue.push_back(ns);
-            }
+        self.drain_completed(true);
+        let mut wait_for_pending = if self.pending_plain.is_empty() && self.pending_proxy.is_empty()
+        {
+            None
+        } else {
+            Some(self.completion_wake_tx.subscribe())
+        };
+        self.drain_completed(true);
+        if self.pending_plain.is_empty() && self.pending_proxy.is_empty() {
+            wait_for_pending = None;
         }
-        while let Some(result) = self.pending_proxy.join_next().await {
-            if let Ok(Ok(ns)) = result {
-                self.proxy_queue.push_back(ns);
-            }
+
+        let namespaces = self
+            .plain_queue
+            .iter()
+            .chain(self.proxy_queue.iter())
+            .cloned()
+            .collect::<Vec<_>>();
+        CleanupPlan {
+            done: namespaces.is_empty() && wait_for_pending.is_none(),
+            namespaces,
+            ops: self.ops.clone(),
+            wait_for_pending,
         }
-
-        let count = self.plain_queue.len() + self.proxy_queue.len();
-        info!(count, "cleaning up namespace pool");
-
-        Self::delete_queued_namespaces(&mut self.plain_queue).await;
-        Self::delete_queued_namespaces(&mut self.proxy_queue).await;
-
-        info!("namespace pool cleanup complete");
-        Ok(())
     }
 
-    async fn delete_queued_namespaces(queue: &mut VecDeque<NetnsInfo>) {
-        Self::delete_queued_namespaces_with(queue, |ns| async move {
-            delete_namespace_resources(&ns.name, &ns.host_device).await;
-        })
-        .await;
+    fn remove_queued_namespaces(&mut self, names: &HashSet<String>) {
+        self.plain_queue.retain(|ns| !names.contains(&ns.name));
+        self.proxy_queue.retain(|ns| !names.contains(&ns.name));
     }
 
+    #[cfg(test)]
     async fn delete_queued_namespaces_with<F, Fut>(queue: &mut VecDeque<NetnsInfo>, mut delete: F)
     where
         F: FnMut(NetnsInfo) -> Fut,
@@ -1401,8 +1763,157 @@ impl Drop for NetnsPool {
     }
 }
 
+impl NetnsPoolHandle {
+    pub(crate) async fn create_checked(config: CheckedNetnsPoolConfig) -> Result<Self> {
+        Ok(Self::new(NetnsPool::create_checked(config).await?))
+    }
+
+    pub(crate) fn new(pool: NetnsPool) -> Self {
+        Self {
+            inner: Arc::new(tokio::sync::Mutex::new(pool)),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test(pool: NetnsPool) -> Self {
+        Self::new(pool)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn strong_count_for_test(&self) -> usize {
+        Arc::strong_count(&self.inner)
+    }
+
+    pub(crate) async fn acquire(&self) -> Result<NetnsLease> {
+        loop {
+            let plan = {
+                let mut pool = self.inner.lock().await;
+                pool.prepare_acquire()?
+            };
+            match plan {
+                AcquirePlan::Ready(lease) => return Ok(lease),
+                AcquirePlan::Delete(namespaces, ops) => {
+                    delete_namespaces_with_ops(ops, namespaces).await;
+                }
+                AcquirePlan::Wait(mut waiter) => {
+                    if waiter.changed().await.is_err() {
+                        return Err(NetworkError::Prerequisite(
+                            "namespace creation notifier closed".into(),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn release(&self, lease: &mut Option<NetnsLease>) -> NetnsReleaseOutcome {
+        let plan = {
+            let pool = self.inner.lock().await;
+            match pool.prepare_release(lease) {
+                Ok(plan) => plan,
+                Err(message) => return NetnsReleaseOutcome::InvalidLease(message),
+            }
+        };
+
+        let can_requeue = if plan.active_at_prepare {
+            (plan.ops.flush_conntrack)(plan.info.peer_ip.clone())
+                .await
+                .is_trusted()
+        } else {
+            false
+        };
+
+        if can_requeue {
+            {
+                let mut pool = self.inner.lock().await;
+                if pool.active {
+                    return pool.commit_release_requeue(lease, &plan);
+                }
+            }
+        } else if plan.active_at_prepare {
+            let mut pool = self.inner.lock().await;
+            pool.mark_non_reusable(&plan);
+        }
+
+        let delete = (plan.ops.delete_namespace)(plan.info.clone()).await;
+        let mut pool = self.inner.lock().await;
+        pool.commit_release_delete(lease, &plan, delete)
+    }
+
+    pub(crate) async fn cleanup(&self) -> Result<()> {
+        loop {
+            let plan = {
+                let mut pool = self.inner.lock().await;
+                pool.prepare_cleanup()
+            };
+            if plan.done {
+                info!("namespace pool cleanup complete");
+                return Ok(());
+            }
+
+            let names = cleanup_namespace_names(&plan.namespaces);
+            delete_namespaces_with_ops(plan.ops, plan.namespaces).await;
+            {
+                let mut pool = self.inner.lock().await;
+                pool.remove_queued_namespaces(&names);
+            }
+
+            if let Some(mut waiter) = plan.wait_for_pending
+                && waiter.changed().await.is_err()
+            {
+                return Err(NetworkError::Prerequisite(
+                    "namespace creation notifier closed".into(),
+                ));
+            }
+        }
+    }
+}
+
+fn spawn_creation_worker<F>(id: PendingId, kind: PendingKind, notifier: CreationNotifier, future: F)
+where
+    F: Future<Output = Result<NetnsInfo>> + Send + 'static,
+{
+    let worker = tokio::spawn(future);
+    tokio::spawn(async move {
+        let result = match worker.await {
+            Ok(result) => result,
+            Err(e) => Err(join_error_to_creation_error(e, kind)),
+        };
+        notifier.send(CreationCompletion { id, kind, result }).await;
+    });
+}
+
+fn join_error_to_creation_error(e: tokio::task::JoinError, kind: PendingKind) -> NetworkError {
+    if e.is_panic() {
+        NetworkError::Prerequisite(format!("{kind:?} namespace creation task panicked: {e}"))
+    } else {
+        NetworkError::Prerequisite(format!("{kind:?} namespace creation task cancelled: {e}"))
+    }
+}
+
+async fn delete_namespaces_with_ops(ops: NetnsLifecycleOps, namespaces: Vec<NetnsInfo>) {
+    let count = namespaces.len();
+    if count > 0 {
+        info!(count, "cleaning up namespace pool entries");
+    }
+    for ns in namespaces {
+        let outcome = (ops.delete_namespace)(ns.clone()).await;
+        if matches!(outcome, NamespaceDeleteOutcome::Abandoned) {
+            warn!(
+                name = %ns.name,
+                host_device = %ns.host_device,
+                "namespace cleanup was abandoned; startup orphan reconciliation will retry"
+            );
+        }
+    }
+}
+
+fn cleanup_namespace_names(namespaces: &[NetnsInfo]) -> HashSet<String> {
+    namespaces.iter().map(|ns| ns.name.clone()).collect()
+}
+
 // ---------------------------------------------------------------------------
-// Namespace creation (free functions for JoinSet compatibility)
+// Namespace creation
 // ---------------------------------------------------------------------------
 
 /// Create a single namespace with full connectivity, optionally adding proxy
@@ -1512,7 +2023,8 @@ pub async fn cleanup_namespaces_by_index(index: u32) {
     delete_iptables_rules_by_comment(&prefix).await;
 
     // 2. Discover and delete any remaining namespaces (+ their veth devices).
-    let Ok(output) = exec("ip", &["netns", "list"]).await else {
+    let Ok(output) = exec_with_timeout("ip", &["netns", "list"], NETNS_COMMAND_TIMEOUT).await
+    else {
         error!(index, "failed to list namespaces for cleanup");
         return;
     };
@@ -1559,7 +2071,7 @@ async fn reconcile_orphan_namespaces(locks: &LockPaths, own_index: u32, _own_loc
     // `cleanup_namespaces_by_index` swallows failures by design — its
     // only fallible step (`ip netns list`) is near-infallible on a
     // working runner, and the inner deletes go through
-    // `exec_ignore_errors` so a per-namespace `Result` would carry no
+    // best-effort command helpers so a per-namespace `Result` would carry no
     // signal. If reconcile silently fails here, the EEXIST that
     // warm-up's `ip netns add` produces is the diagnostic — chronologically
     // paired with the `error!` at the cleanup site. See #10826 for the
@@ -1603,6 +2115,18 @@ fn try_claim_idle_pool_lock(locks: &LockPaths, index: u32) -> Option<Flock<File>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    async fn blocking_plain_creation(
+        name: &'static str,
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    ) -> Result<NetnsInfo> {
+        entered.notify_one();
+        release.notified().await;
+        Ok(test_info(name))
+    }
 
     #[test]
     fn format_hex_index_zero() {
@@ -1796,6 +2320,358 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shared_acquire_does_not_hold_mutex_while_creation_is_pending() {
+        let waiting = Arc::new(tokio::sync::Notify::new());
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        pool.next_ns_index = MAX_NAMESPACES;
+        pool.acquire_waiting_notify = Some(Arc::clone(&waiting));
+        pool.spawn_plain_creation_for_test(blocking_plain_creation(
+            "test-ns",
+            Arc::clone(&entered),
+            Arc::clone(&release),
+        ));
+        let handle = NetnsPoolHandle::new_for_test(pool);
+
+        let acquire = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.acquire().await }
+        });
+        entered.notified().await;
+        waiting.notified().await;
+
+        let guard = handle
+            .inner
+            .try_lock()
+            .expect("shared acquire must not hold netns pool mutex while waiting");
+        drop(guard);
+
+        release.notify_one();
+        let mut lease = Some(acquire.await.unwrap().unwrap());
+        assert_eq!(lease.as_ref().unwrap().name(), "test-ns");
+        let outcome = handle.release(&mut lease).await;
+        assert!(matches!(outcome, NetnsReleaseOutcome::Released));
+        handle.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn shared_acquire_cancellation_preserves_completed_creation() {
+        let waiting = Arc::new(tokio::sync::Notify::new());
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        pool.next_ns_index = MAX_NAMESPACES;
+        pool.acquire_waiting_notify = Some(Arc::clone(&waiting));
+        pool.spawn_plain_creation_for_test(blocking_plain_creation(
+            "test-ns",
+            Arc::clone(&entered),
+            Arc::clone(&release),
+        ));
+        let handle = NetnsPoolHandle::new_for_test(pool);
+
+        let acquire = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.acquire().await }
+        });
+        entered.notified().await;
+        waiting.notified().await;
+        acquire.abort();
+        let _ = acquire.await;
+
+        release.notify_one();
+        let mut lease = Some(handle.acquire().await.unwrap());
+        assert_eq!(lease.as_ref().unwrap().name(), "test-ns");
+
+        let outcome = handle.release(&mut lease).await;
+        assert!(matches!(outcome, NetnsReleaseOutcome::Released));
+        handle.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn creation_worker_panic_clears_pending_during_cleanup() {
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        pool.spawn_plain_creation_for_test(async {
+            panic!("creation panic for test");
+            #[allow(unreachable_code)]
+            Ok(test_info("never"))
+        });
+        let handle = NetnsPoolHandle::new_for_test(pool);
+
+        handle.cleanup().await.unwrap();
+
+        let pool = handle.inner.lock().await;
+        assert!(pool.pending_plain.is_empty());
+        assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn completion_send_failure_deletes_created_namespace() {
+        let deleted = Arc::new(AtomicUsize::new(0));
+        let mut pool = NetnsPool::inactive_for_test();
+        let deleted_for_ops = Arc::clone(&deleted);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(|_| Box::pin(async { ConntrackFlushOutcome::Trusted })),
+            delete_namespace: Arc::new(move |_| {
+                let deleted = Arc::clone(&deleted_for_ops);
+                Box::pin(async move {
+                    deleted.fetch_add(1, Ordering::SeqCst);
+                    NamespaceDeleteOutcome::Deleted
+                })
+            }),
+        };
+        let notifier = pool.creation_notifier();
+        drop(pool);
+
+        notifier
+            .send(CreationCompletion {
+                id: PendingId(0),
+                kind: PendingKind::Plain,
+                result: Ok(test_info("orphan-ns")),
+            })
+            .await;
+
+        assert_eq!(deleted.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cleanup_rejects_acquire_and_deletes_late_completion() {
+        let release = Arc::new(tokio::sync::Notify::new());
+        let delete_count = Arc::new(AtomicUsize::new(0));
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let delete_count_for_ops = Arc::clone(&delete_count);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(|_| Box::pin(async { ConntrackFlushOutcome::Trusted })),
+            delete_namespace: Arc::new(move |_| {
+                let delete_count = Arc::clone(&delete_count_for_ops);
+                Box::pin(async move {
+                    delete_count.fetch_add(1, Ordering::SeqCst);
+                    NamespaceDeleteOutcome::Deleted
+                })
+            }),
+        };
+        pool.spawn_plain_creation_for_test({
+            let release = Arc::clone(&release);
+            async move {
+                release.notified().await;
+                Ok(test_info("late-ns"))
+            }
+        });
+        let handle = NetnsPoolHandle::new_for_test(pool);
+
+        let cleanup = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.cleanup().await }
+        });
+        loop {
+            if !handle.inner.lock().await.active {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        let err = handle.acquire().await.unwrap_err();
+        assert!(matches!(err, NetworkError::PoolNotActive));
+
+        release.notify_one();
+        cleanup.await.unwrap().unwrap();
+        let pool = handle.inner.lock().await;
+        assert!(pool.pending_plain.is_empty());
+        assert!(pool.plain_queue.is_empty());
+        assert_eq!(delete_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn shared_release_does_not_hold_mutex_while_flush_blocks() {
+        let flush_entered = Arc::new(tokio::sync::Notify::new());
+        let flush_release = Arc::new(tokio::sync::Notify::new());
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let flush_entered_for_ops = Arc::clone(&flush_entered);
+        let flush_release_for_ops = Arc::clone(&flush_release);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(move |_| {
+                let flush_entered = Arc::clone(&flush_entered_for_ops);
+                let flush_release = Arc::clone(&flush_release_for_ops);
+                Box::pin(async move {
+                    flush_entered.notify_one();
+                    flush_release.notified().await;
+                    ConntrackFlushOutcome::Trusted
+                })
+            }),
+            delete_namespace: Arc::new(|_| Box::pin(async { NamespaceDeleteOutcome::Deleted })),
+        };
+        let lease = Some(pool.checkout(test_info("test-ns")).unwrap());
+        let handle = NetnsPoolHandle::new_for_test(pool);
+
+        let release_task = tokio::spawn({
+            let handle = handle.clone();
+            async move {
+                let mut lease = lease;
+                let outcome = handle.release(&mut lease).await;
+                (outcome, lease)
+            }
+        });
+        flush_entered.notified().await;
+
+        let guard = handle
+            .inner
+            .try_lock()
+            .expect("shared release must not hold netns pool mutex while flushing conntrack");
+        drop(guard);
+
+        flush_release.notify_one();
+        let (outcome, lease) = release_task.await.unwrap();
+        assert!(matches!(outcome, NetnsReleaseOutcome::Released));
+        assert!(lease.is_none());
+        handle.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn untrusted_conntrack_flush_deletes_without_requeue() {
+        let delete_count = Arc::new(AtomicUsize::new(0));
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let delete_count_for_ops = Arc::clone(&delete_count);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(|_| Box::pin(async { ConntrackFlushOutcome::Untrusted })),
+            delete_namespace: Arc::new(move |_| {
+                let delete_count = Arc::clone(&delete_count_for_ops);
+                Box::pin(async move {
+                    delete_count.fetch_add(1, Ordering::SeqCst);
+                    NamespaceDeleteOutcome::Deleted
+                })
+            }),
+        };
+        let mut lease = Some(pool.checkout(test_info("test-ns")).unwrap());
+        let handle = NetnsPoolHandle::new_for_test(pool);
+
+        let outcome = handle.release(&mut lease).await;
+
+        assert!(matches!(outcome, NetnsReleaseOutcome::Deleted));
+        assert!(lease.is_none());
+        assert_eq!(delete_count.load(Ordering::SeqCst), 1);
+        let pool = handle.inner.lock().await;
+        assert!(pool.in_flight.is_empty());
+        assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancelled_untrusted_release_marks_namespace_non_reusable_for_retry() {
+        let delete_entered = Arc::new(tokio::sync::Notify::new());
+        let first_delete_release = Arc::new(tokio::sync::Notify::new());
+        let flush_count = Arc::new(AtomicUsize::new(0));
+        let delete_count = Arc::new(AtomicUsize::new(0));
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let flush_count_for_ops = Arc::clone(&flush_count);
+        let delete_count_for_ops = Arc::clone(&delete_count);
+        let delete_entered_for_ops = Arc::clone(&delete_entered);
+        let first_delete_release_for_ops = Arc::clone(&first_delete_release);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(move |_| {
+                let flush_count = Arc::clone(&flush_count_for_ops);
+                Box::pin(async move {
+                    flush_count.fetch_add(1, Ordering::SeqCst);
+                    ConntrackFlushOutcome::Untrusted
+                })
+            }),
+            delete_namespace: Arc::new(move |_| {
+                let delete_count = Arc::clone(&delete_count_for_ops);
+                let delete_entered = Arc::clone(&delete_entered_for_ops);
+                let first_delete_release = Arc::clone(&first_delete_release_for_ops);
+                Box::pin(async move {
+                    let attempt = delete_count.fetch_add(1, Ordering::SeqCst);
+                    delete_entered.notify_one();
+                    if attempt == 0 {
+                        first_delete_release.notified().await;
+                    }
+                    NamespaceDeleteOutcome::Deleted
+                })
+            }),
+        };
+        let mut lease = Some(pool.checkout(test_info("test-ns")).unwrap());
+        let handle = NetnsPoolHandle::new_for_test(pool);
+
+        {
+            let release = handle.release(&mut lease);
+            tokio::pin!(release);
+            tokio::select! {
+                outcome = &mut release => panic!("release completed before delete was cancelled: {outcome:?}"),
+                _ = delete_entered.notified() => {}
+            }
+        }
+
+        assert!(lease.is_some());
+        assert_eq!(flush_count.load(Ordering::SeqCst), 1);
+        assert_eq!(delete_count.load(Ordering::SeqCst), 1);
+        {
+            let pool = handle.inner.lock().await;
+            assert!(pool.non_reusable.contains("test-ns"));
+        }
+
+        first_delete_release.notify_one();
+        let outcome = handle.release(&mut lease).await;
+
+        assert!(matches!(outcome, NetnsReleaseOutcome::Deleted));
+        assert!(lease.is_none());
+        assert_eq!(
+            flush_count.load(Ordering::SeqCst),
+            1,
+            "tainted retry must not flush and requeue"
+        );
+        assert_eq!(delete_count.load(Ordering::SeqCst), 2);
+        let pool = handle.inner.lock().await;
+        assert!(pool.non_reusable.is_empty());
+        assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn shared_cleanup_does_not_hold_mutex_while_delete_blocks() {
+        let delete_entered = Arc::new(tokio::sync::Notify::new());
+        let delete_release = Arc::new(tokio::sync::Notify::new());
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        pool.plain_queue.push_back(test_info("test-ns"));
+        let delete_entered_for_ops = Arc::clone(&delete_entered);
+        let delete_release_for_ops = Arc::clone(&delete_release);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(|_| Box::pin(async { ConntrackFlushOutcome::Trusted })),
+            delete_namespace: Arc::new(move |_| {
+                let delete_entered = Arc::clone(&delete_entered_for_ops);
+                let delete_release = Arc::clone(&delete_release_for_ops);
+                Box::pin(async move {
+                    delete_entered.notify_one();
+                    delete_release.notified().await;
+                    NamespaceDeleteOutcome::Deleted
+                })
+            }),
+        };
+        let handle = NetnsPoolHandle::new_for_test(pool);
+
+        let cleanup = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.cleanup().await }
+        });
+        delete_entered.notified().await;
+
+        let guard = handle
+            .inner
+            .try_lock()
+            .expect("shared cleanup must not hold netns pool mutex while deleting namespace");
+        drop(guard);
+
+        delete_release.notify_one();
+        cleanup.await.unwrap().unwrap();
+        let pool = handle.inner.lock().await;
+        assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
     async fn release_disarms_lease_and_returns_info_to_queue() {
         let mut pool = NetnsPool::inactive_for_test();
         pool.active = true;
@@ -1842,7 +2718,7 @@ mod tests {
         let release = std::sync::Arc::new(tokio::sync::Notify::new());
         let entered_task = std::sync::Arc::clone(&entered);
         let release_task = std::sync::Arc::clone(&release);
-        pool.pending_plain.spawn(async move {
+        pool.spawn_plain_creation_for_test(async move {
             entered_task.notify_one();
             release_task.notified().await;
             Ok(test_info("test-ns"))
@@ -1876,7 +2752,7 @@ mod tests {
         let release = std::sync::Arc::new(tokio::sync::Notify::new());
         let entered_task = std::sync::Arc::clone(&entered);
         let release_task = std::sync::Arc::clone(&release);
-        pool.pending_plain.spawn(async move {
+        pool.spawn_plain_creation_for_test(async move {
             entered_task.notify_one();
             release_task.notified().await;
             Ok(test_info("test-ns"))

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -3198,6 +3198,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn release_abandoned_delete_consumes_lease_and_clears_tracking() {
+        let delete_count = Arc::new(AtomicUsize::new(0));
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let delete_count_for_ops = Arc::clone(&delete_count);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(|_| Box::pin(async { ConntrackFlushOutcome::Untrusted })),
+            delete_namespace: Arc::new(move |_| {
+                let delete_count = Arc::clone(&delete_count_for_ops);
+                Box::pin(async move {
+                    delete_count.fetch_add(1, Ordering::SeqCst);
+                    NamespaceDeleteOutcome::Abandoned
+                })
+            }),
+        };
+        let mut lease = Some(pool.checkout(test_info("test-ns")).unwrap());
+
+        let outcome = pool.release_outcome(&mut lease).await;
+
+        assert!(matches!(outcome, NetnsReleaseOutcome::Abandoned));
+        assert!(lease.is_none());
+        assert_eq!(delete_count.load(Ordering::SeqCst), 1);
+        assert!(pool.in_flight.is_empty());
+        assert!(pool.non_reusable.is_empty());
+        assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
     async fn cleanup_retry_drains_pending_creation_after_cancel() {
         let mut pool = NetnsPool::inactive_for_test();
         pool.active = true;
@@ -3308,6 +3336,31 @@ mod tests {
 
         pool.cleanup().await.unwrap();
 
+        assert!(!pool.active);
+        assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cleanup_removes_queued_namespace_after_abandoned_delete() {
+        let delete_count = Arc::new(AtomicUsize::new(0));
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        pool.plain_queue.push_back(test_info("test-ns"));
+        let delete_count_for_ops = Arc::clone(&delete_count);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(|_| Box::pin(async { ConntrackFlushOutcome::Trusted })),
+            delete_namespace: Arc::new(move |_| {
+                let delete_count = Arc::clone(&delete_count_for_ops);
+                Box::pin(async move {
+                    delete_count.fetch_add(1, Ordering::SeqCst);
+                    NamespaceDeleteOutcome::Abandoned
+                })
+            }),
+        };
+
+        pool.cleanup().await.unwrap();
+
+        assert_eq!(delete_count.load(Ordering::SeqCst), 1);
         assert!(!pool.active);
         assert!(pool.plain_queue.is_empty());
     }

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -2762,6 +2762,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn direct_release_cancelled_during_flush_marks_namespace_non_reusable_for_retry() {
+        let flush_entered = Arc::new(tokio::sync::Notify::new());
+        let first_flush_release = Arc::new(tokio::sync::Notify::new());
+        let flush_count = Arc::new(AtomicUsize::new(0));
+        let delete_count = Arc::new(AtomicUsize::new(0));
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let flush_entered_for_ops = Arc::clone(&flush_entered);
+        let first_flush_release_for_ops = Arc::clone(&first_flush_release);
+        let flush_count_for_ops = Arc::clone(&flush_count);
+        let delete_count_for_ops = Arc::clone(&delete_count);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(move |_| {
+                let flush_entered = Arc::clone(&flush_entered_for_ops);
+                let first_flush_release = Arc::clone(&first_flush_release_for_ops);
+                let flush_count = Arc::clone(&flush_count_for_ops);
+                Box::pin(async move {
+                    let attempt = flush_count.fetch_add(1, Ordering::SeqCst);
+                    if attempt == 0 {
+                        flush_entered.notify_one();
+                        first_flush_release.notified().await;
+                    }
+                    ConntrackFlushOutcome::Trusted
+                })
+            }),
+            delete_namespace: Arc::new(move |_| {
+                let delete_count = Arc::clone(&delete_count_for_ops);
+                Box::pin(async move {
+                    delete_count.fetch_add(1, Ordering::SeqCst);
+                    NamespaceDeleteOutcome::Deleted
+                })
+            }),
+        };
+        let mut lease = Some(pool.checkout(test_info("test-ns")).unwrap());
+
+        {
+            let release = pool.release(&mut lease);
+            tokio::pin!(release);
+            tokio::select! {
+                result = &mut release => panic!("release completed before flush was cancelled: {result:?}"),
+                _ = flush_entered.notified() => {}
+            }
+        }
+
+        assert!(lease.is_some());
+        assert_eq!(flush_count.load(Ordering::SeqCst), 1);
+        assert!(pool.non_reusable.contains("test-ns"));
+
+        first_flush_release.notify_one();
+        pool.release(&mut lease).await.unwrap();
+
+        assert!(lease.is_none());
+        assert_eq!(
+            flush_count.load(Ordering::SeqCst),
+            1,
+            "direct cancelled flush must taint the namespace before retry"
+        );
+        assert_eq!(delete_count.load(Ordering::SeqCst), 1);
+        assert!(pool.non_reusable.is_empty());
+        assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
     async fn untrusted_conntrack_flush_deletes_without_requeue() {
         let delete_count = Arc::new(AtomicUsize::new(0));
         let mut pool = NetnsPool::inactive_for_test();

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -2292,6 +2292,24 @@ mod tests {
     }
 
     #[test]
+    fn conntrack_flush_does_not_trust_uncertain_command_failures() {
+        for outcome in [
+            IgnoredCommandOutcome::SpawnError,
+            IgnoredCommandOutcome::WaitError,
+            IgnoredCommandOutcome::PipeError,
+        ] {
+            assert!(
+                !conntrack_flush_is_trusted(outcome, IgnoredCommandOutcome::Success),
+                "trusted left-side outcome: {outcome:?}"
+            );
+            assert!(
+                !conntrack_flush_is_trusted(IgnoredCommandOutcome::Success, outcome),
+                "trusted right-side outcome: {outcome:?}"
+            );
+        }
+    }
+
+    #[test]
     fn generate_veth_ip_pair_no_overlap_all_pools() {
         let mut seen = std::collections::HashSet::new();
         for pool in 0..MAX_POOLS {
@@ -2584,6 +2602,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shared_release_deletes_when_cleanup_races_after_flush_started() {
+        let flush_entered = Arc::new(tokio::sync::Notify::new());
+        let flush_release = Arc::new(tokio::sync::Notify::new());
+        let delete_count = Arc::new(AtomicUsize::new(0));
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let flush_entered_for_ops = Arc::clone(&flush_entered);
+        let flush_release_for_ops = Arc::clone(&flush_release);
+        let delete_count_for_ops = Arc::clone(&delete_count);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(move |_| {
+                let flush_entered = Arc::clone(&flush_entered_for_ops);
+                let flush_release = Arc::clone(&flush_release_for_ops);
+                Box::pin(async move {
+                    flush_entered.notify_one();
+                    flush_release.notified().await;
+                    ConntrackFlushOutcome::Trusted
+                })
+            }),
+            delete_namespace: Arc::new(move |_| {
+                let delete_count = Arc::clone(&delete_count_for_ops);
+                Box::pin(async move {
+                    delete_count.fetch_add(1, Ordering::SeqCst);
+                    NamespaceDeleteOutcome::Deleted
+                })
+            }),
+        };
+        let lease = Some(pool.checkout(test_info("test-ns")).unwrap());
+        let handle = NetnsPoolHandle::new_for_test(pool);
+
+        let release_task = tokio::spawn({
+            let handle = handle.clone();
+            async move {
+                let mut lease = lease;
+                let outcome = handle.release(&mut lease).await;
+                (outcome, lease)
+            }
+        });
+        flush_entered.notified().await;
+
+        handle.cleanup().await.unwrap();
+        flush_release.notify_one();
+        let (outcome, lease) = release_task.await.unwrap();
+
+        assert!(matches!(outcome, NetnsReleaseOutcome::Deleted));
+        assert!(lease.is_none());
+        assert_eq!(delete_count.load(Ordering::SeqCst), 1);
+        let pool = handle.inner.lock().await;
+        assert!(!pool.active);
+        assert!(pool.in_flight.is_empty());
+        assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
     async fn untrusted_conntrack_flush_deletes_without_requeue() {
         let delete_count = Arc::new(AtomicUsize::new(0));
         let mut pool = NetnsPool::inactive_for_test();
@@ -2721,6 +2793,57 @@ mod tests {
         cleanup.await.unwrap().unwrap();
         let pool = handle.inner.lock().await;
         assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn shared_cleanup_retry_keeps_queue_when_cancelled_during_delete() {
+        let delete_entered = Arc::new(tokio::sync::Notify::new());
+        let delete_release = Arc::new(tokio::sync::Notify::new());
+        let delete_count = Arc::new(AtomicUsize::new(0));
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        pool.plain_queue.push_back(test_info("test-ns"));
+        let delete_entered_for_ops = Arc::clone(&delete_entered);
+        let delete_release_for_ops = Arc::clone(&delete_release);
+        let delete_count_for_ops = Arc::clone(&delete_count);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(|_| Box::pin(async { ConntrackFlushOutcome::Trusted })),
+            delete_namespace: Arc::new(move |_| {
+                let delete_entered = Arc::clone(&delete_entered_for_ops);
+                let delete_release = Arc::clone(&delete_release_for_ops);
+                let delete_count = Arc::clone(&delete_count_for_ops);
+                Box::pin(async move {
+                    let attempt = delete_count.fetch_add(1, Ordering::SeqCst);
+                    delete_entered.notify_one();
+                    if attempt == 0 {
+                        delete_release.notified().await;
+                    }
+                    NamespaceDeleteOutcome::Deleted
+                })
+            }),
+        };
+        let handle = NetnsPoolHandle::new_for_test(pool);
+
+        let cleanup = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.cleanup().await }
+        });
+        delete_entered.notified().await;
+        cleanup.abort();
+        let _ = cleanup.await;
+
+        {
+            let pool = handle.inner.lock().await;
+            assert!(!pool.active);
+            assert_eq!(pool.plain_queue.len(), 1);
+            assert_eq!(pool.plain_queue.front().unwrap().name(), "test-ns");
+        }
+
+        delete_release.notify_one();
+        handle.cleanup().await.unwrap();
+        let pool = handle.inner.lock().await;
+        assert!(pool.plain_queue.is_empty());
+        assert_eq!(delete_count.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -1505,6 +1505,9 @@ impl NetnsPool {
             Ok(plan) => plan,
             Err(message) => return NetnsReleaseOutcome::InvalidLease(message),
         };
+        if plan.active_at_prepare {
+            self.mark_non_reusable(&plan);
+        }
 
         let can_requeue = if plan.active_at_prepare {
             (plan.ops.flush_conntrack)(plan.info.peer_ip.clone())
@@ -1516,9 +1519,6 @@ impl NetnsPool {
 
         if can_requeue && self.active {
             return self.commit_release_requeue(lease, &plan);
-        }
-        if plan.active_at_prepare {
-            self.mark_non_reusable(&plan);
         }
 
         let delete = (plan.ops.delete_namespace)(plan.info.clone()).await;
@@ -1832,11 +1832,15 @@ impl NetnsPoolHandle {
 
     pub(crate) async fn release(&self, lease: &mut Option<NetnsLease>) -> NetnsReleaseOutcome {
         let plan = {
-            let pool = self.inner.lock().await;
-            match pool.prepare_release(lease) {
+            let mut pool = self.inner.lock().await;
+            let plan = match pool.prepare_release(lease) {
                 Ok(plan) => plan,
                 Err(message) => return NetnsReleaseOutcome::InvalidLease(message),
+            };
+            if plan.active_at_prepare {
+                pool.mark_non_reusable(&plan);
             }
+            plan
         };
 
         let can_requeue = if plan.active_at_prepare {
@@ -1854,9 +1858,6 @@ impl NetnsPoolHandle {
                     return pool.commit_release_requeue(lease, &plan);
                 }
             }
-        } else if plan.active_at_prepare {
-            let mut pool = self.inner.lock().await;
-            pool.mark_non_reusable(&plan);
         }
 
         let delete = (plan.ops.delete_namespace)(plan.info.clone()).await;
@@ -2652,6 +2653,75 @@ mod tests {
         let pool = handle.inner.lock().await;
         assert!(!pool.active);
         assert!(pool.in_flight.is_empty());
+        assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancelled_release_during_flush_marks_namespace_non_reusable_for_retry() {
+        let flush_entered = Arc::new(tokio::sync::Notify::new());
+        let first_flush_release = Arc::new(tokio::sync::Notify::new());
+        let flush_count = Arc::new(AtomicUsize::new(0));
+        let delete_count = Arc::new(AtomicUsize::new(0));
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let flush_entered_for_ops = Arc::clone(&flush_entered);
+        let first_flush_release_for_ops = Arc::clone(&first_flush_release);
+        let flush_count_for_ops = Arc::clone(&flush_count);
+        let delete_count_for_ops = Arc::clone(&delete_count);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(move |_| {
+                let flush_entered = Arc::clone(&flush_entered_for_ops);
+                let first_flush_release = Arc::clone(&first_flush_release_for_ops);
+                let flush_count = Arc::clone(&flush_count_for_ops);
+                Box::pin(async move {
+                    let attempt = flush_count.fetch_add(1, Ordering::SeqCst);
+                    if attempt == 0 {
+                        flush_entered.notify_one();
+                        first_flush_release.notified().await;
+                    }
+                    ConntrackFlushOutcome::Trusted
+                })
+            }),
+            delete_namespace: Arc::new(move |_| {
+                let delete_count = Arc::clone(&delete_count_for_ops);
+                Box::pin(async move {
+                    delete_count.fetch_add(1, Ordering::SeqCst);
+                    NamespaceDeleteOutcome::Deleted
+                })
+            }),
+        };
+        let mut lease = Some(pool.checkout(test_info("test-ns")).unwrap());
+        let handle = NetnsPoolHandle::new_for_test(pool);
+
+        {
+            let release = handle.release(&mut lease);
+            tokio::pin!(release);
+            tokio::select! {
+                outcome = &mut release => panic!("release completed before flush was cancelled: {outcome:?}"),
+                _ = flush_entered.notified() => {}
+            }
+        }
+
+        assert!(lease.is_some());
+        assert_eq!(flush_count.load(Ordering::SeqCst), 1);
+        {
+            let pool = handle.inner.lock().await;
+            assert!(pool.non_reusable.contains("test-ns"));
+        }
+
+        first_flush_release.notify_one();
+        let outcome = handle.release(&mut lease).await;
+
+        assert!(matches!(outcome, NetnsReleaseOutcome::Deleted));
+        assert!(lease.is_none());
+        assert_eq!(
+            flush_count.load(Ordering::SeqCst),
+            1,
+            "cancelled flush must taint the namespace before retry"
+        );
+        assert_eq!(delete_count.load(Ordering::SeqCst), 1);
+        let pool = handle.inner.lock().await;
+        assert!(pool.non_reusable.is_empty());
         assert!(pool.plain_queue.is_empty());
     }
 

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -1155,63 +1155,8 @@ impl NetnsPool {
         // `reconcile_orphan_namespaces` above MUST have finished
         // synchronously — otherwise `vm0-ns-{own}-00` may still exist from
         // a previous runner and `ip netns add` will fail with EEXIST.
-        if BUFFER_SIZE > 0 {
-            let mut plain_set = tokio::task::JoinSet::new();
-            let mut proxy_set = tokio::task::JoinSet::new();
-
-            // Plain namespaces (connectivity only). Only needed when proxy
-            // is disabled; with proxy configured, `acquire()` always routes
-            // to the proxy queue, so plain entries would be unreachable
-            // until `cleanup()`.
-            if pool.proxy_port.is_none() {
-                for _ in 0..BUFFER_SIZE {
-                    let ns_index = pool.next_ns_index;
-                    pool.next_ns_index += 1;
-                    let pool_index = pool.pool_index;
-                    let default_iface = pool.default_iface.clone();
-                    plain_set.spawn(create_single_namespace(
-                        pool_index,
-                        ns_index,
-                        default_iface,
-                        None,
-                        None,
-                    ));
-                }
-            }
-
-            // Proxy namespaces (connectivity + REDIRECT rules).
-            if let Some(proxy_port) = pool.proxy_port {
-                let dns_port = pool.dns_port;
-                for _ in 0..BUFFER_SIZE {
-                    let ns_index = pool.next_ns_index;
-                    pool.next_ns_index += 1;
-                    let pool_index = pool.pool_index;
-                    let default_iface = pool.default_iface.clone();
-                    proxy_set.spawn(create_single_namespace(
-                        pool_index,
-                        ns_index,
-                        default_iface,
-                        Some(proxy_port),
-                        dns_port,
-                    ));
-                }
-            }
-
-            while let Some(result) = plain_set.join_next().await {
-                match result {
-                    Ok(Ok(ns)) => pool.plain_queue.push_back(ns),
-                    Ok(Err(e)) => error!(error = %e, "failed to create namespace"),
-                    Err(e) => error!(error = %e, "namespace creation task panicked"),
-                }
-            }
-            while let Some(result) = proxy_set.join_next().await {
-                match result {
-                    Ok(Ok(ns)) => pool.proxy_queue.push_back(ns),
-                    Ok(Err(e)) => error!(error = %e, "failed to create proxy namespace"),
-                    Err(e) => error!(error = %e, "proxy namespace creation task panicked"),
-                }
-            }
-        }
+        pool.spawn_initial_warmup();
+        pool.drain_initial_warmup().await;
 
         info!(
             plain = pool.plain_queue.len(),
@@ -1277,6 +1222,61 @@ impl NetnsPool {
 
     fn spawn_proxy_creation(&mut self) -> Result<()> {
         self.spawn_creation(PendingKind::Proxy)
+    }
+
+    fn spawn_initial_warmup(&mut self) {
+        if BUFFER_SIZE == 0 {
+            return;
+        }
+
+        // Plain namespaces (connectivity only). Only needed when proxy
+        // is disabled; with proxy configured, `acquire()` always routes
+        // to the proxy queue, so plain entries would be unreachable
+        // until `cleanup()`.
+        if self.proxy_port.is_none() {
+            for _ in 0..BUFFER_SIZE {
+                if let Err(e) = self.spawn_plain_creation() {
+                    warn!(error = %e, "failed to start initial namespace creation");
+                    break;
+                }
+            }
+        }
+
+        // Proxy namespaces (connectivity + REDIRECT rules).
+        if self.proxy_port.is_some() {
+            for _ in 0..BUFFER_SIZE {
+                if let Err(e) = self.spawn_proxy_creation() {
+                    warn!(error = %e, "failed to start initial proxy namespace creation");
+                    break;
+                }
+            }
+        }
+    }
+
+    async fn drain_initial_warmup(&mut self) {
+        loop {
+            let mut waiter = if self.pending_plain.is_empty() && self.pending_proxy.is_empty() {
+                None
+            } else {
+                Some(self.completion_wake_tx.subscribe())
+            };
+
+            let delete = self.drain_completed(true);
+            if !delete.is_empty() {
+                delete_namespaces_with_ops(self.ops.clone(), delete).await;
+            }
+            if self.pending_plain.is_empty() && self.pending_proxy.is_empty() {
+                return;
+            }
+
+            let Some(waiter) = waiter.as_mut() else {
+                continue;
+            };
+            if waiter.changed().await.is_err() {
+                warn!("namespace creation notifier closed during initial warmup");
+                return;
+            }
+        }
     }
 
     fn spawn_creation(&mut self, kind: PendingKind) -> Result<()> {
@@ -2506,6 +2506,42 @@ mod tests {
             .await;
 
         assert_eq!(deleted.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn dropped_pool_deletes_late_pending_creation() {
+        let release = Arc::new(tokio::sync::Notify::new());
+        let deleted = Arc::new(AtomicUsize::new(0));
+        let mut pool = NetnsPool::inactive_for_test();
+        let deleted_for_ops = Arc::clone(&deleted);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(|_| Box::pin(async { ConntrackFlushOutcome::Trusted })),
+            delete_namespace: Arc::new(move |_| {
+                let deleted = Arc::clone(&deleted_for_ops);
+                Box::pin(async move {
+                    deleted.fetch_add(1, Ordering::SeqCst);
+                    NamespaceDeleteOutcome::Deleted
+                })
+            }),
+        };
+        pool.spawn_plain_creation_for_test({
+            let release = Arc::clone(&release);
+            async move {
+                release.notified().await;
+                Ok(test_info("late-ns"))
+            }
+        });
+
+        drop(pool);
+        release.notify_one();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while deleted.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("late pending namespace should be deleted after pool drop");
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -45,7 +45,7 @@ use std::fs::File;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 use nix::fcntl::{Flock, FlockArg};
@@ -82,6 +82,7 @@ const MAX_NAMESPACES: u32 = 256;
 const BUFFER_SIZE: usize = 4;
 /// Maximum time for host commands that create, reset, or delete netns state.
 const NETNS_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+static CONNTRACK_NOT_FOUND_LOGGED: AtomicBool = AtomicBool::new(false);
 
 // Compile-time check: all /30 subnets fit within `10.200.0.0/16`.
 // 64 pools × 256 ns × 4 addresses per /30 = 65536 = exactly 2^16.
@@ -903,7 +904,15 @@ async fn flush_conntrack(peer_ip: &str) -> ConntrackFlushOutcome {
         exec_ignore_errors_with_timeout("conntrack", &src_args, NETNS_COMMAND_TIMEOUT),
         exec_ignore_errors_with_timeout("conntrack", &dst_args, NETNS_COMMAND_TIMEOUT),
     );
-    if src.completed_without_timeout() && dst.completed_without_timeout() {
+    if conntrack_flush_is_trusted(src, dst) {
+        if conntrack_command_missing(src, dst)
+            && !CONNTRACK_NOT_FOUND_LOGGED.swap(true, Ordering::Relaxed)
+        {
+            warn!(
+                peer_ip,
+                "conntrack command not found; reusing namespace without conntrack flush"
+            );
+        }
         ConntrackFlushOutcome::Trusted
     } else {
         warn!(
@@ -914,6 +923,21 @@ async fn flush_conntrack(peer_ip: &str) -> ConntrackFlushOutcome {
         );
         ConntrackFlushOutcome::Untrusted
     }
+}
+
+fn conntrack_flush_is_trusted(src: IgnoredCommandOutcome, dst: IgnoredCommandOutcome) -> bool {
+    (src.completed_without_timeout() && dst.completed_without_timeout())
+        || conntrack_command_missing(src, dst)
+}
+
+fn conntrack_command_missing(src: IgnoredCommandOutcome, dst: IgnoredCommandOutcome) -> bool {
+    matches!(
+        (src, dst),
+        (
+            IgnoredCommandOutcome::NotFound,
+            IgnoredCommandOutcome::NotFound
+        )
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -2237,6 +2261,34 @@ mod tests {
         assert_eq!(pi, "05");
         assert_eq!(ni, "2a");
         assert_eq!(make_host_device(pi, ni), "vm0-ve-05-2a");
+    }
+
+    #[test]
+    fn conntrack_flush_trusts_completed_deletes() {
+        assert!(conntrack_flush_is_trusted(
+            IgnoredCommandOutcome::Success,
+            IgnoredCommandOutcome::NonZero
+        ));
+    }
+
+    #[test]
+    fn conntrack_flush_trusts_missing_optional_command() {
+        assert!(conntrack_flush_is_trusted(
+            IgnoredCommandOutcome::NotFound,
+            IgnoredCommandOutcome::NotFound
+        ));
+    }
+
+    #[test]
+    fn conntrack_flush_does_not_trust_timeout_or_partial_missing_command() {
+        assert!(!conntrack_flush_is_trusted(
+            IgnoredCommandOutcome::Timeout,
+            IgnoredCommandOutcome::Success
+        ));
+        assert!(!conntrack_flush_is_trusted(
+            IgnoredCommandOutcome::NotFound,
+            IgnoredCommandOutcome::Success
+        ));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -2762,6 +2762,77 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn release_cancelled_after_trusted_flush_before_commit_deletes_on_retry() {
+        let flush_entered = Arc::new(tokio::sync::Notify::new());
+        let first_flush_release = Arc::new(tokio::sync::Notify::new());
+        let flush_count = Arc::new(AtomicUsize::new(0));
+        let delete_count = Arc::new(AtomicUsize::new(0));
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let flush_entered_for_ops = Arc::clone(&flush_entered);
+        let first_flush_release_for_ops = Arc::clone(&first_flush_release);
+        let flush_count_for_ops = Arc::clone(&flush_count);
+        let delete_count_for_ops = Arc::clone(&delete_count);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(move |_| {
+                let flush_entered = Arc::clone(&flush_entered_for_ops);
+                let first_flush_release = Arc::clone(&first_flush_release_for_ops);
+                let flush_count = Arc::clone(&flush_count_for_ops);
+                Box::pin(async move {
+                    let attempt = flush_count.fetch_add(1, Ordering::SeqCst);
+                    if attempt == 0 {
+                        flush_entered.notify_one();
+                        first_flush_release.notified().await;
+                    }
+                    ConntrackFlushOutcome::Trusted
+                })
+            }),
+            delete_namespace: Arc::new(move |_| {
+                let delete_count = Arc::clone(&delete_count_for_ops);
+                Box::pin(async move {
+                    delete_count.fetch_add(1, Ordering::SeqCst);
+                    NamespaceDeleteOutcome::Deleted
+                })
+            }),
+        };
+        let mut lease = Some(pool.checkout(test_info("test-ns")).unwrap());
+        let handle = NetnsPoolHandle::new_for_test(pool);
+
+        let mut release = Box::pin(handle.release(&mut lease));
+        tokio::select! {
+            outcome = &mut release => panic!("release completed before flush finished: {outcome:?}"),
+            _ = flush_entered.notified() => {}
+        }
+        let guard = handle.inner.lock().await;
+        first_flush_release.notify_one();
+        tokio::select! {
+            outcome = &mut release => panic!("release completed while pool lock was held: {outcome:?}"),
+            _ = tokio::task::yield_now() => {}
+        }
+        assert!(guard.non_reusable.contains("test-ns"));
+        drop(release);
+
+        assert!(lease.is_some());
+        assert_eq!(flush_count.load(Ordering::SeqCst), 1);
+        drop(guard);
+
+        let outcome = handle.release(&mut lease).await;
+
+        assert!(matches!(outcome, NetnsReleaseOutcome::Deleted));
+        assert!(lease.is_none());
+        assert_eq!(
+            flush_count.load(Ordering::SeqCst),
+            1,
+            "cancelled post-flush commit must not flush/requeue on retry"
+        );
+        assert_eq!(delete_count.load(Ordering::SeqCst), 1);
+        let pool = handle.inner.lock().await;
+        assert!(pool.non_reusable.is_empty());
+        assert!(pool.in_flight.is_empty());
+        assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
     async fn direct_release_cancelled_during_flush_marks_namespace_non_reusable_for_retry() {
         let flush_entered = Arc::new(tokio::sync::Notify::new());
         let first_flush_release = Arc::new(tokio::sync::Notify::new());
@@ -2920,6 +2991,78 @@ mod tests {
         assert_eq!(delete_count.load(Ordering::SeqCst), 2);
         let pool = handle.inner.lock().await;
         assert!(pool.non_reusable.is_empty());
+        assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn release_cancelled_after_delete_before_commit_retries_delete_without_flush() {
+        let delete_entered = Arc::new(tokio::sync::Notify::new());
+        let first_delete_release = Arc::new(tokio::sync::Notify::new());
+        let flush_count = Arc::new(AtomicUsize::new(0));
+        let delete_count = Arc::new(AtomicUsize::new(0));
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let flush_count_for_ops = Arc::clone(&flush_count);
+        let delete_count_for_ops = Arc::clone(&delete_count);
+        let delete_entered_for_ops = Arc::clone(&delete_entered);
+        let first_delete_release_for_ops = Arc::clone(&first_delete_release);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(move |_| {
+                let flush_count = Arc::clone(&flush_count_for_ops);
+                Box::pin(async move {
+                    flush_count.fetch_add(1, Ordering::SeqCst);
+                    ConntrackFlushOutcome::Untrusted
+                })
+            }),
+            delete_namespace: Arc::new(move |_| {
+                let delete_count = Arc::clone(&delete_count_for_ops);
+                let delete_entered = Arc::clone(&delete_entered_for_ops);
+                let first_delete_release = Arc::clone(&first_delete_release_for_ops);
+                Box::pin(async move {
+                    let attempt = delete_count.fetch_add(1, Ordering::SeqCst);
+                    if attempt == 0 {
+                        delete_entered.notify_one();
+                        first_delete_release.notified().await;
+                    }
+                    NamespaceDeleteOutcome::Deleted
+                })
+            }),
+        };
+        let mut lease = Some(pool.checkout(test_info("test-ns")).unwrap());
+        let handle = NetnsPoolHandle::new_for_test(pool);
+
+        let mut release = Box::pin(handle.release(&mut lease));
+        tokio::select! {
+            outcome = &mut release => panic!("release completed before delete finished: {outcome:?}"),
+            _ = delete_entered.notified() => {}
+        }
+        let guard = handle.inner.lock().await;
+        first_delete_release.notify_one();
+        tokio::select! {
+            outcome = &mut release => panic!("release completed while pool lock was held: {outcome:?}"),
+            _ = tokio::task::yield_now() => {}
+        }
+        assert!(guard.non_reusable.contains("test-ns"));
+        drop(release);
+
+        assert!(lease.is_some());
+        assert_eq!(flush_count.load(Ordering::SeqCst), 1);
+        assert_eq!(delete_count.load(Ordering::SeqCst), 1);
+        drop(guard);
+
+        let outcome = handle.release(&mut lease).await;
+
+        assert!(matches!(outcome, NetnsReleaseOutcome::Deleted));
+        assert!(lease.is_none());
+        assert_eq!(
+            flush_count.load(Ordering::SeqCst),
+            1,
+            "tainted post-delete retry must not flush/requeue"
+        );
+        assert_eq!(delete_count.load(Ordering::SeqCst), 2);
+        let pool = handle.inner.lock().await;
+        assert!(pool.non_reusable.is_empty());
+        assert!(pool.in_flight.is_empty());
         assert!(pool.plain_queue.is_empty());
     }
 

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -1727,24 +1727,24 @@ impl NetnsPool {
             );
         }
 
-        self.drain_completed(true);
+        let mut namespaces = self.drain_completed(true);
         let mut wait_for_pending = if self.pending_plain.is_empty() && self.pending_proxy.is_empty()
         {
             None
         } else {
             Some(self.completion_wake_tx.subscribe())
         };
-        self.drain_completed(true);
+        namespaces.extend(self.drain_completed(true));
         if self.pending_plain.is_empty() && self.pending_proxy.is_empty() {
             wait_for_pending = None;
         }
 
-        let namespaces = self
-            .plain_queue
-            .iter()
-            .chain(self.proxy_queue.iter())
-            .cloned()
-            .collect::<Vec<_>>();
+        namespaces.extend(
+            self.plain_queue
+                .iter()
+                .chain(self.proxy_queue.iter())
+                .cloned(),
+        );
         CleanupPlan {
             done: namespaces.is_empty() && wait_for_pending.is_none(),
             namespaces,
@@ -2506,6 +2506,37 @@ mod tests {
             .await;
 
         assert_eq!(deleted.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cleanup_deletes_unknown_completed_namespace() {
+        let deleted = Arc::new(AtomicUsize::new(0));
+        let mut pool = NetnsPool::inactive_for_test();
+        pool.active = true;
+        let deleted_for_ops = Arc::clone(&deleted);
+        pool.ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(|_| Box::pin(async { ConntrackFlushOutcome::Trusted })),
+            delete_namespace: Arc::new(move |_| {
+                let deleted = Arc::clone(&deleted_for_ops);
+                Box::pin(async move {
+                    deleted.fetch_add(1, Ordering::SeqCst);
+                    NamespaceDeleteOutcome::Deleted
+                })
+            }),
+        };
+        pool.completion_tx
+            .send(CreationCompletion {
+                id: PendingId(999),
+                kind: PendingKind::Plain,
+                result: Ok(test_info("unknown-ns")),
+            })
+            .unwrap();
+
+        pool.cleanup().await.unwrap();
+
+        assert_eq!(deleted.load(Ordering::SeqCst), 1);
+        assert!(pool.plain_queue.is_empty());
+        assert!(pool.proxy_queue.is_empty());
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use tracing::{info, warn};
 
@@ -12,15 +10,15 @@ use nbd_cow::pool::{DevicePoolConfig, DevicePoolHandle};
 
 use crate::config::{FirecrackerConfig, SnapshotConfig};
 use crate::factory::FirecrackerFactory;
-use crate::network::{NetnsPool, NetnsPoolConfig};
+use crate::network::{NetnsPoolConfig, NetnsPoolHandle};
 use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
 
 /// Firecracker-backed sandbox runtime.
 ///
-/// Manages shared resources ([`NetnsPool`], [`DevicePoolHandle`]) and creates
+/// Manages shared resources (`NetnsPoolHandle`, [`DevicePoolHandle`]) and creates
 /// [`FirecrackerFactory`] instances that share them.
 pub struct FirecrackerRuntime {
-    netns_pool: Arc<tokio::sync::Mutex<NetnsPool>>,
+    netns_pool: NetnsPoolHandle,
     device_pool: DevicePoolHandle,
     proxy_port: Option<u16>,
     dns_port: Option<u16>,
@@ -39,12 +37,12 @@ impl FirecrackerRuntime {
             dns_port: config.dns_port,
         }
         .into_checked()?;
-        let netns_pool = NetnsPool::create_checked(netns_config).await.map_err(|e| {
-            SandboxError::Initialization {
+        let netns_pool = NetnsPoolHandle::create_checked(netns_config)
+            .await
+            .map_err(|e| SandboxError::Initialization {
                 phase: SandboxInitializationPhase::Runtime,
                 message: format!("netns pool: {e}"),
-            }
-        })?;
+            })?;
         info!(
             elapsed_ms = t.elapsed().as_millis() as u64,
             "runtime netns pool created"
@@ -59,7 +57,7 @@ impl FirecrackerRuntime {
         );
 
         Ok(Self {
-            netns_pool: Arc::new(tokio::sync::Mutex::new(netns_pool)),
+            netns_pool,
             device_pool,
             proxy_port: config.proxy_port,
             dns_port: config.dns_port,
@@ -104,7 +102,7 @@ impl SandboxRuntime for FirecrackerRuntime {
         let fc_config = self.to_firecracker_config(config);
         let mut factory = FirecrackerFactory::new(
             fc_config,
-            Some(Arc::clone(&self.netns_pool)),
+            Some(self.netns_pool.clone()),
             self.device_pool.clone(),
         )
         .await?;
@@ -114,11 +112,9 @@ impl SandboxRuntime for FirecrackerRuntime {
 
     async fn shutdown(&mut self) {
         // Clean up shared netns pool.
-        let mut pool = self.netns_pool.lock().await;
-        if let Err(e) = pool.cleanup().await {
+        if let Err(e) = self.netns_pool.cleanup().await {
             warn!(error = %e, "failed to cleanup shared netns pool");
         }
-        drop(pool);
 
         // Clean up shared device pool.
         self.device_pool.cleanup().await;


### PR DESCRIPTION
## Summary
- Introduce `NetnsPoolHandle` for shared factory/runtime netns pools so acquire/release/cleanup no longer await while holding the shared mutex.
- Replace shared pending creation `JoinSet` waits with `PendingId` completion events plus generation wakeups, preserving cancellation ownership and panic accounting.
- Add timeout-aware netns lifecycle command helpers and explicit release outcomes so untrusted conntrack/delete paths do not requeue unsafe namespaces.

Closes #11590

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets`
- pre-commit `crates` hook (fmt, clippy, doc)