### PR TITLE
feat(api): add cors middleware for cross-origin browser access

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -119,7 +119,7 @@ runs:
           app_url="${INPUT_APP_URL:-https://app.vm0.ai}"
           api_url="${INPUT_API_URL:-$(repo_var VM0_API_URL)}"
           axiom_dataset_suffix="prod"
-          sentry_env="production"
+          deploy_env="production"
           runner_default_group="vm0/production"
           concurrent_run_limit_cap="10"
           slack_redirect_base_url="$(repo_var SLACK_REDIRECT_BASE_URL)"
@@ -130,7 +130,7 @@ runs:
           app_url="$INPUT_APP_URL"
           api_url="$INPUT_API_URL"
           axiom_dataset_suffix="dev"
-          sentry_env="preview"
+          deploy_env="preview"
           runner_default_group="vm0/development-${INPUT_JOB_REF}"
           concurrent_run_limit_cap="0"
           slack_redirect_base_url="$INPUT_WEB_URL"
@@ -141,7 +141,7 @@ runs:
         add_env VM0_API_URL "$api_url"
         if [[ "$INPUT_APP" == "api" ]]; then
           add_env VM0_WEB_URL "$web_url"
-          add_env SENTRY_ENV "$sentry_env"
+          add_env ENV "$deploy_env"
         fi
         # Inject the workflow head commit explicitly so OTel / Sentry can tag
         # service.version and release on every deploy. Vercel CLI prebuilt

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -344,4 +344,69 @@ describe("createApp", () => {
       expect(response.status).toBe(200);
     });
   });
+
+  describe("cors", () => {
+    it("echoes allowed cross-origin on registered route responses", async () => {
+      mockEnv("ENV", "production");
+      const app = createApp({ signal: context.signal });
+      const response = await app.request("/health", {
+        method: "GET",
+        headers: { origin: "https://app.vm0.ai" },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("access-control-allow-origin")).toBe(
+        "https://app.vm0.ai",
+      );
+      expect(response.headers.get("access-control-allow-credentials")).toBe(
+        "true",
+      );
+    });
+
+    it("answers preflight without invoking the route handler", async () => {
+      mockEnv("ENV", "production");
+      const app = createApp({ signal: context.signal });
+      const response = await app.request("/api/zero/org", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://app.vm0.ai",
+          "access-control-request-method": "GET",
+          "access-control-request-headers": "authorization",
+        },
+      });
+
+      expect(response.status).toBe(204);
+      expect(response.headers.get("access-control-allow-origin")).toBe(
+        "https://app.vm0.ai",
+      );
+      expect(response.headers.get("access-control-allow-methods")).toContain(
+        "GET",
+      );
+    });
+
+    it("rejects disallowed origins by omitting the allow-origin header", async () => {
+      mockEnv("ENV", "production");
+      const app = createApp({ signal: context.signal });
+      const response = await app.request("/health", {
+        method: "GET",
+        headers: { origin: "https://evil.example.com" },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("access-control-allow-origin")).toBe(null);
+    });
+
+    it("allows *.vm7.ai over http only in development", async () => {
+      mockEnv("ENV", "development");
+      const app = createApp({ signal: context.signal });
+      const response = await app.request("/health", {
+        method: "GET",
+        headers: { origin: "https://app.vm7.ai:8443" },
+      });
+
+      expect(response.headers.get("access-control-allow-origin")).toBe(
+        "https://app.vm7.ai:8443",
+      );
+    });
+  });
 });

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -393,7 +393,7 @@ describe("createApp", () => {
       });
 
       expect(response.status).toBe(200);
