### PR TITLE
feat(connector): add chatgpt-oauth provider handler with pkce and token refresh

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -6,6 +6,7 @@ import { cn } from "@vm0/ui";
 
 const CONNECTOR_ICON_ALIASES = {
   "slack-webhook": "slack",
+  "chatgpt-oauth": "openai",
 } as const satisfies Partial<Record<ConnectorType, ConnectorType>>;
 
 export const CONNECTOR_ICONS: Readonly<Record<ConnectorType, string>> =

--- a/turbo/apps/web/src/lib/zero/connector/provider-registry.ts
+++ b/turbo/apps/web/src/lib/zero/connector/provider-registry.ts
@@ -114,6 +114,7 @@ import { neonHandler } from "./providers/neon-handler";
 import { notionHandler } from "./providers/notion-handler";
 import { onyxHandler } from "./providers/onyx-handler";
 import { openaiHandler } from "./providers/openai-handler";
+import { chatgptOauthHandler } from "./providers/chatgpt-oauth-handler";
 import { redditHandler } from "./providers/reddit-handler";
 import { reporteiHandler } from "./providers/reportei-handler";
 import { serpapiHandler } from "./providers/serpapi-handler";
@@ -292,6 +293,7 @@ export const PROVIDER_HANDLERS: Record<
   notion: notionHandler,
   onyx: onyxHandler,
   openai: openaiHandler,
+  "chatgpt-oauth": chatgptOauthHandler,
   "outlook-calendar": outlookCalendarHandler,
   "outlook-mail": outlookMailHandler,
   reddit: redditHandler,

