### PR TITLE
feat(zero): compute personal eager-pin in chat thread creation

### DIFF
--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -7,6 +7,8 @@ import {
   createTestCompose,
   insertOrgDefaultModelProvider,
   insertOrgNonDefaultModelProvider,
+  insertUserDefaultModelProvider,
+  enablePersonalModelProviderForUser,
   deleteTestModelProvider,
   setTestZeroAgentModelProvider,
   setOrgCredits,
@@ -17,7 +19,10 @@ import {
   countUserRows,
   completeTestRun,
 } from "../../../../../../src/__tests__/api-test-helpers";
-import { setTestSessionFramework } from "../../../../../../src/__tests__/db-test-seeders/agents";
+import {
+  setTestSessionFramework,
+  setTestZeroAgentPreferPersonalProvider,
+} from "../../../../../../src/__tests__/db-test-seeders/agents";
 import {
   getTestChatThreadModelOverride,
   getTestModelProviderIdByType,
@@ -1211,6 +1216,206 @@ describe("POST /api/zero/chat/messages", () => {
         const after = await getTestChatThreadModelOverride(threadId);
         expect(after.modelProviderId).toBeNull();
         expect(after.selectedModel).toBeNull();
+      });
+    });
+
+    describe("personal-tier eager-pin (#11918)", () => {
+      it("falls through to agent's pin when feature switch is OFF", async () => {
+        // Agent has the flag on but the staff-only switch is not flipped
+        // for this user — pin must remain agent's id, not personal's.
+        const orgProviderId = await getTestModelProviderIdByType(
+          user.orgId,
+          "anthropic-api-key",
+        );
+        await setTestZeroAgentModelProvider(
+          agentId,
+          orgProviderId,
+          "claude-opus-4-7",
+        );
+        await setTestZeroAgentPreferPersonalProvider(agentId, true);
+        await insertUserDefaultModelProvider(
+          user.orgId,
+          user.userId,
+          "openai-api-key",
+          "gpt-5.4",
+        );
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ agentId, prompt: "switch off" }),
+          }),
+        );
+        expect(response.status).toBe(201);
+        const { threadId } = await response.json();
+
+        const override = await getTestChatThreadModelOverride(threadId);
+        expect(override.modelProviderId).toBe(orgProviderId);
+        expect(override.selectedModel).toBe("claude-opus-4-7");
+      });
+
+      it("falls through to agent's pin when flag is OFF", async () => {
+        const orgProviderId = await getTestModelProviderIdByType(
+          user.orgId,
+          "anthropic-api-key",
+        );
+        await setTestZeroAgentModelProvider(
+          agentId,
+          orgProviderId,
+          "claude-opus-4-7",
+        );
+        // Switch enabled but flag default false — eligibility false.
+        await enablePersonalModelProviderForUser(user.orgId, user.userId);
+        await insertUserDefaultModelProvider(
+          user.orgId,
+          user.userId,
+          "openai-api-key",
+          "gpt-5.4",
+        );
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ agentId, prompt: "flag off" }),
+          }),
+        );
+        expect(response.status).toBe(201);
+        const { threadId } = await response.json();
+
+        const override = await getTestChatThreadModelOverride(threadId);
+        expect(override.modelProviderId).toBe(orgProviderId);
+        expect(override.selectedModel).toBe("claude-opus-4-7");
+      });
+
+      it("pins to user's personal default id when both flag and switch are ON", async () => {
+        // Both gates open + user has a personal default with its own
+        // selectedModel — pin must be the personal row's id and selectedModel.
+        const orgProviderId = await getTestModelProviderIdByType(
+          user.orgId,
+          "anthropic-api-key",
+        );
+        await setTestZeroAgentModelProvider(
+          agentId,
+          orgProviderId,
+          "claude-opus-4-7",
+        );
+        await setTestZeroAgentPreferPersonalProvider(agentId, true);
+        await enablePersonalModelProviderForUser(user.orgId, user.userId);
+        const personalProviderId = await insertUserDefaultModelProvider(
+          user.orgId,
+          user.userId,
+          "openai-api-key",
+          "gpt-5.4",
+        );
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ agentId, prompt: "personal pin" }),
+          }),
+        );
+        expect(response.status).toBe(201);
+        const { threadId } = await response.json();
+
+        const override = await getTestChatThreadModelOverride(threadId);
+        expect(override.modelProviderId).toBe(personalProviderId);
+        expect(override.selectedModel).toBe("gpt-5.4");
+      });
+
+      it("falls back to agent's selectedModel when personal row has none", async () => {
+        // Personal default has no selectedModel — precedence is
+        // user > agent > null, so the agent's selectedModel surfaces.
+        const orgProviderId = await getTestModelProviderIdByType(
+          user.orgId,
+          "anthropic-api-key",
+        );
+        await setTestZeroAgentModelProvider(
+          agentId,
+          orgProviderId,
+          "claude-opus-4-7",
+        );
+        await setTestZeroAgentPreferPersonalProvider(agentId, true);
+        await enablePersonalModelProviderForUser(user.orgId, user.userId);
+        const personalProviderId = await insertUserDefaultModelProvider(
+          user.orgId,
+          user.userId,
+          "openai-api-key",
+          // selectedModel intentionally omitted
+        );
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ agentId, prompt: "fallback selected" }),
+          }),
+        );
+        expect(response.status).toBe(201);
+        const { threadId } = await response.json();
+
+        const override = await getTestChatThreadModelOverride(threadId);
+        expect(override.modelProviderId).toBe(personalProviderId);
+        expect(override.selectedModel).toBe("claude-opus-4-7");
+      });
+
+      it("falls through to agent's pin when user has no personal providers", async () => {
+        // Eligible but the user has not seeded any personal rows yet —
+        // graceful degradation to the agent's pin.
+        const orgProviderId = await getTestModelProviderIdByType(
+          user.orgId,
+          "anthropic-api-key",
+        );
+        await setTestZeroAgentModelProvider(
+          agentId,
+          orgProviderId,
+          "claude-opus-4-7",
+        );
+        await setTestZeroAgentPreferPersonalProvider(agentId, true);
+        await enablePersonalModelProviderForUser(user.orgId, user.userId);
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ agentId, prompt: "no personal" }),
+          }),
+        );
+        expect(response.status).toBe(201);
+        const { threadId } = await response.json();
+
+        const override = await getTestChatThreadModelOverride(threadId);
+        expect(override.modelProviderId).toBe(orgProviderId);
+        expect(override.selectedModel).toBe("claude-opus-4-7");
+      });
+
+      it("pins to user's personal id even when agent has no provider configured", async () => {
+        // Agent has no modelProviderId/selectedModel, but user has a
+        // personal default and is eligible — pin uses the personal row.
+        await setTestZeroAgentPreferPersonalProvider(agentId, true);
+        await enablePersonalModelProviderForUser(user.orgId, user.userId);
+        const personalProviderId = await insertUserDefaultModelProvider(
+          user.orgId,
+          user.userId,
+          "openai-api-key",
+          "gpt-5.4",
+        );
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ agentId, prompt: "no agent pin" }),
+          }),
+        );
+        expect(response.status).toBe(201);
+        const { threadId } = await response.json();
+
+        const override = await getTestChatThreadModelOverride(threadId);
+        expect(override.modelProviderId).toBe(personalProviderId);
+        expect(override.selectedModel).toBe("gpt-5.4");
       });
     });
 

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -26,7 +26,11 @@ import {
   type WebChatIncompleteRound,
 } from "../../../../../src/lib/zero/integration-prompt";
 import { isApiError, providerDeleted } from "@vm0/api-services/errors";
