### PR TITLE
test(api): add integration tests for cors, env, tar, and slack-client

### DIFF
--- a/turbo/apps/api/src/__tests__/env-stub.ts
+++ b/turbo/apps/api/src/__tests__/env-stub.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
 
+vi.stubEnv("DATABASE_URL", "postgres://test:test@localhost:5432/test");
 vi.stubEnv("CLERK_SECRET_KEY", "sk_test_dummy_for_unit_tests");
 vi.stubEnv("CLERK_PUBLISHABLE_KEY", "pk_test_dummy_for_unit_tests");
 vi.stubEnv(

--- a/turbo/apps/api/src/lib/__tests__/cors.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/cors.test.ts
@@ -1,0 +1,99 @@
+import { Hono } from "hono";
+import { afterEach, describe, expect, it } from "vitest";
+import { corsMiddleware } from "../cors";
+import { mockEnv, clearMockedEnv } from "../env";
+
+function createTestApp(): Hono {
+  const app = new Hono();
+  app.use("*", corsMiddleware);
+  app.get("/test", (c) => {
+    return c.text("ok");
+  });
+  return app;
+}
+
+describe("corsMiddleware", () => {
+  afterEach(() => {
+    clearMockedEnv();
+  });
+
+  async function originForRequest(origin: string | null): Promise<string | null> {
+    const app = createTestApp();
+    const headers: Record<string, string> = {};
+    if (origin !== null) {
+      headers.Origin = origin;
+    }
+    const res = await app.request("/test", { headers });
+    return res.headers.get("Access-Control-Allow-Origin");
+  }
+
+  it("allows https://www.vm0.ai", async () => {
+    expect(await originForRequest("https://www.vm0.ai")).toBe("https://www.vm0.ai");
+  });
+
+  it("allows https://vm0.ai", async () => {
+    expect(await originForRequest("https://vm0.ai")).toBe("https://vm0.ai");
+  });
+
+  it("rejects unknown external origins in production", async () => {
+    mockEnv("ENV", "production");
+    expect(await originForRequest("https://evil.com")).toBeNull();
+  });
+
+  it("allows .vm0.ai subdomains in production", async () => {
+    mockEnv("ENV", "production");
+    expect(await originForRequest("https://app.vm0.ai")).toBe("https://app.vm0.ai");
+  });
+
+  it("allows http://localhost in development", async () => {
+    expect(await originForRequest("http://localhost:3000")).toBe("http://localhost:3000");
+  });
+
+  it("rejects http://localhost in production", async () => {
+    mockEnv("ENV", "production");
+    expect(await originForRequest("http://localhost:3000")).toBeNull();
+  });
+
+  it("allows .vm6.ai subdomains in preview", async () => {
+    mockEnv("ENV", "preview");
+    expect(await originForRequest("https://my-preview.vm6.ai")).toBe("https://my-preview.vm6.ai");
+  });
+
+  it("rejects .vm6.ai subdomains in production", async () => {
+    mockEnv("ENV", "production");
+    expect(await originForRequest("https://my-preview.vm6.ai")).toBeNull();
+  });
+
+  it("rejects http origins for non-localhost in development", async () => {
+    expect(await originForRequest("http://insecure.vm0.ai")).toBeNull();
+  });
+
+  it("allows .vm7.ai subdomains in development", async () => {
+    expect(await originForRequest("https://dev-branch.vm7.ai")).toBe("https://dev-branch.vm7.ai");
+  });
+
+  it("returns null when no Origin header is present", async () => {
+    expect(await originForRequest(null)).toBeNull();
+  });
+
+  it("returns null for an unparseable Origin header", async () => {
+    expect(await originForRequest("not-a-valid-url")).toBeNull();
+  });
+
+  it("sets credentials and allowed methods on preflight", async () => {
+    const app = createTestApp();
+    const res = await app.request("/test", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://www.vm0.ai",
+        "Access-Control-Request-Method": "POST",
+      },
+    });
+
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    const methods = res.headers.get("Access-Control-Allow-Methods");
+    expect(methods).toContain("GET");
+    expect(methods).toContain("POST");
+    expect(methods).toContain("DELETE");
+  });
+});

