### PR TITLE
docs(runner): document doctor entry points

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -16,6 +16,7 @@ use serde::Deserialize;
 // CLI args
 // ---------------------------------------------------------------------------
 
+/// CLI arguments for the `doctor` subcommand.
 #[derive(Args)]
 pub struct DoctorArgs {
     /// Only check the runner with this name (matches config `name` field)
@@ -346,6 +347,10 @@ struct StoppedInfo {
 // Entry point
 // ---------------------------------------------------------------------------
 
+/// Run runtime health diagnostics for runner processes on this host.
+///
+/// Returns `ExitCode::FAILURE` when any per-runner or global anomaly still
+/// persists after targeted rechecks; otherwise returns `ExitCode::SUCCESS`.
 pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
     // Phase 1: Discover running processes (single /proc scan)
     let discovered = process::discover_all().await;


### PR DESCRIPTION
## Summary

- document `DoctorArgs` as the `doctor` subcommand argument type
- document `run_doctor` return semantics for persistent anomalies after targeted rechecks

Closes #11674

## Tests

- `cargo fmt --manifest-path crates/runner/Cargo.toml --check`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- pre-commit: `cargo-fmt`, `cargo-doc`, `cargo-clippy`
