### PR TITLE
fix(guest-agent): persist recoverable sessions on abnormal exit

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -419,15 +419,11 @@ async fn create_checkpoint_impl(mode: CheckpointMode) -> Result<(), AgentError> 
         record_sandbox_op("checkpoint_api_call", api_start.elapsed(), true, None);
         Ok(())
     } else {
-        log_error!(LOG_TAG, "Checkpoint API returned invalid response");
-        record_sandbox_op(
+        Err(fail(
+            mode,
             "checkpoint_api_call",
-            api_start.elapsed(),
-            false,
-            Some("Invalid response"),
-        );
-        Err(AgentError::Checkpoint(
-            "Invalid checkpoint API response".into(),
+            api_start,
+            "Invalid checkpoint API response",
         ))
     }
 }

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -12,19 +12,53 @@ use crate::session_history;
 use crate::urls;
 use bytes::Bytes;
 use guest_common::telemetry::record_sandbox_op;
-use guest_common::{log_error, log_info};
+use guest_common::{log_error, log_info, log_warn};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::io::ErrorKind;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
+#[derive(Clone, Copy)]
+enum CheckpointMode {
+    Success,
+    Recovery,
+}
+
+impl CheckpointMode {
+    fn total_op(self) -> &'static str {
+        match self {
+            Self::Success => "checkpoint_total",
+            Self::Recovery => "recovery_checkpoint_total",
+        }
+    }
+
+    fn log_label(self) -> &'static str {
+        match self {
+            Self::Success => "checkpoint",
+            Self::Recovery => "recovery checkpoint",
+        }
+    }
+
+    fn validate_history(self) -> bool {
+        matches!(self, Self::Recovery)
+    }
+}
+
 /// Log the message, record a failed `sandbox_op`, and build a matching
