### PR TITLE
fix: stop vsock reconnect after shutdown

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -7,10 +7,9 @@ use std::time::Duration;
 use vsock_proto::{self, MSG_EXEC, MSG_EXEC_RESULT, MSG_READY, MSG_SPAWN_WATCH};
 
 use crate::error::to_io_error;
-use crate::handlers::{handle_exec, handle_message};
+use crate::handlers::{MessageOutcome, handle_exec, handle_message};
 use crate::log::log;
 use crate::monitor::{SpawnWatchRequest, handle_spawn_watch};
-use crate::shutdown::shutdown_received;
 
 // Vsock constants (only used on Linux)
 #[cfg(target_os = "linux")]
@@ -18,6 +17,11 @@ const VSOCK_CID_HOST: u32 = 2;
 
 /// Read buffer size for the connection event loop (local tuning constant).
 const READ_BUFFER_SIZE: usize = 64 * 1024; // 64KB
+
+enum ConnectionEnd {
+    Closed,
+    Shutdown,
+}
 
 /// Connect to vsock (Linux only - this binary runs inside Firecracker VM)
 #[cfg(target_os = "linux")]
@@ -75,6 +79,10 @@ pub fn connect_unix(path: &str) -> io::Result<UnixStream> {
 /// Handle connection - the main event loop
 /// Uses separate reader/writer to avoid deadlock between main loop and background threads
 pub fn handle_connection(stream: UnixStream) -> io::Result<()> {
+    handle_connection_with_outcome(stream).map(|_| ())
+}
+
+fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEnd> {
     // Clone the stream to get separate reader and writer
     // This avoids deadlock: reader can block while writer sends process_exit
     let mut reader = stream.try_clone()?;
@@ -161,17 +169,26 @@ pub fn handle_connection(stream: UnixStream) -> io::Result<()> {
                     }
                 });
             } else {
-                let response = handle_message(&msg)?;
-                if let Some(response) = response {
-                    let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
-                    w.write_all(&response)?;
+                match handle_message(&msg)? {
+                    MessageOutcome::Response(response) => {
+                        let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
+                        w.write_all(&response)?;
+                    }
+                    MessageOutcome::Shutdown(response) => {
+                        let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
+                        if let Err(e) = w.write_all(&response) {
+                            log("WARN", &format!("Failed to send shutdown_ack: {e}"));
+                        }
+                        log("INFO", "Shutdown complete, exiting");
+                        return Ok(ConnectionEnd::Shutdown);
+                    }
                 }
             }
         }
     }
 
     log("INFO", "Host disconnected");
-    Ok(())
+    Ok(ConnectionEnd::Closed)
 }
 
 /// Maximum reconnection attempts before giving up
@@ -194,7 +211,7 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                 log("INFO", "Connected");
                 // Reset attempts on successful connection
                 attempts = 0;
