### PR TITLE
docs: document guest agent error variants

### DIFF
--- a/crates/guest-agent/src/error.rs
+++ b/crates/guest-agent/src/error.rs
@@ -3,21 +3,32 @@
 /// Agent error type covering all failure modes.
 #[derive(thiserror::Error, Debug)]
 pub enum AgentError {
+    /// HTTP helper boundary failure: request send/retry exhaustion, non-2xx
+    /// status, response body read, or response JSON parsing for webhook/S3 calls.
     #[error("http: {0}")]
     Http(String),
 
+    /// Local OS I/O failure outside the HTTP helper, such as filesystem access,
+    /// temporary directory creation, or child-process stdout/stderr pipes.
     #[error("io: {0}")]
     Io(#[from] std::io::Error),
 
+    /// JSON parse/serialize failure outside HTTP response handling.
     #[error("json: {0}")]
     Json(#[from] serde_json::Error),
 
+    /// Guest CLI or child-process lifecycle failure, including command setup,
+    /// missing pipes, timeout/termination, heartbeat fatal errors, and task panics.
     #[error("execution: {0}")]
     Execution(String),
 
+    /// Checkpoint, session-history, or artifact snapshot workflow failure inside
+    /// the guest-agent; this does not refer to Firecracker/rootfs snapshots.
     #[error("checkpoint: {0}")]
     Checkpoint(String),
 
+    /// Telemetry flush channel is unavailable because the uploader task was not
+    /// initialized, has exited, or dropped the per-flush response channel.
     #[error("telemetry uploader unavailable")]
     TelemetryUnavailable,
 }


### PR DESCRIPTION
## Summary
- add doc comments for each `AgentError` variant
- document subsystem boundaries for HTTP, IO, JSON, execution, checkpoint, and telemetry errors
- clarify that checkpoint errors are guest-agent artifact/session-history/checkpoint workflow failures, not Firecracker/rootfs snapshots

Closes #11681

## Tests
- cargo check --manifest-path crates/Cargo.toml -p guest-agent --all-targets
- cargo doc --manifest-path crates/Cargo.toml -p guest-agent --no-deps
- git diff --check
- pre-commit: cargo-fmt, cargo-clippy, cargo-doc