### PR TITLE
fix: add missing display flex to nav-center CSS

### DIFF
--- a/turbo/apps/web/app/landing.css
+++ b/turbo/apps/web/app/landing.css
@@ -335,6 +335,7 @@ body {
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
+  display: flex;
   align-items: center;
   gap: 32px;
 }


### PR DESCRIPTION
## Summary

- Fix navigation links not being clickable after #11610
- Add `display: flex` to `.nav-center` CSS rule

## Root cause

PR #11610 moved the inline `style={{ display: "flex", gap: "32px" }}` from the `<div className="nav-center nav-desktop">` into the `.nav-center` CSS class, but only copied `align-items: center` and `gap: 32px` — **`display: flex` was not included**. The `.nav-desktop` class also sets `display: flex`, but relying on cascading from a separate class for a critical layout property is fragile. Without `display: flex`, the `align-items` and `gap` properties are ignored, and the absolutely-positioned `.nav-center` container collapses, making its child links unclickable.

## Fix

Added `display: flex` to the `.nav-center` CSS rule in `landing.css`.

## Test plan

- [ ] Verify desktop nav links (Use Cases, Resources, Trust & Tech, Pricing) are clickable at >960px viewport
- [ ] Verify hamburger menu works correctly at <=960px viewport
- [ ] Verify dark mode nav links are clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)