### PR TITLE
feat: warn when selected model cannot recognize images

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -17,7 +17,7 @@ import {
 import {
   collectSuccessfulAttachmentInfos,
   prepareUserMessageFromDraft$,
-  shouldExcludeVisualAttachments,
+  shouldExcludeVisualAttachmentsForModel,
 } from "./resolve-draft-attachments.ts";
 import { reloadChatThreads$, type ChatThread } from "../agent-chat.ts";
 import {
@@ -27,6 +27,10 @@ import {
   type ModelSelectionRequest,
   type PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  getDefaultModel,
+  type ModelProviderResponse,
+} from "@vm0/api-contracts/contracts/model-providers";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
@@ -1096,14 +1100,37 @@ function createSendMessage(deps: SendMessageDeps) {
         L.debug("sendMessage$ no agentId, abort", { threadId });
         return;
       }
+      let effectiveSelectedModel = modelSelection?.selectedModel;
+      if (!effectiveSelectedModel) {
+        const agent = await get(agentById(agentId));
+        signal.throwIfAborted();
+        if (agent?.modelProviderId && agent.selectedModel) {
+          effectiveSelectedModel = agent.selectedModel;
+        }
+      }
+      if (!effectiveSelectedModel) {
+        const { modelProviders } = await get(orgModelProviders$);
+        signal.throwIfAborted();
+        const defaultProvider = (
+          modelProviders as ModelProviderResponse[]
+        ).find((provider) => {
+          return provider.isDefault;
+        });
+        const defaultModel = defaultProvider
+          ? getDefaultModel(defaultProvider.type)
+          : undefined;
+        effectiveSelectedModel =
+          defaultProvider?.selectedModel ?? defaultModel ?? undefined;
+      }
 
       const result = await set(
         prepareUserMessageFromDraft$,
         draft,
         prompt,
         {
-          excludeVisualAttachments:
-            shouldExcludeVisualAttachments(modelSelection),
+          excludeVisualAttachments: shouldExcludeVisualAttachmentsForModel(
+            effectiveSelectedModel,
+          ),
         },
         signal,
       );

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -17,6 +17,7 @@ import {
 import {
   collectSuccessfulAttachmentInfos,
   prepareUserMessageFromDraft$,
+  shouldExcludeVisualAttachments,
 } from "./resolve-draft-attachments.ts";
 import { reloadChatThreads$, type ChatThread } from "../agent-chat.ts";
 import {
@@ -1100,6 +1101,10 @@ function createSendMessage(deps: SendMessageDeps) {
         prepareUserMessageFromDraft$,
         draft,
         prompt,
+        {
+          excludeVisualAttachments:
+            shouldExcludeVisualAttachments(modelSelection),
+        },
         signal,
       );
       if (!result) {

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -9,6 +9,10 @@ import {
   type ChatThreadListItem,
   type ModelSelectionRequest,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  getDefaultModel,
+  type ModelProviderResponse,
+} from "@vm0/api-contracts/contracts/model-providers";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
 import {
@@ -26,7 +30,7 @@ import { createLocalChatThreadDataSource } from "./local-chat-thread-data-source
 import { createPendingChatThread } from "./pending-chat-thread.ts";
 import {
   prepareUserMessageFromDraft$,
-  shouldExcludeVisualAttachments,
+  shouldExcludeVisualAttachmentsForModel,
 } from "./resolve-draft-attachments.ts";
 import {
   allPendingChatThreads$,
@@ -38,6 +42,8 @@ import {
   type PendingChatThread,
 } from "./optimistic-chat-thread-state.ts";
 import { toVoid } from "../utils.ts";
+import { agentById } from "../agent.ts";
+import { orgModelProviders$ } from "../external/org-model-providers.ts";
 
 export type { OptimisticChatPane };
 export { optimisticChatThread$ };
@@ -345,13 +351,36 @@ const sendNewThreadMessage$ = command(
     signal: AbortSignal,
   ): Promise<SendNewThreadMessagePending | null> => {
     const draft = get(talkDraft$);
+    let effectiveSelectedModel = modelSelection?.selectedModel;
+    if (!effectiveSelectedModel) {
+      const agent = await get(agentById(agentId));
+      signal.throwIfAborted();
+      if (agent?.modelProviderId && agent.selectedModel) {
+        effectiveSelectedModel = agent.selectedModel;
+      }
+    }
+    if (!effectiveSelectedModel) {
+      const { modelProviders } = await get(orgModelProviders$);
+      signal.throwIfAborted();
+      const defaultProvider = (modelProviders as ModelProviderResponse[]).find(
+        (provider) => {
+          return provider.isDefault;
+        },
+      );
+      const defaultModel = defaultProvider
+        ? getDefaultModel(defaultProvider.type)
+        : undefined;
+      effectiveSelectedModel =
+        defaultProvider?.selectedModel ?? defaultModel ?? undefined;
+    }
     const prepared = await set(
       prepareUserMessageFromDraft$,
       draft,
       prompt,
       {
-        excludeVisualAttachments:
-          shouldExcludeVisualAttachments(modelSelection),
+        excludeVisualAttachments: shouldExcludeVisualAttachmentsForModel(
+          effectiveSelectedModel,
+        ),
       },
       signal,
     );

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -24,7 +24,10 @@ import { zeroOnboardingStatus$ } from "../zero-page/zero-onboarding.ts";
 import { createChatThreadSignals, ensureDraft$ } from "./create-chat-thread.ts";
 import { createLocalChatThreadDataSource } from "./local-chat-thread-data-source.ts";
 import { createPendingChatThread } from "./pending-chat-thread.ts";
-import { prepareUserMessageFromDraft$ } from "./resolve-draft-attachments.ts";
+import {
+  prepareUserMessageFromDraft$,
+  shouldExcludeVisualAttachments,
+} from "./resolve-draft-attachments.ts";
 import {
   allPendingChatThreads$,
   clearMatchingOptimisticChatThread$,
@@ -346,6 +349,10 @@ const sendNewThreadMessage$ = command(
       prepareUserMessageFromDraft$,
       draft,
       prompt,
+      {
+        excludeVisualAttachments:
+          shouldExcludeVisualAttachments(modelSelection),
+      },
       signal,
     );
 

--- a/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
+++ b/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
@@ -1,7 +1,6 @@
 import { command } from "ccstate";
 import type {
   AttachFile,
-  ModelSelectionRequest,
   PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { getModelImageInputSupport } from "@vm0/api-contracts/contracts/model-providers";
@@ -71,12 +70,10 @@ export function isVisualAttachment({
   return VISUAL_ATTACHMENT_EXTENSION_RE.test(filename ?? "");
 }
 
-export function shouldExcludeVisualAttachments(
-  modelSelection: ModelSelectionRequest | null,
+export function shouldExcludeVisualAttachmentsForModel(
+  selectedModel: string | null | undefined,
 ): boolean {
-  return (
-    getModelImageInputSupport(modelSelection?.selectedModel) === "unsupported"
-  );
+  return getModelImageInputSupport(selectedModel) === "unsupported";
 }
 
 export function collectSuccessfulAttachmentInfos(

--- a/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
+++ b/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
@@ -1,8 +1,10 @@
 import { command } from "ccstate";
 import type {
   AttachFile,
+  ModelSelectionRequest,
   PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { getModelImageInputSupport } from "@vm0/api-contracts/contracts/model-providers";
 import type {
   DraftSignals,
   ZeroChatAttachment,
@@ -43,6 +45,40 @@ interface ResolvedDraftAttachment {
   info: AttachmentFileInfo;
 }
 
+interface VisualAttachmentDescriptor {
+  contentType?: string | null;
+  filename?: string | null;
+}
+
+interface PrepareUserMessageOptions {
+  excludeVisualAttachments?: boolean;
+}
+
+const VISUAL_ATTACHMENT_EXTENSION_RE =
+  /\.(?:png|jpe?g|gif|webp|avif|heic|heif|bmp|svg|mp4|m4v|mov|webm|avi|mkv)$/i;
+
+export function isVisualAttachment({
+  contentType,
+  filename,
+}: VisualAttachmentDescriptor): boolean {
+  const normalizedContentType = contentType?.toLowerCase() ?? "";
+  if (
+    normalizedContentType.startsWith("image/") ||
+    normalizedContentType.startsWith("video/")
+  ) {
+    return true;
+  }
+  return VISUAL_ATTACHMENT_EXTENSION_RE.test(filename ?? "");
+}
+
+export function shouldExcludeVisualAttachments(
+  modelSelection: ModelSelectionRequest | null,
+): boolean {
+  return (
+    getModelImageInputSupport(modelSelection?.selectedModel) === "unsupported"
+  );
+}
+
 export function collectSuccessfulAttachmentInfos(
   attachments: readonly ZeroChatAttachment[],
   results: readonly PromiseSettledResult<AttachmentFileInfo | null>[],
@@ -75,9 +111,15 @@ export const prepareUserMessageFromDraft$ = command(
     { get },
     draft: DraftSignals,
     prompt: string,
+    options: PrepareUserMessageOptions,
     signal: AbortSignal,
   ): Promise<PreparedUserMessage | null> => {
-    const allAttachments = get(draft.attachments$);
+    const draftAttachments = get(draft.attachments$);
+    const allAttachments = options.excludeVisualAttachments
+      ? draftAttachments.filter((attachment) => {
+          return !isVisualAttachment(attachment);
+        })
+      : draftAttachments;
     const allInfos = await Promise.allSettled(
       allAttachments.map((a) => {
         return get(a.fileInfo$);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
@@ -39,6 +39,7 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
+import { mockUploadSuccess } from "../../../mocks/upload-helpers.ts";
 import {
   setMockOrgModelProviders,
   resetMockOrgModelProviders,
@@ -48,6 +49,7 @@ import {
   setMockOnboardingStatus,
   resetMockOnboardingStatus,
 } from "../../../mocks/handlers/api-onboarding.ts";
+import { PLACEHOLDER, sendMessageInUI } from "./chat-test-helpers.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -343,7 +345,7 @@ describe("chat composer — default model resolution", () => {
     await expectComposerShowsModel("Claude Sonnet 4.6");
   });
 
-  it("warns for image uploads on a text-only model and switches to a vision model", async () => {
+  it("blocks visual attachments on a text-only model but allows other files", async () => {
     const user = userEvent.setup();
     mockOrgProviders({
       defaultProviderId: ZAI_PROVIDER_ID,
@@ -353,17 +355,157 @@ describe("chat composer — default model resolution", () => {
 
     detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
     await expectAgentChatLoaded();
+    server.use(
+      ...mockUploadSuccess({
+        id: "notes-upload",
+        filename: "notes.txt",
+        contentType: "text/plain",
+        size: 12,
+        url: "https://example.com/notes.txt",
+      }),
+    );
 
     await expectComposerShowsModel("GLM-5.1");
-    expect(screen.getByText(/cannot recognize images/i)).toBeInTheDocument();
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    const attachButton = screen.getByLabelText("Attach");
+    expect(attachButton).not.toBeDisabled();
 
-    await user.click(screen.getByText("Switch to Claude Sonnet 4.6"));
+    await user.upload(
+      fileInput,
+      new File(["image"], "screenshot.png", { type: "image/png" }),
+    );
+    await expect(
+      screen.findAllByText(/GLM-5\.1 cannot recognize images or videos/i),
+    ).resolves.not.toHaveLength(0);
 
+    await user.upload(
+      fileInput,
+      new File(["plain text"], "notes.txt", { type: "text/plain" }),
+    );
+    await expect(
+      screen.findByLabelText("Remove notes.txt"),
+    ).resolves.toBeInTheDocument();
+  });
+
+  it("filters existing visual attachments while a text-only model is selected", async () => {
+    const user = userEvent.setup();
+    mockOrgProviders({
+      defaultProviderId: ANTHROPIC_PROVIDER_ID,
+      defaultSelectedModel: "claude-sonnet-4-6",
+    });
+    mockAgent({ modelProviderId: null, selectedModel: null });
+    server.use(
+      ...mockUploadSuccess({
+        id: "screenshot-upload",
+        filename: "screenshot.png",
+        contentType: "image/png",
+        size: 12,
+        url: "https://example.com/screenshot.png",
+      }),
+    );
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+    await expectAgentChatLoaded();
     await expectComposerShowsModel("Claude Sonnet 4.6");
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    await user.upload(
+      fileInput,
+      new File(["image"], "screenshot.png", { type: "image/png" }),
+    );
+    await expect(
+      screen.findByLabelText("Open image preview for screenshot.png"),
+    ).resolves.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
+    );
+    await user.click(await screen.findByRole("option", { name: /GLM-5\.1/ }));
+
+    await expectComposerShowsModel("GLM-5.1");
+    await expect(
+      screen.findAllByText(/GLM-5\.1 cannot recognize images or videos/i),
+    ).resolves.not.toHaveLength(0);
     await waitFor(() => {
       expect(
-        screen.queryByText(/cannot recognize images/i),
+        screen.queryByLabelText("Open image preview for screenshot.png"),
       ).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Remove screenshot.png"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Send")).toBeDisabled();
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "GLM-5.1" }));
+    await user.click(
+      await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
+    );
+
+    await expectComposerShowsModel("Claude Sonnet 4.6");
+    await expect(
+      screen.findByLabelText("Open image preview for screenshot.png"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByLabelText("Send")).not.toBeDisabled();
+  });
+
+  it("filters visual attachments from submit on a text-only model", async () => {
+    const user = userEvent.setup();
+    let capturedAttachFiles: unknown = "not-called";
+    mockOrgProviders({
+      defaultProviderId: ANTHROPIC_PROVIDER_ID,
+      defaultSelectedModel: "claude-sonnet-4-6",
+    });
+    mockAgent({ modelProviderId: null, selectedModel: null });
+    mockThread({ modelProviderId: null, selectedModel: null });
+    server.use(
+      ...mockUploadSuccess({
+        id: "screenshot-upload",
+        filename: "screenshot.png",
+        contentType: "image/png",
+        size: 12,
+        url: "https://example.com/screenshot.png",
+      }),
+    );
+    server.use(
+      mockApi(chatMessagesContract.send, ({ body, respond }) => {
+        capturedAttachFiles = body.attachFiles;
+        return respond(201, {
+          runId: "run-1",
+          threadId: THREAD_ID,
+          status: "pending",
+          createdAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+    await expectComposerShowsModel("Claude Sonnet 4.6");
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    await user.upload(
+      fileInput,
+      new File(["image"], "screenshot.png", { type: "image/png" }),
+    );
+    await expect(
+      screen.findByLabelText("Open image preview for screenshot.png"),
+    ).resolves.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
+    );
+    await user.click(await screen.findByRole("option", { name: /GLM-5\.1/ }));
+    await expectComposerShowsModel("GLM-5.1");
+
+    const textarea = screen.getByPlaceholderText(
+      PLACEHOLDER,
+    ) as HTMLTextAreaElement;
+    await sendMessageInUI(user, textarea, "Please review");
+
+    await waitFor(() => {
+      expect(capturedAttachFiles).toBeUndefined();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
@@ -509,6 +509,71 @@ describe("chat composer — default model resolution", () => {
     });
   });
 
+  it("filters visual attachments from submit when inheriting a text-only default model", async () => {
+    const user = userEvent.setup();
+    let capturedAttachFiles: unknown = "not-called";
+    mockOrgProviders({
+      defaultProviderId: ZAI_PROVIDER_ID,
+      defaultSelectedModel: "glm-5.1",
+    });
+    mockAgent({ modelProviderId: null, selectedModel: null });
+    server.use(
+      ...mockUploadSuccess({
+        id: "screenshot-upload",
+        filename: "screenshot.png",
+        contentType: "image/png",
+        size: 12,
+        url: "https://example.com/screenshot.png",
+      }),
+    );
+    server.use(
+      mockApi(chatMessagesContract.send, ({ body, respond }) => {
+        capturedAttachFiles = body.attachFiles;
+        return respond(201, {
+          runId: "run-1",
+          threadId: THREAD_ID,
+          status: "pending",
+          createdAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+    await expectAgentChatLoaded();
+    await expectComposerShowsModel("GLM-5.1");
+
+    await user.click(screen.getByRole("combobox", { name: "GLM-5.1" }));
+    await user.click(
+      await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
+    );
+    await expectComposerShowsModel("Claude Sonnet 4.6");
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    await user.upload(
+      fileInput,
+      new File(["image"], "screenshot.png", { type: "image/png" }),
+    );
+    await expect(
+      screen.findByLabelText("Open image preview for screenshot.png"),
+    ).resolves.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
+    );
+    await user.click(await screen.findByLabelText("Use agent default model"));
+    await expectComposerShowsModel("GLM-5.1");
+
+    const textarea = screen.getByPlaceholderText(
+      PLACEHOLDER,
+    ) as HTMLTextAreaElement;
+    await sendMessageInUI(user, textarea, "Please review");
+
+    await waitFor(() => {
+      expect(capturedAttachFiles).toBeUndefined();
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // Scenario 3 — thread override outranks both agent and org defaults
   // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
@@ -23,6 +23,7 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
   chatMessagesContract,
   chatThreadByIdContract,
@@ -340,6 +341,30 @@ describe("chat composer — default model resolution", () => {
     await expectAgentChatLoaded();
 
     await expectComposerShowsModel("Claude Sonnet 4.6");
+  });
+
+  it("warns for image uploads on a text-only model and switches to a vision model", async () => {
+    const user = userEvent.setup();
+    mockOrgProviders({
+      defaultProviderId: ZAI_PROVIDER_ID,
+      defaultSelectedModel: "glm-5.1",
+    });
+    mockAgent({ modelProviderId: null, selectedModel: null });
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+    await expectAgentChatLoaded();
+
+    await expectComposerShowsModel("GLM-5.1");
+    expect(screen.getByText(/cannot recognize images/i)).toBeInTheDocument();
+
+    await user.click(screen.getByText("Switch to Claude Sonnet 4.6"));
+
+    await expectComposerShowsModel("Claude Sonnet 4.6");
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/cannot recognize images/i),
+      ).not.toBeInTheDocument();
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -16,6 +16,7 @@ import {
   IconPaperclip,
   IconPlayerStop,
   IconPlug,
+  IconPhotoOff,
   IconPlus,
 } from "@tabler/icons-react";
 import {
@@ -67,10 +68,15 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import type {
-  ModelProviderResponse,
-  ModelProviderType,
+import {
+  getDefaultModel,
+  getModelImageInputSupport,
+  getModels,
+  modelSupportsImageInput,
+  type ModelProviderResponse,
+  type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
+import { getModelDisplayName } from "@vm0/core/model-display-name";
 import {
   ModelProviderPicker,
   type ModelProviderSelection,
@@ -196,6 +202,8 @@ interface ZeroChatComposerProps {
   };
 }
 
+type ComposerModelPicker = NonNullable<ZeroChatComposerProps["modelPicker"]>;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -215,6 +223,92 @@ function resolveConnectorLabel(
   connectorMap: Map<ConnectorType, { label: string }>,
 ): string {
   return connectorMap.get(type as ConnectorType)?.label ?? type;
+}
+
+interface ResolvedComposerModel {
+  modelProviderId: string;
+  selectedModel: string;
+}
+
+function resolveProviderSelection(
+  provider: ModelProviderResponse | undefined,
+): ResolvedComposerModel | null {
+  if (!provider) {
+    return null;
+  }
+  const selectedModel =
+    provider.selectedModel ?? getDefaultModel(provider.type);
+  if (!selectedModel) {
+    return null;
+  }
+  return {
+    modelProviderId: provider.id,
+    selectedModel,
+  };
+}
+
+function resolveCurrentComposerModel(
+  modelPicker: ComposerModelPicker | undefined,
+): ResolvedComposerModel | null {
+  if (!modelPicker) {
+    return null;
+  }
+  if (modelPicker.value) {
+    return modelPicker.value;
+  }
+  if (modelPicker.agentDefault) {
+    return modelPicker.agentDefault;
+  }
+  const defaultProvider = modelPicker.providers.find((provider) => {
+    return provider.isDefault;
+  });
+  return resolveProviderSelection(defaultProvider);
+}
+
+function findRecommendedImageInputModel(
+  modelPicker: ComposerModelPicker | undefined,
+): ResolvedComposerModel | null {
+  if (!modelPicker || modelPicker.disabled) {
+    return null;
+  }
+  const candidates = modelPicker.providers.flatMap((provider) => {
+    return (getModels(provider.type) ?? [])
+      .filter((model) => {
+        return modelSupportsImageInput(model);
+      })
+      .map((model) => {
+        return {
+          modelProviderId: provider.id,
+          selectedModel: model,
+        };
+      });
+  });
+  return (
+    candidates.find((candidate) => {
+      return candidate.selectedModel === "claude-sonnet-4-6";
+    }) ??
+    candidates[0] ??
+    null
+  );
+}
+
+function getImageInputWarningState(
+  modelPicker: ComposerModelPicker | undefined,
+): {
+  currentModelName: string;
+  recommendation: ResolvedComposerModel | null;
+} | null {
+  const currentModel = resolveCurrentComposerModel(modelPicker);
+  if (
+    getModelImageInputSupport(currentModel?.selectedModel) !== "unsupported" ||
+    !currentModel
+  ) {
+    return null;
+  }
+  return {
+    currentModelName: getModelDisplayName(currentModel.selectedModel),
+    recommendation: findRecommendedImageInputModel(modelPicker),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -706,6 +800,40 @@ function toPersistedAttachments(
     });
 }
 
+function ImageInputWarning({
+  currentModelName,
+  recommendation,
+  onSwitch,
+}: {
+  currentModelName: string;
+  recommendation: ResolvedComposerModel | null;
+  onSwitch: (selection: ResolvedComposerModel) => void;
+}) {
+  return (
+    <div className="mx-3 mt-3 flex flex-col gap-2 rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2 text-xs text-amber-950 dark:border-amber-400/30 dark:bg-amber-400/10 dark:text-amber-50 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex min-w-0 items-center gap-2">
+        <IconPhotoOff size={16} stroke={1.7} className="shrink-0" />
+        <span className="min-w-0">
+          <span className="font-medium">{currentModelName}</span> cannot
+          recognize images.
+        </span>
+      </div>
+      {recommendation && (
+        <button
+          type="button"
+          className="self-start rounded-md px-2 py-1 font-medium text-amber-950 underline-offset-2 transition-colors hover:bg-amber-100 hover:underline dark:text-amber-50 dark:hover:bg-amber-400/20 sm:self-auto"
+          onClick={() => {
+            onSwitch(recommendation);
+          }}
+          aria-label={`Switch to ${getModelDisplayName(recommendation.selectedModel)}`}
+        >
+          Switch to {getModelDisplayName(recommendation.selectedModel)}
+        </button>
+      )}
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Main composer
 // ---------------------------------------------------------------------------
@@ -979,6 +1107,8 @@ export function ZeroChatComposer({
     e.target.value = "";
   };
 
+  const imageInputWarning = getImageInputWarningState(modelPicker);
+
   return (
     <>
       <input
@@ -1001,6 +1131,15 @@ export function ZeroChatComposer({
       >
         <CardContent className="p-0">
           <div className="flex flex-col">
+            {imageInputWarning && (
+              <ImageInputWarning
+                currentModelName={imageInputWarning.currentModelName}
+                recommendation={imageInputWarning.recommendation}
+                onSwitch={(selection) => {
+                  modelPicker?.onChange(selection);
+                }}
+              />
+            )}
             {attachments.length > 0 && (
               <AttachmentChips
                 attachments={attachments}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -16,7 +16,6 @@ import {
   IconPaperclip,
   IconPlayerStop,
   IconPlug,
-  IconPhotoOff,
   IconPlus,
 } from "@tabler/icons-react";
 import {
@@ -50,6 +49,7 @@ import {
 import { sendMode$ } from "../../signals/send-mode.ts";
 import { toggleSidebarOff$ } from "../../signals/zero-page/zero-nav.ts";
 import type { DraftSignals } from "../../signals/chat-page/create-chat-thread.ts";
+import { isVisualAttachment } from "../../signals/chat-page/resolve-draft-attachments.ts";
 import type { Command, Computed } from "ccstate";
 import {
   zeroChatAttachments$ as singletonAttachments$,
@@ -71,8 +71,6 @@ import {
 import {
   getDefaultModel,
   getModelImageInputSupport,
-  getModels,
-  modelSupportsImageInput,
   type ModelProviderResponse,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
@@ -247,14 +245,15 @@ function resolveProviderSelection(
   };
 }
 
-function resolveCurrentComposerModel(
+function resolveComposerModelForSelection(
   modelPicker: ComposerModelPicker | undefined,
+  selection: ModelProviderSelection | null,
 ): ResolvedComposerModel | null {
   if (!modelPicker) {
     return null;
   }
-  if (modelPicker.value) {
-    return modelPicker.value;
+  if (selection) {
+    return selection;
   }
   if (modelPicker.agentDefault) {
     return modelPicker.agentDefault;
@@ -265,40 +264,13 @@ function resolveCurrentComposerModel(
   return resolveProviderSelection(defaultProvider);
 }
 
-function findRecommendedImageInputModel(
+function getVisualAttachmentUnsupportedState(
   modelPicker: ComposerModelPicker | undefined,
-): ResolvedComposerModel | null {
-  if (!modelPicker || modelPicker.disabled) {
-    return null;
-  }
-  const candidates = modelPicker.providers.flatMap((provider) => {
-    return (getModels(provider.type) ?? [])
-      .filter((model) => {
-        return modelSupportsImageInput(model);
-      })
-      .map((model) => {
-        return {
-          modelProviderId: provider.id,
-          selectedModel: model,
-        };
-      });
-  });
-  return (
-    candidates.find((candidate) => {
-      return candidate.selectedModel === "claude-sonnet-4-6";
-    }) ??
-    candidates[0] ??
-    null
-  );
-}
-
-function getImageInputWarningState(
-  modelPicker: ComposerModelPicker | undefined,
+  selection: ModelProviderSelection | null = modelPicker?.value ?? null,
 ): {
   currentModelName: string;
-  recommendation: ResolvedComposerModel | null;
 } | null {
-  const currentModel = resolveCurrentComposerModel(modelPicker);
+  const currentModel = resolveComposerModelForSelection(modelPicker, selection);
   if (
     getModelImageInputSupport(currentModel?.selectedModel) !== "unsupported" ||
     !currentModel
@@ -307,8 +279,23 @@ function getImageInputWarningState(
   }
   return {
     currentModelName: getModelDisplayName(currentModel.selectedModel),
-    recommendation: findRecommendedImageInputModel(modelPicker),
   };
+}
+
+function isVisualAttachmentFile(file: File): boolean {
+  return isVisualAttachment({
+    contentType: file.type,
+    filename: file.name,
+  });
+}
+
+function showVisualAttachmentUnsupportedToast(state: {
+  currentModelName: string;
+}): void {
+  toast.error(
+    `${state.currentModelName} cannot recognize images or videos. Switch to a vision-capable model to attach them.`,
+    { id: "visual-attachment-unsupported" },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -800,40 +787,6 @@ function toPersistedAttachments(
     });
 }
 
-function ImageInputWarning({
-  currentModelName,
-  recommendation,
-  onSwitch,
-}: {
-  currentModelName: string;
-  recommendation: ResolvedComposerModel | null;
-  onSwitch: (selection: ResolvedComposerModel) => void;
-}) {
-  return (
-    <div className="mx-3 mt-3 flex flex-col gap-2 rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2 text-xs text-amber-950 dark:border-amber-400/30 dark:bg-amber-400/10 dark:text-amber-50 sm:flex-row sm:items-center sm:justify-between">
-      <div className="flex min-w-0 items-center gap-2">
-        <IconPhotoOff size={16} stroke={1.7} className="shrink-0" />
-        <span className="min-w-0">
-          <span className="font-medium">{currentModelName}</span> cannot
-          recognize images.
-        </span>
-      </div>
-      {recommendation && (
-        <button
-          type="button"
-          className="self-start rounded-md px-2 py-1 font-medium text-amber-950 underline-offset-2 transition-colors hover:bg-amber-100 hover:underline dark:text-amber-50 dark:hover:bg-amber-400/20 sm:self-auto"
-          onClick={() => {
-            onSwitch(recommendation);
-          }}
-          aria-label={`Switch to ${getModelDisplayName(recommendation.selectedModel)}`}
-        >
-          Switch to {getModelDisplayName(recommendation.selectedModel)}
-        </button>
-      )}
-    </div>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Main composer
 // ---------------------------------------------------------------------------
@@ -867,7 +820,7 @@ export function ZeroChatComposer({
     setComposerFileInputProp$,
   );
   const {
-    canSend,
+    canSend: draftCanSend,
     attachments,
     uploadAttachment,
     restoreAttachments,
@@ -880,6 +833,15 @@ export function ZeroChatComposer({
 
   const ensurePushSubscription = useSet(ensurePushSubscription$);
   const rootSignal = useGet(rootSignal$);
+  const visualAttachmentUnsupported =
+    getVisualAttachmentUnsupportedState(modelPicker);
+  const visibleAttachments = visualAttachmentUnsupported
+    ? attachments.filter((attachment) => {
+        return !isVisualAttachment(attachment);
+      })
+    : attachments;
+  const canSend =
+    draftCanSend && (input.trim() !== "" || visibleAttachments.length > 0);
 
   // File upload handlers (paste / drag-drop)
   const handlePaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
@@ -889,6 +851,17 @@ export function ZeroChatComposer({
         chatPayload.attachments,
       );
       if (persistedAttachments.length > 0) {
+        const allowedAttachments = visualAttachmentUnsupported
+          ? persistedAttachments.filter((attachment) => {
+              return !isVisualAttachment({
+                contentType: attachment.contentType,
+                filename: attachment.filename,
+              });
+            })
+          : persistedAttachments;
+        if (allowedAttachments.length < persistedAttachments.length) {
+          showVisualAttachmentUnsupportedToast(visualAttachmentUnsupported!);
+        }
         e.preventDefault();
         const nextInput = insertPastedText(
           e.currentTarget,
@@ -898,7 +871,9 @@ export function ZeroChatComposer({
         if (nextInput !== input) {
           onInputChange(nextInput);
         }
-        restoreAttachments(persistedAttachments);
+        if (allowedAttachments.length > 0) {
+          restoreAttachments(allowedAttachments);
+        }
         onDraftChange?.();
         return;
       }
@@ -928,6 +903,12 @@ export function ZeroChatComposer({
       if (!file) {
         continue;
       }
+      if (visualAttachmentUnsupported && isVisualAttachmentFile(file)) {
+        e.preventDefault();
+        applyPlainText();
+        showVisualAttachmentUnsupportedToast(visualAttachmentUnsupported);
+        continue;
+      }
       if (file.size > MAX_FILE_SIZE) {
         toast.error(`${file.name} exceeds the 1 GB limit`);
         continue;
@@ -946,14 +927,22 @@ export function ZeroChatComposer({
     if (!files) {
       return;
     }
+    let uploaded = false;
     for (const file of files) {
+      if (visualAttachmentUnsupported && isVisualAttachmentFile(file)) {
+        showVisualAttachmentUnsupportedToast(visualAttachmentUnsupported);
+        continue;
+      }
       if (file.size > MAX_FILE_SIZE) {
         toast.error(`${file.name} exceeds the 1 GB limit`);
         continue;
       }
       detach(uploadAttachment(file, rootSignal), Reason.DomCallback);
+      uploaded = true;
     }
-    onDraftChange?.();
+    if (uploaded) {
+      onDraftChange?.();
+    }
   };
 
   const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
@@ -1096,18 +1085,42 @@ export function ZeroChatComposer({
     if (!files) {
       return;
     }
+    let uploaded = false;
     for (const file of files) {
+      if (visualAttachmentUnsupported && isVisualAttachmentFile(file)) {
+        showVisualAttachmentUnsupportedToast(visualAttachmentUnsupported);
+        continue;
+      }
       if (file.size > MAX_FILE_SIZE) {
         toast.error(`${file.name} exceeds the 1 GB limit`);
         continue;
       }
       detach(uploadAttachment(file, rootSignal), Reason.DomCallback);
+      uploaded = true;
     }
-    onDraftChange?.();
+    if (uploaded) {
+      onDraftChange?.();
+    }
     e.target.value = "";
   };
 
-  const imageInputWarning = getImageInputWarningState(modelPicker);
+  const handleModelPickerChange = (
+    selection: ModelProviderSelection | null,
+  ) => {
+    const nextUnsupported = getVisualAttachmentUnsupportedState(
+      modelPicker,
+      selection,
+    );
+    if (
+      nextUnsupported &&
+      attachments.some((attachment) => {
+        return isVisualAttachment(attachment);
+      })
+    ) {
+      showVisualAttachmentUnsupportedToast(nextUnsupported);
+    }
+    modelPicker?.onChange(selection);
+  };
 
   return (
     <>
@@ -1131,18 +1144,9 @@ export function ZeroChatComposer({
       >
         <CardContent className="p-0">
           <div className="flex flex-col">
-            {imageInputWarning && (
-              <ImageInputWarning
-                currentModelName={imageInputWarning.currentModelName}
-                recommendation={imageInputWarning.recommendation}
-                onSwitch={(selection) => {
-                  modelPicker?.onChange(selection);
-                }}
-              />
-            )}
-            {attachments.length > 0 && (
+            {visibleAttachments.length > 0 && (
               <AttachmentChips
-                attachments={attachments}
+                attachments={visibleAttachments}
                 onRemove={(attachment) => {
                   removeAttachment(attachment);
                   onDraftChange?.();
@@ -1214,7 +1218,7 @@ export function ZeroChatComposer({
                       <ModelProviderPicker
                         providers={modelPicker.providers}
                         value={modelPicker.value}
-                        onChange={modelPicker.onChange}
+                        onChange={handleModelPickerChange}
                         placeholder="Default"
                         triggerClassName={cn(
                           "h-9 w-9 max-w-none gap-0 border-transparent bg-transparent px-0 text-sm text-muted-foreground transition-colors sm:w-auto sm:max-w-[14rem] sm:gap-1 sm:px-2",

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -9,6 +9,8 @@ import {
   getFrameworkForType,
   getVm0VisibleModels,
   normalizeVm0ModelId,
+  getModelImageInputSupport,
+  modelSupportsImageInput,
   getSelectableProviderTypes,
   getAuthMethodsForType,
   getSecretsForAuthMethod,
@@ -184,6 +186,34 @@ describe("normalizeVm0ModelId", () => {
 
   it("keeps unknown model ids unchanged", () => {
     expect(normalizeVm0ModelId("custom/model")).toBe("custom/model");
+  });
+});
+
+describe("model image input support", () => {
+  it.each([
+    "claude-sonnet-4-6",
+    "claude-opus-4-7",
+    "kimi-k2.6",
+    "kimi-k2.5",
+    "moonshotai/kimi-k2.5",
+  ])("marks %s as image-input capable", (model) => {
+    expect(modelSupportsImageInput(model)).toBe(true);
+    expect(getModelImageInputSupport(model)).toBe("supported");
+  });
+
+  it.each([
+    "glm-5.1",
+    "deepseek-v4-pro",
+    "deepseek/deepseek-v4-flash",
+    "MiniMax-M2.7",
+  ])("marks %s as not image-input capable", (model) => {
+    expect(modelSupportsImageInput(model)).toBe(false);
+    expect(getModelImageInputSupport(model)).toBe("unsupported");
+  });
+
+  it("treats unknown model ids as unknown rather than unsupported", () => {
+    expect(modelSupportsImageInput("custom/model")).toBe(false);
+    expect(getModelImageInputSupport("custom/model")).toBe("unknown");
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -119,6 +119,70 @@ export function normalizeVm0ModelId(model: string): string {
   return VM0_MODEL_ALIAS_LOOKUP[model] ?? model;
 }
 
+export type ModelImageInputSupport = "supported" | "unsupported" | "unknown";
+
+const IMAGE_INPUT_SUPPORTED_MODELS = new Set([
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+  "claude-haiku-4-5",
+  "anthropic/claude-opus-4.7",
+  "anthropic/claude-opus-4.6",
+  "anthropic/claude-opus-4.5",
+  "anthropic/claude-sonnet-4.6",
+  "anthropic/claude-sonnet-4.5",
+  "anthropic/claude-haiku-4.5",
+  "kimi-k2.6",
+  "kimi-k2.5",
+  "moonshotai/kimi-k2.6",
+  "moonshotai/kimi-k2.5",
+]);
+
+const IMAGE_INPUT_UNSUPPORTED_MODELS = new Set([
+  "glm-5.1",
+  "glm-5",
+  "glm-4.7",
+  "glm-4.5-air",
+  "z-ai/glm-5.1",
+  "zai/glm-5-turbo",
+  "deepseek-v4-pro",
+  "deepseek-v4-flash",
+  "deepseek/deepseek-v4-pro",
+  "deepseek/deepseek-v4-flash",
+  "MiniMax-M2.7",
+  "MiniMax-M2.1",
+  "minimax/minimax-m2.7",
+  "minimax/minimax-m2.5",
+]);
+
+export function getModelImageInputSupport(
+  model: string | null | undefined,
+): ModelImageInputSupport {
+  if (!model) {
+    return "unknown";
+  }
+  const normalized = normalizeVm0ModelId(model);
+  if (
+    IMAGE_INPUT_SUPPORTED_MODELS.has(normalized) ||
+    IMAGE_INPUT_SUPPORTED_MODELS.has(model)
+  ) {
+    return "supported";
+  }
+  if (
+    IMAGE_INPUT_UNSUPPORTED_MODELS.has(normalized) ||
+    IMAGE_INPUT_UNSUPPORTED_MODELS.has(model)
+  ) {
+    return "unsupported";
+  }
+  return "unknown";
+}
+
+export function modelSupportsImageInput(
+  model: string | null | undefined,
+): boolean {
+  return getModelImageInputSupport(model) === "supported";
+}
+
 /**
  * Return the VM0 managed models visible to the caller, filtered by feature
  * switches. Models without a featureFlag are always visible; models with a


### PR DESCRIPTION
## Summary
- add shared model image-input capability helpers for supported, unsupported, and unknown model IDs
- show a composer warning when the effective selected model is known not to support image recognition
- add a quick action that switches to an available vision-capable model, preferring Claude Sonnet 4.6

Closes #11917

## Tests
- pnpm --filter @vm0/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts
- pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
- pnpm --filter @vm0/api-contracts lint
- pnpm --filter @vm0/api-contracts check-types
- pnpm --filter @vm0/app exec oxlint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
- pnpm --filter @vm0/app exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
- pnpm --filter @vm0/app exec eslint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx --max-warnings 0

## Notes
- Local full `pnpm check-types` is currently blocked by existing `apps/api` ts-rest response typing errors such as `Property 'body' does not exist on type 'never'` in API route tests.
