### PR TITLE
fix(platform): restore stt recording cleanup

### DIFF
--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -11,14 +11,13 @@ import {
 } from "../zero-page/settings/org-manage-tabs-state.ts";
 import { setOrgManageDialogOpen$ } from "../zero-page/settings/org-manage-dialog.ts";
 import { logger } from "../log.ts";
-import { createDeferredPromise, resetSignal } from "../utils.ts";
+import { createDeferredPromise } from "../utils.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { stopTts$ } from "./voice-io-tts.ts";
 import { accept } from "../../lib/accept.ts";
 
 const L = logger("VoiceIO:STT");
 
-const resetRecord$ = resetSignal();
 // ---------------------------------------------------------------------------
 // Internal state
 // ---------------------------------------------------------------------------
@@ -109,40 +108,32 @@ const refreshAudioInputQuota$ = command(({ set }) => {
   });
 });
 
-async function openMedia(signal: AbortSignal) {
-  // confirmed by ethan@vm0.ai
-  // eslint-disable-next-line no-restricted-syntax -- getUserMedia rejects on permission denied
-  try {
-    const stream = await navigator.mediaDevices.getUserMedia({
-      audio: {
-        echoCancellation: true,
-        noiseSuppression: true,
-        autoGainControl: true,
-      },
-    });
-    signal.throwIfAborted();
-    return stream;
-  } catch (error) {
-    L.error("Microphone access denied", error);
-    toast.error("Microphone access denied");
-    return;
-  }
-}
-
 export const startRecording$ = command(
-  async ({ get, set }, parentSignal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
     if (get(internalRecording$) || get(internalTranscribing$)) {
       return;
     }
 
+    // Stop any ongoing TTS playback to prevent recording AI voice
     set(stopTts$);
 
-    const signal = set(resetRecord$, parentSignal);
-
-    const stream = await openMedia(signal);
-    if (!stream) {
+    let stream: MediaStream;
+    // confirmed by ethan at vm0.ai
+    // eslint-disable-next-line no-restricted-syntax -- getUserMedia rejects on permission denied
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+      });
+    } catch (error) {
+      L.error("Microphone access denied", error);
+      toast.error("Microphone access denied");
       return;
     }
+    signal.throwIfAborted();
 
     const mimeType = chooseMimeType();
     const recorder = mimeType
@@ -158,14 +149,6 @@ export const startRecording$ = command(
       }
     };
 
-    signal.addEventListener("abort", () => {
-      if (recorder.state !== "inactive") {
-        recorder.stop();
-      }
-      stopAllTracks(stream);
-      set(resetState$);
-    });
-
     recorder.start();
     set(internalRecording$, true);
     set(internalStream$, stream);
@@ -180,7 +163,9 @@ export const stopAndTranscribe$ = command(
     }
 
     const recorder = get(internalRecorder$);
+    const stream = get(internalStream$);
 
+    // Stop recording and wait for final data
     if (recorder && recorder.state !== "inactive") {
       const stopDeferred = createDeferredPromise<void>(signal);
       recorder.addEventListener(
@@ -196,10 +181,13 @@ export const stopAndTranscribe$ = command(
 
     set(internalRecording$, false);
 
+    // Release mic hardware
+    stopAllTracks(stream);
+
     // Collect recorded audio
     const chunks = get(internalChunks$);
     if (chunks.length === 0) {
-      set(resetRecord$);
+      set(resetState$);
       return "";
     }
 
@@ -214,6 +202,8 @@ export const stopAndTranscribe$ = command(
     const extension = mimeType.includes("mp4") ? "mp4" : "webm";
     formData.append("file", blob, `recording.${extension}`);
 
+    let text = "";
+    // confirmed by ethan at vm0.ai
     // eslint-disable-next-line no-restricted-syntax -- raw fetch for FormData upload (not a ts-rest contract)
     try {
       const response = await fetchFn("/api/zero/voice-io/stt", {
@@ -234,24 +224,28 @@ export const stopAndTranscribe$ = command(
             set(setActiveOrgManageTab$, "billing");
             set(setBillingSubPage$, true);
             await set(setOrgManageDialogOpen$, true, signal);
+            set(resetState$);
             return "";
           }
         }
         L.error("STT API error", { status: response.status });
         toast.error("Transcription failed");
+        set(resetState$);
         return "";
       }
 
       const result = (await response.json()) as { text: string };
+      text = result.text.trim();
       // Refresh cached quota so the UI reflects the new count for free-tier users.
       set(refreshAudioInputQuota$);
-      return result.text.trim();
     } catch (error) {
       L.error("STT fetch failed", error);
       toast.error("Transcription failed");
+      set(resetState$);
       return "";
-    } finally {
-      set(resetRecord$);
     }
+
+    set(resetState$);
+    return text;
   },
 );


### PR DESCRIPTION
## Summary
- restore `voice-io-stt.ts` to the STT recording flow from main before PR #11769 merged
- keep explicit inline lint approvals for the two intentional try/catch blocks

## Validation
- pnpm -F @vm0/app run lint
- pnpm vitest run --project=@vm0/app src/views/zero-page/__tests__/zero-chat-composer-mic-button.test.tsx
- pre-commit hook: prettier, knip, check-types