### PR TITLE
feat(zero): plumb prefer_personal_provider through agent and schedule contracts

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-agent-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agent-data.service.ts
@@ -23,6 +23,7 @@ function agentResponse(row: {
   readonly customSkills: readonly string[];
   readonly modelProviderId: string | null;
   readonly selectedModel: string | null;
+  readonly preferPersonalProvider: boolean;
 }): ZeroAgentResponse {
   return {
     agentId: row.agentId,
@@ -38,6 +39,7 @@ function agentResponse(row: {
     customSkills: [...row.customSkills],
     modelProviderId: row.modelProviderId,
     selectedModel: row.selectedModel,
+    preferPersonalProvider: row.preferPersonalProvider,
   };
 }
 
@@ -75,6 +77,7 @@ export function zeroAgentList(
         customSkills: zeroAgents.customSkills,
         modelProviderId: zeroAgents.modelProviderId,
         selectedModel: zeroAgents.selectedModel,
+        preferPersonalProvider: zeroAgents.preferPersonalProvider,
       })
       .from(zeroAgents)
       .innerJoin(agentComposes, eq(zeroAgents.id, agentComposes.id))
@@ -104,6 +107,7 @@ export function zeroAgentDetail(args: {
         customSkills: zeroAgents.customSkills,
         modelProviderId: zeroAgents.modelProviderId,
         selectedModel: zeroAgents.selectedModel,
+        preferPersonalProvider: zeroAgents.preferPersonalProvider,
       })
       .from(zeroAgents)
       .innerJoin(agentComposes, eq(zeroAgents.id, agentComposes.id))

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -76,6 +76,7 @@ function scheduleResponse(
     updatedAt: schedule.updatedAt.toISOString(),
     modelProviderId: schedule.modelProviderId ?? null,
     selectedModel: schedule.selectedModel ?? null,
+    preferPersonalProvider: schedule.preferPersonalProvider ?? false,
   };
 }
 

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -114,6 +114,7 @@ export const apiAgentsHandlers = [
       customSkills: [],
       modelProviderId: null,
       selectedModel: null,
+      preferPersonalProvider: false,
     });
   }),
 

--- a/turbo/apps/platform/src/mocks/handlers/api-schedules.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-schedules.ts
@@ -36,6 +36,7 @@ export function createMockScheduleResponse(
     consecutiveFailures: 0,
     modelProviderId: null,
     selectedModel: null,
+    preferPersonalProvider: false,
     createdAt: "2026-03-01T00:00:00Z",
     updatedAt: "2026-03-01T00:00:00Z",
     ...overrides,
@@ -83,6 +84,7 @@ export const apiSchedulesHandlers = [
       consecutiveFailures: 0,
       modelProviderId: body.modelProviderId ?? null,
       selectedModel: body.selectedModel ?? null,
+      preferPersonalProvider: body.preferPersonalProvider ?? false,
       createdAt: now,
       updatedAt: now,
     };

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -58,6 +58,7 @@ function mockAgentResponse() {
     customSkills: [],
     modelProviderId: null,
     selectedModel: null,
+    preferPersonalProvider: false,
   };
 }
 

