### PR TITLE
fix(voice-io): log error code and rejection reason for stt 400s

### DIFF
--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -223,21 +223,28 @@ export const stopAndTranscribe$ = command(
       });
 
       if (!response.ok) {
-        if (response.status === 402) {
-          const body = (await response.json().catch(() => {
-            return null;
-          })) as {
-            error?: { code?: string };
-          } | null;
-          if (body?.error?.code === "AUDIO_INPUT_QUOTA_EXCEEDED") {
-            set(refreshAudioInputQuota$);
-            set(setActiveOrgManageTab$, "billing");
-            set(setBillingSubPage$, true);
-            await set(setOrgManageDialogOpen$, true, signal);
-            return "";
-          }
+        const body = (await response.json().catch(() => {
+          return null;
+        })) as {
+          error?: { code?: string; message?: string };
+        } | null;
+        const code = body?.error?.code;
+
+        if (response.status === 402 && code === "AUDIO_INPUT_QUOTA_EXCEEDED") {
+          set(refreshAudioInputQuota$);
+          set(setActiveOrgManageTab$, "billing");
+          set(setBillingSubPage$, true);
+          await set(setOrgManageDialogOpen$, true, signal);
+          return "";
         }
-        L.error("STT API error", { status: response.status });
+
+        L.error("STT API error", {
+          status: response.status,
+          code,
+          message: body?.error?.message,
+          recordedMime: mimeType,
+          recordedSize: blob.size,
+        });
         toast.error("Transcription failed");
         return "";
       }

--- a/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
@@ -118,6 +118,10 @@ export async function POST(request: Request): Promise<Response> {
   const file = formData.get("file");
 
   if (!file || !(file instanceof File)) {
+    log.warn("STT validation rejected: no file", {
+      hasField: file !== null,
+      fieldType: typeof file,
+    });
     return NextResponse.json(
       { error: { message: "No audio file provided", code: "BAD_REQUEST" } },
       { status: 400 },
@@ -126,6 +130,10 @@ export async function POST(request: Request): Promise<Response> {
 
   // 5. Validate file size
   if (file.size > MAX_FILE_SIZE) {
+    log.warn("STT validation rejected: file too large", {
+      fileSize: file.size,
+      fileMime: file.type,
+    });
     return NextResponse.json(
       {
         error: {
@@ -140,6 +148,11 @@ export async function POST(request: Request): Promise<Response> {
   // 6. Validate file type (strip codec suffix, e.g. "audio/webm;codecs=opus" → "audio/webm")
   const baseMimeType = file.type.split(";")[0] ?? file.type;
   if (!ALLOWED_MIME_TYPES.has(baseMimeType)) {
+    log.warn("STT validation rejected: unsupported mime", {
+      fileMime: file.type,
+      baseMimeType,
+      fileSize: file.size,
+    });
     return NextResponse.json(
       {
         error: {
@@ -158,6 +171,12 @@ export async function POST(request: Request): Promise<Response> {
     durationSeconds !== null &&
     durationSeconds > MAX_REQUEST_DURATION_SECONDS
   ) {
+    log.warn("STT validation rejected: duration too long", {
+      durationSeconds,
+      maxSeconds: MAX_REQUEST_DURATION_SECONDS,
+      fileMime: file.type,
+      fileSize: file.size,
+    });
     return NextResponse.json(
       {
         error: {


### PR DESCRIPTION
## Summary

- Client now parses the JSON error body on every non-OK STT response and includes `code`, `message`, recorded mime, and blob size in the Sentry log (instead of just `status`, which surfaced as `[object Object]`).
- Server adds `log.warn` at all four 400 validation branches in `app/api/zero/voice-io/stt/route.ts` so Axiom captures the rejection reason and relevant context.
- Pure observability change — no behavior change. The 402 quota upsell path is preserved.

## Why

Tracking #11847 — desktop Chrome users (Chrome 147 / Mac) hit `POST /api/zero/voice-io/stt` 400s, but neither Sentry nor Axiom records which of the four validation branches fired (no file / file too large / unsupported mime / duration too long). The Sentry message reads `STT API error [object Object]` with no `error.code`, and the four 400 branches return silently on the server side. Without this we cannot tell whether the cause is mime, duration parsing, or something else, so any code fix would be a guess.

I verified empirically (via headless Chrome) that `recorder.mimeType = "audio/webm"` but the resulting `blob.type = "audio/webm;codecs=opus"`, that the codec suffix survives FormData upload, and that the server's `baseMimeType.split(";")[0]` correctly normalizes it. So the prior hypothesis "Chrome's blob.type is empty" was wrong and we need real telemetry to find the actual branch.

## Test plan

- [x] `pnpm turbo run lint --filter=@vm0/app --filter=web` — passes
- [x] `pnpm turbo run check-types --filter=@vm0/app --filter=web` — passes
- [x] `pnpm -F @vm0/app exec vitest run src/signals/voice-io` — 8/8 pass
- [x] `pnpm -F web exec vitest run app/api/zero/voice-io` — 37/37 pass
- [ ] After deploy: confirm a fresh Chrome 400 from a real user shows `error.code` in Sentry and the matching `STT validation rejected: …` line in Axiom

## Follow-up

Once we see one real Chrome 400 with the new logs, file the actual fix PR against the identified branch (likely the WebM duration parser based on Chrome's typical live-recording shape, but worth confirming first).

Refs #11847

🤖 Generated with [Claude Code](https://claude.com/claude-code)