--- a/turbo/apps/web/src/lib/zero/connector/providers/__tests__/chatgpt-oauth.test.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/__tests__/chatgpt-oauth.test.ts
@@ -1,0 +1,520 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { HttpResponse } from "msw";
+import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
+import { server } from "../../../../../mocks/server";
+import { http } from "../../../../../__tests__/msw";
+import { testContext } from "../../../../../__tests__/test-helpers";
+import { PROVIDER_HANDLERS } from "../../provider-registry";
+import {
+  buildChatgptAuthorizationUrl,
+  exchangeChatgptCode,
+  refreshChatgptToken,
+  revokeChatgptToken,
+  getChatgptSecretName,
+  getChatgptRefreshSecretName,
+  isChatgptRefreshError,
+  type ChatgptRefreshError,
+  CHATGPT_OAUTH_CLIENT_ID,
+  CHATGPT_OAUTH_ISSUER,
+  CHATGPT_OAUTH_SCOPES,
+} from "../chatgpt-oauth";
+import { chatgptOauthHandler } from "../chatgpt-oauth-handler";
+
+const TOKEN_URL = `${CHATGPT_OAUTH_ISSUER}/oauth/token`;
+const REVOKE_URL = `${CHATGPT_OAUTH_ISSUER}/oauth/revoke`;
+
+const context = testContext();
+
+function base64UrlEncode(input: string): string {
+  return Buffer.from(input, "utf-8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = base64UrlEncode(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const body = base64UrlEncode(JSON.stringify(payload));
+  return `${header}.${body}.fake-signature`;
+}
+
+interface IdTokenOpts {
+  accountId?: string;
+  planType?: string;
+  workspaceName?: string;
+  workspaceClaim?:
+    | "organization.title"
+    | "workspace.name"
+    | "chatgpt_workspace_name";
+  exp?: number;
+  omitAuth?: boolean;
+}
+
+function makeIdToken(opts: IdTokenOpts = {}): string {
+  if (opts.omitAuth) {
+    return makeJwt({ exp: opts.exp ?? Math.floor(Date.now() / 1000) + 3600 });
+  }
+  const auth: Record<string, unknown> = {};
+  if (opts.accountId !== undefined) {
+    auth.chatgpt_account_id = opts.accountId;
+  }
+  if (opts.planType !== undefined) {
+    auth.chatgpt_plan_type = opts.planType;
+  }
+  if (opts.workspaceName !== undefined) {
+    if (opts.workspaceClaim === "organization.title") {
+      auth.organization = { title: opts.workspaceName };
+    } else if (opts.workspaceClaim === "workspace.name") {
+      auth.workspace = { name: opts.workspaceName };
+    } else {
+      auth.chatgpt_workspace_name = opts.workspaceName;
+    }
+  }
+  return makeJwt({
+    "https://api.openai.com/auth": auth,
+    exp: opts.exp ?? Math.floor(Date.now() / 1000) + 3600,
+  });
+}
+
+async function sha256Base64Url(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return Buffer.from(new Uint8Array(hash))
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+describe("connector/providers/chatgpt-oauth", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  describe("buildChatgptAuthorizationUrl", () => {
+    it("builds URL with required PKCE params and scopes", async () => {
+      const result = await buildChatgptAuthorizationUrl(
+        "ignored-client-id",
+        "https://example.com/callback",
+        "test-state",
+      );
+
+      const url = new URL(result.url);
+      expect(url.origin + url.pathname).toBe(
+        `${CHATGPT_OAUTH_ISSUER}/oauth/authorize`,
+      );
+      expect(url.searchParams.get("response_type")).toBe("code");
+      expect(url.searchParams.get("client_id")).toBe(CHATGPT_OAUTH_CLIENT_ID);
+      expect(url.searchParams.get("redirect_uri")).toBe(
+        "https://example.com/callback",
+      );
+      expect(url.searchParams.get("scope")).toBe(CHATGPT_OAUTH_SCOPES);
+      expect(url.searchParams.get("state")).toBe("test-state");
+      expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+      expect(url.searchParams.get("id_token_add_organizations")).toBe("true");
+    });
+
+    it("returns a code_verifier in the base64url charset", async () => {
+      const result = await buildChatgptAuthorizationUrl(
+        "x",
+        "https://example.com/cb",
+        "s",
+      );
+      expect(result.codeVerifier.length).toBeGreaterThanOrEqual(43);
+      expect(result.codeVerifier.length).toBeLessThanOrEqual(128);
+      expect(result.codeVerifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it("computes the code_challenge as S256 of the returned verifier", async () => {
+      const result = await buildChatgptAuthorizationUrl(
+        "x",
+        "https://example.com/cb",
+        "s",
+      );
+      const url = new URL(result.url);
+      const challenge = url.searchParams.get("code_challenge");
+      expect(challenge).toBeTruthy();
+      expect(challenge).toBe(await sha256Base64Url(result.codeVerifier));
+    });
+  });
+
+  describe("exchangeChatgptCode", () => {
+    it("exchanges code for tokens and decodes id_token claims", async () => {
+      const idToken = makeIdToken({
+        accountId: "acc-123",
+        planType: "plus",
+        workspaceName: "Acme Org",
+        workspaceClaim: "organization.title",
+      });
+      const { handler } = http.post(TOKEN_URL, async ({ request }) => {
+        const body = await request.text();
+        const params = new URLSearchParams(body);
+        expect(params.get("grant_type")).toBe("authorization_code");
+        expect(params.get("code")).toBe("auth-code");
+        expect(params.get("redirect_uri")).toBe("https://example.com/cb");
+        expect(params.get("client_id")).toBe(CHATGPT_OAUTH_CLIENT_ID);
+        expect(params.get("code_verifier")).toBe("verifier-xyz");
+        return HttpResponse.json({
+          id_token: idToken,
+          access_token: "at-1",
+          refresh_token: "rt-1",
+          expires_in: 600000,
+          scope: CHATGPT_OAUTH_SCOPES,
+        });
+      });
+      server.use(handler);
+
+      const result = await exchangeChatgptCode(
+        "ignored",
+        "ignored",
+        "auth-code",
+        "https://example.com/cb",
+        "verifier-xyz",
+      );
+
+      expect(result.accessToken).toBe("at-1");
+      expect(result.refreshToken).toBe("rt-1");
+      expect(result.idToken).toBe(idToken);
+      expect(result.accountId).toBe("acc-123");
+      expect(result.planType).toBe("plus");
+      expect(result.workspaceName).toBe("Acme Org");
+      expect(result.expiresIn).toBe(600000);
+      expect(result.scopes).toEqual(CHATGPT_OAUTH_SCOPES.split(" "));
+    });
+
+    it("extracts workspace name from workspace.name claim", async () => {
+      const idToken = makeIdToken({
+        accountId: "a",
+        planType: "pro",
+        workspaceName: "Workspace Alpha",
+        workspaceClaim: "workspace.name",
+      });
+      const { handler } = http.post(TOKEN_URL, () => {
+        return HttpResponse.json({
+          id_token: idToken,
+          access_token: "at",
+          refresh_token: "rt",
+        });
+      });
+      server.use(handler);
+
+      const result = await exchangeChatgptCode(
+        "x",
+        "x",
+        "c",
+        "https://example.com/cb",
+        "v",
+      );
+      expect(result.workspaceName).toBe("Workspace Alpha");
+    });
+
+    it("extracts workspace name from chatgpt_workspace_name claim as fallback", async () => {
+      const idToken = makeIdToken({
+        accountId: "a",
+        planType: "business",
+        workspaceName: "Fallback WS",
+        workspaceClaim: "chatgpt_workspace_name",
+      });
+      const { handler } = http.post(TOKEN_URL, () => {
+        return HttpResponse.json({
+          id_token: idToken,
+          access_token: "at",
+          refresh_token: "rt",
+        });
+      });
+      server.use(handler);
+
+      const result = await exchangeChatgptCode(
+        "x",
+        "x",
+        "c",
+        "https://example.com/cb",
+        "v",
+      );
+      expect(result.workspaceName).toBe("Fallback WS");
+    });
+
+    it("returns null workspace name when no workspace claim is present", async () => {
+      const idToken = makeIdToken({ accountId: "a", planType: "plus" });
+      const { handler } = http.post(TOKEN_URL, () => {
+        return HttpResponse.json({
+          id_token: idToken,
+          access_token: "at",
+          refresh_token: "rt",
+        });
+      });
+      server.use(handler);
+
+      const result = await exchangeChatgptCode(
+        "x",
+        "x",
+        "c",
+        "https://example.com/cb",
+        "v",
+      );
+      expect(result.workspaceName).toBeNull();
+    });
+
+    it("rejects free plan_type", async () => {
+      const idToken = makeIdToken({ accountId: "a", planType: "free" });
+      const { handler } = http.post(TOKEN_URL, () => {
+        return HttpResponse.json({
+          id_token: idToken,
+          access_token: "at",
+          refresh_token: "rt",
+        });
+      });
+      server.use(handler);
+
+      await expect(
+        exchangeChatgptCode("x", "x", "c", "https://example.com/cb", "v"),
+      ).rejects.toThrow(/free plan/i);
+    });
+
+    it("throws when id_token is missing required auth claims", async () => {
+      const idToken = makeIdToken({ omitAuth: true });
+      const { handler } = http.post(TOKEN_URL, () => {
+        return HttpResponse.json({
+          id_token: idToken,
+          access_token: "at",
+          refresh_token: "rt",
+        });
+      });
+      server.use(handler);
+
+      await expect(
+        exchangeChatgptCode("x", "x", "c", "https://example.com/cb", "v"),
+      ).rejects.toThrow(/missing required auth claims/);
+    });
+
+    it("throws when token endpoint returns HTTP error", async () => {
+      const { handler } = http.post(TOKEN_URL, () => {
+        return new HttpResponse("Internal Server Error", { status: 500 });
+      });
+      server.use(handler);
+
+      await expect(
+        exchangeChatgptCode("x", "x", "c", "https://example.com/cb", "v"),
+      ).rejects.toThrow(/ChatGPT token exchange failed/);
+    });
+
+    it("throws when response is missing tokens", async () => {
+      const { handler } = http.post(TOKEN_URL, () => {
+        return HttpResponse.json({});
+      });
+      server.use(handler);
+
+      await expect(
+        exchangeChatgptCode("x", "x", "c", "https://example.com/cb", "v"),
+      ).rejects.toThrow(/missing tokens/);
+    });
+  });
+
+  describe("refreshChatgptToken", () => {
+    it("refreshes access token and returns rotated refresh token", async () => {
+      const { handler } = http.post(TOKEN_URL, async ({ request }) => {
+        expect(request.headers.get("content-type")).toBe("application/json");
+        const body = (await request.json()) as Record<string, unknown>;
+        expect(body.client_id).toBe(CHATGPT_OAUTH_CLIENT_ID);
+        expect(body.grant_type).toBe("refresh_token");
+        expect(body.refresh_token).toBe("old-rt");
+        return HttpResponse.json({
+          access_token: "new-at",
+          refresh_token: "new-rt",
+          expires_in: 600000,
+        });
+      });
+      server.use(handler);
+
+      const result = await refreshChatgptToken("x", "x", "old-rt");
+      expect(result.accessToken).toBe("new-at");
+      expect(result.refreshToken).toBe("new-rt");
+      expect(result.expiresIn).toBe(600000);
+    });
+
+    it("returns null refresh token when response omits it", async () => {
+      const { handler } = http.post(TOKEN_URL, () => {
+        return HttpResponse.json({ access_token: "new-at" });
+      });
+      server.use(handler);
+
+      const result = await refreshChatgptToken("x", "x", "old-rt");
+      expect(result.accessToken).toBe("new-at");
+      expect(result.refreshToken).toBeNull();
+    });
+
+    it("classifies refresh_token_expired into ChatgptRefreshError", async () => {
+      const { handler } = http.post(TOKEN_URL, () => {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "refresh_token_expired",
+              message: "token expired",
+            },
+          },
+          { status: 401 },
+        );
+      });
+      server.use(handler);
+
+      await expect(
+        refreshChatgptToken("x", "x", "old-rt"),
+      ).rejects.toMatchObject({
+        name: "ChatgptRefreshError",
+        code: "refresh_token_expired",
+      });
+    });
+
+    it("classifies refresh_token_reused into ChatgptRefreshError", async () => {
+      const { handler } = http.post(TOKEN_URL, () => {
+        return HttpResponse.json(
+          { error: { code: "refresh_token_reused", message: "reused" } },
+          { status: 401 },
+        );
+      });
+      server.use(handler);
+
+      await expect(
+        refreshChatgptToken("x", "x", "old-rt"),
+      ).rejects.toMatchObject({
+        name: "ChatgptRefreshError",
+        code: "refresh_token_reused",
+      });
+    });
+
+    it("classifies refresh_token_invalidated into ChatgptRefreshError", async () => {
+      const { handler } = http.post(TOKEN_URL, () => {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "refresh_token_invalidated",
+              message: "invalidated",
+            },
+          },
+          { status: 401 },
+        );
+      });
+      server.use(handler);
+
+      const error = await refreshChatgptToken("x", "x", "old-rt").catch(
+        (e: unknown) => {
+          return e;
+        },
+      );
+      expect(isChatgptRefreshError(error)).toBe(true);
+      expect((error as ChatgptRefreshError).code).toBe(
+        "refresh_token_invalidated",
+      );
+    });
+
+    it("classifies unknown 401 codes into refresh_token_other", async () => {
+      const { handler } = http.post(TOKEN_URL, () => {
+        return HttpResponse.json(
+          { error: { code: "weird_unrelated_error", message: "huh" } },
+          { status: 401 },
+        );
+      });
+      server.use(handler);
+
+      const error = await refreshChatgptToken("x", "x", "old-rt").catch(
+        (e: unknown) => {
+          return e;
+        },
+      );
+      expect(isChatgptRefreshError(error)).toBe(true);
+      expect((error as ChatgptRefreshError).code).toBe("refresh_token_other");
+    });
+
+    it("throws non-typed error on 5xx so caller can retry", async () => {
+      const { handler } = http.post(TOKEN_URL, () => {
+        return new HttpResponse("Bad Gateway", { status: 502 });
+      });
+      server.use(handler);
+
+      const error = await refreshChatgptToken("x", "x", "old-rt").catch(
+        (e: unknown) => {
+          return e;
+        },
+      );
+      expect(error).toBeInstanceOf(Error);
+      expect(isChatgptRefreshError(error)).toBe(false);
+    });
+
+    it("throws when refresh response is missing access_token", async () => {
+      const { handler } = http.post(TOKEN_URL, () => {
+        return HttpResponse.json({});
+      });
+      server.use(handler);
+
+      await expect(refreshChatgptToken("x", "x", "old-rt")).rejects.toThrow(
+        /No access token in ChatGPT refresh response/,
+      );
+    });
+  });
+
+  describe("revokeChatgptToken", () => {
+    it("posts to revoke endpoint and resolves on 200", async () => {
+      const { handler } = http.post(REVOKE_URL, async ({ request }) => {
+        const body = await request.text();
+        const params = new URLSearchParams(body);
+        expect(params.get("token")).toBe("at-to-revoke");
+        return new HttpResponse(null, { status: 200 });
+      });
+      server.use(handler);
+
+      await expect(
+        revokeChatgptToken("x", "x", "at-to-revoke"),
+      ).resolves.toBeUndefined();
+    });
+
+    it("throws on non-2xx status", async () => {
+      const { handler } = http.post(REVOKE_URL, () => {
+        return new HttpResponse("forbidden", { status: 403 });
+      });
+      server.use(handler);
+
+      await expect(revokeChatgptToken("x", "x", "at")).rejects.toThrow(
+        /ChatGPT token revoke failed/,
+      );
+    });
+  });
+
+  describe("chatgptOauthHandler", () => {
+    it("is registered in PROVIDER_HANDLERS under chatgpt-oauth key", () => {
+      expect(PROVIDER_HANDLERS["chatgpt-oauth"]).toBe(chatgptOauthHandler);
+    });
+
+    it("getClientId returns the hardcoded Codex public client_id", () => {
+      const env = {} as Parameters<typeof chatgptOauthHandler.getClientId>[0];
+      expect(chatgptOauthHandler.getClientId(env)).toBe(
+        CHATGPT_OAUTH_CLIENT_ID,
+      );
+    });
+
+    it("getClientSecret returns undefined (PKCE-only)", () => {
+      const env = {} as Parameters<
+        typeof chatgptOauthHandler.getClientSecret
+      >[0];
+      expect(chatgptOauthHandler.getClientSecret(env)).toBeUndefined();
+    });
+
+    it("returns documented secret names", () => {
+      expect(getChatgptSecretName()).toBe("CHATGPT_ACCESS_TOKEN");
+      expect(getChatgptRefreshSecretName()).toBe("CHATGPT_REFRESH_TOKEN");
+    });
+  });
+
+  describe("registry/implementation drift guard", () => {
+    it("connector entry oauth URLs match the implementation constants", () => {
+      const connector = CONNECTOR_TYPES["chatgpt-oauth"];
+      expect(connector.oauth?.authorizationUrl).toBe(
+        `${CHATGPT_OAUTH_ISSUER}/oauth/authorize`,
+      );
+      expect(connector.oauth?.tokenUrl).toBe(
+        `${CHATGPT_OAUTH_ISSUER}/oauth/token`,
+      );
+      expect(connector.oauth?.scopes.join(" ")).toBe(CHATGPT_OAUTH_SCOPES);
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/zero/connector/providers/__tests__/chatgpt-oauth.test.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/__tests__/chatgpt-oauth.test.ts
@@ -516,5 +516,29 @@ describe("connector/providers/chatgpt-oauth", () => {
       );
       expect(connector.oauth?.scopes.join(" ")).toBe(CHATGPT_OAUTH_SCOPES);
     });
+
+    it("connector oauth entry exposes only authorizationUrl/tokenUrl/scopes (PKCE-only, no clientId)", () => {
+      // Wave 2's refresh pipeline reads client identity through the handler,
+      // not the registry — assert structurally that the registry oauth entry
+      // does not leak a `clientId` (or any unexpected key) so the PKCE-only
+      // boundary stays explicit.
+      const oauth = CONNECTOR_TYPES["chatgpt-oauth"].oauth;
+      expect(oauth).toBeDefined();
+      expect(Object.keys(oauth ?? {}).sort()).toEqual([
+        "authorizationUrl",
+        "scopes",
+        "tokenUrl",
+      ]);
+    });
+
+    it("handler client identity matches the implementation constant (PKCE-only)", () => {
+      // Pair check: registry has no clientId, handler resolves to the
+      // canonical Codex public client_id, and getClientSecret stays undefined.
+      const env = {} as Parameters<typeof chatgptOauthHandler.getClientId>[0];
+      expect(chatgptOauthHandler.getClientId(env)).toBe(
+        CHATGPT_OAUTH_CLIENT_ID,
+      );
+      expect(chatgptOauthHandler.getClientSecret(env)).toBeUndefined();
+    });
   });
 });

