### PR TITLE
fix(platform): unify sidebar list so optimistic threads render once and keyboard nav reaches them

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -1,5 +1,4 @@
 import { command } from "ccstate";
-import { chatThreads$ } from "../agent-chat.ts";
 import {
   currentLeftThread$,
   currentRightThread$,
@@ -8,6 +7,7 @@ import {
 } from "./chat-thread-panes.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import type { ChatThreadSignals } from "./create-chat-thread.ts";
+import { sidebarChatThreads$ } from "./optimistic-chat-thread-page.ts";
 
 export const navigateToAdjacentThread$ = command(
   async (
@@ -26,7 +26,11 @@ export const navigateToAdjacentThread$ = command(
       return;
     }
 
-    const threads = await get(chatThreads$);
+    // Use the merged sidebar list (persisted + optimistic, deduped/sorted) so
+    // mod+shift+arrow navigation works on a freshly-created optimistic thread
+    // before the server's `threadListChanged` reload pulls it into
+    // `chatThreads$`.
+    const threads = await get(sidebarChatThreads$);
     signal.throwIfAborted();
     const excludedThreadId = inMainPane ? rightThreadId : leftThreadId;
     const availableThreads = threads.filter((thread) => {

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -263,30 +263,48 @@ export const createNewChatThreadOptimistically$ = command(
   },
 );
 
-export const pendingOptimisticChatThreads$ = computed(
+/**
+ * Unified sidebar list: persisted threads merged with the optimistic-only
+ * pending threads for the current agent, deduped by id, sorted (pinned first
+ * then most-recent activity desc).
+ *
+ * Returning a single signal — instead of letting the sidebar read persisted
+ * and optimistic separately — guarantees that the optimistic→persisted
+ * handoff happens in one ccstate compute. That removes the React render
+ * window where two `useLastResolved` subscribers update one after the other
+ * and briefly emit two `<ChatThreadItem>` siblings sharing the same `key`.
+ *
+ * Sort key:
+ * - When the persisted version exists, dedupe drops the optimistic entry and
+ *   the server's `updatedAt` decides position.
+ * - While only the optimistic exists, its browser-side `createdAt` (captured
+ *   when `createNewChatThread$` minted the threadId) participates in the
+ *   same sort, so a freshly-created thread lands at the top of the unpinned
+ *   section without being pinned to a fixed slot.
+ */
+export const sidebarChatThreads$ = computed(
   async (get): Promise<ChatThreadListItem[]> => {
-    const optimisticThreads = get(allPendingChatThreads$);
-    if (optimisticThreads.length === 0) {
-      return [];
+    const persisted = await get(chatThreads$);
+    const pending = get(allPendingChatThreads$);
+    if (pending.length === 0) {
+      return persisted;
     }
 
     const currentAgentId = await get(currentChatAgentId$);
     if (!currentAgentId) {
-      return [];
+      return persisted;
     }
 
-    const persistedThreads = await get(chatThreads$);
-    const persistedThreadIds = new Set(
-      persistedThreads.map((thread) => {
+    const persistedIds = new Set(
+      persisted.map((thread) => {
         return thread.id;
       }),
     );
-
-    return optimisticThreads
+    const optimisticItems: ChatThreadListItem[] = pending
       .filter((thread) => {
         return (
           thread.agentId === currentAgentId &&
-          !persistedThreadIds.has(thread.threadId)
+          !persistedIds.has(thread.threadId)
         );
       })
       .map((thread) => {
@@ -301,6 +319,19 @@ export const pendingOptimisticChatThreads$ = computed(
           running: thread.running,
         };
       });
+
+    if (optimisticItems.length === 0) {
+      return persisted;
+    }
+
+    return [...persisted, ...optimisticItems].sort((a, b) => {
+      const aPinned = a.pinnedAt ? 0 : 1;
+      const bPinned = b.pinnedAt ? 0 : 1;
+      if (aPinned !== bPinned) {
+        return aPinned - bPinned;
+      }
+      return b.updatedAt.localeCompare(a.updatedAt);
+    });
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-new-chat-flicker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-new-chat-flicker.test.tsx
@@ -109,7 +109,7 @@ describe("sidebar new-chat flicker", () => {
 
     // Drive the optimistic-create flow through the actual sidebar button.
     const newChatBtn = within(getSidebar()).getByLabelText(/^New chat with /i);
-    await act(async () => {
+    await act(() => {
       click(newChatBtn);
     });
 
@@ -122,7 +122,7 @@ describe("sidebar new-chat flicker", () => {
         "[data-chat-thread-id]",
       );
       expect(rows.length).toBeGreaterThan(0);
-      const id = rows[0].getAttribute("data-chat-thread-id");
+      const id = rows[0].dataset.chatThreadId ?? null;
       expect(id).toBeTruthy();
       newThreadId = id ?? "";
     });
@@ -158,7 +158,7 @@ describe("sidebar new-chat flicker", () => {
       },
     ];
 
-    await act(async () => {
+    await act(() => {
       triggerAblyEvent("threadListChanged");
     });
 
@@ -192,10 +192,7 @@ describe("sidebar new-chat flicker", () => {
     const collided = snapshots.filter((c) => {
       return c > 1;
     }).length;
-    expect(
-      { snapshots, dropped, collided },
-      "the new chat row must remain rendered exactly once at every mutation",
-    ).toMatchObject({
+    expect({ snapshots, dropped, collided }).toMatchObject({
       dropped: 0,
       collided: 0,
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-new-chat-flicker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-new-chat-flicker.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Reproduces the sidebar flicker on creating a new chat thread:
+ *   appears (optimistic) → disappears → appears (persisted)
+ *
+ * Root cause: `<ChatThreads>` renders the optimistic list and the persisted
+ * list as two adjacent fragments using `key={session.id}`. When `chatThreads$`
+ * resolves with the new thread BEFORE `pendingOptimisticChatThreads$` has
+ * recomputed and filtered the entry out, both fragments emit the same key —
+ * React drops one, then on the next render the survivor moves between
+ * fragments, causing an unmount + remount.
+ *
+ * Drives the flow exclusively through user-visible DOM (clicking the
+ * sidebar's "+ New chat" button); reads the optimistic thread id back out of
+ * the rendered `data-chat-thread-id` attribute. Holds the persisted-list
+ * refetch with a deferred so the test can deterministically interleave the
+ * chat-threads response with the optimistic-list recomputation, then records
+ * the sidebar across every microtask between the Ably trigger and the final
+ * settle.
+ */
+import { describe, expect, it } from "vitest";
+import { act, screen, waitFor, within } from "@testing-library/react";
+import {
+  chatThreadByIdContract,
+  chatThreadMessagesContract,
+  chatThreadsContract,
+  type ChatThreadListItem,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { server } from "../../../mocks/server.ts";
+import { triggerAblyEvent } from "../../../mocks/ably.ts";
+import { createMockApi } from "../../../mocks/msw-contract.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { click, detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
+
+const context = testContext();
+const mockApi = createMockApi(context);
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+function getSidebar(): HTMLElement {
+  return screen.getByRole("navigation", { name: "Sidebar" });
+}
+
+function countNewThreadRows(sidebar: HTMLElement, threadId: string): number {
+  return sidebar.querySelectorAll(`[data-chat-thread-id="${threadId}"]`).length;
+}
+
+describe("sidebar new-chat flicker", () => {
+  it("renders the new chat row continuously across the optimistic→persisted handoff", async () => {
+    // The first chatThreads$ list call resolves immediately so the page can
+    // render. Subsequent calls (Ably-triggered reload) are held by the
+    // deferred so the test can deliberately interleave its resolution.
+    let listResponseThreads: ChatThreadListItem[] = [];
+    let listCallCount = 0;
+    let holdNextListCalls = false;
+    const reloadDeferred = createDeferredPromise<void>(context.signal);
+    // Hold the create POST so the optimistic entry stays registered for the
+    // duration of the test. Without this, settleResult resolves before the
+    // route's loadRoute$ promotes `currentChatThreadId$`, and
+    // `routeOptimisticChatThread$` clears the optimistic immediately — which
+    // is itself the "disappear" half of the user-visible flicker.
+    const createDeferred = createDeferredPromise<void>(context.signal);
+
+    server.use(
+      mockApi(chatThreadsContract.list, async ({ respond }) => {
+        listCallCount += 1;
+        if (holdNextListCalls) {
+          await reloadDeferred.promise;
+        }
+        return respond(200, { threads: listResponseThreads });
+      }),
+      mockApi(chatThreadsContract.create, async ({ body, respond }) => {
+        await createDeferred.promise;
+        return respond(201, {
+          id: body.clientThreadId ?? "fallback",
+          title: null,
+          createdAt: "2026-05-05T00:00:00Z",
+        });
+      }),
+      mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
+        return respond(200, {
+          id: params.id,
+          title: null,
+          agentId: AGENT_ID,
+          chatMessages: [],
+          latestSessionId: null,
+          activeRunIds: [],
+          draftContent: null,
+          draftAttachments: null,
+          createdAt: "2026-05-05T00:00:00Z",
+          updatedAt: "2026-05-05T00:00:00Z",
+        });
+      }),
+      mockApi(chatThreadMessagesContract.list, ({ respond }) => {
+        return respond(200, { messages: [] });
+      }),
+    );
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    // Wait until the initial chatThreads$ list call has resolved and the
+    // sidebar's "+ New chat" button is mounted.
+    await waitFor(() => {
+      expect(listCallCount).toBeGreaterThanOrEqual(1);
+      expect(
+        within(getSidebar()).getByLabelText(/^New chat with /i),
+      ).toBeInTheDocument();
+    });
+
+    // Drive the optimistic-create flow through the actual sidebar button.
+    const newChatBtn = within(getSidebar()).getByLabelText(/^New chat with /i);
+    await act(async () => {
+      click(newChatBtn);
+    });
+
+    // Read the optimistic thread id back out of the DOM. The id is the
+    // crypto.randomUUID() that `createNewChatThread$` minted client-side and
+    // wrote into `data-chat-thread-id` on the rendered row.
+    let newThreadId = "";
+    await waitFor(() => {
+      const rows = getSidebar().querySelectorAll<HTMLElement>(
+        "[data-chat-thread-id]",
+      );
+      expect(rows.length).toBeGreaterThan(0);
+      const id = rows[0].getAttribute("data-chat-thread-id");
+      expect(id).toBeTruthy();
+      newThreadId = id ?? "";
+    });
+
+    // Snapshot the row count on every sidebar DOM mutation throughout the
+    // optimistic→persisted handoff. The row should remain present (count >= 1)
+    // and never appear duplicated (count <= 1). Combine MutationObserver
+    // (catches React-driven DOM commits) with a tight microtask poll
+    // (catches synchronous re-renders that occur within the same task).
+    const sidebar = getSidebar();
+    const snapshots: number[] = [countNewThreadRows(sidebar, newThreadId)];
+    const observer = new MutationObserver(() => {
+      snapshots.push(countNewThreadRows(sidebar, newThreadId));
+    });
+    observer.observe(sidebar, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+    });
+
+    // Server now "knows about" the new thread and publishes threadListChanged.
+    holdNextListCalls = true;
+    listResponseThreads = [
+      {
+        id: newThreadId,
+        title: null,
+        agent: { id: AGENT_ID, avatarUrl: null },
+        createdAt: "2026-05-05T00:00:00Z",
+        updatedAt: "2026-05-05T00:00:00Z",
+        isRead: true,
+        isArchived: false,
+        running: false,
+      },
+    ];
+
+    await act(async () => {
+      triggerAblyEvent("threadListChanged");
+    });
+
+    // Release the persisted-list refetch — chatThreads$ resolves, then
+    // pendingOptimisticChatThreads$ recomputes. This is the window where
+    // the bug is observable.
+    await act(async () => {
+      reloadDeferred.resolve();
+      // Poll the DOM at every microtask boundary so we catch the synchronous
+      // React re-renders that happen as `useSyncExternalStore` subscribers
+      // fire one after the other (chatThreads$ first, then pendingOptimistic).
+      for (let i = 0; i < 50; i++) {
+        snapshots.push(countNewThreadRows(sidebar, newThreadId));
+        await Promise.resolve();
+      }
+    });
+
+    await waitFor(() => {
+      expect(listCallCount).toBeGreaterThanOrEqual(2);
+      expect(countNewThreadRows(sidebar, newThreadId)).toBe(1);
+    });
+    snapshots.push(countNewThreadRows(sidebar, newThreadId));
+    observer.disconnect();
+    // Let the still-suspended create POST settle so signal teardown can
+    // unwind cleanly.
+    createDeferred.resolve();
+
+    const dropped = snapshots.filter((c) => {
+      return c === 0;
+    }).length;
+    const collided = snapshots.filter((c) => {
+      return c > 1;
+    }).length;
+    expect(
+      { snapshots, dropped, collided },
+      "the new chat row must remain rendered exactly once at every mutation",
+    ).toMatchObject({
+      dropped: 0,
+      collided: 0,
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-new-chat-keyboard-nav.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-new-chat-keyboard-nav.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Reproduces the keyboard-navigation regression on optimistic threads:
+ * after creating a new chat via the sidebar's "+ New chat" button, the new
+ * thread is the active page but `mod+shift+ArrowDown` (and ArrowUp) do not
+ * move to the adjacent persisted thread until the server's
+ * `threadListChanged` reload pulls the newly-created thread into
+ * `chatThreads$`.
+ *
+ * Root cause: `navigateToAdjacentThread$` (chat-keyboard.ts) reads
+ * `chatThreads$` directly. The optimistic thread lives only in
+ * `allPendingChatThreads$` / `sidebarChatThreads$` until the server-side
+ * round-trip arrives, so `findIndex(currentThreadId)` returns -1 and the
+ * command early-returns without navigating.
+ */
+import { describe, expect, it } from "vitest";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import {
+  chatThreadByIdContract,
+  chatThreadMessagesContract,
+  chatThreadsContract,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { server } from "../../../mocks/server.ts";
+import { createMockApi } from "../../../mocks/msw-contract.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { click, detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
+import { pathname } from "../../../signals/location.ts";
+
+const context = testContext();
+const mockApi = createMockApi(context);
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const PERSISTED_THREAD_ID = "p0000000-0000-4000-a000-000000000099";
+
+function getSidebar(): HTMLElement {
+  return screen.getByRole("navigation", { name: "Sidebar" });
+}
+
+function paneFor(threadId: string): HTMLElement {
+  const el = document.querySelector<HTMLElement>(
+    `[data-chat-thread-container-id="${threadId}"]`,
+  );
+  expect(el).not.toBeNull();
+  return el!;
+}
+
+describe("sidebar new-chat keyboard navigation", () => {
+  it("mod+shift+ArrowDown from a freshly-created optimistic thread navigates to the next persisted thread", async () => {
+    // Hold the create POST so the optimistic entry stays registered for the
+    // entire test — without it, `routeOptimisticChatThread$` may clear the
+    // optimistic before route load promotes `currentChatThreadId$`.
+    const createDeferred = createDeferredPromise<void>(context.signal);
+
+    server.use(
+      // Persisted list never updates during the test — this simulates the
+      // window before the server's `threadListChanged` reload arrives.
+      mockApi(chatThreadsContract.list, ({ respond }) => {
+        return respond(200, {
+          threads: [
+            {
+              id: PERSISTED_THREAD_ID,
+              title: "Persisted thread",
+              agent: { id: AGENT_ID, avatarUrl: null },
+              createdAt: "2026-03-10T00:00:00Z",
+              updatedAt: "2026-03-10T00:00:00Z",
+              isRead: true,
+              isArchived: false,
+              running: false,
+            },
+          ],
+        });
+      }),
+      mockApi(chatThreadsContract.create, async ({ body, respond }) => {
+        await createDeferred.promise;
+        return respond(201, {
+          id: body.clientThreadId ?? "fallback",
+          title: null,
+          createdAt: "2026-05-05T00:00:00Z",
+        });
+      }),
+      mockApi(chatThreadByIdContract.get, ({ params, respond }) => {
+        return respond(200, {
+          id: params.id,
+          title: params.id === PERSISTED_THREAD_ID ? "Persisted thread" : null,
+          agentId: AGENT_ID,
+          chatMessages: [],
+          latestSessionId: null,
+          activeRunIds: [],
+          draftContent: null,
+          draftAttachments: null,
+          createdAt: "2026-05-05T00:00:00Z",
+          updatedAt: "2026-05-05T00:00:00Z",
+        });
+      }),
+      mockApi(chatThreadMessagesContract.list, ({ respond }) => {
+        return respond(200, { messages: [] });
+      }),
+    );
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    // Wait until the sidebar's "+ New chat" button is mounted.
+    await waitFor(() => {
+      expect(
+        within(getSidebar()).getByLabelText(/^New chat with /i),
+      ).toBeInTheDocument();
+    });
+
+    // Click the sidebar "+ New chat" button.
+    click(within(getSidebar()).getByLabelText(/^New chat with /i));
+
+    // The optimistic flow navigates to /chats/<newId>; capture the new id from
+    // the URL once it lands.
+    let newThreadId = "";
+    await waitFor(() => {
+      const m = pathname().match(/^\/chats\/([^/?#]+)$/);
+      expect(m).not.toBeNull();
+      newThreadId = m![1];
+      // The chat-thread pane for the new thread should have rendered too.
+      expect(
+        document.querySelector(
+          `[data-chat-thread-container-id="${newThreadId}"]`,
+        ),
+      ).not.toBeNull();
+    });
+    expect(newThreadId).not.toBe(PERSISTED_THREAD_ID);
+
+    // Sanity: both rows are visible in the sidebar (sidebarChatThreads$ now
+    // unifies persisted + optimistic).
+    await waitFor(() => {
+      expect(
+        getSidebar().querySelector(
+          `[data-chat-thread-id="${PERSISTED_THREAD_ID}"]`,
+        ),
+      ).not.toBeNull();
+      expect(
+        getSidebar().querySelector(`[data-chat-thread-id="${newThreadId}"]`),
+      ).not.toBeNull();
+    });
+
+    // The freshly-created optimistic thread sits at the top (newest). Press
+    // mod+shift+ArrowDown to navigate to the next thread (persisted).
+    fireEvent.keyDown(paneFor(newThreadId), {
+      key: "ArrowDown",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    // BUG: the keyboard handler reads chatThreads$ (server list), which still
+    // contains only the persisted thread. The current thread id is the
+    // optimistic one, so `findIndex` returns -1 and the command does nothing.
+    // EXPECTED (post-fix): navigation lands on the persisted thread.
+    await waitFor(() => {
+      expect(pathname()).toBe(`/chats/${PERSISTED_THREAD_ID}`);
+    });
+
+    // Let the still-suspended create POST settle so signal teardown can
+    // unwind cleanly.
+    createDeferred.resolve();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -62,7 +62,7 @@ import {
   createNewChatThreadOptimistically$,
   optimisticChatThread$,
   type OptimisticChatPane,
-  pendingOptimisticChatThreads$,
+  sidebarChatThreads$,
 } from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 import { currentChatAgentId$ } from "../../signals/agent-chat.ts";
 import { pathParams$, searchParams$ } from "../../signals/route.ts";
@@ -617,9 +617,7 @@ function ChatThreads() {
   const deleteChatThread = useSet(deleteChatThread$);
   const pageSignal = useGet(pageSignal$);
 
-  const chatThreads = useLastResolved(chatThreads$) ?? [];
-  const optimisticChatThreads =
-    useLastResolved(pendingOptimisticChatThreads$) ?? [];
+  const chatThreads = useLastResolved(sidebarChatThreads$) ?? [];
   const searchTerm = useGet(sidebarSearchTerm$);
   const trimmedTerm = searchTerm.trim().toLowerCase();
   const filteredChatThreads = trimmedTerm
@@ -627,11 +625,6 @@ function ChatThreads() {
         return (s.title ?? "").toLowerCase().includes(trimmedTerm);
       })
     : chatThreads;
-  const filteredOptimisticChatThreads = trimmedTerm
-    ? optimisticChatThreads.filter((s) => {
-        return (s.title ?? "").toLowerCase().includes(trimmedTerm);
-      })
-    : optimisticChatThreads;
 
   function confirmDelete() {
     if (!pendingDeleteThreadId) {
@@ -642,10 +635,7 @@ function ChatThreads() {
     detach(deleteChatThread(threadId, pageSignal), Reason.DomCallback);
   }
 
-  if (
-    filteredOptimisticChatThreads.length === 0 &&
-    filteredChatThreads.length === 0
-  ) {
+  if (filteredChatThreads.length === 0) {
     return (
       <p className="px-2 py-2 text-xs text-muted-foreground/70 leading-relaxed">
         {trimmedTerm
@@ -656,9 +646,6 @@ function ChatThreads() {
   }
   return (
     <>
-      {filteredOptimisticChatThreads.map((session) => {
-        return <ChatThreadItem key={session.id} session={session} />;
-      })}
       {filteredChatThreads.map((session) => {
         return <ChatThreadItem key={session.id} session={session} />;
       })}


### PR DESCRIPTION
## Summary

Two small bugs around optimistic chat-thread creation, both rooted in the sidebar reading two separate signals (\`chatThreads\$\` + \`pendingOptimisticChatThreads\$\`) for what is logically one list.

1. **Sidebar flicker on \"+ New chat\"** — the new row appeared, briefly disappeared, then reappeared. The two \`useLastResolved\` subscribers updated in different microtasks: \`chatThreads\$\` resolved with the new id while \`pendingOptimisticChatThreads\$\` (its dependent) hadn't yet recomputed. For one render, both fragments emitted \`<ChatThreadItem key={newId}>\` siblings, React dropped one, and on the next render the survivor moved between fragments → unmount + remount.
2. **Keyboard nav stuck on the optimistic thread** — \`mod+shift+ArrowUp/Down\` did nothing on a freshly-created chat until the server's \`threadListChanged\` reload landed. \`navigateToAdjacentThread\$\` read \`chatThreads\$\` directly, so \`findIndex(currentThreadId)\` returned -1 and the command early-returned.

## Changes

- New unified computed \`sidebarChatThreads\$\` (in \`optimistic-chat-thread-page.ts\`): merges persisted + optimistic, dedupes by id, sorts (pinned first then \`updatedAt\` desc). The optimistic-only entries use the browser-side \`createdAt\` minted in \`createNewChatThread\$\`; once the persisted version arrives, dedupe drops the optimistic and the server's \`updatedAt\` takes over.
- \`<ChatThreads>\` now reads only \`sidebarChatThreads\$\` and renders one \`.map\` — no more shared key space.
- \`navigateToAdjacentThread\$\` reads \`sidebarChatThreads\$\` so the optimistic thread is reachable by keyboard immediately.
- Removed the now-unused \`pendingOptimisticChatThreads\$\` export.

## Tests added

- \`sidebar-new-chat-flicker.test.tsx\` — drives the flow only through DOM (clicks the sidebar \"+ New chat\" button, reads the new id from \`data-chat-thread-id\`), holds the persisted-list reload with a deferred, polls the sidebar every microtask + uses MutationObserver. Asserts the new row is rendered exactly once across the optimistic→persisted handoff (no \`count == 0\` and no \`count > 1\`).
- \`sidebar-new-chat-keyboard-nav.test.tsx\` — clicks \"+ New chat\", fires \`mod+shift+ArrowDown\` on the new pane, asserts the URL lands on the adjacent persisted thread.

Both tests fail on \`main\` (deterministic — 5/5 stable), pass with this fix.

## Test plan

- [ ] \`pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/sidebar-new-chat-flicker.test.tsx\`
- [ ] \`pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/sidebar-new-chat-keyboard-nav.test.tsx\`
- [ ] \`pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__ src/views/zero-page/__tests__\` (full chat + zero-page suite — 1086 tests pass locally)
- [ ] Manual: in dev, create a new chat from the sidebar — row should appear once with no flicker; \`Cmd+Shift+Down\` from the new chat should jump to the next thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)