### PR TITLE
refactor(runner): split ably control plane from discovery

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -64,9 +64,10 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
     else {
         return;
     };
-    // Insert cancel token before claiming so it is available when discover()
-    // next processes a buffered Ably cancel event. Skip duplicates from push +
-    // poll races; overwriting would break cancel delivery for the executor.
+    // Insert cancel token before claiming so provider-side cancel channels
+    // (Ably supervisor for ApiProvider, `.cancel` scan for LocalProvider) can
+    // find the active job. Skip duplicate discoveries; overwriting would break
+    // cancel delivery for the executor.
     let job_cancel = CancellationToken::new();
     {
         let mut tokens = ctx.cancel_tokens.lock().await;

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -3619,7 +3619,7 @@ mod tests {
         // Wait for job to be claimed and executing (cancel_tokens now has run_id).
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        // Push the same run_id again (simulates Ably push + poll race).
+        // Push the same run_id again (simulates duplicate discovery).
         // Budget has room, but cancel_tokens already contains this run_id →
         // the duplicate is rejected and budget is released.
         env.handle

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -755,7 +755,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             false
         };
         tokio::select! {
-            // Job discovery via provider (Ably push + poll).
+            // Job discovery via provider (Ably wakeups + HTTP poll).
             // The future is pinned outside the loop so heartbeat/cleanup
             // ticks don't cancel and restart its internal poll timer. See #8747.
             discovered = &mut discover_fut, if can_discover => {
@@ -848,9 +848,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // -----------------------------------------------------------------------
     let teardown = TeardownTimer::start();
 
-    // Drop the pinned discover future so it releases the discovery Mutex.
-    // Without this, provider.shutdown() deadlocks trying to acquire the
-    // same Mutex that the still-alive discover_fut holds.
+    // Drop the pinned discover future before provider shutdown so any
+    // provider-local discovery resources are released first. This also keeps
+    // the historical shutdown-deadlock regression covered by mock providers.
     drop(discover_fut);
     teardown.event("drop_discover_fut");
 

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1,4 +1,4 @@
-//! [`JobProvider`] backed by Ably push notifications + HTTP polling + REST API.
+//! [`JobProvider`] backed by an Ably control plane + HTTP polling + REST API.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -12,10 +12,10 @@ use reqwest::{RequestBuilder, Response, StatusCode};
 use serde::de::DeserializeOwned;
 
 use super::JobProvider;
+use super::api_ably_supervisor::{AblySupervisor, PollOutcome, PollWakeups};
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
 use crate::ids::RunId;
-use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::types::{
     CompleteRequest, ExecutionContext, HeartbeatState, Job, PollResponse, SandboxReuseResult,
 };
@@ -29,21 +29,19 @@ use sandbox::SandboxId;
 const POLL_SLOW: Duration = Duration::from_secs(30);
 /// Poll interval when Ably is disconnected or unavailable (primary mechanism).
 const POLL_FAST: Duration = Duration::from_secs(5);
-/// Initial backoff before retrying Ably connection.
-const ABLY_BACKOFF_INITIAL: Duration = Duration::from_secs(5);
-/// Maximum backoff between Ably reconnection attempts.
-const ABLY_BACKOFF_MAX: Duration = Duration::from_secs(60);
-/// Log one error if Ably has not recovered within this window.
-const ABLY_DISCONNECT_ERROR_AFTER: Duration = Duration::from_secs(60);
+/// Retry delay after a job-notification wakeup reaches poll but poll fails.
+const POLL_WAKEUP_RETRY: Duration = POLL_FAST;
 
 // ---------------------------------------------------------------------------
 // ApiProvider
 // ---------------------------------------------------------------------------
 
-/// [`JobProvider`] backed by Ably push notifications + HTTP polling + REST API.
+/// [`JobProvider`] backed by Ably control-plane notifications + HTTP polling + REST API.
 ///
 /// This wraps the current production job lifecycle:
-/// - **Discovery**: Ably push + HTTP poll fallback (adaptive interval)
+/// - **Control plane**: Ably supervisor for reconnect visibility, cancel notifications,
+///   and poll wakeups
+/// - **Discovery**: HTTP poll fallback (adaptive interval)
 /// - **Claim**: `POST /api/runners/jobs/{id}/claim`
 /// - **Complete**: `POST /api/webhooks/agent/complete` with per-job sandbox token
 pub struct ApiProvider {
@@ -52,40 +50,20 @@ pub struct ApiProvider {
     /// Profile names this runner supports (e.g., ["vm0/default"]).
     /// Sent in poll requests so the server only returns jobs this runner can handle.
     profiles: Vec<String>,
-    /// Unique runner identity (UUID). Used to filter targeted Ably notifications.
-    runner_id: String,
-    /// Mutable discovery state, behind Mutex for `&self` compatibility.
-    /// Only one caller (main loop) — never contended in practice.
-    discovery: tokio::sync::Mutex<DiscoveryState>,
+    /// Coalesced poll wakeup state updated by the Ably supervisor.
+    poll_wakeups: Arc<PollWakeups>,
+    /// Background Ably control-plane task.
+    ably_supervisor: AblySupervisor,
     /// Per-job sandbox tokens for completion auth.
     tokens: tokio::sync::Mutex<HashMap<RunId, String>>,
-    /// Shared map of per-job cancel tokens. When a `"cancel"` event arrives
-    /// via Ably, `discover()` looks up the run and cancels it directly.
-    cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
     /// Session IDs held in the idle pool, sent in poll requests for affinity ordering.
     held_sessions: tokio::sync::Mutex<Vec<String>>,
     /// Shutdown signal.
     cancel: CancellationToken,
 }
 
-struct DiscoveryState {
-    ably: Option<ably_subscriber::Subscription>,
-    ably_retry: RetryState<AblyReconnectHandle>,
-    ably_connected: bool,
-    ably_disconnected_at: Option<tokio::time::Instant>,
-    ably_disconnect_error_logged: bool,
-    ably_disconnect_reason: Option<String>,
-    poll_now: bool,
-    /// When set, schedules a deferred poll so non-targeted runners can pick up
-    /// jobs that the targeted runner may not have claimed.
-    deferred_poll_at: Option<tokio::time::Instant>,
-}
-
-type AblyReconnectHandle =
-    tokio::task::JoinHandle<Result<ably_subscriber::Subscription, ably_subscriber::Error>>;
-
 impl ApiProvider {
-    /// Create a new API-backed provider with initial Ably connection attempt.
+    /// Create a new API-backed provider and start the Ably supervisor.
     pub async fn new(
         http: HttpClient,
         token: String,
@@ -96,45 +74,23 @@ impl ApiProvider {
         cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
     ) -> Arc<Self> {
         let api = ApiClient::new(http, token);
-        let mut ably_retry: RetryState<AblyReconnectHandle> =
-            RetryState::new(ABLY_BACKOFF_INITIAL, ABLY_BACKOFF_MAX, None);
-
-        let ably_config = make_ably_config(&api, &group);
-        let (ably, ably_connected, ably_disconnect_reason) =
-            match ably_subscriber::subscribe(ably_config).await {
-                Ok(sub) => {
-                    info!("ably connected");
-                    (Some(sub), true, None)
-                }
-                Err(e) => {
-                    let reason = e.to_string();
-                    warn!(error = %e, "ably unavailable, will retry");
-                    ably_retry.record_initial_failure();
-                    (None, false, Some(reason))
-                }
-            };
+        let poll_wakeups = Arc::new(PollWakeups::new(false));
+        let ably_supervisor = AblySupervisor::spawn(
+            api.clone(),
+            group.clone(),
+            runner_id,
+            Arc::clone(&poll_wakeups),
+            cancel_tokens,
+            cancel.clone(),
+        );
 
         Arc::new(Self {
             api,
             group,
             profiles,
-            runner_id,
-            discovery: tokio::sync::Mutex::new(DiscoveryState {
-                ably,
-                ably_retry,
-                ably_connected,
-                ably_disconnected_at: if ably_connected {
-                    None
-                } else {
-                    Some(tokio::time::Instant::now())
-                },
-                ably_disconnect_error_logged: false,
-                ably_disconnect_reason,
-                poll_now: true, // immediate first poll
-                deferred_poll_at: None,
-            }),
+            poll_wakeups,
+            ably_supervisor,
             tokens: tokio::sync::Mutex::new(HashMap::new()),
-            cancel_tokens,
             held_sessions: tokio::sync::Mutex::new(Vec::new()),
             cancel,
         })
@@ -144,200 +100,47 @@ impl ApiProvider {
 #[async_trait::async_trait]
 impl JobProvider for ApiProvider {
     async fn discover(&self) -> Option<(RunId, String)> {
-        let mut state = self.discovery.lock().await;
         loop {
-            // Check shutdown
-            if self.cancel.is_cancelled() {
-                return None;
-            }
+            let reason = self
+                .poll_wakeups
+                .wait_for_poll_due(&self.cancel, POLL_SLOW, POLL_FAST)
+                .await?;
 
-            // Destructure to get disjoint borrows for tokio::select!
-            let DiscoveryState {
-                ref mut ably,
-                ref mut ably_retry,
-                ref mut ably_connected,
-                ref mut ably_disconnected_at,
-                ref mut ably_disconnect_error_logged,
-                ref mut ably_disconnect_reason,
-                ref mut poll_now,
-                ref mut deferred_poll_at,
-            } = *state;
-
-            // Spawn Ably reconnection when timer fires
-            maybe_spawn_ably_reconnect(ably, &self.api, &self.group, ably_retry);
-
-            let ably_disconnect_error_at = if !*ably_connected && !*ably_disconnect_error_logged {
-                ably_disconnected_at.map(|at| at + ABLY_DISCONNECT_ERROR_AFTER)
-            } else {
-                None
-            };
-
-            let sleep_dur = if *poll_now {
-                Duration::ZERO
-            } else if let Some(at) = *deferred_poll_at {
-                at.saturating_duration_since(tokio::time::Instant::now())
-            } else if *ably_connected {
-                POLL_SLOW
-            } else {
-                POLL_FAST
-            };
-
-            tokio::select! {
-                // Shutdown
+            let sessions = self.held_sessions.lock().await.clone();
+            let poll_result = tokio::select! {
+                biased;
                 () = self.cancel.cancelled() => {
                     return None;
                 }
-                // Ably push notification
-                event = recv_ably(ably) => {
-                    match event {
-                        Some(ably_subscriber::Event::Message(msg)) => {
-                            if let Some(run_id) = parse_cancel_notification(&msg) {
-                                let token = self.cancel_tokens.lock().await.get(&run_id).cloned();
-                                if let Some(token) = token {
-                                    info!(run_id = %run_id, "ably: cancel notification, killing job");
-                                    token.cancel();
-                                }
-                                continue;
-                            }
-                            if let Some(notif) = parse_job_notification(&msg) {
-                                // Targeted to another runner: defer poll instead of
-                                // claiming immediately, giving the target a 2s head start.
-                                if notif.target_runner_id.as_deref().is_some_and(|t| t != self.runner_id) {
-                                    info!(
-                                        run_id = %notif.run_id,
-                                        target = notif.target_runner_id.as_deref().unwrap_or(""),
-                                        "ably: job targeted to another runner, deferring poll"
-                                    );
-                                    // Only set if no deferred poll is already pending,
-                                    // to avoid pushing the deadline further on rapid bursts.
-                                    if deferred_poll_at.is_none() {
-                                        *deferred_poll_at = Some(
-                                            tokio::time::Instant::now() + Duration::from_secs(2)
-                                        );
-                                    }
-                                    continue;
-                                }
-                                if self.cancel.is_cancelled() {
-                                    return None;
-                                }
-                                // Fall back to default profile when server doesn't send one
-                                // (backwards compat with pre-profile API).
-                                let profile = notif.profile.unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
-                                let targeted = notif.target_runner_id.as_deref().is_some_and(|t| t == self.runner_id);
-                                info!(run_id = %notif.run_id, %profile, targeted, "ably: job notification");
-                                return Some((notif.run_id, profile));
-                            }
-                        }
-                        Some(ably_subscriber::Event::Connected) => {
-                            if !*ably_connected {
-                                *ably_connected = true;
-                                info!("ably reconnected");
-                            }
-                            *ably_disconnected_at = None;
-                            *ably_disconnect_error_logged = false;
-                            *ably_disconnect_reason = None;
-                        }
-                        Some(ably_subscriber::Event::Disconnected { reason }) => {
-                            let reason = reason.as_deref().unwrap_or("unknown").to_owned();
-                            record_ably_disconnected(
-                                ably_connected,
-                                ably_disconnected_at,
-                                ably_disconnect_error_logged,
-                                ably_disconnect_reason,
-                                reason.clone(),
-                            );
-                            info!(reason = %reason, "ably disconnected, switching to fast poll");
-                        }
-                        Some(ably_subscriber::Event::Error { code, message }) => {
-                            error!(code, message = %message, "ably fatal error, will reconnect");
-                            record_ably_disconnected(
-                                ably_connected,
-                                ably_disconnected_at,
-                                ably_disconnect_error_logged,
-                                ably_disconnect_reason,
-                                message.clone(),
-                            );
-                            *ably = None;
-                            ably_retry.schedule();
-                        }
-                        None => {
-                            warn!("ably subscription closed, will reconnect");
-                            record_ably_disconnected(
-                                ably_connected,
-                                ably_disconnected_at,
-                                ably_disconnect_error_logged,
-                                ably_disconnect_reason,
-                                "subscription closed".to_string(),
-                            );
-                            *ably = None;
-                            ably_retry.schedule();
-                        }
+                result = self.api.poll(&self.group, &self.profiles, &sessions) => result,
+            };
+
+            match poll_result {
+                Ok(Some(job)) => {
+                    self.poll_wakeups
+                        .record_poll_result(reason, PollOutcome::JobFound, POLL_WAKEUP_RETRY)
+                        .await;
+                    if self.cancel.is_cancelled() {
+                        return None;
                     }
-                    continue;
+                    // Fall back to default profile when server doesn't send one
+                    // (backwards compat with pre-profile API).
+                    let profile = job
+                        .experimental_profile
+                        .unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
+                    info!(run_id = %job.run_id, %profile, poll_reason = ?reason, "poll: job found");
+                    return Some((job.run_id, profile));
                 }
-                // Poll fallback (adaptive interval)
-                () = tokio::time::sleep(sleep_dur) => {
-                    *poll_now = false;
-                    *deferred_poll_at = None;
-                    let sessions = self.held_sessions.lock().await.clone();
-                    let poll_result = tokio::select! {
-                        biased;
-                        () = self.cancel.cancelled() => {
-                            return None;
-                        }
-                        result = self.api.poll(&self.group, &self.profiles, &sessions) => result,
-                    };
-                    match poll_result {
-                        Ok(Some(job)) => {
-                            if self.cancel.is_cancelled() {
-                                return None;
-                            }
-                            // Fall back to default profile when server doesn't send one
-                            // (backwards compat with pre-profile API).
-                            let profile = job.experimental_profile.unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
-                            info!(run_id = %job.run_id, %profile, "poll: job found");
-                            *poll_now = true;
-                            return Some((job.run_id, profile));
-                        }
-                        Ok(None) => {}
-                        Err(e) => {
-                            error!(error = %e, "poll failed");
-                        }
-                    }
+                Ok(None) => {
+                    self.poll_wakeups
+                        .record_poll_result(reason, PollOutcome::Empty, POLL_WAKEUP_RETRY)
+                        .await;
                 }
-                // Ably reconnection result
-                result = recv_retry(&mut ably_retry.handle) => {
-                    let reconnect_error =
-                        handle_ably_reconnect_result(result, ably, ably_connected, ably_retry);
-                    if *ably_connected {
-                        *ably_disconnected_at = None;
-                        *ably_disconnect_error_logged = false;
-                        *ably_disconnect_reason = None;
-                    } else if let Some(reason) = reconnect_error {
-                        record_ably_disconnected(
-                            ably_connected,
-                            ably_disconnected_at,
-                            ably_disconnect_error_logged,
-                            ably_disconnect_reason,
-                            reason,
-                        );
-                    }
-                }
-                // Ably retry timer
-                () = sleep_until_retry(&ably_retry.restart_at) => {}
-                () = sleep_until_optional(ably_disconnect_error_at), if ably_disconnect_error_at.is_some() => {
-                    *ably_disconnect_error_logged = true;
-                    let disconnected_secs = ably_disconnected_at
-                        .map(|at| at.elapsed().as_secs())
-                        .unwrap_or_else(|| ABLY_DISCONNECT_ERROR_AFTER.as_secs());
-                    let reason = ably_disconnect_reason
-                        .as_deref()
-                        .unwrap_or("unknown");
-                    error!(
-                        reason = %reason,
-                        disconnected_secs,
-                        "ably disconnected for too long, continuing fast poll"
-                    );
+                Err(e) => {
+                    self.poll_wakeups
+                        .record_poll_result(reason, PollOutcome::Failure, POLL_WAKEUP_RETRY)
+                        .await;
+                    error!(error = %e, poll_reason = ?reason, "poll failed");
                 }
             }
         }
@@ -374,32 +177,8 @@ impl JobProvider for ApiProvider {
         *self.held_sessions.lock().await = sessions;
     }
 
-    /// # Ordering requirement
-    ///
-    /// `discover()` holds the discovery Mutex for its entire loop.
-    /// The caller must ensure the `discover()` future is no longer
-    /// alive before calling `shutdown()`. Two paths accomplish this:
-    ///
-    /// 1. `discover()` observes the cancelled token and returns `None`,
-    ///    releasing the lock naturally.
-    /// 2. The main loop breaks (e.g. on `Draining` mode) and explicitly
-    ///    drops the pinned future, which releases the lock.
     async fn shutdown(&self) {
-        let reconnect_handle = {
-            let mut state = self.discovery.lock().await;
-            // Drop Ably subscription to close WebSocket
-            state.ably = None;
-            state.ably_connected = false;
-            state.ably_disconnected_at = None;
-            state.ably_disconnect_error_logged = false;
-            state.ably_disconnect_reason = None;
-            // Take the in-flight reconnection task before awaiting its abort.
-            state.ably_retry.handle.take()
-        };
-        if let Some(h) = reconnect_handle {
-            h.abort();
-            let _ = h.await;
-        }
+        self.ably_supervisor.shutdown().await;
     }
 
     async fn complete(
@@ -441,178 +220,12 @@ impl JobProvider for ApiProvider {
 }
 
 // ---------------------------------------------------------------------------
-// Ably helpers (private)
-// ---------------------------------------------------------------------------
-
-/// Parsed job notification from Ably.
-struct JobNotification {
-    run_id: RunId,
-    profile: Option<String>,
-    target_runner_id: Option<String>,
-}
-
-fn parse_cancel_notification(msg: &ably_subscriber::Message) -> Option<RunId> {
-    if msg.name.as_deref() != Some("cancel") {
-        return None;
-    }
-    let raw = msg.data.get("runId").and_then(|v| v.as_str())?;
-    match raw.parse() {
-        Ok(id) => Some(id),
-        Err(e) => {
-            warn!(value = %raw, error = %e, "ably: invalid cancel runId");
-            None
-        }
-    }
-}
-
-fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotification> {
-    if msg.name.as_deref() != Some("job") {
-        return None;
-    }
-    let raw = msg.data.get("runId").and_then(|v| v.as_str());
-    let run_id = match raw {
-        Some(s) => match s.parse() {
-            Ok(id) => id,
-            Err(e) => {
-                warn!(value = %s, error = %e, "ably: invalid runId");
-                return None;
-            }
-        },
-        None => {
-            warn!(data = %msg.data, "ably: job message missing runId");
-            return None;
-        }
-    };
-    let profile = msg
-        .data
-        .get("profile")
-        .and_then(|v| v.as_str())
-        .map(String::from);
-    let target_runner_id = msg
-        .data
-        .get("targetRunnerId")
-        .and_then(|v| v.as_str())
-        .map(String::from);
-    Some(JobNotification {
-        run_id,
-        profile,
-        target_runner_id,
-    })
-}
-
-/// Receive from Ably subscription, or pend forever if not connected.
-async fn recv_ably(
-    ably: &mut Option<ably_subscriber::Subscription>,
-) -> Option<ably_subscriber::Event> {
-    match ably {
-        Some(sub) => sub.next().await,
-        None => std::future::pending().await,
-    }
-}
-
-async fn sleep_until_optional(deadline: Option<tokio::time::Instant>) {
-    match deadline {
-        Some(deadline) => tokio::time::sleep_until(deadline).await,
-        None => std::future::pending().await,
-    }
-}
-
-fn record_ably_disconnected(
-    ably_connected: &mut bool,
-    ably_disconnected_at: &mut Option<tokio::time::Instant>,
-    ably_disconnect_error_logged: &mut bool,
-    ably_disconnect_reason: &mut Option<String>,
-    reason: String,
-) {
-    if *ably_connected || ably_disconnected_at.is_none() {
-        *ably_disconnected_at = Some(tokio::time::Instant::now());
-        *ably_disconnect_error_logged = false;
-    }
-    *ably_connected = false;
-    *ably_disconnect_reason = Some(reason);
-}
-
-/// Create a fresh `SubscribeConfig` for Ably connection.
-///
-/// `SubscribeConfig` is consumed by `subscribe()` and is not `Clone`,
-/// so we recreate it for each connection attempt.
-fn make_ably_config(api: &ApiClient, group: &str) -> ably_subscriber::SubscribeConfig {
-    let api = api.clone();
-    let channel = format!("runner-group:{group}");
-    let group = group.to_owned();
-    let get_token: Box<dyn Fn() -> ably_subscriber::TokenFuture + Send + Sync> =
-        Box::new(move || {
-            let api = api.clone();
-            let group = group.clone();
-            Box::pin(async move {
-                api.realtime_token(&group)
-                    .await
-                    .map_err(|e| Box::new(e) as ably_subscriber::BoxError)
-            })
-        });
-    ably_subscriber::SubscribeConfig::new(get_token, channel)
-}
-
-/// Handle the result of a background Ably reconnection task.
-fn handle_ably_reconnect_result(
-    result: Result<ably_subscriber::Subscription, String>,
-    ably: &mut Option<ably_subscriber::Subscription>,
-    ably_connected: &mut bool,
-    retry: &mut RetryState<AblyReconnectHandle>,
-) -> Option<String> {
-    match result {
-        Ok(sub) => {
-            if retry.consecutive_failures() > 0 {
-                info!(
-                    attempts = retry.consecutive_failures(),
-                    "ably reconnected after failures"
-                );
-            } else {
-                info!("ably reconnected");
-            }
-            *ably = Some(sub);
-            *ably_connected = true;
-            retry.on_success();
-            None
-        }
-        Err(e) => {
-            // Capture before on_failure() — matches the delay actually scheduled.
-            let next_secs = retry.backoff().as_secs();
-            // Ably retries forever (max_failures = None), so this always returns true.
-            let _ = retry.on_failure();
-            warn!(
-                error = %e,
-                failures = retry.consecutive_failures(),
-                next_attempt_secs = next_secs,
-                "ably reconnect failed"
-            );
-            Some(e)
-        }
-    }
-}
-
-/// Spawn a background Ably reconnection task when the timer fires.
-fn maybe_spawn_ably_reconnect(
-    ably: &mut Option<ably_subscriber::Subscription>,
-    api: &ApiClient,
-    group: &str,
-    retry: &mut RetryState<AblyReconnectHandle>,
-) {
-    if ably.is_some() || !retry.timer_ready() {
-        return;
-    }
-    retry.clear_timer();
-    let ably_config = make_ably_config(api, group);
-    retry.handle = Some(tokio::spawn(ably_subscriber::subscribe(ably_config)));
-}
-
-// ---------------------------------------------------------------------------
 // ApiClient (HTTP transport)
 // ---------------------------------------------------------------------------
 
 /// Low-level HTTP client for the vm0 runner API endpoints.
 #[derive(Clone)]
-struct ApiClient {
+pub(super) struct ApiClient {
     http: HttpClient,
     token: String,
 }
@@ -734,7 +347,10 @@ impl ApiClient {
     }
 
     /// Fetch an Ably token for subscribing to runner group notifications.
-    async fn realtime_token(&self, group: &str) -> RunnerResult<ably_subscriber::TokenRequest> {
+    pub(super) async fn realtime_token(
+        &self,
+        group: &str,
+    ) -> RunnerResult<ably_subscriber::TokenRequest> {
         let resp = send_api(
             self.http
                 .request_route(routes::runners::realtime::token::CREATE, &self.token)
@@ -791,16 +407,6 @@ mod tests {
     use tokio::io::AsyncReadExt;
     use tokio::net::TcpListener;
 
-    struct DropSignal(Option<tokio::sync::oneshot::Sender<()>>);
-
-    impl Drop for DropSignal {
-        fn drop(&mut self) {
-            if let Some(tx) = self.0.take() {
-                let _ = tx.send(());
-            }
-        }
-    }
-
     fn api_client_for_server(server: &MockServer) -> ApiClient {
         ApiClient::new(
             HttpClient::new(server.base_url()).unwrap(),
@@ -815,67 +421,24 @@ mod tests {
         }
     }
 
-    fn make_message(name: Option<&str>, data: serde_json::Value) -> ably_subscriber::Message {
-        ably_subscriber::Message {
-            name: name.map(String::from),
-            data,
-            id: None,
-            client_id: None,
-            timestamp: None,
-        }
-    }
-
-    #[tokio::test]
-    async fn shutdown_aborts_and_awaits_in_flight_ably_reconnect() {
-        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
-        let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel();
-        let mut ably_retry = RetryState::new(ABLY_BACKOFF_INITIAL, ABLY_BACKOFF_MAX, None);
-        ably_retry.handle = Some(tokio::spawn(async move {
-            let _drop_signal = DropSignal(Some(dropped_tx));
-            let _ = started_tx.send(());
-            std::future::pending::<Result<ably_subscriber::Subscription, ably_subscriber::Error>>()
-                .await
-        }));
-
-        let provider = ApiProvider {
+    fn api_provider_for_test(
+        api_url: String,
+        cancel: CancellationToken,
+        poll_wakeups: Arc<PollWakeups>,
+    ) -> Arc<ApiProvider> {
+        Arc::new(ApiProvider {
             api: ApiClient::new(
-                HttpClient::new("https://api.vm0.dev".to_string()).unwrap(),
+                HttpClient::new(api_url).unwrap(),
                 "runner-token".to_string(),
             ),
             group: "default".to_string(),
             profiles: Vec::new(),
-            runner_id: "runner-1".to_string(),
-            discovery: tokio::sync::Mutex::new(DiscoveryState {
-                ably: None,
-                ably_retry,
-                ably_connected: true,
-                ably_disconnected_at: None,
-                ably_disconnect_error_logged: false,
-                ably_disconnect_reason: None,
-                poll_now: false,
-                deferred_poll_at: None,
-            }),
+            poll_wakeups,
+            ably_supervisor: AblySupervisor::disabled(),
             tokens: tokio::sync::Mutex::new(HashMap::new()),
-            cancel_tokens: std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             held_sessions: tokio::sync::Mutex::new(Vec::new()),
-            cancel: CancellationToken::new(),
-        };
-
-        tokio::time::timeout(Duration::from_secs(1), started_rx)
-            .await
-            .expect("Ably reconnect task should start")
-            .unwrap();
-
-        provider.shutdown().await;
-
-        tokio::time::timeout(Duration::from_secs(1), dropped_rx)
-            .await
-            .expect("shutdown should await aborted Ably reconnect task")
-            .unwrap();
-
-        let state = provider.discovery.lock().await;
-        assert!(state.ably_retry.handle.is_none());
-        assert!(!state.ably_connected);
+            cancel,
+        })
     }
 
     #[tokio::test]
@@ -892,29 +455,8 @@ mod tests {
         });
 
         let cancel = CancellationToken::new();
-        let provider = Arc::new(ApiProvider {
-            api: ApiClient::new(
-                HttpClient::new(api_url).unwrap(),
-                "runner-token".to_string(),
-            ),
-            group: "default".to_string(),
-            profiles: Vec::new(),
-            runner_id: "runner-1".to_string(),
-            discovery: tokio::sync::Mutex::new(DiscoveryState {
-                ably: None,
-                ably_retry: RetryState::new(ABLY_BACKOFF_INITIAL, ABLY_BACKOFF_MAX, None),
-                ably_connected: false,
-                ably_disconnected_at: Some(tokio::time::Instant::now()),
-                ably_disconnect_error_logged: false,
-                ably_disconnect_reason: Some("test disconnected".to_string()),
-                poll_now: true,
-                deferred_poll_at: None,
-            }),
-            tokens: tokio::sync::Mutex::new(HashMap::new()),
-            cancel_tokens: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-            held_sessions: tokio::sync::Mutex::new(Vec::new()),
-            cancel: cancel.clone(),
-        });
+        let provider =
+            api_provider_for_test(api_url, cancel.clone(), Arc::new(PollWakeups::new(false)));
 
         let provider_for_discover = Arc::clone(&provider);
         let discover_task = tokio::spawn(async move { provider_for_discover.discover().await });
@@ -936,39 +478,34 @@ mod tests {
         let _ = server_task.await;
     }
 
-    #[test]
-    fn record_ably_disconnected_preserves_one_shot_escalation_state() {
-        let mut ably_connected = true;
-        let mut ably_disconnected_at = None;
-        let mut ably_disconnect_error_logged = false;
-        let mut ably_disconnect_reason = None;
-
-        record_ably_disconnected(
-            &mut ably_connected,
-            &mut ably_disconnected_at,
-            &mut ably_disconnect_error_logged,
-            &mut ably_disconnect_reason,
-            "first disconnect".to_string(),
+    #[tokio::test]
+    async fn discover_returns_http_poll_job_after_wakeup() {
+        let server = MockServer::start_async().await;
+        let run_id: RunId = "00000000-0000-0000-0000-000000000003".parse().unwrap();
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(routes::runners::poll::POLL.path);
+                then.status(200).json_body(serde_json::json!({
+                    "job": {
+                        "runId": run_id,
+                        "experimentalProfile": "vm0/default"
+                    }
+                }));
+            })
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
         );
 
-        let first_disconnected_at = ably_disconnected_at;
-        ably_disconnect_error_logged = true;
+        let discovered = tokio::time::timeout(Duration::from_secs(1), provider.discover())
+            .await
+            .expect("discover should poll after wakeup")
+            .unwrap();
 
-        record_ably_disconnected(
-            &mut ably_connected,
-            &mut ably_disconnected_at,
-            &mut ably_disconnect_error_logged,
-            &mut ably_disconnect_reason,
-            "second disconnect event".to_string(),
-        );
-
-        assert!(!ably_connected);
-        assert_eq!(ably_disconnected_at, first_disconnected_at);
-        assert!(ably_disconnect_error_logged);
-        assert_eq!(
-            ably_disconnect_reason.as_deref(),
-            Some("second disconnect event")
-        );
+        assert_eq!(discovered, (run_id, "vm0/default".to_string()));
+        mock.assert_async().await;
     }
 
     #[tokio::test]
@@ -1051,130 +588,5 @@ mod tests {
 
         assert_api_error(err, "complete 500 Internal Server Error: complete failed");
         mock.assert_async().await;
-    }
-
-    #[test]
-    fn parse_job_notification_valid() {
-        let msg = make_message(
-            Some("job"),
-            serde_json::json!({ "runId": "00000000-0000-0000-0000-000000000001" }),
-        );
-        let notif = parse_job_notification(&msg).unwrap();
-        assert_eq!(
-            notif.run_id.to_string(),
-            "00000000-0000-0000-0000-000000000001"
-        );
-        assert!(notif.profile.is_none());
-    }
-
-    #[test]
-    fn parse_job_notification_with_profile() {
-        let msg = make_message(
-            Some("job"),
-            serde_json::json!({ "runId": "00000000-0000-0000-0000-000000000001", "profile": "vm0/default" }),
-        );
-        let notif = parse_job_notification(&msg).unwrap();
-        assert_eq!(
-            notif.run_id.to_string(),
-            "00000000-0000-0000-0000-000000000001"
-        );
-        assert_eq!(notif.profile.as_deref(), Some("vm0/default"));
-    }
-
-    #[test]
-    fn parse_job_notification_wrong_event_name() {
-        let msg = make_message(
-            Some("status"),
-            serde_json::json!({ "runId": "00000000-0000-0000-0000-000000000001" }),
-        );
-        assert!(parse_job_notification(&msg).is_none());
-    }
-
-    #[test]
-    fn parse_job_notification_missing_name() {
-        let msg = make_message(
-            None,
-            serde_json::json!({ "runId": "00000000-0000-0000-0000-000000000001" }),
-        );
-        assert!(parse_job_notification(&msg).is_none());
-    }
-
-    #[test]
-    fn parse_job_notification_invalid_uuid() {
-        let msg = make_message(Some("job"), serde_json::json!({ "runId": "not-a-uuid" }));
-        assert!(parse_job_notification(&msg).is_none());
-    }
-
-    #[test]
-    fn parse_job_notification_missing_field() {
-        let msg = make_message(Some("job"), serde_json::json!({ "other": "data" }));
-        assert!(parse_job_notification(&msg).is_none());
-    }
-
-    #[test]
-    fn parse_cancel_notification_valid() {
-        let msg = make_message(
-            Some("cancel"),
-            serde_json::json!({ "runId": "00000000-0000-0000-0000-000000000002" }),
-        );
-        let run_id = parse_cancel_notification(&msg).unwrap();
-        assert_eq!(run_id.to_string(), "00000000-0000-0000-0000-000000000002");
-    }
-
-    #[test]
-    fn parse_cancel_notification_wrong_event_name() {
-        let msg = make_message(
-            Some("job"),
-            serde_json::json!({ "runId": "00000000-0000-0000-0000-000000000002" }),
-        );
-        assert!(parse_cancel_notification(&msg).is_none());
-    }
-
-    #[test]
-    fn parse_cancel_notification_missing_name() {
-        let msg = make_message(
-            None,
-            serde_json::json!({ "runId": "00000000-0000-0000-0000-000000000002" }),
-        );
-        assert!(parse_cancel_notification(&msg).is_none());
-    }
-
-    #[test]
-    fn parse_cancel_notification_invalid_uuid() {
-        let msg = make_message(Some("cancel"), serde_json::json!({ "runId": "not-a-uuid" }));
-        assert!(parse_cancel_notification(&msg).is_none());
-    }
-
-    #[test]
-    fn parse_cancel_notification_missing_field() {
-        let msg = make_message(Some("cancel"), serde_json::json!({ "other": "data" }));
-        assert!(parse_cancel_notification(&msg).is_none());
-    }
-
-    #[test]
-    fn parse_job_notification_with_target_runner_id() {
-        let msg = make_message(
-            Some("job"),
-            serde_json::json!({
-                "runId": "00000000-0000-0000-0000-000000000001",
-                "profile": "vm0/default",
-                "targetRunnerId": "00000000-0000-0000-0000-000000000099"
-            }),
-        );
-        let notif = parse_job_notification(&msg).unwrap();
-        assert_eq!(
-            notif.target_runner_id.as_deref(),
-            Some("00000000-0000-0000-0000-000000000099")
-        );
-    }
-
-    #[test]
-    fn parse_job_notification_without_target_runner_id() {
-        let msg = make_message(
-            Some("job"),
-            serde_json::json!({ "runId": "00000000-0000-0000-0000-000000000001" }),
-        );
-        let notif = parse_job_notification(&msg).unwrap();
-        assert!(notif.target_runner_id.is_none());
     }
 }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -414,7 +414,7 @@ mod tests {
     use super::*;
     use httpmock::Method::POST;
     use httpmock::MockServer;
-    use tokio::io::AsyncReadExt;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
     fn api_client_for_server(server: &MockServer) -> ApiClient {
@@ -449,6 +449,27 @@ mod tests {
             held_sessions: tokio::sync::Mutex::new(Vec::new()),
             cancel,
         })
+    }
+
+    async fn read_http_request(socket: &mut tokio::net::TcpStream) {
+        let mut buf = [0_u8; 4096];
+        let _ = socket.read(&mut buf).await.unwrap();
+    }
+
+    async fn write_poll_job_response(socket: &mut tokio::net::TcpStream, run_id: RunId) {
+        let body = serde_json::json!({
+            "job": {
+                "runId": run_id,
+                "experimentalProfile": "vm0/default"
+            }
+        })
+        .to_string();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        socket.write_all(response.as_bytes()).await.unwrap();
     }
 
     #[tokio::test]
@@ -516,6 +537,53 @@ mod tests {
 
         assert_eq!(discovered, (run_id, "vm0/default".to_string()));
         mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn discover_defers_job_return_when_target_other_wakeup_arrives_during_poll() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let api_url = format!("http://{}", listener.local_addr().unwrap());
+        let first_run_id: RunId = "00000000-0000-0000-0000-000000000004".parse().unwrap();
+        let second_run_id: RunId = "00000000-0000-0000-0000-000000000005".parse().unwrap();
+        let (first_accepted_tx, first_accepted_rx) = tokio::sync::oneshot::channel();
+        let (release_first_tx, release_first_rx) = tokio::sync::oneshot::channel();
+        let server_task = tokio::spawn(async move {
+            let (mut first_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut first_socket).await;
+            let _ = first_accepted_tx.send(());
+            release_first_rx.await.unwrap();
+            write_poll_job_response(&mut first_socket, first_run_id).await;
+            drop(first_socket);
+
+            let (mut second_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut second_socket).await;
+            write_poll_job_response(&mut second_socket, second_run_id).await;
+        });
+        let wakeups = Arc::new(PollWakeups::new(false));
+        let provider =
+            api_provider_for_test(api_url, CancellationToken::new(), Arc::clone(&wakeups));
+        let provider_for_discover = Arc::clone(&provider);
+        let discover_task = tokio::spawn(async move { provider_for_discover.discover().await });
+
+        tokio::time::timeout(Duration::from_secs(1), first_accepted_rx)
+            .await
+            .expect("first poll should reach the server")
+            .unwrap();
+        wakeups
+            .request_deferred_poll_after_for_test(Duration::from_millis(10))
+            .await;
+        release_first_tx.send(()).unwrap();
+        tokio::task::yield_now().await;
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let discovered = tokio::time::timeout(Duration::from_secs(1), discover_task)
+            .await
+            .expect("discover should retry after target-other defer")
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(discovered, (second_run_id, "vm0/default".to_string()));
+        server_task.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -101,10 +101,11 @@ impl ApiProvider {
 impl JobProvider for ApiProvider {
     async fn discover(&self) -> Option<(RunId, String)> {
         loop {
-            let reason = self
+            let due = self
                 .poll_wakeups
                 .wait_for_poll_due(&self.cancel, POLL_SLOW, POLL_FAST)
                 .await?;
+            let reason = due.reason();
 
             let sessions = self.held_sessions.lock().await.clone();
             let poll_result = tokio::select! {
@@ -118,7 +119,7 @@ impl JobProvider for ApiProvider {
             match poll_result {
                 Ok(Some(job)) => {
                     self.poll_wakeups
-                        .record_poll_result(reason, PollOutcome::JobFound, POLL_WAKEUP_RETRY)
+                        .record_poll_result(due, PollOutcome::JobFound, POLL_WAKEUP_RETRY)
                         .await;
                     if self.cancel.is_cancelled() {
                         return None;
@@ -133,12 +134,12 @@ impl JobProvider for ApiProvider {
                 }
                 Ok(None) => {
                     self.poll_wakeups
-                        .record_poll_result(reason, PollOutcome::Empty, POLL_WAKEUP_RETRY)
+                        .record_poll_result(due, PollOutcome::Empty, POLL_WAKEUP_RETRY)
                         .await;
                 }
                 Err(e) => {
                     self.poll_wakeups
-                        .record_poll_result(reason, PollOutcome::Failure, POLL_WAKEUP_RETRY)
+                        .record_poll_result(due, PollOutcome::Failure, POLL_WAKEUP_RETRY)
                         .await;
                     error!(error = %e, poll_reason = ?reason, "poll failed");
                 }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -118,9 +118,18 @@ impl JobProvider for ApiProvider {
 
             match poll_result {
                 Ok(Some(job)) => {
-                    self.poll_wakeups
+                    let record = self
+                        .poll_wakeups
                         .record_poll_result(due, PollOutcome::JobFound, POLL_WAKEUP_RETRY)
                         .await;
+                    if record.defer_job_return() {
+                        info!(
+                            run_id = %job.run_id,
+                            poll_reason = ?reason,
+                            "poll: job found while target-other defer arrived, retrying after defer"
+                        );
+                        continue;
+                    }
                     if self.cancel.is_cancelled() {
                         return None;
                     }

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -139,6 +139,11 @@ impl PollWakeups {
         self.notify.notify_waiters();
     }
 
+    #[cfg(test)]
+    pub(super) async fn request_deferred_poll_after_for_test(&self, delay: Duration) {
+        self.request_deferred_poll_after(delay).await;
+    }
+
     pub(super) async fn record_poll_result(
         &self,
         due: PollDue,

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -54,6 +54,17 @@ pub(super) enum PollOutcome {
     Failure,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct PollRecord {
+    defer_job_return: bool,
+}
+
+impl PollRecord {
+    pub(super) fn defer_job_return(self) -> bool {
+        self.defer_job_return
+    }
+}
+
 pub(super) struct PollWakeups {
     inner: Mutex<PollWakeupsInner>,
     notify: Notify,
@@ -133,10 +144,12 @@ impl PollWakeups {
         due: PollDue,
         outcome: PollOutcome,
         wakeup_retry_delay: Duration,
-    ) {
+    ) -> PollRecord {
         let mut should_notify = false;
         let mut inner = self.inner.lock().await;
         let has_new_wakeup = inner.generation != due.generation;
+        let defer_job_return =
+            outcome == PollOutcome::JobFound && has_new_wakeup && inner.deferred_poll_at.is_some();
         match outcome {
             PollOutcome::JobFound => {
                 inner.poll_now = true;
@@ -164,6 +177,7 @@ impl PollWakeups {
         if should_notify {
             self.notify.notify_waiters();
         }
+        PollRecord { defer_job_return }
     }
 
     pub(super) async fn wait_for_poll_due(
@@ -180,28 +194,31 @@ impl PollWakeups {
             let scheduled = {
                 let mut inner = self.inner.lock().await;
                 let now = tokio::time::Instant::now();
-                if inner.poll_now {
-                    inner.poll_now = false;
-                    return Some(PollDue {
-                        reason: PollReason::Immediate,
-                        generation: inner.generation,
-                    });
-                }
-                if inner.wakeup_retry_at.is_some_and(|at| at <= now) {
-                    inner.wakeup_retry_at = None;
-                    return Some(PollDue {
-                        reason: PollReason::WakeupRetry,
-                        generation: inner.generation,
-                    });
-                }
                 if inner.deferred_poll_at.is_some_and(|at| at <= now) {
                     inner.deferred_poll_at = None;
+                    inner.poll_now = false;
                     return Some(PollDue {
                         reason: PollReason::Deferred,
                         generation: inner.generation,
                     });
                 }
-                Self::next_scheduled(&inner, now, slow_interval, fast_interval)
+                if inner.deferred_poll_at.is_some() {
+                    Self::next_scheduled(&inner, now, slow_interval, fast_interval)
+                } else if inner.poll_now {
+                    inner.poll_now = false;
+                    return Some(PollDue {
+                        reason: PollReason::Immediate,
+                        generation: inner.generation,
+                    });
+                } else if inner.wakeup_retry_at.is_some_and(|at| at <= now) {
+                    inner.wakeup_retry_at = None;
+                    return Some(PollDue {
+                        reason: PollReason::WakeupRetry,
+                        generation: inner.generation,
+                    });
+                } else {
+                    Self::next_scheduled(&inner, now, slow_interval, fast_interval)
+                }
             };
 
             tokio::select! {
@@ -224,7 +241,12 @@ impl PollWakeups {
         slow_interval: Duration,
         fast_interval: Duration,
     ) -> ScheduledPoll {
-        let mut scheduled = if inner.ably_connected {
+        let mut scheduled = if let Some(at) = inner.deferred_poll_at {
+            ScheduledPoll {
+                at,
+                reason: PollReason::Deferred,
+            }
+        } else if inner.ably_connected {
             ScheduledPoll {
                 at: now + slow_interval,
                 reason: PollReason::Slow,
@@ -236,7 +258,8 @@ impl PollWakeups {
             }
         };
 
-        if let Some(at) = inner.wakeup_retry_at
+        if inner.deferred_poll_at.is_none()
+            && let Some(at) = inner.wakeup_retry_at
             && at <= scheduled.at
         {
             scheduled = ScheduledPoll {
@@ -244,15 +267,6 @@ impl PollWakeups {
                 reason: PollReason::WakeupRetry,
             };
         }
-        if let Some(at) = inner.deferred_poll_at
-            && at <= scheduled.at
-        {
-            scheduled = ScheduledPoll {
-                at,
-                reason: PollReason::Deferred,
-            };
-        }
-
         scheduled
     }
 
@@ -263,7 +277,9 @@ impl PollWakeups {
         let is_due = match scheduled.reason {
             PollReason::Immediate => false,
             PollReason::WakeupRetry => {
-                if inner.wakeup_retry_at.is_some_and(|at| at <= now) {
+                if inner.deferred_poll_at.is_none()
+                    && inner.wakeup_retry_at.is_some_and(|at| at <= now)
+                {
                     inner.wakeup_retry_at = None;
                     true
                 } else {
@@ -273,16 +289,23 @@ impl PollWakeups {
             PollReason::Deferred => {
                 if inner.deferred_poll_at.is_some_and(|at| at <= now) {
                     inner.deferred_poll_at = None;
+                    inner.poll_now = false;
                     true
                 } else {
                     false
                 }
             }
             PollReason::Slow => {
-                inner.ably_connected && !inner.poll_now && !Self::has_due_wakeup(&inner, now)
+                inner.deferred_poll_at.is_none()
+                    && inner.ably_connected
+                    && !inner.poll_now
+                    && !Self::has_due_wakeup(&inner, now)
             }
             PollReason::Fast => {
-                !inner.ably_connected && !inner.poll_now && !Self::has_due_wakeup(&inner, now)
+                inner.deferred_poll_at.is_none()
+                    && !inner.ably_connected
+                    && !inner.poll_now
+                    && !Self::has_due_wakeup(&inner, now)
             }
         };
         is_due.then_some(PollDue {
@@ -925,6 +948,80 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn target_other_runner_deferred_poll_blocks_pending_immediate_until_deadline() {
+        let wakeups = Arc::new(PollWakeups::new(true));
+        let initial = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+        wakeups
+            .record_poll_result(initial, PollOutcome::JobFound, Duration::from_secs(5))
+            .await;
+        assert!(wakeups.snapshot().await.poll_now);
+
+        wakeups
+            .request_deferred_poll_at(tokio::time::Instant::now() + Duration::from_secs(2))
+            .await;
+
+        let wakeups_for_wait = Arc::clone(&wakeups);
+        let cancel = CancellationToken::new();
+        let wait = tokio::spawn(async move {
+            wakeups_for_wait
+                .wait_for_poll_due(&cancel, Duration::from_secs(30), Duration::from_secs(5))
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !wait.is_finished(),
+            "pending immediate must not bypass target-other defer window"
+        );
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        assert_eq!(poll_reason(wait.await.unwrap()), Some(PollReason::Deferred));
+        assert!(!wakeups.snapshot().await.poll_now);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn target_other_runner_deferred_poll_blocks_wakeup_retry_until_deadline() {
+        let wakeups = Arc::new(PollWakeups::new(true));
+        let initial = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+        wakeups
+            .record_poll_result(initial, PollOutcome::Failure, Duration::from_secs(1))
+            .await;
+        wakeups
+            .request_deferred_poll_at(tokio::time::Instant::now() + Duration::from_secs(2))
+            .await;
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        let wakeups_for_wait = Arc::clone(&wakeups);
+        let cancel = CancellationToken::new();
+        let wait = tokio::spawn(async move {
+            wakeups_for_wait
+                .wait_for_poll_due(&cancel, Duration::from_secs(30), Duration::from_secs(5))
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !wait.is_finished(),
+            "wakeup retry must not bypass target-other defer window"
+        );
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert_eq!(poll_reason(wait.await.unwrap()), Some(PollReason::Deferred));
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn empty_poll_keeps_deferred_wakeup_created_after_poll_started() {
         let wakeups = PollWakeups::new(true);
         let due = wakeups
@@ -943,6 +1040,63 @@ mod tests {
             .await;
 
         assert_eq!(wakeups.snapshot().await.deferred_poll_at, Some(deferred_at));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn job_found_defers_return_when_target_other_wakeup_arrived_after_poll_started() {
+        let wakeups = PollWakeups::new(true);
+        let due = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        wakeups
+            .request_deferred_poll_at(tokio::time::Instant::now() + Duration::from_secs(2))
+            .await;
+        let record = wakeups
+            .record_poll_result(due, PollOutcome::JobFound, Duration::from_secs(5))
+            .await;
+
+        assert!(record.defer_job_return());
+        assert!(wakeups.snapshot().await.deferred_poll_at.is_some());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn job_found_returns_when_target_other_defer_was_the_poll_reason() {
+        let wakeups = PollWakeups::new(true);
+        let initial = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+        wakeups
+            .record_poll_result(initial, PollOutcome::Empty, Duration::from_secs(5))
+            .await;
+        wakeups
+            .request_deferred_poll_at(tokio::time::Instant::now() + Duration::from_secs(2))
+            .await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let due = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        let record = wakeups
+            .record_poll_result(due, PollOutcome::JobFound, Duration::from_secs(5))
+            .await;
+
+        assert!(!record.defer_job_return());
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -1034,6 +1034,59 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn target_other_runner_deferred_poll_cap_resets_after_deadline() {
+        let wakeups = PollWakeups::new(true);
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+
+        wakeups
+            .request_deferred_poll_after(Duration::from_secs(2))
+            .await;
+        let initial_cap = wakeups
+            .snapshot()
+            .await
+            .deferred_poll_cap_at
+            .expect("initial defer cap");
+        for _ in 0..9 {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            wakeups
+                .request_deferred_poll_after(Duration::from_secs(2))
+                .await;
+        }
+
+        tokio::time::sleep_until(initial_cap).await;
+        let reason = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        assert_eq!(poll_reason(reason), Some(PollReason::Deferred));
+        let snapshot = wakeups.snapshot().await;
+        assert!(snapshot.deferred_poll_at.is_none());
+        assert!(snapshot.deferred_poll_cap_at.is_none());
+
+        wakeups
+            .request_deferred_poll_after(Duration::from_secs(2))
+            .await;
+        let snapshot = wakeups.snapshot().await;
+        let next_deadline = snapshot
+            .deferred_poll_at
+            .expect("next defer deadline should be scheduled");
+        let next_cap = snapshot
+            .deferred_poll_cap_at
+            .expect("next defer cap should be scheduled");
+        assert!(next_deadline > initial_cap);
+        assert!(next_cap > next_deadline);
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn target_other_runner_deferred_poll_blocks_pending_immediate_until_deadline() {
         let wakeups = Arc::new(PollWakeups::new(true));
         let initial = wakeups

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -1,0 +1,1032 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant as StdInstant};
+
+use tokio::sync::{Mutex, Notify};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+
+use super::api::ApiClient;
+use crate::ids::RunId;
+use crate::retry::{RetryState, recv_retry, sleep_until_retry};
+
+const ABLY_BACKOFF_INITIAL: Duration = Duration::from_secs(5);
+const ABLY_BACKOFF_MAX: Duration = Duration::from_secs(60);
+const ABLY_DISCONNECT_ERROR_AFTER: Duration = Duration::from_secs(60);
+const TARGETED_RUNNER_DEFER: Duration = Duration::from_secs(2);
+
+type AblyConnectHandle =
+    tokio::task::JoinHandle<Result<ably_subscriber::Subscription, ably_subscriber::Error>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PollReason {
+    Immediate,
+    Deferred,
+    WakeupRetry,
+    Slow,
+    Fast,
+}
+
+impl PollReason {
+    pub(super) fn is_wakeup(self) -> bool {
+        matches!(self, Self::Immediate | Self::Deferred | Self::WakeupRetry)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PollOutcome {
+    JobFound,
+    Empty,
+    Failure,
+}
+
+pub(super) struct PollWakeups {
+    inner: Mutex<PollWakeupsInner>,
+    notify: Notify,
+}
+
+#[derive(Debug)]
+struct PollWakeupsInner {
+    ably_connected: bool,
+    poll_now: bool,
+    deferred_poll_at: Option<tokio::time::Instant>,
+    wakeup_retry_at: Option<tokio::time::Instant>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ScheduledPoll {
+    at: tokio::time::Instant,
+    reason: PollReason,
+}
+
+impl PollWakeups {
+    pub(super) fn new(ably_connected: bool) -> Self {
+        Self {
+            inner: Mutex::new(PollWakeupsInner {
+                ably_connected,
+                poll_now: true,
+                deferred_poll_at: None,
+                wakeup_retry_at: None,
+            }),
+            notify: Notify::new(),
+        }
+    }
+
+    pub(super) async fn mark_ably_connected(&self) {
+        self.inner.lock().await.ably_connected = true;
+        self.notify.notify_waiters();
+    }
+
+    pub(super) async fn mark_ably_disconnected(&self) {
+        self.inner.lock().await.ably_connected = false;
+        self.notify.notify_waiters();
+    }
+
+    async fn request_immediate_poll(&self) {
+        self.inner.lock().await.poll_now = true;
+        self.notify.notify_waiters();
+    }
+
+    async fn request_deferred_poll_after(&self, delay: Duration) {
+        self.request_deferred_poll_at(tokio::time::Instant::now() + delay)
+            .await;
+    }
+
+    async fn request_deferred_poll_at(&self, at: tokio::time::Instant) {
+        let mut inner = self.inner.lock().await;
+        if inner.deferred_poll_at.is_none_or(|existing| at < existing) {
+            inner.deferred_poll_at = Some(at);
+        }
+        drop(inner);
+        self.notify.notify_waiters();
+    }
+
+    pub(super) async fn record_poll_result(
+        &self,
+        reason: PollReason,
+        outcome: PollOutcome,
+        wakeup_retry_delay: Duration,
+    ) {
+        let mut should_notify = false;
+        let mut inner = self.inner.lock().await;
+        match outcome {
+            PollOutcome::JobFound => {
+                inner.poll_now = true;
+                inner.deferred_poll_at = None;
+                inner.wakeup_retry_at = None;
+                should_notify = true;
+            }
+            PollOutcome::Empty => {
+                inner.deferred_poll_at = None;
+                inner.wakeup_retry_at = None;
+            }
+            PollOutcome::Failure if reason.is_wakeup() => {
+                inner.wakeup_retry_at = Some(tokio::time::Instant::now() + wakeup_retry_delay);
+                should_notify = true;
+            }
+            PollOutcome::Failure => {}
+        }
+        drop(inner);
+        if should_notify {
+            self.notify.notify_waiters();
+        }
+    }
+
+    pub(super) async fn wait_for_poll_due(
+        &self,
+        cancel: &CancellationToken,
+        slow_interval: Duration,
+        fast_interval: Duration,
+    ) -> Option<PollReason> {
+        loop {
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            let scheduled = {
+                let mut inner = self.inner.lock().await;
+                let now = tokio::time::Instant::now();
+                if inner.poll_now {
+                    inner.poll_now = false;
+                    return Some(PollReason::Immediate);
+                }
+                if inner.wakeup_retry_at.is_some_and(|at| at <= now) {
+                    inner.wakeup_retry_at = None;
+                    return Some(PollReason::WakeupRetry);
+                }
+                if inner.deferred_poll_at.is_some_and(|at| at <= now) {
+                    inner.deferred_poll_at = None;
+                    return Some(PollReason::Deferred);
+                }
+                Self::next_scheduled(&inner, now, slow_interval, fast_interval)
+            };
+
+            tokio::select! {
+                () = cancel.cancelled() => {
+                    return None;
+                }
+                () = &mut notified => {}
+                () = tokio::time::sleep_until(scheduled.at) => {
+                    if self.consume_scheduled(scheduled).await {
+                        return Some(scheduled.reason);
+                    }
+                }
+            }
+        }
+    }
+
+    fn next_scheduled(
+        inner: &PollWakeupsInner,
+        now: tokio::time::Instant,
+        slow_interval: Duration,
+        fast_interval: Duration,
+    ) -> ScheduledPoll {
+        let mut scheduled = if inner.ably_connected {
+            ScheduledPoll {
+                at: now + slow_interval,
+                reason: PollReason::Slow,
+            }
+        } else {
+            ScheduledPoll {
+                at: now + fast_interval,
+                reason: PollReason::Fast,
+            }
+        };
+
+        if let Some(at) = inner.wakeup_retry_at
+            && at <= scheduled.at
+        {
+            scheduled = ScheduledPoll {
+                at,
+                reason: PollReason::WakeupRetry,
+            };
+        }
+        if let Some(at) = inner.deferred_poll_at
+            && at <= scheduled.at
+        {
+            scheduled = ScheduledPoll {
+                at,
+                reason: PollReason::Deferred,
+            };
+        }
+
+        scheduled
+    }
+
+    async fn consume_scheduled(&self, scheduled: ScheduledPoll) -> bool {
+        let mut inner = self.inner.lock().await;
+        let now = tokio::time::Instant::now();
+
+        match scheduled.reason {
+            PollReason::Immediate => false,
+            PollReason::WakeupRetry => {
+                if inner.wakeup_retry_at.is_some_and(|at| at <= now) {
+                    inner.wakeup_retry_at = None;
+                    true
+                } else {
+                    false
+                }
+            }
+            PollReason::Deferred => {
+                if inner.deferred_poll_at.is_some_and(|at| at <= now) {
+                    inner.deferred_poll_at = None;
+                    true
+                } else {
+                    false
+                }
+            }
+            PollReason::Slow => {
+                inner.ably_connected && !inner.poll_now && !Self::has_due_wakeup(&inner, now)
+            }
+            PollReason::Fast => {
+                !inner.ably_connected && !inner.poll_now && !Self::has_due_wakeup(&inner, now)
+            }
+        }
+    }
+
+    fn has_due_wakeup(inner: &PollWakeupsInner, now: tokio::time::Instant) -> bool {
+        inner.wakeup_retry_at.is_some_and(|at| at <= now)
+            || inner.deferred_poll_at.is_some_and(|at| at <= now)
+    }
+
+    #[cfg(test)]
+    async fn snapshot(&self) -> PollWakeupsSnapshot {
+        let inner = self.inner.lock().await;
+        PollWakeupsSnapshot {
+            ably_connected: inner.ably_connected,
+            poll_now: inner.poll_now,
+            deferred_poll_at: inner.deferred_poll_at,
+            wakeup_retry_at: inner.wakeup_retry_at,
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct PollWakeupsSnapshot {
+    ably_connected: bool,
+    poll_now: bool,
+    deferred_poll_at: Option<tokio::time::Instant>,
+    wakeup_retry_at: Option<tokio::time::Instant>,
+}
+
+pub(super) struct AblySupervisor {
+    shutdown: CancellationToken,
+    task: Mutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+impl AblySupervisor {
+    pub(super) fn spawn(
+        api: ApiClient,
+        group: String,
+        runner_id: String,
+        poll_wakeups: Arc<PollWakeups>,
+        cancel_tokens: Arc<Mutex<HashMap<RunId, CancellationToken>>>,
+        provider_cancel: CancellationToken,
+    ) -> Self {
+        let shutdown = CancellationToken::new();
+        let task_shutdown = shutdown.clone();
+        let task = tokio::spawn(async move {
+            run_supervisor(
+                api,
+                group,
+                runner_id,
+                poll_wakeups,
+                cancel_tokens,
+                provider_cancel,
+                task_shutdown,
+            )
+            .await;
+        });
+        Self {
+            shutdown,
+            task: Mutex::new(Some(task)),
+        }
+    }
+
+    pub(super) async fn shutdown(&self) {
+        self.shutdown.cancel();
+        let task = self.task.lock().await.take();
+        if let Some(task) = task
+            && let Err(e) = task.await
+        {
+            warn!(error = %e, "ably supervisor task failed during shutdown");
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn disabled() -> Self {
+        Self {
+            shutdown: CancellationToken::new(),
+            task: Mutex::new(None),
+        }
+    }
+
+    #[cfg(test)]
+    fn spawn_test_task<F>(build: impl FnOnce(CancellationToken) -> F) -> Self
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let shutdown = CancellationToken::new();
+        let task = tokio::spawn(build(shutdown.clone()));
+        Self {
+            shutdown,
+            task: Mutex::new(Some(task)),
+        }
+    }
+}
+
+async fn run_supervisor(
+    api: ApiClient,
+    group: String,
+    runner_id: String,
+    poll_wakeups: Arc<PollWakeups>,
+    cancel_tokens: Arc<Mutex<HashMap<RunId, CancellationToken>>>,
+    provider_cancel: CancellationToken,
+    shutdown: CancellationToken,
+) {
+    let mut ably: Option<ably_subscriber::Subscription> = None;
+    let mut ably_retry: RetryState<AblyConnectHandle> =
+        RetryState::new(ABLY_BACKOFF_INITIAL, ABLY_BACKOFF_MAX, None);
+    ably_retry.restart_at = Some(StdInstant::now());
+    let mut disconnect = AblyDisconnectState::disconnected("connecting".to_string());
+
+    loop {
+        maybe_spawn_ably_connect(&mut ably, &api, &group, &mut ably_retry);
+        let disconnect_error_at = disconnect.error_deadline();
+
+        tokio::select! {
+            () = shutdown.cancelled() => {
+                break;
+            }
+            () = provider_cancel.cancelled() => {
+                break;
+            }
+            event = recv_ably(&mut ably) => {
+                match event {
+                    Some(ably_subscriber::Event::Message(msg)) => {
+                        handle_ably_message(&msg, &runner_id, &poll_wakeups, &cancel_tokens).await;
+                    }
+                    Some(ably_subscriber::Event::Connected) => {
+                        if !disconnect.is_connected() {
+                            info!("ably reconnected");
+                        }
+                        disconnect.mark_connected();
+                        poll_wakeups.mark_ably_connected().await;
+                    }
+                    Some(ably_subscriber::Event::Disconnected { reason }) => {
+                        let reason = reason.unwrap_or_else(|| "unknown".to_string());
+                        disconnect.record_disconnected(reason.clone());
+                        poll_wakeups.mark_ably_disconnected().await;
+                        info!(reason = %reason, "ably disconnected, switching to fast poll");
+                    }
+                    Some(ably_subscriber::Event::Error { code, message }) => {
+                        error!(code, message = %message, "ably fatal error, will reconnect");
+                        disconnect.record_disconnected(message.clone());
+                        poll_wakeups.mark_ably_disconnected().await;
+                        ably = None;
+                        ably_retry.schedule();
+                    }
+                    None => {
+                        warn!("ably subscription closed, will reconnect");
+                        disconnect.record_disconnected("subscription closed".to_string());
+                        poll_wakeups.mark_ably_disconnected().await;
+                        ably = None;
+                        ably_retry.schedule();
+                    }
+                }
+            }
+            result = recv_retry(&mut ably_retry.handle) => {
+                match handle_ably_connect_result(result, &mut ably, &mut ably_retry) {
+                    Ok(()) => {
+                        disconnect.mark_connected();
+                        poll_wakeups.mark_ably_connected().await;
+                    }
+                    Err(reason) => {
+                        disconnect.record_disconnected(reason);
+                        poll_wakeups.mark_ably_disconnected().await;
+                    }
+                }
+            }
+            () = sleep_until_retry(&ably_retry.restart_at) => {}
+            () = sleep_until_optional(disconnect_error_at), if disconnect_error_at.is_some() => {
+                disconnect.mark_error_logged();
+                error!(
+                    reason = %disconnect.reason(),
+                    disconnected_secs = disconnect.disconnected_secs(),
+                    "ably disconnected for too long, continuing fast poll"
+                );
+            }
+        }
+    }
+
+    if let Some(sub) = ably.take() {
+        sub.close();
+    }
+    if let Some(handle) = ably_retry.handle.take() {
+        handle.abort();
+        let _ = handle.await;
+    }
+}
+
+async fn handle_ably_message(
+    msg: &ably_subscriber::Message,
+    runner_id: &str,
+    poll_wakeups: &PollWakeups,
+    cancel_tokens: &Mutex<HashMap<RunId, CancellationToken>>,
+) {
+    if let Some(run_id) = parse_cancel_notification(msg) {
+        let token = cancel_tokens.lock().await.get(&run_id).cloned();
+        if let Some(token) = token {
+            info!(run_id = %run_id, "ably: cancel notification, killing job");
+            token.cancel();
+        }
+        return;
+    }
+
+    if let Some(notif) = parse_job_notification(msg) {
+        if notif
+            .target_runner_id
+            .as_deref()
+            .is_some_and(|target| target != runner_id)
+        {
+            info!(
+                run_id = %notif.run_id,
+                target = notif.target_runner_id.as_deref().unwrap_or(""),
+                "ably: job targeted to another runner, deferring poll"
+            );
+            poll_wakeups
+                .request_deferred_poll_after(TARGETED_RUNNER_DEFER)
+                .await;
+            return;
+        }
+
+        let targeted = notif
+            .target_runner_id
+            .as_deref()
+            .is_some_and(|target| target == runner_id);
+        info!(
+            run_id = %notif.run_id,
+            profile = notif.profile.as_deref().unwrap_or(""),
+            targeted,
+            "ably: job notification, waking poll"
+        );
+        poll_wakeups.request_immediate_poll().await;
+    }
+}
+
+struct JobNotification {
+    run_id: RunId,
+    profile: Option<String>,
+    target_runner_id: Option<String>,
+}
+
+fn parse_cancel_notification(msg: &ably_subscriber::Message) -> Option<RunId> {
+    if msg.name.as_deref() != Some("cancel") {
+        return None;
+    }
+    let raw = msg.data.get("runId").and_then(|v| v.as_str())?;
+    match raw.parse() {
+        Ok(id) => Some(id),
+        Err(e) => {
+            warn!(value = %raw, error = %e, "ably: invalid cancel runId");
+            None
+        }
+    }
+}
+
+fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotification> {
+    if msg.name.as_deref() != Some("job") {
+        return None;
+    }
+    let raw = msg.data.get("runId").and_then(|v| v.as_str());
+    let run_id = match raw {
+        Some(s) => match s.parse() {
+            Ok(id) => id,
+            Err(e) => {
+                warn!(value = %s, error = %e, "ably: invalid runId");
+                return None;
+            }
+        },
+        None => {
+            warn!(data = %msg.data, "ably: job message missing runId");
+            return None;
+        }
+    };
+    let profile = msg
+        .data
+        .get("profile")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let target_runner_id = msg
+        .data
+        .get("targetRunnerId")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    Some(JobNotification {
+        run_id,
+        profile,
+        target_runner_id,
+    })
+}
+
+async fn recv_ably(
+    ably: &mut Option<ably_subscriber::Subscription>,
+) -> Option<ably_subscriber::Event> {
+    match ably {
+        Some(sub) => sub.next().await,
+        None => std::future::pending().await,
+    }
+}
+
+async fn sleep_until_optional(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending().await,
+    }
+}
+
+fn make_ably_config(api: &ApiClient, group: &str) -> ably_subscriber::SubscribeConfig {
+    let api = api.clone();
+    let channel = format!("runner-group:{group}");
+    let group = group.to_owned();
+    let get_token: Box<dyn Fn() -> ably_subscriber::TokenFuture + Send + Sync> =
+        Box::new(move || {
+            let api = api.clone();
+            let group = group.clone();
+            Box::pin(async move {
+                api.realtime_token(&group)
+                    .await
+                    .map_err(|e| Box::new(e) as ably_subscriber::BoxError)
+            })
+        });
+    ably_subscriber::SubscribeConfig::new(get_token, channel)
+}
+
+fn maybe_spawn_ably_connect(
+    ably: &mut Option<ably_subscriber::Subscription>,
+    api: &ApiClient,
+    group: &str,
+    retry: &mut RetryState<AblyConnectHandle>,
+) {
+    if ably.is_some() || !retry.timer_ready() {
+        return;
+    }
+    retry.clear_timer();
+    let ably_config = make_ably_config(api, group);
+    retry.handle = Some(tokio::spawn(ably_subscriber::subscribe(ably_config)));
+}
+
+fn handle_ably_connect_result(
+    result: Result<ably_subscriber::Subscription, String>,
+    ably: &mut Option<ably_subscriber::Subscription>,
+    retry: &mut RetryState<AblyConnectHandle>,
+) -> Result<(), String> {
+    match result {
+        Ok(sub) => {
+            if retry.consecutive_failures() > 0 {
+                info!(
+                    attempts = retry.consecutive_failures(),
+                    "ably connected after failures"
+                );
+            } else {
+                info!("ably connected");
+            }
+            *ably = Some(sub);
+            retry.on_success();
+            Ok(())
+        }
+        Err(e) => {
+            let next_secs = retry.backoff().as_secs();
+            let _ = retry.on_failure();
+            warn!(
+                error = %e,
+                failures = retry.consecutive_failures(),
+                next_attempt_secs = next_secs,
+                "ably connect failed"
+            );
+            Err(e)
+        }
+    }
+}
+
+struct AblyDisconnectState {
+    connected: bool,
+    disconnected_at: Option<tokio::time::Instant>,
+    error_logged: bool,
+    reason: Option<String>,
+}
+
+impl AblyDisconnectState {
+    fn disconnected(reason: String) -> Self {
+        Self {
+            connected: false,
+            disconnected_at: Some(tokio::time::Instant::now()),
+            error_logged: false,
+            reason: Some(reason),
+        }
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected
+    }
+
+    fn mark_connected(&mut self) {
+        self.connected = true;
+        self.disconnected_at = None;
+        self.error_logged = false;
+        self.reason = None;
+    }
+
+    fn record_disconnected(&mut self, reason: String) {
+        if self.connected || self.disconnected_at.is_none() {
+            self.disconnected_at = Some(tokio::time::Instant::now());
+            self.error_logged = false;
+        }
+        self.connected = false;
+        self.reason = Some(reason);
+    }
+
+    fn error_deadline(&self) -> Option<tokio::time::Instant> {
+        if self.connected || self.error_logged {
+            None
+        } else {
+            self.disconnected_at
+                .map(|at| at + ABLY_DISCONNECT_ERROR_AFTER)
+        }
+    }
+
+    fn mark_error_logged(&mut self) {
+        self.error_logged = true;
+    }
+
+    fn disconnected_secs(&self) -> u64 {
+        self.disconnected_at
+            .map(|at| at.elapsed().as_secs())
+            .unwrap_or_else(|| ABLY_DISCONNECT_ERROR_AFTER.as_secs())
+    }
+
+    fn reason(&self) -> &str {
+        self.reason.as_deref().unwrap_or("unknown")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_message(name: Option<&str>, data: serde_json::Value) -> ably_subscriber::Message {
+        ably_subscriber::Message {
+            name: name.map(String::from),
+            data,
+            id: None,
+            client_id: None,
+            timestamp: None,
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_for_poll_due_consumes_stateful_immediate_wakeup() {
+        let wakeups = PollWakeups::new(true);
+
+        let reason = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+
+        assert_eq!(reason, Some(PollReason::Immediate));
+        let snapshot = wakeups.snapshot().await;
+        assert!(snapshot.ably_connected);
+        assert!(!snapshot.poll_now);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wakeup_poll_failure_schedules_short_retry() {
+        let wakeups = PollWakeups::new(true);
+        let reason = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        wakeups
+            .record_poll_result(reason, PollOutcome::Failure, Duration::from_secs(5))
+            .await;
+        let snapshot = wakeups.snapshot().await;
+        assert!(snapshot.wakeup_retry_at.is_some());
+
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        let reason = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        assert_eq!(reason, Some(PollReason::WakeupRetry));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn regular_poll_failure_does_not_schedule_wakeup_retry() {
+        let wakeups = PollWakeups::new(false);
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        wakeups
+            .record_poll_result(
+                PollReason::Fast,
+                PollOutcome::Failure,
+                Duration::from_secs(5),
+            )
+            .await;
+        assert!(wakeups.snapshot().await.wakeup_retry_at.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn disconnected_state_uses_fast_poll_interval() {
+        let wakeups = Arc::new(PollWakeups::new(false));
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        wakeups
+            .record_poll_result(
+                PollReason::Immediate,
+                PollOutcome::Empty,
+                Duration::from_secs(5),
+            )
+            .await;
+
+        let wakeups_for_wait = Arc::clone(&wakeups);
+        let cancel = CancellationToken::new();
+        let wait = tokio::spawn(async move {
+            wakeups_for_wait
+                .wait_for_poll_due(&cancel, Duration::from_secs(30), Duration::from_secs(5))
+                .await
+        });
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        assert_eq!(wait.await.unwrap(), Some(PollReason::Fast));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn connected_state_uses_slow_poll_interval() {
+        let wakeups = Arc::new(PollWakeups::new(true));
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        wakeups
+            .record_poll_result(
+                PollReason::Immediate,
+                PollOutcome::Empty,
+                Duration::from_secs(5),
+            )
+            .await;
+
+        let wakeups_for_wait = Arc::clone(&wakeups);
+        let cancel = CancellationToken::new();
+        let wait = tokio::spawn(async move {
+            wakeups_for_wait
+                .wait_for_poll_due(&cancel, Duration::from_secs(30), Duration::from_secs(5))
+                .await
+        });
+        tokio::time::sleep(Duration::from_secs(30)).await;
+
+        assert_eq!(wait.await.unwrap(), Some(PollReason::Slow));
+    }
+
+    #[tokio::test]
+    async fn job_found_rearms_immediate_poll_for_backlog_drain() {
+        let wakeups = PollWakeups::new(true);
+        let reason = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        wakeups
+            .record_poll_result(reason, PollOutcome::JobFound, Duration::from_secs(5))
+            .await;
+
+        assert!(wakeups.snapshot().await.poll_now);
+        let reason = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        assert_eq!(reason, Some(PollReason::Immediate));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn target_other_runner_deferred_poll_keeps_earliest_deadline() {
+        let wakeups = PollWakeups::new(true);
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+
+        let later = tokio::time::Instant::now() + Duration::from_secs(10);
+        let earlier = tokio::time::Instant::now() + Duration::from_secs(3);
+        wakeups.request_deferred_poll_at(later).await;
+        wakeups.request_deferred_poll_at(earlier).await;
+
+        assert_eq!(wakeups.snapshot().await.deferred_poll_at, Some(earlier));
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        let reason = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        assert_eq!(reason, Some(PollReason::Deferred));
+    }
+
+    #[test]
+    fn disconnect_state_preserves_one_shot_escalation_window() {
+        let mut state = AblyDisconnectState {
+            connected: true,
+            disconnected_at: None,
+            error_logged: false,
+            reason: None,
+        };
+
+        state.record_disconnected("first disconnect".to_string());
+        let first_disconnected_at = state.disconnected_at;
+        state.mark_error_logged();
+        state.record_disconnected("second disconnect event".to_string());
+
+        assert!(!state.connected);
+        assert_eq!(state.disconnected_at, first_disconnected_at);
+        assert!(state.error_logged);
+        assert_eq!(state.reason(), "second disconnect event");
+        assert!(state.error_deadline().is_none());
+
+        state.mark_connected();
+        state.record_disconnected("new window".to_string());
+        assert!(!state.error_logged);
+        assert!(state.error_deadline().is_some());
+    }
+
+    #[tokio::test]
+    async fn cancel_notification_cancels_token_without_discovery() {
+        let run_id: RunId = "00000000-0000-0000-0000-000000000002".parse().unwrap();
+        let token = CancellationToken::new();
+        let tokens = Mutex::new(HashMap::from([(run_id, token.clone())]));
+        let wakeups = PollWakeups::new(true);
+        let msg = make_message(Some("cancel"), serde_json::json!({ "runId": run_id }));
+
+        handle_ably_message(&msg, "runner-1", &wakeups, &tokens).await;
+
+        assert!(token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn job_notifications_coalesce_into_poll_wakeup() {
+        let tokens = Mutex::new(HashMap::new());
+        let wakeups = PollWakeups::new(true);
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000001",
+                "profile": "vm0/default"
+            }),
+        );
+
+        handle_ably_message(&msg, "runner-1", &wakeups, &tokens).await;
+        handle_ably_message(&msg, "runner-1", &wakeups, &tokens).await;
+
+        assert!(wakeups.snapshot().await.poll_now);
+        let reason = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        assert_eq!(reason, Some(PollReason::Immediate));
+        assert!(!wakeups.snapshot().await.poll_now);
+    }
+
+    #[tokio::test]
+    async fn target_other_runner_job_notification_defers_poll() {
+        let tokens = Mutex::new(HashMap::new());
+        let wakeups = PollWakeups::new(true);
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000001",
+                "targetRunnerId": "runner-2"
+            }),
+        );
+
+        handle_ably_message(&msg, "runner-1", &wakeups, &tokens).await;
+
+        let snapshot = wakeups.snapshot().await;
+        assert!(!snapshot.poll_now);
+        assert!(snapshot.deferred_poll_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn invalid_job_notification_does_not_mutate_wakeup_state() {
+        let tokens = Mutex::new(HashMap::new());
+        let wakeups = PollWakeups::new(true);
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        let msg = make_message(Some("job"), serde_json::json!({ "runId": "not-a-uuid" }));
+
+        handle_ably_message(&msg, "runner-1", &wakeups, &tokens).await;
+
+        let snapshot = wakeups.snapshot().await;
+        assert!(!snapshot.poll_now);
+        assert!(snapshot.deferred_poll_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn supervisor_shutdown_awaits_task_termination() {
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let supervisor = AblySupervisor::spawn_test_task(|shutdown| async move {
+            shutdown.cancelled().await;
+            let _ = done_tx.send(());
+        });
+
+        supervisor.shutdown().await;
+
+        tokio::time::timeout(Duration::from_secs(1), done_rx)
+            .await
+            .expect("supervisor shutdown should await task termination")
+            .unwrap();
+    }
+
+    #[test]
+    fn parse_job_notification_with_target_runner_id() {
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000001",
+                "profile": "vm0/default",
+                "targetRunnerId": "00000000-0000-0000-0000-000000000099"
+            }),
+        );
+        let notif = parse_job_notification(&msg).unwrap();
+        assert_eq!(
+            notif.target_runner_id.as_deref(),
+            Some("00000000-0000-0000-0000-000000000099")
+        );
+        assert_eq!(notif.profile.as_deref(), Some("vm0/default"));
+    }
+
+    #[test]
+    fn parse_cancel_notification_valid() {
+        let msg = make_message(
+            Some("cancel"),
+            serde_json::json!({ "runId": "00000000-0000-0000-0000-000000000002" }),
+        );
+        let run_id = parse_cancel_notification(&msg).unwrap();
+        assert_eq!(run_id.to_string(), "00000000-0000-0000-0000-000000000002");
+    }
+}

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -34,6 +34,20 @@ impl PollReason {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct PollDue {
+    reason: PollReason,
+    /// Wakeup generation observed immediately before starting the HTTP poll.
+    /// Poll results must not clear wakeups that arrive while that request is in flight.
+    generation: u64,
+}
+
+impl PollDue {
+    pub(super) fn reason(self) -> PollReason {
+        self.reason
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum PollOutcome {
     JobFound,
     Empty,
@@ -51,6 +65,15 @@ struct PollWakeupsInner {
     poll_now: bool,
     deferred_poll_at: Option<tokio::time::Instant>,
     wakeup_retry_at: Option<tokio::time::Instant>,
+    /// Bumped whenever a new wakeup is recorded. This keeps an older HTTP poll
+    /// result from clearing a wakeup that arrived after the poll started.
+    generation: u64,
+}
+
+impl PollWakeupsInner {
+    fn bump_generation(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -67,6 +90,7 @@ impl PollWakeups {
                 poll_now: true,
                 deferred_poll_at: None,
                 wakeup_retry_at: None,
+                generation: 0,
             }),
             notify: Notify::new(),
         }
@@ -83,7 +107,9 @@ impl PollWakeups {
     }
 
     async fn request_immediate_poll(&self) {
-        self.inner.lock().await.poll_now = true;
+        let mut inner = self.inner.lock().await;
+        inner.poll_now = true;
+        inner.bump_generation();
         self.notify.notify_waiters();
     }
 
@@ -97,31 +123,39 @@ impl PollWakeups {
         if inner.deferred_poll_at.is_none_or(|existing| at < existing) {
             inner.deferred_poll_at = Some(at);
         }
+        inner.bump_generation();
         drop(inner);
         self.notify.notify_waiters();
     }
 
     pub(super) async fn record_poll_result(
         &self,
-        reason: PollReason,
+        due: PollDue,
         outcome: PollOutcome,
         wakeup_retry_delay: Duration,
     ) {
         let mut should_notify = false;
         let mut inner = self.inner.lock().await;
+        let has_new_wakeup = inner.generation != due.generation;
         match outcome {
             PollOutcome::JobFound => {
                 inner.poll_now = true;
-                inner.deferred_poll_at = None;
-                inner.wakeup_retry_at = None;
+                if !has_new_wakeup {
+                    inner.deferred_poll_at = None;
+                    inner.wakeup_retry_at = None;
+                }
+                inner.bump_generation();
                 should_notify = true;
             }
             PollOutcome::Empty => {
-                inner.deferred_poll_at = None;
-                inner.wakeup_retry_at = None;
+                if !has_new_wakeup {
+                    inner.deferred_poll_at = None;
+                    inner.wakeup_retry_at = None;
+                }
             }
-            PollOutcome::Failure if reason.is_wakeup() => {
+            PollOutcome::Failure if due.reason.is_wakeup() => {
                 inner.wakeup_retry_at = Some(tokio::time::Instant::now() + wakeup_retry_delay);
+                inner.bump_generation();
                 should_notify = true;
             }
             PollOutcome::Failure => {}
@@ -137,7 +171,7 @@ impl PollWakeups {
         cancel: &CancellationToken,
         slow_interval: Duration,
         fast_interval: Duration,
-    ) -> Option<PollReason> {
+    ) -> Option<PollDue> {
         loop {
             let notified = self.notify.notified();
             tokio::pin!(notified);
@@ -148,15 +182,24 @@ impl PollWakeups {
                 let now = tokio::time::Instant::now();
                 if inner.poll_now {
                     inner.poll_now = false;
-                    return Some(PollReason::Immediate);
+                    return Some(PollDue {
+                        reason: PollReason::Immediate,
+                        generation: inner.generation,
+                    });
                 }
                 if inner.wakeup_retry_at.is_some_and(|at| at <= now) {
                     inner.wakeup_retry_at = None;
-                    return Some(PollReason::WakeupRetry);
+                    return Some(PollDue {
+                        reason: PollReason::WakeupRetry,
+                        generation: inner.generation,
+                    });
                 }
                 if inner.deferred_poll_at.is_some_and(|at| at <= now) {
                     inner.deferred_poll_at = None;
-                    return Some(PollReason::Deferred);
+                    return Some(PollDue {
+                        reason: PollReason::Deferred,
+                        generation: inner.generation,
+                    });
                 }
                 Self::next_scheduled(&inner, now, slow_interval, fast_interval)
             };
@@ -167,8 +210,8 @@ impl PollWakeups {
                 }
                 () = &mut notified => {}
                 () = tokio::time::sleep_until(scheduled.at) => {
-                    if self.consume_scheduled(scheduled).await {
-                        return Some(scheduled.reason);
+                    if let Some(due) = self.consume_scheduled(scheduled).await {
+                        return Some(due);
                     }
                 }
             }
@@ -213,11 +256,11 @@ impl PollWakeups {
         scheduled
     }
 
-    async fn consume_scheduled(&self, scheduled: ScheduledPoll) -> bool {
+    async fn consume_scheduled(&self, scheduled: ScheduledPoll) -> Option<PollDue> {
         let mut inner = self.inner.lock().await;
         let now = tokio::time::Instant::now();
 
-        match scheduled.reason {
+        let is_due = match scheduled.reason {
             PollReason::Immediate => false,
             PollReason::WakeupRetry => {
                 if inner.wakeup_retry_at.is_some_and(|at| at <= now) {
@@ -241,7 +284,11 @@ impl PollWakeups {
             PollReason::Fast => {
                 !inner.ably_connected && !inner.poll_now && !Self::has_due_wakeup(&inner, now)
             }
-        }
+        };
+        is_due.then_some(PollDue {
+            reason: scheduled.reason,
+            generation: inner.generation,
+        })
     }
 
     fn has_due_wakeup(inner: &PollWakeupsInner, now: tokio::time::Instant) -> bool {
@@ -685,6 +732,10 @@ mod tests {
         }
     }
 
+    fn poll_reason(due: Option<PollDue>) -> Option<PollReason> {
+        due.map(PollDue::reason)
+    }
+
     #[tokio::test(start_paused = true)]
     async fn wait_for_poll_due_consumes_stateful_immediate_wakeup() {
         let wakeups = PollWakeups::new(true);
@@ -697,7 +748,7 @@ mod tests {
             )
             .await;
 
-        assert_eq!(reason, Some(PollReason::Immediate));
+        assert_eq!(poll_reason(reason), Some(PollReason::Immediate));
         let snapshot = wakeups.snapshot().await;
         assert!(snapshot.ably_connected);
         assert!(!snapshot.poll_now);
@@ -729,25 +780,37 @@ mod tests {
                 Duration::from_secs(5),
             )
             .await;
-        assert_eq!(reason, Some(PollReason::WakeupRetry));
+        assert_eq!(poll_reason(reason), Some(PollReason::WakeupRetry));
     }
 
     #[tokio::test(start_paused = true)]
     async fn regular_poll_failure_does_not_schedule_wakeup_retry() {
         let wakeups = PollWakeups::new(false);
-        let _ = wakeups
+        let due = wakeups
             .wait_for_poll_due(
                 &CancellationToken::new(),
                 Duration::from_secs(30),
                 Duration::from_secs(5),
             )
-            .await;
+            .await
+            .unwrap();
         wakeups
-            .record_poll_result(
-                PollReason::Fast,
-                PollOutcome::Failure,
+            .record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5))
+            .await;
+
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        let due = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
                 Duration::from_secs(5),
             )
+            .await
+            .unwrap();
+        assert_eq!(due.reason(), PollReason::Fast);
+
+        wakeups
+            .record_poll_result(due, PollOutcome::Failure, Duration::from_secs(5))
             .await;
         assert!(wakeups.snapshot().await.wakeup_retry_at.is_none());
     }
@@ -755,19 +818,16 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn disconnected_state_uses_fast_poll_interval() {
         let wakeups = Arc::new(PollWakeups::new(false));
-        let _ = wakeups
+        let due = wakeups
             .wait_for_poll_due(
                 &CancellationToken::new(),
                 Duration::from_secs(30),
                 Duration::from_secs(5),
             )
-            .await;
+            .await
+            .unwrap();
         wakeups
-            .record_poll_result(
-                PollReason::Immediate,
-                PollOutcome::Empty,
-                Duration::from_secs(5),
-            )
+            .record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5))
             .await;
 
         let wakeups_for_wait = Arc::clone(&wakeups);
@@ -779,25 +839,22 @@ mod tests {
         });
         tokio::time::sleep(Duration::from_secs(5)).await;
 
-        assert_eq!(wait.await.unwrap(), Some(PollReason::Fast));
+        assert_eq!(poll_reason(wait.await.unwrap()), Some(PollReason::Fast));
     }
 
     #[tokio::test(start_paused = true)]
     async fn connected_state_uses_slow_poll_interval() {
         let wakeups = Arc::new(PollWakeups::new(true));
-        let _ = wakeups
+        let due = wakeups
             .wait_for_poll_due(
                 &CancellationToken::new(),
                 Duration::from_secs(30),
                 Duration::from_secs(5),
             )
-            .await;
+            .await
+            .unwrap();
         wakeups
-            .record_poll_result(
-                PollReason::Immediate,
-                PollOutcome::Empty,
-                Duration::from_secs(5),
-            )
+            .record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5))
             .await;
 
         let wakeups_for_wait = Arc::clone(&wakeups);
@@ -809,7 +866,7 @@ mod tests {
         });
         tokio::time::sleep(Duration::from_secs(30)).await;
 
-        assert_eq!(wait.await.unwrap(), Some(PollReason::Slow));
+        assert_eq!(poll_reason(wait.await.unwrap()), Some(PollReason::Slow));
     }
 
     #[tokio::test]
@@ -836,7 +893,7 @@ mod tests {
                 Duration::from_secs(5),
             )
             .await;
-        assert_eq!(reason, Some(PollReason::Immediate));
+        assert_eq!(poll_reason(reason), Some(PollReason::Immediate));
     }
 
     #[tokio::test(start_paused = true)]
@@ -864,7 +921,63 @@ mod tests {
                 Duration::from_secs(5),
             )
             .await;
-        assert_eq!(reason, Some(PollReason::Deferred));
+        assert_eq!(poll_reason(reason), Some(PollReason::Deferred));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn empty_poll_keeps_deferred_wakeup_created_after_poll_started() {
+        let wakeups = PollWakeups::new(true);
+        let due = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        let deferred_at = tokio::time::Instant::now() + Duration::from_secs(2);
+        wakeups.request_deferred_poll_at(deferred_at).await;
+        wakeups
+            .record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5))
+            .await;
+
+        assert_eq!(wakeups.snapshot().await.deferred_poll_at, Some(deferred_at));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn empty_poll_clears_deferred_wakeup_seen_by_poll() {
+        let wakeups = PollWakeups::new(true);
+        let initial = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+        wakeups
+            .record_poll_result(initial, PollOutcome::Empty, Duration::from_secs(5))
+            .await;
+
+        wakeups
+            .request_deferred_poll_at(tokio::time::Instant::now() + Duration::from_secs(2))
+            .await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let deferred = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        wakeups
+            .record_poll_result(deferred, PollOutcome::Empty, Duration::from_secs(5))
+            .await;
+
+        assert!(wakeups.snapshot().await.deferred_poll_at.is_none());
     }
 
     #[test]
@@ -936,7 +1049,7 @@ mod tests {
                 Duration::from_secs(5),
             )
             .await;
-        assert_eq!(reason, Some(PollReason::Immediate));
+        assert_eq!(poll_reason(reason), Some(PollReason::Immediate));
         assert!(!wakeups.snapshot().await.poll_now);
     }
 

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -14,6 +14,8 @@ const ABLY_BACKOFF_INITIAL: Duration = Duration::from_secs(5);
 const ABLY_BACKOFF_MAX: Duration = Duration::from_secs(60);
 const ABLY_DISCONNECT_ERROR_AFTER: Duration = Duration::from_secs(60);
 const TARGETED_RUNNER_DEFER: Duration = Duration::from_secs(2);
+// Bound repeated target-other notifications so one runner is not starved forever.
+const TARGETED_RUNNER_DEFER_MAX: Duration = Duration::from_secs(10);
 
 type AblyConnectHandle =
     tokio::task::JoinHandle<Result<ably_subscriber::Subscription, ably_subscriber::Error>>;
@@ -75,6 +77,7 @@ struct PollWakeupsInner {
     ably_connected: bool,
     poll_now: bool,
     deferred_poll_at: Option<tokio::time::Instant>,
+    deferred_poll_cap_at: Option<tokio::time::Instant>,
     wakeup_retry_at: Option<tokio::time::Instant>,
     /// Bumped whenever a new wakeup is recorded. This keeps an older HTTP poll
     /// result from clearing a wakeup that arrived after the poll started.
@@ -100,6 +103,7 @@ impl PollWakeups {
                 ably_connected,
                 poll_now: true,
                 deferred_poll_at: None,
+                deferred_poll_cap_at: None,
                 wakeup_retry_at: None,
                 generation: 0,
             }),
@@ -125,18 +129,30 @@ impl PollWakeups {
     }
 
     async fn request_deferred_poll_after(&self, delay: Duration) {
-        self.request_deferred_poll_at(tokio::time::Instant::now() + delay)
+        let now = tokio::time::Instant::now();
+        self.request_deferred_poll_capped_at(now + delay, now + TARGETED_RUNNER_DEFER_MAX)
             .await;
     }
 
-    async fn request_deferred_poll_at(&self, at: tokio::time::Instant) {
+    async fn request_deferred_poll_capped_at(
+        &self,
+        at: tokio::time::Instant,
+        cap_at: tokio::time::Instant,
+    ) {
         let mut inner = self.inner.lock().await;
-        if inner.deferred_poll_at.is_none_or(|existing| at < existing) {
+        let cap_at = *inner.deferred_poll_cap_at.get_or_insert(cap_at);
+        let at = at.min(cap_at);
+        if inner.deferred_poll_at.is_none_or(|existing| at > existing) {
             inner.deferred_poll_at = Some(at);
         }
         inner.bump_generation();
         drop(inner);
         self.notify.notify_waiters();
+    }
+
+    #[cfg(test)]
+    async fn request_deferred_poll_at(&self, at: tokio::time::Instant) {
+        self.request_deferred_poll_capped_at(at, at).await;
     }
 
     #[cfg(test)]
@@ -160,6 +176,7 @@ impl PollWakeups {
                 inner.poll_now = true;
                 if !has_new_wakeup {
                     inner.deferred_poll_at = None;
+                    inner.deferred_poll_cap_at = None;
                     inner.wakeup_retry_at = None;
                 }
                 inner.bump_generation();
@@ -168,6 +185,7 @@ impl PollWakeups {
             PollOutcome::Empty => {
                 if !has_new_wakeup {
                     inner.deferred_poll_at = None;
+                    inner.deferred_poll_cap_at = None;
                     inner.wakeup_retry_at = None;
                 }
             }
@@ -201,6 +219,7 @@ impl PollWakeups {
                 let now = tokio::time::Instant::now();
                 if inner.deferred_poll_at.is_some_and(|at| at <= now) {
                     inner.deferred_poll_at = None;
+                    inner.deferred_poll_cap_at = None;
                     inner.poll_now = false;
                     return Some(PollDue {
                         reason: PollReason::Deferred,
@@ -294,6 +313,7 @@ impl PollWakeups {
             PollReason::Deferred => {
                 if inner.deferred_poll_at.is_some_and(|at| at <= now) {
                     inner.deferred_poll_at = None;
+                    inner.deferred_poll_cap_at = None;
                     inner.poll_now = false;
                     true
                 } else {
@@ -331,6 +351,7 @@ impl PollWakeups {
             ably_connected: inner.ably_connected,
             poll_now: inner.poll_now,
             deferred_poll_at: inner.deferred_poll_at,
+            deferred_poll_cap_at: inner.deferred_poll_cap_at,
             wakeup_retry_at: inner.wakeup_retry_at,
         }
     }
@@ -342,6 +363,7 @@ struct PollWakeupsSnapshot {
     ably_connected: bool,
     poll_now: bool,
     deferred_poll_at: Option<tokio::time::Instant>,
+    deferred_poll_cap_at: Option<tokio::time::Instant>,
     wakeup_retry_at: Option<tokio::time::Instant>,
 }
 
@@ -925,7 +947,54 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn target_other_runner_deferred_poll_keeps_earliest_deadline() {
+    async fn target_other_runner_deferred_poll_extends_until_latest_deadline() {
+        let wakeups = Arc::new(PollWakeups::new(true));
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+
+        wakeups
+            .request_deferred_poll_after(Duration::from_secs(2))
+            .await;
+        let first_deadline = wakeups
+            .snapshot()
+            .await
+            .deferred_poll_at
+            .expect("first defer deadline");
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        wakeups
+            .request_deferred_poll_after(Duration::from_secs(2))
+            .await;
+        let extended_deadline = wakeups
+            .snapshot()
+            .await
+            .deferred_poll_at
+            .expect("extended defer deadline");
+
+        assert!(extended_deadline > first_deadline);
+        let wakeups_for_wait = Arc::clone(&wakeups);
+        let cancel = CancellationToken::new();
+        let wait = tokio::spawn(async move {
+            wakeups_for_wait
+                .wait_for_poll_due(&cancel, Duration::from_secs(30), Duration::from_secs(5))
+                .await
+        });
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert!(
+            !wait.is_finished(),
+            "new target-other notification should extend the defer window"
+        );
+
+        tokio::time::sleep_until(extended_deadline).await;
+        assert_eq!(poll_reason(wait.await.unwrap()), Some(PollReason::Deferred));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn target_other_runner_deferred_poll_extension_is_bounded() {
         let wakeups = PollWakeups::new(true);
         let _ = wakeups
             .wait_for_poll_due(
@@ -935,13 +1004,25 @@ mod tests {
             )
             .await;
 
-        let later = tokio::time::Instant::now() + Duration::from_secs(10);
-        let earlier = tokio::time::Instant::now() + Duration::from_secs(3);
-        wakeups.request_deferred_poll_at(later).await;
-        wakeups.request_deferred_poll_at(earlier).await;
+        wakeups
+            .request_deferred_poll_after(Duration::from_secs(2))
+            .await;
+        let cap = wakeups
+            .snapshot()
+            .await
+            .deferred_poll_cap_at
+            .expect("defer cap");
+        for _ in 0..9 {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            wakeups
+                .request_deferred_poll_after(Duration::from_secs(2))
+                .await;
+        }
 
-        assert_eq!(wakeups.snapshot().await.deferred_poll_at, Some(earlier));
-        tokio::time::sleep(Duration::from_secs(3)).await;
+        let snapshot = wakeups.snapshot().await;
+        assert_eq!(snapshot.deferred_poll_at, Some(cap));
+        assert_eq!(snapshot.deferred_poll_cap_at, Some(cap));
+        tokio::time::sleep_until(cap).await;
         let reason = wakeups
             .wait_for_poll_due(
                 &CancellationToken::new(),

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -1,11 +1,11 @@
 //! Channel-driven mock [`JobProvider`] for integration testing.
 //!
-//! Reproduces the key concurrency properties of [`ApiProvider`]:
+//! Reproduces the key main-loop stress cases that previously came from
+//! [`ApiProvider`]:
 //!
-//! - `discover()` holds a `tokio::sync::Mutex` for its entire duration
-//!   (same as ApiProvider's discovery Mutex).
-//! - `shutdown()` acquires the same Mutex (same as ApiProvider).
-//! - `discover()` has an optional pre-channel delay simulating ApiProvider's
+//! - `discover()` can hold a resource for its entire duration and `shutdown()`
+//!   can wait on that resource, preserving the shutdown regression shape.
+//! - `discover()` has an optional pre-channel delay simulating the API provider's
 //!   poll timer that restarts from scratch when the future is cancelled.
 //!
 //! This lets integration tests catch:
@@ -39,14 +39,15 @@ pub struct Completion {
 
 /// Channel-driven mock provider.
 ///
-/// `discover()` holds `discovery` Mutex for its entire duration, mirroring
-/// `ApiProvider`. `shutdown()` acquires the same Mutex, so omitting the
+/// `discover()` holds `discovery` Mutex for its entire duration. `shutdown()`
+/// acquires the same Mutex, so omitting the
 /// `drop(discover_fut)` before `shutdown()` causes a real deadlock.
 pub struct MockJobProvider {
     /// Held by `discover()` for its entire lifetime and acquired by
-    /// `shutdown()`. Reproduces the ApiProvider discovery Mutex semantics.
+    /// `shutdown()`. Reproduces the historical API-provider shutdown deadlock
+    /// shape used by main-loop regression tests.
     discovery: Mutex<mpsc::UnboundedReceiver<(RunId, String)>>,
-    /// Optional delay before checking the channel, simulating ApiProvider's
+    /// Optional delay before checking the channel, simulating the API provider's
     /// internal poll timer. If the future is cancelled and recreated (not
     /// pinned), this delay restarts from scratch — jobs pushed during the
     /// delay won't be discovered until it completes.
@@ -100,7 +101,7 @@ impl MockJobProvider {
     /// Create a mock provider with an explicit poll delay.
     ///
     /// When set, `discover()` sleeps for this duration before checking the
-    /// channel. This simulates ApiProvider's HTTP poll timer — if the main
+    /// channel. This simulates the API provider's HTTP poll timer — if the main
     /// loop cancels and recreates `discover()` (e.g. not pinned), the sleep
     /// restarts from scratch and jobs are never discovered.
     pub fn with_poll_delay(
@@ -217,8 +218,8 @@ impl MockProviderHandle {
 impl JobProvider for MockJobProvider {
     /// Block until a job is pushed or the token is cancelled.
     ///
-    /// Holds `self.discovery` Mutex for the entire call — same as
-    /// `ApiProvider::discover()`. This is critical for regression tests:
+    /// Holds `self.discovery` Mutex for the entire call. This keeps the
+    /// historical API-provider deadlock shape available for regression tests:
     ///
     /// - If `poll_delay` is set, the delay must complete before checking
     ///   the channel. Without pinning (#8783), heartbeat ticks cancel and
@@ -280,7 +281,7 @@ impl JobProvider for MockJobProvider {
         self.heartbeat_notify.notify_waiters();
     }
 
-    /// Acquire the discovery Mutex — same as `ApiProvider::shutdown()`.
+    /// Acquire the discovery Mutex to preserve the shutdown deadlock regression shape.
     ///
     /// If `discover()` is still alive and holding the Mutex, this deadlocks.
     /// The main loop must `drop(discover_fut)` before calling this.

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -5,6 +5,7 @@
 //! changing the executor or main loop.
 
 mod api;
+mod api_ably_supervisor;
 mod local;
 #[cfg(test)]
 pub mod mock;
@@ -23,7 +24,8 @@ use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
 /// The runner main loop calls [`discover()`](JobProvider::discover) to find work,
 /// [`claim()`](JobProvider::claim) to claim it, and
 /// [`complete()`](JobProvider::complete) to report results. All transport
-/// details (Ably push, HTTP poll, WebSocket, etc.) are hidden behind this trait.
+/// details (Ably control-plane notifications, HTTP poll, WebSocket, etc.) are
+/// hidden behind this trait.
 ///
 /// `discover()` and `claim()` are deliberately separate so that `discover()`
 /// can live as a cancellable `select!` branch future while `claim()` runs

--- a/crates/runner/src/retry.rs
+++ b/crates/runner/src/retry.rs
@@ -27,13 +27,6 @@ impl<H> RetryState<H> {
         }
     }
 
-    /// Record that the very first attempt failed (e.g. initial Ably connect).
-    /// Schedules a retry with the initial backoff and sets failures to 1.
-    pub(crate) fn record_initial_failure(&mut self) {
-        self.consecutive_failures = 1;
-        self.schedule();
-    }
-
     /// Schedule a restart after the current backoff delay.
     pub(crate) fn schedule(&mut self) {
         self.restart_at = Some(Instant::now() + self.backoff);
@@ -161,15 +154,6 @@ mod tests {
         rs.on_success();
         assert_eq!(rs.backoff, Duration::from_secs(1));
         assert_eq!(rs.consecutive_failures, 0);
-    }
-
-    #[test]
-    fn record_initial_failure_sets_state() {
-        let mut rs: RetryState<()> =
-            RetryState::new(Duration::from_secs(1), Duration::from_secs(60), None);
-        rs.record_initial_failure();
-        assert_eq!(rs.consecutive_failures(), 1);
-        assert!(rs.restart_at.is_some());
     }
 
     #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,16 +100,17 @@ Extracts to mount paths
 The orchestration layer coordinates job execution between web API and runners.
 
 **Job Notification**:
-- **Push**: Ably realtime notifications for instant job pickup (~100-200ms)
-- **Fallback**: Polling every 30s catches missed notifications
+- **Wakeup**: Ably realtime notifications wake runners for instant HTTP polling (~100-200ms)
+- **Fallback**: HTTP polling every 30s catches missed notifications
 
 **Runner Behavior**:
 1. Subscribe to Ably channel `runner-group:{org}/{name}`
-2. Receive job notification: `{ runId }`
-3. Claim job atomically via `/api/runners/jobs/{id}/claim` (sets `claimed_at`)
-4. Execute in Firecracker VM
-5. Report completion via webhook
-6. Job deleted from queue
+2. Receive job notification and wake HTTP poll
+3. Select the next job via `/api/runners/poll`
+4. Claim job atomically via `/api/runners/jobs/{id}/claim` (sets `claimed_at`)
+5. Execute in Firecracker VM
+6. Report completion via webhook
+7. Job deleted from queue
 
 #### Runner Groups
 
@@ -197,7 +198,7 @@ sandbox:
 
 #### Execution Flow
 
-1. Runner receives job via Ably push (or 30s polling fallback)
+1. Runner selects job via HTTP poll, woken by Ably notification or 30s polling fallback
 2. Creates Firecracker VM (3-5s boot)
 3. Vsock connection to guest agent
 4. Upload scripts, configure DNS, install proxy CA


### PR DESCRIPTION
## Summary

- split API runner Ably handling into a dedicated supervisor task
- turn Ably job notifications into coalesced HTTP poll wakeups instead of local run-id candidates
- keep cancel notifications, reconnect state, and long-disconnect escalation running outside `discover()`
- simplify `ApiProvider::discover()` to wait for wakeups/timers and return only HTTP poll-selected jobs

Closes #11837

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api`
- `cargo test --manifest-path crates/Cargo.toml -p runner retry`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- pre-commit: cargo fmt, cargo clippy, cargo doc
