### PR TITLE
perf: bound brotli body capture decompression

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -37,7 +37,8 @@ _UTF8_LEAD_MAX_3BYTE = 0xF0  # 3-byte lead: 1110xxxx
 LARGE_RESPONSE_DECOMPRESS_LIMIT = 5 * 1024 * 1024  # 5 MB
 
 # Python's brotli binding has no max-output API. Feed compressed data in small
-# chunks so large compressible responses cannot be materialised in one call.
+# chunks and stop once the caller's cap is accumulated; process() can still
+# transiently emit a multi-MB chunk from a tiny input.
 _BROTLI_DECOMPRESS_INPUT_CHUNK_SIZE = 16
 
 

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -36,6 +36,10 @@ _UTF8_LEAD_MAX_3BYTE = 0xF0  # 3-byte lead: 1110xxxx
 # calls while still bounding decompression bombs.
 LARGE_RESPONSE_DECOMPRESS_LIMIT = 5 * 1024 * 1024  # 5 MB
 
+# Python's brotli binding has no max-output API. Feed compressed data in small
+# chunks so large compressible responses cannot be materialised in one call.
+_BROTLI_DECOMPRESS_INPUT_CHUNK_SIZE = 16
+
 
 # ---------------------------------------------------------------------------
 # Body capture helpers (opt-in per run via captureNetworkBodies registry flag)
@@ -137,15 +141,11 @@ def decompress_body(
     - zstd: hard cap via ``ZstdDecompressor.stream_reader(data).read(max_output)``;
       zstd reads incrementally so total memory is bounded by
       ``max_output`` plus library internal buffers.
-    - br: **no hard cap.**  The Python ``brotli`` bindings expose only
-      ``Decompressor.process(data)`` which materialises the full decompressed
-      output before returning; slicing afterwards does not prevent the
-      transient allocation.  Input chunking is not a reliable defence —
-      a single brotli copy command can emit up to 16 MB from a handful of
-      encoded bytes, so chunk-level bounds don't hold for adversarial
-      input.  This is acceptable given the callers only decompress
-      bodies from the pre-configured model-provider and billable-connector
-      allowlist (not arbitrary user-supplied URLs).
+    - br: bounded accumulator over small compressed input chunks.  The
+      Python ``brotli`` bindings expose no max-output API, so ``process`` may
+      still transiently emit a multi-MB chunk, but decoding stops once
+      ``max_output`` bytes have been accumulated instead of materialising the
+      full response before slicing.
 
     Returns the original data unchanged when the encoding is missing,
     ``identity``, or unrecognised, and on decompression error.  A valid
@@ -162,8 +162,7 @@ def decompress_body(
             obj = zlib.decompressobj(wbits)
             return obj.decompress(data, max_length=max_output)
         if encoding == "br":
-            dec = brotli.Decompressor()
-            return dec.process(data)[:max_output]
+            return _decompress_brotli_bounded(data, max_output)
         if encoding == "zstd":
             # stream_reader.read(n) reads *up to* n bytes: the full frame if
             # smaller than n, exactly n if larger — so total memory is bounded
@@ -175,6 +174,27 @@ def decompress_body(
             # ctx.log unavailable outside mitmproxy runtime
             ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
     return data
+
+
+def _decompress_brotli_bounded(data: bytes, max_output: int) -> bytes:
+    if max_output <= 0:
+        return b""
+
+    dec = brotli.Decompressor()
+    out = bytearray()
+    for offset in range(0, len(data), _BROTLI_DECOMPRESS_INPUT_CHUNK_SIZE):
+        chunk = data[offset : offset + _BROTLI_DECOMPRESS_INPUT_CHUNK_SIZE]
+        decoded = dec.process(chunk)
+        if not decoded:
+            continue
+
+        remaining = max_output - len(out)
+        if len(decoded) >= remaining:
+            out.extend(decoded[:remaining])
+            return bytes(out)
+        out.extend(decoded)
+
+    return bytes(out)
 
 
 def _is_text_content(content_type: str) -> bool:

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -633,6 +633,27 @@ class TestDecompression:
         add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "hello world"}'
 
+    def test_brotli_exact_limit_not_truncated(self, real_flow):
+        original = b"x" * STREAM_BUFFER_LIMIT
+        compressed = brotli.compress(original)
+        assert len(compressed) < STREAM_BUFFER_LIMIT
+        flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "br", "text/plain")
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "response_body_truncated" not in entry
+        assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
+
+    def test_brotli_truncation_preserves_utf8_boundary(self, real_flow):
+        original = b"x" * STREAM_BUFFER_LIMIT + "\u20ac".encode("utf-8")
+        compressed = brotli.compress(original)
+        assert len(compressed) < STREAM_BUFFER_LIMIT
+        flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "br", "text/plain")
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["response_body_truncated"] is True
+        assert entry["response_body_encoding"] == "utf-8"
+        assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
+
     def test_brotli_zip_bomb_capped_without_full_decode(self, real_flow, monkeypatch):
         original = b"\x00" * (10 * 1024 * 1024)
         compressed = brotli.compress(original)

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -634,7 +634,7 @@ class TestDecompression:
         assert entry["response_body"] == '{"result": "hello world"}'
 
     def test_brotli_zip_bomb_capped_without_full_decode(self, real_flow, monkeypatch):
