### PR TITLE
perf: parallelise thread-load pipelines on the chat page

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -330,6 +330,7 @@ export const bootstrap$ = command(
     set(handleSlackRedirect$);
 
     await Promise.all([
+      set(setupRoutes$, signal),
       set(startSkeletonCycling$, signal),
       set(setupRealtime$, signal),
       set(setupGlobalMethod$, signal),
@@ -339,7 +340,6 @@ export const bootstrap$ = command(
       set(setupSidebarShortcut$, signal),
       set(setupClerk$, signal),
       set(watchOrgSwitch$, signal),
-      set(setupRoutes$, signal),
     ]);
 
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-page-setup.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-page-setup.test.ts
@@ -10,7 +10,6 @@ import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { mockApi } from "../../../mocks/msw-contract.ts";
 import { server } from "../../../mocks/server.ts";
 import { hasSubscription } from "../../../mocks/ably.ts";
-import { pathname, search } from "../../location.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 
 const context = testContext();
@@ -60,31 +59,6 @@ function mockThreadPage(
 }
 
 describe("chat page setup", () => {
-  it("redirects missing chat threads through the home route", async () => {
-    server.use(
-      mockApi(chatThreadByIdContract.get, ({ respond }) => {
-        return respond(404, {
-          error: { message: "Not found", code: "NOT_FOUND" },
-        });
-      }),
-      mockApi(chatThreadMessagesContract.list, ({ respond }) => {
-        return respond(404, {
-          error: { message: "Not found", code: "NOT_FOUND" },
-        });
-      }),
-    );
-
-    detachedSetupPage({
-      context,
-      path: "/chats/123?source=legacy",
-    });
-
-    await waitFor(() => {
-      expect(pathname()).toBe(`/agents/${DEFAULT_AGENT_ID}/chat`);
-      expect(search()).toBe("");
-    });
-  });
-
   it("does not mark empty chat threads as read", async () => {
     const threadId = "empty-read-thread";
     const tracker = mockThreadPage(threadId, [], null);

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
@@ -240,18 +240,20 @@ describe("fetchNextPage$ cursor", () => {
           hasHistoryBefore: false,
         }),
       ),
-      patchDraft$: command(async () => {}),
-      listMessagesAfter$: command(async (_, args) => {
+      patchDraft$: command(() => {}),
+      listMessagesAfter$: command((_, args) => {
         capturedSinceId = args.sinceId;
-        return { messages: [], reachedEnd: true };
+        return Promise.resolve({ messages: [], reachedEnd: true });
       }),
-      listMessagesBefore$: command(async () => ({
-        messages: [],
-        hasMore: false,
-      })),
-      cancelRuns$: command(async () => {}),
-      markRead$: command(async () => null),
-      subscribeRealtime$: command(async () => {}),
+      listMessagesBefore$: command(() =>
+        Promise.resolve({
+          messages: [],
+          hasMore: false,
+        }),
+      ),
+      cancelRuns$: command(() => {}),
+      markRead$: command(() => Promise.resolve(null)),
+      subscribeRealtime$: command(() => {}),
     };
 
     const { draft } = context.store.set(ensureDraft$, threadId);

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
@@ -221,8 +221,8 @@ describe("fetchNextPage$ cursor", () => {
     let capturedSinceId: string | undefined;
 
     const mockDataSource: ChatThreadDataSource = {
-      getThread$: computed(() =>
-        Promise.resolve({
+      getThread$: computed(() => {
+        return Promise.resolve({
           id: threadId,
           title: null,
           agentId: "agent-1",
@@ -236,15 +236,15 @@ describe("fetchNextPage$ cursor", () => {
           draftAttachments: null,
           modelProviderId: null,
           selectedModel: null,
-        }),
-      ),
+        });
+      }),
       reloadThread$: command(() => {}),
-      initialPage$: computed(() =>
-        Promise.resolve({
+      initialPage$: computed(() => {
+        return Promise.resolve({
           messages: serverMessages,
           hasHistoryBefore: false,
-        }),
-      ),
+        });
+      }),
       patchDraft$: command(
         (_ctx, _args: PatchDraftArgs, _signal: AbortSignal) => {},
       ),
@@ -252,16 +252,18 @@ describe("fetchNextPage$ cursor", () => {
         capturedSinceId = args.sinceId;
         return Promise.resolve({ messages: [], reachedEnd: true });
       }),
-      listMessagesBefore$: command(() =>
-        Promise.resolve({
+      listMessagesBefore$: command(() => {
+        return Promise.resolve({
           messages: [],
           hasMore: false,
-        }),
-      ),
+        });
+      }),
       cancelRuns$: command(
         (_ctx, _args: CancelRunsArgs, _signal: AbortSignal) => {},
       ),
-      markRead$: command(() => Promise.resolve(null)),
+      markRead$: command(() => {
+        return Promise.resolve(null);
+      }),
       subscribeRealtime$: command(
         (_ctx, _args: SubscribeRealtimeArgs, _signal: AbortSignal) => {},
       ),

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
@@ -15,7 +15,12 @@ import {
   chatThreadMessagesContract,
   type PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import type { ChatThreadDataSource } from "../chat-thread-data-source.ts";
+import type {
+  ChatThreadDataSource,
+  PatchDraftArgs,
+  CancelRunsArgs,
+  SubscribeRealtimeArgs,
+} from "../chat-thread-data-source.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -240,7 +245,9 @@ describe("fetchNextPage$ cursor", () => {
           hasHistoryBefore: false,
         }),
       ),
-      patchDraft$: command(() => {}),
+      patchDraft$: command(
+        (_ctx, _args: PatchDraftArgs, _signal: AbortSignal) => {},
+      ),
       listMessagesAfter$: command((_, args) => {
         capturedSinceId = args.sinceId;
         return Promise.resolve({ messages: [], reachedEnd: true });
@@ -251,9 +258,13 @@ describe("fetchNextPage$ cursor", () => {
           hasMore: false,
         }),
       ),
-      cancelRuns$: command(() => {}),
+      cancelRuns$: command(
+        (_ctx, _args: CancelRunsArgs, _signal: AbortSignal) => {},
+      ),
       markRead$: command(() => Promise.resolve(null)),
-      subscribeRealtime$: command(() => {}),
+      subscribeRealtime$: command(
+        (_ctx, _args: SubscribeRealtimeArgs, _signal: AbortSignal) => {},
+      ),
     };
 
     const { draft } = context.store.set(ensureDraft$, threadId);

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
@@ -246,7 +246,9 @@ describe("fetchNextPage$ cursor", () => {
         });
       }),
       patchDraft$: command(
-        (_ctx, _args: PatchDraftArgs, _signal: AbortSignal) => {},
+        (_ctx, _args: PatchDraftArgs, _signal: AbortSignal) => {
+          return Promise.resolve();
+        },
       ),
       listMessagesAfter$: command((_, args) => {
         capturedSinceId = args.sinceId;
@@ -259,13 +261,17 @@ describe("fetchNextPage$ cursor", () => {
         });
       }),
       cancelRuns$: command(
-        (_ctx, _args: CancelRunsArgs, _signal: AbortSignal) => {},
+        (_ctx, _args: CancelRunsArgs, _signal: AbortSignal) => {
+          return Promise.resolve();
+        },
       ),
       markRead$: command(() => {
         return Promise.resolve(null);
       }),
       subscribeRealtime$: command(
-        (_ctx, _args: SubscribeRealtimeArgs, _signal: AbortSignal) => {},
+        (_ctx, _args: SubscribeRealtimeArgs, _signal: AbortSignal) => {
+          return Promise.resolve();
+        },
       ),
     };
 

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { command, computed } from "ccstate";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -12,7 +13,9 @@ import {
   chatThreadsContract,
   chatThreadByIdContract,
   chatThreadMessagesContract,
+  type PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import type { ChatThreadDataSource } from "../chat-thread-data-source.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -189,5 +192,85 @@ describe("createDraftSync — scheduleDraftSync$, cancelDraftSync$, flushDraftCl
         draftAttachments: null,
       });
     });
+  });
+});
+
+describe("fetchNextPage$ cursor", () => {
+  it("uses the last server-validated message ID, not the optimistic message ID", async () => {
+    const threadId = "thread-cursor-test";
+    const serverMessages: PagedChatMessage[] = [
+      {
+        id: "server-msg-1",
+        role: "user",
+        content: "hello",
+        createdAt: "2026-05-01T00:00:00Z",
+      },
+      {
+        id: "server-msg-2",
+        role: "assistant",
+        content: "hi there",
+        createdAt: "2026-05-01T00:00:01Z",
+      },
+    ];
+
+    let capturedSinceId: string | undefined;
+
+    const mockDataSource: ChatThreadDataSource = {
+      getThread$: computed(() =>
+        Promise.resolve({
+          id: threadId,
+          title: null,
+          agentId: "agent-1",
+          latestSessionId: null,
+          lastReadMessageId: null,
+          latestSessionProviderType: null,
+          activeRunIds: [],
+          activeRuns: [],
+          isLegacySession: false,
+          draftContent: null,
+          draftAttachments: null,
+          modelProviderId: null,
+          selectedModel: null,
+        }),
+      ),
+      reloadThread$: command(() => {}),
+      initialPage$: computed(() =>
+        Promise.resolve({
+          messages: serverMessages,
+          hasHistoryBefore: false,
+        }),
+      ),
+      patchDraft$: command(async () => {}),
+      listMessagesAfter$: command(async (_, args) => {
+        capturedSinceId = args.sinceId;
+        return { messages: [], reachedEnd: true };
+      }),
+      listMessagesBefore$: command(async () => ({
+        messages: [],
+        hasMore: false,
+      })),
+      cancelRuns$: command(async () => {}),
+      markRead$: command(async () => null),
+      subscribeRealtime$: command(async () => {}),
+    };
+
+    const { draft } = context.store.set(ensureDraft$, threadId);
+    const thread = createChatThreadSignals(threadId, draft, mockDataSource);
+
+    // Insert an optimistic message with a client-generated UUID
+    context.store.set(thread.insertOptimisticMessage$, {
+      id: crypto.randomUUID(),
+      role: "user",
+      content: "optimistic message",
+      createdAt: new Date().toISOString(),
+    });
+
+    // Call fetchNextPage$ — this triggers listMessagesAfter$ with a sinceId
+    await context.store.set(thread.fetchNextPage$, context.signal);
+
+    // The sinceId must be the last server-validated ID, not the optimistic UUID.
+    // If optimistic IDs leak into the cursor, the server can't resolve them
+    // and returns empty, so the real server message never reaches the client.
+    expect(capturedSinceId).toBe("server-msg-2");
   });
 });

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -17,7 +17,7 @@ import {
   markRouteSetupBegin$,
 } from "../../lib/posthog.ts";
 
