### PR TITLE
fix(zero): drop residual framework strict-equality check (#11616)

### DIFF
--- a/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
+++ b/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
@@ -33,16 +33,12 @@ setup_file() {
     # 2. Org-level openai-api-key provider — picked up as default by eager-pin
     $ZERO_CLI org model-provider setup --type "openai-api-key" --secret "$OPENAI_API_KEY" >/dev/null
 
-    # 3. Compose declares framework: codex (required by agentDefinitionSchema
-    # in turbo/packages/api-contracts/src/contracts/composes.ts:169). No
-    # `model_provider:` is declared — the org's only provider is the
-    # openai-api-key one set up in step (2), so eager-pin (#11528) is the
-    # path that wires the thread to that provider. The framework is matched
-    # both at admission (zero-run-policy.ts:213-238 calls
-    # getOrgDefaultModelProvider(orgId, composeFramework)) and at secret
-    # resolution (resolve-model-provider.ts:77-83 enforces
-    # providerFramework === composeFramework strictly), so a mismatched
-    # compose framework would fail with noModelProvider() or badRequest().
+    # 3. Compose declares framework: codex explicitly. The framework is
+    # matched at admission (zero-run-policy.ts:213-238 calls
+    # getOrgDefaultModelProvider(orgId, composeFramework)). At secret
+    # resolution the provider's declared framework wins (Epic #11520) and
+    # is propagated downstream via build-zero-context.ts's
+    # resolvedFramework, with no compose-vs-provider equality check.
     cat > "$TEST_DIR/vm0-basic.yaml" <<EOF
 version: "1.0"
 agents:

--- a/turbo/apps/web/src/lib/zero/context/__tests__/resolve-model-provider.test.ts
+++ b/turbo/apps/web/src/lib/zero/context/__tests__/resolve-model-provider.test.ts
@@ -6,6 +6,7 @@ import {
   createTestOrg,
   insertOrgDefaultModelProvider,
 } from "../../../../__tests__/api-test-helpers";
+import { getTestModelProviderIdByType } from "../../../../__tests__/db-test-assertions/org";
 import { mockClerk } from "../../../../__tests__/clerk-mock";
 
 const context = testContext();
@@ -82,5 +83,30 @@ describe("resolveModelProviderSecrets — framework gate removed (#11526)", () =
 
     expect(result.resolvedModelProvider).toBe("anthropic-api-key");
     expect(result.framework).toBe("claude-code");
+  });
+
+  it("provider's framework wins when modelProviderId pin disagrees with compose framework (#11616)", async () => {
+    // Production-shaped path: compose declares (or defaults to) framework:
+    // claude-code, but the thread is eager-pinned (#11528) to a modelProviderId
+    // for an openai-api-key provider whose declared framework is codex. Per
+    // Epic #11520 the provider's framework must win — no throw.
+    const userId = uniqueId("eager-pin-codex");
+    const orgId = await setupOrg(userId);
+    await insertOrgDefaultModelProvider(orgId, "openai-api-key");
+    const modelProviderId = await getTestModelProviderIdByType(
+      orgId,
+      "openai-api-key",
+    );
+
+    const result = await resolveModelProviderSecrets(
+      orgId,
+      "claude-code",
+      false,
+      undefined,
+      modelProviderId,
+    );
+
+    expect(result.resolvedModelProvider).toBe("openai-api-key");
+    expect(result.framework).toBe("codex");
   });
 });

--- a/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
@@ -55,7 +55,6 @@ export const MODEL_PROVIDER_ENV_VARS = [
  * Single DB query: caller passes the already-fetched defaultProvider.
  */
 function resolveProviderType(
-  framework: string,
   defaultProvider: Awaited<ReturnType<typeof getOrgDefaultModelProvider>>,
   explicitModelProvider?: string,
 ): ModelProviderType {
@@ -72,14 +71,6 @@ function resolveProviderType(
     providerType = defaultProvider.type;
   } else {
     throw noModelProvider();
-  }
-
-  const providerFramework = getFrameworkForType(providerType);
-  if (providerFramework !== framework) {
-    throw badRequest(
-      `Model provider "${providerType}" is not compatible with framework "${framework}". ` +
-        `This provider is for "${providerFramework}" agents.`,
-    );
   }
 
   return providerType;
@@ -313,7 +304,6 @@ export async function resolveModelProviderSecrets(
   const secretUserId = ORG_SENTINEL_USER_ID;
 
   const providerType = resolveProviderType(
-    framework,
     defaultProvider,
     explicitModelProvider,
   );


### PR DESCRIPTION
## Summary

- Removes the residual provider/compose framework strict-equality throw inside `resolveProviderType`. Provider's declared framework already wins downstream via `modelProviderResult.framework` + `build-zero-context.ts`'s `resolvedFramework`, so the gate contradicted Epic #11520's design intent.
- Cleans up the now-unused `framework` parameter on `resolveProviderType` and updates its single caller.
- Adds a vitest case asserting eager-pin (codex provider, claude-code compose) yields `framework: "codex"` instead of throwing — locks in the regression covered by issue #11616.
- Updates the obsolete comment in `t-codex-zero-byok-smoke.bats` that referenced the deleted check.

Closes #11616

## Test plan

- [x] `pnpm -F web exec vitest run src/lib/zero/context/__tests__/resolve-model-provider.test.ts` — 5/5 pass
- [x] `pnpm -F web exec vitest run src/lib/zero/context src/lib/infra/run/utils` — 19/19 pass
- [x] `pnpm turbo run lint` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — clean
- [x] `pnpm knip` — no issues

## Rollback

Revert either or both commits independently. The fix commit (`88ddf1b5e`) is safe to revert on its own; the test commit (`62588ac29`) would then fail and clearly mark the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)