-        original = b"\x00" * (32 * 1024 * 1024)
+        original = b"\x00" * (10 * 1024 * 1024)
         compressed = brotli.compress(original)
         assert len(compressed) < STREAM_BUFFER_LIMIT
 

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -633,6 +633,36 @@ class TestDecompression:
         add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "hello world"}'
 
+    def test_brotli_zip_bomb_capped_without_full_decode(self, real_flow, monkeypatch):
+        original = b"\x00" * (32 * 1024 * 1024)
+        compressed = brotli.compress(original)
+        assert len(compressed) < STREAM_BUFFER_LIMIT
+
+        real_decompressor = brotli.Decompressor
+        stats = {"calls": 0, "max_input": 0, "max_output": 0}
+
+        class CountingDecompressor:
+            def __init__(self):
+                self._inner = real_decompressor()
+
+            def process(self, chunk: bytes) -> bytes:
+                out = self._inner.process(chunk)
+                stats["calls"] += 1
+                stats["max_input"] = max(stats["max_input"], len(chunk))
+                stats["max_output"] = max(stats["max_output"], len(out))
+                return out
+
+        monkeypatch.setattr("body_utils.brotli.Decompressor", CountingDecompressor)
+
+        flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "br", "text/plain")
+        entry = {}
+        add_capture_fields(flow, entry)
+
+        assert entry["response_body_truncated"] is True
+        assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
+        assert stats["max_input"] < len(compressed)
+        assert stats["max_output"] < len(original)
+
     def test_zstd_decompressed(self, real_flow):
         original = b'{"result": "hello world"}'
         compressed = zstandard.ZstdCompressor().compress(original)
@@ -926,9 +956,9 @@ class TestDecompressBody:
     ``LARGE_RESPONSE_DECOMPRESS_LIMIT``) for JSON parsing.
 
     Focus: verify the documented ``max_output`` cap is enforced during
-    decompression (not only via after-the-fact slicing) for gzip/zstd.
-    brotli is intentionally not tested for strict bounding — see the
-    ``decompress_body`` docstring for why that codec is best-effort.
+    decompression (not only via after-the-fact slicing) for codecs with
+    hard output-limit APIs.  Brotli's Python binding is best-effort; the
+    high-compression capture regression is covered in ``TestDecompression``.
     """
 
     def test_gzip_respects_max_output(self, headers):


### PR DESCRIPTION
## Summary
- Replace brotli one-shot decompression slicing with a bounded accumulator that feeds compressed input in small chunks and stops once the requested capture cap is accumulated.
- Document the brotli limitation: Python brotli still has no hard max-output API, so one `process()` call can transiently emit a multi-MB chunk, but we no longer materialize the full decompressed response before slicing.
- Add a high-compression brotli network body capture regression test that verifies truncation semantics and that the full compressed response is not decoded in one call.

Closes #11795

## Tests
- pytest tests/test_body_capture.py::TestDecompression::test_brotli_zip_bomb_capped_without_full_decode
- pytest tests/test_body_capture.py
- pytest tests/
- python3 -m ruff check src/body_utils.py tests/test_body_capture.py
- python3 -m ruff format --check src/body_utils.py tests/test_body_capture.py