-export const setupChatPage$ = command(
+const internalSetupChatPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(markRouteSetupBegin$);
     const threadId = get(currentChatThreadId$);
@@ -25,19 +25,8 @@ export const setupChatPage$ = command(
       throw new Error("threadId is required to load chat page");
     }
 
-    // Mount the page shell synchronously so the sidebar can start its own
-    // ccstate fetches (team / billing / slack / org / user-prefs / chat
-    // threads list) in parallel with onboardGuard$ + hideAppSkeleton$.
-    // Everything visible is still covered by the AppSkeleton overlay until
-    // hideAppSkeleton$ resolves, so no flash even if the guard redirects.
     set(updatePage$, createElement(ZeroChatThreadPage), "sidebar");
 
-    if (await set(onboardGuard$, signal)) {
-      return;
-    }
-
-    await set(hideAppSkeleton$, signal);
-    signal.throwIfAborted();
     set(captureNavigationTiming$);
 
     const sidebarThreadId = get(searchParams$).get(SIDEBAR_PARAM);
@@ -52,9 +41,16 @@ export const setupChatPage$ = command(
     signal.throwIfAborted();
 
     if (sidebarThreadId && !shouldLoadRight) {
-      // URL referenced sidebar thread that matched the primary thread —
-      // strip it to keep state coherent.
       set(unloadRightThread$);
     }
   },
 );
+
+export const setupChatPage$ = command(async ({ set }, signal: AbortSignal) => {
+  await Promise.all([
+    set(onboardGuard$, signal),
+    set(internalSetupChatPage$, signal),
+    set(hideAppSkeleton$, signal),
+  ]);
+  signal.throwIfAborted();
+});

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -25,11 +25,17 @@ export const setupChatPage$ = command(
       throw new Error("threadId is required to load chat page");
     }
 
+    // Mount the page shell synchronously so the sidebar can start its own
+    // ccstate fetches (team / billing / slack / org / user-prefs / chat
+    // threads list) in parallel with onboardGuard$ + hideAppSkeleton$.
+    // Everything visible is still covered by the AppSkeleton overlay until
+    // hideAppSkeleton$ resolves, so no flash even if the guard redirects.
+    set(updatePage$, createElement(ZeroChatThreadPage), "sidebar");
+
     if (await set(onboardGuard$, signal)) {
       return;
     }
 
-    set(updatePage$, createElement(ZeroChatThreadPage), "sidebar");
     await set(hideAppSkeleton$, signal);
     signal.throwIfAborted();
     set(captureNavigationTiming$);

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
@@ -65,5 +65,4 @@ export interface ChatThreadDataSource {
     Promise<void>,
     [SubscribeRealtimeArgs, AbortSignal]
   >;
-  isCancelRequested$: Computed<boolean>;
 }

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -1,14 +1,7 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
-import {
-  currentChatAgentId$,
-  currentChatThreadId$,
-  setChatAgentId$,
-} from "../agent-chat.ts";
-import { updateDocumentTitle$ } from "../document-title.ts";
+import { currentChatThreadId$ } from "../agent-chat.ts";
 import { idbMessageEnabled$ } from "../external/feature-switch.ts";
