### PR TITLE
fix: mark truncated decompressed network bodies

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -287,7 +287,11 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     if flow.response:
         stream_buf = flow.metadata.get("stream_buffer")
         if stream_buf is not None:
-            body = decompress_body(bytes(stream_buf), flow.response.headers)
+            body = decompress_body(
+                bytes(stream_buf),
+                flow.response.headers,
+                max_output=STREAM_BUFFER_LIMIT + 1,
+            )
         else:
             try:
                 body = flow.response.content

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -688,7 +688,8 @@ class TestDecompression:
         entry = {}
         add_capture_fields(flow, entry)
         # Body should be capped, not 1MB
-        assert len(entry.get("response_body", "")) <= STREAM_BUFFER_LIMIT
+        assert entry["response_body_truncated"] is True
+        assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
 
     def test_truncated_brotli_falls_back(self, real_flow):
         """Truncated brotli data should fall back gracefully."""


### PR DESCRIPTION
## Summary
- Request one extra decompressed byte for captured response stream buffers so add_capture_fields can distinguish exactly-at-limit bodies from decompression-cap truncation.
- Assert gzip bodies that expand past the capture limit are logged with response_body_truncated=true and trimmed back to the configured limit.

Closes #11791

## Tests
- pytest tests/test_body_capture.py::TestDecompression::test_gzip_zip_bomb_capped
- pytest tests/test_body_capture.py
- pytest tests/
- python3 -m ruff check src/body_utils.py tests/test_body_capture.py
- python3 -m ruff format --check src/body_utils.py tests/test_body_capture.py