### PR TITLE
docs: expand vsock guest log docs

### DIFF
--- a/crates/vsock-guest/src/log.rs
+++ b/crates/vsock-guest/src/log.rs
@@ -1,4 +1,15 @@
-/// Log a message to stderr
+//! Lightweight stderr logging for the vsock guest process.
+
+/// Logs a message to stderr.
+///
+/// The logger writes one line in the form `[vsock-guest] [{level}] {msg}`.
+/// `level` is passed through as a free-form label without validation or
+/// normalization; current call sites conventionally use `INFO`, `WARN`, and
+/// `ERROR`.
+///
+/// `msg` is written as provided, and the trailing line break is added by this
+/// function. Callers that need one physical log line should avoid embedding
+/// newlines in `msg`.
 pub fn log(level: &str, msg: &str) {
     eprintln!("[vsock-guest] [{level}] {msg}");
 }


### PR DESCRIPTION
## Summary
- add module-level docs for the vsock guest logger
- document the public log() output format and free-form level/message behavior

Closes #11781

## Tests
- cargo fmt --manifest-path crates/Cargo.toml -p vsock-guest --check
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest --lib
- cargo doc --manifest-path crates/Cargo.toml -p vsock-guest --no-deps
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc