### PR TITLE
docs(sandbox): document runtime module

### DIFF
--- a/crates/sandbox/src/runtime.rs
+++ b/crates/sandbox/src/runtime.rs
@@ -1,3 +1,12 @@
+//! Runtime-level sandbox backend abstractions.
+//!
+//! A [`RuntimeProvider`] builds a backend runtime from [`RuntimeConfig`]. The
+//! resulting [`SandboxRuntime`] owns runtime-wide shared resources and creates
+//! started [`SandboxFactory`] instances for individual profiles.
+//!
+//! Factories created from a runtime must be shut down before
+//! [`SandboxRuntime::shutdown`] releases the shared resources they depend on.
+
 use async_trait::async_trait;
 
 use crate::config::{FactoryConfig, RuntimeConfig};


### PR DESCRIPTION
## Summary
- add module-level docs for sandbox runtime abstractions
- describe provider -> runtime -> factory construction flow
- document factory-before-runtime shutdown ordering

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --check --package sandbox
- cargo doc --manifest-path crates/Cargo.toml -p sandbox --no-deps

Closes #11779