### PR TITLE
feat(web): add chatgpt oauth connect and callback routes

### DIFF
--- a/turbo/apps/web/app/api/zero/chatgpt/oauth/_cookies.ts
+++ b/turbo/apps/web/app/api/zero/chatgpt/oauth/_cookies.ts
@@ -1,0 +1,45 @@
+/**
+ * Cookie helpers for the ChatGPT OAuth connect/callback routes.
+ *
+ * Mirrors the helpers in `app/api/connectors/[type]/{authorize,callback}/route.ts`.
+ * If you change one, consider updating the other.
+ *
+ * Cookie names are namespaced (`chatgpt_oauth_*`) so a user mid-connector-OAuth
+ * doesn't collide with a user mid-chatgpt-OAuth.
+ */
+import { env } from "../../../../../src/env";
+
+export const STATE_COOKIE_NAME = "chatgpt_oauth_state";
+export const PKCE_COOKIE_NAME = "chatgpt_oauth_pkce";
+export const COOKIE_MAX_AGE = 15 * 60;
+
+export function buildCookieHeader(
+  name: string,
+  value: string,
+  maxAge: number,
+): string {
+  const parts = [
+    `${name}=${value}`,
+    `Max-Age=${maxAge}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+  ];
+  if (env().NODE_ENV === "production") parts.push("Secure");
+  return parts.join("; ");
+}
+
+export function buildDeleteCookieHeader(name: string): string {
+  return `${name}=; Max-Age=0; Path=/`;
+}
+
+export function getCookie(request: Request, name: string): string | undefined {
+  const cookieHeader = request.headers.get("cookie");
+  if (!cookieHeader) return undefined;
+  for (const cookie of cookieHeader.split(";")) {
+    const trimmed = cookie.trim();
+    const [cookieName, ...rest] = trimmed.split("=");
+    if (cookieName === name) return rest.join("=");
+  }
+  return undefined;
+}

--- a/turbo/apps/web/app/api/zero/chatgpt/oauth/_state.ts
+++ b/turbo/apps/web/app/api/zero/chatgpt/oauth/_state.ts
@@ -1,0 +1,27 @@
+/**
+ * Typed state JSON used as the OAuth `state` parameter. Carries
+ * orgId + vm0UserId across the connect→callback boundary so the
+ * callback can re-check eligibility and persist against the right org.
+ */
+import { z } from "zod";
+
+const stateSchema = z.object({
+  orgId: z.string().min(1),
+  vm0UserId: z.string().min(1),
+  flow: z.literal("connect"),
+});
+
+type ChatgptOAuthState = z.infer<typeof stateSchema>;
+
+export function serializeState(state: ChatgptOAuthState): string {
+  return JSON.stringify(state);
+}
+
+export function parseState(raw: string | null): ChatgptOAuthState | null {
+  if (!raw) return null;
+  try {
+    return stateSchema.parse(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}

--- a/turbo/apps/web/app/api/zero/chatgpt/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chatgpt/oauth/callback/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { HttpResponse } from "msw";
 import { GET } from "../route";
 import { GET as listModelProvidersRoute } from "../../../../model-providers/route";
 import { createTestRequest } from "../../../../../../../src/__tests__/api-test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import { server } from "../../../../../../../src/mocks/server";
 import { http } from "../../../../../../../src/__tests__/msw";
 import {
@@ -116,6 +117,7 @@ describe("GET /api/zero/chatgpt/oauth/callback", () => {
   let stateValue: string;
 
   beforeEach(async () => {
+    vi.clearAllMocks();
     context.setupMocks();
     mockIsFeatureEnabled.mockReturnValue(true);
     user = await context.setupUser();
@@ -292,6 +294,64 @@ describe("GET /api/zero/chatgpt/oauth/callback", () => {
 
     expect(response.status).toBe(307);
     expect(response.headers.get("location")).toContain("error=ineligible");
+
+    const providers = await listOrgProviders();
+    expect(providers).toHaveLength(0);
+  });
+
+  it("returns unauthenticated when caller has no session", async () => {
+    mockClerk({ userId: null });
+
+    const request = makeCallbackRequest({
+      code: "c",
+      state: stateValue,
+      stateCookie: stateValue,
+      pkceCookie: "v",
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain("error=unauthenticated");
+
+    // Re-auth as the original user to verify nothing was persisted
+    mockClerk({ userId: user.userId });
+    const providers = await listOrgProviders();
+    expect(providers).toHaveLength(0);
+  });
+
+  it("rejects state cookie bound to a different org than the auth context", async () => {
+    // Forged state cookie carrying another org's id
+    const forgedState = makeState("attacker-org-id", user.userId);
+
+    const request = makeCallbackRequest({
+      code: "c",
+      state: forgedState,
+      stateCookie: forgedState,
+      pkceCookie: "v",
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain("error=state_mismatch");
+
+    const providers = await listOrgProviders();
+    expect(providers).toHaveLength(0);
+  });
+
+  it("rejects state cookie bound to a different user than the auth context", async () => {
+    // Forged state cookie carrying the right org but a different vm0UserId
+    const forgedState = makeState(user.orgId, "attacker-user-id");
+
+    const request = makeCallbackRequest({
+      code: "c",
+      state: forgedState,
+      stateCookie: forgedState,
+      pkceCookie: "v",
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain("error=state_mismatch");
 
     const providers = await listOrgProviders();
     expect(providers).toHaveLength(0);

--- a/turbo/apps/web/app/api/zero/chatgpt/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chatgpt/oauth/callback/__tests__/route.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { HttpResponse } from "msw";
+import { GET } from "../route";
+import { GET as listModelProvidersRoute } from "../../../../model-providers/route";
+import { createTestRequest } from "../../../../../../../src/__tests__/api-test-helpers";
+import { server } from "../../../../../../../src/mocks/server";
+import { http } from "../../../../../../../src/__tests__/msw";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../../../src/__tests__/test-helpers";
+
+interface ListedProvider {
+  type: string;
+  authMethod: string | null;
+  secretNames: string[] | null;
+}
+
+async function listOrgProviders(): Promise<ListedProvider[]> {
+  const request = createTestRequest(
+    "http://localhost:3000/api/zero/model-providers",
+  );
+  const response = await listModelProvidersRoute(request);
+  const data = (await response.json()) as { modelProviders: ListedProvider[] };
+  return data.modelProviders;
+}
+
+vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@vm0/core/feature-switch")>();
+  return {
+    ...actual,
+    isFeatureEnabled: vi.fn().mockReturnValue(true),
+  };
+});
+
+const { isFeatureEnabled } = await import("@vm0/core/feature-switch");
+const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
+
+const TOKEN_URL = "https://auth.openai.com/oauth/token";
+const CALLBACK_BASE = "http://localhost:3000/api/zero/chatgpt/oauth/callback";
+
+const context = testContext();
+
+function base64UrlEncode(input: string): string {
+  return Buffer.from(input, "utf-8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = base64UrlEncode(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const body = base64UrlEncode(JSON.stringify(payload));
+  return `${header}.${body}.fake-sig`;
+}
+
+function makeIdToken(
+  opts: {
+    accountId?: string;
+    planType?: string;
+    workspaceName?: string;
+  } = {},
+): string {
+  return makeJwt({
+    "https://api.openai.com/auth": {
+      chatgpt_account_id: opts.accountId ?? "acct_test",
+      chatgpt_plan_type: opts.planType ?? "plus",
+      chatgpt_workspace_name: opts.workspaceName ?? "Test Workspace",
+    },
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  });
+}
+
+function makeState(orgId: string, vm0UserId: string): string {
+  return JSON.stringify({ orgId, vm0UserId, flow: "connect" });
+}
+
+function makeCallbackRequest(opts: {
+  code?: string;
+  state?: string;
+  stateCookie?: string;
+  pkceCookie?: string;
+  error?: string;
+}): Request {
+  const url = new URL(CALLBACK_BASE);
+  if (opts.code) url.searchParams.set("code", opts.code);
+  if (opts.state) url.searchParams.set("state", opts.state);
+  if (opts.error) url.searchParams.set("error", opts.error);
+  const cookies: string[] = [];
+  if (opts.stateCookie) {
+    cookies.push(`chatgpt_oauth_state=${opts.stateCookie}`);
+  }
+  if (opts.pkceCookie) {
+    cookies.push(`chatgpt_oauth_pkce=${opts.pkceCookie}`);
+  }
+  const headers: Record<string, string> = {};
+  if (cookies.length) headers["Cookie"] = cookies.join("; ");
+  return new Request(url.toString(), { headers });
+}
+
+function clearedCookieNames(response: Response): string[] {
+  return response.headers
+    .getSetCookie()
+    .filter((c) => {
+      return c.includes("Max-Age=0");
+    })
+    .map((c) => {
+      return c.split("=")[0] ?? "";
+    });
+}
+
+describe("GET /api/zero/chatgpt/oauth/callback", () => {
+  let user: UserContext;
+  let stateValue: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    mockIsFeatureEnabled.mockReturnValue(true);
+    user = await context.setupUser();
+    stateValue = makeState(user.orgId, user.userId);
+  });
+
+  it("happy path persists provider and redirects with success", async () => {
+    server.use(
+      http.post(TOKEN_URL, () => {
+        return HttpResponse.json({
+          id_token: makeIdToken(),
+          access_token: "at_xxx",
+          refresh_token: "rt_xxx",
+          expires_in: 3600,
+        });
+      }).handler,
+    );
+
+    const request = makeCallbackRequest({
+      code: "auth-code-xyz",
+      state: stateValue,
+      stateCookie: stateValue,
+      pkceCookie: "verifier-xyz",
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).toContain("/settings/model-providers");
+    expect(location).toContain("connected=chatgpt");
+
+    const providers = await listOrgProviders();
+    expect(providers).toHaveLength(1);
+    expect(providers[0]?.type).toBe("chatgpt-oauth-token");
+    expect(providers[0]?.authMethod).toBe("oauth");
+  });
+
+  it("persists all four secrets including serverOnly fields", async () => {
+    server.use(
+      http.post(TOKEN_URL, () => {
+        return HttpResponse.json({
+          id_token: makeIdToken(),
+          access_token: "at_xxx",
+          refresh_token: "rt_xxx",
+          expires_in: 3600,
+        });
+      }).handler,
+    );
+
+    const request = makeCallbackRequest({
+      code: "code1",
+      state: stateValue,
+      stateCookie: stateValue,
+      pkceCookie: "verifier1",
+    });
+    await GET(request);
+
+    const providers = await listOrgProviders();
+    const secretNames = providers[0]?.secretNames ?? [];
+    expect(secretNames).toContain("CHATGPT_ACCESS_TOKEN");
+    expect(secretNames).toContain("CHATGPT_REFRESH_TOKEN");
+    expect(secretNames).toContain("CHATGPT_ACCOUNT_ID");
+    expect(secretNames).toContain("CHATGPT_ID_TOKEN");
+  });
+
+  it("rejects free plan with error redirect and no DB row", async () => {
+    server.use(
+      http.post(TOKEN_URL, () => {
+        return HttpResponse.json({
+          id_token: makeIdToken({ planType: "free" }),
+          access_token: "at_xxx",
+          refresh_token: "rt_xxx",
+        });
+      }).handler,
+    );
+
+    const request = makeCallbackRequest({
+      code: "code-free",
+      state: stateValue,
+      stateCookie: stateValue,
+      pkceCookie: "verifier-free",
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).toContain("error=free_plan");
+
+    const providers = await listOrgProviders();
+    expect(providers).toHaveLength(0);
+  });
+
+  it("returns error when state cookie is missing", async () => {
+    const request = makeCallbackRequest({
+      code: "c",
+      state: stateValue,
+      pkceCookie: "v",
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain("error=state_mismatch");
+  });
+
+  it("returns error when state param doesn't match cookie", async () => {
+    const request = makeCallbackRequest({
+      code: "c",
+      state: stateValue,
+      stateCookie: "different-state-value",
+      pkceCookie: "v",
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain("error=state_mismatch");
+  });
+
+  it("returns error when PKCE cookie is missing", async () => {
+    const request = makeCallbackRequest({
+      code: "c",
+      state: stateValue,
+      stateCookie: stateValue,
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain("error=expired");
+  });
+
+  it("forwards OAuth provider error in the redirect", async () => {
+    const request = makeCallbackRequest({
+      error: "access_denied",
+      stateCookie: stateValue,
+      pkceCookie: "v",
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain("error=access_denied");
+  });
+
+  it("returns exchange_failed on token endpoint 5xx", async () => {
+    server.use(
+      http.post(TOKEN_URL, () => {
+        return new HttpResponse("internal", { status: 500 });
+      }).handler,
+    );
+
+    const request = makeCallbackRequest({
+      code: "c",
+      state: stateValue,
+      stateCookie: stateValue,
+      pkceCookie: "v",
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain("error=exchange_failed");
+
+    const providers = await listOrgProviders();
+    expect(providers).toHaveLength(0);
+  });
+
+  it("returns ineligible when feature switch is off mid-flow", async () => {
+    mockIsFeatureEnabled.mockReturnValue(false);
+
+    const request = makeCallbackRequest({
+      code: "c",
+      state: stateValue,
+      stateCookie: stateValue,
+      pkceCookie: "v",
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain("error=ineligible");
+
+    const providers = await listOrgProviders();
+    expect(providers).toHaveLength(0);
+  });
+
+  it("clears state and PKCE cookies on every branch", async () => {
+    // Error branch (no exchange) clears cookies
+    const errResp = await GET(
+      makeCallbackRequest({
+        error: "access_denied",
+        stateCookie: stateValue,
+        pkceCookie: "v",
+      }),
+    );
+    const errCleared = clearedCookieNames(errResp);
+    expect(errCleared).toContain("chatgpt_oauth_state");
+    expect(errCleared).toContain("chatgpt_oauth_pkce");
+
+    // Happy path also clears cookies
+    server.use(
+      http.post(TOKEN_URL, () => {
+        return HttpResponse.json({
+          id_token: makeIdToken(),
+          access_token: "at",
+          refresh_token: "rt",
+          expires_in: 3600,
+        });
+      }).handler,
+    );
+    const okResp = await GET(
+      makeCallbackRequest({
+        code: "c",
+        state: stateValue,
+        stateCookie: stateValue,
+        pkceCookie: "v",
+      }),
+    );
+    const okCleared = clearedCookieNames(okResp);
+    expect(okCleared).toContain("chatgpt_oauth_state");
+    expect(okCleared).toContain("chatgpt_oauth_pkce");
+  });
+});

--- a/turbo/apps/web/app/api/zero/chatgpt/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/zero/chatgpt/oauth/callback/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 import { initServices } from "../../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../../src/lib/auth/get-auth-context";
+import { resolveOrg } from "../../../../../../src/lib/zero/org/resolve-org";
 import { getOrigin } from "../../../../../../src/lib/shared/request/get-origin";
 import { getAppUrl } from "../../../../../../src/lib/zero/url";
 import { logger } from "../../../../../../src/lib/shared/logger";
@@ -24,12 +26,16 @@ const log = logger("api:zero-chatgpt-oauth-callback");
  *
  * GET /api/zero/chatgpt/oauth/callback?code=...&state=...&error=...
  *
- * 1. Validate state matches the cookie set at connect time (CSRF).
- * 2. Re-check eligibility (in case the feature switch was disabled mid-flow).
- * 3. Exchange code → tokens via PKCE (uses code_verifier from cookie).
- * 4. Reject free-plan accounts with a clear redirect.
- * 5. Persist the 4 secrets via upsertOrgMultiAuthModelProvider.
- * 6. Redirect to the model-providers settings page.
+ * 1. Require an authenticated session (matches the connect-time session).
+ * 2. Validate state matches the cookie set at connect time (CSRF).
+ * 3. Bind state to the auth context: state.orgId/vm0UserId MUST match the
+ *    resolved org and authenticated user — prevents an attacker from
+ *    completing OAuth against an org they don't belong to.
+ * 4. Re-check eligibility (in case the feature switch was disabled mid-flow).
+ * 5. Exchange code → tokens via PKCE (uses code_verifier from cookie).
+ * 6. Reject free-plan accounts with a clear redirect.
+ * 7. Persist the 4 secrets via upsertOrgMultiAuthModelProvider.
+ * 8. Redirect to the model-providers settings page.
  *
  * `CHATGPT_REFRESH_TOKEN` and `CHATGPT_ID_TOKEN` are flagged `serverOnly`
  * in the model-provider type definition; the runner-secret-forwarding
@@ -59,6 +65,13 @@ export async function GET(request: Request) {
     return response;
   };
 
+  const authHeader = request.headers.get("authorization") ?? undefined;
+  const authCtx = await getAuthContext(authHeader);
+  if (!authCtx) {
+    return clearCookies(redirectError(appUrl, "unauthenticated"));
+  }
+  const { org } = await resolveOrg(authCtx);
+
   if (error) {
     return clearCookies(redirectError(appUrl, error));
   }
@@ -75,6 +88,14 @@ export async function GET(request: Request) {
   const state = parseState(stateParam);
   if (!state) {
     return clearCookies(redirectError(appUrl, "invalid_state"));
+  }
+
+  // Bind state to the auth context. The state cookie is HttpOnly + SameSite=Lax,
+  // but we still verify the encoded orgId/vm0UserId match the authenticated
+  // session — defense-in-depth against any path that might let an attacker
+  // forge or replay a state cookie for another org.
+  if (state.orgId !== org.orgId || state.vm0UserId !== authCtx.userId) {
+    return clearCookies(redirectError(appUrl, "state_mismatch"));
   }
 
   const eligible = await isChatgptOauthEligible(state.orgId, state.vm0UserId);

--- a/turbo/apps/web/app/api/zero/chatgpt/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/zero/chatgpt/oauth/callback/route.ts
@@ -1,0 +1,136 @@
+import { NextResponse } from "next/server";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { getOrigin } from "../../../../../../src/lib/shared/request/get-origin";
+import { getAppUrl } from "../../../../../../src/lib/zero/url";
+import { logger } from "../../../../../../src/lib/shared/logger";
+import { isChatgptOauthEligible } from "../../../../../../src/lib/zero/model-provider/chatgpt-oauth-eligibility";
+import {
+  exchangeChatgptCode,
+  isChatgptFreePlanError,
+} from "../../../../../../src/lib/zero/connector/providers/chatgpt-oauth";
+import { upsertOrgMultiAuthModelProvider } from "../../../../../../src/lib/zero/model-provider/model-provider-service";
+import {
+  STATE_COOKIE_NAME,
+  PKCE_COOKIE_NAME,
+  buildDeleteCookieHeader,
+  getCookie,
+} from "../_cookies";
+import { parseState } from "../_state";
+
+const log = logger("api:zero-chatgpt-oauth-callback");
+
+/**
+ * ChatGPT OAuth Callback Endpoint
+ *
+ * GET /api/zero/chatgpt/oauth/callback?code=...&state=...&error=...
+ *
+ * 1. Validate state matches the cookie set at connect time (CSRF).
+ * 2. Re-check eligibility (in case the feature switch was disabled mid-flow).
+ * 3. Exchange code → tokens via PKCE (uses code_verifier from cookie).
+ * 4. Reject free-plan accounts with a clear redirect.
+ * 5. Persist the 4 secrets via upsertOrgMultiAuthModelProvider.
+ * 6. Redirect to the model-providers settings page.
+ *
+ * `CHATGPT_REFRESH_TOKEN` and `CHATGPT_ID_TOKEN` are flagged `serverOnly`
+ * in the model-provider type definition; the runner-secret-forwarding
+ * pipeline strips them before sandbox dispatch (per #7365 invariant).
+ */
+export async function GET(request: Request) {
+  initServices();
+
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const error = url.searchParams.get("error");
+  const stateParam = url.searchParams.get("state");
+  const origin = getOrigin(request);
+  const appUrl = getAppUrl();
+
+  // Always clear OAuth cookies on the way out — applies to every branch
+  // below regardless of success.
+  const clearCookies = (response: NextResponse): NextResponse => {
+    response.headers.append(
+      "Set-Cookie",
+      buildDeleteCookieHeader(STATE_COOKIE_NAME),
+    );
+    response.headers.append(
+      "Set-Cookie",
+      buildDeleteCookieHeader(PKCE_COOKIE_NAME),
+    );
+    return response;
+  };
+
+  if (error) {
+    return clearCookies(redirectError(appUrl, error));
+  }
+
+  if (!code || !stateParam) {
+    return clearCookies(redirectError(appUrl, "missing_params"));
+  }
+
+  const savedState = getCookie(request, STATE_COOKIE_NAME);
+  if (!savedState || savedState !== stateParam) {
+    return clearCookies(redirectError(appUrl, "state_mismatch"));
+  }
+
+  const state = parseState(stateParam);
+  if (!state) {
+    return clearCookies(redirectError(appUrl, "invalid_state"));
+  }
+
+  const eligible = await isChatgptOauthEligible(state.orgId, state.vm0UserId);
+  if (!eligible) {
+    return clearCookies(redirectError(appUrl, "ineligible"));
+  }
+
+  const codeVerifier = getCookie(request, PKCE_COOKIE_NAME);
+  if (!codeVerifier) {
+    return clearCookies(redirectError(appUrl, "expired"));
+  }
+
+  const redirectUri = `${origin}/api/zero/chatgpt/oauth/callback`;
+
+  let result;
+  try {
+    result = await exchangeChatgptCode("", "", code, redirectUri, codeVerifier);
+  } catch (err) {
+    if (isChatgptFreePlanError(err)) {
+      log.info("Rejected free-plan ChatGPT OAuth", { orgId: state.orgId });
+      return clearCookies(redirectError(appUrl, "free_plan"));
+    }
+    log.warn("ChatGPT OAuth exchange failed", { error: err });
+    return clearCookies(redirectError(appUrl, "exchange_failed"));
+  }
+
+  // TODO(#11908): once tokenExpiresAt column ships, add:
+  //   tokenExpiresAt: new Date(Date.now() + result.expiresIn * 1000),
+  // Until then, refresh pipeline treats null as 'never refreshes' — safe
+  // because chatgptOauthProvider feature switch is OFF in production
+  // (no user-reachable path).
+  await upsertOrgMultiAuthModelProvider(
+    state.orgId,
+    "chatgpt-oauth-token",
+    "oauth",
+    {
+      CHATGPT_ACCESS_TOKEN: result.accessToken,
+      CHATGPT_REFRESH_TOKEN: result.refreshToken,
+      CHATGPT_ACCOUNT_ID: result.accountId,
+      CHATGPT_ID_TOKEN: result.idToken,
+    },
+  );
+
+  log.info("ChatGPT OAuth provider connected", {
+    orgId: state.orgId,
+    workspaceName: result.workspaceName,
+    planType: result.planType,
+  });
+
+  const successUrl = new URL("/settings/model-providers", appUrl);
+  successUrl.searchParams.set("connected", "chatgpt");
+  return clearCookies(NextResponse.redirect(successUrl.toString()));
+}
+
+function redirectError(appUrl: string, code: string): NextResponse {
+  const url = new URL("/settings/model-providers", appUrl);
+  url.searchParams.set("error", code);
+  return NextResponse.redirect(url.toString());
+}

--- a/turbo/apps/web/app/api/zero/chatgpt/oauth/connect/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chatgpt/oauth/connect/__tests__/route.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET } from "../route";
 import { createTestRequest } from "../../../../../../../src/__tests__/api-test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import {
   testContext,
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
+import { CHATGPT_OAUTH_CLIENT_ID } from "../../../../../../../src/lib/zero/connector/providers/chatgpt-oauth";
 
 vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
   const actual =
@@ -20,23 +22,20 @@ const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
 
 const context = testContext();
 
-const BASE_URL = "http://localhost:3000/api/zero/chatgpt/oauth/connect";
-
-function connectUrl(orgId: string, vm0UserId: string): string {
-  return `${BASE_URL}?orgId=${encodeURIComponent(orgId)}&vm0UserId=${encodeURIComponent(vm0UserId)}`;
-}
+const CONNECT_URL = "http://localhost:3000/api/zero/chatgpt/oauth/connect";
 
 describe("GET /api/zero/chatgpt/oauth/connect", () => {
   let user: UserContext;
 
   beforeEach(async () => {
+    vi.clearAllMocks();
     context.setupMocks();
     mockIsFeatureEnabled.mockReturnValue(true);
     user = await context.setupUser();
   });
 
   it("redirects to auth.openai.com authorize URL with PKCE params", async () => {
-    const request = createTestRequest(connectUrl(user.orgId, user.userId));
+    const request = createTestRequest(CONNECT_URL);
     const response = await GET(request);
 
     expect(response.status).toBe(307);
@@ -46,9 +45,7 @@ describe("GET /api/zero/chatgpt/oauth/connect", () => {
     expect(locUrl.origin).toBe("https://auth.openai.com");
     expect(locUrl.pathname).toBe("/oauth/authorize");
     expect(locUrl.searchParams.get("response_type")).toBe("code");
-    expect(locUrl.searchParams.get("client_id")).toBe(
-      "app_EMoamEEZ73f0CkXaXp7hrann",
-    );
+    expect(locUrl.searchParams.get("client_id")).toBe(CHATGPT_OAUTH_CLIENT_ID);
     expect(locUrl.searchParams.get("code_challenge_method")).toBe("S256");
     expect(locUrl.searchParams.get("code_challenge")).toMatch(
       /^[A-Za-z0-9_-]+$/,
@@ -61,7 +58,7 @@ describe("GET /api/zero/chatgpt/oauth/connect", () => {
   });
 
   it("sets state and PKCE cookies with HttpOnly + 15 min Max-Age", async () => {
-    const request = createTestRequest(connectUrl(user.orgId, user.userId));
+    const request = createTestRequest(CONNECT_URL);
     const response = await GET(request);
 
     const cookies = response.headers.getSetCookie();
@@ -85,32 +82,23 @@ describe("GET /api/zero/chatgpt/oauth/connect", () => {
   it("returns 404 when feature switch is off (ineligible)", async () => {
     mockIsFeatureEnabled.mockReturnValue(false);
 
-    const request = createTestRequest(connectUrl(user.orgId, user.userId));
+    const request = createTestRequest(CONNECT_URL);
     const response = await GET(request);
 
     expect(response.status).toBe(404);
   });
 
-  it("returns 400 when orgId is missing", async () => {
-    const request = createTestRequest(
-      `${BASE_URL}?vm0UserId=${encodeURIComponent(user.userId)}`,
-    );
+  it("returns 401 when caller is not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(CONNECT_URL);
     const response = await GET(request);
 
-    expect(response.status).toBe(400);
-  });
-
-  it("returns 400 when vm0UserId is missing", async () => {
-    const request = createTestRequest(
-      `${BASE_URL}?orgId=${encodeURIComponent(user.orgId)}`,
-    );
-    const response = await GET(request);
-
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(401);
   });
 
   it("encodes orgId, vm0UserId, and flow=connect into the state JSON", async () => {
-    const request = createTestRequest(connectUrl(user.orgId, user.userId));
+    const request = createTestRequest(CONNECT_URL);
     const response = await GET(request);
 
     const location = response.headers.get("location");
@@ -124,5 +112,23 @@ describe("GET /api/zero/chatgpt/oauth/connect", () => {
     expect(state.orgId).toBe(user.orgId);
     expect(state.vm0UserId).toBe(user.userId);
     expect(state.flow).toBe("connect");
+  });
+
+  it("ignores client-supplied orgId/vm0UserId query params", async () => {
+    const request = createTestRequest(
+      `${CONNECT_URL}?orgId=attacker-org&vm0UserId=attacker-user`,
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    const stateRaw = new URL(location!).searchParams.get("state");
+    const state = JSON.parse(stateRaw!) as {
+      orgId: string;
+      vm0UserId: string;
+    };
+    // Auth context wins: query params are ignored
+    expect(state.orgId).toBe(user.orgId);
+    expect(state.vm0UserId).toBe(user.userId);
   });
 });

--- a/turbo/apps/web/app/api/zero/chatgpt/oauth/connect/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chatgpt/oauth/connect/__tests__/route.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GET } from "../route";
+import { createTestRequest } from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../../../src/__tests__/test-helpers";
+
+vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@vm0/core/feature-switch")>();
+  return {
+    ...actual,
+    isFeatureEnabled: vi.fn().mockReturnValue(true),
+  };
+});
+
+const { isFeatureEnabled } = await import("@vm0/core/feature-switch");
+const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
+
+const context = testContext();
+
+const BASE_URL = "http://localhost:3000/api/zero/chatgpt/oauth/connect";
+
+function connectUrl(orgId: string, vm0UserId: string): string {
+  return `${BASE_URL}?orgId=${encodeURIComponent(orgId)}&vm0UserId=${encodeURIComponent(vm0UserId)}`;
+}
+
+describe("GET /api/zero/chatgpt/oauth/connect", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    mockIsFeatureEnabled.mockReturnValue(true);
+    user = await context.setupUser();
+  });
+
+  it("redirects to auth.openai.com authorize URL with PKCE params", async () => {
+    const request = createTestRequest(connectUrl(user.orgId, user.userId));
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).toBeTruthy();
+    const locUrl = new URL(location!);
+    expect(locUrl.origin).toBe("https://auth.openai.com");
+    expect(locUrl.pathname).toBe("/oauth/authorize");
+    expect(locUrl.searchParams.get("response_type")).toBe("code");
+    expect(locUrl.searchParams.get("client_id")).toBe(
+      "app_EMoamEEZ73f0CkXaXp7hrann",
+    );
+    expect(locUrl.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(locUrl.searchParams.get("code_challenge")).toMatch(
+      /^[A-Za-z0-9_-]+$/,
+    );
+    expect(locUrl.searchParams.get("state")).toBeTruthy();
+    expect(locUrl.searchParams.get("redirect_uri")).toContain(
+      "/api/zero/chatgpt/oauth/callback",
+    );
+    expect(locUrl.searchParams.get("scope")).toContain("openid");
+  });
+
+  it("sets state and PKCE cookies with HttpOnly + 15 min Max-Age", async () => {
+    const request = createTestRequest(connectUrl(user.orgId, user.userId));
+    const response = await GET(request);
+
+    const cookies = response.headers.getSetCookie();
+    const stateCookie = cookies.find((c) => {
+      return c.startsWith("chatgpt_oauth_state=");
+    });
+    const pkceCookie = cookies.find((c) => {
+      return c.startsWith("chatgpt_oauth_pkce=");
+    });
+
+    expect(stateCookie).toBeDefined();
+    expect(stateCookie).toContain("HttpOnly");
+    expect(stateCookie).toContain("SameSite=Lax");
+    expect(stateCookie).toContain("Max-Age=900");
+
+    expect(pkceCookie).toBeDefined();
+    expect(pkceCookie).toContain("HttpOnly");
+    expect(pkceCookie).toContain("Max-Age=900");
+  });
+
+  it("returns 404 when feature switch is off (ineligible)", async () => {
+    mockIsFeatureEnabled.mockReturnValue(false);
+
+    const request = createTestRequest(connectUrl(user.orgId, user.userId));
+    const response = await GET(request);
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 when orgId is missing", async () => {
+    const request = createTestRequest(
+      `${BASE_URL}?vm0UserId=${encodeURIComponent(user.userId)}`,
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when vm0UserId is missing", async () => {
+    const request = createTestRequest(
+      `${BASE_URL}?orgId=${encodeURIComponent(user.orgId)}`,
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(400);
+  });
+
+  it("encodes orgId, vm0UserId, and flow=connect into the state JSON", async () => {
+    const request = createTestRequest(connectUrl(user.orgId, user.userId));
+    const response = await GET(request);
+
+    const location = response.headers.get("location");
+    const stateRaw = new URL(location!).searchParams.get("state");
+    expect(stateRaw).toBeTruthy();
+    const state = JSON.parse(stateRaw!) as {
+      orgId: string;
+      vm0UserId: string;
+      flow: string;
+    };
+    expect(state.orgId).toBe(user.orgId);
+    expect(state.vm0UserId).toBe(user.userId);
+    expect(state.flow).toBe("connect");
+  });
+});

--- a/turbo/apps/web/app/api/zero/chatgpt/oauth/connect/route.ts
+++ b/turbo/apps/web/app/api/zero/chatgpt/oauth/connect/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 import { initServices } from "../../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../../src/lib/auth/get-auth-context";
+import { resolveOrg } from "../../../../../../src/lib/zero/org/resolve-org";
 import { getOrigin } from "../../../../../../src/lib/shared/request/get-origin";
 import { isChatgptOauthEligible } from "../../../../../../src/lib/zero/model-provider/chatgpt-oauth-eligibility";
 import { buildChatgptAuthorizationUrl } from "../../../../../../src/lib/zero/connector/providers/chatgpt-oauth";
@@ -14,12 +16,17 @@ import { serializeState } from "../_state";
 /**
  * ChatGPT OAuth Connect Endpoint
  *
- * GET /api/zero/chatgpt/oauth/connect?orgId=<orgId>&vm0UserId=<userId>
+ * GET /api/zero/chatgpt/oauth/connect
  *
  * Builds the PKCE authorize URL for `auth.openai.com`, persists the
  * code_verifier in an HttpOnly cookie keyed for this OAuth flow, and
  * redirects (302) to the authorize URL. The user picks their workspace
  * on auth.openai.com; the callback handles the rest.
+ *
+ * Authorization: requires an authenticated session (via `getAuthContext`)
+ * with an active org. `orgId`/`vm0UserId` are derived from the session —
+ * never accepted from the client — so a caller cannot initiate OAuth for
+ * an arbitrary org.
  *
  * Gated by `isChatgptOauthEligible(orgId, userId)` — returns 404 when
  * the feature switch is off so the entire surface stays hidden.
@@ -27,16 +34,15 @@ import { serializeState } from "../_state";
 export async function GET(request: Request) {
   initServices();
 
-  const url = new URL(request.url);
-  const orgId = url.searchParams.get("orgId");
-  const vm0UserId = url.searchParams.get("vm0UserId");
-
-  if (!orgId || !vm0UserId) {
-    return NextResponse.json(
-      { error: "Missing orgId or vm0UserId" },
-      { status: 400 },
-    );
+  const authHeader = request.headers.get("authorization") ?? undefined;
+  const authCtx = await getAuthContext(authHeader);
+  if (!authCtx) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
   }
+
+  const { org } = await resolveOrg(authCtx);
+  const orgId = org.orgId;
+  const vm0UserId = authCtx.userId;
 
   const eligible = await isChatgptOauthEligible(orgId, vm0UserId);
   if (!eligible) {

--- a/turbo/apps/web/app/api/zero/chatgpt/oauth/connect/route.ts
+++ b/turbo/apps/web/app/api/zero/chatgpt/oauth/connect/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { getOrigin } from "../../../../../../src/lib/shared/request/get-origin";
+import { isChatgptOauthEligible } from "../../../../../../src/lib/zero/model-provider/chatgpt-oauth-eligibility";
+import { buildChatgptAuthorizationUrl } from "../../../../../../src/lib/zero/connector/providers/chatgpt-oauth";
+import {
+  STATE_COOKIE_NAME,
+  PKCE_COOKIE_NAME,
+  COOKIE_MAX_AGE,
+  buildCookieHeader,
+} from "../_cookies";
+import { serializeState } from "../_state";
+
+/**
+ * ChatGPT OAuth Connect Endpoint
+ *
+ * GET /api/zero/chatgpt/oauth/connect?orgId=<orgId>&vm0UserId=<userId>
+ *
+ * Builds the PKCE authorize URL for `auth.openai.com`, persists the
+ * code_verifier in an HttpOnly cookie keyed for this OAuth flow, and
+ * redirects (302) to the authorize URL. The user picks their workspace
+ * on auth.openai.com; the callback handles the rest.
+ *
+ * Gated by `isChatgptOauthEligible(orgId, userId)` — returns 404 when
+ * the feature switch is off so the entire surface stays hidden.
+ */
+export async function GET(request: Request) {
+  initServices();
+
+  const url = new URL(request.url);
+  const orgId = url.searchParams.get("orgId");
+  const vm0UserId = url.searchParams.get("vm0UserId");
+
+  if (!orgId || !vm0UserId) {
+    return NextResponse.json(
+      { error: "Missing orgId or vm0UserId" },
+      { status: 400 },
+    );
+  }
+
+  const eligible = await isChatgptOauthEligible(orgId, vm0UserId);
+  if (!eligible) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const origin = getOrigin(request);
+  const redirectUri = `${origin}/api/zero/chatgpt/oauth/callback`;
+  const state = serializeState({ orgId, vm0UserId, flow: "connect" });
+
+  const { url: authUrl, codeVerifier } = await buildChatgptAuthorizationUrl(
+    "",
+    redirectUri,
+    state,
+  );
+
+  const response = NextResponse.redirect(authUrl, {
+    headers: { "Cache-Control": "no-store" },
+  });
+  response.headers.append(
+    "Set-Cookie",
+    buildCookieHeader(STATE_COOKIE_NAME, state, COOKIE_MAX_AGE),
+  );
+  response.headers.append(
+    "Set-Cookie",
+    buildCookieHeader(PKCE_COOKIE_NAME, codeVerifier, COOKIE_MAX_AGE),
+  );
+  return response;
+}

--- a/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
+++ b/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
@@ -142,6 +142,13 @@ export const WEB_API_ROUTE_BASELINE = [
   "app/api/zero/chat-threads/[id]/route.ts",
   "app/api/zero/chat-threads/[id]/unpin/route.ts",
   "app/api/zero/chat-threads/route.ts",
+  // OAuth connect/callback for the ChatGPT model provider (Epic #11872, sub-issue
+  // #11909). Third-party OAuth callbacks need a stable Next.js route to receive
+  // auth.openai.com's redirect; mirrors the existing apps/web/app/api/connectors
+  // and Slack OAuth patterns. Re-evaluate when an apps/api OAuth-callback
+  // primitive lands.
+  "app/api/zero/chatgpt/oauth/callback/route.ts",
+  "app/api/zero/chatgpt/oauth/connect/route.ts",
   "app/api/zero/composes/[id]/metadata/route.ts",
   "app/api/zero/composes/[id]/route.ts",
   "app/api/zero/composes/list/route.ts",

--- a/turbo/apps/web/src/lib/zero/connector/providers/__tests__/chatgpt-oauth.test.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/__tests__/chatgpt-oauth.test.ts
@@ -13,6 +13,7 @@ import {
   getChatgptSecretName,
   getChatgptRefreshSecretName,
   isChatgptRefreshError,
+  isChatgptFreePlanError,
   type ChatgptRefreshError,
   CHATGPT_OAUTH_CLIENT_ID,
   CHATGPT_OAUTH_ISSUER,
@@ -256,7 +257,7 @@ describe("connector/providers/chatgpt-oauth", () => {
       expect(result.workspaceName).toBeNull();
     });
 
-    it("rejects free plan_type", async () => {
+    it("rejects free plan_type with typed ChatgptFreePlanError", async () => {
       const idToken = makeIdToken({ accountId: "a", planType: "free" });
       const { handler } = http.post(TOKEN_URL, () => {
         return HttpResponse.json({
@@ -267,9 +268,22 @@ describe("connector/providers/chatgpt-oauth", () => {
       });
       server.use(handler);
 
-      await expect(
-        exchangeChatgptCode("x", "x", "c", "https://example.com/cb", "v"),
-      ).rejects.toThrow(/free plan/i);
+      const promise = exchangeChatgptCode(
+        "x",
+        "x",
+        "c",
+        "https://example.com/cb",
+        "v",
+      );
+      await expect(promise).rejects.toThrow(/free plan/i);
+      await expect(promise).rejects.toSatisfy(isChatgptFreePlanError);
+    });
+
+    it("isChatgptFreePlanError type guard rejects unrelated errors", () => {
+      expect(isChatgptFreePlanError(new Error("anything else"))).toBe(false);
+      expect(isChatgptFreePlanError("not even an error")).toBe(false);
+      expect(isChatgptFreePlanError(null)).toBe(false);
+      expect(isChatgptFreePlanError(undefined)).toBe(false);
     });
 
     it("throws when id_token is missing required auth claims", async () => {

--- a/turbo/apps/web/src/lib/zero/connector/providers/chatgpt-oauth.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/chatgpt-oauth.ts
@@ -46,6 +46,30 @@ export function isChatgptRefreshError(
   );
 }
 
+/**
+ * Typed error thrown when an OAuth exchange returns an account whose
+ * `chatgpt_plan_type` is `"free"`. ChatGPT free plans don't have access
+ * to the Codex backend; the calling route should surface a clear
+ * "upgrade required" message to the user rather than a generic error.
+ */
+interface ChatgptFreePlanError extends Error {
+  readonly name: "ChatgptFreePlanError";
+}
+
+function createChatgptFreePlanError(): ChatgptFreePlanError {
+  const err = new Error(
+    "ChatGPT free plan is not supported — upgrade to Plus, Pro, Business, Edu, or Enterprise",
+  );
+  err.name = "ChatgptFreePlanError";
+  return err as ChatgptFreePlanError;
+}
+
+export function isChatgptFreePlanError(
+  value: unknown,
+): value is ChatgptFreePlanError {
+  return value instanceof Error && value.name === "ChatgptFreePlanError";
+}
+
 interface ChatgptExchangeResult {
   accessToken: string;
   refreshToken: string;
@@ -229,9 +253,7 @@ export async function exchangeChatgptCode(
     throw new Error("ChatGPT id_token missing required auth claims");
   }
   if (auth.chatgpt_plan_type === "free") {
-    throw new Error(
-      "ChatGPT free plan is not supported — upgrade to Plus, Pro, Business, Edu, or Enterprise",
-    );
+    throw createChatgptFreePlanError();
   }
 
   const expiresIn =


### PR DESCRIPTION
## Summary

Two new GET routes drive the ChatGPT OAuth dance for the new `chatgpt-oauth-token` model provider (Wave 2 of Epic #11872):

- **`/api/zero/chatgpt/oauth/connect`** — eligibility check, build PKCE authorize URL via `buildChatgptAuthorizationUrl`, persist `code_verifier` in HttpOnly cookie, 302-redirect to `auth.openai.com`.
- **`/api/zero/chatgpt/oauth/callback`** — validate state cookie, re-check eligibility, exchange code via PKCE, reject free plan with clear redirect (using new typed `ChatgptFreePlanError`), persist all 4 secrets via `upsertOrgMultiAuthModelProvider`, redirect to `/settings/model-providers?connected=chatgpt`.

Both routes gated by `isChatgptOauthEligible(orgId, userId)`.

Closes #11909; part of Epic #11872.

## Design highlights

| Decision | Rationale |
|---|---|
| Call `exchangeChatgptCode` directly (not via `chatgptOauthHandler`) | Handler's generic `OAuthTokenResult` drops `idToken`/`planType`/`workspaceName`, all of which we need to persist or validate |
| `getOrigin(request)` for `redirect_uri` | Symmetric in connect+callback; survives dev tunnels (matches existing `/api/connectors/[type]/...` flow) |
| HttpOnly cookies with namespaced names (`chatgpt_oauth_*`) | Avoids collision with the connector OAuth flow's cookies; same security posture as existing PKCE routes |
| Typed `ChatgptFreePlanError` + `isChatgptFreePlanError` (refactor commit) | Mirrors existing `ChatgptRefreshError` pattern; route uses type guard instead of message string-match |
| Routes added to `web-api-routes.ts` baseline as intentional exception | Third-party OAuth callbacks need stable Next.js paths; matches Slack + connector patterns |

## Cross-cut deferred

`tokenExpiresAt` persistence is deferred to a follow-up after #11908 (b2's refresh-pipeline SI) ships its schema migration + extended `upsertOrgMultiAuthModelProvider` signature. TODO comment at the upsert call site marks the future code. Safe to defer because the `chatgptOauthProvider` feature switch is OFF in production — no user-reachable path consumes the missing field.

Per leader (b) decision: proceed-and-amend, not block-on-#11908.

## Test plan

- [x] 17 new tests across two route files + 2 new tests in `chatgpt-oauth.test.ts` (typed error coverage)
- [x] All 45 tests in `app/api/zero/chatgpt/oauth/` and `chatgpt-oauth.test.ts` pass
- [x] MSW for `auth.openai.com/oauth/token` (no internal-module mocks per `/testing` rule)
- [x] Real DB assertions via the existing `GET /api/zero/model-providers` route (no direct service imports per `web/no-direct-db-in-tests`)
- [x] `pnpm turbo run lint --filter=web` clean
- [x] `pnpm -F web check-types` clean
- [x] `pnpm format --check` clean
- [x] `pnpm knip` clean
- [ ] E2E (Wave 4): real OAuth dance against `auth.openai.com` with a test ChatGPT account

## Coverage

| Test | Verifies |
|---|---|
| `connect_redirects_to_authorize_url` | 302 + PKCE params (`response_type=code`, `code_challenge_method=S256`, `state`, `client_id`, `redirect_uri`, `scope`) |
| `connect_sets_state_and_pkce_cookies` | HttpOnly + 15-min Max-Age + namespaced cookie names |
| `connect_returns_404_when_ineligible` | Feature-switch off → 404 |
| `connect_returns_400_when_*_missing` | orgId / vm0UserId required |
| `connect_state_includes_flow_connect` | State JSON shape |
| `callback_happy_path_*` | 302 to success URL + provider row exists |
| `callback_persists_all_four_secrets` | 4 secrets including serverOnly `CHATGPT_REFRESH_TOKEN` + `CHATGPT_ID_TOKEN` |
| `callback_rejects_free_plan_*` | Typed error → `error=free_plan` redirect, no DB row |
| `callback_state_*` (3 cases) | Missing cookie / mismatch / invalid state |
| `callback_pkce_*` | Missing pkce → `error=expired` |
| `callback_oauth_provider_error` | Forwards `?error=access_denied` |
| `callback_exchange_failed` | 5xx from token endpoint → `error=exchange_failed` |
| `callback_ineligible_at_callback_time` | Mid-flow feature switch off → `error=ineligible` |
| `callback_clears_cookies_on_every_branch` | Both error and success paths set `Max-Age=0` for both cookies |

🤖 Generated with [Claude Code](https://claude.com/claude-code)