--- a/turbo/apps/web/src/lib/zero/connector/providers/chatgpt-oauth-handler.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/chatgpt-oauth-handler.ts
@@ -1,0 +1,56 @@
+import { type ProviderHandler } from "../provider-types";
+import {
+  CHATGPT_OAUTH_CLIENT_ID,
+  buildChatgptAuthorizationUrl,
+  exchangeChatgptCode,
+  getChatgptRefreshSecretName,
+  getChatgptSecretName,
+  refreshChatgptToken,
+  revokeChatgptToken,
+} from "./chatgpt-oauth";
+
+export const chatgptOauthHandler: ProviderHandler = {
+  buildAuthUrl: buildChatgptAuthorizationUrl,
+  async exchangeCode(
+    clientId,
+    clientSecret,
+    code,
+    redirectUri,
+    _state,
+    codeVerifier,
+  ) {
+    if (!codeVerifier) {
+      throw new Error(
+        "ChatGPT OAuth requires PKCE code_verifier for token exchange",
+      );
+    }
+    const result = await exchangeChatgptCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+      codeVerifier,
+    );
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresIn: result.expiresIn,
+      scopes: result.scopes,
+      userInfo: {
+        id: result.accountId,
+        username: result.workspaceName,
+        email: null,
+      },
+    };
+  },
+  refreshToken: refreshChatgptToken,
+  revokeToken: revokeChatgptToken,
+  getClientId: () => {
+    return CHATGPT_OAUTH_CLIENT_ID;
+  },
+  getClientSecret: () => {
+    return undefined;
+  },
+  getSecretName: getChatgptSecretName,
+  getRefreshSecretName: getChatgptRefreshSecretName,
+};

