### PR TITLE
fix: respect dark mode in rankings table background

### DIFF
--- a/turbo/apps/web/app/[locale]/rankings/page.tsx
+++ b/turbo/apps/web/app/[locale]/rankings/page.tsx
@@ -465,7 +465,7 @@ function RankingTable({
           textAlign: "center",
           border: "1px solid var(--border-light)",
           borderRadius: "16px",
-          background: "white",
+          background: "var(--card-bg)",
           color: "var(--text-secondary)",
           fontSize: "15px",
           fontWeight: 300,
@@ -481,7 +481,7 @@ function RankingTable({
       style={{
         border: "1px solid var(--border-light)",
         borderRadius: "16px",
-        background: "white",
+        background: "var(--card-bg)",
         overflow: "hidden",
       }}
     >
@@ -550,7 +550,7 @@ function RankingTable({
                           height: 36,
                           borderRadius: 10,
                           border: "1px solid var(--border-light)",
-                          background: "white",
+                          background: "var(--card-bg)",
                           display: "flex",
                           alignItems: "center",
                           justifyContent: "center",


### PR DESCRIPTION
## Summary
- The rankings page table card, empty state, and model icon container all hardcoded `background: "white"`, so in dark mode the card stayed white while the surrounding page went dark — and the text inside (which uses `var(--text-primary)` = `#ffffff` in dark mode) became unreadable.
- Replaced with `var(--card-bg)`, which is already defined to switch between `#222222` (dark, default) and `#ffffff` (light).

## Before
The screenshot Ming sent shows the rankings table as a white block in an otherwise dark page, with all text barely visible.

## Test plan
- [ ] Open `/rankings` in dark mode — table card should be dark, text fully legible
- [ ] Open `/rankings` in light mode — appearance unchanged
- [ ] Empty state path renders with the same dark/light treatment

🤖 Generated with [Claude Code](https://claude.com/claude-code)