--- a/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-misc-components.test.tsx
@@ -160,6 +160,7 @@ function testSchedule(
     lastRunAt: null,
     modelProviderId: null,
     selectedModel: null,
+    preferPersonalProvider: false,
     ...overrides,
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/schedule-calendar-view.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/schedule-calendar-view.test.tsx
@@ -23,6 +23,7 @@ function mockScheduleBase() {
     lastRunAt: null,
     modelProviderId: null,
     selectedModel: null,
+    preferPersonalProvider: false,
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-card-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-card-tab.test.tsx
@@ -54,6 +54,7 @@ function defaultSchedule(
     consecutiveFailures: 0,
     modelProviderId: null,
     selectedModel: null,
+    preferPersonalProvider: false,
     ...overrides,
   };
 }

--- a/turbo/apps/web/app/api/zero/agents/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/instructions/route.ts
@@ -71,22 +71,42 @@ async function updateInstructions(
     .where(and(eq(zeroAgents.orgId, orgId), eq(zeroAgents.name, compose.name)))
     .limit(1);
 
+  if (!agent) {
+    return {
+      status: 200 as const,
+      body: {
+        agentId: result.composeId,
+        ownerId: userId,
+        description: null,
+        displayName: null,
+        sound: null,
+        avatarUrl: null,
+        permissionPolicies: toFirewallPolicies(undefined, undefined),
+        modelProviderId: null,
+        selectedModel: null,
+        preferPersonalProvider: false,
+        customSkills: [],
+      },
+    };
+  }
+
   return {
     status: 200 as const,
     body: {
       agentId: result.composeId,
-      ownerId: agent?.owner ?? userId,
-      description: agent?.description ?? null,
-      displayName: agent?.displayName ?? null,
-      sound: agent?.sound ?? null,
-      avatarUrl: agent?.avatarUrl ?? null,
+      ownerId: agent.owner,
+      description: agent.description,
+      displayName: agent.displayName,
+      sound: agent.sound,
+      avatarUrl: agent.avatarUrl,
       permissionPolicies: toFirewallPolicies(
-        agent?.permissionPolicies,
-        agent?.unknownPermissionPolicies,
+        agent.permissionPolicies,
+        agent.unknownPermissionPolicies,
       ),
-      modelProviderId: agent?.modelProviderId ?? null,
-      selectedModel: agent?.selectedModel ?? null,
-      customSkills: agent?.customSkills ?? [],
+      modelProviderId: agent.modelProviderId,
+      selectedModel: agent.selectedModel,
+      preferPersonalProvider: agent.preferPersonalProvider,
+      customSkills: agent.customSkills,
     },
   };
 }

--- a/turbo/apps/web/app/api/zero/agents/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/route.ts
@@ -32,6 +32,7 @@ type AgentUpdateBody = {
   customSkills?: string[];
   modelProviderId?: string | null;
   selectedModel?: string | null;
+  preferPersonalProvider?: boolean;
 };
 
 function buildAgentUpsertConflictSet(body: AgentUpdateBody, now: Date) {
@@ -48,6 +49,9 @@ function buildAgentUpsertConflictSet(body: AgentUpdateBody, now: Date) {
     ...(body.selectedModel !== undefined && {
       selectedModel: body.selectedModel,
     }),
+    ...(body.preferPersonalProvider !== undefined && {
+      preferPersonalProvider: body.preferPersonalProvider,
+    }),
   };
 }
 
@@ -55,20 +59,36 @@ function agentResponseBody(
   agent: typeof zeroAgents.$inferSelect | undefined,
   fallback: { id: string; ownerId: string },
 ) {
+  if (!agent) {
+    return {
+      agentId: fallback.id,
+      ownerId: fallback.ownerId,
+      description: null,
+      displayName: null,
+      sound: null,
+      avatarUrl: null,
+      permissionPolicies: toFirewallPolicies(undefined, undefined),
+      customSkills: [],
+      modelProviderId: null,
+      selectedModel: null,
+      preferPersonalProvider: false,
+    };
+  }
   return {
     agentId: fallback.id,
-    ownerId: agent?.owner ?? fallback.ownerId,
-    description: agent?.description ?? null,
-    displayName: agent?.displayName ?? null,
-    sound: agent?.sound ?? null,
-    avatarUrl: agent?.avatarUrl ?? null,
+    ownerId: agent.owner,
+    description: agent.description,
+    displayName: agent.displayName,
+    sound: agent.sound,
+    avatarUrl: agent.avatarUrl,
     permissionPolicies: toFirewallPolicies(
-      agent?.permissionPolicies,
-      agent?.unknownPermissionPolicies,
+      agent.permissionPolicies,
+      agent.unknownPermissionPolicies,
     ),
-    customSkills: agent?.customSkills ?? [],
-    modelProviderId: agent?.modelProviderId ?? null,
-    selectedModel: agent?.selectedModel ?? null,
+    customSkills: agent.customSkills,
+    modelProviderId: agent.modelProviderId,
+    selectedModel: agent.selectedModel,
+    preferPersonalProvider: agent.preferPersonalProvider,
   };
 }
 
@@ -234,6 +254,7 @@ const router = tsr.router(zeroAgentsByIdContract, {
         customSkills,
         modelProviderId: body.modelProviderId ?? null,
         selectedModel: body.selectedModel ?? null,
+        preferPersonalProvider: body.preferPersonalProvider ?? false,
       })
       .onConflictDoUpdate({
         target: [zeroAgents.orgId, zeroAgents.name],
@@ -331,6 +352,9 @@ const router = tsr.router(zeroAgentsByIdContract, {
         }),
         ...(body.selectedModel !== undefined && {
           selectedModel: body.selectedModel,
+        }),
+        ...(body.preferPersonalProvider !== undefined && {
+          preferPersonalProvider: body.preferPersonalProvider,
         }),
       })
       .where(eq(zeroAgents.id, params.id));

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -1731,6 +1731,53 @@ describe("Zero Agents API", () => {
     });
   });
 
