### PR TITLE
[codex] link agent skills in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,7 +49,7 @@
     "source=agent-browser,target=/home/vscode/.local/share/agent-browser"
   ],
   "postCreateCommand": "bash .devcontainer/setup.sh",
-  "postStartCommand": "gh auth setup-git && bash .devcontainer/start-vnc.sh",
+  "postStartCommand": "bash .devcontainer/link-agent-skills.sh && gh auth setup-git && bash .devcontainer/start-vnc.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/link-agent-skills.sh
+++ b/.devcontainer/link-agent-skills.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+WORKSPACE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLAUDE_SKILLS_DIR="$WORKSPACE_DIR/.claude/skills"
+AGENTS_DIR="$WORKSPACE_DIR/.agents"
+AGENT_SKILLS_LINK="$AGENTS_DIR/skills"
+LINK_TARGET="../.claude/skills"
+
+if [ ! -d "$CLAUDE_SKILLS_DIR" ]; then
+  exit 0
+fi
+
+mkdir -p "$AGENTS_DIR"
+
+if [ -L "$AGENT_SKILLS_LINK" ]; then
+  ln -sfn "$LINK_TARGET" "$AGENT_SKILLS_LINK"
+elif [ -e "$AGENT_SKILLS_LINK" ]; then
+  if [ ! -d "$AGENT_SKILLS_LINK" ]; then
+    echo "Refusing to replace non-directory: $AGENT_SKILLS_LINK" >&2
+    exit 1
+  fi
+
+  if find "$AGENT_SKILLS_LINK" -mindepth 1 -maxdepth 1 ! -type l | grep -q .; then
+    echo "Refusing to replace .agents/skills because it contains non-symlink entries" >&2
+    exit 1
+  fi
+
+  find "$AGENT_SKILLS_LINK" -mindepth 1 -maxdepth 1 -type l -exec rm {} +
+  rmdir "$AGENT_SKILLS_LINK"
+  ln -s "$LINK_TARGET" "$AGENT_SKILLS_LINK"
+else
+  ln -s "$LINK_TARGET" "$AGENT_SKILLS_LINK"
+fi
+
+echo "Linked .agents/skills to .claude/skills"


### PR DESCRIPTION
## Summary

- Add a devcontainer startup script that links `.agents/skills` to `.claude/skills`.
- Run the script from `postStartCommand` before the existing Git and VNC startup steps.

## Why

Codex discovers workspace skills under `.agents/skills`, while this repository keeps team skills under `.claude/skills`. A directory-level symlink keeps both tools pointed at the same skill files, including newly created skills.

## Validation

- `bash -n .devcontainer/link-agent-skills.sh`
- `jq empty .devcontainer/devcontainer.json`
- `bash .devcontainer/link-agent-skills.sh && test "$(readlink .agents/skills)" = "../.claude/skills"`
- `codex debug prompt-input "ping"` confirmed project skills are discoverable