### PR TITLE
fix(api): pass null body to fallthrough proxy for null-body upstream statuses

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -343,6 +343,30 @@ describe("createApp", () => {
 
       expect(response.status).toBe(200);
     });
+
+    it.each([204, 205, 304])(
+      "forwards null-body status %s without constructing a Response with a stream",
+      async (statusCode) => {
+        mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
+        useUndiciMock()
+          .get("https://www.vm0.ai")
+          .intercept({
+            path: "/api/zero/chat-threads/abc",
+            method: "PATCH",
+          })
+          .reply(statusCode, "");
+
+        const app = createApp({ signal: context.signal });
+        const response = await app.request("/api/zero/chat-threads/abc", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: '{"draftContent":"hello"}',
+        });
+
+        expect(response.status).toBe(statusCode);
+        await expect(response.text()).resolves.toBe("");
+      },
+    );
   });
 
   describe("cors", () => {

--- a/turbo/apps/api/src/app-factory.ts
+++ b/turbo/apps/api/src/app-factory.ts
@@ -50,6 +50,22 @@ function isProxyRequestHeader(name: string): boolean {
   return Object.hasOwn(PROXY_REQUEST_HEADERS, name.toLowerCase());
 }
 
+// Statuses for which the WHATWG Response constructor rejects a non-null body
+// argument (fetch spec: "null body status"). Even an empty stream is a
+// non-null body object, so we must hand `null` to `new Response` here — and
+// drain the upstream stream separately so undici can release the connection.
+const NULL_BODY_STATUSES: Readonly<Record<number, true>> = {
+  101: true,
+  103: true,
+  204: true,
+  205: true,
+  304: true,
+};
+
+function isNullBodyStatus(status: number): boolean {
+  return Object.hasOwn(NULL_BODY_STATUSES, status);
+}
+
 async function proxyToWeb(context: Context, webUrl: string): Promise<Response> {
   const incoming = new URL(context.req.url);
   const target = new URL(`${incoming.pathname}${incoming.search}`, webUrl);
@@ -97,6 +113,14 @@ async function proxyToWeb(context: Context, webUrl: string): Promise<Response> {
     for (const cookie of list) {
       responseHeaders.append("set-cookie", cookie);
     }
+  }
+
+  if (isNullBodyStatus(upstream.statusCode)) {
+    upstream.body.resume();
+    return new Response(null, {
+      status: upstream.statusCode,
+      headers: responseHeaders,
+    });
   }
 
   return new Response(Readable.toWeb(upstream.body) as ReadableStream, {


### PR DESCRIPTION
## Summary
- The legacy fallthrough proxy in `apps/api/src/app-factory.ts` (`proxyToWeb`) unconditionally wrapped the undici upstream body in `new Response(...)`, even when the upstream status was in the WHATWG "null body status" set (101 / 103 / 204 / 205 / 304). The Response constructor rejects any non-null body for those statuses with `TypeError: Response constructor: Invalid response status code 204`, which the api Hono `onError` handler then converts into a generic 500 with empty body.
- This surfaced once the `apiBackend` feature switch routed `PATCH /api/zero/chat-threads/:id` (and any other 204/205/304-returning endpoint not yet ported off the web app) through the fallthrough proxy: web returns 204, the proxy crashes, browser sees 500.
- Fix: hand `null` to `new Response(...)` for null-body statuses and call `upstream.body.resume()` so undici can release the keep-alive connection. Adds an `it.each([204, 205, 304])` regression test in `app-factory.test.ts`. (101 / 103 are unreachable as terminal responses through `undici.request()` and trigger an unrelated mock-utils crash, so they remain in the runtime check but are skipped from the test parameterization.)

## Test plan
- [x] `pnpm -F api lint`
- [x] `pnpm -F api exec vitest run` (31 files / 209 tests)
- [x] `pnpm check-types`
- [x] `pnpm format` (no changes)
- [x] Manual: stash the fix → all 3 new tests fail with status 500; reapply → all pass
- [x] Manual: with `apiBackend` lab flag on, `PATCH /api/zero/chat-threads/:id` previously returned 500 (`TypeError: ... 204`); same path on this branch returns 204 cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)