-import { getModelProviderById } from "../../../../../src/lib/zero/model-provider/model-provider-service";
+import {
+  getModelProviderById,
+  getUserAnyDefaultModelProvider,
+} from "../../../../../src/lib/zero/model-provider/model-provider-service";
+import { isPersonalTierEligible } from "../../../../../src/lib/zero/personal-tier-gate";
 import {
   createChatThread,
   getChatThread,
@@ -184,6 +188,72 @@ async function rejectIfThreadModelLocked(
     existing.modelProviderId !== incoming.modelProviderId ||
     existing.selectedModel !== incoming.selectedModel
   );
+}
+
+/**
+ * Compute the eager-pin written into `chat_threads.modelProviderId` /
+ * `selected_model` at NEW thread creation. Defaults to the agent's stored
+ * pin; promotes to the caller's personal-tier default when (Epic #11868):
+ *   1. the agent has `prefer_personal_provider=true`, AND
+ *   2. the `personalModelProvider` feature switch is on for the caller, AND
+ *   3. the user has a personal default provider in this workspace.
+ *
+ * `selectedModel` precedence: user's personal row > agent's > null —
+ * mirrors the resolver's runtime fallback chain.
+ *
+ * Why a single `getUserAnyDefaultModelProvider` is sufficient here (vs the
+ * resolver's two-step `getUserDefaultModelProvider(framework) ?? any-default`
+ * chain): #11752 introduced the workspace single-default invariant
+ * (`idx_model_providers_one_default_per_user`) — at most one
+ * `isDefault=true` row per `(orgId, userId)`. The framework-scoped variant
+ * therefore returns either that same row (when its framework matches) or
+ * null (cross-framework), and the any-default fallback returns the row
+ * unconditionally. The two-step chain is NOT redundant in the resolver
+ * because of the framework-propagation handshake (Epic #11520 — provider's
+ * framework wins, and the resolver returns `framework: getFrameworkForType(
+ * providerType)` derived from the row it picked). At pin time we don't
+ * propagate framework — we persist row id + model and let the resolver
+ * re-derive framework when the run dispatches via `getModelProviderById`.
+ * One read suffices; documenting the asymmetry so the optimization isn't
+ * mistakenly mirrored back into the resolver.
+ *
+ * Existing-thread sends bypass this helper — see Decision F2 in plan.md
+ * for the per-thread immutability rationale.
+ */
+async function computeEagerPin(
+  orgId: string,
+  userId: string,
+  agent: {
+    modelProviderId: string | null;
+    selectedModel: string | null;
+    preferPersonalProvider: boolean;
+  },
+): Promise<{
+  modelProviderId: string | null;
+  selectedModel: string | null;
+}> {
+  const personalEligible = await isPersonalTierEligible(
+    orgId,
+    userId,
+    agent.preferPersonalProvider,
+  );
+  if (!personalEligible) {
+    return {
+      modelProviderId: agent.modelProviderId,
+      selectedModel: agent.selectedModel,
+    };
+  }
+  const userRow = await getUserAnyDefaultModelProvider(orgId, userId);
+  if (!userRow) {
+    return {
+      modelProviderId: agent.modelProviderId,
+      selectedModel: agent.selectedModel,
+    };
+  }
+  return {
+    modelProviderId: userRow.id,
+    selectedModel: userRow.selectedModel ?? agent.selectedModel ?? null,
+  };
 }
 
 /**
@@ -406,16 +476,30 @@ const router = tsr.router(chatMessagesContract, {
     }
 
     try {
+      // Existing-thread sends pass the agent's pin literally — `resolveThread`
+      // doesn't use it on that branch (it reads the persisted pin instead),
+      // so the personal-tier eligibility check is skipped. NEW threads
+      // compute the eager-pin via `computeEagerPin` so per-Epic #11868 the
+      // user's personal default lands in the persisted pin when the agent's
+      // `prefer_personal_provider` is on and the switch is enabled for
+      // the caller.
+      const eagerPin = body.threadId
+        ? {
+            modelProviderId: agent.modelProviderId,
+            selectedModel: agent.selectedModel,
+          }
+        : await computeEagerPin(callerOrg.orgId, authCtx.userId, {
+            modelProviderId: agent.modelProviderId,
+            selectedModel: agent.selectedModel,
+            preferPersonalProvider: agent.preferPersonalProvider,
+          });
       const { threadId, sessionId, incompleteContext, isNewThread } =
         await resolveThread(
           authCtx.userId,
           body.agentId,
           body.threadId,
           body.clientThreadId,
-          {
-            modelProviderId: agent.modelProviderId,
-            selectedModel: agent.selectedModel,
-          },
+          eagerPin,
           dims,
         );
 

--- a/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
@@ -26,11 +26,9 @@ import {
 } from "../model-provider/model-provider-service";
 import { getVm0ApiKey } from "../vm0-key/vm0-key-service";
 import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
-import { loadFeatureSwitchOverrides } from "../user/feature-switches-service";
 import { MODEL_PROVIDER_HANDLER_KEY } from "../handler-key-bridge";
 import { PROVIDER_HANDLERS } from "../connector/provider-registry";
+import { isPersonalTierEligible } from "../personal-tier-gate";
 
 const log = logger("zero:build-context");
 
@@ -329,26 +327,6 @@ async function resolveMultiAuthProviderSecrets(
     selectedModel,
     secretConnectorMap: buildModelProviderSecretConnectorMap(providerType),
   };
-}
-
-/**
- * Personal-tier eligibility: caller must opt-in via the agent/schedule flag
- * AND the `personalModelProvider` feature switch must be on for them.
- * Loads the per-user feature switch overrides only when the flag is true so
- * the common (flag=false) path stays free of the DB read.
- */
-async function isPersonalTierEligible(
-  orgId: string,
-  userId: string,
-  preferPersonalProvider: boolean | undefined,
-): Promise<boolean> {
-  if (!preferPersonalProvider) return false;
-  const overrides = await loadFeatureSwitchOverrides(orgId, userId);
-  return isFeatureEnabled(FeatureSwitchKey.PersonalModelProvider, {
-    orgId,
-    userId,
-    overrides,
-  });
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/personal-tier-gate.ts
+++ b/turbo/apps/web/src/lib/zero/personal-tier-gate.ts
@@ -1,0 +1,35 @@
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { loadFeatureSwitchOverrides } from "./user/feature-switches-service";
+
+/**
+ * Personal-tier eligibility for Epic #11868. Resolves to true only when
+ * BOTH conditions hold:
+ *   1. caller opted in via the agent/schedule `prefer_personal_provider`
+ *      flag (or the equivalent at any other call site), AND
+ *   2. the `personalModelProvider` feature switch is on for the caller
+ *      (staff-only by default; per-user override flips it for tests and
+ *      gradual rollout).
+ *
+ * Loads the per-user feature switch overrides only when the flag is true
+ * so the common (flag=false) path stays free of the DB read.
+ *
+ * Consumed by the resolver (`context/resolve-model-provider.ts`),
+ * admission (`zero-run-policy.ts`), and the chat-thread eager-pin
+ * (`app/api/zero/chat/messages/route.ts`). The shared module retires
+ * the file-private duplicate that lived in two of those files prior to
+ * the third call site landing.
+ */
+export async function isPersonalTierEligible(
+  orgId: string,
+  userId: string,
+  preferPersonalProvider: boolean | undefined,
+): Promise<boolean> {
+  if (!preferPersonalProvider) return false;
+  const overrides = await loadFeatureSwitchOverrides(orgId, userId);
+  return isFeatureEnabled(FeatureSwitchKey.PersonalModelProvider, {
+    orgId,
+    userId,
+    overrides,
+  });
+}

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -10,8 +10,6 @@ import {
   MODEL_PROVIDER_TYPES,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { canAccessCompose } from "../infra/agent/compose-access";
 import { validateFrameworkApiKey } from "../infra/run/utils";
 import { logger } from "../shared/logger";
@@ -26,7 +24,7 @@ import {
   getUserDefaultModelProvider,
   getUserAnyDefaultModelProvider,
 } from "./model-provider/model-provider-service";
-import { loadFeatureSwitchOverrides } from "./user/feature-switches-service";
+import { isPersonalTierEligible } from "./personal-tier-gate";
 import type { Database } from "../../types/global";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
 import type { AgentComposeYaml } from "../infra/agent-compose/types";
@@ -144,26 +142,6 @@ export async function validateComposeRequirements(
 }
 
 /**
- * Personal-tier eligibility at the admission boundary. Mirrors the resolver's
- * gate (resolve-model-provider.ts) so admission and runtime apply the same
- * (flag && switch on) check; duplicating the helper rather than sharing it
- * is intentional — see Decision E in plan.md (Epic #11868).
- */
-async function isPersonalTierEligibleForAdmission(
-  orgId: string,
-  userId: string,
-  preferPersonalProvider: boolean | undefined,
-): Promise<boolean> {
-  if (!preferPersonalProvider) return false;
-  const overrides = await loadFeatureSwitchOverrides(orgId, userId);
-  return isFeatureEnabled(FeatureSwitchKey.PersonalModelProvider, {
-    orgId,
-    userId,
-    overrides,
-  });
-}
-
-/**
  * Resolve the provider type that admission checks should treat as the
  * effective key source for this run. Precedence:
  *   explicit override → explicit modelProviderId → personal-tier (gated) →
@@ -201,7 +179,7 @@ export async function resolveProviderTypeForAdmission(params: {
     );
     return row?.type ?? null;
   }
-  const personalEligible = await isPersonalTierEligibleForAdmission(
+  const personalEligible = await isPersonalTierEligible(
     params.orgId,
     params.userId,
     params.preferPersonalProvider,
@@ -291,13 +269,7 @@ export async function checkModelProviderConfigured(
   });
   if (hasExplicitConfig) return;
 
-  if (
-    await isPersonalTierEligibleForAdmission(
-      orgId,
-      userId,
-      preferPersonalProvider,
-    )
-  ) {
+  if (await isPersonalTierEligible(orgId, userId, preferPersonalProvider)) {
     const userType =
       (await getUserDefaultModelProvider(orgId, userId, framework))?.type ??
       (await getUserAnyDefaultModelProvider(orgId, userId))?.type;


### PR DESCRIPTION
## Summary

Closes the eager-pin half of Wave 2. After #11906 made the resolver consult personal-tier providers, the chat-thread eager-pin still wrote `agent.modelProviderId` (org-tier) on new threads — and `getModelProviderById` for pinned ids bypasses the user-tier branch, so the pin always won. This PR computes the pin via the same eligibility check at thread creation. Closes #11918.

## What changes

- **`personal-tier-gate.ts`** — extracts the shared `isPersonalTierEligible(orgId, userId, flag)` helper. Retires the file-private duplicate in `resolve-model-provider.ts` and the `isPersonalTierEligibleForAdmission` inline copy in `zero-run-policy.ts` ("hoist when third appears" rule cited in the #11899 plan).
- **`computeEagerPin` in `chat/messages/route.ts`** — when (flag && switch on && user has a personal default), pins the new thread to `userRow.id` + `userRow.selectedModel ?? agent.selectedModel ?? null`. Existing-thread sends bypass this path (preserves per-thread immutability invariant).
- **Documented optimization** — the resolver uses a two-step `getUserDefaultModelProvider(framework) ?? getUserAnyDefaultModelProvider` chain because of the framework-propagation handshake (Epic #11520). At pin time we don't propagate framework — the persisted row id + model is enough; the resolver re-derives framework on dispatch via `getModelProviderById`. The single-default invariant (#11752) collapses the two-step chain to a single any-default lookup at pin time. Comment in `route.ts:computeEagerPin` explains why mirroring this optimization back into the resolver would be wrong.

## Test plan

- [x] `pnpm -F web exec vitest run app/api/zero/chat/messages/__tests__/route.test.ts` — 47/47 (41 existing + 6 new for personal-tier eager-pin).
- [x] `pnpm -F web exec vitest run src/lib/zero/context/__tests__/resolve-model-provider.test.ts src/lib/zero/__tests__/build-zero-context.test.ts` — 36/36 (no regression after gate extraction).
- [x] `pnpm turbo run lint` — clean.
- [x] `pnpm -F web check-types` — clean.
- [x] `pnpm format` — clean.
- [x] `pnpm knip` — clean.
- [x] Six new cases cover: switch off / flag off / both on with personal+selectedModel / both on with personal-no-selectedModel (fallback to agent) / no personal rows (graceful) / agent has no provider but personal pin fires.
- [ ] Personal Preferences UI (Wave 3 — out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)