### PR TITLE
fix: use resolved admission provider type for credit check

### DIFF
--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -6,8 +6,10 @@ import {
   createTestRequest,
   createTestCompose,
   insertOrgDefaultModelProvider,
+  insertOrgNonDefaultModelProvider,
   deleteTestModelProvider,
   setTestZeroAgentModelProvider,
+  setOrgCredits,
   findTestCallbacksByRunId,
   findTestRunnerJobEntry,
   getTestRun,
@@ -1000,6 +1002,36 @@ describe("POST /api/zero/chat/messages", () => {
           }),
         );
         expect(response.status).toBe(400);
+      });
+    });
+
+    describe("credit check with modelSelection", () => {
+      it("rejects vm0 provider via modelSelection when org credits depleted", async () => {
+        await setOrgCredits(user.orgId, 0);
+        await insertOrgNonDefaultModelProvider(user.orgId, "vm0");
+        const vm0ProviderId = await getTestModelProviderIdByType(
+          user.orgId,
+          "vm0",
+        );
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId,
+              prompt: "should be rejected due to credits",
+              modelSelection: {
+                modelProviderId: vm0ProviderId,
+                selectedModel: "claude-opus-4-7",
+              },
+            }),
+          }),
+        );
+
+        expect(response.status).toBe(402);
+        const data = await response.json();
+        expect(data.error.code).toBe("INSUFFICIENT_CREDITS");
       });
     });
 

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -33,10 +33,10 @@ import {
   checkRunConcurrencyLimit,
   authorizeCompose,
   validateComposeRequirements,
-  checkOrgCreditsForRun,
   checkModelProviderConfigured,
   resolveProviderTypeForAdmission,
 } from "./zero-run-policy";
+import { checkOrgCredits } from "./credit/check-org-credits";
 import {
   enqueueRun,
   drainOrgQueue,
@@ -669,11 +669,9 @@ async function createZeroRunRecord(
   }
 
   const round3Credits = timed(async () => {
-    return checkOrgCreditsForRun(
-      resolved.orgId,
-      params.userId,
-      params.modelProvider,
-    );
+    if (admissionProviderType === "vm0") {
+      return checkOrgCredits(resolved.orgId, params.userId);
+    }
   });
   const round3ModelProvider = timed(async () => {
     return checkModelProviderConfigured(


### PR DESCRIPTION
## Summary

- `checkOrgCreditsForRun` was using the raw `modelProvider` string parameter for credit gating. When the web UI sends only `modelProviderId` (UUID), `modelProvider` is `undefined`, causing the function to fall back to the org's default provider type. If the org default is BYOK but the user selects a vm0 provider via `modelSelection`, the credit check was incorrectly skipped — allowing runs that should be blocked to proceed and accumulate negative credit balances.

- The fix uses `admissionProviderType`, which is already correctly resolved at admission time from both `modelProvider` (string) and `modelProviderId` (UUID) by `resolveProviderTypeForAdmission()`.

- Added a chat messages API test that verifies: BYOK default provider + vm0 non-default provider selected via `modelSelection.modelProviderId` + zero credits → 402 INSUFFICIENT_CREDITS.

## Test plan

- [x] New test: vm0 provider via modelSelection rejects when credits depleted
- [x] Existing tests: BYOK default + no modelProviderId → 201 (unchanged behavior)
- [x] Existing tests: VM0 default + zero credits → 402 (unchanged behavior)

Fixes #11833

🤖 Generated with [Claude Code](https://claude.com/claude-code)