### PR TITLE
fix: harden ably disconnect handling

### DIFF
--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -8,6 +8,7 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Instant;
 use tokio_tungstenite::tungstenite;
+use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 
 use crate::Error;
 use crate::TokenRequest;
@@ -15,7 +16,7 @@ use crate::protocol::{
     AuthDetails, ErrorInfo, ProtocolMessage, action, build_attach_msg, decode_msg, encode_msg,
     error_code, flags,
 };
-use crate::types::{Event, Message, TimingConfig, TokenDetails, TokenFuture};
+use crate::types::{Event, Message, TimingConfig, TokenDetails, TokenFuture, redact_access_token};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -125,14 +126,14 @@ async fn wait_for_connected(ws_read: &mut WsRead) -> Result<ProtocolMessage, Err
                     let err = error_or_unknown(msg.error);
                     return Err(Error::Protocol {
                         code: err.code,
-                        message: err.message,
+                        message: protocol_error_message(err.message),
                     });
                 }
                 action::DISCONNECTED => {
                     let err = error_or_unknown(msg.error);
                     return Err(Error::Protocol {
                         code: err.code,
-                        message: err.message,
+                        message: protocol_error_message(err.message),
                     });
                 }
                 _ => {
@@ -162,14 +163,14 @@ async fn wait_for_attached(ws_read: &mut WsRead, channel: &str) -> Result<Protoc
                     let err = error_or_unknown(msg.error);
                     return Err(Error::Protocol {
                         code: err.code,
-                        message: err.message,
+                        message: protocol_error_message(err.message),
                     });
                 }
                 action::DETACHED => {
                     let err = error_or_unknown(msg.error);
                     return Err(Error::Protocol {
                         code: err.code,
-                        message: format!("Channel detached: {}", err.message),
+                        message: channel_detached_message(&err.message),
                     });
                 }
                 _ => {
@@ -289,8 +290,7 @@ impl ConnState {
 // ---------------------------------------------------------------------------
 
 pub(crate) struct EventLoopState {
-    pub ws_read: WsRead,
-    pub ws_write: WsWrite,
+    pub transport: Option<WsTransport>,
     pub event_tx: mpsc::Sender<Event>,
     pub conn_state: ConnState,
     pub channel: String,
@@ -304,25 +304,191 @@ pub(crate) struct EventLoopState {
     pub dropped_messages: u64,
 }
 
+pub(crate) struct WsTransport {
+    ws_read: WsRead,
+    ws_write: WsWrite,
+}
+
+impl WsTransport {
+    pub(crate) fn new(ws_read: WsRead, ws_write: WsWrite) -> Self {
+        Self { ws_read, ws_write }
+    }
+}
+
+fn websocket_close_reason(frame: Option<&CloseFrame>) -> String {
+    match frame {
+        Some(frame) if frame.reason.is_empty() => {
+            format!("websocket closed code={}", frame.code)
+        }
+        Some(frame) => {
+            let reason = websocket_close_frame_reason(frame);
+            format!("websocket closed code={} reason={}", frame.code, reason)
+        }
+        None => "websocket closed without close frame".to_string(),
+    }
+}
+
+fn websocket_close_frame_reason(frame: &CloseFrame) -> String {
+    redact_access_token(frame.reason.as_ref())
+}
+
+fn websocket_error_reason(error: &tungstenite::Error) -> String {
+    format!(
+        "websocket error: {}",
+        redact_access_token(&error.to_string())
+    )
+}
+
+fn protocol_disconnect_reason(error: Option<ErrorInfo>) -> String {
+    match error {
+        Some(error) if !error.message.is_empty() => redact_access_token(&error.message),
+        Some(error) => {
+            let status = error
+                .status_code
+                .map(|status_code| format!(" status={status_code}"))
+                .unwrap_or_default();
+            format!("server sent DISCONNECTED code={}{}", error.code, status)
+        }
+        None => "server sent DISCONNECTED without error details".to_string(),
+    }
+}
+
+fn protocol_error_message(message: String) -> String {
+    redact_access_token(&message)
+}
+
+fn channel_detached_message(message: &str) -> String {
+    format!("Channel detached: {}", redact_access_token(message))
+}
+
+fn reconnect_spacing_delay(last_attempt: Option<Instant>, min_interval: Duration) -> Duration {
+    last_attempt.map_or(Duration::ZERO, |attempt| {
+        min_interval.saturating_sub(attempt.elapsed())
+    })
+}
+
+// Caller-requested shutdown should send Ably CLOSE before closing the WebSocket
+// so the connection state is explicitly terminated.
+async fn send_close_message(p: &mut EventLoopState) {
+    let Some(transport) = p.transport.take() else {
+        return;
+    };
+    let WsTransport {
+        ws_read: _ws_read,
+        mut ws_write,
+    } = transport;
+    let close_timeout = p.timing.close_timeout;
+    let result = tokio::time::timeout(close_timeout, async move {
+        let close_msg = ProtocolMessage {
+            action: action::CLOSE,
+            ..Default::default()
+        };
+        if let Ok(data) = encode_msg(&close_msg) {
+            let _ = ws_write
+                .send(tungstenite::Message::Binary(data.into()))
+                .await;
+        }
+        let _ = ws_write.close().await;
+    })
+    .await;
+    if result.is_err() {
+        tracing::warn!(
+            timeout_ms = close_timeout.as_millis(),
+            "Timed out while closing websocket"
+        );
+    }
+}
+
+// Reconnect paths should only close the current WebSocket transport. Sending
+// Ably CLOSE here would terminate the resumable connection state on the server.
+async fn close_websocket_transport(p: &mut EventLoopState) {
+    let Some(transport) = p.transport.take() else {
+        return;
+    };
+    let WsTransport {
+        ws_read: _ws_read,
+        mut ws_write,
+    } = transport;
+    let close_timeout = p.timing.close_timeout;
+    let result = tokio::time::timeout(close_timeout, async move {
+        let _ = ws_write.close().await;
+    })
+    .await;
+    if result.is_err() {
+        tracing::warn!(
+            timeout_ms = close_timeout.as_millis(),
+            "Timed out while closing websocket transport"
+        );
+    }
+}
+
+async fn send_status_event(
+    p: &mut EventLoopState,
+    close_rx: &mut oneshot::Receiver<()>,
+    event: Event,
+    status_event: &'static str,
+) -> bool {
+    tokio::select! {
+        biased;
+        _ = &mut *close_rx => {
+            tracing::info!(status_event, "Close requested while sending status event");
+            send_close_message(p).await;
+            false
+        }
+        result = p.event_tx.send(event) => result.is_ok(),
+    }
+}
+
 pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot::Receiver<()>) {
     let mut retry_count: u32 = 0;
+    let mut last_reconnect_attempt: Option<Instant> = None;
 
     'outer: loop {
         let mut disconnected_sent = false;
         let mut immediate_retry = false;
+        let mut disconnect_reason = None;
+        let mut close_before_reconnect = false;
         // Main message processing loop
         loop {
+            let Some(transport) = p.transport.as_mut() else {
+                tracing::warn!("WebSocket transport missing before receive loop");
+                break;
+            };
             let idle_timeout = p.conn_state.max_idle_interval + p.timing.heartbeat_margin;
             let idle_deadline = Instant::now() + idle_timeout;
 
             tokio::select! {
-                frame = p.ws_read.next() => {
+                biased;
+
+                _ = &mut close_rx => {
+                    tracing::info!("Close requested");
+                    send_close_message(&mut p).await;
+                    return;
+                }
+
+                _ = tokio::time::sleep_until(p.conn_state.token_renewal_at) => {
+                    let connect_timeout = p.timing.connect_timeout;
+                    let result = tokio::select! {
+                        biased;
+                        _ = &mut close_rx => {
+                            tracing::info!("Close requested during token renewal");
+                            send_close_message(&mut p).await;
+                            return;
+                        }
+                        result = tokio::time::timeout(connect_timeout, renew_token(&mut p)) => result,
+                    };
+                    if handle_renewal_result(&mut p, &mut close_rx, result).await {
+                        return;
+                    }
+                }
+
+                frame = transport.ws_read.next() => {
                     match frame {
                         Some(Ok(tungstenite::Message::Binary(data))) => {
                             retry_count = 0;
                             match decode_msg(&data) {
                                 Ok(msg) => {
-                                    match handle_message(&mut p, msg).await {
+                                    match handle_message(&mut p, msg, &mut close_rx).await {
                                         LoopAction::Stop => return,
                                         LoopAction::Reconnect => {
                                             disconnected_sent = true;
@@ -337,54 +503,46 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                             }
                         }
                         Some(Ok(tungstenite::Message::Close(frame))) => {
+                            let reason = websocket_close_reason(frame.as_ref());
                             if let Some(ref f) = frame {
+                                let close_reason = websocket_close_frame_reason(f);
                                 tracing::info!(
                                     code = %f.code,
-                                    reason = %f.reason,
+                                    reason = %close_reason,
                                     "WebSocket Close frame received",
                                 );
                             } else {
-                                tracing::info!("WebSocket Close frame received (no reason)");
+                                tracing::info!("WebSocket Close frame received without close frame");
                             }
+                            disconnect_reason = Some(reason);
                             immediate_retry = true;
+                            close_before_reconnect = true;
                             break; // → reconnect
                         }
                         Some(Ok(_)) => {
                             // Ignore text, ping, pong frames
                         }
                         Some(Err(e)) => {
-                            tracing::warn!("WebSocket error: {e}");
+                            let reason = websocket_error_reason(&e);
+                            tracing::warn!(%reason, "WebSocket error");
+                            disconnect_reason = Some(reason);
+                            close_before_reconnect = true;
                             break; // → reconnect
                         }
                         None => {
+                            disconnect_reason = Some("websocket stream ended".to_string());
                             tracing::info!("WebSocket stream ended");
+                            close_before_reconnect = true;
                             break; // → reconnect
                         }
                     }
                 }
 
                 _ = tokio::time::sleep_until(idle_deadline) => {
+                    disconnect_reason = Some(format!("heartbeat timeout after {idle_timeout:?}"));
+                    close_before_reconnect = true;
                     tracing::warn!("Heartbeat timeout");
                     break; // → reconnect
-                }
-
-                _ = tokio::time::sleep_until(p.conn_state.token_renewal_at) => {
-                    let result = tokio::time::timeout(p.timing.connect_timeout, renew_token(&mut p)).await;
-                    if handle_renewal_result(&mut p, result).await {
-                        return;
-                    }
-                }
-
-                _ = &mut close_rx => {
-                    tracing::info!("Close requested");
-                    let close_msg = ProtocolMessage {
-                        action: action::CLOSE,
-                        ..Default::default()
-                    };
-                    if let Ok(data) = encode_msg(&close_msg) {
-                        let _ = p.ws_write.send(tungstenite::Message::Binary(data.into())).await;
-                    }
-                    return;
                 }
             }
         }
@@ -392,30 +550,48 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
         // --- Reconnection ---
         p.conn_state.disconnected_at = Some(Instant::now());
         if !disconnected_sent {
-            let _ = p.event_tx.send(Event::Disconnected { reason: None }).await;
+            let event = Event::Disconnected {
+                reason: disconnect_reason,
+            };
+            if !send_status_event(&mut p, &mut close_rx, event, "disconnected").await {
+                return;
+            }
+        }
+        if close_before_reconnect {
+            close_websocket_transport(&mut p).await;
         }
 
         loop {
             retry_count += 1;
             if retry_count > p.timing.max_retry_attempts {
-                let _ = p
-                    .event_tx
-                    .send(Event::Error {
-                        code: error_code::FAILED,
-                        message: format!(
-                            "Connection failed after {} attempts",
-                            p.timing.max_retry_attempts
-                        ),
-                    })
-                    .await;
+                let event = Event::Error {
+                    code: error_code::FAILED,
+                    message: format!(
+                        "Connection failed after {} attempts",
+                        p.timing.max_retry_attempts
+                    ),
+                };
+                let _ = send_status_event(&mut p, &mut close_rx, event, "error").await;
                 return;
             }
 
-            // Skip backoff on first attempt after a clean close (server
-            // closed the connection gracefully — reconnect immediately).
+            // Skip backoff on the first attempt after a transport close frame,
+            // but keep a small minimum gap between repeated reconnect attempts
+            // to avoid tight close loops.
             let backoff_duration = if retry_count == 1 && immediate_retry {
-                tracing::info!("Reconnecting immediately after clean close");
-                Duration::ZERO
+                let delay = reconnect_spacing_delay(
+                    last_reconnect_attempt,
+                    p.timing.min_reconnect_interval,
+                );
+                if delay == Duration::ZERO {
+                    tracing::info!("Reconnecting immediately after close frame");
+                } else {
+                    tracing::info!(
+                        delay_ms = delay.as_millis(),
+                        "Delaying reconnect after repeated close frame"
+                    );
+                }
+                delay
             } else {
                 // Exponential backoff: 1s, 2s, 4s, 8s, 15s, 15s, ...
                 let exp = retry_count.saturating_sub(1).min(30);
@@ -433,19 +609,36 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                 backoff + jitter
             };
             tokio::select! {
-                _ = tokio::time::sleep(backoff_duration) => {}
+                biased;
                 _ = &mut close_rx => {
                     tracing::info!("Close requested during reconnect");
+                    send_close_message(&mut p).await;
                     return;
                 }
+                _ = tokio::time::sleep(backoff_duration) => {}
             }
 
-            match tokio::time::timeout(p.timing.reconnect_timeout, attempt_reconnect(&mut p)).await
-            {
+            last_reconnect_attempt = Some(Instant::now());
+            let reconnect_timeout = p.timing.reconnect_timeout;
+            let reconnect_result = tokio::select! {
+                biased;
+                _ = &mut close_rx => {
+                    tracing::info!("Close requested during reconnect attempt");
+                    send_close_message(&mut p).await;
+                    return;
+                }
+                result = tokio::time::timeout(reconnect_timeout, attempt_reconnect(&mut p)) => result,
+            };
+
+            match reconnect_result {
                 Ok(Ok(())) => {
                     retry_count = 0;
                     p.token_renewal_failures = 0;
-                    let _ = p.event_tx.send(Event::Connected).await;
+                    if !send_status_event(&mut p, &mut close_rx, Event::Connected, "connected")
+                        .await
+                    {
+                        return;
+                    }
                     continue 'outer;
                 }
                 Ok(Err(e)) => {
@@ -547,7 +740,11 @@ fn decode_data(data: serde_json::Value, encoding: Option<&str>) -> serde_json::V
     result
 }
 
-async fn handle_message(p: &mut EventLoopState, msg: ProtocolMessage) -> LoopAction {
+async fn handle_message(
+    p: &mut EventLoopState,
+    msg: ProtocolMessage,
+    close_rx: &mut oneshot::Receiver<()>,
+) -> LoopAction {
     match msg.action {
         action::HEARTBEAT => {
             tracing::trace!("Heartbeat received");
@@ -597,19 +794,21 @@ async fn handle_message(p: &mut EventLoopState, msg: ProtocolMessage) -> LoopAct
             // of retriability. The server may send DISCONNECTED with a non-
             // retriable error (e.g. 429 rate limit) but still expect the client
             // to reconnect after backoff. Only connection-level ERROR is fatal.
-            let reason = msg.error.map(|e| e.message);
-            let _ = p.event_tx.send(Event::Disconnected { reason }).await;
+            let reason = Some(protocol_disconnect_reason(msg.error));
+            if !send_status_event(p, close_rx, Event::Disconnected { reason }, "disconnected").await
+            {
+                return LoopAction::Stop;
+            }
+            close_websocket_transport(p).await;
             return LoopAction::Reconnect;
         }
         action::ERROR => {
             let err = error_or_unknown(msg.error);
-            let _ = p
-                .event_tx
-                .send(Event::Error {
-                    code: err.code,
-                    message: err.message,
-                })
-                .await;
+            let event = Event::Error {
+                code: err.code,
+                message: protocol_error_message(err.message),
+            };
+            let _ = send_status_event(p, close_rx, event, "error").await;
             return LoopAction::Stop;
         }
         action::DETACHED => {
@@ -617,13 +816,11 @@ async fn handle_message(p: &mut EventLoopState, msg: ProtocolMessage) -> LoopAct
                 && !is_retriable(err)
             {
                 p.conn_state.channel_serial = None; // RTP5a1
-                let _ = p
-                    .event_tx
-                    .send(Event::Error {
-                        code: err.code,
-                        message: format!("Channel detached: {}", err.message),
-                    })
-                    .await;
+                let event = Event::Error {
+                    code: err.code,
+                    message: channel_detached_message(&err.message),
+                };
+                let _ = send_status_event(p, close_rx, event, "error").await;
                 return LoopAction::Stop;
             }
             if p.conn_state
@@ -631,6 +828,7 @@ async fn handle_message(p: &mut EventLoopState, msg: ProtocolMessage) -> LoopAct
                 .is_some_and(|t| t.elapsed() < p.timing.reattach_window)
             {
                 tracing::warn!("Channel detached again within retry window, reconnecting");
+                close_websocket_transport(p).await;
                 return LoopAction::Reconnect;
             }
             tracing::warn!(channel = ?msg.channel, "Channel detached, re-attaching");
@@ -642,17 +840,40 @@ async fn handle_message(p: &mut EventLoopState, msg: ProtocolMessage) -> LoopAct
             );
             match encode_msg(&attach) {
                 Ok(data) => {
-                    if p.ws_write
-                        .send(tungstenite::Message::Binary(data.into()))
-                        .await
-                        .is_err()
-                    {
-                        tracing::warn!("Failed to send re-attach, triggering reconnect");
+                    let connect_timeout = p.timing.connect_timeout;
+                    let Some(transport) = p.transport.as_mut() else {
+                        tracing::warn!("Missing websocket transport for re-attach");
                         return LoopAction::Reconnect;
+                    };
+                    let send_result = tokio::select! {
+                        biased;
+                        _ = &mut *close_rx => {
+                            tracing::info!("Close requested during channel re-attach");
+                            send_close_message(p).await;
+                            return LoopAction::Stop;
+                        }
+                        result = tokio::time::timeout(
+                            connect_timeout,
+                            transport.ws_write.send(tungstenite::Message::Binary(data.into())),
+                        ) => result,
+                    };
+                    match send_result {
+                        Ok(Ok(())) => {}
+                        Ok(Err(_)) => {
+                            tracing::warn!("Failed to send re-attach, triggering reconnect");
+                            close_websocket_transport(p).await;
+                            return LoopAction::Reconnect;
+                        }
+                        Err(_) => {
+                            tracing::warn!("Timed out sending re-attach, triggering reconnect");
+                            close_websocket_transport(p).await;
+                            return LoopAction::Reconnect;
+                        }
                     }
                 }
                 Err(e) => {
                     tracing::warn!("Failed to encode re-attach message: {e}");
+                    close_websocket_transport(p).await;
                     return LoopAction::Reconnect;
                 }
             }
@@ -683,8 +904,17 @@ async fn handle_message(p: &mut EventLoopState, msg: ProtocolMessage) -> LoopAct
         }
         action::AUTH => {
             tracing::info!("Server requested reauthentication");
-            let result = tokio::time::timeout(p.timing.connect_timeout, renew_token(p)).await;
-            if handle_renewal_result(p, result).await {
+            let connect_timeout = p.timing.connect_timeout;
+            let result = tokio::select! {
+                biased;
+                _ = &mut *close_rx => {
+                    tracing::info!("Close requested during server-requested token renewal");
+                    send_close_message(p).await;
+                    return LoopAction::Stop;
+                }
+                result = tokio::time::timeout(connect_timeout, renew_token(p)) => result,
+            };
+            if handle_renewal_result(p, close_rx, result).await {
                 return LoopAction::Stop;
             }
         }
@@ -703,6 +933,7 @@ async fn handle_message(p: &mut EventLoopState, msg: ProtocolMessage) -> LoopAct
 /// is fatal (caller should terminate).
 async fn handle_renewal_result(
     p: &mut EventLoopState,
+    close_rx: &mut oneshot::Receiver<()>,
     result: Result<Result<(), Error>, tokio::time::error::Elapsed>,
 ) -> bool {
     let failure_reason = match result {
@@ -722,16 +953,14 @@ async fn handle_renewal_result(
     );
 
     if p.token_renewal_failures >= p.timing.max_token_renewal_failures {
-        let _ = p
-            .event_tx
-            .send(Event::Error {
-                code: error_code::FAILED,
-                message: format!(
-                    "Token renewal failed {} consecutive times",
-                    p.timing.max_token_renewal_failures
-                ),
-            })
-            .await;
+        let event = Event::Error {
+            code: error_code::FAILED,
+            message: format!(
+                "Token renewal failed {} consecutive times",
+                p.timing.max_token_renewal_failures
+            ),
+        };
+        let _ = send_status_event(p, close_rx, event, "error").await;
         return true;
     }
 
@@ -754,7 +983,14 @@ async fn renew_token(p: &mut EventLoopState) -> Result<(), Error> {
         ..Default::default()
     };
     let data = encode_msg(&auth_msg)?;
-    p.ws_write
+    let Some(transport) = p.transport.as_mut() else {
+        return Err(Error::Protocol {
+            code: error_code::FAILED,
+            message: "WebSocket transport missing during token renewal".to_string(),
+        });
+    };
+    transport
+        .ws_write
         .send(tungstenite::Message::Binary(data.into()))
         .await?;
 
@@ -845,8 +1081,7 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<(), Error> {
         p.conn_state.token_renewal_at =
             ConnState::compute_renewal_at(&p.conn_state.token, p.timing.token_renewal_margin);
     }
-    p.ws_read = ws_read;
-    p.ws_write = ws_write;
+    p.transport = Some(WsTransport::new(ws_read, ws_write));
     p.conn_state.disconnected_at = None;
     p.conn_state.last_reattach_at = None;
 
@@ -961,6 +1196,80 @@ mod tests {
         // No connection key → cannot resume
         state.connection_key = None;
         assert!(!state.can_resume());
+    }
+
+    #[test]
+    fn websocket_close_reason_redacts_access_token_from_reason() {
+        let frame = CloseFrame {
+            code: tungstenite::protocol::frame::coding::CloseCode::Normal,
+            reason: "url=wss://example/?access_token=close-secret&format=msgpack".into(),
+        };
+
+        let reason = websocket_close_reason(Some(&frame));
+        let log_reason = websocket_close_frame_reason(&frame);
+
+        assert_eq!(
+            reason,
+            "websocket closed code=1000 reason=url=wss://example/?access_token=<redacted>&format=msgpack"
+        );
+        assert_eq!(
+            log_reason,
+            "url=wss://example/?access_token=<redacted>&format=msgpack"
+        );
+        assert!(!reason.contains("close-secret"));
+        assert!(!log_reason.contains("close-secret"));
+    }
+
+    #[test]
+    fn websocket_error_reason_redacts_access_token() {
+        let err = tungstenite::Error::Url(tungstenite::error::UrlError::UnableToConnect(
+            "wss://example/?access_token=error-secret&format=msgpack".to_string(),
+        ));
+
+        let reason = websocket_error_reason(&err);
+
+        assert_eq!(
+            reason,
+            "websocket error: URL error: Unable to connect to wss://example/?access_token=<redacted>&format=msgpack"
+        );
+        assert!(!reason.contains("error-secret"));
+    }
+
+    #[test]
+    fn protocol_disconnect_reason_redacts_access_token_from_message() {
+        let reason = protocol_disconnect_reason(Some(ErrorInfo {
+            code: 80003,
+            status_code: Some(500),
+            message: "failed url=wss://example/?access_token=protocol-secret&format=msgpack"
+                .to_string(),
+        }));
+
+        assert_eq!(
+            reason,
+            "failed url=wss://example/?access_token=<redacted>&format=msgpack"
+        );
+        assert!(!reason.contains("protocol-secret"));
+    }
+
+    #[test]
+    fn event_error_helpers_redact_access_token() {
+        let protocol_message = protocol_error_message(
+            "failed url=wss://example/?access_token=event-secret&format=msgpack".to_string(),
+        );
+        let detached_message = channel_detached_message(
+            "failed url=wss://example/?access_token=detached-secret&format=msgpack",
+        );
+
+        assert_eq!(
+            protocol_message,
+            "failed url=wss://example/?access_token=<redacted>&format=msgpack"
+        );
+        assert_eq!(
+            detached_message,
+            "Channel detached: failed url=wss://example/?access_token=<redacted>&format=msgpack"
+        );
+        assert!(!protocol_message.contains("event-secret"));
+        assert!(!detached_message.contains("detached-secret"));
     }
 
     #[test]

--- a/crates/ably-subscriber/src/subscribe.rs
+++ b/crates/ably-subscriber/src/subscribe.rs
@@ -3,8 +3,8 @@
 use tokio::sync::{mpsc, oneshot};
 
 use crate::connection::{
-    DEFAULT_REALTIME_HOST, EventLoopState, connect_and_attach, exchange_token, rest_host,
-    run_event_loop,
+    DEFAULT_REALTIME_HOST, EventLoopState, WsTransport, connect_and_attach, exchange_token,
+    rest_host, run_event_loop,
 };
 use crate::protocol::error_code;
 use crate::types::{Error, Event, SubscribeConfig};
@@ -26,7 +26,7 @@ impl Subscription {
         self.rx.recv().await
     }
 
-    /// Gracefully close the connection.
+    /// Request a graceful close of the background WebSocket connection.
     pub fn close(mut self) {
         if let Some(tx) = self.close_tx.take() {
             let _ = tx.send(());
@@ -51,7 +51,8 @@ impl Drop for Subscription {
 /// heartbeat timeout detection.
 pub async fn subscribe(config: SubscribeConfig) -> Result<Subscription, Error> {
     let timing = config.timing.unwrap_or_default();
-    let (event_tx, event_rx) = mpsc::channel::<Event>(timing.event_channel_capacity);
+    let event_channel_capacity = timing.event_channel_capacity.max(1);
+    let (event_tx, event_rx) = mpsc::channel::<Event>(event_channel_capacity);
     let (close_tx, close_rx) = oneshot::channel::<()>();
 
     let realtime_host = config
@@ -98,8 +99,7 @@ pub async fn subscribe(config: SubscribeConfig) -> Result<Subscription, Error> {
     // Spawn background event loop
     tokio::spawn(run_event_loop(
         EventLoopState {
-            ws_read,
-            ws_write,
+            transport: Some(WsTransport::new(ws_read, ws_write)),
             event_tx,
             conn_state,
             channel: config.channel,

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -8,6 +8,25 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use tokio_tungstenite::tungstenite;
 
+pub(crate) fn redact_access_token(input: &str) -> String {
+    const PARAM: &str = "access_token=";
+
+    let mut output = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(start) = rest.find(PARAM) {
+        output.push_str(&rest[..start + PARAM.len()]);
+        output.push_str("<redacted>");
+
+        rest = &rest[start + PARAM.len()..];
+        let end = rest
+            .find(['&', ' ', '"', '\'', ')', ']', '}'])
+            .unwrap_or(rest.len());
+        rest = &rest[end..];
+    }
+    output.push_str(rest);
+    output
+}
+
 /// A future that returns a `Result<TokenRequest>`.
 pub type TokenFuture = Pin<Box<dyn Future<Output = Result<TokenRequest, BoxError>> + Send>>;
 
@@ -77,15 +96,16 @@ pub enum Event {
 }
 
 /// Timing parameters that control reconnection, heartbeat, token renewal, and
-/// backpressure behavior. All fields use the same defaults as the hardcoded
-/// constants they replace, so `TimingConfig::default()` preserves existing
-/// production behavior.
+/// backpressure behavior. Defaults are production-oriented; values that replace
+/// previous hardcoded constants keep their prior values.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct TimingConfig {
     // -- Connection ----------------------------------------------------------
     /// Timeout for WebSocket connect, HTTP requests, and token operations.
     pub connect_timeout: Duration,
+    /// Timeout for best-effort protocol/WebSocket close during shutdown.
+    pub close_timeout: Duration,
     /// Timeout wrapping each individual reconnect attempt.
     pub reconnect_timeout: Duration,
     /// Default `max_idle_interval` when the server doesn't specify one.
@@ -102,6 +122,10 @@ pub struct TimingConfig {
     pub initial_retry_interval: Duration,
     /// Cap on exponential backoff between retries.
     pub max_retry_interval: Duration,
+    /// Minimum spacing between reconnect attempts after transport-level
+    /// disconnects. This mirrors ably-js' guard against tight reconnect loops
+    /// when a server or proxy repeatedly closes otherwise healthy sockets.
+    pub min_reconnect_interval: Duration,
     /// Maximum number of consecutive reconnection attempts before giving up.
     pub max_retry_attempts: u32,
 
@@ -119,7 +143,8 @@ pub struct TimingConfig {
     pub max_token_renewal_failures: u32,
 
     // -- Backpressure --------------------------------------------------------
-    /// Bounded capacity of the internal event channel (mpsc).
+    /// Bounded capacity of the internal event channel (mpsc). Values below 1
+    /// are treated as 1 because Tokio channels do not support zero capacity.
     pub event_channel_capacity: usize,
 }
 
@@ -128,6 +153,7 @@ impl Default for TimingConfig {
         Self {
             // Connection
             connect_timeout: Duration::from_secs(30),
+            close_timeout: Duration::from_secs(5),
             reconnect_timeout: Duration::from_secs(60),
             default_max_idle_interval: Duration::from_secs(15),
             default_connection_state_ttl: Duration::from_secs(120),
@@ -136,6 +162,7 @@ impl Default for TimingConfig {
             // Reconnection retry
             initial_retry_interval: Duration::from_secs(1),
             max_retry_interval: Duration::from_secs(15),
+            min_reconnect_interval: Duration::from_secs(1),
             max_retry_attempts: 40,
             // Channel re-attach
             reattach_window: Duration::from_secs(15),
@@ -188,9 +215,9 @@ impl SubscribeConfig {
 }
 
 /// Errors returned by this crate.
-#[derive(Debug, thiserror::Error)]
+#[derive(thiserror::Error)]
 pub enum Error {
-    #[error("WebSocket error: {0}")]
+    #[error("WebSocket error: {}", redact_access_token(&.0.to_string()))]
     WebSocket(Box<tungstenite::Error>),
 
     #[error("Token exchange HTTP error: {0}")]
@@ -199,14 +226,22 @@ pub enum Error {
     #[error("MessagePack encode error: {0}")]
     MsgpackEncode(#[from] rmp_serde::encode::Error),
 
-    #[error("Ably protocol error: code={code}, {message}")]
+    #[error("Ably protocol error: code={code}, {}", redact_access_token(message))]
     Protocol { code: i32, message: String },
 
-    #[error("Token fetch failed: {0}")]
+    #[error("Token fetch failed: {}", redact_access_token(&.0.to_string()))]
     TokenFetch(BoxError),
 
     #[error("URL parse error: {0}")]
     Url(#[from] url::ParseError),
+}
+
+impl std::fmt::Debug for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Error")
+            .field(&redact_access_token(&self.to_string()))
+            .finish()
+    }
 }
 
 impl From<tungstenite::Error> for Error {
@@ -253,5 +288,107 @@ mod tests {
         assert_eq!(td.token, "xVLyHw.some-token-string");
         assert_eq!(td.expires, 1700003600000);
         assert_eq!(td.issued, 1700000000000);
+    }
+
+    #[test]
+    fn timing_config_close_timeout_is_shorter_than_connect_timeout() {
+        let timing = TimingConfig::default();
+
+        assert_eq!(timing.close_timeout, Duration::from_secs(5));
+        assert!(
+            timing.close_timeout < timing.connect_timeout,
+            "best-effort close should not wait as long as connect"
+        );
+    }
+
+    #[test]
+    fn websocket_error_display_redacts_access_token_query_param() {
+        let err = Error::from(tungstenite::Error::Url(
+            tungstenite::error::UrlError::UnableToConnect(
+                "wss://realtime.ably.io/?access_token=secret-token&format=msgpack \
+                 retry_url=wss://realtime.ably.io/?format=msgpack&access_token=second-secret"
+                    .to_string(),
+            ),
+        ));
+
+        let message = err.to_string();
+        assert_eq!(
+            message,
+            "WebSocket error: URL error: Unable to connect to \
+             wss://realtime.ably.io/?access_token=<redacted>&format=msgpack \
+             retry_url=wss://realtime.ably.io/?format=msgpack&access_token=<redacted>"
+        );
+        assert!(!message.contains("secret-token"));
+        assert!(!message.contains("second-secret"));
+
+        let debug_message = format!("{err:?}");
+        assert!(debug_message.contains("access_token=<redacted>"));
+        assert!(!debug_message.contains("secret-token"));
+        assert!(!debug_message.contains("second-secret"));
+    }
+
+    #[test]
+    fn protocol_error_display_redacts_access_token_query_param() {
+        let err = Error::Protocol {
+            code: 80003,
+            message: "failed wss://realtime.ably.io/?access_token=secret-token&format=msgpack"
+                .to_string(),
+        };
+
+        let message = err.to_string();
+        assert_eq!(
+            message,
+            "Ably protocol error: code=80003, failed \
+             wss://realtime.ably.io/?access_token=<redacted>&format=msgpack"
+        );
+        assert!(!message.contains("secret-token"));
+    }
+
+    #[test]
+    fn token_fetch_error_display_redacts_access_token_query_param() {
+        let err = Error::TokenFetch(Box::new(std::io::Error::other(
+            "failed wss://realtime.ably.io/?access_token=secret-token&format=msgpack",
+        )));
+
+        let message = err.to_string();
+        assert_eq!(
+            message,
+            "Token fetch failed: failed \
+             wss://realtime.ably.io/?access_token=<redacted>&format=msgpack"
+        );
+        assert!(!message.contains("secret-token"));
+    }
+
+    #[test]
+    fn access_token_redaction_handles_common_message_delimiters() {
+        let message = concat!(
+            "url=\"wss://example/?access_token=quoted-secret\" ",
+            "url='wss://example/?access_token=single-quoted' ",
+            "url=(wss://example/?access_token=paren-secret) ",
+            "url=[wss://example/?access_token=bracket-secret] ",
+            "json={\"url\":\"wss://example/?access_token=json-secret\"}",
+        );
+
+        let redacted = redact_access_token(message);
+
+        assert_eq!(
+            redacted,
+            concat!(
+                "url=\"wss://example/?access_token=<redacted>\" ",
+                "url='wss://example/?access_token=<redacted>' ",
+                "url=(wss://example/?access_token=<redacted>) ",
+                "url=[wss://example/?access_token=<redacted>] ",
+                "json={\"url\":\"wss://example/?access_token=<redacted>\"}",
+            )
+        );
+        for secret in [
+            "quoted-secret",
+            "single-quoted",
+            "paren-secret",
+            "bracket-secret",
+            "json-secret",
+        ] {
+            assert!(!redacted.contains(secret));
+        }
     }
 }

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -7,6 +7,7 @@ use ably_subscriber::protocol::{
 use ably_subscriber::{Event, SubscribeConfig, TimingConfig, subscribe};
 use futures_util::{SinkExt, StreamExt};
 use httpmock::prelude::*;
+use tokio::io::AsyncReadExt;
 use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite;
 
@@ -128,6 +129,32 @@ async fn read_protocol_msg(
     }
 }
 
+async fn expect_websocket_close_frame(ws: &mut WsStream) -> Result<(), Box<dyn std::error::Error>> {
+    let frame = tokio::time::timeout(Duration::from_secs(5), ws.next())
+        .await
+        .map_err(|_| std::io::Error::other("timed out waiting for websocket close frame"))?
+        .ok_or_else(|| std::io::Error::other("websocket closed before close frame"))??;
+    if !matches!(frame, tungstenite::Message::Close(_)) {
+        return Err(std::io::Error::other(format!(
+            "expected websocket close frame, got {frame:?}"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+async fn expect_websocket_closed(ws: &mut WsStream) -> Result<(), Box<dyn std::error::Error>> {
+    let frame = tokio::time::timeout(Duration::from_secs(5), ws.next())
+        .await
+        .map_err(|_| std::io::Error::other("timed out waiting for websocket to close"))?;
+    match frame {
+        None | Some(Err(_)) | Some(Ok(tungstenite::Message::Close(_))) => Ok(()),
+        Some(Ok(frame)) => {
+            Err(std::io::Error::other(format!("expected websocket close, got {frame:?}")).into())
+        }
+    }
+}
+
 async fn send_message(
     ws: &mut WsStream,
     channel: &str,
@@ -208,6 +235,52 @@ fn test_config_with_timing(
     config
 }
 
+fn test_config_with_pending_renewal(
+    ws_port: u16,
+    http_port: u16,
+    channel: &str,
+    renewal_started: tokio::sync::oneshot::Sender<()>,
+) -> SubscribeConfig {
+    let host = format!("127.0.0.1:{ws_port}");
+    let rest_host = format!("127.0.0.1:{http_port}");
+    let call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let renewal_started = std::sync::Arc::new(std::sync::Mutex::new(Some(renewal_started)));
+    let mut config = SubscribeConfig::new(
+        Box::new(move || {
+            let n = call_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let renewal_started = renewal_started.clone();
+            Box::pin(async move {
+                if n > 0 {
+                    let tx = match renewal_started.lock() {
+                        Ok(mut guard) => guard.take(),
+                        Err(poisoned) => poisoned.into_inner().take(),
+                    };
+                    if let Some(tx) = tx {
+                        let _ = tx.send(());
+                    }
+                    return std::future::pending::<
+                        Result<ably_subscriber::TokenRequest, ably_subscriber::BoxError>,
+                    >()
+                    .await;
+                }
+                Ok(ably_subscriber::TokenRequest {
+                    key_name: "testKey.testId".into(),
+                    timestamp: now_ms(),
+                    nonce: "nonce-1".into(),
+                    mac: "fake-mac".into(),
+                    capability: r#"{"*":["subscribe"]}"#.into(),
+                    ttl: None,
+                    client_id: None,
+                })
+            })
+        }),
+        channel.to_string(),
+    );
+    config.host = Some(host);
+    config.rest_host = Some(rest_host);
+    config
+}
+
 // ---------------------------------------------------------------------------
 // Test 1: connect and receive a single message
 // ---------------------------------------------------------------------------
@@ -219,7 +292,7 @@ async fn connect_and_receive_message() {
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
-    tokio::spawn(async move {
+    let server_task = tokio::spawn(async move {
         let mut conn = ws.accept_and_handshake("test-ch", "conn-1").await.unwrap();
         send_message(
             &mut conn,
@@ -246,6 +319,42 @@ async fn connect_and_receive_message() {
         }
         other => panic!("expected Message, got {other:?}"),
     }
+
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn zero_event_channel_capacity_uses_minimum_capacity() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        send_message(&mut conn, "ch", "after-connect", serde_json::json!(1))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.event_channel_capacity = 0;
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message")
+        .unwrap();
+    match event {
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-connect")),
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
 }
 
 // ---------------------------------------------------------------------------
@@ -259,7 +368,7 @@ async fn multiple_messages() {
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
-    tokio::spawn(async move {
+    let server_task = tokio::spawn(async move {
         let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
         for i in 0..3 {
             send_message(&mut conn, "ch", &format!("evt-{i}"), serde_json::json!(i))
@@ -281,6 +390,8 @@ async fn multiple_messages() {
             other => panic!("expected Message, got {other:?}"),
         }
     }
+
+    server_task.await.unwrap();
 }
 
 // ---------------------------------------------------------------------------
@@ -294,7 +405,7 @@ async fn batched_messages_in_single_frame() {
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
-    tokio::spawn(async move {
+    let server_task = tokio::spawn(async move {
         let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
         let msg = ProtocolMessage {
             action: action::MESSAGE,
@@ -343,6 +454,8 @@ async fn batched_messages_in_single_frame() {
     .await;
 
     assert_eq!(names, vec!["a", "b", "c"]);
+
+    server_task.await.unwrap();
 }
 
 // ---------------------------------------------------------------------------
@@ -565,6 +678,62 @@ async fn token_renewal() {
     );
 }
 
+#[tokio::test]
+async fn close_during_pending_token_renewal_sends_close() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+
+    let now = now_ms();
+    let short_token = serde_json::json!({
+        "token": "short-lived-token",
+        "expires": now + 1_000,
+        "issued": now,
+    });
+    let path = "/keys/testKey.testId/requestToken";
+    http.mock(|when, then| {
+        when.method(POST).path(path);
+        then.status(201)
+            .header("content-type", "application/json")
+            .json_body(short_token);
+    });
+
+    let ws_port = ws.port;
+    let (renewal_started_tx, renewal_started_rx) = tokio::sync::oneshot::channel::<()>();
+    let (close_tx, close_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for CLOSE during renewal")
+            .unwrap();
+        assert_eq!(msg.action, action::CLOSE);
+        close_tx.send(()).unwrap();
+    });
+
+    let mut sub = subscribe(test_config_with_pending_renewal(
+        ws_port,
+        http.port(),
+        "ch",
+        renewal_started_tx,
+    ))
+    .await
+    .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    tokio::time::timeout(Duration::from_secs(5), renewal_started_rx)
+        .await
+        .expect("timed out waiting for token renewal to start")
+        .unwrap();
+
+    sub.close();
+
+    tokio::time::timeout(Duration::from_secs(5), close_rx)
+        .await
+        .expect("timed out waiting for CLOSE during pending renewal")
+        .unwrap();
+    server_task.await.unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // Test 9: reconnect after server drops connection
 // ---------------------------------------------------------------------------
@@ -612,10 +781,17 @@ async fn reconnect_after_server_drop() {
         .await
         .expect("timed out waiting for Disconnected")
         .unwrap();
-    assert!(
-        matches!(event, Event::Disconnected { .. }),
-        "expected Disconnected, got {event:?}"
-    );
+    match event {
+        Event::Disconnected { reason } => {
+            let reason = reason.expect("dropped stream should include a disconnect reason");
+            assert!(
+                reason.contains("websocket")
+                    || reason.contains("connection")
+                    || reason.contains("stream")
+            );
+        }
+        other => panic!("expected Disconnected, got {other:?}"),
+    }
 
     // Reconnected
     let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
@@ -663,6 +839,7 @@ async fn reconnect_immediately_after_close_frame() {
         }))
         .await
         .unwrap();
+        expect_websocket_close_frame(&mut conn).await.unwrap();
 
         // Second connection after reconnect
         let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
@@ -688,10 +865,14 @@ async fn reconnect_immediately_after_close_frame() {
         .await
         .expect("timed out waiting for Disconnected")
         .unwrap();
-    assert!(
-        matches!(event, Event::Disconnected { .. }),
-        "expected Disconnected, got {event:?}"
-    );
+    match event {
+        Event::Disconnected { reason } => {
+            let reason = reason.expect("close frame should include a disconnect reason");
+            assert!(reason.contains("websocket closed code=1000"));
+            assert!(reason.contains("server maintenance"));
+        }
+        other => panic!("expected Disconnected, got {other:?}"),
+    }
 
     // Should reconnect within 500ms (no backoff), NOT 1-2 seconds
     let event = tokio::time::timeout(Duration::from_millis(500), sub.next())
@@ -715,7 +896,7 @@ async fn reconnect_immediately_after_close_frame() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 9c: server sends Close frame without reason, client reconnects immediately
+// Test 9c: server sends Close without a close frame, client reconnects immediately
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
@@ -734,6 +915,7 @@ async fn reconnect_immediately_after_close_frame_no_reason() {
         tokio::time::sleep(Duration::from_millis(100)).await;
         // Close without reason
         conn.close(None).await.unwrap();
+        expect_websocket_close_frame(&mut conn).await.unwrap();
 
         let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
         send_message(&mut conn2, "ch", "after-close", serde_json::json!(2))
@@ -757,10 +939,15 @@ async fn reconnect_immediately_after_close_frame_no_reason() {
         .await
         .expect("timed out waiting for Disconnected")
         .unwrap();
-    assert!(
-        matches!(event, Event::Disconnected { .. }),
-        "expected Disconnected, got {event:?}"
-    );
+    match event {
+        Event::Disconnected { reason } => {
+            assert_eq!(
+                reason.as_deref(),
+                Some("websocket closed without close frame")
+            );
+        }
+        other => panic!("expected Disconnected, got {other:?}"),
+    }
 
     // Should reconnect within 500ms (no backoff)
     let event = tokio::time::timeout(Duration::from_millis(500), sub.next())
@@ -783,6 +970,167 @@ async fn reconnect_immediately_after_close_frame_no_reason() {
 }
 
 // ---------------------------------------------------------------------------
+// Test 9d: server sends Close frame with empty reason
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn reconnect_after_close_frame_empty_reason_reports_code_only() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        conn.close(Some(tungstenite::protocol::CloseFrame {
+            code: tungstenite::protocol::frame::coding::CloseCode::Normal,
+            reason: "".into(),
+        }))
+        .await
+        .unwrap();
+        expect_websocket_close_frame(&mut conn).await.unwrap();
+
+        let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
+        send_message(&mut conn2, "ch", "after-close", serde_json::json!(2))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    match event {
+        Event::Disconnected { reason } => {
+            assert_eq!(reason.as_deref(), Some("websocket closed code=1000"));
+        }
+        other => panic!("expected Disconnected, got {other:?}"),
+    }
+
+    let event = tokio::time::timeout(Duration::from_millis(500), sub.next())
+        .await
+        .expect("reconnect took too long — backoff was not skipped")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after reconnect")
+        .unwrap();
+    match event {
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-close")),
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Test 9e: repeated clean close frames are rate-limited
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn repeated_clean_close_reconnect_is_rate_limited() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        conn.close(Some(tungstenite::protocol::CloseFrame {
+            code: tungstenite::protocol::frame::coding::CloseCode::Normal,
+            reason: "rotate".into(),
+        }))
+        .await
+        .unwrap();
+        expect_websocket_close_frame(&mut conn).await.unwrap();
+
+        let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
+        conn2
+            .close(Some(tungstenite::protocol::CloseFrame {
+                code: tungstenite::protocol::frame::coding::CloseCode::Normal,
+                reason: "rotate-again".into(),
+            }))
+            .await
+            .unwrap();
+        expect_websocket_close_frame(&mut conn2).await.unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(250), ws.accept_raw())
+                .await
+                .is_err(),
+            "third reconnect should wait for the minimum reconnect interval"
+        );
+
+        let mut conn3 = tokio::time::timeout(
+            Duration::from_secs(5),
+            ws.accept_and_handshake("ch", "conn-3"),
+        )
+        .await
+        .expect("third reconnect did not happen")
+        .unwrap();
+        send_message(&mut conn3, "ch", "after-rate-limit", serde_json::json!(3))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.min_reconnect_interval = Duration::from_secs(2);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    assert!(matches!(
+        sub.next().await.unwrap(),
+        Event::Disconnected { .. }
+    ));
+    assert!(matches!(
+        tokio::time::timeout(Duration::from_secs(1), sub.next())
+            .await
+            .expect("first reconnect should not be rate-limited")
+            .unwrap(),
+        Event::Connected
+    ));
+    assert!(matches!(
+        sub.next().await.unwrap(),
+        Event::Disconnected { .. }
+    ));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for rate-limited reconnect")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for post-reconnect message")
+        .unwrap();
+    match event {
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-rate-limit")),
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
 // Test 10: server sends DISCONNECTED, client reconnects
 // ---------------------------------------------------------------------------
 
@@ -793,7 +1141,7 @@ async fn server_sends_disconnected() {
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
-    tokio::spawn(async move {
+    let server_task = tokio::spawn(async move {
         let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
 
         // Send DISCONNECTED (retriable)
@@ -812,12 +1160,21 @@ async fn server_sends_disconnected() {
         .await
         .unwrap();
 
+        let frame = tokio::time::timeout(Duration::from_secs(5), conn.next())
+            .await
+            .expect("timed out waiting for websocket close after protocol DISCONNECTED")
+            .expect("websocket closed before close frame")
+            .unwrap();
+        assert!(
+            matches!(frame, tungstenite::Message::Close(_)),
+            "expected websocket close frame, got {frame:?}"
+        );
+
         // Second connection
         let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
         send_message(&mut conn2, "ch", "reconnected", serde_json::json!("ok"))
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_secs(5)).await;
     });
 
     let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
@@ -831,10 +1188,12 @@ async fn server_sends_disconnected() {
         .await
         .expect("timed out")
         .unwrap();
-    assert!(
-        matches!(event, Event::Disconnected { .. }),
-        "expected Disconnected, got {event:?}"
-    );
+    match event {
+        Event::Disconnected { reason } => {
+            assert_eq!(reason.as_deref(), Some("server going away"));
+        }
+        other => panic!("expected Disconnected, got {other:?}"),
+    }
 
     // Reconnected
     let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
@@ -855,6 +1214,121 @@ async fn server_sends_disconnected() {
         Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("reconnected")),
         other => panic!("expected Message, got {other:?}"),
     }
+
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn server_sends_disconnected_without_message_reports_reason() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        let disconnected_without_error = ProtocolMessage {
+            action: action::DISCONNECTED,
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&disconnected_without_error).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        expect_websocket_close_frame(&mut conn).await.unwrap();
+
+        let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
+        let disconnected_without_message = ProtocolMessage {
+            action: action::DISCONNECTED,
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: String::new(),
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&disconnected_without_message).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        expect_websocket_close_frame(&mut conn2).await.unwrap();
+
+        let mut conn3 = ws.accept_and_handshake("ch", "conn-3").await.unwrap();
+        send_message(&mut conn3, "ch", "reconnected", serde_json::json!("ok"))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.initial_retry_interval = Duration::from_millis(10);
+    timing.max_retry_interval = Duration::from_millis(50);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out")
+        .unwrap();
+    match event {
+        Event::Disconnected { reason } => {
+            assert_eq!(
+                reason.as_deref(),
+                Some("server sent DISCONNECTED without error details")
+            );
+        }
+        other => panic!("expected Disconnected, got {other:?}"),
+    }
+
+    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
+        .await
+        .expect("timed out")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out")
+        .unwrap();
+    match event {
+        Event::Disconnected { reason } => {
+            assert_eq!(
+                reason.as_deref(),
+                Some("server sent DISCONNECTED code=80003 status=500")
+            );
+        }
+        other => panic!("expected Disconnected, got {other:?}"),
+    }
+
+    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
+        .await
+        .expect("timed out")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out")
+        .unwrap();
+    match event {
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("reconnected")),
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
 }
 
 // ---------------------------------------------------------------------------
@@ -946,15 +1420,27 @@ async fn close_subscription() {
     let ws_port = ws.port;
     let (close_tx, close_rx) = tokio::sync::oneshot::channel::<()>();
 
-    tokio::spawn(async move {
+    let server_task = tokio::spawn(async move {
         let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
 
-        // Wait for CLOSE from client
+        // Wait for Ably protocol CLOSE from client.
         let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
             .await
             .expect("timed out waiting for CLOSE")
             .unwrap();
         assert_eq!(msg.action, action::CLOSE);
+
+        // Then the websocket itself should be closed instead of relying on task
+        // drop to release the socket.
+        let frame = tokio::time::timeout(Duration::from_secs(5), conn.next())
+            .await
+            .expect("timed out waiting for websocket close")
+            .expect("websocket closed before close frame")
+            .unwrap();
+        assert!(
+            matches!(frame, tungstenite::Message::Close(_)),
+            "expected websocket close frame, got {frame:?}"
+        );
         close_tx.send(()).unwrap();
     });
 
@@ -971,6 +1457,51 @@ async fn close_subscription() {
         .await
         .expect("timed out waiting for server to confirm CLOSE")
         .unwrap();
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn drop_subscription_sends_close() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (close_tx, close_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for CLOSE after drop")
+            .unwrap();
+        assert_eq!(msg.action, action::CLOSE);
+
+        let frame = tokio::time::timeout(Duration::from_secs(5), conn.next())
+            .await
+            .expect("timed out waiting for websocket close after drop")
+            .expect("websocket closed before close frame")
+            .unwrap();
+        assert!(
+            matches!(frame, tungstenite::Message::Close(_)),
+            "expected websocket close frame, got {frame:?}"
+        );
+        close_tx.send(()).unwrap();
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    drop(sub);
+
+    tokio::time::timeout(Duration::from_secs(5), close_rx)
+        .await
+        .expect("timed out waiting for server to confirm drop close")
+        .unwrap();
+    server_task.await.unwrap();
 }
 
 // ---------------------------------------------------------------------------
@@ -1005,9 +1536,7 @@ async fn non_retriable_disconnected_triggers_reconnect() {
         ))
         .await
         .unwrap();
-        // Yield so the client can process the DISCONNECTED before we drop.
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        drop(conn);
+        expect_websocket_close_frame(&mut conn).await.unwrap();
 
         // Client should reconnect (fresh connect with new token)
         let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
@@ -1036,10 +1565,12 @@ async fn non_retriable_disconnected_triggers_reconnect() {
         .await
         .expect("timed out waiting for Disconnected")
         .unwrap();
-    assert!(
-        matches!(event, Event::Disconnected { .. }),
-        "expected Disconnected, got {event:?}"
-    );
+    match event {
+        Event::Disconnected { reason } => {
+            assert_eq!(reason.as_deref(), Some("Token expired"));
+        }
+        other => panic!("expected Disconnected, got {other:?}"),
+    }
 
     // Should reconnect
     let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
@@ -1075,7 +1606,7 @@ async fn error_during_event_loop() {
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
-    tokio::spawn(async move {
+    let server_task = tokio::spawn(async move {
         let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
 
         let error_msg = ProtocolMessage {
@@ -1092,7 +1623,7 @@ async fn error_during_event_loop() {
         ))
         .await
         .unwrap();
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        expect_websocket_closed(&mut conn).await.unwrap();
     });
 
     let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
@@ -1111,6 +1642,7 @@ async fn error_during_event_loop() {
     }
 
     assert!(sub.next().await.is_none());
+    server_task.await.unwrap();
 }
 
 // ---------------------------------------------------------------------------
@@ -1178,7 +1710,7 @@ async fn server_sends_closed() {
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
-    tokio::spawn(async move {
+    let server_task = tokio::spawn(async move {
         let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
 
         let closed = ProtocolMessage {
@@ -1190,7 +1722,7 @@ async fn server_sends_closed() {
         ))
         .await
         .unwrap();
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        expect_websocket_closed(&mut conn).await.unwrap();
     });
 
     let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
@@ -1204,6 +1736,7 @@ async fn server_sends_closed() {
         .await
         .expect("timed out");
     assert!(event.is_none(), "expected None after CLOSED, got {event:?}");
+    server_task.await.unwrap();
 }
 
 // ---------------------------------------------------------------------------
@@ -1270,6 +1803,60 @@ async fn server_initiated_auth() {
     }
 }
 
+#[tokio::test]
+async fn close_during_server_requested_pending_token_renewal_sends_close() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (renewal_started_tx, renewal_started_rx) = tokio::sync::oneshot::channel::<()>();
+    let (close_tx, close_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        let auth_request = ProtocolMessage {
+            action: action::AUTH,
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&auth_request).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for CLOSE during server-requested renewal")
+            .unwrap();
+        assert_eq!(msg.action, action::CLOSE);
+        close_tx.send(()).unwrap();
+    });
+
+    let mut sub = subscribe(test_config_with_pending_renewal(
+        ws_port,
+        http.port(),
+        "ch",
+        renewal_started_tx,
+    ))
+    .await
+    .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    tokio::time::timeout(Duration::from_secs(5), renewal_started_rx)
+        .await
+        .expect("timed out waiting for server-requested token renewal to start")
+        .unwrap();
+
+    sub.close();
+
+    tokio::time::timeout(Duration::from_secs(5), close_rx)
+        .await
+        .expect("timed out waiting for CLOSE during pending server-requested renewal")
+        .unwrap();
+    server_task.await.unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // Test 18: get_token callback returns error → subscribe fails
 // ---------------------------------------------------------------------------
@@ -1302,9 +1889,9 @@ async fn heartbeat_timeout_triggers_reconnect() {
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
-    tokio::spawn(async move {
+    let server_task = tokio::spawn(async move {
         // First connection: tiny max_idle_interval, then silence (no heartbeats)
-        let _conn = ws
+        let mut conn = ws
             .accept_and_handshake_with_opts(
                 "ch",
                 "conn-1",
@@ -1317,6 +1904,16 @@ async fn heartbeat_timeout_triggers_reconnect() {
             .unwrap();
         // Don't send anything — let the heartbeat timeout fire
 
+        let frame = tokio::time::timeout(Duration::from_secs(5), conn.next())
+            .await
+            .expect("timed out waiting for websocket close after heartbeat timeout")
+            .expect("websocket closed before close frame")
+            .unwrap();
+        assert!(
+            matches!(frame, tungstenite::Message::Close(_)),
+            "expected websocket close frame, got {frame:?}"
+        );
+
         // Second connection after reconnect
         let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
         send_message(
@@ -1327,7 +1924,6 @@ async fn heartbeat_timeout_triggers_reconnect() {
         )
         .await
         .unwrap();
-        tokio::time::sleep(Duration::from_secs(5)).await;
     });
 
     let mut timing = TimingConfig::default();
@@ -1369,6 +1965,8 @@ async fn heartbeat_timeout_triggers_reconnect() {
         Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-hb-timeout")),
         other => panic!("expected Message, got {other:?}"),
     }
+
+    server_task.await.unwrap();
 }
 
 // ---------------------------------------------------------------------------
@@ -1655,7 +2253,7 @@ async fn detached_within_retry_window_triggers_reconnect() {
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
-    tokio::spawn(async move {
+    let server_task = tokio::spawn(async move {
         let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
 
         let detached = ProtocolMessage {
@@ -1691,6 +2289,16 @@ async fn detached_within_retry_window_triggers_reconnect() {
         .await
         .unwrap();
 
+        let frame = tokio::time::timeout(Duration::from_secs(5), conn.next())
+            .await
+            .expect("timed out waiting for websocket close after repeated DETACHED")
+            .expect("websocket closed before close frame")
+            .unwrap();
+        assert!(
+            matches!(frame, tungstenite::Message::Close(_)),
+            "expected websocket close frame, got {frame:?}"
+        );
+
         // Client should do a full reconnect
         let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
         send_message(
@@ -1701,7 +2309,6 @@ async fn detached_within_retry_window_triggers_reconnect() {
         )
         .await
         .unwrap();
-        tokio::time::sleep(Duration::from_secs(5)).await;
     });
 
     let mut timing = TimingConfig::default();
@@ -1735,6 +2342,8 @@ async fn detached_within_retry_window_triggers_reconnect() {
         Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-full-reconnect")),
         other => panic!("expected Message, got {other:?}"),
     }
+
+    server_task.await.unwrap();
 }
 
 // ---------------------------------------------------------------------------
@@ -1833,6 +2442,641 @@ async fn reconnect_timeout_fires() {
     }
 
     assert!(sub.next().await.is_none());
+}
+
+#[tokio::test]
+async fn close_during_hanging_reconnect_attempt_closes_socket() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel::<()>();
+    let (closed_tx, closed_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        drop(conn);
+
+        let (mut tcp, _) = ws.listener.accept().await.unwrap();
+        accepted_tx.send(()).unwrap();
+
+        let mut buf = Vec::new();
+        let _ = tcp.read_to_end(&mut buf).await;
+        let _ = closed_tx.send(());
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.reconnect_timeout = Duration::from_secs(30);
+    timing.initial_retry_interval = Duration::from_millis(10);
+    timing.max_retry_interval = Duration::from_millis(10);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    tokio::time::timeout(Duration::from_secs(5), accepted_rx)
+        .await
+        .expect("timed out waiting for hanging reconnect attempt")
+        .unwrap();
+
+    sub.close();
+
+    tokio::time::timeout(Duration::from_secs(1), closed_rx)
+        .await
+        .expect("hanging reconnect socket was not closed after subscription close")
+        .unwrap();
+
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn close_during_protocol_disconnected_reconnect_attempt_closes_sockets() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel::<()>();
+    let (closed_tx, closed_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        let disconnected = ProtocolMessage {
+            action: action::DISCONNECTED,
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "server going away".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&disconnected).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let frame = tokio::time::timeout(Duration::from_secs(5), conn.next())
+            .await
+            .expect("timed out waiting for websocket close after protocol DISCONNECTED")
+            .expect("websocket closed before close frame")
+            .unwrap();
+        assert!(
+            matches!(frame, tungstenite::Message::Close(_)),
+            "expected websocket close frame, got {frame:?}"
+        );
+
+        let (mut tcp, _) = ws.listener.accept().await.unwrap();
+        accepted_tx.send(()).unwrap();
+
+        let mut buf = Vec::new();
+        tokio::time::timeout(Duration::from_secs(5), tcp.read_to_end(&mut buf))
+            .await
+            .expect("hanging reconnect socket was not closed after subscription close")
+            .unwrap();
+
+        closed_tx.send(()).unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.initial_retry_interval = Duration::ZERO;
+    timing.max_retry_interval = Duration::ZERO;
+    timing.reconnect_timeout = Duration::from_secs(30);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for protocol DISCONNECTED")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    tokio::time::timeout(Duration::from_secs(5), accepted_rx)
+        .await
+        .expect("timed out waiting for reconnect attempt")
+        .unwrap();
+
+    sub.close();
+
+    tokio::time::timeout(Duration::from_secs(5), closed_rx)
+        .await
+        .expect("timed out waiting for reconnect-attempt close check")
+        .unwrap();
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn close_during_reconnect_backoff_stops_before_next_attempt() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (checked_tx, checked_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        drop(conn);
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(1500), ws.accept_raw())
+                .await
+                .is_err(),
+            "subscription close during reconnect backoff should stop before the next attempt"
+        );
+        checked_tx.send(()).unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.initial_retry_interval = Duration::from_millis(250);
+    timing.max_retry_interval = Duration::from_millis(250);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    sub.close();
+
+    tokio::time::timeout(Duration::from_secs(3), checked_rx)
+        .await
+        .expect("timed out waiting for reconnect suppression check")
+        .unwrap();
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn close_during_protocol_disconnected_reconnect_backoff_closes_socket() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (closed_tx, closed_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        let disconnected = ProtocolMessage {
+            action: action::DISCONNECTED,
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "server going away".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&disconnected).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let frame = tokio::time::timeout(Duration::from_secs(5), conn.next())
+            .await
+            .expect("timed out waiting for websocket close during protocol DISCONNECTED backoff")
+            .expect("websocket closed before close frame")
+            .unwrap();
+        assert!(
+            matches!(frame, tungstenite::Message::Close(_)),
+            "expected websocket close frame, got {frame:?}"
+        );
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(500), ws.accept_raw())
+                .await
+                .is_err(),
+            "subscription close should stop before reconnecting after protocol DISCONNECTED"
+        );
+        closed_tx.send(()).unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.initial_retry_interval = Duration::from_secs(5);
+    timing.max_retry_interval = Duration::from_secs(5);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for protocol DISCONNECTED")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    sub.close();
+
+    tokio::time::timeout(Duration::from_secs(5), closed_rx)
+        .await
+        .expect("timed out waiting for protocol DISCONNECTED backoff close check")
+        .unwrap();
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn close_while_disconnected_event_send_is_backpressured_stops_without_reconnect() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (blocked_tx, blocked_rx) = tokio::sync::oneshot::channel::<()>();
+    let (close_sent_tx, close_sent_rx) = tokio::sync::oneshot::channel::<()>();
+    let (checked_tx, checked_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        conn.close(Some(tungstenite::protocol::CloseFrame {
+            code: tungstenite::protocol::frame::coding::CloseCode::Normal,
+            reason: "rotate".into(),
+        }))
+        .await
+        .unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(250), ws.accept_raw())
+                .await
+                .is_err(),
+            "full event channel should backpressure Disconnected before reconnect"
+        );
+        blocked_tx.send(()).unwrap();
+        close_sent_rx.await.unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(500), ws.accept_raw())
+                .await
+                .is_err(),
+            "subscription close should stop the backpressured event loop before reconnect"
+        );
+        checked_tx.send(()).unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.event_channel_capacity = 1;
+    let sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    // Do not consume the initial Connected event. With capacity=1, the next
+    // status event blocks until close drops the receiver.
+    tokio::time::timeout(Duration::from_secs(5), blocked_rx)
+        .await
+        .expect("timed out waiting for status-event backpressure")
+        .unwrap();
+
+    sub.close();
+    close_sent_tx.send(()).unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), checked_rx)
+        .await
+        .expect("timed out waiting for reconnect suppression after close")
+        .unwrap();
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn close_while_protocol_disconnected_backpressure_closes_socket() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (blocked_tx, blocked_rx) = tokio::sync::oneshot::channel::<()>();
+    let (close_sent_tx, close_sent_rx) = tokio::sync::oneshot::channel::<()>();
+    let (checked_tx, checked_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        let disconnected = ProtocolMessage {
+            action: action::DISCONNECTED,
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "server going away".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&disconnected).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(250), ws.accept_raw())
+                .await
+                .is_err(),
+            "full event channel should backpressure protocol DISCONNECTED before reconnect"
+        );
+        blocked_tx.send(()).unwrap();
+        close_sent_rx.await.unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for CLOSE after protocol DISCONNECTED backpressure")
+            .unwrap();
+        assert_eq!(msg.action, action::CLOSE);
+
+        let frame = tokio::time::timeout(Duration::from_secs(5), conn.next())
+            .await
+            .expect(
+                "timed out waiting for websocket close after protocol DISCONNECTED backpressure",
+            )
+            .expect("websocket closed before close frame")
+            .unwrap();
+        assert!(
+            matches!(frame, tungstenite::Message::Close(_)),
+            "expected websocket close frame, got {frame:?}"
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(500), ws.accept_raw())
+                .await
+                .is_err(),
+            "subscription close should stop before reconnecting after protocol DISCONNECTED"
+        );
+        checked_tx.send(()).unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.event_channel_capacity = 1;
+    timing.initial_retry_interval = Duration::from_millis(10);
+    timing.max_retry_interval = Duration::from_millis(10);
+    let sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    // Do not consume the initial Connected event. With capacity=1, the
+    // protocol DISCONNECTED status event blocks until close drops the receiver.
+    tokio::time::timeout(Duration::from_secs(5), blocked_rx)
+        .await
+        .expect("timed out waiting for protocol DISCONNECTED backpressure")
+        .unwrap();
+
+    sub.close();
+    close_sent_tx.send(()).unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), checked_rx)
+        .await
+        .expect("timed out waiting for protocol DISCONNECTED close check")
+        .unwrap();
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn drop_while_protocol_disconnected_backpressure_closes_socket() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (blocked_tx, blocked_rx) = tokio::sync::oneshot::channel::<()>();
+    let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel::<()>();
+    let (checked_tx, checked_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        let disconnected = ProtocolMessage {
+            action: action::DISCONNECTED,
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "server going away".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&disconnected).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(250), ws.accept_raw())
+                .await
+                .is_err(),
+            "full event channel should backpressure protocol DISCONNECTED before reconnect"
+        );
+        blocked_tx.send(()).unwrap();
+        dropped_rx.await.unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for CLOSE after subscription drop")
+            .unwrap();
+        assert_eq!(msg.action, action::CLOSE);
+
+        let frame = tokio::time::timeout(Duration::from_secs(5), conn.next())
+            .await
+            .expect("timed out waiting for websocket close after subscription drop")
+            .expect("websocket closed before close frame")
+            .unwrap();
+        assert!(
+            matches!(frame, tungstenite::Message::Close(_)),
+            "expected websocket close frame, got {frame:?}"
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(500), ws.accept_raw())
+                .await
+                .is_err(),
+            "subscription drop should stop before reconnecting after protocol DISCONNECTED"
+        );
+        checked_tx.send(()).unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.event_channel_capacity = 1;
+    timing.initial_retry_interval = Duration::from_millis(10);
+    timing.max_retry_interval = Duration::from_millis(10);
+    let sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    // Do not consume the initial Connected event. With capacity=1, the
+    // protocol DISCONNECTED status event blocks until drop closes the receiver.
+    tokio::time::timeout(Duration::from_secs(5), blocked_rx)
+        .await
+        .expect("timed out waiting for protocol DISCONNECTED backpressure")
+        .unwrap();
+
+    drop(sub);
+    dropped_tx.send(()).unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), checked_rx)
+        .await
+        .expect("timed out waiting for protocol DISCONNECTED drop check")
+        .unwrap();
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn close_while_connected_event_send_is_backpressured_closes_reconnected_socket() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (reconnected_tx, reconnected_rx) = tokio::sync::oneshot::channel::<()>();
+    let (blocked_tx, blocked_rx) = tokio::sync::oneshot::channel::<()>();
+    let (close_sent_tx, close_sent_rx) = tokio::sync::oneshot::channel::<()>();
+    let (closed_tx, closed_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        drop(conn);
+
+        let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
+        reconnected_tx.send(()).unwrap();
+
+        match tokio::time::timeout(Duration::from_millis(250), conn2.next()).await {
+            Err(_) => {}
+            Ok(frame) => {
+                panic!(
+                    "queued Disconnected event should backpressure the post-reconnect Connected event, got {frame:?}"
+                );
+            }
+        }
+        blocked_tx.send(()).unwrap();
+        close_sent_rx.await.unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for CLOSE after connected-event backpressure")
+            .unwrap();
+        assert_eq!(msg.action, action::CLOSE);
+
+        let frame = tokio::time::timeout(Duration::from_secs(5), conn2.next())
+            .await
+            .expect("timed out waiting for websocket close after connected-event backpressure")
+            .expect("websocket closed before close frame")
+            .unwrap();
+        assert!(
+            matches!(frame, tungstenite::Message::Close(_)),
+            "expected websocket close frame, got {frame:?}"
+        );
+        closed_tx.send(()).unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.event_channel_capacity = 1;
+    timing.initial_retry_interval = Duration::from_millis(10);
+    timing.max_retry_interval = Duration::from_millis(10);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    tokio::time::timeout(Duration::from_secs(5), reconnected_rx)
+        .await
+        .expect("timed out waiting for reconnect")
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(5), blocked_rx)
+        .await
+        .expect("timed out waiting for connected-event backpressure")
+        .unwrap();
+
+    sub.close();
+    close_sent_tx.send(()).unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), closed_rx)
+        .await
+        .expect("timed out waiting for reconnected socket close")
+        .unwrap();
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn close_while_error_event_send_is_backpressured_stops_and_closes_socket() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (blocked_tx, blocked_rx) = tokio::sync::oneshot::channel::<()>();
+    let (close_sent_tx, close_sent_rx) = tokio::sync::oneshot::channel::<()>();
+    let (closed_tx, closed_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        let error = ProtocolMessage {
+            action: action::ERROR,
+            error: Some(ErrorInfo {
+                code: 40000,
+                status_code: Some(400),
+                message: "bad request".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&error).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(250), conn.next())
+                .await
+                .is_err(),
+            "full event channel should backpressure Error before the socket closes"
+        );
+        blocked_tx.send(()).unwrap();
+        close_sent_rx.await.unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for CLOSE after error-event backpressure")
+            .unwrap();
+        assert_eq!(msg.action, action::CLOSE);
+
+        let frame = tokio::time::timeout(Duration::from_secs(5), conn.next())
+            .await
+            .expect("timed out waiting for websocket close after error-event backpressure")
+            .expect("websocket closed before close frame")
+            .unwrap();
+        assert!(
+            matches!(frame, tungstenite::Message::Close(_)),
+            "expected websocket close frame, got {frame:?}"
+        );
+        closed_tx.send(()).unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.event_channel_capacity = 1;
+    let sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    // Do not consume the initial Connected event. With capacity=1, the fatal
+    // Error status event blocks until close drops the receiver.
+    tokio::time::timeout(Duration::from_secs(5), blocked_rx)
+        .await
+        .expect("timed out waiting for status-event backpressure")
+        .unwrap();
+
+    sub.close();
+    close_sent_tx.send(()).unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), closed_rx)
+        .await
+        .expect("timed out waiting for socket close after backpressured Error")
+        .unwrap();
+    server_task.await.unwrap();
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -168,7 +168,8 @@ impl JobProvider for ApiProvider {
                     match event {
                         Some(ably_subscriber::Event::Message(msg)) => {
                             if let Some(run_id) = parse_cancel_notification(&msg) {
-                                if let Some(token) = self.cancel_tokens.lock().await.get(&run_id) {
+                                let token = self.cancel_tokens.lock().await.get(&run_id).cloned();
+                                if let Some(token) = token {
                                     info!(run_id = %run_id, "ably: cancel notification, killing job");
                                     token.cancel();
                                 }
@@ -192,6 +193,9 @@ impl JobProvider for ApiProvider {
                                     }
                                     continue;
                                 }
+                                if self.cancel.is_cancelled() {
+                                    return None;
+                                }
                                 // Fall back to default profile when server doesn't send one
                                 // (backwards compat with pre-profile API).
                                 let profile = notif.profile.unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
@@ -208,10 +212,8 @@ impl JobProvider for ApiProvider {
                         }
                         Some(ably_subscriber::Event::Disconnected { reason }) => {
                             *ably_connected = false;
-                            warn!(
-                                reason = reason.as_deref().unwrap_or("unknown"),
-                                "ably disconnected, switching to fast poll"
-                            );
+                            let reason = reason.as_deref().unwrap_or("unknown");
+                            warn!(reason = %reason, "ably disconnected, switching to fast poll");
                         }
                         Some(ably_subscriber::Event::Error { code, message }) => {
                             error!(code, message = %message, "ably fatal error, will reconnect");
@@ -233,8 +235,18 @@ impl JobProvider for ApiProvider {
                     *poll_now = false;
                     *deferred_poll_at = None;
                     let sessions = self.held_sessions.lock().await.clone();
-                    match self.api.poll(&self.group, &self.profiles, &sessions).await {
+                    let poll_result = tokio::select! {
+                        biased;
+                        () = self.cancel.cancelled() => {
+                            return None;
+                        }
+                        result = self.api.poll(&self.group, &self.profiles, &sessions) => result,
+                    };
+                    match poll_result {
                         Ok(Some(job)) => {
+                            if self.cancel.is_cancelled() {
+                                return None;
+                            }
                             // Fall back to default profile when server doesn't send one
                             // (backwards compat with pre-profile API).
                             let profile = job.experimental_profile.unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
@@ -300,13 +312,17 @@ impl JobProvider for ApiProvider {
     /// 2. The main loop breaks (e.g. on `Draining` mode) and explicitly
     ///    drops the pinned future, which releases the lock.
     async fn shutdown(&self) {
-        let mut state = self.discovery.lock().await;
-        // Drop Ably subscription to close WebSocket
-        state.ably = None;
-        state.ably_connected = false;
-        // Abort in-flight reconnection task
-        if let Some(h) = state.ably_retry.handle.take() {
+        let reconnect_handle = {
+            let mut state = self.discovery.lock().await;
+            // Drop Ably subscription to close WebSocket
+            state.ably = None;
+            state.ably_connected = false;
+            // Take the in-flight reconnection task before awaiting its abort.
+            state.ably_retry.handle.take()
+        };
+        if let Some(h) = reconnect_handle {
             h.abort();
+            let _ = h.await;
         }
     }
 
@@ -671,6 +687,18 @@ impl ApiClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::AsyncReadExt;
+    use tokio::net::TcpListener;
+
+    struct DropSignal(Option<tokio::sync::oneshot::Sender<()>>);
+
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            if let Some(tx) = self.0.take() {
+                let _ = tx.send(());
+            }
+        }
+    }
 
     fn make_message(name: Option<&str>, data: serde_json::Value) -> ably_subscriber::Message {
         ably_subscriber::Message {
@@ -680,6 +708,111 @@ mod tests {
             client_id: None,
             timestamp: None,
         }
+    }
+
+    #[tokio::test]
+    async fn shutdown_aborts_and_awaits_in_flight_ably_reconnect() {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel();
+        let mut ably_retry = RetryState::new(ABLY_BACKOFF_INITIAL, ABLY_BACKOFF_MAX, None);
+        ably_retry.handle = Some(tokio::spawn(async move {
+            let _drop_signal = DropSignal(Some(dropped_tx));
+            let _ = started_tx.send(());
+            std::future::pending::<Result<ably_subscriber::Subscription, ably_subscriber::Error>>()
+                .await
+        }));
+
+        let provider = ApiProvider {
+            api: ApiClient::new(
+                HttpClient::new("https://api.vm0.dev".to_string()).unwrap(),
+                "runner-token".to_string(),
+            ),
+            group: "default".to_string(),
+            profiles: Vec::new(),
+            runner_id: "runner-1".to_string(),
+            discovery: tokio::sync::Mutex::new(DiscoveryState {
+                ably: None,
+                ably_retry,
+                ably_connected: true,
+                poll_now: false,
+                deferred_poll_at: None,
+            }),
+            tokens: tokio::sync::Mutex::new(HashMap::new()),
+            cancel_tokens: std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            held_sessions: tokio::sync::Mutex::new(Vec::new()),
+            cancel: CancellationToken::new(),
+        };
+
+        tokio::time::timeout(Duration::from_secs(1), started_rx)
+            .await
+            .expect("Ably reconnect task should start")
+            .unwrap();
+
+        provider.shutdown().await;
+
+        tokio::time::timeout(Duration::from_secs(1), dropped_rx)
+            .await
+            .expect("shutdown should await aborted Ably reconnect task")
+            .unwrap();
+
+        let state = provider.discovery.lock().await;
+        assert!(state.ably_retry.handle.is_none());
+        assert!(!state.ably_connected);
+    }
+
+    #[tokio::test]
+    async fn discover_cancel_aborts_in_flight_poll() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let api_url = format!("http://{}", listener.local_addr().unwrap());
+        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+        let server_task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = [0_u8; 1024];
+            let _ = socket.read(&mut buf).await;
+            let _ = accepted_tx.send(());
+            std::future::pending::<()>().await;
+        });
+
+        let cancel = CancellationToken::new();
+        let provider = Arc::new(ApiProvider {
+            api: ApiClient::new(
+                HttpClient::new(api_url).unwrap(),
+                "runner-token".to_string(),
+            ),
+            group: "default".to_string(),
+            profiles: Vec::new(),
+            runner_id: "runner-1".to_string(),
+            discovery: tokio::sync::Mutex::new(DiscoveryState {
+                ably: None,
+                ably_retry: RetryState::new(ABLY_BACKOFF_INITIAL, ABLY_BACKOFF_MAX, None),
+                ably_connected: false,
+                poll_now: true,
+                deferred_poll_at: None,
+            }),
+            tokens: tokio::sync::Mutex::new(HashMap::new()),
+            cancel_tokens: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            held_sessions: tokio::sync::Mutex::new(Vec::new()),
+            cancel: cancel.clone(),
+        });
+
+        let provider_for_discover = Arc::clone(&provider);
+        let discover_task = tokio::spawn(async move { provider_for_discover.discover().await });
+
+        tokio::time::timeout(Duration::from_secs(1), accepted_rx)
+            .await
+            .expect("poll request should reach the server")
+            .unwrap();
+
+        cancel.cancel();
+
+        let result = tokio::time::timeout(Duration::from_secs(1), discover_task)
+            .await
+            .expect("discover should not wait for the HTTP poll timeout")
+            .unwrap();
+        assert!(result.is_none());
+
+        server_task.abort();
+        let _ = server_task.await;
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- close Ably websocket transports on reconnect and shutdown paths with bounded timeouts
- make status-event sends close-aware and surface disconnect reasons safely
- abort and await runner Ably reconnect tasks during shutdown
- add integration coverage for close/drop, reconnect, backpressure, and fatal protocol close paths

## Tests
- cargo test --manifest-path crates/Cargo.toml -p ably-subscriber
- cargo test --manifest-path crates/Cargo.toml -p runner provider::api
- cargo test --manifest-path crates/Cargo.toml -p runner shutdown_completes_without_deadlock
- cargo test --manifest-path crates/Cargo.toml -p runner discover_survives_heartbeat_ticks
- cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber -p runner --all-targets --all-features -- -D warnings
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- git diff --check
- pre-commit: cargo-fmt, cargo-clippy, cargo-doc
