### PR TITLE
refactor(vsock-guest): deduplicate concurrency helpers

### DIFF
--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -1,9 +1,8 @@
 use std::io::{self, Write};
 use std::process::Stdio;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::thread;
-use std::time::Duration;
 
 use vsock_proto::{
     self, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
@@ -17,7 +16,7 @@ use crate::log::log;
 use crate::process::extract_exit_code;
 use crate::shutdown::handle_shutdown;
 use crate::wait::{
-    DRAIN_DEADLINE_SECS, WaitOutcome, finalize_buffered_result, wait_with_drain_and_timeout,
+    WaitOutcome, await_drain_deadline, finalize_buffered_result, wait_with_drain_and_timeout,
     wait_with_kill_timeout,
 };
 
@@ -162,11 +161,7 @@ fn handle_write_file(path: &str, content: &[u8], use_sudo: bool, append: bool) -
 
     let outcome = wait_with_kill_timeout(child, WRITE_TIMEOUT_MS);
 
-    // Wait for drain to finish naturally up to the deadline; otherwise cancel
-    // so the drain thread drops its fd and a still-writing grandchild gets
-    // EPIPE on its next write.
-    let _ = done_rx.recv_timeout(Duration::from_secs(DRAIN_DEADLINE_SECS));
-    cancel.store(true, Ordering::Release);
+    let _ = await_drain_deadline(&done_rx, 1, &cancel);
     let stderr = stderr_handle.join().unwrap_or_default();
 
     match outcome {

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -11,9 +11,10 @@ use crate::drain::{drain_into_vec_cancellable, drain_until_eof_or_cancelled};
 use crate::error::to_io_error;
 use crate::exec::{prepend_env, spawn_with_pipes, truncate_preview};
 use crate::log::log;
-use crate::process::{extract_exit_code, kill_process_tree};
+use crate::process::extract_exit_code;
 use crate::wait::{
-    DRAIN_DEADLINE_SECS, EXIT_CODE_TIMEOUT, finalize_buffered_result, wait_with_drain_and_timeout,
+    DRAIN_DEADLINE_SECS, EXIT_CODE_TIMEOUT, KillWatchdog, await_drain_deadline,
+    finalize_buffered_result, wait_with_drain_and_timeout,
 };
 
 pub(crate) struct SpawnWatchRequest<'a> {
@@ -148,19 +149,11 @@ fn spawn_streaming_monitor(
         // Set up timeout BEFORE the stdout loop — if the process runs past the
         // deadline it must be killed even while we are still reading output.
         let child_id = child.id();
-        let (timeout_done_tx, timeout_handle) = if timeout_ms > 0 {
+        let mut watchdog = if timeout_ms > 0 {
             let timeout = Duration::from_millis(u64::from(timeout_ms));
-            let (tx, rx) = std::sync::mpsc::channel::<()>();
-            let handle = thread::spawn(move || -> bool {
-                if rx.recv_timeout(timeout).is_err() {
-                    // SAFETY: child_id is a valid PID.
-                    return unsafe { kill_process_tree(child_id) };
-                }
-                false
-            });
-            (Some(tx), Some(handle))
+            Some(KillWatchdog::spawn(child_id, timeout))
         } else {
-            (None, None)
+            None
         };
 
         let cancel = Arc::new(AtomicBool::new(false));
@@ -251,32 +244,20 @@ fn spawn_streaming_monitor(
         // child.wait() is now UNBLOCKED — no pipe fds held by this thread.
         let status = child.wait();
 
-        // Signal timeout thread that process completed.
-        // Must send() not drop — dropping disconnects the channel, which
-        // recv_timeout treats as an error and would fire the killer.
-        if let Some(tx) = timeout_done_tx {
-            let _ = tx.send(());
+        // Signal timeout thread that process completed. This must happen
+        // before drain cleanup; otherwise a cleanly exited process could be
+        // killed while we are still draining its pipes.
+        if let Some(watchdog) = watchdog.as_mut() {
+            watchdog.stand_down();
         }
 
         // Shared drain deadline: stdout + stderr share a single budget.
         // This matches guest-agent's 5s drain behavior.
         let expected = stdout_handle.is_some() as usize + stderr_handle.is_some() as usize;
-        let deadline = std::time::Instant::now() + Duration::from_secs(DRAIN_DEADLINE_SECS);
-        let mut completed = 0usize;
-        while completed < expected {
-            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-            if remaining.is_zero() {
-                break;
-            }
-            match drain_done_rx.recv_timeout(remaining) {
-                Ok(()) => completed += 1,
-                Err(_) => break,
-            }
-        }
-        // Cancel either side that's still draining. The thread observes the
-        // flag within ~100 ms (poll cadence), drops its fd, and grandchild
-        // writes start failing with EPIPE.
-        cancel.store(true, Ordering::Release);
+        let completed = await_drain_deadline(&drain_done_rx, expected, &cancel);
+        // await_drain_deadline cancels either side that's still draining. The
+        // thread observes the flag within ~100 ms (poll cadence), drops its fd,
+        // and grandchild writes start failing with EPIPE.
         if completed < expected {
             log(
                 "WARN",
@@ -294,9 +275,7 @@ fn spawn_streaming_monitor(
             let _ = h.join();
         }
 
-        let killed_by_timeout = timeout_handle
-            .map(|h| h.join().unwrap_or(false))
-            .unwrap_or(false);
+        let killed_by_timeout = watchdog.map(KillWatchdog::join).unwrap_or(false);
         let (exit_code, stderr) = if killed_by_timeout {
             (EXIT_CODE_TIMEOUT, b"Timeout".to_vec())
         } else {

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -1,8 +1,8 @@
 use std::process::{Child, ExitStatus};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, mpsc};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::drain::drain_into_vec_cancellable;
 use crate::process::{extract_exit_code, kill_process_tree};
@@ -26,6 +26,71 @@ pub(crate) enum WaitOutcome {
     WaitFailed(String),
 }
 
+/// Watchdog that kills a child process tree if it is not stood down before
+/// `timeout` elapses.
+#[must_use = "watchdogs must be stood down and joined so timeout verdicts are observed"]
+pub(crate) struct KillWatchdog {
+    done_tx: Option<mpsc::Sender<()>>,
+    handle: thread::JoinHandle<bool>,
+}
+
+impl KillWatchdog {
+    pub(crate) fn spawn(child_id: u32, timeout: Duration) -> Self {
+        let (done_tx, done_rx) = mpsc::channel::<()>();
+        let handle = thread::spawn(move || -> bool {
+            if done_rx.recv_timeout(timeout).is_err() {
+                // SAFETY: child_id is a valid PID from Command::spawn.
+                return unsafe { kill_process_tree(child_id) };
+            }
+            false
+        });
+
+        Self {
+            done_tx: Some(done_tx),
+            handle,
+        }
+    }
+
+    /// Stand the watchdog down without joining it yet.
+    ///
+    /// This lets callers preserve existing timing where the child has exited,
+    /// the watchdog is disarmed immediately, and the join verdict is collected
+    /// after other cleanup work.
+    pub(crate) fn stand_down(&mut self) {
+        if let Some(done_tx) = self.done_tx.take() {
+            let _ = done_tx.send(());
+        }
+    }
+
+    pub(crate) fn join(mut self) -> bool {
+        self.stand_down();
+        self.handle.join().unwrap_or(false)
+    }
+}
+
+/// Wait for drain workers to complete within the shared drain deadline, then
+/// cancel any laggards.
+pub(crate) fn await_drain_deadline(
+    done_rx: &mpsc::Receiver<()>,
+    expected: usize,
+    cancel: &AtomicBool,
+) -> usize {
+    let deadline = Instant::now() + Duration::from_secs(DRAIN_DEADLINE_SECS);
+    let mut completed = 0usize;
+    while completed < expected {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match done_rx.recv_timeout(remaining) {
+            Ok(()) => completed += 1,
+            Err(_) => break,
+        }
+    }
+    cancel.store(true, Ordering::Release);
+    completed
+}
+
 /// Wait for `child` to exit, optionally killing it after `timeout_ms`.
 /// `timeout_ms == 0` means "no timeout".
 ///
@@ -34,8 +99,6 @@ pub(crate) enum WaitOutcome {
 /// otherwise a child producing more than the kernel pipe buffer (~64 KB) will
 /// deadlock on its next write while we wait.
 pub(crate) fn wait_with_kill_timeout(mut child: Child, timeout_ms: u32) -> WaitOutcome {
-    use std::sync::mpsc;
-
     if timeout_ms == 0 {
         return match child.wait() {
             Ok(s) => WaitOutcome::Exited(s),
@@ -46,22 +109,11 @@ pub(crate) fn wait_with_kill_timeout(mut child: Child, timeout_ms: u32) -> WaitO
     let timeout = Duration::from_millis(u64::from(timeout_ms));
     let child_id = child.id();
 
-    // Channel to signal that the child has exited and the watchdog can stand down.
-    let (tx, rx) = mpsc::channel::<()>();
-
-    // Watchdog: kills the process tree if `recv_timeout` expires before the
-    // child reports exit. Its return value *is* the "did we time out?" verdict.
-    let timeout_handle = thread::spawn(move || -> bool {
-        if rx.recv_timeout(timeout).is_err() {
-            // SAFETY: child_id is a valid PID from Command::spawn.
-            return unsafe { kill_process_tree(child_id) };
-        }
-        false
-    });
-
+    // Watchdog: kills the process tree if the child does not report exit
+    // before the timeout. Its return value is the timeout verdict.
+    let watchdog = KillWatchdog::spawn(child_id, timeout);
     let status = child.wait();
-    let _ = tx.send(());
-    let killed_by_timeout = timeout_handle.join().unwrap_or(false);
+    let killed_by_timeout = watchdog.join();
 
     match status {
         Ok(_) if killed_by_timeout => WaitOutcome::TimedOut,
@@ -85,8 +137,6 @@ pub(crate) fn wait_with_drain_and_timeout(
     mut child: Child,
     timeout_ms: u32,
 ) -> (WaitOutcome, Vec<u8>, Vec<u8>) {
-    use std::sync::mpsc;
-
     // Defensive: if either pipe is missing the caller broke the
     // `spawn_with_pipes` invariant. Reap the child before returning so we
     // don't leave a zombie — `Child`'s `Drop` doesn't wait.
@@ -140,22 +190,7 @@ pub(crate) fn wait_with_drain_and_timeout(
 
     let outcome = wait_with_kill_timeout(child, timeout_ms);
 
-    // Grace period for in-flight bytes — most clean exits finish drain within
-    // a few ms. We bound the wait at DRAIN_DEADLINE_SECS to defang
-    // orphaned grandchildren that still hold the pipe.
-    let deadline = std::time::Instant::now() + Duration::from_secs(DRAIN_DEADLINE_SECS);
-    let mut completed = 0;
-    while completed < 2 {
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        if remaining.is_zero() {
-            break;
-        }
-        match done_rx.recv_timeout(remaining) {
-            Ok(()) => completed += 1,
-            Err(_) => break,
-        }
-    }
-    cancel.store(true, Ordering::Release);
+    let _ = await_drain_deadline(&done_rx, 2, &cancel);
 
     let stdout_buf = stdout_handle.join().unwrap_or_default();
     let stderr_buf = stderr_handle.join().unwrap_or_default();

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -466,6 +466,41 @@ fn streaming_monitor_normal_exit() {
     let _ = handle.join();
 }
 
+/// A cleanly exiting streaming process should not wait for the timeout watchdog
+/// before reporting `MSG_PROCESS_EXIT`.
+#[test]
+fn streaming_monitor_clean_exit_returns_before_long_timeout() {
+    use std::os::unix::net::UnixStream as StdUnixStream;
+    use std::time::Instant;
+
+    let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+
+    read_and_discard_message(&mut host_stream); // MSG_READY
+    host_stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    let start = Instant::now();
+    send_spawn_watch(&mut host_stream, 1, "printf clean-exit", None, 60_000);
+    let (pid, stdout_data, exit_code, stderr) = read_streaming_result(&mut host_stream, 1);
+    let elapsed = start.elapsed();
+
+    assert!(pid > 0);
+    assert_eq!(exit_code, 0);
+    assert_eq!(String::from_utf8_lossy(&stdout_data), "clean-exit");
+    assert_eq!(stderr, b"");
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "clean exit should not wait for 60s watchdog timeout, took {elapsed:?}",
+    );
+
+    drop(host_stream);
+    let _ = handle.join();
+}
+
 /// `MSG_SPAWN_WATCH_RESULT` must arrive before stdout chunks for that pid.
 /// The host only registers the stdout stream after processing the spawn
 /// result, so a chunk sent first would be dropped by older host code.
@@ -779,6 +814,55 @@ fn exec_returns_when_orphaned_grandchild_holds_stdout() {
     let _ = std::process::Command::new("pkill")
         .args(["-f", "sleep 30"])
         .status();
+    drop(host_writer);
+    drop(host_reader);
+    let _ = handle.join();
+}
+
+/// Output written by an inherited-fd grandchild within the drain deadline must
+/// still be included after the foreground shell exits.
+#[test]
+fn exec_captures_grandchild_output_before_drain_deadline() {
+    use std::os::unix::net::UnixStream as StdUnixStream;
+    use std::time::Instant;
+
+    let (guest_stream, host_stream) = StdUnixStream::pair().unwrap();
+    let mut host_writer = host_stream.try_clone().unwrap();
+    let mut host_reader = host_stream;
+
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+
+    read_and_discard_message(&mut host_reader); // MSG_READY
+    host_reader
+        .set_read_timeout(Some(Duration::from_secs(8)))
+        .unwrap();
+
+    let start = Instant::now();
+    let (code, stdout, stderr) = send_exec_and_read_result(
+        &mut host_writer,
+        &mut host_reader,
+        1,
+        "echo stdout-early; echo stderr-early >&2; { sleep 1; echo stdout-late; echo stderr-late >&2; } &",
+        0,
+    );
+    let elapsed = start.elapsed();
+
+    assert_eq!(code, 0);
+    assert_eq!(
+        String::from_utf8_lossy(&stdout),
+        "stdout-early\nstdout-late\n"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&stderr),
+        "stderr-early\nstderr-late\n"
+    );
+    assert!(
+        elapsed < Duration::from_secs(DRAIN_DEADLINE_SECS),
+        "late output should be captured before drain deadline, took {elapsed:?}",
+    );
+
     drop(host_writer);
     drop(host_reader);
     let _ = handle.join();


### PR DESCRIPTION
## Summary
- add a KillWatchdog helper to centralize child timeout kill-thread lifecycle
- add await_drain_deadline to centralize shared drain-deadline cancellation
- replace inline watchdog/drain deadline copies in exec, write_file, and streaming monitor paths

Closes #11722

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo check --manifest-path crates/Cargo.toml -p vsock-guest
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest exec_timeout_returns_124 -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --tests -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p vsock-test
- RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml -p vsock-guest --no-deps
- pre-commit: cargo-clippy, cargo-doc