### PR TITLE
refactor(sandbox-fc): add factory cleanup task group

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2777,6 +2777,7 @@ dependencies = [
  "async-trait",
  "base64",
  "clap",
+ "futures-util",
  "hex",
  "libc",
  "nbd-cow",

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 async-trait.workspace = true
 base64.workspace = true
+futures-util.workspace = true
 nbd-cow.workspace = true
 libc.workspace = true
 nix = { workspace = true, features = ["user", "inotify", "fs", "signal"] }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -2142,10 +2142,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn factory_cleanup_group_shutdown_cancel_reinserts_running_task() {
+    async fn factory_cleanup_group_shutdown_cancel_reinserts_running_and_late_tasks() {
         let group = Arc::new(FactoryCleanupGroup::new());
         let (release_tx, release_rx) = tokio::sync::oneshot::channel();
         let completed = Arc::new(AtomicBool::new(false));
+        let late_completed = Arc::new(AtomicBool::new(false));
         let (started_tx, started_rx) = tokio::sync::oneshot::channel();
 
         let completed_clone = Arc::clone(&completed);
@@ -2167,6 +2168,12 @@ mod tests {
         shutdown_task.abort();
         assert!(shutdown_task.await.unwrap_err().is_cancelled());
 
+        let late_completed_clone = Arc::clone(&late_completed);
+        let late_waiter = group.spawn(FactoryCleanupTaskKind::Destroy, "late", async move {
+            late_completed_clone.store(true, Ordering::SeqCst);
+        });
+        drop(late_waiter);
+
         let retry_group = Arc::clone(&group);
         let retry_shutdown = tokio::spawn(async move {
             retry_group.shutdown().await;
@@ -2178,6 +2185,7 @@ mod tests {
         retry_shutdown.await.unwrap();
 
         assert!(completed.load(Ordering::SeqCst));
+        assert!(late_completed.load(Ordering::SeqCst));
     }
 
     #[tokio::test]
@@ -2228,6 +2236,37 @@ mod tests {
         cleanup.wait_propagating_panic().await;
 
         assert!(ran.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn factory_cleanup_group_start_accepting_reopens_after_shutdown() {
+        let group = Arc::new(FactoryCleanupGroup::new());
+        group.shutdown().await;
+        group.start_accepting();
+
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let completed = Arc::new(AtomicBool::new(false));
+        let completed_clone = Arc::clone(&completed);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let waiter = group.spawn(FactoryCleanupTaskKind::Destroy, "restart", async move {
+            let _ = started_tx.send(());
+            let _ = release_rx.await;
+            completed_clone.store(true, Ordering::SeqCst);
+        });
+        drop(waiter);
+
+        started_rx.await.unwrap();
+        let shutdown_group = Arc::clone(&group);
+        let shutdown_task = tokio::spawn(async move {
+            shutdown_group.shutdown().await;
+        });
+        tokio::task::yield_now().await;
+        assert!(!shutdown_task.is_finished());
+
+        release_tx.send(()).unwrap();
+        shutdown_task.await.unwrap();
+
+        assert!(completed.load(Ordering::SeqCst));
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -904,13 +904,15 @@ impl SandboxCreateTransaction {
         C: CreateRollbackCleanup + Sync,
     {
         let keep_workspace = if let Some(cow_device) = self.cow_device.take() {
-            !cleanup.destroy_cow_device(cow_device).await
+            // The COW finalizer continues in the background if this future is
+            // cancelled. Keep the workspace until the finalizer reports success.
+            self.delete_workspace_on_leak_cleanup = false;
+            let cow_destroyed = cleanup.destroy_cow_device(cow_device).await;
+            self.delete_workspace_on_leak_cleanup = cow_destroyed;
+            !cow_destroyed
         } else {
             false
         };
-        if keep_workspace {
-            self.delete_workspace_on_leak_cleanup = false;
-        }
         if let Some(network) = self.network.take() {
             self.network = Some(network);
             cleanup.release_network(&mut self.network).await;
@@ -1660,12 +1662,18 @@ async fn destroy_firecracker_sandbox(mut sandbox: FirecrackerSandbox, netns_pool
     // releasing file descriptors (particularly the NBD device fd).
     // Retry a few times to let it finish.
     let cow_destroyed = match sandbox.cow_device.take() {
-        Some(cow_device) => destroy_cow_device_with_retries(&sandbox_id, cow_device).await,
+        Some(cow_device) => {
+            // If shutdown aborts this task while the COW finalizer is running,
+            // Drop-based leak cleanup must not delete the backing workspace.
+            sandbox.preserve_workspace_on_leak_cleanup();
+            let cow_destroyed = destroy_cow_device_with_retries(&sandbox_id, cow_device).await;
+            if cow_destroyed {
+                sandbox.allow_workspace_delete_on_leak_cleanup();
+            }
+            cow_destroyed
+        }
         None => true,
     };
-    if !cow_destroyed {
-        sandbox.preserve_workspace_on_leak_cleanup();
-    }
 
     // Return the network namespace to the pool.
     let outcome = netns_pool.release(sandbox.network.lease_mut()).await;

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -187,14 +187,6 @@ struct FactoryCleanupWaiter {
 }
 
 impl FactoryCleanupWaiter {
-    async fn wait_propagating_panic(self) {
-        self.wait(FactoryCleanupPanicPolicy::Propagate).await;
-    }
-
-    async fn wait_logging_panic(self) {
-        self.wait(FactoryCleanupPanicPolicy::Log).await;
-    }
-
     async fn wait(self, panic_policy: FactoryCleanupPanicPolicy) {
         match self.rx.await {
             Ok(FactoryCleanupTaskOutcome::Completed) => {}
@@ -225,6 +217,7 @@ struct FactoryCleanupGroup {
 
 struct FactoryCleanupGroupState {
     accepting: bool,
+    closed: bool,
     tasks: JoinSet<FactoryCleanupTaskFinished>,
     records: HashMap<TaskId, FactoryCleanupTaskRecord>,
 }
@@ -233,8 +226,67 @@ impl FactoryCleanupGroupState {
     fn new() -> Self {
         Self {
             accepting: true,
+            closed: false,
             tasks: JoinSet::new(),
             records: HashMap::new(),
+        }
+    }
+}
+
+struct FactoryCleanupRejected<F> {
+    kind: FactoryCleanupTaskKind,
+    label: String,
+    cleanup: F,
+}
+
+enum FactoryCleanupRegistration<F> {
+    Waiter(FactoryCleanupWaiter),
+    Rejected(FactoryCleanupRejected<F>),
+}
+
+impl<F> FactoryCleanupRegistration<F>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    async fn wait_propagating_panic(self) {
+        self.wait(FactoryCleanupPanicPolicy::Propagate).await;
+    }
+
+    async fn wait_logging_panic(self) {
+        self.wait(FactoryCleanupPanicPolicy::Log).await;
+    }
+
+    async fn wait(self, panic_policy: FactoryCleanupPanicPolicy) {
+        match self {
+            Self::Waiter(waiter) => waiter.wait(panic_policy).await,
+            Self::Rejected(rejected) => rejected.wait(panic_policy).await,
+        }
+    }
+}
+
+impl<F> FactoryCleanupRejected<F>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    async fn wait(self, panic_policy: FactoryCleanupPanicPolicy) {
+        warn!(
+            kind = self.kind.as_str(),
+            label = %self.label,
+            "factory cleanup group is closed; running cleanup in caller task"
+        );
+
+        match AssertUnwindSafe(self.cleanup).catch_unwind().await {
+            Ok(()) => {}
+            Err(payload) => match panic_policy {
+                FactoryCleanupPanicPolicy::Propagate => std::panic::resume_unwind(payload),
+                FactoryCleanupPanicPolicy::Log => {
+                    warn!(
+                        kind = self.kind.as_str(),
+                        label = %self.label,
+                        "factory cleanup task panicked"
+                    );
+                }
+            },
         }
     }
 }
@@ -250,6 +302,7 @@ impl FactoryCleanupGroup {
         let mut state = self.state.lock().await;
         Self::reap_completed_locked(&mut state, false);
         state.accepting = true;
+        state.closed = false;
     }
 
     async fn spawn<F>(
@@ -257,69 +310,107 @@ impl FactoryCleanupGroup {
         kind: FactoryCleanupTaskKind,
         label: impl Into<String>,
         cleanup: F,
-    ) -> FactoryCleanupWaiter
+    ) -> FactoryCleanupRegistration<F>
     where
         F: Future<Output = ()> + Send + 'static,
     {
         let label = label.into();
         let waiter_label = label.clone();
-        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
-        let task = Self::cleanup_task(kind, label.clone(), cleanup, done_tx);
-
         let mut state = self.state.lock().await;
         Self::reap_completed_locked(&mut state, false);
-        if state.accepting {
-            let abort_handle = state.tasks.spawn(task);
-            state.records.insert(
-                abort_handle.id(),
-                FactoryCleanupTaskRecord {
-                    kind,
-                    label: label.clone(),
-                },
-            );
-        } else {
+        if state.closed {
             warn!(
                 kind = kind.as_str(),
                 label = %label,
-                "factory cleanup group is shutting down; cleanup task is not tracked by shutdown"
+                "factory cleanup group is closed; rejecting tracked cleanup registration"
             );
-            std::mem::drop(tokio::spawn(task));
+            return FactoryCleanupRegistration::Rejected(FactoryCleanupRejected {
+                kind,
+                label,
+                cleanup,
+            });
         }
 
-        FactoryCleanupWaiter {
+        if !state.accepting {
+            warn!(
+                kind = kind.as_str(),
+                label = %label,
+                "factory cleanup group is shutting down; registered cleanup task for shutdown drain"
+            );
+        }
+
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let task = Self::cleanup_task(kind, label.clone(), cleanup, done_tx);
+        let abort_handle = state.tasks.spawn(task);
+        state.records.insert(
+            abort_handle.id(),
+            FactoryCleanupTaskRecord {
+                kind,
+                label: label.clone(),
+            },
+        );
+
+        FactoryCleanupRegistration::Waiter(FactoryCleanupWaiter {
             kind,
             label: waiter_label,
             rx: done_rx,
-        }
+        })
     }
 
     async fn shutdown(&self) {
-        let (mut tasks, mut records) = {
-            let mut state = self.state.lock().await;
-            state.accepting = false;
-            Self::reap_completed_locked(&mut state, false);
-            if state.tasks.is_empty() {
-                return;
-            }
-            (
-                std::mem::replace(&mut state.tasks, JoinSet::new()),
-                std::mem::take(&mut state.records),
-            )
-        };
-
         let timeout = tokio::time::sleep(FACTORY_CLEANUP_SHUTDOWN_TIMEOUT);
         tokio::pin!(timeout);
 
         loop {
-            if tasks.is_empty() {
+            let Some((mut tasks, mut records)) = self.take_shutdown_batch().await else {
                 return;
+            };
+
+            if self
+                .drain_shutdown_batch(&mut tasks, &mut records, &mut timeout)
+                .await
+            {
+                self.abort_remaining_after_shutdown_timeout().await;
+                return;
+            }
+        }
+    }
+
+    async fn take_shutdown_batch(
+        &self,
+    ) -> Option<(
+        JoinSet<FactoryCleanupTaskFinished>,
+        HashMap<TaskId, FactoryCleanupTaskRecord>,
+    )> {
+        let mut state = self.state.lock().await;
+        state.accepting = false;
+        Self::reap_completed_locked(&mut state, false);
+        if state.tasks.is_empty() {
+            state.closed = true;
+            return None;
+        }
+        Some((
+            std::mem::replace(&mut state.tasks, JoinSet::new()),
+            std::mem::take(&mut state.records),
+        ))
+    }
+
+    async fn drain_shutdown_batch(
+        &self,
+        tasks: &mut JoinSet<FactoryCleanupTaskFinished>,
+        records: &mut HashMap<TaskId, FactoryCleanupTaskRecord>,
+        timeout: &mut std::pin::Pin<&mut tokio::time::Sleep>,
+    ) -> bool {
+        loop {
+            if tasks.is_empty() {
+                return false;
             }
 
             tokio::select! {
                 result = tasks.join_next_with_id() => {
-                    Self::handle_join_result(&mut records, result, false);
+                    Self::handle_join_result(records, result, false);
                 }
-                () = &mut timeout => {
+                () = timeout.as_mut() => {
                     let task_count = tasks.len();
                     warn!(
                         task_count,
@@ -336,12 +427,44 @@ impl FactoryCleanupGroup {
                     tasks.abort_all();
                     while !tasks.is_empty() {
                         let result = tasks.join_next_with_id().await;
-                        Self::handle_join_result(&mut records, result, true);
+                        Self::handle_join_result(records, result, true);
                     }
                     records.clear();
-                    return;
+                    return true;
                 }
             }
+        }
+    }
+
+    async fn abort_remaining_after_shutdown_timeout(&self) {
+        loop {
+            let (mut tasks, mut records) = {
+                let mut state = self.state.lock().await;
+                state.accepting = false;
+                state.closed = true;
+                Self::reap_completed_locked(&mut state, false);
+                if state.tasks.is_empty() {
+                    return;
+                }
+                (
+                    std::mem::replace(&mut state.tasks, JoinSet::new()),
+                    std::mem::take(&mut state.records),
+                )
+            };
+
+            for record in records.values() {
+                warn!(
+                    kind = record.kind.as_str(),
+                    label = %record.label,
+                    "aborting late factory cleanup task after shutdown timeout"
+                );
+            }
+            tasks.abort_all();
+            while !tasks.is_empty() {
+                let result = tasks.join_next_with_id().await;
+                Self::handle_join_result(&mut records, result, true);
+            }
+            records.clear();
         }
     }
 
@@ -1900,6 +2023,62 @@ mod tests {
         shutdown_task.await.unwrap();
 
         assert!(completed.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn factory_cleanup_group_shutdown_drains_late_registered_task() {
+        let group = Arc::new(FactoryCleanupGroup::new());
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let late_completed = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let waiter = group
+            .spawn(FactoryCleanupTaskKind::Destroy, "first", async move {
+                let _ = started_tx.send(());
+                let _ = release_rx.await;
+            })
+            .await;
+        drop(waiter);
+
+        started_rx.await.unwrap();
+        let shutdown_group = Arc::clone(&group);
+        let shutdown_task = tokio::spawn(async move {
+            shutdown_group.shutdown().await;
+        });
+        tokio::task::yield_now().await;
+        assert!(!shutdown_task.is_finished());
+
+        let late_completed_clone = Arc::clone(&late_completed);
+        let late_waiter = group
+            .spawn(FactoryCleanupTaskKind::Destroy, "late", async move {
+                late_completed_clone.store(true, Ordering::SeqCst);
+            })
+            .await;
+        drop(late_waiter);
+
+        release_tx.send(()).unwrap();
+        shutdown_task.await.unwrap();
+
+        assert!(late_completed.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn factory_cleanup_group_closed_registration_runs_in_caller_task() {
+        let group = FactoryCleanupGroup::new();
+        group.shutdown().await;
+
+        let ran = Arc::new(AtomicBool::new(false));
+        let ran_clone = Arc::clone(&ran);
+        let cleanup = group
+            .spawn(FactoryCleanupTaskKind::Destroy, "closed", async move {
+                ran_clone.store(true, Ordering::SeqCst);
+            })
+            .await;
+
+        assert!(!ran.load(Ordering::SeqCst));
+        cleanup.wait_propagating_panic().await;
+
+        assert!(ran.load(Ordering::SeqCst));
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -2155,6 +2155,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn factory_cleanup_group_drains_task_after_waiter_drop_without_waiting() {
+        let group = FactoryCleanupGroup::new();
+        let completed = Arc::new(AtomicBool::new(false));
+        let completed_clone = Arc::clone(&completed);
+
+        let waiter = group.spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
+            completed_clone.store(true, Ordering::SeqCst);
+        });
+        drop(waiter);
+
+        group.shutdown().await;
+
+        assert!(completed.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
     async fn factory_cleanup_group_shutdown_waits_for_running_task() {
         let group = Arc::new(FactoryCleanupGroup::new());
         let (release_tx, release_rx) = tokio::sync::oneshot::channel();

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -1,11 +1,13 @@
-use std::path::PathBuf;
+use std::{any::Any, collections::HashMap, future::Future, panic::AssertUnwindSafe, path::PathBuf};
 
 use async_trait::async_trait;
+use futures_util::FutureExt;
 use sandbox::{
     Sandbox, SandboxConfig, SandboxError, SandboxFactory, SandboxInitializationPhase,
     SandboxInvalidStateContext,
 };
 use sha2::{Digest, Sha256};
+use tokio::task::{Id as TaskId, JoinError, JoinSet};
 use tracing::{info, warn};
 
 use nbd_cow::{DestroyRetryPolicy, PooledNbdCowDevice};
@@ -34,6 +36,13 @@ pub(crate) const DESTROY_RETRY_DELAY: std::time::Duration = std::time::Duration:
 /// COW destroy retry budget because leaked sandbox cleanup now owns the pooled
 /// COW device and may need a full finalizer pass before releasing netns/dirs.
 const LEAK_CLEANUP_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Maximum time to wait for explicit factory cleanup tasks during shutdown.
+///
+/// These tasks own normal destroy/rollback cleanup work. If they stall, abort
+/// them before shutting down leak cleanup and factory-owned pools; runner GC
+/// remains the final backstop for orphaned host resources.
+const FACTORY_CLEANUP_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Resources that require async cleanup when a sandbox is dropped without
 /// going through `factory.destroy()` or when create is dropped mid-allocation.
@@ -133,6 +142,303 @@ impl LeakCleaner {
 impl Drop for LeakCleaner {
     fn drop(&mut self) {
         self.detach_for_drop();
+    }
+}
+
+#[derive(Clone, Copy)]
+enum FactoryCleanupTaskKind {
+    Destroy,
+    Rollback,
+}
+
+impl FactoryCleanupTaskKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Destroy => "destroy",
+            Self::Rollback => "rollback",
+        }
+    }
+}
+
+struct FactoryCleanupTaskRecord {
+    kind: FactoryCleanupTaskKind,
+    label: String,
+}
+
+struct FactoryCleanupTaskFinished {
+    kind: FactoryCleanupTaskKind,
+    label: String,
+}
+
+enum FactoryCleanupTaskOutcome {
+    Completed,
+    Panicked(Box<dyn Any + Send + 'static>),
+}
+
+enum FactoryCleanupPanicPolicy {
+    Propagate,
+    Log,
+}
+
+struct FactoryCleanupWaiter {
+    kind: FactoryCleanupTaskKind,
+    label: String,
+    rx: tokio::sync::oneshot::Receiver<FactoryCleanupTaskOutcome>,
+}
+
+impl FactoryCleanupWaiter {
+    async fn wait_propagating_panic(self) {
+        self.wait(FactoryCleanupPanicPolicy::Propagate).await;
+    }
+
+    async fn wait_logging_panic(self) {
+        self.wait(FactoryCleanupPanicPolicy::Log).await;
+    }
+
+    async fn wait(self, panic_policy: FactoryCleanupPanicPolicy) {
+        match self.rx.await {
+            Ok(FactoryCleanupTaskOutcome::Completed) => {}
+            Ok(FactoryCleanupTaskOutcome::Panicked(payload)) => match panic_policy {
+                FactoryCleanupPanicPolicy::Propagate => std::panic::resume_unwind(payload),
+                FactoryCleanupPanicPolicy::Log => {
+                    warn!(
+                        kind = self.kind.as_str(),
+                        label = %self.label,
+                        "factory cleanup task panicked"
+                    );
+                }
+            },
+            Err(_) => {
+                info!(
+                    kind = self.kind.as_str(),
+                    label = %self.label,
+                    "factory cleanup task ended before reporting completion"
+                );
+            }
+        }
+    }
+}
+
+struct FactoryCleanupGroup {
+    state: tokio::sync::Mutex<FactoryCleanupGroupState>,
+}
+
+struct FactoryCleanupGroupState {
+    accepting: bool,
+    tasks: JoinSet<FactoryCleanupTaskFinished>,
+    records: HashMap<TaskId, FactoryCleanupTaskRecord>,
+}
+
+impl FactoryCleanupGroupState {
+    fn new() -> Self {
+        Self {
+            accepting: true,
+            tasks: JoinSet::new(),
+            records: HashMap::new(),
+        }
+    }
+}
+
+impl FactoryCleanupGroup {
+    fn new() -> Self {
+        Self {
+            state: tokio::sync::Mutex::new(FactoryCleanupGroupState::new()),
+        }
+    }
+
+    async fn start_accepting(&self) {
+        let mut state = self.state.lock().await;
+        Self::reap_completed_locked(&mut state, false);
+        state.accepting = true;
+    }
+
+    async fn spawn<F>(
+        &self,
+        kind: FactoryCleanupTaskKind,
+        label: impl Into<String>,
+        cleanup: F,
+    ) -> FactoryCleanupWaiter
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let label = label.into();
+        let waiter_label = label.clone();
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let task = Self::cleanup_task(kind, label.clone(), cleanup, done_tx);
+
+        let mut state = self.state.lock().await;
+        Self::reap_completed_locked(&mut state, false);
+        if state.accepting {
+            let abort_handle = state.tasks.spawn(task);
+            state.records.insert(
+                abort_handle.id(),
+                FactoryCleanupTaskRecord {
+                    kind,
+                    label: label.clone(),
+                },
+            );
+        } else {
+            warn!(
+                kind = kind.as_str(),
+                label = %label,
+                "factory cleanup group is shutting down; cleanup task is not tracked by shutdown"
+            );
+            std::mem::drop(tokio::spawn(task));
+        }
+
+        FactoryCleanupWaiter {
+            kind,
+            label: waiter_label,
+            rx: done_rx,
+        }
+    }
+
+    async fn shutdown(&self) {
+        let (mut tasks, mut records) = {
+            let mut state = self.state.lock().await;
+            state.accepting = false;
+            Self::reap_completed_locked(&mut state, false);
+            if state.tasks.is_empty() {
+                return;
+            }
+            (
+                std::mem::replace(&mut state.tasks, JoinSet::new()),
+                std::mem::take(&mut state.records),
+            )
+        };
+
+        let timeout = tokio::time::sleep(FACTORY_CLEANUP_SHUTDOWN_TIMEOUT);
+        tokio::pin!(timeout);
+
+        loop {
+            if tasks.is_empty() {
+                return;
+            }
+
+            tokio::select! {
+                result = tasks.join_next_with_id() => {
+                    Self::handle_join_result(&mut records, result, false);
+                }
+                () = &mut timeout => {
+                    let task_count = tasks.len();
+                    warn!(
+                        task_count,
+                        timeout_ms = FACTORY_CLEANUP_SHUTDOWN_TIMEOUT.as_millis() as u64,
+                        "timed out waiting for factory cleanup tasks; aborting"
+                    );
+                    for record in records.values() {
+                        warn!(
+                            kind = record.kind.as_str(),
+                            label = %record.label,
+                            "aborting factory cleanup task; runner gc may need to clean leftovers"
+                        );
+                    }
+                    tasks.abort_all();
+                    while !tasks.is_empty() {
+                        let result = tasks.join_next_with_id().await;
+                        Self::handle_join_result(&mut records, result, true);
+                    }
+                    records.clear();
+                    return;
+                }
+            }
+        }
+    }
+
+    async fn cleanup_task<F>(
+        kind: FactoryCleanupTaskKind,
+        label: String,
+        cleanup: F,
+        done_tx: tokio::sync::oneshot::Sender<FactoryCleanupTaskOutcome>,
+    ) -> FactoryCleanupTaskFinished
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let result = AssertUnwindSafe(cleanup).catch_unwind().await;
+        match result {
+            Ok(()) => {
+                let _ = done_tx.send(FactoryCleanupTaskOutcome::Completed);
+            }
+            Err(payload) => {
+                if let Err(FactoryCleanupTaskOutcome::Panicked(_)) =
+                    done_tx.send(FactoryCleanupTaskOutcome::Panicked(payload))
+                {
+                    warn!(
+                        kind = kind.as_str(),
+                        label = %label,
+                        "factory cleanup task panicked after waiter dropped"
+                    );
+                }
+            }
+        }
+        FactoryCleanupTaskFinished { kind, label }
+    }
+
+    fn reap_completed_locked(state: &mut FactoryCleanupGroupState, after_abort: bool) {
+        while let Some(result) = state.tasks.try_join_next_with_id() {
+            Self::handle_join_result(&mut state.records, Some(result), after_abort);
+        }
+    }
+
+    fn handle_join_result(
+        records: &mut HashMap<TaskId, FactoryCleanupTaskRecord>,
+        result: Option<Result<(TaskId, FactoryCleanupTaskFinished), JoinError>>,
+        after_abort: bool,
+    ) {
+        match result {
+            Some(Ok((task_id, finished))) => {
+                records.remove(&task_id);
+                if after_abort {
+                    info!(
+                        kind = finished.kind.as_str(),
+                        label = %finished.label,
+                        "factory cleanup task completed while shutdown abort was in progress"
+                    );
+                }
+            }
+            Some(Err(err)) => {
+                let record = records.remove(&err.id());
+                let (kind, label) = record
+                    .map(|record| (record.kind.as_str(), record.label))
+                    .unwrap_or(("unknown", err.id().to_string()));
+                if err.is_cancelled() && after_abort {
+                    info!(
+                        kind,
+                        label = %label,
+                        "factory cleanup task aborted during shutdown"
+                    );
+                } else {
+                    warn!(
+                        kind,
+                        label = %label,
+                        error = %err,
+                        "factory cleanup task exited unexpectedly"
+                    );
+                }
+            }
+            None => {}
+        }
+    }
+}
+
+impl Drop for FactoryCleanupGroup {
+    fn drop(&mut self) {
+        match self.state.try_lock() {
+            Ok(mut state) => {
+                Self::reap_completed_locked(&mut state, false);
+                if state.tasks.is_empty() {
+                    return;
+                }
+                warn!(
+                    task_count = state.tasks.len(),
+                    "factory cleanup group dropped with in-flight tasks; aborting without await"
+                );
+                state.tasks.abort_all();
+            }
+            Err(_) => {
+                warn!("factory cleanup group dropped while locked; cleanup tasks may keep running");
+            }
+        }
     }
 }
 
@@ -477,22 +783,25 @@ fn create_transaction_invalid_state(message: &str) -> SandboxError {
     }
 }
 
-async fn rollback_create_transaction<C>(tx: SandboxCreateTransaction, cleanup: C)
-where
+async fn rollback_create_transaction<C>(
+    tx: SandboxCreateTransaction,
+    cleanup: C,
+    cleanup_group: &FactoryCleanupGroup,
+) where
     C: CreateRollbackCleanup + Send + Sync + 'static,
 {
     let rollback_id = tx.id.clone();
-    let rollback_task = tokio::spawn(async move {
-        let mut tx = tx;
-        tx.rollback(&cleanup).await;
-    });
-    if let Err(rollback_err) = rollback_task.await {
-        warn!(
-            id = %rollback_id,
-            error = %rollback_err,
-            "sandbox create rollback task failed"
-        );
-    }
+    let rollback_waiter = cleanup_group
+        .spawn(
+            FactoryCleanupTaskKind::Rollback,
+            rollback_id.clone(),
+            async move {
+                let mut tx = tx;
+                tx.rollback(&cleanup).await;
+            },
+        )
+        .await;
+    rollback_waiter.wait_logging_panic().await;
 }
 
 fn cow_destroy_retry_policy() -> DestroyRetryPolicy {
@@ -726,6 +1035,7 @@ pub struct FirecrackerFactory {
     /// Pre-warming pool for COW files.
     cow_pool: Option<tokio::sync::Mutex<crate::cow_pool::CowPool>>,
     started: bool,
+    cleanup_group: FactoryCleanupGroup,
     /// Owns the channel/task that drains leaked sandbox resources from Drop.
     leak_cleaner: Option<LeakCleaner>,
 }
@@ -773,6 +1083,7 @@ impl FirecrackerFactory {
             base_image_size: 0,
             cow_pool: None,
             started: false,
+            cleanup_group: FactoryCleanupGroup::new(),
             leak_cleaner: None,
         })
     }
@@ -815,6 +1126,7 @@ impl SandboxFactory for FirecrackerFactory {
                 message: "factory already started".into(),
             });
         }
+        self.cleanup_group.start_accepting().await;
 
         // Create netns pool only if not provided externally (shared pool case).
         if self.netns_pool.is_none() {
@@ -984,7 +1296,7 @@ impl SandboxFactory for FirecrackerFactory {
         let resources = match create_result {
             Ok(resources) => resources,
             Err(e) => {
-                rollback_create_transaction(tx, rollback_cleanup).await;
+                rollback_create_transaction(tx, rollback_cleanup, &self.cleanup_group).await;
                 return Err(e);
             }
         };
@@ -1019,20 +1331,26 @@ impl SandboxFactory for FirecrackerFactory {
             }
         };
         let netns_pool = self.netns_pool().clone();
+        let sandbox_id = sandbox.id.clone();
 
         // Move all cleanup-owned resources into a task before the first await.
         // If the caller drops this destroy future mid-cleanup, the task keeps
         // running instead of letting FirecrackerSandbox::Drop race the COW
         // finalizer and directory cleanup.
-        let handle = tokio::spawn(destroy_firecracker_sandbox(sandbox, netns_pool));
-        match handle.await {
-            Ok(()) => {}
-            Err(e) if e.is_panic() => std::panic::resume_unwind(e.into_panic()),
-            Err(e) => warn!(error = %e, "sandbox destroy task was cancelled"),
-        }
+        let waiter = self
+            .cleanup_group
+            .spawn(
+                FactoryCleanupTaskKind::Destroy,
+                sandbox_id,
+                destroy_firecracker_sandbox(sandbox, netns_pool),
+            )
+            .await;
+        waiter.wait_propagating_panic().await;
     }
 
     async fn shutdown(&mut self) {
+        self.cleanup_group.shutdown().await;
+
         // Close the leak channel and let the drain task finish queued cleanup
         // before we unwrap the shared pool Arcs below.
         if let Some(cleaner) = self.leak_cleaner.take() {
@@ -1448,7 +1766,16 @@ mod tests {
             base_image_size: 0,
             cow_pool: None,
             started,
+            cleanup_group: FactoryCleanupGroup::new(),
             leak_cleaner: None,
+        }
+    }
+
+    struct AbortFlag(Arc<AtomicBool>);
+
+    impl Drop for AbortFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
         }
     }
 
@@ -1497,6 +1824,160 @@ mod tests {
         };
 
         assert_factory_invalid_state(err, "not started", "factory not started");
+    }
+
+    #[tokio::test]
+    async fn factory_cleanup_group_returns_completion_to_waiter() {
+        let group = FactoryCleanupGroup::new();
+        let ran = Arc::new(AtomicBool::new(false));
+        let ran_clone = Arc::clone(&ran);
+
+        let waiter = group
+            .spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
+                ran_clone.store(true, Ordering::SeqCst);
+            })
+            .await;
+
+        waiter.wait_propagating_panic().await;
+        group.shutdown().await;
+
+        assert!(ran.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn factory_cleanup_group_keeps_task_after_waiter_abort() {
+        let group = Arc::new(FactoryCleanupGroup::new());
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let completed = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let completed_clone = Arc::clone(&completed);
+        let waiter = group
+            .spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
+                let _ = started_tx.send(());
+                let _ = release_rx.await;
+                completed_clone.store(true, Ordering::SeqCst);
+            })
+            .await;
+
+        started_rx.await.unwrap();
+        let waiter_task = tokio::spawn(waiter.wait_propagating_panic());
+        waiter_task.abort();
+        assert!(waiter_task.await.unwrap_err().is_cancelled());
+
+        release_tx.send(()).unwrap();
+        group.shutdown().await;
+
+        assert!(completed.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn factory_cleanup_group_shutdown_waits_for_running_task() {
+        let group = Arc::new(FactoryCleanupGroup::new());
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let completed = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let completed_clone = Arc::clone(&completed);
+        let waiter = group
+            .spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
+                let _ = started_tx.send(());
+                let _ = release_rx.await;
+                completed_clone.store(true, Ordering::SeqCst);
+            })
+            .await;
+        drop(waiter);
+
+        started_rx.await.unwrap();
+        let shutdown_group = Arc::clone(&group);
+        let shutdown_task = tokio::spawn(async move {
+            shutdown_group.shutdown().await;
+        });
+        tokio::task::yield_now().await;
+        assert!(!shutdown_task.is_finished());
+
+        release_tx.send(()).unwrap();
+        shutdown_task.await.unwrap();
+
+        assert!(completed.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn factory_cleanup_group_shutdown_aborts_stuck_task_after_timeout() {
+        let group = FactoryCleanupGroup::new();
+        let aborted = Arc::new(AtomicBool::new(false));
+        let aborted_clone = Arc::clone(&aborted);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let waiter = group
+            .spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
+                let _flag = AbortFlag(aborted_clone);
+                let _ = started_tx.send(());
+                std::future::pending::<()>().await;
+            })
+            .await;
+        drop(waiter);
+
+        started_rx.await.unwrap();
+        let shutdown = group.shutdown();
+        tokio::pin!(shutdown);
+        tokio::task::yield_now().await;
+        tokio::time::advance(FACTORY_CLEANUP_SHUTDOWN_TIMEOUT).await;
+        shutdown.await;
+
+        assert!(aborted.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn factory_cleanup_destroy_waiter_propagates_panic() {
+        let group = FactoryCleanupGroup::new();
+        let waiter = group
+            .spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async {
+                panic!("destroy cleanup failed");
+            })
+            .await;
+
+        let result = AssertUnwindSafe(waiter.wait_propagating_panic())
+            .catch_unwind()
+            .await;
+        group.shutdown().await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn factory_shutdown_drains_cleanup_group_before_leak_cleaner() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let cleanup_events = Arc::clone(&events);
+        let leak_events = Arc::clone(&events);
+        let mut factory = test_factory(true);
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<LeakedResources>();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(async move {
+            let _ = shutdown_rx.await;
+            leak_events.lock().unwrap().push("leak_cleaner");
+        });
+        factory.leak_cleaner = Some(LeakCleaner {
+            tx: Some(tx),
+            shutdown_tx: Some(shutdown_tx),
+            handle: Some(handle),
+        });
+
+        let waiter = factory
+            .cleanup_group
+            .spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
+                cleanup_events.lock().unwrap().push("cleanup_group");
+            })
+            .await;
+        drop(waiter);
+
+        factory.shutdown().await;
+
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec!["cleanup_group", "leak_cleaner"]
+        );
     }
 
     #[tokio::test]
@@ -1803,7 +2284,12 @@ mod tests {
         tx.track_sock_dir(sock_dir.clone());
 
         let cleanup = BlockingRemoveDirCleanup::default();
-        let waiter = tokio::spawn(rollback_create_transaction(tx, cleanup.clone()));
+        let cleanup_group = Arc::new(FactoryCleanupGroup::new());
+        let rollback_group = Arc::clone(&cleanup_group);
+        let rollback_cleanup = cleanup.clone();
+        let waiter = tokio::spawn(async move {
+            rollback_create_transaction(tx, rollback_cleanup, &rollback_group).await;
+        });
 
         tokio::time::timeout(std::time::Duration::from_secs(1), cleanup.wait_entered(1))
             .await
@@ -1811,10 +2297,19 @@ mod tests {
         waiter.abort();
         assert!(waiter.await.unwrap_err().is_cancelled());
 
+        let shutdown_group = Arc::clone(&cleanup_group);
+        let shutdown_task = tokio::spawn(async move {
+            shutdown_group.shutdown().await;
+        });
+        tokio::task::yield_now().await;
+        assert!(!shutdown_task.is_finished());
+
         cleanup.release();
-        tokio::time::timeout(std::time::Duration::from_secs(1), cleanup.wait_removed(2))
+        tokio::time::timeout(std::time::Duration::from_secs(1), shutdown_task)
             .await
+            .unwrap()
             .unwrap();
+        cleanup.wait_removed(2).await;
 
         assert!(!sock_dir.exists());
         assert!(!workspace.exists());

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -2045,6 +2045,26 @@ mod tests {
         }
     }
 
+    struct SpawnLateCleanupOnDrop {
+        group: Arc<FactoryCleanupGroup>,
+        late_aborted: Arc<AtomicBool>,
+    }
+
+    impl Drop for SpawnLateCleanupOnDrop {
+        fn drop(&mut self) {
+            let late_flag = AbortFlag(Arc::clone(&self.late_aborted));
+            let waiter = self.group.spawn(
+                FactoryCleanupTaskKind::Destroy,
+                "late-after-timeout",
+                async move {
+                    let _flag = late_flag;
+                    std::future::pending::<()>().await;
+                },
+            );
+            drop(waiter);
+        }
+    }
+
     fn assert_factory_invalid_state(
         err: SandboxError,
         expected_state: &str,
@@ -2312,6 +2332,33 @@ mod tests {
         shutdown.await;
 
         assert!(aborted.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn factory_cleanup_group_shutdown_aborts_task_registered_during_timeout_abort() {
+        let group = Arc::new(FactoryCleanupGroup::new());
+        let late_aborted = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let on_drop = SpawnLateCleanupOnDrop {
+            group: Arc::clone(&group),
+            late_aborted: Arc::clone(&late_aborted),
+        };
+        let waiter = group.spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
+            let _on_drop = on_drop;
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+        });
+        drop(waiter);
+
+        started_rx.await.unwrap();
+        let shutdown = group.shutdown();
+        tokio::pin!(shutdown);
+        tokio::task::yield_now().await;
+        tokio::time::advance(FACTORY_CLEANUP_SHUTDOWN_TIMEOUT).await;
+        shutdown.await;
+
+        assert!(late_aborted.load(Ordering::SeqCst));
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -1,4 +1,11 @@
-use std::{any::Any, collections::HashMap, future::Future, panic::AssertUnwindSafe, path::PathBuf};
+use std::{
+    any::Any,
+    collections::HashMap,
+    future::Future,
+    panic::AssertUnwindSafe,
+    path::PathBuf,
+    sync::{Mutex as StdMutex, MutexGuard as StdMutexGuard, TryLockError},
+};
 
 use async_trait::async_trait;
 use futures_util::FutureExt;
@@ -212,7 +219,7 @@ impl FactoryCleanupWaiter {
 }
 
 struct FactoryCleanupGroup {
-    state: tokio::sync::Mutex<FactoryCleanupGroupState>,
+    state: StdMutex<FactoryCleanupGroupState>,
 }
 
 struct FactoryCleanupGroupState {
@@ -294,18 +301,28 @@ where
 impl FactoryCleanupGroup {
     fn new() -> Self {
         Self {
-            state: tokio::sync::Mutex::new(FactoryCleanupGroupState::new()),
+            state: StdMutex::new(FactoryCleanupGroupState::new()),
         }
     }
 
-    async fn start_accepting(&self) {
-        let mut state = self.state.lock().await;
+    fn lock_state(&self) -> StdMutexGuard<'_, FactoryCleanupGroupState> {
+        match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => {
+                warn!("factory cleanup group state mutex was poisoned; continuing");
+                poisoned.into_inner()
+            }
+        }
+    }
+
+    fn start_accepting(&self) {
+        let mut state = self.lock_state();
         Self::reap_completed_locked(&mut state, false);
         state.accepting = true;
         state.closed = false;
     }
 
-    async fn spawn<F>(
+    fn spawn<F>(
         &self,
         kind: FactoryCleanupTaskKind,
         label: impl Into<String>,
@@ -316,7 +333,7 @@ impl FactoryCleanupGroup {
     {
         let label = label.into();
         let waiter_label = label.clone();
-        let mut state = self.state.lock().await;
+        let mut state = self.lock_state();
         Self::reap_completed_locked(&mut state, false);
         if state.closed {
             warn!(
@@ -362,7 +379,7 @@ impl FactoryCleanupGroup {
         tokio::pin!(timeout);
 
         loop {
-            let Some((mut tasks, mut records)) = self.take_shutdown_batch().await else {
+            let Some((mut tasks, mut records)) = self.take_shutdown_batch() else {
                 return;
             };
 
@@ -376,13 +393,13 @@ impl FactoryCleanupGroup {
         }
     }
 
-    async fn take_shutdown_batch(
+    fn take_shutdown_batch(
         &self,
     ) -> Option<(
         JoinSet<FactoryCleanupTaskFinished>,
         HashMap<TaskId, FactoryCleanupTaskRecord>,
     )> {
-        let mut state = self.state.lock().await;
+        let mut state = self.lock_state();
         state.accepting = false;
         Self::reap_completed_locked(&mut state, false);
         if state.tasks.is_empty() {
@@ -439,7 +456,7 @@ impl FactoryCleanupGroup {
     async fn abort_remaining_after_shutdown_timeout(&self) {
         loop {
             let (mut tasks, mut records) = {
-                let mut state = self.state.lock().await;
+                let mut state = self.lock_state();
                 state.accepting = false;
                 state.closed = true;
                 Self::reap_completed_locked(&mut state, false);
@@ -558,8 +575,19 @@ impl Drop for FactoryCleanupGroup {
                 );
                 state.tasks.abort_all();
             }
-            Err(_) => {
+            Err(TryLockError::WouldBlock) => {
                 warn!("factory cleanup group dropped while locked; cleanup tasks may keep running");
+            }
+            Err(TryLockError::Poisoned(poisoned)) => {
+                let mut state = poisoned.into_inner();
+                Self::reap_completed_locked(&mut state, false);
+                if !state.tasks.is_empty() {
+                    warn!(
+                        task_count = state.tasks.len(),
+                        "factory cleanup group dropped with poisoned state and in-flight tasks; aborting without await"
+                    );
+                    state.tasks.abort_all();
+                }
             }
         }
     }
@@ -914,16 +942,14 @@ async fn rollback_create_transaction<C>(
     C: CreateRollbackCleanup + Send + Sync + 'static,
 {
     let rollback_id = tx.id.clone();
-    let rollback_waiter = cleanup_group
-        .spawn(
-            FactoryCleanupTaskKind::Rollback,
-            rollback_id.clone(),
-            async move {
-                let mut tx = tx;
-                tx.rollback(&cleanup).await;
-            },
-        )
-        .await;
+    let rollback_waiter = cleanup_group.spawn(
+        FactoryCleanupTaskKind::Rollback,
+        rollback_id.clone(),
+        async move {
+            let mut tx = tx;
+            tx.rollback(&cleanup).await;
+        },
+    );
     rollback_waiter.wait_logging_panic().await;
 }
 
@@ -1249,7 +1275,7 @@ impl SandboxFactory for FirecrackerFactory {
                 message: "factory already started".into(),
             });
         }
-        self.cleanup_group.start_accepting().await;
+        self.cleanup_group.start_accepting();
 
         // Create netns pool only if not provided externally (shared pool case).
         if self.netns_pool.is_none() {
@@ -1460,14 +1486,11 @@ impl SandboxFactory for FirecrackerFactory {
         // If the caller drops this destroy future mid-cleanup, the task keeps
         // running instead of letting FirecrackerSandbox::Drop race the COW
         // finalizer and directory cleanup.
-        let waiter = self
-            .cleanup_group
-            .spawn(
-                FactoryCleanupTaskKind::Destroy,
-                sandbox_id,
-                destroy_firecracker_sandbox(sandbox, netns_pool),
-            )
-            .await;
+        let waiter = self.cleanup_group.spawn(
+            FactoryCleanupTaskKind::Destroy,
+            sandbox_id,
+            destroy_firecracker_sandbox(sandbox, netns_pool),
+        );
         waiter.wait_propagating_panic().await;
     }
 
@@ -1955,11 +1978,9 @@ mod tests {
         let ran = Arc::new(AtomicBool::new(false));
         let ran_clone = Arc::clone(&ran);
 
-        let waiter = group
-            .spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
-                ran_clone.store(true, Ordering::SeqCst);
-            })
-            .await;
+        let waiter = group.spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
+            ran_clone.store(true, Ordering::SeqCst);
+        });
 
         waiter.wait_propagating_panic().await;
         group.shutdown().await;
@@ -1975,13 +1996,11 @@ mod tests {
         let (started_tx, started_rx) = tokio::sync::oneshot::channel();
 
         let completed_clone = Arc::clone(&completed);
-        let waiter = group
-            .spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
-                let _ = started_tx.send(());
-                let _ = release_rx.await;
-                completed_clone.store(true, Ordering::SeqCst);
-            })
-            .await;
+        let waiter = group.spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
+            let _ = started_tx.send(());
+            let _ = release_rx.await;
+            completed_clone.store(true, Ordering::SeqCst);
+        });
 
         started_rx.await.unwrap();
         let waiter_task = tokio::spawn(waiter.wait_propagating_panic());
@@ -2002,13 +2021,11 @@ mod tests {
         let (started_tx, started_rx) = tokio::sync::oneshot::channel();
 
         let completed_clone = Arc::clone(&completed);
-        let waiter = group
-            .spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
-                let _ = started_tx.send(());
-                let _ = release_rx.await;
-                completed_clone.store(true, Ordering::SeqCst);
-            })
-            .await;
+        let waiter = group.spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
+            let _ = started_tx.send(());
+            let _ = release_rx.await;
+            completed_clone.store(true, Ordering::SeqCst);
+        });
         drop(waiter);
 
         started_rx.await.unwrap();
@@ -2032,12 +2049,10 @@ mod tests {
         let late_completed = Arc::new(AtomicBool::new(false));
         let (started_tx, started_rx) = tokio::sync::oneshot::channel();
 
-        let waiter = group
-            .spawn(FactoryCleanupTaskKind::Destroy, "first", async move {
-                let _ = started_tx.send(());
-                let _ = release_rx.await;
-            })
-            .await;
+        let waiter = group.spawn(FactoryCleanupTaskKind::Destroy, "first", async move {
+            let _ = started_tx.send(());
+            let _ = release_rx.await;
+        });
         drop(waiter);
 
         started_rx.await.unwrap();
@@ -2049,11 +2064,9 @@ mod tests {
         assert!(!shutdown_task.is_finished());
 
         let late_completed_clone = Arc::clone(&late_completed);
-        let late_waiter = group
-            .spawn(FactoryCleanupTaskKind::Destroy, "late", async move {
-                late_completed_clone.store(true, Ordering::SeqCst);
-            })
-            .await;
+        let late_waiter = group.spawn(FactoryCleanupTaskKind::Destroy, "late", async move {
+            late_completed_clone.store(true, Ordering::SeqCst);
+        });
         drop(late_waiter);
 
         release_tx.send(()).unwrap();
@@ -2069,11 +2082,9 @@ mod tests {
 
         let ran = Arc::new(AtomicBool::new(false));
         let ran_clone = Arc::clone(&ran);
-        let cleanup = group
-            .spawn(FactoryCleanupTaskKind::Destroy, "closed", async move {
-                ran_clone.store(true, Ordering::SeqCst);
-            })
-            .await;
+        let cleanup = group.spawn(FactoryCleanupTaskKind::Destroy, "closed", async move {
+            ran_clone.store(true, Ordering::SeqCst);
+        });
 
         assert!(!ran.load(Ordering::SeqCst));
         cleanup.wait_propagating_panic().await;
@@ -2088,13 +2099,11 @@ mod tests {
         let aborted_clone = Arc::clone(&aborted);
         let (started_tx, started_rx) = tokio::sync::oneshot::channel();
 
-        let waiter = group
-            .spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
-                let _flag = AbortFlag(aborted_clone);
-                let _ = started_tx.send(());
-                std::future::pending::<()>().await;
-            })
-            .await;
+        let waiter = group.spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
+            let _flag = AbortFlag(aborted_clone);
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+        });
         drop(waiter);
 
         started_rx.await.unwrap();
@@ -2110,11 +2119,9 @@ mod tests {
     #[tokio::test]
     async fn factory_cleanup_destroy_waiter_propagates_panic() {
         let group = FactoryCleanupGroup::new();
-        let waiter = group
-            .spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async {
-                panic!("destroy cleanup failed");
-            })
-            .await;
+        let waiter = group.spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async {
+            panic!("destroy cleanup failed");
+        });
 
         let result = AssertUnwindSafe(waiter.wait_propagating_panic())
             .catch_unwind()
@@ -2143,12 +2150,12 @@ mod tests {
             handle: Some(handle),
         });
 
-        let waiter = factory
-            .cleanup_group
-            .spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
-                cleanup_events.lock().unwrap().push("cleanup_group");
-            })
-            .await;
+        let waiter =
+            factory
+                .cleanup_group
+                .spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
+                    cleanup_events.lock().unwrap().push("cleanup_group");
+                });
         drop(waiter);
 
         factory.shutdown().await;

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -558,9 +558,9 @@ impl FactoryCleanupGroup {
             let mut batch = {
                 let mut state = self.lock_state();
                 state.accepting = false;
-                state.closed = true;
                 Self::reap_completed_locked(&mut state);
                 if state.tasks.is_empty() {
+                    state.closed = true;
                     return;
                 }
                 FactoryCleanupBatch {

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -626,7 +626,8 @@ impl FactoryCleanupGroup {
                     Self::handle_join_result(record, result, false);
                 }
                 Poll::Pending => {
-                    state.tasks.push(task);
+                    state.tasks.insert(index, task);
+                    index += 1;
                 }
             };
         }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -1,10 +1,11 @@
 use std::{
     any::Any,
-    collections::HashMap,
     future::Future,
     panic::AssertUnwindSafe,
     path::PathBuf,
+    pin::Pin,
     sync::{Mutex as StdMutex, MutexGuard as StdMutexGuard, TryLockError},
+    task::{Context, Poll},
 };
 
 use async_trait::async_trait;
@@ -14,7 +15,7 @@ use sandbox::{
     SandboxInvalidStateContext,
 };
 use sha2::{Digest, Sha256};
-use tokio::task::{Id as TaskId, JoinError, JoinSet};
+use tokio::task::{JoinError, JoinHandle};
 use tracing::{info, warn};
 
 use nbd_cow::{DestroyRetryPolicy, PooledNbdCowDevice};
@@ -167,6 +168,7 @@ impl FactoryCleanupTaskKind {
     }
 }
 
+#[derive(Clone)]
 struct FactoryCleanupTaskRecord {
     kind: FactoryCleanupTaskKind,
     label: String,
@@ -175,6 +177,40 @@ struct FactoryCleanupTaskRecord {
 struct FactoryCleanupTaskFinished {
     kind: FactoryCleanupTaskKind,
     label: String,
+}
+
+struct FactoryCleanupTaskHandle {
+    record: FactoryCleanupTaskRecord,
+    handle: JoinHandle<FactoryCleanupTaskFinished>,
+}
+
+impl FactoryCleanupTaskHandle {
+    fn abort(&self) {
+        self.handle.abort();
+    }
+
+    fn is_finished(&self) -> bool {
+        self.handle.is_finished()
+    }
+
+    fn record(&self) -> &FactoryCleanupTaskRecord {
+        &self.record
+    }
+}
+
+impl Future for FactoryCleanupTaskHandle {
+    type Output = (
+        FactoryCleanupTaskRecord,
+        Result<FactoryCleanupTaskFinished, JoinError>,
+    );
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let result = match Pin::new(&mut self.handle).poll(cx) {
+            Poll::Ready(result) => result,
+            Poll::Pending => return Poll::Pending,
+        };
+        Poll::Ready((self.record.clone(), result))
+    }
 }
 
 enum FactoryCleanupTaskOutcome {
@@ -225,8 +261,7 @@ struct FactoryCleanupGroup {
 struct FactoryCleanupGroupState {
     accepting: bool,
     closed: bool,
-    tasks: JoinSet<FactoryCleanupTaskFinished>,
-    records: HashMap<TaskId, FactoryCleanupTaskRecord>,
+    tasks: Vec<FactoryCleanupTaskHandle>,
 }
 
 impl FactoryCleanupGroupState {
@@ -234,9 +269,79 @@ impl FactoryCleanupGroupState {
         Self {
             accepting: true,
             closed: false,
-            tasks: JoinSet::new(),
-            records: HashMap::new(),
+            tasks: Vec::new(),
         }
+    }
+}
+
+struct FactoryCleanupBatch<'a> {
+    group: &'a FactoryCleanupGroup,
+    tasks: Vec<FactoryCleanupTaskHandle>,
+}
+
+impl FactoryCleanupBatch<'_> {
+    fn is_empty(&self) -> bool {
+        self.tasks.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.tasks.len()
+    }
+
+    fn abort_all(&self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+    }
+
+    fn records(&self) -> impl Iterator<Item = &FactoryCleanupTaskRecord> {
+        self.tasks.iter().map(FactoryCleanupTaskHandle::record)
+    }
+
+    async fn next_finished(
+        &mut self,
+    ) -> Option<(
+        FactoryCleanupTaskRecord,
+        Result<FactoryCleanupTaskFinished, JoinError>,
+    )> {
+        std::future::poll_fn(|cx| {
+            let mut index = 0;
+            while index < self.tasks.len() {
+                let poll_result = {
+                    let Some(task) = self.tasks.get_mut(index) else {
+                        break;
+                    };
+                    Pin::new(task).poll(cx)
+                };
+                match poll_result {
+                    Poll::Ready(result) => {
+                        self.tasks.swap_remove(index);
+                        return Poll::Ready(Some(result));
+                    }
+                    Poll::Pending => {
+                        index += 1;
+                    }
+                }
+            }
+
+            if self.tasks.is_empty() {
+                Poll::Ready(None)
+            } else {
+                Poll::Pending
+            }
+        })
+        .await
+    }
+}
+
+impl Drop for FactoryCleanupBatch<'_> {
+    fn drop(&mut self) {
+        if self.tasks.is_empty() {
+            return;
+        }
+
+        let mut state = self.group.lock_state();
+        state.tasks.append(&mut self.tasks);
     }
 }
 
@@ -317,7 +422,7 @@ impl FactoryCleanupGroup {
 
     fn start_accepting(&self) {
         let mut state = self.lock_state();
-        Self::reap_completed_locked(&mut state, false);
+        Self::reap_completed_locked(&mut state);
         state.accepting = true;
         state.closed = false;
     }
@@ -334,7 +439,7 @@ impl FactoryCleanupGroup {
         let label = label.into();
         let waiter_label = label.clone();
         let mut state = self.lock_state();
-        Self::reap_completed_locked(&mut state, false);
+        Self::reap_completed_locked(&mut state);
         if state.closed {
             warn!(
                 kind = kind.as_str(),
@@ -358,14 +463,14 @@ impl FactoryCleanupGroup {
 
         let (done_tx, done_rx) = tokio::sync::oneshot::channel();
         let task = Self::cleanup_task(kind, label.clone(), cleanup, done_tx);
-        let abort_handle = state.tasks.spawn(task);
-        state.records.insert(
-            abort_handle.id(),
-            FactoryCleanupTaskRecord {
+        let handle = tokio::spawn(task);
+        state.tasks.push(FactoryCleanupTaskHandle {
+            record: FactoryCleanupTaskRecord {
                 kind,
                 label: label.clone(),
             },
-        );
+            handle,
+        });
 
         FactoryCleanupRegistration::Waiter(FactoryCleanupWaiter {
             kind,
@@ -379,74 +484,69 @@ impl FactoryCleanupGroup {
         tokio::pin!(timeout);
 
         loop {
-            let Some((mut tasks, mut records)) = self.take_shutdown_batch() else {
+            let Some(mut batch) = self.take_shutdown_batch() else {
                 return;
             };
 
-            if self
-                .drain_shutdown_batch(&mut tasks, &mut records, &mut timeout)
-                .await
-            {
+            if self.drain_shutdown_batch(&mut batch, &mut timeout).await {
                 self.abort_remaining_after_shutdown_timeout().await;
                 return;
             }
         }
     }
 
-    fn take_shutdown_batch(
-        &self,
-    ) -> Option<(
-        JoinSet<FactoryCleanupTaskFinished>,
-        HashMap<TaskId, FactoryCleanupTaskRecord>,
-    )> {
+    fn take_shutdown_batch(&self) -> Option<FactoryCleanupBatch<'_>> {
         let mut state = self.lock_state();
         state.accepting = false;
-        Self::reap_completed_locked(&mut state, false);
+        Self::reap_completed_locked(&mut state);
         if state.tasks.is_empty() {
             state.closed = true;
             return None;
         }
-        Some((
-            std::mem::replace(&mut state.tasks, JoinSet::new()),
-            std::mem::take(&mut state.records),
-        ))
+        Some(FactoryCleanupBatch {
+            group: self,
+            tasks: std::mem::take(&mut state.tasks),
+        })
     }
 
     async fn drain_shutdown_batch(
         &self,
-        tasks: &mut JoinSet<FactoryCleanupTaskFinished>,
-        records: &mut HashMap<TaskId, FactoryCleanupTaskRecord>,
+        batch: &mut FactoryCleanupBatch<'_>,
         timeout: &mut std::pin::Pin<&mut tokio::time::Sleep>,
     ) -> bool {
         loop {
-            if tasks.is_empty() {
+            if batch.is_empty() {
                 return false;
             }
 
             tokio::select! {
-                result = tasks.join_next_with_id() => {
-                    Self::handle_join_result(records, result, false);
+                result = batch.next_finished() => {
+                    let Some((record, result)) = result else {
+                        return false;
+                    };
+                    Self::handle_join_result(record, result, false);
                 }
                 () = timeout.as_mut() => {
-                    let task_count = tasks.len();
+                    let task_count = batch.len();
                     warn!(
                         task_count,
                         timeout_ms = FACTORY_CLEANUP_SHUTDOWN_TIMEOUT.as_millis() as u64,
                         "timed out waiting for factory cleanup tasks; aborting"
                     );
-                    for record in records.values() {
+                    for record in batch.records() {
                         warn!(
                             kind = record.kind.as_str(),
                             label = %record.label,
                             "aborting factory cleanup task; runner gc may need to clean leftovers"
                         );
                     }
-                    tasks.abort_all();
-                    while !tasks.is_empty() {
-                        let result = tasks.join_next_with_id().await;
-                        Self::handle_join_result(records, result, true);
+                    batch.abort_all();
+                    while !batch.is_empty() {
+                        let Some((record, result)) = batch.next_finished().await else {
+                            break;
+                        };
+                        Self::handle_join_result(record, result, true);
                     }
-                    records.clear();
                     return true;
                 }
             }
@@ -455,33 +555,34 @@ impl FactoryCleanupGroup {
 
     async fn abort_remaining_after_shutdown_timeout(&self) {
         loop {
-            let (mut tasks, mut records) = {
+            let mut batch = {
                 let mut state = self.lock_state();
                 state.accepting = false;
                 state.closed = true;
-                Self::reap_completed_locked(&mut state, false);
+                Self::reap_completed_locked(&mut state);
                 if state.tasks.is_empty() {
                     return;
                 }
-                (
-                    std::mem::replace(&mut state.tasks, JoinSet::new()),
-                    std::mem::take(&mut state.records),
-                )
+                FactoryCleanupBatch {
+                    group: self,
+                    tasks: std::mem::take(&mut state.tasks),
+                }
             };
 
-            for record in records.values() {
+            for record in batch.records() {
                 warn!(
                     kind = record.kind.as_str(),
                     label = %record.label,
                     "aborting late factory cleanup task after shutdown timeout"
                 );
             }
-            tasks.abort_all();
-            while !tasks.is_empty() {
-                let result = tasks.join_next_with_id().await;
-                Self::handle_join_result(&mut records, result, true);
+            batch.abort_all();
+            while !batch.is_empty() {
+                let Some((record, result)) = batch.next_finished().await else {
+                    break;
+                };
+                Self::handle_join_result(record, result, true);
             }
-            records.clear();
         }
     }
 
@@ -514,20 +615,17 @@ impl FactoryCleanupGroup {
         FactoryCleanupTaskFinished { kind, label }
     }
 
-    fn reap_completed_locked(state: &mut FactoryCleanupGroupState, after_abort: bool) {
-        while let Some(result) = state.tasks.try_join_next_with_id() {
-            Self::handle_join_result(&mut state.records, Some(result), after_abort);
-        }
+    fn reap_completed_locked(state: &mut FactoryCleanupGroupState) {
+        state.tasks.retain(|task| !task.is_finished());
     }
 
     fn handle_join_result(
-        records: &mut HashMap<TaskId, FactoryCleanupTaskRecord>,
-        result: Option<Result<(TaskId, FactoryCleanupTaskFinished), JoinError>>,
+        record: FactoryCleanupTaskRecord,
+        result: Result<FactoryCleanupTaskFinished, JoinError>,
         after_abort: bool,
     ) {
         match result {
-            Some(Ok((task_id, finished))) => {
-                records.remove(&task_id);
+            Ok(finished) => {
                 if after_abort {
                     info!(
                         kind = finished.kind.as_str(),
@@ -536,11 +634,9 @@ impl FactoryCleanupGroup {
                     );
                 }
             }
-            Some(Err(err)) => {
-                let record = records.remove(&err.id());
-                let (kind, label) = record
-                    .map(|record| (record.kind.as_str(), record.label))
-                    .unwrap_or(("unknown", err.id().to_string()));
+            Err(err) => {
+                let kind = record.kind.as_str();
+                let label = record.label;
                 if err.is_cancelled() && after_abort {
                     info!(
                         kind,
@@ -556,7 +652,6 @@ impl FactoryCleanupGroup {
                     );
                 }
             }
-            None => {}
         }
     }
 }
@@ -565,7 +660,7 @@ impl Drop for FactoryCleanupGroup {
     fn drop(&mut self) {
         match self.state.try_lock() {
             Ok(mut state) => {
-                Self::reap_completed_locked(&mut state, false);
+                Self::reap_completed_locked(&mut state);
                 if state.tasks.is_empty() {
                     return;
                 }
@@ -573,20 +668,24 @@ impl Drop for FactoryCleanupGroup {
                     task_count = state.tasks.len(),
                     "factory cleanup group dropped with in-flight tasks; aborting without await"
                 );
-                state.tasks.abort_all();
+                for task in state.tasks.iter() {
+                    task.abort();
+                }
             }
             Err(TryLockError::WouldBlock) => {
                 warn!("factory cleanup group dropped while locked; cleanup tasks may keep running");
             }
             Err(TryLockError::Poisoned(poisoned)) => {
                 let mut state = poisoned.into_inner();
-                Self::reap_completed_locked(&mut state, false);
+                Self::reap_completed_locked(&mut state);
                 if !state.tasks.is_empty() {
                     warn!(
                         task_count = state.tasks.len(),
                         "factory cleanup group dropped with poisoned state and in-flight tasks; aborting without await"
                     );
-                    state.tasks.abort_all();
+                    for task in state.tasks.iter() {
+                        task.abort();
+                    }
                 }
             }
         }
@@ -2038,6 +2137,45 @@ mod tests {
 
         release_tx.send(()).unwrap();
         shutdown_task.await.unwrap();
+
+        assert!(completed.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn factory_cleanup_group_shutdown_cancel_reinserts_running_task() {
+        let group = Arc::new(FactoryCleanupGroup::new());
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let completed = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let completed_clone = Arc::clone(&completed);
+        let waiter = group.spawn(FactoryCleanupTaskKind::Destroy, "sandbox", async move {
+            let _ = started_tx.send(());
+            let _ = release_rx.await;
+            completed_clone.store(true, Ordering::SeqCst);
+        });
+        drop(waiter);
+
+        started_rx.await.unwrap();
+        let shutdown_group = Arc::clone(&group);
+        let shutdown_task = tokio::spawn(async move {
+            shutdown_group.shutdown().await;
+        });
+        tokio::task::yield_now().await;
+        assert!(!shutdown_task.is_finished());
+
+        shutdown_task.abort();
+        assert!(shutdown_task.await.unwrap_err().is_cancelled());
+
+        let retry_group = Arc::clone(&group);
+        let retry_shutdown = tokio::spawn(async move {
+            retry_group.shutdown().await;
+        });
+        tokio::task::yield_now().await;
+        assert!(!retry_shutdown.is_finished());
+
+        assert!(release_tx.send(()).is_ok());
+        retry_shutdown.await.unwrap();
 
         assert!(completed.load(Ordering::SeqCst));
     }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use futures_util::FutureExt;
+use futures_util::{FutureExt, task::noop_waker_ref};
 use sandbox::{
     Sandbox, SandboxConfig, SandboxError, SandboxFactory, SandboxInitializationPhase,
     SandboxInvalidStateContext,
@@ -618,11 +618,17 @@ impl FactoryCleanupGroup {
                 continue;
             }
 
-            let task = state.tasks.swap_remove(index);
-            let Some((record, result)) = task.now_or_never() else {
-                continue;
+            let mut task = state.tasks.swap_remove(index);
+            let waker = noop_waker_ref();
+            let mut cx = Context::from_waker(waker);
+            match Pin::new(&mut task).poll(&mut cx) {
+                Poll::Ready((record, result)) => {
+                    Self::handle_join_result(record, result, false);
+                }
+                Poll::Pending => {
+                    state.tasks.push(task);
+                }
             };
-            Self::handle_join_result(record, result, false);
         }
     }
 

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -235,13 +235,7 @@ impl FactoryCleanupWaiter {
             Ok(FactoryCleanupTaskOutcome::Completed) => {}
             Ok(FactoryCleanupTaskOutcome::Panicked(payload)) => match panic_policy {
                 FactoryCleanupPanicPolicy::Propagate => std::panic::resume_unwind(payload),
-                FactoryCleanupPanicPolicy::Log => {
-                    warn!(
-                        kind = self.kind.as_str(),
-                        label = %self.label,
-                        "factory cleanup task panicked"
-                    );
-                }
+                FactoryCleanupPanicPolicy::Log => {}
             },
             Err(_) => {
                 info!(
@@ -351,6 +345,7 @@ struct FactoryCleanupRejected<F> {
     cleanup: F,
 }
 
+#[must_use = "factory cleanup registrations must be awaited so closed-group cleanup can run"]
 enum FactoryCleanupRegistration<F> {
     Waiter(FactoryCleanupWaiter),
     Rejected(FactoryCleanupRejected<F>),
@@ -601,22 +596,34 @@ impl FactoryCleanupGroup {
                 let _ = done_tx.send(FactoryCleanupTaskOutcome::Completed);
             }
             Err(payload) => {
-                if let Err(FactoryCleanupTaskOutcome::Panicked(_)) =
-                    done_tx.send(FactoryCleanupTaskOutcome::Panicked(payload))
-                {
-                    warn!(
-                        kind = kind.as_str(),
-                        label = %label,
-                        "factory cleanup task panicked after waiter dropped"
-                    );
-                }
+                warn!(
+                    kind = kind.as_str(),
+                    label = %label,
+                    "factory cleanup task panicked"
+                );
+                let _ = done_tx.send(FactoryCleanupTaskOutcome::Panicked(payload));
             }
         }
         FactoryCleanupTaskFinished { kind, label }
     }
 
     fn reap_completed_locked(state: &mut FactoryCleanupGroupState) {
-        state.tasks.retain(|task| !task.is_finished());
+        let mut index = 0;
+        while index < state.tasks.len() {
+            let Some(task) = state.tasks.get(index) else {
+                break;
+            };
+            if !task.is_finished() {
+                index += 1;
+                continue;
+            }
+
+            let task = state.tasks.swap_remove(index);
+            let Some((record, result)) = task.now_or_never() else {
+                continue;
+            };
+            Self::handle_join_result(record, result, false);
+        }
     }
 
     fn handle_join_result(

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -2281,6 +2281,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn factory_cleanup_group_closed_logging_wait_suppresses_panic() {
+        let group = FactoryCleanupGroup::new();
+        group.shutdown().await;
+
+        let cleanup = group.spawn(FactoryCleanupTaskKind::Rollback, "closed", async {
+            panic!("rollback cleanup failed");
+        });
+
+        let result = AssertUnwindSafe(cleanup.wait_logging_panic())
+            .catch_unwind()
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn factory_cleanup_group_drop_aborts_in_flight_task() {
+        let group = FactoryCleanupGroup::new();
+        let aborted = Arc::new(AtomicBool::new(false));
+        let aborted_clone = Arc::clone(&aborted);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let waiter = group.spawn(FactoryCleanupTaskKind::Destroy, "drop-abort", async move {
+            let _flag = AbortFlag(aborted_clone);
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+        });
+        drop(waiter);
+
+        started_rx.await.unwrap();
+        drop(group);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !aborted.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
     async fn factory_cleanup_group_start_accepting_reopens_after_shutdown() {
         let group = Arc::new(FactoryCleanupGroup::new());
         group.shutdown().await;

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -386,6 +386,10 @@ impl FirecrackerSandbox {
         self.delete_workspace_on_leak_cleanup = false;
     }
 
+    pub(crate) fn allow_workspace_delete_on_leak_cleanup(&mut self) {
+        self.delete_workspace_on_leak_cleanup = true;
+    }
+
     fn current_state(&self) -> SandboxState {
         SandboxState::from_u8(self.state.load(Ordering::Acquire))
     }


### PR DESCRIPTION
## Summary
- Add a factory-owned cleanup group for explicit destroy and create rollback cleanup tasks.
- Route destroy and rollback cleanup through per-task wait handles so caller cancellation does not detach cleanup from factory ownership.
- Drain or abort factory cleanup tasks before LeakCleaner and pool cleanup during shutdown.

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc factory
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc

Closes #11521