### PR TITLE
test: add API tests for schedule model resolution (#10899)

### DIFF
--- a/turbo/apps/web/src/__tests__/schedule-model-resolution.test.ts
+++ b/turbo/apps/web/src/__tests__/schedule-model-resolution.test.ts
@@ -54,9 +54,9 @@ describe("Schedule model resolution", () => {
       // Create model provider for the agent's model
       mockClerk({ userId, orgId, orgRole: "org:admin" });
       const provider = await createTestOrgModelProvider(
-        "openai-api-key",
-        "test-openai-key",
-        "gpt-4o",
+        "moonshot-api-key",
+        "test-moonshot-key",
+        "kimi-k2.6",
       );
 
       mockClerk({ userId, orgId, orgRole: "org:admin" });
@@ -72,7 +72,7 @@ describe("Schedule model resolution", () => {
             prompt: "Test schedule with explicit model override",
             cronExpression: "0 0 * * *",
             modelProviderId: provider.id,
-            selectedModel: "gpt-4o",
+            selectedModel: "kimi-k2.6",
           }),
         }),
       );
@@ -80,7 +80,7 @@ describe("Schedule model resolution", () => {
       expect(response.status).toBe(201);
       const data = await response.json();
       expect(data.schedule.modelProviderId).toBe(provider.id);
-      expect(data.schedule.selectedModel).toBe("gpt-4o");
+      expect(data.schedule.selectedModel).toBe("kimi-k2.6");
     });
 
     it("returns 400 when modelProviderId references a provider not in the org", async () => {
@@ -123,18 +123,22 @@ describe("Schedule model resolution", () => {
         "claude-sonnet-4-6",
       );
 
-      // Create an openai provider that will be the agent's custom model
+      // Create a moonshot provider that will be the agent's custom model
       mockClerk({ userId, orgId, orgRole: "org:admin" });
       const agentProvider = await createTestOrgModelProvider(
-        "openai-api-key",
-        "test-openai-key",
-        "gpt-4o",
+        "moonshot-api-key",
+        "test-moonshot-key",
+        "kimi-k2.6",
       );
 
       // Create agent with a specific model (different from org default)
       mockClerk({ userId, orgId, orgRole: "org:admin" });
       const { agentId } = await createTestCompose(uniqueId("agent"));
-      await setTestZeroAgentModelProvider(agentId, agentProvider.id, "gpt-4o");
+      await setTestZeroAgentModelProvider(
+        agentId,
+        agentProvider.id,
+        "kimi-k2.6",
+      );
 
       // Create schedule with "agent default" (null model fields)
       mockClerk({ userId, orgId, orgRole: "org:admin" });

--- a/turbo/apps/web/src/__tests__/schedule-model-resolution.test.ts
+++ b/turbo/apps/web/src/__tests__/schedule-model-resolution.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { POST as deployScheduleRoute } from "../../app/api/zero/schedules/route";
+import { adaptScheduleTrigger } from "../lib/zero/schedule/adapt-schedule-trigger";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestOrgModelProvider,
+  createTestOrg,
+  setTestZeroAgentModelProvider,
+} from "./api-test-helpers";
+import { mockClerk } from "./clerk-mock";
+import { testContext, uniqueId } from "./test-helpers";
+import { initServices } from "../lib/init-services";
+
+const context = testContext();
+
+async function setupOrgWithProviders(
+  userId: string,
+  orgDefaultType: string,
+  orgDefaultModel?: string,
+) {
+  const slug = uniqueId("schedmod");
+  mockClerk({ userId, orgRole: "org:admin" });
+  const { id: orgId } = await createTestOrg(slug);
+
+  // Create the org default model provider if needed
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrgModelProvider(
+    orgDefaultType,
+    `test-secret-${slug}`,
+    orgDefaultModel,
+  );
+
+  return { orgId, slug };
+}
+
+describe("Schedule model resolution", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+  });
+
+  describe("POST /api/zero/schedules (deploy)", () => {
+    it("stores schedule with explicit model override values", async () => {
+      const userId = uniqueId("sched-api-ovrd");
+      const { orgId } = await setupOrgWithProviders(
+        userId,
+        "anthropic-api-key",
+        "claude-sonnet-4-6",
+      );
+
+      mockClerk({ userId, orgId, orgRole: "org:admin" });
+      const agentName = uniqueId("agent");
+      const { agentId } = await createTestCompose(agentName);
+
+      // Create model provider for the agent's model
+      mockClerk({ userId, orgId, orgRole: "org:admin" });
+      const provider = await createTestOrgModelProvider(
+        "google-gemini-api-key",
+        "test-gemini-key",
+        "gemini-2.5-pro",
+      );
+
+      mockClerk({ userId, orgId, orgRole: "org:admin" });
+      const scheduleName = uniqueId("sched");
+      const response = await deployScheduleRoute(
+        createTestRequest("http://localhost:3000/api/zero/schedules", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: scheduleName,
+            agentId,
+            timezone: "UTC",
+            prompt: "Test schedule with explicit model override",
+            cronExpression: "0 0 * * *",
+            modelProviderId: provider.id,
+            selectedModel: "gemini-2.5-pro",
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.schedule.modelProviderId).toBe(provider.id);
+      expect(data.schedule.selectedModel).toBe("gemini-2.5-pro");
+    });
+
+    it("returns 400 when modelProviderId references a provider not in the org", async () => {
+      const userId = uniqueId("sched-api-400");
+      const { orgId } = await setupOrgWithProviders(
+        userId,
+        "anthropic-api-key",
+        "claude-sonnet-4-6",
+      );
+
+      mockClerk({ userId, orgId, orgRole: "org:admin" });
+      const agentName = uniqueId("agent");
+      const { agentId } = await createTestCompose(agentName);
+
+      mockClerk({ userId, orgId, orgRole: "org:admin" });
+      const response = await deployScheduleRoute(
+        createTestRequest("http://localhost:3000/api/zero/schedules", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: uniqueId("sched"),
+            agentId,
+            timezone: "UTC",
+            prompt: "Test with bad provider",
+            cronExpression: "0 0 * * *",
+            modelProviderId: "00000000-0000-0000-0000-000000000000",
+            selectedModel: "nonexistent-model",
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("stores schedule with null model when agent has custom model but schedule uses agent default", async () => {
+      const userId = uniqueId("sched-api-agent");
+      const { orgId } = await setupOrgWithProviders(
+        userId,
+        "anthropic-api-key",
+        "claude-sonnet-4-6",
+      );
+
+      // Create a gemini provider that will be the agent's custom model
+      mockClerk({ userId, orgId, orgRole: "org:admin" });
+      const agentProvider = await createTestOrgModelProvider(
+        "google-gemini-api-key",
+        "test-gemini-key",
+        "gemini-2.5-pro",
+      );
+
+      // Create agent with a specific model (different from org default)
+      mockClerk({ userId, orgId, orgRole: "org:admin" });
+      const { agentId } = await createTestCompose(uniqueId("agent"));
+      await setTestZeroAgentModelProvider(
+        agentId,
+        agentProvider.id,
+        "gemini-2.5-pro",
+      );
+
+      // Verify agent model is set
+      initServices();
+      const [agent] = await globalThis.services.db
+        .select({
+          modelProviderId: zeroAgents.modelProviderId,
+          selectedModel: zeroAgents.selectedModel,
+        })
+        .from(zeroAgents)
+        .where(eq(zeroAgents.id, agentId))
+        .limit(1);
+      expect(agent!.modelProviderId).toBe(agentProvider.id);
+      expect(agent!.selectedModel).toBe("gemini-2.5-pro");
+
+      // Create schedule with "agent default" (null model fields)
+      mockClerk({ userId, orgId, orgRole: "org:admin" });
+      const scheduleName = uniqueId("sched");
+      const response = await deployScheduleRoute(
+        createTestRequest("http://localhost:3000/api/zero/schedules", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: scheduleName,
+            agentId,
+            timezone: "UTC",
+            prompt: "Schedule using agent default model",
+            cronExpression: "0 0 * * *",
+            modelProviderId: null,
+            selectedModel: null,
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+
+      // The schedule stores null for both model fields when agent default is selected
+      expect(data.schedule.modelProviderId).toBeNull();
+      expect(data.schedule.selectedModel).toBeNull();
+    });
+  });
+
+  describe("adaptScheduleTrigger model passthrough", () => {
+    it("converts null modelProviderId to undefined so runtime fallback kicks in", () => {
+      const result = adaptScheduleTrigger({
+        userId: "test-user",
+        agentId: "test-agent",
+        scheduleId: "test-schedule",
+        prompt: "test",
+        appendSystemPrompt: undefined,
+        triggerType: "cron",
+        cronExpression: "0 0 * * *",
+        timezone: "UTC",
+        modelProviderId: null,
+        selectedModel: null,
+        apiStartTime: Date.now(),
+      });
+
+      // null → undefined so resolveEffectiveModel's ?? chain falls through to agent model
+      expect(result.modelProviderId).toBeUndefined();
+      expect(result.selectedModelOverride).toBeUndefined();
+    });
+
+    it("passes through explicit model values", () => {
+      const result = adaptScheduleTrigger({
+        userId: "test-user",
+        agentId: "test-agent",
+        scheduleId: "test-schedule",
+        prompt: "test",
+        appendSystemPrompt: undefined,
+        triggerType: "cron",
+        cronExpression: "0 0 * * *",
+        timezone: "UTC",
+        modelProviderId: "provider-123",
+        selectedModel: "claude-opus-4-7",
+        apiStartTime: Date.now(),
+      });
+
+      expect(result.modelProviderId).toBe("provider-123");
+      expect(result.selectedModelOverride).toBe("claude-opus-4-7");
+    });
+
+    it("converts undefined modelProviderId to undefined", () => {
+      const result = adaptScheduleTrigger({
+        userId: "test-user",
+        agentId: "test-agent",
+        scheduleId: "test-schedule",
+        prompt: "test",
+        appendSystemPrompt: undefined,
+        triggerType: "loop",
+        cronExpression: undefined,
+        timezone: "UTC",
+        apiStartTime: Date.now(),
+        // modelProviderId and selectedModel omitted entirely
+      });
+
+      expect(result.modelProviderId).toBeUndefined();
+      expect(result.selectedModelOverride).toBeUndefined();
+    });
+  });
+});

--- a/turbo/apps/web/src/__tests__/schedule-model-resolution.test.ts
+++ b/turbo/apps/web/src/__tests__/schedule-model-resolution.test.ts
@@ -54,9 +54,9 @@ describe("Schedule model resolution", () => {
       // Create model provider for the agent's model
       mockClerk({ userId, orgId, orgRole: "org:admin" });
       const provider = await createTestOrgModelProvider(
-        "google-gemini-api-key",
-        "test-gemini-key",
-        "gemini-2.5-pro",
+        "openai-api-key",
+        "test-openai-key",
+        "gpt-4o",
       );
 
       mockClerk({ userId, orgId, orgRole: "org:admin" });
@@ -72,7 +72,7 @@ describe("Schedule model resolution", () => {
             prompt: "Test schedule with explicit model override",
             cronExpression: "0 0 * * *",
             modelProviderId: provider.id,
-            selectedModel: "gemini-2.5-pro",
+            selectedModel: "gpt-4o",
           }),
         }),
       );
@@ -80,7 +80,7 @@ describe("Schedule model resolution", () => {
       expect(response.status).toBe(201);
       const data = await response.json();
       expect(data.schedule.modelProviderId).toBe(provider.id);
-      expect(data.schedule.selectedModel).toBe("gemini-2.5-pro");
+      expect(data.schedule.selectedModel).toBe("gpt-4o");
     });
 
     it("returns 400 when modelProviderId references a provider not in the org", async () => {
@@ -123,22 +123,18 @@ describe("Schedule model resolution", () => {
         "claude-sonnet-4-6",
       );
 
-      // Create a gemini provider that will be the agent's custom model
+      // Create an openai provider that will be the agent's custom model
       mockClerk({ userId, orgId, orgRole: "org:admin" });
       const agentProvider = await createTestOrgModelProvider(
-        "google-gemini-api-key",
-        "test-gemini-key",
-        "gemini-2.5-pro",
+        "openai-api-key",
+        "test-openai-key",
+        "gpt-4o",
       );
 
       // Create agent with a specific model (different from org default)
       mockClerk({ userId, orgId, orgRole: "org:admin" });
       const { agentId } = await createTestCompose(uniqueId("agent"));
-      await setTestZeroAgentModelProvider(
-        agentId,
-        agentProvider.id,
-        "gemini-2.5-pro",
-      );
+      await setTestZeroAgentModelProvider(agentId, agentProvider.id, "gpt-4o");
 
       // Create schedule with "agent default" (null model fields)
       mockClerk({ userId, orgId, orgRole: "org:admin" });

--- a/turbo/apps/web/src/__tests__/schedule-model-resolution.test.ts
+++ b/turbo/apps/web/src/__tests__/schedule-model-resolution.test.ts
@@ -1,6 +1,4 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { eq } from "drizzle-orm";
-import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { POST as deployScheduleRoute } from "../../app/api/zero/schedules/route";
 import { adaptScheduleTrigger } from "../lib/zero/schedule/adapt-schedule-trigger";
 import {
@@ -12,7 +10,6 @@ import {
 } from "./api-test-helpers";
 import { mockClerk } from "./clerk-mock";
 import { testContext, uniqueId } from "./test-helpers";
-import { initServices } from "../lib/init-services";
 
 const context = testContext();
 
@@ -142,19 +139,6 @@ describe("Schedule model resolution", () => {
         agentProvider.id,
         "gemini-2.5-pro",
       );
-
-      // Verify agent model is set
-      initServices();
-      const [agent] = await globalThis.services.db
-        .select({
-          modelProviderId: zeroAgents.modelProviderId,
-          selectedModel: zeroAgents.selectedModel,
-        })
-        .from(zeroAgents)
-        .where(eq(zeroAgents.id, agentId))
-        .limit(1);
-      expect(agent!.modelProviderId).toBe(agentProvider.id);
-      expect(agent!.selectedModel).toBe("gemini-2.5-pro");
 
       // Create schedule with "agent default" (null model fields)
       mockClerk({ userId, orgId, orgRole: "org:admin" });


### PR DESCRIPTION
## Summary

Adds web-tier API tests for schedule model resolution to prevent regression of #10899.

PR #11016 (`c8e31b3f1`) fixed the runtime model fallback — when a schedule has null `modelProviderId`/`selectedModel` (meaning "use agent default"), the runtime now correctly falls back to the agent's configured model instead of the org default.

These tests verify the two layers that feed into that runtime resolution:

### API layer (deploy endpoint)
- Creating a schedule with explicit model override stores the override values
- Creating a schedule with `modelProviderId: null` (agent default) stores null without resolving to org default
- Non-existent provider IDs are rejected with 400

### Bridge layer (adaptScheduleTrigger)
- `null` model fields are converted to `undefined` so `resolveEffectiveModel`'s `??` chain kicks in
- Explicit model values pass through unchanged
- Omitted model fields also produce `undefined`

## Test plan

- [x] Verify tests follow existing conventions (mockClerk + testContext pattern)
- [x] CI passes on the new tests

Closes #10899

🤖 Generated with [Claude Code](https://claude.com/claude-code)