### PR TITLE
fix: resolve credit checks from run admission context

### DIFF
--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -672,7 +672,7 @@ describe("POST /api/zero/chat/messages", () => {
     });
 
     // One `org_metadata` SELECT per POST: the `resolveOrg` tier+credits read.
-    // The credits-admission path (checkOrgCreditsForRun) only touches
+    // The credits-admission path (checkOrgCreditsForRunAdmission) only touches
     // org_metadata on the vm0 branch; BYOK and default-non-vm0 paths
     // short-circuit before the balance check (#10951).
     describe("deduplicates per-request reads", () => {
@@ -722,8 +722,8 @@ describe("POST /api/zero/chat/messages", () => {
 
           expect(response.status).toBe(201);
           expect(counter.countMatching(/from\s+"?zero_agents"?/i)).toBe(1);
-          // modelProvider="anthropic" triggers checkOrgCreditsForRun's BYOK
-          // fast-exit — no org_metadata read from credits admission. Round 2
+          // The modelSelection resolves to a BYOK provider, so credit admission
+          // fast-exits — no org_metadata read from credits admission. Round 2
           // uses resolveOrg's preloaded tier (the eliminated dup from #10594).
           expect(counter.countMatching(/from\s+"?org_metadata"?/i)).toBe(1);
         } finally {

--- a/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
@@ -11,12 +11,14 @@ import {
   markRunningRunsAsCompleted,
   setOrgCredits,
   insertOrgDefaultModelProvider,
+  insertOrgNonDefaultModelProvider,
   insertOrgMembersEntry,
   insertTestZeroRun,
   deleteOrgRow,
   insertCreditExpiresRecord,
 } from "../../../__tests__/api-test-helpers";
 import { getTestZeroAgentId } from "../../../__tests__/db-test-assertions/agents";
+import { getTestModelProviderIdByType } from "../../../__tests__/db-test-assertions/org";
 import { reloadEnv } from "../../../env";
 import type { CreateRunParams } from "../../infra/run/run-service";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
@@ -25,7 +27,10 @@ import {
   enqueueRun,
   dispatchQueuedZeroRun,
 } from "../zero-run-queue-service";
-import { checkOrgCreditsForRun } from "../zero-run-policy";
+import {
+  checkOrgCreditsForRunAdmission,
+  resolveRunAdmissionContext,
+} from "../zero-run-policy";
 import { checkOrgCredits } from "../credit/check-org-credits";
 import { isInsufficientCredits } from "@vm0/api-services/errors";
 import { seedTestRun } from "../../../__tests__/db-test-seeders/runs";
@@ -87,6 +92,37 @@ describe("credit check (infra queue path)", () => {
       // Queue entry should be deleted
       const queueEntry = await findTestQueueEntry(queued.runId);
       expect(queueEntry).toBeUndefined();
+    });
+
+    it("should fail queued modelProviderId VM0 run when credits deplete before dispatch", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+      reloadEnv();
+
+      await insertOrgDefaultModelProvider(user.orgId, "anthropic-api-key");
+      await insertOrgNonDefaultModelProvider(user.orgId, "vm0");
+      const vm0ProviderId = await getTestModelProviderIdByType(
+        user.orgId,
+        "vm0",
+      );
+
+      await seedTestRun(user.userId, composeId, { prompt: "Running" });
+      const queued = await enqueueRun(
+        queueBaseParams({
+          prompt: "Queued VM0 by provider id",
+          modelProviderId: vm0ProviderId,
+          selectedModelOverride: "claude-opus-4-7",
+        }),
+      );
+      await insertTestZeroRun(queued.runId);
+
+      await setOrgCredits(user.orgId, 0);
+      await markRunningRunsAsCompleted(user.userId);
+
+      await drainOrgQueue(user.orgId, dispatchQueuedZeroRun);
+
+      const run = await findTestRunRecord(queued.runId);
+      expect(run!.status).toBe("failed");
+      expect(run!.error).toContain("Insufficient credits");
     });
 
     it("should dequeue non-VM0 run when credits depleted", async () => {
@@ -396,7 +432,7 @@ describe("checkOrgCredits (general vm0 credit gate)", () => {
   });
 });
 
-describe("checkOrgCreditsForRun (provider-aware LLM wrapper)", () => {
+describe("checkOrgCreditsForRunAdmission (resolved provider LLM wrapper)", () => {
   let user: UserContext;
 
   beforeEach(async () => {
@@ -412,22 +448,31 @@ describe("checkOrgCreditsForRun (provider-aware LLM wrapper)", () => {
       return;
     }
     throw new Error(
-      "expected checkOrgCreditsForRun to throw insufficientCredits",
+      "expected checkOrgCreditsForRunAdmission to throw insufficientCredits",
     );
   }
 
-  it("returns OK when modelProvider is non-vm0 (fast exit, no DB call)", async () => {
+  it("returns OK when resolved provider is non-vm0", async () => {
     await setOrgCredits(user.orgId, 0);
     await expect(
-      checkOrgCreditsForRun(user.orgId, user.userId, "anthropic"),
+      checkOrgCreditsForRunAdmission({
+        orgId: user.orgId,
+        userId: user.userId,
+        providerType: "anthropic-api-key",
+      }),
     ).resolves.toBeUndefined();
   });
 
   it("returns OK when default provider is vm0 and credits are available", async () => {
     await insertOrgDefaultModelProvider(user.orgId, "vm0");
     await setOrgCredits(user.orgId, 10000);
+    const admission = await resolveRunAdmissionContext({
+      orgId: user.orgId,
+      userId: user.userId,
+      composeFramework: "claude-code",
+    });
     await expect(
-      checkOrgCreditsForRun(user.orgId, user.userId, undefined),
+      checkOrgCreditsForRunAdmission(admission),
     ).resolves.toBeUndefined();
   });
 
@@ -441,7 +486,11 @@ describe("checkOrgCreditsForRun (provider-aware LLM wrapper)", () => {
     });
 
     await expectInsufficientCredits(() => {
-      return checkOrgCreditsForRun(user.orgId, user.userId, undefined);
+      return checkOrgCreditsForRunAdmission({
+        orgId: user.orgId,
+        userId: user.userId,
+        providerType: "vm0",
+      });
     });
   });
 
@@ -457,22 +506,35 @@ describe("checkOrgCreditsForRun (provider-aware LLM wrapper)", () => {
     });
 
     await expectInsufficientCredits(() => {
-      return checkOrgCreditsForRun(user.orgId, user.userId, undefined);
+      return checkOrgCreditsForRunAdmission({
+        orgId: user.orgId,
+        userId: user.userId,
+        providerType: "vm0",
+      });
     });
   });
 
   it("returns OK when default provider is non-vm0 even when credits are depleted", async () => {
-    await insertOrgDefaultModelProvider(user.orgId, "anthropic");
+    await insertOrgDefaultModelProvider(user.orgId, "anthropic-api-key");
     await setOrgCredits(user.orgId, 0);
+    const admission = await resolveRunAdmissionContext({
+      orgId: user.orgId,
+      userId: user.userId,
+      composeFramework: "claude-code",
+    });
     await expect(
-      checkOrgCreditsForRun(user.orgId, user.userId, undefined),
+      checkOrgCreditsForRunAdmission(admission),
     ).resolves.toBeUndefined();
   });
 
-  it("throws when explicit modelProvider is vm0 and org_metadata row is missing", async () => {
+  it("throws when resolved provider is vm0 and org_metadata row is missing", async () => {
     await deleteOrgRow(user.orgId);
     await expectInsufficientCredits(() => {
-      return checkOrgCreditsForRun(user.orgId, user.userId, "vm0");
+      return checkOrgCreditsForRunAdmission({
+        orgId: user.orgId,
+        userId: user.userId,
+        providerType: "vm0",
+      });
     });
   });
 });

--- a/turbo/apps/web/src/lib/zero/credit/check-org-credits.ts
+++ b/turbo/apps/web/src/lib/zero/credit/check-org-credits.ts
@@ -15,8 +15,8 @@ import type { Database } from "../../../types/global";
  * stale inflated balance — same form `getBillingStatus` presents in the UI.
  *
  * Callable from any vm0-billable route. For LLM runs that may use BYOK,
- * use `checkOrgCreditsForRun` in zero-run-policy which wraps this with
- * provider resolution and a BYOK fast-exit.
+ * first resolve the run admission context, then call
+ * `checkOrgCreditsForRunAdmission` in zero-run-policy.
  *
  * Accepts an optional `db` so callers inside a transaction (e.g. queue drain
  * under `pg_advisory_xact_lock`) can keep the read within the same boundary.

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -182,7 +182,7 @@ async function isPersonalTierEligibleForAdmission(
  * Returns null only when the user has no personal tier (or it's gated off)
  * AND the org has no `isDefault: true` provider at all.
  */
-export async function resolveProviderTypeForAdmission(params: {
+async function resolveProviderTypeForAdmission(params: {
   orgId: string;
   userId: string;
   modelProvider?: string | null;
@@ -221,43 +221,43 @@ export async function resolveProviderTypeForAdmission(params: {
   return def?.type ?? null;
 }
 
+interface RunAdmissionContext {
+  orgId: string;
+  userId: string;
+  providerType: ModelProviderType | null;
+}
+
+export async function resolveRunAdmissionContext(params: {
+  orgId: string;
+  userId: string;
+  modelProvider?: string | null;
+  modelProviderId?: string | null;
+  composeFramework: string;
+  preferPersonalProvider?: boolean;
+}): Promise<RunAdmissionContext> {
+  return {
+    orgId: params.orgId,
+    userId: params.userId,
+    providerType: await resolveProviderTypeForAdmission(params),
+  };
+}
+
 /**
- * LLM-run credit admission. Resolves vm0 vs. BYOK from `modelProvider`
- * (or the org default when nullish) and delegates to `checkOrgCredits`
- * for the vm0 case. Returns silently for BYOK — the user pays the
- * provider, so no vm0 balance is touched.
+ * Credit admission for an already-resolved run context.
  *
- * Accepts an optional `db` so callers inside a transaction (e.g.
- * `drainOrgQueue` under `pg_advisory_xact_lock`) keep the read within
- * the same boundary. Non-LLM callers use `checkOrgCredits` directly.
+ * vm0-managed providers spend vm0 credits and must pass the org/member credit
+ * gate. BYOK and personal providers are paid outside vm0, so they skip this
+ * check. Callers must resolve the provider from the current run context first;
+ * raw `modelProvider` strings are not sufficient because UI calls can carry
+ * only `modelProviderId`.
  */
-export async function checkOrgCreditsForRun(
-  orgId: string,
-  userId: string,
-  modelProvider: string | null | undefined,
+export async function checkOrgCreditsForRunAdmission(
+  context: RunAdmissionContext,
   db: Database = globalThis.services.db,
 ): Promise<void> {
-  // Fast exit for explicit BYOK — no DB touch.
-  if (modelProvider && modelProvider !== "vm0") {
-    return;
-  }
+  if (context.providerType !== "vm0") return;
 
-  let isVm0 = modelProvider === "vm0";
-  if (!isVm0) {
-    // vm0 is the only credit-triggering provider, and it lives under
-    // claude-code, so the "is the org's default vm0?" check is intrinsically
-    // claude-code-scoped regardless of the run's framework.
-    const defaultProviderType = await getOrgDefaultModelProviderType(
-      orgId,
-      "claude-code",
-      db,
-    );
-    isVm0 = defaultProviderType === "vm0";
-  }
-
-  if (!isVm0) return;
-
-  await checkOrgCredits(orgId, userId, db);
+  await checkOrgCredits(context.orgId, context.userId, db);
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -31,9 +31,9 @@ import {
   checkRunConcurrencyLimit,
   authorizeCompose,
   validateComposeRequirements,
-  checkOrgCreditsForRun,
   checkModelProviderConfigured,
-  resolveProviderTypeForAdmission,
+  resolveRunAdmissionContext,
+  checkOrgCreditsForRunAdmission,
 } from "./zero-run-policy";
 import {
   buildAndDispatchRun,
@@ -52,10 +52,7 @@ import {
   encryptSecretsMap,
   decryptSecretsMap,
 } from "../shared/crypto/secrets-encryption";
-import {
-  isConcurrentRunLimit,
-  isInsufficientCredits,
-} from "@vm0/api-services/errors";
+import { isConcurrentRunLimit } from "@vm0/api-services/errors";
 import { logger } from "../shared/logger";
 import { publishOrgSignal } from "./realtime";
 import { publishChatThreadRunUpdated } from "./chat-thread/chat-message-service";
@@ -332,7 +329,9 @@ async function dequeueNextAtomic(
 
       // Look up org tier from org table (source of truth).
       // Falls back to "free" (most conservative limit) if row is missing.
-      // Credits are checked by checkOrgCreditsForRun() within this transaction.
+      // Credits are re-checked during queued dispatch with the decrypted
+      // CreateRunParams, so modelProviderId and personal-provider preferences
+      // are resolved from the same run context that dispatch uses.
       const [orgRow] = await tx
         .select({ tier: orgMetadata.tier })
         .from(orgMetadata)
@@ -346,18 +345,15 @@ async function dequeueNextAtomic(
       // Fetch all queue entries for this org (ordered FIFO).
       // Typically 0-2 entries; iterating in-transaction to skip
       // already-processed runs without releasing the advisory lock.
-      // LEFT JOIN zeroRuns to read modelProvider for credit check.
       const rows = await tx.execute<{
         run_id: string;
         user_id: string;
         encrypted_params: string | null;
-        model_provider: string | null;
         created_at: Date;
       }>(
-        sql`SELECT q.run_id, q.user_id, q.encrypted_params, zr.model_provider, q.created_at
+        sql`SELECT q.run_id, q.user_id, q.encrypted_params, q.created_at
          FROM agent_run_queue q
          JOIN agent_runs r ON r.id = q.run_id
-         LEFT JOIN zero_runs zr ON zr.id = r.id
          WHERE q.org_id = ${orgId}
          ORDER BY q.created_at ASC`,
       );
@@ -367,32 +363,6 @@ async function dequeueNextAtomic(
         await tx
           .delete(agentRunQueue)
           .where(eq(agentRunQueue.runId, row.run_id));
-
-        // Unified pre-flight credit check (org-level + per-member cap)
-        try {
-          await checkOrgCreditsForRun(
-            orgId,
-            row.user_id,
-            row.model_provider,
-            tx,
-          );
-        } catch (error) {
-          if (isInsufficientCredits(error)) {
-            await transitionRunStatus(
-              row.run_id,
-              {
-                status: "failed",
-                error: error.message,
-                completedAt: new Date(),
-              },
-              ["queued"],
-              tx,
-            );
-            log.debug(`Run ${row.run_id} failed credit check, skipping`);
-            continue;
-          }
-          throw error;
-        }
 
         // Update run status — fails silently if run was already cancelled/failed
         const [updated] = await tx
@@ -604,7 +574,7 @@ export async function dispatchQueuedZeroRun(
     ? Object.values(composeContent.agents)
     : [];
   const composeFramework = composeAgents[0]?.framework ?? "claude-code";
-  const admissionProviderType = await resolveProviderTypeForAdmission({
+  const admissionContext = await resolveRunAdmissionContext({
     orgId: params.orgId,
     userId: params.userId,
     modelProvider: params.modelProvider,
@@ -613,9 +583,14 @@ export async function dispatchQueuedZeroRun(
     preferPersonalProvider: params.preferPersonalProvider,
   });
 
+  await checkOrgCreditsForRunAdmission(admissionContext);
+
   // Validate compose requirements for new runs only
   if (!params.checkpointId && !params.sessionId) {
-    await validateComposeRequirements(composeContent, admissionProviderType);
+    await validateComposeRequirements(
+      composeContent,
+      admissionContext.providerType,
+    );
   }
 
   // Register callbacks early so they persist even if context building fails

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -34,9 +34,9 @@ import {
   authorizeCompose,
   validateComposeRequirements,
   checkModelProviderConfigured,
-  resolveProviderTypeForAdmission,
+  resolveRunAdmissionContext,
+  checkOrgCreditsForRunAdmission,
 } from "./zero-run-policy";
-import { checkOrgCredits } from "./credit/check-org-credits";
 import {
   enqueueRun,
   drainOrgQueue,
@@ -678,7 +678,7 @@ async function createZeroRunRecord(
     ? Object.values(resolved.composeContent.agents)
     : [];
   const composeFramework = composeAgents[0]?.framework ?? "claude-code";
-  const admissionProviderType = await resolveProviderTypeForAdmission({
+  const admissionContext = await resolveRunAdmissionContext({
     orgId: resolved.orgId,
     userId: params.userId,
     modelProvider: params.modelProvider,
@@ -690,14 +690,12 @@ async function createZeroRunRecord(
   if (!params.sessionId) {
     await validateComposeRequirements(
       resolved.composeContent,
-      admissionProviderType,
+      admissionContext.providerType,
     );
   }
 
   const round3Credits = timed(async () => {
-    if (admissionProviderType === "vm0") {
-      return checkOrgCredits(resolved.orgId, params.userId);
-    }
+    return checkOrgCreditsForRunAdmission(admissionContext);
   });
   const round3ModelProvider = timed(async () => {
     return checkModelProviderConfigured(


### PR DESCRIPTION
## Summary
- Resolve a run admission context from the actual run params, including `modelProviderId` and personal-provider preference.
- Use that context for VM0 credit admission in both direct run creation and queued dispatch.
- Stop queue dequeue from relying on stale `zero_runs.model_provider`, and add a queued `modelProviderId` VM0 regression test.

## Test plan
- `pnpm lint`
- `pnpm check-types`
- pre-commit: prettier, knip, workspace `turbo run check-types --concurrency=1`
- `pnpm test src/lib/zero/__tests__/credit-check.test.ts app/api/zero/chat/messages/__tests__/route.test.ts` currently blocked locally by stale DB schema: test setup fails on missing `zero_agents.model_provider_id`. `pnpm db:migrate` is also blocked by an older local migration trying to drop missing table `imessage_thread_sessions`.
