### PR TITLE
fix(seo): disallow /_next/ static assets in robots.txt

### DIFF
--- a/turbo/apps/web/app/robots.ts
+++ b/turbo/apps/web/app/robots.ts
@@ -7,6 +7,7 @@ export default function robots(): MetadataRoute.Robots {
         userAgent: "*",
         allow: "/",
         disallow: [
+          "/_next/",
           "/api/",
           "/cli-auth/",
           "/sign-in/",


### PR DESCRIPTION
## Summary
- Add `/_next/` to robots.txt disallow list to prevent crawlers from wasting budget on Next.js build output (JS chunks, CSS bundles, image optimization endpoints)
- This is [standard Next.js SEO practice](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)

## Test plan
- [x] Confirm `/_next/static/` URLs are listed under `Disallow` in the generated `robots.txt`
- [x] Verify existing disallowed paths (`/api/`, `/sign-in/`, etc.) remain unchanged