### PR TITLE
fix(api): raise shadow-compare default timeout to 5 minutes

### DIFF
--- a/turbo/apps/api/src/signals/context/shadow-compare.ts
+++ b/turbo/apps/api/src/signals/context/shadow-compare.ts
@@ -255,7 +255,7 @@ function selectedSource(route: AppRoute): ShadowCompareSource {
 export function shadowCompareRoute({
   route,
   handler,
-  timeoutMs = 2000,
+  timeoutMs = 300_000,
 }: ShadowCompareOptions): Command<Promise<unknown>, [AbortSignal]> {
   return command(
     async ({ get, set }, signal: AbortSignal): Promise<unknown> => {


### PR DESCRIPTION
## Summary
- Bumps the default `shadowCompareRoute` timeout from `2_000` ms to `300_000` ms in `turbo/apps/api/src/signals/context/shadow-compare.ts`.
- Eliminates spurious 500s when the shadow's `web` source is selected and the upstream (legacy Next.js handler) takes longer than 2s — frequent on cold dev compiles, but also possible in prod for legitimately slow legacy routes.
- 5 minutes mirrors undici's default request timeout used elsewhere in the proxy path, so shadow behaviour stops diverging from the proxy fallback.

## Why 5 minutes
The shadow request only exists to observe the web result for diff comparison. Aborting it early doesn't protect the user — `selectedSource === "web"` means we *return* `selected.reason` to the client (`shadow-compare.ts:297`), so a 2s shadow timeout becomes a 500 even when the web side would have answered in 3s. The request `AbortSignal` already covers client-disconnect, so the timeout is just a safety net for a stuck upstream.

## Test plan
- [ ] Re-hit the previously failing routes in dev (`/api/zero/onboarding/status`, `/billing/status`, `/integrations/slack`, `/agents/:id`) on a cold compile and confirm 200 instead of 500.
- [ ] `pnpm -F api exec vitest run shadow-compare` (existing 2 tests still pass).
- [ ] `pnpm turbo run lint --filter=api`, `pnpm check-types`, `pnpm format` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)