### PR TITLE
fix(vsock-guest): bound guest frame writes

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -1,6 +1,5 @@
-use std::io::{self, Read, Write};
+use std::io::{self, Read};
 use std::os::unix::net::UnixStream;
-use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
@@ -10,6 +9,7 @@ use crate::error::to_io_error;
 use crate::handlers::{MessageOutcome, handle_exec, handle_message};
 use crate::log::log;
 use crate::monitor::{SpawnWatchRequest, handle_spawn_watch};
+use crate::writer::GuestWriter;
 
 // Vsock constants (only used on Linux)
 #[cfg(target_os = "linux")]
@@ -86,17 +86,14 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
     // Clone the stream to get separate reader and writer
     // This avoids deadlock: reader can block while writer sends process_exit
     let mut reader = stream.try_clone()?;
-    let writer = Arc::new(Mutex::new(stream));
+    let writer = GuestWriter::new(stream);
 
     let mut decoder = vsock_proto::Decoder::new();
 
     // Send ready signal
     {
         let ready = vsock_proto::encode(MSG_READY, 0, &[]).map_err(to_io_error)?;
-        // Recover from poisoned mutex: prefer sending ready over propagating a
-        // panic from an unrelated thread.
-        let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
-        w.write_all(&ready)?;
+        writer.write_frame(&ready)?;
     }
     log("INFO", "Sent ready signal");
 
@@ -132,7 +129,7 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                         stdout_log_path: d.stdout_log_path,
                     },
                     msg.seq,
