### PR TITLE
refactor: collapse LocalChatThreadSnapshot into polymorphic ChatThreadDataSource

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/optimistic-chat-thread.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/optimistic-chat-thread.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { createMockApi } from "../../../mocks/msw-contract.ts";
+import {
+  chatThreadsContract,
+  chatThreadByIdContract,
+  chatThreadMessagesContract,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { createDeferredPromise, detach, Reason } from "../../utils.ts";
+import {
+  createNewChatThreadOptimistically$,
+  optimisticChatThread$,
+} from "../optimistic-chat-thread-page.ts";
+
+const context = testContext();
+const mockApi = createMockApi(context);
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+function setupBaseHandlers() {
+  server.use(
+    mockApi(chatThreadsContract.list, ({ respond }) => {
+      return respond(200, { threads: [] });
+    }),
+    mockApi(chatThreadMessagesContract.list, ({ respond }) => {
+      return respond(200, { messages: [] });
+    }),
+    mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
+      return respond(200, {
+        id: params.id,
+        title: null,
+        agentId: AGENT_ID,
+        chatMessages: [],
+        latestSessionId: null,
+        activeRunIds: [],
+        draftContent: null,
+        draftAttachments: null,
+        createdAt: "2026-04-13T00:00:00Z",
+        updatedAt: "2026-04-13T00:00:00Z",
+      });
+    }),
+  );
+}
+
+describe("optimistic chat thread (local mode)", () => {
+  it("exposes a placeholder thread with empty active runs and zero messages", async () => {
+    setupBaseHandlers();
+    // Hold create open so the optimistic entry stays around for assertions.
+    const createDeferred = createDeferredPromise<void>(context.signal);
+    server.use(
+      mockApi(chatThreadsContract.create, async ({ body, respond }) => {
+        await createDeferred.promise;
+        return respond(201, {
+          id: body.clientThreadId ?? "fallback-thread-id",
+          title: null,
+          createdAt: "2026-04-13T00:00:00Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      withoutRender: true,
+    });
+
+    detach(
+      context.store.set(
+        createNewChatThreadOptimistically$,
+        AGENT_ID,
+        "main",
+        context.signal,
+      ),
+      Reason.DomCallback,
+    );
+
+    const pending = await expect
+      .poll(() => {
+        return context.store.get(optimisticChatThread$);
+      })
+      .not.toBeNull();
+    void pending;
+
+    const optimistic = context.store.get(optimisticChatThread$)!;
+    const threadData = await context.store.get(
+      optimistic.pendingThread.threadData$,
+    );
+    expect(threadData).toMatchObject({
+      id: optimistic.threadId,
+      title: null,
+      agentId: AGENT_ID,
+      activeRunIds: [],
+      activeRuns: [],
+      isLegacySession: false,
+      draftContent: null,
+      draftAttachments: null,
+      modelProviderId: null,
+      selectedModel: null,
+    });
+
+    const initiallyFinished = await context.store.get(
+      optimistic.pendingThread.allFinished$,
+    );
+    expect(initiallyFinished).toBeTruthy();
+
+    createDeferred.resolve();
+  });
+
+  it("flips allFinished$ to true when cancelRun$ runs against a pending optimistic thread", async () => {
+    setupBaseHandlers();
+    const createDeferred = createDeferredPromise<void>(context.signal);
+    server.use(
+      mockApi(chatThreadsContract.create, async ({ body, respond }) => {
+        await createDeferred.promise;
+        return respond(201, {
+          id: body.clientThreadId ?? "fallback-thread-id",
+          title: null,
+          createdAt: "2026-04-13T00:00:00Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      withoutRender: true,
+    });
+
+    detach(
+      context.store.set(
+        createNewChatThreadOptimistically$,
+        AGENT_ID,
+        "main",
+        context.signal,
+      ),
+      Reason.DomCallback,
+    );
+
+    await expect
+      .poll(() => {
+        return context.store.get(optimisticChatThread$);
+      })
+      .not.toBeNull();
+
+    const optimistic = context.store.get(optimisticChatThread$)!;
+    await context.store.set(
+      optimistic.pendingThread.cancelRun$,
+      context.signal,
+    );
+
+    const finished = await context.store.get(
+      optimistic.pendingThread.allFinished$,
+    );
+    expect(finished).toBeTruthy();
+
+    createDeferred.resolve();
+  });
+
+  it("does not PATCH the server when scheduleDraftSync$ runs on a local thread", async () => {
+    setupBaseHandlers();
+    let patchCount = 0;
+    const createDeferred = createDeferredPromise<void>(context.signal);
+    server.use(
+      mockApi(chatThreadByIdContract.patch, ({ respond }) => {
+        patchCount++;
+        return respond(204);
+      }),
+      mockApi(chatThreadsContract.create, async ({ body, respond }) => {
+        await createDeferred.promise;
+        return respond(201, {
+          id: body.clientThreadId ?? "fallback-thread-id",
+          title: null,
+          createdAt: "2026-04-13T00:00:00Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      withoutRender: true,
+    });
+
+    detach(
+      context.store.set(
+        createNewChatThreadOptimistically$,
+        AGENT_ID,
+        "main",
+        context.signal,
+      ),
+      Reason.DomCallback,
+    );
+
+    await expect
+      .poll(() => {
+        return context.store.get(optimisticChatThread$);
+      })
+      .not.toBeNull();
+
+    const optimistic = context.store.get(optimisticChatThread$)!;
+    context.store.set(
+      optimistic.pendingThread.draft.setInput$,
+      "draft text that should not reach the server",
+    );
+    await context.store.set(
+      optimistic.pendingThread.scheduleDraftSync$,
+      context.signal,
+    );
+
+    expect(patchCount).toBe(0);
+
+    createDeferred.resolve();
+  });
+});

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
@@ -1,0 +1,69 @@
+import type { Command, Computed } from "ccstate";
+import type {
+  PagedChatMessage,
+  PersistedAttachment,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import type { ChatThread } from "../agent-chat.ts";
+
+export interface ChatThreadRealtimeHandlers {
+  onMessageCreated$: Command<Promise<boolean>, [AbortSignal]>;
+  onRunChanged$: Command<boolean, []>;
+}
+
+export interface InitialPage {
+  messages: PagedChatMessage[];
+  hasHistoryBefore: boolean;
+}
+
+export interface PatchDraftArgs {
+  threadId: string;
+  content: string | null;
+  attachments: PersistedAttachment[] | null;
+}
+
+export interface ListMessagesAfterArgs {
+  threadId: string;
+  sinceId: string | undefined;
+}
+
+export interface ListMessagesBeforeArgs {
+  threadId: string;
+  beforeId: string;
+}
+
+export interface CancelRunsArgs {
+  threadId: string;
+  activeRunIds: string[];
+}
+
+export interface MarkReadArgs {
+  threadId: string;
+  latestMessageId: string;
+}
+
+export interface SubscribeRealtimeArgs {
+  threadId: string;
+  handlers: ChatThreadRealtimeHandlers;
+}
+
+export interface ChatThreadDataSource {
+  getThread$: Computed<Promise<ChatThread | null>>;
+  reloadThread$: Command<void, []>;
+  initialPage$: Computed<Promise<InitialPage>>;
+  patchDraft$: Command<Promise<void>, [PatchDraftArgs, AbortSignal]>;
+  listMessagesAfter$: Command<
+    Promise<{ messages: PagedChatMessage[]; reachedEnd: boolean }>,
+    [ListMessagesAfterArgs, AbortSignal]
+  >;
+  listMessagesBefore$: Command<
+    Promise<{ messages: PagedChatMessage[]; hasMore: boolean }>,
+    [ListMessagesBeforeArgs, AbortSignal]
+  >;
+  cancelRuns$: Command<Promise<void>, [CancelRunsArgs, AbortSignal]>;
+  markRead$: Command<Promise<string | null>, [MarkReadArgs, AbortSignal]>;
+  subscribeRealtime$: Command<
+    Promise<void>,
+    [SubscribeRealtimeArgs, AbortSignal]
+  >;
+  isCancelRequested$: Computed<boolean>;
+}

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -20,15 +20,10 @@ import { reloadChatThreads$, type ChatThread } from "../agent-chat.ts";
 import {
   chatMessagesContract,
   chatThreadArtifactsContract,
-  chatThreadByIdContract,
-  chatThreadMarkReadContract,
-  chatThreadMessagesContract,
   type ChatThreadArtifactRun,
   type ModelSelectionRequest,
-  type PersistedAttachment,
   type PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import { zeroRunsCancelContract } from "@vm0/api-contracts/contracts/zero-runs";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
@@ -41,6 +36,8 @@ import {
 } from "../zero-page/clipboard.ts";
 import type { GroupedChatMessageGroup } from "./chat-message.ts";
 import { logger } from "../log.ts";
+import type { ChatThreadDataSource } from "./chat-thread-data-source.ts";
+import { createRemoteChatThreadDataSource } from "./remote-chat-thread-data-source.ts";
 
 export type { DraftSignals } from "../zero-page/chat-draft.ts";
 
@@ -205,69 +202,18 @@ export interface ChatThreadSignals {
   setArtifactPreviewKey$: Command<void, [string | null]>;
 }
 
-export interface LocalChatThreadSnapshot {
-  threadData: ChatThread;
-  messages: PagedChatMessage[];
-  cancelRequested$: State<boolean>;
-}
-
-interface ChatThreadSignalOptions {
-  localSnapshot?: LocalChatThreadSnapshot;
-}
-
 // ---------------------------------------------------------------------------
 // Sub-factory: thread data fetching
 // ---------------------------------------------------------------------------
 
-// This per-thread `threadData$` is scoped to a single signal factory so it can
-// be reloaded independently via `reloadThread$`. Keep the accept list aligned
-// so missing-thread redirects and title merging both treat 404s the same way.
-function createThreadData(
-  threadId: string,
-  options: ChatThreadSignalOptions = {},
-) {
-  const internalReload$ = state(0);
-
-  const threadData$ = computed(async (get): Promise<ChatThread | null> => {
-    get(internalReload$);
-    if (options.localSnapshot) {
-      return options.localSnapshot.threadData;
-    }
-
-    const threadClient = get(zeroClient$)(chatThreadByIdContract);
-    const threadResult = await accept(
-      threadClient.get({ params: { id: threadId } }),
-      [200, 404],
-      { toast: false },
-    );
-    if (threadResult.status === 404) {
-      return null;
-    }
-    const body = threadResult.body;
-    return {
-      id: threadId,
-      title: body.title ?? null,
-      agentId: body.agentId,
-      latestSessionId: body.latestSessionId ?? null,
-      lastReadMessageId: body.lastReadMessageId ?? null,
-      latestSessionProviderType: body.latestSessionProviderType ?? null,
-      activeRunIds: body.activeRunIds,
-      activeRuns: body.activeRuns ?? [],
-      isLegacySession: false,
-      draftContent: body.draftContent ?? null,
-      draftAttachments: body.draftAttachments ?? null,
-      modelProviderId: body.modelProviderId ?? null,
-      selectedModel: body.selectedModel ?? null,
-    };
-  });
-
-  const reloadThread$ = command(({ set }) => {
-    set(internalReload$, (v) => {
-      return v + 1;
-    });
-  });
-
-  return { threadData$, reloadThread$ };
+// The data source owns both `getThread$` (the resolved thread) and
+// `reloadThread$` (the invalidation lever). Local mode never reloads;
+// remote mode bumps an internal counter on its `getThread$` computed.
+function createThreadData(dataSource: ChatThreadDataSource) {
+  return {
+    threadData$: dataSource.getThread$,
+    reloadThread$: dataSource.reloadThread$,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -493,30 +439,11 @@ export const setDraftSyncDebounceMs$ = command(({ set }, ms: number) => {
 function createDraftSync(
   threadId: string,
   draft: DraftSignals,
-  options: ChatThreadSignalOptions = {},
+  dataSource: ChatThreadDataSource,
 ) {
   // A reset signal is used to abort any in-flight debounced sync when a new
   // change comes in or when the draft is cleared on send.
   const draftSyncReset$ = resetSignal();
-
-  const syncWithContent$ = command(
-    async (
-      { get },
-      content: string | null,
-      attachments: PersistedAttachment[] | null,
-      signal: AbortSignal,
-    ) => {
-      const client = get(zeroClient$)(chatThreadByIdContract);
-      await accept(
-        client.patch({
-          params: { id: threadId },
-          body: { draftContent: content, draftAttachments: attachments },
-          fetchOptions: { signal },
-        }),
-        [204],
-      );
-    },
-  );
 
   const debouncedSyncDraft$ = command(
     async ({ get, set }, signal: AbortSignal) => {
@@ -558,18 +485,18 @@ function createDraftSync(
         });
 
       await set(
-        syncWithContent$,
-        content,
-        persisted.length > 0 ? persisted : null,
+        dataSource.patchDraft$,
+        {
+          threadId,
+          content,
+          attachments: persisted.length > 0 ? persisted : null,
+        },
         signal,
       );
     },
   );
 
   const scheduleDraftSync$ = command(async ({ set }, signal: AbortSignal) => {
-    if (options.localSnapshot) {
-      return;
-    }
     const debouncedSignal = set(draftSyncReset$, signal);
     await set(debouncedSyncDraft$, debouncedSignal);
   });
@@ -579,11 +506,12 @@ function createDraftSync(
   });
 
   const flushDraftClear$ = command(async ({ set }, signal: AbortSignal) => {
-    if (options.localSnapshot) {
-      return;
-    }
     set(draftSyncReset$);
-    await set(syncWithContent$, null, null, signal);
+    await set(
+      dataSource.patchDraft$,
+      { threadId, content: null, attachments: null },
+      signal,
+    );
   });
 
   return { scheduleDraftSync$, cancelDraftSync$, flushDraftClear$ };
@@ -669,9 +597,8 @@ function createAppendDelta(deltaMessages$: DeltaMessages$) {
 }
 
 function createInitialPage$(
-  threadId: string,
   threadData$: Computed<Promise<ChatThread | null>>,
-  options: ChatThreadSignalOptions = {},
+  dataSource: ChatThreadDataSource,
 ) {
   return computed(
     async (
@@ -684,27 +611,7 @@ function createInitialPage$(
       if (!thread) {
         return { messages: [], hasHistoryBefore: false };
       }
-      if (options.localSnapshot) {
-        return {
-          messages: options.localSnapshot.messages,
-          hasHistoryBefore: false,
-        };
-      }
-      const client = get(zeroClient$)(chatThreadMessagesContract);
-      const result = await accept(
-        client.list({ params: { threadId }, query: { limit: 50 } }),
-        [200],
-      );
-      const hasHistoryBefore = result.body.hasHistoryBefore ?? false;
-      L.debug("initialPage$", {
-        threadId,
-        count: result.body.messages.length,
-        hasHistoryBefore,
-      });
-      return {
-        messages: result.body.messages,
-        hasHistoryBefore,
-      };
+      return get(dataSource.initialPage$);
     },
   );
 }
@@ -712,11 +619,11 @@ function createInitialPage$(
 function createPagedMessages(
   threadId: string,
   threadData$: Computed<Promise<ChatThread | null>>,
-  options: ChatThreadSignalOptions = {},
+  dataSource: ChatThreadDataSource,
 ) {
   const loadedHistoryHasMore$ = state<boolean | null>(null);
   const historyMessages$ = state<PagedChatMessage[]>([]);
-  const initialPage$ = createInitialPage$(threadId, threadData$, options);
+  const initialPage$ = createInitialPage$(threadData$, dataSource);
 
   const deltaMessages$ = state<PagedChatMessage[]>([]);
   const appendDeltaMessages$ = createAppendDelta(deltaMessages$);
@@ -763,38 +670,19 @@ function createPagedMessages(
     if (!thread) {
       return true;
     }
-    if (options.localSnapshot) {
-      return true;
-    }
 
     const sinceId = await get(latestChatMessageId$);
     signal.throwIfAborted();
-    const client = get(zeroClient$)(chatThreadMessagesContract);
-    const result = await accept(
-      client.list({
-        params: { threadId },
-        query: { sinceId, limit: 50 },
-        fetchOptions: { signal },
-      }),
-      [200],
+    const result = await set(
+      dataSource.listMessagesAfter$,
+      { threadId, sinceId },
+      signal,
     );
     signal.throwIfAborted();
-    L.debug("fetchNextPage$", {
-      threadId,
-      sinceId,
-      count: result.body.messages.length,
-      runStatuses: result.body.messages
-        .filter((m) => {
-          return m.runId;
-        })
-        .map((m) => {
-          return { id: m.id, runId: m.runId, status: m.status };
-        }),
-    });
-    if (result.body.messages.length === 0) {
+    if (result.reachedEnd) {
       return true;
     }
-    set(appendDeltaMessages$, result.body.messages);
+    set(appendDeltaMessages$, result.messages);
     return false;
   });
 
@@ -808,7 +696,7 @@ function createPagedMessages(
     earliestChatMessageId$,
     historyMessages$,
     loadedHistoryHasMore$,
-    options,
+    dataSource,
   });
 
   return {
@@ -828,23 +716,19 @@ function createLoadHistoryCommand({
   earliestChatMessageId$,
   historyMessages$,
   loadedHistoryHasMore$,
-  options = {},
+  dataSource,
 }: {
   threadId: string;
   threadData$: Computed<Promise<ChatThread | null>>;
   earliestChatMessageId$: Computed<Promise<string | undefined>>;
   historyMessages$: State<PagedChatMessage[]>;
   loadedHistoryHasMore$: State<boolean | null>;
-  options?: ChatThreadSignalOptions;
+  dataSource: ChatThreadDataSource;
 }): Command<Promise<void>, [AbortSignal]> {
   return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
     const thread = await get(threadData$);
     signal.throwIfAborted();
     if (!thread) {
-      set(loadedHistoryHasMore$, false);
-      return;
-    }
-    if (options.localSnapshot) {
       set(loadedHistoryHasMore$, false);
       return;
     }
@@ -856,24 +740,20 @@ function createLoadHistoryCommand({
       return;
     }
 
-    const client = get(zeroClient$)(chatThreadMessagesContract);
-    const result = await accept(
-      client.list({
-        params: { threadId },
-        query: { beforeId, limit: 50 },
-        fetchOptions: { signal },
-      }),
-      [200],
+    const result = await set(
+      dataSource.listMessagesBefore$,
+      { threadId, beforeId },
+      signal,
     );
     signal.throwIfAborted();
 
     set(historyMessages$, (prev) => {
-      if (result.body.messages.length === 0) {
+      if (result.messages.length === 0) {
         return prev;
       }
-      return [...result.body.messages, ...prev];
+      return [...result.messages, ...prev];
     });
-    set(loadedHistoryHasMore$, result.body.hasHistoryBefore ?? false);
+    set(loadedHistoryHasMore$, result.hasMore);
   });
 }
 
@@ -1061,7 +941,7 @@ interface RunTrackingDeps {
   latestChatMessageId$: Computed<Promise<string | undefined>>;
   fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>;
   autoScroll$: Command<void, []>;
-  options: ChatThreadSignalOptions;
+  dataSource: ChatThreadDataSource;
 }
 
 interface MarkThreadReadDeps {
@@ -1069,6 +949,7 @@ interface MarkThreadReadDeps {
   threadData$: Computed<Promise<ChatThread | null>>;
   latestChatMessageId$: Computed<Promise<string | undefined>>;
   locallyMarkedReadMessageId$: State<string | undefined>;
+  dataSource: ChatThreadDataSource;
 }
 
 function createMarkThreadReadIfNeeded({
@@ -1076,6 +957,7 @@ function createMarkThreadReadIfNeeded({
   threadData$,
   latestChatMessageId$,
   locallyMarkedReadMessageId$,
+  dataSource,
 }: MarkThreadReadDeps) {
   return command(async ({ get, set }, sig: AbortSignal) => {
     const latestMessageId = await get(latestChatMessageId$);
@@ -1092,19 +974,15 @@ function createMarkThreadReadIfNeeded({
       return;
     }
 
-    const client = get(zeroClient$)(chatThreadMarkReadContract);
-    const result = await accept(
-      client.markRead({
-        params: { id: threadId },
-        fetchOptions: { signal: sig },
-      }),
-      [200],
+    const newLastReadId = await set(
+      dataSource.markRead$,
+      { threadId, latestMessageId },
+      sig,
     );
     sig.throwIfAborted();
-    set(
-      locallyMarkedReadMessageId$,
-      result.body.lastReadMessageId ?? latestMessageId,
-    );
+    if (newLastReadId !== null) {
+      set(locallyMarkedReadMessageId$, newLastReadId);
+    }
     // Server broadcasts `threadListChanged` via Ably on mark-read; the
     // sidebar reloads from that channel. Bumping reloadChatThreads$ here too
     // forces a redundant refetch that blocks subsequent keyboard navigation.
@@ -1118,15 +996,12 @@ function createRunTracking({
   latestChatMessageId$,
   fetchNextPage$,
   autoScroll$,
-  options,
+  dataSource,
 }: RunTrackingDeps) {
   const locallyMarkedReadMessageId$ = state<string | undefined>(undefined);
 
   const allFinished$ = computed(async (get) => {
-    const cancelRequested = options.localSnapshot
-      ? get(options.localSnapshot.cancelRequested$)
-      : false;
-    if (cancelRequested) {
+    if (get(dataSource.isCancelRequested$)) {
       return true;
     }
     const thread = await get(threadData$);
@@ -1141,6 +1016,7 @@ function createRunTracking({
     threadData$,
     latestChatMessageId$,
     locallyMarkedReadMessageId$,
+    dataSource,
   });
 
   const loadPagedMessages$ = command(
@@ -1155,9 +1031,6 @@ function createRunTracking({
         threadId,
         activeRunIds: thread.activeRunIds,
       });
-      if (options.localSnapshot) {
-        return;
-      }
 
       await set(markThreadReadIfNeeded$, signal);
 
@@ -1185,53 +1058,26 @@ function createRunTracking({
       // here; dropped because `threadListChanged` already fans out to the
       // sidebar, and the extra reload blocks keyboard navigation.
 
-      await Promise.all([
-        set(
-          setAblyLoop$,
-          `chatThreadMessageCreated:${threadId}`,
-          onMessageCreated$,
-          signal,
-        ),
-        set(
-          setAblyLoop$,
-          `chatThreadRunCreated:${thread.id}`,
-          onRunChanged$,
-          signal,
-        ),
-        set(
-          setAblyLoop$,
-          `chatThreadRunUpdated:${thread.id}`,
-          onRunChanged$,
-          signal,
-        ),
-      ]);
+      await set(
+        dataSource.subscribeRealtime$,
+        { threadId, handlers: { onMessageCreated$, onRunChanged$ } },
+        signal,
+      );
 
       signal.throwIfAborted();
     },
   );
 
   const cancelRun$ = command(async ({ get, set }, signal: AbortSignal) => {
-    if (options.localSnapshot) {
-      set(options.localSnapshot.cancelRequested$, true);
-      return;
-    }
     const thread = await get(threadData$);
     signal.throwIfAborted();
     if (!thread) {
       return;
     }
-    const client = get(zeroClient$)(zeroRunsCancelContract);
-    const before = thread.activeRunIds;
-    L.debug("cancelRun$ start", { threadId, pendingRunIds: before });
-
-    await Promise.all(
-      before.map(async (runId) => {
-        await accept(
-          client.cancel({ params: { id: runId }, fetchOptions: { signal } }),
-          [200],
-        );
-        L.debug("cancelRun$ server accepted cancel", { threadId, runId });
-      }),
+    await set(
+      dataSource.cancelRuns$,
+      { threadId, activeRunIds: thread.activeRunIds },
+      signal,
     );
     signal.throwIfAborted();
   });
@@ -1412,9 +1258,9 @@ function createPhraseLoop(
 export function createChatThreadSignals(
   threadId: string,
   draft: DraftSignals,
-  options: ChatThreadSignalOptions = {},
+  dataSource: ChatThreadDataSource = createRemoteChatThreadDataSource(threadId),
 ): ChatThreadSignals {
-  const { threadData$, reloadThread$ } = createThreadData(threadId, options);
+  const { threadData$, reloadThread$ } = createThreadData(dataSource);
   const { modelSelection$, setModelSelection$ } =
     createModelSelection(threadData$);
   const {
@@ -1443,7 +1289,7 @@ export function createChatThreadSignals(
     fetchNextPage$,
     loadHistory$: loadPagedHistory$,
     insertOptimisticMessage$,
-  } = createPagedMessages(threadId, threadData$, options);
+  } = createPagedMessages(threadId, threadData$, dataSource);
 
   const loadHistory$ = createLoadHistoryWithPrependScroll(
     recordScrollHeightForPrepend$,
@@ -1451,7 +1297,7 @@ export function createChatThreadSignals(
   );
 
   const { scheduleDraftSync$, cancelDraftSync$, flushDraftClear$ } =
-    createDraftSync(threadId, draft, options);
+    createDraftSync(threadId, draft, dataSource);
   const { allFinished$, loadPagedMessages$, cancelRun$ } = createRunTracking({
     threadId,
     reloadThread$,
@@ -1459,7 +1305,7 @@ export function createChatThreadSignals(
     latestChatMessageId$,
     fetchNextPage$,
     autoScroll$,
-    options,
+    dataSource,
   });
 
   const { sendMessage$ } = createSendMessage({

--- a/turbo/apps/platform/src/signals/chat-page/local-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/local-chat-thread-data-source.ts
@@ -1,0 +1,72 @@
+import { command, computed, state } from "ccstate";
+import type { PagedChatMessage } from "@vm0/api-contracts/contracts/chat-threads";
+import type { ChatThread } from "../agent-chat.ts";
+import type { ChatThreadDataSource } from "./chat-thread-data-source.ts";
+
+const localPatchDraft$ = command((): Promise<void> => {
+  return Promise.resolve();
+});
+
+const localListMessagesAfter$ = command(() => {
+  return Promise.resolve({
+    messages: [] as PagedChatMessage[],
+    reachedEnd: true,
+  });
+});
+
+const localListMessagesBefore$ = command(() => {
+  return Promise.resolve({
+    messages: [] as PagedChatMessage[],
+    hasMore: false,
+  });
+});
+
+const localMarkRead$ = command((): Promise<string | null> => {
+  return Promise.resolve(null);
+});
+
+const localSubscribeRealtime$ = command((): Promise<void> => {
+  return Promise.resolve();
+});
+
+const localReloadThread$ = command(() => {
+  // Local snapshot is fixed for the optimistic lifetime — nothing to reload.
+});
+
+export function createLocalChatThreadDataSource(input: {
+  threadData: ChatThread;
+  messages: PagedChatMessage[];
+}): ChatThreadDataSource {
+  const { threadData, messages } = input;
+  const cancelRequested$ = state(false);
+
+  const getThread$ = computed((): Promise<ChatThread | null> => {
+    return Promise.resolve(threadData);
+  });
+
+  const initialPage$ = computed(() => {
+    return Promise.resolve({ messages, hasHistoryBefore: false });
+  });
+
+  const cancelRuns$ = command(({ set }): Promise<void> => {
+    set(cancelRequested$, true);
+    return Promise.resolve();
+  });
+
+  const isCancelRequested$ = computed((get) => {
+    return get(cancelRequested$);
+  });
+
+  return {
+    getThread$,
+    reloadThread$: localReloadThread$,
+    initialPage$,
+    patchDraft$: localPatchDraft$,
+    listMessagesAfter$: localListMessagesAfter$,
+    listMessagesBefore$: localListMessagesBefore$,
+    cancelRuns$,
+    markRead$: localMarkRead$,
+    subscribeRealtime$: localSubscribeRealtime$,
+    isCancelRequested$,
+  };
+}

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -21,11 +21,9 @@ import {
 } from "../route.ts";
 import { talkDraft$ } from "../zero-page/chat-draft.ts";
 import { zeroOnboardingStatus$ } from "../zero-page/zero-onboarding.ts";
-import {
-  createChatThreadSignals,
-  ensureDraft$,
-  type LocalChatThreadSnapshot,
-} from "./create-chat-thread.ts";
+import { createChatThreadSignals, ensureDraft$ } from "./create-chat-thread.ts";
+import { createLocalChatThreadDataSource } from "./local-chat-thread-data-source.ts";
+import { createPendingChatThread } from "./pending-chat-thread.ts";
 import { prepareUserMessageFromDraft$ } from "./resolve-draft-attachments.ts";
 
 const SIDEBAR_PARAM = "sidebar";
@@ -197,30 +195,16 @@ const createNewChatThread$ = command(
 
     const threadId = crypto.randomUUID();
     const createdAt = new Date().toISOString();
-    const cancelRequested$ = state(false);
-    const localSnapshot: LocalChatThreadSnapshot = {
-      threadData: {
-        id: threadId,
-        title: null,
-        agentId: resolvedComposeId,
-        latestSessionId: null,
-        lastReadMessageId: null,
-        latestSessionProviderType: null,
-        activeRunIds: [],
-        activeRuns: [],
-        isLegacySession: false,
-        draftContent: null,
-        draftAttachments: null,
-        modelProviderId: null,
-        selectedModel: null,
-      },
+    const dataSource = createLocalChatThreadDataSource({
+      threadData: createPendingChatThread(threadId, resolvedComposeId),
       messages: [],
-      cancelRequested$,
-    };
-    const { draft: threadDraft } = set(ensureDraft$, threadId);
-    const localThread = createChatThreadSignals(threadId, threadDraft, {
-      localSnapshot,
     });
+    const { draft: threadDraft } = set(ensureDraft$, threadId);
+    const localThread = createChatThreadSignals(
+      threadId,
+      threadDraft,
+      dataSource,
+    );
     set(localThread.hideSkeleton$);
 
     const createClient = get(zeroClient$);
@@ -342,23 +326,12 @@ const sendNewThreadMessage$ = command(
     const threadId = crypto.randomUUID();
     const clientMessageId = crypto.randomUUID();
     const createdAt = new Date().toISOString();
-    const cancelRequested$ = state(false);
-    const localSnapshot: LocalChatThreadSnapshot = {
-      threadData: {
-        id: threadId,
-        title: null,
+    const dataSource = createLocalChatThreadDataSource({
+      threadData: createPendingChatThread(
+        threadId,
         agentId,
-        latestSessionId: null,
-        lastReadMessageId: null,
-        latestSessionProviderType: null,
-        activeRunIds: [`pending-${threadId}`],
-        activeRuns: [{ id: `pending-${threadId}`, status: "pending" }],
-        isLegacySession: false,
-        draftContent: null,
-        draftAttachments: null,
-        modelProviderId: null,
-        selectedModel: null,
-      },
+        `pending-${threadId}`,
+      ),
       messages: [
         {
           id: clientMessageId,
@@ -368,12 +341,13 @@ const sendNewThreadMessage$ = command(
           createdAt,
         },
       ],
-      cancelRequested$,
-    };
-    const { draft: threadDraft } = set(ensureDraft$, threadId);
-    const localThread = createChatThreadSignals(threadId, threadDraft, {
-      localSnapshot,
     });
+    const { draft: threadDraft } = set(ensureDraft$, threadId);
+    const localThread = createChatThreadSignals(
+      threadId,
+      threadDraft,
+      dataSource,
+    );
     set(localThread.hideSkeleton$);
     set(draft.clear$);
 

--- a/turbo/apps/platform/src/signals/chat-page/pending-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/pending-chat-thread.ts
@@ -1,0 +1,27 @@
+import type { ChatThread } from "../agent-chat.ts";
+
+export function createPendingChatThread(
+  threadId: string,
+  agentId: string,
+  pendingRunId?: string,
+): ChatThread {
+  const activeRunIds: string[] = pendingRunId ? [pendingRunId] : [];
+  const activeRuns: { id: string; status: string }[] = pendingRunId
+    ? [{ id: pendingRunId, status: "pending" }]
+    : [];
+  return {
+    id: threadId,
+    title: null,
+    agentId,
+    latestSessionId: null,
+    lastReadMessageId: null,
+    latestSessionProviderType: null,
+    activeRunIds,
+    activeRuns,
+    isLegacySession: false,
+    draftContent: null,
+    draftAttachments: null,
+    modelProviderId: null,
+    selectedModel: null,
+  };
+}

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -1,0 +1,242 @@
+import { command, computed, state } from "ccstate";
+import {
+  chatThreadByIdContract,
+  chatThreadMarkReadContract,
+  chatThreadMessagesContract,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { zeroRunsCancelContract } from "@vm0/api-contracts/contracts/zero-runs";
+import { accept } from "../../lib/accept.ts";
+import { zeroClient$ } from "../api-client.ts";
+import { setAblyLoop$ } from "../realtime.ts";
+import { logger } from "../log.ts";
+import type { ChatThread } from "../agent-chat.ts";
+import type {
+  CancelRunsArgs,
+  ChatThreadDataSource,
+  InitialPage,
+  ListMessagesAfterArgs,
+  ListMessagesBeforeArgs,
+  MarkReadArgs,
+  PatchDraftArgs,
+  SubscribeRealtimeArgs,
+} from "./chat-thread-data-source.ts";
+
+const L = logger("ChatThread");
+
+const remoteIsCancelRequested$ = computed(() => {
+  return false;
+});
+
+const patchDraft$ = command(
+  async (
+    { get },
+    { threadId, content, attachments }: PatchDraftArgs,
+    signal: AbortSignal,
+  ) => {
+    const client = get(zeroClient$)(chatThreadByIdContract);
+    await accept(
+      client.patch({
+        params: { id: threadId },
+        body: { draftContent: content, draftAttachments: attachments },
+        fetchOptions: { signal },
+      }),
+      [204],
+    );
+  },
+);
+
+const listMessagesAfter$ = command(
+  async (
+    { get },
+    { threadId, sinceId }: ListMessagesAfterArgs,
+    signal: AbortSignal,
+  ) => {
+    const client = get(zeroClient$)(chatThreadMessagesContract);
+    const result = await accept(
+      client.list({
+        params: { threadId },
+        query: { sinceId, limit: 50 },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    L.debug("fetchNextPage$", {
+      threadId,
+      sinceId,
+      count: result.body.messages.length,
+      runStatuses: result.body.messages
+        .filter((m) => {
+          return m.runId;
+        })
+        .map((m) => {
+          return { id: m.id, runId: m.runId, status: m.status };
+        }),
+    });
+    if (result.body.messages.length === 0) {
+      return { messages: [], reachedEnd: true };
+    }
+    return { messages: result.body.messages, reachedEnd: false };
+  },
+);
+
+const listMessagesBefore$ = command(
+  async (
+    { get },
+    { threadId, beforeId }: ListMessagesBeforeArgs,
+    signal: AbortSignal,
+  ) => {
+    const client = get(zeroClient$)(chatThreadMessagesContract);
+    const result = await accept(
+      client.list({
+        params: { threadId },
+        query: { beforeId, limit: 50 },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    return {
+      messages: result.body.messages,
+      hasMore: result.body.hasHistoryBefore ?? false,
+    };
+  },
+);
+
+const cancelRuns$ = command(
+  async (
+    { get },
+    { threadId, activeRunIds }: CancelRunsArgs,
+    signal: AbortSignal,
+  ) => {
+    const client = get(zeroClient$)(zeroRunsCancelContract);
+    L.debug("cancelRun$ start", { threadId, pendingRunIds: activeRunIds });
+    await Promise.all(
+      activeRunIds.map(async (runId) => {
+        await accept(
+          client.cancel({ params: { id: runId }, fetchOptions: { signal } }),
+          [200],
+        );
+        L.debug("cancelRun$ server accepted cancel", { threadId, runId });
+      }),
+    );
+  },
+);
+
+const markRead$ = command(
+  async (
+    { get },
+    { threadId, latestMessageId }: MarkReadArgs,
+    signal: AbortSignal,
+  ): Promise<string | null> => {
+    const client = get(zeroClient$)(chatThreadMarkReadContract);
+    const result = await accept(
+      client.markRead({
+        params: { id: threadId },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    return result.body.lastReadMessageId ?? latestMessageId;
+  },
+);
+
+const subscribeRealtime$ = command(
+  async (
+    { set },
+    { threadId, handlers }: SubscribeRealtimeArgs,
+    signal: AbortSignal,
+  ) => {
+    await Promise.all([
+      set(
+        setAblyLoop$,
+        `chatThreadMessageCreated:${threadId}`,
+        handlers.onMessageCreated$,
+        signal,
+      ),
+      set(
+        setAblyLoop$,
+        `chatThreadRunCreated:${threadId}`,
+        handlers.onRunChanged$,
+        signal,
+      ),
+      set(
+        setAblyLoop$,
+        `chatThreadRunUpdated:${threadId}`,
+        handlers.onRunChanged$,
+        signal,
+      ),
+    ]);
+    signal.throwIfAborted();
+  },
+);
+
+export function createRemoteChatThreadDataSource(
+  threadId: string,
+): ChatThreadDataSource {
+  const reloadCounter$ = state(0);
+
+  const getThread$ = computed(async (get): Promise<ChatThread | null> => {
+    get(reloadCounter$);
+    const threadClient = get(zeroClient$)(chatThreadByIdContract);
+    const threadResult = await accept(
+      threadClient.get({ params: { id: threadId } }),
+      [200, 404],
+      { toast: false },
+    );
+    if (threadResult.status === 404) {
+      return null;
+    }
+    const body = threadResult.body;
+    return {
+      id: threadId,
+      title: body.title ?? null,
+      agentId: body.agentId,
+      latestSessionId: body.latestSessionId ?? null,
+      lastReadMessageId: body.lastReadMessageId ?? null,
+      latestSessionProviderType: body.latestSessionProviderType ?? null,
+      activeRunIds: body.activeRunIds,
+      activeRuns: body.activeRuns ?? [],
+      isLegacySession: false,
+      draftContent: body.draftContent ?? null,
+      draftAttachments: body.draftAttachments ?? null,
+      modelProviderId: body.modelProviderId ?? null,
+      selectedModel: body.selectedModel ?? null,
+    };
+  });
+
+  const reloadThread$ = command(({ set }) => {
+    set(reloadCounter$, (v) => {
+      return v + 1;
+    });
+  });
+
+  const initialPage$ = computed(async (get): Promise<InitialPage> => {
+    const client = get(zeroClient$)(chatThreadMessagesContract);
+    const result = await accept(
+      client.list({ params: { threadId }, query: { limit: 50 } }),
+      [200],
+    );
+    const hasHistoryBefore = result.body.hasHistoryBefore ?? false;
+    L.debug("initialPage$", {
+      threadId,
+      count: result.body.messages.length,
+      hasHistoryBefore,
+    });
+    return { messages: result.body.messages, hasHistoryBefore };
+  });
+
+  return {
+    getThread$,
+    reloadThread$,
+    initialPage$,
+    patchDraft$,
+    listMessagesAfter$,
+    listMessagesBefore$,
+    cancelRuns$,
+    markRead$,
+    subscribeRealtime$,
+    isCancelRequested$: remoteIsCancelRequested$,
+  };
+}


### PR DESCRIPTION
## Summary

- Replace `options.localSnapshot` mode flag in `createChatThreadSignals` with a polymorphic `ChatThreadDataSource` interface backed by `RemoteChatThreadDataSource` / `LocalChatThreadDataSource`. All nine ad-hoc `if (options.localSnapshot)` branches across the factory are gone.
- Internalize `cancelRequested$`: it now lives privately inside `LocalChatThreadDataSource` instead of being constructed by callers and threaded through a snapshot.
- Extract `createPendingChatThread(threadId, agentId, pendingRunId?)` helper, deduplicating the 13-field placeholder `ChatThread` literal that both optimistic call sites used to construct inline. The optional `pendingRunId` covers the empty-runs / pending-run divergence in `optimistic-chat-thread-page.ts`.

## Design notes

- `ChatThreadDataSource` exposes `Computed`/`Command` fields. Commands accept an args object that includes `threadId`, e.g. `set(dataSource.patchDraft$, { threadId, content, attachments }, signal)`. Module-level commands (remote impl) are thus shared across instances; per-instance state (cancel-requested, reload counter) lives in the factory closure.
- Risk §1 from the design plan (`markThreadReadIfNeeded$` would 404 against an unpersisted thread for `sendNewThreadMessage$`) is addressed by adding `markRead\$` to the data source. Local impl returns `null`; the factory skips the state write when null.
- This refactor is the precursor to #11635 (IndexedDB cache). The data source seam — `initialPage\$`, `listMessagesAfter\$`, `listMessagesBefore\$` — is exactly where IDB hooks land. Pending threads using `LocalChatThreadDataSource` never touch the network, so optimistic messages can never leak into the IDB cache.

## Test plan

- [x] New integration test `__tests__/optimistic-chat-thread.test.ts` passes (3 cases: placeholder shape, cancel flips `allFinished\$`, `scheduleDraftSync\$` makes no PATCH in local mode).
- [x] Existing `__tests__/create-chat-thread.test.ts` continues to pass — implicitly exercises `RemoteChatThreadDataSource.patchDraft\$`.
- [x] Sidebar navigation/delete E2E tests pass (covers optimistic create + settle flow).
- [x] `pnpm format`, `pnpm turbo run lint`, `pnpm -F @vm0/app exec tsc --noEmit`, `pnpm knip` all clean.
- [ ] Manual smoke test via `/dev-tunnel`: create new chat from sidebar, send new message into a fresh thread, cancel an optimistic run.

Closes #11632