### PR TITLE
fix(seo): return 410 for localized docs paths

### DIFF
--- a/turbo/apps/web/app/[locale]/docs/[[...slug]]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/[locale]/docs/[[...slug]]/__tests__/route.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { GET, HEAD } from "../route";
+
+describe("retired /[locale]/docs catch-all", () => {
+  it("returns 410 Gone with HTML body on GET", async () => {
+    const response = GET();
+    const body = await response.text();
+
+    expect(response.status).toBe(410);
+    expect(response.headers.get("content-type")).toContain("text/html");
+    expect(response.headers.get("x-robots-tag")).toBe("noindex");
+    expect(body).toContain("This page has been removed");
+  });
+
+  it("returns 410 Gone with empty body on HEAD", async () => {
+    const response = HEAD();
+    const body = await response.text();
+
+    expect(response.status).toBe(410);
+    expect(response.headers.get("x-robots-tag")).toBe("noindex");
+    expect(body).toBe("");
+  });
+});

--- a/turbo/apps/web/app/[locale]/docs/[[...slug]]/route.ts
+++ b/turbo/apps/web/app/[locale]/docs/[[...slug]]/route.ts
@@ -1,0 +1,37 @@
+// Localized docs paths (e.g. /en/docs/quickstart) that Google still has
+// indexed. Return 410 Gone so search engines de-index them faster, instead of
+// letting them fall through to auth redirects.
+
+const HTML_BODY = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Page removed | VM0</title>
+<style>
+  body { font-family: system-ui, -apple-system, sans-serif; max-width: 480px; margin: 10vh auto; padding: 0 24px; color: #1a1a1a; }
+  h1 { font-size: 24px; margin: 0 0 12px; }
+  p { line-height: 1.6; color: #555; }
+  a { color: #0066cc; }
+</style>
+</head>
+<body>
+<h1>This page has been removed</h1>
+<p>The VM0 documentation has been retired. Visit the <a href="/">homepage</a> for current resources.</p>
+</body>
+</html>`;
+
+const HEADERS = {
+  "Content-Type": "text/html; charset=utf-8",
+  "X-Robots-Tag": "noindex",
+  "Cache-Control": "public, max-age=3600",
+};
+
+export function GET(): Response {
+  return new Response(HTML_BODY, { status: 410, headers: HEADERS });
+}
+
+export function HEAD(): Response {
+  return new Response(null, { status: 410, headers: HEADERS });
+}


### PR DESCRIPTION
## Summary
- Add `app/[locale]/docs/[[...slug]]/route.ts` that returns 410 Gone with `noindex` for localized docs paths (`/en/docs/*`, `/de/docs/*`, etc.)
- Previously these paths fell through to an auth redirect (307 → sign-in), which prevented Google from properly de-indexing them
- The root-level `/docs/*` already returns 410 — this mirrors the same behavior for locale-prefixed paths

## Why
Google still has indexed docs URLs like `/en/docs/quickstart`. Without this route, those URLs get redirected to sign-in instead of getting a proper 410 + noindex signal.

## Test plan
- [x] GET `/en/docs/anything` returns 410 with `X-Robots-Tag: noindex` header
- [x] HEAD `/en/docs/anything` returns 410 with `X-Robots-Tag: noindex` header
- [x] Existing `/docs/*` 410 behavior is unchanged