-/// `Checkpoint` error — all three channels share the same message so
-/// telemetry and logs stay in sync.
-fn fail(op: &str, start: std::time::Instant, msg: impl Into<String>) -> AgentError {
+/// `Checkpoint` error. Success-path checkpoint failures are run-fatal and
+/// logged as errors; recovery checkpoint skips are best-effort and stay warn.
+fn fail(
+    mode: CheckpointMode,
+    op: &str,
+    start: std::time::Instant,
+    msg: impl Into<String>,
+) -> AgentError {
     let msg = msg.into();
-    log_error!(LOG_TAG, "{msg}");
+    match mode {
+        CheckpointMode::Success => log_error!(LOG_TAG, "{msg}"),
+        CheckpointMode::Recovery => log_warn!(LOG_TAG, "{msg}"),
+    }
     record_sandbox_op(op, start.elapsed(), false, Some(&msg));
     AgentError::Checkpoint(msg)
 }
@@ -209,13 +243,31 @@ async fn snapshot_artifacts() -> Result<Option<serde_json::Value>, AgentError> {
 /// Create a checkpoint after a successful run.
 pub async fn create_checkpoint() -> Result<(), AgentError> {
     let start = std::time::Instant::now();
-    let result = create_checkpoint_impl().await;
-    record_sandbox_op("checkpoint_total", start.elapsed(), result.is_ok(), None);
+    let result = create_checkpoint_impl(CheckpointMode::Success).await;
+    record_sandbox_op(
+        CheckpointMode::Success.total_op(),
+        start.elapsed(),
+        result.is_ok(),
+        None,
+    );
     result
 }
 
-async fn create_checkpoint_impl() -> Result<(), AgentError> {
-    log_info!(LOG_TAG, "Creating checkpoint...");
+/// Create a best-effort recovery checkpoint after an abnormal CLI exit.
+pub async fn create_recovery_checkpoint() -> Result<(), AgentError> {
+    let start = std::time::Instant::now();
+    let result = create_checkpoint_impl(CheckpointMode::Recovery).await;
+    record_sandbox_op(
+        CheckpointMode::Recovery.total_op(),
+        start.elapsed(),
+        result.is_ok(),
+        None,
+    );
+    result
+}
+
+async fn create_checkpoint_impl(mode: CheckpointMode) -> Result<(), AgentError> {
+    log_info!(LOG_TAG, "Creating {}...", mode.log_label());
 
     // Read session ID. Let `read_to_string` surface `NotFound` directly — an
     // explicit `exists()` check would be a redundant stat plus a TOCTOU race
@@ -225,6 +277,7 @@ async fn create_checkpoint_impl() -> Result<(), AgentError> {
         Ok(s) => s.trim().to_string(),
         Err(e) if e.kind() == ErrorKind::NotFound => {
             return Err(fail(
+                mode,
                 "session_id_read",
                 session_id_start,
                 "No session ID found",
@@ -232,6 +285,7 @@ async fn create_checkpoint_impl() -> Result<(), AgentError> {
         }
         Err(e) => {
             return Err(fail(
+                mode,
                 "session_id_read",
                 session_id_start,
                 format!("Failed to read session ID: {e}"),
@@ -240,6 +294,7 @@ async fn create_checkpoint_impl() -> Result<(), AgentError> {
     };
     if session_id.is_empty() {
         return Err(fail(
+            mode,
             "session_id_read",
             session_id_start,
             "Session ID is empty",
@@ -257,6 +312,7 @@ async fn create_checkpoint_impl() -> Result<(), AgentError> {
             Ok(b) => b,
             Err(e) => {
                 return Err(fail(
+                    mode,
                     "session_history_read",
                     history_read_start,
                     e.to_string(),
@@ -268,6 +324,7 @@ async fn create_checkpoint_impl() -> Result<(), AgentError> {
         Ok(s) => s,
         Err(e) => {
             return Err(fail(
+                mode,
                 "session_history_read",
                 history_read_start,
                 format!("Session history is not valid UTF-8: {e}"),
@@ -277,10 +334,16 @@ async fn create_checkpoint_impl() -> Result<(), AgentError> {
 
     if session_history.trim().is_empty() {
         return Err(fail(
+            mode,
             "session_history_read",
             history_read_start,
             "Session history is empty",
         ));
+    }
+
+    if mode.validate_history() {
+        validate_recoverable_session_history(&session_history)
+            .map_err(|msg| fail(mode, "session_history_validate", history_read_start, msg))?;
     }
 
     let line_count = session_history.lines().count();
@@ -352,7 +415,7 @@ async fn create_checkpoint_impl() -> Result<(), AgentError> {
         .and_then(|v| v.as_str());
 
     if let Some(id) = checkpoint_id {
-        log_info!(LOG_TAG, "Checkpoint created successfully: {id}");
+        log_info!(LOG_TAG, "{} created successfully: {id}", mode.log_label());
         record_sandbox_op("checkpoint_api_call", api_start.elapsed(), true, None);
         Ok(())
     } else {
@@ -367,6 +430,31 @@ async fn create_checkpoint_impl() -> Result<(), AgentError> {
             "Invalid checkpoint API response".into(),
         ))
     }
+}
+
+fn validate_recoverable_session_history(session_history: &str) -> Result<(), String> {
+    let mut line_count = 0usize;
+    for (index, line) in session_history.lines().enumerate() {
+        if line.trim().is_empty() {
+            return Err(format!(
+                "Session history line {} is empty; recovery checkpoint skipped",
+                index + 1
+            ));
+        }
+        serde_json::from_str::<serde_json::Value>(line).map_err(|e| {
+            format!(
+                "Session history line {} is not valid JSON; recovery checkpoint skipped: {e}",
+                index + 1
+            )
+        })?;
+        line_count += 1;
+    }
+
+    if line_count == 0 {
+        return Err("Session history has no JSONL entries; recovery checkpoint skipped".into());
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -397,5 +485,30 @@ mod tests {
         assert!(obj.contains_key("version"));
         assert!(obj.contains_key("mountPath"));
         assert!(!obj.contains_key("mount_path"));
+    }
+
+    #[test]
+    fn recoverable_session_history_accepts_valid_jsonl() {
+        let history = r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant"}"#;
+
+        assert!(validate_recoverable_session_history(&history).is_ok());
+    }
+
+    #[test]
+    fn recoverable_session_history_rejects_partial_trailing_json() {
+        let history = r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant""#;
+
+        let err = validate_recoverable_session_history(&history).unwrap_err();
+
+        assert!(err.contains("line 2"));
+    }
+
+    #[test]
+    fn recoverable_session_history_rejects_blank_lines() {
+        let history = r#"{"type":"system"}"#.to_string() + "\n\n" + r#"{"type":"assistant"}"#;
+
+        let err = validate_recoverable_session_history(&history).unwrap_err();
+
+        assert!(err.contains("line 2"));
     }
 }

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -384,6 +384,7 @@ async fn create_checkpoint_impl(mode: CheckpointMode) -> Result<(), AgentError> 
         "cliAgentType": cli_agent_type,
         "cliAgentSessionId": session_id,
         "cliAgentSessionHistoryHash": history_hash,
+        "cliAgentSessionHistorySize": history_size,
     });
 
     if let Some(snaps) = artifact_snapshots

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -13,7 +13,7 @@ use guest_agent::paths;
 use guest_agent::telemetry::{Telemetry, UploadMode};
 
 use guest_common::telemetry::record_sandbox_op;
-use guest_common::{log_error, log_info};
+use guest_common::{log_error, log_info, log_warn};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio_util::sync::CancellationToken;
@@ -277,6 +277,15 @@ async fn execute(
         } else if cli_exit_code != 0 {
             log_info!(LOG_TAG, "claude-code failed with exit code {cli_exit_code}");
         }
+
+        if env::has_api() {
+            log_info!(LOG_TAG, "Attempting best-effort recovery checkpoint");
+            match checkpoint::create_recovery_checkpoint().await {
+                Ok(()) => log_info!(LOG_TAG, "Recovery checkpoint created"),
+                Err(e) => log_warn!(LOG_TAG, "Recovery checkpoint skipped: {e}"),
+            }
+        }
+
         log_info!(LOG_TAG, "▷ Cleanup");
         final_telemetry(telemetry).await;
     }

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -54,6 +54,21 @@ fn cleanup_session_checkpoint_files() {
     let _ = std::fs::remove_file(guest_agent::paths::checkpoint_error_file());
 }
 
+struct SessionCheckpointFilesGuard;
+
+impl SessionCheckpointFilesGuard {
+    fn new() -> Self {
+        cleanup_session_checkpoint_files();
+        Self
+    }
+}
+
+impl Drop for SessionCheckpointFilesGuard {
+    fn drop(&mut self) {
+        cleanup_session_checkpoint_files();
+    }
+}
+
 // =========================================================================
 // Group 1: post_json core
 // =========================================================================
@@ -944,7 +959,7 @@ async fn recovery_checkpoint_uploads_valid_session_history() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
 
-    cleanup_session_checkpoint_files();
+    let _files_guard = SessionCheckpointFilesGuard::new();
     let dir = tempfile::tempdir().unwrap();
     let history_path = dir.path().join("history.jsonl");
     let history = r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant"}"# + "\n";
@@ -992,7 +1007,6 @@ async fn recovery_checkpoint_uploads_valid_session_history() {
     prepare_mock.delete_async().await;
     upload_mock.delete_async().await;
     checkpoint_mock.delete_async().await;
-    cleanup_session_checkpoint_files();
 }
 
 #[tokio::test]
@@ -1000,7 +1014,7 @@ async fn recovery_checkpoint_rejects_partial_jsonl_without_error_file() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
 
-    cleanup_session_checkpoint_files();
+    let _files_guard = SessionCheckpointFilesGuard::new();
     let dir = tempfile::tempdir().unwrap();
     let history_path = dir.path().join("partial.jsonl");
     std::fs::write(
@@ -1036,7 +1050,6 @@ async fn recovery_checkpoint_rejects_partial_jsonl_without_error_file() {
     checkpoint_mock.assert_calls_async(0).await;
     prepare_mock.delete_async().await;
     checkpoint_mock.delete_async().await;
-    cleanup_session_checkpoint_files();
 }
 
 #[tokio::test]
@@ -1044,7 +1057,7 @@ async fn recovery_checkpoint_skips_when_session_id_is_missing() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
 
-    cleanup_session_checkpoint_files();
+    let _files_guard = SessionCheckpointFilesGuard::new();
 
     let prepare_mock = server.mock(|when, then| {
         when.method(POST)
@@ -1067,7 +1080,6 @@ async fn recovery_checkpoint_skips_when_session_id_is_missing() {
     checkpoint_mock.assert_calls_async(0).await;
     prepare_mock.delete_async().await;
     checkpoint_mock.delete_async().await;
-    cleanup_session_checkpoint_files();
 }
 
 #[tokio::test]
@@ -1075,7 +1087,7 @@ async fn recovery_checkpoint_skips_when_history_marker_is_missing() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
 
-    cleanup_session_checkpoint_files();
+    let _files_guard = SessionCheckpointFilesGuard::new();
     std::fs::write(guest_agent::paths::session_id_file(), "missing-history").unwrap();
 
     let prepare_mock = server.mock(|when, then| {
@@ -1099,7 +1111,6 @@ async fn recovery_checkpoint_skips_when_history_marker_is_missing() {
     checkpoint_mock.assert_calls_async(0).await;
     prepare_mock.delete_async().await;
     checkpoint_mock.delete_async().await;
-    cleanup_session_checkpoint_files();
 }
 
 // =========================================================================

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -48,6 +48,12 @@ impl Drop for SystemLogOverrideGuard {
     }
 }
 
+fn cleanup_session_checkpoint_files() {
+    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
+    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
+    let _ = std::fs::remove_file(guest_agent::paths::checkpoint_error_file());
+}
+
 // =========================================================================
 // Group 1: post_json core
 // =========================================================================
@@ -927,6 +933,173 @@ async fn send_event_skips_session_id_for_non_init() {
     );
 
     mock.delete_async().await;
+}
+
+// =========================================================================
+// Group 6b: Recovery checkpoint
+// =========================================================================
+
+#[tokio::test]
+async fn recovery_checkpoint_uploads_valid_session_history() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    cleanup_session_checkpoint_files();
+    let dir = tempfile::tempdir().unwrap();
+    let history_path = dir.path().join("history.jsonl");
+    let history = r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant"}"# + "\n";
+    std::fs::write(&history_path, &history).unwrap();
+    std::fs::write(guest_agent::paths::session_id_file(), "recovery-session").unwrap();
+    std::fs::write(
+        guest_agent::paths::session_history_path_file(),
+        history_path.to_string_lossy().as_ref(),
+    )
+    .unwrap();
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(r#"{"runId":"test-run-001"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url("/test/recovery-history-upload"),
+                "existing": false
+            }));
+    });
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT)
+            .path("/test/recovery-history-upload")
+            .header("Content-Type", "application/octet-stream")
+            .body(history.as_str());
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(r#"{"cliAgentSessionId":"recovery-session"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "checkpoint-recovery"}));
+    });
+
+    let result = guest_agent::checkpoint::create_recovery_checkpoint().await;
+
+    assert!(result.is_ok());
+    prepare_mock.assert_calls_async(1).await;
+    upload_mock.assert_calls_async(1).await;
+    checkpoint_mock.assert_calls_async(1).await;
+    prepare_mock.delete_async().await;
+    upload_mock.delete_async().await;
+    checkpoint_mock.delete_async().await;
+    cleanup_session_checkpoint_files();
+}
+
+#[tokio::test]
+async fn recovery_checkpoint_rejects_partial_jsonl_without_error_file() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    cleanup_session_checkpoint_files();
+    let dir = tempfile::tempdir().unwrap();
+    let history_path = dir.path().join("partial.jsonl");
+    std::fs::write(
+        &history_path,
+        r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant""#,
+    )
+    .unwrap();
+    std::fs::write(guest_agent::paths::session_id_file(), "partial-session").unwrap();
+    std::fs::write(
+        guest_agent::paths::session_history_path_file(),
+        history_path.to_string_lossy().as_ref(),
+    )
+    .unwrap();
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200);
+    });
+
+    let result = guest_agent::checkpoint::create_recovery_checkpoint().await;
+
+    assert!(result.is_err());
+    assert!(
+        !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
+        "recovery checkpoint must not write the success-path checkpoint error file"
+    );
+    prepare_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(0).await;
+    prepare_mock.delete_async().await;
+    checkpoint_mock.delete_async().await;
+    cleanup_session_checkpoint_files();
+}
+
+#[tokio::test]
+async fn recovery_checkpoint_skips_when_session_id_is_missing() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    cleanup_session_checkpoint_files();
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200);
+    });
+
+    let result = guest_agent::checkpoint::create_recovery_checkpoint().await;
+
+    assert!(result.is_err());
+    assert!(
+        !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
+        "recovery checkpoint must not write the success-path checkpoint error file"
+    );
+    prepare_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(0).await;
+    prepare_mock.delete_async().await;
+    checkpoint_mock.delete_async().await;
+    cleanup_session_checkpoint_files();
+}
+
+#[tokio::test]
+async fn recovery_checkpoint_skips_when_history_marker_is_missing() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    cleanup_session_checkpoint_files();
+    std::fs::write(guest_agent::paths::session_id_file(), "missing-history").unwrap();
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200);
+    });
+
+    let result = guest_agent::checkpoint::create_recovery_checkpoint().await;
+
+    assert!(result.is_err());
+    assert!(
+        !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
+        "recovery checkpoint must not write the success-path checkpoint error file"
+    );
+    prepare_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(0).await;
+    prepare_mock.delete_async().await;
+    checkpoint_mock.delete_async().await;
+    cleanup_session_checkpoint_files();
 }
 
 // =========================================================================

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
@@ -6,6 +6,9 @@ import {
   createTestCompose,
   createTestRun,
   completeTestRun,
+  createTestCheckpoint,
+  failTestRun,
+  setTestRunResult,
   createTestCliToken,
   deleteTestCliToken,
 } from "../../../../../../../src/__tests__/api-test-helpers";
@@ -438,6 +441,28 @@ describe("GET /api/agent/runs/:id/events", () => {
       expect(data.run.error).toBeUndefined();
     });
 
+    it("should not expose result while run is still in-flight", async () => {
+      await setTestRunResult(testRunId, {
+        checkpointId: "checkpoint-dirty",
+        agentSessionId: "session-dirty",
+        conversationId: "conversation-dirty",
+      });
+
+      context.mocks.axiom.queryAxiom.mockResolvedValue([]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${testRunId}/events`,
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.run).toBeDefined();
+      expect(data.run.status).toBe("pending");
+      expect(data.run.result).toBeUndefined();
+    });
+
     it("should return run state with result for completed run", async () => {
       // Complete the run via webhook helpers
       await completeTestRun(user.userId, testRunId);
@@ -454,6 +479,27 @@ describe("GET /api/agent/runs/:id/events", () => {
       const data = await response.json();
       expect(data.run).toBeDefined();
       expect(data.run.status).toBe("completed");
+      expect(data.run.result).toBeDefined();
+      expect(data.run.result.checkpointId).toBeDefined();
+    });
+
+    it("should return run state with result for failed recoverable run", async () => {
+      await createTestCheckpoint(user.userId, testRunId);
+      await failTestRun(user.userId, testRunId);
+
+      context.mocks.axiom.queryAxiom.mockResolvedValue([]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${testRunId}/events`,
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.run).toBeDefined();
+      expect(data.run.status).toBe("failed");
+      expect(data.run.error).toBeDefined();
       expect(data.run.result).toBeDefined();
       expect(data.run.result.checkpointId).toBeDefined();
     });

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
@@ -15,10 +15,11 @@ import {
   getDatasetName,
   DATASETS,
 } from "../../../../../../src/lib/shared/axiom";
-import type {
-  RunStatus,
-  RunResult,
-  RunState,
+import {
+  isCheckpointResumableRunStatus,
+  type RunResult,
+  type RunStatus,
+  type RunState,
 } from "../../../../../../src/lib/infra/run/types";
 import { extractFrameworkFromCompose } from "../../../../../../src/lib/infra/framework/framework-config";
 import { filterConsecutiveEvents, type AxiomAgentEvent } from "./filter-events";
@@ -114,8 +115,12 @@ const router = tsr.router(runEventsContract, {
       status: runWithCompose.status as RunStatus,
     };
 
-    // Include result if completed
-    if (runWithCompose.status === "completed" && runWithCompose.result) {
+    // Include checkpoint metadata for any terminal run that saved it. Failed
+    // recoverable runs keep status/error, but still expose the resume result.
+    if (
+      runWithCompose.result &&
+      isCheckpointResumableRunStatus(runWithCompose.status)
+    ) {
       runState.result = runWithCompose.result as RunResult;
     }
 

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -13,6 +13,7 @@ import {
   createTestOrgMultiAuthModelProvider,
   createTestConnector,
   createTestRun,
+  createTestCheckpoint,
   getTestRun,
   completeTestRun,
   insertOrgCacheEntry,
@@ -1195,6 +1196,33 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
       expect(response.status).toBe(404);
       expect(data.error.code).toBe("NOT_FOUND");
+    });
+
+    it("should return 409 when checkpoint run is still in flight", async () => {
+      const { runId } = await createTestRun(
+        testComposeId,
+        "In-flight checkpoint",
+      );
+      const { checkpointId } = await createTestCheckpoint(user.userId, runId);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            checkpointId,
+            prompt: "Resume in-flight checkpoint",
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data.error.code).toBe("CONFLICT");
+      expect(data.error.message).toContain("not ready to resume");
     });
 
     it("should return 404 when checkpoint belongs to different user (security)", async () => {

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -113,7 +113,7 @@ function handleCreateRunError(error: unknown) {
     const message =
       error.code === "UNAUTHORIZED" ? "Resource not found" : error.message;
     return {
-      status: status as 400 | 401 | 402 | 403 | 404 | 422 | 429 | 503,
+      status: status as 400 | 401 | 402 | 403 | 404 | 409 | 422 | 429 | 503,
       body: { error: { message, code } },
     };
   }

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
@@ -237,14 +237,12 @@ const router = tsr.router(cronCleanupSandboxesContract, {
           }
 
           // Dispatch callbacks (e.g., loop schedule advancement) and drain queue
-          await dispatchTerminalSideEffects(
-            run.id,
-            "timeout",
-            timeoutReason,
-            () => {
+          await dispatchTerminalSideEffects(run.id, "timeout", {
+            error: timeoutReason,
+            drain: () => {
               return drainOrgQueue(run.orgId, dispatchQueuedZeroRun);
             },
-          );
+          });
 
           await processOrgUsageEvents(run.orgId);
 

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { POST } from "../route";
+import { blobs } from "@vm0/db/schema/blob";
+import { conversations } from "@vm0/db/schema/conversation";
+import { eq } from "drizzle-orm";
 import {
   createTestRequest,
   createTestCompose,
@@ -24,6 +27,26 @@ import type { VolumeVersionsSnapshot } from "../../../../../../src/lib/infra/che
 
 function sha256(content: string): string {
   return createHash("sha256").update(content).digest("hex");
+}
+
+async function getBlobRefCount(hash: string): Promise<number | undefined> {
+  const [row] = await globalThis.services.db
+    .select({ refCount: blobs.refCount })
+    .from(blobs)
+    .where(eq(blobs.hash, hash))
+    .limit(1);
+  return row?.refCount;
+}
+
+async function getConversationHistoryHash(
+  runId: string,
+): Promise<string | null | undefined> {
+  const [row] = await globalThis.services.db
+    .select({ hash: conversations.cliAgentSessionHistoryHash })
+    .from(conversations)
+    .where(eq(conversations.runId, runId))
+    .limit(1);
+  return row?.hash;
 }
 
 const context = testContext();
@@ -750,11 +773,12 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
 
   describe("Uniqueness", () => {
     it("should handle duplicate checkpoint requests via upsert", async () => {
+      const historyHash = sha256(`test-session-unique-history-${testRunId}`);
       const requestBody = {
         runId: testRunId,
         cliAgentType: "claude-code",
         cliAgentSessionId: "test-session-unique",
-        cliAgentSessionHistoryHash: sha256("test-session-unique-history"),
+        cliAgentSessionHistoryHash: historyHash,
         artifactSnapshots: [
           {
             name: "test-artifact",
@@ -764,7 +788,6 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
         ],
       };
 
-      // First request - should succeed
       const request1 = createTestRequest(
         "http://localhost:3000/api/webhooks/agent/checkpoints",
         {
@@ -777,10 +800,6 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
         },
       );
 
-      const response1 = await POST(request1);
-      expect(response1.status).toBe(200);
-
-      // Second request - should succeed via upsert (update existing)
       const request2 = createTestRequest(
         "http://localhost:3000/api/webhooks/agent/checkpoints",
         {
@@ -793,8 +812,50 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
         },
       );
 
-      const response2 = await POST(request2);
+      const [response1, response2] = await Promise.all([
+        POST(request1),
+        POST(request2),
+      ]);
+      expect(response1.status).toBe(200);
       expect(response2.status).toBe(200);
+      expect(await getBlobRefCount(historyHash)).toBe(1);
+    });
+
+    it("should move session history blob reference when upsert replaces hash", async () => {
+      const firstHistoryHash = sha256(`history-first-${testRunId}`);
+      const secondHistoryHash = sha256(`history-second-${testRunId}`);
+
+      const makeRequest = (historyHash: string) => {
+        return createTestRequest(
+          "http://localhost:3000/api/webhooks/agent/checkpoints",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${testToken}`,
+            },
+            body: JSON.stringify({
+              runId: testRunId,
+              cliAgentType: "claude-code",
+              cliAgentSessionId: `session-${historyHash.slice(0, 8)}`,
+              cliAgentSessionHistoryHash: historyHash,
+            }),
+          },
+        );
+      };
+
+      const firstResponse = await POST(makeRequest(firstHistoryHash));
+      expect(firstResponse.status).toBe(200);
+      expect(await getBlobRefCount(firstHistoryHash)).toBe(1);
+
+      const secondResponse = await POST(makeRequest(secondHistoryHash));
+      expect(secondResponse.status).toBe(200);
+
+      expect(await getConversationHistoryHash(testRunId)).toBe(
+        secondHistoryHash,
+      );
+      expect(await getBlobRefCount(firstHistoryHash)).toBe(0);
+      expect(await getBlobRefCount(secondHistoryHash)).toBe(1);
     });
   });
 

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { POST } from "../route";
-import { blobs } from "@vm0/db/schema/blob";
-import { conversations } from "@vm0/db/schema/conversation";
-import { eq } from "drizzle-orm";
 import {
   createTestRequest,
   createTestCompose,
@@ -13,6 +10,8 @@ import {
   getTestAgentSessionWithConversation,
   setTestRunResult,
   setTestRunStatus,
+  getTestBlobRefCount,
+  getTestConversationHistoryHash,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 import {
@@ -27,26 +26,6 @@ import type { VolumeVersionsSnapshot } from "../../../../../../src/lib/infra/che
 
 function sha256(content: string): string {
   return createHash("sha256").update(content).digest("hex");
-}
-
-async function getBlobRefCount(hash: string): Promise<number | undefined> {
-  const [row] = await globalThis.services.db
-    .select({ refCount: blobs.refCount })
-    .from(blobs)
-    .where(eq(blobs.hash, hash))
-    .limit(1);
-  return row?.refCount;
-}
-
-async function getConversationHistoryHash(
-  runId: string,
-): Promise<string | null | undefined> {
-  const [row] = await globalThis.services.db
-    .select({ hash: conversations.cliAgentSessionHistoryHash })
-    .from(conversations)
-    .where(eq(conversations.runId, runId))
-    .limit(1);
-  return row?.hash;
 }
 
 const context = testContext();
@@ -569,8 +548,8 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       expect(run?.result).toMatchObject({
         artifact: { "test-artifact": "version-first" },
       });
-      expect(await getBlobRefCount(firstHistoryHash)).toBe(1);
-      expect(await getBlobRefCount(staleHistoryHash)).toBeUndefined();
+      expect(await getTestBlobRefCount(firstHistoryHash)).toBe(1);
+      expect(await getTestBlobRefCount(staleHistoryHash)).toBeUndefined();
     });
 
     it("should keep checkpoint and result consistent for concurrent terminal checkpoints", async () => {
@@ -822,7 +801,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       ]);
       expect(response1.status).toBe(200);
       expect(response2.status).toBe(200);
-      expect(await getBlobRefCount(historyHash)).toBe(1);
+      expect(await getTestBlobRefCount(historyHash)).toBe(1);
     });
 
     it("should move session history blob reference when upsert replaces hash", async () => {
@@ -850,16 +829,16 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
 
       const firstResponse = await POST(makeRequest(firstHistoryHash));
       expect(firstResponse.status).toBe(200);
-      expect(await getBlobRefCount(firstHistoryHash)).toBe(1);
+      expect(await getTestBlobRefCount(firstHistoryHash)).toBe(1);
 
       const secondResponse = await POST(makeRequest(secondHistoryHash));
       expect(secondResponse.status).toBe(200);
 
-      expect(await getConversationHistoryHash(testRunId)).toBe(
+      expect(await getTestConversationHistoryHash(testRunId)).toBe(
         secondHistoryHash,
       );
-      expect(await getBlobRefCount(firstHistoryHash)).toBe(0);
-      expect(await getBlobRefCount(secondHistoryHash)).toBe(1);
+      expect(await getTestBlobRefCount(firstHistoryHash)).toBe(0);
+      expect(await getTestBlobRefCount(secondHistoryHash)).toBe(1);
     });
   });
 

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
@@ -10,6 +10,7 @@ import {
   getTestAgentSessionWithConversation,
   setTestRunResult,
   setTestRunStatus,
+  getTestBlobRecord,
   getTestBlobRefCount,
   getTestConversationHistoryHash,
 } from "../../../../../../src/__tests__/api-test-helpers";
@@ -757,11 +758,13 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
   describe("Uniqueness", () => {
     it("should handle duplicate checkpoint requests via upsert", async () => {
       const historyHash = sha256(`test-session-unique-history-${testRunId}`);
+      const historySize = 1234;
       const requestBody = {
         runId: testRunId,
         cliAgentType: "claude-code",
         cliAgentSessionId: "test-session-unique",
         cliAgentSessionHistoryHash: historyHash,
+        cliAgentSessionHistorySize: historySize,
         artifactSnapshots: [
           {
             name: "test-artifact",
@@ -801,7 +804,10 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       ]);
       expect(response1.status).toBe(200);
       expect(response2.status).toBe(200);
-      expect(await getTestBlobRefCount(historyHash)).toBe(1);
+      expect(await getTestBlobRecord(historyHash)).toEqual({
+        refCount: 1,
+        size: historySize,
+      });
     });
 
     it("should move session history blob reference when upsert replaces hash", async () => {

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
@@ -489,6 +489,8 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
     });
 
     it("should not overwrite checkpoint when terminal result already exists", async () => {
+      const firstHistoryHash = sha256(`first-terminal-history-${testRunId}`);
+      const staleHistoryHash = sha256(`stale-terminal-history-${testRunId}`);
       const artifactSnapshots = [
         {
           name: "test-artifact",
@@ -510,7 +512,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
               runId: testRunId,
               cliAgentType: "claude-code",
               cliAgentSessionId: "first-terminal-session",
-              cliAgentSessionHistoryHash: sha256("first-terminal-history"),
+              cliAgentSessionHistoryHash: firstHistoryHash,
               artifactSnapshots,
             }),
           },
@@ -540,7 +542,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
               runId: testRunId,
               cliAgentType: "claude-code",
               cliAgentSessionId: "stale-terminal-session",
-              cliAgentSessionHistoryHash: sha256("stale-terminal-history"),
+              cliAgentSessionHistoryHash: staleHistoryHash,
               artifactSnapshots: [
                 {
                   name: "test-artifact",
@@ -567,6 +569,8 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       expect(run?.result).toMatchObject({
         artifact: { "test-artifact": "version-first" },
       });
+      expect(await getBlobRefCount(firstHistoryHash)).toBe(1);
+      expect(await getBlobRefCount(staleHistoryHash)).toBeUndefined();
     });
 
     it("should keep checkpoint and result consistent for concurrent terminal checkpoints", async () => {

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
   findTestCheckpoint,
   findTestRunRecord,
   getTestAgentSessionWithConversation,
+  setTestRunStatus,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 import {
@@ -416,6 +417,51 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       const checkpoint = await findTestCheckpoint(testRunId);
       expect(checkpoint).toBeDefined();
       expect(checkpoint!.artifactSnapshots).toEqual(artifactSnapshots);
+    });
+
+    it("should backfill run result when checkpoint arrives after terminal status", async () => {
+      await setTestRunStatus(testRunId, "failed");
+      const artifactSnapshots = [
+        {
+          name: "test-artifact",
+          version: "version-late",
+          mountPath: "/home/user/workspace",
+        },
+      ];
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "late-checkpoint-session",
+            cliAgentSessionHistoryHash: sha256("late-checkpoint-history"),
+            artifactSnapshots,
+            volumeVersionsSnapshot: {
+              versions: { workspace: "vol-late" },
+            },
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      const run = await findTestRunRecord(testRunId);
+      expect(run?.result).toMatchObject({
+        checkpointId: body.checkpointId,
+        agentSessionId: body.agentSessionId,
+        conversationId: body.conversationId,
+        artifact: { "test-artifact": "version-late" },
+        volumes: { workspace: "vol-late" },
+      });
     });
   });
 

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
   findTestCheckpoint,
   findTestRunRecord,
   getTestAgentSessionWithConversation,
+  setTestRunResult,
   setTestRunStatus,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
@@ -462,6 +463,150 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
         artifact: { "test-artifact": "version-late" },
         volumes: { workspace: "vol-late" },
       });
+    });
+
+    it("should not overwrite checkpoint when terminal result already exists", async () => {
+      const artifactSnapshots = [
+        {
+          name: "test-artifact",
+          version: "version-first",
+          mountPath: "/home/user/workspace",
+        },
+      ];
+
+      const firstResponse = await POST(
+        createTestRequest(
+          "http://localhost:3000/api/webhooks/agent/checkpoints",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${testToken}`,
+            },
+            body: JSON.stringify({
+              runId: testRunId,
+              cliAgentType: "claude-code",
+              cliAgentSessionId: "first-terminal-session",
+              cliAgentSessionHistoryHash: sha256("first-terminal-history"),
+              artifactSnapshots,
+            }),
+          },
+        ),
+      );
+      expect(firstResponse.status).toBe(200);
+      const firstBody = await firstResponse.json();
+
+      await setTestRunStatus(testRunId, "failed");
+      await setTestRunResult(testRunId, {
+        checkpointId: firstBody.checkpointId,
+        agentSessionId: firstBody.agentSessionId,
+        conversationId: firstBody.conversationId,
+        artifact: { "test-artifact": "version-first" },
+      });
+
+      const lateResponse = await POST(
+        createTestRequest(
+          "http://localhost:3000/api/webhooks/agent/checkpoints",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${testToken}`,
+            },
+            body: JSON.stringify({
+              runId: testRunId,
+              cliAgentType: "claude-code",
+              cliAgentSessionId: "stale-terminal-session",
+              cliAgentSessionHistoryHash: sha256("stale-terminal-history"),
+              artifactSnapshots: [
+                {
+                  name: "test-artifact",
+                  version: "version-stale",
+                  mountPath: "/home/user/workspace",
+                },
+              ],
+            }),
+          },
+        ),
+      );
+
+      expect(lateResponse.status).toBe(200);
+      expect(await lateResponse.json()).toMatchObject({
+        checkpointId: firstBody.checkpointId,
+        agentSessionId: firstBody.agentSessionId,
+        conversationId: firstBody.conversationId,
+        artifacts: artifactSnapshots,
+      });
+
+      const checkpoint = await findTestCheckpoint(testRunId);
+      expect(checkpoint?.artifactSnapshots).toEqual(artifactSnapshots);
+      const run = await findTestRunRecord(testRunId);
+      expect(run?.result).toMatchObject({
+        artifact: { "test-artifact": "version-first" },
+      });
+    });
+
+    it("should keep checkpoint and result consistent for concurrent terminal checkpoints", async () => {
+      await setTestRunStatus(testRunId, "failed");
+
+      const makeRequest = (version: string) => {
+        return createTestRequest(
+          "http://localhost:3000/api/webhooks/agent/checkpoints",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${testToken}`,
+            },
+            body: JSON.stringify({
+              runId: testRunId,
+              cliAgentType: "claude-code",
+              cliAgentSessionId: `parallel-${version}`,
+              cliAgentSessionHistoryHash: sha256(`parallel-${version}`),
+              artifactSnapshots: [
+                {
+                  name: "test-artifact",
+                  version,
+                  mountPath: "/home/user/workspace",
+                },
+              ],
+            }),
+          },
+        );
+      };
+
+      const [leftResponse, rightResponse] = await Promise.all([
+        POST(makeRequest("version-left")),
+        POST(makeRequest("version-right")),
+      ]);
+
+      expect(leftResponse.status).toBe(200);
+      expect(rightResponse.status).toBe(200);
+      const [leftBody, rightBody] = await Promise.all([
+        leftResponse.json(),
+        rightResponse.json(),
+      ]);
+
+      const checkpoint = await findTestCheckpoint(testRunId);
+      const run = await findTestRunRecord(testRunId);
+      const artifactVersion = (
+        run?.result as {
+          artifact?: {
+            "test-artifact"?: string;
+          };
+        } | null
+      )?.artifact?.["test-artifact"];
+
+      expect(["version-left", "version-right"]).toContain(artifactVersion);
+      expect(checkpoint?.artifactSnapshots).toEqual([
+        {
+          name: "test-artifact",
+          version: artifactVersion,
+          mountPath: "/home/user/workspace",
+        },
+      ]);
+      expect(leftBody.artifacts).toEqual(checkpoint?.artifactSnapshots);
+      expect(rightBody.artifacts).toEqual(checkpoint?.artifactSnapshots);
     });
   });
 

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/prepare-history/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/prepare-history/__tests__/route.test.ts
@@ -5,6 +5,7 @@ import {
   createTestCompose,
   createTestRun,
   createTestSandboxToken,
+  getTestBlobRefCount,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -49,6 +50,7 @@ describe("POST /api/webhooks/agent/checkpoints/prepare-history", () => {
 
   beforeEach(async () => {
     context.setupMocks();
+    context.mocks.s3.s3ObjectExists.mockResolvedValue(false);
     user = await context.setupUser();
 
     const { composeId } = await createTestCompose(uniqueId("prep-history"));
@@ -127,21 +129,23 @@ describe("POST /api/webhooks/agent/checkpoints/prepare-history", () => {
       expect(data.existing).toBe(false);
       expect(data.presignedUrl).toBeDefined();
       expect(typeof data.presignedUrl).toBe("string");
+      expect(await getTestBlobRefCount(hash)).toBeUndefined();
     });
 
-    it("should return existing=true for blob already in DB and S3", async () => {
-      // Pre-seed the blob via the service layer + upload to S3
-      const content = Buffer.from("pre-existing-content", "utf-8");
+    it("should return existing=true for blob already in S3", async () => {
+      // Pre-seed the content-addressed object in S3. The DB reference is
+      // claimed later by the checkpoint webhook, not by prepare-history.
+      const content = Buffer.from(
+        `pre-existing-content-${randomUUID()}`,
+        "utf-8",
+      );
       const hash = createHash("sha256").update(content).digest("hex");
 
       const { uploadS3Buffer } =
         await import("../../../../../../../src/lib/infra/s3/s3-client");
       const bucketName = "test-storages-bucket";
       await uploadS3Buffer(bucketName, `blobs/${hash}.blob`, content);
-
-      const { registerSessionHistoryBlob } =
-        await import("../../../../../../../src/lib/infra/session-history/session-history-service");
-      await registerSessionHistoryBlob(hash);
+      context.mocks.s3.s3ObjectExists.mockResolvedValueOnce(true);
 
       const request = makePrepareRequest(testToken, {
         runId: testRunId,
@@ -155,6 +159,7 @@ describe("POST /api/webhooks/agent/checkpoints/prepare-history", () => {
       const data = await response.json();
       expect(data.existing).toBe(true);
       expect(data.presignedUrl).toBeUndefined();
+      expect(await getTestBlobRefCount(hash)).toBeUndefined();
     });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/prepare-history/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/prepare-history/route.ts
@@ -2,9 +2,7 @@ import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { webhookCheckpointsPrepareHistoryContract } from "@vm0/api-contracts/contracts/webhooks";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { agentRuns } from "@vm0/db/schema/agent-run";
-import { blobs } from "@vm0/db/schema/blob";
 import { eq, and } from "drizzle-orm";
-import { preRegisterSessionHistoryBlob } from "../../../../../../src/lib/infra/session-history";
 import { getSandboxAuthForRun } from "../../../../../../src/lib/auth/get-sandbox-auth";
 import {
   generatePresignedPutUrl,
@@ -60,26 +58,18 @@ const router = tsr.router(webhookCheckpointsPrepareHistoryContract, {
     const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
     const s3Key = `blobs/${hash}.blob`;
 
-    // Check if blob already exists in DB
-    const [existingBlob] = await globalThis.services.db
-      .select({ hash: blobs.hash })
-      .from(blobs)
-      .where(eq(blobs.hash, hash))
-      .limit(1);
-
-    if (existingBlob) {
-      // Verify blob actually exists in S3 (DB record might be stale)
-      const exists = await s3ObjectExists(bucketName, s3Key);
-      if (exists) {
-        log.debug(`Session history blob already exists: hash=${hash}`);
-        return {
-          status: 200 as const,
-          body: { existing: true },
-        };
-      }
-      log.debug(
-        `Session history blob in DB but missing from S3, generating new presigned URL: hash=${hash}`,
-      );
+    // The R2 object is the source of truth during prepare. We intentionally do
+    // not pre-register a refCount=0 blob row here: if the sandbox is killed
+    // after upload but before checkpoint, that DB row would become a permanent
+    // unreferenced resource. The checkpoint webhook claims the DB reference
+    // atomically once the uploaded history is actually used.
+    const exists = await s3ObjectExists(bucketName, s3Key);
+    if (exists) {
+      log.debug(`Session history blob already exists: hash=${hash}`);
+      return {
+        status: 200 as const,
+        body: { existing: true },
+      };
     }
 
     // Generate presigned PUT URL for direct S3 upload
@@ -90,11 +80,6 @@ const router = tsr.router(webhookCheckpointsPrepareHistoryContract, {
       3600,
       true, // usePublicEndpoint for sandbox access
     );
-
-    // Pre-register the blob record with the correct size.
-    // The subsequent checkpoint call claims a refCount when the conversation
-    // does not already reference this hash.
-    await preRegisterSessionHistoryBlob(hash, size);
 
     log.debug(`Presigned URL generated for session history: hash=${hash}`);
 

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/prepare-history/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/prepare-history/route.ts
@@ -92,7 +92,8 @@ const router = tsr.router(webhookCheckpointsPrepareHistoryContract, {
     );
 
     // Pre-register the blob record with the correct size.
-    // The subsequent checkpoint call will increment refCount via registerSessionHistoryBlob.
+    // The subsequent checkpoint call claims a refCount when the conversation
+    // does not already reference this hash.
     await preRegisterSessionHistoryBlob(hash, size);
 
     log.debug(`Presigned URL generated for session history: hash=${hash}`);

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -43,8 +43,37 @@ import { randomUUID } from "crypto";
 import { POST as checkpointWebhook } from "../../checkpoints/route";
 import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
 import { transitionRunStatus } from "../../../../../../src/lib/infra/run/run-status";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { checkpoints } from "@vm0/db/schema/checkpoint";
+import { conversations } from "@vm0/db/schema/conversation";
+import { eq, sql } from "drizzle-orm";
 
 const context = testContext();
+
+async function waitForBlockedAgentRunsQuery(): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const [row] = await globalThis.services.db
+      .select({
+        blocked: sql<boolean>`EXISTS (
+          SELECT 1
+          FROM pg_locks l
+          JOIN pg_stat_activity a ON a.pid = l.pid
+          WHERE NOT l.granted
+            AND a.datname = current_database()
+            AND a.query ILIKE '%agent_runs%'
+        )`,
+      })
+      .from(agentRuns)
+      .limit(1);
+
+    if (row?.blocked) {
+      return;
+    }
+  }
+
+  throw new Error("complete webhook did not wait for held agent_runs lock");
+}
 
 describe("POST /api/webhooks/agent/complete", () => {
   let user: UserContext;
@@ -590,6 +619,110 @@ describe("POST /api/webhooks/agent/complete", () => {
         checkpointId: checkpoint.checkpointId,
         agentSessionId: checkpoint.agentSessionId,
         conversationId: checkpoint.conversationId,
+        artifact: {
+          "test-artifact": "v1",
+        },
+      });
+    });
+
+    it("should wait for an in-flight checkpoint transaction before completing", async () => {
+      const artifactSnapshots = [
+        {
+          name: "test-artifact",
+          version: "v1",
+          mountPath: "/home/user/workspace",
+        },
+      ];
+      const completeRequest = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+          }),
+        },
+      );
+
+      let completePromise: Promise<Response> | undefined;
+      let checkpointId: string | undefined;
+      let conversationId: string | undefined;
+
+      await globalThis.services.db.transaction(async (tx) => {
+        const [run] = await tx
+          .select()
+          .from(agentRuns)
+          .where(eq(agentRuns.id, testRunId))
+          .for("update")
+          .limit(1);
+
+        if (!run?.agentComposeVersionId) {
+          throw new Error("test run is missing agentComposeVersionId");
+        }
+
+        const [conversation] = await tx
+          .insert(conversations)
+          .values({
+            runId: testRunId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "in-flight-checkpoint-session",
+            cliAgentSessionHistoryHash:
+              "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
+          })
+          .returning();
+
+        if (!conversation) {
+          throw new Error("failed to seed in-flight conversation");
+        }
+
+        const [checkpoint] = await tx
+          .insert(checkpoints)
+          .values({
+            runId: testRunId,
+            conversationId: conversation.id,
+            agentComposeSnapshot: {
+              agentComposeVersionId: run.agentComposeVersionId,
+            },
+            artifactSnapshots,
+            volumeVersionsSnapshot: null,
+          })
+          .returning();
+
+        if (!checkpoint) {
+          throw new Error("failed to seed in-flight checkpoint");
+        }
+
+        await tx
+          .update(agentSessions)
+          .set({
+            conversationId: conversation.id,
+            updatedAt: new Date(),
+          })
+          .where(eq(agentSessions.id, run.sessionId));
+
+        checkpointId = checkpoint.id;
+        conversationId = conversation.id;
+        completePromise = POST(completeRequest);
+
+        // Hold the uncommitted checkpoint until /complete reaches its own
+        // agent_runs lock. Without this ordering, old code could sometimes
+        // read the checkpoint after commit and miss the regression.
+        await waitForBlockedAgentRunsQuery();
+      });
+
+      const response = await completePromise;
+
+      expect(response?.status).toBe(200);
+      const run = await findTestRunRecord(testRunId);
+      expect(run!.status).toBe("completed");
+      expect(run!.result).toMatchObject({
+        checkpointId,
+        agentSessionId: run!.sessionId,
+        conversationId,
         artifact: {
           "test-artifact": "v1",
         },

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -100,6 +100,11 @@ describe("POST /api/webhooks/agent/complete", () => {
     );
     const checkpointResponse = await checkpointWebhook(checkpointRequest);
     expect(checkpointResponse.status).toBe(200);
+    return checkpointResponse.json() as Promise<{
+      checkpointId: string;
+      agentSessionId: string;
+      conversationId: string;
+    }>;
   }
 
   describe("Authentication", () => {
@@ -558,8 +563,8 @@ describe("POST /api/webhooks/agent/complete", () => {
       expect(context.mocks.axiom.queryAxiom).not.toHaveBeenCalled();
     });
 
-    it("should keep failed run result empty even when a recovery checkpoint exists", async () => {
-      await createCheckpoint();
+    it("should store failed run result when a recovery checkpoint exists", async () => {
+      const checkpoint = await createCheckpoint();
 
       const request = createTestRequest(
         "http://localhost:3000/api/webhooks/agent/complete",
@@ -581,7 +586,14 @@ describe("POST /api/webhooks/agent/complete", () => {
       expect(response.status).toBe(200);
       const run = await findTestRunRecord(testRunId);
       expect(run!.status).toBe("failed");
-      expect(run!.result).toBeNull();
+      expect(run!.result).toMatchObject({
+        checkpointId: checkpoint.checkpointId,
+        agentSessionId: checkpoint.agentSessionId,
+        conversationId: checkpoint.conversationId,
+        artifact: {
+          "test-artifact": "v1",
+        },
+      });
     });
   });
 
@@ -768,6 +780,56 @@ describe("POST /api/webhooks/agent/complete", () => {
       // Verify the callback received the error with report-error link
       expect(capturedBody).toBeDefined();
       expect(capturedBody!.error).toContain(`/runs/${testRunId}/report-error`);
+    });
+
+    it("should dispatch callback with result for failed recoverable run", async () => {
+      const checkpoint = await createCheckpoint();
+      let capturedBody:
+        | { result?: { checkpointId?: string; agentSessionId?: string } }
+        | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost/api/internal/callbacks/test",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as {
+              result?: { checkpointId?: string; agentSessionId?: string };
+            };
+            return HttpResponse.json({ success: true });
+          },
+        ),
+      );
+
+      await createTestCallback({
+        runId: testRunId,
+        url: "http://localhost/api/internal/callbacks/test",
+        payload: { testKey: "testValue" },
+      });
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 1,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await context.mocks.flushAfter();
+
+      expect(capturedBody?.result).toMatchObject({
+        checkpointId: checkpoint.checkpointId,
+        agentSessionId: checkpoint.agentSessionId,
+      });
     });
 
     it("should register an after() callback for dispatch", async () => {

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -557,6 +557,32 @@ describe("POST /api/webhooks/agent/complete", () => {
       expect(response.status).toBe(200);
       expect(context.mocks.axiom.queryAxiom).not.toHaveBeenCalled();
     });
+
+    it("should keep failed run result empty even when a recovery checkpoint exists", async () => {
+      await createCheckpoint();
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 1,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const run = await findTestRunRecord(testRunId);
+      expect(run!.status).toBe("failed");
+      expect(run!.result).toBeNull();
+    });
   });
 
   describe("Error Handling", () => {

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -41,39 +41,13 @@ import {
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
 import { POST as checkpointWebhook } from "../../checkpoints/route";
-import { seedTestRun } from "../../../../../../src/__tests__/db-test-seeders/runs";
+import {
+  seedInFlightCheckpointWhileAgentRunLocked,
+  seedTestRun,
+} from "../../../../../../src/__tests__/db-test-seeders/runs";
 import { transitionRunStatus } from "../../../../../../src/lib/infra/run/run-status";
-import { agentRuns } from "@vm0/db/schema/agent-run";
-import { agentSessions } from "@vm0/db/schema/agent-session";
-import { checkpoints } from "@vm0/db/schema/checkpoint";
-import { conversations } from "@vm0/db/schema/conversation";
-import { eq, sql } from "drizzle-orm";
 
 const context = testContext();
-
-async function waitForBlockedAgentRunsQuery(): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    const [row] = await globalThis.services.db
-      .select({
-        blocked: sql<boolean>`EXISTS (
-          SELECT 1
-          FROM pg_locks l
-          JOIN pg_stat_activity a ON a.pid = l.pid
-          WHERE NOT l.granted
-            AND a.datname = current_database()
-            AND a.query ILIKE '%agent_runs%'
-        )`,
-      })
-      .from(agentRuns)
-      .limit(1);
-
-    if (row?.blocked) {
-      return;
-    }
-  }
-
-  throw new Error("complete webhook did not wait for held agent_runs lock");
-}
 
 describe("POST /api/webhooks/agent/complete", () => {
   let user: UserContext;
@@ -648,75 +622,22 @@ describe("POST /api/webhooks/agent/complete", () => {
         },
       );
 
-      let completePromise: Promise<Response> | undefined;
-      let checkpointId: string | undefined;
-      let conversationId: string | undefined;
-
-      await globalThis.services.db.transaction(async (tx) => {
-        const [run] = await tx
-          .select()
-          .from(agentRuns)
-          .where(eq(agentRuns.id, testRunId))
-          .for("update")
-          .limit(1);
-
-        if (!run?.agentComposeVersionId) {
-          throw new Error("test run is missing agentComposeVersionId");
-        }
-
-        const [conversation] = await tx
-          .insert(conversations)
-          .values({
-            runId: testRunId,
-            cliAgentType: "claude-code",
-            cliAgentSessionId: "in-flight-checkpoint-session",
-            cliAgentSessionHistoryHash:
-              "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
-          })
-          .returning();
-
-        if (!conversation) {
-          throw new Error("failed to seed in-flight conversation");
-        }
-
-        const [checkpoint] = await tx
-          .insert(checkpoints)
-          .values({
-            runId: testRunId,
-            conversationId: conversation.id,
-            agentComposeSnapshot: {
-              agentComposeVersionId: run.agentComposeVersionId,
-            },
-            artifactSnapshots,
-            volumeVersionsSnapshot: null,
-          })
-          .returning();
-
-        if (!checkpoint) {
-          throw new Error("failed to seed in-flight checkpoint");
-        }
-
-        await tx
-          .update(agentSessions)
-          .set({
-            conversationId: conversation.id,
-            updatedAt: new Date(),
-          })
-          .where(eq(agentSessions.id, run.sessionId));
-
-        checkpointId = checkpoint.id;
-        conversationId = conversation.id;
-        completePromise = POST(completeRequest);
-
-        // Hold the uncommitted checkpoint until /complete reaches its own
-        // agent_runs lock. Without this ordering, old code could sometimes
-        // read the checkpoint after commit and miss the regression.
-        await waitForBlockedAgentRunsQuery();
+      const {
+        checkpointId,
+        conversationId,
+        result: response,
+      } = await seedInFlightCheckpointWhileAgentRunLocked({
+        runId: testRunId,
+        cliAgentSessionId: "in-flight-checkpoint-session",
+        cliAgentSessionHistoryHash:
+          "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
+        artifactSnapshots,
+        startWhileLocked: () => {
+          return POST(completeRequest);
+        },
       });
 
-      const response = await completePromise;
-
-      expect(response?.status).toBe(200);
+      expect(response.status).toBe(200);
       const run = await findTestRunRecord(testRunId);
       expect(run!.status).toBe("completed");
       expect(run!.result).toMatchObject({

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -595,6 +595,39 @@ describe("POST /api/webhooks/agent/complete", () => {
         },
       });
     });
+
+    it("should backfill result when recovery checkpoint arrives after failed complete", async () => {
+      const completeRequest = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 1,
+          }),
+        },
+      );
+
+      const completeResponse = await POST(completeRequest);
+      expect(completeResponse.status).toBe(200);
+
+      const checkpoint = await createCheckpoint();
+
+      const run = await findTestRunRecord(testRunId);
+      expect(run!.status).toBe("failed");
+      expect(run!.result).toMatchObject({
+        checkpointId: checkpoint.checkpointId,
+        agentSessionId: checkpoint.agentSessionId,
+        conversationId: checkpoint.conversationId,
+        artifact: {
+          "test-artifact": "v1",
+        },
+      });
+    });
   });
 
   describe("Error Handling", () => {

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -8,7 +8,7 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { checkpoints } from "@vm0/db/schema/checkpoint";
 import { agentSessions } from "@vm0/db/schema/agent-session";
-import { eq, and } from "drizzle-orm";
+import { eq, and, isNull } from "drizzle-orm";
 import {
   transitionRunStatus,
   dispatchTerminalSideEffects,
@@ -232,15 +232,12 @@ const router = tsr.router(webhookCompleteContract, {
       // Also accept "timeout" so the sandbox's own exit-code-based error
       // (with the report-error link) supersedes a stale "Run timed out
       // (no heartbeat)" stamped earlier by the cleanup cron.
-      const result = await buildRunResultForRun(body.runId);
-      finalResult = result;
       const transitioned = await transitionRunStatus(
         body.runId,
         {
           status: "failed",
           completedAt: new Date(),
           error: errorMessage,
-          ...(result ? { result } : {}),
           sandboxId: body.sandboxId,
           sandboxReuseResult: body.sandboxReuseResult,
         },
@@ -257,6 +254,20 @@ const router = tsr.router(webhookCompleteContract, {
         };
       }
 
+      const result = await buildRunResultForRun(body.runId);
+      if (result) {
+        finalResult = result;
+        await globalThis.services.db
+          .update(agentRuns)
+          .set({ result })
+          .where(
+            and(
+              eq(agentRuns.id, body.runId),
+              eq(agentRuns.status, "failed"),
+              isNull(agentRuns.result),
+            ),
+          );
+      }
       await publishRunChangedForUserSafely(run.userId, body.runId, {
         status: "failed",
       });

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -37,10 +37,15 @@ function scheduleTerminalSideEffects(
   status: "completed" | "failed",
   orgId: string,
   errorMsg?: string,
+  result?: RunResult,
 ): void {
   after(async () => {
-    await dispatchTerminalSideEffects(runId, status, errorMsg, () => {
-      return drainOrgQueue(orgId, dispatchQueuedZeroRun);
+    await dispatchTerminalSideEffects(runId, status, {
+      error: errorMsg,
+      result,
+      drain: () => {
+        return drainOrgQueue(orgId, dispatchQueuedZeroRun);
+      },
     });
     await processOrgUsageEvents(orgId);
   });
@@ -76,6 +81,29 @@ function buildRunResult(
   }
 
   return result;
+}
+
+async function buildRunResultForRun(
+  runId: string,
+): Promise<RunResult | undefined> {
+  const [checkpoint] = await globalThis.services.db
+    .select()
+    .from(checkpoints)
+    .where(eq(checkpoints.runId, runId))
+    .limit(1);
+
+  if (!checkpoint) {
+    return undefined;
+  }
+
+  // Get agent session for the conversation
+  const [session] = await globalThis.services.db
+    .select()
+    .from(agentSessions)
+    .where(eq(agentSessions.conversationId, checkpoint.conversationId))
+    .limit(1);
+
+  return buildRunResult(checkpoint, session?.id);
 }
 
 const router = tsr.router(webhookCompleteContract, {
@@ -134,16 +162,13 @@ const router = tsr.router(webhookCompleteContract, {
 
     let finalStatus: "completed" | "failed";
     let errorMessage: string | undefined;
+    let finalResult: RunResult | undefined;
 
     if (body.exitCode === 0) {
       // Success: query checkpoint and store result in run table
-      const [checkpoint] = await globalThis.services.db
-        .select()
-        .from(checkpoints)
-        .where(eq(checkpoints.runId, body.runId))
-        .limit(1);
+      const result = await buildRunResultForRun(body.runId);
 
-      if (!checkpoint) {
+      if (!result) {
         const transitioned = await transitionRunStatus(
           body.runId,
           {
@@ -180,15 +205,6 @@ const router = tsr.router(webhookCompleteContract, {
           },
         };
       }
-
-      // Get agent session for the conversation
-      const [session] = await globalThis.services.db
-        .select()
-        .from(agentSessions)
-        .where(eq(agentSessions.conversationId, checkpoint.conversationId))
-        .limit(1);
-
-      const result = buildRunResult(checkpoint, session?.id);
 
       if (body.lastEventSequence !== undefined) {
         const visibility = await waitForAgentEventPrefixVisible(
@@ -237,6 +253,7 @@ const router = tsr.router(webhookCompleteContract, {
       await publishRunChangedForUserSafely(run.userId, body.runId, {
         status: "completed",
       });
+      finalResult = result;
       finalStatus = "completed";
       log.debug(`Run ${body.runId} completed successfully`);
     } else {
@@ -247,12 +264,15 @@ const router = tsr.router(webhookCompleteContract, {
       // Also accept "timeout" so the sandbox's own exit-code-based error
       // (with the report-error link) supersedes a stale "Run timed out
       // (no heartbeat)" stamped earlier by the cleanup cron.
+      const result = await buildRunResultForRun(body.runId);
+      finalResult = result;
       const transitioned = await transitionRunStatus(
         body.runId,
         {
           status: "failed",
           completedAt: new Date(),
           error: errorMessage,
+          ...(result ? { result } : {}),
           sandboxId: body.sandboxId,
           sandboxReuseResult: body.sandboxReuseResult,
         },
@@ -282,6 +302,7 @@ const router = tsr.router(webhookCompleteContract, {
       finalStatus,
       run.orgId,
       errorMessage,
+      finalResult,
     );
 
     return {

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -8,14 +8,14 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { checkpoints } from "@vm0/db/schema/checkpoint";
 import { agentSessions } from "@vm0/db/schema/agent-session";
-import { eq, and, isNull } from "drizzle-orm";
-import {
-  transitionRunStatus,
-  dispatchTerminalSideEffects,
-} from "../../../../../src/lib/infra/run/run-status";
+import { eq, and, inArray } from "drizzle-orm";
+import { dispatchTerminalSideEffects } from "../../../../../src/lib/infra/run/run-status";
 import { getSandboxAuthForRun } from "../../../../../src/lib/auth/get-sandbox-auth";
 import { buildRunResultFromCheckpoint } from "../../../../../src/lib/infra/run/run-result";
-import type { RunResult } from "../../../../../src/lib/infra/run/types";
+import type {
+  RunResult,
+  RunStatus,
+} from "../../../../../src/lib/infra/run/types";
 import { logger } from "../../../../../src/lib/shared/logger";
 import {
   drainOrgQueue,
@@ -26,8 +26,11 @@ import { waitForAgentEventPrefixVisible } from "../../../../../src/lib/infra/run
 import { publishRunChangedForUserSafely } from "../../../../../src/lib/infra/run/run-realtime";
 import { after } from "next/server";
 import { env } from "../../../../../src/env";
+import type { Database } from "../../../../../src/types/global";
 
 const log = logger("webhook:complete");
+
+const COMPLETABLE_RUN_STATUSES: RunStatus[] = ["pending", "running", "timeout"];
 
 /**
  * Schedule terminal side effects in a non-blocking after() block.
@@ -53,8 +56,9 @@ function scheduleTerminalSideEffects(
 
 async function buildRunResultForRun(
   runId: string,
+  db: Pick<Database, "select"> = globalThis.services.db,
 ): Promise<RunResult | undefined> {
-  const [checkpoint] = await globalThis.services.db
+  const [checkpoint] = await db
     .select()
     .from(checkpoints)
     .where(eq(checkpoints.runId, runId))
@@ -65,7 +69,7 @@ async function buildRunResultForRun(
   }
 
   // Get agent session for the conversation
-  const [session] = await globalThis.services.db
+  const [session] = await db
     .select()
     .from(agentSessions)
     .where(eq(agentSessions.conversationId, checkpoint.conversationId))
@@ -73,6 +77,14 @@ async function buildRunResultForRun(
 
   return buildRunResultFromCheckpoint(checkpoint, session?.id);
 }
+
+type CompleteTransitionResult =
+  | { kind: "not-found" }
+  | { kind: "already-terminal"; status: "completed" | "failed" }
+  | { kind: "missing-checkpoint"; transitioned: boolean }
+  | { kind: "completed"; result: RunResult }
+  | { kind: "failed"; errorMessage: string; result?: RunResult }
+  | { kind: "skipped"; status: "completed" | "failed" };
 
 const router = tsr.router(webhookCompleteContract, {
   complete: async ({ body, headers }) => {
@@ -128,52 +140,7 @@ const router = tsr.router(webhookCompleteContract, {
       };
     }
 
-    let finalStatus: "completed" | "failed";
-    let errorMessage: string | undefined;
-    let finalResult: RunResult | undefined;
-
     if (body.exitCode === 0) {
-      // Success: query checkpoint and store result in run table
-      const result = await buildRunResultForRun(body.runId);
-
-      if (!result) {
-        const transitioned = await transitionRunStatus(
-          body.runId,
-          {
-            status: "failed",
-            completedAt: new Date(),
-            error: "Checkpoint for run not found",
-            sandboxId: body.sandboxId,
-            sandboxReuseResult: body.sandboxReuseResult,
-          },
-          ["pending", "running", "timeout"],
-        );
-
-        // Dispatch callbacks so the user gets notified about the failure
-        // (previously this path returned without dispatching)
-        if (transitioned) {
-          await publishRunChangedForUserSafely(run.userId, body.runId, {
-            status: "failed",
-          });
-          scheduleTerminalSideEffects(
-            body.runId,
-            "failed",
-            run.orgId,
-            "Checkpoint for run not found",
-          );
-        }
-
-        return {
-          status: 404 as const,
-          body: {
-            error: {
-              message: "Checkpoint for run not found",
-              code: "NOT_FOUND",
-            },
-          },
-        };
-      }
-
       if (body.lastEventSequence !== undefined) {
         const visibility = await waitForAgentEventPrefixVisible(
           body.runId,
@@ -192,86 +159,203 @@ const router = tsr.router(webhookCompleteContract, {
           });
         }
       }
+    }
 
-      // Atomically transition to "completed". Also accept "timeout" so a
-      // sandbox that eventually reports success after a heartbeat-timeout
-      // sweep can still upgrade the run state.
-      const transitioned = await transitionRunStatus(
-        body.runId,
-        {
-          status: "completed",
-          completedAt: new Date(),
-          result,
-          sandboxId: body.sandboxId,
-          sandboxReuseResult: body.sandboxReuseResult,
+    const transitionResult =
+      await globalThis.services.db.transaction<CompleteTransitionResult>(
+        async (tx) => {
+          // Serialize the terminal decision with checkpoint writes. A checkpoint
+          // webhook can hold this row lock while inserting the checkpoint row;
+          // reading checkpoint before waiting for that lock can falsely decide
+          // that a recoverable checkpoint is missing.
+          const [lockedRun] = await tx
+            .select()
+            .from(agentRuns)
+            .where(
+              and(eq(agentRuns.id, body.runId), eq(agentRuns.userId, userId)),
+            )
+            .for("update")
+            .limit(1);
+
+          if (!lockedRun) {
+            return { kind: "not-found" };
+          }
+
+          if (
+            lockedRun.status === "completed" ||
+            lockedRun.status === "failed"
+          ) {
+            return {
+              kind: "already-terminal",
+              status: lockedRun.status as "completed" | "failed",
+            };
+          }
+
+          if (body.exitCode === 0) {
+            // Success: query checkpoint under the same run lock used for the
+            // terminal transition, then store the result in agent_runs.
+            const result = await buildRunResultForRun(body.runId, tx);
+
+            if (!result) {
+              const [updated] = await tx
+                .update(agentRuns)
+                .set({
+                  status: "failed",
+                  completedAt: new Date(),
+                  error: "Checkpoint for run not found",
+                  sandboxId: body.sandboxId,
+                  sandboxReuseResult: body.sandboxReuseResult,
+                })
+                .where(
+                  and(
+                    eq(agentRuns.id, body.runId),
+                    inArray(agentRuns.status, COMPLETABLE_RUN_STATUSES),
+                  ),
+                )
+                .returning({ id: agentRuns.id });
+
+              return {
+                kind: "missing-checkpoint",
+                transitioned: Boolean(updated),
+              };
+            }
+
+            const [updated] = await tx
+              .update(agentRuns)
+              .set({
+                status: "completed",
+                completedAt: new Date(),
+                result,
+                sandboxId: body.sandboxId,
+                sandboxReuseResult: body.sandboxReuseResult,
+              })
+              .where(
+                and(
+                  eq(agentRuns.id, body.runId),
+                  inArray(agentRuns.status, COMPLETABLE_RUN_STATUSES),
+                ),
+              )
+              .returning({ id: agentRuns.id });
+
+            if (!updated) {
+              return { kind: "skipped", status: "completed" };
+            }
+
+            return { kind: "completed", result };
+          }
+
+          const reportUrl = `${env().NEXT_PUBLIC_APP_URL}/runs/${body.runId}/report-error`;
+          const errorMessage = `An unexpected error occurred. [Report this issue](${reportUrl})`;
+          const result = await buildRunResultForRun(body.runId, tx);
+          const update = {
+            status: "failed" as const,
+            completedAt: new Date(),
+            error: errorMessage,
+            sandboxId: body.sandboxId,
+            sandboxReuseResult: body.sandboxReuseResult,
+            ...(result ? { result } : {}),
+          };
+
+          const [updated] = await tx
+            .update(agentRuns)
+            .set(update)
+            .where(
+              and(
+                eq(agentRuns.id, body.runId),
+                inArray(agentRuns.status, COMPLETABLE_RUN_STATUSES),
+              ),
+            )
+            .returning({ id: agentRuns.id });
+
+          if (!updated) {
+            return { kind: "skipped", status: "failed" };
+          }
+
+          return { kind: "failed", errorMessage, result };
         },
-        ["pending", "running", "timeout"],
       );
 
-      if (!transitioned) {
+    if (transitionResult.kind === "not-found") {
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Agent run not found", code: "NOT_FOUND" },
+        },
+      };
+    }
+
+    if (transitionResult.kind === "already-terminal") {
+      log.debug(
+        `Run ${body.runId} already ${transitionResult.status}, skipping duplicate completion`,
+      );
+      return {
+        status: 200 as const,
+        body: {
+          success: true,
+          status: transitionResult.status,
+        },
+      };
+    }
+
+    if (transitionResult.kind === "missing-checkpoint") {
+      // Dispatch callbacks so the user gets notified about the failure
+      // (previously this path returned without dispatching).
+      if (transitionResult.transitioned) {
+        await publishRunChangedForUserSafely(run.userId, body.runId, {
+          status: "failed",
+        });
+        scheduleTerminalSideEffects(
+          body.runId,
+          "failed",
+          run.orgId,
+          "Checkpoint for run not found",
+        );
+      }
+
+      return {
+        status: 404 as const,
+        body: {
+          error: {
+            message: "Checkpoint for run not found",
+            code: "NOT_FOUND",
+          },
+        },
+      };
+    }
+
+    if (transitionResult.kind === "skipped") {
+      if (transitionResult.status === "completed") {
         log.debug(
           `Run ${body.runId} already transitioned, skipping duplicate completion`,
         );
-        return {
-          status: 200 as const,
-          body: { success: true, status: "completed" as const },
-        };
-      }
-
-      await publishRunChangedForUserSafely(run.userId, body.runId, {
-        status: "completed",
-      });
-      finalResult = result;
-      finalStatus = "completed";
-      log.debug(`Run ${body.runId} completed successfully`);
-    } else {
-      // Failure: store error in run table
-      const reportUrl = `${env().NEXT_PUBLIC_APP_URL}/runs/${body.runId}/report-error`;
-      errorMessage = `An unexpected error occurred. [Report this issue](${reportUrl})`;
-
-      // Also accept "timeout" so the sandbox's own exit-code-based error
-      // (with the report-error link) supersedes a stale "Run timed out
-      // (no heartbeat)" stamped earlier by the cleanup cron.
-      const transitioned = await transitionRunStatus(
-        body.runId,
-        {
-          status: "failed",
-          completedAt: new Date(),
-          error: errorMessage,
-          sandboxId: body.sandboxId,
-          sandboxReuseResult: body.sandboxReuseResult,
-        },
-        ["pending", "running", "timeout"],
-      );
-
-      if (!transitioned) {
+      } else {
         log.debug(
           `Run ${body.runId} already transitioned, skipping duplicate failure`,
         );
-        return {
-          status: 200 as const,
-          body: { success: true, status: "failed" as const },
-        };
       }
+      return {
+        status: 200 as const,
+        body: { success: true, status: transitionResult.status },
+      };
+    }
 
-      const result = await buildRunResultForRun(body.runId);
-      if (result) {
-        finalResult = result;
-        await globalThis.services.db
-          .update(agentRuns)
-          .set({ result })
-          .where(
-            and(
-              eq(agentRuns.id, body.runId),
-              eq(agentRuns.status, "failed"),
-              isNull(agentRuns.result),
-            ),
-          );
-      }
+    const finalStatus =
+      transitionResult.kind === "completed" ? "completed" : "failed";
+    const errorMessage =
+      transitionResult.kind === "failed"
+        ? transitionResult.errorMessage
+        : undefined;
+    const finalResult = transitionResult.result;
+
+    if (finalStatus === "completed") {
+      await publishRunChangedForUserSafely(run.userId, body.runId, {
+        status: "completed",
+      });
+      log.debug(`Run ${body.runId} completed successfully`);
+    } else {
       await publishRunChangedForUserSafely(run.userId, body.runId, {
         status: "failed",
       });
-      finalStatus = "failed";
       log.warn(`Run ${body.runId} failed: ${errorMessage}`);
     }
 

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -14,7 +14,7 @@ import {
   dispatchTerminalSideEffects,
 } from "../../../../../src/lib/infra/run/run-status";
 import { getSandboxAuthForRun } from "../../../../../src/lib/auth/get-sandbox-auth";
-import { decodeToRecord } from "../../../../../src/lib/infra/checkpoint/decode-artifact-snapshots";
+import { buildRunResultFromCheckpoint } from "../../../../../src/lib/infra/run/run-result";
 import type { RunResult } from "../../../../../src/lib/infra/run/types";
 import { logger } from "../../../../../src/lib/shared/logger";
 import {
@@ -51,38 +51,6 @@ function scheduleTerminalSideEffects(
   });
 }
 
-/**
- * Build a RunResult from a checkpoint record.
- *
- * `checkpoint.artifactSnapshots` is a JSONB column (runtime type `unknown`)
- * that may contain either the legacy Record<name, version> shape or the
- * canonical Array<{name, version, mountPath}>. `RunResult.artifact` is still
- * Record-shaped for downstream consumers, so we project the array shape back
- * to Record on the way out. Empty payloads project to null and are dropped.
- */
-function buildRunResult(
-  checkpoint: typeof checkpoints.$inferSelect,
-  sessionId: string | undefined,
-): RunResult {
-  const artifactRecord = decodeToRecord(checkpoint.artifactSnapshots);
-  const volumeVersions = checkpoint.volumeVersionsSnapshot as
-    | { versions: Record<string, string> }
-    | undefined;
-
-  const result: RunResult = {
-    checkpointId: checkpoint.id,
-    agentSessionId: sessionId ?? checkpoint.conversationId,
-    conversationId: checkpoint.conversationId,
-    volumes: volumeVersions?.versions,
-  };
-
-  if (artifactRecord) {
-    result.artifact = artifactRecord;
-  }
-
-  return result;
-}
-
 async function buildRunResultForRun(
   runId: string,
 ): Promise<RunResult | undefined> {
@@ -103,7 +71,7 @@ async function buildRunResultForRun(
     .where(eq(agentSessions.conversationId, checkpoint.conversationId))
     .limit(1);
 
-  return buildRunResult(checkpoint, session?.id);
+  return buildRunResultFromCheckpoint(checkpoint, session?.id);
 }
 
 const router = tsr.router(webhookCompleteContract, {

--- a/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
@@ -94,6 +94,8 @@ export {
   findTestCallbacksByRunId,
   findMostRecentRunForUser,
   findTestSandboxTelemetry,
+  getTestBlobRefCount,
+  getTestConversationHistoryHash,
   createTestRun,
   getTestRun,
   createTestCheckpoint,

--- a/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
@@ -94,6 +94,7 @@ export {
   findTestCallbacksByRunId,
   findMostRecentRunForUser,
   findTestSandboxTelemetry,
+  getTestBlobRecord,
   getTestBlobRefCount,
   getTestConversationHistoryHash,
   createTestRun,

--- a/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
@@ -35,6 +35,7 @@ export {
   findTestCallbacksByRunId,
   findMostRecentRunForUser,
   findTestSandboxTelemetry,
+  getTestBlobRecord,
   getTestBlobRefCount,
   getTestConversationHistoryHash,
 } from "../db-test-assertions/runs";

--- a/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
@@ -35,6 +35,8 @@ export {
   findTestCallbacksByRunId,
   findMostRecentRunForUser,
   findTestSandboxTelemetry,
+  getTestBlobRefCount,
+  getTestConversationHistoryHash,
 } from "../db-test-assertions/runs";
 
 export async function createTestRun(

--- a/turbo/apps/web/src/__tests__/db-test-assertions/runs.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/runs.ts
@@ -181,6 +181,21 @@ export async function getTestBlobRefCount(
 }
 
 /**
+ * Read blob metadata for checkpoint/session-history reference tests.
+ */
+export async function getTestBlobRecord(
+  hash: string,
+): Promise<{ refCount: number; size: number } | undefined> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({ refCount: blobs.refCount, size: blobs.size })
+    .from(blobs)
+    .where(eq(blobs.hash, hash))
+    .limit(1);
+  return row;
+}
+
+/**
  * Read the persisted session-history blob hash for a run conversation.
  */
 export async function getTestConversationHistoryHash(

--- a/turbo/apps/web/src/__tests__/db-test-assertions/runs.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/runs.ts
@@ -6,6 +6,8 @@ import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { sandboxTelemetry } from "@vm0/db/schema/sandbox-telemetry";
+import { blobs } from "@vm0/db/schema/blob";
+import { conversations } from "@vm0/db/schema/conversation";
 
 /**
  * Find agent runs matching a given userId and prompt.
@@ -161,4 +163,34 @@ export async function findTestCheckpoint(
     .where(eq(checkpoints.runId, runId))
     .limit(1);
   return row;
+}
+
+/**
+ * Read a blob ref_count for checkpoint/session-history reference tests.
+ */
+export async function getTestBlobRefCount(
+  hash: string,
+): Promise<number | undefined> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({ refCount: blobs.refCount })
+    .from(blobs)
+    .where(eq(blobs.hash, hash))
+    .limit(1);
+  return row?.refCount;
+}
+
+/**
+ * Read the persisted session-history blob hash for a run conversation.
+ */
+export async function getTestConversationHistoryHash(
+  runId: string,
+): Promise<string | null | undefined> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({ hash: conversations.cliAgentSessionHistoryHash })
+    .from(conversations)
+    .where(eq(conversations.runId, runId))
+    .limit(1);
+  return row?.hash;
 }

--- a/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
@@ -844,6 +844,171 @@ export async function insertTestUsageDaily(params: {
   });
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForBlockedAgentRunsQuery(params: {
+  lockingBackendPid: number;
+  hasOperationSettled: () => boolean;
+  getOperationError: () => unknown;
+}): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (params.hasOperationSettled()) {
+      const operationError = params.getOperationError();
+      if (operationError) {
+        throw operationError;
+      }
+      throw new Error(
+        "operation completed before waiting on the held agent_runs lock",
+      );
+    }
+
+    const [row] = await globalThis.services.db
+      .select({
+        blocked: sql<boolean>`EXISTS (
+          SELECT 1
+          FROM pg_locks l
+          JOIN pg_stat_activity a ON a.pid = l.pid
+          WHERE NOT l.granted
+            AND a.datname = current_database()
+            AND ${params.lockingBackendPid} = ANY(pg_blocking_pids(a.pid))
+            AND a.query ILIKE '%agent_runs%'
+        )`,
+      })
+      .from(agentRuns)
+      .limit(1);
+
+    if (row?.blocked) {
+      return;
+    }
+
+    await sleep(10);
+  }
+
+  throw new Error("operation did not wait for held agent_runs lock");
+}
+
+/**
+ * Seed a checkpoint inside an uncommitted transaction, start an operation, and
+ * only commit after the operation is blocked on the same `agent_runs` row.
+ *
+ * @why-db-direct This creates a precise concurrency shape for webhook tests:
+ * the checkpoint exists but is still invisible until the tested operation
+ * waits on the run row lock. There is no API-only way to hold that transaction
+ * boundary open while invoking the route under test.
+ */
+export async function seedInFlightCheckpointWhileAgentRunLocked<T>(params: {
+  runId: string;
+  cliAgentSessionId: string;
+  cliAgentSessionHistoryHash: string;
+  artifactSnapshots: ContextArtifact[];
+  startWhileLocked: () => Promise<T>;
+}): Promise<{
+  checkpointId: string;
+  conversationId: string;
+  result: T;
+}> {
+  initServices();
+
+  let checkpointId: string | undefined;
+  let conversationId: string | undefined;
+  let operationError: unknown;
+  let operationSettled = false;
+  let operationPromise: Promise<T> | undefined;
+
+  try {
+    await globalThis.services.db.transaction(async (tx) => {
+      const [run] = await tx
+        .select()
+        .from(agentRuns)
+        .where(eq(agentRuns.id, params.runId))
+        .for("update")
+        .limit(1);
+
+      if (!run?.agentComposeVersionId) {
+        throw new Error("test run is missing agentComposeVersionId");
+      }
+      const [lockingBackend] = await tx
+        .select({ pid: sql<number>`pg_backend_pid()` })
+        .from(agentRuns)
+        .where(eq(agentRuns.id, params.runId))
+        .limit(1);
+      if (!lockingBackend) {
+        throw new Error("failed to read locking transaction backend pid");
+      }
+
+      const [conversation] = await tx
+        .insert(conversations)
+        .values({
+          runId: params.runId,
+          cliAgentType: "claude-code",
+          cliAgentSessionId: params.cliAgentSessionId,
+          cliAgentSessionHistoryHash: params.cliAgentSessionHistoryHash,
+        })
+        .returning({ id: conversations.id });
+
+      if (!conversation) {
+        throw new Error("failed to seed in-flight conversation");
+      }
+
+      const [checkpoint] = await tx
+        .insert(checkpoints)
+        .values({
+          runId: params.runId,
+          conversationId: conversation.id,
+          agentComposeSnapshot: {
+            agentComposeVersionId: run.agentComposeVersionId,
+          },
+          artifactSnapshots: params.artifactSnapshots,
+          volumeVersionsSnapshot: null,
+        })
+        .returning({ id: checkpoints.id });
+
+      if (!checkpoint) {
+        throw new Error("failed to seed in-flight checkpoint");
+      }
+
+      await tx
+        .update(agentSessions)
+        .set({
+          conversationId: conversation.id,
+          updatedAt: new Date(),
+        })
+        .where(eq(agentSessions.id, run.sessionId));
+
+      checkpointId = checkpoint.id;
+      conversationId = conversation.id;
+      operationPromise = Promise.resolve()
+        .then(params.startWhileLocked)
+        .catch((error: unknown) => {
+          operationError = error;
+          throw error;
+        })
+        .finally(() => {
+          operationSettled = true;
+        });
+      void operationPromise.catch(() => {});
+
+      await waitForBlockedAgentRunsQuery({
+        lockingBackendPid: lockingBackend.pid,
+        hasOperationSettled: () => operationSettled,
+        getOperationError: () => operationError,
+      });
+    });
+  } catch (error) {
+    await operationPromise?.catch(() => {});
+    throw error;
+  }
+
+  if (!operationPromise || !checkpointId || !conversationId) {
+    throw new Error("failed to seed in-flight checkpoint");
+  }
+
+  const result = await operationPromise;
+  return { checkpointId, conversationId, result };
+}
+
 /**
  * Seed a checkpoint row directly with the given `artifact_snapshots`.
  *

--- a/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
@@ -921,3 +921,22 @@ export async function setTestCheckpointArtifactSnapshots(
     WHERE id = ${checkpointId}::uuid
   `);
 }
+
+/**
+ * Overwrite `checkpoints.agent_compose_snapshot` JSONB for a checkpoint.
+ *
+ * @why-db-direct Resolver auth-order tests need to seed malformed checkpoint
+ * internals and verify unauthorized callers do not observe shape errors.
+ */
+export async function setTestCheckpointAgentComposeSnapshot(
+  checkpointId: string,
+  snapshot: unknown,
+): Promise<void> {
+  initServices();
+  const payload = JSON.stringify(snapshot);
+  await globalThis.services.db.execute(sql`
+    UPDATE checkpoints
+    SET agent_compose_snapshot = ${payload}::jsonb
+    WHERE id = ${checkpointId}::uuid
+  `);
+}

--- a/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
@@ -845,7 +845,9 @@ export async function insertTestUsageDaily(params: {
 }
 
 function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 async function waitForBlockedAgentRunsQuery(params: {
@@ -992,8 +994,12 @@ export async function seedInFlightCheckpointWhileAgentRunLocked<T>(params: {
 
       await waitForBlockedAgentRunsQuery({
         lockingBackendPid: lockingBackend.pid,
-        hasOperationSettled: () => operationSettled,
-        getOperationError: () => operationError,
+        hasOperationSettled: () => {
+          return operationSettled;
+        },
+        getOperationError: () => {
+          return operationError;
+        },
       });
     });
   } catch (error) {

--- a/turbo/apps/web/src/lib/infra/agent-session/agent-session-service.ts
+++ b/turbo/apps/web/src/lib/infra/agent-session/agent-session-service.ts
@@ -1,7 +1,6 @@
 import { eq } from "drizzle-orm";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { conversations } from "@vm0/db/schema/conversation";
-import { notFound } from "@vm0/api-services/errors";
 import type { AgentSessionData, AgentSessionWithConversation } from "./types";
 
 /**
@@ -45,29 +44,6 @@ export async function getAgentSessionWithConversation(
         }
       : null,
   };
-}
-
-/**
- * Update an existing agent session's conversation reference.
- */
-export async function updateAgentSession(
-  id: string,
-  conversationId: string,
-): Promise<AgentSessionData> {
-  const [session] = await globalThis.services.db
-    .update(agentSessions)
-    .set({
-      conversationId,
-      updatedAt: new Date(),
-    })
-    .where(eq(agentSessions.id, id))
-    .returning();
-
-  if (!session) {
-    throw notFound("AgentSession not found");
-  }
-
-  return mapToAgentSessionData(session);
 }
 
 function mapToAgentSessionData(

--- a/turbo/apps/web/src/lib/infra/agent-session/index.ts
+++ b/turbo/apps/web/src/lib/infra/agent-session/index.ts
@@ -1,4 +1,1 @@
-export {
-  getAgentSessionWithConversation,
-  updateAgentSession,
-} from "./agent-session-service";
+export { getAgentSessionWithConversation } from "./agent-session-service";

--- a/turbo/apps/web/src/lib/infra/callback/dispatcher.ts
+++ b/turbo/apps/web/src/lib/infra/callback/dispatcher.ts
@@ -41,7 +41,7 @@ export function getApiUrl(): string {
 export async function dispatchCallbacks(
   runId: string,
   status: "completed" | "failed",
-  result?: Record<string, unknown>,
+  result?: unknown,
   error?: string,
 ): Promise<DispatchResult[]> {
   const { SECRETS_ENCRYPTION_KEY } = env();
@@ -103,7 +103,7 @@ async function dispatchSingleCallback(
   callback: CallbackRecord,
   runId: string,
   status: "completed" | "failed",
-  result: Record<string, unknown> | undefined,
+  result: unknown,
   error: string | undefined,
   encryptionKey: string,
 ): Promise<DispatchResult> {

--- a/turbo/apps/web/src/lib/infra/callback/verify-callback.ts
+++ b/turbo/apps/web/src/lib/infra/callback/verify-callback.ts
@@ -19,7 +19,7 @@ interface VerifiedCallback<P = unknown> {
   callbackId?: string;
   runId: string;
   status: "completed" | "failed" | "progress";
-  result?: Record<string, unknown>;
+  result?: unknown;
   error?: string;
   payload: P;
 }
@@ -53,7 +53,7 @@ export async function verifyCallback<P = unknown>(
     callbackId?: string;
     runId?: string;
     status: "completed" | "failed" | "progress";
-    result?: Record<string, unknown>;
+    result?: unknown;
     error?: string;
     payload: P;
   };

--- a/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { conversations } from "@vm0/db/schema/conversation";
@@ -16,6 +16,8 @@ import {
   decodeToContextArtifacts,
   isEmptyArtifactPayload,
 } from "./decode-artifact-snapshots";
+import { buildRunResultFromCheckpoint } from "../run/run-result";
+import { CHECKPOINT_RESUMABLE_RUN_STATUSES } from "../run/types";
 
 const log = logger("checkpoint");
 
@@ -62,12 +64,6 @@ export async function createCheckpoint(
   log.debug(
     `Creating conversation record for CLI agent: ${request.cliAgentType}`,
   );
-
-  // Register session history blob (content already uploaded via presigned URL)
-  const historyHash = await registerSessionHistoryBlob(
-    request.cliAgentSessionHistoryHash,
-  );
-  log.debug(`Session history blob registered, hash=${historyHash}`);
 
   // Build agent compose snapshot using version ID for reproducibility
   // Environment is re-expanded from vars/secrets on resume
@@ -136,6 +132,13 @@ export async function createCheckpoint(
       // Upsert conversation, checkpoint, and session link together. A failed
       // session update must not leave a checkpoint row that normal sessionId
       // continuation cannot discover.
+      // Register session history blob (content already uploaded via presigned URL).
+      const historyHash = await registerSessionHistoryBlob(
+        request.cliAgentSessionHistoryHash,
+        tx,
+      );
+      log.debug(`Session history blob registered, hash=${historyHash}`);
+
       const [conversation] = await tx
         .insert(conversations)
         .values({
@@ -198,6 +201,23 @@ export async function createCheckpoint(
       if (!agentSession) {
         throw notFound("AgentSession not found");
       }
+
+      // If /complete or cleanup already made the run terminal before this
+      // checkpoint webhook arrived, backfill result so events/session consumers
+      // can still discover the recoverable checkpoint. Normal ordering is still
+      // checkpoint -> complete; this only covers webhook retry/reordering edges.
+      await tx
+        .update(agentRuns)
+        .set({
+          result: buildRunResultFromCheckpoint(checkpoint, agentSession.id),
+        })
+        .where(
+          and(
+            eq(agentRuns.id, request.runId),
+            inArray(agentRuns.status, CHECKPOINT_RESUMABLE_RUN_STATUSES),
+            isNull(agentRuns.result),
+          ),
+        );
 
       return { conversation, checkpoint, agentSession };
     });

--- a/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
@@ -4,7 +4,7 @@ import { agentSessions } from "@vm0/db/schema/agent-session";
 import { conversations } from "@vm0/db/schema/conversation";
 import { checkpoints } from "@vm0/db/schema/checkpoint";
 import { notFound } from "@vm0/api-services/errors";
-import { registerSessionHistoryBlob } from "../session-history";
+import { replaceSessionHistoryBlobReference } from "../session-history";
 import { logger } from "../../shared/logger";
 import type {
   CheckpointRequest,
@@ -170,12 +170,21 @@ export async function createCheckpoint(
         > | null,
       };
 
+      const [existingConversation] = await tx
+        .select({
+          cliAgentSessionHistoryHash: conversations.cliAgentSessionHistoryHash,
+        })
+        .from(conversations)
+        .where(eq(conversations.runId, request.runId))
+        .limit(1);
+
       // Upsert conversation, checkpoint, and session link together. A failed
       // session update must not leave a checkpoint row that normal sessionId
       // continuation cannot discover.
       // Register session history blob (content already uploaded via presigned URL).
-      const historyHash = await registerSessionHistoryBlob(
+      const historyHash = await replaceSessionHistoryBlobReference(
         request.cliAgentSessionHistoryHash,
+        existingConversation?.cliAgentSessionHistoryHash,
         tx,
       );
       log.debug(`Session history blob registered, hash=${historyHash}`);

--- a/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
@@ -1,9 +1,9 @@
 import { and, eq } from "drizzle-orm";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { conversations } from "@vm0/db/schema/conversation";
 import { checkpoints } from "@vm0/db/schema/checkpoint";
 import { notFound } from "@vm0/api-services/errors";
-import { updateAgentSession } from "../agent-session";
 import { registerSessionHistoryBlob } from "../session-history";
 import { logger } from "../../shared/logger";
 import type {
@@ -69,31 +69,6 @@ export async function createCheckpoint(
   );
   log.debug(`Session history blob registered, hash=${historyHash}`);
 
-  // Upsert conversation record (handles retries atomically)
-  const [conversation] = await globalThis.services.db
-    .insert(conversations)
-    .values({
-      runId: request.runId,
-      cliAgentType: request.cliAgentType,
-      cliAgentSessionId: request.cliAgentSessionId,
-      cliAgentSessionHistoryHash: historyHash,
-    })
-    .onConflictDoUpdate({
-      target: conversations.runId,
-      set: {
-        cliAgentType: request.cliAgentType,
-        cliAgentSessionId: request.cliAgentSessionId,
-        cliAgentSessionHistoryHash: historyHash,
-      },
-    })
-    .returning();
-
-  if (!conversation) {
-    throw new Error("Failed to upsert conversation record");
-  }
-
-  log.debug(`Conversation created: ${conversation.id}, storing checkpoint...`);
-
   // Build agent compose snapshot using version ID for reproducibility
   // Environment is re-expanded from vars/secrets on resume
   // Note: secrets values are NEVER stored - only names for validation
@@ -145,7 +120,6 @@ export async function createCheckpoint(
     : decodeToContextArtifacts(rawPayload);
 
   const snapshotFields = {
-    conversationId: conversation.id,
     agentComposeSnapshot: agentComposeSnapshot as unknown as Record<
       string,
       unknown
@@ -157,38 +131,83 @@ export async function createCheckpoint(
     > | null,
   };
 
-  const [checkpoint] = await globalThis.services.db
-    .insert(checkpoints)
-    .values({
-      runId: request.runId,
-      ...snapshotFields,
-    })
-    .onConflictDoUpdate({
-      target: checkpoints.runId,
-      set: snapshotFields,
-    })
-    .returning();
+  const { conversation, checkpoint, agentSession } =
+    await globalThis.services.db.transaction(async (tx) => {
+      // Upsert conversation, checkpoint, and session link together. A failed
+      // session update must not leave a checkpoint row that normal sessionId
+      // continuation cannot discover.
+      const [conversation] = await tx
+        .insert(conversations)
+        .values({
+          runId: request.runId,
+          cliAgentType: request.cliAgentType,
+          cliAgentSessionId: request.cliAgentSessionId,
+          cliAgentSessionHistoryHash: historyHash,
+        })
+        .onConflictDoUpdate({
+          target: conversations.runId,
+          set: {
+            cliAgentType: request.cliAgentType,
+            cliAgentSessionId: request.cliAgentSessionId,
+            cliAgentSessionHistoryHash: historyHash,
+          },
+        })
+        .returning();
 
-  if (!checkpoint) {
-    throw new Error("Failed to upsert checkpoint record");
-  }
+      if (!conversation) {
+        throw new Error("Failed to upsert conversation record");
+      }
+
+      log.debug(
+        `Conversation created: ${conversation.id}, storing checkpoint...`,
+      );
+
+      const [checkpoint] = await tx
+        .insert(checkpoints)
+        .values({
+          runId: request.runId,
+          conversationId: conversation.id,
+          ...snapshotFields,
+        })
+        .onConflictDoUpdate({
+          target: checkpoints.runId,
+          set: {
+            conversationId: conversation.id,
+            ...snapshotFields,
+          },
+        })
+        .returning();
+
+      if (!checkpoint) {
+        throw new Error("Failed to upsert checkpoint record");
+      }
+
+      if (!run.sessionId) {
+        throw notFound("Agent run has no session_id");
+      }
+
+      const [agentSession] = await tx
+        .update(agentSessions)
+        .set({
+          conversationId: conversation.id,
+          updatedAt: new Date(),
+        })
+        .where(eq(agentSessions.id, run.sessionId))
+        .returning();
+
+      if (!agentSession) {
+        throw notFound("AgentSession not found");
+      }
+
+      return { conversation, checkpoint, agentSession };
+    });
 
   log.debug(`Checkpoint created successfully: ${checkpoint.id}`);
+  log.debug(`Agent session updated/created: ${agentSession.id}`);
 
-  // Bind the pre-created agent session (always populated since #10323 made
-  // agent_runs.session_id NOT NULL) to this conversation and record per-run
-  // snapshot fields that were not known when the session was created eagerly
-  // at run insertion.
   const volumeSnapshot = request.volumeVersionsSnapshot as
     | VolumeVersionsSnapshot
     | undefined;
-
-  if (!run.sessionId) {
-    throw notFound("Agent run has no session_id");
-  }
-  const agentSession = await updateAgentSession(run.sessionId, conversation.id);
-
-  log.debug(`Agent session updated/created: ${agentSession.id}`);
 
   // Use volume versions from snapshot for return value
   const volumes = volumeSnapshot?.versions;

--- a/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
@@ -185,6 +185,7 @@ export async function createCheckpoint(
       const historyHash = await replaceSessionHistoryBlobReference(
         request.cliAgentSessionHistoryHash,
         existingConversation?.cliAgentSessionHistoryHash,
+        request.cliAgentSessionHistorySize,
         tx,
       );
       log.debug(`Session history blob registered, hash=${historyHash}`);

--- a/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/checkpoint-service.ts
@@ -17,7 +17,10 @@ import {
   isEmptyArtifactPayload,
 } from "./decode-artifact-snapshots";
 import { buildRunResultFromCheckpoint } from "../run/run-result";
-import { CHECKPOINT_RESUMABLE_RUN_STATUSES } from "../run/types";
+import {
+  CHECKPOINT_RESUMABLE_RUN_STATUSES,
+  isCheckpointResumableRunStatus,
+} from "../run/types";
 
 const log = logger("checkpoint");
 
@@ -42,93 +45,131 @@ export async function createCheckpoint(
 ): Promise<CheckpointResponse> {
   log.debug(`Creating checkpoint for run ${request.runId}`);
 
-  // Fetch agent run from database
-  const [run] = await globalThis.services.db
-    .select()
-    .from(agentRuns)
-    .where(and(eq(agentRuns.id, request.runId), eq(agentRuns.userId, userId)))
-    .limit(1);
-
-  if (!run) {
-    throw notFound("Agent run not found");
-  }
-
-  // agentComposeVersionId may be null if agent was deleted (historical runs)
-  // but during active run execution it should always be present
-  if (!run.agentComposeVersionId) {
-    throw notFound(
-      "Agent compose version not found (agent may have been deleted)",
-    );
-  }
-
-  log.debug(
-    `Creating conversation record for CLI agent: ${request.cliAgentType}`,
-  );
-
-  // Build agent compose snapshot using version ID for reproducibility
-  // Environment is re-expanded from vars/secrets on resume
-  // Note: secrets values are NEVER stored - only names for validation
-  const agentComposeSnapshot: AgentComposeSnapshot = {
-    agentComposeVersionId: run.agentComposeVersionId,
-    vars: (run.vars as Record<string, string>) || undefined,
-    secretNames: (run.secretNames as string[]) || undefined,
-  };
-
-  // Enrich volume versions snapshot with additional volumes from run record
-  const runAdditionalVolumes = run.additionalVolumes as Array<{
-    name: string;
-    version?: string;
-    mountPath: string;
-  }> | null;
-
-  const enrichedVolumeSnapshot = request.volumeVersionsSnapshot
-    ? {
-        versions: request.volumeVersionsSnapshot.versions,
-        ...(runAdditionalVolumes && runAdditionalVolumes.length > 0
-          ? {
-              additionalVolumes: runAdditionalVolumes.map((vol) => {
-                const versionId =
-                  request.volumeVersionsSnapshot!.versions[vol.name] ??
-                  vol.version;
-                if (!versionId) {
-                  log.warn(
-                    `Additional volume "${vol.name}" has no resolved version from runner and no version specified at run time, defaulting to "latest"`,
-                  );
-                }
-                return {
-                  name: vol.name,
-                  versionId: versionId ?? "latest",
-                  mountPath: vol.mountPath,
-                };
-              }),
-            }
-          : {}),
-      }
-    : null;
-
-  // Normalise the artifactSnapshots payload before persisting. The webhook
-  // contract now only accepts the canonical Array<{name, version, mountPath}>
-  // shape; empty payloads (null, []) collapse to NULL so "no artifacts" has
-  // a single on-disk representation.
-  const rawPayload = request.artifactSnapshots ?? null;
-  const artifactSnapshotsForDb = isEmptyArtifactPayload(rawPayload)
-    ? null
-    : decodeToContextArtifacts(rawPayload);
-
-  const snapshotFields = {
-    agentComposeSnapshot: agentComposeSnapshot as unknown as Record<
-      string,
-      unknown
-    >,
-    artifactSnapshots: artifactSnapshotsForDb,
-    volumeVersionsSnapshot: enrichedVolumeSnapshot as unknown as Record<
-      string,
-      unknown
-    > | null,
-  };
-
   const { conversation, checkpoint, agentSession } =
     await globalThis.services.db.transaction(async (tx) => {
+      // Serialize checkpoint writes with terminal status transitions for this
+      // run. Without this lock, two late checkpoint requests can both observe
+      // result=NULL, then the loser can overwrite the checkpoint row after the
+      // winner already published agent_runs.result.
+      const [run] = await tx
+        .select()
+        .from(agentRuns)
+        .where(
+          and(eq(agentRuns.id, request.runId), eq(agentRuns.userId, userId)),
+        )
+        .for("update")
+        .limit(1);
+
+      if (!run) {
+        throw notFound("Agent run not found");
+      }
+
+      if (isCheckpointResumableRunStatus(run.status) && run.result !== null) {
+        const [checkpoint] = await tx
+          .select()
+          .from(checkpoints)
+          .where(eq(checkpoints.runId, request.runId))
+          .limit(1);
+        if (!checkpoint) {
+          throw notFound("Checkpoint not found for terminal run");
+        }
+
+        const [conversation] = await tx
+          .select()
+          .from(conversations)
+          .where(eq(conversations.id, checkpoint.conversationId))
+          .limit(1);
+        if (!conversation) {
+          throw notFound("Conversation not found for terminal run");
+        }
+
+        const [agentSession] = await tx
+          .select()
+          .from(agentSessions)
+          .where(eq(agentSessions.id, run.sessionId))
+          .limit(1);
+        if (!agentSession) {
+          throw notFound("AgentSession not found");
+        }
+
+        return { conversation, checkpoint, agentSession };
+      }
+
+      // agentComposeVersionId may be null if agent was deleted (historical
+      // runs) but during active run execution it should always be present.
+      if (!run.agentComposeVersionId) {
+        throw notFound(
+          "Agent compose version not found (agent may have been deleted)",
+        );
+      }
+
+      log.debug(
+        `Creating conversation record for CLI agent: ${request.cliAgentType}`,
+      );
+
+      // Build agent compose snapshot using version ID for reproducibility.
+      // Environment is re-expanded from vars/secrets on resume.
+      // Note: secrets values are NEVER stored - only names for validation.
+      const agentComposeSnapshot: AgentComposeSnapshot = {
+        agentComposeVersionId: run.agentComposeVersionId,
+        vars: (run.vars as Record<string, string>) || undefined,
+        secretNames: (run.secretNames as string[]) || undefined,
+      };
+
+      // Enrich volume versions snapshot with additional volumes from run
+      // record.
+      const runAdditionalVolumes = run.additionalVolumes as Array<{
+        name: string;
+        version?: string;
+        mountPath: string;
+      }> | null;
+
+      const enrichedVolumeSnapshot = request.volumeVersionsSnapshot
+        ? {
+            versions: request.volumeVersionsSnapshot.versions,
+            ...(runAdditionalVolumes && runAdditionalVolumes.length > 0
+              ? {
+                  additionalVolumes: runAdditionalVolumes.map((vol) => {
+                    const versionId =
+                      request.volumeVersionsSnapshot!.versions[vol.name] ??
+                      vol.version;
+                    if (!versionId) {
+                      log.warn(
+                        `Additional volume "${vol.name}" has no resolved version from runner and no version specified at run time, defaulting to "latest"`,
+                      );
+                    }
+                    return {
+                      name: vol.name,
+                      versionId: versionId ?? "latest",
+                      mountPath: vol.mountPath,
+                    };
+                  }),
+                }
+              : {}),
+          }
+        : null;
+
+      // Normalise the artifactSnapshots payload before persisting. The webhook
+      // contract now only accepts the canonical Array<{name, version,
+      // mountPath}> shape; empty payloads (null, []) collapse to NULL so "no
+      // artifacts" has a single on-disk representation.
+      const rawPayload = request.artifactSnapshots ?? null;
+      const artifactSnapshotsForDb = isEmptyArtifactPayload(rawPayload)
+        ? null
+        : decodeToContextArtifacts(rawPayload);
+
+      const snapshotFields = {
+        agentComposeSnapshot: agentComposeSnapshot as unknown as Record<
+          string,
+          unknown
+        >,
+        artifactSnapshots: artifactSnapshotsForDb,
+        volumeVersionsSnapshot: enrichedVolumeSnapshot as unknown as Record<
+          string,
+          unknown
+        > | null,
+      };
+
       // Upsert conversation, checkpoint, and session link together. A failed
       // session update must not leave a checkpoint row that normal sessionId
       // continuation cannot discover.
@@ -225,17 +266,19 @@ export async function createCheckpoint(
   log.debug(`Checkpoint created successfully: ${checkpoint.id}`);
   log.debug(`Agent session updated/created: ${agentSession.id}`);
 
-  const volumeSnapshot = request.volumeVersionsSnapshot as
-    | VolumeVersionsSnapshot
-    | undefined;
+  const volumeSnapshot =
+    checkpoint.volumeVersionsSnapshot as VolumeVersionsSnapshot | null;
 
-  // Use volume versions from snapshot for return value
+  // Use persisted volume versions for return value.
   const volumes = volumeSnapshot?.versions;
 
   // Echo back the persisted canonical shape. The webhook contract requires
   // `version` on every entry, so the undefined-branch assertion guards
   // against a ContextArtifact leaking in from a non-webhook caller.
-  const responseArtifacts = artifactSnapshotsForDb?.map((entry) => {
+  const responseArtifactsRaw = decodeToContextArtifacts(
+    checkpoint.artifactSnapshots,
+  );
+  const responseArtifacts = responseArtifactsRaw.map((entry) => {
     if (entry.version === undefined) {
       throw new Error(
         `Invalid checkpoint: artifact "${entry.name}" missing version after normalisation`,
@@ -252,7 +295,7 @@ export async function createCheckpoint(
     checkpointId: checkpoint.id,
     agentSessionId: agentSession.id,
     conversationId: conversation.id,
-    artifacts: responseArtifacts,
+    artifacts: responseArtifacts.length > 0 ? responseArtifacts : undefined,
     volumes,
   };
 }

--- a/turbo/apps/web/src/lib/infra/checkpoint/types.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/types.ts
@@ -49,6 +49,7 @@ export interface CheckpointRequest {
   cliAgentType: string;
   cliAgentSessionId: string;
   cliAgentSessionHistoryHash: string;
+  cliAgentSessionHistorySize?: number;
   // Multi-artifact snapshot payload. Canonical array shape only; persisted
   // verbatim to the JSONB column. May be empty or missing when the guest
   // snapshotted nothing.

--- a/turbo/apps/web/src/lib/infra/run/__tests__/run-status.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/run-status.test.ts
@@ -6,10 +6,14 @@ import {
 } from "../../../../__tests__/test-helpers";
 import {
   createTestCompose,
+  createTestCheckpoint,
   findTestRunRecord,
 } from "../../../../__tests__/api-test-helpers";
 import { transitionRunStatus } from "../run-status";
-import { seedTestRun } from "../../../../__tests__/db-test-seeders/runs";
+import {
+  seedInFlightCheckpointWhileAgentRunLocked,
+  seedTestRun,
+} from "../../../../__tests__/db-test-seeders/runs";
 
 const context = testContext();
 
@@ -106,5 +110,71 @@ describe("transitionRunStatus", () => {
 
     const run = await findTestRunRecord(runId);
     expect(["completed", "failed"]).toContain(run!.status);
+  });
+
+  it("should attach an existing checkpoint result on terminal transition", async () => {
+    const { runId } = await seedTestRun(user.userId, composeId, {
+      status: "running",
+    });
+    const checkpoint = await createTestCheckpoint(user.userId, runId);
+
+    const result = await transitionRunStatus(
+      runId,
+      { status: "timeout", completedAt: new Date() },
+      ["pending", "running"],
+    );
+
+    expect(result).toBe(true);
+    const run = await findTestRunRecord(runId);
+    expect(run!.status).toBe("timeout");
+    expect(run!.result).toMatchObject({
+      checkpointId: checkpoint.checkpointId,
+      agentSessionId: checkpoint.agentSessionId,
+      conversationId: checkpoint.conversationId,
+    });
+  });
+
+  it("should wait for in-flight checkpoint before terminal transition", async () => {
+    const { runId } = await seedTestRun(user.userId, composeId, {
+      status: "running",
+    });
+    const artifactSnapshots = [
+      {
+        name: "test-artifact",
+        version: "v1",
+        mountPath: "/home/user/workspace",
+      },
+    ];
+
+    const {
+      checkpointId,
+      conversationId,
+      result: transitioned,
+    } = await seedInFlightCheckpointWhileAgentRunLocked({
+      runId,
+      cliAgentSessionId: "in-flight-checkpoint-session",
+      cliAgentSessionHistoryHash:
+        "ec3ac9679505be3bb8233c4ef0b39c8ee206d2c37fc8610edc19f41fbfb9661e",
+      artifactSnapshots,
+      startWhileLocked: () => {
+        return transitionRunStatus(
+          runId,
+          { status: "cancelled", completedAt: new Date() },
+          ["pending", "running"],
+        );
+      },
+    });
+
+    expect(transitioned).toBe(true);
+    const run = await findTestRunRecord(runId);
+    expect(run!.status).toBe("cancelled");
+    expect(run!.result).toMatchObject({
+      checkpointId,
+      agentSessionId: run!.sessionId,
+      conversationId,
+      artifact: {
+        "test-artifact": "v1",
+      },
+    });
   });
 });

--- a/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-checkpoint.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-checkpoint.test.ts
@@ -6,7 +6,10 @@ import {
   createTestRun,
   setTestRunStatus,
 } from "../../../../../__tests__/api-test-helpers";
-import { setTestCheckpointArtifactSnapshots } from "../../../../../__tests__/db-test-seeders/runs";
+import {
+  setTestCheckpointAgentComposeSnapshot,
+  setTestCheckpointArtifactSnapshots,
+} from "../../../../../__tests__/db-test-seeders/runs";
 import {
   testContext,
   uniqueId,
@@ -79,6 +82,13 @@ describe("resolveCheckpoint — artifactSnapshots decoding", () => {
     await expect(resolveCheckpoint(checkpointId, user.userId)).rejects.toThrow(
       /not ready to resume/,
     );
+    await expect(
+      resolveCheckpoint(checkpointId, user.userId),
+    ).rejects.toMatchObject({
+      name: "ConflictError",
+      code: "CONFLICT",
+      statusCode: 409,
+    });
   });
 
   it("allows terminal failed checkpoints", async () => {
@@ -89,5 +99,26 @@ describe("resolveCheckpoint — artifactSnapshots decoding", () => {
     const resolution = await resolveCheckpoint(checkpointId, user.userId);
 
     expect(resolution.conversationId).toBeDefined();
+  });
+
+  it("checks ownership before exposing malformed checkpoint snapshot errors", async () => {
+    const otherUser = await context.setupUser({ prefix: "other-cp" });
+    const otherCompose = await createTestCompose(uniqueId("other-cp"));
+    const { runId } = await createTestRun(
+      otherCompose.composeId,
+      "foreign malformed checkpoint run",
+    );
+    const { checkpointId } = await createTestCheckpoint(
+      otherUser.userId,
+      runId,
+    );
+    await setTestCheckpointAgentComposeSnapshot(checkpointId, {});
+
+    await expect(
+      resolveCheckpoint(checkpointId, user.userId),
+    ).rejects.toMatchObject({
+      name: "UnauthorizedError",
+      code: "UNAUTHORIZED",
+    });
   });
 });

--- a/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-checkpoint.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-checkpoint.test.ts
@@ -4,6 +4,7 @@ import {
   createTestCheckpoint,
   createTestCompose,
   createTestRun,
+  setTestRunStatus,
 } from "../../../../../__tests__/api-test-helpers";
 import { setTestCheckpointArtifactSnapshots } from "../../../../../__tests__/db-test-seeders/runs";
 import {
@@ -29,6 +30,7 @@ describe("resolveCheckpoint — artifactSnapshots decoding", () => {
   it("passes canonical ContextArtifact[] through unchanged", async () => {
     const { runId } = await createTestRun(composeId, "new shape run");
     const { checkpointId } = await createTestCheckpoint(user.userId, runId);
+    await setTestRunStatus(runId, "completed");
 
     const newShape: ContextArtifact[] = [
       { name: "m", version: "v", mountPath: "/custom/mount" },
@@ -45,6 +47,7 @@ describe("resolveCheckpoint — artifactSnapshots decoding", () => {
   it("returns empty artifact list when artifactSnapshots is null", async () => {
     const { runId } = await createTestRun(composeId, "null snapshot run");
     const { checkpointId } = await createTestCheckpoint(user.userId, runId);
+    await setTestRunStatus(runId, "completed");
 
     await setTestCheckpointArtifactSnapshots(checkpointId, null);
 
@@ -56,6 +59,7 @@ describe("resolveCheckpoint — artifactSnapshots decoding", () => {
   it("rejects malformed array entries with a descriptive error", async () => {
     const { runId } = await createTestRun(composeId, "malformed array run");
     const { checkpointId } = await createTestCheckpoint(user.userId, runId);
+    await setTestRunStatus(runId, "completed");
 
     // Array-shape snapshot with a malformed entry (missing mountPath).
     // Bypass the ContextArtifact type so we can stuff a bad payload into jsonb.
@@ -66,5 +70,24 @@ describe("resolveCheckpoint — artifactSnapshots decoding", () => {
     await expect(resolveCheckpoint(checkpointId, user.userId)).rejects.toThrow(
       /artifactSnapshots\[0\]/,
     );
+  });
+
+  it("rejects in-flight checkpoints before the run reaches a terminal state", async () => {
+    const { runId } = await createTestRun(composeId, "running checkpoint run");
+    const { checkpointId } = await createTestCheckpoint(user.userId, runId);
+
+    await expect(resolveCheckpoint(checkpointId, user.userId)).rejects.toThrow(
+      /not ready to resume/,
+    );
+  });
+
+  it("allows terminal failed checkpoints", async () => {
+    const { runId } = await createTestRun(composeId, "failed checkpoint run");
+    const { checkpointId } = await createTestCheckpoint(user.userId, runId);
+    await setTestRunStatus(runId, "failed");
+
+    const resolution = await resolveCheckpoint(checkpointId, user.userId);
+
+    expect(resolution.conversationId).toBeDefined();
   });
 });

--- a/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
@@ -2,13 +2,16 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { resolveSession } from "../resolve-session";
 import {
   completeTestRun,
+  createTestCheckpoint,
   createTestCompose,
   createTestRun,
+  setTestRunStatus,
 } from "../../../../../__tests__/api-test-helpers";
 import {
   setTestSessionArtifacts,
   setTestSessionFramework,
 } from "../../../../../__tests__/db-test-seeders/agents";
+import { setTestCheckpointArtifactSnapshots } from "../../../../../__tests__/db-test-seeders/runs";
 import {
   testContext,
   uniqueId,
@@ -64,5 +67,72 @@ describe("resolveSession — artifacts passthrough", () => {
     const resolution = await resolveSession(agentSessionId, user.userId);
 
     expect(resolution.sessionFramework).toBe("codex");
+  });
+
+  it("uses failed checkpoint artifacts when continuing a recoverable failed session", async () => {
+    const { runId } = await createTestRun(composeId, "failed recovery run", {
+      additionalVolumes: [
+        {
+          name: "memory",
+          version: "mem-base",
+          mountPath: "/home/user/.claude/projects/-home-user-workspace/memory",
+        },
+      ],
+    });
+    const { agentSessionId, checkpointId } = await createTestCheckpoint(
+      user.userId,
+      runId,
+      {
+        volumeVersionsSnapshot: {
+          versions: { workspace: "vol-failed", memory: "mem-failed" },
+        },
+      },
+    );
+    await setTestRunStatus(runId, "failed");
+    await setTestSessionFramework(agentSessionId, "claude-code");
+    await setTestSessionArtifacts(agentSessionId, [
+      { name: "stale", version: "latest", mountPath: WORKING_DIR },
+    ]);
+
+    const checkpointArtifacts = [
+      { name: "workspace", version: "snap-failed", mountPath: WORKING_DIR },
+    ];
+    await setTestCheckpointArtifactSnapshots(checkpointId, checkpointArtifacts);
+
+    const resolution = await resolveSession(agentSessionId, user.userId);
+
+    expect(resolution.artifacts).toEqual(checkpointArtifacts);
+    expect(resolution.volumeVersions).toEqual({
+      workspace: "vol-failed",
+      memory: "mem-failed",
+    });
+    expect(resolution.additionalVolumes).toEqual([
+      {
+        name: "memory",
+        version: "mem-failed",
+        mountPath: "/home/user/.claude/projects/-home-user-workspace/memory",
+      },
+    ]);
+  });
+
+  it("does not use checkpoint artifacts while the linked run is still running", async () => {
+    const { runId } = await createTestRun(composeId, "in-flight recovery run");
+    const { agentSessionId, checkpointId } = await createTestCheckpoint(
+      user.userId,
+      runId,
+    );
+    await setTestSessionFramework(agentSessionId, "claude-code");
+    const sessionArtifacts = [
+      { name: "session", version: "latest", mountPath: WORKING_DIR },
+    ];
+    await setTestSessionArtifacts(agentSessionId, sessionArtifacts);
+    await setTestCheckpointArtifactSnapshots(checkpointId, [
+      { name: "checkpoint", version: "snap", mountPath: WORKING_DIR },
+    ]);
+
+    const resolution = await resolveSession(agentSessionId, user.userId);
+
+    expect(resolution.artifacts).toEqual(sessionArtifacts);
+    expect(resolution.volumeVersions).toBeUndefined();
   });
 });

--- a/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
@@ -8,6 +8,7 @@ import {
   setTestRunStatus,
 } from "../../../../../__tests__/api-test-helpers";
 import {
+  createTestSessionWithConversation,
   setTestSessionArtifacts,
   setTestSessionFramework,
 } from "../../../../../__tests__/db-test-seeders/agents";
@@ -25,18 +26,23 @@ const WORKING_DIR = "/home/user/workspace";
 describe("resolveSession — artifacts passthrough", () => {
   let user: UserContext;
   let composeId: string;
+  let composeVersionId: string;
 
   beforeEach(async () => {
     context.setupMocks();
     user = await context.setupUser();
     const compose = await createTestCompose(uniqueId("sess-resolver"));
     composeId = compose.composeId;
+    composeVersionId = compose.versionId;
   });
 
   it("returns session.artifacts verbatim from the DB", async () => {
-    const { runId } = await createTestRun(composeId, "session expansion run");
-    const { agentSessionId } = await completeTestRun(user.userId, runId);
-    await setTestSessionFramework(agentSessionId, "claude-code");
+    const { id: agentSessionId } = await createTestSessionWithConversation(
+      user.userId,
+      composeId,
+      composeVersionId,
+      "claude-code",
+    );
     const entries = [
       { name: "mem", version: "latest", mountPath: "/opt/mem" },
       { name: "ctx", version: "latest", mountPath: WORKING_DIR },
@@ -49,9 +55,12 @@ describe("resolveSession — artifacts passthrough", () => {
   });
 
   it("returns empty artifact list when session has no artifacts", async () => {
-    const { runId } = await createTestRun(composeId, "empty session run");
-    const { agentSessionId } = await completeTestRun(user.userId, runId);
-    await setTestSessionFramework(agentSessionId, "claude-code");
+    const { id: agentSessionId } = await createTestSessionWithConversation(
+      user.userId,
+      composeId,
+      composeVersionId,
+      "claude-code",
+    );
     await setTestSessionArtifacts(agentSessionId, []);
 
     const resolution = await resolveSession(agentSessionId, user.userId);
@@ -69,7 +78,66 @@ describe("resolveSession — artifacts passthrough", () => {
     expect(resolution.sessionFramework).toBe("codex");
   });
 
-  it("uses failed checkpoint artifacts when continuing a recoverable failed session", async () => {
+  it("uses checkpoint artifacts when continuing a completed session with checkpoint", async () => {
+    const { runId } = await createTestRun(
+      composeId,
+      "completed checkpoint run",
+    );
+    const { agentSessionId, checkpointId } = await completeTestRun(
+      user.userId,
+      runId,
+      {
+        volumeVersionsSnapshot: {
+          versions: { workspace: "vol-completed" },
+        },
+      },
+    );
+    await setTestSessionFramework(agentSessionId, "claude-code");
+    await setTestSessionArtifacts(agentSessionId, [
+      { name: "stale", version: "latest", mountPath: WORKING_DIR },
+    ]);
+
+    const checkpointArtifacts = [
+      { name: "workspace", version: "snap-completed", mountPath: WORKING_DIR },
+    ];
+    await setTestCheckpointArtifactSnapshots(checkpointId, checkpointArtifacts);
+
+    const resolution = await resolveSession(agentSessionId, user.userId);
+
+    expect(resolution.artifacts).toEqual(checkpointArtifacts);
+    expect(resolution.volumeVersions).toEqual({
+      workspace: "vol-completed",
+    });
+    expect(resolution.additionalVolumes).toBeUndefined();
+  });
+
+  it("falls back to session artifacts when terminal checkpoint has no artifact snapshot", async () => {
+    const { runId } = await createTestRun(composeId, "null checkpoint run");
+    const { agentSessionId, checkpointId } = await completeTestRun(
+      user.userId,
+      runId,
+      {
+        volumeVersionsSnapshot: {
+          versions: { workspace: "vol-completed" },
+        },
+      },
+    );
+    const sessionArtifacts = [
+      { name: "session", version: "latest", mountPath: WORKING_DIR },
+    ];
+    await setTestSessionFramework(agentSessionId, "claude-code");
+    await setTestSessionArtifacts(agentSessionId, sessionArtifacts);
+    await setTestCheckpointArtifactSnapshots(checkpointId, null);
+
+    const resolution = await resolveSession(agentSessionId, user.userId);
+
+    expect(resolution.artifacts).toEqual(sessionArtifacts);
+    expect(resolution.volumeVersions).toEqual({
+      workspace: "vol-completed",
+    });
+  });
+
+  it("uses checkpoint artifacts when continuing a recoverable failed session", async () => {
     const { runId } = await createTestRun(composeId, "failed recovery run", {
       additionalVolumes: [
         {
@@ -106,13 +174,7 @@ describe("resolveSession — artifacts passthrough", () => {
       workspace: "vol-failed",
       memory: "mem-failed",
     });
-    expect(resolution.additionalVolumes).toEqual([
-      {
-        name: "memory",
-        version: "mem-failed",
-        mountPath: "/home/user/.claude/projects/-home-user-workspace/memory",
-      },
-    ]);
+    expect(resolution.additionalVolumes).toBeUndefined();
   });
 
   it("does not use checkpoint artifacts while the linked run is still running", async () => {

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
@@ -17,6 +17,13 @@ import { resolveSessionHistory } from "./resolve-session-history";
 
 const log = logger("run:resolve-checkpoint");
 
+const RESUMABLE_CHECKPOINT_RUN_STATUSES = new Set([
+  "completed",
+  "failed",
+  "timeout",
+  "cancelled",
+]);
+
 /**
  * Resolve checkpoint to ConversationResolution
  *
@@ -71,7 +78,7 @@ export async function resolveCheckpoint(
 
   // Verify checkpoint belongs to user
   const [originalRun] = await globalThis.services.db
-    .select({ runId: agentRuns.id })
+    .select({ runId: agentRuns.id, status: agentRuns.status })
     .from(agentRuns)
     .where(
       and(eq(agentRuns.id, checkpoint.runId), eq(agentRuns.userId, userId)),
@@ -80,6 +87,12 @@ export async function resolveCheckpoint(
 
   if (!originalRun) {
     throw unauthorized("Checkpoint does not belong to authenticated user");
+  }
+
+  if (!RESUMABLE_CHECKPOINT_RUN_STATUSES.has(originalRun.status)) {
+    throw badRequest(
+      `Checkpoint is not ready to resume while run is ${originalRun.status}`,
+    );
   }
 
   // Run independent queries in parallel:

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
@@ -3,7 +3,12 @@ import { checkpoints } from "@vm0/db/schema/checkpoint";
 import { conversations } from "@vm0/db/schema/conversation";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
-import { notFound, unauthorized, badRequest } from "@vm0/api-services/errors";
+import {
+  notFound,
+  unauthorized,
+  badRequest,
+  conflict,
+} from "@vm0/api-services/errors";
 import { logger } from "../../../shared/logger";
 import type {
   AgentComposeSnapshot,
@@ -11,18 +16,12 @@ import type {
 } from "../../checkpoint/types";
 import { decodeToContextArtifacts } from "../../checkpoint/decode-artifact-snapshots";
 import type { AgentComposeYaml } from "../../agent-compose/types";
+import { isCheckpointResumableRunStatus } from "../types";
 import type { ConversationResolution } from "./types";
 import { extractWorkingDir } from "../utils";
 import { resolveSessionHistory } from "./resolve-session-history";
 
 const log = logger("run:resolve-checkpoint");
-
-const RESUMABLE_CHECKPOINT_RUN_STATUSES = new Set([
-  "completed",
-  "failed",
-  "timeout",
-  "cancelled",
-]);
 
 /**
  * Resolve checkpoint to ConversationResolution
@@ -50,8 +49,28 @@ export async function resolveCheckpoint(
     throw notFound("Checkpoint not found");
   }
 
-  // Extract snapshots. Artifact entries are stored directly in
-  // checkpoint.artifactSnapshots — no join to agent_sessions required.
+  // Verify checkpoint belongs to user
+  const [originalRun] = await globalThis.services.db
+    .select({ runId: agentRuns.id, status: agentRuns.status })
+    .from(agentRuns)
+    .where(
+      and(eq(agentRuns.id, checkpoint.runId), eq(agentRuns.userId, userId)),
+    )
+    .limit(1);
+
+  if (!originalRun) {
+    throw unauthorized("Checkpoint does not belong to authenticated user");
+  }
+
+  if (!isCheckpointResumableRunStatus(originalRun.status)) {
+    throw conflict(
+      `Checkpoint is not ready to resume while run is ${originalRun.status}`,
+    );
+  }
+
+  // Extract snapshots only after ownership/status checks. Unauthorized callers
+  // must not be able to distinguish malformed checkpoint internals from valid
+  // checkpoint internals owned by another user.
   const agentComposeSnapshot =
     checkpoint.agentComposeSnapshot as unknown as AgentComposeSnapshot;
   // artifactSnapshots is a Drizzle jsonb column (runtime type `unknown`).
@@ -74,25 +93,6 @@ export async function resolveCheckpoint(
   const agentComposeVersionId = agentComposeSnapshot.agentComposeVersionId;
   if (!agentComposeVersionId) {
     throw badRequest("Invalid checkpoint: missing agentComposeVersionId");
-  }
-
-  // Verify checkpoint belongs to user
-  const [originalRun] = await globalThis.services.db
-    .select({ runId: agentRuns.id, status: agentRuns.status })
-    .from(agentRuns)
-    .where(
-      and(eq(agentRuns.id, checkpoint.runId), eq(agentRuns.userId, userId)),
-    )
-    .limit(1);
-
-  if (!originalRun) {
-    throw unauthorized("Checkpoint does not belong to authenticated user");
-  }
-
-  if (!RESUMABLE_CHECKPOINT_RUN_STATUSES.has(originalRun.status)) {
-    throw badRequest(
-      `Checkpoint is not ready to resume while run is ${originalRun.status}`,
-    );
   }
 
   // Run independent queries in parallel:

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-session.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-session.ts
@@ -13,14 +13,9 @@ import { extractWorkingDir } from "../utils";
 import { resolveSessionHistory } from "./resolve-session-history";
 import type { VolumeVersionsSnapshot } from "../../checkpoint/types";
 import { decodeToContextArtifacts } from "../../checkpoint/decode-artifact-snapshots";
+import { isCheckpointResumableRunStatus } from "../types";
 
 const log = logger("run:resolve-session");
-
-const FAILED_RECOVERABLE_RUN_STATUSES = new Set([
-  "failed",
-  "timeout",
-  "cancelled",
-]);
 
 /**
  * Resolve session to ConversationResolution
@@ -66,7 +61,7 @@ export async function resolveSession(
   // Run independent operations in parallel:
   // - Compose → version chain (needs session.agentComposeId)
   // - Session history from R2 (needs session.conversation)
-  // - Last run vars and optional failed-recovery checkpoint snapshot
+  // - Last run vars and optional terminal checkpoint snapshot
   //   (needs conversation.runId)
   const [composeResult, sessionHistory, runSnapshotResult] = await Promise.all([
     // Compose → version (serial chain)
@@ -107,9 +102,9 @@ export async function resolveSession(
       conversation.cliAgentSessionHistory,
     ),
     // Last run vars as fallback for continue operations. When the linked
-    // conversation belongs to a terminal failed run with a checkpoint, the
-    // checkpoint snapshot is the only durable workspace state left after VM
-    // teardown, so session continue must restore from it.
+    // conversation belongs to a terminal run with a checkpoint, the checkpoint
+    // snapshot is the durable workspace state left after VM teardown, so
+    // session continue restores artifacts and compose volumes from it.
     globalThis.services.db
       .select({
         vars: agentRuns.vars,
@@ -128,27 +123,19 @@ export async function resolveSession(
   const [lastRun] = runSnapshotResult;
   const lastRunVars =
     (lastRun?.vars as Record<string, string> | null) ?? undefined;
-  const failedRecoveryCheckpoint = Boolean(
-    lastRun?.checkpointId &&
-    FAILED_RECOVERABLE_RUN_STATUSES.has(lastRun.status),
+  const terminalCheckpoint = Boolean(
+    lastRun?.checkpointId && isCheckpointResumableRunStatus(lastRun.status),
   );
-  const checkpointVolumeVersions = failedRecoveryCheckpoint
+  const checkpointVolumeVersions = terminalCheckpoint
     ? (lastRun?.volumeVersionsSnapshot as VolumeVersionsSnapshot | null)
     : null;
-  const checkpointAdditionalVolumes =
-    checkpointVolumeVersions?.additionalVolumes?.map((vol) => {
-      return {
-        name: vol.name,
-        version: vol.versionId,
-        mountPath: vol.mountPath,
-      };
-    });
-  const checkpointArtifacts = failedRecoveryCheckpoint
+  const checkpointArtifacts = terminalCheckpoint
     ? lastRun?.artifactSnapshots
     : null;
-  const artifacts = failedRecoveryCheckpoint
-    ? decodeToContextArtifacts(checkpointArtifacts)
-    : session.artifacts;
+  const artifacts =
+    terminalCheckpoint && checkpointArtifacts != null
+      ? decodeToContextArtifacts(checkpointArtifacts)
+      : session.artifacts;
   const workingDir = extractWorkingDir(version.content);
 
   return {
@@ -163,7 +150,6 @@ export async function resolveSession(
     artifacts,
     vars: lastRunVars,
     volumeVersions: checkpointVolumeVersions?.versions,
-    additionalVolumes: checkpointAdditionalVolumes,
     previousRunId: conversation.runId,
     sessionFramework: conversation.cliAgentType,
   };

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-session.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-session.ts
@@ -4,14 +4,23 @@ import {
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { checkpoints } from "@vm0/db/schema/checkpoint";
 import { notFound, unauthorized, badRequest } from "@vm0/api-services/errors";
 import { logger } from "../../../shared/logger";
 import { getAgentSessionWithConversation } from "../../agent-session";
 import type { ConversationResolution } from "./types";
 import { extractWorkingDir } from "../utils";
 import { resolveSessionHistory } from "./resolve-session-history";
+import type { VolumeVersionsSnapshot } from "../../checkpoint/types";
+import { decodeToContextArtifacts } from "../../checkpoint/decode-artifact-snapshots";
 
 const log = logger("run:resolve-session");
+
+const FAILED_RECOVERABLE_RUN_STATUSES = new Set([
+  "failed",
+  "timeout",
+  "cancelled",
+]);
 
 /**
  * Resolve session to ConversationResolution
@@ -57,8 +66,9 @@ export async function resolveSession(
   // Run independent operations in parallel:
   // - Compose → version chain (needs session.agentComposeId)
   // - Session history from R2 (needs session.conversation)
-  // - Last run vars (needs conversation.runId)
-  const [composeResult, sessionHistory, lastRunResult] = await Promise.all([
+  // - Last run vars and optional failed-recovery checkpoint snapshot
+  //   (needs conversation.runId)
+  const [composeResult, sessionHistory, runSnapshotResult] = await Promise.all([
     // Compose → version (serial chain)
     (async () => {
       const [compose] = await globalThis.services.db
@@ -96,20 +106,49 @@ export async function resolveSession(
       conversation.cliAgentSessionHistoryHash,
       conversation.cliAgentSessionHistory,
     ),
-    // Last run vars as fallback for continue operations
+    // Last run vars as fallback for continue operations. When the linked
+    // conversation belongs to a terminal failed run with a checkpoint, the
+    // checkpoint snapshot is the only durable workspace state left after VM
+    // teardown, so session continue must restore from it.
     globalThis.services.db
       .select({
         vars: agentRuns.vars,
+        status: agentRuns.status,
+        checkpointId: checkpoints.id,
+        artifactSnapshots: checkpoints.artifactSnapshots,
+        volumeVersionsSnapshot: checkpoints.volumeVersionsSnapshot,
       })
       .from(agentRuns)
+      .leftJoin(checkpoints, eq(checkpoints.runId, agentRuns.id))
       .where(eq(agentRuns.id, conversation.runId))
       .limit(1),
   ]);
 
   const { versionId, version } = composeResult;
-  const [lastRun] = lastRunResult;
+  const [lastRun] = runSnapshotResult;
   const lastRunVars =
     (lastRun?.vars as Record<string, string> | null) ?? undefined;
+  const failedRecoveryCheckpoint = Boolean(
+    lastRun?.checkpointId &&
+    FAILED_RECOVERABLE_RUN_STATUSES.has(lastRun.status),
+  );
+  const checkpointVolumeVersions = failedRecoveryCheckpoint
+    ? (lastRun?.volumeVersionsSnapshot as VolumeVersionsSnapshot | null)
+    : null;
+  const checkpointAdditionalVolumes =
+    checkpointVolumeVersions?.additionalVolumes?.map((vol) => {
+      return {
+        name: vol.name,
+        version: vol.versionId,
+        mountPath: vol.mountPath,
+      };
+    });
+  const checkpointArtifacts = failedRecoveryCheckpoint
+    ? lastRun?.artifactSnapshots
+    : null;
+  const artifacts = failedRecoveryCheckpoint
+    ? decodeToContextArtifacts(checkpointArtifacts)
+    : session.artifacts;
   const workingDir = extractWorkingDir(version.content);
 
   return {
@@ -121,9 +160,10 @@ export async function resolveSession(
       cliAgentSessionId: conversation.cliAgentSessionId,
       cliAgentSessionHistory: sessionHistory,
     },
-    artifacts: session.artifacts,
+    artifacts,
     vars: lastRunVars,
-    volumeVersions: undefined,
+    volumeVersions: checkpointVolumeVersions?.versions,
+    additionalVolumes: checkpointAdditionalVolumes,
     previousRunId: conversation.runId,
     sessionFramework: conversation.cliAgentType,
   };

--- a/turbo/apps/web/src/lib/infra/run/run-result.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-result.ts
@@ -1,0 +1,33 @@
+import { checkpoints } from "@vm0/db/schema/checkpoint";
+import { decodeToRecord } from "../checkpoint/decode-artifact-snapshots";
+import type { RunResult } from "./types";
+
+/**
+ * Build the public run result shape from a persisted checkpoint row.
+ *
+ * Checkpoints store artifact snapshots in the canonical array shape while older
+ * callback/event consumers still expect the compact Record<name, version> form.
+ */
+export function buildRunResultFromCheckpoint(
+  checkpoint: typeof checkpoints.$inferSelect,
+  sessionId: string | undefined,
+): RunResult {
+  const artifactRecord = decodeToRecord(checkpoint.artifactSnapshots);
+  const volumeVersions = checkpoint.volumeVersionsSnapshot as
+    | { versions?: Record<string, string> }
+    | null
+    | undefined;
+
+  const result: RunResult = {
+    checkpointId: checkpoint.id,
+    agentSessionId: sessionId ?? checkpoint.conversationId,
+    conversationId: checkpoint.conversationId,
+    volumes: volumeVersions?.versions,
+  };
+
+  if (artifactRecord) {
+    result.artifact = artifactRecord;
+  }
+
+  return result;
+}

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -284,7 +284,9 @@ export async function markRunFailed(
   // Dispatch callbacks (e.g., loop schedule advancement) if transition succeeded
   if (transitioned) {
     await publishRunChangedSafely(runId, { status: "failed" });
-    await dispatchTerminalSideEffects(runId, "failed", errorMessage);
+    await dispatchTerminalSideEffects(runId, "failed", {
+      error: errorMessage,
+    });
   }
 
   // Attach run metadata so callers can return partial results. sessionId is
@@ -615,16 +617,14 @@ export async function dispatchCancelSideEffects(
   const shouldDrain =
     result.previousStatus === "running" || result.previousStatus === "pending";
 
-  await dispatchTerminalSideEffects(
-    result.runId,
-    "cancelled",
-    "Run cancelled",
-    shouldDrain
+  await dispatchTerminalSideEffects(result.runId, "cancelled", {
+    error: "Run cancelled",
+    drain: shouldDrain
       ? () => {
           return drain(result.orgId);
         }
       : undefined,
-  );
+  });
 
   return shouldDrain;
 }

--- a/turbo/apps/web/src/lib/infra/run/run-status.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-status.ts
@@ -58,17 +58,23 @@ export async function transitionRunStatus(
 export async function dispatchTerminalSideEffects(
   runId: string,
   status: RunStatus,
-  error?: string,
-  drain?: () => Promise<void>,
+  options: {
+    error?: string;
+    result?: RunResult;
+    drain?: () => Promise<void>;
+  } = {},
 ): Promise<void> {
   const callbackStatus = status === "completed" ? "completed" : "failed";
-  await dispatchCallbacks(runId, callbackStatus, undefined, error).catch(
-    (err) => {
-      return log.error("Failed to dispatch callbacks", { err });
-    },
-  );
-  if (drain) {
-    await drain().catch((err) => {
+  await dispatchCallbacks(
+    runId,
+    callbackStatus,
+    options.result,
+    options.error,
+  ).catch((err) => {
+    return log.error("Failed to dispatch callbacks", { err });
+  });
+  if (options.drain) {
+    await options.drain().catch((err) => {
       return log.error("Failed to drain org queue", { err });
     });
   }

--- a/turbo/apps/web/src/lib/infra/run/run-status.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-status.ts
@@ -1,12 +1,111 @@
 import { and, eq, inArray } from "drizzle-orm";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { checkpoints } from "@vm0/db/schema/checkpoint";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { dispatchCallbacks } from "../callback";
 import { logger } from "../../shared/logger";
+import { buildRunResultFromCheckpoint } from "./run-result";
 import type { RunResult, RunStatus } from "./types";
 import type { Database } from "../../../types/global";
 import type { SandboxReuseResult } from "@vm0/api-contracts/contracts/webhooks";
 
 const log = logger("service:run-status");
+
+type RunStatusUpdate = {
+  status: RunStatus;
+  completedAt?: Date;
+  startedAt?: Date;
+  lastHeartbeatAt?: Date;
+  error?: string;
+  result?: RunResult;
+  sandboxId?: string;
+  sandboxReuseResult?: SandboxReuseResult;
+};
+
+type TransitionDb = Pick<Database, "select" | "update">;
+
+const TERMINAL_RUN_STATUSES = new Set<RunStatus>([
+  "completed",
+  "failed",
+  "timeout",
+  "cancelled",
+]);
+
+function shouldAttachExistingCheckpointResult(
+  update: RunStatusUpdate,
+): boolean {
+  return (
+    TERMINAL_RUN_STATUSES.has(update.status) && update.result === undefined
+  );
+}
+
+async function buildExistingCheckpointRunResult(
+  runId: string,
+  db: Pick<Database, "select">,
+): Promise<RunResult | undefined> {
+  const [checkpoint] = await db
+    .select()
+    .from(checkpoints)
+    .where(eq(checkpoints.runId, runId))
+    .limit(1);
+
+  if (!checkpoint) {
+    return undefined;
+  }
+
+  const [session] = await db
+    .select()
+    .from(agentSessions)
+    .where(eq(agentSessions.conversationId, checkpoint.conversationId))
+    .limit(1);
+
+  return buildRunResultFromCheckpoint(checkpoint, session?.id);
+}
+
+async function transitionRunStatusWithDb(
+  runId: string,
+  update: RunStatusUpdate,
+  allowedFromStatuses: RunStatus[],
+  db: TransitionDb,
+  attachExistingCheckpointResult: boolean,
+): Promise<boolean> {
+  if (attachExistingCheckpointResult) {
+    const [lockedRun] = await db
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.id, runId),
+          inArray(agentRuns.status, allowedFromStatuses),
+        ),
+      )
+      .for("update")
+      .limit(1);
+
+    if (!lockedRun) {
+      return false;
+    }
+  }
+
+  const checkpointResult = attachExistingCheckpointResult
+    ? await buildExistingCheckpointRunResult(runId, db)
+    : undefined;
+  const nextUpdate: RunStatusUpdate = checkpointResult
+    ? { ...update, result: checkpointResult }
+    : update;
+
+  const [updated] = await db
+    .update(agentRuns)
+    .set(nextUpdate)
+    .where(
+      and(
+        eq(agentRuns.id, runId),
+        inArray(agentRuns.status, allowedFromStatuses),
+      ),
+    )
+    .returning({ id: agentRuns.id });
+  return !!updated;
+}
 
 /**
  * Atomically transition a run to a new status.
@@ -16,31 +115,42 @@ const log = logger("service:run-status");
  */
 export async function transitionRunStatus(
   runId: string,
-  update: {
-    status: RunStatus;
-    completedAt?: Date;
-    startedAt?: Date;
-    lastHeartbeatAt?: Date;
-    error?: string;
-    result?: RunResult;
-    sandboxId?: string;
-    sandboxReuseResult?: SandboxReuseResult;
-  },
+  update: RunStatusUpdate,
   allowedFromStatuses: RunStatus[],
-  db?: Database,
+  db?: TransitionDb,
 ): Promise<boolean> {
-  const queryDb = db ?? globalThis.services.db;
-  const [updated] = await queryDb
-    .update(agentRuns)
-    .set(update)
-    .where(
-      and(
-        eq(agentRuns.id, runId),
-        inArray(agentRuns.status, allowedFromStatuses),
-      ),
-    )
-    .returning({ id: agentRuns.id });
-  return !!updated;
+  const attachExistingCheckpointResult =
+    shouldAttachExistingCheckpointResult(update);
+
+  if (db) {
+    return transitionRunStatusWithDb(
+      runId,
+      update,
+      allowedFromStatuses,
+      db,
+      attachExistingCheckpointResult,
+    );
+  }
+
+  if (attachExistingCheckpointResult) {
+    return globalThis.services.db.transaction((tx) => {
+      return transitionRunStatusWithDb(
+        runId,
+        update,
+        allowedFromStatuses,
+        tx,
+        true,
+      );
+    });
+  }
+
+  return transitionRunStatusWithDb(
+    runId,
+    update,
+    allowedFromStatuses,
+    globalThis.services.db,
+    false,
+  );
 }
 
 /**

--- a/turbo/apps/web/src/lib/infra/run/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/types.ts
@@ -31,7 +31,7 @@ export type RunStatus =
  * In-flight checkpoints are not resumable because their snapshots may lag
  * behind the still-running sandbox.
  */
-const CHECKPOINT_RESUMABLE_RUN_STATUSES = [
+export const CHECKPOINT_RESUMABLE_RUN_STATUSES = [
   "completed",
   "failed",
   "timeout",

--- a/turbo/apps/web/src/lib/infra/run/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/types.ts
@@ -27,8 +27,33 @@ export type RunStatus =
   | "cancelled";
 
 /**
- * Run result stored in agent_runs.result when status = 'completed'
- * Contains checkpoint and artifact information for session continuation
+ * Run statuses whose checkpoint can be used as a stable resume source.
+ * In-flight checkpoints are not resumable because their snapshots may lag
+ * behind the still-running sandbox.
+ */
+const CHECKPOINT_RESUMABLE_RUN_STATUSES = [
+  "completed",
+  "failed",
+  "timeout",
+  "cancelled",
+] as const satisfies readonly RunStatus[];
+
+type CheckpointResumableRunStatus =
+  (typeof CHECKPOINT_RESUMABLE_RUN_STATUSES)[number];
+
+export function isCheckpointResumableRunStatus(
+  status: string | null | undefined,
+): status is CheckpointResumableRunStatus {
+  return (
+    status !== null &&
+    status !== undefined &&
+    (CHECKPOINT_RESUMABLE_RUN_STATUSES as readonly string[]).includes(status)
+  );
+}
+
+/**
+ * Run result stored in agent_runs.result when a terminal run has a checkpoint.
+ * Contains checkpoint and artifact information for session continuation.
  */
 export interface RunResult {
   checkpointId: string;
@@ -44,7 +69,7 @@ export interface RunResult {
  */
 export interface RunState {
   status: RunStatus;
-  result?: RunResult; // Present when status = 'completed'
+  result?: RunResult; // Present when terminal run has checkpoint metadata
   error?: string; // Present when status = 'failed'
 }
 

--- a/turbo/apps/web/src/lib/infra/session-history/index.ts
+++ b/turbo/apps/web/src/lib/infra/session-history/index.ts
@@ -1,5 +1,4 @@
 export {
-  preRegisterSessionHistoryBlob,
   replaceSessionHistoryBlobReference,
   resolveSessionHistory,
 } from "./session-history-service";

--- a/turbo/apps/web/src/lib/infra/session-history/index.ts
+++ b/turbo/apps/web/src/lib/infra/session-history/index.ts
@@ -1,5 +1,5 @@
 export {
   preRegisterSessionHistoryBlob,
-  registerSessionHistoryBlob,
+  replaceSessionHistoryBlobReference,
   resolveSessionHistory,
 } from "./session-history-service";

--- a/turbo/apps/web/src/lib/infra/session-history/session-history-service.ts
+++ b/turbo/apps/web/src/lib/infra/session-history/session-history-service.ts
@@ -13,53 +13,37 @@ import type { Database } from "../../../types/global";
 const log = logger("session-history");
 
 /**
- * Pre-register a session history blob with correct size before S3 upload.
- * Creates the blob record with refCount 0; a subsequent checkpoint call claims
- * the reference if its conversation does not already point at this hash.
- *
- * On conflict (blob already exists), updates size to the correct value.
- *
- * @param hash SHA-256 hash of the content
- * @param size File size in bytes
- */
-export async function preRegisterSessionHistoryBlob(
-  hash: string,
-  size: number,
-): Promise<void> {
-  log.debug(`Pre-registering session history blob, hash=${hash}, size=${size}`);
-
-  await globalThis.services.db
-    .insert(blobs)
-    .values({ hash, size, refCount: 0 })
-    .onConflictDoUpdate({
-      target: blobs.hash,
-      set: { size },
-    });
-}
-
-/**
  * Register a session history blob that was uploaded directly to S3 via presigned URL.
- * The blob record (with correct size) is pre-created by the prepare-history endpoint;
- * this function increments refCount to track usage.
+ * The checkpoint webhook calls this only when a conversation claims the
+ * uploaded content, so abnormal exits do not leave refCount=0 DB rows behind.
  *
  * Note: The guest-agent flow is sequential: prepare-history → S3 upload → checkpoint.
- * The blob record and S3 object are guaranteed to exist before this is called.
+ * The S3 object is guaranteed to exist before this is called.
  *
  * @param hash SHA-256 hash of the content (already verified by the caller)
+ * @param size File size in bytes. Older callers may omit it; existing non-zero
+ * sizes are preserved when size is 0.
  * @returns The hash
  */
-export async function registerSessionHistoryBlob(
+async function registerSessionHistoryBlob(
   hash: string,
+  size: number = 0,
   db: Pick<Database, "insert"> = globalThis.services.db,
 ): Promise<string> {
   log.debug(`Registering session history blob, hash=${hash}`);
 
   await db
     .insert(blobs)
-    .values({ hash, size: 0, refCount: 1 })
+    .values({ hash, size, refCount: 1 })
     .onConflictDoUpdate({
       target: blobs.hash,
-      set: { refCount: sql`${blobs.refCount} + 1` },
+      set: {
+        size:
+          size > 0
+            ? sql`CASE WHEN ${blobs.size} = 0 THEN ${size} ELSE ${blobs.size} END`
+            : sql`${blobs.size}`,
+        refCount: sql`${blobs.refCount} + 1`,
+      },
     });
 
   return hash;
@@ -75,13 +59,14 @@ export async function registerSessionHistoryBlob(
 export async function replaceSessionHistoryBlobReference(
   hash: string,
   previousHash: string | null | undefined,
+  size: number = 0,
   db: Pick<Database, "insert" | "update"> = globalThis.services.db,
 ): Promise<string> {
   if (previousHash === hash) {
     return hash;
   }
 
-  await registerSessionHistoryBlob(hash, db);
+  await registerSessionHistoryBlob(hash, size, db);
 
   if (previousHash) {
     await db

--- a/turbo/apps/web/src/lib/infra/session-history/session-history-service.ts
+++ b/turbo/apps/web/src/lib/infra/session-history/session-history-service.ts
@@ -6,7 +6,7 @@
 
 import { downloadBlob } from "../blob/blob-service";
 import { blobs } from "@vm0/db/schema/blob";
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { logger } from "../../shared/logger";
 import type { Database } from "../../../types/global";
 
@@ -14,8 +14,8 @@ const log = logger("session-history");
 
 /**
  * Pre-register a session history blob with correct size before S3 upload.
- * Creates the blob record with refCount 0; the subsequent checkpoint call
- * will increment refCount via registerSessionHistoryBlob.
+ * Creates the blob record with refCount 0; a subsequent checkpoint call claims
+ * the reference if its conversation does not already point at this hash.
  *
  * On conflict (blob already exists), updates size to the correct value.
  *
@@ -61,6 +61,34 @@ export async function registerSessionHistoryBlob(
       target: blobs.hash,
       set: { refCount: sql`${blobs.refCount} + 1` },
     });
+
+  return hash;
+}
+
+/**
+ * Move one conversation's session-history reference to `hash`.
+ *
+ * Checkpoint writes are upserts: repeated webhook delivery for the same run
+ * should not keep incrementing the same blob, and replacing a checkpoint's
+ * history hash must release the old blob reference for future GC.
+ */
+export async function replaceSessionHistoryBlobReference(
+  hash: string,
+  previousHash: string | null | undefined,
+  db: Pick<Database, "insert" | "update"> = globalThis.services.db,
+): Promise<string> {
+  if (previousHash === hash) {
+    return hash;
+  }
+
+  await registerSessionHistoryBlob(hash, db);
+
+  if (previousHash) {
+    await db
+      .update(blobs)
+      .set({ refCount: sql`${blobs.refCount} - 1` })
+      .where(eq(blobs.hash, previousHash));
+  }
 
   return hash;
 }

--- a/turbo/apps/web/src/lib/infra/session-history/session-history-service.ts
+++ b/turbo/apps/web/src/lib/infra/session-history/session-history-service.ts
@@ -8,6 +8,7 @@ import { downloadBlob } from "../blob/blob-service";
 import { blobs } from "@vm0/db/schema/blob";
 import { sql } from "drizzle-orm";
 import { logger } from "../../shared/logger";
+import type { Database } from "../../../types/global";
 
 const log = logger("session-history");
 
@@ -49,10 +50,11 @@ export async function preRegisterSessionHistoryBlob(
  */
 export async function registerSessionHistoryBlob(
   hash: string,
+  db: Pick<Database, "insert"> = globalThis.services.db,
 ): Promise<string> {
   log.debug(`Registering session history blob, hash=${hash}`);
 
-  await globalThis.services.db
+  await db
     .insert(blobs)
     .values({ hash, size: 0, refCount: 1 })
     .onConflictDoUpdate({

--- a/turbo/apps/web/src/lib/zero/zero-run-validation.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-validation.ts
@@ -52,11 +52,19 @@ async function validateCheckpoint(
 }> {
   log.debug(`Validating checkpoint ${checkpointId} for user ${userId}`);
 
+  const resumableStatuses = new Set([
+    "completed",
+    "failed",
+    "timeout",
+    "cancelled",
+  ]);
+
   // Load checkpoint with associated run in a single query
   const [result] = await globalThis.services.db
     .select({
       agentComposeSnapshot: checkpoints.agentComposeSnapshot,
       runUserId: agentRuns.userId,
+      runStatus: agentRuns.status,
       runVars: agentRuns.vars,
       runSecretNames: agentRuns.secretNames,
     })
@@ -76,6 +84,12 @@ async function validateCheckpoint(
 
   if (result.runUserId !== userId) {
     throw unauthorized("Checkpoint does not belong to authenticated user");
+  }
+
+  if (!result.runStatus || !resumableStatuses.has(result.runStatus)) {
+    throw badRequest(
+      `Checkpoint is not ready to resume while run is ${result.runStatus ?? "missing"}`,
+    );
   }
 
   // Get version ID from snapshot

--- a/turbo/apps/web/src/lib/zero/zero-run-validation.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-validation.ts
@@ -5,11 +5,17 @@ import {
   agentComposeVersions,
   agentComposes,
 } from "@vm0/db/schema/agent-compose";
-import { notFound, unauthorized, badRequest } from "@vm0/api-services/errors";
+import {
+  notFound,
+  unauthorized,
+  badRequest,
+  conflict,
+} from "@vm0/api-services/errors";
 import { logger } from "../shared/logger";
 import type { AgentComposeSnapshot } from "../infra/checkpoint/types";
 import type { AgentComposeYaml } from "../infra/agent-compose/types";
 import { getAgentSessionWithConversation } from "../infra/agent-session";
+import { isCheckpointResumableRunStatus } from "../infra/run/types";
 
 const log = logger("service:zero-run-validation");
 
@@ -52,13 +58,6 @@ async function validateCheckpoint(
 }> {
   log.debug(`Validating checkpoint ${checkpointId} for user ${userId}`);
 
-  const resumableStatuses = new Set([
-    "completed",
-    "failed",
-    "timeout",
-    "cancelled",
-  ]);
-
   // Load checkpoint with associated run in a single query
   const [result] = await globalThis.services.db
     .select({
@@ -86,8 +85,8 @@ async function validateCheckpoint(
     throw unauthorized("Checkpoint does not belong to authenticated user");
   }
 
-  if (!result.runStatus || !resumableStatuses.has(result.runStatus)) {
-    throw badRequest(
+  if (!isCheckpointResumableRunStatus(result.runStatus)) {
+    throw conflict(
       `Checkpoint is not ready to resume while run is ${result.runStatus ?? "missing"}`,
     );
   }

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -148,7 +148,7 @@ const runEventSchema = z.object({
 });
 
 /**
- * Run result schema (present when status = 'completed')
+ * Run result schema (present when a terminal run has checkpoint metadata)
  */
 const runResultSchema = z.object({
   checkpointId: z.string(),
@@ -242,6 +242,7 @@ export const runsMainContract = c.router({
       402: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
+      409: apiErrorSchema,
       422: apiErrorSchema,
       503: apiErrorSchema,
     },

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -143,7 +143,7 @@ export const webhookCompleteContract = c.router({
 export const webhookCheckpointsContract = c.router({
   /**
    * POST /api/webhooks/agent/checkpoints
-   * Create checkpoint for completed agent run
+   * Create a recoverable checkpoint for an agent run.
    */
   create: {
     method: "POST",

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -160,6 +160,11 @@ export const webhookCheckpointsContract = c.router({
             64,
             "cliAgentSessionHistoryHash must be a 64-character SHA-256 hex string",
           ),
+        cliAgentSessionHistorySize: z
+          .number()
+          .int()
+          .nonnegative("cliAgentSessionHistorySize must be non-negative")
+          .optional(),
         // Multi-artifact snapshot payload. Canonical
         // `Array<{name, version, mountPath}>` form persisted verbatim to
         // checkpoints.artifact_snapshots.


### PR DESCRIPTION
## Summary
- add a best-effort guest-agent recovery checkpoint path for abnormal exits with recoverable session history
- keep failed runs failed while allowing completed/terminal-failed checkpoints to resume and rejecting in-flight checkpoints
- make sessionId continue restore failed checkpoint artifact/volume snapshots and transactionally link checkpoint conversations to sessions

## Tests
- cargo test --manifest-path crates/Cargo.toml -p guest-agent
- pnpm exec vitest run app/api/webhooks/agent/checkpoints/__tests__/route.test.ts app/api/webhooks/agent/complete/__tests__/route.test.ts src/lib/infra/run/resolvers/__tests__/resolve-checkpoint.test.ts src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
- pnpm check-types
- pre-commit: cargo fmt/doc/clippy, prettier, knip, turbo check-types

Fixes #11805