--- a/turbo/apps/web/src/lib/zero/connector/providers/chatgpt-oauth.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/chatgpt-oauth.ts
@@ -1,0 +1,337 @@
+import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
+
+export const CHATGPT_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+export const CHATGPT_OAUTH_ISSUER = "https://auth.openai.com";
+export const CHATGPT_OAUTH_SCOPES =
+  "openid profile email offline_access api.connectors.read api.connectors.invoke";
+
+const TOKEN_URL = `${CHATGPT_OAUTH_ISSUER}/oauth/token`;
+const AUTHORIZE_URL = `${CHATGPT_OAUTH_ISSUER}/oauth/authorize`;
+const REVOKE_URL = `${CHATGPT_OAUTH_ISSUER}/oauth/revoke`;
+
+export type ChatgptRefreshErrorCode =
+  | "refresh_token_expired"
+  | "refresh_token_reused"
+  | "refresh_token_invalidated"
+  | "refresh_token_other";
+
+/**
+ * Typed error for refresh-token failures so the firewall pipeline can
+ * distinguish stale-token cases (must re-OAuth) from transient HTTP errors
+ * (retry next time).
+ */
+export interface ChatgptRefreshError extends Error {
+  readonly name: "ChatgptRefreshError";
+  readonly code: ChatgptRefreshErrorCode;
+}
+
+function createChatgptRefreshError(
+  code: ChatgptRefreshErrorCode,
+  message: string,
+): ChatgptRefreshError {
+  const err = new Error(message);
+  err.name = "ChatgptRefreshError";
+  Object.assign(err, { code });
+  return err as ChatgptRefreshError;
+}
+
+export function isChatgptRefreshError(
+  value: unknown,
+): value is ChatgptRefreshError {
+  return (
+    value instanceof Error &&
+    value.name === "ChatgptRefreshError" &&
+    typeof (value as { code?: unknown }).code === "string"
+  );
+}
+
+interface ChatgptExchangeResult {
+  accessToken: string;
+  refreshToken: string;
+  idToken: string;
+  accountId: string;
+  planType: string;
+  workspaceName: string | null;
+  expiresIn: number;
+  scopes: string[];
+}
+
+interface ChatgptRefreshResult {
+  accessToken: string;
+  refreshToken: string | null;
+  expiresIn?: number;
+}
+
+function generateCodeVerifier(): string {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  return btoa(String.fromCharCode(...array))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+async function computeCodeChallenge(codeVerifier: string): Promise<string> {
+  const data = new TextEncoder().encode(codeVerifier);
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return btoa(String.fromCharCode(...new Uint8Array(hash)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+// Skip JWT signature verification: the response is over TLS to auth.openai.com
+// from a request we initiated, and the access_token is the auth-bearing artifact
+// validated server-side by the ChatGPT backend. Codex's official client also
+// does not verify locally.
+function decodeJwtPayload(token: string): unknown {
+  const parts = token.split(".");
+  const payload = parts[1];
+  if (parts.length !== 3 || !payload) {
+    throw new Error("Invalid JWT structure");
+  }
+  const padded = payload.replace(/-/g, "+").replace(/_/g, "/");
+  const padding =
+    padded.length % 4 === 0 ? "" : "=".repeat(4 - (padded.length % 4));
+  const json = Buffer.from(padded + padding, "base64").toString("utf-8");
+  return JSON.parse(json);
+}
+
+const chatgptAuthClaimsSchema = z
+  .object({
+    chatgpt_account_id: z.string().optional(),
+    chatgpt_plan_type: z.string().optional(),
+    organization: z
+      .object({ title: z.string().optional() })
+      .partial()
+      .optional(),
+    workspace: z.object({ name: z.string().optional() }).partial().optional(),
+    chatgpt_workspace_name: z.string().optional(),
+  })
+  .passthrough();
+
+const chatgptIdTokenClaimsSchema = z
+  .object({
+    exp: z.number().optional(),
+    "https://api.openai.com/auth": chatgptAuthClaimsSchema.optional(),
+  })
+  .passthrough();
+
+type ChatgptAuthClaims = z.infer<typeof chatgptAuthClaimsSchema>;
+
+function extractWorkspaceName(authClaims: ChatgptAuthClaims): string | null {
+  return (
+    authClaims.organization?.title ??
+    authClaims.workspace?.name ??
+    authClaims.chatgpt_workspace_name ??
+    null
+  );
+}
+
+const exchangeResponseSchema = z.object({
+  id_token: z.string().optional(),
+  access_token: z.string().optional(),
+  refresh_token: z.string().optional(),
+  expires_in: z.number().optional(),
+  scope: z.string().optional(),
+  error: z.string().optional(),
+  error_description: z.string().optional(),
+});
+
+const refreshResponseSchema = z.object({
+  id_token: z.string().optional(),
+  access_token: z.string().optional(),
+  refresh_token: z.string().nullable().optional(),
+  expires_in: z.number().optional(),
+});
+
+const refreshErrorBodySchema = z.object({
+  error: z
+    .object({
+      code: z.string().optional(),
+      message: z.string().optional(),
+    })
+    .optional(),
+});
+
+/**
+ * Build the ChatGPT OAuth authorize URL with PKCE (S256).
+ * The clientId parameter from the ProviderHandler interface is ignored —
+ * ChatGPT's OAuth uses the public Codex client_id.
+ */
+export async function buildChatgptAuthorizationUrl(
+  _clientId: string,
+  redirectUri: string,
+  state: string,
+): Promise<{ url: string; codeVerifier: string }> {
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = await computeCodeChallenge(codeVerifier);
+
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: CHATGPT_OAUTH_CLIENT_ID,
+    redirect_uri: redirectUri,
+    scope: CHATGPT_OAUTH_SCOPES,
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    id_token_add_organizations: "true",
+  });
+
+  return {
+    url: `${AUTHORIZE_URL}?${params.toString()}`,
+    codeVerifier,
+  };
+}
+
+/**
+ * Exchange an authorization code for ChatGPT tokens via PKCE.
+ * Decodes the id_token to extract account_id, plan_type, and workspace name.
+ * Rejects free-plan accounts.
+ */
+export async function exchangeChatgptCode(
+  _clientId: string,
+  _clientSecret: string,
+  code: string,
+  redirectUri: string,
+  codeVerifier: string,
+): Promise<ChatgptExchangeResult> {
+  const response = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri,
+      client_id: CHATGPT_OAUTH_CLIENT_ID,
+      code_verifier: codeVerifier,
+    }),
+  });
+
+  if (!response.ok) {
+    await throwOAuthError("ChatGPT", "exchange", response);
+  }
+
+  const data = exchangeResponseSchema.parse(await response.json());
+  if (data.error) {
+    throw new Error(data.error_description ?? data.error);
+  }
+  if (!data.access_token || !data.refresh_token || !data.id_token) {
+    throw new Error("ChatGPT exchange response missing tokens");
+  }
+
+  const claims = chatgptIdTokenClaimsSchema.parse(
+    decodeJwtPayload(data.id_token),
+  );
+  const auth = claims["https://api.openai.com/auth"];
+  if (!auth?.chatgpt_account_id || !auth.chatgpt_plan_type) {
+    throw new Error("ChatGPT id_token missing required auth claims");
+  }
+  if (auth.chatgpt_plan_type === "free") {
+    throw new Error(
+      "ChatGPT free plan is not supported — upgrade to Plus, Pro, Business, Edu, or Enterprise",
+    );
+  }
+
+  const expiresIn =
+    data.expires_in ??
+    (claims.exp ? claims.exp - Math.floor(Date.now() / 1000) : 0);
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    idToken: data.id_token,
+    accountId: auth.chatgpt_account_id,
+    planType: auth.chatgpt_plan_type,
+    workspaceName: extractWorkspaceName(auth),
+    expiresIn,
+    scopes: data.scope
+      ? data.scope.split(" ")
+      : CHATGPT_OAUTH_SCOPES.split(" "),
+  };
+}
+
+/**
+ * Refresh a ChatGPT access token. Refresh tokens rotate on each call —
+ * the new refresh_token (when present) is returned and must be persisted by
+ * the caller. 401 responses are classified into ChatgptRefreshError codes
+ * so the firewall pipeline can distinguish stale-token from transient errors.
+ */
+export async function refreshChatgptToken(
+  _clientId: string,
+  _clientSecret: string,
+  refreshToken: string,
+): Promise<ChatgptRefreshResult> {
+  const response = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      client_id: CHATGPT_OAUTH_CLIENT_ID,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (response.status === 401) {
+    const body = await response.text();
+    let code: ChatgptRefreshErrorCode = "refresh_token_other";
+    let message = body;
+    try {
+      const parsed = refreshErrorBodySchema.parse(JSON.parse(body));
+      const errCode = parsed.error?.code;
+      if (
+        errCode === "refresh_token_expired" ||
+        errCode === "refresh_token_reused" ||
+        errCode === "refresh_token_invalidated"
+      ) {
+        code = errCode;
+      }
+      message = parsed.error?.message ?? body;
+    } catch {
+      // body wasn't JSON — keep raw text as message, code stays "refresh_token_other"
+    }
+    throw createChatgptRefreshError(code, `ChatGPT refresh failed: ${message}`);
+  }
+
+  if (!response.ok) {
+    await throwOAuthError("ChatGPT", "refresh", response);
+  }
+
+  const data = refreshResponseSchema.parse(await response.json());
+  if (!data.access_token) {
+    throw new Error("No access token in ChatGPT refresh response");
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
+  };
+}
+
+/**
+ * Revoke a ChatGPT access token (used on user-initiated disconnect).
+ */
+export async function revokeChatgptToken(
+  _clientId: string,
+  _clientSecret: string,
+  accessToken: string,
+): Promise<void> {
+  const response = await fetch(REVOKE_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ token: accessToken }),
+  });
+  if (!response.ok) {
+    await throwOAuthError("ChatGPT", "revoke", response);
+  }
+}
+
+export function getChatgptSecretName(): string {
+  return "CHATGPT_ACCESS_TOKEN";
+}
+
+export function getChatgptRefreshSecretName(): string {
+  return "CHATGPT_REFRESH_TOKEN";
+}

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -82,6 +82,7 @@ import { metaAds } from "./connectors/meta-ads";
 import { stripe } from "./connectors/stripe";
 import { onyx } from "./connectors/onyx";
 import { openai } from "./connectors/openai";
