### PR TITLE
chore(feature-switch): add chatgpt-oauth-provider key and helper

### DIFF
--- a/turbo/apps/web/src/lib/zero/model-provider/__tests__/chatgpt-oauth-eligibility.test.ts
+++ b/turbo/apps/web/src/lib/zero/model-provider/__tests__/chatgpt-oauth-eligibility.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { testContext } from "../../../../__tests__/test-helpers";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
+import { updateUserFeatureSwitches } from "../../user/feature-switches-service";
+import { isChatgptOauthEligible } from "../chatgpt-oauth-eligibility";
+
+const context = testContext();
+
+describe("isChatgptOauthEligible", () => {
+  it("returns false when registry default is OFF and no per-user override exists", async () => {
+    context.setupMocks();
+    const { userId, orgId } = await context.setupUser();
+
+    const result = await isChatgptOauthEligible(orgId, userId);
+
+    expect(result).toBe(false);
+  });
+
+  it("returns true when per-user override sets the switch to true", async () => {
+    context.setupMocks();
+    const { userId, orgId } = await context.setupUser();
+    await updateUserFeatureSwitches(orgId, userId, {
+      [FeatureSwitchKey.ChatgptOauthProvider]: true,
+    });
+
+    const result = await isChatgptOauthEligible(orgId, userId);
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when per-user override explicitly sets the switch to false", async () => {
+    context.setupMocks();
+    const { userId, orgId } = await context.setupUser();
+    await updateUserFeatureSwitches(orgId, userId, {
+      [FeatureSwitchKey.ChatgptOauthProvider]: false,
+    });
+
+    const result = await isChatgptOauthEligible(orgId, userId);
+
+    expect(result).toBe(false);
+  });
+});

--- a/turbo/apps/web/src/lib/zero/model-provider/chatgpt-oauth-eligibility.ts
+++ b/turbo/apps/web/src/lib/zero/model-provider/chatgpt-oauth-eligibility.ts
@@ -1,0 +1,23 @@
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { loadFeatureSwitchOverrides } from "../user/feature-switches-service";
+
+/**
+ * Eligibility gate for the ChatGPT OAuth model provider (Epic #11872).
+ *
+ * Single seam consumed by downstream sub-issues to gate the new provider's
+ * UI tile, server routes that initiate the OAuth dance, and stale-provider
+ * banner suppression. Returning false MUST hide the entire surface so the
+ * new provider type does not leak into UI or API responses.
+ */
+export async function isChatgptOauthEligible(
+  orgId: string,
+  userId: string,
+): Promise<boolean> {
+  const overrides = await loadFeatureSwitchOverrides(orgId, userId);
+  return isFeatureEnabled(FeatureSwitchKey.ChatgptOauthProvider, {
+    orgId,
+    userId,
+    overrides,
+  });
+}

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -53,6 +53,7 @@ export enum FeatureSwitchKey {
   Trinity = "trinity",
   ZapierConnector = "zapierConnector",
   CodexBeta = "codexBeta",
+  ChatgptOauthProvider = "chatgpt-oauth-provider",
   IdbMessage = "idbMessage",
   SkeletonNoPreload = "skeletonNoPreload",
 }

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -53,7 +53,7 @@ export enum FeatureSwitchKey {
   Trinity = "trinity",
   ZapierConnector = "zapierConnector",
   CodexBeta = "codexBeta",
-  ChatgptOauthProvider = "chatgpt-oauth-provider",
+  ChatgptOauthProvider = "chatgptOauthProvider",
   IdbMessage = "idbMessage",
   SkeletonNoPreload = "skeletonNoPreload",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -297,6 +297,17 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ChatgptOauthProvider]: {
+    maintainer: "lancy@vm0.ai",
+    description:
+      "Gate the ChatGPT-OAuth model provider in zero web (Epic #11872). " +
+      "When off, the 'Connect ChatGPT' tile is hidden in the add-provider " +
+      "dialog, server routes that initiate the OAuth dance return 404, and " +
+      "stale-provider UX is bypassed. Staff-only during rollout; per-user " +
+      "toggle via Lab.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.IdbMessage]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- Register `chatgpt-oauth-provider` feature switch (default OFF, staff-only ON via `STAFF_ORG_ID_HASHES`, mirroring the `CodexBeta` precedent).
- Add `isChatgptOauthEligible(orgId, userId)` server-side helper at `turbo/apps/web/src/lib/zero/model-provider/chatgpt-oauth-eligibility.ts` — single seam for downstream sub-issues to gate the UI tile, OAuth server routes, and stale-provider banner.
- Helper uses the established two-call pattern (`loadFeatureSwitchOverrides` + `isFeatureEnabled`) so it inherits per-user Lab toggle support and the kill-switch override property.

Refs #11875, parent Epic #11872 (Wave 1 sub-issue). No live callers in this PR; SI #11876, #11877, #11878 and Wave 2 sub-issues will consume the helper.

## Test plan
- [x] `pnpm -F web exec vitest run src/lib/zero/model-provider/__tests__/chatgpt-oauth-eligibility.test.ts` — 3/3 pass
  - default OFF + no override → `false`
  - per-user override `true` → `true`
  - per-user kill-switch override `false` → `false`
- [x] `pnpm -F web exec vitest run` — full web workspace, 4069/4069 pass
- [x] `pnpm turbo run lint` — 10/10 packages clean
- [x] `pnpm check-types` — 11/11 tasks clean
- [x] `pnpm format` — clean
- [x] `pnpm knip` — clean
- [ ] CI green (lint, test-web, deploy, cli-e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)