### PR TITLE
fix(web): redirect bare root to default locale to clear gsc alternate page report

### DIFF
--- a/turbo/apps/web/proxy.layers.ts
+++ b/turbo/apps/web/proxy.layers.ts
@@ -177,11 +177,11 @@ export const localeGuardLayer: ProxyLayer = (ctx) => {
 /**
  * Apply i18n for page routes.
  *
- * next-intl redirects locale-less paths (e.g. /use-cases/foo) with 307
- * (temporary). We normalise these:
- * - "/" → rewrite to "/en" so the root URL stays indexable as 200
- * - everything else → 301 so search engines consolidate PageRank on the
- *   canonical /en/… URL
+ * next-intl redirects locale-less paths (e.g. /use-cases/foo, /) with 307
+ * (temporary). We upgrade them to 301 so search engines consolidate PageRank
+ * on the canonical /:locale/… URL. The sitemap and canonical/hreflang tags
+ * all point at the locale-prefixed form, so there is no need to keep a
+ * locale-less variant indexable.
  */
 export const i18nLayer: ProxyLayer = (ctx) => {
   if (ctx.routeKind === "page") {
@@ -189,9 +189,6 @@ export const i18nLayer: ProxyLayer = (ctx) => {
     const location = response.headers.get("location");
     if (location) {
       const url = new URL(location, ctx.request.nextUrl.origin);
-      if (ctx.request.nextUrl.pathname === "/") {
-        return NextResponse.rewrite(url);
-      }
       return NextResponse.redirect(url, 301);
     }
     return response;


### PR DESCRIPTION
## Summary

- Drop the special-case rewrite of `/` → `/en` content in `proxy.layers.ts` and let next-intl's locale-less redirect propagate as a 301 like every other path
- Resolves a Google Search Console **"Alternate page with proper canonical tag"** report that flagged `https://www.vm0.ai/` because the root rewrote `/en` content while the page's canonical tag pointed at `/en`

## Why

The previous behavior was internally inconsistent:

- `proxy.layers.ts` rewrote `/` → render `/en` content with HTTP 200 ("keep root indexable")
- `app/[locale]/page.tsx` set `<link rel="canonical" href="https://www.vm0.ai/en"/>` via `buildLocaleAlternates`
- `app/sitemap.ts` only emits `/en`, `/de`, `/ja`, `/es` — never the bare `/`

So the canonical tag, sitemap, and hreflang annotations all already treat `/en` as the indexable URL. The bare-root rewrite was the lone outlier, and the duplicate-content signal it produced is exactly what GSC was flagging.

After this change, `/` returns 301 → `/en` (or the visitor's preferred supported locale via `Accept-Language`), aligning the runtime with the SEO source-of-truth.

## Out of scope

- The three other URLs in the GSC report (`docs.vm0.ai/docs`, `/en/glossary`, `/es/skills`) are already offline. Once Google recrawls and sees 404, they drop from the report on their own (~2–4 weeks)
- `/zh` `noindex` is intentional — `zh` is not in the production locale list (`i18n.ts`)

## Test plan

- [ ] CI green (lint, type, test)
- [ ] After deploy, `curl -I https://www.vm0.ai/` returns `301` with `location: /en`
- [ ] `curl -I https://www.vm0.ai/use-cases` still returns `301` to a locale (regression check — this path was already a 301 before this change)
- [ ] In Google Search Console, click **Validate Fix** on the "Alternate page" issue; the `vm0.ai/` row should drop within ~28 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)