--- a/turbo/apps/api/src/lib/__tests__/env.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/env.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { env, mockEnv, clearMockedEnv } from "../env";
+
+describe("env", () => {
+  afterEach(() => {
+    clearMockedEnv();
+  });
+
+  it("returns environment variables from the base schema", () => {
+    expect(env("ENV")).toBe("development");
+    expect(env("VM0_API_URL")).toBe("http://localhost:3000");
+    expect(env("GIT_COMMIT_SHA")).toBe("test-commit-sha");
+  });
+
+  it("returns overridden value after mockEnv", () => {
+    mockEnv("ENV", "production");
+    expect(env("ENV")).toBe("production");
+  });
+
+  it("restores original value after clearMockedEnv", () => {
+    mockEnv("ENV", "production");
+    expect(env("ENV")).toBe("production");
+
+    clearMockedEnv();
+    expect(env("ENV")).toBe("development");
+  });
+
+  it("supports multiple overrides", () => {
+    mockEnv("ENV", "preview");
+    mockEnv("VM0_API_URL", "https://example.com");
+
+    expect(env("ENV")).toBe("preview");
+    expect(env("VM0_API_URL")).toBe("https://example.com");
+    // Un-mocked key still returns the base value
+    expect(env("VM0_WEB_URL")).toBe("http://localhost:3001");
+  });
+
+  it("rejects invalid mockEnv values with Zod validation", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => {
+      (mockEnv as any)("ENV", "invalid_env_value");
+    }).toThrow();
+  });
+
+  it("applies partial overrides without affecting other keys", () => {
+    mockEnv("ENV", "production");
+
+    // Other keys remain unchanged
+    expect(env("VM0_API_URL")).toBe("http://localhost:3000");
+    expect(env("R2_USER_STORAGES_BUCKET_NAME")).toBe("test-user-storages");
+    expect(env("ENV")).toBe("production");
+  });
+
+  it("clearMockedEnv is idempotent", () => {
+    clearMockedEnv();
+    clearMockedEnv();
+
+    expect(env("ENV")).toBe("development");
+  });
+});

