### PR TITLE
refactor(runner): split start factory lifecycle

### DIFF
--- a/crates/runner/src/cmd/start/factory_lifecycle.rs
+++ b/crates/runner/src/cmd/start/factory_lifecycle.rs
@@ -1,0 +1,211 @@
+//! Sandbox factory startup and shutdown for `runner start`.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+
+use sandbox::{SandboxFactory, SandboxRuntime};
+use tracing::{info, warn};
+
+use super::TeardownTimer;
+use crate::config::{self, ProfileConfig};
+use crate::error::RunnerResult;
+use crate::paths::HomePaths;
+
+/// A sandbox factory shared across concurrent job executors.
+///
+/// Uses `Arc<Box<...>>` instead of `Arc<dyn ...>` because `Arc::try_unwrap`
+/// requires a sized type -- `dyn SandboxFactory` is unsized, but `Box<dyn
+/// SandboxFactory>` is sized, allowing `try_unwrap` at shutdown.
+pub(super) type SharedFactory = Arc<Box<dyn SandboxFactory>>;
+
+/// Build one sandbox factory per configured profile.
+pub(super) async fn start_factories(
+    profiles: &BTreeMap<String, ProfileConfig>,
+    firecracker: &config::FirecrackerConfig,
+    base_dir: &Path,
+    home: &HomePaths,
+    runtime: &mut dyn SandboxRuntime,
+) -> RunnerResult<BTreeMap<String, (SharedFactory, bool)>> {
+    let mut factories: BTreeMap<String, (SharedFactory, bool)> = BTreeMap::new();
+    for (profile_name, profile_config) in profiles {
+        let factory_config = config::RunnerConfig::build_factory_config(
+            firecracker,
+            base_dir,
+            profile_name,
+            profile_config,
+            home,
+        );
+        let restore_guest_state = factory_config.snapshot.is_some();
+        let factory_result = runtime.create_factory(factory_config).await;
+        let factory = match factory_result {
+            Ok(factory) => factory,
+            Err(e) => {
+                shutdown_factories(&mut factories, runtime, None).await;
+                return Err(e.into());
+            }
+        };
+        factories.insert(
+            profile_name.clone(),
+            (Arc::new(factory), restore_guest_state),
+        );
+        info!(profile = %profile_name, "factory started");
+    }
+    Ok(factories)
+}
+
+/// Shut down all factories, then release shared runtime resources.
+pub(super) async fn shutdown_factories(
+    factories: &mut BTreeMap<String, (SharedFactory, bool)>,
+    runtime: &mut dyn SandboxRuntime,
+    teardown: Option<&TeardownTimer>,
+) {
+    for (name, (factory, _)) in std::mem::take(factories) {
+        match Arc::try_unwrap(factory) {
+            Ok(mut f) => {
+                let phase = teardown.map(|timer| {
+                    let phase_start = Instant::now();
+                    info!(
+                        phase = "factory_shutdown",
+                        profile = %name,
+                        elapsed_ms = timer.elapsed_ms(),
+                        "teardown phase started"
+                    );
+                    phase_start
+                });
+                f.shutdown().await;
+                if let (Some(timer), Some(phase)) = (teardown, phase) {
+                    info!(
+                        phase = "factory_shutdown",
+                        profile = %name,
+                        phase_ms = TeardownTimer::duration_ms(phase.elapsed()),
+                        elapsed_ms = timer.elapsed_ms(),
+                        "teardown phase complete"
+                    );
+                }
+            }
+            Err(_) => warn!(profile = %name, "factory still referenced at shutdown"),
+        }
+    }
+    // Clean up shared resources (netns pool, base loop cache).
+    let phase = teardown.map(|timer| timer.phase_start("runtime_shutdown"));
+    runtime.shutdown().await;
+    if let (Some(timer), Some(phase)) = (teardown, phase) {
+        timer.phase_complete("runtime_shutdown", phase);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use sandbox::{Sandbox, SandboxError, SandboxInitializationPhase};
+
+    struct RecordingRuntime {
+        create_calls: AtomicUsize,
+        factory_shutdowns: Arc<AtomicUsize>,
+        runtime_shutdowns: AtomicUsize,
+        fail_at: usize,
+    }
+
+    impl RecordingRuntime {
+        fn new(fail_at: usize) -> Self {
+            Self {
+                create_calls: AtomicUsize::new(0),
+                factory_shutdowns: Arc::new(AtomicUsize::new(0)),
+                runtime_shutdowns: AtomicUsize::new(0),
+                fail_at,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SandboxRuntime for RecordingRuntime {
+        async fn create_factory(
+            &self,
+            _config: sandbox::FactoryConfig,
+        ) -> sandbox::Result<Box<dyn SandboxFactory>> {
+            let call = self.create_calls.fetch_add(1, Ordering::SeqCst) + 1;
+            if call == self.fail_at {
+                return Err(SandboxError::Initialization {
+                    phase: SandboxInitializationPhase::Factory,
+                    message: "factory failed".into(),
+                });
+            }
+            Ok(Box::new(RecordingFactory {
+                shutdowns: Arc::clone(&self.factory_shutdowns),
+            }))
+        }
+
+        async fn shutdown(&mut self) {
+            self.runtime_shutdowns.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct RecordingFactory {
+        shutdowns: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl SandboxFactory for RecordingFactory {
+        fn name(&self) -> &str {
+            "recording"
+        }
+
+        fn config_hash(&self) -> String {
+            "recording".into()
+        }
+
+        async fn startup(&mut self) -> sandbox::Result<()> {
+            Ok(())
+        }
+
+        async fn create(
+            &self,
+            _config: sandbox::SandboxConfig,
+        ) -> sandbox::Result<Box<dyn Sandbox>> {
+            panic!("factory lifecycle tests do not create sandboxes")
+        }
+
+        async fn destroy(&self, _sandbox: Box<dyn Sandbox>) {}
+
+        async fn shutdown(&mut self) {
+            self.shutdowns.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn profile(rootfs_hash: &str, snapshot_hash: &str) -> ProfileConfig {
+        ProfileConfig {
+            rootfs_hash: rootfs_hash.into(),
+            snapshot_hash: snapshot_hash.into(),
+            vcpu: 2,
+            memory_mb: 4096,
+            disk_mb: 10240,
+        }
+    }
+
+    #[tokio::test]
+    async fn start_factories_shuts_down_started_factories_after_create_error() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(temp.path().join("home"));
+        let base_dir = temp.path().join("base");
+        let firecracker = config::FirecrackerConfig {
+            binary: temp.path().join("firecracker"),
+            kernel: temp.path().join("vmlinux"),
+        };
+        let mut profiles = BTreeMap::new();
+        profiles.insert("vm0/first".into(), profile("rootfs-1", "snapshot-1"));
+        profiles.insert("vm0/second".into(), profile("rootfs-2", "snapshot-2"));
+        let mut runtime = RecordingRuntime::new(2);
+
+        let result = start_factories(&profiles, &firecracker, &base_dir, &home, &mut runtime).await;
+
+        assert!(result.is_err());
+        assert_eq!(runtime.create_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(runtime.factory_shutdowns.load(Ordering::SeqCst), 1);
+        assert_eq!(runtime.runtime_shutdowns.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -7,6 +7,7 @@
 //!
 //! The sibling modules keep focused responsibilities out of this orchestration
 //! file:
+//! - `factory_lifecycle`: sandbox factory startup and shutdown.
 //! - `identity`: persistent runner id storage.
 //! - `job_lifecycle`: cleanup, budget, and completion ownership state.
 //! - `mitm_restart`: mitmproxy crash restart and backoff.
@@ -63,6 +64,7 @@ use crate::status::{RunnerMode, StatusTracker};
 use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, SandboxReuseResult};
 
+mod factory_lifecycle;
 mod heartbeat;
 mod identity;
 mod job_lifecycle;
@@ -70,6 +72,7 @@ mod mitm_restart;
 mod orphan_reap;
 mod signals;
 
+use factory_lifecycle::{SharedFactory, shutdown_factories, start_factories};
 use heartbeat::{HEARTBEAT_PERIOD, HeartbeatContext, collect_heartbeat_state, send_heartbeat};
 use identity::load_or_generate_runner_id;
 use job_lifecycle::{
@@ -554,31 +557,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         outer_job_panic,
     } = config;
 
-    // Build per-profile factories via the sandbox runtime.
-    let mut factories: BTreeMap<String, (SharedFactory, bool)> = BTreeMap::new();
-    for (profile_name, profile_config) in &profiles {
-        let factory_config = config::RunnerConfig::build_factory_config(
-            &firecracker,
-            &base_dir,
-            profile_name,
-            profile_config,
-            &home,
-        );
-        let restore_guest_state = factory_config.snapshot.is_some();
-        let factory_result = runtime.create_factory(factory_config).await;
-        let factory = match factory_result {
-            Ok(f) => f,
-            Err(e) => {
-                shutdown_factories(&mut factories, runtime.as_mut(), None).await;
-                return Err(e.into());
-            }
-        };
-        factories.insert(
-            profile_name.clone(),
-            (Arc::new(factory), restore_guest_state),
-        );
-        info!(profile = %profile_name, "factory started");
-    }
+    let mut factories =
+        start_factories(&profiles, &firecracker, &base_dir, &home, runtime.as_mut()).await?;
 
     let mut jobs: JoinSet<Option<RunId>> = JoinSet::new();
     // Tracked destroy tasks — JoinSet ensures we can await all in-flight
@@ -1027,13 +1007,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     Ok(())
 }
 
-/// A sandbox factory shared across concurrent job executors.
-///
-/// Uses `Arc<Box<...>>` instead of `Arc<dyn ...>` because `Arc::try_unwrap`
-/// requires a sized type — `dyn SandboxFactory` is unsized, but `Box<dyn
-/// SandboxFactory>` is sized, allowing `try_unwrap` at shutdown.
-type SharedFactory = Arc<Box<dyn SandboxFactory>>;
-
 struct DiscoveredJob {
     run_id: RunId,
     profile_name: String,
@@ -1238,47 +1211,6 @@ struct JobProfile {
     restore_guest_state: bool,
     factory: SharedFactory,
     cancel: CancellationToken,
-}
-
-/// Shut down all factories, then release shared runtime resources.
-async fn shutdown_factories(
-    factories: &mut BTreeMap<String, (SharedFactory, bool)>,
-    runtime: &mut dyn SandboxRuntime,
-    teardown: Option<&TeardownTimer>,
-) {
-    for (name, (factory, _)) in std::mem::take(factories) {
-        match Arc::try_unwrap(factory) {
-            Ok(mut f) => {
-                let phase = teardown.map(|timer| {
-                    let phase_start = Instant::now();
-                    info!(
-                        phase = "factory_shutdown",
-                        profile = %name,
-                        elapsed_ms = timer.elapsed_ms(),
-                        "teardown phase started"
-                    );
-                    phase_start
-                });
-                f.shutdown().await;
-                if let (Some(timer), Some(phase)) = (teardown, phase) {
-                    info!(
-                        phase = "factory_shutdown",
-                        profile = %name,
-                        phase_ms = TeardownTimer::duration_ms(phase.elapsed()),
-                        elapsed_ms = timer.elapsed_ms(),
-                        "teardown phase complete"
-                    );
-                }
-            }
-            Err(_) => warn!(profile = %name, "factory still referenced at shutdown"),
-        }
-    }
-    // Clean up shared resources (netns pool, base loop cache).
-    let phase = teardown.map(|timer| timer.phase_start("runtime_shutdown"));
-    runtime.shutdown().await;
-    if let (Some(timer), Some(phase)) = (teardown, phase) {
-        timer.phase_complete("runtime_shutdown", phase);
-    }
 }
 
 type SharedIdlePool = Arc<tokio::sync::Mutex<IdlePool>>;


### PR DESCRIPTION
## Summary
- move runner start factory startup/shutdown into start/factory_lifecycle.rs
- keep factory creation order, restore detection, startup cleanup, and teardown logging behavior intact
- add a regression test for cleanup after a profile factory creation failure

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p runner start_factories
- cargo test --manifest-path crates/Cargo.toml -p runner create_failure
- cargo test --manifest-path crates/Cargo.toml -p runner main_loop_discover_claim_execute_complete
- cargo test --manifest-path crates/Cargo.toml -p runner shutdown_completes_without_deadlock
- cargo test --manifest-path crates/Cargo.toml -p runner --all-features

Closes #11822