### PR TITLE
fix: remove idempotency guard in loadLeftThread$ so notification click refreshes messages

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -204,9 +204,9 @@ const setupPaneThread$ = command(
 );
 
 /**
- * Make the left (primary) chat pane show `threadId`. Idempotent — re-loading
- * the current left thread is a no-op. Updates the URL pathname silently so
- * subsequent route re-entries (browser back / link share) replay correctly.
+ * Make the left (primary) chat pane show `threadId`. Updates the URL pathname
+ * silently so subsequent route re-entries (browser back / link share) replay
+ * correctly.
  *
  * If the requested thread is currently the right pane, the right pane is
  * unloaded first (a thread cannot occupy both panes).
@@ -221,10 +221,6 @@ export const loadLeftThread$ = command(
     threadId: string,
     parentSignal: AbortSignal,
   ): Promise<void> => {
-    if (get(internalLeftThread$)?.threadId === threadId) {
-      return;
-    }
-
     if (get(internalRightThread$)?.threadId === threadId) {
       set(unloadRightThread$);
     }


### PR DESCRIPTION
## Summary

When a push notification is clicked for the currently-open chat thread, `resetRouteSignal$` aborts the existing Ably subscriptions before `loadLeftThread$` runs. The early return (`if threadId === current return`) left the page with no realtime subscriptions and no `visibilitychange` handler — so new messages never appeared.

## Root Cause

`loadLeftThread$` in `chat-thread-panes.ts` had an idempotency guard that returned early when asked to load the same thread. This was normally correct, but `resetRouteSignal$` in `route.ts` aborts the previous route's signal *before* `loadLeftThread$` runs, tearing down all Ably subscriptions. With the early return, no new subscriptions were created.

## Fix

Remove the idempotency guard. On same-thread re-entry, `loadLeftThread$` now re-runs `setupPaneThread$`, which creates fresh Ably subscriptions and catches up missed messages via `fetchNextPage$`.

## Test plan

- [ ] Open a chat thread, send a message from another device/agent to trigger a push notification
- [ ] Click the push notification while the same thread is already open
- [ ] Verify new messages appear without manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)