### PR TITLE
chore(devcontainer): forward host VM0_DEV_CONTAINER_SERVICE_ACCOUNT_TOKEN as OP_SERVICE_ACCOUNT_TOKEN

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,8 @@
     "PATH": "/home/vscode/.cache/cargo/bin:/home/vscode/.local/bin:${containerWorkspaceFolder}/bin:${containerEnv:PATH}",
     "VM0_API_URL": "https://www.vm7.ai:8443",
     "AGENT_BROWSER_HEADED": "1",
-    "DISPLAY": ":99"
+    "DISPLAY": ":99",
+    "OP_SERVICE_ACCOUNT_TOKEN": "${localEnv:VM0_DEV_CONTAINER_SERVICE_ACCOUNT_TOKEN}"
   },
   "mounts": [
     "source=config,target=/home/vscode/.config",


### PR DESCRIPTION
## Summary
- Forward host env var `VM0_DEV_CONTAINER_SERVICE_ACCOUNT_TOKEN` into the devcontainer as `OP_SERVICE_ACCOUNT_TOKEN` so 1Password CLI works inside the container.

## Test plan
- [ ] Rebuild devcontainer and confirm `OP_SERVICE_ACCOUNT_TOKEN` is set when the host has `VM0_DEV_CONTAINER_SERVICE_ACCOUNT_TOKEN` exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)