### PR TITLE
perf(auth): preconnect to clerk frontend api host

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -8,6 +8,24 @@
       // total white-screen duration up to the first `hideAppSkeleton$` call.
       window.__appBootstrapStart = performance.now();
     </script>
+    <script>
+      // Preconnect to the Clerk Frontend API host so the DNS+TCP+TLS
+      // handshake overlaps with bundle download. The publishable key is
+      // shaped pk_<env>_<base64(host$)>; decoding it here avoids hard-coding
+      // the FAPI domain per environment.
+      (function () {
+        var k = "%VITE_CLERK_PUBLISHABLE_KEY%";
+        var m = /^pk_(?:test|live)_(.+)$/.exec(k);
+        if (!m) return;
+        var host = atob(m[1]).replace(/\$+$/, "");
+        if (!/^[a-z0-9.-]+$/i.test(host)) return;
+        var l = document.createElement("link");
+        l.rel = "preconnect";
+        l.href = "https://" + host;
+        l.crossOrigin = "anonymous";
+        document.head.appendChild(l);
+      })();
+    </script>
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="manifest" href="/manifest.webmanifest" />

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -9,7 +9,10 @@ import {
   JetBrains_Mono,
 } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
-import { getClerkPublishableKey } from "../src/lib/shared/clerk-config";
+import {
+  getClerkFrontendApiHost,
+  getClerkPublishableKey,
+} from "../src/lib/shared/clerk-config";
 import { getAppUrl } from "../src/lib/zero/url";
 import { ThemeProvider } from "./components/ThemeProvider";
 import { env } from "../src/env";
@@ -135,6 +138,7 @@ export default async function RootLayout({
   // Locale is derived via next-intl (set by middleware + i18n.ts request config).
   // Drives the <html lang> attribute so non-English pages are indexed correctly.
   const htmlLang = await getLocale();
+  const clerkFapiHost = getClerkFrontendApiHost();
   return (
     <ClerkProvider
       publishableKey={getClerkPublishableKey()}
@@ -156,6 +160,13 @@ export default async function RootLayout({
             href="https://fonts.gstatic.com"
             crossOrigin="anonymous"
           />
+          {clerkFapiHost && (
+            <link
+              rel="preconnect"
+              href={`https://${clerkFapiHost}`}
+              crossOrigin="anonymous"
+            />
+          )}
           <link rel="dns-prefetch" href="https://plausible.io" />
           {/*
             Theme init must run synchronously in <head> before paint to avoid

--- a/turbo/apps/web/src/lib/shared/clerk-config.ts
+++ b/turbo/apps/web/src/lib/shared/clerk-config.ts
@@ -7,3 +7,16 @@ export function getClerkPublishableKey(): string {
   const environment = env();
   return environment.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? "";
 }
+
+// Publishable key shape: pk_<test|live>_<base64(host$)>. Decoding lets us
+// emit a <link rel="preconnect"> to the Frontend API host before clerk-js
+// boots, saving the DNS+TCP+TLS round trips on first auth request.
+export function getClerkFrontendApiHost(): string | null {
+  const [, encoded] =
+    /^pk_(?:test|live)_(.+)$/.exec(getClerkPublishableKey()) ?? [];
+  if (!encoded) return null;
+  const host = Buffer.from(encoded, "base64")
+    .toString("utf8")
+    .replace(/\$+$/, "");
+  return /^[a-z0-9.-]+$/i.test(host) ? host : null;
+}


### PR DESCRIPTION
## Summary

- Decode the Frontend API host from the Clerk publishable key (`pk_<env>_<base64(host$)>`) and emit `<link rel="preconnect">` in both the Next.js web app `<head>` and the platform Vite `index.html`.
- Saves the DNS+TCP+TLS handshake (~100–300ms) so it overlaps with clerk-js bundle download instead of blocking the first `/v1/environment` and `/v1/client` calls.
- Deriving the host from the key (rather than hard-coding) keeps dev (`*.clerk.accounts.dev`) and prod (custom domain) working from the same code path.

## Why preconnect, not preload-fetch

Investigated whether we could preload `/v1/environment` or even the first JWT in `index.html`. Conclusion:

- `/v1/environment` can be HTTP-cache-prewarmed but `clerk-js` won't reuse the response — its own `BaseResource` fetcher always re-fetches. Marginal benefit.
- The session JWT (`POST /v1/client/sessions/{sid}/tokens`) cannot be fetched early: `sid` only comes from `/v1/client`, the SDK's `tokenCache` has no public injection path, and tokens TTL out at 60s anyway.
- Preconnecting the FAPI host is the highest-ROI optimization with zero contract risk.

## Behavior on edge cases

- Missing key, malformed prefix, or non-base64 payload → helper returns `null` / inline IIFE returns early. No `<link>` emitted.
- Hostname is sanity-checked with `/^[a-z0-9.-]+$/i` before being used.

## Test plan

- [x] `pnpm lint` clean (web + platform)
- [x] `pnpm check-types` clean (turbo run, all 14 packages)
- [x] `pnpm vitest run` clean (web: 4056 tests; platform: 2262 tests)
- [x] `pnpm knip` clean
- [x] Verified base64 decode against the actual dev key (`pk_test_aW5mb3JtZWQtY2FsZi02LmNsZXJrLmFjY291bnRzLmRldiQ` → `informed-calf-6.clerk.accounts.dev`)
- [ ] DevTools Network panel: confirm preconnect fires before `clerk-js` bundle download starts
- [ ] Verify a `pk_live_*` production key decodes to the custom FAPI domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)