### PR TITLE
refactor(platform): split feature-switch reader and writer modules

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -53,7 +53,7 @@ import { setupRedeemCampaignPage$ } from "./redeem-campaign/redeem-campaign-page
 import { setupRealtime$ } from "./realtime.ts";
 import { setupPwaEdgeSwipe$ } from "./zero-page/pwa-edge-swipe.ts";
 import { setupSidebarShortcut$ } from "./zero-page/zero-nav.ts";
-import { reloadFeatureSwitch$ } from "./external/feature-switch.ts";
+import { reloadFeatureSwitch$ } from "./external/update-feature-switch.ts";
 
 /**
  * Catch-all fallback — redirects unknown paths to /.

--- a/turbo/apps/platform/src/signals/external/__tests__/feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/feature-switch.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { testContext } from "../../__tests__/test-helpers";
 import { detachedSetupPage, setupPage } from "../../../__tests__/page-helper";
+import { featureSwitch$ } from "../feature-switch";
 import {
-  featureSwitch$,
   reloadFeatureSwitch$,
   setFeatureSwitch$,
   resetFeatureSwitches$,
-} from "../feature-switch";
+} from "../update-feature-switch";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.helpers";

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -1,11 +1,6 @@
-import { command, computed } from "ccstate";
+import { computed } from "ccstate";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
-import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { clerk$ } from "../auth";
-import { accept } from "../../lib/accept.ts";
-import { resolveApiBase } from "../api-base.ts";
-import { createAuthedTsRestClient } from "../api-client-base.ts";
 import { localStorageSignals } from "./local-storage.ts";
 
 export const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v1";
@@ -13,34 +8,7 @@ export const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v1";
 const { set$: setFeatureSwitchLocalStorage$, get$: featureSwitchCache$ } =
   localStorageSignals(FEATURE_SWITCH_CACHE_KEY);
 
-// Pinned to the web backend: feature switches must load before
-// `apiBackendEnabled$` is known, so the transport that fetches them cannot
-// itself depend on it. Going through `zeroClient$` (which routes via
-// `apiBase$` → `apiBackendEnabled$` → `featureSwitch$`) creates a static
-// import cycle even though the runtime read is now sync from localStorage.
-const webFeatureSwitchClient$ = computed((get) => {
-  return createAuthedTsRestClient(zeroFeatureSwitchesContract, {
-    baseUrl: resolveApiBase(false),
-    getClerk: () => {
-      return get(clerk$);
-    },
-  });
-});
-
-function applySwitches(
-  result: Record<FeatureSwitchKey, boolean>,
-  overrides: Partial<Record<string, boolean>> | undefined,
-) {
-  if (!overrides) {
-    return;
-  }
-  for (const key of Object.values(FeatureSwitchKey)) {
-    const value = overrides[key];
-    if (value !== undefined) {
-      result[key] = Boolean(value);
-    }
-  }
-}
+export { setFeatureSwitchLocalStorage$ };
 
 export const featureSwitch$ = computed((get) => {
   const raw = get(featureSwitchCache$);
@@ -55,64 +23,6 @@ export const featureSwitch$ = computed((get) => {
 export const apiBackendEnabled$ = computed((get) => {
   return get(featureSwitch$)[FeatureSwitchKey.ApiBackend] ?? false;
 });
-
-export const reloadFeatureSwitch$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const clerk = await get(clerk$);
-    signal.throwIfAborted();
-
-    const user = clerk.user;
-    if (!user) {
-      return;
-    }
-
-    const client = get(webFeatureSwitchClient$);
-    const result = await accept(
-      client.get({ fetchOptions: { signal } }),
-      [200],
-    );
-    signal.throwIfAborted();
-
-    const combined = getAllFeatureStates({
-      userId: user.id,
-      email: user.primaryEmailAddress?.emailAddress,
-      orgId: clerk.organization?.id,
-    });
-    applySwitches(combined, result.body.switches);
-
-    set(setFeatureSwitchLocalStorage$, JSON.stringify(combined));
-  },
-);
-
-export const setFeatureSwitch$ = command(
-  async (
-    { get, set },
-    overrides: Partial<Record<FeatureSwitchKey, boolean>>,
-    signal: AbortSignal,
-  ) => {
-    const client = get(webFeatureSwitchClient$);
-    signal.throwIfAborted();
-    await accept(
-      client.update({
-        body: { switches: overrides },
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    signal.throwIfAborted();
-    await set(reloadFeatureSwitch$, signal);
-  },
-);
-
-export const resetFeatureSwitches$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const client = get(webFeatureSwitchClient$);
-    signal.throwIfAborted();
-    await accept(client.delete({ fetchOptions: { signal } }), [200]);
-    signal.throwIfAborted();
-    await set(reloadFeatureSwitch$, signal);
-  },
-);
 
 export const trinityEnabled$ = computed((get) => {
   return get(featureSwitch$)[FeatureSwitchKey.Trinity] ?? false;

--- a/turbo/apps/platform/src/signals/external/update-feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/update-feature-switch.ts
@@ -1,0 +1,79 @@
+import { command } from "ccstate";
+import { getAllFeatureStates } from "@vm0/core/feature-switch";
+import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { clerk$ } from "../auth";
+import { accept } from "../../lib/accept.ts";
+import { zeroClient$ } from "../api-client.ts";
+import { setFeatureSwitchLocalStorage$ } from "./feature-switch.ts";
+
+function applySwitches(
+  result: Record<FeatureSwitchKey, boolean>,
+  overrides: Partial<Record<string, boolean>> | undefined,
+) {
+  if (!overrides) {
+    return;
+  }
+  for (const key of Object.values(FeatureSwitchKey)) {
+    const value = overrides[key];
+    if (value !== undefined) {
+      result[key] = Boolean(value);
+    }
+  }
+}
+
+export const reloadFeatureSwitch$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+
+    const user = clerk.user;
+    if (!user) {
+      return;
+    }
+
+    const client = get(zeroClient$)(zeroFeatureSwitchesContract);
+    const result = await accept(
+      client.get({ fetchOptions: { signal } }),
+      [200],
+    );
+    signal.throwIfAborted();
+
+    const combined = getAllFeatureStates({
+      userId: user.id,
+      email: user.primaryEmailAddress?.emailAddress,
+      orgId: clerk.organization?.id,
+    });
+    applySwitches(combined, result.body.switches);
+
+    set(setFeatureSwitchLocalStorage$, JSON.stringify(combined));
+  },
+);
+
+export const setFeatureSwitch$ = command(
+  async (
+    { get, set },
+    overrides: Partial<Record<FeatureSwitchKey, boolean>>,
+    signal: AbortSignal,
+  ) => {
+    const client = get(zeroClient$)(zeroFeatureSwitchesContract);
+    await accept(
+      client.update({
+        body: { switches: overrides },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    await set(reloadFeatureSwitch$, signal);
+  },
+);
+
+export const resetFeatureSwitches$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const client = get(zeroClient$)(zeroFeatureSwitchesContract);
+    await accept(client.delete({ fetchOptions: { signal } }), [200]);
+    signal.throwIfAborted();
+    await set(reloadFeatureSwitch$, signal);
+  },
+);

--- a/turbo/apps/platform/src/views/lab-page/lab-page.tsx
+++ b/turbo/apps/platform/src/views/lab-page/lab-page.tsx
@@ -3,11 +3,11 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import { getFeatureSwitchDescriptions } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { Switch, Button } from "@vm0/ui";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
-  featureSwitch$,
   setFeatureSwitch$,
   resetFeatureSwitches$,
-} from "../../signals/external/feature-switch.ts";
+} from "../../signals/external/update-feature-switch.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 


### PR DESCRIPTION
## Summary

Stacked on top of #11729. Splits `feature-switch.ts` into a reader module (cache + computed selectors) and a new `update-feature-switch.ts` writer module (reload/set/reset commands using `zeroClient\$`).

The reader must be importable from \`fetch.ts\` to derive the api base url. Routing the writer through \`zeroClient\$\` therefore forms a static cycle:

\`\`\`
feature-switch.ts -> api-client.ts -> fetch.ts -> feature-switch.ts
\`\`\`

Moving the writer to its own module breaks the cycle — nothing imports the writer back through \`fetch.ts\`.

## Test plan

- [x] \`pnpm -F @vm0/app exec oxlint\` (no-cycle clean)
- [x] \`pnpm -F @vm0/app exec tsc --noEmit\`
- [x] Vitest: feature-switch + lab-page (13/13)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)