### PR TITLE
fix: stabilize landing nav dropdown clicks

### DIFF
--- a/turbo/apps/web/app/components/NavMenu.tsx
+++ b/turbo/apps/web/app/components/NavMenu.tsx
@@ -23,7 +23,7 @@ interface NavMenuProps {
   onOpenChange: (id: string | null) => void;
 }
 
-const CLOSE_DELAY_MS = 120;
+const CLOSE_DELAY_MS = 250;
 
 export function NavMenu({
   id,

--- a/turbo/apps/web/app/landing.css
+++ b/turbo/apps/web/app/landing.css
@@ -433,6 +433,17 @@ body {
     0 12px 32px -12px rgba(20, 22, 28, 0.16);
 }
 
+/* Invisible hover-bridge over the trigger gap so pointerenter on the
+   popover fires before the close-timer expires. */
+.nav-popover::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -10px;
+  height: 10px;
+}
+
 .nav-popover[data-state="open"] {
   animation: nav-popover-in 0.15s ease-out;
 }


### PR DESCRIPTION
## Summary

Reported by Ming: nav dropdown items on the landing page were sometimes unclickable.

The mega-menu opens on hover but used an 8px `sideOffset` between the trigger and the popover panel, plus a 120ms close-timer driven by `onPointerLeave`. As the pointer crossed the 8px dead-zone moving from "Trust & Tech" / "Resources" toward an item, neither element was hovered — often the close timer fired before the popover's `onPointerEnter` cancelled it, so the popover unmounted mid-click and the link click landed on empty space.

## Changes

- `turbo/apps/web/app/landing.css` — add an invisible `::before` hover-bridge on `.nav-popover` that extends 10px above the panel, covering the trigger gap so `pointerenter` on the popover fires reliably as the cursor passes through.
- `turbo/apps/web/app/components/NavMenu.tsx` — bump `CLOSE_DELAY_MS` from 120 → 250 for a bit more forgiveness on slow pointer movement.

The 8px visual gap is preserved (the bridge is transparent and only used for hit-testing).

## Test plan

- [ ] Open the landing page, hover "Trust & Tech", move cursor at varying speeds to each item — all three (Models / Model Rankings / Security) click reliably.
- [ ] Same for "Resources" dropdown.
- [ ] Move cursor diagonally from trigger to the bottom-most item — popover stays open.
- [ ] Move cursor away from the popover entirely — closes after ~250ms.
- [ ] Mobile menu (no hover) unaffected.