+  describe("preferPersonalProvider", () => {
+    it("should default to false when omitted on POST", async () => {
+      const response = await postAgent(
+        { displayName: "default-prefer" },
+        testCliToken,
+      );
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.preferPersonalProvider).toBe(false);
+    });
+
+    it("should round-trip true and false on PUT", async () => {
+      const created = await (await postAgent({}, testCliToken)).json();
+
+      let response = await putAgent(
+        created.agentId,
+        { preferPersonalProvider: true },
+        testCliToken,
+      );
+      expect(response.status).toBe(200);
+      expect((await response.json()).preferPersonalProvider).toBe(true);
+
+      response = await putAgent(
+        created.agentId,
+        { preferPersonalProvider: false },
+        testCliToken,
+      );
+      expect(response.status).toBe(200);
+      expect((await response.json()).preferPersonalProvider).toBe(false);
+    });
+
+    it("should round-trip via PATCH updateMetadata and persist on GET", async () => {
+      const created = await (await postAgent({}, testCliToken)).json();
+
+      const patchResponse = await patchAgent(
+        created.agentId,
+        { preferPersonalProvider: true },
+        testCliToken,
+      );
+      expect(patchResponse.status).toBe(200);
+      expect((await patchResponse.json()).preferPersonalProvider).toBe(true);
+
+      const got = await (await getAgent(created.agentId, testCliToken)).json();
+      expect(got.preferPersonalProvider).toBe(true);
+    });
+  });
+
   describe("schedule run integration", () => {
     it("should execute schedule for agent created via POST /api/zero/agents", async () => {
       // Regression: serverSideCompose was called without instructions param,

--- a/turbo/apps/web/app/api/zero/agents/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/route.ts
@@ -73,6 +73,7 @@ const router = tsr.router(zeroAgentsMainContract, {
       customSkills,
       modelProviderId: body.modelProviderId ?? null,
       selectedModel: body.selectedModel ?? null,
+      preferPersonalProvider: body.preferPersonalProvider ?? false,
     };
 
     // Enforce maximum 7 agents per organization.
@@ -160,6 +161,7 @@ const router = tsr.router(zeroAgentsMainContract, {
         customSkills: zeroAgents.customSkills,
         modelProviderId: zeroAgents.modelProviderId,
         selectedModel: zeroAgents.selectedModel,
+        preferPersonalProvider: zeroAgents.preferPersonalProvider,
       })
       .from(zeroAgents)
       .innerJoin(agentComposes, eq(zeroAgents.id, agentComposes.id))
@@ -182,6 +184,7 @@ const router = tsr.router(zeroAgentsMainContract, {
           ),
           modelProviderId: row.modelProviderId ?? null,
           selectedModel: row.selectedModel ?? null,
+          preferPersonalProvider: row.preferPersonalProvider ?? false,
           customSkills: row.customSkills,
         };
       }),

--- a/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
@@ -175,7 +175,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
     expect(data.schedule.preferPersonalProvider).toBe(true);
   });
 
-  it("should reset preferPersonalProvider to false on update without field", async () => {
+  it("should preserve preferPersonalProvider on update without field", async () => {
     await POST(
       createTestRequest(`http://localhost:3000/api/zero/schedules`, {
         method: "POST",
@@ -191,6 +191,8 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
       }),
     );
 
+    // Re-deploy without the field — partial-update semantics preserve the
+    // previously persisted value (mirrors agent PUT/PATCH behaviour).
     const response = await POST(
       createTestRequest(`http://localhost:3000/api/zero/schedules`, {
         method: "POST",
@@ -201,6 +203,42 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
           cronExpression: "0 9 * * *",
           timezone: "UTC",
           prompt: "Test",
+        }),
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.schedule.preferPersonalProvider).toBe(true);
+  });
+
+  it("should clear preferPersonalProvider when explicitly set to false", async () => {
+    await POST(
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "explicit-clear-prefer",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "Test",
+          preferPersonalProvider: true,
+        }),
+      }),
+    );
+
+    const response = await POST(
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "explicit-clear-prefer",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "Test",
+          preferPersonalProvider: false,
         }),
       }),
     );

