### PR TITLE
fix(zero): admit cross-framework default provider at admission and dispatch

### DIFF
--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -1253,6 +1253,81 @@ describe("POST /api/zero/chat/messages", () => {
       });
     });
 
+    describe("admission cross-framework default (Issue #11684)", () => {
+      // Admission-layer regression for Epic #11520's residual gap:
+      // a claude-code compose with no env block, served by an org whose
+      // only isDefault provider is openai-api-key (codex framework). The
+      // request body carries no modelProviderId or modelSelection — the
+      // path the Web UI takes when the org has no claude-code default.
+      // Pre-fix, admission threw noModelProvider() and the UI rendered
+      // "Oops, something went wrong". Post-fix, admission falls back to
+      // the org's cross-framework default and the provider's framework
+      // propagates downstream via resolvedFramework.
+      it("admits a claude-code compose when the org's only default is openai-api-key (codex)", async () => {
+        const { agentId: composeAgentId } = await createTestCompose(
+          uniqueId("admit-cross-framework"),
+          { noEnvironmentBlock: true },
+        );
+
+        // Wipe the beforeEach-seeded anthropic provider so the org has
+        // only an openai-api-key (codex) provider as its default.
+        const anthropicId = await getTestModelProviderIdByType(
+          user.orgId,
+          "anthropic-api-key",
+        );
+        await deleteTestModelProvider(anthropicId);
+        await insertOrgDefaultModelProvider(user.orgId, "openai-api-key");
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId: composeAgentId,
+              prompt: "claude-code compose, codex provider",
+            }),
+          }),
+        );
+        expect(response.status).toBe(201);
+        const { runId } = await response.json();
+        await context.mocks.flushAfter();
+
+        const job = await findTestRunnerJobEntry(runId);
+        expect(job).toBeDefined();
+        expect(job!.executionContext.cliAgentType).toBe("codex");
+      });
+
+      it("returns 422 NO_MODEL_PROVIDER when org has no default provider at all", async () => {
+        const { agentId: composeAgentId } = await createTestCompose(
+          uniqueId("no-default-provider"),
+          { noEnvironmentBlock: true },
+        );
+
+        // Wipe the beforeEach-seeded anthropic provider so the org has
+        // no isDefault: true provider for any framework — the genuine
+        // "no provider configured at all" failure mode.
+        const anthropicId = await getTestModelProviderIdByType(
+          user.orgId,
+          "anthropic-api-key",
+        );
+        await deleteTestModelProvider(anthropicId);
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId: composeAgentId,
+              prompt: "should fail",
+            }),
+          }),
+        );
+        expect(response.status).toBe(422);
+        const data = await response.json();
+        expect(data.error.code).toBe("NO_MODEL_PROVIDER");
+      });
+    });
+
     describe("user info source", () => {
       it("short-circuits getCachedUser when sessionClaims carry email + name", async () => {
         const email = `${user.userId}@claims.example.com`;

--- a/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
@@ -16,6 +16,7 @@ import { logger } from "../../shared/logger";
 import { getSecretValue, getSecretValues } from "../secret/secret-service";
 import {
   getOrgDefaultModelProvider,
+  getOrgAnyDefaultModelProvider,
   getModelProviderByIdForOrg,
 } from "../model-provider/model-provider-service";
 import { getVm0ApiKey } from "../vm0-key/vm0-key-service";
@@ -293,12 +294,19 @@ export async function resolveModelProviderSecrets(
     };
   }
 
-  // Resolve provider: specific ID override → org default
+  // Resolve provider: specific ID override → framework-scoped org default →
+  // cross-framework fallback. The cross-framework fallback mirrors admission
+  // (zero-run-policy.ts) and implements Epic #11520's "provider's framework
+  // wins" rule at the dispatch boundary: an org with only a codex provider
+  // still resolves secrets for a claude-code compose; the provider's
+  // framework propagates downstream via `resolvedFramework`.
   let defaultProvider: Awaited<ReturnType<typeof getOrgDefaultModelProvider>>;
   if (modelProviderId) {
     defaultProvider = await getModelProviderByIdForOrg(orgId, modelProviderId);
   } else {
-    defaultProvider = await getOrgDefaultModelProvider(orgId, framework);
+    defaultProvider =
+      (await getOrgDefaultModelProvider(orgId, framework)) ??
+      (await getOrgAnyDefaultModelProvider(orgId));
   }
 
   const secretUserId = ORG_SENTINEL_USER_ID;

--- a/turbo/apps/web/src/lib/zero/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/zero/model-provider/model-provider-service.ts
@@ -916,6 +916,53 @@ async function getDefaultModelProvider(
   });
 }
 
+/**
+ * Get the default model provider regardless of framework. Returns the first
+ * `isDefault: true` provider for the (orgId, userId) scope. Used as the
+ * cross-framework fallback in admission (see Epic #11520 — provider's
+ * framework wins over compose's once admission resolves a provider).
+ */
+async function getAnyDefaultModelProvider(
+  orgId: string,
+  userId: string,
+): Promise<ModelProviderInfo | null> {
+  const allProviders = await globalThis.services.db
+    .select({
+      id: modelProviders.id,
+      type: modelProviders.type,
+      isDefault: modelProviders.isDefault,
+      selectedModel: modelProviders.selectedModel,
+      authMethod: modelProviders.authMethod,
+      secretName: secrets.name,
+      createdAt: modelProviders.createdAt,
+      updatedAt: modelProviders.updatedAt,
+    })
+    .from(modelProviders)
+    .leftJoin(secrets, eq(modelProviders.secretId, secrets.id))
+    .where(
+      and(eq(modelProviders.orgId, orgId), eq(modelProviders.userId, userId)),
+    );
+
+  const defaultProvider = allProviders.find((p) => {
+    return p.isDefault && p.type in MODEL_PROVIDER_TYPES;
+  });
+
+  if (!defaultProvider) {
+    return null;
+  }
+
+  return toModelProviderInfo({
+    id: defaultProvider.id,
+    type: defaultProvider.type as ModelProviderType,
+    secretName: defaultProvider.secretName,
+    authMethod: defaultProvider.authMethod,
+    isDefault: defaultProvider.isDefault,
+    selectedModel: defaultProvider.selectedModel,
+    createdAt: defaultProvider.createdAt,
+    updatedAt: defaultProvider.updatedAt,
+  });
+}
+
 // ============================================================================
 // Org-Level Model Provider Functions
 //
@@ -1069,6 +1116,48 @@ export async function getOrgDefaultModelProviderType(
         eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
         eq(modelProviders.isDefault, true),
         inArray(modelProviders.type, frameworkTypes),
+      ),
+    )
+    .limit(1);
+
+  return row?.type ?? null;
+}
+
+/**
+ * Get the org-level default model provider regardless of framework.
+ *
+ * Used as the cross-framework fallback by admission (Stage B) when
+ * `getOrgDefaultModelProvider(orgId, composeFramework)` returns null. Per
+ * Epic #11520, the provider's framework wins; admission accepts any default
+ * and downstream stages route via `resolvedFramework`.
+ *
+ * Returns null only when the org has no `isDefault: true` provider for any
+ * framework. Telegram / Slack / chat-title callers keep using the strict
+ * framework-scoped variant — they want the claude-code default specifically.
+ */
+export function getOrgAnyDefaultModelProvider(
+  orgId: string,
+): Promise<ModelProviderInfo | null> {
+  return getAnyDefaultModelProvider(orgId, ORG_SENTINEL_USER_ID);
+}
+
+/**
+ * Type-only variant of `getOrgAnyDefaultModelProvider`, mirroring the shape
+ * of `getOrgDefaultModelProviderType`. Accepts a db handle so callers inside
+ * queue-drain transactions can keep the read in the same boundary.
+ */
+export async function getOrgAnyDefaultModelProviderType(
+  orgId: string,
+  db: Database = globalThis.services.db,
+): Promise<string | null> {
+  const [row] = await db
+    .select({ type: modelProviders.type })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.orgId, orgId),
+        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+        eq(modelProviders.isDefault, true),
       ),
     )
     .limit(1);

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -18,6 +18,8 @@ import { checkOrgCredits } from "./credit/check-org-credits";
 import {
   getOrgDefaultModelProvider,
   getOrgDefaultModelProviderType,
+  getOrgAnyDefaultModelProvider,
+  getOrgAnyDefaultModelProviderType,
   getModelProviderByIdForOrg,
 } from "./model-provider/model-provider-service";
 import type { Database } from "../../types/global";
