### PR TITLE
fix(web): make credit-expiry summary test calendar-independent

### DIFF
--- a/turbo/apps/web/src/lib/zero/credit/__tests__/credit-expiry.test.ts
+++ b/turbo/apps/web/src/lib/zero/credit/__tests__/credit-expiry.test.ts
@@ -192,7 +192,8 @@ describe("credit expires service", () => {
     it("returns summary for active records", async () => {
       const { orgId } = await context.setupUser({ prefix: "summary" });
 
-      const expiryDate = new Date("2026-05-01T00:00:00Z");
+      const expiryDate = new Date();
+      expiryDate.setDate(expiryDate.getDate() + 60);
       await insertCreditExpiresRecord({
         orgId,
         amount: 10000,


### PR DESCRIPTION
## Summary

- Replaces a hardcoded `new Date("2026-05-01T00:00:00Z")` "future" expiry in `credit-expiry.test.ts` with a runtime-relative `now + 60 days`, so the test stops failing once wall-clock time crosses the literal.
- Mirrors the `futureDate.setMonth(...)` pattern already used 9× elsewhere in the same file — keeps the suite internally consistent.
- Unblocks the `test-web (5)` shard for **every** PR touching web code (today's date is on/after the literal, so the inserted record is excluded by `gt(expiresAt, new Date())` in `getExpiresRecordsSummary`, the summary returns 0 instead of 7000, and the assertion fails).

Closes #11650.

## Test plan

- [x] `cd turbo && pnpm -F web exec vitest run src/lib/zero/credit/__tests__/credit-expiry.test.ts` — all 13 tests pass locally
- [x] `pnpm turbo run lint --filter=web` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — no diff
- [x] `pnpm knip --workspace web` — clean
- [ ] CI `test-web (5)` shard turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)