### PR TITLE
feat: enable idb message cache for staff org

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -315,6 +315,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Cache chat thread messages in IndexedDB for instant cold open. " +
       "When off, every thread open fetches messages from the server.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
 };
 


### PR DESCRIPTION
## Summary
- Add `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` to `FeatureSwitchKey.IdbMessage` so the IndexedDB message cache is enabled for staff org members during rollout, consistent with other staff-gated feature switches (ConnectorCategories, PlatformConnectors, Trinity, CodexBeta).

## Test plan
- [ ] Verify staff org members see messages cached in IndexedDB
- [ ] Verify non-staff users still fetch messages from server

🤖 Generated with [Claude Code](https://claude.com/claude-code)