### PR TITLE
fix: prevent IDB cache gaps by checking anchor continuity before writing

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -62,6 +62,7 @@
     "eslint": "^9.34.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
+    "fake-indexeddb": "^6.2.5",
     "happy-dom": "^20.9.0",
     "msw": "^2.13.2",
     "oxlint": "^1.57.0",

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.btest.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.btest.ts
@@ -36,10 +36,12 @@ function setupAuth() {
 
 // Mock the remote data source to avoid importing MSW, which pulls in
 // node:http (unavailable in real browser test environments).
+// eslint-disable-next-line arrow-body-style
 const { remoteMessages } = vi.hoisted(() => ({
   remoteMessages: [] as PagedChatMessage[],
 }));
 
+/* eslint-disable arrow-body-style, ccstate/computed-const-args-package-scope */
 vi.mock("../remote-chat-thread-data-source", () => ({
   createRemoteChatThreadDataSource: () => ({
     getThread$: computed(() => null),
@@ -62,6 +64,7 @@ vi.mock("../remote-chat-thread-data-source", () => ({
     subscribeRealtime$: command((_ctx: unknown) => {}),
   }),
 }));
+/* eslint-enable arrow-body-style, ccstate/computed-const-args-package-scope */
 
 // Import the module under test after the mock is registered (vi.mock is
 // hoisted, so the import order doesn't matter, but keeping it after is

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.btest.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.btest.ts
@@ -1,21 +1,15 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { command, computed } from "ccstate";
 import {
   mockUser,
   mockOrganization,
   clearMockedAuth,
 } from "../../../__tests__/mock-auth.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
-import { createMockApi } from "../../../mocks/msw-contract.ts";
-import { server } from "../../../mocks/server.ts";
-import {
-  chatThreadMessagesContract,
-  type PagedChatMessage,
-} from "@vm0/api-contracts/contracts/chat-threads";
-import { createIdbCachedDataSource } from "../idb-cached-chat-thread-data-source.ts";
+import type { PagedChatMessage } from "@vm0/api-contracts/contracts/chat-threads";
 import { createIdbMessageStores } from "../../external/idb-message-store.ts";
 
 const context = testContext();
-const mockApi = createMockApi(context);
 
 function makeMsg(
   id: string,
@@ -40,10 +34,46 @@ function setupAuth() {
   });
 }
 
+// Mock the remote data source to avoid importing MSW, which pulls in
+// node:http (unavailable in real browser test environments).
+const { remoteMessages } = vi.hoisted(() => ({
+  remoteMessages: [] as PagedChatMessage[],
+}));
+
+vi.mock("../remote-chat-thread-data-source", () => ({
+  createRemoteChatThreadDataSource: () => ({
+    getThread$: computed(async () => null),
+    reloadThread$: command((_ctx: unknown) => {}),
+    initialPage$: computed(async () => ({
+      messages: [],
+      hasHistoryBefore: false,
+    })),
+    listMessagesAfter$: command(async () => ({
+      messages: remoteMessages,
+      reachedEnd: false,
+    })),
+    listMessagesBefore$: command(async () => ({
+      messages: [],
+      hasMore: false,
+    })),
+    patchDraft$: command(async (_ctx: unknown) => {}),
+    cancelRuns$: command(async (_ctx: unknown) => {}),
+    markRead$: command(async () => ""),
+    subscribeRealtime$: command(async (_ctx: unknown) => {}),
+  }),
+}));
+
+// Import the module under test after the mock is registered (vi.mock is
+// hoisted, so the import order doesn't matter, but keeping it after is
+// clearer about dependencies).
+const { createIdbCachedDataSource } =
+  await import("../idb-cached-chat-thread-data-source");
+
 describe("createIdbCachedDataSource.listMessagesAfter$", () => {
   beforeEach(() => {
     clearMockedAuth();
     setupAuth();
+    remoteMessages.splice(0, remoteMessages.length);
   });
 
   it("caches remote messages when sinceId anchor exists in local IDB", async () => {
@@ -55,19 +85,10 @@ describe("createIdbCachedDataSource.listMessagesAfter$", () => {
       makeMsg("anchor-1", threadId, "2026-01-01T00:00:00Z"),
     ]);
 
-    // Set up remote to return messages after the anchor
-    server.use(
-      mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {
-        if (query.sinceId === "anchor-1") {
-          return respond(200, {
-            messages: [
-              makeMsg("new-1", threadId, "2026-01-02T00:00:00Z"),
-              makeMsg("new-2", threadId, "2026-01-03T00:00:00Z"),
-            ],
-          });
-        }
-        return respond(200, { messages: [] });
-      }),
+    // Configure the mock remote to return messages after the anchor
+    remoteMessages.push(
+      makeMsg("new-1", threadId, "2026-01-02T00:00:00Z"),
+      makeMsg("new-2", threadId, "2026-01-03T00:00:00Z"),
     );
 
     const ds = createIdbCachedDataSource(threadId);
@@ -97,19 +118,10 @@ describe("createIdbCachedDataSource.listMessagesAfter$", () => {
 
     // Do NOT pre-populate IDB — anchor will be missing
 
-    // Set up remote to return messages even though anchor doesn't exist locally
-    server.use(
-      mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {
-        if (query.sinceId === "missing-anchor") {
-          return respond(200, {
-            messages: [
-              makeMsg("gap-1", threadId, "2026-02-01T00:00:00Z"),
-              makeMsg("gap-2", threadId, "2026-02-02T00:00:00Z"),
-            ],
-          });
-        }
-        return respond(200, { messages: [] });
-      }),
+    // Configure the mock remote to return messages for the missing anchor
+    remoteMessages.push(
+      makeMsg("gap-1", threadId, "2026-02-01T00:00:00Z"),
+      makeMsg("gap-2", threadId, "2026-02-02T00:00:00Z"),
     );
 
     const ds = createIdbCachedDataSource(threadId);
@@ -132,15 +144,9 @@ describe("createIdbCachedDataSource.listMessagesAfter$", () => {
   it("caches remote messages when sinceId is undefined (bootstrap)", async () => {
     const threadId = "thread-bootstrap";
 
-    server.use(
-      mockApi(chatThreadMessagesContract.list, ({ respond }) => {
-        return respond(200, {
-          messages: [
-            makeMsg("boot-1", threadId, "2026-03-01T00:00:00Z"),
-            makeMsg("boot-2", threadId, "2026-03-02T00:00:00Z"),
-          ],
-        });
-      }),
+    remoteMessages.push(
+      makeMsg("boot-1", threadId, "2026-03-01T00:00:00Z"),
+      makeMsg("boot-2", threadId, "2026-03-02T00:00:00Z"),
     );
 
     const ds = createIdbCachedDataSource(threadId);

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.btest.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.btest.ts
@@ -42,24 +42,24 @@ const { remoteMessages } = vi.hoisted(() => ({
 
 vi.mock("../remote-chat-thread-data-source", () => ({
   createRemoteChatThreadDataSource: () => ({
-    getThread$: computed(async () => null),
+    getThread$: computed(() => null),
     reloadThread$: command((_ctx: unknown) => {}),
-    initialPage$: computed(async () => ({
+    initialPage$: computed(() => ({
       messages: [],
       hasHistoryBefore: false,
     })),
-    listMessagesAfter$: command(async () => ({
+    listMessagesAfter$: command(() => ({
       messages: remoteMessages,
       reachedEnd: false,
     })),
-    listMessagesBefore$: command(async () => ({
+    listMessagesBefore$: command(() => ({
       messages: [],
       hasMore: false,
     })),
-    patchDraft$: command(async (_ctx: unknown) => {}),
-    cancelRuns$: command(async (_ctx: unknown) => {}),
-    markRead$: command(async () => ""),
-    subscribeRealtime$: command(async (_ctx: unknown) => {}),
+    patchDraft$: command((_ctx: unknown) => {}),
+    cancelRuns$: command((_ctx: unknown) => {}),
+    markRead$: command(() => ""),
+    subscribeRealtime$: command((_ctx: unknown) => {}),
   }),
 }));
 

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.btest.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.btest.ts
@@ -34,10 +34,7 @@ const USER_ID = "test-idb-cache-user";
 const ORG_ID = "test-idb-cache-org";
 
 function setupAuth() {
-  mockUser(
-    { id: USER_ID, fullName: "Test User" },
-    { token: "test-token" },
-  );
+  mockUser({ id: USER_ID, fullName: "Test User" }, { token: "test-token" });
   mockOrganization({
     activeOrg: { id: ORG_ID, name: "Test Org" },
   });
@@ -86,11 +83,13 @@ describe("createIdbCachedDataSource.listMessagesAfter$", () => {
     // Anchor existed → messages should be cached
     const cached = await stores.readStore.readLatest(threadId, 10);
     expect(cached).toHaveLength(3); // anchor + new-1 + new-2
-    expect(cached.map((m) => m.id).sort()).toStrictEqual([
-      "anchor-1",
-      "new-1",
-      "new-2",
-    ]);
+    expect(
+      cached
+        .map((m) => {
+          return m.id;
+        })
+        .sort(),
+    ).toStrictEqual(["anchor-1", "new-1", "new-2"]);
   });
 
   it("skips caching when sinceId anchor is missing from local IDB", async () => {

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.test.ts
@@ -3,7 +3,7 @@ import {
   mockUser,
   mockOrganization,
   clearMockedAuth,
-} from "../../__tests__/mock-auth.ts";
+} from "../../../__tests__/mock-auth.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { server } from "../../../mocks/server.ts";
@@ -19,7 +19,7 @@ const mockApi = createMockApi(context);
 
 function makeMsg(
   id: string,
-  threadId: string,
+  _threadId: string,
   createdAt: string,
 ): PagedChatMessage {
   return {
@@ -86,7 +86,7 @@ describe("createIdbCachedDataSource.listMessagesAfter$", () => {
     // Anchor existed → messages should be cached
     const cached = await stores.readStore.readLatest(threadId, 10);
     expect(cached).toHaveLength(3); // anchor + new-1 + new-2
-    expect(cached.map((m) => m.id).sort()).toEqual([
+    expect(cached.map((m) => m.id).sort()).toStrictEqual([
       "anchor-1",
       "new-1",
       "new-2",

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.test.ts
@@ -1,15 +1,21 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { command, computed } from "ccstate";
+import { describe, it, expect, beforeEach } from "vitest";
 import {
   mockUser,
   mockOrganization,
   clearMockedAuth,
 } from "../../../__tests__/mock-auth.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
-import type { PagedChatMessage } from "@vm0/api-contracts/contracts/chat-threads";
+import { createMockApi } from "../../../mocks/msw-contract.ts";
+import { server } from "../../../mocks/server.ts";
+import {
+  chatThreadMessagesContract,
+  type PagedChatMessage,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { createIdbCachedDataSource } from "../idb-cached-chat-thread-data-source.ts";
 import { createIdbMessageStores } from "../../external/idb-message-store.ts";
 
 const context = testContext();
+const mockApi = createMockApi(context);
 
 function makeMsg(
   id: string,
@@ -34,49 +40,10 @@ function setupAuth() {
   });
 }
 
-// Mock the remote data source to avoid importing MSW, which pulls in
-// node:http (unavailable in real browser test environments).
-// eslint-disable-next-line arrow-body-style
-const { remoteMessages } = vi.hoisted(() => ({
-  remoteMessages: [] as PagedChatMessage[],
-}));
-
-/* eslint-disable arrow-body-style, ccstate/computed-const-args-package-scope */
-vi.mock("../remote-chat-thread-data-source", () => ({
-  createRemoteChatThreadDataSource: () => ({
-    getThread$: computed(() => null),
-    reloadThread$: command((_ctx: unknown) => {}),
-    initialPage$: computed(() => ({
-      messages: [],
-      hasHistoryBefore: false,
-    })),
-    listMessagesAfter$: command(() => ({
-      messages: remoteMessages,
-      reachedEnd: false,
-    })),
-    listMessagesBefore$: command(() => ({
-      messages: [],
-      hasMore: false,
-    })),
-    patchDraft$: command((_ctx: unknown) => {}),
-    cancelRuns$: command((_ctx: unknown) => {}),
-    markRead$: command(() => ""),
-    subscribeRealtime$: command((_ctx: unknown) => {}),
-  }),
-}));
-/* eslint-enable arrow-body-style, ccstate/computed-const-args-package-scope */
-
-// Import the module under test after the mock is registered (vi.mock is
-// hoisted, so the import order doesn't matter, but keeping it after is
-// clearer about dependencies).
-const { createIdbCachedDataSource } =
-  await import("../idb-cached-chat-thread-data-source");
-
 describe("createIdbCachedDataSource.listMessagesAfter$", () => {
   beforeEach(() => {
     clearMockedAuth();
     setupAuth();
-    remoteMessages.splice(0, remoteMessages.length);
   });
 
   it("caches remote messages when sinceId anchor exists in local IDB", async () => {
@@ -88,10 +55,19 @@ describe("createIdbCachedDataSource.listMessagesAfter$", () => {
       makeMsg("anchor-1", threadId, "2026-01-01T00:00:00Z"),
     ]);
 
-    // Configure the mock remote to return messages after the anchor
-    remoteMessages.push(
-      makeMsg("new-1", threadId, "2026-01-02T00:00:00Z"),
-      makeMsg("new-2", threadId, "2026-01-03T00:00:00Z"),
+    // Set up remote to return messages after the anchor
+    server.use(
+      mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {
+        if (query.sinceId === "anchor-1") {
+          return respond(200, {
+            messages: [
+              makeMsg("new-1", threadId, "2026-01-02T00:00:00Z"),
+              makeMsg("new-2", threadId, "2026-01-03T00:00:00Z"),
+            ],
+          });
+        }
+        return respond(200, { messages: [] });
+      }),
     );
 
     const ds = createIdbCachedDataSource(threadId);
@@ -121,10 +97,19 @@ describe("createIdbCachedDataSource.listMessagesAfter$", () => {
 
     // Do NOT pre-populate IDB — anchor will be missing
 
-    // Configure the mock remote to return messages for the missing anchor
-    remoteMessages.push(
-      makeMsg("gap-1", threadId, "2026-02-01T00:00:00Z"),
-      makeMsg("gap-2", threadId, "2026-02-02T00:00:00Z"),
+    // Set up remote to return messages even though anchor doesn't exist locally
+    server.use(
+      mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {
+        if (query.sinceId === "missing-anchor") {
+          return respond(200, {
+            messages: [
+              makeMsg("gap-1", threadId, "2026-02-01T00:00:00Z"),
+              makeMsg("gap-2", threadId, "2026-02-02T00:00:00Z"),
+            ],
+          });
+        }
+        return respond(200, { messages: [] });
+      }),
     );
 
     const ds = createIdbCachedDataSource(threadId);
@@ -147,9 +132,15 @@ describe("createIdbCachedDataSource.listMessagesAfter$", () => {
   it("caches remote messages when sinceId is undefined (bootstrap)", async () => {
     const threadId = "thread-bootstrap";
 
-    remoteMessages.push(
-      makeMsg("boot-1", threadId, "2026-03-01T00:00:00Z"),
-      makeMsg("boot-2", threadId, "2026-03-02T00:00:00Z"),
+    server.use(
+      mockApi(chatThreadMessagesContract.list, ({ respond }) => {
+        return respond(200, {
+          messages: [
+            makeMsg("boot-1", threadId, "2026-03-01T00:00:00Z"),
+            makeMsg("boot-2", threadId, "2026-03-02T00:00:00Z"),
+          ],
+        });
+      }),
     );
 
     const ds = createIdbCachedDataSource(threadId);

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  mockUser,
+  mockOrganization,
+  clearMockedAuth,
+} from "../../__tests__/mock-auth.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { createMockApi } from "../../../mocks/msw-contract.ts";
+import { server } from "../../../mocks/server.ts";
+import {
+  chatThreadMessagesContract,
+  type PagedChatMessage,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { createIdbCachedDataSource } from "../idb-cached-chat-thread-data-source.ts";
+import { createIdbMessageStores } from "../../external/idb-message-store.ts";
+
+const context = testContext();
+const mockApi = createMockApi(context);
+
+function makeMsg(
+  id: string,
+  threadId: string,
+  createdAt: string,
+): PagedChatMessage {
+  return {
+    id,
+    role: "user" as const,
+    content: `msg ${id}`,
+    createdAt,
+  };
+}
+
+const USER_ID = "test-idb-cache-user";
+const ORG_ID = "test-idb-cache-org";
+
+function setupAuth() {
+  mockUser(
+    { id: USER_ID, fullName: "Test User" },
+    { token: "test-token" },
+  );
+  mockOrganization({
+    activeOrg: { id: ORG_ID, name: "Test Org" },
+  });
+}
+
+describe("createIdbCachedDataSource.listMessagesAfter$", () => {
+  beforeEach(() => {
+    clearMockedAuth();
+    setupAuth();
+  });
+
+  it("caches remote messages when sinceId anchor exists in local IDB", async () => {
+    const threadId = "thread-anchor-exists";
+
+    // Pre-populate IDB with the anchor message
+    const stores = createIdbMessageStores(USER_ID, ORG_ID);
+    await stores.writeStore.upsertMessages(threadId, [
+      makeMsg("anchor-1", threadId, "2026-01-01T00:00:00Z"),
+    ]);
+
+    // Set up remote to return messages after the anchor
+    server.use(
+      mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {
+        if (query.sinceId === "anchor-1") {
+          return respond(200, {
+            messages: [
+              makeMsg("new-1", threadId, "2026-01-02T00:00:00Z"),
+              makeMsg("new-2", threadId, "2026-01-03T00:00:00Z"),
+            ],
+          });
+        }
+        return respond(200, { messages: [] });
+      }),
+    );
+
+    const ds = createIdbCachedDataSource(threadId);
+
+    const result = await context.store.set(
+      ds.listMessagesAfter$,
+      { threadId, sinceId: "anchor-1" },
+      context.signal,
+    );
+
+    expect(result.messages).toHaveLength(2);
+
+    // Anchor existed → messages should be cached
+    const cached = await stores.readStore.readLatest(threadId, 10);
+    expect(cached).toHaveLength(3); // anchor + new-1 + new-2
+    expect(cached.map((m) => m.id).sort()).toEqual([
+      "anchor-1",
+      "new-1",
+      "new-2",
+    ]);
+  });
+
+  it("skips caching when sinceId anchor is missing from local IDB", async () => {
+    const threadId = "thread-anchor-missing";
+
+    // Do NOT pre-populate IDB — anchor will be missing
+
+    // Set up remote to return messages even though anchor doesn't exist locally
+    server.use(
+      mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {
+        if (query.sinceId === "missing-anchor") {
+          return respond(200, {
+            messages: [
+              makeMsg("gap-1", threadId, "2026-02-01T00:00:00Z"),
+              makeMsg("gap-2", threadId, "2026-02-02T00:00:00Z"),
+            ],
+          });
+        }
+        return respond(200, { messages: [] });
+      }),
+    );
+
+    const ds = createIdbCachedDataSource(threadId);
+    const stores = createIdbMessageStores(USER_ID, ORG_ID);
+
+    const result = await context.store.set(
+      ds.listMessagesAfter$,
+      { threadId, sinceId: "missing-anchor" },
+      context.signal,
+    );
+
+    // Messages are still returned to the UI
+    expect(result.messages).toHaveLength(2);
+
+    // But they must NOT be cached (anchor was lost → gap risk)
+    const cached = await stores.readStore.readLatest(threadId, 10);
+    expect(cached).toHaveLength(0);
+  });
+
+  it("caches remote messages when sinceId is undefined (bootstrap)", async () => {
+    const threadId = "thread-bootstrap";
+
+    server.use(
+      mockApi(chatThreadMessagesContract.list, ({ respond }) => {
+        return respond(200, {
+          messages: [
+            makeMsg("boot-1", threadId, "2026-03-01T00:00:00Z"),
+            makeMsg("boot-2", threadId, "2026-03-02T00:00:00Z"),
+          ],
+        });
+      }),
+    );
+
+    const ds = createIdbCachedDataSource(threadId);
+    const stores = createIdbMessageStores(USER_ID, ORG_ID);
+
+    const result = await context.store.set(
+      ds.listMessagesAfter$,
+      { threadId, sinceId: undefined },
+      context.signal,
+    );
+
+    expect(result.messages).toHaveLength(2);
+
+    // sinceId undefined → no anchor check → always cache
+    const cached = await stores.readStore.readLatest(threadId, 10);
+    expect(cached).toHaveLength(2);
+  });
+});

--- a/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
@@ -95,8 +95,21 @@ function createListMessagesAfter(
 
       if (userId && orgId && result.messages.length > 0) {
         const stores = getStores(userId, orgId);
-        const writeStore = stores.writeStore;
-        await writeStore.upsertMessages(tid, result.messages, signal);
+        // Only cache when the anchor (sinceId) still exists locally.
+        // If it doesn't, local state has diverged and writing would create
+        // a permanent gap between the last cached message and the new batch.
+        if (sinceId) {
+          const anchorExists = await stores.readStore.messageExists(
+            tid,
+            sinceId,
+            signal,
+          );
+          if (!anchorExists) {
+            L.debug("listAfter:anchorLost", { threadId: tid, sinceId });
+            return result;
+          }
+        }
+        await stores.writeStore.upsertMessages(tid, result.messages, signal);
         L.debug("listAfter:cacheFilled", {
           threadId: tid,
           sinceId,

--- a/turbo/apps/platform/src/signals/external/__tests__/idb-message-store.btest.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/idb-message-store.btest.ts
@@ -136,7 +136,7 @@ describe("idb-message-store", () => {
     ]);
 
     const exists = await readStore.messageExists(THREAD, "e1");
-    expect(exists).toBe(true);
+    expect(exists).toBeTruthy();
   });
 
   it("messageExists returns false when message does not exist", async () => {
@@ -150,7 +150,7 @@ describe("idb-message-store", () => {
     ]);
 
     const exists = await readStore.messageExists(THREAD, "nonexistent");
-    expect(exists).toBe(false);
+    expect(exists).toBeFalsy();
   });
 
   it("messageExists returns false when message exists but threadId differs", async () => {
@@ -164,7 +164,7 @@ describe("idb-message-store", () => {
     ]);
 
     const exists = await readStore.messageExists("other-thread", "g1");
-    expect(exists).toBe(false);
+    expect(exists).toBeFalsy();
   });
 
   it("scopes messages by user and org", async () => {

--- a/turbo/apps/platform/src/signals/external/__tests__/idb-message-store.btest.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/idb-message-store.btest.ts
@@ -125,6 +125,48 @@ describe("idb-message-store", () => {
     await expect(readStore.readLatest(THREAD, 10)).rejects.toThrow();
   });
 
+  it("messageExists returns true when message exists with matching threadId", async () => {
+    const { readStore, writeStore } = createIdbMessageStores(
+      USER + "-exists",
+      ORG,
+    );
+
+    await writeStore.upsertMessages(THREAD, [
+      makeMsg("e1", THREAD, "2026-05-01T00:00:00Z"),
+    ]);
+
+    const exists = await readStore.messageExists(THREAD, "e1");
+    expect(exists).toBe(true);
+  });
+
+  it("messageExists returns false when message does not exist", async () => {
+    const { readStore, writeStore } = createIdbMessageStores(
+      USER + "-notfound",
+      ORG,
+    );
+
+    await writeStore.upsertMessages(THREAD, [
+      makeMsg("f1", THREAD, "2026-05-01T00:00:00Z"),
+    ]);
+
+    const exists = await readStore.messageExists(THREAD, "nonexistent");
+    expect(exists).toBe(false);
+  });
+
+  it("messageExists returns false when message exists but threadId differs", async () => {
+    const { readStore, writeStore } = createIdbMessageStores(
+      USER + "-wrongthread",
+      ORG,
+    );
+
+    await writeStore.upsertMessages(THREAD, [
+      makeMsg("g1", THREAD, "2026-05-01T00:00:00Z"),
+    ]);
+
+    const exists = await readStore.messageExists("other-thread", "g1");
+    expect(exists).toBe(false);
+  });
+
   it("scopes messages by user and org", async () => {
     const storesA = createIdbMessageStores("user-a", "org-a");
     const storesB = createIdbMessageStores("user-b", "org-b");

--- a/turbo/apps/platform/src/signals/external/idb-message-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-message-store.ts
@@ -19,6 +19,11 @@ interface ChatMessageReadStore {
     limit: number,
     signal?: AbortSignal,
   ): Promise<PagedChatMessage[]>;
+  messageExists(
+    threadId: string,
+    messageId: string,
+    signal?: AbortSignal,
+  ): Promise<boolean>;
 }
 
 interface ChatMessageWriteStore {
@@ -79,6 +84,14 @@ function createIdbMessageStores(userId: string, orgId: string) {
       }
       L.debug("readLatest:done", { threadId, count: messages.length });
       return messages.reverse();
+    },
+
+    async messageExists(threadId, messageId, signal) {
+      const db = await getDb();
+      signal?.throwIfAborted();
+      const tx = db.transaction(storeName, "readonly");
+      const msg = await tx.store.get(messageId);
+      return msg !== undefined && (msg as { threadId?: string }).threadId === threadId;
     },
 
     async readBefore(threadId, beforeId, limit, signal) {

--- a/turbo/apps/platform/src/signals/external/idb-message-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-message-store.ts
@@ -91,7 +91,10 @@ function createIdbMessageStores(userId: string, orgId: string) {
       signal?.throwIfAborted();
       const tx = db.transaction(storeName, "readonly");
       const msg = await tx.store.get(messageId);
-      return msg !== undefined && (msg as { threadId?: string }).threadId === threadId;
+      return (
+        msg !== undefined &&
+        (msg as { threadId?: string }).threadId === threadId
+      );
     },
 
     async readBefore(threadId, beforeId, limit, signal) {

--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+import { indexedDB, IDBKeyRange } from "fake-indexeddb";
 import { server } from "../mocks/server.ts";
 import { afterAll, afterEach, beforeEach, beforeAll, vi } from "vitest";
 import { mockedClerk } from "../__tests__/mock-auth.ts";
@@ -16,6 +17,9 @@ vi.hoisted(() => {
   vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY", "test_key");
   vi.stubEnv("VITE_API_URL", "http://localhost:3000");
 });
+
+globalThis.indexedDB = indexedDB;
+globalThis.IDBKeyRange = IDBKeyRange;
 
 beforeAll(() => {
   // Disable CSS animations/transitions so Radix UI dialog open/close

--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -1,5 +1,18 @@
 import "@testing-library/jest-dom/vitest";
-import { indexedDB, IDBKeyRange } from "fake-indexeddb";
+import {
+  IDBCursor,
+  IDBCursorWithValue,
+  IDBDatabase,
+  IDBFactory,
+  IDBIndex,
+  IDBKeyRange,
+  IDBObjectStore,
+  IDBOpenDBRequest,
+  IDBRequest,
+  IDBTransaction,
+  IDBVersionChangeEvent,
+  indexedDB,
+} from "fake-indexeddb";
 import { server } from "../mocks/server.ts";
 import { afterAll, afterEach, beforeEach, beforeAll, vi } from "vitest";
 import { mockedClerk } from "../__tests__/mock-auth.ts";
@@ -19,7 +32,17 @@ vi.hoisted(() => {
 });
 
 globalThis.indexedDB = indexedDB;
+globalThis.IDBCursor = IDBCursor;
+globalThis.IDBCursorWithValue = IDBCursorWithValue;
+globalThis.IDBDatabase = IDBDatabase;
+globalThis.IDBFactory = IDBFactory;
+globalThis.IDBIndex = IDBIndex;
 globalThis.IDBKeyRange = IDBKeyRange;
+globalThis.IDBObjectStore = IDBObjectStore;
+globalThis.IDBOpenDBRequest = IDBOpenDBRequest;
+globalThis.IDBRequest = IDBRequest;
+globalThis.IDBTransaction = IDBTransaction;
+globalThis.IDBVersionChangeEvent = IDBVersionChangeEvent;
 
 beforeAll(() => {
   // Disable CSS animations/transitions so Radix UI dialog open/close

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -415,6 +415,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.4(jiti@2.6.1))
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       happy-dom:
         specifier: ^20.9.0
         version: 20.9.0
@@ -1317,8 +1320,8 @@ packages:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
-  '@clerk/localizations@3.37.4':
-    resolution: {integrity: sha512-Hb+PnarcVfHhRlOlOXcX0xx5TK3T2NtlYi1GHFy+MWcHZDG32/XxdXJbwYKnQ+Bx+aoCDGx0fUP4lGkoYaeZ9Q==}
+  '@clerk/localizations@3.37.5':
+    resolution: {integrity: sha512-OpFJuC77V/Kz6MvW9zYFxSIXDYhbmsmZ1f8jOxuvlIZXmXQPgyP8Eypq5495514uN/mWBrIbCNRsX/Rh1aFz0Q==}
     engines: {node: '>=18.17.0'}
 
   '@clerk/nextjs@7.2.7':
@@ -1360,8 +1363,8 @@ packages:
       react-dom:
         optional: true
 
-  '@clerk/types@4.101.22':
-    resolution: {integrity: sha512-74hV9MMw9MzOOSuJNJMFP95XZ2jDfPS1v3pfALS3rSQa+h/lNREU+fLGArzYckEpqNtuF6xy0odg9YqF5BLNhA==}
+  '@clerk/types@4.101.23':
+    resolution: {integrity: sha512-t5ypYYDkT5TPaNIDjLnYk9GpkJgwNTBiS7h6FuUTjoySQtf7amNDS1A1eOu7NOcVpqiSeKg+0wzGxxcre00kMA==}
     engines: {node: '>=18.17.0'}
 
   '@coinbase/wallet-sdk@4.3.0':
@@ -6449,6 +6452,10 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -9876,7 +9883,7 @@ snapshots:
   '@clerk/clerk-js@5.125.10(@types/react@19.2.14)(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)':
     dependencies:
       '@base-org/account': 2.0.1(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
-      '@clerk/localizations': 3.37.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@clerk/localizations': 3.37.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@clerk/shared': 3.47.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@coinbase/wallet-sdk': 4.3.0
       '@emotion/cache': 11.11.0
@@ -9925,9 +9932,9 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       tslib: 2.8.1
 
-  '@clerk/localizations@3.37.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@clerk/localizations@3.37.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@clerk/types': 4.101.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@clerk/types': 4.101.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -9973,7 +9980,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@clerk/types@4.101.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@clerk/types@4.101.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@clerk/shared': 3.47.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
@@ -15155,6 +15162,8 @@ snapshots:
   expect-type@1.3.0: {}
 
   extend@3.0.2: {}
+
+  fake-indexeddb@6.2.5: {}
 
   fast-deep-equal@3.1.3: {}
 


### PR DESCRIPTION
## Summary

When `listMessagesAfter` fetches remote messages and writes them to the local IDB cache, it previously did so unconditionally. This could create a permanent gap: if the `sinceId` anchor no longer exists in local IDB (e.g., cache eviction, stale state), the remote batch would be written in isolation, leaving a hole between the last cached message and the new batch that will never be re-fetched.

## Changes

### `idb-message-store.ts`
- Added `messageExists(threadId, messageId)` to the read store — checks whether a message by primary key exists and belongs to the expected thread

### `idb-cached-chat-thread-data-source.ts`
- Before `upsertMessages` in `createListMessagesAfter`, verify that `sinceId` still exists in local IDB
- If the anchor is missing → skip caching (gap risk), but still return messages to the UI
- If `sinceId` is undefined → always cache (bootstrap / no-anchor case)

### Tests
- `idb-message-store.btest.ts`: 3 new tests for `messageExists` — exists, not found, wrong threadId
- `idb-cached-chat-thread-data-source.test.ts`: new integration tests covering anchor-exists, anchor-missing, and undefined-sinceId cases

## Test plan
- [ ] CI passes (lint, type-check, tests)
- [ ] Manual: scroll down in a chat thread after loading → messages appear from cache on revisit

🤖 Generated with [Claude Code](https://claude.com/claude-code)