### PR TITLE
fix(seo): add /rankings page to sitemap

### DIFF
--- a/turbo/apps/web/app/sitemap.ts
+++ b/turbo/apps/web/app/sitemap.ts
@@ -78,6 +78,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "monthly" as const,
       lastModified: BUILD_DATE,
     },
+    {
+      path: "/rankings",
+      priority: 0.8,
+      changeFrequency: "daily" as const,
+      lastModified: BUILD_DATE,
+    },
   ];
 
   const rootRoutes = [


### PR DESCRIPTION
## Summary
- Added the `/rankings` page to the sitemap with priority 0.8 and daily change frequency
- The rankings page (`/[locale]/rankings`) was already a public page with full SEO metadata but was missing from the sitemap entirely
- This affects 4 locale URLs: `/en/rankings`, `/de/rankings`, `/ja/rankings`, `/es/rankings`

## Test plan
- [ ] Verify `/en/rankings` appears in sitemap XML at `https://www.vm0.ai/sitemap.xml` after deploy
- [ ] Verify all 4 locale variants are present with correct hreflang alternates
- [ ] Confirm `changeFrequency: daily` is appropriate (rankings data refreshes daily)

🤖 Generated with [Claude Code](https://claude.com/claude-code)