### PR TITLE
fix(seo): drop incomplete Product JSON-LD on model detail pages

### DIFF
--- a/turbo/apps/web/app/[locale]/models/[slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/models/[slug]/page.tsx
@@ -87,18 +87,6 @@ export default async function ModelDetailPage({ params }: PageProps) {
   const modelName = t(`${cn}.name`);
   const faqs = t.raw(`${cn}.faqs`) as { q: string; a: string }[];
 
-  const productJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "Product",
-    name: `${modelName} on VM0`,
-    description: t(`${cn}.metaDescription`),
-    brand: {
-      "@type": "Brand",
-      name: model.vendor,
-    },
-    category: "AI Model",
-  };
-
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
@@ -141,9 +129,6 @@ export default async function ModelDetailPage({ params }: PageProps) {
 
   return (
     <>
-      <script type="application/ld+json" suppressHydrationWarning>
-        {JSON.stringify(productJsonLd)}
-      </script>
       <script type="application/ld+json" suppressHydrationWarning>
         {JSON.stringify(breadcrumbJsonLd)}
       </script>


### PR DESCRIPTION
## Summary

- Google Search Console flagged \`/models/[slug]\` pages: the \`Product\` JSON-LD was missing the required \`offers\`, \`review\`, or \`aggregateRating\` field.
- This page is purely an SEO landing page introducing third-party AI models — nothing on it is directly purchasable from vm0, so \`Product\` is semantically wrong. Adding fake offers/ratings would invite Google policy issues; using vendor list prices doesn't represent a vm0 transaction.
- Per discussion, simplest accurate fix: drop the \`Product\` block entirely. The page keeps its existing \`BreadcrumbList\` and \`FAQPage\` JSON-LD, both of which remain valid and rich-result-eligible.

## Test plan

- [ ] After deploy, fetch a model page (e.g. https://www.vm0.ai/en/models/claude-opus-4-7) and confirm only \`BreadcrumbList\` and \`FAQPage\` JSON-LD remain in the page source
- [ ] Run Google's Rich Results Test on a deployed model URL — expect zero Product errors, FAQ rich result still detected
- [ ] In GSC, request validation for the "在 vm0.ai 中检测到产品摘要结构化数据问题" issue once the change is live