@@ -139,9 +141,14 @@ export async function validateComposeRequirements(
 /**
  * Resolve the provider type that admission checks should treat as the
  * effective key source for this run. Precedence:
- *   explicit override → explicit modelProviderId → org default for framework.
- * Returns null when nothing is configured (admission decides whether that
- * is fatal).
+ *   explicit override → explicit modelProviderId → org default for compose
+ *   framework → any org default (cross-framework fallback).
+ *
+ * The cross-framework fallback implements Epic #11520's "provider's framework
+ * wins" rule at the admission boundary: an org with only a codex provider
+ * still admits a claude-code compose; the provider's framework propagates
+ * downstream via `resolvedFramework` so dispatch launches the right binary.
+ * Returns null only when the org has no `isDefault: true` provider at all.
  */
 export async function resolveProviderTypeForAdmission(params: {
   orgId: string;
@@ -159,10 +166,9 @@ export async function resolveProviderTypeForAdmission(params: {
     );
     return row?.type ?? null;
   }
-  const def = await getOrgDefaultModelProvider(
-    params.orgId,
-    params.composeFramework,
-  );
+  const def =
+    (await getOrgDefaultModelProvider(params.orgId, params.composeFramework)) ??
+    (await getOrgAnyDefaultModelProvider(params.orgId));
   return def?.type ?? null;
 }
 
@@ -227,10 +233,13 @@ export async function checkModelProviderConfigured(
   });
   if (hasExplicitConfig) return;
 
-  const defaultProviderType = await getOrgDefaultModelProviderType(
-    orgId,
-    framework,
-  );
+  // Framework-scoped default first; fall back to any org default so a
+  // codex-only org still admits a claude-code compose. Mirrors the
+  // cross-framework fallback in resolveProviderTypeForAdmission — see
+  // Epic #11520 for the provider-framework-wins design intent.
+  const defaultProviderType =
+    (await getOrgDefaultModelProviderType(orgId, framework)) ??
+    (await getOrgAnyDefaultModelProviderType(orgId));
 
   if (!defaultProviderType) {
     throw noModelProvider();


### PR DESCRIPTION
## Summary

Closes #11684. Fixes the residual gap from Epic #11520: when an org has only an `openai-api-key` (codex framework) provider marked as default and submits a `framework: claude-code` compose, admission previously rejected with `noModelProvider()` because the lookup filtered by compose framework. Dispatch had the same gap when no `modelProviderId` was pinned.

- Adds paired helpers `getOrgAnyDefaultModelProvider` / `getOrgAnyDefaultModelProviderType` for cross-framework lookup
- Wires them as the fallback after the framework-scoped query returns null in three call sites:
  - `resolveProviderTypeForAdmission` (Stage B admission)
  - `checkModelProviderConfigured` (Stage B pre-flight)
  - `resolveModelProviderSecrets` (Stage C dispatch)
- Framework-scoped lookup remains the **preferred** path so Telegram footer (`telegram/footer.ts`) and Slack callback (`callbacks/slack/org/route.ts`) keep their strict claude-code semantics
- Implements Epic #11520's "provider's framework wins" rule end-to-end across admission and dispatch

## Why new helpers (Option A) over a flag

The framework-scoped helpers `getOrgDefaultModelProvider*` are used by Telegram and Slack callsites that intentionally request the org's claude-code default. Adding an `allowCrossFramework` flag would force those callsites to opt-out and risks future regressions. A separate paired helper expresses the cross-framework intent at the callsite — readers see "framework first, then any default" without digging into SQL.

## Test plan

- [x] New regression test (happy path): codex-only org admits a claude-code compose → 201 + `cliAgentType=codex`
- [x] New regression test (negative twin): org with no default provider → 422 `NO_MODEL_PROVIDER`
- [x] Full route test suite passes (38/38)
- [x] Full `src/lib/zero` test suite passes (771/771)
- [x] Lint clean, knip clean, format clean, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)