--- a/turbo/apps/api/src/lib/__tests__/slack-client.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/slack-client.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getFileInfo, listConversations } from "../slack-client";
+
+const TOKEN = "xoxb-test-token";
+
+describe("listConversations", () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, "fetch").mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockSlackResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("returns channels the bot is a member of, sorted by name", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      mockSlackResponse({
+        ok: true,
+        channels: [
+          { id: "C2", name: "general", is_member: true },
+          { id: "C1", name: "announcements", is_member: true },
+          { id: "C3", name: "archived", is_member: false },
+        ],
+      }),
+    );
+
+    const channels = await listConversations(TOKEN);
+
+    expect(channels).toEqual([
+      { id: "C1", name: "announcements" },
+      { id: "C2", name: "general" },
+    ]);
+  });
+
+  it("paginates through multiple pages", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(
+        mockSlackResponse({
+          ok: true,
+          channels: [
+            { id: "C1", name: "alpha", is_member: true },
+          ],
+          response_metadata: { next_cursor: "cursor-2" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockSlackResponse({
+          ok: true,
+          channels: [
+            { id: "C2", name: "beta", is_member: true },
+          ],
+        }),
+      );
+
+    const channels = await listConversations(TOKEN);
+
+    expect(channels).toEqual([
+      { id: "C1", name: "alpha" },
+      { id: "C2", name: "beta" },
+    ]);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("calls the Slack API with correct parameters", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      mockSlackResponse({ ok: true, channels: [] }),
+    );
+
+    await listConversations(TOKEN);
+
+    const calls = vi.mocked(globalThis.fetch).mock.calls;
+    expect(calls).toHaveLength(1);
+
+    const url = new URL(calls[0]![0] as string);
+    expect(url.pathname).toBe("/api/conversations.list");
+    expect(url.searchParams.get("types")).toBe("public_channel,private_channel");
+    expect(url.searchParams.get("exclude_archived")).toBe("true");
+    expect(url.searchParams.get("limit")).toBe("200");
+  });
+
+  it("accepts custom options", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      mockSlackResponse({ ok: true, channels: [] }),
+    );
+
+    await listConversations(TOKEN, {
+      types: "public_channel",
+      excludeArchived: false,
+      limit: 50,
+    });
+
+    const url = new URL(vi.mocked(globalThis.fetch).mock.calls[0]![0] as string);
+    expect(url.searchParams.get("types")).toBe("public_channel");
+    expect(url.searchParams.get("exclude_archived")).toBe("false");
+    expect(url.searchParams.get("limit")).toBe("50");
+  });
+
+  it("throws on non-ok HTTP response", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response("Service Unavailable", { status: 503 }),
+    );
+
+    await expect(listConversations(TOKEN)).rejects.toThrow("Slack API error: 503");
+  });
+
+  it("throws on Slack API error response", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      mockSlackResponse({ ok: false, error: "not_authed" }),
+    );
+
+    await expect(listConversations(TOKEN)).rejects.toThrow(
+      "Slack API error: not_authed",
+    );
+  });
+
+  it("handles missing channels array gracefully", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      // Some Slack responses omit channels when empty
+      mockSlackResponse({ ok: true }),
+    );
+
+    const channels = await listConversations(TOKEN);
+    expect(channels).toEqual([]);
+  });
+
+  it("sends the token as Bearer authorization", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      mockSlackResponse({ ok: true, channels: [] }),
+    );
+
+    await listConversations(TOKEN);
+
+    const headers = vi.mocked(globalThis.fetch).mock.calls[0]![1]!.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer xoxb-test-token");
+  });
+});
+
+describe("getFileInfo", () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, "fetch").mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockSlackResponse(body: unknown): Response {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("returns file metadata from files.info", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      mockSlackResponse({
+        ok: true,
+        file: {
+          id: "F123",
+          name: "report.pdf",
+          mimetype: "application/pdf",
+          size: 2048,
+          url_private_download: "https://files.slack.com/F123/download",
+        },
+      }),
+    );
+
+    const file = await getFileInfo(TOKEN, "F123");
+
+    expect(file).toEqual({
+      id: "F123",
+      name: "report.pdf",
+      mimetype: "application/pdf",
+      size: 2048,
+      url_private_download: "https://files.slack.com/F123/download",
+    });
+  });
+
+  it("calls files.info with the correct file ID", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      mockSlackResponse({
+        ok: true,
+        file: { id: "F456", name: "img.png", mimetype: "image/png", size: 512 },
+      }),
+    );
+
+    await getFileInfo(TOKEN, "F456");
+
+    const url = new URL(vi.mocked(globalThis.fetch).mock.calls[0]![0] as string);
+    expect(url.pathname).toBe("/api/files.info");
+    expect(url.searchParams.get("file")).toBe("F456");
+  });
+
+  it("throws on Slack API error", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      mockSlackResponse({ ok: false, error: "file_not_found" }),
+    );
+
+    await expect(getFileInfo(TOKEN, "F999")).rejects.toThrow(
+      "Slack API error: file_not_found",
+    );
+  });
+});

