### PR TITLE
docs(runner): restore start loop comments

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -748,7 +748,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             false
         };
         tokio::select! {
-            // Job discovery via provider (Ably push + poll).
+            // Job discovery via provider (Ably wakeups + HTTP poll).
             // The future is pinned outside the loop so heartbeat/cleanup
             // ticks don't cancel and restart its internal poll timer. See #8747.
             discovered = &mut discover_fut, if can_discover => {
@@ -841,9 +841,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // -----------------------------------------------------------------------
     let teardown = TeardownTimer::start();
 
-    // Drop the pinned discover future so it releases the discovery Mutex.
-    // Without this, provider.shutdown() deadlocks trying to acquire the
-    // same Mutex that the still-alive discover_fut holds.
+    // Drop the pinned discover future before provider shutdown so any
+    // provider-local discovery resources are released first. This also keeps
+    // the historical shutdown-deadlock regression covered by mock providers.
     drop(discover_fut);
     teardown.event("drop_discover_fut");
 


### PR DESCRIPTION
## Summary
- restore the broader start-loop discovery comment wording from before the test-harness split
- restore the shutdown discover-future comment so it describes provider-local cleanup instead of a mock-specific mutex detail

## Verification
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- pre-commit cargo-fmt/cargo-clippy/cargo-doc

Follow-up to PR #11870.