-import { setAblyLoop$ } from "../realtime.ts";
 import {
-  detachedNavigateTo$,
   pushPathSilently$,
   searchParams$,
   updateSearchParams$,
@@ -28,7 +21,8 @@ import {
   sidebarOptimisticChatThread$,
   type PendingChatThread,
 } from "./optimistic-chat-thread-state.ts";
-import { setupChatThreadSignals$ } from "./setup-chat-thread-signals.ts";
+import { setupChatThreadInitScroll$ } from "./setup-chat-thread-signals.ts";
+import { syncPrimaryThread$ } from "./sync-primary-thread.ts";
 
 export const SIDEBAR_PARAM = "sidebar";
 
@@ -54,11 +48,6 @@ const setRightThread$ = command(({ set }, thread: ChatThreadSignals | null) => {
 const resetLeftSetupSignal$ = resetSignal();
 const resetRightSetupSignal$ = resetSignal();
 
-const unloadLeftThreadGoHome$ = command(({ set }) => {
-  set(internalLeftThread$, null);
-  set(detachedNavigateTo$, "/", { replace: true });
-});
-
 export const unloadRightThread$ = command(({ get, set }) => {
   set(resetRightSetupSignal$);
   set(internalRightThread$, null);
@@ -70,24 +59,18 @@ export const unloadRightThread$ = command(({ get, set }) => {
 });
 
 /**
- * Per-pane wiring + the side-effects that differ between left (primary) and
- * right (sidebar). The shared body lives in `setupPaneThread$`; this spec
- * captures everything that varies so the two `loadX$` commands stay parallel.
+ * Per-pane wiring. The shared body lives in `setupPaneThread$`; this spec
+ * captures the bits that vary so the two `loadX$` commands stay parallel.
+ *
+ * Document-title / agent-context / Ably title-sync used to live here as
+ * boolean flags, but they only ever flipped on for the left pane. They've
+ * moved to `syncPrimaryThread$`, which `loadLeftThread$` runs alongside
+ * `setupPaneThread$`.
  */
 interface PaneSpec {
   setPaneThread$: Command<void, [ChatThreadSignals | null]>;
   optimisticSource$: Computed<PendingChatThread | null>;
   resetSetupSignal$: ReturnType<typeof resetSignal>;
-  /** Title to set when the pane first publishes; `null` to leave untouched. */
-  initialDocumentTitle: ((isOptimistic: boolean) => string) | null;
-  /** When the thread resolves: align the global agent context to it. */
-  syncAgentContextOnResolved: boolean;
-  /** When the thread resolves: push its title into the document title. */
-  syncDocumentTitleFromThread: boolean;
-  /** Subscribe to Ably run-updates to keep the document title in sync. */
-  subscribeAblyTitleUpdates: boolean;
-  /** Cleanup when threadData$ resolves to null (404). */
-  onMissing$: Command<void, []>;
 }
 
 /**
@@ -100,60 +83,18 @@ const resolvePaneThread$ = command(
     { get, set },
     args: {
       spec: PaneSpec;
-      threadId: string;
       thread: ReturnType<typeof createChatThreadSignals>;
       isNew: boolean;
       matchingOptimistic: PendingChatThread | null;
     },
     signal: AbortSignal,
   ): Promise<void> => {
-    const { spec, threadId, thread, isNew, matchingOptimistic } = args;
-
-    // Fire all three thread-load requests in parallel:
-    //   - chat-threads/:id           (via threadData$)
-    //   - messages initial page      (via groupedChatMessages$ → initialPage$)
-    //   - messages catch-up + Ably   (via loadPagedMessages$)
-    // None of these depend on each other any more, so triggering them up
-    // front lets them race rather than cascade.
-    //
-    // loadPagedMessages$ owns a forever-running Ably subscription that only
-    // resolves when the parent signal aborts. We hand it to the final
-    // Promise.all (or the missing-path drain below) so its rejection is
-    // observed there rather than left floating.
-    const groupedPromise = get(thread.groupedChatMessages$);
-    const loadPagedPromise = set(thread.loadPagedMessages$, signal);
-
+    const { spec, thread, isNew, matchingOptimistic } = args;
     const threadData = await get(thread.threadData$);
-    if (signal.aborted) {
-      // Drain in-flight pipelines so their abort surfaces here rather than
-      // floating, then propagate.
-      await Promise.all([groupedPromise, loadPagedPromise]);
-      signal.throwIfAborted();
-    }
+    signal.throwIfAborted();
 
     if (!threadData) {
-      if (matchingOptimistic) {
-        set(clearMatchingOptimisticChatThread$, matchingOptimistic);
-      }
-      set(spec.onMissing$);
-      // spec.onMissing$ navigates away, which aborts the parent signal.
-      // Drain both pipelines so the AbortError propagates through this
-      // command rather than being left as an unhandled rejection.
-      await Promise.all([groupedPromise, loadPagedPromise]);
-      signal.throwIfAborted();
-      return;
-    }
-
-    if (spec.syncAgentContextOnResolved) {
-      const currentAgentId = await get(currentChatAgentId$);
-      signal.throwIfAborted();
-      if (currentAgentId !== threadData.agentId) {
-        set(setChatAgentId$, threadData.agentId);
-      }
-    }
-
-    if (spec.syncDocumentTitleFromThread) {
-      set(updateDocumentTitle$, threadData.title ?? "New chat");
+      throw new Error("Thread data missing");
     }
 
     const hasDraftContent = threadData.draftContent !== null;
@@ -172,46 +113,18 @@ const resolvePaneThread$ = command(
     }
 
     if (matchingOptimistic) {
-      // Optimistic swap needs the initial page rendered before swapping the
-      // pane, otherwise the user sees a flash of empty thread.
-      await groupedPromise;
+      await thread.groupedChatMessages$;
       signal.throwIfAborted();
       set(thread.hideSkeleton$);
       set(spec.setPaneThread$, thread);
       set(clearMatchingOptimisticChatThread$, matchingOptimistic);
     }
 
-    const tasks: Promise<unknown>[] = [
-      // Non-optimistic path waits on initial messages alongside the rest.
-      // Optimistic path already awaited groupedPromise above; including it
-      // again is free (resolved) and keeps the single drain point.
-      groupedPromise,
-      set(setupChatThreadSignals$, thread, signal),
-      loadPagedPromise,
-    ];
-
-    if (spec.subscribeAblyTitleUpdates) {
-      const onThreadUpdated$ = command(
-        async ({ get, set }, sig: AbortSignal) => {
-          const data = await get(thread.threadData$);
-          sig.throwIfAborted();
-          if (data) {
-            set(updateDocumentTitle$, data.title ?? "New chat");
-          }
-          return false;
-        },
-      );
-      tasks.push(
-        set(
-          setAblyLoop$,
-          `chatThreadRunUpdated:${threadId}`,
-          onThreadUpdated$,
-          signal,
-        ),
-      );
-    }
-
-    await Promise.all(tasks);
+    await Promise.all([
+      set(setupChatThreadInitScroll$, thread, signal),
+      set(thread.runPhraseLoop$, signal),
+      set(thread.subscribeChatThread$, signal),
+    ]);
   },
 );
 
@@ -219,10 +132,6 @@ const resolvePaneThread$ = command(
  * Shared body for `loadLeftThread$` / `loadRightThread$`. Owns: data-source
  * selection, optimistic publish + settle dance, then delegates the second
  * half to `resolvePaneThread$`.
- *
- * Per-pane variations are routed through `spec` so the two callers reduce to
- * tiny preambles that only express what's actually different (URL shape,
- * conflict policy with the opposite pane).
  */
 const setupPaneThread$ = command(
   async (
@@ -239,12 +148,6 @@ const setupPaneThread$ = command(
 
     if (matchingOptimistic) {
       set(spec.setPaneThread$, matchingOptimistic.pendingThread);
-    }
-    if (spec.initialDocumentTitle) {
-      set(
-        updateDocumentTitle$,
-        spec.initialDocumentTitle(matchingOptimistic !== null),
-      );
     }
 
     const { draft, isNew } = set(ensureDraft$, threadId);
@@ -268,7 +171,6 @@ const setupPaneThread$ = command(
       resolvePaneThread$,
       {
         spec,
-        threadId,
         thread,
         isNew,
         matchingOptimistic,
@@ -285,6 +187,10 @@ const setupPaneThread$ = command(
  *
  * If the requested thread is currently the right pane, the right pane is
  * unloaded first (a thread cannot occupy both panes).
+ *
+ * Runs `syncPrimaryThread$` in parallel with the pane wiring so the document
+ * title / global agent context / Ably title loop start as soon as the
+ * primary thread switches, independent of how long the messages page takes.
  */
 export const loadLeftThread$ = command(
   async (
@@ -304,23 +210,19 @@ export const loadLeftThread$ = command(
       set(pushPathSilently$, "/chats/:threadId", { threadId });
     }
 
-    await set(
-      setupPaneThread$,
-      {
-        setPaneThread$: setLeftThread$,
-        optimisticSource$: optimisticChatThread$,
-        resetSetupSignal$: resetLeftSetupSignal$,
-        initialDocumentTitle: (isOptimistic) => {
-          return isOptimistic ? "New chat" : "Chat";
+    await Promise.all([
+      set(syncPrimaryThread$, threadId, parentSignal),
+      set(
+        setupPaneThread$,
+        {
+          setPaneThread$: setLeftThread$,
+          optimisticSource$: optimisticChatThread$,
+          resetSetupSignal$: resetLeftSetupSignal$,
         },
-        syncAgentContextOnResolved: true,
-        syncDocumentTitleFromThread: true,
-        subscribeAblyTitleUpdates: true,
-        onMissing$: unloadLeftThreadGoHome$,
-      },
-      threadId,
-      parentSignal,
-    );
+        threadId,
+        parentSignal,
+      ),
+    ]);
   },
 );
 
@@ -328,9 +230,6 @@ export const loadLeftThread$ = command(
  * Make the right (sidebar) chat pane show `threadId`. Idempotent — re-loading
  * the current right thread is a no-op. Refuses to load the same thread that's
  * already in the left pane.
- *
- * Mirrors `loadLeftThread$` except: this pane does not own the document
- * title, the global agent context, or the Ably title-sync subscription.
  */
 export const loadRightThread$ = command(
   async (
@@ -358,11 +257,6 @@ export const loadRightThread$ = command(
         setPaneThread$: setRightThread$,
         optimisticSource$: sidebarOptimisticChatThread$,
         resetSetupSignal$: resetRightSetupSignal$,
-        initialDocumentTitle: null,
-        syncAgentContextOnResolved: false,
-        syncDocumentTitleFromThread: false,
-        subscribeAblyTitleUpdates: false,
-        onMissing$: unloadRightThread$,
       },
       threadId,
       parentSignal,

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -73,23 +73,13 @@ interface PaneSpec {
   resetSetupSignal$: ReturnType<typeof resetSignal>;
 }
 
-/**
- * Second half of pane thread setup — called after the threadData$ resolves.
- * Owns: draft seeding, message page warm-up, optimistic swap, and the inner
- * setup loops. Extracted to keep cyclomatic complexity under the lint cap.
- */
-const resolvePaneThread$ = command(
+const loadDraft$ = command(
   async (
     { get, set },
-    args: {
-      spec: PaneSpec;
-      thread: ReturnType<typeof createChatThreadSignals>;
-      isNew: boolean;
-      matchingOptimistic: PendingChatThread | null;
-    },
+    thread: ChatThreadSignals,
+    isNew: boolean,
     signal: AbortSignal,
-  ): Promise<void> => {
-    const { spec, thread, isNew, matchingOptimistic } = args;
+  ) => {
     const threadData = await get(thread.threadData$);
     signal.throwIfAborted();
 
@@ -111,6 +101,25 @@ const resolvePaneThread$ = command(
         restoredAttachments,
       );
     }
+  },
+);
+/**
+ * Second half of pane thread setup — called after the threadData$ resolves.
+ * Owns: draft seeding, message page warm-up, optimistic swap, and the inner
+ * setup loops. Extracted to keep cyclomatic complexity under the lint cap.
+ */
+const resolvePaneThread$ = command(
+  async (
+    { set },
+    args: {
+      spec: PaneSpec;
+      thread: ReturnType<typeof createChatThreadSignals>;
+      isNew: boolean;
+      matchingOptimistic: PendingChatThread | null;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const { spec, thread, isNew, matchingOptimistic } = args;
 
     if (matchingOptimistic) {
       await thread.groupedChatMessages$;
@@ -121,6 +130,7 @@ const resolvePaneThread$ = command(
     }
 
     await Promise.all([
+      set(loadDraft$, thread, isNew, signal),
       set(setupChatThreadInitScroll$, thread, signal),
       set(thread.runPhraseLoop$, signal),
       set(thread.subscribeChatThread$, signal),

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -109,13 +109,38 @@ const resolvePaneThread$ = command(
   ): Promise<void> => {
     const { spec, threadId, thread, isNew, matchingOptimistic } = args;
 
+    // Fire all three thread-load requests in parallel:
+    //   - chat-threads/:id           (via threadData$)
+    //   - messages initial page      (via groupedChatMessages$ → initialPage$)
+    //   - messages catch-up + Ably   (via loadPagedMessages$)
+    // None of these depend on each other any more, so triggering them up
+    // front lets them race rather than cascade.
+    //
+    // loadPagedMessages$ owns a forever-running Ably subscription that only
+    // resolves when the parent signal aborts. We hand it to the final
+    // Promise.all (or the missing-path drain below) so its rejection is
+    // observed there rather than left floating.
+    const groupedPromise = get(thread.groupedChatMessages$);
+    const loadPagedPromise = set(thread.loadPagedMessages$, signal);
+
     const threadData = await get(thread.threadData$);
-    signal.throwIfAborted();
+    if (signal.aborted) {
+      // Drain in-flight pipelines so their abort surfaces here rather than
+      // floating, then propagate.
+      await Promise.all([groupedPromise, loadPagedPromise]);
+      signal.throwIfAborted();
+    }
+
     if (!threadData) {
       if (matchingOptimistic) {
         set(clearMatchingOptimisticChatThread$, matchingOptimistic);
       }
       set(spec.onMissing$);
+      // spec.onMissing$ navigates away, which aborts the parent signal.
+      // Drain both pipelines so the AbortError propagates through this
+      // command rather than being left as an unhandled rejection.
+      await Promise.all([groupedPromise, loadPagedPromise]);
+      signal.throwIfAborted();
       return;
     }
 
@@ -146,17 +171,23 @@ const resolvePaneThread$ = command(
       );
     }
 
-    await get(thread.groupedChatMessages$);
-    signal.throwIfAborted();
-
     if (matchingOptimistic) {
+      // Optimistic swap needs the initial page rendered before swapping the
+      // pane, otherwise the user sees a flash of empty thread.
+      await groupedPromise;
+      signal.throwIfAborted();
       set(thread.hideSkeleton$);
       set(spec.setPaneThread$, thread);
       set(clearMatchingOptimisticChatThread$, matchingOptimistic);
     }
 
     const tasks: Promise<unknown>[] = [
+      // Non-optimistic path waits on initial messages alongside the rest.
+      // Optimistic path already awaited groupedPromise above; including it
+      // again is free (resolved) and keeps the single drain point.
+      groupedPromise,
       set(setupChatThreadSignals$, thread, signal),
+      loadPagedPromise,
     ];
 
     if (spec.subscribeAblyTitleUpdates) {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -190,6 +190,7 @@ export interface ChatThreadSignals {
   fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>;
   loadHistory$: Command<Promise<void>, [AbortSignal]>;
   subscribeChatThread$: Command<Promise<void>, [AbortSignal]>;
+  insertOptimisticMessage$: Command<void, [PagedChatMessage]>;
   // ── Thinking indicator ───────────────────────────────────────────────────
   blockColors$: Computed<[string, string, string]>;
   rotatingPhrase$: Computed<string>;
@@ -1326,6 +1327,7 @@ export function createChatThreadSignals(
     fetchNextPage$,
     loadHistory$,
     subscribeChatThread$,
+    insertOptimisticMessage$,
     blockColors$,
     rotatingPhrase$,
     donePhrase$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -999,6 +999,11 @@ function createRunTracking({
   const subscribeChatThread$ = command(async ({ set }, signal: AbortSignal) => {
     L.debug("subscribeChatThread$ start", { threadId });
 
+    // Catch up any messages that arrived since the initial page was loaded.
+    // On IDB cache hit this fetches messages that arrived after the cache
+    // was written; on cache miss fetchNextPage$ hits reachedEnd (no-op).
+    await set(fetchNextPage$, signal);
+
     const onMessageCreated$ = command(async ({ set }, sig: AbortSignal) => {
       await set(fetchNextPage$, sig);
       await set(markThreadReadIfNeeded$, sig);

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -595,24 +595,13 @@ function createAppendDelta(deltaMessages$: DeltaMessages$) {
   });
 }
 
-function createInitialPage$(
-  threadData$: Computed<Promise<ChatThread | null>>,
-  dataSource: ChatThreadDataSource,
-) {
-  return computed(
-    async (
-      get,
-    ): Promise<{
-      messages: PagedChatMessage[];
-      hasHistoryBefore: boolean;
-    }> => {
-      const thread = await get(threadData$);
-      if (!thread) {
-        return { messages: [], hasHistoryBefore: false };
-      }
-      return get(dataSource.initialPage$);
-    },
-  );
+function createInitialPage$(dataSource: ChatThreadDataSource) {
+  // Delegates straight to the dataSource. We intentionally do NOT gate this
+  // behind threadData$ so the messages fetch races chat-threads/:id rather
+  // than waiting for it. The remote initialPage$ resolves a 404 to an empty
+  // page so the rare missing-thread case still terminates cleanly; the
+  // pane setup catches that via threadData$ being null and routes home.
+  return dataSource.initialPage$;
 }
 
 function createPagedMessages(
@@ -622,7 +611,7 @@ function createPagedMessages(
 ) {
   const loadedHistoryHasMore$ = state<boolean | null>(null);
   const historyMessages$ = state<PagedChatMessage[]>([]);
-  const initialPage$ = createInitialPage$(threadData$, dataSource);
+  const initialPage$ = createInitialPage$(dataSource);
 
   const deltaMessages$ = state<PagedChatMessage[]>([]);
   const appendDeltaMessages$ = createAppendDelta(deltaMessages$);
@@ -977,19 +966,6 @@ function createRunTracking({
 
   const loadPagedMessages$ = command(
     async ({ get, set }, signal: AbortSignal) => {
-      const thread = await get(threadData$);
-      signal.throwIfAborted();
-      if (!thread) {
-        throw new Error("invalid thread");
-      }
-
-      L.debug("loadPagedMessages$ start", {
-        threadId,
-        activeRunIds: thread.activeRunIds,
-      });
-
-      await set(markThreadReadIfNeeded$, signal);
-
       const onMessageCreated$ = command(async ({ set }, sig: AbortSignal) => {
         await set(fetchNextPage$, sig);
         // Advance read marker when a new message arrives while focused.
@@ -1014,12 +990,36 @@ function createRunTracking({
       // here; dropped because `threadListChanged` already fans out to the
       // sidebar, and the extra reload blocks keyboard navigation.
 
-      await set(
-        dataSource.subscribeRealtime$,
-        { threadId, handlers: { onMessageCreated$, onRunChanged$ } },
-        signal,
-      );
+      // Bail before subscribing to Ably if the thread doesn't exist. The
+      // caller fires this command in parallel with chat-threads/:id, so we
+      // can't gate the call site on the metadata; instead we let
+      // threadData$ resolve here and short-circuit on null. Without this
+      // check, the missing-thread path leaves a forever-running subscribe
+      // loop attached until the parent navigation aborts the signal —
+      // surfacing as an unhandled AbortError.
+      const thread = await get(threadData$);
+      signal.throwIfAborted();
+      if (!thread) {
+        return;
+      }
+      L.debug("loadPagedMessages$ start", {
+        threadId,
+        activeRunIds: thread.activeRunIds,
+      });
 
+      // Run mark-read and realtime subscribe in parallel. subscribeRealtime$
+      // owns the IDB cache catch-up; gating it behind mark-read serialised
+      // those into back-to-back round trips. markThreadReadIfNeeded$ does
+      // its own threadData$ wait, so the only outer wait is the existence
+      // check above.
+      await Promise.all([
+        set(markThreadReadIfNeeded$, signal),
+        set(
+          dataSource.subscribeRealtime$,
+          { threadId, handlers: { onMessageCreated$, onRunChanged$ } },
+          signal,
+        ),
+      ]);
       signal.throwIfAborted();
     },
   );

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -686,6 +686,7 @@ function createPagedMessages(
     let sinceId = get(nextCursorId$);
     if (!sinceId) {
       const initial = await get(initialPage$);
+      signal.throwIfAborted();
       sinceId = initial.messages[initial.messages.length - 1]?.id;
       if (sinceId) {
         set(nextCursorId$, sinceId);

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -38,6 +38,12 @@ import type { GroupedChatMessageGroup } from "./chat-message.ts";
 import { logger } from "../log.ts";
 import type { ChatThreadDataSource } from "./chat-thread-data-source.ts";
 import { createRemoteChatThreadDataSource } from "./remote-chat-thread-data-source.ts";
+import { idbMessageEnabled$ } from "../external/feature-switch.ts";
+import { clerk$ } from "../auth.ts";
+import {
+  readThreadAgentId$,
+  writeThreadAgentId$,
+} from "../external/idb-thread-agent-store.ts";
 
 export type { DraftSignals } from "../zero-page/chat-draft.ts";
 
@@ -183,7 +189,7 @@ export interface ChatThreadSignals {
   allFinished$: Computed<Promise<boolean>>;
   fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>;
   loadHistory$: Command<Promise<void>, [AbortSignal]>;
-  loadPagedMessages$: Command<Promise<void>, [AbortSignal]>;
+  subscribeChatThread$: Command<Promise<void>, [AbortSignal]>;
   // ── Thinking indicator ───────────────────────────────────────────────────
   blockColors$: Computed<[string, string, string]>;
   rotatingPhrase$: Computed<string>;
@@ -306,11 +312,33 @@ function createComposerFileInput() {
 // ---------------------------------------------------------------------------
 
 function createAgentInfoSignals(
+  threadId: string,
   threadData$: Computed<Promise<ChatThread | null>>,
 ) {
+  // agentId$ is read by avatar / pinned / model-default UI on first paint.
+  // Resolving it via threadData$ blocks the avatar render on the
+  // chat-threads/:id round-trip, even though the agentId rarely changes
+  // for a given thread. Consult the IDB cache first; on miss, fall back
+  // to threadData$ and backfill so the next visit hits the cache.
   const agentId$ = computed(async (get): Promise<string | null> => {
+    const cacheEnabled = await get(idbMessageEnabled$);
+    const clerk = cacheEnabled ? await get(clerk$) : null;
+    const userId = clerk?.user?.id ?? null;
+    const orgId = clerk?.organization?.id ?? null;
+    const cacheActive = cacheEnabled && userId !== null && orgId !== null;
+
+    if (cacheActive && userId !== null && orgId !== null) {
+      const cached = await readThreadAgentId$(userId, orgId, threadId);
+      if (cached) {
+        return cached;
+      }
+    }
     const thread = await get(threadData$);
-    return thread?.agentId ?? null;
+    const agentId = thread?.agentId ?? null;
+    if (agentId && cacheActive && userId !== null && orgId !== null) {
+      await writeThreadAgentId$(userId, orgId, threadId, agentId);
+    }
+    return agentId;
   });
 
   const agentDisplayName$ = computed(async (get): Promise<string | null> => {
@@ -946,9 +974,6 @@ function createRunTracking({
   const locallyMarkedReadMessageId$ = state<string | undefined>(undefined);
 
   const allFinished$ = computed(async (get) => {
-    if (get(dataSource.isCancelRequested$)) {
-      return true;
-    }
     const thread = await get(threadData$);
     if (!thread) {
       return false;
@@ -964,65 +989,36 @@ function createRunTracking({
     dataSource,
   });
 
-  const loadPagedMessages$ = command(
-    async ({ get, set }, signal: AbortSignal) => {
-      const onMessageCreated$ = command(async ({ set }, sig: AbortSignal) => {
-        await set(fetchNextPage$, sig);
-        // Advance read marker when a new message arrives while focused.
-        if (document.visibilityState === "visible") {
-          await set(markThreadReadIfNeeded$, sig);
-        }
-        animationFrame(
-          () => {
-            set(autoScroll$);
-          },
-          { signal },
-        );
-        return false;
-      });
+  const subscribeChatThread$ = command(async ({ set }, signal: AbortSignal) => {
+    L.debug("subscribeChatThread$ start", { threadId });
 
-      const onRunChanged$ = command(({ set }) => {
-        set(reloadThread$);
-        return false;
-      });
+    const onMessageCreated$ = command(async ({ set }, sig: AbortSignal) => {
+      await set(fetchNextPage$, sig);
+      await set(markThreadReadIfNeeded$, sig);
+      animationFrame(
+        () => {
+          set(autoScroll$);
+        },
+        { signal },
+      );
+      return false;
+    });
 
-      // `chatThreadReadCursorUpdated:<id>` used to bump `patchThreadRead$`
-      // here; dropped because `threadListChanged` already fans out to the
-      // sidebar, and the extra reload blocks keyboard navigation.
+    const onRunChanged$ = command(({ set }) => {
+      set(reloadThread$);
+      return false;
+    });
 
-      // Bail before subscribing to Ably if the thread doesn't exist. The
-      // caller fires this command in parallel with chat-threads/:id, so we
-      // can't gate the call site on the metadata; instead we let
-      // threadData$ resolve here and short-circuit on null. Without this
-      // check, the missing-thread path leaves a forever-running subscribe
-      // loop attached until the parent navigation aborts the signal —
-      // surfacing as an unhandled AbortError.
-      const thread = await get(threadData$);
-      signal.throwIfAborted();
-      if (!thread) {
-        return;
-      }
-      L.debug("loadPagedMessages$ start", {
-        threadId,
-        activeRunIds: thread.activeRunIds,
-      });
-
-      // Run mark-read and realtime subscribe in parallel. subscribeRealtime$
-      // owns the IDB cache catch-up; gating it behind mark-read serialised
-      // those into back-to-back round trips. markThreadReadIfNeeded$ does
-      // its own threadData$ wait, so the only outer wait is the existence
-      // check above.
-      await Promise.all([
-        set(markThreadReadIfNeeded$, signal),
-        set(
-          dataSource.subscribeRealtime$,
-          { threadId, handlers: { onMessageCreated$, onRunChanged$ } },
-          signal,
-        ),
-      ]);
-      signal.throwIfAborted();
-    },
-  );
+    await Promise.all([
+      set(markThreadReadIfNeeded$, signal),
+      set(
+        dataSource.subscribeRealtime$,
+        { threadId, handlers: { onMessageCreated$, onRunChanged$ } },
+        signal,
+      ),
+    ]);
+    signal.throwIfAborted();
+  });
 
   const cancelRun$ = command(async ({ get, set }, signal: AbortSignal) => {
     const thread = await get(threadData$);
@@ -1038,7 +1034,7 @@ function createRunTracking({
     signal.throwIfAborted();
   });
 
-  return { allFinished$, loadPagedMessages$, cancelRun$ };
+  return { allFinished$, subscribeChatThread$, cancelRun$ };
 }
 
 // ---------------------------------------------------------------------------
@@ -1230,7 +1226,7 @@ export function createChatThreadSignals(
   const { composerFileInput$, setComposerFileInput$ } =
     createComposerFileInput();
   const { agentId$, agentDisplayName$, agentModelDefault$, agentPinned$ } =
-    createAgentInfoSignals(threadData$);
+    createAgentInfoSignals(threadId, threadData$);
   const {
     timelineExpandedIds$,
     toggleTimelineExpanded$,
@@ -1254,7 +1250,7 @@ export function createChatThreadSignals(
 
   const { scheduleDraftSync$, cancelDraftSync$, flushDraftClear$ } =
     createDraftSync(threadId, draft, dataSource);
-  const { allFinished$, loadPagedMessages$, cancelRun$ } = createRunTracking({
+  const { allFinished$, subscribeChatThread$, cancelRun$ } = createRunTracking({
     threadId,
     reloadThread$,
     threadData$,
@@ -1323,7 +1319,7 @@ export function createChatThreadSignals(
     allFinished$,
     fetchNextPage$,
     loadHistory$,
-    loadPagedMessages$,
+    subscribeChatThread$,
     blockColors$,
     rotatingPhrase$,
     donePhrase$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -623,12 +623,7 @@ function createAppendDelta(deltaMessages$: DeltaMessages$) {
   });
 }
 
-function createInitialPage$(dataSource: ChatThreadDataSource) {
-  // Delegates straight to the dataSource. We intentionally do NOT gate this
-  // behind threadData$ so the messages fetch races chat-threads/:id rather
-  // than waiting for it. The remote initialPage$ resolves a 404 to an empty
-  // page so the rare missing-thread case still terminates cleanly; the
-  // pane setup catches that via threadData$ being null and routes home.
+function createInitialPage(dataSource: ChatThreadDataSource) {
   return dataSource.initialPage$;
 }
 
@@ -639,7 +634,7 @@ function createPagedMessages(
 ) {
   const loadedHistoryHasMore$ = state<boolean | null>(null);
   const historyMessages$ = state<PagedChatMessage[]>([]);
-  const initialPage$ = createInitialPage$(dataSource);
+  const initialPage$ = createInitialPage(dataSource);
 
   const deltaMessages$ = state<PagedChatMessage[]>([]);
   const appendDeltaMessages$ = createAppendDelta(deltaMessages$);
@@ -681,12 +676,6 @@ function createPagedMessages(
   });
 
   const fetchNextPage$ = command(async ({ get, set }, signal: AbortSignal) => {
-    const thread = await get(threadData$);
-    signal.throwIfAborted();
-    if (!thread) {
-      return true;
-    }
-
     const sinceId = await get(latestChatMessageId$);
     signal.throwIfAborted();
     const result = await set(

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -639,6 +639,12 @@ function createPagedMessages(
   const deltaMessages$ = state<PagedChatMessage[]>([]);
   const appendDeltaMessages$ = createAppendDelta(deltaMessages$);
 
+  // Tracks the last known server-validated message ID so optimistic
+  // (client-generated) IDs never leak into sinceId calls.
+  // Lazy-init from initialPage$ on first fetchNextPage$ call, then
+  // advanced after each successful fetch to the last returned message.
+  const nextCursorId$ = state<string | undefined>(undefined);
+
   const allMessages$ = computed(async (get): Promise<PagedChatMessage[]> => {
     const initial = await get(initialPage$);
     const history = get(historyMessages$);
@@ -676,8 +682,18 @@ function createPagedMessages(
   });
 
   const fetchNextPage$ = command(async ({ get, set }, signal: AbortSignal) => {
-    const sinceId = await get(latestChatMessageId$);
+    let sinceId = get(nextCursorId$);
+    if (!sinceId) {
+      const initial = await get(initialPage$);
+      sinceId = initial.messages[initial.messages.length - 1]?.id;
+      if (sinceId) {
+        set(nextCursorId$, sinceId);
+      }
+    }
     signal.throwIfAborted();
+    if (!sinceId) {
+      return true;
+    }
     const result = await set(
       dataSource.listMessagesAfter$,
       { threadId, sinceId },
@@ -688,6 +704,7 @@ function createPagedMessages(
       return true;
     }
     set(appendDeltaMessages$, result.messages);
+    set(nextCursorId$, result.messages[result.messages.length - 1].id);
     return false;
   });
 

--- a/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
@@ -220,6 +220,5 @@ export function createIdbCachedDataSource(
       cacheFlags,
       listMessagesAfter$,
     ),
-    isCancelRequested$: remote.isCancelRequested$,
   };
 }

--- a/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
@@ -1,4 +1,4 @@
-import { command, computed, type Computed } from "ccstate";
+import { command, computed } from "ccstate";
 import { clerk$ } from "../auth.ts";
 import { createIdbMessageStores } from "../external/idb-message-store.ts";
 import { logger } from "../log.ts";
@@ -116,35 +116,13 @@ function createListMessagesAfter(
   );
 }
 
-function createSubscribeRealtime(
-  remote: ChatThreadDataSource,
-  initialPage$: Computed<Promise<InitialPage>>,
-  initialPageFromCache: { current: boolean },
-  listMessagesAfter$: ChatThreadDataSource["listMessagesAfter$"],
-) {
+function createSubscribeRealtime(remote: ChatThreadDataSource) {
   return command(
     async (
-      { get, set },
+      { set },
       { threadId: tid, handlers }: SubscribeRealtimeArgs,
       signal: AbortSignal,
     ) => {
-      if (initialPageFromCache.current) {
-        const page = await get(initialPage$);
-        signal.throwIfAborted();
-        const latestMessageId = page.messages[page.messages.length - 1]?.id;
-        if (latestMessageId) {
-          L.debug("subscribeRealtime:catchUp", {
-            threadId: tid,
-            sinceId: latestMessageId,
-          });
-          await set(
-            listMessagesAfter$,
-            { threadId: tid, sinceId: latestMessageId },
-            signal,
-          );
-        }
-      }
-
       return set(
         remote.subscribeRealtime$,
         { threadId: tid, handlers },
@@ -159,7 +137,6 @@ export function createIdbCachedDataSource(
 ): ChatThreadDataSource {
   const remote = createRemoteChatThreadDataSource(threadId);
 
-  const cacheFlags = { current: false };
   let stores: Stores | null = null;
 
   function getStores(userId: string, orgId: string) {
@@ -176,7 +153,6 @@ export function createIdbCachedDataSource(
 
     if (!userId || !orgId) {
       L.debug("initialPage:noAuth", { threadId });
-      cacheFlags.current = false;
       return get(remote.initialPage$);
     }
 
@@ -186,12 +162,10 @@ export function createIdbCachedDataSource(
 
     if (cached.length > 0) {
       L.debug("initialPage:cacheHit", { threadId, count: cached.length });
-      cacheFlags.current = true;
       return { messages: cached, hasHistoryBefore: true };
     }
 
     L.debug("initialPage:cacheMiss", { threadId });
-    cacheFlags.current = false;
     const page = await get(remote.initialPage$);
     const writeStore = stores.writeStore;
     await writeStore.upsertMessages(threadId, page.messages);
@@ -214,11 +188,6 @@ export function createIdbCachedDataSource(
     listMessagesBefore$: createListMessagesBefore(remote, getStores),
     cancelRuns$: remote.cancelRuns$,
     markRead$: remote.markRead$,
-    subscribeRealtime$: createSubscribeRealtime(
-      remote,
-      initialPage$,
-      cacheFlags,
-      listMessagesAfter$,
-    ),
+    subscribeRealtime$: createSubscribeRealtime(remote),
   };
 }

--- a/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
@@ -40,7 +40,7 @@ function createListMessagesBefore(
       }
 
       const stores = getStores(userId, orgId);
-      const readStore = stores.readStore$;
+      const readStore = stores.readStore;
       const cached = await readStore.readBefore(tid, beforeId, 50, signal);
 
       if (cached.length > 0) {
@@ -59,7 +59,7 @@ function createListMessagesBefore(
         signal,
       );
 
-      const writeStore = stores.writeStore$;
+      const writeStore = stores.writeStore;
       await writeStore.upsertMessages(tid, result.messages, signal);
       L.debug("listBefore:cacheFilled", {
         threadId: tid,
@@ -95,7 +95,7 @@ function createListMessagesAfter(
 
       if (userId && orgId && result.messages.length > 0) {
         const stores = getStores(userId, orgId);
-        const writeStore = stores.writeStore$;
+        const writeStore = stores.writeStore;
         await writeStore.upsertMessages(tid, result.messages, signal);
         L.debug("listAfter:cacheFilled", {
           threadId: tid,
@@ -181,7 +181,7 @@ export function createIdbCachedDataSource(
     }
 
     const stores = getStores(userId, orgId);
-    const readStore = stores.readStore$;
+    const readStore = stores.readStore;
     const cached = await readStore.readLatest(threadId, 50);
 
     if (cached.length > 0) {
@@ -193,7 +193,7 @@ export function createIdbCachedDataSource(
     L.debug("initialPage:cacheMiss", { threadId });
     cacheFlags.current = false;
     const page = await get(remote.initialPage$);
-    const writeStore = stores.writeStore$;
+    const writeStore = stores.writeStore;
     await writeStore.upsertMessages(threadId, page.messages);
     L.debug("initialPage:cacheFilled", {
       threadId,

--- a/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
@@ -118,7 +118,7 @@ function createListMessagesAfter(
 
 function createSubscribeRealtime(remote: ChatThreadDataSource) {
   return command(
-    async (
+    (
       { set },
       { threadId: tid, handlers }: SubscribeRealtimeArgs,
       signal: AbortSignal,

--- a/turbo/apps/platform/src/signals/chat-page/local-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/local-chat-thread-data-source.ts
@@ -1,4 +1,4 @@
-import { command, computed, state } from "ccstate";
+import { command, computed } from "ccstate";
 import type { PagedChatMessage } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ChatThread } from "../agent-chat.ts";
 import type { ChatThreadDataSource } from "./chat-thread-data-source.ts";
@@ -38,7 +38,6 @@ export function createLocalChatThreadDataSource(input: {
   messages: PagedChatMessage[];
 }): ChatThreadDataSource {
   const { threadData, messages } = input;
-  const cancelRequested$ = state(false);
 
   const getThread$ = computed((): Promise<ChatThread | null> => {
     return Promise.resolve(threadData);
@@ -48,13 +47,8 @@ export function createLocalChatThreadDataSource(input: {
     return Promise.resolve({ messages, hasHistoryBefore: false });
   });
 
-  const cancelRuns$ = command(({ set }): Promise<void> => {
-    set(cancelRequested$, true);
+  const cancelRuns$ = command((): Promise<void> => {
     return Promise.resolve();
-  });
-
-  const isCancelRequested$ = computed((get) => {
-    return get(cancelRequested$);
   });
 
   return {
@@ -67,6 +61,5 @@ export function createLocalChatThreadDataSource(input: {
     cancelRuns$,
     markRead$: localMarkRead$,
     subscribeRealtime$: localSubscribeRealtime$,
-    isCancelRequested$,
   };
 }

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -1,5 +1,8 @@
 import { command, computed } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
+import { clerk$ } from "../auth.ts";
+import { idbMessageEnabled$ } from "../external/feature-switch.ts";
+import { writeThreadAgentId$ } from "../external/idb-thread-agent-store.ts";
 import {
   chatMessagesContract,
   chatThreadsContract,
@@ -36,6 +39,33 @@ export type { OptimisticChatPane };
 export { optimisticChatThread$ };
 
 const SIDEBAR_PARAM = "sidebar";
+
+/**
+ * Persist the (threadId, agentId) pairing into the IDB cache the moment the
+ * client mints a new threadId. Lets `agentId$` resolve from cache on the
+ * very first render of the new thread page, before chat-threads/:id returns.
+ */
+const writeThreadAgentToCache$ = command(
+  async (
+    { get },
+    threadId: string,
+    agentId: string,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    if (!(await get(idbMessageEnabled$))) {
+      return;
+    }
+    signal.throwIfAborted();
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+    const userId = clerk.user?.id;
+    const orgId = clerk.organization?.id;
+    if (!userId || !orgId) {
+      return;
+    }
+    await writeThreadAgentId$(userId, orgId, threadId, agentId, signal);
+  },
+);
 
 interface SendNewThreadMessageRequest {
   agentId: string;
@@ -171,6 +201,7 @@ const createNewChatThread$ = command(
     }
 
     const threadId = crypto.randomUUID();
+    await set(writeThreadAgentToCache$, threadId, resolvedComposeId, signal);
     const createdAt = new Date().toISOString();
     const dataSource = createLocalChatThreadDataSource({
       threadData: createPendingChatThread(threadId, resolvedComposeId),
@@ -297,6 +328,7 @@ const sendNewThreadMessage$ = command(
     }
 
     const threadId = crypto.randomUUID();
+    await set(writeThreadAgentToCache$, threadId, agentId, signal);
     const clientMessageId = crypto.randomUUID();
     const createdAt = new Date().toISOString();
     const dataSource = createLocalChatThreadDataSource({

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -216,8 +216,15 @@ export function createRemoteChatThreadDataSource(
     const client = get(zeroClient$)(chatThreadMessagesContract);
     const result = await accept(
       client.list({ params: { threadId }, query: { limit: 50 } }),
-      [200],
+      [200, 404],
+      { toast: false },
     );
+    if (result.status === 404) {
+      // Thread does not exist (or the caller lost access). The pane setup
+      // detects this via threadData$ being null and routes home; returning
+      // an empty page keeps the messages stream from rejecting in parallel.
+      return { messages: [], hasHistoryBefore: false };
+    }
     const hasHistoryBefore = result.body.hasHistoryBefore ?? false;
     L.debug("initialPage$", {
       threadId,

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -23,10 +23,6 @@ import type {
 
 const L = logger("ChatThread");
 
-const remoteIsCancelRequested$ = computed(() => {
-  return false;
-});
-
 const patchDraft$ = command(
   async (
     { get },
@@ -244,6 +240,5 @@ export function createRemoteChatThreadDataSource(
     cancelRuns$,
     markRead$,
     subscribeRealtime$,
-    isCancelRequested$: remoteIsCancelRequested$,
   };
 }

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -213,10 +213,8 @@ export function createRemoteChatThreadDataSource(
     const result = await accept(
       client.list({ params: { threadId }, query: { limit: 50 } }),
       [200, 404],
-      { toast: false },
     );
     if (result.status === 404) {
-      // Thread does not exist (or the caller lost access). The pane setup
       // detects this via threadData$ being null and routes home; returning
       // an empty page keeps the messages stream from rejecting in parallel.
       return { messages: [], hasHistoryBefore: false };

--- a/turbo/apps/platform/src/signals/chat-page/setup-chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/setup-chat-thread-signals.ts
@@ -2,26 +2,8 @@ import { command } from "ccstate";
 import { animationFrame } from "signal-timers";
 import type { ChatThreadSignals } from "./create-chat-thread.ts";
 
-/**
- * Bootstrap a thread's signals after construction:
- *   - resolve thread metadata (early-exit if missing)
- *   - await the first page of messages
- *   - schedule scroll-to-bottom + skeleton hide on the next animation frame
- *   - start runPhraseLoop
- *
- * loadPagedMessages$ (mark-read + Ably + IDB catch-up) is fired earlier from
- * resolvePaneThread$ so it races chat-threads/:id; the caller awaits that
- * promise alongside this command.
- */
-export const setupChatThreadSignals$ = command(
+export const setupChatThreadInitScroll$ = command(
   async ({ get, set }, thread: ChatThreadSignals, signal: AbortSignal) => {
-    const threadData = await get(thread.threadData$);
-    signal.throwIfAborted();
-    if (!threadData) {
-      set(thread.hideSkeleton$);
-      return;
-    }
-
     await get(thread.groupedChatMessages$);
     signal.throwIfAborted();
 
@@ -32,9 +14,5 @@ export const setupChatThreadSignals$ = command(
       },
       { signal },
     );
-
-    // loadPagedMessages$ is started earlier from resolvePaneThread$ so the
-    // IDB catch-up races chat-threads/:id. The caller awaits that promise.
-    await set(thread.runPhraseLoop$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/setup-chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/setup-chat-thread-signals.ts
@@ -5,13 +5,13 @@ import type { ChatThreadSignals } from "./create-chat-thread.ts";
 /**
  * Bootstrap a thread's signals after construction:
  *   - resolve thread metadata (early-exit if missing)
- *   - load the first page of messages
+ *   - await the first page of messages
  *   - schedule scroll-to-bottom + skeleton hide on the next animation frame
- *   - start runPhraseLoop + loadPagedMessages
+ *   - start runPhraseLoop
  *
- * Called from setupChatPage$ for the primary thread and from
- * openOrSwitchSidebarThread$ for the sidebar thread, so both surfaces share
- * the same lifecycle without depending on DOM ref attachment.
+ * loadPagedMessages$ (mark-read + Ably + IDB catch-up) is fired earlier from
+ * resolvePaneThread$ so it races chat-threads/:id; the caller awaits that
+ * promise alongside this command.
  */
 export const setupChatThreadSignals$ = command(
   async ({ get, set }, thread: ChatThreadSignals, signal: AbortSignal) => {
@@ -33,9 +33,8 @@ export const setupChatThreadSignals$ = command(
       { signal },
     );
 
-    await Promise.all([
-      set(thread.runPhraseLoop$, signal),
-      set(thread.loadPagedMessages$, signal),
-    ]);
+    // loadPagedMessages$ is started earlier from resolvePaneThread$ so the
+    // IDB catch-up races chat-threads/:id. The caller awaits that promise.
+    await set(thread.runPhraseLoop$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/sync-primary-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sync-primary-thread.ts
@@ -1,0 +1,81 @@
+import { command } from "ccstate";
+import { currentChatAgentId$, setChatAgentId$ } from "../agent-chat.ts";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { idbMessageEnabled$ } from "../external/feature-switch.ts";
+import { setAblyLoop$ } from "../realtime.ts";
+import { resetSignal } from "../utils.ts";
+import { createIdbCachedDataSource } from "./idb-cached-chat-thread-data-source.ts";
+import { createRemoteChatThreadDataSource } from "./remote-chat-thread-data-source.ts";
+import { optimisticChatThread$ } from "./optimistic-chat-thread-state.ts";
+
+const resetSyncPrimarySignal$ = resetSignal();
+
+/**
+ * Drives the document title, the global agent context, and the Ably
+ * title-update loop in response to whichever thread is showing in the
+ * primary (left) pane. Decoupled from `chat-thread-panes.ts` so the pane
+ * wiring stays focused on per-pane state, optimistic swaps, and URL.
+ *
+ * Lifecycle: call once per primary-thread switch with the new threadId
+ * and parentSignal. The internal reset signal aborts any previous Ably
+ * loop before the new one starts. 404 silently returns — the pane setup
+ * path already throws on missing thread data; no need to double-error.
+ *
+ * Owns its own data source (Option A from the plan) so it doesn't have to
+ * thread state through the pane wiring. On non-IDB users this issues one
+ * extra `chat-threads/:id` GET that the pane setup also fires; on IDB users
+ * the second GET is collapsed by the cache.
+ */
+export const syncPrimaryThread$ = command(
+  async (
+    { get, set },
+    threadId: string,
+    parentSignal: AbortSignal,
+  ): Promise<void> => {
+    const signal = set(resetSyncPrimarySignal$, parentSignal);
+
+    // Initial title, set synchronously so the document tab updates on the
+    // very first frame after the pane switch.
+    const optimistic = get(optimisticChatThread$);
+    const isOptimistic = optimistic?.threadId === threadId;
+    set(updateDocumentTitle$, isOptimistic ? "New chat" : "Chat");
+
+    const idbEnabled = await get(idbMessageEnabled$);
+    signal.throwIfAborted();
+    const dataSource = idbEnabled
+      ? createIdbCachedDataSource(threadId)
+      : createRemoteChatThreadDataSource(threadId);
+
+    const threadData = await get(dataSource.getThread$);
+    signal.throwIfAborted();
+    if (!threadData) {
+      // pane setup throws "Thread data missing" on the same condition; no
+      // value in double-erroring here.
+      return;
+    }
+
+    const currentAgentId = await get(currentChatAgentId$);
+    signal.throwIfAborted();
+    if (currentAgentId !== threadData.agentId) {
+      set(setChatAgentId$, threadData.agentId);
+    }
+
+    set(updateDocumentTitle$, threadData.title ?? "New chat");
+
+    // Forever-running Ably loop until signal aborts.
+    const onThreadUpdated$ = command(async ({ get, set }, sig: AbortSignal) => {
+      const data = await get(dataSource.getThread$);
+      sig.throwIfAborted();
+      if (data) {
+        set(updateDocumentTitle$, data.title ?? "New chat");
+      }
+      return false;
+    });
+    await set(
+      setAblyLoop$,
+      `chatThreadRunUpdated:${threadId}`,
+      onThreadUpdated$,
+      signal,
+    );
+  },
+);

--- a/turbo/apps/platform/src/signals/external/__tests__/idb-message-store.btest.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/idb-message-store.btest.ts
@@ -22,7 +22,8 @@ const ORG = "test-org";
 
 describe("idb-message-store", () => {
   it("upserts and reads latest messages", async () => {
-    const { readStore$, writeStore$ } = createIdbMessageStores(USER, ORG);
+    const { readStore: readStore$, writeStore: writeStore$ } =
+      createIdbMessageStores(USER, ORG);
     const writeStore = writeStore$;
     const readStore = readStore$;
 
@@ -38,10 +39,8 @@ describe("idb-message-store", () => {
   });
 
   it("readLatest respects limit", async () => {
-    const { readStore$, writeStore$ } = createIdbMessageStores(
-      USER + "-limit",
-      ORG,
-    );
+    const { readStore: readStore$, writeStore: writeStore$ } =
+      createIdbMessageStores(USER + "-limit", ORG);
     const writeStore = writeStore$;
     const readStore = readStore$;
 
@@ -59,10 +58,8 @@ describe("idb-message-store", () => {
   });
 
   it("readBefore paginates before an anchor", async () => {
-    const { readStore$, writeStore$ } = createIdbMessageStores(
-      USER + "-before",
-      ORG,
-    );
+    const { readStore: readStore$, writeStore: writeStore$ } =
+      createIdbMessageStores(USER + "-before", ORG);
     const writeStore = writeStore$;
     const readStore = readStore$;
 
@@ -82,10 +79,8 @@ describe("idb-message-store", () => {
   });
 
   it("readBefore skips anchor row when messages share createdAt", async () => {
-    const { readStore$, writeStore$ } = createIdbMessageStores(
-      USER + "-same-time",
-      ORG,
-    );
+    const { readStore: readStore$, writeStore: writeStore$ } =
+      createIdbMessageStores(USER + "-same-time", ORG);
     const writeStore = writeStore$;
     const readStore = readStore$;
 
@@ -103,10 +98,8 @@ describe("idb-message-store", () => {
   });
 
   it("rejects invalid data from IDB", async () => {
-    const { readStore$, writeStore$ } = createIdbMessageStores(
-      USER + "-invalid",
-      ORG,
-    );
+    const { readStore: readStore$, writeStore: writeStore$ } =
+      createIdbMessageStores(USER + "-invalid", ORG);
     const writeStore = writeStore$;
 
     // Initialize the DB with a valid write first so the store exists
@@ -136,15 +129,15 @@ describe("idb-message-store", () => {
     const storesA = createIdbMessageStores("user-a", "org-a");
     const storesB = createIdbMessageStores("user-b", "org-b");
 
-    await storesA.writeStore$.upsertMessages(THREAD, [
+    await storesA.writeStore.upsertMessages(THREAD, [
       makeMsg("da1", THREAD, "2026-04-01T00:00:00Z"),
     ]);
-    await storesB.writeStore$.upsertMessages(THREAD, [
+    await storesB.writeStore.upsertMessages(THREAD, [
       makeMsg("db1", THREAD, "2026-04-01T00:00:00Z"),
     ]);
 
-    const msgsA = await storesA.readStore$.readLatest(THREAD, 10);
-    const msgsB = await storesB.readStore$.readLatest(THREAD, 10);
+    const msgsA = await storesA.readStore.readLatest(THREAD, 10);
+    const msgsB = await storesB.readStore.readLatest(THREAD, 10);
 
     expect(msgsA).toHaveLength(1);
     expect(msgsA[0].id).toBe("da1");

--- a/turbo/apps/platform/src/signals/external/__tests__/idb-message-store.btest.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/idb-message-store.btest.ts
@@ -109,7 +109,7 @@ describe("idb-message-store", () => {
 
     // Write a malformed row directly via the raw store (bypassing type safety)
     const { openDB } = await import("idb");
-    const db = await openDB(`vm0-chat-${USER}-invalid-${ORG}`, 1);
+    const db = await openDB(`vm0-chat-${USER}-invalid-${ORG}`, 2);
     // Put an object with threadId so it matches the index, but missing required
     // fields (role) so schema validation rejects it
     await db.put("chat_messages", {

--- a/turbo/apps/platform/src/signals/external/__tests__/idb-thread-agent-store.btest.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/idb-thread-agent-store.btest.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  readThreadAgentId$,
+  writeThreadAgentId$,
+} from "../idb-thread-agent-store";
+import { createIdbMessageStores } from "../idb-message-store";
+
+const USER = "test-user";
+const ORG = "test-org";
+
+describe("idb-thread-agent-store", () => {
+  it("write then read returns the cached agentId", async () => {
+    await writeThreadAgentId$(USER + "-rw", ORG, "thread-rw", "agent-rw");
+    const got = await readThreadAgentId$(USER + "-rw", ORG, "thread-rw");
+    expect(got).toBe("agent-rw");
+  });
+
+  it("read on missing key returns null", async () => {
+    const got = await readThreadAgentId$(USER + "-miss", ORG, "thread-missing");
+    expect(got).toBeNull();
+  });
+
+  it("second write replaces the row (latest-wins)", async () => {
+    await writeThreadAgentId$(
+      USER + "-update",
+      ORG,
+      "thread-update",
+      "agent-1",
+    );
+    await writeThreadAgentId$(
+      USER + "-update",
+      ORG,
+      "thread-update",
+      "agent-2",
+    );
+    const got = await readThreadAgentId$(
+      USER + "-update",
+      ORG,
+      "thread-update",
+    );
+    expect(got).toBe("agent-2");
+  });
+
+  it("scopes rows by (userId, orgId)", async () => {
+    await writeThreadAgentId$("user-a", "org-a", "shared-thread", "agent-a");
+    await writeThreadAgentId$("user-b", "org-b", "shared-thread", "agent-b");
+    const a = await readThreadAgentId$("user-a", "org-a", "shared-thread");
+    const b = await readThreadAgentId$("user-b", "org-b", "shared-thread");
+    expect(a).toBe("agent-a");
+    expect(b).toBe("agent-b");
+  });
+
+  it("returns null for a corrupt row instead of throwing", async () => {
+    // Seed the store via a normal write so the DB exists.
+    await writeThreadAgentId$(
+      USER + "-corrupt",
+      ORG,
+      "thread-corrupt",
+      "agent-corrupt",
+    );
+    // Inject a malformed row directly. Reusing `openDB` here is intentional:
+    // we want to bypass the schema-aware writer.
+    const { openDB } = await import("idb");
+    const db = await openDB(`vm0-chat-${USER}-corrupt-${ORG}`, 2);
+    await db.put("chat_thread_agents", {
+      threadId: "thread-bad",
+      // missing agentId, updatedAt
+    });
+    db.close();
+
+    const got = await readThreadAgentId$(USER + "-corrupt", ORG, "thread-bad");
+    expect(got).toBeNull();
+  });
+
+  it("coexists with the chat_messages store under the same DB", async () => {
+    const stores = createIdbMessageStores(USER + "-coexist", ORG);
+    await stores.writeStore$.upsertMessages("thread-coexist", [
+      {
+        id: "m1",
+        role: "user",
+        content: "hi",
+        createdAt: "2026-05-01T00:00:00Z",
+      },
+    ]);
+    await writeThreadAgentId$(
+      USER + "-coexist",
+      ORG,
+      "thread-coexist",
+      "agent-coexist",
+    );
+
+    const messages = await stores.readStore$.readLatest("thread-coexist", 10);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.id).toBe("m1");
+
+    const agentId = await readThreadAgentId$(
+      USER + "-coexist",
+      ORG,
+      "thread-coexist",
+    );
+    expect(agentId).toBe("agent-coexist");
+  });
+});

--- a/turbo/apps/platform/src/signals/external/__tests__/idb-thread-agent-store.btest.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/idb-thread-agent-store.btest.ts
@@ -74,7 +74,7 @@ describe("idb-thread-agent-store", () => {
 
   it("coexists with the chat_messages store under the same DB", async () => {
     const stores = createIdbMessageStores(USER + "-coexist", ORG);
-    await stores.writeStore$.upsertMessages("thread-coexist", [
+    await stores.writeStore.upsertMessages("thread-coexist", [
       {
         id: "m1",
         role: "user",
@@ -89,7 +89,7 @@ describe("idb-thread-agent-store", () => {
       "agent-coexist",
     );
 
-    const messages = await stores.readStore$.readLatest("thread-coexist", 10);
+    const messages = await stores.readStore.readLatest("thread-coexist", 10);
     expect(messages).toHaveLength(1);
     expect(messages[0]?.id).toBe("m1");
 

--- a/turbo/apps/platform/src/signals/external/idb-message-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-message-store.ts
@@ -38,11 +38,20 @@ function createIdbMessageStores(userId: string, orgId: string) {
   function getDb(): Promise<IDBPDatabase> {
     if (!dbPromise) {
       L.debug("openDB", { dbName, storeName });
-      dbPromise = openDB(dbName, 1, {
+      // Schema is shared with idb-thread-agent-store.ts: both modules open
+      // the same DB at version 2. The upgrade callback creates every store
+      // the schema currently defines, idempotently, so whichever module
+      // triggers the version bump leaves a complete schema for the other.
+      dbPromise = openDB(dbName, 2, {
         upgrade(db) {
           L.debug("openDB:upgrade", { dbName, storeName });
-          const store = db.createObjectStore(storeName, { keyPath: "id" });
-          store.createIndex("byThreadAndTime", ["threadId", "createdAt"]);
+          if (!db.objectStoreNames.contains(storeName)) {
+            const store = db.createObjectStore(storeName, { keyPath: "id" });
+            store.createIndex("byThreadAndTime", ["threadId", "createdAt"]);
+          }
+          if (!db.objectStoreNames.contains("chat_thread_agents")) {
+            db.createObjectStore("chat_thread_agents", { keyPath: "threadId" });
+          }
         },
       });
     }

--- a/turbo/apps/platform/src/signals/external/idb-message-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-message-store.ts
@@ -145,8 +145,8 @@ function createIdbMessageStores(userId: string, orgId: string) {
   };
 
   return Object.freeze({
-    readStore$: readStore,
-    writeStore$: writeStore,
+    readStore,
+    writeStore,
   });
 }
 

--- a/turbo/apps/platform/src/signals/external/idb-thread-agent-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-thread-agent-store.ts
@@ -1,0 +1,98 @@
+import { openDB, type IDBPDatabase } from "idb";
+import { logger } from "../log.ts";
+
+const L = logger("ChatIdbThreadAgent");
+
+interface ThreadAgentRow {
+  threadId: string;
+  agentId: string;
+  updatedAt: string;
+}
+
+function isThreadAgentRow(raw: unknown): raw is ThreadAgentRow {
+  if (raw === null || typeof raw !== "object") {
+    return false;
+  }
+  const row = raw as Record<string, unknown>;
+  return (
+    typeof row.threadId === "string" &&
+    typeof row.agentId === "string" &&
+    typeof row.updatedAt === "string"
+  );
+}
+
+const STORE = "chat_thread_agents";
+const MESSAGE_STORE = "chat_messages";
+const DB_VERSION = 2;
+
+// Connection cache hidden behind an IIFE so module-scope rules don't see a
+// raw mutable Map. Two callers (this module + `idb-message-store.ts`) can
+// race to open the same DB; this cache de-dupes within this module, and
+// the upgrade callback below idempotently creates both schema stores so
+// whichever caller wins the v1 → v2 upgrade leaves a complete schema.
+const getDb = (() => {
+  const cache: Record<string, Promise<IDBPDatabase>> = {};
+  return (userId: string, orgId: string): Promise<IDBPDatabase> => {
+    const dbName = `vm0-chat-${userId}-${orgId}`;
+    const existing = cache[dbName];
+    if (existing !== undefined) {
+      return existing;
+    }
+    L.debug("openDB", { dbName });
+    const promise = openDB(dbName, DB_VERSION, {
+      upgrade(db) {
+        L.debug("openDB:upgrade", { dbName });
+        if (!db.objectStoreNames.contains(MESSAGE_STORE)) {
+          const messageStore = db.createObjectStore(MESSAGE_STORE, {
+            keyPath: "id",
+          });
+          messageStore.createIndex("byThreadAndTime", [
+            "threadId",
+            "createdAt",
+          ]);
+        }
+        if (!db.objectStoreNames.contains(STORE)) {
+          db.createObjectStore(STORE, { keyPath: "threadId" });
+        }
+      },
+    });
+    cache[dbName] = promise;
+    return promise;
+  };
+})();
+
+export async function readThreadAgentId$(
+  userId: string,
+  orgId: string,
+  threadId: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  const db = await getDb(userId, orgId);
+  signal?.throwIfAborted();
+  const raw = await db.get(STORE, threadId);
+  if (!raw) {
+    return null;
+  }
+  if (!isThreadAgentRow(raw)) {
+    L.debug("read:corruptRow", { threadId });
+    return null;
+  }
+  return raw.agentId;
+}
+
+export async function writeThreadAgentId$(
+  userId: string,
+  orgId: string,
+  threadId: string,
+  agentId: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const db = await getDb(userId, orgId);
+  signal?.throwIfAborted();
+  await db.put(STORE, {
+    threadId,
+    agentId,
+    updatedAt: new Date().toISOString(),
+  });
+  L.debug("write:done", { threadId, agentId });
+}

--- a/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
@@ -29,9 +29,6 @@ export const onboardGuard$ = command(
       return false;
     }
 
-    // If the backend couldn't resolve the org (deleted / stale JWT) but the
-    // user still has memberships in other orgs, send them to org selection
-    // instead of onboarding.
     const status = await get(zeroOnboardingStatus$);
     signal.throwIfAborted();
     if (!status.hasOrg) {


### PR DESCRIPTION
## Summary

Two incremental commits on this branch attack the cascade observed in `tmp/app.vm7.ai.har`:

**Commit 1 — parallelise the messages / catch-up pipeline within `resolvePaneThread$`.** `chat-threads/:id`, the initial messages page, and the IDB catch-up call now race instead of cascading.

**Commit 2 — IDB cache for `(threadId → agentId)` + extract `syncPrimaryThread$`.**

- New `idb-thread-agent-store.ts` and a v1 → v2 bump of the shared chat DB. Both modules' `upgrade` callbacks idempotently create both stores so whichever caller wins the version race leaves a complete schema.
- `createAgentInfoSignals` reads the cache first (avatar / pinned / model-default UI no longer waits on `chat-threads/:id`), falls back to `threadData$` on miss, and `await`s a backfill before resolving.
- `optimistic-chat-thread-page.ts` writes the cache row in `createNewChatThread$` and `sendNewThreadMessage$` immediately after `crypto.randomUUID()`, so the warm-cache path also covers the very first visit of a freshly minted thread.
- `syncPrimaryThread$` extracts the four primary-pane side-effects (initial doc title, title-from-thread, global agent context, Ably title loop) out of `chat-thread-panes.ts`. `loadLeftThread$` runs it in parallel with `setupPaneThread$`. `PaneSpec` shrinks from 8 fields to 3.
- 404 path is now fail-fast (`throw "Thread data missing"`); per-thread missing-thread UX is a follow-up.
- Fixes the `await set(thread.runPhraseLoop$, signal)` array-literal bug in `resolvePaneThread$`'s final `Promise.all` (the in-line `await` blocked subsequent entries from being evaluated, since `runPhraseLoop$` is forever-running).
- `loadPagedMessages$` renamed to `subscribeChatThread$`; `isCancelRequested$` signal removed.

## Test plan

- [x] `pnpm -F @vm0/app exec tsc --noEmit`
- [x] `pnpm turbo run lint`
- [x] `pnpm -F @vm0/app exec vitest run src/signals/chat-page src/views/zero-page` — 1082 passed
- [x] New `idb-thread-agent-store.btest.ts` covers write/read round-trip, miss, latest-wins, `(user, org)` scoping, corrupt-row tolerance, and coexistence with the message store.
- [ ] Re-capture HAR on a chat thread page and confirm `chat-threads/:id` no longer gates the avatar / pinned UI on the warm-cache visit, and that `messages?sinceId=…` fires together with `chat-threads/:id` rather than after it.

## Test impact

- Removed `chat-page-setup > "redirects missing chat threads through the home route"` — the navigate-on-404 path it asserted no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)