### PR TITLE
chore: remove optional page signal

### DIFF
--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -7,7 +7,6 @@ import type { ConnectorType } from "@vm0/connectors/connectors";
 import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { zeroClient$ } from "../api-client";
 import { accept } from "../../lib/accept.ts";
-import { maybePageSignal$ } from "../page-signal.ts";
 
 /**
  * Reload trigger for connector signals.
@@ -20,13 +19,10 @@ const internalReloadConnectors$ = state(0);
  */
 export const connectors$ = computed(async (get) => {
   get(internalReloadConnectors$);
-  const signal = get(maybePageSignal$);
+
   const createClient = get(zeroClient$);
   const client = createClient(zeroConnectorsMainContract);
-  const result = await accept(
-    client.list({ fetchOptions: signal ? { signal } : undefined }),
-    [200],
-  );
+  const result = await accept(client.list(), [200]);
   return result.body as ConnectorListResponse;
 });
 

--- a/turbo/apps/platform/src/signals/page-signal.ts
+++ b/turbo/apps/platform/src/signals/page-signal.ts
@@ -1,21 +1,16 @@
 import { command, computed, state } from "ccstate";
 
-interface SignalHolder {
-  readonly signal: AbortSignal;
-}
-
-const innerPageSignal$ = state<SignalHolder | undefined>(undefined);
+const innerPageSignal$ = state<AbortSignal | undefined>(undefined);
 
 export const setPageSignal$ = command(({ set }, signal: AbortSignal) => {
-  set(innerPageSignal$, { signal });
-});
-
-export const maybePageSignal$ = computed((get) => {
-  return get(innerPageSignal$)?.signal;
+  set(innerPageSignal$, signal);
 });
 
 export const pageSignal$ = computed((get) => {
-  const signal = get(maybePageSignal$);
+  // This part is essential. We mainly need to control the downstream "get" of this method so that it cannot retrieve a Signal.
+  // confirmed by ethan@vm0.ai
+  // eslint-disable-next-line ccstate/no-get-signal
+  const signal = get(innerPageSignal$);
   if (!signal) {
     throw new Error("page signal not set");
   }

--- a/turbo/apps/platform/src/signals/queue-page/queue-drawer-state.ts
+++ b/turbo/apps/platform/src/signals/queue-page/queue-drawer-state.ts
@@ -2,7 +2,6 @@ import { command, computed, state } from "ccstate";
 import { searchParams$, replaceSearchParams$ } from "../route.ts";
 import { startQueuePolling$ } from "./queue-signals.ts";
 import { detach, Reason, resetSignal } from "../utils.ts";
-import { maybePageSignal$ } from "../page-signal.ts";
 
 const internalQueueDrawerOpen$ = state(false);
 const resetQueuePollingSignal$ = resetSignal();
@@ -11,35 +10,34 @@ export const queueDrawerOpen$ = computed((get) => {
   return get(internalQueueDrawerOpen$);
 });
 
-export const setQueueDrawerOpen$ = command(({ get, set }, open: boolean) => {
-  set(internalQueueDrawerOpen$, open);
-  const pageSignal = get(maybePageSignal$);
+export const setQueueDrawerOpen$ = command(
+  ({ get, set }, open: boolean, parentSignal: AbortSignal) => {
+    set(internalQueueDrawerOpen$, open);
 
-  const params = get(searchParams$);
-  const next = new URLSearchParams(params);
+    const params = get(searchParams$);
+    const next = new URLSearchParams(params);
 
-  if (open) {
-    if (!next.has("queue")) {
-      next.set("queue", "1");
-      set(replaceSearchParams$, next);
+    if (open) {
+      if (!next.has("queue")) {
+        next.set("queue", "1");
+        set(replaceSearchParams$, next);
+      }
+
+      const signal = set(resetQueuePollingSignal$, parentSignal);
+
+      // confirmed by ethan@vm0.ai
+      // eslint-disable-next-line ccstate/no-detach-in-signals -- polling is a long-running background task, fire-and-forget by design
+      detach(set(startQueuePolling$, signal), Reason.Entrance);
+    } else {
+      if (next.has("queue")) {
+        next.delete("queue");
+        set(replaceSearchParams$, next);
+      }
+      set(resetQueuePollingSignal$);
     }
+  },
+);
 
-    const signal = pageSignal
-      ? set(resetQueuePollingSignal$, pageSignal)
-      : set(resetQueuePollingSignal$);
-
-    // confirmed by ethan@vm0.ai
-    // eslint-disable-next-line ccstate/no-detach-in-signals -- polling is a long-running background task, fire-and-forget by design
-    detach(set(startQueuePolling$, signal), Reason.Entrance);
-  } else {
-    if (next.has("queue")) {
-      next.delete("queue");
-      set(replaceSearchParams$, next);
-    }
-    set(resetQueuePollingSignal$);
-  }
-});
-
-export const openQueueDrawer$ = command(({ set }) => {
-  set(setQueueDrawerOpen$, true);
+export const openQueueDrawer$ = command(({ set }, signal: AbortSignal) => {
+  set(setQueueDrawerOpen$, true, signal);
 });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
@@ -169,7 +169,7 @@ describe("zero-nav", () => {
       const pushStateMock = await setupNav();
 
       context.store.set(setZeroShowAboutPage$, true);
-      context.store.set(handleZeroNavSelect$, "schedules");
+      context.store.set(handleZeroNavSelect$, "schedules", context.signal);
 
       expect(pushStateMock).toHaveBeenCalledWith({}, "", "/schedules");
       expect(context.store.get(activeRoute$)).toBe("schedules");

--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
@@ -86,7 +86,7 @@ export const setupAgentChatPage$ = command(
       set(updateSearchParams$, next);
     }
     if (queue === "1") {
-      set(openQueueDrawer$);
+      set(openQueueDrawer$, signal);
     }
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -81,28 +81,30 @@ export function isChatRoute(key: RouteKey | null): boolean {
   );
 }
 
-export const handleZeroNavSelect$ = command(({ set }, id: SidebarNavId) => {
-  if (id === "queues") {
-    set(openQueueDrawer$);
-  } else {
-    const navRoutes = {
-      chat: ROUTES.home,
-      agents: ROUTES.agents,
-      connectors: ROUTES.connectors,
-      schedules: ROUTES.schedules,
-      activities: ROUTES.activities,
-      insights: ROUTES.insights,
-      works: ROUTES.works,
-      settings: ROUTES.settings,
-      lab: ROUTES.lab,
-    } satisfies Record<
-      Exclude<SidebarNavId, "queues">,
-      (typeof ROUTES)[keyof typeof ROUTES]
-    >;
-    set(detachedNavigateTo$, navRoutes[id]);
-  }
-  set(internalShowAboutPage$, false);
-});
+export const handleZeroNavSelect$ = command(
+  ({ set }, id: SidebarNavId, signal: AbortSignal) => {
+    if (id === "queues") {
+      set(openQueueDrawer$, signal);
+    } else {
+      const navRoutes = {
+        chat: ROUTES.home,
+        agents: ROUTES.agents,
+        connectors: ROUTES.connectors,
+        schedules: ROUTES.schedules,
+        activities: ROUTES.activities,
+        insights: ROUTES.insights,
+        works: ROUTES.works,
+        settings: ROUTES.settings,
+        lab: ROUTES.lab,
+      } satisfies Record<
+        Exclude<SidebarNavId, "queues">,
+        (typeof ROUTES)[keyof typeof ROUTES]
+      >;
+      set(detachedNavigateTo$, navRoutes[id]);
+    }
+    set(internalShowAboutPage$, false);
+  },
+);
 
 export type ZeroAccountAction =
   | "preferences"

--- a/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
+++ b/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
@@ -49,7 +49,7 @@ function queueResponse(overrides?: {
 function openDrawer() {
   mockHomeAPIs();
   detachedSetupPage({ context, path: "/" });
-  context.store.set(openQueueDrawer$);
+  context.store.set(openQueueDrawer$, context.signal);
 }
 
 describe("queue drawer", () => {

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -217,6 +217,7 @@ function QueueDrawerContent() {
 
 export function QueueDrawer() {
   const open = useGet(queueDrawerOpen$);
+  const pageSignal = useGet(pageSignal$);
   const setOpen = useSet(setQueueDrawerOpen$);
 
   return (
@@ -224,7 +225,7 @@ export function QueueDrawer() {
       open={open}
       onOpenChange={(v) => {
         if (!v) {
-          setOpen(false);
+          setOpen(false, pageSignal);
         }
       }}
     >

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-to-queue-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-to-queue-navigation.test.tsx
@@ -91,7 +91,7 @@ describe("chat to queue navigation", () => {
 
     // Open queue drawer (simulates clicking the queues nav item)
     act(() => {
-      context.store.set(openQueueDrawer$);
+      context.store.set(openQueueDrawer$, context.signal);
     });
 
     // The queue drawer should open and show concurrency info

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1849,6 +1849,7 @@ function ThinkingIndicator({ thread }: { thread: ChatThreadSignals }) {
   const latestRunStatus = useLastResolved(thread.latestRunStatus$);
   const isQueued = latestRunStatus === "queued";
   const openQueueDrawer = useSet(openQueueDrawer$);
+  const pageSignal = useGet(pageSignal$);
 
   const thinkingLabel = isQueued ? (
     <p className="zero-shimmer-text text-xs truncate">
@@ -1856,7 +1857,7 @@ function ThinkingIndicator({ thread }: { thread: ChatThreadSignals }) {
       <button
         type="button"
         onClick={() => {
-          openQueueDrawer();
+          openQueueDrawer(pageSignal);
         }}
         className="cursor-pointer underline underline-offset-2"
       >

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -198,8 +198,9 @@ function SidebarNavContent() {
   };
   const rawOnSelect = useSet(handleZeroNavSelect$);
   const onAccountAction = useSet(handleZeroAccountAction$);
+  const pageSignal = useGet(pageSignal$);
   const onSelect = (id: SidebarNavId) => {
-    rawOnSelect(id);
+    rawOnSelect(id, pageSignal);
     setExpanded(false);
   };
   const isScrolled = useGet(isScrolled$);


### PR DESCRIPTION
## Summary

- Remove `maybePageSignal$` and keep `pageSignal$` as the required page signal accessor.
- Require queue drawer commands to receive an explicit `AbortSignal` instead of reading an optional page signal internally.
- Update queue drawer/nav callers and tests to pass the page or test signal explicitly.

## Validation

- `pnpm prettier --check apps/platform/src/signals/external/connectors.ts apps/platform/src/signals/page-signal.ts apps/platform/src/signals/queue-page/queue-drawer-state.ts apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts apps/platform/src/signals/zero-page/agent-chat-page-setup.ts apps/platform/src/signals/zero-page/zero-nav.ts apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx apps/platform/src/views/queue-page/queue-drawer.tsx apps/platform/src/views/zero-page/__tests__/chat-to-queue-navigation.test.tsx apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/zero-sidebar.tsx` from `turbo`
- `pnpm exec eslint --max-warnings 0 src/signals/external/connectors.ts src/signals/page-signal.ts src/signals/queue-page/queue-drawer-state.ts src/signals/zero-page/__tests__/zero-nav.test.ts src/signals/zero-page/agent-chat-page-setup.ts src/signals/zero-page/zero-nav.ts src/views/queue-page/__tests__/queue-drawer.test.tsx src/views/queue-page/queue-drawer.tsx src/views/zero-page/__tests__/chat-to-queue-navigation.test.tsx src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/zero-sidebar.tsx` from `turbo/apps/platform`
- `pnpm exec oxlint --format unix` from `turbo/apps/platform`
- `pnpm exec vitest run src/signals/zero-page/__tests__/zero-nav.test.ts src/views/zero-page/__tests__/chat-to-queue-navigation.test.tsx src/views/queue-page/__tests__/queue-drawer.test.tsx` from `turbo/apps/platform`
- `pnpm check-types` from `turbo/apps/platform`
- Lefthook pre-commit for `2eba61eb0`: prettier, knip, and `turbo run check-types --concurrency=1`