### PR TITLE
fix: remove broken wall-clock animation sync from RunningIndicator

### DIFF
--- a/turbo/packages/ui/src/components/ui/running-indicator.tsx
+++ b/turbo/packages/ui/src/components/ui/running-indicator.tsx
@@ -1,7 +1,5 @@
-import { useLayoutEffect, useRef, type HTMLAttributes } from "react";
+import { type HTMLAttributes } from "react";
 import { cn } from "../../lib/utils";
-
-const RUNNING_INDICATOR_DURATION_MS = 2400;
 
 interface RunningIndicatorProps extends HTMLAttributes<HTMLSpanElement> {
   label?: string;
@@ -12,24 +10,8 @@ function RunningIndicator({
   label = "Running",
   ...rest
 }: RunningIndicatorProps) {
-  const ref = useRef<HTMLSpanElement | null>(null);
-  useLayoutEffect(() => {
-    const el = ref.current;
-    // getAnimations is unavailable in some non-browser test DOMs (e.g.
-    // happy-dom); skip phase syncing there.
-    if (!el || typeof el.getAnimations !== "function") {
-      return;
-    }
-    // Anchor every indicator's animation phase to wall-clock time, so
-    // instances mounted at different moments stay visually synchronized.
-    const phase = Date.now() % RUNNING_INDICATOR_DURATION_MS;
-    for (const animation of el.getAnimations({ subtree: true })) {
-      animation.currentTime = phase;
-    }
-  }, []);
   return (
     <span
-      ref={ref}
       aria-label={label}
       className={cn("running-indicator", className)}
       {...rest}

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -396,12 +396,7 @@
     background-color: rgba(128, 128, 128, 0.5);
   }
 
-  /*
-   * Running indicator — synchronized breathing dot for "in progress" state.
-   * Phase is anchored to wall-clock time by <RunningIndicator/> via the Web
-   * Animations API (Animation.currentTime), so multiple instances mounted at
-   * different moments stay visually in sync.
-   */
+  /* Running indicator — breathing dot for "in progress" state. */
   .running-indicator {
     position: relative;
     display: inline-flex;


### PR DESCRIPTION
## Summary
- Removes the `useLayoutEffect` wall-clock sync that was causing `RunningIndicator` CSS animations to freeze at dim/invisible frames on remount ("running" state looking like "done")
- The `Animation.currentTime` setter is unreliable on `CSSAnimation` objects targeting pseudo-elements — it can leave animations paused rather than in a playing state

## Root Cause
`useLayoutEffect` fires before the browser starts CSS animations. Writing `currentTime` to an idle `CSSAnimation` frequently leaves it paused — the animation never starts playing. On remount (state flipping away from "running" and back), the animation freezes at a near-invisible frame.

## Changes
- `running-indicator.tsx` — stripped to a pure presentational component (12 lines), no JS sync logic
- `globals.css` — simplified comment, removed the now-incorrect sync description

The CSS `@keyframes` animations now run naturally without JS interference.

## Test plan
- [ ] Running indicator breathes correctly on initial mount
- [ ] Running indicator continues animating through re-renders
- [ ] Running indicator animates correctly after navigating away and back

🤖 Generated with [Claude Code](https://claude.com/claude-code)