### PR TITLE
fix(cli): guide disconnected authorized connectors

### DIFF
--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
@@ -193,6 +193,39 @@ describe("zero connector status command", () => {
       expect(logCalls).not.toContain("[Authorize github]");
     });
 
+    it("shows connect and doctor guidance when connector is authorized but not connected", async () => {
+      server.use(
+        stubConnector(
+          { error: { message: "Not found", code: "NOT_FOUND" } },
+          404,
+        ),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, ["github"]),
+      );
+
+      await statusCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--agent",
+        AGENT_UUID,
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("not connected");
+      expect(logCalls).toContain(
+        `The github connector is authorized for agent maya (${AGENT_UUID}), but it is not connected.`,
+      );
+      expect(logCalls).toContain("[Connect github](");
+      expect(logCalls).toContain(
+        `/connectors/github/connect?agentId=${AGENT_UUID}`,
+      );
+      expect(logCalls).toContain(
+        "zero doctor check-connector --env-name GH_TOKEN",
+      );
+      expect(logCalls).not.toContain("[Authorize github]");
+    });
+
     it("uses $ZERO_AGENT_ID when --agent flag is not provided", async () => {
       vi.stubEnv("ZERO_AGENT_ID", AGENT_UUID);
       server.use(

--- a/turbo/apps/cli/src/commands/zero/connector/status.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/status.ts
@@ -2,9 +2,11 @@ import { Command } from "commander";
 import chalk from "chalk";
 import {
   CONNECTOR_TYPES,
+  type ConnectorType,
   connectorTypeSchema,
 } from "@vm0/connectors/connectors";
 import {
+  getConnectorEnvironmentMapping,
   getScopeDiff,
   hasRequiredScopes,
 } from "@vm0/connectors/connector-utils";
@@ -15,6 +17,20 @@ import { resolveAgentContext } from "./agent-context";
 import { getPlatformOrigin } from "../doctor/platform-url";
 
 const LABEL_WIDTH = 16;
+
+function getDoctorCommand(type: ConnectorType): string | null {
+  const [envName] = Object.keys(getConnectorEnvironmentMapping(type));
+  return envName ? `zero doctor check-connector --env-name ${envName}` : null;
+}
+
+function printDoctorHint(type: ConnectorType): void {
+  const command = getDoctorCommand(type);
+  if (command) {
+    console.log(`Diagnose it with: ${command}`);
+  } else {
+    console.log("Having trouble? Run: zero doctor --help");
+  }
+}
 
 export const statusCommand = new Command()
   .name("status")
@@ -100,7 +116,15 @@ export const statusCommand = new Command()
             : `${agentCtx.displayName} (${agentCtx.agentId})`;
 
         console.log();
-        if (authorized) {
+        if (authorized && !isConnected) {
+          const origin = await getPlatformOrigin();
+          const url = `${origin}/connectors/${parseResult.data}/connect?agentId=${agentCtx.agentId}`;
+          console.log(
+            `The ${parseResult.data} connector is authorized for agent ${agentLabel}, but it is not connected.`,
+          );
+          console.log(`Connect it at: [Connect ${parseResult.data}](${url})`);
+          printDoctorHint(parseResult.data);
+        } else if (authorized) {
           console.log(
             `The ${parseResult.data} connector is authorized for agent ${agentLabel}.`,
           );
@@ -111,6 +135,7 @@ export const statusCommand = new Command()
             `The ${parseResult.data} connector is not connected. Once connected, it will be authorized for agent ${agentLabel}.`,
           );
           console.log(`Connect it at: [Connect ${parseResult.data}](${url})`);
+          printDoctorHint(parseResult.data);
         } else {
           const origin = await getPlatformOrigin();
           const url = `${origin}/connectors/${parseResult.data}/authorize?agentId=${agentCtx.agentId}`;
@@ -121,6 +146,9 @@ export const statusCommand = new Command()
             `Authorize it at: [Authorize ${parseResult.data}](${url})`,
           );
         }
+      } else if (!connector) {
+        console.log();
+        printDoctorHint(parseResult.data);
       }
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -219,6 +219,47 @@ describe("zero doctor check-connector command", () => {
       expect(output).toContain("needs to be connected and authorized");
     });
 
+    it("should report connector authorized but not connected with a connect URL", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
+        http.get(
+          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json(runContextResponse);
+        }),
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain("not connected");
+      expect(output).toContain(
+        "The GitHub connector is authorized for this agent, but it is not connected.",
+      );
+      expect(output).toContain(
+        "[Connect GitHub](https://app.vm0.ai/connectors/github/connect?agentId=agent-abc-123)",
+      );
+      expect(output).not.toContain("[Authorize GitHub]");
+    });
+
     it("should report connector expired with reconnect URL", async () => {
       vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
       vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -153,7 +153,10 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
   console.log("");
   if (!isConnected) {
     console.log(`The ${ctx.label} connector is not connected.`);
-    if (!ctx.agentId) {
+    if (ctx.agentId && hasPermission) {
+      const connectUrl = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/connect?agentId=${ctx.agentId}`;
+      console.log(`Connect it at: [Connect ${ctx.label}](${connectUrl})`);
+    } else if (!ctx.agentId) {
       // No agentId: can't scope the authorize page, so fall back to a plain
       // connect link. With agentId, 2b's Authorize link performs the initial
       // OAuth connect before granting permission — one link covers both steps.
@@ -185,7 +188,11 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
       `Skipped — agent authorization can only be checked once the ${ctx.label} connector is reconnected (see 2a).`,
     );
   } else if (hasPermission) {
-    console.log(`The ${ctx.label} connector is authorized for this agent.`);
+    console.log(
+      isConnected
+        ? `The ${ctx.label} connector is authorized for this agent.`
+        : `The ${ctx.label} connector is authorized for this agent, but it is not connected.`,
+    );
   } else {
     const url = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/authorize?agentId=${ctx.agentId}`;
     console.log(

--- a/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
@@ -55,7 +55,7 @@ export async function getComputerUseHost(): Promise<{
   const config = await getClientConfig();
   const client = initClient(zeroComputerUseHostContract, config);
 
-  const result = await client.getHost({});
+  const result = await client.getHost({ headers: {} });
 
   if (result.status === 200) {
     return result.body;

--- a/turbo/apps/cli/src/lib/api/domains/zero-skills.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-skills.ts
@@ -11,7 +11,7 @@ import { getClientConfig, handleError } from "../core/client-factory";
 export async function listSkills(): Promise<ZeroAgentCustomSkill[]> {
   const config = await getClientConfig();
   const client = initClient(zeroSkillsCollectionContract, config);
-  const result = await client.list();
+  const result = await client.list({ headers: {} });
   if (result.status === 200) return result.body;
   handleError(result, "Failed to list skills");
 }


### PR DESCRIPTION
## Summary
- Show an explicit authorized-but-not-connected state in `zero connector status` for agent-scoped connectors.
- Point users to the connector connect flow and matching doctor command when GitHub is authorized but not connected.
- Teach `zero doctor check-connector` to distinguish authorized-but-not-connected from fully connected.
- Add CLI regression coverage for status and doctor guidance.
- Pass explicit empty headers to two CLI ts-rest calls required by CLI typecheck.

Fixes #10686

## Tests
- `pnpm -F @vm0/cli exec vitest src/commands/zero/connector/__tests__/status.test.ts src/commands/zero/doctor/__tests__/check-connector.test.ts`
- `pnpm -F @vm0/cli run check-types`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm knip` (no issues; configuration hints only)
- `pnpm vitest run --project=@vm0/cli`

## Local note
- `pnpm check-types` is blocked locally by unmodified `@vm0/app` platform ts-rest/Zod typing errors after rebasing onto latest `origin/main`. The latest main Turbo workflow is green, and this PR relies on CI for the full monorepo gate.