### PR TITLE
chore: restore dev runner r2 env

### DIFF
--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -16,6 +16,23 @@ CRATES_DIR="$PROJECT_ROOT/crates"
 
 log() { echo "[runner] $1" >&2; }
 
+shell_env_assignments() {
+  local output=""
+  local name
+  local value
+
+  while (($#)); do
+    name="$1"
+    value="${2-}"
+    shift 2
+
+    value=${value//\'/\'\\\'\'}
+    output+="$name='$value' "
+  done
+
+  printf "%s" "${output% }"
+}
+
 # --- Load config ---
 ENV_FILE="$SCRIPT_DIR/.env.local"
 if [[ ! -f "$ENV_FILE" ]]; then
@@ -93,7 +110,11 @@ cmd_deploy() {
   # ansible/playbooks/build-runner.yml's R2 env block. Applied to both
   # `gc` (sweeps shared R2 objects older than 7d) and `build` (pulls
   # cached rootfs instead of rebuilding ~3-5min locally).
-  R2_ENV="R2_ACCOUNT_ID='${R2_ACCOUNT_ID:-}' R2_ACCESS_KEY_ID='${R2_ACCESS_KEY_ID:-}' R2_SECRET_ACCESS_KEY='${R2_SECRET_ACCESS_KEY:-}' R2_USER_STORAGES_BUCKET_NAME='${R2_USER_STORAGES_BUCKET_NAME:-}'"
+  R2_ENV="$(shell_env_assignments \
+    R2_ACCOUNT_ID "${R2_ACCOUNT_ID:-}" \
+    R2_ACCESS_KEY_ID "${R2_ACCESS_KEY_ID:-}" \
+    R2_SECRET_ACCESS_KEY "${R2_SECRET_ACCESS_KEY:-}" \
+    R2_USER_STORAGES_BUCKET_NAME "${R2_USER_STORAGES_BUCKET_NAME:-}")"
 
   # Clean up old images (keep 3 most recent deploys)
   ssh_cmd "sudo $R2_ENV $REMOTE_BIN_DIR/runner gc --keep-latest 3"

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -88,10 +88,15 @@ cmd_deploy() {
   log "Running setup..."
   ssh_cmd "$RUNNER_BIN setup"
 
-  # Clean up old local images (keep 3 most recent deploys). Dev runner builds
-  # guest binaries locally, so its rootfs hash does not reliably match CI's
-  # x64-built artifacts; keep R2 disabled here to avoid misleading cache misses.
-  ssh_cmd "sudo $REMOTE_BIN_DIR/runner gc --keep-latest 3"
+  # R2 creds passed as sudo args so they survive sudo's env scrub. Empty
+  # values are treated as "unset" by r2_cache.rs, matching
+  # ansible/playbooks/build-runner.yml's R2 env block. Applied to both
+  # `gc` (sweeps shared R2 objects older than 7d) and `build` (pulls
+  # cached rootfs instead of rebuilding ~3-5min locally).
+  R2_ENV="R2_ACCOUNT_ID='${R2_ACCOUNT_ID:-}' R2_ACCESS_KEY_ID='${R2_ACCESS_KEY_ID:-}' R2_SECRET_ACCESS_KEY='${R2_SECRET_ACCESS_KEY:-}' R2_USER_STORAGES_BUCKET_NAME='${R2_USER_STORAGES_BUCKET_NAME:-}'"
+
+  # Clean up old images (keep 3 most recent deploys)
+  ssh_cmd "sudo $R2_ENV $REMOTE_BIN_DIR/runner gc --keep-latest 3"
 
   # Build unified image (rootfs + snapshot)
   PROFILES=("vm0/default")
@@ -100,7 +105,7 @@ cmd_deploy() {
   for PROFILE in "${PROFILES[@]}"; do
     log "Building $PROFILE..."
     BUILD_LOG=$(mktemp)
-    ssh_cmd "sudo $REMOTE_BIN_DIR/runner build --profile $PROFILE" | tee "$BUILD_LOG"
+    ssh_cmd "sudo $R2_ENV $REMOTE_BIN_DIR/runner build --profile $PROFILE" | tee "$BUILD_LOG"
     ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG" | cut -d= -f2)
     SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG" | cut -d= -f2)
     rm -f "$BUILD_LOG"


### PR DESCRIPTION
## Summary
- restore R2 env passthrough for dev runner gc and build commands
- keep empty R2 values behaving as unset for local dev environments

## Tests
- bash -n scripts/dev-runner.sh