### PR TITLE
fix(vsock-guest): define timeout wait outcome semantics

### DIFF
--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -10,10 +10,9 @@ use crate::drain::{drain_into_vec_cancellable, drain_until_eof_or_cancelled};
 use crate::error::to_io_error;
 use crate::exec::{prepend_env, spawn_with_pipes, truncate_preview};
 use crate::log::log;
-use crate::process::extract_exit_code;
 use crate::wait::{
-    DRAIN_DEADLINE_SECS, EXIT_CODE_TIMEOUT, KillWatchdog, await_drain_deadline,
-    finalize_buffered_result, wait_with_drain_and_timeout,
+    DRAIN_DEADLINE_SECS, KillWatchdog, await_drain_deadline, finalize_buffered_result,
+    finalize_wait_outcome, resolve_wait_outcome, wait_with_drain_and_timeout,
 };
 use crate::writer::GuestWriter;
 
@@ -269,15 +268,9 @@ fn spawn_streaming_monitor(
             let _ = h.join();
         }
 
-        let killed_by_timeout = watchdog.map(KillWatchdog::join).unwrap_or(false);
-        let (exit_code, stderr) = if killed_by_timeout {
-            (EXIT_CODE_TIMEOUT, b"Timeout".to_vec())
-        } else {
-            match status {
-                Ok(s) => (extract_exit_code(s), stderr),
-                Err(e) => (1, format!("Failed to wait: {e}").into_bytes()),
-            }
-        };
+        let outcome =
+            resolve_wait_outcome(status, watchdog.map(KillWatchdog::join).unwrap_or(false));
+        let (exit_code, stderr) = finalize_wait_outcome(outcome, stderr);
 
         log(
             "INFO",

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::process::{Child, ExitStatus};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, mpsc};
@@ -24,6 +25,23 @@ pub(crate) enum WaitOutcome {
     TimedOut,
     /// `wait()` itself failed; carries the error message.
     WaitFailed(String),
+}
+
+pub(crate) fn resolve_wait_outcome(
+    status: io::Result<ExitStatus>,
+    killed_by_timeout: bool,
+) -> WaitOutcome {
+    match status {
+        // Timeout is a deadline verdict: if the watchdog fired and the kill
+        // syscall succeeded, the child was not observed as complete before the
+        // deadline. Preserve that timeout verdict even if wait() races back
+        // with a status around the same boundary.
+        Ok(_) if killed_by_timeout => WaitOutcome::TimedOut,
+        Ok(s) => WaitOutcome::Exited(s),
+        // A real wait() failure is more actionable than the watchdog verdict.
+        // Do not hide wait/reap errors behind timeout classification.
+        Err(e) => WaitOutcome::WaitFailed(e.to_string()),
+    }
 }
 
 /// Watchdog that kills a child process tree if it is not stood down before
@@ -115,11 +133,7 @@ pub(crate) fn wait_with_kill_timeout(mut child: Child, timeout_ms: u32) -> WaitO
     let status = child.wait();
     let killed_by_timeout = watchdog.join();
 
-    match status {
-        Ok(_) if killed_by_timeout => WaitOutcome::TimedOut,
-        Ok(s) => WaitOutcome::Exited(s),
-        Err(e) => WaitOutcome::WaitFailed(e.to_string()),
-    }
+    resolve_wait_outcome(status, killed_by_timeout)
 }
 
 /// Coordinate child wait + concurrent stdout/stderr drain + timeout-driven kill.
@@ -198,18 +212,68 @@ pub(crate) fn wait_with_drain_and_timeout(
     (outcome, stdout_buf, stderr_buf)
 }
 