-                handle_connection(stream)
+                handle_connection_with_outcome(stream)
             })
         } else {
             log("INFO", "Connecting to host (CID=2)...");
@@ -202,19 +219,15 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                 log("INFO", "Connected");
                 // Reset attempts on successful connection
                 attempts = 0;
-                handle_connection(stream)
+                handle_connection_with_outcome(stream)
             })
         };
 
         attempts += 1;
 
         match result {
-            Ok(()) => {
-                // If shutdown was received, exit gracefully without reconnecting
-                if shutdown_received() {
-                    log("INFO", "Shutdown complete, exiting");
-                    return Ok(());
-                }
+            Ok(ConnectionEnd::Shutdown) => return Ok(()),
+            Ok(ConnectionEnd::Closed) => {
                 // Connection closed gracefully, try to reconnect
                 if attempts >= MAX_RECONNECT_ATTEMPTS {
                     log(

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -21,6 +21,11 @@ use crate::wait::{
     wait_with_kill_timeout,
 };
 
+pub(crate) enum MessageOutcome {
+    Response(Vec<u8>),
+    Shutdown(Vec<u8>),
+}
+
 /// Handle exec message
 pub(crate) fn handle_exec(
     timeout_ms: u32,
@@ -178,18 +183,18 @@ fn handle_write_file(path: &str, content: &[u8], use_sudo: bool, append: bool) -
     }
 }
 
-/// Handle incoming message and return response.
+/// Handle incoming message and return the connection-loop outcome.
 ///
 /// `MSG_EXEC` and `MSG_SPAWN_WATCH` are handled separately in
 /// `handle_connection` because they run in background threads.
-pub(crate) fn handle_message(msg: &RawMessage) -> io::Result<Option<Vec<u8>>> {
+pub(crate) fn handle_message(msg: &RawMessage) -> io::Result<MessageOutcome> {
     log(
         "INFO",
         &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),
     );
 
     match msg.msg_type {
-        MSG_PING => Ok(Some(
+        MSG_PING => Ok(MessageOutcome::Response(
             vsock_proto::encode(MSG_PONG, msg.seq, &[]).map_err(to_io_error)?,
         )),
         MSG_WRITE_FILE => {
@@ -197,16 +202,16 @@ pub(crate) fn handle_message(msg: &RawMessage) -> io::Result<Option<Vec<u8>>> {
                 vsock_proto::decode_write_file(&msg.payload).map_err(to_io_error)?;
             let (success, error) = handle_write_file(path, content, use_sudo, append);
             let payload = vsock_proto::encode_write_file_result(success, &error);
-            Ok(Some(
+            Ok(MessageOutcome::Response(
                 vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload)
                     .map_err(to_io_error)?,
             ))
         }
-        MSG_SHUTDOWN => Ok(Some(handle_shutdown(msg.seq)?)),
+        MSG_SHUTDOWN => Ok(MessageOutcome::Shutdown(handle_shutdown(msg.seq)?)),
         _ => {
             let payload =
                 vsock_proto::encode_error(&format!("Unknown message type: 0x{:02X}", msg.msg_type));
-            Ok(Some(
+            Ok(MessageOutcome::Response(
                 vsock_proto::encode(MSG_ERROR, msg.seq, &payload).map_err(to_io_error)?,
             ))
         }

--- a/crates/vsock-guest/src/shutdown.rs
+++ b/crates/vsock-guest/src/shutdown.rs
@@ -1,30 +1,17 @@
 use std::io;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use vsock_proto::{self, MSG_SHUTDOWN_ACK};
 
 use crate::error::to_io_error;
 use crate::log::log;
 
-/// Flag indicating shutdown was received (don't reconnect after shutdown).
-///
-/// Process-level static: safe because integration tests use `handle_connection` per-thread
-/// (not `run()`), and each test gets its own connection. Only `run()` reads this flag.
-static SHUTDOWN_RECEIVED: AtomicBool = AtomicBool::new(false);
-
-pub(crate) fn shutdown_received() -> bool {
-    SHUTDOWN_RECEIVED.load(Ordering::SeqCst)
-}
-
-/// Handle shutdown message — acknowledge and suppress reconnection.
+/// Handle shutdown message by building the acknowledgement payload.
 ///
 /// The guest rootfs is ext4 on an ephemeral COW device that is destroyed
-/// when the VM is killed, so there is nothing to sync. The primary purpose
-/// of this handler is to set `SHUTDOWN_RECEIVED` so the reconnection loop
-/// in `run()` exits cleanly instead of retrying (which it would otherwise
-/// do, since reconnection is the normal path after snapshot restore).
+/// when the VM is killed, so there is nothing to sync. The connection loop
+/// treats this response as terminal: after attempting to write the ACK, it
+/// exits cleanly instead of reconnecting.
 pub(crate) fn handle_shutdown(seq: u32) -> io::Result<Vec<u8>> {
     log("INFO", "Shutdown requested");
-    SHUTDOWN_RECEIVED.store(true, Ordering::SeqCst);
     vsock_proto::encode(MSG_SHUTDOWN_ACK, seq, &[]).map_err(to_io_error)
 }

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -9,14 +9,44 @@ use std::io::{Read, Write};
 use std::thread;
 use std::time::Duration;
 
-use vsock_guest::handle_connection;
+use vsock_guest::{handle_connection, run};
 use vsock_proto::{
-    self, MSG_EXEC, MSG_EXEC_RESULT, MSG_PROCESS_EXIT, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT,
-    MSG_STDOUT_CHUNK,
+    self, MSG_EXEC, MSG_EXEC_RESULT, MSG_PROCESS_EXIT, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
+    MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK,
 };
 
 const EXIT_CODE_TIMEOUT: i32 = 124;
 const DRAIN_DEADLINE_SECS: u64 = 5;
+
+struct SocketPathGuard(String);
+
+impl SocketPathGuard {
+    fn new(path: String) -> Self {
+        let _ = std::fs::remove_file(&path);
+        Self(path)
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Drop for SocketPathGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn unique_socket_path(label: &str) -> SocketPathGuard {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    SocketPathGuard::new(format!(
+        "/tmp/vsock-test-{label}-{}-{nonce}.sock",
+        std::process::id()
+    ))
+}
 
 /// Helper: send a MSG_EXEC via the writer half, read MSG_EXEC_RESULT from the
 /// reader half, and return `(exit_code, stdout, stderr)`.
@@ -236,17 +266,102 @@ fn exec_timeout_zero_means_no_timeout() {
     let _ = handle.join();
 }
 
+#[test]
+fn run_exits_after_shutdown_even_when_ack_write_fails() {
+    use std::net::Shutdown;
+    use std::os::unix::net::UnixListener;
+
+    let socket_path = unique_socket_path("shutdown-failed-ack");
+    let listener = UnixListener::bind(socket_path.as_str()).unwrap();
+
+    let guest_socket_path = socket_path.as_str().to_owned();
+    let handle = thread::spawn(move || run(Some(&guest_socket_path)));
+
+    let (mut host_stream, _) = listener.accept().unwrap();
+    drop(listener);
+    read_and_discard_message(&mut host_stream);
+
+    host_stream.shutdown(Shutdown::Read).unwrap();
+    let msg = vsock_proto::encode(MSG_SHUTDOWN, 1, &[]).unwrap();
+    host_stream.write_all(&msg).unwrap();
+
+    // Refuse the ACK write before delivering MSG_SHUTDOWN. The write half is
+    // still open, so the shutdown request is delivered, but the guest's final
+    // ACK write fails with EPIPE/BrokenPipe.
+    drop(host_stream);
+
+    let result = handle.join().unwrap();
+    assert!(
+        result.is_ok(),
+        "shutdown should stop run() cleanly even if ACK write fails: {result:?}",
+    );
+}
+
+#[test]
+fn run_sends_shutdown_ack_and_exits_without_waiting_for_disconnect() {
+    use std::os::unix::net::UnixListener;
+    use std::sync::mpsc;
+
+    let socket_path = unique_socket_path("shutdown-ack");
+    let listener = UnixListener::bind(socket_path.as_str()).unwrap();
+
+    let guest_socket_path = socket_path.as_str().to_owned();
+    let (done_tx, done_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let result = run(Some(&guest_socket_path));
+        let _ = done_tx.send(());
+        result
+    });
+
+    let (mut host_stream, _) = listener.accept().unwrap();
+    drop(listener);
+    read_and_discard_message(&mut host_stream);
+
+    let msg = vsock_proto::encode(MSG_SHUTDOWN, 42, &[]).unwrap();
+    host_stream.write_all(&msg).unwrap();
+
+    let ack = read_message(&mut host_stream);
+    assert_eq!(ack.msg_type, MSG_SHUTDOWN_ACK);
+    assert_eq!(ack.seq, 42);
+
+    let finished_before_disconnect = done_rx.recv_timeout(Duration::from_secs(1)).is_ok();
+    drop(host_stream);
+
+    let result = handle.join().unwrap();
+    assert!(
+        finished_before_disconnect,
+        "run() should exit after MSG_SHUTDOWN without waiting for host disconnect",
+    );
+    assert!(
+        result.is_ok(),
+        "shutdown should stop run() cleanly: {result:?}"
+    );
+}
+
 // -----------------------------------------------------------------------
 // Helpers for spawn_watch streaming tests
 // -----------------------------------------------------------------------
 
-/// Read one framed message from the stream and discard it.
-fn read_and_discard_message(stream: &mut impl std::io::Read) {
+/// Read one framed message from the stream.
+fn read_message(stream: &mut impl std::io::Read) -> vsock_proto::RawMessage {
     let mut hdr = [0u8; 4];
     stream.read_exact(&mut hdr).unwrap();
     let body_len = u32::from_be_bytes(hdr) as usize;
     let mut body = vec![0u8; body_len];
     stream.read_exact(&mut body).unwrap();
+
+    let mut full = Vec::with_capacity(4 + body_len);
+    full.extend_from_slice(&hdr);
+    full.extend_from_slice(&body);
+    let mut decoder = vsock_proto::Decoder::new();
+    let msgs = decoder.decode(&full).unwrap();
+    assert_eq!(msgs.len(), 1);
+    msgs.into_iter().next().unwrap()
+}
+
+/// Read one framed message from the stream and discard it.
+fn read_and_discard_message(stream: &mut impl std::io::Read) {
+    let _ = read_message(stream);
 }
 
 /// Like `Read::read`, but retries on EINTR. `read_exact` retries


### PR DESCRIPTION
## Summary
- replace process-global shutdown flag with a per-connection shutdown outcome
- make MSG_SHUTDOWN terminal even when shutdown_ack write fails
- add run-level regression coverage for successful and failed shutdown ACK paths

Fixes #11723

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --tests -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p vsock-test
- RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml -p vsock-guest --no-deps
- pre-commit: cargo-doc, cargo-clippy