### PR TITLE
test(runner): cover nbd orphan disconnect branches

### DIFF
--- a/crates/runner/src/cmd/nbd.rs
+++ b/crates/runner/src/cmd/nbd.rs
@@ -134,6 +134,29 @@ mod tests {
     }
 
     #[test]
+    fn orphan_disconnect_reports_disconnect_error() {
+        let result = disconnect_orphan_if_still_dead_with(
+            3,
+            123,
+            |_| Ok(Some(())),
+            |_| Some(123),
+            |_| false,
+            |_| {
+                Err(nbd_cow::error::NbdCowError::Io(std::io::Error::other(
+                    "netlink failed",
+                )))
+            },
+        );
+
+        match result {
+            NbdOrphanDisconnect::Failed(message) => {
+                assert!(message.contains("netlink failed"));
+            }
+            other => panic!("expected disconnect failure, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn orphan_disconnect_rechecks_pid_after_lock() {
         let result = disconnect_orphan_if_still_dead_with(
             3,
@@ -142,6 +165,34 @@ mod tests {
             |_| Some(456),
             |_| false,
             |_| panic!("disconnect should not run after pid change"),
+        );
+
+        assert!(matches!(result, NbdOrphanDisconnect::Changed));
+    }
+
+    #[test]
+    fn orphan_disconnect_skips_when_pid_cleared_after_lock() {
+        let result = disconnect_orphan_if_still_dead_with(
+            3,
+            123,
+            |_| Ok(Some(())),
+            |_| None,
+            |_| panic!("pid_exists should not run after pid is cleared"),
+            |_| panic!("disconnect should not run after pid is cleared"),
+        );
+
+        assert!(matches!(result, NbdOrphanDisconnect::Changed));
+    }
+
+    #[test]
+    fn orphan_disconnect_skips_when_same_pid_is_live_after_lock() {
+        let result = disconnect_orphan_if_still_dead_with(
+            3,
+            123,
+            |_| Ok(Some(())),
+            |_| Some(123),
+            |_| true,
+            |_| panic!("disconnect should not run for a live pid"),
         );
 
         assert!(matches!(result, NbdOrphanDisconnect::Changed));


### PR DESCRIPTION
## Summary
- add regression coverage for NBD orphan disconnect failure propagation
- add race coverage for pid clearing after lock acquisition
- add race coverage for same pid becoming live after lock acquisition

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --check --package runner
- cargo test --manifest-path crates/Cargo.toml -p runner orphan_disconnect --jobs 1 -- --nocapture

Note: the first runner test attempt without `--jobs 1` failed during linking with local `Cannot allocate memory`; the single-job retry passed.

Closes #11786