-      expect(response.headers.get("access-control-allow-origin")).toBe(null);
+      expect(response.headers.get("access-control-allow-origin")).toBeNull();
     });
 
     it("allows *.vm7.ai over http only in development", async () => {

--- a/turbo/apps/api/src/__tests__/env-stub.ts
+++ b/turbo/apps/api/src/__tests__/env-stub.ts
@@ -19,7 +19,7 @@ vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-user-storages");
 vi.stubEnv("VM0_API_URL", "http://localhost:3000");
 vi.stubEnv("VM0_WEB_URL", "http://localhost:3001");
 vi.stubEnv("GIT_COMMIT_SHA", "test-commit-sha");
-vi.stubEnv("SENTRY_ENV", "development");
+vi.stubEnv("ENV", "development");
 vi.stubEnv("AXIOM_TOKEN_SESSIONS", "xaat-test-sessions");
 vi.stubEnv("AXIOM_TOKEN_TELEMETRY", "xaat-test-telemetry");
 vi.stubEnv("AXIOM_DATASET_SUFFIX", "dev");

--- a/turbo/apps/api/src/__tests__/instrument.test.ts
+++ b/turbo/apps/api/src/__tests__/instrument.test.ts
@@ -48,7 +48,7 @@ describe("instrument", () => {
         "SENTRY_DSN",
         "https://examplePublicKey@o0.ingest.sentry.io/0",
       );
-      envModule.mockEnv("SENTRY_ENV", "production");
+      envModule.mockEnv("ENV", "production");
       envModule.mockEnv("GIT_COMMIT_SHA", "abc123");
     });
 

--- a/turbo/apps/api/src/app-factory.ts
+++ b/turbo/apps/api/src/app-factory.ts
@@ -10,6 +10,7 @@ import { Readable } from "node:stream";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { request as undiciRequest, type Dispatcher } from "undici";
 
+import { corsMiddleware } from "./lib/cors";
 import { env } from "./lib/env";
 import { logger } from "./lib/log";
 import { honoSignalHandler } from "./signals/context/route";
@@ -171,6 +172,11 @@ export function createApp({ routes = ROUTES, signal }: CreateAppOptions): Hono {
   // `http.route` for direct slicing without trace_id joins.
   app.use("*", httpInstrumentationMiddleware({ serviceName: "vm0-api" }));
   app.use("*", httpRouteBaggage);
+  // Browser cross-origin requests (e.g. https://app.vm0.ai → api.vm0.ai). Must
+  // run before the route handlers so OPTIONS preflight short-circuits without
+  // matching a registered method, and so registered route responses receive
+  // Access-Control-Allow-Origin without relying on the legacy web proxy.
+  app.use("*", corsMiddleware);
 
   for (const { route, handler } of routes) {
     app.on(route.method, route.path, honoSignalHandler(handler, route, signal));

--- a/turbo/apps/api/src/instrument.ts
+++ b/turbo/apps/api/src/instrument.ts
@@ -39,7 +39,7 @@ function setupSentry() {
 
   init({
     dsn,
-    environment: env("SENTRY_ENV"),
+    environment: env("ENV"),
     initialScope: {
       tags: {
         app: "api",

--- a/turbo/apps/api/src/lib/cors.ts
+++ b/turbo/apps/api/src/lib/cors.ts
@@ -1,0 +1,75 @@
+// oxlint-disable-next-line no-restricted-imports -- this file is the api's
+// CORS owner and wraps hono's cors helper into a single middleware.
+import { cors } from "hono/cors";
+import type { MiddlewareHandler } from "hono";
+
+import { env } from "./env";
+
+// Mirrors apps/web/proxy.cors.ts. Now that /api/zero/* is served by hono
+// directly (not proxied to Next), responses from registered routes need their
+// own CORS headers — the web proxy fallthrough is no longer in the request
+// path for migrated endpoints.
+const STATIC_ALLOWED_ORIGINS: readonly string[] = [
+  "https://www.vm0.ai",
+  "https://vm0.ai",
+];
+
+function getAllowedOrigin(origin: string | undefined): string | null {
+  if (!origin) return null;
+
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch {
+    return null;
+  }
+
+  const normalizedOrigin = url.origin;
+  const { hostname, protocol } = url;
+
+  if (STATIC_ALLOWED_ORIGINS.includes(normalizedOrigin)) {
+    return normalizedOrigin;
+  }
+
+  const deployEnv = env("ENV");
+
+  const allowHttpLocalhost =
+    deployEnv === "development" &&
+    protocol === "http:" &&
+    hostname === "localhost";
+  if (!allowHttpLocalhost && protocol !== "https:") return null;
+
+  if (hostname.endsWith(".vm0.ai")) return normalizedOrigin;
+
+  if (deployEnv === "preview" && hostname.endsWith(".vm6.ai")) {
+    return normalizedOrigin;
+  }
+
+  if (deployEnv === "development") {
+    if (hostname === "localhost") return normalizedOrigin;
+    if (hostname.endsWith(".vm6.ai")) return normalizedOrigin;
+    if (hostname.endsWith(".vm7.ai")) return normalizedOrigin;
+  }
+
+  return null;
+}
+
+export const corsMiddleware: MiddlewareHandler = cors({
+  origin: (origin) => getAllowedOrigin(origin),
+  credentials: true,
+  allowMethods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
+  allowHeaders: [
+    "X-CSRF-Token",
+    "X-Requested-With",
+    "Accept",
+    "Accept-Version",
+    "Content-Length",
+    "Content-MD5",
+    "Content-Type",
+    "Date",
+    "X-Api-Version",
+    "Authorization",
+    "Range",
+  ],
+  maxAge: 86400,
+});

--- a/turbo/apps/api/src/lib/cors.ts
+++ b/turbo/apps/api/src/lib/cors.ts
@@ -3,6 +3,7 @@
 import { cors } from "hono/cors";
 import type { MiddlewareHandler } from "hono";
 
+import { safeUrlParse } from "../signals/utils";
 import { env } from "./env";
 
 // Mirrors apps/web/proxy.cors.ts. Now that /api/zero/* is served by hono
@@ -17,12 +18,8 @@ const STATIC_ALLOWED_ORIGINS: readonly string[] = [
 function getAllowedOrigin(origin: string | undefined): string | null {
   if (!origin) return null;
 
-  let url: URL;
-  try {
-    url = new URL(origin);
-  } catch {
-    return null;
-  }
+  const url = safeUrlParse(origin);
+  if (!url) return null;
 
   const normalizedOrigin = url.origin;
   const { hostname, protocol } = url;
@@ -55,7 +52,9 @@ function getAllowedOrigin(origin: string | undefined): string | null {
 }
 
 export const corsMiddleware: MiddlewareHandler = cors({
-  origin: (origin) => getAllowedOrigin(origin),
+  origin: (origin) => {
+    return getAllowedOrigin(origin);
+  },
   credentials: true,
   allowMethods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
   allowHeaders: [

--- a/turbo/apps/api/src/lib/cors.ts
+++ b/turbo/apps/api/src/lib/cors.ts
@@ -10,10 +10,9 @@ import { env } from "./env";
 // directly (not proxied to Next), responses from registered routes need their
 // own CORS headers — the web proxy fallthrough is no longer in the request
 // path for migrated endpoints.
-const STATIC_ALLOWED_ORIGINS = new Set([
-  "https://www.vm0.ai",
-  "https://vm0.ai",
-]);
+const STATIC_ALLOWED_ORIGINS = Object.freeze(
+  new Set(["https://www.vm0.ai", "https://vm0.ai"]),
+);
 
 function getAllowedOrigin(origin: string | undefined): string | null {
   if (!origin) {

--- a/turbo/apps/api/src/lib/cors.ts
+++ b/turbo/apps/api/src/lib/cors.ts
@@ -10,21 +10,25 @@ import { env } from "./env";
 // directly (not proxied to Next), responses from registered routes need their
 // own CORS headers — the web proxy fallthrough is no longer in the request
 // path for migrated endpoints.
-const STATIC_ALLOWED_ORIGINS: readonly string[] = [
+const STATIC_ALLOWED_ORIGINS = new Set([
   "https://www.vm0.ai",
   "https://vm0.ai",
-];
+]);
 
 function getAllowedOrigin(origin: string | undefined): string | null {
-  if (!origin) return null;
+  if (!origin) {
+    return null;
+  }
 
   const url = safeUrlParse(origin);
-  if (!url) return null;
+  if (!url) {
+    return null;
+  }
 
   const normalizedOrigin = url.origin;
   const { hostname, protocol } = url;
 
-  if (STATIC_ALLOWED_ORIGINS.includes(normalizedOrigin)) {
+  if (STATIC_ALLOWED_ORIGINS.has(normalizedOrigin)) {
     return normalizedOrigin;
   }
 
@@ -34,18 +38,28 @@ function getAllowedOrigin(origin: string | undefined): string | null {
     deployEnv === "development" &&
     protocol === "http:" &&
     hostname === "localhost";
-  if (!allowHttpLocalhost && protocol !== "https:") return null;
+  if (!allowHttpLocalhost && protocol !== "https:") {
+    return null;
+  }
 
-  if (hostname.endsWith(".vm0.ai")) return normalizedOrigin;
+  if (hostname.endsWith(".vm0.ai")) {
+    return normalizedOrigin;
+  }
 
   if (deployEnv === "preview" && hostname.endsWith(".vm6.ai")) {
     return normalizedOrigin;
   }
 
   if (deployEnv === "development") {
-    if (hostname === "localhost") return normalizedOrigin;
-    if (hostname.endsWith(".vm6.ai")) return normalizedOrigin;
-    if (hostname.endsWith(".vm7.ai")) return normalizedOrigin;
+    if (hostname === "localhost") {
+      return normalizedOrigin;
+    }
+    if (hostname.endsWith(".vm6.ai")) {
+      return normalizedOrigin;
+    }
+    if (hostname.endsWith(".vm7.ai")) {
+      return normalizedOrigin;
+    }
   }
 
   return null;
@@ -70,5 +84,5 @@ export const corsMiddleware: MiddlewareHandler = cors({
     "Authorization",
     "Range",
   ],
-  maxAge: 86400,
+  maxAge: 86_400,
 });

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -12,7 +12,7 @@ const SCHEMA = {
   OPENAI_API_KEY: z.string().min(1),
   SENTRY_DSN: z.url().optional(),
   GIT_COMMIT_SHA: z.string(),
-  SENTRY_ENV: z.enum(["production", "preview", "development"]),
+  ENV: z.enum(["production", "preview", "development"]),
   VITEST: z.enum(["true", "false"]).default("false"),
   VM0_DEBUG: z.string().default(""),
   VM0_API_URL: z.url(),

--- a/turbo/apps/api/src/signals/utils.ts
+++ b/turbo/apps/api/src/signals/utils.ts
@@ -42,6 +42,16 @@ export function safeJsonParse(input: string): unknown {
   }
 }
 
+export function safeUrlParse(input: string): URL | undefined {
+  // eslint-disable-next-line no-restricted-syntax -- centralized guarded URL constructor
+  try {
+    return new URL(input);
+  } catch (error) {
+    throwIfAbort(error);
+    return undefined;
+  }
+}
+
 export function detach(
   promise: Promise<unknown>,
   mechanism: Mechanism,

--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -23,9 +23,9 @@ AXIOM_TOKEN_SESSIONS=op://Development/axiom/AXIOM_TOKEN_SESSIONS
 AXIOM_TOKEN_TELEMETRY=op://Development/axiom/AXIOM_TOKEN_TELEMETRY
 AXIOM_DATASET_SUFFIX=dev
 
-# Required: apps/api Sentry environment tag. CI injects "production" or
+# Required: apps/api deploy stage tag. CI injects "production" or
 # "preview" via .github/actions/web-api-env. Local dev uses "development".
-SENTRY_ENV=development
+ENV=development
 
 # Required: git commit SHA used as OTel service.version and Sentry release.
 # CI injects ${GITHUB_SHA} via web-api-env; locally any non-empty marker works.


### PR DESCRIPTION
## Summary

- **CORS middleware** in apps/api hono — `/api/zero/*` routes are now served by hono directly (no longer falling through to the web proxy), so responses lost the `Access-Control-Allow-Origin` header that `apps/web/proxy.cors.ts` injects. Browsers calling `api.vm0.ai` from `app.vm0.ai` were rejected on every migrated route. New `lib/cors.ts` mirrors the web allowlist semantics exactly (production: `*.vm0.ai`; preview: + `*.vm6.ai`; development: + `localhost` over http and `*.vm6.ai` / `*.vm7.ai` over https). Registered before the route handlers so OPTIONS preflight short-circuits without needing a per-route OPTIONS handler.
- **Rename `SENTRY_ENV` → `ENV`** — the variable identifies the deploy stage, not Sentry-specific. The new cors module is the first cross-cutting consumer; future code shouldn't have to read a sentry-prefixed name to learn the stage.

## Test plan

- [x] `pnpm -F api check-types`
- [x] `pnpm -F api exec vitest` — 13/13 pass (4 new cors tests cover allowed-origin echo, preflight short-circuit, disallowed-origin rejection, dev-only `*.vm7.ai`)
- [ ] After merge, smoke-test `https://app.vm0.ai` calling `https://api.vm0.ai/api/zero/org` in the browser and verify the cross-origin response carries `Access-Control-Allow-Origin: https://app.vm0.ai`
- [ ] Confirm Vercel build picks up the renamed `ENV` env var (the github action `web-api-env` is updated; Vercel project env may need a manual rename if it's set there too)

## Notes

- `cors.ts` reads `env("ENV")` to scope the allowlist, so the rename has to land in the same PR.
- `.env.local` is not in this PR — your local copies need a manual `SENTRY_ENV=` → `ENV=` swap to keep the dev server starting.
- `SENTRY_ENVIRONMENT` (in `turbo.json` and `apps/cli/src/instrument.ts`) is the Sentry SDK's own standard variable name and is unrelated; left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)