### PR TITLE
docs(nbd-cow): clarify DeviceLease authority

### DIFF
--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -38,10 +38,11 @@ impl CooldownSlot {
     }
 }
 
-/// Owned authority for a checked-out NBD device index.
+/// Owned authority for a checked-out NBD device.
 ///
-/// This intentionally does not implement `Clone` or `Copy`: returning an index
-/// to the pool must consume the lease, not copied diagnostic metadata.
+/// This is intentionally move-only: releasing, discarding, or retiring the
+/// device must consume the lease, which owns the underlying `NbdDeviceClaim`.
+/// The copied device index is only diagnostic metadata, not pool authority.
 pub struct DeviceLease {
     index: u32,
     claim: Option<NbdDeviceClaim>,


### PR DESCRIPTION
## Summary

- Clarify the `DeviceLease` doc comment so it describes move-only pool authority instead of copied device-index metadata.
- Mention the actual lease-consuming transitions: release, discard, and retire.

Closes #11845

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --check -p nbd-cow`
- pre-commit: cargo-fmt, cargo-clippy, cargo-doc, commitlint