### PR TITLE
fix: correct Infisical connector secret name to INFISICAL_TOKEN

### DIFF
--- a/turbo/apps/web/src/lib/zero/connector/providers/infisical-handler.ts
+++ b/turbo/apps/web/src/lib/zero/connector/providers/infisical-handler.ts
@@ -18,6 +18,6 @@ export const infisicalHandler: ProviderHandler = {
     return undefined;
   },
   getSecretName: () => {
-    return "INFISICAL_CLIENT_ID";
+    return "INFISICAL_TOKEN";
   },
 };


### PR DESCRIPTION
## Summary

The Infisical connector's `getSecretName()` was returning `"INFISICAL_CLIENT_ID"` instead of `"INFISICAL_TOKEN"`. Since Infisical uses **api-token** auth (not OAuth), there is no client ID/secret — the only secret defined in the connector config is `INFISICAL_TOKEN`.

This mismatch caused the sandbox environment to receive unresolved template placeholder values (`${{ secrets.INFISICAL_CLIENT_ID }}`) instead of the actual API token, because `getSecretName()` is the function the system uses to determine which env var to inject at runtime.

## Root cause

A copy-paste error: the handler template for api-token connectors should return the token env var name (e.g., `DOPPLER_TOKEN`, `APIFY_TOKEN`, `BRIGHTDATA_TOKEN`), not an OAuth-style client ID name (e.g., `INFISICAL_CLIENT_ID`).

## Fix

One-line change in `infisical-handler.ts`:
```
-    return "INFISICAL_CLIENT_ID";
+    return "INFISICAL_TOKEN";
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)