### PR TITLE
fix: buffer undici response body in proxyToWeb to prevent body loss

### DIFF
--- a/turbo/apps/api/src/app-factory.ts
+++ b/turbo/apps/api/src/app-factory.ts
@@ -99,7 +99,17 @@ async function proxyToWeb(context: Context, webUrl: string): Promise<Response> {
     }
   }
 
-  return new Response(Readable.toWeb(upstream.body) as ReadableStream, {
+  // Buffer the upstream body to avoid losing it when the undici Readable
+  // stream is re-wrapped in a new Response. In Vercel's Node.js runtime the
+  // ReadableStream wrapper may silently drop chunks beyond the first one,
+  // just as it does with the fetch-based code path.
+  const chunks: Buffer[] = [];
+  for await (const chunk of upstream.body) {
+    chunks.push(chunk);
+  }
+  const body = Buffer.concat(chunks);
+
+  return new Response(body, {
     status: upstream.statusCode,
     headers: responseHeaders,
   });


### PR DESCRIPTION
## Summary

`proxyToWeb` was refactored from `fetch` to `undici.request`, but the body buffering fix from #11572 was lost in the refactor.  The current code wraps the undici `Readable` body via `Readable.toWeb()` into a new `Response`, which causes multi-chunk streams to be silently dropped in Vercel's Node.js runtime — the same root cause as the original proxy body loss bug.

**Impact**: `POST /api/zero/chat/messages` and all other unregistered routes proxied to web return empty response bodies, causing the frontend to fail with a 500 toast when sending messages through the API backend.

## Fix

Buffer the undici `Readable` body before creating the `Response`, matching the same pattern from the original fix.

## Test plan

- [ ] CI passes
- [ ] Deploy to preview and verify `POST /api/zero/chat/messages` returns a non-empty body
- [ ] Verify the chat send flow works end-to-end via `api.vm0.ai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)