### PR TITLE
refactor(runner): share bounded sse usage scanner

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -52,6 +52,7 @@ vendor_check.verify()
 # HTTP status boundaries used in response-phase classification.
 _HTTP_STATUS_UNAUTHORIZED = 401
 _HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
+_MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
 
 # ============================================================================
 # Addon Configuration
@@ -284,6 +285,15 @@ def _release_tracked_usage_flow(flow: http.HTTPFlow) -> None:
         usage.decrement_flows()
 
 
+def _report_model_provider_usage_once(flow: http.HTTPFlow, run_id: str) -> None:
+    """Avoid duplicate usage webhook enqueue if response/error both fire."""
+    if flow.metadata.get(_MODEL_PROVIDER_USAGE_REPORTED, False):
+        return
+    usage.report_model_provider_usage(flow, run_id)
+    if flow.metadata.get("model_provider_usage"):
+        flow.metadata[_MODEL_PROVIDER_USAGE_REPORTED] = True
+
+
 # ============================================================================
 # HTTP Response Handlers
 # ============================================================================
@@ -417,7 +427,7 @@ def response(flow: http.HTTPFlow) -> None:
                 )
             if json_usage:
                 flow.metadata["model_provider_usage"] = json_usage
-    usage.report_model_provider_usage(flow, run_id)
+    _report_model_provider_usage_once(flow, run_id)
 
     # Billable connector usage observation (issue #9504, stage 0).
     response_streaming.finalize_x_json_state(flow)
@@ -508,7 +518,7 @@ def error(flow: http.HTTPFlow) -> None:
     # The SSE parser may have partially populated model_provider_usage before the
     # connection error occurred.  Partial data is better than none.
     response_streaming.finalize_model_sse_usage(flow)
-    usage.report_model_provider_usage(flow, run_id)
+    _report_model_provider_usage_once(flow, run_id)
 
     # Billable connector usage for X NDJSON streams that crash mid-flight
     # (issue #9534): the incremental parser populated x_ndjson_state during

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -289,8 +289,7 @@ def _report_model_provider_usage_once(flow: http.HTTPFlow, run_id: str) -> None:
     """Avoid duplicate usage webhook enqueue if response/error both fire."""
     if flow.metadata.get(_MODEL_PROVIDER_USAGE_REPORTED, False):
         return
-    usage.report_model_provider_usage(flow, run_id)
-    if flow.metadata.get("model_provider_usage"):
+    if usage.report_model_provider_usage(flow, run_id):
         flow.metadata[_MODEL_PROVIDER_USAGE_REPORTED] = True
 
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -389,6 +389,7 @@ def response(flow: http.HTTPFlow) -> None:
 
         log_network_entry(network_log_path, log_entry)
 
+    response_streaming.finalize_model_sse_usage(flow)
     response_streaming.finalize_model_json_usage(flow, proxy_log_path)
 
     # Report proxy-extracted usage for model provider responses.
@@ -506,6 +507,7 @@ def error(flow: http.HTTPFlow) -> None:
     # Report proxy-extracted usage for model provider responses.
     # The SSE parser may have partially populated model_provider_usage before the
     # connection error occurred.  Partial data is better than none.
+    response_streaming.finalize_model_sse_usage(flow)
     usage.report_model_provider_usage(flow, run_id)
 
     # Billable connector usage for X NDJSON streams that crash mid-flight

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -15,6 +15,7 @@ _HTTP_STATUS_REDIRECT_MIN = 300
 
 _MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
 _MODEL_JSON_USAGE_FINALIZED = "_model_json_usage_finalized"
+_MODEL_SSE_USAGE_FINISH = "model_sse_usage_finish"
 _RESPONSE_STREAM_CALLBACK = "_vm0_response_stream_callback"
 _X_JSON_RESPONSE_FINISH = "x_json_response_finish"
 
@@ -91,6 +92,7 @@ def configure_response_stream(flow: http.HTTPFlow) -> None:
                 parser_fn, usage_dict = usage.create_anthropic_messages_sse_usage_extractor()
             sse_parser = parser_fn
             flow.metadata["model_provider_usage"] = usage_dict
+            flow.metadata[_MODEL_SSE_USAGE_FINISH] = parser_fn.finish
             sse_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
         else:
             if _is_openai_responses_provider(firewall_name):
@@ -172,6 +174,12 @@ def finalize_model_json_usage(flow: http.HTTPFlow, proxy_log_path: str) -> None:
         )
 
 
+def finalize_model_sse_usage(flow: http.HTTPFlow) -> None:
+    finish = flow.metadata.pop(_MODEL_SSE_USAGE_FINISH, None)
+    if finish is not None:
+        finish()
+
+
 def finalize_x_json_state(flow: http.HTTPFlow) -> None:
     finish = flow.metadata.pop(_X_JSON_RESPONSE_FINISH, None)
     if finish is None:
@@ -187,6 +195,7 @@ def release_response_stream_state(flow: http.HTTPFlow) -> None:
     flow.metadata.pop("stream_buffer", None)
     flow.metadata.pop("stream_buffer_state", None)
     flow.metadata.pop(_MODEL_JSON_USAGE_FINISH, None)
+    flow.metadata.pop(_MODEL_SSE_USAGE_FINISH, None)
     flow.metadata.pop(_X_JSON_RESPONSE_FINISH, None)
     if stream_callback is not None and flow.response and flow.response.stream is stream_callback:
         flow.response.stream = False

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -4,24 +4,32 @@ Pure parsers shared by both the SSE streaming path and the non-streaming
 JSON fallback.
 """
 
-import json
 from collections.abc import Callable
 
 import body_utils
 
 from .json_selective import JsonSelectiveExtractor, ScalarField
 from .model_tokens import ANTHROPIC_USAGE_FIELD_CATEGORIES
+from .sse import SseUsageScanner
 
-# SSE event boundaries we scan for.  When no boundary is found we keep
-# ``_MAX_SEPARATOR_LEN - 1`` trailing bytes so a boundary split across the
-# next chunk can still complete.  Deriving the max from the tuple means
-# adding a longer separator here updates the tail automatically.
-_SSE_SEPARATORS: tuple[bytes, ...] = (b"\r\n\r\n", b"\n\n")
-_MAX_SEPARATOR_LEN = max(len(s) for s in _SSE_SEPARATORS)
+_ANTHROPIC_MESSAGES_USAGE_EVENTS = frozenset(("message_start", "message_delta"))
 
 _MODEL_JSON_SCALAR_FIELDS = {
     ("id",): ScalarField("string", max_bytes=1024),
     ("model",): ScalarField("string", max_bytes=1024),
+    **{
+        ("usage", field): ScalarField("int", max_bytes=64)
+        for field in ANTHROPIC_USAGE_FIELD_CATEGORIES
+    },
+}
+
+_ANTHROPIC_SSE_SCALAR_FIELDS = {
+    ("message", "id"): ScalarField("string", max_bytes=1024),
+    ("message", "model"): ScalarField("string", max_bytes=1024),
+    **{
+        ("message", "usage", field): ScalarField("int", max_bytes=64)
+        for field in ANTHROPIC_USAGE_FIELD_CATEGORIES
+    },
     **{
         ("usage", field): ScalarField("int", max_bytes=64)
         for field in ANTHROPIC_USAGE_FIELD_CATEGORIES
@@ -51,6 +59,13 @@ def _is_usage_quantity(value: object) -> bool:
     return isinstance(value, int) and not isinstance(value, bool) and value >= 0
 
 
+def _store_selected_usage_values(values: dict, target: dict, prefix: tuple[str, ...]) -> None:
+    for raw_field, category in ANTHROPIC_USAGE_FIELD_CATEGORIES.items():
+        value = values.get((*prefix, raw_field))
+        if _is_usage_quantity(value) and (value > 0 or category not in target):
+            target[category] = value
+
+
 def create_anthropic_messages_sse_usage_extractor() -> tuple[Callable[[bytes], None], dict]:
     """Create an incremental SSE parser that extracts usage from Anthropic API streams.
 
