### PR TITLE
test(guest-init): cover env values with equals

### DIFF
--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -204,9 +204,10 @@ mod tests {
 
     #[test]
     fn parse_env_value_with_equals() {
-        let content = "NODE_EXTRA_CA_CERTS=/etc/ssl/ca.pem";
+        // Values may legitimately contain `=`; only the first one separates key/value.
+        let content = "TOKEN=abc=def==";
         let pairs = parse_env_content(content);
-        assert_eq!(pairs, vec![("NODE_EXTRA_CA_CERTS", "/etc/ssl/ca.pem")]);
+        assert_eq!(pairs, vec![("TOKEN", "abc=def==")]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- update `parse_env_value_with_equals` so the test value actually contains `=`
- document that only the first `=` separates the key and value

## Testing
- cargo test -p guest-init parse_env
- cargo test -p guest-init
- cargo clippy -p guest-init --all-targets --all-features -- -D warnings

Closes #11718