### PR TITLE
fix: add safe-area-inset-top to mobile top bar for PWA

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -205,7 +205,10 @@ function MobileTopBar() {
   const activeId = useGet(activeRoute$);
 
   return (
-    <div className="md:hidden shrink-0 flex items-center h-12 px-3 gap-2 bg-background border-b border-border/50 z-10">
+    <div
+      className="md:hidden shrink-0 flex items-center min-h-12 px-3 gap-2 bg-background border-b border-border/50 z-10"
+      style={{ paddingTop: "env(safe-area-inset-top)" }}
+    >
       <button
         type="button"
         onClick={() => {


### PR DESCRIPTION
## Summary
- Fixes the PWA hamburger menu overlapping with the iOS status bar by adding `env(safe-area-inset-top)` padding to the `MobileTopBar`
- Changes `h-12` to `min-h-12` so the bar can grow with the safe area inset

## Root Cause
The app uses `viewport-fit=cover` (index.html) and `display: standalone` (manifest), which makes content render edge-to-edge under the iOS status bar. The `MobileTopBar` had a fixed 48px height with no safe-area awareness, placing the hamburger button directly underneath the status bar clock/text.

## Fix
- `sidebar-layout.tsx`: Added `style={{ paddingTop: "env(safe-area-inset-top)" }}` to the `MobileTopBar` container, following the same pattern already used in `zero-chat-thread-page.tsx` for `safe-area-inset-bottom`
- Changed `h-12` → `min-h-12` so the bar grows when safe-area padding is applied

## Test Plan
- [ ] Open PWA on iPhone (notch or dynamic island model) — hamburger menu should be visible below the status bar
- [ ] Tap hamburger — sidebar should open/close normally
- [ ] Verify desktop (md+) layout is unaffected (mobile top bar is `md:hidden`)

Closes #11708

🤖 Generated with [Claude Code](https://claude.com/claude-code)