### PR TITLE
fix: remove permissive auth probe default to eliminate shadow mismatches

### DIFF
--- a/turbo/apps/api/src/signals/auth/auth-context.ts
+++ b/turbo/apps/api/src/signals/auth/auth-context.ts
@@ -128,7 +128,10 @@ const zeroAuth$ = command(
       return null;
     }
 
-    if (!options.acceptAnySandboxCapability && options.requiredCapability) {
+    if (!options.acceptAnySandboxCapability) {
+      if (!options.requiredCapability) {
+        return null;
+      }
       const hasCapability = zeroAuth.capabilities.some((capability) => {
         return capability === options.requiredCapability;
       });

--- a/turbo/apps/api/src/signals/routes/__tests__/health-auth-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/health-auth-probe.test.ts
@@ -555,7 +555,7 @@ describe("GET /health/auth", () => {
   });
 
   describe("Sandbox bearer", () => {
-    it("resolves a sandbox bearer token", async () => {
+    it("rejects a sandbox bearer token without capability opt-in", async () => {
       const token = signSandboxJwtForTests({
         scope: "sandbox",
         userId: "user_sandbox",
@@ -568,14 +568,11 @@ describe("GET /health/auth", () => {
       const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({ headers: { authorization: `Bearer ${token}` } }),
-        [200],
+        [401],
       );
 
       expect(response.body).toStrictEqual({
-        tokenType: "sandbox",
-        userId: "user_sandbox",
-        orgId: "org_sandbox",
-        runId: "run_sandbox",
+        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
       });
     });
   });
@@ -597,7 +594,10 @@ describe("GET /health/auth", () => {
 
       const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
-        client.check({ headers: { authorization: `Bearer ${token}` } }),
+        client.check({
+          headers: { authorization: `Bearer ${token}` },
+          query: { acceptAnySandboxCapability: "true" },
+        }),
         [200],
       );
 
@@ -627,7 +627,10 @@ describe("GET /health/auth", () => {
 
       const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
-        client.check({ headers: { authorization: `Bearer ${token}` } }),
+        client.check({
+          headers: { authorization: `Bearer ${token}` },
+          query: { acceptAnySandboxCapability: "true" },
+        }),
         [200],
       );
 
@@ -660,7 +663,10 @@ describe("GET /health/auth", () => {
 
       const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
-        client.check({ headers: { authorization: `Bearer ${token}` } }),
+        client.check({
+          headers: { authorization: `Bearer ${token}` },
+          query: { acceptAnySandboxCapability: "true" },
+        }),
         [200],
       );
 
@@ -957,10 +963,11 @@ describe("GET /health/auth", () => {
     });
 
     // authRoute with no options — matches the default route auth pattern
-    // that most routes use. Zero tokens must still authenticate here.
+    // that most routes use. Zero tokens without capability opt-in are
+    // rejected, matching web's authenticateSandboxToken behavior.
     const noOptionRoute$ = authRoute({}, noOptionHandler$);
 
-    it("resolves a zero token on a route with no auth options", async () => {
+    it("rejects a zero token on a route with no auth options", async () => {
       const fixture = await seedPatFixture({ role: "admin" });
       fixtures.push(fixture);
       const nowSeconds = currentSecond();
@@ -983,16 +990,11 @@ describe("GET /health/auth", () => {
       })(noOptionContract);
       const response = await accept(
         client.check({ headers: { authorization: `Bearer ${token}` } }),
-        [200],
+        [401],
       );
 
       expect(response.body).toStrictEqual({
-        tokenType: "zero",
-        userId: fixture.userId,
-        orgId: fixture.orgId,
-        orgRole: "admin",
-        runId: "run_zero",
-        capabilities: ["file:read"],
+        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
       });
     });
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/health-auth-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/health-auth-probe.test.ts
@@ -568,11 +568,14 @@ describe("GET /health/auth", () => {
       const client = setupApp({ context })(healthAuthProbeContract);
       const response = await accept(
         client.check({ headers: { authorization: `Bearer ${token}` } }),
-        [401],
+        [403],
       );
 
       expect(response.body).toStrictEqual({
-        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        error: {
+          message: "This endpoint is not available for sandbox tokens",
+          code: "FORBIDDEN",
+        },
       });
     });
   });
@@ -990,11 +993,14 @@ describe("GET /health/auth", () => {
       })(noOptionContract);
       const response = await accept(
         client.check({ headers: { authorization: `Bearer ${token}` } }),
-        [401],
+        [403],
       );
 
       expect(response.body).toStrictEqual({
-        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        error: {
+          message: "This endpoint is not available for sandbox tokens",
+          code: "FORBIDDEN",
+        },
       });
     });
   });

--- a/turbo/apps/api/src/signals/routes/health-auth-probe.ts
+++ b/turbo/apps/api/src/signals/routes/health-auth-probe.ts
@@ -57,15 +57,6 @@ const probe$ = command(
       options.accept = query.accept.split(",") as AuthTokenType[];
     }
 
-    // Backward-compat: no params defaults to the old permissive behaviour
-    if (
-      !options.acceptAnySandboxCapability &&
-      !options.requiredCapability &&
-      !options.accept
-    ) {
-      options.acceptAnySandboxCapability = true;
-    }
-
     const result = await set(requiredAuthContext$, options, signal);
     if ("status" in result) {
       // PAT-only routes: rewrite 401 message to match requireApiKeyAuth phrasing

--- a/turbo/apps/api/src/signals/routes/health-auth-probe.ts
+++ b/turbo/apps/api/src/signals/routes/health-auth-probe.ts
@@ -22,9 +22,17 @@ const probeRoute = c.router({
       authorization: z.string().optional(),
       cookie: z.string().optional(),
     }),
+    query: z.object({
+      acceptAnySandboxCapability: z.string().optional(),
+      requiredCapability: z.string().optional(),
+      accept: z.string().optional(),
+    }),
     responses: {
       200: z.unknown(),
       401: z.object({
+        error: z.object({ message: z.string(), code: z.string() }),
+      }),
+      403: z.object({
         error: z.object({ message: z.string(), code: z.string() }),
       }),
     },

--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -14,8 +14,8 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
-    "@clerk/clerk-js": "^5.125.9",
-    "@clerk/clerk-react": "^5.61.5",
+    "@clerk/clerk-js": "^5.125.10",
+    "@clerk/clerk-react": "^5.61.6",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/s3-request-presigner": "^3.1037.0",
     "@axiomhq/js": "^1.3.1",
     "@axiomhq/logging": "^0.1.6",
-    "@clerk/backend": "^3.2.12",
+    "@clerk/backend": "^3.4.1",
     "@clerk/nextjs": "^7.2.7",
     "@google/genai": "^1.50.1",
     "@neondatabase/serverless": "^1.0.2",

--- a/turbo/apps/web/src/lib/zero/credit/__tests__/credit-expiry.test.ts
+++ b/turbo/apps/web/src/lib/zero/credit/__tests__/credit-expiry.test.ts
@@ -192,7 +192,9 @@ describe("credit expires service", () => {
     it("returns summary for active records", async () => {
       const { orgId } = await context.setupUser({ prefix: "summary" });
 
-      const expiryDate = new Date("2026-05-01T00:00:00Z");
+      const expiryDate = new Date();
+      expiryDate.setMonth(expiryDate.getMonth() + 1);
+      expiryDate.setHours(0, 0, 0, 0);
       await insertCreditExpiresRecord({
         orgId,
         amount: 10000,

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -458,8 +458,8 @@ importers:
         specifier: ^0.1.6
         version: 0.1.7(@axiomhq/js@1.5.0)
       '@clerk/backend':
-        specifier: ^3.2.12
-        version: 3.2.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^3.4.1
+        version: 3.4.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@clerk/nextjs':
         specifier: ^7.2.7
         version: 7.2.7(next@16.2.3(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1295,10 +1295,6 @@ packages:
 
   '@bufbuild/protobuf@2.11.0':
     resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
-
-  '@clerk/backend@3.2.12':
-    resolution: {integrity: sha512-pTuD3+3IvLrjx9XMYdbqpttTltrWc7npxkOIDzhtID5/+IOomxZAzsnxU1G1hvOeBoR1Jl68ZgKQw66aZ+DRFQ==}
-    engines: {node: '>=20.9.0'}
 
   '@clerk/backend@3.4.1':
     resolution: {integrity: sha512-+Tgo1uPEFpBRvyFW3JtPbrTMRgiP+pWBo9gi2tTB0AxEqR2I/kSYy5l3+KqWciUpbVZtVvLXm1j+NEE2WEG+jg==}
@@ -9871,15 +9867,6 @@ snapshots:
   '@blazediff/core@1.9.1': {}
 
   '@bufbuild/protobuf@2.11.0': {}
-
-  '@clerk/backend@3.2.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@clerk/shared': 4.8.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      standardwebhooks: 1.0.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - react
-      - react-dom
 
   '@clerk/backend@3.4.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -277,11 +277,11 @@ importers:
   apps/platform:
     dependencies:
       '@clerk/clerk-js':
-        specifier: ^5.125.9
-        version: 5.125.9(@types/react@19.2.14)(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
+        specifier: ^5.125.10
+        version: 5.125.10(@types/react@19.2.14)(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
       '@clerk/clerk-react':
-        specifier: ^5.61.5
-        version: 5.61.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^5.61.6
+        version: 5.61.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1300,14 +1300,14 @@ packages:
     resolution: {integrity: sha512-+Tgo1uPEFpBRvyFW3JtPbrTMRgiP+pWBo9gi2tTB0AxEqR2I/kSYy5l3+KqWciUpbVZtVvLXm1j+NEE2WEG+jg==}
     engines: {node: '>=20.9.0'}
 
-  '@clerk/clerk-js@5.125.9':
+  '@clerk/clerk-js@5.125.10':
     resolution: {integrity: sha512-5F3u/Ki082vsWTyYz8SWDDGXb06jMujY7JgwqFTJsSlEuUxwQLKMZbhdsewtgTqjY/DfKgF138x0EXiVCaBYxw==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
-  '@clerk/clerk-react@5.61.5':
+  '@clerk/clerk-react@5.61.6':
     resolution: {integrity: sha512-MKVEsvRR47WlizFki5BPjLIm1TPbJju4m2CNJGzrRqhEMide0Yjm4DGYfh/r2k/uFjOGMWfSJ7EToM1y2AQ5rg==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
@@ -1333,21 +1333,9 @@ packages:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
-  '@clerk/shared@3.47.4':
+  '@clerk/shared@3.47.5':
     resolution: {integrity: sha512-0O5/zgB5SO26PKarAIw7uj4j+4JsnT2/uiJ7SPI3LQMb62sM+AjDlVadcXuYc+4sY6w1szrAIVepI5Bkv57hnQ==}
     engines: {node: '>=18.17.0'}
-    peerDependencies:
-      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
-      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
-  '@clerk/shared@4.8.2':
-    resolution: {integrity: sha512-kBFDNeLdiNZkOHavTkOB00NMuqsmOGgVtDlzCS0/yivxsCUZXk3AT6+UsTfeSBGV7QD80YxjeFMNSrpqnSv4Gg==}
-    engines: {node: '>=20.9.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -9877,11 +9865,11 @@ snapshots:
       - react
       - react-dom
 
-  '@clerk/clerk-js@5.125.9(@types/react@19.2.14)(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)':
+  '@clerk/clerk-js@5.125.10(@types/react@19.2.14)(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)':
     dependencies:
       '@base-org/account': 2.0.1(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
       '@clerk/localizations': 3.37.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@clerk/shared': 3.47.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@clerk/shared': 3.47.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@coinbase/wallet-sdk': 4.3.0
       '@emotion/cache': 11.11.0
       '@emotion/react': 11.11.1(@types/react@19.2.14)(react@19.2.4)
@@ -9922,9 +9910,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@clerk/clerk-react@5.61.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@clerk/clerk-react@5.61.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@clerk/shared': 3.47.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@clerk/shared': 3.47.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       tslib: 2.8.1
@@ -9954,7 +9942,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       tslib: 2.8.1
 
-  '@clerk/shared@3.47.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@clerk/shared@3.47.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       csstype: 3.1.3
       dequal: 2.0.3
@@ -9962,17 +9950,6 @@ snapshots:
       js-cookie: 3.0.5
       std-env: 3.10.0
       swr: 2.3.4(react@19.2.4)
-    optionalDependencies:
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-
-  '@clerk/shared@4.8.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@tanstack/query-core': 5.90.16
-      dequal: 2.0.3
-      glob-to-regexp: 0.4.1
-      js-cookie: 3.0.5
-      std-env: 3.10.0
     optionalDependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -9990,7 +9967,7 @@ snapshots:
 
   '@clerk/types@4.101.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@clerk/shared': 3.47.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@clerk/shared': 3.47.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - react
       - react-dom

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -1301,14 +1301,14 @@ packages:
     engines: {node: '>=20.9.0'}
 
   '@clerk/clerk-js@5.125.10':
-    resolution: {integrity: sha512-5F3u/Ki082vsWTyYz8SWDDGXb06jMujY7JgwqFTJsSlEuUxwQLKMZbhdsewtgTqjY/DfKgF138x0EXiVCaBYxw==}
+    resolution: {integrity: sha512-R0sZ5n4ND7xnHKkMoSuhcYa5+qcgHeYEsQ8eN0ti5hUgGH3LzQX1vJg0GHTEceJI68SrVETArRR7bxyMwS8QAg==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
   '@clerk/clerk-react@5.61.6':
-    resolution: {integrity: sha512-MKVEsvRR47WlizFki5BPjLIm1TPbJju4m2CNJGzrRqhEMide0Yjm4DGYfh/r2k/uFjOGMWfSJ7EToM1y2AQ5rg==}
+    resolution: {integrity: sha512-OiyBlrnkRr9IhZtPd7EwlzhYScBpvNKJ8lgg7Uw6JElzJYz854IeQaez5mAfpiib3LcW/Dn53E2PQhagcuLJ3Q==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -1334,7 +1334,7 @@ packages:
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
   '@clerk/shared@3.47.5':
-    resolution: {integrity: sha512-0O5/zgB5SO26PKarAIw7uj4j+4JsnT2/uiJ7SPI3LQMb62sM+AjDlVadcXuYc+4sY6w1szrAIVepI5Bkv57hnQ==}
+    resolution: {integrity: sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0


### PR DESCRIPTION
## Summary

- Removed the backward-compat permissive default in `/health/auth` probe that caused 22 false-positive auth shadow mismatches (API=200 vs Web=403 for sandbox tokens)
- Fixed `zeroAuth$` to reject zero tokens when neither `acceptAnySandboxCapability` nor `requiredCapability` is set, matching web's `authenticateSandboxToken` behavior
- Updated 5 tests to reflect the corrected auth behavior

## Root cause

The auth shadow probe (`/health/auth`) had a backward-compat block that defaulted to `acceptAnySandboxCapability=true` when called without query params. This made the API always accept sandbox tokens, while the web app's `requireAuth` correctly rejected them (no capability opt-in → 403).

Additionally, `zeroAuth$` in the API accepted zero tokens unconditionally when no capability opt-in was set, while the web's `authenticateSandboxToken` rejects them upfront. Fixed to match.

## Changes

| File | Change |
|------|--------|
| `health-auth-probe.ts` | Remove backward-compat block (9 lines) |
| `auth-context.ts` | Fix `zeroAuth$` to require capability opt-in for zero tokens |
| `health-auth-probe.test.ts` | Update sandbox test (200→401), add opt-in query to zero tests, update no-options route test (200→401) |

## Test plan

- [ ] `pnpm -F @vm0/api exec vitest src/signals/routes/__tests__/health-auth-probe.test.ts` passes
- [ ] Deploy and verify auth shadow mismatches drop to zero for sandbox/zero token routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)