### PR TITLE
refactor: model ably subscriber lifecycle states

### DIFF
--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -293,6 +293,7 @@ pub(crate) struct EventLoopState {
     pub transport: Option<WsTransport>,
     pub event_tx: mpsc::Sender<Event>,
     pub conn_state: ConnState,
+    pub lifecycle: RealtimeStateMachine,
     pub channel: String,
     pub channel_params: Option<HashMap<String, String>>,
     pub realtime_host: String,
@@ -312,6 +313,154 @@ pub(crate) struct WsTransport {
 impl WsTransport {
     pub(crate) fn new(ws_read: WsRead, ws_write: WsWrite) -> Self {
         Self { ws_read, ws_write }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConnectionLifecycleState {
+    Connecting,
+    Connected,
+    Disconnected,
+    Closing,
+    Closed,
+    Failed,
+}
+
+impl ConnectionLifecycleState {
+    fn send_events(self) -> bool {
+        matches!(self, Self::Connected)
+    }
+
+    fn queue_events(self) -> bool {
+        matches!(self, Self::Connecting | Self::Disconnected)
+    }
+
+    fn terminal(self) -> bool {
+        matches!(self, Self::Closed | Self::Failed)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChannelLifecycleState {
+    Attaching,
+    Attached,
+    Detached,
+    Suspended,
+    Failed,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RealtimeStateMachine {
+    connection: ConnectionLifecycleState,
+    channel: ChannelLifecycleState,
+}
+
+impl RealtimeStateMachine {
+    pub(crate) fn connected() -> Self {
+        Self {
+            connection: ConnectionLifecycleState::Connected,
+            channel: ChannelLifecycleState::Attached,
+        }
+    }
+
+    fn request_connecting(&mut self) {
+        self.transition_connection(ConnectionLifecycleState::Connecting);
+        // Our reconnect attempt performs transport activation and channel attach
+        // in one async step. Mark the channel as attaching before that step so
+        // the lifecycle still mirrors ably-js' attached -> attaching -> attached
+        // transition for every new transport.
+        if matches!(
+            self.channel,
+            ChannelLifecycleState::Attached | ChannelLifecycleState::Suspended
+        ) {
+            self.transition_channel(ChannelLifecycleState::Attaching);
+        }
+    }
+
+    fn notify_connected(&mut self) {
+        self.transition_connection(ConnectionLifecycleState::Connected);
+        self.on_transport_active();
+        self.notify_channel_attached();
+    }
+
+    fn notify_disconnected(&mut self) {
+        self.transition_connection(ConnectionLifecycleState::Disconnected);
+    }
+
+    fn request_closing(&mut self) {
+        self.transition_connection(ConnectionLifecycleState::Closing);
+        self.notify_channel_detached();
+    }
+
+    fn notify_closed(&mut self) {
+        self.transition_connection(ConnectionLifecycleState::Closed);
+        self.notify_channel_detached();
+    }
+
+    fn notify_failed(&mut self) {
+        self.transition_connection(ConnectionLifecycleState::Failed);
+        self.notify_channel_failed();
+    }
+
+    fn request_channel_attaching(&mut self) {
+        if self.connection.send_events() {
+            self.transition_channel(ChannelLifecycleState::Attaching);
+        }
+    }
+
+    fn notify_channel_attached(&mut self) {
+        self.transition_channel(ChannelLifecycleState::Attached);
+    }
+
+    fn notify_channel_detached(&mut self) {
+        self.transition_channel(ChannelLifecycleState::Detached);
+    }
+
+    fn notify_channel_suspended(&mut self) {
+        self.transition_channel(ChannelLifecycleState::Suspended);
+    }
+
+    fn notify_channel_failed(&mut self) {
+        self.transition_channel(ChannelLifecycleState::Failed);
+    }
+
+    fn on_transport_active(&mut self) {
+        // Matches ably-js Channels.onTransportActive(): when a new transport
+        // becomes active, any attached/suspended channel must re-attach on that
+        // transport rather than assuming server-side channel state survived.
+        match self.channel {
+            ChannelLifecycleState::Attaching => {}
+            ChannelLifecycleState::Suspended | ChannelLifecycleState::Attached => {
+                self.request_channel_attaching();
+            }
+            ChannelLifecycleState::Detached | ChannelLifecycleState::Failed => {}
+        }
+    }
+
+    fn transition_connection(&mut self, next: ConnectionLifecycleState) {
+        if self.connection.terminal() || self.connection == next {
+            return;
+        }
+        tracing::debug!(
+            previous = ?self.connection,
+            current = ?next,
+            queue_events = next.queue_events(),
+            send_events = next.send_events(),
+            "Ably connection state transition",
+        );
+        self.connection = next;
+    }
+
+    fn transition_channel(&mut self, next: ChannelLifecycleState) {
+        if self.channel == next {
+            return;
+        }
+        tracing::debug!(
+            previous = ?self.channel,
+            current = ?next,
+            "Ably channel state transition",
+        );
+        self.channel = next;
     }
 }
 
@@ -370,7 +519,9 @@ fn reconnect_spacing_delay(last_attempt: Option<Instant>, min_interval: Duration
 // Caller-requested shutdown should send Ably CLOSE before closing the WebSocket
 // so the connection state is explicitly terminated.
 async fn send_close_message(p: &mut EventLoopState) {
+    p.lifecycle.request_closing();
     let Some(transport) = p.transport.take() else {
+        p.lifecycle.notify_closed();
         return;
     };
     let WsTransport {
@@ -397,6 +548,7 @@ async fn send_close_message(p: &mut EventLoopState) {
             "Timed out while closing websocket"
         );
     }
+    p.lifecycle.notify_closed();
 }
 
 // Reconnect paths should only close the current WebSocket transport. Sending
@@ -549,6 +701,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
 
         // --- Reconnection ---
         p.conn_state.disconnected_at = Some(Instant::now());
+        p.lifecycle.notify_disconnected();
         if !disconnected_sent {
             let event = Event::Disconnected {
                 reason: disconnect_reason,
@@ -564,6 +717,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
         loop {
             retry_count += 1;
             if retry_count > p.timing.max_retry_attempts {
+                p.lifecycle.notify_failed();
                 let event = Event::Error {
                     code: error_code::FAILED,
                     message: format!(
@@ -619,6 +773,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
             }
 
             last_reconnect_attempt = Some(Instant::now());
+            p.lifecycle.request_connecting();
             let reconnect_timeout = p.timing.reconnect_timeout;
             let reconnect_result = tokio::select! {
                 biased;
@@ -634,6 +789,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                 Ok(Ok(())) => {
                     retry_count = 0;
                     p.token_renewal_failures = 0;
+                    p.lifecycle.notify_connected();
                     if !send_status_event(&mut p, &mut close_rx, Event::Connected, "connected")
                         .await
                     {
@@ -795,6 +951,7 @@ async fn handle_message(
             // retriable error (e.g. 429 rate limit) but still expect the client
             // to reconnect after backoff. Only connection-level ERROR is fatal.
             let reason = Some(protocol_disconnect_reason(msg.error));
+            p.lifecycle.notify_disconnected();
             if !send_status_event(p, close_rx, Event::Disconnected { reason }, "disconnected").await
             {
                 return LoopAction::Stop;
@@ -804,6 +961,7 @@ async fn handle_message(
         }
         action::ERROR => {
             let err = error_or_unknown(msg.error);
+            p.lifecycle.notify_failed();
             let event = Event::Error {
                 code: err.code,
                 message: protocol_error_message(err.message),
@@ -816,6 +974,7 @@ async fn handle_message(
                 && !is_retriable(err)
             {
                 p.conn_state.channel_serial = None; // RTP5a1
+                p.lifecycle.notify_channel_failed();
                 let event = Event::Error {
                     code: err.code,
                     message: channel_detached_message(&err.message),
@@ -828,11 +987,13 @@ async fn handle_message(
                 .is_some_and(|t| t.elapsed() < p.timing.reattach_window)
             {
                 tracing::warn!("Channel detached again within retry window, reconnecting");
+                p.lifecycle.notify_channel_suspended();
                 close_websocket_transport(p).await;
                 return LoopAction::Reconnect;
             }
             tracing::warn!(channel = ?msg.channel, "Channel detached, re-attaching");
             p.conn_state.last_reattach_at = Some(Instant::now());
+            p.lifecycle.request_channel_attaching();
             let attach = build_attach_msg(
                 &p.channel,
                 p.channel_params.as_ref(),
@@ -883,6 +1044,7 @@ async fn handle_message(
                 p.conn_state.channel_serial = Some(serial);
             }
             p.conn_state.last_reattach_at = None;
+            p.lifecycle.notify_channel_attached();
             let f = msg.flags.unwrap_or(0);
             let resumed = f & flags::HAS_CHANNEL_RESUMED != 0;
             let has_backlog = f & flags::HAS_BACKLOG != 0;
@@ -900,6 +1062,7 @@ async fn handle_message(
         }
         action::CLOSED => {
             tracing::info!("Connection closed by server");
+            p.lifecycle.notify_closed();
             return LoopAction::Stop;
         }
         action::AUTH => {
@@ -953,6 +1116,7 @@ async fn handle_renewal_result(
     );
 
     if p.token_renewal_failures >= p.timing.max_token_renewal_failures {
+        p.lifecycle.notify_failed();
         let event = Event::Error {
             code: error_code::FAILED,
             message: format!(
@@ -1196,6 +1360,45 @@ mod tests {
         // No connection key → cannot resume
         state.connection_key = None;
         assert!(!state.can_resume());
+    }
+
+    #[test]
+    fn realtime_state_machine_reattaches_attached_channel_on_new_transport() {
+        let mut lifecycle = RealtimeStateMachine::connected();
+
+        lifecycle.notify_disconnected();
+        lifecycle.request_connecting();
+
+        assert_eq!(lifecycle.connection, ConnectionLifecycleState::Connecting);
+        assert_eq!(lifecycle.channel, ChannelLifecycleState::Attaching);
+
+        lifecycle.notify_connected();
+
+        assert_eq!(lifecycle.connection, ConnectionLifecycleState::Connected);
+        assert_eq!(lifecycle.channel, ChannelLifecycleState::Attached);
+    }
+
+    #[test]
+    fn realtime_state_machine_close_detaches_channel_and_becomes_terminal() {
+        let mut lifecycle = RealtimeStateMachine::connected();
+
+        lifecycle.request_closing();
+        lifecycle.notify_closed();
+        lifecycle.notify_disconnected();
+
+        assert_eq!(lifecycle.connection, ConnectionLifecycleState::Closed);
+        assert_eq!(lifecycle.channel, ChannelLifecycleState::Detached);
+    }
+
+    #[test]
+    fn realtime_state_machine_failure_fails_channel_and_becomes_terminal() {
+        let mut lifecycle = RealtimeStateMachine::connected();
+
+        lifecycle.notify_failed();
+        lifecycle.request_connecting();
+
+        assert_eq!(lifecycle.connection, ConnectionLifecycleState::Failed);
+        assert_eq!(lifecycle.channel, ChannelLifecycleState::Failed);
     }
 
     #[test]

--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -151,6 +151,7 @@ async fn wait_for_connected(ws_read: &mut WsRead) -> Result<ProtocolMessage, Err
 enum AttachOutcome {
     Attached { channel_serial: Option<String> },
     Detached(ErrorInfo),
+    RetryAttach(ErrorInfo),
     TimedOut,
 }
 
@@ -180,6 +181,14 @@ async fn wait_for_attach_outcome(
                 }
                 action::ERROR => {
                     let err = error_or_unknown(msg.error);
+                    if let Some(msg_channel) = msg.channel.as_deref() {
+                        if msg_channel != channel {
+                            continue;
+                        }
+                        if err.code == 80016 {
+                            return Ok(AttachOutcome::RetryAttach(err));
+                        }
+                    }
                     return Err(Error::Protocol {
                         code: err.code,
                         message: protocol_error_message(err.message),
@@ -210,6 +219,10 @@ async fn wait_for_attached(ws_read: &mut WsRead, channel: &str) -> Result<Option
         AttachOutcome::Detached(err) => Err(Error::Protocol {
             code: err.code,
             message: channel_detached_message(&err.message),
+        }),
+        AttachOutcome::RetryAttach(err) => Err(Error::Protocol {
+            code: err.code,
+            message: protocol_error_message(err.message),
         }),
         AttachOutcome::TimedOut => Err(Error::Protocol {
             code: error_code::TIMEOUT,
@@ -593,6 +606,15 @@ async fn sleep_until_optional(deadline: Option<Instant>) {
 
 fn message_targets_channel(msg: &ProtocolMessage, channel: &str) -> bool {
     msg.channel.as_deref() == Some(channel)
+}
+
+fn encode_attach_for_channel(
+    channel: &str,
+    channel_params: Option<&HashMap<String, String>>,
+    channel_serial: Option<&str>,
+) -> Result<Vec<u8>, Error> {
+    let attach = build_attach_msg(channel, channel_params, channel_serial);
+    encode_msg(&attach)
 }
 
 fn request_channel_attach(p: &mut EventLoopState) -> bool {
@@ -1028,12 +1050,11 @@ enum ReconnectOutcome {
 }
 
 async fn send_attach(p: &mut EventLoopState, close_rx: &mut oneshot::Receiver<()>) -> LoopAction {
-    let attach = build_attach_msg(
+    let data = match encode_attach_for_channel(
         &p.channel,
         p.channel_params.as_ref(),
         p.conn_state.channel_serial.as_deref(),
-    );
-    let data = match encode_msg(&attach) {
+    ) {
         Ok(data) => data,
         Err(e) => {
             tracing::warn!("Failed to encode attach message: {e}");
@@ -1409,7 +1430,7 @@ async fn renew_token(p: &mut EventLoopState) -> Result<(), Error> {
 /// caller moves the channel into suspended retry, matching ably-js.
 async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, Error> {
     let reconnect_timeout = p.timing.reconnect_timeout;
-    let (connected_msg, mut ws_read, ws_write, new_token) =
+    let (connected_msg, mut ws_read, mut ws_write, new_token) =
         tokio::time::timeout(reconnect_timeout, async {
             let use_resume = p.conn_state.can_resume();
 
@@ -1458,12 +1479,11 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
             } else {
                 tracing::info!("Fresh connect, attaching channel");
             }
-            let attach = build_attach_msg(
+            let data = encode_attach_for_channel(
                 &p.channel,
                 p.channel_params.as_ref(),
                 p.conn_state.channel_serial.as_deref(),
-            );
-            let data = encode_msg(&attach)?;
+            )?;
             ws_write
                 .send(tungstenite::Message::Binary(data.into()))
                 .await?;
@@ -1476,10 +1496,28 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
             message: "Reconnect attempt timed out".to_string(),
         })??;
 
-    let attach_outcome = match tokio::time::timeout(
-        p.timing.realtime_request_timeout,
-        wait_for_attach_outcome(&mut ws_read, &p.channel),
-    )
+    let attach_outcome = match tokio::time::timeout(p.timing.realtime_request_timeout, async {
+        loop {
+            match wait_for_attach_outcome(&mut ws_read, &p.channel).await? {
+                AttachOutcome::RetryAttach(err) => {
+                    tracing::warn!(
+                        code = err.code,
+                        message = %protocol_error_message(err.message),
+                        "Channel attach was superseded while re-attaching after reconnect; retrying attach",
+                    );
+                    let data = encode_attach_for_channel(
+                        &p.channel,
+                        p.channel_params.as_ref(),
+                        p.conn_state.channel_serial.as_deref(),
+                    )?;
+                    ws_write
+                        .send(tungstenite::Message::Binary(data.into()))
+                        .await?;
+                }
+                outcome => return Ok::<_, Error>(outcome),
+            }
+        }
+    })
     .await
     {
         Ok(Ok(outcome)) => outcome,
@@ -1487,8 +1525,6 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
         Err(_) => AttachOutcome::TimedOut,
     };
 
-    // Commit state only after all steps succeeded.
-    p.conn_state.update_from_connected(&connected_msg);
     let reconnect_outcome = match attach_outcome {
         AttachOutcome::Attached { channel_serial } => {
             if let Some(serial) = channel_serial {
@@ -1504,6 +1540,12 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
             p.conn_state.channel_serial = None;
             ReconnectOutcome::ChannelSuspended
         }
+        AttachOutcome::RetryAttach(err) => {
+            return Err(Error::Protocol {
+                code: err.code,
+                message: protocol_error_message(err.message),
+            });
+        }
         AttachOutcome::TimedOut => {
             tracing::warn!(
                 timeout_ms = p.timing.realtime_request_timeout.as_millis(),
@@ -1513,6 +1555,10 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
             ReconnectOutcome::ChannelSuspended
         }
     };
+
+    // Commit connection state only after all reconnect steps have produced a
+    // definitive channel outcome.
+    p.conn_state.update_from_connected(&connected_msg);
     if let Some(token) = new_token {
         p.conn_state.token = token;
         p.conn_state.token_renewal_at =

--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -592,9 +592,7 @@ async fn sleep_until_optional(deadline: Option<Instant>) {
 }
 
 fn message_targets_channel(msg: &ProtocolMessage, channel: &str) -> bool {
-    msg.channel
-        .as_deref()
-        .is_none_or(|msg_channel| msg_channel == channel)
+    msg.channel.as_deref() == Some(channel)
 }
 
 fn request_channel_attach(p: &mut EventLoopState) -> bool {

--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -148,7 +148,23 @@ async fn wait_for_connected(ws_read: &mut WsRead) -> Result<ProtocolMessage, Err
     })
 }
 
-async fn wait_for_attached(ws_read: &mut WsRead, channel: &str) -> Result<ProtocolMessage, Error> {
+enum AttachOutcome {
+    Attached { channel_serial: Option<String> },
+    Detached(ErrorInfo),
+}
+
+fn detached_error_or_default(error: Option<ErrorInfo>) -> ErrorInfo {
+    error.unwrap_or_else(|| ErrorInfo {
+        code: error_code::CHANNEL_OPERATION_FAILED,
+        status_code: Some(404),
+        message: "Channel detached".to_string(),
+    })
+}
+
+async fn wait_for_attach_outcome(
+    ws_read: &mut WsRead,
+    channel: &str,
+) -> Result<AttachOutcome, Error> {
     while let Some(frame) = ws_read.next().await {
         let frame = frame?;
         if let tungstenite::Message::Binary(data) = frame {
@@ -156,7 +172,9 @@ async fn wait_for_attached(ws_read: &mut WsRead, channel: &str) -> Result<Protoc
             match msg.action {
                 action::ATTACHED => {
                     if msg.channel.as_deref() == Some(channel) {
-                        return Ok(msg);
+                        return Ok(AttachOutcome::Attached {
+                            channel_serial: msg.channel_serial,
+                        });
                     }
                 }
                 action::ERROR => {
@@ -167,11 +185,11 @@ async fn wait_for_attached(ws_read: &mut WsRead, channel: &str) -> Result<Protoc
                     });
                 }
                 action::DETACHED => {
-                    let err = error_or_unknown(msg.error);
-                    return Err(Error::Protocol {
-                        code: err.code,
-                        message: channel_detached_message(&err.message),
-                    });
+                    if msg.channel.as_deref() == Some(channel) {
+                        return Ok(AttachOutcome::Detached(detached_error_or_default(
+                            msg.error,
+                        )));
+                    }
                 }
                 _ => {
                     tracing::debug!(action = msg.action, "Ignoring pre-ATTACHED message");
@@ -183,6 +201,16 @@ async fn wait_for_attached(ws_read: &mut WsRead, channel: &str) -> Result<Protoc
         code: error_code::CHANNEL_OPERATION_FAILED,
         message: "Connection closed before ATTACHED received".to_string(),
     })
+}
+
+async fn wait_for_attached(ws_read: &mut WsRead, channel: &str) -> Result<Option<String>, Error> {
+    match wait_for_attach_outcome(ws_read, channel).await? {
+        AttachOutcome::Attached { channel_serial } => Ok(channel_serial),
+        AttachOutcome::Detached(err) => Err(Error::Protocol {
+            code: err.code,
+            message: channel_detached_message(&err.message),
+        }),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -205,8 +233,7 @@ pub(crate) async fn connect_and_attach(
     ws_write
         .send(tungstenite::Message::Binary(encoded.into()))
         .await?;
-    let attached_msg = wait_for_attached(&mut ws_read, channel).await?;
-    conn_state.channel_serial = attached_msg.channel_serial;
+    conn_state.channel_serial = wait_for_attached(&mut ws_read, channel).await?;
     Ok((ws_write, ws_read, conn_state))
 }
 
@@ -221,7 +248,6 @@ pub(crate) struct ConnState {
     pub connection_state_ttl: Duration,
     pub max_idle_interval: Duration,
     pub disconnected_at: Option<Instant>,
-    pub last_reattach_at: Option<Instant>,
     pub token: TokenDetails,
     pub token_renewal_at: Instant,
 }
@@ -235,7 +261,6 @@ impl ConnState {
             connection_state_ttl: timing.default_connection_state_ttl,
             max_idle_interval: timing.default_max_idle_interval,
             disconnected_at: None,
-            last_reattach_at: None,
             token_renewal_at: Self::compute_renewal_at(&token, timing.token_renewal_margin),
             token,
         };
@@ -273,12 +298,13 @@ impl ConnState {
         Instant::now() + renew_in
     }
 
-    /// RTN15h: resume is allowed when elapsed time since disconnect is less
-    /// than `connection_state_ttl + max_idle_interval` and we have a key.
+    /// Resume is allowed while the Ably connection state is still retained and
+    /// we have a connection key. This mirrors ably-js' suspend timer: once a
+    /// connection has been detected as disconnected, the resumable window is
+    /// `connection_state_ttl`.
     fn can_resume(&self) -> bool {
         if let Some(disconnected_at) = self.disconnected_at {
-            disconnected_at.elapsed() < self.connection_state_ttl + self.max_idle_interval
-                && self.connection_key.is_some()
+            disconnected_at.elapsed() < self.connection_state_ttl && self.connection_key.is_some()
         } else {
             false
         }
@@ -303,6 +329,10 @@ pub(crate) struct EventLoopState {
     pub timing: TimingConfig,
     pub token_renewal_failures: u32,
     pub dropped_messages: u64,
+    pub channel_retry_at: Option<Instant>,
+    pub channel_retry_count: u32,
+    pub channel_operation_deadline: Option<Instant>,
+    pub connected_event_pending: bool,
 }
 
 pub(crate) struct WsTransport {
@@ -321,6 +351,7 @@ enum ConnectionLifecycleState {
     Connecting,
     Connected,
     Disconnected,
+    Suspended,
     Closing,
     Closed,
     Failed,
@@ -377,14 +408,23 @@ impl RealtimeStateMachine {
         }
     }
 
-    fn notify_connected(&mut self) {
+    fn notify_transport_connected(&mut self) {
         self.transition_connection(ConnectionLifecycleState::Connected);
         self.on_transport_active();
+    }
+
+    fn notify_connected(&mut self) {
+        self.notify_transport_connected();
         self.notify_channel_attached();
     }
 
     fn notify_disconnected(&mut self) {
         self.transition_connection(ConnectionLifecycleState::Disconnected);
+    }
+
+    fn notify_suspended(&mut self) {
+        self.transition_connection(ConnectionLifecycleState::Suspended);
+        self.notify_channel_suspended();
     }
 
     fn request_closing(&mut self) {
@@ -464,6 +504,14 @@ impl RealtimeStateMachine {
     }
 }
 
+impl ConnState {
+    fn clear_resume_state(&mut self) {
+        self.connection_id = None;
+        self.connection_key = None;
+        self.channel_serial = None;
+    }
+}
+
 fn websocket_close_reason(frame: Option<&CloseFrame>) -> String {
     match frame {
         Some(frame) if frame.reason.is_empty() => {
@@ -514,6 +562,82 @@ fn reconnect_spacing_delay(last_attempt: Option<Instant>, min_interval: Duration
     last_attempt.map_or(Duration::ZERO, |attempt| {
         min_interval.saturating_sub(attempt.elapsed())
     })
+}
+
+fn retry_delay(initial_timeout: Duration, retry_attempt: u32) -> Duration {
+    // Mirrors ably-js Utils.getRetryTime(): base * min((attempt + 2) / 3, 2)
+    // with jitter in [0.8, 1.0). Use wall-clock subsecond nanos as a cheap
+    // process-local jitter source; cryptographic randomness is unnecessary.
+    let backoff_num = (retry_attempt + 2).min(6) as u128;
+    let base_ms = initial_timeout.as_millis();
+    let upper_ms = base_ms.saturating_mul(backoff_num) / 3;
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos() as u128;
+    let jitter_per_mille = 800 + (nanos % 200);
+    Duration::from_millis(upper_ms.saturating_mul(jitter_per_mille) as u64 / 1000)
+}
+
+async fn sleep_until_optional(deadline: Option<Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending().await,
+    }
+}
+
+fn message_targets_channel(msg: &ProtocolMessage, channel: &str) -> bool {
+    msg.channel
+        .as_deref()
+        .is_none_or(|msg_channel| msg_channel == channel)
+}
+
+fn request_channel_attach(p: &mut EventLoopState) -> bool {
+    p.lifecycle.request_channel_attaching();
+    if p.lifecycle.channel != ChannelLifecycleState::Attaching
+        || !p.lifecycle.connection.send_events()
+    {
+        return false;
+    }
+
+    p.channel_retry_at = None;
+    p.channel_operation_deadline = Some(Instant::now() + p.timing.realtime_request_timeout);
+    true
+}
+
+fn schedule_channel_retry(p: &mut EventLoopState) {
+    p.channel_operation_deadline = None;
+    if p.lifecycle.channel == ChannelLifecycleState::Suspended
+        && p.lifecycle.connection.send_events()
+    {
+        p.channel_retry_count += 1;
+        p.channel_retry_at = Some(
+            Instant::now() + retry_delay(p.timing.channel_retry_timeout, p.channel_retry_count),
+        );
+    } else {
+        p.channel_retry_at = None;
+    }
+}
+
+fn notify_channel_suspended(p: &mut EventLoopState) {
+    p.conn_state.channel_serial = None;
+    p.lifecycle.notify_channel_suspended();
+    schedule_channel_retry(p);
+}
+
+fn notify_channel_attached(p: &mut EventLoopState) {
+    p.lifecycle.notify_channel_attached();
+    p.channel_retry_at = None;
+    p.channel_retry_count = 0;
+    p.channel_operation_deadline = None;
+}
+
+fn notify_channel_failed(p: &mut EventLoopState) {
+    p.conn_state.channel_serial = None;
+    p.lifecycle.notify_channel_failed();
+    p.channel_retry_at = None;
+    p.channel_operation_deadline = None;
+    p.connected_event_pending = false;
 }
 
 // Caller-requested shutdown should send Ably CLOSE before closing the WebSocket
@@ -592,7 +716,6 @@ async fn send_status_event(
 }
 
 pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot::Receiver<()>) {
-    let mut retry_count: u32 = 0;
     let mut last_reconnect_attempt: Option<Instant> = None;
 
     'outer: loop {
@@ -602,6 +725,39 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
         let mut close_before_reconnect = false;
         // Main message processing loop
         loop {
+            if p.channel_operation_deadline
+                .is_some_and(|deadline| deadline <= Instant::now())
+            {
+                p.channel_operation_deadline = None;
+                if p.lifecycle.channel == ChannelLifecycleState::Attaching {
+                    tracing::warn!(
+                        timeout_ms = p.timing.realtime_request_timeout.as_millis(),
+                        "Channel attach timed out, entering suspended channel retry"
+                    );
+                    notify_channel_suspended(&mut p);
+                }
+                continue;
+            }
+
+            if p.channel_retry_at
+                .is_some_and(|deadline| deadline <= Instant::now())
+            {
+                p.channel_retry_at = None;
+                if p.lifecycle.channel == ChannelLifecycleState::Suspended
+                    && request_channel_attach(&mut p)
+                {
+                    match send_attach(&mut p, &mut close_rx).await {
+                        LoopAction::Stop => return,
+                        LoopAction::Reconnect => {
+                            immediate_retry = true;
+                            break;
+                        }
+                        LoopAction::Continue => {}
+                    }
+                }
+                continue;
+            }
+
             let Some(transport) = p.transport.as_mut() else {
                 tracing::warn!("WebSocket transport missing before receive loop");
                 break;
@@ -634,16 +790,20 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                     }
                 }
 
+                _ = sleep_until_optional(p.channel_operation_deadline), if p.channel_operation_deadline.is_some() => {}
+
+                _ = sleep_until_optional(p.channel_retry_at), if p.channel_retry_at.is_some() => {}
+
                 frame = transport.ws_read.next() => {
                     match frame {
                         Some(Ok(tungstenite::Message::Binary(data))) => {
-                            retry_count = 0;
                             match decode_msg(&data) {
                                 Ok(msg) => {
                                     match handle_message(&mut p, msg, &mut close_rx).await {
                                         LoopAction::Stop => return,
                                         LoopAction::Reconnect => {
                                             disconnected_sent = true;
+                                            immediate_retry = true;
                                             break;
                                         }
                                         LoopAction::Continue => {}
@@ -678,12 +838,14 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                             let reason = websocket_error_reason(&e);
                             tracing::warn!(%reason, "WebSocket error");
                             disconnect_reason = Some(reason);
+                            immediate_retry = true;
                             close_before_reconnect = true;
                             break; // → reconnect
                         }
                         None => {
                             disconnect_reason = Some("websocket stream ended".to_string());
                             tracing::info!("WebSocket stream ended");
+                            immediate_retry = true;
                             close_before_reconnect = true;
                             break; // → reconnect
                         }
@@ -692,6 +854,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
 
                 _ = tokio::time::sleep_until(idle_deadline) => {
                     disconnect_reason = Some(format!("heartbeat timeout after {idle_timeout:?}"));
+                    immediate_retry = true;
                     close_before_reconnect = true;
                     tracing::warn!("Heartbeat timeout");
                     break; // → reconnect
@@ -714,53 +877,55 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
             close_websocket_transport(&mut p).await;
         }
 
+        let mut retry_immediately = immediate_retry;
+        let mut disconnected_retry_count: u32 = 0;
+        let mut suspended_retry_count: u32 = 0;
         loop {
-            retry_count += 1;
-            if retry_count > p.timing.max_retry_attempts {
-                p.lifecycle.notify_failed();
-                let event = Event::Error {
-                    code: error_code::FAILED,
-                    message: format!(
-                        "Connection failed after {} attempts",
-                        p.timing.max_retry_attempts
-                    ),
+            if !p.conn_state.can_resume()
+                && p.lifecycle.connection != ConnectionLifecycleState::Suspended
+            {
+                p.conn_state.clear_resume_state();
+                p.lifecycle.notify_suspended();
+                p.conn_state.channel_serial = None;
+                p.channel_retry_at = None;
+                p.channel_operation_deadline = None;
+                disconnected_retry_count = 0;
+                let event = Event::Disconnected {
+                    reason: Some("connection state expired; entering suspended retry".to_string()),
                 };
-                let _ = send_status_event(&mut p, &mut close_rx, event, "error").await;
-                return;
+                if !send_status_event(&mut p, &mut close_rx, event, "suspended").await {
+                    return;
+                }
             }
 
-            // Skip backoff on the first attempt after a transport close frame,
-            // but keep a small minimum gap between repeated reconnect attempts
-            // to avoid tight close loops.
-            let backoff_duration = if retry_count == 1 && immediate_retry {
+            // ably-js retries immediately when an active connection becomes
+            // disconnected, with a one-second guard against tight reconnect
+            // loops. Subsequent disconnected/suspended retries use the state's
+            // retry timeout and jitter.
+            let backoff_duration = if retry_immediately {
+                retry_immediately = false;
                 let delay = reconnect_spacing_delay(
                     last_reconnect_attempt,
                     p.timing.min_reconnect_interval,
                 );
                 if delay == Duration::ZERO {
-                    tracing::info!("Reconnecting immediately after close frame");
+                    tracing::info!("Reconnecting immediately after connection interruption");
                 } else {
                     tracing::info!(
                         delay_ms = delay.as_millis(),
-                        "Delaying reconnect after repeated close frame"
+                        "Delaying reconnect after repeated connection interruption"
                     );
                 }
                 delay
+            } else if p.lifecycle.connection == ConnectionLifecycleState::Suspended {
+                suspended_retry_count += 1;
+                retry_delay(p.timing.suspended_retry_timeout, suspended_retry_count)
             } else {
-                // Exponential backoff: 1s, 2s, 4s, 8s, 15s, 15s, ...
-                let exp = retry_count.saturating_sub(1).min(30);
-                let backoff = p
-                    .timing
-                    .initial_retry_interval
-                    .saturating_mul(1u32 << exp)
-                    .min(p.timing.max_retry_interval);
-                // Use subsecond nanos from wall clock for non-deterministic jitter
-                let nanos = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .subsec_nanos() as u64;
-                let jitter = Duration::from_millis(nanos % 1000);
-                backoff + jitter
+                disconnected_retry_count += 1;
+                retry_delay(
+                    p.timing.disconnected_retry_timeout,
+                    disconnected_retry_count,
+                )
             };
             tokio::select! {
                 biased;
@@ -786,9 +951,9 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
             };
 
             match reconnect_result {
-                Ok(Ok(())) => {
-                    retry_count = 0;
+                Ok(Ok(ReconnectOutcome::Attached)) => {
                     p.token_renewal_failures = 0;
+                    p.connected_event_pending = false;
                     p.lifecycle.notify_connected();
                     if !send_status_event(&mut p, &mut close_rx, Event::Connected, "connected")
                         .await
@@ -797,12 +962,22 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                     }
                     continue 'outer;
                 }
+                Ok(Ok(ReconnectOutcome::ChannelSuspended)) => {
+                    p.token_renewal_failures = 0;
+                    p.lifecycle.notify_transport_connected();
+                    notify_channel_suspended(&mut p);
+                    p.connected_event_pending = true;
+                    continue 'outer;
+                }
                 Ok(Err(e)) => {
-                    tracing::warn!("Reconnect attempt {retry_count} failed: {e}");
+                    tracing::warn!("Reconnect attempt failed: {e}");
                 }
                 Err(_) => {
-                    tracing::warn!("Reconnect attempt {retry_count} timed out");
+                    tracing::warn!("Reconnect attempt timed out");
                 }
+            }
+            if p.lifecycle.connection != ConnectionLifecycleState::Suspended {
+                p.lifecycle.notify_disconnected();
             }
         }
     }
@@ -814,27 +989,55 @@ enum LoopAction {
     Reconnect,
 }
 
-/// Mirrors ably-js `isRetriable()` from `connectionerrors.ts`.
-///
-/// An error is retriable when it has no status code, no error code, is a
-/// server error (5xx), or carries a well-known connection error code even
-/// at 4xx.
-fn is_retriable(err: &ErrorInfo) -> bool {
-    const CONNECTION_ERROR_CODES: &[i32] = &[
-        80003, // DISCONNECTED
-        80002, // SUSPENDED
-        80000, // FAILED
-        80017, // CLOSING / CLOSED
-        50002, // UNKNOWN_CONNECTION_ERR
-        50001, // UNKNOWN_CHANNEL_ERR
-    ];
-    if err.code == 0 {
-        return true;
-    }
-    match err.status_code {
-        None => true,
-        Some(sc) if sc >= 500 => true,
-        Some(_) => CONNECTION_ERROR_CODES.contains(&err.code),
+enum ReconnectOutcome {
+    Attached,
+    ChannelSuspended,
+}
+
+async fn send_attach(p: &mut EventLoopState, close_rx: &mut oneshot::Receiver<()>) -> LoopAction {
+    let attach = build_attach_msg(
+        &p.channel,
+        p.channel_params.as_ref(),
+        p.conn_state.channel_serial.as_deref(),
+    );
+    let data = match encode_msg(&attach) {
+        Ok(data) => data,
+        Err(e) => {
+            tracing::warn!("Failed to encode attach message: {e}");
+            close_websocket_transport(p).await;
+            return LoopAction::Reconnect;
+        }
+    };
+
+    let connect_timeout = p.timing.connect_timeout;
+    let Some(transport) = p.transport.as_mut() else {
+        tracing::warn!("Missing websocket transport for attach");
+        return LoopAction::Reconnect;
+    };
+    let send_result = tokio::select! {
+        biased;
+        _ = &mut *close_rx => {
+            tracing::info!("Close requested during channel attach");
+            send_close_message(p).await;
+            return LoopAction::Stop;
+        }
+        result = tokio::time::timeout(
+            connect_timeout,
+            transport.ws_write.send(tungstenite::Message::Binary(data.into())),
+        ) => result,
+    };
+    match send_result {
+        Ok(Ok(())) => LoopAction::Continue,
+        Ok(Err(_)) => {
+            tracing::warn!("Failed to send attach, triggering reconnect");
+            close_websocket_transport(p).await;
+            LoopAction::Reconnect
+        }
+        Err(_) => {
+            tracing::warn!("Timed out sending attach, triggering reconnect");
+            close_websocket_transport(p).await;
+            LoopAction::Reconnect
+        }
     }
 }
 
@@ -906,6 +1109,16 @@ async fn handle_message(
             tracing::trace!("Heartbeat received");
         }
         action::MESSAGE => {
+            if !message_targets_channel(&msg, &p.channel) {
+                return LoopAction::Continue;
+            }
+            if p.lifecycle.channel != ChannelLifecycleState::Attached {
+                tracing::debug!(
+                    channel_state = ?p.lifecycle.channel,
+                    "Skipping message while channel is not attached"
+                );
+                return LoopAction::Continue;
+            }
             if let Some(serial) = msg.channel_serial {
                 p.conn_state.channel_serial = Some(serial);
             }
@@ -961,7 +1174,25 @@ async fn handle_message(
         }
         action::ERROR => {
             let err = error_or_unknown(msg.error);
-            p.lifecycle.notify_failed();
+            if let Some(channel) = msg.channel.as_deref() {
+                if channel != p.channel {
+                    return LoopAction::Continue;
+                }
+
+                if err.code == 80016 {
+                    if request_channel_attach(p) {
+                        return send_attach(p, close_rx).await;
+                    }
+                    return LoopAction::Continue;
+                }
+
+                notify_channel_failed(p);
+            } else {
+                p.lifecycle.notify_failed();
+                p.conn_state.channel_serial = None;
+                p.channel_retry_at = None;
+                p.channel_operation_deadline = None;
+            }
             let event = Event::Error {
                 code: err.code,
                 message: protocol_error_message(err.message),
@@ -970,81 +1201,42 @@ async fn handle_message(
             return LoopAction::Stop;
         }
         action::DETACHED => {
-            if let Some(ref err) = msg.error
-                && !is_retriable(err)
-            {
-                p.conn_state.channel_serial = None; // RTP5a1
-                p.lifecycle.notify_channel_failed();
-                let event = Event::Error {
-                    code: err.code,
-                    message: channel_detached_message(&err.message),
-                };
-                let _ = send_status_event(p, close_rx, event, "error").await;
-                return LoopAction::Stop;
+            if !message_targets_channel(&msg, &p.channel) {
+                return LoopAction::Continue;
             }
-            if p.conn_state
-                .last_reattach_at
-                .is_some_and(|t| t.elapsed() < p.timing.reattach_window)
-            {
-                tracing::warn!("Channel detached again within retry window, reconnecting");
-                p.lifecycle.notify_channel_suspended();
-                close_websocket_transport(p).await;
-                return LoopAction::Reconnect;
-            }
-            tracing::warn!(channel = ?msg.channel, "Channel detached, re-attaching");
-            p.conn_state.last_reattach_at = Some(Instant::now());
-            p.lifecycle.request_channel_attaching();
-            let attach = build_attach_msg(
-                &p.channel,
-                p.channel_params.as_ref(),
-                p.conn_state.channel_serial.as_deref(),
+
+            let reason = msg.error.as_ref().map_or_else(
+                || "Channel detached".to_string(),
+                |err| channel_detached_message(&err.message),
             );
-            match encode_msg(&attach) {
-                Ok(data) => {
-                    let connect_timeout = p.timing.connect_timeout;
-                    let Some(transport) = p.transport.as_mut() else {
-                        tracing::warn!("Missing websocket transport for re-attach");
-                        return LoopAction::Reconnect;
-                    };
-                    let send_result = tokio::select! {
-                        biased;
-                        _ = &mut *close_rx => {
-                            tracing::info!("Close requested during channel re-attach");
-                            send_close_message(p).await;
-                            return LoopAction::Stop;
-                        }
-                        result = tokio::time::timeout(
-                            connect_timeout,
-                            transport.ws_write.send(tungstenite::Message::Binary(data.into())),
-                        ) => result,
-                    };
-                    match send_result {
-                        Ok(Ok(())) => {}
-                        Ok(Err(_)) => {
-                            tracing::warn!("Failed to send re-attach, triggering reconnect");
-                            close_websocket_transport(p).await;
-                            return LoopAction::Reconnect;
-                        }
-                        Err(_) => {
-                            tracing::warn!("Timed out sending re-attach, triggering reconnect");
-                            close_websocket_transport(p).await;
-                            return LoopAction::Reconnect;
-                        }
+            match p.lifecycle.channel {
+                ChannelLifecycleState::Attaching => {
+                    // Mirrors ably-js RealtimeChannel.processMessage(DETACHED):
+                    // a detach while an attach is in progress moves the
+                    // channel to suspended and starts the channel retry timer.
+                    tracing::warn!(channel = ?msg.channel, %reason, "Channel detached while attaching");
+                    notify_channel_suspended(p);
+                }
+                ChannelLifecycleState::Attached | ChannelLifecycleState::Suspended => {
+                    // RTL13a in ably-js: attached/suspended channels request
+                    // attaching again immediately on DETACHED, independent of
+                    // the error's retriability.
+                    tracing::warn!(channel = ?msg.channel, %reason, "Channel detached, re-attaching");
+                    if request_channel_attach(p) {
+                        return send_attach(p, close_rx).await;
                     }
                 }
-                Err(e) => {
-                    tracing::warn!("Failed to encode re-attach message: {e}");
-                    close_websocket_transport(p).await;
-                    return LoopAction::Reconnect;
-                }
+                ChannelLifecycleState::Detached | ChannelLifecycleState::Failed => {}
             }
         }
         action::ATTACHED => {
+            if !message_targets_channel(&msg, &p.channel) {
+                return LoopAction::Continue;
+            }
             if let Some(serial) = msg.channel_serial {
                 p.conn_state.channel_serial = Some(serial);
             }
-            p.conn_state.last_reattach_at = None;
-            p.lifecycle.notify_channel_attached();
+            notify_channel_attached(p);
             let f = msg.flags.unwrap_or(0);
             let resumed = f & flags::HAS_CHANNEL_RESUMED != 0;
             let has_backlog = f & flags::HAS_BACKLOG != 0;
@@ -1056,6 +1248,12 @@ async fn handle_message(
                 has_presence,
                 "Channel attached",
             );
+            if p.connected_event_pending {
+                p.connected_event_pending = false;
+                if !send_status_event(p, close_rx, Event::Connected, "connected").await {
+                    return LoopAction::Stop;
+                }
+            }
         }
         action::CONNECTED => {
             p.conn_state.update_from_connected(&msg);
@@ -1172,10 +1370,11 @@ async fn renew_token(p: &mut EventLoopState) -> Result<(), Error> {
 /// Attempt a single reconnect (resume or fresh). Callers are responsible for
 /// applying an outer timeout (e.g. `timing.reconnect_timeout`).
 ///
-/// All mutations to `p` are deferred until every step (connect, handshake,
-/// channel attach) has succeeded. This prevents a partial reconnect from
-/// corrupting state and causing a subsequent resume to skip channel attach.
-async fn attempt_reconnect(p: &mut EventLoopState) -> Result<(), Error> {
+/// Connection mutations are deferred until the transport is connected and the
+/// channel attach attempt has produced a definitive outcome. If the server
+/// responds DETACHED to the ATTACH, the connected transport is kept and the
+/// caller moves the channel into suspended retry, matching ably-js.
+async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, Error> {
     let use_resume = p.conn_state.can_resume();
 
     // For fresh connects, obtain a new token up front (kept in a local until
@@ -1232,14 +1431,26 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<(), Error> {
     ws_write
         .send(tungstenite::Message::Binary(data.into()))
         .await?;
-    let attached_msg = wait_for_attached(&mut ws_read, &p.channel).await?;
-    let new_channel_serial = attached_msg.channel_serial;
+    let attach_outcome = wait_for_attach_outcome(&mut ws_read, &p.channel).await?;
 
     // Commit state only after all steps succeeded.
     p.conn_state.update_from_connected(&connected_msg);
-    if let Some(serial) = new_channel_serial {
-        p.conn_state.channel_serial = Some(serial);
-    }
+    let reconnect_outcome = match attach_outcome {
+        AttachOutcome::Attached { channel_serial } => {
+            if let Some(serial) = channel_serial {
+                p.conn_state.channel_serial = Some(serial);
+            }
+            ReconnectOutcome::Attached
+        }
+        AttachOutcome::Detached(err) => {
+            tracing::warn!(
+                reason = %channel_detached_message(&err.message),
+                "Channel detached while re-attaching after reconnect",
+            );
+            p.conn_state.channel_serial = None;
+            ReconnectOutcome::ChannelSuspended
+        }
+    };
     if let Some(token) = new_token {
         p.conn_state.token = token;
         p.conn_state.token_renewal_at =
@@ -1247,9 +1458,11 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<(), Error> {
     }
     p.transport = Some(WsTransport::new(ws_read, ws_write));
     p.conn_state.disconnected_at = None;
-    p.conn_state.last_reattach_at = None;
+    p.channel_retry_at = None;
+    p.channel_retry_count = 0;
+    p.channel_operation_deadline = None;
 
-    Ok(())
+    Ok(reconnect_outcome)
 }
 
 // ---------------------------------------------------------------------------
@@ -1339,7 +1552,6 @@ mod tests {
             connection_state_ttl: Duration::from_secs(120),
             max_idle_interval: Duration::from_secs(15),
             disconnected_at: None,
-            last_reattach_at: None,
             token: TokenDetails {
                 token: "t".to_string(),
                 expires: i64::MAX,
@@ -1356,6 +1568,11 @@ mod tests {
         // Just disconnected → can resume
         state.disconnected_at = Some(Instant::now());
         assert!(state.can_resume());
+
+        // Expired connection state TTL → cannot resume
+        state.disconnected_at = Some(Instant::now() - Duration::from_secs(121));
+        assert!(!state.can_resume());
+        state.disconnected_at = Some(Instant::now());
 
         // No connection key → cannot resume
         state.connection_key = None;
@@ -1523,66 +1740,6 @@ mod tests {
         let data = serde_json::json!("encoded-data");
         let result = decode_data(data.clone(), Some("cipher+aes-256-cbc"));
         assert_eq!(result, data);
-    }
-
-    #[test]
-    fn is_retriable_no_status_code() {
-        let err = ErrorInfo {
-            code: 12345,
-            status_code: None,
-            message: String::new(),
-        };
-        assert!(is_retriable(&err));
-    }
-
-    #[test]
-    fn is_retriable_server_error() {
-        let err = ErrorInfo {
-            code: 50000,
-            status_code: Some(500),
-            message: String::new(),
-        };
-        assert!(is_retriable(&err));
-    }
-
-    #[test]
-    fn is_retriable_connection_error_code_with_4xx() {
-        let err = ErrorInfo {
-            code: 80003, // DISCONNECTED connection error
-            status_code: Some(400),
-            message: String::new(),
-        };
-        assert!(is_retriable(&err));
-    }
-
-    #[test]
-    fn is_retriable_auth_error_not_retriable() {
-        let err = ErrorInfo {
-            code: 40142, // token expired
-            status_code: Some(401),
-            message: String::new(),
-        };
-        assert!(!is_retriable(&err));
-    }
-
-    #[test]
-    fn is_retriable_rate_limit_not_retriable() {
-        let err = ErrorInfo {
-            code: 42910,
-            status_code: Some(429),
-            message: String::new(),
-        };
-        assert!(!is_retriable(&err));
-    }
-
-    #[test]
-    fn is_retriable_zero_code() {
-        let err = ErrorInfo {
-            code: 0,
-            status_code: Some(400),
-            message: String::new(),
-        };
-        assert!(is_retriable(&err));
     }
 
     #[test]

--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -758,7 +758,11 @@ async fn send_close_message(p: &mut EventLoopState) {
 
 // Reconnect paths should only close the current WebSocket transport. Sending
 // Ably CLOSE here would terminate the resumable connection state on the server.
-async fn close_websocket_transport(p: &mut EventLoopState) {
+//
+// The transport is detached synchronously so status events and reconnects are
+// not delayed by a slow close handshake. The bounded background close still
+// releases the socket without keeping it in `EventLoopState`.
+fn close_websocket_transport(p: &mut EventLoopState) {
     let Some(transport) = p.transport.take() else {
         return;
     };
@@ -767,16 +771,19 @@ async fn close_websocket_transport(p: &mut EventLoopState) {
         mut ws_write,
     } = transport;
     let close_timeout = p.timing.close_timeout;
-    let result = tokio::time::timeout(close_timeout, async move {
-        let _ = ws_write.close().await;
-    })
-    .await;
-    if result.is_err() {
-        tracing::warn!(
-            timeout_ms = close_timeout.as_millis(),
-            "Timed out while closing websocket transport"
-        );
-    }
+    let close_task = tokio::spawn(async move {
+        let result = tokio::time::timeout(close_timeout, async move {
+            let _ = ws_write.close().await;
+        })
+        .await;
+        if result.is_err() {
+            tracing::warn!(
+                timeout_ms = close_timeout.as_millis(),
+                "Timed out while closing websocket transport"
+            );
+        }
+    });
+    drop(close_task);
 }
 
 async fn send_status_event(
@@ -804,7 +811,7 @@ async fn send_terminal_status_event(
 ) -> bool {
     // Terminal status events can be backpressured by a slow consumer. Release
     // the socket first so an unpolled Subscription cannot keep it alive.
-    close_websocket_transport(p).await;
+    close_websocket_transport(p);
     send_status_event(p, close_rx, event, status_event).await
 }
 
@@ -959,7 +966,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
         p.conn_state.disconnected_at = Some(Instant::now());
         p.lifecycle.notify_disconnected();
         if close_before_reconnect {
-            close_websocket_transport(&mut p).await;
+            close_websocket_transport(&mut p);
         }
         if !disconnected_sent {
             let event = Event::Disconnected {
@@ -1098,7 +1105,7 @@ async fn send_attach(p: &mut EventLoopState, close_rx: &mut oneshot::Receiver<()
         Ok(data) => data,
         Err(e) => {
             tracing::warn!("Failed to encode attach message: {e}");
-            close_websocket_transport(p).await;
+            close_websocket_transport(p);
             return LoopAction::Reconnect;
         }
     };
@@ -1124,12 +1131,12 @@ async fn send_attach(p: &mut EventLoopState, close_rx: &mut oneshot::Receiver<()
         Ok(Ok(())) => LoopAction::Continue,
         Ok(Err(_)) => {
             tracing::warn!("Failed to send attach, triggering reconnect");
-            close_websocket_transport(p).await;
+            close_websocket_transport(p);
             LoopAction::Reconnect
         }
         Err(_) => {
             tracing::warn!("Timed out sending attach, triggering reconnect");
-            close_websocket_transport(p).await;
+            close_websocket_transport(p);
             LoopAction::Reconnect
         }
     }
@@ -1259,7 +1266,7 @@ async fn handle_message(
             // to reconnect after backoff. Only connection-level ERROR is fatal.
             let reason = Some(protocol_disconnect_reason(msg.error));
             p.lifecycle.notify_disconnected();
-            close_websocket_transport(p).await;
+            close_websocket_transport(p);
             if !send_status_event(p, close_rx, Event::Disconnected { reason }, "disconnected").await
             {
                 return LoopAction::Stop;

--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -152,6 +152,7 @@ enum AttachOutcome {
     Attached { channel_serial: Option<String> },
     Detached(ErrorInfo),
     RetryAttach(ErrorInfo),
+    Closed(ErrorInfo),
     TimedOut,
 }
 
@@ -160,6 +161,14 @@ fn detached_error_or_default(error: Option<ErrorInfo>) -> ErrorInfo {
         code: error_code::CHANNEL_OPERATION_FAILED,
         status_code: Some(404),
         message: "Channel detached".to_string(),
+    })
+}
+
+fn closed_error_or_default(error: Option<ErrorInfo>) -> ErrorInfo {
+    error.unwrap_or_else(|| ErrorInfo {
+        code: error_code::FAILED,
+        status_code: None,
+        message: "Connection closed by server".to_string(),
     })
 }
 
@@ -201,6 +210,16 @@ async fn wait_for_attach_outcome(
                         )));
                     }
                 }
+                action::DISCONNECTED => {
+                    let err = error_or_unknown(msg.error.clone());
+                    return Err(Error::Protocol {
+                        code: err.code,
+                        message: protocol_disconnect_reason(msg.error),
+                    });
+                }
+                action::CLOSED => {
+                    return Ok(AttachOutcome::Closed(closed_error_or_default(msg.error)));
+                }
                 _ => {
                     tracing::debug!(action = msg.action, "Ignoring pre-ATTACHED message");
                 }
@@ -221,6 +240,10 @@ async fn wait_for_attached(ws_read: &mut WsRead, channel: &str) -> Result<Option
             message: channel_detached_message(&err.message),
         }),
         AttachOutcome::RetryAttach(err) => Err(Error::Protocol {
+            code: err.code,
+            message: protocol_error_message(err.message),
+        }),
+        AttachOutcome::Closed(err) => Err(Error::Protocol {
             code: err.code,
             message: protocol_error_message(err.message),
         }),
@@ -1027,6 +1050,10 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                     p.connected_event_pending = true;
                     continue 'outer;
                 }
+                Ok(ReconnectOutcome::Closed) => {
+                    p.lifecycle.notify_closed();
+                    return;
+                }
                 Err(e) => {
                     tracing::warn!("Reconnect attempt failed: {e}");
                 }
@@ -1047,6 +1074,7 @@ enum LoopAction {
 enum ReconnectOutcome {
     Attached,
     ChannelSuspended,
+    Closed,
 }
 
 async fn send_attach(p: &mut EventLoopState, close_rx: &mut oneshot::Receiver<()>) -> LoopAction {
@@ -1545,6 +1573,15 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
                 code: err.code,
                 message: protocol_error_message(err.message),
             });
+        }
+        AttachOutcome::Closed(err) => {
+            tracing::info!(
+                code = err.code,
+                message = %protocol_error_message(err.message),
+                "Connection closed while re-attaching after reconnect",
+            );
+            p.conn_state.channel_serial = None;
+            return Ok(ReconnectOutcome::Closed);
         }
         AttachOutcome::TimedOut => {
             tracing::warn!(

--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -796,6 +796,18 @@ async fn send_status_event(
     }
 }
 
+async fn send_terminal_status_event(
+    p: &mut EventLoopState,
+    close_rx: &mut oneshot::Receiver<()>,
+    event: Event,
+    status_event: &'static str,
+) -> bool {
+    // Terminal status events can be backpressured by a slow consumer. Release
+    // the socket first so an unpolled Subscription cannot keep it alive.
+    close_websocket_transport(p).await;
+    send_status_event(p, close_rx, event, status_event).await
+}
+
 pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot::Receiver<()>) {
     let mut last_reconnect_attempt: Option<Instant> = None;
 
@@ -946,6 +958,9 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
         // --- Reconnection ---
         p.conn_state.disconnected_at = Some(Instant::now());
         p.lifecycle.notify_disconnected();
+        if close_before_reconnect {
+            close_websocket_transport(&mut p).await;
+        }
         if !disconnected_sent {
             let event = Event::Disconnected {
                 reason: disconnect_reason,
@@ -953,9 +968,6 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
             if !send_status_event(&mut p, &mut close_rx, event, "disconnected").await {
                 return;
             }
-        }
-        if close_before_reconnect {
-            close_websocket_transport(&mut p).await;
         }
 
         let mut retry_immediately = immediate_retry;
@@ -1247,11 +1259,11 @@ async fn handle_message(
             // to reconnect after backoff. Only connection-level ERROR is fatal.
             let reason = Some(protocol_disconnect_reason(msg.error));
             p.lifecycle.notify_disconnected();
+            close_websocket_transport(p).await;
             if !send_status_event(p, close_rx, Event::Disconnected { reason }, "disconnected").await
             {
                 return LoopAction::Stop;
             }
-            close_websocket_transport(p).await;
             return LoopAction::Reconnect;
         }
         action::ERROR => {
@@ -1279,7 +1291,7 @@ async fn handle_message(
                 code: err.code,
                 message: protocol_error_message(err.message),
             };
-            let _ = send_status_event(p, close_rx, event, "error").await;
+            let _ = send_terminal_status_event(p, close_rx, event, "error").await;
             return LoopAction::Stop;
         }
         action::DETACHED => {
@@ -1404,7 +1416,7 @@ async fn handle_renewal_result(
                 p.timing.max_token_renewal_failures
             ),
         };
-        let _ = send_status_event(p, close_rx, event, "error").await;
+        let _ = send_terminal_status_event(p, close_rx, event, "error").await;
         return true;
     }
 

--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -151,6 +151,7 @@ async fn wait_for_connected(ws_read: &mut WsRead) -> Result<ProtocolMessage, Err
 enum AttachOutcome {
     Attached { channel_serial: Option<String> },
     Detached(ErrorInfo),
+    TimedOut,
 }
 
 fn detached_error_or_default(error: Option<ErrorInfo>) -> ErrorInfo {
@@ -209,6 +210,10 @@ async fn wait_for_attached(ws_read: &mut WsRead, channel: &str) -> Result<Option
         AttachOutcome::Detached(err) => Err(Error::Protocol {
             code: err.code,
             message: channel_detached_message(&err.message),
+        }),
+        AttachOutcome::TimedOut => Err(Error::Protocol {
+            code: error_code::TIMEOUT,
+            message: "Channel attach timed out".to_string(),
         }),
     }
 }
@@ -640,6 +645,39 @@ fn notify_channel_failed(p: &mut EventLoopState) {
     p.connected_event_pending = false;
 }
 
+fn suspend_deadline(p: &EventLoopState) -> Option<Instant> {
+    if p.lifecycle.connection == ConnectionLifecycleState::Suspended
+        || p.conn_state.connection_key.is_none()
+    {
+        return None;
+    }
+    p.conn_state
+        .disconnected_at
+        .map(|disconnected_at| disconnected_at + p.conn_state.connection_state_ttl)
+}
+
+fn should_enter_suspended_retry(p: &EventLoopState) -> bool {
+    p.lifecycle.connection != ConnectionLifecycleState::Suspended
+        && p.conn_state.disconnected_at.is_some()
+        && !p.conn_state.can_resume()
+}
+
+async fn enter_suspended_retry(
+    p: &mut EventLoopState,
+    close_rx: &mut oneshot::Receiver<()>,
+) -> bool {
+    p.conn_state.clear_resume_state();
+    p.lifecycle.notify_suspended();
+    p.conn_state.channel_serial = None;
+    p.channel_retry_at = None;
+    p.channel_operation_deadline = None;
+    p.connected_event_pending = false;
+    let event = Event::Disconnected {
+        reason: Some("connection state expired; entering suspended retry".to_string()),
+    };
+    send_status_event(p, close_rx, event, "suspended").await
+}
+
 // Caller-requested shutdown should send Ably CLOSE before closing the WebSocket
 // so the connection state is explicitly terminated.
 async fn send_close_message(p: &mut EventLoopState) {
@@ -879,29 +917,17 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
 
         let mut retry_immediately = immediate_retry;
         let mut disconnected_retry_count: u32 = 0;
-        let mut suspended_retry_count: u32 = 0;
         loop {
-            if !p.conn_state.can_resume()
-                && p.lifecycle.connection != ConnectionLifecycleState::Suspended
+            if should_enter_suspended_retry(&p)
+                && !enter_suspended_retry(&mut p, &mut close_rx).await
             {
-                p.conn_state.clear_resume_state();
-                p.lifecycle.notify_suspended();
-                p.conn_state.channel_serial = None;
-                p.channel_retry_at = None;
-                p.channel_operation_deadline = None;
-                disconnected_retry_count = 0;
-                let event = Event::Disconnected {
-                    reason: Some("connection state expired; entering suspended retry".to_string()),
-                };
-                if !send_status_event(&mut p, &mut close_rx, event, "suspended").await {
-                    return;
-                }
+                return;
             }
 
             // ably-js retries immediately when an active connection becomes
             // disconnected, with a one-second guard against tight reconnect
-            // loops. Subsequent disconnected/suspended retries use the state's
-            // retry timeout and jitter.
+            // loops. Subsequent disconnected retries use jittered retry time;
+            // suspended retries use the fixed suspendedRetryTimeout.
             let backoff_duration = if retry_immediately {
                 retry_immediately = false;
                 let delay = reconnect_spacing_delay(
@@ -918,8 +944,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                 }
                 delay
             } else if p.lifecycle.connection == ConnectionLifecycleState::Suspended {
-                suspended_retry_count += 1;
-                retry_delay(p.timing.suspended_retry_timeout, suspended_retry_count)
+                p.timing.suspended_retry_timeout
             } else {
                 disconnected_retry_count += 1;
                 retry_delay(
@@ -927,6 +952,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                     disconnected_retry_count,
                 )
             };
+            let suspend_at = suspend_deadline(&p);
             tokio::select! {
                 biased;
                 _ = &mut close_rx => {
@@ -934,12 +960,18 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                     send_close_message(&mut p).await;
                     return;
                 }
+                _ = sleep_until_optional(suspend_at), if suspend_at.is_some() => {
+                    if !enter_suspended_retry(&mut p, &mut close_rx).await {
+                        return;
+                    }
+                    continue;
+                }
                 _ = tokio::time::sleep(backoff_duration) => {}
             }
 
             last_reconnect_attempt = Some(Instant::now());
             p.lifecycle.request_connecting();
-            let reconnect_timeout = p.timing.reconnect_timeout;
+            let suspend_at = suspend_deadline(&p);
             let reconnect_result = tokio::select! {
                 biased;
                 _ = &mut close_rx => {
@@ -947,11 +979,17 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                     send_close_message(&mut p).await;
                     return;
                 }
-                result = tokio::time::timeout(reconnect_timeout, attempt_reconnect(&mut p)) => result,
+                _ = sleep_until_optional(suspend_at), if suspend_at.is_some() => {
+                    if !enter_suspended_retry(&mut p, &mut close_rx).await {
+                        return;
+                    }
+                    continue;
+                }
+                result = attempt_reconnect(&mut p) => result,
             };
 
             match reconnect_result {
-                Ok(Ok(ReconnectOutcome::Attached)) => {
+                Ok(ReconnectOutcome::Attached) => {
                     p.token_renewal_failures = 0;
                     p.connected_event_pending = false;
                     p.lifecycle.notify_connected();
@@ -962,18 +1000,15 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                     }
                     continue 'outer;
                 }
-                Ok(Ok(ReconnectOutcome::ChannelSuspended)) => {
+                Ok(ReconnectOutcome::ChannelSuspended) => {
                     p.token_renewal_failures = 0;
                     p.lifecycle.notify_transport_connected();
                     notify_channel_suspended(&mut p);
                     p.connected_event_pending = true;
                     continue 'outer;
                 }
-                Ok(Err(e)) => {
+                Err(e) => {
                     tracing::warn!("Reconnect attempt failed: {e}");
-                }
-                Err(_) => {
-                    tracing::warn!("Reconnect attempt timed out");
                 }
             }
             if p.lifecycle.connection != ConnectionLifecycleState::Suspended {
@@ -1375,63 +1410,84 @@ async fn renew_token(p: &mut EventLoopState) -> Result<(), Error> {
 /// responds DETACHED to the ATTACH, the connected transport is kept and the
 /// caller moves the channel into suspended retry, matching ably-js.
 async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, Error> {
-    let use_resume = p.conn_state.can_resume();
+    let reconnect_timeout = p.timing.reconnect_timeout;
+    let (connected_msg, mut ws_read, ws_write, new_token) =
+        tokio::time::timeout(reconnect_timeout, async {
+            let use_resume = p.conn_state.can_resume();
 
-    // For fresh connects, obtain a new token up front (kept in a local until
-    // we know the full reconnect succeeded).
-    let new_token = if !use_resume {
-        let token_request = (p.get_token)().await.map_err(Error::TokenFetch)?;
-        Some(exchange_token(&p.http, &token_request, &p.rest_host).await?)
-    } else {
-        None
+            // For fresh connects, obtain a new token up front (kept in a local until
+            // we know the transport connected).
+            let new_token = if !use_resume {
+                let token_request = (p.get_token)().await.map_err(Error::TokenFetch)?;
+                Some(exchange_token(&p.http, &token_request, &p.rest_host).await?)
+            } else {
+                None
+            };
+
+            let active_token = new_token
+                .as_ref()
+                .map_or_else(|| p.conn_state.token.token.clone(), |t| t.token.clone());
+
+            let resume = if use_resume {
+                p.conn_state.connection_key.as_deref()
+            } else {
+                None
+            };
+
+            let ws_url = build_ws_url(&p.realtime_host, &active_token, resume)?;
+            let (mut ws_write, mut ws_read) = connect_and_split(&ws_url).await?;
+
+            let connected_msg = wait_for_connected(&mut ws_read).await?;
+
+            let resumed = use_resume
+                && connected_msg.connection_id == p.conn_state.connection_id
+                && connected_msg.error.is_none();
+
+            // Always re-attach the channel, even after a successful connection resume.
+            // The server may silently lose channel state without sending DETACHED,
+            // creating a "zombie subscription" where messages stop being delivered.
+            // ATTACH is idempotent — the server responds with ATTACHED regardless.
+            //
+            // This matches ably-js behavior: `Channels.onTransportActive()` calls
+            // `channel.requestState('attaching')` for every attached channel whenever
+            // a transport becomes active, including after resume.
+            // See: ably-js/src/common/lib/client/baserealtime.ts
+            if resumed {
+                tracing::info!(
+                    channel_serial = ?p.conn_state.channel_serial,
+                    "Connection resumed, re-attaching channel to verify state",
+                );
+            } else {
+                tracing::info!("Fresh connect, attaching channel");
+            }
+            let attach = build_attach_msg(
+                &p.channel,
+                p.channel_params.as_ref(),
+                p.conn_state.channel_serial.as_deref(),
+            );
+            let data = encode_msg(&attach)?;
+            ws_write
+                .send(tungstenite::Message::Binary(data.into()))
+                .await?;
+
+            Ok::<_, Error>((connected_msg, ws_read, ws_write, new_token))
+        })
+        .await
+        .map_err(|_| Error::Protocol {
+            code: error_code::TIMEOUT,
+            message: "Reconnect attempt timed out".to_string(),
+        })??;
+
+    let attach_outcome = match tokio::time::timeout(
+        p.timing.realtime_request_timeout,
+        wait_for_attach_outcome(&mut ws_read, &p.channel),
+    )
+    .await
+    {
+        Ok(Ok(outcome)) => outcome,
+        Ok(Err(e)) => return Err(e),
+        Err(_) => AttachOutcome::TimedOut,
     };
-
-    let active_token = new_token
-        .as_ref()
-        .map_or(&p.conn_state.token.token, |t| &t.token);
-
-    let resume = if use_resume {
-        p.conn_state.connection_key.as_deref()
-    } else {
-        None
-    };
-
-    let ws_url = build_ws_url(&p.realtime_host, active_token, resume)?;
-    let (mut ws_write, mut ws_read) = connect_and_split(&ws_url).await?;
-
-    let connected_msg = wait_for_connected(&mut ws_read).await?;
-
-    let resumed = use_resume
-        && connected_msg.connection_id == p.conn_state.connection_id
-        && connected_msg.error.is_none();
-
-    // Always re-attach the channel, even after a successful connection resume.
-    // The server may silently lose channel state without sending DETACHED,
-    // creating a "zombie subscription" where messages stop being delivered.
-    // ATTACH is idempotent — the server responds with ATTACHED regardless.
-    //
-    // This matches ably-js behavior: `Channels.onTransportActive()` calls
-    // `channel.requestState('attaching')` for every attached channel whenever
-    // a transport becomes active, including after resume.
-    // See: ably-js/src/common/lib/client/baserealtime.ts
-    if resumed {
-        tracing::info!(
-            channel_serial = ?p.conn_state.channel_serial,
-            "Connection resumed, re-attaching channel to verify state",
-        );
-    } else {
-        tracing::info!("Fresh connect, attaching channel");
-    }
-    let attach = build_attach_msg(
-        &p.channel,
-        p.channel_params.as_ref(),
-        p.conn_state.channel_serial.as_deref(),
-    );
-    let data = encode_msg(&attach)?;
-    ws_write
-        .send(tungstenite::Message::Binary(data.into()))
-        .await?;
-    let attach_outcome = wait_for_attach_outcome(&mut ws_read, &p.channel).await?;
 
     // Commit state only after all steps succeeded.
     p.conn_state.update_from_connected(&connected_msg);
@@ -1446,6 +1502,14 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
             tracing::warn!(
                 reason = %channel_detached_message(&err.message),
                 "Channel detached while re-attaching after reconnect",
+            );
+            p.conn_state.channel_serial = None;
+            ReconnectOutcome::ChannelSuspended
+        }
+        AttachOutcome::TimedOut => {
+            tracing::warn!(
+                timeout_ms = p.timing.realtime_request_timeout.as_millis(),
+                "Channel attach timed out while re-attaching after reconnect",
             );
             p.conn_state.channel_serial = None;
             ReconnectOutcome::ChannelSuspended

--- a/crates/ably-subscriber/src/subscribe.rs
+++ b/crates/ably-subscriber/src/subscribe.rs
@@ -102,6 +102,7 @@ pub async fn subscribe(config: SubscribeConfig) -> Result<Subscription, Error> {
             transport: Some(WsTransport::new(ws_read, ws_write)),
             event_tx,
             conn_state,
+            lifecycle: crate::connection::RealtimeStateMachine::connected(),
             channel: config.channel,
             channel_params: config.channel_params,
             realtime_host,

--- a/crates/ably-subscriber/src/subscribe.rs
+++ b/crates/ably-subscriber/src/subscribe.rs
@@ -112,6 +112,10 @@ pub async fn subscribe(config: SubscribeConfig) -> Result<Subscription, Error> {
             timing,
             token_renewal_failures: 0,
             dropped_messages: 0,
+            channel_retry_at: None,
+            channel_retry_count: 0,
+            channel_operation_deadline: None,
+            connected_event_pending: false,
         },
         close_rx,
     ));

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -118,20 +118,46 @@ pub struct TimingConfig {
     pub heartbeat_margin: Duration,
 
     // -- Reconnection retry --------------------------------------------------
-    /// Base interval for the first retry attempt.
+    /// Retry timeout while in the Ably `disconnected` state.
+    ///
+    /// Matches ably-js `disconnectedRetryTimeout`.
+    pub disconnected_retry_timeout: Duration,
+    /// Retry timeout while in the Ably `suspended` state.
+    ///
+    /// Matches ably-js `suspendedRetryTimeout`.
+    pub suspended_retry_timeout: Duration,
+    /// Retry timeout while a channel is `suspended` after an attach failure.
+    ///
+    /// Matches ably-js `channelRetryTimeout`.
+    pub channel_retry_timeout: Duration,
+    /// Timeout for an in-flight realtime channel ATTACH operation.
+    ///
+    /// Matches ably-js `realtimeRequestTimeout`.
+    pub realtime_request_timeout: Duration,
+    /// Legacy base interval for the first retry attempt.
+    ///
+    /// Kept for API compatibility; the Ably-aligned state machine uses
+    /// [`disconnected_retry_timeout`](Self::disconnected_retry_timeout) and
+    /// [`suspended_retry_timeout`](Self::suspended_retry_timeout).
     pub initial_retry_interval: Duration,
-    /// Cap on exponential backoff between retries.
+    /// Legacy cap on exponential backoff between retries.
+    ///
+    /// Kept for API compatibility.
     pub max_retry_interval: Duration,
     /// Minimum spacing between reconnect attempts after transport-level
     /// disconnects. This mirrors ably-js' guard against tight reconnect loops
     /// when a server or proxy repeatedly closes otherwise healthy sockets.
     pub min_reconnect_interval: Duration,
-    /// Maximum number of consecutive reconnection attempts before giving up.
+    /// Legacy maximum number of consecutive reconnection attempts before giving up.
+    ///
+    /// Kept for API compatibility. Ably-js retries disconnected/suspended
+    /// connections indefinitely, so this field is not used by the current state
+    /// machine.
     pub max_retry_attempts: u32,
 
     // -- Channel re-attach ---------------------------------------------------
-    /// If a channel is DETACHED again within this window after a re-attach,
-    /// a full reconnect is triggered instead.
+    /// Legacy re-attach window used by the previous reconnect-on-repeat-detach
+    /// behavior. Kept for API compatibility.
     pub reattach_window: Duration,
 
     // -- Token renewal -------------------------------------------------------
@@ -160,6 +186,10 @@ impl Default for TimingConfig {
             // Heartbeat
             heartbeat_margin: Duration::from_secs(10),
             // Reconnection retry
+            disconnected_retry_timeout: Duration::from_secs(15),
+            suspended_retry_timeout: Duration::from_secs(30),
+            channel_retry_timeout: Duration::from_secs(15),
+            realtime_request_timeout: Duration::from_secs(10),
             initial_retry_interval: Duration::from_secs(1),
             max_retry_interval: Duration::from_secs(15),
             min_reconnect_interval: Duration::from_secs(1),

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -131,6 +131,9 @@ pub struct TimingConfig {
     /// Matches ably-js `channelRetryTimeout`.
     pub channel_retry_timeout: Duration,
     /// Timeout for an in-flight realtime channel ATTACH operation.
+    /// Initial subscribe connect+attach is bounded by
+    /// [`connect_timeout`](Self::connect_timeout); this timeout applies after
+    /// the subscription is established.
     ///
     /// Matches ably-js `realtimeRequestTimeout`.
     pub realtime_request_timeout: Duration,

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -3053,6 +3053,48 @@ async fn drop_while_protocol_disconnected_backpressure_closes_socket() {
 }
 
 #[tokio::test]
+async fn heartbeat_backpressure_closes_socket_before_subscription_close() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (closed_tx, closed_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws
+            .accept_and_handshake_with_opts(
+                "ch",
+                "conn-1",
+                HandshakeOptions {
+                    max_idle_interval_ms: 25,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        expect_websocket_close_frame(&mut conn).await.unwrap();
+        closed_tx.send(()).unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.event_channel_capacity = 1;
+    timing.heartbeat_margin = Duration::from_millis(25);
+    let sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    // Do not consume the initial Connected event. The heartbeat Disconnected
+    // status event is backpressured, but the stale socket must still close.
+    tokio::time::timeout(Duration::from_secs(5), closed_rx)
+        .await
+        .expect("timed out waiting for heartbeat socket close")
+        .unwrap();
+    sub.close();
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
 async fn close_while_connected_event_send_is_backpressured_closes_reconnected_socket() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();
@@ -3166,6 +3208,52 @@ async fn error_event_backpressure_closes_socket_before_subscription_close() {
     tokio::time::timeout(Duration::from_secs(5), closed_rx)
         .await
         .expect("timed out waiting for socket close before subscription close")
+        .unwrap();
+    sub.close();
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn channel_error_backpressure_closes_socket_before_subscription_close() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (closed_tx, closed_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        let error = ProtocolMessage {
+            action: action::ERROR,
+            channel: Some("ch".into()),
+            error: Some(ErrorInfo {
+                code: 40001,
+                status_code: Some(400),
+                message: "channel failed".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&error).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        expect_websocket_close_frame(&mut conn).await.unwrap();
+        closed_tx.send(()).unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.event_channel_capacity = 1;
+    let sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    // Do not consume the initial Connected event. The channel-scoped fatal
+    // Error status event is backpressured, but the socket must close anyway.
+    tokio::time::timeout(Duration::from_secs(5), closed_rx)
+        .await
+        .expect("timed out waiting for channel error socket close")
         .unwrap();
     sub.close();
     server_task.await.unwrap();

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -3750,6 +3750,203 @@ async fn other_channel_error_during_reconnect_attach_is_ignored() {
 }
 
 #[tokio::test]
+async fn disconnected_during_reconnect_attach_retries_with_new_connection() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let server_task = tokio::spawn(async move {
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        drop(conn);
+
+        let (tcp, _) = ws.listener.accept().await.unwrap();
+        let mut conn2 = tokio_tungstenite::accept_async(tcp).await.unwrap();
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some("conn-2".into()),
+            connection_key: Some("conn-2!key".into()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some("conn-2!key".into()),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&connected).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for reconnect ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+
+        let disconnected = ProtocolMessage {
+            action: action::DISCONNECTED,
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "server disconnected during attach".into(),
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&disconnected).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let mut conn3 = tokio::time::timeout(
+            Duration::from_secs(5),
+            ws.accept_and_handshake("ch", "conn-3"),
+        )
+        .await
+        .expect("timed out waiting for reconnect after DISCONNECTED during attach")
+        .unwrap();
+        send_message(
+            &mut conn3,
+            "ch",
+            "after-disconnected-during-attach",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
+    timing.realtime_request_timeout = Duration::from_secs(30);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Connected after reconnect attach DISCONNECTED")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected after reconnect attach DISCONNECTED, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after reconnect attach DISCONNECTED")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(
+                msg.name.as_deref(),
+                Some("after-disconnected-during-attach")
+            );
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn closed_during_reconnect_attach_stops_subscription() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let server_task = tokio::spawn(async move {
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        drop(conn);
+
+        let (tcp, _) = ws.listener.accept().await.unwrap();
+        let mut conn2 = tokio_tungstenite::accept_async(tcp).await.unwrap();
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some("conn-2".into()),
+            connection_key: Some("conn-2!key".into()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some("conn-2!key".into()),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&connected).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for reconnect ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+
+        let closed = ProtocolMessage {
+            action: action::CLOSED,
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&closed).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        expect_websocket_closed(&mut conn2).await.unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
+    timing.realtime_request_timeout = Duration::from_secs(30);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for subscription to end after CLOSED during attach");
+    assert!(
+        event.is_none(),
+        "expected stream end after CLOSED, got {event:?}"
+    );
+
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
 async fn superseded_reconnect_attach_timeout_retries_channel_on_same_transport() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -3626,6 +3626,341 @@ async fn superseded_error_during_reconnect_attach_retries_on_same_transport() {
 }
 
 #[tokio::test]
+async fn other_channel_error_during_reconnect_attach_is_ignored() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        drop(conn);
+
+        let (tcp, _) = ws.listener.accept().await.unwrap();
+        let mut conn2 = tokio_tungstenite::accept_async(tcp).await.unwrap();
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some("conn-2".into()),
+            connection_key: Some("conn-2!key".into()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some("conn-2!key".into()),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&connected).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for reconnect ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+
+        let other_channel_error = ProtocolMessage {
+            action: action::ERROR,
+            channel: Some("other-channel".into()),
+            error: Some(ErrorInfo {
+                code: 80016,
+                status_code: Some(400),
+                message: "operation attempted on superseded transport".into(),
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&other_channel_error).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(250), conn2.next())
+                .await
+                .is_err(),
+            "other-channel ERROR should not close the socket or trigger another ATTACH"
+        );
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-ok".into()),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&attached).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        send_message(
+            &mut conn2,
+            "ch",
+            "after-other-channel-error",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Connected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("after-other-channel-error"));
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn superseded_reconnect_attach_timeout_retries_channel_on_same_transport() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        drop(conn);
+
+        let (tcp, _) = ws.listener.accept().await.unwrap();
+        let mut conn2 = tokio_tungstenite::accept_async(tcp).await.unwrap();
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some("conn-2".into()),
+            connection_key: Some("conn-2!key".into()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some("conn-2!key".into()),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&connected).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for reconnect ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+
+        let superseded = ProtocolMessage {
+            action: action::ERROR,
+            channel: Some("ch".into()),
+            error: Some(ErrorInfo {
+                code: 80016,
+                status_code: Some(400),
+                message: "operation attempted on superseded transport".into(),
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&superseded).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for retry ATTACH after 80016")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for channel retry ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-after-timeout".into()),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&attached).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        send_message(
+            &mut conn2,
+            "ch",
+            "after-superseded-timeout",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
+    timing.channel_retry_timeout = Duration::from_millis(10);
+    timing.realtime_request_timeout = Duration::from_millis(20);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Connected after channel retry")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected after channel retry, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after channel retry")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("after-superseded-timeout"));
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn close_during_reconnect_attach_wait_closes_temporary_socket() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (attach_sent_tx, attach_sent_rx) = tokio::sync::oneshot::channel::<()>();
+    let (closed_tx, closed_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        drop(conn);
+
+        let (tcp, _) = ws.listener.accept().await.unwrap();
+        let mut conn2 = tokio_tungstenite::accept_async(tcp).await.unwrap();
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some("conn-2".into()),
+            connection_key: Some("conn-2!key".into()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some("conn-2!key".into()),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&connected).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for reconnect ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+        attach_sent_tx.send(()).unwrap();
+
+        expect_websocket_closed(&mut conn2).await.unwrap();
+        closed_tx.send(()).unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
+    timing.realtime_request_timeout = Duration::from_secs(30);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    tokio::time::timeout(Duration::from_secs(5), attach_sent_rx)
+        .await
+        .expect("timed out waiting for reconnect ATTACH")
+        .unwrap();
+
+    sub.close();
+
+    tokio::time::timeout(Duration::from_secs(5), closed_rx)
+        .await
+        .expect("timed out waiting for reconnect attach socket close")
+        .unwrap();
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
 async fn reconnect_attach_timeout_retries_channel_on_same_transport() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -1265,8 +1265,7 @@ async fn server_sends_disconnected_without_message_reports_reason() {
     });
 
     let mut timing = TimingConfig::default();
-    timing.initial_retry_interval = Duration::from_millis(10);
-    timing.max_retry_interval = Duration::from_millis(50);
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -1552,8 +1551,7 @@ async fn non_retriable_disconnected_triggers_reconnect() {
     });
 
     let mut timing = TimingConfig::default();
-    timing.initial_retry_interval = Duration::from_millis(10);
-    timing.max_retry_interval = Duration::from_millis(50);
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -1646,11 +1644,11 @@ async fn error_during_event_loop() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 15: non-retriable DETACHED → Event::Error (not re-attach)
+// Test 15: DETACHED with a client error still follows ably-js re-attach flow
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn non_retriable_detached_emits_error() {
+async fn detached_with_client_error_reattaches() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();
     mock_token_endpoint(&http, "testKey.testId");
@@ -1659,7 +1657,8 @@ async fn non_retriable_detached_emits_error() {
     tokio::spawn(async move {
         let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
 
-        // DETACHED with non-retriable error (401 + non-connection code)
+        // ably-js does not gate DETACHED handling on error retriability:
+        // attached channels request ATTACH again regardless of the reason.
         let detached = ProtocolMessage {
             action: action::DETACHED,
             channel: Some("ch".into()),
@@ -1673,6 +1672,33 @@ async fn non_retriable_detached_emits_error() {
         conn.send(tungstenite::Message::Binary(
             encode_msg(&detached).unwrap().into(),
         ))
+        .await
+        .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for ATTACH after DETACHED")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-2".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&attached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        send_message(
+            &mut conn,
+            "ch",
+            "after-client-detached",
+            serde_json::json!("ok"),
+        )
         .await
         .unwrap();
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -1689,14 +1715,9 @@ async fn non_retriable_detached_emits_error() {
         .expect("timed out")
         .unwrap();
     match event {
-        Event::Error { code, message } => {
-            assert_eq!(code, 40160);
-            assert!(message.contains("Channel detached"), "got: {message}");
-        }
-        other => panic!("expected Error, got {other:?}"),
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-client-detached")),
+        other => panic!("expected Message, got {other:?}"),
     }
-
-    assert!(sub.next().await.is_none());
 }
 
 // ---------------------------------------------------------------------------
@@ -1928,8 +1949,7 @@ async fn heartbeat_timeout_triggers_reconnect() {
 
     let mut timing = TimingConfig::default();
     timing.heartbeat_margin = Duration::from_millis(50);
-    timing.initial_retry_interval = Duration::from_millis(10);
-    timing.max_retry_interval = Duration::from_millis(50);
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -1970,11 +1990,11 @@ async fn heartbeat_timeout_triggers_reconnect() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 20: retry exhaustion emits error (fast with TimingConfig)
+// Test 20: retry continues indefinitely and enters suspended after TTL expiry
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn retry_exhaustion_emits_error() {
+async fn retry_enters_suspended_after_connection_state_ttl() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();
     mock_token_endpoint(&http, "testKey.testId");
@@ -1982,7 +2002,17 @@ async fn retry_exhaustion_emits_error() {
     let ws_port = ws.port;
     tokio::spawn(async move {
         // First connection: handshake then drop
-        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        let conn = ws
+            .accept_and_handshake_with_opts(
+                "ch",
+                "conn-1",
+                HandshakeOptions {
+                    connection_state_ttl_ms: 20,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
         drop(conn);
         // Drop the server so the port is unbound — reconnects fail with
         // "connection refused" immediately instead of hanging on the listener.
@@ -1991,9 +2021,8 @@ async fn retry_exhaustion_emits_error() {
     });
 
     let mut timing = TimingConfig::default();
-    timing.max_retry_attempts = 2;
-    timing.initial_retry_interval = Duration::from_millis(10);
-    timing.max_retry_interval = Duration::from_millis(10);
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
+    timing.suspended_retry_timeout = Duration::from_millis(10);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -2010,22 +2039,25 @@ async fn retry_exhaustion_emits_error() {
         "expected Disconnected, got {event:?}"
     );
 
-    // Error after exhausting retries
-    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
-        .await
-        .expect("timed out waiting for Error")
-        .unwrap();
-    match event {
-        Event::Error { message, .. } => {
-            assert!(
-                message.contains("failed after 2 attempts"),
-                "unexpected message: {message}"
-            );
+    // ably-js does not exhaust reconnect attempts. Once the connection state
+    // TTL expires, it moves to suspended retry and keeps trying fresh connects.
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+            .await
+            .expect("timed out waiting for suspended transition")
+            .unwrap();
+        match event {
+            Event::Disconnected { reason }
+                if reason
+                    .as_deref()
+                    .is_some_and(|reason| reason.contains("connection state expired")) =>
+            {
+                break;
+            }
+            Event::Disconnected { .. } => {}
+            other => panic!("expected Disconnected while retrying, got {other:?}"),
         }
-        other => panic!("expected Error, got {other:?}"),
     }
-
-    assert!(sub.next().await.is_none());
 }
 
 // ---------------------------------------------------------------------------
@@ -2243,11 +2275,11 @@ async fn backpressure_drops_messages() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 23: detached within retry window triggers full reconnect
+// Test 23: DETACHED while attaching suspends channel and retries ATTACH
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn detached_within_retry_window_triggers_reconnect() {
+async fn detached_while_attaching_suspends_and_retries_attach() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();
     mock_token_endpoint(&http, "testKey.testId");
@@ -2267,7 +2299,7 @@ async fn detached_within_retry_window_triggers_reconnect() {
             ..Default::default()
         };
 
-        // First DETACHED (retriable) → client sets last_reattach_at and sends ATTACH
+        // First DETACHED while attached → client sends ATTACH immediately.
         conn.send(tungstenite::Message::Binary(
             encode_msg(&detached).unwrap().into(),
         ))
@@ -2281,30 +2313,37 @@ async fn detached_within_retry_window_triggers_reconnect() {
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
 
-        // Send second DETACHED *before* ATTACHED — while last_reattach_at is
-        // still set. This is within the retry window → triggers full reconnect.
+        // Second DETACHED before ATTACHED means the channel is currently
+        // attaching. ably-js moves it to suspended and retries ATTACH on the
+        // same active transport after channelRetryTimeout.
         conn.send(tungstenite::Message::Binary(
             encode_msg(&detached).unwrap().into(),
         ))
         .await
         .unwrap();
 
-        let frame = tokio::time::timeout(Duration::from_secs(5), conn.next())
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
             .await
-            .expect("timed out waiting for websocket close after repeated DETACHED")
-            .expect("websocket closed before close frame")
+            .expect("timed out waiting for retry ATTACH")
             .unwrap();
-        assert!(
-            matches!(frame, tungstenite::Message::Close(_)),
-            "expected websocket close frame, got {frame:?}"
-        );
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
 
-        // Client should do a full reconnect
-        let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-2".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&attached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
         send_message(
-            &mut conn2,
+            &mut conn,
             "ch",
-            "after-full-reconnect",
+            "after-channel-retry",
             serde_json::json!("ok"),
         )
         .await
@@ -2312,34 +2351,21 @@ async fn detached_within_retry_window_triggers_reconnect() {
     });
 
     let mut timing = TimingConfig::default();
-    timing.reattach_window = Duration::from_secs(60);
-    timing.initial_retry_interval = Duration::from_millis(10);
-    timing.max_retry_interval = Duration::from_millis(50);
+    timing.channel_retry_timeout = Duration::from_millis(10);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
 
     assert!(matches!(sub.next().await.unwrap(), Event::Connected));
 
-    // The DETACHED→Reconnect code path does NOT emit a Disconnected event
-    // (unlike the DISCONNECTED action handler which does). So we expect
-    // Connected directly after the full reconnect completes.
-    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
-        .await
-        .expect("timed out waiting for Connected")
-        .unwrap();
-    assert!(
-        matches!(event, Event::Connected),
-        "expected Connected, got {event:?}"
-    );
-
-    // Message after full reconnect
+    // Message after the channel retry proves the websocket stayed active and
+    // no full reconnect was required.
     let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
         .await
         .expect("timed out waiting for message")
         .unwrap();
     match event {
-        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-full-reconnect")),
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-channel-retry")),
         other => panic!("expected Message, got {other:?}"),
     }
 
@@ -2381,11 +2407,11 @@ async fn connect_timeout_fires() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 25: reconnect_timeout fires when reconnect attempt hangs
+// Test 25: reconnect_timeout retries until connection state becomes suspended
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn reconnect_timeout_fires() {
+async fn reconnect_timeout_retries_until_suspended() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();
     mock_token_endpoint(&http, "testKey.testId");
@@ -2393,22 +2419,33 @@ async fn reconnect_timeout_fires() {
     let ws_port = ws.port;
     tokio::spawn(async move {
         // First connection succeeds, then drop
-        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        let conn = ws
+            .accept_and_handshake_with_opts(
+                "ch",
+                "conn-1",
+                HandshakeOptions {
+                    connection_state_ttl_ms: 250,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
         drop(conn);
 
         // For reconnect attempts: accept TCP but never complete WebSocket
         // handshake — forces reconnect_timeout to fire (not "connection refused").
         while let Ok((tcp, _)) = ws.listener.accept().await {
-            let _hold = tcp;
-            tokio::time::sleep(Duration::from_secs(30)).await;
+            tokio::spawn(async move {
+                let _hold = tcp;
+                tokio::time::sleep(Duration::from_secs(30)).await;
+            });
         }
     });
 
     let mut timing = TimingConfig::default();
     timing.reconnect_timeout = Duration::from_millis(100);
-    timing.max_retry_attempts = 2;
-    timing.initial_retry_interval = Duration::from_millis(10);
-    timing.max_retry_interval = Duration::from_millis(10);
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
+    timing.suspended_retry_timeout = Duration::from_millis(10);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -2425,23 +2462,26 @@ async fn reconnect_timeout_fires() {
         "expected Disconnected, got {event:?}"
     );
 
-    // Each reconnect attempt hangs → reconnect_timeout fires → retry.
-    // After max_retry_attempts, we get a fatal error.
-    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
-        .await
-        .expect("timed out waiting for Error")
-        .unwrap();
-    match event {
-        Event::Error { message, .. } => {
-            assert!(
-                message.contains("failed after 2 attempts"),
-                "unexpected message: {message}"
-            );
+    // Each reconnect attempt hangs → reconnect_timeout fires → retry. Matching
+    // ably-js, retries do not exhaust; once connection_state_ttl expires, the
+    // connection enters suspended retry.
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+            .await
+            .expect("timed out waiting for suspended transition")
+            .unwrap();
+        match event {
+            Event::Disconnected { reason }
+                if reason
+                    .as_deref()
+                    .is_some_and(|reason| reason.contains("connection state expired")) =>
+            {
+                break;
+            }
+            Event::Disconnected { .. } => {}
+            other => panic!("expected Disconnected while retrying, got {other:?}"),
         }
-        other => panic!("expected Error, got {other:?}"),
     }
-
-    assert!(sub.next().await.is_none());
 }
 
 #[tokio::test]
@@ -2467,8 +2507,7 @@ async fn close_during_hanging_reconnect_attempt_closes_socket() {
 
     let mut timing = TimingConfig::default();
     timing.reconnect_timeout = Duration::from_secs(30);
-    timing.initial_retry_interval = Duration::from_millis(10);
-    timing.max_retry_interval = Duration::from_millis(10);
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -2547,8 +2586,7 @@ async fn close_during_protocol_disconnected_reconnect_attempt_closes_sockets() {
     });
 
     let mut timing = TimingConfig::default();
-    timing.initial_retry_interval = Duration::ZERO;
-    timing.max_retry_interval = Duration::ZERO;
+    timing.disconnected_retry_timeout = Duration::ZERO;
     timing.reconnect_timeout = Duration::from_secs(30);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
@@ -2600,8 +2638,7 @@ async fn close_during_reconnect_backoff_stops_before_next_attempt() {
     });
 
     let mut timing = TimingConfig::default();
-    timing.initial_retry_interval = Duration::from_millis(250);
-    timing.max_retry_interval = Duration::from_millis(250);
+    timing.disconnected_retry_timeout = Duration::from_millis(250);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -2670,8 +2707,7 @@ async fn close_during_protocol_disconnected_reconnect_backoff_closes_socket() {
     });
 
     let mut timing = TimingConfig::default();
-    timing.initial_retry_interval = Duration::from_secs(5);
-    timing.max_retry_interval = Duration::from_secs(5);
+    timing.disconnected_retry_timeout = Duration::from_secs(5);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -2819,8 +2855,7 @@ async fn close_while_protocol_disconnected_backpressure_closes_socket() {
 
     let mut timing = TimingConfig::default();
     timing.event_channel_capacity = 1;
-    timing.initial_retry_interval = Duration::from_millis(10);
-    timing.max_retry_interval = Duration::from_millis(10);
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
     let sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -2904,8 +2939,7 @@ async fn drop_while_protocol_disconnected_backpressure_closes_socket() {
 
     let mut timing = TimingConfig::default();
     timing.event_channel_capacity = 1;
-    timing.initial_retry_interval = Duration::from_millis(10);
-    timing.max_retry_interval = Duration::from_millis(10);
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
     let sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -2976,8 +3010,7 @@ async fn close_while_connected_event_send_is_backpressured_closes_reconnected_so
 
     let mut timing = TimingConfig::default();
     timing.event_channel_capacity = 1;
-    timing.initial_retry_interval = Duration::from_millis(10);
-    timing.max_retry_interval = Duration::from_millis(10);
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -3132,8 +3165,7 @@ async fn expired_ttl_skips_resume() {
     });
 
     let mut timing = TimingConfig::default();
-    timing.initial_retry_interval = Duration::from_millis(10);
-    timing.max_retry_interval = Duration::from_millis(50);
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -3253,8 +3285,7 @@ async fn resumed_connection_reattaches_channel() {
     });
 
     let mut timing = TimingConfig::default();
-    timing.initial_retry_interval = Duration::from_millis(10);
-    timing.max_retry_interval = Duration::from_millis(50);
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -3292,14 +3323,135 @@ async fn resumed_connection_reattaches_channel() {
     );
 }
 
+#[tokio::test]
+async fn detached_during_reconnect_attach_retries_channel_on_same_transport() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        drop(conn);
+
+        let (tcp, _) = ws.listener.accept().await.unwrap();
+        let mut conn2 = tokio_tungstenite::accept_async(tcp).await.unwrap();
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some("conn-2".into()),
+            connection_key: Some("conn-2!key".into()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some("conn-2!key".into()),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&connected).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for reconnect ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+
+        let detached = ProtocolMessage {
+            action: action::DETACHED,
+            channel: Some("ch".into()),
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "attach rejected temporarily".into(),
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&detached).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for channel retry ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-retry".into()),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&attached).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        send_message(
+            &mut conn2,
+            "ch",
+            "after-reconnect-channel-retry",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
+    timing.channel_retry_timeout = Duration::from_millis(10);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Connected after channel retry")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected after channel retry, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after channel retry")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("after-reconnect-channel-retry"));
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+}
+
 // ---------------------------------------------------------------------------
-// Test 28: detach after reconnect reattaches instead of full reconnect
+// Test 28: detach after reconnect reattaches on the active transport
 // ---------------------------------------------------------------------------
 
-/// Regression test: after a successful reconnect, `last_reattach_at` must be
-/// reset so that a DETACH on the new connection triggers a re-attach (ATTACH)
-/// rather than an unnecessary full reconnect.
-///
 /// Sequence: DETACH → send ATTACH → connection drops → reconnect succeeds →
 /// DETACH on new connection → client should send ATTACH (not open conn-3).
 #[tokio::test]
@@ -3323,7 +3475,7 @@ async fn detach_after_reconnect_reattaches_not_full_reconnect() {
             ..Default::default()
         };
 
-        // DETACH → client sets last_reattach_at and sends ATTACH
+        // DETACH while attached → client sends ATTACH.
         conn1
             .send(tungstenite::Message::Binary(
                 encode_msg(&detached).unwrap().into(),
@@ -3343,9 +3495,8 @@ async fn detach_after_reconnect_reattaches_not_full_reconnect() {
         // Client reconnects (conn-2)
         let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
 
-        // Send DETACH on the new connection (within the 60s reattach_window).
-        // Before the fix, last_reattach_at was stale from conn-1, so this
-        // would trigger a full reconnect. After the fix, it should re-attach.
+        // Send DETACH on the new connection. ably-js re-attaches on the active
+        // transport instead of forcing a full reconnect.
         conn2
             .send(tungstenite::Message::Binary(
                 encode_msg(&detached).unwrap().into(),
@@ -3385,9 +3536,7 @@ async fn detach_after_reconnect_reattaches_not_full_reconnect() {
     });
 
     let mut timing = TimingConfig::default();
-    timing.reattach_window = Duration::from_secs(60);
-    timing.initial_retry_interval = Duration::from_millis(10);
-    timing.max_retry_interval = Duration::from_millis(50);
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -2197,6 +2197,77 @@ async fn token_renewal_failures_fatal() {
     assert!(sub.next().await.is_none());
 }
 
+#[tokio::test]
+async fn token_renewal_error_backpressure_closes_socket_before_subscription_close() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+
+    let now = now_ms();
+    let short_token = serde_json::json!({
+        "token": "short-lived-token",
+        "expires": now + 1_000,
+        "issued": now,
+    });
+    let path = "/keys/testKey.testId/requestToken";
+    http.mock(|when, then| {
+        when.method(POST).path(path);
+        then.status(201)
+            .header("content-type", "application/json")
+            .json_body(short_token);
+    });
+
+    let ws_port = ws.port;
+    let host = format!("127.0.0.1:{ws_port}");
+    let rest_host = format!("127.0.0.1:{}", http.port());
+    let (closed_tx, closed_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        expect_websocket_close_frame(&mut conn).await.unwrap();
+        closed_tx.send(()).unwrap();
+    });
+
+    let call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let cc = call_count.clone();
+    let mut config = SubscribeConfig::new(
+        Box::new(move || {
+            let n = cc.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Box::pin(async move {
+                if n > 0 {
+                    return Err("simulated token fetch failure".into());
+                }
+                Ok(ably_subscriber::TokenRequest {
+                    key_name: "testKey.testId".into(),
+                    timestamp: now_ms(),
+                    nonce: "nonce-1".into(),
+                    mac: "fake-mac".into(),
+                    capability: r#"{"*":["subscribe"]}"#.into(),
+                    ttl: None,
+                    client_id: None,
+                })
+            })
+        }),
+        "ch",
+    );
+    config.host = Some(host);
+    config.rest_host = Some(rest_host);
+    config.timing = Some({
+        let mut t = TimingConfig::default();
+        t.event_channel_capacity = 1;
+        t.max_token_renewal_failures = 1;
+        t
+    });
+    let sub = subscribe(config).await.unwrap();
+
+    // Do not consume the initial Connected event. With capacity=1, the fatal
+    // renewal Error is backpressured, but the socket must close anyway.
+    tokio::time::timeout(Duration::from_secs(5), closed_rx)
+        .await
+        .expect("timed out waiting for socket close before subscription close")
+        .unwrap();
+    sub.close();
+    server_task.await.unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // Test 22: backpressure drops messages when channel is full
 // ---------------------------------------------------------------------------
@@ -2846,7 +2917,7 @@ async fn close_while_protocol_disconnected_backpressure_closes_socket() {
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
-    let (blocked_tx, blocked_rx) = tokio::sync::oneshot::channel::<()>();
+    let (closed_tx, closed_rx) = tokio::sync::oneshot::channel::<()>();
     let (close_sent_tx, close_sent_rx) = tokio::sync::oneshot::channel::<()>();
     let (checked_tx, checked_rx) = tokio::sync::oneshot::channel::<()>();
     let server_task = tokio::spawn(async move {
@@ -2866,32 +2937,16 @@ async fn close_while_protocol_disconnected_backpressure_closes_socket() {
         .await
         .unwrap();
 
+        expect_websocket_close_frame(&mut conn).await.unwrap();
         assert!(
             tokio::time::timeout(Duration::from_millis(250), ws.accept_raw())
                 .await
                 .is_err(),
             "full event channel should backpressure protocol DISCONNECTED before reconnect"
         );
-        blocked_tx.send(()).unwrap();
+        closed_tx.send(()).unwrap();
         close_sent_rx.await.unwrap();
 
-        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
-            .await
-            .expect("timed out waiting for CLOSE after protocol DISCONNECTED backpressure")
-            .unwrap();
-        assert_eq!(msg.action, action::CLOSE);
-
-        let frame = tokio::time::timeout(Duration::from_secs(5), conn.next())
-            .await
-            .expect(
-                "timed out waiting for websocket close after protocol DISCONNECTED backpressure",
-            )
-            .expect("websocket closed before close frame")
-            .unwrap();
-        assert!(
-            matches!(frame, tungstenite::Message::Close(_)),
-            "expected websocket close frame, got {frame:?}"
-        );
         assert!(
             tokio::time::timeout(Duration::from_millis(500), ws.accept_raw())
                 .await
@@ -2909,10 +2964,11 @@ async fn close_while_protocol_disconnected_backpressure_closes_socket() {
         .unwrap();
 
     // Do not consume the initial Connected event. With capacity=1, the
-    // protocol DISCONNECTED status event blocks until close drops the receiver.
-    tokio::time::timeout(Duration::from_secs(5), blocked_rx)
+    // protocol DISCONNECTED status event is backpressured, but the socket must
+    // close before the subscription is explicitly closed.
+    tokio::time::timeout(Duration::from_secs(5), closed_rx)
         .await
-        .expect("timed out waiting for protocol DISCONNECTED backpressure")
+        .expect("timed out waiting for protocol DISCONNECTED socket close")
         .unwrap();
 
     sub.close();
@@ -2932,7 +2988,7 @@ async fn drop_while_protocol_disconnected_backpressure_closes_socket() {
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
-    let (blocked_tx, blocked_rx) = tokio::sync::oneshot::channel::<()>();
+    let (closed_tx, closed_rx) = tokio::sync::oneshot::channel::<()>();
     let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel::<()>();
     let (checked_tx, checked_rx) = tokio::sync::oneshot::channel::<()>();
     let server_task = tokio::spawn(async move {
@@ -2952,30 +3008,16 @@ async fn drop_while_protocol_disconnected_backpressure_closes_socket() {
         .await
         .unwrap();
 
+        expect_websocket_close_frame(&mut conn).await.unwrap();
         assert!(
             tokio::time::timeout(Duration::from_millis(250), ws.accept_raw())
                 .await
                 .is_err(),
             "full event channel should backpressure protocol DISCONNECTED before reconnect"
         );
-        blocked_tx.send(()).unwrap();
+        closed_tx.send(()).unwrap();
         dropped_rx.await.unwrap();
 
-        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
-            .await
-            .expect("timed out waiting for CLOSE after subscription drop")
-            .unwrap();
-        assert_eq!(msg.action, action::CLOSE);
-
-        let frame = tokio::time::timeout(Duration::from_secs(5), conn.next())
-            .await
-            .expect("timed out waiting for websocket close after subscription drop")
-            .expect("websocket closed before close frame")
-            .unwrap();
-        assert!(
-            matches!(frame, tungstenite::Message::Close(_)),
-            "expected websocket close frame, got {frame:?}"
-        );
         assert!(
             tokio::time::timeout(Duration::from_millis(500), ws.accept_raw())
                 .await
@@ -2993,10 +3035,11 @@ async fn drop_while_protocol_disconnected_backpressure_closes_socket() {
         .unwrap();
 
     // Do not consume the initial Connected event. With capacity=1, the
-    // protocol DISCONNECTED status event blocks until drop closes the receiver.
-    tokio::time::timeout(Duration::from_secs(5), blocked_rx)
+    // protocol DISCONNECTED status event is backpressured, but the socket must
+    // close before the subscription is dropped.
+    tokio::time::timeout(Duration::from_secs(5), closed_rx)
         .await
-        .expect("timed out waiting for protocol DISCONNECTED backpressure")
+        .expect("timed out waiting for protocol DISCONNECTED socket close")
         .unwrap();
 
     drop(sub);
@@ -3084,14 +3127,12 @@ async fn close_while_connected_event_send_is_backpressured_closes_reconnected_so
 }
 
 #[tokio::test]
-async fn close_while_error_event_send_is_backpressured_stops_and_closes_socket() {
+async fn error_event_backpressure_closes_socket_before_subscription_close() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
-    let (blocked_tx, blocked_rx) = tokio::sync::oneshot::channel::<()>();
-    let (close_sent_tx, close_sent_rx) = tokio::sync::oneshot::channel::<()>();
     let (closed_tx, closed_rx) = tokio::sync::oneshot::channel::<()>();
     let server_task = tokio::spawn(async move {
         let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
@@ -3110,30 +3151,7 @@ async fn close_while_error_event_send_is_backpressured_stops_and_closes_socket()
         .await
         .unwrap();
 
-        assert!(
-            tokio::time::timeout(Duration::from_millis(250), conn.next())
-                .await
-                .is_err(),
-            "full event channel should backpressure Error before the socket closes"
-        );
-        blocked_tx.send(()).unwrap();
-        close_sent_rx.await.unwrap();
-
-        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
-            .await
-            .expect("timed out waiting for CLOSE after error-event backpressure")
-            .unwrap();
-        assert_eq!(msg.action, action::CLOSE);
-
-        let frame = tokio::time::timeout(Duration::from_secs(5), conn.next())
-            .await
-            .expect("timed out waiting for websocket close after error-event backpressure")
-            .expect("websocket closed before close frame")
-            .unwrap();
-        assert!(
-            matches!(frame, tungstenite::Message::Close(_)),
-            "expected websocket close frame, got {frame:?}"
-        );
+        expect_websocket_close_frame(&mut conn).await.unwrap();
         closed_tx.send(()).unwrap();
     });
 
@@ -3144,19 +3162,12 @@ async fn close_while_error_event_send_is_backpressured_stops_and_closes_socket()
         .unwrap();
 
     // Do not consume the initial Connected event. With capacity=1, the fatal
-    // Error status event blocks until close drops the receiver.
-    tokio::time::timeout(Duration::from_secs(5), blocked_rx)
-        .await
-        .expect("timed out waiting for status-event backpressure")
-        .unwrap();
-
-    sub.close();
-    close_sent_tx.send(()).unwrap();
-
+    // Error status event is backpressured, but the socket must close anyway.
     tokio::time::timeout(Duration::from_secs(5), closed_rx)
         .await
-        .expect("timed out waiting for socket close after backpressured Error")
+        .expect("timed out waiting for socket close before subscription close")
         .unwrap();
+    sub.close();
     server_task.await.unwrap();
 }
 

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -3502,6 +3502,130 @@ async fn detached_during_reconnect_attach_retries_channel_on_same_transport() {
 }
 
 #[tokio::test]
+async fn superseded_error_during_reconnect_attach_retries_on_same_transport() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        drop(conn);
+
+        let (tcp, _) = ws.listener.accept().await.unwrap();
+        let mut conn2 = tokio_tungstenite::accept_async(tcp).await.unwrap();
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some("conn-2".into()),
+            connection_key: Some("conn-2!key".into()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some("conn-2!key".into()),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&connected).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for reconnect ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+
+        let superseded = ProtocolMessage {
+            action: action::ERROR,
+            channel: Some("ch".into()),
+            error: Some(ErrorInfo {
+                code: 80016,
+                status_code: Some(400),
+                message: "operation attempted on superseded transport".into(),
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&superseded).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for retry ATTACH after 80016")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-retry".into()),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&attached).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        send_message(
+            &mut conn2,
+            "ch",
+            "after-superseded-retry",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Connected after retry ATTACH")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected after retry ATTACH, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after retry ATTACH")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("after-superseded-retry"));
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn reconnect_attach_timeout_retries_channel_on_same_transport() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -324,6 +324,54 @@ async fn connect_and_receive_message() {
 }
 
 #[tokio::test]
+async fn message_without_channel_is_ignored() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        let missing_channel = ProtocolMessage {
+            action: action::MESSAGE,
+            channel: None,
+            channel_serial: Some("serial-missing-channel".into()),
+            messages: Some(vec![AblyMessage {
+                name: Some("wrong".into()),
+                data: Some(serde_json::json!("ignored")),
+                timestamp: Some(now_ms()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&missing_channel).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        send_message(&mut conn, "ch", "expected", serde_json::json!("ok"))
+            .await
+            .unwrap();
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for matching-channel message")
+        .unwrap();
+    match event {
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("expected")),
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
 async fn zero_event_channel_capacity_uses_minimum_capacity() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -1378,6 +1378,55 @@ async fn server_sends_disconnected_without_message_reports_reason() {
     server_task.await.unwrap();
 }
 
+#[tokio::test]
+async fn disconnected_event_is_not_delayed_by_transport_close() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (event_seen_tx, event_seen_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        let disconnected = ProtocolMessage {
+            action: action::DISCONNECTED,
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "server going away".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&disconnected).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        event_seen_rx.await.unwrap();
+        expect_websocket_close_frame(&mut conn).await.unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.close_timeout = Duration::from_secs(5);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    let event = tokio::time::timeout(Duration::from_millis(250), sub.next())
+        .await
+        .expect("Disconnected should not wait for transport close")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+    event_seen_tx.send(()).unwrap();
+    sub.close();
+    server_task.await.unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // Test 11: server sends DETACHED, client re-attaches
 // ---------------------------------------------------------------------------

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -3126,22 +3126,20 @@ async fn expired_ttl_skips_resume() {
     let (resume_tx, resume_rx) = tokio::sync::oneshot::channel::<bool>();
 
     tokio::spawn(async move {
-        // First connection with a tiny connection_state_ttl (1ms).
+        // First connection with an already-expired connection_state_ttl.
         // The server-provided TTL overrides the TimingConfig default, so we
-        // set it here to ensure can_resume() sees a short TTL.
+        // set it here to ensure can_resume() is false on reconnect.
         let conn = ws
             .accept_and_handshake_with_opts(
                 "ch",
                 "conn-1",
                 HandshakeOptions {
-                    connection_state_ttl_ms: 1,
+                    connection_state_ttl_ms: 0,
                     ..Default::default()
                 },
             )
             .await
             .unwrap();
-        // Small delay so the 1ms TTL expires before the reconnect attempt.
-        tokio::time::sleep(Duration::from_millis(50)).await;
         drop(conn);
 
         // Second connection — send CONNECTED with the *same* conn_id.
@@ -3166,6 +3164,7 @@ async fn expired_ttl_skips_resume() {
 
     let mut timing = TimingConfig::default();
     timing.disconnected_retry_timeout = Duration::from_millis(10);
+    timing.suspended_retry_timeout = Duration::from_millis(10);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -3179,11 +3178,17 @@ async fn expired_ttl_skips_resume() {
         .unwrap();
     assert!(matches!(event, Event::Disconnected { .. }));
 
-    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
-        .await
-        .expect("timed out waiting for Connected")
-        .unwrap();
-    assert!(matches!(event, Event::Connected));
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
+            .await
+            .expect("timed out waiting for Connected")
+            .unwrap();
+        match event {
+            Event::Connected => break,
+            Event::Disconnected { .. } => {}
+            other => panic!("expected Connected, got {other:?}"),
+        }
+    }
 
     // Message after fresh connect
     let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
@@ -3443,6 +3448,118 @@ async fn detached_during_reconnect_attach_retries_channel_on_same_transport() {
     match event {
         Event::Message(msg) => {
             assert_eq!(msg.name.as_deref(), Some("after-reconnect-channel-retry"));
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn reconnect_attach_timeout_retries_channel_on_same_transport() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        drop(conn);
+
+        let (tcp, _) = ws.listener.accept().await.unwrap();
+        let mut conn2 = tokio_tungstenite::accept_async(tcp).await.unwrap();
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some("conn-2".into()),
+            connection_key: Some("conn-2!key".into()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some("conn-2!key".into()),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&connected).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for reconnect ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+
+        // Do not answer the first ATTACH. The client should treat this as a
+        // channel attach timeout, keep conn-2 connected, and retry ATTACH on
+        // the same websocket instead of opening conn-3.
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for channel retry ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-retry".into()),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&attached).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        send_message(
+            &mut conn2,
+            "ch",
+            "after-reconnect-attach-timeout",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
+    timing.channel_retry_timeout = Duration::from_millis(10);
+    timing.realtime_request_timeout = Duration::from_millis(20);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Connected after channel retry")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected after channel retry, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after channel retry")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("after-reconnect-attach-timeout"));
         }
         other => panic!("expected Message, got {other:?}"),
     }


### PR DESCRIPTION
## Summary
- add explicit Ably connection/channel lifecycle state tracking inside ably-subscriber
- route reconnect, close, DISCONNECTED, ERROR, ATTACHED, and DETACHED paths through lifecycle transitions
- document the new-transport reattach behavior against ably-js' onTransportActive model
- add regression tests for reattach-on-new-transport and terminal close/failure transitions

## Reference
- Downloaded ably-js source to /tmp/ably-js-state-machine and compared against src/common/lib/transport/connectionmanager.ts, src/common/lib/client/baserealtime.ts, and src/common/lib/client/realtimechannel.ts

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all
- CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p ably-subscriber
- CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p runner provider::api
- CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber -p runner --all-targets --all-features -- -D warnings
- git diff --check
- pre-commit: cargo-fmt, cargo-clippy, cargo-doc