### PR TITLE
feat(platform): add Connect ChatGPT entry on model-providers settings

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-add-provider-dialog-chatgpt.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-add-provider-dialog-chatgpt.test.tsx
@@ -21,15 +21,17 @@ import {
   vi,
   type Mock,
 } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
 import { setOrgAddProviderDialogOpen$ } from "../../../signals/zero-page/settings/org-model-providers.ts";
 import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.helpers.ts";
-import { resetMockOrgModelProviders } from "../../../mocks/handlers/api-org-model-providers.ts";
-import { ProviderRowFooter } from "../components/org-manage/org-providers-tab.tsx";
+import {
+  resetMockOrgModelProviders,
+  setMockOrgModelProviders,
+} from "../../../mocks/handlers/api-org-model-providers.ts";
 
 const context = testContext();
 
@@ -38,6 +40,36 @@ async function openProvidersPage() {
   await waitFor(() => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
+}
+
+/**
+ * Build a chatgpt-oauth-token provider row with optional workspaceName /
+ * planType fields. These fields are part of the model-provider response
+ * contract (declared optional so other provider types can omit them); the
+ * chatgpt-oauth-token callback delivered in #11909 populates them.
+ */
+function makeChatgptProvider(
+  extras: { workspaceName?: string; planType?: string } = {},
+): ModelProviderResponse {
+  return {
+    id: "00000000-0000-4000-a000-000000000010",
+    type: "chatgpt-oauth-token",
+    framework: "codex",
+    secretName: "CHATGPT_ACCESS_TOKEN",
+    authMethod: "oauth",
+    secretNames: [
+      "CHATGPT_ACCESS_TOKEN",
+      "CHATGPT_REFRESH_TOKEN",
+      "CHATGPT_ACCOUNT_ID",
+      "CHATGPT_ID_TOKEN",
+    ],
+    isDefault: true,
+    selectedModel: null,
+    createdAt: "2026-05-06T00:00:00Z",
+    updatedAt: "2026-05-06T00:00:00Z",
+    workspaceName: extras.workspaceName,
+    planType: extras.planType,
+  };
 }
 
 describe("connect ChatGPT card — feature switch gating", () => {
@@ -114,82 +146,89 @@ describe("connect ChatGPT card — click handler", () => {
   });
 });
 
-describe("providerRowFooter — workspace + plan display", () => {
-  function makeChatgptProvider(
-    extras: { workspaceName?: string; planType?: string } = {},
-  ): ModelProviderResponse {
-    const base: ModelProviderResponse = {
-      id: "00000000-0000-4000-a000-000000000010",
-      type: "chatgpt-oauth-token",
-      framework: "codex",
-      secretName: "CHATGPT_ACCESS_TOKEN",
-      authMethod: "oauth",
-      secretNames: [
-        "CHATGPT_ACCESS_TOKEN",
-        "CHATGPT_REFRESH_TOKEN",
-        "CHATGPT_ACCOUNT_ID",
-        "CHATGPT_ID_TOKEN",
-      ],
-      isDefault: true,
-      selectedModel: null,
-      createdAt: "2026-05-06T00:00:00Z",
-      updatedAt: "2026-05-06T00:00:00Z",
-    };
-    // Forward-compatible extras delivered by #11909 — the platform reads them
-    // defensively, so attaching them here on top of the contract type works
-    // for the test today and will be a no-op cast once the contract widens.
-    return { ...base, ...extras } as ModelProviderResponse;
-  }
+describe("provider row footer — workspace + plan display", () => {
+  beforeEach(() => {
+    setMockFeatureSwitches({});
+    resetMockOrgModelProviders();
+  });
 
-  it("renders workspace name and plan pill when extras are present", () => {
-    render(
-      <ProviderRowFooter
-        provider={makeChatgptProvider({
-          workspaceName: "Acme Corp Workspace",
-          planType: "plus",
-        })}
-      />,
-    );
+  it("renders workspace name and plan pill when extras are present", async () => {
+    setMockOrgModelProviders([
+      makeChatgptProvider({
+        workspaceName: "Acme Corp Workspace",
+        planType: "plus",
+      }),
+    ]);
 
-    expect(screen.getByText("Acme Corp Workspace")).toBeInTheDocument();
+    await openProvidersPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Acme Corp Workspace")).toBeInTheDocument();
+    });
     expect(screen.getByText("Plus")).toBeInTheDocument();
   });
 
-  it("renders only the workspace name when planType is absent", () => {
-    render(
-      <ProviderRowFooter
-        provider={makeChatgptProvider({ workspaceName: "Acme Corp" })}
-      />,
-    );
+  it("renders only the workspace name when planType is absent", async () => {
+    setMockOrgModelProviders([
+      makeChatgptProvider({ workspaceName: "Acme Corp" }),
+    ]);
 
-    expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+    await openProvidersPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+    });
     expect(
       screen.queryByText(/^(Plus|Pro|Business|Edu|Enterprise)$/),
     ).toBeNull();
   });
 
-  it("falls back to 'Configured' label when extras are absent", () => {
-    render(<ProviderRowFooter provider={makeChatgptProvider()} />);
+  it("renders only the workspace name when planType is an unknown string", async () => {
+    // Drift guard: server may ship a value outside the known plan set
+    // (e.g. "team"). Render the workspace name without a plan pill rather
+    // than capitalizing an unrecognized value.
+    setMockOrgModelProviders([
+      makeChatgptProvider({ workspaceName: "Acme Corp", planType: "team" }),
+    ]);
 
-    expect(screen.getByText("Configured")).toBeInTheDocument();
+    await openProvidersPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Team")).toBeNull();
   });
 
-  it("falls back to 'Configured' label for non-chatgpt provider types", () => {
-    const anthropic: ModelProviderResponse = {
-      id: "00000000-0000-4000-a000-000000000020",
-      type: "anthropic-api-key",
-      framework: "claude-code",
-      secretName: "ANTHROPIC_API_KEY",
-      authMethod: null,
-      secretNames: null,
-      isDefault: false,
-      selectedModel: null,
-      createdAt: "2026-05-06T00:00:00Z",
-      updatedAt: "2026-05-06T00:00:00Z",
-    };
+  it("falls back to 'Configured' label when extras are absent", async () => {
+    setMockOrgModelProviders([makeChatgptProvider()]);
 
-    render(<ProviderRowFooter provider={anthropic} />);
+    await openProvidersPage();
 
-    expect(screen.getByText("Configured")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Configured")).toBeInTheDocument();
+    });
+  });
+
+  it("falls back to 'Configured' label for non-chatgpt provider types", async () => {
+    setMockOrgModelProviders([
+      {
+        id: "00000000-0000-4000-a000-000000000020",
+        type: "anthropic-api-key",
+        framework: "claude-code",
+        secretName: "ANTHROPIC_API_KEY",
+        authMethod: null,
+        secretNames: null,
+        isDefault: false,
+        selectedModel: null,
+        createdAt: "2026-05-06T00:00:00Z",
+        updatedAt: "2026-05-06T00:00:00Z",
+      },
+    ]);
+
+    await openProvidersPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Configured")).toBeInTheDocument();
+    });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-add-provider-dialog-chatgpt.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-add-provider-dialog-chatgpt.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Tests for the Connect ChatGPT entry on the model-providers settings tab.
+ *
+ * Covers:
+ * - Card hidden when ChatgptOauthProvider feature switch is off (DoD: gate-off)
+ * - Card visible when feature switch is on (DoD: gate-on)
+ * - Click on the card redirects to /api/zero/chatgpt/oauth/connect (DoD: redirect)
+ * - Existing-provider row renders workspace name + plan pill when fields
+ *   present on chatgpt-oauth-token provider (DoD: post-OAuth display)
+ *
+ * Wave 2 sub-issue of Epic #11872 (issue #11907). Server-side OAuth route
+ * delivered in #11909; this test mocks the redirect target.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
+import { setOrgAddProviderDialogOpen$ } from "../../../signals/zero-page/settings/org-model-providers.ts";
+import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.helpers.ts";
+import { resetMockOrgModelProviders } from "../../../mocks/handlers/api-org-model-providers.ts";
+import { ProviderRowFooter } from "../components/org-manage/org-providers-tab.tsx";
+
+const context = testContext();
+
+async function openProvidersPage() {
+  detachedSetupPage({ context, path: "/?settings=providers" });
+  await waitFor(() => {
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+}
+
+describe("connect ChatGPT card — feature switch gating", () => {
+  beforeEach(() => {
+    setMockFeatureSwitches({});
+    resetMockOrgModelProviders();
+  });
+
+  it("hides the ChatGPT card when the feature switch is off", async () => {
+    await openProvidersPage();
+    context.store.set(setOrgAddProviderDialogOpen$, true);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("dialog").length).toBeGreaterThan(0);
+    });
+
+    expect(
+      screen.queryByTestId("org-provider-card-chatgpt-oauth-token"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the ChatGPT card when the feature switch is on", async () => {
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.ChatgptOauthProvider]: true,
+    });
+
+    await openProvidersPage();
+    context.store.set(setOrgAddProviderDialogOpen$, true);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("org-provider-card-chatgpt-oauth-token"),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("connect ChatGPT card — click handler", () => {
+  let assignSpy: Mock;
+  let originalAssign: Location["assign"];
+
+  beforeEach(() => {
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.ChatgptOauthProvider]: true,
+    });
+    resetMockOrgModelProviders();
+    // jsdom marks window.location.assign as non-configurable in some versions;
+    // replace it via defineProperty so we can spy without "Cannot redefine".
+    originalAssign = window.location.assign;
+    assignSpy = vi.fn();
+    Object.defineProperty(window.location, "assign", {
+      configurable: true,
+      value: assignSpy,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window.location, "assign", {
+      configurable: true,
+      value: originalAssign,
+    });
+  });
+
+  it("redirects to /api/zero/chatgpt/oauth/connect when card is clicked", async () => {
+    await openProvidersPage();
+    context.store.set(setOrgAddProviderDialogOpen$, true);
+
+    const card = await screen.findByTestId(
+      "org-provider-card-chatgpt-oauth-token",
+    );
+    click(card);
+
+    expect(assignSpy).toHaveBeenCalledWith("/api/zero/chatgpt/oauth/connect");
+  });
+});
+
+describe("providerRowFooter — workspace + plan display", () => {
+  function makeChatgptProvider(
+    extras: { workspaceName?: string; planType?: string } = {},
+  ): ModelProviderResponse {
+    const base: ModelProviderResponse = {
+      id: "00000000-0000-4000-a000-000000000010",
+      type: "chatgpt-oauth-token",
+      framework: "codex",
+      secretName: "CHATGPT_ACCESS_TOKEN",
+      authMethod: "oauth",
+      secretNames: [
+        "CHATGPT_ACCESS_TOKEN",
+        "CHATGPT_REFRESH_TOKEN",
+        "CHATGPT_ACCOUNT_ID",
+        "CHATGPT_ID_TOKEN",
+      ],
+      isDefault: true,
+      selectedModel: null,
+      createdAt: "2026-05-06T00:00:00Z",
+      updatedAt: "2026-05-06T00:00:00Z",
+    };
+    // Forward-compatible extras delivered by #11909 — the platform reads them
+    // defensively, so attaching them here on top of the contract type works
+    // for the test today and will be a no-op cast once the contract widens.
+    return { ...base, ...extras } as ModelProviderResponse;
+  }
+
+  it("renders workspace name and plan pill when extras are present", () => {
+    render(
+      <ProviderRowFooter
+        provider={makeChatgptProvider({
+          workspaceName: "Acme Corp Workspace",
+          planType: "plus",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Acme Corp Workspace")).toBeInTheDocument();
+    expect(screen.getByText("Plus")).toBeInTheDocument();
+  });
+
+  it("renders only the workspace name when planType is absent", () => {
+    render(
+      <ProviderRowFooter
+        provider={makeChatgptProvider({ workspaceName: "Acme Corp" })}
+      />,
+    );
+
+    expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/^(Plus|Pro|Business|Edu|Enterprise)$/),
+    ).toBeNull();
+  });
+
+  it("falls back to 'Configured' label when extras are absent", () => {
+    render(<ProviderRowFooter provider={makeChatgptProvider()} />);
+
+    expect(screen.getByText("Configured")).toBeInTheDocument();
+  });
+
+  it("falls back to 'Configured' label for non-chatgpt provider types", () => {
+    const anthropic: ModelProviderResponse = {
+      id: "00000000-0000-4000-a000-000000000020",
+      type: "anthropic-api-key",
+      framework: "claude-code",
+      secretName: "ANTHROPIC_API_KEY",
+      authMethod: null,
+      secretNames: null,
+      isDefault: false,
+      selectedModel: null,
+      createdAt: "2026-05-06T00:00:00Z",
+      updatedAt: "2026-05-06T00:00:00Z",
+    };
+
+    render(<ProviderRowFooter provider={anthropic} />);
+
+    expect(screen.getByText("Configured")).toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
@@ -4,6 +4,7 @@ import { useGet, useSet, useLoadable } from "ccstate-react";
 import { IconDotsVertical, IconPlus } from "@tabler/icons-react";
 import {
   MODEL_PROVIDER_TYPES,
+  type ModelProviderResponse,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import {
@@ -135,6 +136,50 @@ function DefaultProviderSection() {
   );
 }
 
+/**
+ * Optional fields that the chatgpt-oauth-token callback populates on a
+ * provider row (delivered in #11909). The platform reads them defensively
+ * so this PR ships before the API contract widens.
+ */
+type ChatgptProviderExtras = {
+  workspaceName?: string;
+  planType?: "plus" | "pro" | "business" | "edu" | "enterprise";
+};
+
+function capitalizePlan(plan: string): string {
+  return plan.charAt(0).toUpperCase() + plan.slice(1);
+}
+
+export function ProviderRowFooter({
+  provider,
+}: {
+  provider: ModelProviderResponse;
+}) {
+  if (provider.type === "chatgpt-oauth-token") {
+    const extras = provider as ModelProviderResponse &
+      Partial<ChatgptProviderExtras>;
+    if (extras.workspaceName) {
+      return (
+        <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
+          <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
+          <span className="truncate">{extras.workspaceName}</span>
+          {extras.planType && (
+            <span className="ml-1 shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-foreground">
+              {capitalizePlan(extras.planType)}
+            </span>
+          )}
+        </span>
+      );
+    }
+  }
+  return (
+    <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
+      <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
+      Configured
+    </span>
+  );
+}
+
 function ProviderListSection({ isAdmin }: { isAdmin: boolean }) {
   const providersLoadable = useLoadable(orgConfiguredProviders$);
   const addDialogOpen = useGet(orgAddProviderDialogOpen$);
@@ -234,10 +279,7 @@ function ProviderListSection({ isAdmin }: { isAdmin: boolean }) {
                       : undefined
                   }
                 >
-                  <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
-                    <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
-                    Configured
-                  </span>
+                  <ProviderRowFooter provider={p} />
                   {isAdmin && (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
@@ -137,40 +137,45 @@ function DefaultProviderSection() {
 }
 
 /**
- * Optional fields that the chatgpt-oauth-token callback populates on a
- * provider row (delivered in #11909). The platform reads them defensively
- * so this PR ships before the API contract widens.
+ * Plan strings the chatgpt-oauth-token callback emits today. Values outside
+ * this set still come through as a `string` on the contract — we render the
+ * workspace name without a plan pill rather than capitalizing an
+ * unrecognized value. Mirrors the ChatGPT subscription tiers documented in
+ * provider-ui-config.ts.
  */
-type ChatgptProviderExtras = {
-  workspaceName?: string;
-  planType?: "plus" | "pro" | "business" | "edu" | "enterprise";
-};
+function isKnownChatgptPlan(plan: string): boolean {
+  return (
+    plan === "plus" ||
+    plan === "pro" ||
+    plan === "business" ||
+    plan === "edu" ||
+    plan === "enterprise"
+  );
+}
 
 function capitalizePlan(plan: string): string {
   return plan.charAt(0).toUpperCase() + plan.slice(1);
 }
 
-export function ProviderRowFooter({
-  provider,
-}: {
-  provider: ModelProviderResponse;
-}) {
-  if (provider.type === "chatgpt-oauth-token") {
-    const extras = provider as ModelProviderResponse &
-      Partial<ChatgptProviderExtras>;
-    if (extras.workspaceName) {
-      return (
-        <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
-          <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
-          <span className="truncate">{extras.workspaceName}</span>
-          {extras.planType && (
+function ProviderRowFooter({ provider }: { provider: ModelProviderResponse }) {
+  if (provider.type === "chatgpt-oauth-token" && provider.workspaceName) {
+    const showPlanPill =
+      provider.planType !== null &&
+      provider.planType !== undefined &&
+      isKnownChatgptPlan(provider.planType);
+    return (
+      <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
+        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
+        <span className="truncate">{provider.workspaceName}</span>
+        {showPlanPill &&
+          provider.planType !== null &&
+          provider.planType !== undefined && (
             <span className="ml-1 shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-foreground">
-              {capitalizePlan(extras.planType)}
+              {capitalizePlan(provider.planType)}
             </span>
           )}
-        </span>
-      );
-    }
+      </span>
+    );
   }
   return (
     <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
@@ -74,6 +74,8 @@ export function OrgAddProviderDialog({
   const configuredProviders = useLastResolved(orgConfiguredProviders$);
   const features = useLastResolved(featureSwitch$);
   const codexBetaEnabled = features?.[FeatureSwitchKey.CodexBeta] ?? false;
+  const chatgptOauthEnabled =
+    features?.[FeatureSwitchKey.ChatgptOauthProvider] ?? false;
   const openAdd = useSet(orgOpenAddDialog$);
   const configuredSet = new Set(
     configuredProviders?.map((p) => {
@@ -82,6 +84,13 @@ export function OrgAddProviderDialog({
   );
 
   const handleAdd = (type: ModelProviderType) => {
+    if (type === "chatgpt-oauth-token") {
+      // Server-side eligibility re-check happens in /api/zero/chatgpt/oauth/connect
+      // (delivered in #11909). The client gate above is a UX optimization to keep
+      // the card out of view; the route returns 404 when ineligible.
+      window.location.assign("/api/zero/chatgpt/oauth/connect");
+      return;
+    }
     openAdd(type);
   };
 
@@ -90,6 +99,9 @@ export function OrgAddProviderDialog({
       return false;
     }
     if (type === "openai-api-key" && !codexBetaEnabled) {
+      return false;
+    }
+    if (type === "chatgpt-oauth-token" && !chatgptOauthEnabled) {
       return false;
     }
     return true;

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -52,6 +52,12 @@ function getOverrides(
         "Leverage Claude Code's exceptional intelligence to build and run agents.",
     };
   }
+  if (type === "chatgpt-oauth-token") {
+    return {
+      description:
+        "Sign in with your ChatGPT subscription (Plus / Pro / Business / Edu / Enterprise). Workspace selection happens on auth.openai.com.",
+    };
+  }
   if (type === "anthropic-api-key") {
     return {
       description:

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -998,6 +998,13 @@ export const modelProviderResponseSchema = z.object({
   selectedModel: z.string().nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),
+  // ChatGPT-only metadata populated by the chatgpt-oauth-token callback.
+  // Other provider types omit these. Mirrors the server-side connector
+  // shape in apps/web/src/lib/zero/connector/providers/chatgpt-oauth.ts.
+  // The corresponding server route lands in #11909; declared here so the
+  // platform UI does not have to bypass schema validation to read them.
+  workspaceName: z.string().nullable().optional(),
+  planType: z.string().nullable().optional(),
 });
 
 export type ModelProviderResponse = z.infer<typeof modelProviderResponseSchema>;


### PR DESCRIPTION
## Summary
- Gate the `chatgpt-oauth-token` card in `OrgAddProviderDialog` behind `FeatureSwitchKey.ChatgptOauthProvider` (mirrors the existing `openai-api-key` / `CodexBeta` precedent).
- Special-case the card click handler: redirect to `/api/zero/chatgpt/oauth/connect` (server route owned by #11909) instead of opening the multi-secret form dialog.
- Add a description override on the card so it reads "Sign in with your ChatGPT subscription...".
- Render workspace name + plan pill on existing `chatgpt-oauth-token` provider rows when the optional `workspaceName` / `planType` fields are populated; gracefully fall back to "Configured" when absent.
- Close a card-leak introduced post-Wave-1 (see below).

Wave 2 sub-issue of Epic #11872. Coordinates with #11909 (server routes) and the future Wave 3 stale-UX sub-issue.

## Card-leak fix (urgent, in scope per leader review)
After #11885 registered `chatgpt-oauth-token` in `MODEL_PROVIDER_TYPES`, the type became selectable in `OrgAddProviderDialog` with no gate. Clicking it routed users to the multi-auth form which asks for 4 placeholder JWTs — broken UX. This PR adds the missing gate (default OFF for non-staff orgs), so the card is hidden until the feature switch is on.

## Re-framing vs. issue body
The issue body assumed a new `[locale]/settings/model-providers/page.tsx` Next.js route in `apps/web`. The actual user-facing UI is a Vite SPA at `apps/platform`, and a model-providers settings tab already exists. This PR extends the existing tab + dialog rather than creating a parallel new surface. Re-framing was approved by the leader; see research / innovate / plan comments on issue #11907 for the full rationale.

## Coordination notes for #11909
- The redirect URL `/api/zero/chatgpt/oauth/connect` is owned by #11909. The route 404s until that ships. Feature switch defaults OFF for non-staff orgs, so no public exposure.
- The `workspaceName` and `planType` field names on `ModelProviderResponse` are this PR's suggestion. If #11909 picks different names, this PR adapts in a one-line edit.
- Server-side identity (orgId / userId) is read from the auth context in #11909's route, not passed as query params from the browser.

## Test plan
- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/org-add-provider-dialog-chatgpt.test.tsx` — 7/7 pass
  - Card hidden when `chatgptOauthProvider` switch is off
  - Card visible when switch is on
  - Card click triggers `window.location.assign("/api/zero/chatgpt/oauth/connect")`
  - `ProviderRowFooter` renders workspace + plan pill when extras present
  - `ProviderRowFooter` renders only workspace when `planType` absent
  - `ProviderRowFooter` falls back to "Configured" when extras absent
  - `ProviderRowFooter` falls back to "Configured" for non-chatgpt provider types
- [x] `pnpm -F @vm0/app exec vitest run` — full platform vitest, 2261/2261 pass
- [x] `pnpm turbo run lint` — 10/10 packages clean
- [x] `pnpm check-types` — 11/11 tasks clean
- [x] `pnpm format` — clean
- [x] `pnpm knip` — clean
- [ ] CI green (lint, test-app x8, deploy, lighthouse, cli-e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)