### PR TITLE
fix(vsock-guest): run write file command in process group

### DIFF
--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -125,7 +125,7 @@ pub(crate) fn spawn_with_pipes(command: &str, sudo: bool) -> io::Result<Child> {
 mod tests {
     use super::*;
     use std::path::PathBuf;
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use crate::wait::{WaitOutcome, wait_with_kill_timeout};
 
@@ -135,6 +135,17 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.0);
         }
+    }
+
+    fn wait_for_path(path: &std::path::Path, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if path.exists() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        path.exists()
     }
 
     #[test]
@@ -251,13 +262,20 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).unwrap();
         let _guard = TempDirGuard(dir.clone());
+        let ready = dir.join("ready");
         let survived = dir.join("survived");
+        let ready_arg = shell_escape_value(ready.to_str().unwrap());
         let survived_arg = shell_escape_value(survived.to_str().unwrap());
-        let script = format!("trap '' HUP; (sleep 1; touch {survived_arg}) & wait");
+        let script =
+            format!("trap '' HUP; (sleep 1; touch {survived_arg}) & touch {ready_arg}; wait");
 
         let mut command = build_exec_command(&script, false);
         command.stdout(Stdio::null()).stderr(Stdio::null());
         let child = spawn_in_own_process_group(&mut command).unwrap();
+        assert!(
+            wait_for_path(&ready, Duration::from_secs(2)),
+            "background child should be started before timeout kill is tested"
+        );
 
         let outcome = wait_with_kill_timeout(child, 100);
         assert!(matches!(outcome, WaitOutcome::TimedOut));

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 
 /// Maximum length for command preview in logs
 const COMMAND_PREVIEW_MAX_LEN: usize = 100;
@@ -97,30 +97,45 @@ pub(crate) fn truncate_preview(s: &str) -> String {
     format!("{}...", &s[..end])
 }
 
-/// Spawn `command` with stdout/stderr piped — used by both buffered exec and
-/// streaming spawn-watch.
-pub(crate) fn spawn_with_pipes(command: &str, sudo: bool) -> io::Result<std::process::Child> {
+/// Spawn a command as the leader of a new process group on Unix.
+///
+/// Timeout killing targets the process group by child PID, so every child path
+/// that uses the shared wait helpers must preserve this spawn invariant.
+pub(crate) fn spawn_in_own_process_group(command: &mut Command) -> io::Result<Child> {
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
-        build_exec_command(command, sudo)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .process_group(0)
-            .spawn()
+        command.process_group(0).spawn()
     }
     #[cfg(not(unix))]
     {
-        build_exec_command(command, sudo)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
+        command.spawn()
     }
+}
+
+/// Spawn `command` with stdout/stderr piped — used by both buffered exec and
+/// streaming spawn-watch.
+pub(crate) fn spawn_with_pipes(command: &str, sudo: bool) -> io::Result<Child> {
+    let mut command = build_exec_command(command, sudo);
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    spawn_in_own_process_group(&mut command)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use crate::wait::{WaitOutcome, wait_with_kill_timeout};
+
+    struct TempDirGuard(PathBuf);
+
+    impl Drop for TempDirGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
 
     #[test]
     fn shell_escape_simple() {
@@ -220,6 +235,37 @@ mod tests {
             (prog == "sudo" && args == ["sh", "-c", "reboot"])
                 || (prog == "sh" && args == ["-c", "reboot"]),
             "unexpected sudo command: {prog} {args:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn spawn_in_own_process_group_timeout_kills_background_child() {
+        let dir = std::env::temp_dir().join(format!(
+            "vsock-guest-pg-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let _guard = TempDirGuard(dir.clone());
+        let survived = dir.join("survived");
+        let survived_arg = shell_escape_value(survived.to_str().unwrap());
+        let script = format!("trap '' HUP; (sleep 1; touch {survived_arg}) & wait");
+
+        let mut command = build_exec_command(&script, false);
+        command.stdout(Stdio::null()).stderr(Stdio::null());
+        let child = spawn_in_own_process_group(&mut command).unwrap();
+
+        let outcome = wait_with_kill_timeout(child, 100);
+        assert!(matches!(outcome, WaitOutcome::TimedOut));
+
+        std::thread::sleep(Duration::from_millis(1500));
+        assert!(
+            !survived.exists(),
+            "timeout kill should terminate background children in the process group"
         );
     }
 }

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -1,5 +1,5 @@
 use std::io::{self, Write};
-use std::process::Stdio;
+use std::process::{Child, Stdio};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::thread;
@@ -11,7 +11,9 @@ use vsock_proto::{
 
 use crate::drain::drain_into_vec_cancellable;
 use crate::error::to_io_error;
-use crate::exec::{build_exec_command, prepend_env, spawn_with_pipes, truncate_preview};
+use crate::exec::{
+    build_exec_command, prepend_env, spawn_in_own_process_group, spawn_with_pipes, truncate_preview,
+};
 use crate::log::log;
 use crate::process::extract_exit_code;
 use crate::shutdown::handle_shutdown;
@@ -115,12 +117,7 @@ fn handle_write_file(path: &str, content: &[u8], use_sudo: bool, append: bool) -
         }
     };
 
-    let mut child = match build_exec_command(&write_cmd, use_sudo)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .spawn()
-    {
+    let mut child = match spawn_write_file_command(&write_cmd, use_sudo) {
         Ok(c) => c,
         Err(e) => return (false, format!("Failed to spawn write command: {e}")),
     };
@@ -181,6 +178,15 @@ fn handle_write_file(path: &str, content: &[u8], use_sudo: bool, append: bool) -
     }
 }
 
+fn spawn_write_file_command(write_cmd: &str, use_sudo: bool) -> io::Result<Child> {
+    let mut command = build_exec_command(write_cmd, use_sudo);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    spawn_in_own_process_group(&mut command)
+}
+
 /// Handle incoming message and return the connection-loop outcome.
 ///
 /// `MSG_EXEC` and `MSG_SPAWN_WATCH` are handled separately in
@@ -213,5 +219,23 @@ pub(crate) fn handle_message(msg: &RawMessage) -> io::Result<MessageOutcome> {
                 vsock_proto::encode(MSG_ERROR, msg.seq, &payload).map_err(to_io_error)?,
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn write_file_command_starts_as_process_group_leader() {
+        let mut child = spawn_write_file_command("sleep 10", false).unwrap();
+        let pid = child.id();
+
+        let pgid = unsafe { libc::getpgid(pid as libc::pid_t) };
+        let _ = unsafe { crate::process::kill_process_tree(pid) };
+        let _ = child.wait();
+
+        assert_eq!(pgid, pid as libc::pid_t);
     }
 }


### PR DESCRIPTION
## Summary
- Add a shared `spawn_in_own_process_group` helper for vsock guest child commands.
- Keep exec/spawn-watch on the shared helper and route write_file command spawning through it.
- Add Unix regressions for write_file process-group leadership and timeout killing of background children.

## Tests
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-test --all-features`

Closes #11768