### PR TITLE
feat: network-first navigation in service worker for offline app shell

### DIFF
--- a/turbo/apps/platform/public/sw.js
+++ b/turbo/apps/platform/public/sw.js
@@ -103,7 +103,9 @@ self.addEventListener("fetch", (event) => {
           return response;
         } catch {
           const cached = await caches.match(event.request);
-          if (cached) return cached;
+          if (cached) {
+            return cached;
+          }
           return new Response(
             "You are offline. Connect to the internet and try again.",
             {

--- a/turbo/apps/platform/public/sw.js
+++ b/turbo/apps/platform/public/sw.js
@@ -98,7 +98,7 @@ self.addEventListener("fetch", (event) => {
           const response = await fetch(event.request);
           if (response.ok && !response.redirected) {
             const cache = await caches.open(STATIC_CACHE);
-            cache.put(event.request, response.clone());
+            await cache.put(event.request, response.clone());
           }
           return response;
         } catch {

--- a/turbo/apps/platform/public/sw.js
+++ b/turbo/apps/platform/public/sw.js
@@ -85,8 +85,40 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
-  // All other requests (navigation, third-party, etc.): pass through to
-  // the browser's default handling without SW interception.
+  if (event.request.mode === "navigate") {
+    // Network-First: cache the app shell on each successful navigation so
+    // the PWA can cold-open offline. Vercel serves index.html with
+    // `cache-control: must-revalidate`, which prevents the browser's HTTP
+    // cache from being used without a server check. The SW Cache Storage
+    // is not bound by HTTP cache directives, so we cache explicitly here
+    // and serve from cache when the network is unreachable.
+    event.respondWith(
+      (async () => {
+        try {
+          const response = await fetch(event.request);
+          if (response.ok && !response.redirected) {
+            const cache = await caches.open(STATIC_CACHE);
+            cache.put(event.request, response.clone());
+          }
+          return response;
+        } catch {
+          const cached = await caches.match(event.request);
+          if (cached) return cached;
+          return new Response(
+            "You are offline. Connect to the internet and try again.",
+            {
+              status: 503,
+              headers: { "Content-Type": "text/plain" },
+            },
+          );
+        }
+      })(),
+    );
+    return;
+  }
+
+  // All other requests (third-party, etc.): pass through to the browser's
+  // default handling without SW interception.
 });
 
 // --- Web Push Notifications ---


### PR DESCRIPTION
## Summary
- Add Network-First fetch strategy for navigation requests in the service worker so the PWA can cold-open when offline
- Vercel serves `index.html` with `cache-control: must-revalidate`, which blocks the browser HTTP cache from serving without a server check — SW Cache Storage is not bound by HTTP cache directives, so we cache explicitly on each successful navigation and fall back to cache when the network is unreachable

## How it works
1. Online: fetch navigation request normally, cache the successful response
2. Offline: `fetch()` throws → check SW cache → serve cached `index.html` → SPA router boots → IDB messages render
3. No cached shell at all (first visit while offline): return a plain 503 text page

## Verification
- [x] Existing SW behavior unchanged — static asset CacheFirst, API NetworkOnly, push notifications all pass through unmodified
- [ ] Deploy preview: load app online → toggle offline in DevTools → navigate to `/chats/:id` → app shell renders with cached IDB data
- [ ] Deploy preview: toggle offline → cold-open `app.vm0.ai` → app renders (no "No internet" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)