### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -107,7 +107,7 @@ ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.2"
-CLAUDE_CODE_VERSION="2.1.126"
+CLAUDE_CODE_VERSION="2.1.128"
 CODEX_CLI_VERSION="0.128.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Summary

Bump pinned tool versions in `crates/runner/scripts/build-template.sh`.

| Package | Old | New |
| --- | --- | --- |
| claude-code | 2.1.126 | 2.1.128 |

All other pinned versions (Go 1.26.2, codex 0.128.0, gws 0.22.5, xurl 1.0.3, agent-browser 0.26.0) are already at their latest stable release.

## Test plan

- [ ] CI builds the rootfs template with the new claude-code release
- [ ] `claude --version` inside the VM reports 2.1.128