-/// Resolve a [`WaitOutcome`] + drained bytes into the `(exit_code, stdout, stderr)`
-/// triple the protocol returns. Timeout overrides any drained stderr with the
-/// canonical "Timeout" body so callers can disambiguate from a real exit-1.
+/// Resolve a [`WaitOutcome`] + drained stderr into protocol exit fields.
+/// Timeout overrides any drained stderr with the canonical "Timeout" body so
+/// callers can disambiguate from a real exit-1.
+pub(crate) fn finalize_wait_outcome(outcome: WaitOutcome, stderr_buf: Vec<u8>) -> (i32, Vec<u8>) {
+    match outcome {
+        WaitOutcome::TimedOut => (EXIT_CODE_TIMEOUT, b"Timeout".to_vec()),
+        WaitOutcome::Exited(s) => (extract_exit_code(s), stderr_buf),
+        WaitOutcome::WaitFailed(msg) => (1, format!("Failed to wait: {msg}").into_bytes()),
+    }
+}
+
 pub(crate) fn finalize_buffered_result(
     outcome: WaitOutcome,
     stdout: Vec<u8>,
     stderr_buf: Vec<u8>,
 ) -> (i32, Vec<u8>, Vec<u8>) {
-    let (exit_code, stderr) = match outcome {
-        WaitOutcome::TimedOut => (EXIT_CODE_TIMEOUT, b"Timeout".to_vec()),
-        WaitOutcome::Exited(s) => (extract_exit_code(s), stderr_buf),
-        WaitOutcome::WaitFailed(msg) => (1, format!("Failed to wait: {msg}").into_bytes()),
-    };
+    let (exit_code, stderr) = finalize_wait_outcome(outcome, stderr_buf);
     (exit_code, stdout, stderr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    fn successful_status() -> ExitStatus {
+        Command::new("true").status().unwrap()
+    }
+
+    #[test]
+    fn resolve_wait_outcome_keeps_status_when_watchdog_did_not_fire() {
+        match resolve_wait_outcome(Ok(successful_status()), false) {
+            WaitOutcome::Exited(status) => assert_eq!(extract_exit_code(status), 0),
+            WaitOutcome::TimedOut => panic!("watchdog did not fire"),
+            WaitOutcome::WaitFailed(msg) => panic!("wait unexpectedly failed: {msg}"),
+        }
+    }
+
+    #[test]
+    fn resolve_wait_outcome_timeout_wins_over_observed_status() {
+        match resolve_wait_outcome(Ok(successful_status()), true) {
+            WaitOutcome::TimedOut => {}
+            WaitOutcome::Exited(_) => panic!("timeout should win over boundary status"),
+            WaitOutcome::WaitFailed(msg) => panic!("wait unexpectedly failed: {msg}"),
+        }
+    }
+
+    #[test]
+    fn resolve_wait_outcome_preserves_wait_error_without_timeout() {
+        match resolve_wait_outcome(Err(io::Error::other("wait failed")), false) {
+            WaitOutcome::WaitFailed(msg) => assert_eq!(msg, "wait failed"),
+            WaitOutcome::Exited(_) => panic!("wait error should not produce status"),
+            WaitOutcome::TimedOut => panic!("watchdog did not fire"),
+        }
+    }
+
+    #[test]
+    fn resolve_wait_outcome_preserves_wait_error_when_watchdog_fired() {
+        match resolve_wait_outcome(Err(io::Error::other("wait failed")), true) {
+            WaitOutcome::WaitFailed(msg) => assert_eq!(msg, "wait failed"),
+            WaitOutcome::Exited(_) => panic!("wait error should not produce status"),
+            WaitOutcome::TimedOut => panic!("wait error should not be hidden by timeout"),
+        }
+    }
 }

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -303,4 +303,17 @@ mod tests {
         assert_eq!(code, 1);
         assert_eq!(stderr, b"Failed to wait: wait failed".to_vec());
     }
+
+    #[test]
+    fn finalize_buffered_result_timeout_preserves_stdout() {
+        let (code, stdout, stderr) = finalize_buffered_result(
+            WaitOutcome::TimedOut,
+            b"partial stdout".to_vec(),
+            b"real stderr".to_vec(),
+        );
+
+        assert_eq!(code, EXIT_CODE_TIMEOUT);
+        assert_eq!(stdout, b"partial stdout".to_vec());
+        assert_eq!(stderr, b"Timeout".to_vec());
+    }
 }

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -118,10 +118,7 @@ pub(crate) fn await_drain_deadline(
 /// deadlock on its next write while we wait.
 pub(crate) fn wait_with_kill_timeout(mut child: Child, timeout_ms: u32) -> WaitOutcome {
     if timeout_ms == 0 {
-        return match child.wait() {
-            Ok(s) => WaitOutcome::Exited(s),
-            Err(e) => WaitOutcome::WaitFailed(e.to_string()),
-        };
+        return resolve_wait_outcome(child.wait(), false);
     }
 
     let timeout = Duration::from_millis(u64::from(timeout_ms));
@@ -275,5 +272,35 @@ mod tests {
             WaitOutcome::Exited(_) => panic!("wait error should not produce status"),
             WaitOutcome::TimedOut => panic!("wait error should not be hidden by timeout"),
         }
+    }
+
+    #[test]
+    fn finalize_wait_outcome_preserves_exit_status_and_stderr() {
+        let stderr = b"stderr bytes".to_vec();
+
+        let (code, finalized_stderr) =
+            finalize_wait_outcome(WaitOutcome::Exited(successful_status()), stderr.clone());
+
+        assert_eq!(code, 0);
+        assert_eq!(finalized_stderr, stderr);
+    }
+
+    #[test]
+    fn finalize_wait_outcome_timeout_overrides_stderr() {
+        let (code, stderr) = finalize_wait_outcome(WaitOutcome::TimedOut, b"real stderr".to_vec());
+
+        assert_eq!(code, EXIT_CODE_TIMEOUT);
+        assert_eq!(stderr, b"Timeout".to_vec());
+    }
+
+    #[test]
+    fn finalize_wait_outcome_preserves_wait_failed_message() {
+        let (code, stderr) = finalize_wait_outcome(
+            WaitOutcome::WaitFailed("wait failed".to_string()),
+            b"ignored".to_vec(),
+        );
+
+        assert_eq!(code, 1);
+        assert_eq!(stderr, b"Failed to wait: wait failed".to_vec());
     }
 }


### PR DESCRIPTION
## Summary

- centralize timeout boundary resolution in `resolve_wait_outcome`
- document that watchdog-fired timeout wins over an observed status, while real `wait()` errors are preserved
- route streaming monitor through the same wait outcome and finalization helpers as buffered/exec paths
- add deterministic helper matrix tests instead of timing-boundary sleeps

Closes #11746

## Tests

- cargo test --manifest-path crates/Cargo.toml -p vsock-guest wait::tests:: -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest exec_timeout_returns_124 -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest streaming_monitor_timeout_kills_process -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest streaming_monitor_clean_exit_returns_before_long_timeout -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest exec_timeout_zero_means_no_timeout -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p vsock-guest --no-deps
- git diff --check
- pre-commit lefthook: crates cargo-fmt, cargo-clippy, cargo-doc
