### PR TITLE
fix(zero): respect resolved framework on session continue (#11728)

### DIFF
--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -13,7 +13,9 @@ import {
   getTestRun,
   getTestChatMessagesByThread,
   countUserRows,
+  completeTestRun,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import { setTestSessionFramework } from "../../../../../../src/__tests__/db-test-seeders/agents";
 import {
   getTestChatThreadModelOverride,
   getTestModelProviderIdByType,
@@ -1250,6 +1252,143 @@ describe("POST /api/zero/chat/messages", () => {
         const job = await findTestRunnerJobEntry(runId);
         expect(job).toBeDefined();
         expect(job!.executionContext.cliAgentType).toBe("claude-code");
+      });
+    });
+
+    describe("session continue framework derivation (Issue #11728)", () => {
+      // Production regression: chat thread eager-pinned to an
+      // openai-api-key provider on a compose declaring framework:
+      // claude-code. The first message dispatches cliAgentType=codex
+      // (from #11649), which the runner persists onto
+      // conversation.cliAgentType. Pre-fix, the second message failed
+      // because resolveSession compared the compose's literal framework
+      // ("claude-code") against the conversation's recorded framework
+      // ("codex"). Post-fix, the framework-compatibility check moved
+      // to build-zero-context and uses resolvedFramework.
+      it("dispatches cliAgentType=codex on the second message of an openai-pinned thread", async () => {
+        const { agentId: composeAgentId } = await createTestCompose(
+          uniqueId("continue-codex"),
+          { noEnvironmentBlock: true },
+        );
+        await insertOrgDefaultModelProvider(user.orgId, "openai-api-key");
+        const providerId = await getTestModelProviderIdByType(
+          user.orgId,
+          "openai-api-key",
+        );
+        await setTestZeroAgentModelProvider(
+          composeAgentId,
+          providerId,
+          "gpt-5",
+        );
+
+        const first = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId: composeAgentId,
+              prompt: "first",
+            }),
+          }),
+        );
+        expect(first.status).toBe(201);
+        const { threadId, runId } = await first.json();
+        await context.mocks.flushAfter();
+
+        // Fake the runner completion: creates conversation +
+        // agent_session. Stamp cliAgentType=codex on the conversation
+        // to mirror the post-#11649 webhook behavior (the
+        // createTestCheckpoint helper defaults to "test-agent").
+        const { agentSessionId } = await completeTestRun(user.userId, runId);
+        await setTestSessionFramework(agentSessionId, "codex");
+
+        const second = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId: composeAgentId,
+              prompt: "second",
+              threadId,
+            }),
+          }),
+        );
+        expect(second.status).toBe(201);
+        const { runId: secondRunId } = await second.json();
+        await context.mocks.flushAfter();
+
+        const job = await findTestRunnerJobEntry(secondRunId);
+        expect(job).toBeDefined();
+        expect(job!.executionContext.cliAgentType).toBe("codex");
+      });
+
+      it("fails the second-message run when resolvedFramework no longer matches the conversation's framework", async () => {
+        const { agentId: composeAgentId } = await createTestCompose(
+          uniqueId("continue-codex-mismatch"),
+          { noEnvironmentBlock: true },
+        );
+
+        // Force the cross-framework fallback path (no eager-pin on the
+        // agent or thread, so the route relies on the org default). On
+        // the first message the only default is openai-api-key (codex);
+        // on the second message we flip it back to anthropic-api-key
+        // (claude-code) to surface the framework mismatch against the
+        // conversation's persisted cliAgentType=codex.
+        const anthropicId = await getTestModelProviderIdByType(
+          user.orgId,
+          "anthropic-api-key",
+        );
+        await deleteTestModelProvider(anthropicId);
+        await insertOrgDefaultModelProvider(user.orgId, "openai-api-key");
+
+        const first = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId: composeAgentId,
+              prompt: "first",
+            }),
+          }),
+        );
+        expect(first.status).toBe(201);
+        const { threadId, runId } = await first.json();
+        await context.mocks.flushAfter();
+
+        const { agentSessionId } = await completeTestRun(user.userId, runId);
+        await setTestSessionFramework(agentSessionId, "codex");
+
+        // Flip the org default back to anthropic-api-key so the
+        // resolved framework for the second message is claude-code.
+        const codexId = await getTestModelProviderIdByType(
+          user.orgId,
+          "openai-api-key",
+        );
+        await deleteTestModelProvider(codexId);
+        await insertOrgDefaultModelProvider(user.orgId, "anthropic-api-key");
+
+        const second = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId: composeAgentId,
+              prompt: "second",
+              threadId,
+            }),
+          }),
+        );
+        // Phase 1 admits the run; the framework-compat check runs in
+        // Phase 2 (deferred dispatch) and surfaces as a failed run.
+        expect(second.status).toBe(201);
+        const { runId: secondRunId } = await second.json();
+        await context.mocks.flushAfter();
+
+        const failedRun = await getTestRun(secondRunId);
+        expect(failedRun.status).toBe("failed");
+        expect(failedRun.error).toMatch(
+          /framework changed from "codex" to "claude-code"/,
+        );
       });
     });
 

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -1297,8 +1297,8 @@ describe("POST /api/zero/chat/messages", () => {
 
         // Fake the runner completion: creates conversation +
         // agent_session. Stamp cliAgentType=codex on the conversation
-        // to mirror the post-#11649 webhook behavior (the
-        // createTestCheckpoint helper defaults to "test-agent").
+        // to mirror the post-#11649 webhook behavior (which writes the
+        // actually-dispatched framework, not the compose's literal one).
         const { agentSessionId } = await completeTestRun(user.userId, runId);
         await setTestSessionFramework(agentSessionId, "codex");
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
@@ -128,7 +128,11 @@ export async function createTestCheckpoint(
       },
       body: JSON.stringify({
         runId,
-        cliAgentType: "test-agent",
+        // Default to "claude-code" — the codebase's default framework and
+        // what production webhooks actually persist. Keeping a placeholder
+        // like "test-agent" creates false-positive mismatches in
+        // build-zero-context's framework-compatibility check on resume.
+        cliAgentType: "claude-code",
         cliAgentSessionId: `test-session-${runId}`,
         cliAgentSessionHistoryHash:
           "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",

--- a/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
@@ -631,11 +631,11 @@ export async function setTestSessionArtifacts(
 /**
  * Update the cliAgentType on the conversation linked to a session.
  *
- * @why-db-direct Test checkpoint helpers seed conversations with
- * cliAgentType "test-agent" while composes default to framework
- * "claude-code". Resolver compatibility checks compare these, so
- * resolveSession tests need to align the conversation framework before
- * invoking the resolver.
+ * @why-db-direct The framework-mismatch tests need to set a non-default
+ * cliAgentType on the seeded conversation to surface the
+ * build-zero-context compatibility check; doing it via webhook would
+ * require either a second checkpoint write or exposing internals on the
+ * webhook. A targeted UPDATE is the smallest seam.
  */
 export async function setTestSessionFramework(
   sessionId: string,

--- a/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
@@ -55,4 +55,14 @@ describe("resolveSession — artifacts passthrough", () => {
 
     expect(resolution.artifacts).toEqual([]);
   });
+
+  it("populates sessionFramework from conversation.cliAgentType", async () => {
+    const { runId } = await createTestRun(composeId, "framework field run");
+    const { agentSessionId } = await completeTestRun(user.userId, runId);
+    await setTestSessionFramework(agentSessionId, "codex");
+
+    const resolution = await resolveSession(agentSessionId, user.userId);
+
+    expect(resolution.sessionFramework).toBe("codex");
+  });
 });

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
@@ -136,5 +136,6 @@ export async function resolveCheckpoint(
     vars: agentComposeSnapshot.vars || {},
     volumeVersions: checkpointVolumeVersions?.versions,
     additionalVolumes: checkpointAdditionalVolumes,
+    sessionFramework: conversation.cliAgentType,
   };
 }

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-conversation.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-conversation.ts
@@ -79,5 +79,6 @@ export async function resolveDirectConversation(
     },
     // No defaults for artifact/vars/secrets/volumeVersions - use params directly
     artifacts: [],
+    sessionFramework: conversation.cliAgentType,
   };
 }

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-session.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-session.ts
@@ -8,7 +8,7 @@ import { notFound, unauthorized, badRequest } from "@vm0/api-services/errors";
 import { logger } from "../../../shared/logger";
 import { getAgentSessionWithConversation } from "../../agent-session";
 import type { ConversationResolution } from "./types";
-import { extractWorkingDir, extractCliAgentType } from "../utils";
+import { extractWorkingDir } from "../utils";
 import { resolveSessionHistory } from "./resolve-session-history";
 
 const log = logger("run:resolve-session");
@@ -22,7 +22,7 @@ const log = logger("run:resolve-session");
  * @returns ConversationResolution with all data needed to build execution context
  * @throws NotFoundError if session or related data not found
  * @throws UnauthorizedError if session doesn't belong to user
- * @throws BadRequestError if session data is invalid or framework changed
+ * @throws BadRequestError if session data is invalid
  */
 export async function resolveSession(
   sessionId: string,
@@ -55,11 +55,11 @@ export async function resolveSession(
   const conversation = session.conversation;
 
   // Run independent operations in parallel:
-  // - Compose → version → framework check chain (needs session.agentComposeId)
+  // - Compose → version chain (needs session.agentComposeId)
   // - Session history from R2 (needs session.conversation)
   // - Last run vars (needs conversation.runId)
   const [composeResult, sessionHistory, lastRunResult] = await Promise.all([
-    // Compose → version → framework check (serial chain)
+    // Compose → version (serial chain)
     (async () => {
       const [compose] = await globalThis.services.db
         .select()
@@ -87,16 +87,6 @@ export async function resolveSession(
 
       if (!version) {
         throw notFound(`Agent compose version ${versionId} not found`);
-      }
-
-      // Framework compatibility check: block continue if framework changed
-      const headFramework = extractCliAgentType(version.content);
-      const sessionFramework = conversation.cliAgentType;
-      if (headFramework !== sessionFramework) {
-        throw badRequest(
-          `Cannot continue session: framework changed from "${sessionFramework}" to "${headFramework}". ` +
-            `Start a new run instead.`,
-        );
       }
 
       return { versionId, version };
@@ -135,5 +125,6 @@ export async function resolveSession(
     vars: lastRunVars,
     volumeVersions: undefined,
     previousRunId: conversation.runId,
+    sessionFramework: conversation.cliAgentType,
   };
 }

--- a/turbo/apps/web/src/lib/infra/run/resolvers/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/types.ts
@@ -27,4 +27,12 @@ export interface ConversationResolution {
   additionalVolumes?: AdditionalVolume[];
   /** Run ID from the previous conversation (used by zero layer for provider compatibility) */
   previousRunId?: string;
+  /**
+   * Framework recorded on the conversation being continued
+   * (`conversations.cliAgentType`). Source of truth for the previous run's
+   * framework — compared against `resolvedFramework` in build-zero-context to
+   * detect mid-thread framework switches. Undefined for direct-conversation
+   * resumes from data that predates cliAgentType persistence.
+   */
+  sessionFramework: string | undefined;
 }

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -50,6 +50,7 @@ import {
   verifyOrgAccessForResume,
   resolveComposeFromId,
   checkProviderCompatibility,
+  checkFrameworkCompatibility,
   applyResolutionDefaults,
 } from "./context/resolve-source";
 
@@ -554,6 +555,7 @@ export async function resolveCliRunContext(
     environment,
     secretConnectorMap,
     resolvedModelProvider,
+    resolvedFramework,
     modelProviderConfig,
     selectedModel,
     connectorPermissionConfigs,
@@ -563,8 +565,9 @@ export async function resolveCliRunContext(
   } = secretsResult;
   const userTimezone = userPrefs?.timezone ?? undefined;
 
-  // Step 5: Provider compatibility check for session continues.
+  // Step 5: Compatibility checks for session continues.
   checkProviderCompatibility(originalModelProvider, resolvedModelProvider);
+  checkFrameworkCompatibility(resolution?.sessionFramework, resolvedFramework);
 
   // Build permission manifest
   const permissionResult = mergePermissions(
@@ -735,10 +738,14 @@ export async function buildZeroExecutionContext(
   const userTimezone =
     params.preloadedUserTimezone ?? userPrefs?.timezone ?? undefined;
 
-  // Step 5: Provider compatibility check for session continues.
-  // When resuming a session, verify the new provider is compatible with the
-  // original provider to avoid mid-conversation base URL mismatches.
+  // Step 5: Compatibility checks for session continues.
+  // - Provider: avoid mid-conversation base URL mismatches.
+  // - Framework: persisted cliAgentSessionHistory is in the previous
+  //   framework's format; switching binaries mid-thread can't replay it.
+  //   resolvedFramework is the source of truth (provider-derived since
+  //   #11649); the compose's `framework` field is no longer authoritative.
   checkProviderCompatibility(originalModelProvider, resolvedModelProvider);
+  checkFrameworkCompatibility(resolution?.sessionFramework, resolvedFramework);
 
   // Build permission manifest (base + auth entries for the runner).
   const permissionResult = mergePermissions(

--- a/turbo/apps/web/src/lib/zero/context/resolve-source.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-source.ts
@@ -153,6 +153,28 @@ export async function resolveComposeFromId(
 }
 
 /**
+ * Check that the resolved framework matches the framework recorded on the
+ * conversation being continued. Mid-thread framework changes are incompatible
+ * because the persisted `cliAgentSessionHistory` is in the previous framework's
+ * format and cannot be replayed by a different binary.
+ */
+export function checkFrameworkCompatibility(
+  sessionFramework: string | undefined,
+  resolvedFramework: string | undefined,
+): void {
+  if (
+    sessionFramework &&
+    resolvedFramework &&
+    sessionFramework !== resolvedFramework
+  ) {
+    throw badRequest(
+      `Cannot continue session: framework changed from "${sessionFramework}" to "${resolvedFramework}". ` +
+        `Start a new run instead.`,
+    );
+  }
+}
+
+/**
  * Check that the resolved model provider is compatible with the original
  * provider from the session being continued.
  */


### PR DESCRIPTION
## Summary

Fix [#11728](https://github.com/vm0-ai/vm0/issues/11728) — chat thread pinned to an `openai-api-key` provider on a `framework: claude-code` compose threw `Cannot continue session: framework changed from "codex" to "claude-code"` on every message after the first.

The framework-compatibility check in `resolve-session` was comparing the compose's literal `framework` field against `conversation.cliAgentType`. Since #11649 made the provider-derived `resolvedFramework` the source of truth (a `claude-code` compose backed by an `openai-api-key` provider actually dispatches `cliAgentType=codex`), comparing against the compose's literal field produced a false-positive mismatch on every continuation.

## Changes

- `ConversationResolution` gains a `sessionFramework` field, populated from `conversation.cliAgentType` in all three resolvers (`resolveSession`, `resolveCheckpoint`, `resolveDirectConversation`).
- The framework comparison is removed from `resolveSession` and re-implemented as `checkFrameworkCompatibility(sessionFramework, resolvedFramework)` in `lib/zero/context/resolve-source.ts`, alongside the existing `checkProviderCompatibility`.
- `buildZeroExecutionContext` and `resolveCliRunContext` call the new helper after model resolution, so the comparison uses the actual provider-derived framework instead of the compose declaration.

## Test plan

- [x] `pnpm -F web exec vitest run src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts` — resolver-level test for `sessionFramework` propagation.
- [x] `pnpm -F web exec vitest run app/api/zero/chat/messages/__tests__/route.test.ts -t "Issue #11728"` — chat-route happy path (openai-pinned + claude-code compose dispatches `cliAgentType=codex` on second message) and failed-run regression (org default flips back to anthropic, framework genuinely changes, second-message run fails with the framework-mismatch error in `run.error`).
- [x] `pnpm turbo run lint --filter=web` — clean.
- [x] `pnpm check-types` — clean.
- [x] `pnpm format` — no changes.
- [x] `pnpm knip --workspace web` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)