+import { chatgptOauth } from "./connectors/chatgpt-oauth";
 import { similarweb } from "./connectors/similarweb";
 import { perplexity } from "./connectors/perplexity";
 import { pipedrive } from "./connectors/pipedrive";
@@ -459,6 +460,7 @@ const CONNECTOR_TYPES_DEF = {
   ...stripe,
   ...onyx,
   ...openai,
+  ...chatgptOauth,
   ...similarweb,
   ...perplexity,
   ...pipedrive,

--- a/turbo/packages/connectors/src/connectors/chatgpt-oauth.ts
+++ b/turbo/packages/connectors/src/connectors/chatgpt-oauth.ts
@@ -1,0 +1,36 @@
+import type { ConnectorConfig } from "../connectors";
+
+export const chatgptOauth = {
+  "chatgpt-oauth": {
+    label: "ChatGPT (OAuth)",
+    category: "ai-general-models",
+    environmentMapping: {
+      CHATGPT_TOKEN: "$secrets.CHATGPT_ACCESS_TOKEN",
+    },
+    helpText:
+      "Sign in with your ChatGPT subscription (Plus / Pro / Business / Edu / Enterprise) to use Codex agents against your ChatGPT quota.",
+    authMethods: {
+      oauth: {
+        label: "OAuth",
+        helpText: "Sign in with ChatGPT.",
+        secrets: {
+          CHATGPT_ACCESS_TOKEN: { label: "Access Token", required: true },
+          CHATGPT_REFRESH_TOKEN: { label: "Refresh Token", required: true },
+        },
+      },
+    },
+    defaultAuthMethod: "oauth",
+    oauth: {
+      authorizationUrl: "https://auth.openai.com/oauth/authorize",
+      tokenUrl: "https://auth.openai.com/oauth/token",
+      scopes: [
+        "openid",
+        "profile",
+        "email",
+        "offline_access",
+        "api.connectors.read",
+        "api.connectors.invoke",
+      ],
+    },
+  },
+} as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/firewalls/index.ts
+++ b/turbo/packages/connectors/src/firewalls/index.ts
@@ -550,6 +550,9 @@ export type NonFirewallConnectorType =
   // Signature-based auth — requires computing signatures, not simple header injection
   | "cloudinary" // SHA signature in form body + api_key param
   | "minio" // AWS Signature V4
+  // OAuth-only connectors used by model-provider pipelines (firewall integration
+  // lives in MODEL_PROVIDER_FIREWALL_CONFIGS, not here).
+  | "chatgpt-oauth"
   // Other
   | "computer"; // not an API connector
 


### PR DESCRIPTION
## Summary

- New `chatgpt-oauth` `ProviderHandler` (PKCE authorize, code exchange, refresh, revoke) targeting `auth.openai.com` with the Codex public client_id (`app_EMoamEEZ73f0CkXaXp7hrann`).
- New `chatgpt-oauth` connector type entry to satisfy `PROVIDER_HANDLERS`'s typing — non-user-facing in this PR; Wave 2 (#11874) wires the UI.
- Typed `ChatgptRefreshError` (factory function, no class — repo bans classes) lets the Wave 2 refresh-pipeline integration distinguish stale-token (`refresh_token_expired` / `_reused` / `_invalidated`) from transient failures.
- Test suite uses MSW; no `vi.mock` on internal modules.

Implements issue #11876, part of Epic #11872.

> **Naming note:** the connector handler key here is `chatgpt-oauth`. The model-provider type added in SI #11878 is `chatgpt-oauth-token`. These are intentionally different keys; Wave 2 SI #11879 bridges them.

## Out of scope

- Refresh-pipeline integration (Wave 2 SI #11879).
- Web OAuth callback routes (Wave 2).
- "Connect ChatGPT" UI page (Wave 2 / Wave 3).
- Sandbox-side codex bootstrap (#11877).
- Feature switch key + eligibility helper (#11875).

## Test plan

- [ ] `cd turbo && pnpm -F web exec vitest run src/lib/zero/connector/providers/__tests__/chatgpt-oauth.test.ts` — 26 passed locally
- [ ] `cd turbo && pnpm -F @vm0/connectors test` — 557 passed (includes registry-consistency tests)
- [ ] `cd turbo && pnpm format` clean
- [ ] `cd turbo && pnpm turbo run lint` clean
- [ ] `cd turbo && pnpm check-types` clean
- [ ] `cd turbo && pnpm knip` clean
- [ ] CI: lint, test, deploy, cli-e2e — green
- [ ] Manual smoke deferred to Wave 2 (no UI surface in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)