### PR TITLE
docs(runner): document start command module

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1,3 +1,25 @@
+//! `runner start` — run the long-lived worker loop.
+//!
+//! `run_start` registers lifecycle signals early, loads config, claims the
+//! canonical runner `base_dir` lock, initializes shared resources, then enters
+//! `run()`, the main reactor for discovery, heartbeats, job execution,
+//! idle-pool maintenance, mitmproxy restart, and teardown.
+//!
+//! The sibling modules keep focused responsibilities out of this orchestration
+//! file:
+//! - `identity`: persistent runner id storage.
+//! - `job_lifecycle`: cleanup, budget, and completion ownership state.
+//! - `mitm_restart`: mitmproxy crash restart and backoff.
+//! - `signals`: lifecycle signal registration and mode transitions.
+//!
+//! Important invariants:
+//! - one process owns the canonical `base_dir` lock;
+//! - lifecycle signals are registered before slow startup work;
+//! - discovery is pinned across `select!` ticks so heartbeat and cleanup
+//!   branches do not restart polling;
+//! - the first heartbeat and idle-cleanup ticks are deferred;
+//! - teardown drops discovery before provider shutdown.
+
 use std::collections::{BTreeMap, HashMap};
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;


### PR DESCRIPTION
## Summary
- add a module-level overview for `runner start`
- document the nearby start submodules and their responsibilities
- call out stable invariants around base-dir locking, early signals, pinned discovery, deferred ticks, and teardown ordering

## Testing
- cargo doc -p runner --no-deps
- cargo clippy -p runner --all-targets --all-features -- -D warnings

Closes #11721