-                    Arc::clone(&writer),
+                    writer.clone(),
                 )?;
             } else if msg.msg_type == MSG_EXEC {
                 log(
@@ -149,7 +146,7 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                     .collect();
                 let sudo = d.sudo;
                 let seq = msg.seq;
-                let w = Arc::clone(&writer);
+                let w = writer.clone();
                 thread::spawn(move || {
                     let env_refs: Vec<(&str, &str)> =
                         env.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
@@ -163,20 +160,17 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                             return;
                         }
                     };
-                    let mut w = w.lock().unwrap_or_else(|e| e.into_inner());
-                    if let Err(e) = w.write_all(&encoded) {
+                    if let Err(e) = w.write_frame(&encoded) {
                         log("ERROR", &format!("Failed to send exec_result: {}", e));
                     }
                 });
             } else {
                 match handle_message(&msg)? {
                     MessageOutcome::Response(response) => {
-                        let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
-                        w.write_all(&response)?;
+                        writer.write_frame(&response)?;
                     }
                     MessageOutcome::Shutdown(response) => {
-                        let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
-                        if let Err(e) = w.write_all(&response) {
+                        if let Err(e) = writer.write_frame(&response) {
                             log("WARN", &format!("Failed to send shutdown_ack: {e}"));
                         }
                         log("INFO", "Shutdown complete, exiting");

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -16,6 +16,7 @@ mod monitor;
 mod process;
 mod shutdown;
 mod wait;
+mod writer;
 
 pub use connection::{connect_unix, connect_vsock, handle_connection, run};
 pub use log::log;

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -1,7 +1,6 @@
 use std::io::{self, Write};
-use std::os::unix::net::UnixStream;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
@@ -16,6 +15,7 @@ use crate::wait::{
     DRAIN_DEADLINE_SECS, EXIT_CODE_TIMEOUT, KillWatchdog, await_drain_deadline,
     finalize_buffered_result, wait_with_drain_and_timeout,
 };
+use crate::writer::GuestWriter;
 
 pub(crate) struct SpawnWatchRequest<'a> {
     pub(crate) timeout_ms: u32,
@@ -43,7 +43,7 @@ pub(crate) struct SpawnWatchRequest<'a> {
 pub(crate) fn handle_spawn_watch(
     request: SpawnWatchRequest<'_>,
     seq: u32,
-    writer: Arc<Mutex<UnixStream>>,
+    writer: GuestWriter,
 ) -> io::Result<()> {
     log(
         "INFO",
@@ -63,8 +63,7 @@ pub(crate) fn handle_spawn_watch(
         Err(e) => {
             let payload = vsock_proto::encode_error(&format!("Failed to spawn: {e}"));
             let response = vsock_proto::encode(MSG_ERROR, seq, &payload).map_err(to_io_error)?;
-            let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
-            w.write_all(&response)?;
+            writer.write_frame(&response)?;
             return Ok(());
         }
     };
@@ -90,14 +89,10 @@ pub(crate) fn handle_spawn_watch(
             return Err(to_io_error(e));
         }
     };
-    {
-        let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
-        if let Err(e) = w.write_all(&response) {
-            drop(w);
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(e);
-        }
+    if let Err(e) = writer.write_frame(&response) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(e);
     }
 
     if request.stream_stdout {
@@ -143,7 +138,7 @@ fn spawn_streaming_monitor(
     timeout_ms: u32,
     stdout_pipe: Option<std::process::ChildStdout>,
     log_path: Option<String>,
-    writer: Arc<Mutex<UnixStream>>,
+    writer: GuestWriter,
 ) {
     thread::spawn(move || {
         // Set up timeout BEFORE the stdout loop — if the process runs past the
@@ -182,7 +177,7 @@ fn spawn_streaming_monitor(
         let stdout_handle = if let Some(stdout) = stdout_pipe {
             let cancel = cancel.clone();
             let tx = drain_done_tx.clone();
-            let stdout_writer = Arc::clone(&writer);
+            let stdout_writer = writer.clone();
             Some(thread::spawn(move || {
                 let mut log_file = match log_path.as_deref() {
                     Some(path) => match std::fs::OpenOptions::new()
@@ -223,15 +218,14 @@ fn spawn_streaming_monitor(
                     // is itself unreachable, so retaining bytes we cannot
                     // deliver buys nothing.
                     let payload = vsock_proto::encode_stdout_chunk(pid, chunk);
-                    if let Ok(msg) = vsock_proto::encode(MSG_STDOUT_CHUNK, 0, &payload) {
-                        let mut w = stdout_writer.lock().unwrap_or_else(|e| e.into_inner());
-                        if let Err(e) = w.write_all(&msg) {
-                            log(
-                                "WARN",
-                                &format!("spawn_watch: failed to send stdout chunk: {e}"),
-                            );
-                            cancel.store(true, Ordering::Release);
-                        }
+                    if let Ok(msg) = vsock_proto::encode(MSG_STDOUT_CHUNK, 0, &payload)
+                        && let Err(e) = stdout_writer.write_frame(&msg)
+                    {
+                        log(
+                            "WARN",
+                            &format!("spawn_watch: failed to send stdout chunk: {e}"),
+                        );
+                        cancel.store(true, Ordering::Release);
                     }
                 });
                 let _ = tx.send(());
@@ -305,7 +299,7 @@ fn spawn_buffered_monitor(
     pid: u32,
     child: std::process::Child,
     timeout_ms: u32,
-    writer: Arc<Mutex<UnixStream>>,
+    writer: GuestWriter,
 ) {
     thread::spawn(move || {
         let (outcome, stdout, stderr_buf) = wait_with_drain_and_timeout(child, timeout_ms);
@@ -327,13 +321,7 @@ fn spawn_buffered_monitor(
 }
 
 /// Send a process_exit notification over vsock (best-effort).
-fn send_process_exit(
-    pid: u32,
-    exit_code: i32,
-    stdout: &[u8],
-    stderr: &[u8],
-    writer: &Arc<Mutex<UnixStream>>,
-) {
+fn send_process_exit(pid: u32, exit_code: i32, stdout: &[u8], stderr: &[u8], writer: &GuestWriter) {
     let payload = vsock_proto::encode_process_exit(pid, exit_code, stdout, stderr);
     let exit_msg = match vsock_proto::encode(MSG_PROCESS_EXIT, 0, &payload) {
         Ok(msg) => msg,
@@ -342,8 +330,7 @@ fn send_process_exit(
             return;
         }
     };
-    let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
-    if let Err(e) = w.write_all(&exit_msg) {
+    if let Err(e) = writer.write_frame(&exit_msg) {
         log("ERROR", &format!("Failed to send process_exit: {}", e));
     }
 }

--- a/crates/vsock-guest/src/writer.rs
+++ b/crates/vsock-guest/src/writer.rs
@@ -1,0 +1,236 @@
+use std::cmp;
+use std::io;
+use std::net::Shutdown;
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::net::UnixStream;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+const WRITE_DEADLINE: Duration = Duration::from_secs(10);
+
+/// Shared guest-to-host frame writer.
+///
+/// The mutex is held for exactly one encoded protocol frame, so concurrent
+/// producers cannot interleave bytes on the stream.
+#[derive(Clone)]
+pub(crate) struct GuestWriter {
+    stream: Arc<Mutex<UnixStream>>,
+}
+
+impl GuestWriter {
+    pub(crate) fn new(stream: UnixStream) -> Self {
+        Self {
+            stream: Arc::new(Mutex::new(stream)),
+        }
+    }
+
+    pub(crate) fn write_frame(&self, frame: &[u8]) -> io::Result<()> {
+        self.write_frame_with_deadline(frame, WRITE_DEADLINE)
+    }
+
+    fn write_frame_with_deadline(&self, frame: &[u8], deadline: Duration) -> io::Result<()> {
+        let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
+        let result = send_frame(stream.as_raw_fd(), frame, deadline);
+        if result.is_err() {
+            // The protocol has no resync marker. After a timeout or partial
+            // write failure, keep the stream from carrying corrupted frames.
+            let _ = stream.shutdown(Shutdown::Both);
+        }
+        result
+    }
+}
+
+fn send_frame(fd: RawFd, frame: &[u8], deadline: Duration) -> io::Result<()> {
+    if frame.is_empty() {
+        return Ok(());
+    }
+
+    let Some(deadline_at) = Instant::now().checked_add(deadline) else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "guest writer deadline overflowed",
+        ));
+    };
+
+    let mut written = 0usize;
+    while written < frame.len() {
+        if Instant::now() >= deadline_at {
+            return Err(write_timeout_error());
+        }
+
+        let Some(remaining) = frame.get(written..) else {
+            return Err(io::Error::other(
+                "guest writer offset exceeded frame length",
+            ));
+        };
+        match send_nonblocking(fd, remaining) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "guest writer sent zero bytes",
+                ));
+            }
+            Ok(n) => {
+                written = written
+                    .checked_add(n)
+                    .filter(|next| *next <= frame.len())
+                    .ok_or_else(|| io::Error::other("guest writer sent past frame length"))?;
+            }
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => wait_writable(fd, deadline_at)?,
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(())
+}
+
+fn wait_writable(fd: RawFd, deadline_at: Instant) -> io::Result<()> {
+    loop {
+        let now = Instant::now();
+        if now >= deadline_at {
+            return Err(write_timeout_error());
+        }
+
+        let mut pollfd = libc::pollfd {
+            fd,
+            events: libc::POLLOUT,
+            revents: 0,
+        };
+        // SAFETY: pollfd points to one initialized descriptor entry, and the
+        // timeout is a bounded non-negative millisecond value.
+        let ret = unsafe {
+            libc::poll(
+                &mut pollfd,
+                1 as libc::nfds_t,
+                poll_timeout_ms(deadline_at.saturating_duration_since(now)),
+            )
+        };
+
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err);
+        }
+        if ret == 0 {
+            return Err(write_timeout_error());
+        }
+
+        if pollfd.revents & libc::POLLNVAL != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "guest writer socket fd is invalid",
+            ));
+        }
+        if pollfd.revents & (libc::POLLERR | libc::POLLHUP) != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "guest writer socket is no longer writable",
+            ));
+        }
+        if pollfd.revents & libc::POLLOUT != 0 {
+            return Ok(());
+        }
+    }
+}
+
+fn send_nonblocking(fd: RawFd, bytes: &[u8]) -> io::Result<usize> {
+    // SAFETY: bytes points to a valid buffer for the provided length. send()
+    // does not retain the pointer after returning.
+    let ret = unsafe {
+        libc::send(
+            fd,
+            bytes.as_ptr().cast::<libc::c_void>(),
+            bytes.len(),
+            send_flags(),
+        )
+    };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(ret as usize)
+}
+
+fn poll_timeout_ms(remaining: Duration) -> libc::c_int {
+    cmp::min(cmp::max(remaining.as_millis(), 1), libc::c_int::MAX as u128) as libc::c_int
+}
+
+fn write_timeout_error() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::TimedOut,
+        "guest writer timed out waiting for peer to drain",
+    )
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn send_flags() -> libc::c_int {
+    libc::MSG_DONTWAIT | libc::MSG_NOSIGNAL
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn send_flags() -> libc::c_int {
+    libc::MSG_DONTWAIT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    fn set_send_buffer(stream: &UnixStream, size: libc::c_int) -> io::Result<()> {
+        // SAFETY: setsockopt receives a valid socket fd and a pointer to a
+        // properly sized integer option value for the duration of the call.
+        let ret = unsafe {
+            libc::setsockopt(
+                stream.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_SNDBUF,
+                (&size as *const libc::c_int).cast(),
+                std::mem::size_of_val(&size) as libc::socklen_t,
+            )
+        };
+        if ret < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn write_frame_sends_complete_frame() {
+        let (guest, mut peer) = UnixStream::pair().unwrap();
+        let writer = GuestWriter::new(guest);
+        let frame = vec![7u8; 64 * 1024];
+        let expected = frame.clone();
+
+        let reader = std::thread::spawn(move || {
+            let mut received = Vec::new();
+            peer.read_to_end(&mut received).unwrap();
+            received
+        });
+
+        writer
+            .write_frame_with_deadline(&frame, Duration::from_secs(1))
+            .unwrap();
+        drop(writer);
+
+        assert_eq!(reader.join().unwrap(), expected);
+    }
+
+    #[test]
+    fn write_frame_times_out_when_peer_stops_reading() {
+        let (guest, _peer) = UnixStream::pair().unwrap();
+        set_send_buffer(&guest, 4096).unwrap();
+        let writer = GuestWriter::new(guest);
+        let frame = vec![0xAB; 8 * 1024 * 1024];
+
+        let started = Instant::now();
+        let err = writer
+            .write_frame_with_deadline(&frame, Duration::from_millis(100))
+            .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        assert!(started.elapsed() < Duration::from_secs(2));
+    }
+}

--- a/crates/vsock-guest/src/writer.rs
+++ b/crates/vsock-guest/src/writer.rs
@@ -231,8 +231,9 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.kind(), io::ErrorKind::TimedOut);
-        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(started.elapsed() < Duration::from_secs(5));
 
+        peer.set_read_timeout(Some(Duration::from_secs(1))).unwrap();
         let mut drained = Vec::new();
         peer.read_to_end(&mut drained).unwrap();
     }

--- a/crates/vsock-guest/src/writer.rs
+++ b/crates/vsock-guest/src/writer.rs
@@ -220,7 +220,7 @@ mod tests {
 
     #[test]
     fn write_frame_times_out_when_peer_stops_reading() {
-        let (guest, _peer) = UnixStream::pair().unwrap();
+        let (guest, mut peer) = UnixStream::pair().unwrap();
         set_send_buffer(&guest, 4096).unwrap();
         let writer = GuestWriter::new(guest);
         let frame = vec![0xAB; 8 * 1024 * 1024];
@@ -232,5 +232,8 @@ mod tests {
 
         assert_eq!(err.kind(), io::ErrorKind::TimedOut);
         assert!(started.elapsed() < Duration::from_secs(2));
+
+        let mut drained = Vec::new();
+        peer.read_to_end(&mut drained).unwrap();
     }
 }

--- a/crates/vsock-guest/src/writer.rs
+++ b/crates/vsock-guest/src/writer.rs
@@ -200,8 +200,9 @@ mod tests {
     #[test]
     fn write_frame_sends_complete_frame() {
         let (guest, mut peer) = UnixStream::pair().unwrap();
+        set_send_buffer(&guest, 4096).unwrap();
         let writer = GuestWriter::new(guest);
-        let frame = vec![7u8; 64 * 1024];
+        let frame = vec![7u8; 1024 * 1024];
         let expected = frame.clone();
 
         let reader = std::thread::spawn(move || {
@@ -211,11 +212,27 @@ mod tests {
         });
 
         writer
-            .write_frame_with_deadline(&frame, Duration::from_secs(1))
+            .write_frame_with_deadline(&frame, Duration::from_secs(5))
             .unwrap();
         drop(writer);
 
         assert_eq!(reader.join().unwrap(), expected);
+    }
+
+    #[test]
+    fn write_frame_fails_when_peer_is_closed() {
+        let (guest, peer) = UnixStream::pair().unwrap();
+        drop(peer);
+        let writer = GuestWriter::new(guest);
+
+        let err = writer
+            .write_frame_with_deadline(&[1, 2, 3, 4], Duration::from_secs(1))
+            .unwrap_err();
+
+        assert!(matches!(
+            err.kind(),
+            io::ErrorKind::BrokenPipe | io::ErrorKind::ConnectionReset
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a centralized GuestWriter for guest-to-host protocol frames
- bound each frame write with nonblocking send + POLLOUT polling and shut down the stream on timeout/write failure
- route ready, exec, spawn_watch, stdout chunk, process exit, shutdown ack, and generic response writes through GuestWriter
- add writer regression coverage for a peer that keeps the socket open but stops reading

Closes #11745

## Tests

- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest
- RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p vsock-guest --no-deps
- pre-commit lefthook: crates cargo-fmt, cargo-clippy, cargo-doc