### PR TITLE
perf(chat): skip skeleton on idb cache hit

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -163,10 +163,23 @@ const setupPaneThread$ = command(
     const { draft, isNew } = set(ensureDraft$, threadId);
     const idbEnabled = await get(idbMessageEnabled$);
     signal.throwIfAborted();
+    // Forward-reference so the data source can flip the skeleton on at the
+    // moment it discovers a cache miss, before the network fetch starts.
+    let onIdbMiss: () => void = () => {};
     const dataSource = idbEnabled
-      ? createIdbCachedDataSource(threadId)
+      ? createIdbCachedDataSource(threadId, () => {
+          onIdbMiss();
+        })
       : createRemoteChatThreadDataSource(threadId);
     const thread = createChatThreadSignals(threadId, draft, dataSource);
+    onIdbMiss = () => {
+      set(thread.showSkeleton$);
+    };
+    if (!idbEnabled) {
+      // No local cache — every load goes to the network, so the skeleton is
+      // unconditional.
+      set(thread.showSkeleton$);
+    }
 
     if (!matchingOptimistic) {
       set(spec.setPaneThread$, thread);

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -151,10 +151,11 @@ export interface ChatThreadSignals {
   scrollToBottom$: Command<void, []>;
   scrollToTop$: Command<void, []>;
   // ── Initial-load skeleton ────────────────────────────────────────────────
-  // True until the page setup has fetched messages and scrolled into place.
-  // Keeps the list mounted (visibility:hidden) while the skeleton covers the
-  // viewport, so the first paint the user sees is already at the bottom.
+  // Starts hidden — `setupChatThreadInitScroll$` flips it on only when the
+  // IDB cache misses, so cache hits skip the skeleton entirely. Flipped off
+  // once messages resolve and the viewport is scrolled into place.
   skeletonVisible$: Computed<boolean>;
+  showSkeleton$: Command<void, []>;
   hideSkeleton$: Command<void, []>;
   draft: DraftSignals;
   composerFileInput$: Computed<HTMLElement | null>;
@@ -866,14 +867,17 @@ export const ensureDraft$ = command(
 );
 
 function createSkeletonSignals() {
-  const internalSkeletonVisible$ = state(true);
+  const internalSkeletonVisible$ = state(false);
   const skeletonVisible$ = computed((get) => {
     return get(internalSkeletonVisible$);
+  });
+  const showSkeleton$ = command(({ set }) => {
+    set(internalSkeletonVisible$, true);
   });
   const hideSkeleton$ = command(({ set }) => {
     set(internalSkeletonVisible$, false);
   });
-  return { skeletonVisible$, hideSkeleton$ };
+  return { skeletonVisible$, showSkeleton$, hideSkeleton$ };
 }
 
 function createInputRef() {
@@ -1235,7 +1239,8 @@ export function createChatThreadSignals(
     scrollToTop$,
     recordScrollHeightForPrepend$,
   } = createScrollSignals(threadId);
-  const { skeletonVisible$, hideSkeleton$ } = createSkeletonSignals();
+  const { skeletonVisible$, showSkeleton$, hideSkeleton$ } =
+    createSkeletonSignals();
   const { composerFileInput$, setComposerFileInput$ } =
     createComposerFileInput();
   const { agentId$, agentDisplayName$, agentModelDefault$, agentPinned$ } =
@@ -1309,6 +1314,7 @@ export function createChatThreadSignals(
     scrollToBottom$,
     scrollToTop$,
     skeletonVisible$,
+    showSkeleton$,
     hideSkeleton$,
     draft,
     composerFileInput$,

--- a/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
@@ -147,6 +147,7 @@ function createSubscribeRealtime(remote: ChatThreadDataSource) {
 
 export function createIdbCachedDataSource(
   threadId: string,
+  onInitialPageCacheMiss?: () => void,
 ): ChatThreadDataSource {
   const remote = createRemoteChatThreadDataSource(threadId);
 
@@ -166,6 +167,7 @@ export function createIdbCachedDataSource(
 
     if (!userId || !orgId) {
       L.debug("initialPage:noAuth", { threadId });
+      onInitialPageCacheMiss?.();
       return get(remote.initialPage$);
     }
 
@@ -179,6 +181,7 @@ export function createIdbCachedDataSource(
     }
 
     L.debug("initialPage:cacheMiss", { threadId });
+    onInitialPageCacheMiss?.();
     const page = await get(remote.initialPage$);
     const writeStore = stores.writeStore;
     await writeStore.upsertMessages(threadId, page.messages);


### PR DESCRIPTION
## Summary

- Default the chat thread skeleton to hidden so a cache hit renders messages immediately, with no skeleton flash in between.
- `createIdbCachedDataSource` accepts an `onInitialPageCacheMiss` callback and fires it from the existing miss / no-auth branches inside `initialPage$`. The callback flips `thread.showSkeleton$`.
- Non-IDB code paths (feature switch off) keep the skeleton behavior — `setupPaneThread$` shows it unconditionally before mounting since every load goes to the network.

## Test plan

- [ ] `pnpm -F @vm0/app exec tsc --noEmit`
- [ ] `pnpm -F @vm0/app exec vitest run src/signals/chat-page`
- [ ] Manually open a chat thread that has been visited before (IDB hit) — expect no skeleton flash
- [ ] Manually open a fresh thread (IDB miss) — expect skeleton during fetch, hidden after messages arrive
- [ ] Toggle `idbMessage` feature switch off — expect skeleton on every open

🤖 Generated with [Claude Code](https://claude.com/claude-code)