### PR TITLE
fix(sandbox-fc): require snapshot publish marker

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -10,7 +10,8 @@ use crate::config;
 use crate::deps::MITMPROXY_VERSION;
 use crate::error::{RunnerError, RunnerResult};
 use crate::executor;
-use crate::paths::{HomePaths, RunnerPaths};
+use crate::lock;
+use crate::paths::{HomePaths, RootfsPaths, RunnerPaths};
 use crate::prefetch;
 use crate::proxy;
 
@@ -78,9 +79,17 @@ pub async fn run_benchmark(
     let profile_config = runner_config.profiles.get(profile_name).ok_or_else(|| {
         RunnerError::Config(format!("profile '{profile_name}' not found in config"))
     })?;
+
+    let rootfs_lock = lock::acquire_shared(home.rootfs_lock(&profile_config.rootfs_hash)).await?;
+    let rootfs_paths = RootfsPaths::new(&home, &profile_config.rootfs_hash);
+    let snapshot_lock =
+        lock::acquire_shared(home.snapshot_lock(&profile_config.snapshot_hash)).await?;
+    config::validate_profile_image_artifacts(profile_name, profile_config, &home).await?;
+    let _resource_locks = (rootfs_lock, snapshot_lock);
+
     // Block until memory.bin is in page cache so benchmark numbers are stable.
     {
-        let path = crate::paths::RootfsPaths::new(&home, &profile_config.rootfs_hash)
+        let path = rootfs_paths
             .snapshot(&profile_config.snapshot_hash)
             .memory_bin();
         let _ = tokio::task::spawn_blocking(move || prefetch::prefetch_memory(&path)).await;

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -39,7 +39,7 @@ const TEMPLATE_CACHE_VERSION: u32 = 1;
 const ROOTFS_CACHE_VERSION: u32 = 1;
 
 /// Bump to invalidate all cached snapshots (local only; R2 stores only the template).
-const SNAPSHOT_CACHE_VERSION: u32 = 2;
+const SNAPSHOT_CACHE_VERSION: u32 = 3;
 
 #[cfg(bundled_guests)]
 mod embedded {

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -251,16 +251,20 @@ pub async fn run_start(
 
     // Shared locks on rootfs + snapshot per profile — allows `runner gc` to detect in-use resources.
     let mut _resource_locks = Vec::new();
-    for profile in runner_config.profiles.values() {
+    for (profile_name, profile) in &runner_config.profiles {
         let rootfs_lock = lock::acquire_shared(home.rootfs_lock(&profile.rootfs_hash)).await?;
         let rootfs_paths = crate::paths::RootfsPaths::new(&home, &profile.rootfs_hash);
-        touch_mtime(rootfs_paths.dir());
         _resource_locks.push(rootfs_lock);
         let snapshot_lock =
             lock::acquire_shared(home.snapshot_lock(&profile.snapshot_hash)).await?;
         let snapshot_paths = rootfs_paths.snapshot(&profile.snapshot_hash);
-        touch_mtime(snapshot_paths.dir());
         _resource_locks.push(snapshot_lock);
+
+        // Validate image artifacts only after both shared locks are held.
+        // Reading them before lock acquisition can race with builders or GC.
+        config::validate_profile_image_artifacts(profile_name, profile, &home).await?;
+        touch_mtime(rootfs_paths.dir());
+        touch_mtime(snapshot_paths.dir());
     }
 
     let log_paths = LogPaths::new(home.logs_dir());

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -1052,6 +1052,111 @@ profiles:
     }
 
     #[tokio::test]
+    async fn load_defers_malformed_complete_marker_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        for f in [&fc, &kernel] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let rootfs = RootfsPaths::new(&home, TEST_ROOTFS_HASH);
+        tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
+        tokio::fs::write(rootfs.rootfs(), b"").await.unwrap();
+        let snapshot = rootfs.snapshot(TEST_SNAPSHOT_HASH);
+        tokio::fs::create_dir_all(snapshot.dir()).await.unwrap();
+        for path in [
+            snapshot.snapshot_bin(),
+            snapshot.memory_bin(),
+            snapshot.cow_img(),
+            snapshot.cow_bitmap(),
+        ] {
+            tokio::fs::write(&path, b"").await.unwrap();
+        }
+        tokio::fs::write(snapshot.complete_marker(), b"partial marker")
+            .await
+            .unwrap();
+
+        let yaml = format!(
+            r#"
+name: test
+group: test/group
+base_dir: {base_dir}
+ca_dir: {ca_dir}
+firecracker:
+  binary: {fc}
+  kernel: {kernel}
+profiles:
+  vm0/default:
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
+    vcpu: 2
+    memory_mb: 4096
+    disk_mb: 16384
+"#,
+            base_dir = dir.path().display(),
+            ca_dir = dir.path().display(),
+            fc = fc.display(),
+            kernel = kernel.display(),
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
+        );
+
+        let config_path = dir.path().join("runner.yaml");
+        tokio::fs::write(&config_path, &yaml).await.unwrap();
+
+        let config = load_with_home(&config_path, &home, false).await.unwrap();
+        let profile = config.profiles.get("vm0/default").unwrap();
+        let err = validate_profile_image_artifacts("vm0/default", profile, &home)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("complete marker") && err.to_string().contains("invalid"),
+            "expected deferred invalid complete marker error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_profile_image_artifacts_rejects_missing_cow_bitmap() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let rootfs = RootfsPaths::new(&home, TEST_ROOTFS_HASH);
+        tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
+        tokio::fs::write(rootfs.rootfs(), b"").await.unwrap();
+        let snapshot = rootfs.snapshot(TEST_SNAPSHOT_HASH);
+        tokio::fs::create_dir_all(snapshot.dir()).await.unwrap();
+        for path in [
+            snapshot.snapshot_bin(),
+            snapshot.memory_bin(),
+            snapshot.cow_img(),
+        ] {
+            tokio::fs::write(&path, b"").await.unwrap();
+        }
+        tokio::fs::write(
+            snapshot.complete_marker(),
+            sandbox_fc::SNAPSHOT_COMPLETE_MARKER_CONTENT,
+        )
+        .await
+        .unwrap();
+
+        let profile = ProfileConfig {
+            rootfs_hash: TEST_ROOTFS_HASH.into(),
+            snapshot_hash: TEST_SNAPSHOT_HASH.into(),
+            vcpu: 2,
+            memory_mb: 4096,
+            disk_mb: 16384,
+        };
+        let err = validate_profile_image_artifacts("vm0/default", &profile, &home)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("cow.img.bitmap"),
+            "expected missing cow bitmap error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
     async fn load_rejects_snapshot_without_complete_marker() {
         let dir = tempfile::tempdir().unwrap();
         let fc = dir.path().join("firecracker");

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -8,9 +8,11 @@
 //! # Lifecycle
 //! 1. [`load`] reads the YAML, deserializes into [`RunnerConfig`], and
 //!    resolves any relative paths against the config file's parent directory.
-//! 2. `validate` checks group name, profile names, image hashes, on-disk
-//!    artifacts, resource ceilings, and the concurrency factor.
-//! 3. Callers derive runtime objects (e.g. [`sandbox::FactoryConfig`]) from
+//! 2. `validate` checks group name, profile names, image hashes, static host
+//!    paths, resource ceilings, and the concurrency factor.
+//! 3. Callers that consume image artifacts hold the relevant rootfs/snapshot
+//!    locks and call [`validate_profile_image_artifacts`].
+//! 4. Callers derive runtime objects (e.g. [`sandbox::FactoryConfig`]) from
 //!    the loaded config.
 //!
 //! # Image identity: two content hashes per profile
@@ -158,10 +160,16 @@ pub struct ServerConfig {
 /// Relative paths in the config are resolved against the config file's parent directory.
 pub async fn load(path: &Path) -> RunnerResult<RunnerConfig> {
     let home = HomePaths::new()?;
-    load_with_home(path, &home).await
+    // Image artifacts are mutable cache outputs. Runtime callers validate
+    // them only after acquiring the matching shared rootfs/snapshot locks.
+    load_with_home(path, &home, false).await
 }
 
-async fn load_with_home(path: &Path, home: &HomePaths) -> RunnerResult<RunnerConfig> {
+async fn load_with_home(
+    path: &Path,
+    home: &HomePaths,
+    validate_image_artifacts: bool,
+) -> RunnerResult<RunnerConfig> {
     let content = tokio::fs::read_to_string(path)
         .await
         .map_err(|e| RunnerError::Config(format!("read {}: {e}", path.display())))?;
@@ -170,7 +178,7 @@ async fn load_with_home(path: &Path, home: &HomePaths) -> RunnerResult<RunnerCon
     if let Some(config_dir) = path.parent() {
         config.resolve_relative_paths(config_dir);
     }
-    validate(&config, home).await?;
+    validate(&config, home, validate_image_artifacts).await?;
     Ok(config)
 }
 
@@ -230,7 +238,34 @@ async fn check_snapshot_complete_marker(path: &Path, label: &str) -> RunnerResul
     Ok(())
 }
 
-async fn validate(config: &RunnerConfig, home: &HomePaths) -> RunnerResult<()> {
+pub(crate) async fn validate_profile_image_artifacts(
+    name: &str,
+    profile: &ProfileConfig,
+    home: &HomePaths,
+) -> RunnerResult<()> {
+    // Validate rootfs files exist on disk.
+    let rootfs_paths = RootfsPaths::new(home, &profile.rootfs_hash);
+    for path in rootfs_paths.expected_files() {
+        check_path_exists(&path, &format!("profile {name} rootfs")).await?;
+    }
+    // Validate snapshot files exist on disk.
+    let snapshot_paths = rootfs_paths.snapshot(&profile.snapshot_hash);
+    for path in snapshot_paths.expected_files() {
+        check_path_exists(&path, &format!("profile {name} snapshot")).await?;
+    }
+    check_snapshot_complete_marker(
+        &snapshot_paths.complete_marker(),
+        &format!("profile {name} snapshot complete marker"),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn validate(
+    config: &RunnerConfig,
+    home: &HomePaths,
+    validate_image_artifacts: bool,
+) -> RunnerResult<()> {
     // Pure-CPU checks first — fail fast before any filesystem I/O.
     crate::group::validate_or_err(&config.group)?;
     if config.profiles.is_empty() {
@@ -272,21 +307,9 @@ async fn validate(config: &RunnerConfig, home: &HomePaths) -> RunnerResult<()> {
                 profile.disk_mb
             )));
         }
-        // Validate rootfs files exist on disk.
-        let rootfs_paths = RootfsPaths::new(home, &profile.rootfs_hash);
-        for path in rootfs_paths.expected_files() {
-            check_path_exists(&path, &format!("profile {name} rootfs")).await?;
+        if validate_image_artifacts {
+            validate_profile_image_artifacts(name, profile, home).await?;
         }
-        // Validate snapshot files exist on disk.
-        let snapshot_paths = rootfs_paths.snapshot(&profile.snapshot_hash);
-        for path in snapshot_paths.expected_files() {
-            check_path_exists(&path, &format!("profile {name} snapshot")).await?;
-        }
-        check_snapshot_complete_marker(
-            &snapshot_paths.complete_marker(),
-            &format!("profile {name} snapshot complete marker"),
-        )
-        .await?;
     }
 
     validate_concurrency_factor(config.sandbox.concurrency_factor)?;
@@ -454,7 +477,7 @@ server:
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let config = load_with_home(&config_path, &home).await.unwrap();
+        let config = load_with_home(&config_path, &home, true).await.unwrap();
         assert_eq!(config.name, "test-runner");
         assert_eq!(config.profiles.len(), 1);
         let default = &config.profiles["vm0/default"];
@@ -506,7 +529,7 @@ profiles:
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let config = load_with_home(&config_path, &home).await.unwrap();
+        let config = load_with_home(&config_path, &home, true).await.unwrap();
         assert_eq!(config.sandbox.max_concurrent, DEFAULT_MAX_CONCURRENT);
         assert!(
             (config.sandbox.concurrency_factor - DEFAULT_CONCURRENCY_FACTOR).abs() < f64::EPSILON
@@ -544,7 +567,7 @@ profiles: {{}}
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        let err = load_with_home(&config_path, &home, true).await.unwrap_err();
         assert!(
             err.to_string().contains("profiles must not be empty"),
             "got: {err}"
@@ -589,7 +612,7 @@ profiles:
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        let err = load_with_home(&config_path, &home, true).await.unwrap_err();
         assert!(
             err.to_string().contains("invalid profile name"),
             "got: {err}"
@@ -636,7 +659,7 @@ profiles:
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        let err = load_with_home(&config_path, &home, true).await.unwrap_err();
         assert!(err.to_string().contains("invalid image hash"), "got: {err}");
     }
 
@@ -677,7 +700,7 @@ profiles:
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        let err = load_with_home(&config_path, &home, true).await.unwrap_err();
         assert!(err.to_string().contains("invalid image hash"), "got: {err}");
     }
 
@@ -719,7 +742,7 @@ profiles:
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        let err = load_with_home(&config_path, &home, true).await.unwrap_err();
         assert!(err.to_string().contains("non-zero"), "got: {err}");
     }
 
@@ -761,7 +784,7 @@ profiles:
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        let err = load_with_home(&config_path, &home, true).await.unwrap_err();
         assert!(err.to_string().contains("non-zero"), "got: {err}");
     }
 
@@ -805,7 +828,7 @@ profiles:
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
         // vcpu == MAX_VCPU should be accepted (validation uses >, not >=)
-        let result = load_with_home(&config_path, &home).await;
+        let result = load_with_home(&config_path, &home, true).await;
         assert!(result.is_ok(), "got: {}", result.unwrap_err());
     }
 
@@ -847,7 +870,7 @@ profiles:
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        let err = load_with_home(&config_path, &home, true).await.unwrap_err();
         assert!(err.to_string().contains("exceeds maximum"), "got: {err}");
     }
 
@@ -889,7 +912,7 @@ profiles:
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        let err = load_with_home(&config_path, &home, true).await.unwrap_err();
         assert!(err.to_string().contains("exceeds maximum"), "got: {err}");
     }
 
@@ -931,7 +954,7 @@ profiles:
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        let err = load_with_home(&config_path, &home, true).await.unwrap_err();
         assert!(err.to_string().contains("exceeds maximum"), "got: {err}");
     }
 
@@ -978,11 +1001,54 @@ profiles:
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        let err = load_with_home(&config_path, &home, true).await.unwrap_err();
         assert!(
             err.to_string().contains("not found"),
             "expected missing file error, got: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn load_defers_missing_image_checks() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        for f in [&fc, &kernel] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+
+        let yaml = format!(
+            r#"
+name: test
+group: test/group
+base_dir: {base_dir}
+ca_dir: {ca_dir}
+firecracker:
+  binary: {fc}
+  kernel: {kernel}
+profiles:
+  vm0/default:
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
+    vcpu: 2
+    memory_mb: 4096
+    disk_mb: 16384
+"#,
+            base_dir = dir.path().display(),
+            ca_dir = dir.path().display(),
+            fc = fc.display(),
+            kernel = kernel.display(),
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
+        );
+
+        let config_path = dir.path().join("runner.yaml");
+        tokio::fs::write(&config_path, &yaml).await.unwrap();
+
+        let config = load(&config_path).await.unwrap();
+        let profile = config.profiles.get("vm0/default").unwrap();
+        assert_eq!(profile.rootfs_hash, TEST_ROOTFS_HASH);
+        assert_eq!(profile.snapshot_hash, TEST_SNAPSHOT_HASH);
     }
 
     #[tokio::test]
@@ -1037,7 +1103,7 @@ profiles:
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        let err = load_with_home(&config_path, &home, true).await.unwrap_err();
         assert!(
             err.to_string().contains(".snapshot-complete"),
             "expected missing complete marker error, got: {err}"
@@ -1099,7 +1165,7 @@ profiles:
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        let err = load_with_home(&config_path, &home, true).await.unwrap_err();
         assert!(
             err.to_string().contains("complete marker") && err.to_string().contains("invalid"),
             "expected invalid complete marker error, got: {err}"
@@ -1149,7 +1215,7 @@ sandbox:
             let config_path = dir.path().join("runner.yaml");
             tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-            let err = load_with_home(&config_path, &home).await.unwrap_err();
+            let err = load_with_home(&config_path, &home, true).await.unwrap_err();
             assert!(
                 err.to_string().contains("concurrency_factor"),
                 "expected concurrency_factor error for {bad_value}, got: {err}"
@@ -1189,7 +1255,7 @@ sandbox:
 
         generate(&config).await.unwrap();
 
-        let loaded = load_with_home(&runner_dir.join("runner.yaml"), &home)
+        let loaded = load_with_home(&runner_dir.join("runner.yaml"), &home, true)
             .await
             .unwrap();
         assert_eq!(loaded, config);
@@ -1231,7 +1297,7 @@ profiles:
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, yaml).await.unwrap();
 
-        let config = load_with_home(&config_path, &home).await.unwrap();
+        let config = load_with_home(&config_path, &home, true).await.unwrap();
 
         assert!(config.base_dir.is_absolute());
         assert_eq!(config.base_dir, dir.path().join("my-runner"));
@@ -1303,7 +1369,7 @@ profiles:
 
         generate(&config).await.unwrap();
 
-        let loaded = load_with_home(&runner_dir.join("runner.yaml"), &home)
+        let loaded = load_with_home(&runner_dir.join("runner.yaml"), &home, true)
             .await
             .unwrap();
         assert_eq!(loaded.sandbox.idle_timeout_secs, 600);
@@ -1351,7 +1417,7 @@ profiles:
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let config = load_with_home(&config_path, &home).await.unwrap();
+        let config = load_with_home(&config_path, &home, true).await.unwrap();
         assert_eq!(config.sandbox.idle_timeout_secs, DEFAULT_IDLE_TIMEOUT_SECS);
         assert_eq!(config.sandbox.max_idle, 0);
     }

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -217,6 +217,19 @@ async fn check_path_exists(path: &Path, label: &str) -> RunnerResult<()> {
     Ok(())
 }
 
+async fn check_snapshot_complete_marker(path: &Path, label: &str) -> RunnerResult<()> {
+    let content = tokio::fs::read(path)
+        .await
+        .map_err(|e| RunnerError::Config(format!("read {label}: {e}")))?;
+    if content != sandbox_fc::SNAPSHOT_COMPLETE_MARKER_CONTENT {
+        return Err(RunnerError::Config(format!(
+            "{label} is invalid: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
 async fn validate(config: &RunnerConfig, home: &HomePaths) -> RunnerResult<()> {
     // Pure-CPU checks first — fail fast before any filesystem I/O.
     crate::group::validate_or_err(&config.group)?;
@@ -269,6 +282,11 @@ async fn validate(config: &RunnerConfig, home: &HomePaths) -> RunnerResult<()> {
         for path in snapshot_paths.expected_files() {
             check_path_exists(&path, &format!("profile {name} snapshot")).await?;
         }
+        check_snapshot_complete_marker(
+            &snapshot_paths.complete_marker(),
+            &format!("profile {name} snapshot complete marker"),
+        )
+        .await?;
     }
 
     validate_concurrency_factor(config.sandbox.concurrency_factor)?;
@@ -361,10 +379,15 @@ mod tests {
                     snapshot.memory_bin(),
                     snapshot.cow_img(),
                     snapshot.cow_bitmap(),
-                    snapshot.complete_marker(),
                 ] {
                     tokio::fs::write(&path, b"").await.unwrap();
                 }
+                tokio::fs::write(
+                    snapshot.complete_marker(),
+                    sandbox_fc::SNAPSHOT_COMPLETE_MARKER_CONTENT,
+                )
+                .await
+                .unwrap();
             }
         }
         home
@@ -1018,6 +1041,68 @@ profiles:
         assert!(
             err.to_string().contains(".snapshot-complete"),
             "expected missing complete marker error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_rejects_snapshot_with_malformed_complete_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        for f in [&fc, &kernel] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let rootfs = RootfsPaths::new(&home, TEST_ROOTFS_HASH);
+        tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
+        tokio::fs::write(rootfs.rootfs(), b"").await.unwrap();
+        let snapshot = rootfs.snapshot(TEST_SNAPSHOT_HASH);
+        tokio::fs::create_dir_all(snapshot.dir()).await.unwrap();
+        for path in [
+            snapshot.snapshot_bin(),
+            snapshot.memory_bin(),
+            snapshot.cow_img(),
+            snapshot.cow_bitmap(),
+        ] {
+            tokio::fs::write(&path, b"").await.unwrap();
+        }
+        tokio::fs::write(snapshot.complete_marker(), b"partial marker")
+            .await
+            .unwrap();
+
+        let yaml = format!(
+            r#"
+name: test
+group: test/group
+base_dir: {base_dir}
+ca_dir: {ca_dir}
+firecracker:
+  binary: {fc}
+  kernel: {kernel}
+profiles:
+  vm0/default:
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
+    vcpu: 2
+    memory_mb: 4096
+    disk_mb: 16384
+"#,
+            base_dir = dir.path().display(),
+            ca_dir = dir.path().display(),
+            fc = fc.display(),
+            kernel = kernel.display(),
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
+        );
+
+        let config_path = dir.path().join("runner.yaml");
+        tokio::fs::write(&config_path, &yaml).await.unwrap();
+
+        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        assert!(
+            err.to_string().contains("complete marker") && err.to_string().contains("invalid"),
+            "expected invalid complete marker error, got: {err}"
         );
     }
 

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -360,6 +360,8 @@ mod tests {
                     snapshot.snapshot_bin(),
                     snapshot.memory_bin(),
                     snapshot.cow_img(),
+                    snapshot.cow_bitmap(),
+                    snapshot.complete_marker(),
                 ] {
                     tokio::fs::write(&path, b"").await.unwrap();
                 }
@@ -957,6 +959,65 @@ profiles:
         assert!(
             err.to_string().contains("not found"),
             "expected missing file error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_rejects_snapshot_without_complete_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        for f in [&fc, &kernel] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let rootfs = RootfsPaths::new(&home, TEST_ROOTFS_HASH);
+        tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
+        tokio::fs::write(rootfs.rootfs(), b"").await.unwrap();
+        let snapshot = rootfs.snapshot(TEST_SNAPSHOT_HASH);
+        tokio::fs::create_dir_all(snapshot.dir()).await.unwrap();
+        for path in [
+            snapshot.snapshot_bin(),
+            snapshot.memory_bin(),
+            snapshot.cow_img(),
+            snapshot.cow_bitmap(),
+        ] {
+            tokio::fs::write(&path, b"").await.unwrap();
+        }
+
+        let yaml = format!(
+            r#"
+name: test
+group: test/group
+base_dir: {base_dir}
+ca_dir: {ca_dir}
+firecracker:
+  binary: {fc}
+  kernel: {kernel}
+profiles:
+  vm0/default:
+    rootfs_hash: {hash}
+    snapshot_hash: {snap_hash}
+    vcpu: 2
+    memory_mb: 4096
+    disk_mb: 16384
+"#,
+            base_dir = dir.path().display(),
+            ca_dir = dir.path().display(),
+            fc = fc.display(),
+            kernel = kernel.display(),
+            hash = TEST_ROOTFS_HASH,
+            snap_hash = TEST_SNAPSHOT_HASH,
+        );
+
+        let config_path = dir.path().join("runner.yaml");
+        tokio::fs::write(&config_path, &yaml).await.unwrap();
+
+        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        assert!(
+            err.to_string().contains(".snapshot-complete"),
+            "expected missing complete marker error, got: {err}"
         );
     }
 

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -268,7 +268,7 @@ impl RootfsPaths {
 
 /// Paths for a snapshot build output, nested under a [`RootfsPaths`].
 ///
-/// Layout: `<images_dir>/<rootfs_hash>/snapshots/<snapshot_hash>/{snapshot.bin,memory.bin,cow.img}`
+/// Layout: `<images_dir>/<rootfs_hash>/snapshots/<snapshot_hash>/{snapshot.bin,memory.bin,cow.img,cow.img.bitmap,.snapshot-complete}`
 ///
 /// Constructed via [`RootfsPaths::snapshot`].
 pub struct SnapshotPaths {
@@ -292,9 +292,23 @@ impl SnapshotPaths {
         self.dir.join("cow.img")
     }
 
+    pub fn cow_bitmap(&self) -> PathBuf {
+        self.dir.join("cow.img.bitmap")
+    }
+
+    pub fn complete_marker(&self) -> PathBuf {
+        self.dir.join(".snapshot-complete")
+    }
+
     /// All files that must exist for the snapshot to be considered complete.
-    pub fn expected_files(&self) -> [PathBuf; 3] {
-        [self.snapshot_bin(), self.memory_bin(), self.cow_img()]
+    pub fn expected_files(&self) -> [PathBuf; 5] {
+        [
+            self.snapshot_bin(),
+            self.memory_bin(),
+            self.cow_img(),
+            self.cow_bitmap(),
+            self.complete_marker(),
+        ]
     }
 }
 
@@ -459,7 +473,15 @@ mod tests {
             sp.cow_img(),
             PathBuf::from("/test/images/aaa/snapshots/bbb/cow.img")
         );
-        assert_eq!(sp.expected_files().len(), 3);
+        assert_eq!(
+            sp.cow_bitmap(),
+            PathBuf::from("/test/images/aaa/snapshots/bbb/cow.img.bitmap")
+        );
+        assert_eq!(
+            sp.complete_marker(),
+            PathBuf::from("/test/images/aaa/snapshots/bbb/.snapshot-complete")
+        );
+        assert_eq!(sp.expected_files().len(), 5);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -23,4 +23,6 @@ pub use paths::{
 };
 pub use runtime::{FirecrackerRuntime, FirecrackerRuntimeProvider};
 pub use sandbox::FirecrackerSandbox;
-pub use snapshot::{FirecrackerSnapshotProvider, SnapshotError, create_snapshot};
+pub use snapshot::{
+    FirecrackerSnapshotProvider, SNAPSHOT_COMPLETE_MARKER_CONTENT, SnapshotError, create_snapshot,
+};

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -189,6 +189,11 @@ impl SnapshotOutputPaths {
         self.output_dir.join("cow.img.bitmap")
     }
 
+    /// Commit marker written only after all snapshot artifacts are published.
+    pub fn complete_marker(&self) -> PathBuf {
+        self.output_dir.join(".snapshot-complete")
+    }
+
     /// Work directory used during snapshot creation.
     /// Its layout is preserved as bind-mount targets during restore.
     pub fn work_dir(&self) -> PathBuf {
@@ -307,6 +312,15 @@ mod tests {
             output.cow_bitmap(),
             expected,
             "cow_bitmap() must be cow() + \".bitmap\" suffix"
+        );
+    }
+
+    #[test]
+    fn complete_marker_path_is_hidden_in_output_dir() {
+        let output = SnapshotOutputPaths::new(PathBuf::from("/data/images/abc123"));
+        assert_eq!(
+            output.complete_marker(),
+            PathBuf::from("/data/images/abc123/.snapshot-complete")
         );
     }
 }

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -27,7 +27,7 @@ const API_READY_TIMEOUT: Duration = Duration::from_secs(5);
 /// Timeout for waiting for the guest to connect via vsock after start.
 const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
-const SNAPSHOT_COMPLETE_MARKER_CONTENT: &[u8] = b"snapshot-complete-v1\n";
+pub const SNAPSHOT_COMPLETE_MARKER_CONTENT: &[u8] = b"snapshot-complete-v1\n";
 
 use crate::factory::{DESTROY_RETRIES, DESTROY_RETRY_DELAY};
 

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -1621,6 +1621,36 @@ mod tests {
         assert!(provider.is_complete(output.dir()).await.unwrap());
     }
 
+    #[tokio::test]
+    async fn snapshot_provider_rejects_valid_marker_with_missing_artifact() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = SnapshotOutputPaths::new(dir.path().to_path_buf());
+        tokio::fs::create_dir_all(output.dir())
+            .await
+            .expect("create output dir");
+
+        for artifact in [
+            output.snapshot(),
+            output.memory(),
+            output.cow(),
+            output.cow_bitmap(),
+        ] {
+            tokio::fs::write(&artifact, b"snapshot artifact")
+                .await
+                .unwrap_or_else(|e| panic!("write {}: {e}", artifact.display()));
+        }
+        publish_snapshot_complete_marker(&output).expect("publish complete marker");
+        tokio::fs::remove_file(output.cow_bitmap())
+            .await
+            .expect("remove cow bitmap");
+
+        let provider = FirecrackerSnapshotProvider;
+        assert!(
+            !provider.is_complete(output.dir()).await.unwrap(),
+            "valid marker must not hide a missing snapshot artifact"
+        );
+    }
+
     #[test]
     fn snapshot_attempt_cow_file_is_attempt_scoped() {
         let work = std::path::Path::new("/tmp/snapshot-work");

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -25,6 +26,8 @@ const API_READY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Timeout for waiting for the guest to connect via vsock after start.
 const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+const SNAPSHOT_COMPLETE_MARKER_CONTENT: &[u8] = b"snapshot-complete-v1\n";
 
 use crate::factory::{DESTROY_RETRIES, DESTROY_RETRY_DELAY};
 
@@ -127,6 +130,11 @@ async fn prepare_snapshot_output(output: &SnapshotOutputPaths) -> Result<PathBuf
     //
     // Only remove snapshot-specific artifacts, not the entire output directory.
     let work = output.work_dir();
+    match tokio::fs::remove_file(output.complete_marker()).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e.into()),
+    }
     let _ = tokio::fs::remove_dir_all(&work).await;
     for stale in [
         output.snapshot(),
@@ -225,6 +233,57 @@ async fn cleanup_snapshot_attempt_dir_for_cow(cow_file: &Path) -> bool {
             );
             false
         }
+    }
+}
+
+async fn sync_snapshot_output_dir(output: &SnapshotOutputPaths) -> Result<(), SnapshotError> {
+    let dir = tokio::fs::File::open(output.dir()).await?;
+    dir.sync_all().await?;
+    Ok(())
+}
+
+fn publish_snapshot_complete_marker(output: &SnapshotOutputPaths) -> Result<(), SnapshotError> {
+    fn write_and_sync(output: &SnapshotOutputPaths) -> std::io::Result<()> {
+        for artifact in [
+            output.snapshot(),
+            output.memory(),
+            output.cow(),
+            output.cow_bitmap(),
+        ] {
+            std::fs::metadata(artifact)?;
+        }
+
+        let marker = output.complete_marker();
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&marker)?;
+        file.write_all(SNAPSHOT_COMPLETE_MARKER_CONTENT)?;
+        file.sync_all()?;
+        drop(file);
+
+        std::fs::File::open(output.dir())?.sync_all()?;
+        Ok(())
+    }
+
+    if let Err(e) = write_and_sync(output) {
+        // If marker publication fails after creating the file, remove it so
+        // future readers do not treat an uncommitted publish as complete.
+        let _ = std::fs::remove_file(output.complete_marker());
+        let _ = std::fs::File::open(output.dir()).and_then(|dir| dir.sync_all());
+        return Err(SnapshotError::Io(e));
+    }
+
+    Ok(())
+}
+
+async fn snapshot_complete_marker_present(
+    output: &SnapshotOutputPaths,
+) -> Result<bool, sandbox::SnapshotError> {
+    match tokio::fs::read(output.complete_marker()).await {
+        Ok(content) => Ok(content == SNAPSHOT_COMPLETE_MARKER_CONTENT),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e.into()),
     }
 }
 
@@ -398,7 +457,7 @@ async fn finalize_snapshot_cow_output(
     tokio::fs::rename(&kept_cow.bitmap_file, &output.cow_bitmap()).await?;
     tokio::fs::rename(&kept_cow.cow_file, &output.cow()).await?;
     cleanup_snapshot_attempt_dir_for_cow(&kept_cow.cow_file).await;
-    // Persist the output directory so all four final dir entries
+    // Persist the output directory so all four artifact dir entries
     // (snapshot.bin and memory.bin written by Firecracker via the API,
     // cow.img and cow.img.bitmap just renamed in) are durable. Without
     // this fsync, rename(2) and Firecracker's creates return once the
@@ -408,8 +467,13 @@ async fn finalize_snapshot_cow_output(
     // missing or rolled back — worst case, cow.img present but
     // cow.img.bitmap absent, which silently corrupts restore reads
     // (same failure class as #9794, one layer up).
-    let dir = tokio::fs::File::open(output.dir()).await?;
-    dir.sync_all().await?;
+    sync_snapshot_output_dir(output).await?;
+
+    // Commit point: the marker is written only after all artifacts are present
+    // and the output directory has been synced. Marker publication uses a
+    // synchronous no-await section so async cancellation cannot stop between
+    // marker visibility and the marker directory fsync.
+    publish_snapshot_complete_marker(output)?;
     Ok(())
 }
 
@@ -1398,6 +1462,9 @@ impl SnapshotProvider for FirecrackerSnapshotProvider {
 
     async fn is_complete(&self, output_dir: &Path) -> Result<bool, sandbox::SnapshotError> {
         let output = SnapshotOutputPaths::new(output_dir.to_path_buf());
+        if !snapshot_complete_marker_present(&output).await? {
+            return Ok(false);
+        }
         for path in [
             output.snapshot(),
             output.memory(),
@@ -1438,6 +1505,7 @@ mod tests {
             output.memory(),
             output.cow(),
             output.cow_bitmap(),
+            output.complete_marker(),
         ] {
             tokio::fs::write(&artifact, b"stale")
                 .await
@@ -1462,6 +1530,7 @@ mod tests {
             output.memory(),
             output.cow(),
             output.cow_bitmap(),
+            output.complete_marker(),
         ] {
             assert!(
                 !tokio::fs::try_exists(&artifact).await.unwrap(),
@@ -1494,10 +1563,61 @@ mod tests {
             !provider.is_complete(output.dir()).await.unwrap(),
             "snapshot without dirty bitmap sidecar must be incomplete"
         );
+        assert!(
+            publish_snapshot_complete_marker(&output).is_err(),
+            "complete marker publication must fail before all artifacts exist"
+        );
+        assert!(
+            !tokio::fs::try_exists(output.complete_marker())
+                .await
+                .unwrap(),
+            "failed marker publication must not leave a marker behind"
+        );
 
         tokio::fs::write(output.cow_bitmap(), b"bitmap")
             .await
             .expect("write cow bitmap");
+        publish_snapshot_complete_marker(&output).expect("publish complete marker");
+        assert!(provider.is_complete(output.dir()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn snapshot_provider_requires_complete_marker_for_complete_snapshot() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = SnapshotOutputPaths::new(dir.path().to_path_buf());
+        tokio::fs::create_dir_all(output.dir())
+            .await
+            .expect("create output dir");
+
+        for artifact in [
+            output.snapshot(),
+            output.memory(),
+            output.cow(),
+            output.cow_bitmap(),
+        ] {
+            tokio::fs::write(&artifact, b"snapshot artifact")
+                .await
+                .unwrap_or_else(|e| panic!("write {}: {e}", artifact.display()));
+        }
+
+        let provider = FirecrackerSnapshotProvider;
+        assert!(
+            !provider.is_complete(output.dir()).await.unwrap(),
+            "snapshot artifacts without complete marker must be incomplete"
+        );
+
+        tokio::fs::write(output.complete_marker(), b"wrong marker")
+            .await
+            .expect("write malformed marker");
+        assert!(
+            !provider.is_complete(output.dir()).await.unwrap(),
+            "malformed complete marker must not commit the snapshot"
+        );
+
+        tokio::fs::remove_file(output.complete_marker())
+            .await
+            .expect("remove malformed marker");
+        publish_snapshot_complete_marker(&output).expect("publish complete marker");
         assert!(provider.is_complete(output.dir()).await.unwrap());
     }
 

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -59,7 +59,7 @@ pub struct SandboxConfig {
 /// Reference to a pre-built snapshot for fast VM boot.
 /// The backend resolves individual artifact paths from the output directory.
 pub struct SnapshotRef {
-    /// Directory containing snapshot artifacts (snapshot.bin, memory.bin, cow.img).
+    /// Directory containing backend-specific snapshot artifacts.
     pub output_dir: PathBuf,
     /// Content hash of the snapshot, used as an identifier for path derivation.
     pub hash: String,

--- a/crates/sandbox/src/snapshot.rs
+++ b/crates/sandbox/src/snapshot.rs
@@ -99,6 +99,6 @@ pub trait SnapshotProvider: Send + Sync {
     /// Used by the runner to build a composite cache key for snapshots.
     fn config_hash(&self) -> String;
 
-    /// Check whether all expected snapshot artifacts exist in the output directory.
+    /// Check whether the output directory contains a complete provider-specific snapshot.
     async fn is_complete(&self, output_dir: &Path) -> Result<bool, SnapshotError>;
 }


### PR DESCRIPTION
## Summary

- add a `.snapshot-complete` commit marker for snapshot publish success
- require the marker plus snapshot/memory/COW/bitmap artifacts in build completeness checks
- invalidate old local snapshot cache entries and update runner config validation to require bitmap + marker

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc -p runner --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `git diff --check`

Closes #11818