### PR TITLE
feat(skeleton): gate prefetch await behind a feature switch

### DIFF
--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -1,10 +1,12 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { currentChatAgent$ } from "./agent-chat.ts";
 import { resolveAvatarUrl } from "../views/zero-page/avatar-utils.ts";
 import { resetSignal, bestEffort, setLoop } from "./utils.ts";
 import { agents$ } from "./agent.ts";
 import { getAvatarPresets } from "../views/zero-page/zero-avatars.ts";
 import { captureFirstSkeletonHide$ } from "../lib/posthog.ts";
+import { featureSwitch$ } from "./external/feature-switch.ts";
 
 // ---------------------------------------------------------------------------
 // Visibility
@@ -125,14 +127,17 @@ const prefetchAvatar$ = command(async ({ get }, signal: AbortSignal) => {
 });
 
 export const hideAppSkeleton$ = command(
-  async ({ set }, signal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
     set(resetSkeletonCycling$);
 
-    await Promise.all([
-      set(prefetch$, prefetchAvatar$, signal),
-      set(prefetch$, agents$, signal),
-    ]);
-    signal.throwIfAborted();
+    const noPreload = get(featureSwitch$)[FeatureSwitchKey.SkeletonNoPreload];
+    if (!noPreload) {
+      await Promise.all([
+        set(prefetch$, prefetchAvatar$, signal),
+        set(prefetch$, agents$, signal),
+      ]);
+      signal.throwIfAborted();
+    }
 
     set(internalVisible$, false);
     set(captureFirstSkeletonHide$);

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -56,4 +56,5 @@ export enum FeatureSwitchKey {
   GumroadConnector = "gumroadConnector",
   CodexBeta = "codexBeta",
   IdbMessage = "idbMessage",
+  SkeletonNoPreload = "skeletonNoPreload",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -317,6 +317,15 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.SkeletonNoPreload]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Hide the app skeleton without awaiting agents/avatar prefetch. " +
+      "When on, the skeleton hides as soon as the route resolves, " +
+      "letting components render with their own loading states.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary
- Add staff-only `skeletonNoPreload` feature switch (`FeatureSwitchKey.SkeletonNoPreload`).
- When the switch is on, `hideAppSkeleton$` no longer awaits `agents$` and the avatar prefetch — the skeleton hides as soon as the route resolves and downstream components handle their own loading.

## Motivation
Profiling `app.vm0.ai` shows the skeleton stays up ~1.0–2.2s after HTML response, dominated by the serial chain `currentChatAgent$ → avatar fetch` plus `agents$` (cross-origin to `www.vm0.ai`). Letting components own their loading state should drop perceived bootstrap to roughly the HTML + Clerk + render window.

## Test plan
- [x] `pnpm -F @vm0/app exec tsc --noEmit`
- [x] `pnpm -F @vm0/core exec tsc --noEmit`
- [x] `pnpm -F @vm0/connectors exec tsc --noEmit`
- [x] `pnpm -F @vm0/app exec eslint src/signals/app-skeleton.ts`
- [x] `pnpm -F @vm0/app exec vitest run src/signals/__tests__/app-skeleton.test.ts`
- [x] `pnpm -F @vm0/core exec vitest run feature-switch`
- [ ] Toggle the switch in browser and compare PostHog `app_first_skeleton_hide.duration_ms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)