### PR TITLE
fix(vsock-guest): cancel background work on disconnect

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -1,5 +1,7 @@
 use std::io::{self, Read};
 use std::os::unix::net::UnixStream;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
@@ -21,6 +23,14 @@ const READ_BUFFER_SIZE: usize = 64 * 1024; // 64KB
 enum ConnectionEnd {
     Closed,
     Shutdown,
+}
+
+struct CancelOnDrop(Arc<AtomicBool>);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Release);
+    }
 }
 
 /// Connect to vsock (Linux only - this binary runs inside Firecracker VM)
@@ -87,6 +97,8 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
     // This avoids deadlock: reader can block while writer sends process_exit
     let mut reader = stream.try_clone()?;
     let writer = GuestWriter::new(stream);
+    let connection_cancel = Arc::new(AtomicBool::new(false));
+    let _cancel_on_drop = CancelOnDrop(connection_cancel.clone());
 
     let mut decoder = vsock_proto::Decoder::new();
 
@@ -130,6 +142,7 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                     },
                     msg.seq,
                     writer.clone(),
+                    connection_cancel.clone(),
                 )?;
             } else if msg.msg_type == MSG_EXEC {
                 log(
@@ -147,11 +160,12 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                 let sudo = d.sudo;
                 let seq = msg.seq;
                 let w = writer.clone();
+                let connection_cancel = connection_cancel.clone();
                 thread::spawn(move || {
                     let env_refs: Vec<(&str, &str)> =
                         env.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
                     let (exit_code, stdout, stderr) =
-                        handle_exec(timeout_ms, &command, &env_refs, sudo);
+                        handle_exec(timeout_ms, &command, &env_refs, sudo, &connection_cancel);
                     let payload = vsock_proto::encode_exec_result(exit_code, &stdout, &stderr);
                     let encoded = match vsock_proto::encode(MSG_EXEC_RESULT, seq, &payload) {
                         Ok(msg) => msg,

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -25,9 +25,13 @@ enum ConnectionEnd {
     Shutdown,
 }
 
-struct CancelOnDrop(Arc<AtomicBool>);
+/// Signals all command work spawned for this host connection when the
+/// connection loop exits. `run()` may reconnect after a close, but in-flight
+/// commands belong to the old connection and should not survive into the next
+/// one.
+struct ConnectionCancelGuard(Arc<AtomicBool>);
 
-impl Drop for CancelOnDrop {
+impl Drop for ConnectionCancelGuard {
     fn drop(&mut self) {
         self.0.store(true, Ordering::Release);
     }
@@ -98,7 +102,7 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
     let mut reader = stream.try_clone()?;
     let writer = GuestWriter::new(stream);
     let connection_cancel = Arc::new(AtomicBool::new(false));
-    let _cancel_on_drop = CancelOnDrop(connection_cancel.clone());
+    let _cancel_on_drop = ConnectionCancelGuard(connection_cancel.clone());
 
     let mut decoder = vsock_proto::Decoder::new();
 

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -16,8 +16,8 @@ use crate::log::log;
 use crate::process::extract_exit_code;
 use crate::shutdown::handle_shutdown;
 use crate::wait::{
-    WaitOutcome, await_drain_deadline, finalize_buffered_result, wait_with_drain_and_timeout,
-    wait_with_kill_timeout,
+    WaitOutcome, await_drain_deadline, finalize_buffered_result,
+    wait_with_drain_and_timeout_or_cancelled, wait_with_kill_timeout,
 };
 
 pub(crate) enum MessageOutcome {
@@ -31,6 +31,7 @@ pub(crate) fn handle_exec(
     command: &str,
     env: &[(&str, &str)],
     sudo: bool,
+    connection_cancel: &AtomicBool,
 ) -> (i32, Vec<u8>, Vec<u8>) {
     log(
         "INFO",
@@ -55,7 +56,8 @@ pub(crate) fn handle_exec(
         }
     };
 
-    let (outcome, stdout, stderr_buf) = wait_with_drain_and_timeout(child, timeout_ms);
+    let (outcome, stdout, stderr_buf) =
+        wait_with_drain_and_timeout_or_cancelled(child, timeout_ms, connection_cancel);
     let result = finalize_buffered_result(outcome, stdout, stderr_buf);
 
     log(
@@ -138,8 +140,8 @@ fn handle_write_file(path: &str, content: &[u8], use_sudo: bool, append: bool) -
     // child exits, the drain thread either reaches EOF naturally or — if a
     // grandchild somehow still holds stderr — is cut at the deadline so its
     // last write returns EPIPE.
-    // Defensive: same invariant as wait_with_drain_and_timeout — reap the
-    // child if its stderr is somehow already gone, so we don't leave a zombie.
+    // Defensive: same invariant as the exec drain helper — reap the child if
+    // its stderr is somehow already gone, so we don't leave a zombie.
     let stderr_pipe = match child.stderr.take() {
         Some(p) => p,
         None => {
@@ -166,6 +168,7 @@ fn handle_write_file(path: &str, content: &[u8], use_sudo: bool, append: bool) -
 
     match outcome {
         WaitOutcome::TimedOut => (false, "write timed out".to_string()),
+        WaitOutcome::Cancelled => (false, "write cancelled".to_string()),
         WaitOutcome::WaitFailed(msg) => (false, format!("write wait failed: {msg}")),
         WaitOutcome::Exited(s) => {
             let exit_code = extract_exit_code(s);

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -228,7 +228,9 @@ fn spawn_streaming_monitor(
 
         // child wait is now UNBLOCKED — no pipe fds are held by this thread.
         let outcome = wait_with_kill_timeout_or_cancelled(child, timeout_ms, &connection_cancel);
-        if matches!(outcome, crate::wait::WaitOutcome::Cancelled) {
+        if matches!(outcome, crate::wait::WaitOutcome::Cancelled)
+            || connection_cancel.load(Ordering::Acquire)
+        {
             cancel.store(true, Ordering::Release);
         }
 

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -2,7 +2,6 @@ use std::io::{self, Write};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
-use std::time::Duration;
 
 use vsock_proto::{self, MSG_ERROR, MSG_PROCESS_EXIT, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK};
 
@@ -11,8 +10,8 @@ use crate::error::to_io_error;
 use crate::exec::{prepend_env, spawn_with_pipes, truncate_preview};
 use crate::log::log;
 use crate::wait::{
-    DRAIN_DEADLINE_SECS, KillWatchdog, await_drain_deadline, finalize_buffered_result,
-    finalize_wait_outcome, resolve_wait_outcome, wait_with_drain_and_timeout,
+    DRAIN_DEADLINE_SECS, await_drain_deadline, finalize_buffered_result, finalize_wait_outcome,
+    wait_with_drain_and_timeout_or_cancelled, wait_with_kill_timeout_or_cancelled,
 };
 use crate::writer::GuestWriter;
 
@@ -43,6 +42,7 @@ pub(crate) fn handle_spawn_watch(
     request: SpawnWatchRequest<'_>,
     seq: u32,
     writer: GuestWriter,
+    connection_cancel: Arc<AtomicBool>,
 ) -> io::Result<()> {
     log(
         "INFO",
@@ -105,11 +105,12 @@ pub(crate) fn handle_spawn_watch(
             stdout_pipe,
             request.stdout_log_path.map(str::to_owned),
             writer,
+            connection_cancel,
         );
     } else {
         // Buffered mode: stdout/stderr drained via cancellable helper, sent
         // in a single MSG_PROCESS_EXIT after wait.
-        spawn_buffered_monitor(pid, child, request.timeout_ms, writer);
+        spawn_buffered_monitor(pid, child, request.timeout_ms, writer, connection_cancel);
     }
 
     Ok(())
@@ -138,18 +139,9 @@ fn spawn_streaming_monitor(
     stdout_pipe: Option<std::process::ChildStdout>,
     log_path: Option<String>,
     writer: GuestWriter,
+    connection_cancel: Arc<AtomicBool>,
 ) {
     thread::spawn(move || {
-        // Set up timeout BEFORE the stdout loop — if the process runs past the
-        // deadline it must be killed even while we are still reading output.
-        let child_id = child.id();
-        let mut watchdog = if timeout_ms > 0 {
-            let timeout = Duration::from_millis(u64::from(timeout_ms));
-            Some(KillWatchdog::spawn(child_id, timeout))
-        } else {
-            None
-        };
-
         let cancel = Arc::new(AtomicBool::new(false));
         let (drain_done_tx, drain_done_rx) = std::sync::mpsc::channel::<()>();
 
@@ -234,14 +226,10 @@ fn spawn_streaming_monitor(
         };
         drop(drain_done_tx); // so recv returns Disconnected when both threads die
 
-        // child.wait() is now UNBLOCKED — no pipe fds held by this thread.
-        let status = child.wait();
-
-        // Signal timeout thread that process completed. This must happen
-        // before drain cleanup; otherwise a cleanly exited process could be
-        // killed while we are still draining its pipes.
-        if let Some(watchdog) = watchdog.as_mut() {
-            watchdog.stand_down();
+        // child wait is now UNBLOCKED — no pipe fds are held by this thread.
+        let outcome = wait_with_kill_timeout_or_cancelled(child, timeout_ms, &connection_cancel);
+        if matches!(outcome, crate::wait::WaitOutcome::Cancelled) {
+            cancel.store(true, Ordering::Release);
         }
 
         // Shared drain deadline: stdout + stderr share a single budget.
@@ -268,8 +256,6 @@ fn spawn_streaming_monitor(
             let _ = h.join();
         }
 
-        let outcome =
-            resolve_wait_outcome(status, watchdog.map(KillWatchdog::join).unwrap_or(false));
         let (exit_code, stderr) = finalize_wait_outcome(outcome, stderr);
 
         log(
@@ -293,9 +279,11 @@ fn spawn_buffered_monitor(
     child: std::process::Child,
     timeout_ms: u32,
     writer: GuestWriter,
+    connection_cancel: Arc<AtomicBool>,
 ) {
     thread::spawn(move || {
-        let (outcome, stdout, stderr_buf) = wait_with_drain_and_timeout(child, timeout_ms);
+        let (outcome, stdout, stderr_buf) =
+            wait_with_drain_and_timeout_or_cancelled(child, timeout_ms, &connection_cancel);
         let (exit_code, stdout, stderr) = finalize_buffered_result(outcome, stdout, stderr_buf);
 
         log(

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -121,10 +121,10 @@ pub(crate) fn handle_spawn_watch(
 /// against `child.wait()`.
 ///
 /// Architecture:
-/// - Timeout killer thread: kills process group after deadline
+/// - Monitor thread: waits for child exit, timeout, or connection cancellation
 /// - Stderr reader thread: drains stderr into a `Vec<u8>` (cancellable)
 /// - Stdout reader thread: streams chunks to log + vsock (cancellable)
-/// - Monitor thread: waits for `child.wait()`, then applies drain deadline
+/// - Drain deadline: after child wait completes, bounds lingering pipe readers
 ///
 /// If a grandchild keeps pipe fds open past child exit, the deadline fires
 /// the cancel flag — both reader threads exit promptly, dropping their fds

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -84,7 +84,7 @@ pub(crate) unsafe fn kill_process_tree(child_id: u32) -> bool {
         let err = std::io::Error::last_os_error();
         log(
             "WARN",
-            &format!("timeout kill(-{child_id}, SIGKILL) failed: {err}"),
+            &format!("process-tree kill(-{child_id}, SIGKILL) failed: {err}"),
         );
         return false;
     }
@@ -101,7 +101,7 @@ pub(crate) unsafe fn kill_process_tree(child_id: u32) -> bool {
             let err = std::io::Error::last_os_error();
             log(
                 "WARN",
-                &format!("timeout kill(-{pgid}, SIGKILL) for su child group failed: {err}"),
+                &format!("process-tree kill(-{pgid}, SIGKILL) for su child group failed: {err}"),
             );
         }
     }

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::process::{Child, ExitStatus};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, mpsc};
@@ -35,65 +34,6 @@ enum KillReason {
     Cancelled,
 }
 
-pub(crate) fn resolve_wait_outcome(
-    status: io::Result<ExitStatus>,
-    killed_by_timeout: bool,
-) -> WaitOutcome {
-    match status {
-        // Timeout is a deadline verdict: if the watchdog fired and the kill
-        // syscall succeeded, the child was not observed as complete before the
-        // deadline. Preserve that timeout verdict even if wait() races back
-        // with a status around the same boundary.
-        Ok(_) if killed_by_timeout => WaitOutcome::TimedOut,
-        Ok(s) => WaitOutcome::Exited(s),
-        // A real wait() failure is more actionable than the watchdog verdict.
-        // Do not hide wait/reap errors behind timeout classification.
-        Err(e) => WaitOutcome::WaitFailed(e.to_string()),
-    }
-}
-
-/// Watchdog that kills a child process tree if it is not stood down before
-/// `timeout` elapses.
-#[must_use = "watchdogs must be stood down and joined so timeout verdicts are observed"]
-pub(crate) struct KillWatchdog {
-    done_tx: Option<mpsc::Sender<()>>,
-    handle: thread::JoinHandle<bool>,
-}
-
-impl KillWatchdog {
-    pub(crate) fn spawn(child_id: u32, timeout: Duration) -> Self {
-        let (done_tx, done_rx) = mpsc::channel::<()>();
-        let handle = thread::spawn(move || -> bool {
-            if done_rx.recv_timeout(timeout).is_err() {
-                // SAFETY: child_id is a valid PID from Command::spawn.
-                return unsafe { kill_process_tree(child_id) };
-            }
-            false
-        });
-
-        Self {
-            done_tx: Some(done_tx),
-            handle,
-        }
-    }
-
-    /// Stand the watchdog down without joining it yet.
-    ///
-    /// This lets callers preserve existing timing where the child has exited,
-    /// the watchdog is disarmed immediately, and the join verdict is collected
-    /// after other cleanup work.
-    pub(crate) fn stand_down(&mut self) {
-        if let Some(done_tx) = self.done_tx.take() {
-            let _ = done_tx.send(());
-        }
-    }
-
-    pub(crate) fn join(mut self) -> bool {
-        self.stand_down();
-        self.handle.join().unwrap_or(false)
-    }
-}
-
 /// Wait for drain workers to complete within the shared drain deadline, then
 /// cancel any laggards.
 pub(crate) fn await_drain_deadline(
@@ -126,19 +66,14 @@ pub(crate) fn await_drain_deadline(
 /// deadlock on its next write while we wait.
 pub(crate) fn wait_with_kill_timeout(mut child: Child, timeout_ms: u32) -> WaitOutcome {
     if timeout_ms == 0 {
-        return resolve_wait_outcome(child.wait(), false);
+        return match child.wait() {
+            Ok(status) => WaitOutcome::Exited(status),
+            Err(e) => WaitOutcome::WaitFailed(e.to_string()),
+        };
     }
 
-    let timeout = Duration::from_millis(u64::from(timeout_ms));
-    let child_id = child.id();
-
-    // Watchdog: kills the process tree if the child does not report exit
-    // before the timeout. Its return value is the timeout verdict.
-    let watchdog = KillWatchdog::spawn(child_id, timeout);
-    let status = child.wait();
-    let killed_by_timeout = watchdog.join();
-
-    resolve_wait_outcome(status, killed_by_timeout)
+    let cancel = AtomicBool::new(false);
+    wait_with_kill_timeout_or_cancelled(child, timeout_ms, &cancel)
 }
 
 /// Wait for `child` to exit, killing and reaping it when either the configured
@@ -310,46 +245,6 @@ mod tests {
 
     fn successful_status() -> ExitStatus {
         Command::new("true").status().unwrap()
-    }
-
-    #[test]
-    fn resolve_wait_outcome_keeps_status_when_watchdog_did_not_fire() {
-        match resolve_wait_outcome(Ok(successful_status()), false) {
-            WaitOutcome::Exited(status) => assert_eq!(extract_exit_code(status), 0),
-            WaitOutcome::TimedOut => panic!("watchdog did not fire"),
-            WaitOutcome::Cancelled => panic!("connection was not cancelled"),
-            WaitOutcome::WaitFailed(msg) => panic!("wait unexpectedly failed: {msg}"),
-        }
-    }
-
-    #[test]
-    fn resolve_wait_outcome_timeout_wins_over_observed_status() {
-        match resolve_wait_outcome(Ok(successful_status()), true) {
-            WaitOutcome::TimedOut => {}
-            WaitOutcome::Exited(_) => panic!("timeout should win over boundary status"),
-            WaitOutcome::Cancelled => panic!("connection was not cancelled"),
-            WaitOutcome::WaitFailed(msg) => panic!("wait unexpectedly failed: {msg}"),
-        }
-    }
-
-    #[test]
-    fn resolve_wait_outcome_preserves_wait_error_without_timeout() {
-        match resolve_wait_outcome(Err(io::Error::other("wait failed")), false) {
-            WaitOutcome::WaitFailed(msg) => assert_eq!(msg, "wait failed"),
-            WaitOutcome::Exited(_) => panic!("wait error should not produce status"),
-            WaitOutcome::TimedOut => panic!("watchdog did not fire"),
-            WaitOutcome::Cancelled => panic!("connection was not cancelled"),
-        }
-    }
-
-    #[test]
-    fn resolve_wait_outcome_preserves_wait_error_when_watchdog_fired() {
-        match resolve_wait_outcome(Err(io::Error::other("wait failed")), true) {
-            WaitOutcome::WaitFailed(msg) => assert_eq!(msg, "wait failed"),
-            WaitOutcome::Exited(_) => panic!("wait error should not produce status"),
-            WaitOutcome::TimedOut => panic!("wait error should not be hidden by timeout"),
-            WaitOutcome::Cancelled => panic!("connection was not cancelled"),
-        }
     }
 
     #[test]

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -205,7 +205,7 @@ pub(crate) fn wait_with_drain_and_timeout_or_cancelled(
     drop(done_tx); // so recv returns Disconnected if both drain threads die
 
     let outcome = wait_with_kill_timeout_or_cancelled(child, timeout_ms, external_cancel);
-    if matches!(outcome, WaitOutcome::Cancelled) {
+    if matches!(outcome, WaitOutcome::Cancelled) || external_cancel.load(Ordering::Acquire) {
         cancel.store(true, Ordering::Release);
     }
 

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -16,15 +16,23 @@ pub(crate) const EXIT_CODE_TIMEOUT: i32 = 124;
 /// `send_process_exit()` anyway to prevent indefinite hangs when orphaned
 /// child processes hold pipe fds open.
 pub(crate) const DRAIN_DEADLINE_SECS: u64 = 5;
+const WAIT_CANCEL_POLL_INTERVAL_MS: u64 = 50;
 
-/// Outcome of [`wait_with_kill_timeout`].
+/// Outcome of child wait helpers.
 pub(crate) enum WaitOutcome {
     /// Child exited with this status.
     Exited(ExitStatus),
-    /// Child was killed by the timeout watchdog.
+    /// Child was killed after its timeout elapsed.
     TimedOut,
+    /// Child was killed because its owning connection was cancelled.
+    Cancelled,
     /// `wait()` itself failed; carries the error message.
     WaitFailed(String),
+}
+
+enum KillReason {
+    Timeout,
+    Cancelled,
 }
 
 pub(crate) fn resolve_wait_outcome(
@@ -133,6 +141,67 @@ pub(crate) fn wait_with_kill_timeout(mut child: Child, timeout_ms: u32) -> WaitO
     resolve_wait_outcome(status, killed_by_timeout)
 }
 
+/// Wait for `child` to exit, killing and reaping it when either the configured
+/// timeout expires or `cancel` is signalled.
+///
+/// `timeout_ms == 0` still means "no timeout"; cancellation remains active so
+/// work tied to a disconnected host connection cannot outlive that connection
+/// indefinitely.
+pub(crate) fn wait_with_kill_timeout_or_cancelled(
+    mut child: Child,
+    timeout_ms: u32,
+    cancel: &AtomicBool,
+) -> WaitOutcome {
+    let child_id = child.id();
+    let deadline = if timeout_ms > 0 {
+        let now = Instant::now();
+        Some(
+            now.checked_add(Duration::from_millis(u64::from(timeout_ms)))
+                .unwrap_or(now),
+        )
+    } else {
+        None
+    };
+    let poll_interval = Duration::from_millis(WAIT_CANCEL_POLL_INTERVAL_MS);
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return WaitOutcome::Exited(status),
+            Ok(None) => {}
+            Err(e) => return WaitOutcome::WaitFailed(e.to_string()),
+        }
+
+        let now = Instant::now();
+        let reason = if deadline.is_some_and(|deadline| now >= deadline) {
+            Some(KillReason::Timeout)
+        } else if cancel.load(Ordering::Acquire) {
+            Some(KillReason::Cancelled)
+        } else {
+            None
+        };
+
+        if let Some(reason) = reason {
+            // SAFETY: child_id is a valid PID from Command::spawn.
+            let killed = unsafe { kill_process_tree(child_id) } || child.kill().is_ok();
+            return match child.wait() {
+                Err(e) => WaitOutcome::WaitFailed(e.to_string()),
+                Ok(status) if !killed => WaitOutcome::Exited(status),
+                Ok(_) => match reason {
+                    KillReason::Timeout => WaitOutcome::TimedOut,
+                    KillReason::Cancelled => WaitOutcome::Cancelled,
+                },
+            };
+        }
+
+        let sleep_for = deadline
+            .map(|deadline| deadline.saturating_duration_since(now).min(poll_interval))
+            .unwrap_or(poll_interval);
+        if !sleep_for.is_zero() {
+            thread::sleep(sleep_for);
+        }
+    }
+}
+
 /// Coordinate child wait + concurrent stdout/stderr drain + timeout-driven kill.
 ///
 /// Drain threads run in parallel with `wait()` so a chatty child cannot
@@ -144,9 +213,10 @@ pub(crate) fn wait_with_kill_timeout(mut child: Child, timeout_ms: u32) -> WaitO
 /// which drops the read end of the pipe. The orphan's next write then sees
 /// EPIPE / SIGPIPE, so neither kernel pipe buffers nor our heap accumulate
 /// further bytes.
-pub(crate) fn wait_with_drain_and_timeout(
+pub(crate) fn wait_with_drain_and_timeout_or_cancelled(
     mut child: Child,
     timeout_ms: u32,
+    external_cancel: &AtomicBool,
 ) -> (WaitOutcome, Vec<u8>, Vec<u8>) {
     // Defensive: if either pipe is missing the caller broke the
     // `spawn_with_pipes` invariant. Reap the child before returning so we
@@ -199,7 +269,10 @@ pub(crate) fn wait_with_drain_and_timeout(
     };
     drop(done_tx); // so recv returns Disconnected if both drain threads die
 
-    let outcome = wait_with_kill_timeout(child, timeout_ms);
+    let outcome = wait_with_kill_timeout_or_cancelled(child, timeout_ms, external_cancel);
+    if matches!(outcome, WaitOutcome::Cancelled) {
+        cancel.store(true, Ordering::Release);
+    }
 
     let _ = await_drain_deadline(&done_rx, 2, &cancel);
 
@@ -215,6 +288,7 @@ pub(crate) fn wait_with_drain_and_timeout(
 pub(crate) fn finalize_wait_outcome(outcome: WaitOutcome, stderr_buf: Vec<u8>) -> (i32, Vec<u8>) {
     match outcome {
         WaitOutcome::TimedOut => (EXIT_CODE_TIMEOUT, b"Timeout".to_vec()),
+        WaitOutcome::Cancelled => (1, b"Connection cancelled".to_vec()),
         WaitOutcome::Exited(s) => (extract_exit_code(s), stderr_buf),
         WaitOutcome::WaitFailed(msg) => (1, format!("Failed to wait: {msg}").into_bytes()),
     }
@@ -243,6 +317,7 @@ mod tests {
         match resolve_wait_outcome(Ok(successful_status()), false) {
             WaitOutcome::Exited(status) => assert_eq!(extract_exit_code(status), 0),
             WaitOutcome::TimedOut => panic!("watchdog did not fire"),
+            WaitOutcome::Cancelled => panic!("connection was not cancelled"),
             WaitOutcome::WaitFailed(msg) => panic!("wait unexpectedly failed: {msg}"),
         }
     }
@@ -252,6 +327,7 @@ mod tests {
         match resolve_wait_outcome(Ok(successful_status()), true) {
             WaitOutcome::TimedOut => {}
             WaitOutcome::Exited(_) => panic!("timeout should win over boundary status"),
+            WaitOutcome::Cancelled => panic!("connection was not cancelled"),
             WaitOutcome::WaitFailed(msg) => panic!("wait unexpectedly failed: {msg}"),
         }
     }
@@ -262,6 +338,7 @@ mod tests {
             WaitOutcome::WaitFailed(msg) => assert_eq!(msg, "wait failed"),
             WaitOutcome::Exited(_) => panic!("wait error should not produce status"),
             WaitOutcome::TimedOut => panic!("watchdog did not fire"),
+            WaitOutcome::Cancelled => panic!("connection was not cancelled"),
         }
     }
 
@@ -271,6 +348,7 @@ mod tests {
             WaitOutcome::WaitFailed(msg) => assert_eq!(msg, "wait failed"),
             WaitOutcome::Exited(_) => panic!("wait error should not produce status"),
             WaitOutcome::TimedOut => panic!("wait error should not be hidden by timeout"),
+            WaitOutcome::Cancelled => panic!("connection was not cancelled"),
         }
     }
 
@@ -291,6 +369,14 @@ mod tests {
 
         assert_eq!(code, EXIT_CODE_TIMEOUT);
         assert_eq!(stderr, b"Timeout".to_vec());
+    }
+
+    #[test]
+    fn finalize_wait_outcome_cancelled_reports_connection_cancelled() {
+        let (code, stderr) = finalize_wait_outcome(WaitOutcome::Cancelled, b"real stderr".to_vec());
+
+        assert_eq!(code, 1);
+        assert_eq!(stderr, b"Connection cancelled".to_vec());
     }
 
     #[test]

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -764,6 +764,54 @@ fn read_buffered_spawn_watch_result(
     }
 }
 
+fn read_spawn_watch_pid(stream: &mut impl std::io::Read, seq: u32) -> u32 {
+    let mut decoder = vsock_proto::Decoder::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        let n = read_retry_eintr(stream, &mut buf).unwrap();
+        assert!(n > 0, "unexpected EOF waiting for spawn_watch pid");
+        for msg in decoder.decode(buf.get(..n).unwrap_or_default()).unwrap() {
+            if msg.msg_type == MSG_SPAWN_WATCH_RESULT && msg.seq == seq {
+                return vsock_proto::decode_spawn_watch_result(&msg.payload).unwrap();
+            }
+        }
+    }
+}
+
+fn read_pid_file(path: &str) -> u32 {
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        match std::fs::read_to_string(path) {
+            Ok(contents) => return contents.trim().parse().unwrap(),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => panic!("failed to read pid file {path}: {e}"),
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "pid file {path} was not created",
+        );
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn kill_pid_group(pid: u32) {
+    // SAFETY: best-effort cleanup for a pid produced by a test child process.
+    unsafe {
+        libc::kill(-(pid as i32), libc::SIGKILL);
+    }
+}
+
+fn wait_for_pid_exit(pid: u32, context: &str) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while pid_alive(pid) {
+        if std::time::Instant::now() >= deadline {
+            kill_pid_group(pid);
+            panic!("pid {pid} did not terminate within 5s after {context}");
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
 /// Regression for #11077 (`MSG_EXEC` side): with `timeout_ms = 0`, a
 /// backgrounded grandchild that inherits the stdout fd must NOT keep
 /// `MSG_EXEC_RESULT` from arriving after the foreground shell exits.
@@ -878,6 +926,69 @@ fn pid_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as i32, 0) == 0 }
 }
 
+#[test]
+fn exec_timeout_zero_silent_child_is_cancelled_on_host_disconnect() {
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    let pid_path = format!(
+        "/tmp/vsock-test-exec-cancel-{}-{}.pid",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _ = std::fs::remove_file(&pid_path);
+
+    let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+    read_and_discard_message(&mut host_stream); // MSG_READY
+
+    let payload =
+        vsock_proto::encode_exec(0, &format!("echo $$ > '{pid_path}'; sleep 60"), &[], false);
+    let msg = vsock_proto::encode(MSG_EXEC, 1, &payload).unwrap();
+    host_stream.write_all(&msg).unwrap();
+
+    let pid = read_pid_file(&pid_path);
+    assert!(
+        pid_alive(pid),
+        "child should still be running before disconnect",
+    );
+
+    drop(host_stream);
+    let _ = handle.join();
+    wait_for_pid_exit(pid, "exec host disconnect");
+
+    let _ = std::fs::remove_file(&pid_path);
+}
+
+#[test]
+fn spawn_watch_timeout_zero_silent_child_is_cancelled_on_host_disconnect() {
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+    read_and_discard_message(&mut host_stream); // MSG_READY
+
+    send_spawn_watch(&mut host_stream, 1, "sleep 60", None, 0);
+    host_stream
+        .set_read_timeout(Some(Duration::from_secs(3)))
+        .unwrap();
+    let pid = read_spawn_watch_pid(&mut host_stream, 1);
+    assert!(
+        pid_alive(pid),
+        "child should still be running before disconnect",
+    );
+
+    drop(host_stream);
+    let _ = handle.join();
+    wait_for_pid_exit(pid, "spawn_watch host disconnect");
+}
+
 /// Regression for #11077: when the host drops the vsock connection
 /// mid-stream, the streaming monitor's stdout drain hits a write failure
 /// on its next chunk forward, signals cancel, drops the pipe fd, and the
@@ -974,9 +1085,9 @@ fn streaming_terminates_child_on_vsock_disconnect() {
 /// the second pipe would fill, the child would block on its next write,
 /// and the test would hit the read timeout.
 ///
-/// Pins down the concurrent-drain invariant of `wait_with_drain_and_timeout`
-/// shared by `MSG_EXEC` and buffered `MSG_SPAWN_WATCH`. The streaming
-/// path in `spawn_streaming_monitor` follows the same
+/// Pins down the concurrent-drain invariant shared by `MSG_EXEC` and buffered
+/// `MSG_SPAWN_WATCH`. The streaming path in `spawn_streaming_monitor` follows
+/// the same
 /// stderr-thread-before-stdout-thread structure for the same reason.
 #[test]
 fn buffered_spawn_watch_concurrent_large_stdout_stderr() {

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -782,7 +782,11 @@ fn read_pid_file(path: &str) -> u32 {
     let deadline = std::time::Instant::now() + Duration::from_secs(3);
     loop {
         match std::fs::read_to_string(path) {
-            Ok(contents) => return contents.trim().parse().unwrap(),
+            Ok(contents) => {
+                if let Ok(pid) = contents.trim().parse() {
+                    return pid;
+                }
+            }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => panic!("failed to read pid file {path}: {e}"),
         }

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -18,9 +18,9 @@ use vsock_proto::{
 const EXIT_CODE_TIMEOUT: i32 = 124;
 const DRAIN_DEADLINE_SECS: u64 = 5;
 
-struct SocketPathGuard(String);
+struct TempPathGuard(String);
 
-impl SocketPathGuard {
+impl TempPathGuard {
     fn new(path: String) -> Self {
         let _ = std::fs::remove_file(&path);
         Self(path)
@@ -31,21 +31,29 @@ impl SocketPathGuard {
     }
 }
 
-impl Drop for SocketPathGuard {
+impl Drop for TempPathGuard {
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.0);
     }
 }
 
-fn unique_socket_path(label: &str) -> SocketPathGuard {
+fn unique_tmp_path(label: &str, suffix: &str) -> TempPathGuard {
     let nonce = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    SocketPathGuard::new(format!(
-        "/tmp/vsock-test-{label}-{}-{nonce}.sock",
-        std::process::id()
+    TempPathGuard::new(format!(
+        "/tmp/vsock-test-{label}-{}-{nonce}{suffix}",
+        std::process::id(),
     ))
+}
+
+fn unique_socket_path(label: &str) -> TempPathGuard {
+    unique_tmp_path(label, ".sock")
+}
+
+fn unique_pid_path(label: &str) -> TempPathGuard {
+    unique_tmp_path(label, ".pid")
 }
 
 /// Helper: send a MSG_EXEC via the writer half, read MSG_EXEC_RESULT from the
@@ -934,15 +942,7 @@ fn pid_alive(pid: u32) -> bool {
 fn exec_timeout_zero_silent_child_is_cancelled_on_host_disconnect() {
     use std::os::unix::net::UnixStream as StdUnixStream;
 
-    let pid_path = format!(
-        "/tmp/vsock-test-exec-cancel-{}-{}.pid",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    );
-    let _ = std::fs::remove_file(&pid_path);
+    let pid_path = unique_pid_path("exec-cancel");
 
     let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
     let handle = thread::spawn(move || {
@@ -950,12 +950,16 @@ fn exec_timeout_zero_silent_child_is_cancelled_on_host_disconnect() {
     });
     read_and_discard_message(&mut host_stream); // MSG_READY
 
-    let payload =
-        vsock_proto::encode_exec(0, &format!("echo $$ > '{pid_path}'; sleep 60"), &[], false);
+    let payload = vsock_proto::encode_exec(
+        0,
+        &format!("echo $$ > '{}'; sleep 60", pid_path.as_str()),
+        &[],
+        false,
+    );
     let msg = vsock_proto::encode(MSG_EXEC, 1, &payload).unwrap();
     host_stream.write_all(&msg).unwrap();
 
-    let pid = read_pid_file(&pid_path);
+    let pid = read_pid_file(pid_path.as_str());
     assert!(
         pid_alive(pid),
         "child should still be running before disconnect",
@@ -964,8 +968,6 @@ fn exec_timeout_zero_silent_child_is_cancelled_on_host_disconnect() {
     drop(host_stream);
     let _ = handle.join();
     wait_for_pid_exit(pid, "exec host disconnect");
-
-    let _ = std::fs::remove_file(&pid_path);
 }
 
 #[test]

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -995,6 +995,31 @@ fn spawn_watch_timeout_zero_silent_child_is_cancelled_on_host_disconnect() {
     wait_for_pid_exit(pid, "spawn_watch host disconnect");
 }
 
+#[test]
+fn spawn_watch_buffered_timeout_zero_silent_child_is_cancelled_on_host_disconnect() {
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+    read_and_discard_message(&mut host_stream); // MSG_READY
+
+    send_spawn_watch_buffered(&mut host_stream, 1, "sleep 60", 0);
+    host_stream
+        .set_read_timeout(Some(Duration::from_secs(3)))
+        .unwrap();
+    let pid = read_spawn_watch_pid(&mut host_stream, 1);
+    assert!(
+        pid_alive(pid),
+        "child should still be running before disconnect",
+    );
+
+    drop(host_stream);
+    let _ = handle.join();
+    wait_for_pid_exit(pid, "buffered spawn_watch host disconnect");
+}
+
 /// Regression for #11077: when the host drops the vsock connection
 /// mid-stream, the streaming monitor's stdout drain hits a write failure
 /// on its next chunk forward, signals cancel, drops the pipe fd, and the


### PR DESCRIPTION
## Summary

- add connection-scoped cancellation for vsock-guest background exec and spawn-watch work
- make child waits cancellation-aware so timeout_ms=0 remains unlimited only while the host connection is healthy
- cancel drain workers promptly after connection-cancelled kills and add regression coverage for silent exec/spawn-watch children

Closes #11749

## Tests

- cargo test --manifest-path crates/Cargo.toml -p vsock-guest silent_child_is_cancelled -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest wait::tests:: -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest
- cargo fmt --all --check (in crates/)
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p vsock-guest --no-deps
- git diff --check
- pre-commit lefthook: crates cargo-fmt, cargo-clippy, cargo-doc
