### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1803,16 +1803,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3399,20 +3389,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Weekly Rust dependency refresh on the `crates/` workspace via `cargo update --verbose`. Only `Cargo.lock` changed; no `Cargo.toml` edits were necessary.

## Updated dependencies

| Crate | From | To |
|-------|------|-----|
| `tower-http` | 0.6.8 | 0.6.9 |

`iri-string` v0.7.12 was removed from the lock file (no longer pulled in by `tower-http` 0.6.9, which now depends on `url` instead).

## Dependencies that could not be updated

These have newer versions on crates.io but are pinned by transitive parents in our tree, not by our `workspace.dependencies`. They will move when their parents move; no safe direct bump is possible.

| Crate | Locked | Available | Pinned by |
|-------|--------|-----------|-----------|
| `crc` | 3.3.0 | 3.4.0 | `crc-fast` 1.9.0 → `aws-smithy-checksums` 0.64.7 → `aws-sdk-s3` 1.131.0 |
| `crc-fast` | 1.9.0 | 1.10.0 | `aws-smithy-checksums` 0.64.7 → `aws-sdk-s3` 1.131.0 |
| `generic-array` | 0.14.7 | 0.14.9 | `digest` 0.10.7 / `block-buffer` 0.10.4 (transitive via aws-sdk-s3, sha1, tungstenite) |

## Manual version bumps in Cargo.toml

None. All `workspace.dependencies` use loose specifiers (`"1"`, `"0.4"`, etc.) and `cargo update` already selected the latest compatible patch/minor for everything we depend on directly. No major bumps were attempted (per the policy of not bumping majors without breaking-change review).

## Test status

`cargo test --workspace --no-fail-fast` — **all green**.

- Build: `cargo build --workspace` succeeds
- Tests: every test bin reports `0 failed`
- Doctests: all pass

Run locally on `aarch64-unknown-linux-gnu`, Rust 1.95.0. Linker required `CARGO_BUILD_JOBS=1` for `--no-run` due to sandbox memory (3.8 GiB), but actual test execution and the runtime result are unaffected.