### PR TITLE
chore(rust): update dependencies (2026-05-04)

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -990,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
@@ -1452,7 +1452,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2007,7 +2007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3004,7 +3004,7 @@ checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3015,7 +3015,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Weekly Rust dependency refresh via `cargo update --verbose` against the workspace at `crates/`.

### Updated
- `digest` 0.11.2 → 0.11.3 (transitively bumps the crate in `hmac`, `sha1` 0.11, `sha2`, `md-5`)

Only `Cargo.lock` changed; no `Cargo.toml` edits were necessary.

### Could NOT be updated (transitive constraints — must wait for upstream)

| Crate | Locked | Available | Blocked by |
|---|---|---|---|
| `crc-fast` | 1.9.0 | 1.10.0 | `aws-smithy-checksums` 0.64.7 pins `crc-fast = \"~1.9.0\"` |
| `crc` | 3.3.0 | 3.4.0 | `crc-fast` 1.9.0 pins `crc = \"~3.3\"` |
| `generic-array` | 0.14.7 | 0.14.9 | `crypto-common` 0.1.7 pins `generic-array = \"=0.14.7\"` |

These will unblock automatically when AWS publishes a new `aws-smithy-checksums` and the RustCrypto team a new `crypto-common`.

### Manual version bumps in Cargo.toml
None. All workspace dependency declarations already use loose major-version constraints (e.g. `\"1\"`, `\"0.4\"`), so the resolver had nothing to do beyond what `cargo update` produced.

### Test status
All workspace tests pass locally (`CARGO_BUILD_JOBS=1 cargo test --workspace --no-fail-fast`):
- 0 failed across all crates
- ~1900 unit + integration tests, plus doctests, all green

## Test plan
- [x] `cargo build --workspace` — clean compile
- [x] `cargo test --workspace --no-fail-fast` — all green
- [ ] CI passes