### PR TITLE
perf(guest-common): cache system log file handle

### DIFF
--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -98,9 +98,10 @@ fn default_system_log_file() -> &'static str {
 /// Updating this path drops any cached file handle, including same-path
 /// updates. This lets callers force the next write to reopen the path.
 ///
-/// The write is synchronous and completes before the logging macro returns.
-/// This matters for guest-agent's final telemetry upload, which reads the
-/// same file immediately after some fatal-path log lines are emitted.
+/// The file is still opened lazily by the next log line. System log writes are
+/// synchronous and complete before the logging macro returns. This matters for
+/// guest-agent's final telemetry upload, which reads the same file immediately
+/// after some fatal-path log lines are emitted.
 pub fn set_system_log_file(path: impl AsRef<Path>) {
     let mut guard = SYSTEM_LOG.lock().unwrap_or_else(|e| e.into_inner());
     guard.set_path(path.as_ref().to_path_buf());

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -1,5 +1,7 @@
 //! Logging utilities for VM scripts.
 
+use std::fs::{File, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
 
@@ -10,7 +12,63 @@ static RUN_ID: LazyLock<String> = LazyLock::new(|| match std::env::var("VM0_RUN_
 });
 static DEFAULT_SYSTEM_LOG_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-system-{}.log", &*RUN_ID));
-static SYSTEM_LOG_FILE: Mutex<Option<PathBuf>> = Mutex::new(None);
+static SYSTEM_LOG: Mutex<SystemLogState> = Mutex::new(SystemLogState::disabled());
+
+struct SystemLogState {
+    path: Option<PathBuf>,
+    file: Option<File>,
+}
+
+impl SystemLogState {
+    const fn disabled() -> Self {
+        Self {
+            path: None,
+            file: None,
+        }
+    }
+
+    fn set_path(&mut self, path: PathBuf) {
+        self.path = Some(path);
+        self.file = None;
+    }
+
+    fn clear(&mut self) {
+        self.path = None;
+        self.file = None;
+    }
+
+    fn append_line(&mut self, line: &str) -> std::io::Result<()> {
+        let Some(path) = self.path.as_ref() else {
+            return Ok(());
+        };
+
+        if self.file.is_none() {
+            self.file = Some(
+                OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(path)
+                    .map_err(|e| {
+                        std::io::Error::new(e.kind(), format!("{}: {e}", path.display()))
+                    })?,
+            );
+        }
+
+        let Some(file) = self.file.as_mut() else {
+            return Ok(());
+        };
+
+        let mut line = line.as_bytes().to_vec();
+        line.push(b'\n');
+        let result = file.write_all(&line).and_then(|()| file.flush());
+
+        if result.is_err() {
+            self.file = None;
+        }
+
+        result
+    }
+}
 
 /// Get current timestamp in RFC3339 format with milliseconds.
 pub fn timestamp() -> String {
@@ -37,31 +95,19 @@ fn default_system_log_file() -> &'static str {
 /// This matters for guest-agent's final telemetry upload, which reads the
 /// same file immediately after some fatal-path log lines are emitted.
 pub fn set_system_log_file(path: impl AsRef<Path>) {
-    let mut guard = SYSTEM_LOG_FILE.lock().unwrap_or_else(|e| e.into_inner());
-    *guard = Some(path.as_ref().to_path_buf());
+    let mut guard = SYSTEM_LOG.lock().unwrap_or_else(|e| e.into_inner());
+    guard.set_path(path.as_ref().to_path_buf());
 }
 
 #[doc(hidden)]
 pub fn clear_system_log_file() {
-    let mut guard = SYSTEM_LOG_FILE.lock().unwrap_or_else(|e| e.into_inner());
-    *guard = None;
+    let mut guard = SYSTEM_LOG.lock().unwrap_or_else(|e| e.into_inner());
+    guard.clear();
 }
 
 fn append_system_log_line(line: &str) -> std::io::Result<()> {
-    let guard = SYSTEM_LOG_FILE.lock().unwrap_or_else(|e| e.into_inner());
-    let Some(path) = guard.as_ref() else {
-        return Ok(());
-    };
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .map_err(|e| std::io::Error::new(e.kind(), format!("{}: {e}", path.display())))?;
-    use std::io::Write;
-    let mut line = line.as_bytes().to_vec();
-    line.push(b'\n');
-    file.write_all(&line)?;
-    file.flush()
+    let mut guard = SYSTEM_LOG.lock().unwrap_or_else(|e| e.into_inner());
+    guard.append_line(line)
 }
 
 fn write_stderr_line(line: &str) {
@@ -214,6 +260,100 @@ mod tests {
             !path.exists(),
             "test setup expected append to fail for missing parent dir",
         );
+    }
+
+    #[test]
+    fn set_system_log_file_switches_paths_and_drops_cached_handle() {
+        let _guard = LOG_TEST_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let first_path = dir.path().join("first.log");
+        let second_path = dir.path().join("second.log");
+        let _system_log = SystemLogFileGuard::set(&first_path);
+
+        append_system_log_line("first path line").unwrap();
+        set_system_log_file(&second_path);
+        append_system_log_line("second path line").unwrap();
+
+        let first_content = std::fs::read_to_string(first_path).unwrap();
+        let second_content = std::fs::read_to_string(second_path).unwrap();
+        assert_eq!(first_content, "first path line\n");
+        assert_eq!(second_content, "second path line\n");
+    }
+
+    #[test]
+    fn setting_same_system_log_file_path_forces_reopen() {
+        let _guard = LOG_TEST_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("system.log");
+        let _system_log = SystemLogFileGuard::set(&path);
+
+        append_system_log_line("before removal").unwrap();
+        std::fs::remove_file(&path).unwrap();
+
+        set_system_log_file(&path);
+        append_system_log_line("after reopen").unwrap();
+
+        let content = std::fs::read_to_string(path).unwrap();
+        assert_eq!(content, "after reopen\n");
+    }
+
+    #[test]
+    fn clear_system_log_file_drops_cached_handle() {
+        let _guard = LOG_TEST_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("system.log");
+        let _system_log = SystemLogFileGuard::set(&path);
+
+        append_system_log_line("before clear").unwrap();
+        clear_system_log_file();
+        std::fs::remove_file(&path).unwrap();
+        append_system_log_line("after clear").unwrap();
+
+        assert!(
+            !path.exists(),
+            "cleared system log should not recreate the previous path",
+        );
+    }
+
+    #[test]
+    fn transient_open_failure_is_not_cached() {
+        let _guard = LOG_TEST_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("missing-parent");
+        let path = parent.join("system.log");
+        let _system_log = SystemLogFileGuard::set(&path);
+
+        let error = append_system_log_line("before parent exists").unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+
+        std::fs::create_dir(&parent).unwrap();
+        append_system_log_line("after parent exists").unwrap();
+
+        let content = std::fs::read_to_string(path).unwrap();
+        assert_eq!(content, "after parent exists\n");
+    }
+
+    #[test]
+    fn cached_handle_write_failure_reopens_on_next_append() {
+        let _guard = LOG_TEST_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("system.log");
+        std::fs::write(&path, "").unwrap();
+        let read_only_file = File::open(&path).unwrap();
+        let mut state = SystemLogState {
+            path: Some(path.clone()),
+            file: Some(read_only_file),
+        };
+
+        assert!(state.append_line("fails").is_err());
+        assert!(
+            state.file.is_none(),
+            "write failure should drop cached system log handle",
+        );
+
+        state.append_line("recovers").unwrap();
+        let content = std::fs::read_to_string(path).unwrap();
+        assert_eq!(content, "recovers\n");
     }
 
     #[test]

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -289,6 +289,25 @@ mod tests {
     }
 
     #[test]
+    fn set_system_log_file_switches_unopened_path_without_creating_old_file() {
+        let _guard = LOG_TEST_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let first_path = dir.path().join("first.log");
+        let second_path = dir.path().join("second.log");
+        let _system_log = SystemLogFileGuard::set(&first_path);
+
+        set_system_log_file(&second_path);
+        append_system_log_line("final path line").unwrap();
+
+        assert!(
+            !first_path.exists(),
+            "path updates before first append should not create the old path",
+        );
+        let second_content = std::fs::read_to_string(second_path).unwrap();
+        assert_eq!(second_content, "final path line\n");
+    }
+
+    #[test]
     fn setting_same_system_log_file_path_forces_reopen() {
         let _guard = LOG_TEST_MUTEX.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -253,6 +253,31 @@ mod tests {
     }
 
     #[test]
+    fn emit_appends_to_existing_system_log_file_without_truncating() {
+        let _guard = LOG_TEST_MUTEX.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("system.log");
+        std::fs::write(&path, "existing line\n").unwrap();
+        let _system_log = SystemLogFileGuard::set(&path);
+
+        emit(
+            "INFO",
+            "sandbox:guest-agent",
+            format_args!("new line after existing content"),
+        );
+
+        let content = std::fs::read_to_string(path).unwrap();
+        assert!(
+            content.starts_with("existing line\n"),
+            "existing content should be preserved: {content:?}",
+        );
+        assert!(
+            content.contains("[INFO] [sandbox:guest-agent] new line after existing content"),
+            "new log line should be appended: {content:?}",
+        );
+    }
+
+    #[test]
     fn emit_continues_when_system_log_append_fails() {
         let _guard = LOG_TEST_MUTEX.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -95,6 +95,9 @@ fn default_system_log_file() -> &'static str {
 
 /// Override the system log file used by future log lines.
 ///
+/// Updating this path drops any cached file handle, including same-path
+/// updates. This lets callers force the next write to reopen the path.
+///
 /// The write is synchronous and completes before the logging macro returns.
 /// This matters for guest-agent's final telemetry upload, which reads the
 /// same file immediately after some fatal-path log lines are emitted.
@@ -162,6 +165,7 @@ macro_rules! log_error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     static LOG_TEST_MUTEX: Mutex<()> = Mutex::new(());
 
@@ -382,12 +386,18 @@ mod tests {
 
         let content = std::fs::read_to_string(path).unwrap();
         let lines: Vec<_> = content.lines().collect();
+        let expected: HashSet<_> = (0..8)
+            .flat_map(|thread_id| {
+                (0..20).map(move |line_id| {
+                    format!(
+                        "[timestamp] [INFO] [sandbox:guest-agent] concurrent {thread_id}-{line_id}"
+                    )
+                })
+            })
+            .collect();
+        let actual: HashSet<_> = lines.iter().map(|line| (*line).to_owned()).collect();
         assert_eq!(lines.len(), 160);
+        assert_eq!(actual, expected);
         assert!(content.ends_with('\n'));
-        assert!(
-            lines
-                .iter()
-                .all(|line| { line.contains("[INFO] [sandbox:guest-agent] concurrent ") })
-        );
     }
 }

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -14,6 +14,10 @@ static DEFAULT_SYSTEM_LOG_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-system-{}.log", &*RUN_ID));
 static SYSTEM_LOG: Mutex<SystemLogState> = Mutex::new(SystemLogState::disabled());
 
+/// Process-global guest system log state.
+///
+/// The cached handle is dropped on every path update, including same-path
+/// updates, so callers can force a reopen if the path was externally replaced.
 struct SystemLogState {
     path: Option<PathBuf>,
     file: Option<File>,
@@ -42,20 +46,12 @@ impl SystemLogState {
             return Ok(());
         };
 
-        if self.file.is_none() {
-            self.file = Some(
-                OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(path)
-                    .map_err(|e| {
-                        std::io::Error::new(e.kind(), format!("{}: {e}", path.display()))
-                    })?,
-            );
-        }
-
-        let Some(file) = self.file.as_mut() else {
-            return Ok(());
+        let file = match self.file.as_mut() {
+            Some(file) => file,
+            None => {
+                let file = open_system_log_file(path)?;
+                self.file.insert(file)
+            }
         };
 
         let mut line = line.as_bytes().to_vec();
@@ -68,6 +64,14 @@ impl SystemLogState {
 
         result
     }
+}
+
+fn open_system_log_file(path: &Path) -> std::io::Result<File> {
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| std::io::Error::new(e.kind(), format!("{}: {e}", path.display())))
 }
 
 /// Get current timestamp in RFC3339 format with milliseconds.
@@ -346,10 +350,6 @@ mod tests {
         };
 
         assert!(state.append_line("fails").is_err());
-        assert!(
-            state.file.is_none(),
-            "write failure should drop cached system log handle",
-        );
 
         state.append_line("recovers").unwrap();
         let content = std::fs::read_to_string(path).unwrap();


### PR DESCRIPTION
## Summary

- Cache the guest system log `File` after the first successful append to avoid reopening the path for every log line.
- Drop the cached handle on `set_system_log_file`/`clear_system_log_file`, and after write/flush failures so later appends can reopen.
- Add coverage for path switching, same-path reopen, clear behavior, transient open recovery, cached-handle write failure recovery, and final telemetry visibility.

Closes #11849

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --check --package guest-common`
- `cargo test --manifest-path crates/Cargo.toml -p guest-common`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent final_flush_uploads_log_emitted_immediately_before_it`
- pre-commit: cargo-fmt, cargo-doc, cargo-clippy, commitlint