--- a/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
@@ -134,6 +134,82 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
     expect(data.schedule.name).toBe("agent-id-test");
   });
 
+  it("should default preferPersonalProvider to false when omitted", async () => {
+    const response = await POST(
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "no-prefer",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "Test",
+        }),
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.schedule.preferPersonalProvider).toBe(false);
+  });
+
+  it("should round-trip preferPersonalProvider=true on deploy", async () => {
+    const response = await POST(
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "with-prefer",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "Test",
+          preferPersonalProvider: true,
+        }),
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.schedule.preferPersonalProvider).toBe(true);
+  });
+
+  it("should reset preferPersonalProvider to false on update without field", async () => {
+    await POST(
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "flip-prefer",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "Test",
+          preferPersonalProvider: true,
+        }),
+      }),
+    );
+
+    const response = await POST(
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "flip-prefer",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "Test",
+        }),
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.schedule.preferPersonalProvider).toBe(false);
+  });
+
   it("should reject unauthenticated request", async () => {
     mockClerk({ userId: null });
 

--- a/turbo/apps/web/app/api/zero/schedules/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/route.ts
@@ -46,6 +46,7 @@ const router = tsr.router(zeroSchedulesMainContract, {
         volumeVersions: body.volumeVersions,
         modelProviderId: body.modelProviderId,
         selectedModel: body.selectedModel,
+        preferPersonalProvider: body.preferPersonalProvider,
       });
 
       return {

--- a/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
@@ -159,6 +159,7 @@ export async function createTestZeroAgent(
     permissionPolicies?: RawPermissionPolicies;
     modelProviderId?: string | null;
     selectedModel?: string | null;
+    preferPersonalProvider?: boolean;
   },
 ): Promise<void> {
   initServices();
@@ -187,6 +188,7 @@ export async function createTestZeroAgent(
       permissionPolicies: metadata.permissionPolicies ?? null,
       modelProviderId: metadata.modelProviderId ?? null,
       selectedModel: metadata.selectedModel ?? null,
+      preferPersonalProvider: metadata.preferPersonalProvider ?? false,
     })
     .onConflictDoUpdate({
       target: [zeroAgents.orgId, zeroAgents.name],
@@ -197,6 +199,7 @@ export async function createTestZeroAgent(
         permissionPolicies: metadata.permissionPolicies ?? null,
         modelProviderId: metadata.modelProviderId ?? null,
         selectedModel: metadata.selectedModel ?? null,
+        preferPersonalProvider: metadata.preferPersonalProvider ?? false,
       },
     });
 }

--- a/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
@@ -255,6 +255,12 @@ async function updateExistingSchedule(
   triggerType: "cron" | "once" | "loop",
   nextRunAt: Date | null,
 ): Promise<typeof zeroAgentSchedules.$inferSelect> {
+  // `preferPersonalProvider` follows partial-update semantics (mirrors the
+  // agent PUT/PATCH route): omitting the field preserves the persisted value
+  // rather than resetting to false. This avoids a footgun where a client
+  // PATCHing only `name` would silently flip the flag back. Other fields
+  // (modelProviderId / selectedModel) keep the existing reset-on-omit
+  // semantics for backward compatibility.
   const [updated] = await globalThis.services.db
     .update(zeroAgentSchedules)
     .set({
@@ -274,7 +280,9 @@ async function updateExistingSchedule(
       updatedAt: new Date(),
       modelProviderId: request.modelProviderId ?? null,
       selectedModel: request.selectedModel ?? null,
-      preferPersonalProvider: request.preferPersonalProvider ?? false,
+      ...(request.preferPersonalProvider !== undefined && {
+        preferPersonalProvider: request.preferPersonalProvider,
+      }),
     })
     .where(eq(zeroAgentSchedules.id, existingId))
     .returning();

--- a/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
@@ -53,6 +53,7 @@ export interface ScheduleResponse {
   updatedAt: string;
   modelProviderId: string | null;
   selectedModel: string | null;
+  preferPersonalProvider: boolean;
 }
 
 /**
@@ -85,6 +86,7 @@ interface DeployScheduleRequest {
   volumeVersions?: Record<string, string>;
   modelProviderId?: string | null;
   selectedModel?: string | null;
+  preferPersonalProvider?: boolean;
 }
 
 /**
@@ -157,6 +159,7 @@ function toResponse(
     updatedAt: schedule.updatedAt.toISOString(),
     modelProviderId: schedule.modelProviderId ?? null,
     selectedModel: schedule.selectedModel ?? null,
+    preferPersonalProvider: schedule.preferPersonalProvider ?? false,
   };
 }
 
@@ -271,6 +274,7 @@ async function updateExistingSchedule(
       updatedAt: new Date(),
       modelProviderId: request.modelProviderId ?? null,
       selectedModel: request.selectedModel ?? null,
+      preferPersonalProvider: request.preferPersonalProvider ?? false,
     })
     .where(eq(zeroAgentSchedules.id, existingId))
     .returning();
@@ -318,6 +322,7 @@ async function insertNewSchedule(
       updatedAt: now,
       modelProviderId: request.modelProviderId ?? null,
       selectedModel: request.selectedModel ?? null,
+      preferPersonalProvider: request.preferPersonalProvider ?? false,
     })
     .returning();
 

--- a/turbo/packages/api-contracts/src/contracts/zero-agents.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-agents.ts
@@ -30,6 +30,7 @@ export const zeroAgentResponseSchema = z.object({
   customSkills: z.array(z.string()).default([]),
   modelProviderId: z.string().uuid().nullable().default(null),
   selectedModel: z.string().nullable().default(null),
+  preferPersonalProvider: z.boolean().default(false),
 });
 
 /**
@@ -43,6 +44,7 @@ export const zeroAgentRequestSchema = z.object({
   customSkills: z.array(zeroAgentCustomSkillNameSchema).optional(),
   modelProviderId: z.string().uuid().nullable().optional(),
   selectedModel: z.string().nullable().optional(),
+  preferPersonalProvider: z.boolean().optional(),
 });
 
 /**
@@ -55,6 +57,7 @@ export const zeroAgentMetadataRequestSchema = z.object({
   avatarUrl: z.string().nullable().optional(),
   modelProviderId: z.string().uuid().nullable().optional(),
   selectedModel: z.string().nullable().optional(),
+  preferPersonalProvider: z.boolean().optional(),
 });
 
 /**

--- a/turbo/packages/api-contracts/src/contracts/zero-schedules.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-schedules.ts
@@ -33,6 +33,7 @@ export const scheduleResponseSchema = z.object({
   updatedAt: z.string(),
   modelProviderId: z.string().uuid().nullable().default(null),
   selectedModel: z.string().nullable().default(null),
+  preferPersonalProvider: z.boolean().default(false),
 });
 
 export const scheduleListResponseSchema = z.object({
@@ -62,6 +63,7 @@ const zeroDeployScheduleRequestSchema = z
     enabled: z.boolean().optional(),
     modelProviderId: z.string().uuid().nullable().optional(),
     selectedModel: z.string().nullable().optional(),
+    preferPersonalProvider: z.boolean().optional(),
   })
   .refine(
     (data) => {


### PR DESCRIPTION
## Summary

Wave 2 sub-issue of epic #11868. Wires the `prefer_personal_provider` boolean column (added in #11880) through agent + schedule API contracts and route handlers. Clients can now read and write the field via the existing CRUD endpoints. **No behavior change** — the resolver does not yet honor the flag (deferred to a sibling Wave 2 sub-issue).

- Extend `zeroAgentResponseSchema`, `zeroAgentRequestSchema`, `zeroAgentMetadataRequestSchema`, `scheduleResponseSchema`, and `zeroDeployScheduleRequestSchema` with the new field
- Wire field through agent POST/list, GET/PUT/PATCH by id, and instructions PUT response handlers
- Wire field through schedule deploy, list, and `toResponse` mapper
- Update `apps/api` `zeroAgentDetail` / `zeroAgentList` / `zeroScheduleList` selects + mappers
- Update platform MSW mocks (`api-agents`, `api-schedules`) and 3 affected test fixtures
- Extend `createTestZeroAgent` seeder to accept the new field
- Add round-trip integration tests

Closes #11886

## Refactor note

`agentResponseBody` (in `agents/[id]/route.ts`) and the agent-response builder in `agents/[id]/instructions/route.ts` had cyclomatic complexity of 20 each (right at the lint budget). Adding a new optional-chained `??` for `preferPersonalProvider` would have pushed each over the limit. Refactored both to short-circuit on null agent (one branch + literal-default object) instead of chaining ten optional accessors. Same observable behavior, lower complexity, marginally clearer.

## Test plan

- [x] `pnpm db:migrate` already applied (column existed since #11880)
- [x] `pnpm format` — clean
- [x] `pnpm turbo run lint` — pass (0 warnings, 0 errors)
- [x] `pnpm check-types` — pass (11/11 packages)
- [x] `pnpm -F web exec vitest run app/api/zero/agents app/api/zero/schedules` — 142/142 pass
- [x] `pnpm -F @vm0/app exec vitest run` (touched fixtures) — 34/34 pass
- [x] `pnpm knip` — no real findings, only pre-existing config hints
- [x] grep verification matrix from plan satisfied

## Verification grep matrix

| Path | Hits |
| --- | --- |
| `turbo/packages/api-contracts/src/contracts/zero-agents.ts` | 3 |
| `turbo/packages/api-contracts/src/contracts/zero-schedules.ts` | 2 |
| `turbo/apps/web/app/api/zero/agents/` (4 files) | 11 |
| `turbo/apps/web/src/lib/zero/schedule/schedule-service.ts` | 5 |
| `turbo/apps/web/app/api/zero/schedules/route.ts` | 1 |
| `turbo/apps/api/src/signals/services/` (2 files) | 5 |
| `turbo/apps/platform/src/mocks/handlers/` (2 files) | 3 |

## Out of scope (deferred)

- Resolver wiring — `resolveModelProviderSecrets` will read the flag in a Wave 2 sibling sub-issue
- Eager-pin chat thread updates — separate Wave 2 sub-issue
- UI checkbox in agent + schedule settings — Wave 3
- CLI flag — out of scope per epic Decision 8 (web-UI-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)