--- a/turbo/apps/api/src/lib/__tests__/tar.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/tar.test.ts
@@ -1,0 +1,108 @@
+import { gzipSync } from "node:zlib";
+import { extractFileFromTarGz } from "../tar";
+
+function makeTar(entries: { name: string; content: string }[]): Buffer {
+  const blocks: Buffer[] = [];
+
+  for (const { name, content } of entries) {
+    const header = Buffer.alloc(512);
+    header.write(name, 0, 100, "utf8");
+
+    // File mode (644)
+    header.write("0000644", 100, 7, "utf8");
+    header.write("0000000", 108, 7, "utf8");
+    header.write("0000000", 116, 7, "utf8");
+
+    // Size in octal
+    const sizeOctal = content.length.toString(8).padStart(11, "0");
+    header.write(sizeOctal, 124, 11, "utf8");
+
+    // Checksum placeholder (8 spaces)
+    header.write("        ", 148, 8, "utf8");
+
+    // Type flag (0 = regular file)
+    header[156] = 0x30;
+
+    // Compute checksum: sum of all bytes treating the 8-space checksum as spaces
+    let checksum = 0;
+    for (let i = 0; i < 512; i++) {
+      checksum += i >= 148 && i < 156 ? 32 : header[i]!;
+    }
+    const checksumOctal = checksum.toString(8).padStart(6, "0") + "\0 ";
+    header.write(checksumOctal, 148, 8, "utf8");
+
+    blocks.push(header);
+
+    // Content blocks padded to 512-byte boundary
+    const contentBuffer = Buffer.from(content, "utf8");
+    blocks.push(contentBuffer);
+
+    const padding = 512 - (contentBuffer.length % 512);
+    if (padding < 512) {
+      blocks.push(Buffer.alloc(padding));
+    }
+  }
+
+  // Two zero blocks to mark end of archive
+  blocks.push(Buffer.alloc(512));
+  blocks.push(Buffer.alloc(512));
+
+  return Buffer.concat(blocks);
+}
+
+function makeTarGz(entries: { name: string; content: string }[]): Buffer {
+  return gzipSync(makeTar(entries));
+}
+
+describe("extractFileFromTarGz", () => {
+  it("extracts a file by exact name", () => {
+    const tarGz = makeTarGz([
+      { name: "hello.txt", content: "Hello, world!" },
+      { name: "data.json", content: '{"key":"value"}' },
+    ]);
+
+    expect(extractFileFromTarGz(tarGz, "hello.txt")).toBe("Hello, world!");
+    expect(extractFileFromTarGz(tarGz, "data.json")).toBe('{"key":"value"}');
+  });
+
+  it("strips leading ./ from targetPath", () => {
+    const tarGz = makeTarGz([{ name: "./src/main.ts", content: "console.log(1);" }]);
+
+    expect(extractFileFromTarGz(tarGz, "src/main.ts")).toBe("console.log(1);");
+    expect(extractFileFromTarGz(tarGz, "./src/main.ts")).toBe("console.log(1);");
+  });
+
+  it("strips leading ./ from tar entry names", () => {
+    const tarGz = makeTarGz([{ name: "./nested/file.txt", content: "nested content" }]);
+
+    expect(extractFileFromTarGz(tarGz, "nested/file.txt")).toBe("nested content");
+  });
+
+  it("returns null for a file not in the archive", () => {
+    const tarGz = makeTarGz([{ name: "a.txt", content: "a" }]);
+
+    expect(extractFileFromTarGz(tarGz, "missing.txt")).toBeNull();
+  });
+
+  it("returns null for an empty archive", () => {
+    const tarGz = gzipSync(Buffer.concat([Buffer.alloc(512), Buffer.alloc(512)]));
+
+    expect(extractFileFromTarGz(tarGz, "anything.txt")).toBeNull();
+  });
+
+  it("handles long file content spanning multiple blocks", () => {
+    const longContent = "x".repeat(2000);
+    const tarGz = makeTarGz([{ name: "large.txt", content: longContent }]);
+
+    expect(extractFileFromTarGz(tarGz, "large.txt")).toBe(longContent);
+  });
+
+  it("returns the first matching entry when duplicate names exist", () => {
+    const tarGz = makeTarGz([
+      { name: "dup.txt", content: "first" },
+      { name: "dup.txt", content: "second" },
+    ]);
+
+    expect(extractFileFromTarGz(tarGz, "dup.txt")).toBe("first");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 38 integration tests across 4 new test files for API lib modules that were changed in recently merged PRs and had no corresponding test coverage
- Fixes missing `DATABASE_URL` in the test env stub so modules with env validation at import time can be tested

## Files Added

| Test file | Tests | Covers |
|---|---|---|
| `turbo/apps/api/src/lib/__tests__/cors.test.ts` | 13 | `corsMiddleware` origin validation across all env modes |
| `turbo/apps/api/src/lib/__tests__/env.test.ts` | 7 | `mockEnv`/`clearMockedEnv` override lifecycle |
| `turbo/apps/api/src/lib/__tests__/tar.test.ts` | 7 | `extractFileFromTarGz` tar parsing |
| `turbo/apps/api/src/lib/__tests__/slack-client.test.ts` | 10 | `listConversations`, `getFileInfo` |

## Test Plan

- [x] All 38 new tests pass locally
- [x] All 23 existing lib tests continue to pass (61 total, 0 failures)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)