@@ -65,90 +80,60 @@ def create_anthropic_messages_sse_usage_extractor() -> tuple[Callable[[bytes], N
     incrementally and *usage* is a dict that accumulates extracted fields.
     """
     usage: dict = {}
-    # Mutate in-place (``line_buf[:] = ...``, ``extend(...)``) throughout
-    # ``parse_chunk`` — captured by the closure.  Rebinding via
-    # ``line_buf = ...`` would create a new local and lose cross-call state.
-    line_buf = bytearray()
-    event_type = {"current": None}
-    # Events we need to parse — all others are skipped to avoid buffering
-    # large content_block_delta payloads.
-    _usage_events = frozenset(("message_start", "message_delta"))
-    # When True, discard incoming bytes until the next empty line (event
-    # boundary) to avoid buffering irrelevant data lines.
-    skipping = {"active": False}
+    scanner = SseUsageScanner(_AnthropicMessagesSseUsageHandler(usage))
 
     def parse_chunk(chunk: bytes) -> None:
-        # In skip mode, scan for event boundary (empty line) without
-        # buffering the (potentially large) chunk.
-        if skipping["active"]:
-            # Look for \n\n or \r\n\r\n in existing buf + new chunk.
-            combined = line_buf + chunk
-            for sep in _SSE_SEPARATORS:
-                idx = combined.find(sep)
-                if idx != -1:
-                    # Found event boundary — line_buf gets the remainder.
-                    # Do NOT extend again below; data is already in line_buf.
-                    after = idx + len(sep)
-                    line_buf[:] = combined[after:]
-                    skipping["active"] = False
-                    event_type["current"] = None
-                    break
-            else:
-                # No boundary found — discard everything except the
-                # last few bytes (could be a partial \r\n\r\n).
-                tail = _MAX_SEPARATOR_LEN - 1
-                line_buf[:] = combined[-tail:] if len(combined) > tail else combined
-                return
-            # Boundary found — fall through to process line_buf contents.
-            # line_buf already has the data, so skip the extend.
-        else:
-            line_buf.extend(chunk)
-        while b"\n" in line_buf:
-            raw_line, _, remaining = line_buf.partition(b"\n")
-            line_buf[:] = remaining
-            line = raw_line.rstrip(b"\r").decode("utf-8", errors="replace")
-
-            # Blank line = event boundary.
-            if line == "":
-                event_type["current"] = None
-                skipping["active"] = False
-                continue
-
-            if skipping["active"]:
-                continue
-
-            if line.startswith("event: "):
-                evt_name = line[7:]
-                event_type["current"] = evt_name
-                if evt_name not in _usage_events:
-                    # Skip data lines of this event within line_buf.
-                    # Cross-chunk large data lines are handled by the
-                    # skip mode at the top of parse_chunk.
-                    skipping["active"] = True
-                    continue
-            elif line.startswith("data: "):
-                evt = event_type["current"]
-                if evt == "message_start":
-                    try:
-                        data = json.loads(line[6:])
-                        msg = data.get("message") or {}
-                        model = msg.get("model")
-                        if model:
-                            usage["model"] = model
-                        message_id = msg.get("id")
-                        if message_id:
-                            usage["message_id"] = message_id
-                        _extract_billing_usage(msg.get("usage"), usage)
-                    except (json.JSONDecodeError, AttributeError, TypeError):
-                        pass  # SSE data lines may be partial/malformed; best-effort extraction
-                elif evt == "message_delta":
-                    try:
-                        data = json.loads(line[6:])
-                        _extract_billing_usage(data.get("usage"), usage)
-                    except (json.JSONDecodeError, AttributeError, TypeError):
-                        pass  # SSE data lines may be partial/malformed; best-effort extraction
+        scanner.feed(chunk)
 
     return parse_chunk, usage
+
+
+class _AnthropicMessagesSseUsageHandler:
+    def __init__(self, usage: dict) -> None:
+        self._usage = usage
+        self._extractor: JsonSelectiveExtractor | None = None
+        self._event_name: str | None = None
+
+    def should_capture_event(self, event_name: str | None) -> bool:
+        return event_name in _ANTHROPIC_MESSAGES_USAGE_EVENTS
+
+    def on_event_start(self, event_name: str | None) -> None:
+        self._extractor = JsonSelectiveExtractor(scalar_fields=_ANTHROPIC_SSE_SCALAR_FIELDS)
+        self._event_name = event_name
+
+    def on_data(self, chunk: bytes) -> None:
+        if self._extractor is not None:
+            self._extractor.feed(chunk)
+
+    def on_data_separator(self) -> None:
+        self.on_data(b"\n")
+
+    def on_event_end(self, _event_name: str | None) -> None:
+        extractor = self._extractor
+        event_name = self._event_name
+        self._extractor = None
+        self._event_name = None
+        if extractor is None:
+            return
+
+        result = extractor.finish()
+        if not result.complete:
+            return
+
+        if event_name == "message_start":
+            model = result.values.get(("message", "model"))
+            if isinstance(model, str) and model:
+                self._usage["model"] = model
+            message_id = result.values.get(("message", "id"))
+            if isinstance(message_id, str) and message_id:
+                self._usage["message_id"] = message_id
+            _store_selected_usage_values(result.values, self._usage, ("message", "usage"))
+        elif event_name == "message_delta":
+            _store_selected_usage_values(result.values, self._usage, ("usage",))
+
+    def on_event_discard(self, _event_name: str | None) -> None:
+        self._extractor = None
+        self._event_name = None
 
 
 class AnthropicMessagesJsonUsageExtractor:

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -4,13 +4,11 @@ Pure parsers shared by both the SSE streaming path and the non-streaming
 JSON fallback.
 """
 
-from collections.abc import Callable
-
 import body_utils
 
 from .json_selective import JsonSelectiveExtractor, ScalarField
 from .model_tokens import ANTHROPIC_USAGE_FIELD_CATEGORIES
-from .sse import SseUsageScanner
+from .sse import SseUsageParser
 
 _ANTHROPIC_MESSAGES_USAGE_EVENTS = frozenset(("message_start", "message_delta"))
 
@@ -37,24 +35,6 @@ _ANTHROPIC_SSE_SCALAR_FIELDS = {
 }
 
 
-def _extract_billing_usage(raw_usage, target: dict) -> None:
-    """Extract known billing fields from an Anthropic usage object into *target*.
-
-    Anthropic usage fields are normalized to usage_event categories at the
-    extraction boundary so the reporting path can forward category names
-    directly.
-
-    Only positive values overwrite existing entries — ``message_delta`` may
-    send ``0`` for fields already set correctly by ``message_start``.
-    """
-    if not raw_usage or not isinstance(raw_usage, dict):
-        return
-    for k, v in raw_usage.items():
-        category = ANTHROPIC_USAGE_FIELD_CATEGORIES.get(k)
-        if category and _is_usage_quantity(v) and (v > 0 or category not in target):
-            target[category] = v
-
-
 def _is_usage_quantity(value: object) -> bool:
     return isinstance(value, int) and not isinstance(value, bool) and value >= 0
 
@@ -66,7 +46,7 @@ def _store_selected_usage_values(values: dict, target: dict, prefix: tuple[str, 
             target[category] = value
 
 
-def create_anthropic_messages_sse_usage_extractor() -> tuple[Callable[[bytes], None], dict]:
+def create_anthropic_messages_sse_usage_extractor() -> tuple[SseUsageParser, dict]:
     """Create an incremental SSE parser that extracts usage from Anthropic API streams.
 
     Anthropic-shaped model providers use the Anthropic Messages API streaming
@@ -80,26 +60,23 @@ def create_anthropic_messages_sse_usage_extractor() -> tuple[Callable[[bytes], N
     incrementally and *usage* is a dict that accumulates extracted fields.
     """
     usage: dict = {}
-    scanner = SseUsageScanner(_AnthropicMessagesSseUsageHandler(usage))
-
-    def parse_chunk(chunk: bytes) -> None:
-        scanner.feed(chunk)
-
-    return parse_chunk, usage
+    parser = SseUsageParser(
+        _AnthropicMessagesSseUsageHandler(usage),
+        capture_data_without_event=True,
+    )
+    return parser, usage
 
 
 class _AnthropicMessagesSseUsageHandler:
     def __init__(self, usage: dict) -> None:
         self._usage = usage
         self._extractor: JsonSelectiveExtractor | None = None
-        self._event_name: str | None = None
 
     def should_capture_event(self, event_name: str | None) -> bool:
         return event_name in _ANTHROPIC_MESSAGES_USAGE_EVENTS
 
-    def on_event_start(self, event_name: str | None) -> None:
+    def on_event_start(self, _event_name: str | None) -> None:
         self._extractor = JsonSelectiveExtractor(scalar_fields=_ANTHROPIC_SSE_SCALAR_FIELDS)
-        self._event_name = event_name
 
     def on_data(self, chunk: bytes) -> None:
         if self._extractor is not None:
@@ -108,11 +85,9 @@ class _AnthropicMessagesSseUsageHandler:
     def on_data_separator(self) -> None:
         self.on_data(b"\n")
 
-    def on_event_end(self, _event_name: str | None) -> None:
+    def on_event_end(self, event_name: str | None) -> None:
         extractor = self._extractor
-        event_name = self._event_name
         self._extractor = None
-        self._event_name = None
         if extractor is None:
             return
 
@@ -133,7 +108,6 @@ class _AnthropicMessagesSseUsageHandler:
 
     def on_event_discard(self, _event_name: str | None) -> None:
         self._extractor = None
-        self._event_name = None
 
 
 class AnthropicMessagesJsonUsageExtractor:

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -22,6 +22,7 @@ _MODEL_JSON_SCALAR_FIELDS = {
 }
 
 _ANTHROPIC_SSE_SCALAR_FIELDS = {
+    ("type",): ScalarField("string", max_bytes=1024),
     ("message", "id"): ScalarField("string", max_bytes=1024),
     ("message", "model"): ScalarField("string", max_bytes=1024),
     **{
@@ -95,7 +96,13 @@ class _AnthropicMessagesSseUsageHandler:
         if not result.complete:
             return
 
-        if event_name == "message_start":
+        event_type = event_name
+        if event_type is None:
+            data_type = result.values.get(("type",))
+            if isinstance(data_type, str):
+                event_type = data_type
+
+        if event_type == "message_start":
             model = result.values.get(("message", "model"))
             if isinstance(model, str) and model:
                 self._usage["model"] = model
@@ -103,7 +110,7 @@ class _AnthropicMessagesSseUsageHandler:
             if isinstance(message_id, str) and message_id:
                 self._usage["message_id"] = message_id
             _store_selected_usage_values(result.values, self._usage, ("message", "usage"))
-        elif event_name == "message_delta":
+        elif event_type == "message_delta":
             _store_selected_usage_values(result.values, self._usage, ("usage",))
 
     def on_event_discard(self, _event_name: str | None) -> None:

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -1,7 +1,5 @@
 """OpenAI Responses API usage parsing primitives."""
 
-from collections.abc import Callable
-
 import body_utils
 
 from .json_selective import JsonSelectiveExtractor, ScalarField
@@ -10,7 +8,7 @@ from .model_tokens import (
     MODEL_USAGE_CATEGORY_INPUT,
     MODEL_USAGE_CATEGORY_OUTPUT,
 )
-from .sse import SseUsageScanner
+from .sse import SseUsageParser
 
 _RESPONSES_USAGE_EVENTS = frozenset(("response.completed", "response.done"))
 
@@ -111,30 +109,27 @@ def _store_sse_result_values(
     _store_response_values(values, target, prefix)
 
 
-def create_openai_responses_sse_usage_extractor() -> tuple[Callable[[bytes], None], dict]:
+def create_openai_responses_sse_usage_extractor() -> tuple[SseUsageParser, dict]:
     """Create an incremental SSE parser for OpenAI Responses streams."""
 
     usage: dict = {}
-    scanner = SseUsageScanner(_OpenAIResponsesSseUsageHandler(usage))
-
-    def parse_chunk(chunk: bytes) -> None:
-        scanner.feed(chunk)
-
-    return parse_chunk, usage
+    parser = SseUsageParser(
+        _OpenAIResponsesSseUsageHandler(usage),
+        capture_data_without_event=True,
+    )
+    return parser, usage
 
 
 class _OpenAIResponsesSseUsageHandler:
     def __init__(self, usage: dict) -> None:
         self._usage = usage
         self._extractor: JsonSelectiveExtractor | None = None
-        self._event_name: str | None = None
 
     def should_capture_event(self, event_name: str | None) -> bool:
         return event_name is None or event_name in _RESPONSES_USAGE_EVENTS
 
-    def on_event_start(self, event_name: str | None) -> None:
+    def on_event_start(self, _event_name: str | None) -> None:
         self._extractor = JsonSelectiveExtractor(scalar_fields=_RESPONSES_SSE_SCALAR_FIELDS)
-        self._event_name = event_name
 
     def on_data(self, chunk: bytes) -> None:
         if self._extractor is not None:
@@ -143,11 +138,9 @@ class _OpenAIResponsesSseUsageHandler:
     def on_data_separator(self) -> None:
         self.on_data(b"\n")
 
-    def on_event_end(self, _event_name: str | None) -> None:
+    def on_event_end(self, event_name: str | None) -> None:
         extractor = self._extractor
-        event_name = self._event_name
         self._extractor = None
-        self._event_name = None
         if extractor is None:
             return
         result = extractor.finish()
@@ -156,7 +149,6 @@ class _OpenAIResponsesSseUsageHandler:
 
     def on_event_discard(self, _event_name: str | None) -> None:
         self._extractor = None
-        self._event_name = None
 
 
 class OpenAIResponsesJsonUsageExtractor:

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -10,11 +10,7 @@ from .model_tokens import (
     MODEL_USAGE_CATEGORY_INPUT,
     MODEL_USAGE_CATEGORY_OUTPUT,
 )
-
-# Keep these in sync with ``usage.anthropic_messages`` so provider-specific SSE parsers
-# have the same boundary handling and bounded skip behavior.
-_SSE_SEPARATORS: tuple[bytes, ...] = (b"\r\n\r\n", b"\n\n")
-_MAX_SEPARATOR_LEN = max(len(s) for s in _SSE_SEPARATORS)
+from .sse import SseUsageScanner
 
 _RESPONSES_USAGE_EVENTS = frozenset(("response.completed", "response.done"))
 
@@ -31,10 +27,6 @@ _RESPONSES_SSE_SCALAR_FIELDS = {
     **_RESPONSES_RESPONSE_SCALAR_FIELDS,
     **{("response", *path): field for path, field in _RESPONSES_RESPONSE_SCALAR_FIELDS.items()},
 }
-
-# Non-data SSE control lines should be tiny. Cap malformed lines so a provider
-# bug cannot grow memory while we wait for a newline.
-_MAX_SSE_CONTROL_LINE_BYTES = 4096
 
 
 def _is_usage_quantity(value: object) -> bool:
@@ -123,120 +115,48 @@ def create_openai_responses_sse_usage_extractor() -> tuple[Callable[[bytes], Non
     """Create an incremental SSE parser for OpenAI Responses streams."""
 
     usage: dict = {}
-    line_buf = bytearray()
-    event_type = {"current": None}
-    skipping = {"active": False}
-    skipping_line = {"active": False}
-    data_state: dict[str, object] = {"extractor": None, "event": None}
+    scanner = SseUsageScanner(_OpenAIResponsesSseUsageHandler(usage))
 
-    def should_capture_data_line() -> bool:
-        evt = event_type["current"]
-        return evt is None or evt in _RESPONSES_USAGE_EVENTS
+    def parse_chunk(chunk: bytes) -> None:
+        scanner.feed(chunk)
 
-    def start_data_payload() -> None:
-        data_state["extractor"] = JsonSelectiveExtractor(scalar_fields=_RESPONSES_SSE_SCALAR_FIELDS)
-        data_state["event"] = event_type["current"]
+    return parse_chunk, usage
 
-    def finish_data_payload() -> None:
-        extractor = data_state["extractor"]
-        event_name = data_state["event"]
-        data_state["extractor"] = None
-        data_state["event"] = None
-        if not isinstance(extractor, JsonSelectiveExtractor):
+
+class _OpenAIResponsesSseUsageHandler:
+    def __init__(self, usage: dict) -> None:
+        self._usage = usage
+        self._extractor: JsonSelectiveExtractor | None = None
+        self._event_name: str | None = None
+
+    def should_capture_event(self, event_name: str | None) -> bool:
+        return event_name is None or event_name in _RESPONSES_USAGE_EVENTS
+
+    def on_event_start(self, event_name: str | None) -> None:
+        self._extractor = JsonSelectiveExtractor(scalar_fields=_RESPONSES_SSE_SCALAR_FIELDS)
+        self._event_name = event_name
+
+    def on_data(self, chunk: bytes) -> None:
+        if self._extractor is not None:
+            self._extractor.feed(chunk)
+
+    def on_data_separator(self) -> None:
+        self.on_data(b"\n")
+
+    def on_event_end(self, _event_name: str | None) -> None:
+        extractor = self._extractor
+        event_name = self._event_name
+        self._extractor = None
+        self._event_name = None
+        if extractor is None:
             return
         result = extractor.finish()
         if result.complete:
-            _store_sse_result_values(
-                result.values,
-                usage,
-                event_name=event_name if isinstance(event_name, str) else None,
-            )
+            _store_sse_result_values(result.values, self._usage, event_name=event_name)
 
-    def consume_data_payload(chunk: bytes) -> bytes:
-        extractor = data_state["extractor"]
-        if not isinstance(extractor, JsonSelectiveExtractor):
-            return chunk
-
-        idx = chunk.find(b"\n")
-        if idx == -1:
-            extractor.feed(chunk)
-            return b""
-
-        payload = chunk[:idx]
-        if payload.endswith(b"\r"):
-            payload = payload[:-1]
-        extractor.feed(payload)
-        finish_data_payload()
-        return chunk[idx + 1 :]
-
-    def consume_skip(chunk: bytes) -> bytes:
-        combined = line_buf + chunk
-        for sep in _SSE_SEPARATORS:
-            idx = combined.find(sep)
-            if idx != -1:
-                after = idx + len(sep)
-                line_buf.clear()
-                skipping["active"] = False
-                event_type["current"] = None
-                return bytes(combined[after:])
-
-        tail = _MAX_SEPARATOR_LEN - 1
-        line_buf[:] = combined[-tail:] if len(combined) > tail else combined
-        return b""
-
-    def consume_skipped_line(chunk: bytes) -> bytes:
-        idx = chunk.find(b"\n")
-        if idx == -1:
-            return b""
-        skipping_line["active"] = False
-        return chunk[idx + 1 :]
-
-    def process_line(raw_line: bytes) -> None:
-        line = raw_line.rstrip(b"\r")
-        if line == b"":
-            event_type["current"] = None
-            skipping["active"] = False
-            return
-
-        if skipping["active"]:
-            return
-
-        if line.startswith(b"event: "):
-            evt_name = line[7:].decode("utf-8", errors="replace")
-            event_type["current"] = evt_name
-            if evt_name not in _RESPONSES_USAGE_EVENTS:
-                skipping["active"] = True
-
-    def consume_line_prefix(chunk: bytes) -> bytes:
-        line_buf.append(chunk[0])
-        remaining = chunk[1:]
-
-        if line_buf == b"data: " and should_capture_data_line():
-            line_buf.clear()
-            start_data_payload()
-            return remaining
-
-        if line_buf[-1:] == b"\n":
-            process_line(bytes(line_buf[:-1]))
-            line_buf.clear()
-        elif len(line_buf) > _MAX_SSE_CONTROL_LINE_BYTES:
-            line_buf.clear()
-            skipping_line["active"] = True
-
-        return remaining
-
-    def parse_chunk(chunk: bytes) -> None:
-        while chunk:
-            if data_state["extractor"] is not None:
-                chunk = consume_data_payload(chunk)
-            elif skipping["active"]:
-                chunk = consume_skip(chunk)
-            elif skipping_line["active"]:
-                chunk = consume_skipped_line(chunk)
-            else:
-                chunk = consume_line_prefix(chunk)
-
-    return parse_chunk, usage
+    def on_event_discard(self, _event_name: str | None) -> None:
+        self._extractor = None
+        self._event_name = None
 
 
 class OpenAIResponsesJsonUsageExtractor:

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -19,16 +19,19 @@ from ..webhook import _enqueue_webhook
 MODEL_USAGE_KIND = "model"
 
 
-def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> None:
-    """Enqueue extracted token usage for model-provider responses if available."""
+def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> bool:
+    """Enqueue extracted token usage for model-provider responses if available.
+
+    Returns whether a usage webhook was enqueued.
+    """
     firewall_name = flow.metadata.get("firewall_name", "")
     if not (firewall_name.startswith("model-provider:") and run_id):
-        return
+        return False
     if not flow.metadata.get("firewall_billable", False):
-        return
+        return False
     usage = flow.metadata.get("model_provider_usage")
     if not usage or not isinstance(usage, dict):
-        return
+        return False
     message_id = _string_or_none(usage.get("message_id")) or flow.id
     provider = (
         _string_or_none(flow.metadata.get("model_usage_provider"))
@@ -37,7 +40,7 @@ def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> None:
     )
     events = _build_usage_events(run_id, message_id, provider, usage)
     if not events:
-        return
+        return False
     sandbox_token = flow.metadata.get("vm_sandbox_token", "")
     api_url = get_api_url()
     proxy_log_path = flow.metadata.get("vm_proxy_log_path", "")
@@ -48,7 +51,7 @@ def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> None:
             "Cannot report usage event: missing sandbox_token or api_url",
             type="usage_event",
         )
-        return
+        return False
     url = f"{api_url}/api/webhooks/agent/usage-event"
     _enqueue_webhook(
         url,
@@ -57,6 +60,7 @@ def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> None:
         proxy_log_path,
         "usage_event",
     )
+    return True
 
 
 def _build_usage_events(run_id: str, message_id: str, provider: str, usage: dict) -> list[dict]:

--- a/crates/runner/mitm-addon/src/usage/sse.py
+++ b/crates/runner/mitm-addon/src/usage/sse.py
@@ -52,9 +52,11 @@ class SseUsageScanner:
         handler: SseUsageEventHandler,
         *,
         max_control_line_bytes: int = _MAX_CONTROL_LINE_BYTES,
+        capture_data_without_event: bool = False,
     ) -> None:
         self._handler = handler
         self._max_control_line_bytes = max_control_line_bytes
+        self._capture_data_without_event = capture_data_without_event
         self._event_name: str | None = None
         self._line_buf = bytearray()
         self._state = "line"
@@ -81,6 +83,26 @@ class SseUsageScanner:
                 i = self._consume_discard_line(chunk, i)
             else:
                 i = self._consume_line(chunk, i)
+
+    def finish(self) -> None:
+        """Flush a trailing event when the stream ends without a blank line."""
+
+        if self._state == "data_prefix_space":
+            self._start_data_line()
+        elif self._state == "line" and self._line_buf:
+            line = bytes(self._line_buf)
+            self._line_buf.clear()
+            self._process_control_line(line)
+
+        self._state = "line"
+        self._line_buf.clear()
+        self._skip_next_lf = False
+        if self._capturing_event:
+            self._finish_event()
+        else:
+            self._event_name = None
+            self._discard_event = False
+            self._captured_data_lines = 0
 
     def _consume_line(self, chunk: bytes, i: int) -> int:
         byte = chunk[i]
@@ -173,7 +195,10 @@ class SseUsageScanner:
             self._discard_current_event(event_name)
 
     def _start_data_line(self) -> None:
-        if self._discard_event or not self._handler.should_capture_event(self._event_name):
+        should_capture = self._handler.should_capture_event(self._event_name) or (
+            self._event_name is None and self._capture_data_without_event
+        )
+        if self._discard_event or not should_capture:
             self._state = "discard_line"
             return
 
@@ -221,3 +246,27 @@ def _find_next_line_ending(chunk: bytes, start: int) -> int:
     if next_cr == -1:
         return next_lf
     return min(next_lf, next_cr)
+
+
+class SseUsageParser:
+    """Callable parser wrapper with an explicit stream-end flush hook."""
+
+    def __init__(
+        self,
+        handler: SseUsageEventHandler,
+        *,
+        capture_data_without_event: bool = False,
+    ) -> None:
+        self._scanner = SseUsageScanner(
+            handler,
+            capture_data_without_event=capture_data_without_event,
+        )
+
+    def __call__(self, chunk: bytes) -> None:
+        self.feed(chunk)
+
+    def feed(self, chunk: bytes) -> None:
+        self._scanner.feed(chunk)
+
+    def finish(self) -> None:
+        self._scanner.finish()

--- a/crates/runner/mitm-addon/src/usage/sse.py
+++ b/crates/runner/mitm-addon/src/usage/sse.py
@@ -1,0 +1,223 @@
+"""Bounded Server-Sent Events scanner for usage extraction.
+
+The scanner owns only SSE framing: line endings, event names, skipped events,
+and ``data`` field boundaries.  Provider modules own JSON parsing and billing
+field mapping through the callback interface below.
+"""
+
+from typing import Protocol
+
+_CR = ord("\r")
+_LF = ord("\n")
+_SPACE = ord(" ")
+_DATA_FIELD_PREFIX = b"data:"
+
+# Non-data SSE control lines are expected to be tiny.  Cap malformed lines so
+# an upstream bug cannot grow memory while we wait for a newline.
+_MAX_CONTROL_LINE_BYTES = 4096
+
+
+class SseUsageEventHandler(Protocol):
+    """Provider-owned sink for target SSE event data."""
+
+    def should_capture_event(self, event_name: str | None) -> bool:
+        """Return whether data fields for *event_name* should be streamed."""
+
+    def on_event_start(self, event_name: str | None) -> None:
+        """Called before the first captured data field in an event."""
+
+    def on_data(self, chunk: bytes) -> None:
+        """Called with bytes from a captured data field."""
+
+    def on_data_separator(self) -> None:
+        """Called between multiple captured data fields in one event."""
+
+    def on_event_end(self, event_name: str | None) -> None:
+        """Called when a captured event reaches a blank-line boundary."""
+
+    def on_event_discard(self, event_name: str | None) -> None:
+        """Called when an in-progress captured event must be discarded."""
+
+
+class SseUsageScanner:
+    """Incrementally scan SSE bytes and stream target ``data`` fields.
+
+    This is deliberately not a full EventSource implementation and does not
+    return assembled event bodies.  It keeps only bounded control-line state;
+    captured ``data`` payload bytes are streamed directly to the handler.
+    """
+
+    def __init__(
+        self,
+        handler: SseUsageEventHandler,
+        *,
+        max_control_line_bytes: int = _MAX_CONTROL_LINE_BYTES,
+    ) -> None:
+        self._handler = handler
+        self._max_control_line_bytes = max_control_line_bytes
+        self._event_name: str | None = None
+        self._line_buf = bytearray()
+        self._state = "line"
+        self._discard_event = False
+        self._skip_next_lf = False
+        self._capturing_event = False
+        self._captured_data_lines = 0
+
+    def feed(self, chunk: bytes) -> None:
+        i = 0
+        while i < len(chunk):
+            byte = chunk[i]
+            if self._skip_next_lf:
+                self._skip_next_lf = False
+                if byte == _LF:
+                    i += 1
+                    continue
+
+            if self._state == "data":
+                i = self._consume_data(chunk, i)
+            elif self._state == "data_prefix_space":
+                i = self._consume_data_prefix_space(chunk, i)
+            elif self._state == "discard_line":
+                i = self._consume_discard_line(chunk, i)
+            else:
+                i = self._consume_line(chunk, i)
+
+    def _consume_line(self, chunk: bytes, i: int) -> int:
+        byte = chunk[i]
+        if _is_line_ending(byte):
+            self._finish_control_line(byte)
+            return i + 1
+
+        self._line_buf.append(byte)
+        if self._line_buf == _DATA_FIELD_PREFIX:
+            self._line_buf.clear()
+            self._state = "data_prefix_space"
+        elif len(self._line_buf) > self._max_control_line_bytes:
+            self._discard_malformed_control_line()
+        return i + 1
+
+    def _consume_data_prefix_space(self, chunk: bytes, i: int) -> int:
+        byte = chunk[i]
+        if _is_line_ending(byte):
+            self._start_data_line()
+            self._finish_data_or_discard_line(byte)
+            return i + 1
+
+        self._start_data_line()
+        if byte == _SPACE:
+            return i + 1
+        return i
+
+    def _consume_data(self, chunk: bytes, i: int) -> int:
+        line_end = _find_next_line_ending(chunk, i)
+        if line_end == -1:
+            self._handler.on_data(chunk[i:])
+            return len(chunk)
+
+        if line_end > i:
+            self._handler.on_data(chunk[i:line_end])
+        self._finish_data_or_discard_line(chunk[line_end])
+        return line_end + 1
+
+    def _consume_discard_line(self, chunk: bytes, i: int) -> int:
+        line_end = _find_next_line_ending(chunk, i)
+        if line_end == -1:
+            return len(chunk)
+
+        self._finish_data_or_discard_line(chunk[line_end])
+        return line_end + 1
+
+    def _finish_control_line(self, line_ending: int) -> None:
+        line = bytes(self._line_buf)
+        self._line_buf.clear()
+        self._process_control_line(line)
+        self._state = "line"
+        if line_ending == _CR:
+            self._skip_next_lf = True
+
+    def _finish_data_or_discard_line(self, line_ending: int) -> None:
+        self._state = "line"
+        if line_ending == _CR:
+            self._skip_next_lf = True
+
+    def _process_control_line(self, line: bytes) -> None:
+        if line == b"":
+            self._finish_event()
+            return
+
+        if self._discard_event:
+            return
+
+        if line == b"data":
+            self._start_data_line()
+            self._state = "line"
+            return
+
+        if line.startswith(b":"):
+            return
+
+        if b":" in line:
+            field, value = line.split(b":", 1)
+            if value.startswith(b" "):
+                value = value[1:]
+        else:
+            field = line
+            value = b""
+
+        if field != b"event":
+            return
+
+        event_name = value.decode("utf-8", errors="replace")
+        self._event_name = event_name
+        if not self._handler.should_capture_event(event_name):
+            self._discard_current_event(event_name)
+
+    def _start_data_line(self) -> None:
+        if self._discard_event or not self._handler.should_capture_event(self._event_name):
+            self._state = "discard_line"
+            return
+
+        if not self._capturing_event:
+            self._capturing_event = True
+            self._captured_data_lines = 0
+            self._handler.on_event_start(self._event_name)
+        elif self._captured_data_lines > 0:
+            self._handler.on_data_separator()
+
+        self._captured_data_lines += 1
+        self._state = "data"
+
+    def _discard_malformed_control_line(self) -> None:
+        self._line_buf.clear()
+        if self._capturing_event or self._event_name is not None:
+            self._discard_current_event(self._event_name)
+        self._state = "discard_line"
+
+    def _discard_current_event(self, event_name: str | None) -> None:
+        if self._capturing_event:
+            self._handler.on_event_discard(event_name)
+        self._capturing_event = False
+        self._captured_data_lines = 0
+        self._discard_event = True
+
+    def _finish_event(self) -> None:
+        if self._capturing_event:
+            self._handler.on_event_end(self._event_name)
+        self._event_name = None
+        self._discard_event = False
+        self._capturing_event = False
+        self._captured_data_lines = 0
+
+
+def _is_line_ending(byte: int) -> bool:
+    return byte in (_LF, _CR)
+
+
+def _find_next_line_ending(chunk: bytes, start: int) -> int:
+    next_lf = chunk.find(b"\n", start)
+    next_cr = chunk.find(b"\r", start)
+    if next_lf == -1:
+        return next_cr
+    if next_cr == -1:
+        return next_lf
+    return min(next_lf, next_cr)

--- a/crates/runner/mitm-addon/src/usage/sse.py
+++ b/crates/runner/mitm-addon/src/usage/sse.py
@@ -191,7 +191,7 @@ class SseUsageScanner:
 
         event_name = value.decode("utf-8", errors="replace")
         self._event_name = event_name
-        if not self._handler.should_capture_event(event_name):
+        if self._capturing_event and not self._handler.should_capture_event(event_name):
             self._discard_current_event(event_name)
 
     def _start_data_line(self) -> None:
@@ -199,6 +199,10 @@ class SseUsageScanner:
             self._event_name is None and self._capture_data_without_event
         )
         if self._discard_event or not should_capture:
+            if not self._capturing_event:
+                self._discard_event = True
+            else:
+                self._discard_current_event(self._event_name)
             self._state = "discard_line"
             return
 

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -161,3 +161,6 @@ def _enqueue_webhook(
             url=url,
         )
         _post_webhook_with_retry(url, sandbox_token, copied, proxy_log_path, log_type)
+    except Exception:
+        _decrement_reports()
+        raise

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -2637,6 +2637,42 @@ class TestResponseUsageReporting:
             "tokens.cache_read": 10,
         }
 
+    def test_response_then_error_does_not_enqueue_model_usage_twice(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """If mitmproxy fires both hooks for one flow, model usage reports once."""
+        flow = real_flow(with_response=False, host="api.openai.com")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
+        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["model_provider_usage"] = {
+            "model": "gpt-5.5",
+            "tokens.output": 20,
+        }
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            flow.error = Error("connection reset after response")
+            mitm_addon.error(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        assert [event["category"] for event in events] == ["tokens.output"]
+
     def test_full_pipeline_large_model_json_uses_bounded_buffer(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
     ):
@@ -5367,6 +5403,25 @@ class TestUsagePendingCounter:
             }
         finally:
             usage.counters._decrement_reports()
+
+    def test_submit_failure_rolls_back_pending_report(self, tmp_path):
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
+
+        with (
+            patch.object(usage.webhook.usage_executor, "submit", side_effect=OSError("no threads")),
+            pytest.raises(OSError, match="no threads"),
+        ):
+            usage.webhook._enqueue_webhook(
+                "https://api.vm0.ai/api/webhooks/agent/usage-event",
+                "tok",
+                {"runId": "run-1", "events": [{"category": "tokens.input", "quantity": 1}]},
+                "",
+                "usage_event",
+            )
+
+        assert usage.counters._pending_reports == 0
+        _assert_pending(pending_path, flows=0, reports=0)
 
     def test_set_pending_path_accepts_explicit_usage_state_id(self, tmp_path):
         pending_path = tmp_path / "usage-pending"

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1713,6 +1713,15 @@ class TestAnthropicSseUsageExtractor:
         assert usage["model"] == "claude-sonnet-4-6"
         assert usage["tokens.input"] == 56
 
+    def test_accepts_data_level_type_without_event_line(self):
+        parse, usage = create_anthropic_messages_sse_usage_extractor()
+        parse(
+            b'data: {"type":"message_start","message":{"model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":58}}}\n\n'
+        )
+        assert usage["model"] == "claude-sonnet-4-6"
+        assert usage["tokens.input"] == 58
+
     def test_empty_chunks(self):
         parse, usage = create_anthropic_messages_sse_usage_extractor()
         parse(b"")

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1687,11 +1687,21 @@ class TestAnthropicSseUsageExtractor:
         parse(
             b"event: message_start\n"
             b'data: {"message":{"model":"claude-sonnet-4-6",'
-            b'"usage":{"input_tokens":55}}}\n'
+            b'"usage":{"input_tokens":55}}}'
         )
         parse.finish()
         assert usage["model"] == "claude-sonnet-4-6"
         assert usage["tokens.input"] == 55
+
+    def test_accepts_sse_fields_without_optional_space(self):
+        parse, usage = create_anthropic_messages_sse_usage_extractor()
+        parse(
+            b"event:message_start\n"
+            b'data:{"message":{"model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":57}}}\n\n'
+        )
+        assert usage["model"] == "claude-sonnet-4-6"
+        assert usage["tokens.input"] == 57
 
     def test_accepts_event_name_after_data_line(self):
         parse, usage = create_anthropic_messages_sse_usage_extractor()
@@ -1987,11 +1997,21 @@ class TestOpenAIResponsesSseUsageExtractor:
         parse(
             b"event: response.completed\n"
             b'data: {"response":{"model":"gpt-5.4",'
-            b'"usage":{"output_tokens":4}}}\n'
+            b'"usage":{"output_tokens":4}}}'
         )
         parse.finish()
         assert usage["model"] == "gpt-5.4"
         assert usage["tokens.output"] == 4
+
+    def test_accepts_sse_fields_without_optional_space(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b"event:response.completed\n"
+            b'data:{"response":{"model":"gpt-5.4",'
+            b'"usage":{"output_tokens":5}}}\n\n'
+        )
+        assert usage["model"] == "gpt-5.4"
+        assert usage["tokens.output"] == 5
 
     def test_accepts_event_name_after_data_line(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
@@ -2564,6 +2584,49 @@ class TestResponseUsageReporting:
 
         mock_opener.open.assert_not_called()
         assert "model_provider_usage" not in flow.metadata
+
+    def test_full_pipeline_model_sse_finalizes_trailing_event(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """response() must flush a trailing SSE usage event before reporting."""
+        flow = real_flow(with_response=False, host="api.openai.com")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
+        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "text/event-stream"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        flow.response.stream(
+            b"event: response.completed\n"
+            b'data: {"response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":50,"output_tokens":20,'
+            b'"input_tokens_details":{"cached_tokens":10}}}}'
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert by_category == {
+            "tokens.input": 40,
+            "tokens.output": 20,
+            "tokens.cache_read": 10,
+        }
 
     def test_full_pipeline_large_model_json_uses_bounded_buffer(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -2776,6 +2776,30 @@ class TestResponseUsageReporting:
         assert "stream_buffer_state" not in flow.metadata
         assert "x_json_response_finish" not in flow.metadata
 
+    def test_response_without_run_id_releases_sse_streaming_state(self, real_flow):
+        """Early-returning SSE flows should not retain parser closures."""
+        flow = real_flow(with_response=False, host="api.openai.com")
+        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "text/event-stream"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        flow.response.stream(
+            b"event: response.completed\n"
+            b'data: {"response":{"model":"gpt-5.5","usage":{"output_tokens":7}}}\n'
+        )
+        assert "model_sse_usage_finish" in flow.metadata
+
+        mitm_addon.response(flow)
+
+        assert flow.response.stream is False
+        assert "stream_buffer" not in flow.metadata
+        assert "stream_buffer_state" not in flow.metadata
+        assert "model_sse_usage_finish" not in flow.metadata
+
     def test_response_does_not_clear_external_stream_callback(self, tmp_path, real_flow, mitm_ctx):
         """Cleanup should only reset the stream callback installed by this addon."""
         flow = real_flow(with_response=False, host="api.example.com")

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -19,6 +19,7 @@ import auth
 import body_utils
 import mitm_addon
 import registry as registry_cache
+import response_streaming
 import usage
 from usage import (
     create_anthropic_messages_sse_usage_extractor,
@@ -1681,6 +1682,27 @@ class TestAnthropicSseUsageExtractor:
         parse(b"event: message_start\ndata: {invalid json}\n\n")
         assert usage == {}  # no crash, no data
 
+    def test_finish_flushes_message_start_without_blank_line(self):
+        parse, usage = create_anthropic_messages_sse_usage_extractor()
+        parse(
+            b"event: message_start\n"
+            b'data: {"message":{"model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":55}}}\n'
+        )
+        parse.finish()
+        assert usage["model"] == "claude-sonnet-4-6"
+        assert usage["tokens.input"] == 55
+
+    def test_accepts_event_name_after_data_line(self):
+        parse, usage = create_anthropic_messages_sse_usage_extractor()
+        parse(
+            b'data: {"message":{"model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":56}}}\n'
+            b"event: message_start\n\n"
+        )
+        assert usage["model"] == "claude-sonnet-4-6"
+        assert usage["tokens.input"] == 56
+
     def test_empty_chunks(self):
         parse, usage = create_anthropic_messages_sse_usage_extractor()
         parse(b"")
@@ -1959,6 +1981,27 @@ class TestOpenAIResponsesSseUsageExtractor:
         )
         assert usage["model"] == "gpt-5.4-mini"
         assert usage["tokens.input"] == 3
+
+    def test_finish_flushes_response_completed_without_blank_line(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b"event: response.completed\n"
+            b'data: {"response":{"model":"gpt-5.4",'
+            b'"usage":{"output_tokens":4}}}\n'
+        )
+        parse.finish()
+        assert usage["model"] == "gpt-5.4"
+        assert usage["tokens.output"] == 4
+
+    def test_accepts_event_name_after_data_line(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b'data: {"response":{"model":"gpt-5.4",'
+            b'"usage":{"output_tokens":4}}}\n'
+            b"event: response.completed\n\n"
+        )
+        assert usage["model"] == "gpt-5.4"
+        assert usage["tokens.output"] == 4
 
     def test_handles_chunked_event_and_data_prefix(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
@@ -2249,6 +2292,30 @@ class TestResponseHeadersSseParser:
         )
         assert flow.metadata["model_provider_usage"]["model"] == "gpt-5.5"
         assert flow.metadata["model_provider_usage"]["tokens.output"] == 5
+
+    def test_finalizes_sse_parser_for_trailing_event_without_blank_line(self, real_flow):
+        flow = real_flow(with_response=False, host="api.openai.com")
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "text/event-stream"}),
+        )
+        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["firewall_billable"] = True
+
+        mitm_addon.responseheaders(flow)
+
+        callback = flow.response.stream
+        callback(
+            b"event: response.completed\n"
+            b'data: {"response":{"model":"gpt-5.5",'
+            b'"usage":{"output_tokens":7}}}\n'
+        )
+        assert flow.metadata["model_provider_usage"] == {}
+
+        response_streaming.finalize_model_sse_usage(flow)
+
+        assert flow.metadata["model_provider_usage"]["model"] == "gpt-5.5"
+        assert flow.metadata["model_provider_usage"]["tokens.output"] == 7
 
     def test_sets_up_openai_sse_parser_for_openai_model_provider(self, real_flow, headers):
         flow = real_flow(with_response=False, host="api.openai.com")

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1701,6 +1701,17 @@ class TestAnthropicSseUsageExtractor:
         assert usage["model"] == "claude-sonnet-4-6"
         assert usage["tokens.input"] == 77
 
+    def test_standalone_cr_line_endings(self):
+        parse, usage = create_anthropic_messages_sse_usage_extractor()
+        parse(
+            b"event: message_start\r"
+            b'data: {"message":{"model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":88}}}\r'
+            b"\r"
+        )
+        assert usage["model"] == "claude-sonnet-4-6"
+        assert usage["tokens.input"] == 88
+
     def test_skips_content_block_data_without_buffering(self):
         """Large content_block_delta data should not accumulate in line_buf."""
         parse, usage = create_anthropic_messages_sse_usage_extractor()
@@ -1771,6 +1782,24 @@ class TestAnthropicSseUsageExtractor:
         )
         assert usage["tokens.input"] == 5
         assert usage["tokens.output"] == 99
+
+    def test_extracts_usage_from_large_message_start_data_line(self):
+        parse, usage = create_anthropic_messages_sse_usage_extractor()
+        parse(b"event: message_start\n")
+        parse(
+            b'data: {"type":"message_start","message":{"id":"msg_big",'
+            b'"model":"claude-sonnet-4-6","content":[{"type":"text","text":"' + b"x" * 100_000
+        )
+        parse(
+            b'"}],"usage":{"input_tokens":123,"cache_read_input_tokens":45,"output_tokens":6}}}\n\n'
+        )
+        assert usage == {
+            "message_id": "msg_big",
+            "model": "claude-sonnet-4-6",
+            "tokens.input": 123,
+            "tokens.cache_read": 45,
+            "tokens.output": 6,
+        }
 
     def test_empty_usage_dict_not_reported(self):
         """Empty model_provider_usage (SSE ran but no usage found) should not trigger report."""
@@ -1956,6 +1985,16 @@ class TestOpenAIResponsesSseUsageExtractor:
         )
         assert usage["model"] == "gpt-5.4"
         assert usage["tokens.input"] == 10
+        assert usage["tokens.output"] == 4
+
+    def test_multidata_response_completed_event(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b"event: response.completed\n"
+            b'data: {"response":\n'
+            b'data: {"model":"gpt-5.4","usage":{"output_tokens":4}}}\n\n'
+        )
+        assert usage["model"] == "gpt-5.4"
         assert usage["tokens.output"] == 4
 
     def test_skips_large_irrelevant_events_without_buffering(self):

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -2673,6 +2673,42 @@ class TestResponseUsageReporting:
         events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
         assert [event["category"] for event in events] == ["tokens.output"]
 
+    def test_empty_model_usage_does_not_block_later_error_usage(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """A no-event response pass must not mark the flow reported."""
+        flow = real_flow(with_response=False, host="api.openai.com")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
+        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["model_provider_usage"] = {"model": "gpt-5.5"}
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "application/json"}),
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            mock_opener.open.assert_not_called()
+
+            flow.metadata["model_provider_usage"]["tokens.output"] = 20
+            flow.error = Error("connection reset after response")
+            mitm_addon.error(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        assert [event["category"] for event in events] == ["tokens.output"]
+
     def test_full_pipeline_large_model_json_uses_bounded_buffer(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
     ):

--- a/crates/runner/mitm-addon/tests/test_sse.py
+++ b/crates/runner/mitm-addon/tests/test_sse.py
@@ -1,0 +1,88 @@
+"""Tests for the bounded usage SSE scanner."""
+
+import pytest
+
+from usage.sse import SseUsageScanner
+
+
+class _CaptureHandler:
+    def __init__(self, target_events: set[str | None]) -> None:
+        self.target_events = target_events
+        self.current: bytearray | None = None
+        self.started: list[str | None] = []
+        self.events: list[tuple[str | None, bytes]] = []
+        self.discarded: list[str | None] = []
+
+    def should_capture_event(self, event_name: str | None) -> bool:
+        return event_name in self.target_events
+
+    def on_event_start(self, event_name: str | None) -> None:
+        self.started.append(event_name)
+        self.current = bytearray()
+
+    def on_data(self, chunk: bytes) -> None:
+        assert self.current is not None
+        self.current.extend(chunk)
+
+    def on_data_separator(self) -> None:
+        self.on_data(b"\n")
+
+    def on_event_end(self, event_name: str | None) -> None:
+        assert self.current is not None
+        self.events.append((event_name, bytes(self.current)))
+        self.current = None
+
+    def on_event_discard(self, event_name: str | None) -> None:
+        self.discarded.append(event_name)
+        self.current = None
+
+
+def test_streams_target_multi_data_with_newline_injection() -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    scanner.feed(b"eve")
+    scanner.feed(b"nt: target\nda")
+    scanner.feed(b'ta: {"a":')
+    scanner.feed(b"\ndata:")
+    scanner.feed(b" 1}\n\n")
+
+    assert handler.started == ["target"]
+    assert handler.events == [("target", b'{"a":\n1}')]
+    assert handler.discarded == []
+
+
+@pytest.mark.parametrize("newline", [b"\n", b"\r\n", b"\r"])
+def test_supports_sse_line_endings(newline: bytes) -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    scanner.feed(b"event: target" + newline + b"data: payload" + newline + newline)
+
+    assert handler.events == [("target", b"payload")]
+
+
+def test_skips_large_ignored_event_and_recovers_in_same_chunk() -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    scanner.feed(
+        b"event: ignored\n"
+        + b"data: "
+        + b"x" * 200_000
+        + b"\n\n"
+        + b"event: target\n"
+        + b"data: ok\n\n"
+    )
+
+    assert handler.events == [("target", b"ok")]
+    assert handler.discarded == []
+
+
+def test_long_malformed_control_line_recovers_for_next_event() -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    scanner.feed(b"x" * 5000 + b"\n" + b"event: target\n" + b"data: ok\n\n")
+
+    assert handler.events == [("target", b"ok")]

--- a/crates/runner/mitm-addon/tests/test_sse.py
+++ b/crates/runner/mitm-addon/tests/test_sse.py
@@ -96,6 +96,31 @@ def test_discards_data_before_ignored_event_name() -> None:
     assert handler.discarded == ["ignored"]
 
 
+def test_event_name_can_change_before_data_starts() -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    scanner.feed(b"event: ignored\n")
+    scanner.feed(b"event: target\n")
+    scanner.feed(b"data: ok\n\n")
+
+    assert handler.events == [("target", b"ok")]
+    assert handler.discarded == []
+
+
+def test_target_after_discarded_data_does_not_emit_partial_event() -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    scanner.feed(b"event: ignored\n")
+    scanner.feed(b"data: already-discarded\n")
+    scanner.feed(b"event: target\n")
+    scanner.feed(b"data: partial\n\n")
+
+    assert handler.events == []
+    assert handler.discarded == []
+
+
 @pytest.mark.parametrize("newline", [b"\n", b"\r\n", b"\r"])
 def test_supports_sse_line_endings(newline: bytes) -> None:
     handler = _CaptureHandler({"target"})

--- a/crates/runner/mitm-addon/tests/test_sse.py
+++ b/crates/runner/mitm-addon/tests/test_sse.py
@@ -52,6 +52,38 @@ def test_streams_target_multi_data_with_newline_injection() -> None:
     assert handler.discarded == []
 
 
+def test_finish_flushes_current_event_without_blank_line() -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    scanner.feed(b"event: target\ndata: ok\n")
+    scanner.finish()
+    scanner.finish()
+
+    assert handler.events == [("target", b"ok")]
+
+
+def test_can_capture_data_before_target_event_name() -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler, capture_data_without_event=True)
+
+    scanner.feed(b"data: ok\n")
+    scanner.feed(b"event: target\n\n")
+
+    assert handler.events == [("target", b"ok")]
+
+
+def test_discards_data_before_ignored_event_name() -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler, capture_data_without_event=True)
+
+    scanner.feed(b"data: ignored\n")
+    scanner.feed(b"event: ignored\n\n")
+
+    assert handler.events == []
+    assert handler.discarded == ["ignored"]
+
+
 @pytest.mark.parametrize("newline", [b"\n", b"\r\n", b"\r"])
 def test_supports_sse_line_endings(newline: bytes) -> None:
     handler = _CaptureHandler({"target"})

--- a/crates/runner/mitm-addon/tests/test_sse.py
+++ b/crates/runner/mitm-addon/tests/test_sse.py
@@ -56,11 +56,23 @@ def test_finish_flushes_current_event_without_blank_line() -> None:
     handler = _CaptureHandler({"target"})
     scanner = SseUsageScanner(handler)
 
-    scanner.feed(b"event: target\ndata: ok\n")
+    scanner.feed(b"event: target\ndata: ok")
     scanner.finish()
     scanner.finish()
 
     assert handler.events == [("target", b"ok")]
+
+
+def test_supports_no_optional_space_and_split_crlf() -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    scanner.feed(b"event:target\r")
+    scanner.feed(b"\ndata:payload\r")
+    scanner.feed(b"\n\r")
+    scanner.feed(b"\n")
+
+    assert handler.events == [("target", b"payload")]
 
 
 def test_can_capture_data_before_target_event_name() -> None:
@@ -117,4 +129,17 @@ def test_long_malformed_control_line_recovers_for_next_event() -> None:
 
     scanner.feed(b"x" * 5000 + b"\n" + b"event: target\n" + b"data: ok\n\n")
 
+    assert handler.events == [("target", b"ok")]
+
+
+def test_long_malformed_control_line_discards_current_event() -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    scanner.feed(
+        b"event: target\n"
+        b"data: partial\n" + b"x" * 5000 + b"\n\n" + b"event: target\n" + b"data: ok\n\n"
+    )
+
+    assert handler.discarded == ["target"]
     assert handler.events == [("target", b"ok")]

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -897,6 +897,7 @@ PY
             "usage/model_tokens.py",
             "usage/namespaces.py",
             "usage/openai_responses.py",
+            "usage/sse.py",
             "usage/webhook.py",
             "usage/providers/__init__.py",
             "usage/providers/model_provider.py",


### PR DESCRIPTION
## Summary
- add a shared bounded SSE scanner for model-provider usage parsing
- migrate OpenAI Responses and Anthropic Messages SSE usage paths onto the scanner
- switch Anthropic SSE usage JSON parsing to JsonSelectiveExtractor
- add scanner/provider edge tests and embed the new addon module

## Tests
- pytest crates/runner/mitm-addon/tests/test_sse.py crates/runner/mitm-addon/tests/test_handlers.py crates/runner/mitm-addon/tests/test_body_capture.py crates/runner/mitm-addon/tests/test_json_selective.py -q
- ruff check crates/runner/mitm-addon/src/usage crates/runner/mitm-addon/tests/test_sse.py crates/runner/mitm-addon/tests/test_handlers.py crates/runner/mitm-addon/tests/test_body_capture.py
- cargo test -p runner --bin runner proxy::tests::addon_scripts_are_embedded
- cargo fmt --check
- lefthook pre-commit: ruff-fmt, ruff-check, cargo-doc, cargo-clippy, cargo-fmt

Closes #11949