### PR TITLE
docs(vsock-proto): fix decode_exec return docs

### DIFF
--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -418,7 +418,7 @@ fn decode_exec_inner(
     ))
 }
 
-/// Decode exec payload. Returns `(timeout_ms, command, env, sudo)`.
+/// Decode exec payload into a [`DecodedExec`] struct.
 pub fn decode_exec(payload: &[u8]) -> Result<DecodedExec<'_>, ProtocolError> {
     decode_exec_inner(payload, EXEC_FLAG_SUDO).map(|(d, _)| d)
 }


### PR DESCRIPTION
## Summary
- update decode_exec rustdoc to reference the DecodedExec struct instead of stale tuple fields

Fixes #11664

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto --all-targets
- RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml -p vsock-proto --no-deps
- pre-commit: cargo-fmt, cargo-clippy, cargo-doc