### PR TITLE
feat(web): replace sidebar empty state with dashed new-chat ghost row

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -341,9 +341,7 @@ describe("zero sidebar - new chat button creates session (SIDEBAR-D-017)", () =>
     // Wait for the sidebar to finish loading (empty state confirms threads loaded
     // and the default agent id has resolved)
     const newChatButton = await waitFor(() => {
-      expect(
-        screen.getByText("Start a conversation and it'll show up here"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Start a new chat")).toBeInTheDocument();
       return screen.getByLabelText("New chat with Zero");
     });
 

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -318,13 +318,14 @@ function ChatThreads() {
     filteredOptimisticChatThreads.length === 0 &&
     filteredChatThreads.length === 0
   ) {
-    return (
-      <p className="px-2 py-2 text-xs text-muted-foreground/70 leading-relaxed">
-        {trimmedTerm
-          ? "No chats match your search"
-          : "Start a conversation and it'll show up here"}
-      </p>
-    );
+    if (trimmedTerm) {
+      return (
+        <p className="px-2 py-2 text-xs text-muted-foreground/70 leading-relaxed">
+          No chats match your search
+        </p>
+      );
+    }
+    return <NewChatGhostRow />;
   }
   return (
     <>
@@ -369,13 +370,11 @@ function ChatThreads() {
   );
 }
 
-function ChatThreadsTitle() {
+function useNewChat() {
   const currentChatAgentId = useLastResolved(currentChatAgentId$) ?? null;
   const createNewChat = useSet(createNewChatThreadOptimistically$);
   const setExpanded = useSet(setSidebarExpanded$);
   const { signal: rootSignal } = useGet(rootSignal$);
-  const { titleLabel, searchPlaceholder, newChatAriaLabel } =
-    useChatThreadsTitleLabels();
   const newChatDisabled = useGet(optimisticChatThread$) !== null;
   const onNewChat = (pane: OptimisticChatPane) => {
     detach(
@@ -384,6 +383,30 @@ function ChatThreadsTitle() {
     );
     setExpanded(false);
   };
+  return { onNewChat, newChatDisabled };
+}
+
+function NewChatGhostRow() {
+  const { onNewChat, newChatDisabled } = useNewChat();
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        onNewChat(e.altKey ? "sidebar" : "main");
+      }}
+      disabled={newChatDisabled}
+      className="flex h-8 items-center gap-2 rounded-lg border border-dashed border-sidebar-foreground/20 px-2 text-sm text-sidebar-foreground/60 transition-colors hover:border-sidebar-foreground/40 hover:bg-sidebar-accent hover:text-sidebar-foreground disabled:pointer-events-none disabled:opacity-50"
+    >
+      <IconPlus size={14} stroke={2.5} className="shrink-0" />
+      <span className="truncate">Start a new chat</span>
+    </button>
+  );
+}
+
+function ChatThreadsTitle() {
+  const { titleLabel, searchPlaceholder, newChatAriaLabel } =
+    useChatThreadsTitleLabels();
+  const { onNewChat, newChatDisabled } = useNewChat();
   const searchOpen = useGet(threadSearchOpen$);
   const setSearchOpen = useSet(setThreadSearchOpen$);
   const searchTerm = useGet(sidebarSearchTerm$);


### PR DESCRIPTION
## Summary

The "Chats with Zero" sidebar empty state previously rendered a flush-left text hint that looked like a clipped list row and offered no clear CTA — users had to discover the small `+` icon up in the section header.

This PR replaces that text with a dashed ghost row that mirrors a future chat entry and acts as the primary CTA. Clicking it triggers the same new-chat handler the section header `+` already uses (Alt-click still opens in the sidebar pane). When a search filter is active and matches nothing, the original "No chats match your search" message is preserved.

The shared logic between the header `+` and the ghost row was extracted into a small `useNewChat` hook to avoid duplication.

## Design context

Chosen design (Option C) from a four-option mockup set:

![Sidebar empty-state mockups](https://github.com/vm0-ai/vm0/releases/download/web-v12.327.0/sidebar-empty-state-options.png)

## Test plan

- [x] `pnpm -F @vm0/app exec eslint <files>` — clean
- [x] `pnpm -F @vm0/app exec tsc --noEmit` — clean
- [x] `pnpm -F @vm0/app exec vitest run zero-sidebar-interaction zero-chat-list-page` — 26/26 pass
- [ ] Manual: open sidebar with no chats, verify ghost row shows under "Chats with Zero" and click creates a new chat
- [ ] Manual: type a search query that matches nothing, verify "No chats match your search" still renders
- [ ] Manual: verify Alt-click on the ghost row opens the new chat in the sidebar pane