### PR TITLE
fix(voice-io): parse webm duration per spec (4 or 8 byte float, timecodescale units)

### DIFF
--- a/turbo/apps/web/src/lib/zero/voice-io/__tests__/audio-duration.test.ts
+++ b/turbo/apps/web/src/lib/zero/voice-io/__tests__/audio-duration.test.ts
@@ -9,21 +9,38 @@ function fileFromBytes(bytes: Uint8Array, mimeType: string): File {
  * Build a minimal valid WebM file with a given Duration (seconds) in Info.
  * Constructs a correct EBML structure that the parser can traverse.
  */
-function buildWebmFile(durationSeconds: number): File {
+function buildWebmFile(
+  durationSeconds: number,
+  opts: { floatSize?: 4 | 8 } = {},
+): File {
   // Helper: encode an EBML element [vint-ID, vint-size, data]
   function elem(id: number[], data: number[]): number[] {
     const size = encodeVint(data.length);
     return [...id, ...size, ...data];
   }
 
-  // Duration as float64 (nanoseconds)
-  const durationNanos = durationSeconds * 1_000_000_000;
-  const durBuf = new ArrayBuffer(8);
-  new DataView(durBuf).setFloat64(0, durationNanos, false);
+  // Per WebM spec, Duration is stored in TimecodeScale units (default 1 ms),
+  // not nanoseconds. Spec also allows the float to be 4 or 8 bytes — Chrome's
+  // MediaRecorder writes the 4-byte form.
+  const floatSize = opts.floatSize ?? 8;
+  const durationInMs = durationSeconds * 1_000;
+  const durBuf = new ArrayBuffer(floatSize);
+  if (floatSize === 8) {
+    new DataView(durBuf).setFloat64(0, durationInMs, false);
+  } else {
+    new DataView(durBuf).setFloat32(0, durationInMs, false);
+  }
   const durData = [...new Uint8Array(durBuf)];
 
   const durationEl = elem([0x44, 0x89], durData); // Duration
-  const infoEl = elem([0x15, 0x49, 0xa9, 0x66], durationEl); // Info
+  // Append a MuxingApp element after Duration so a buggy parser that
+  // overruns the declared Duration size would mis-read into MuxingApp bytes
+  // (this mirrors Chrome's actual layout).
+  const muxingAppEl = elem([0x4d, 0x80], [0x77, 0x65, 0x62]); // "web"
+  const infoEl = elem(
+    [0x15, 0x49, 0xa9, 0x66],
+    [...durationEl, ...muxingAppEl],
+  ); // Info
   const segmentContent = infoEl;
 
   // Segment size: unknown (all-1s vint) for simplicity
@@ -121,6 +138,15 @@ describe("getAudioDuration", () => {
       const file = buildWebmFile(0);
       const duration = await getAudioDuration(file);
       expect(duration).toBe(0);
+    });
+
+    it("handles 4-byte Float32 Duration (Chrome MediaRecorder shape)", async () => {
+      // Chrome writes Duration as a 4-byte float; the previous parser hard-read
+      // 8 bytes (Duration data + MuxingApp header) and produced ~1e21 seconds,
+      // which tripped the AUDIO_DURATION_TOO_LONG guard for every Chrome user.
+      const file = buildWebmFile(9, { floatSize: 4 });
+      const duration = await getAudioDuration(file);
+      expect(duration).toBe(9);
     });
 
     it("returns null for truncated WebM (no Segment)", async () => {

--- a/turbo/apps/web/src/lib/zero/voice-io/audio-duration.ts
+++ b/turbo/apps/web/src/lib/zero/voice-io/audio-duration.ts
@@ -93,6 +93,48 @@ function findDurationInSegment(buf: Uint8Array, pos: number): number | null {
   return null;
 }
 
+// WebM Info element children we care about. Per spec, Duration is stored in
+// TimecodeScale units (not nanoseconds), and may be a 4- or 8-byte float; the
+// previous implementation hard-read 8 bytes and treated the value as ns, which
+// for Chrome MediaRecorder output (4-byte float, ms units) yielded values on
+// the order of 1e21 seconds and tripped the AUDIO_DURATION_TOO_LONG guard.
+const DEFAULT_TIMECODE_SCALE_NS = 1_000_000;
+
+function readDurationFloat(
+  buf: Uint8Array,
+  valuePos: number,
+  valueSize: number,
+): number | null {
+  // Duration: float in TimecodeScale units (4 or 8 bytes per EBML spec)
+  if (valuePos + valueSize > buf.length) return null;
+  const view = new DataView(buf.buffer, buf.byteOffset + valuePos, valueSize);
+  let value: number;
+  if (valueSize === 8) {
+    value = view.getFloat64(0, false);
+  } else if (valueSize === 4) {
+    value = view.getFloat32(0, false);
+  } else {
+    return null;
+  }
+  if (Number.isNaN(value) || value < 0) return null;
+  return value;
+}
+
+function readTimecodeScale(
+  buf: Uint8Array,
+  valuePos: number,
+  valueSize: number,
+): number | null {
+  // TimecodeScale: unsigned int in nanoseconds (default 1,000,000 = 1 ms)
+  if (valuePos + valueSize > buf.length) return null;
+  if (valueSize <= 0 || valueSize > 8) return null;
+  let scale = 0;
+  for (let i = 0; i < valueSize; i++) {
+    scale = scale * 256 + (buf[valuePos + i] ?? 0);
+  }
+  return scale > 0 ? scale : null;
+}
+
 function findDurationInInfo(
   buf: Uint8Array,
   dataStart: number,
@@ -100,6 +142,9 @@ function findDurationInInfo(
 ): number | null {
   const end = Math.min(dataStart + dataLen, buf.length);
   let pos = dataStart;
+  let durationInScale: number | null = null;
+  let timecodeScaleNs = DEFAULT_TIMECODE_SCALE_NS;
+
   while (pos + 2 <= end) {
     const idLen = vintLen(buf[pos] ?? 0);
     if (idLen === null || pos + idLen > end) return null;
@@ -108,20 +153,27 @@ function findDurationInInfo(
 
     const elemStart = pos;
     const valuePos = sizeResult.next;
+    const valueSize = sizeResult.value;
 
-    // Duration element ID: 0x44 0x89
     if (idLen === 2 && buf[elemStart] === 0x44 && buf[elemStart + 1] === 0x89) {
-      if (valuePos + 8 > buf.length) return null;
-      // Duration is a float64 in nanoseconds
-      const view = new DataView(buf.buffer, buf.byteOffset + valuePos, 8);
-      const nanos = view.getFloat64(0, false);
-      if (Number.isNaN(nanos) || nanos < 0) return null;
-      return Math.ceil(nanos / 1_000_000_000);
+      const value = readDurationFloat(buf, valuePos, valueSize);
+      if (value === null) return null;
+      durationInScale = value;
+    } else if (
+      idLen === 3 &&
+      buf[elemStart] === 0x2a &&
+      buf[elemStart + 1] === 0xd7 &&
+      buf[elemStart + 2] === 0xb1
+    ) {
+      const scale = readTimecodeScale(buf, valuePos, valueSize);
+      if (scale !== null) timecodeScaleNs = scale;
     }
 
-    pos = valuePos + Math.min(sizeResult.value, buf.length - valuePos);
+    pos = valuePos + Math.min(valueSize, buf.length - valuePos);
   }
-  return null;
+
+  if (durationInScale === null) return null;
+  return Math.ceil((durationInScale * timecodeScaleNs) / 1_000_000_000);
 }
 
 function parseWavDuration(buf: Uint8Array): number | null {


### PR DESCRIPTION
## Summary

Fix the WebM Duration parser in `audio-duration.ts` so that desktop Chrome voice input stops returning HTTP 400 `AUDIO_DURATION_TOO_LONG`.

## Why

The hand-rolled parser landed in #11282 makes two spec-incorrect assumptions:

1. It hard-reads **8 bytes** for the Duration value and ignores the size declared by the EBML size vint.
2. It treats that float as **nanoseconds**.

Per the WebM/EBML spec, `Duration` may be a 4- or 8-byte float, and its value is in `TimecodeScale` units (default 1,000,000 ns = 1 ms). Chrome's `MediaRecorder` writes the 4-byte form. The old parser was therefore reading the 4 bytes of the actual Duration value plus the next 4 bytes of the following Info child (typically `MuxingApp`) as a single float64.

For one Chrome sample captured via the new logging from #11850, the 8 bytes read were:

```
44 7e ed f4   4d 80 86 77
└── float32 1019.7 ms ──┘
              └─ MuxingApp ID (4d80) ─┘
```

Parsed as float64 + treated as ns: `9.13e21 / 1e9 = 9.13e12` seconds (≈ 289,000 years). That always exceeded `MAX_REQUEST_DURATION_SECONDS = 300`, so every desktop Chrome `POST /api/zero/voice-io/stt` returned 400 with `AUDIO_DURATION_TOO_LONG`. Mobile Safari was unaffected because its `audio/mp4` upload took the `estimateDurationFromSize` fallback path instead.

Confirmed live: a 17,684-byte Chrome recording reported `Audio duration (9128779793712s) exceeds maximum (300s)` — the new client/server logging from #11850 surfaced the exact `error.code` and `recordedMime` for the first time, which made the diagnosis possible without speculation.

## What changed

`turbo/apps/web/src/lib/zero/voice-io/audio-duration.ts`
- Honor the size vint when reading Duration; pick `getFloat32` vs `getFloat64` accordingly.
- Parse the `TimecodeScale` element when present and apply it; default to 1 ms otherwise.
- Compute `seconds = duration_in_scale × timecodeScaleNs / 1e9`.
- Extracted `readDurationFloat` and `readTimecodeScale` helpers to keep `findDurationInInfo` under the project's complexity ceiling.

`turbo/apps/web/src/lib/zero/voice-io/__tests__/audio-duration.test.ts`
- `buildWebmFile` now writes Duration in TimecodeScale units (ms) rather than nanoseconds — matching the spec — and appends a `MuxingApp` element after Duration so an over-read regression would decode as garbage again, just like the real Chrome file.
- New regression test exercises the Chrome shape: `buildWebmFile(9, { floatSize: 4 })`.

## Test plan

- [x] `pnpm -F web exec vitest run src/lib/zero/voice-io/__tests__/audio-duration.test.ts` — 10/10 pass (including the new Chrome 4-byte case)
- [x] `pnpm -F web exec vitest run app/api/zero/voice-io` — 37/37 pass
- [x] `pnpm turbo run lint check-types --filter=web` — passes (function complexity within limit after extracting helpers)
- [ ] After deploy: confirm desktop Chrome STT reports `200` instead of `400 AUDIO_DURATION_TOO_LONG`, and Sentry issue [PLATFORM-2H](https://vm0.sentry.io/issues/7423093053/) stops accruing events.

Closes #11847

🤖 Generated with [Claude Code](https://claude.com/claude-code)