### PR TITLE
fix: align zero log agent filters with zero agent ids

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -26,6 +26,7 @@ import {
   eq,
   gte,
   ilike,
+  inArray,
   isNotNull,
   lt,
   or,
@@ -113,11 +114,11 @@ export function zeroLogsList(
       }
     }
 
-    // Agent name filter: name takes precedence over agent, which takes precedence over search
+    // name is the explicit compose-name filter; agent is the canonical Zero agent ID.
     if (params.name) {
       conditions.push(eq(agentComposes.name, params.name));
     } else if (params.agent) {
-      conditions.push(eq(agentComposes.name, params.agent));
+      conditions.push(eq(zeroAgents.id, params.agent));
     } else if (params.search) {
       conditions.push(ilike(agentComposes.name, `%${params.search}%`));
     }
@@ -229,7 +230,7 @@ async function getLogsTotalCount(
   if (params.name) {
     conditions.push(eq(agentComposes.name, params.name));
   } else if (params.agent) {
-    conditions.push(eq(agentComposes.name, params.agent));
+    conditions.push(eq(zeroAgents.id, params.agent));
   } else if (params.search) {
     conditions.push(ilike(agentComposes.name, `%${params.search}%`));
   }
@@ -259,6 +260,7 @@ async function getLogsTotalCount(
       agentComposes,
       eq(agentComposeVersions.composeId, agentComposes.id),
     )
+    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
     .where(and(...conditions));
 
   return result?.count ?? 0;
@@ -285,7 +287,7 @@ async function getAvailableFilters(
       .innerJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
       .where(and(...baseConditions)),
     db
-      .selectDistinct({ name: agentComposes.name })
+      .selectDistinct({ id: zeroAgents.id })
       .from(agentRuns)
       .leftJoin(
         agentComposeVersions,
@@ -295,7 +297,8 @@ async function getAvailableFilters(
         agentComposes,
         eq(agentComposeVersions.composeId, agentComposes.id),
       )
-      .where(and(...baseConditions, isNotNull(agentComposes.name))),
+      .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+      .where(and(...baseConditions, isNotNull(zeroAgents.id))),
   ]);
 
   const statuses = statusRows
@@ -334,10 +337,10 @@ async function getAvailableFilters(
 
   const agents = agentRows
     .map((r) => {
-      return r.name;
+      return r.id;
     })
-    .filter((name): name is string => {
-      return name !== null;
+    .filter((id): id is string => {
+      return id !== null;
     });
 
   return { statuses, sources, agents };
@@ -493,7 +496,7 @@ async function getUserRunIds(
   userId: string,
   orgId: string,
   since: Date,
-  agentName?: string,
+  agentId?: string,
 ): Promise<string[]> {
   const conditions = [
     eq(agentRuns.userId, userId),
@@ -501,7 +504,7 @@ async function getUserRunIds(
     gte(agentRuns.createdAt, since),
   ];
 
-  if (agentName) {
+  if (agentId) {
     const rows = await db
       .select({ runId: agentRuns.id })
       .from(agentRuns)
@@ -513,7 +516,8 @@ async function getUserRunIds(
         agentComposes,
         eq(agentComposeVersions.composeId, agentComposes.id),
       )
-      .where(and(...conditions, eq(agentComposes.name, agentName)));
+      .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+      .where(and(...conditions, eq(zeroAgents.id, agentId)));
 
     return rows.map((r) => {
       return r.runId;
@@ -554,7 +558,8 @@ async function getAgentNames(
   const rows = await db
     .select({
       runId: agentRuns.id,
-      composeName: agentComposes.name,
+      composeId: agentComposes.id,
+      displayName: zeroAgents.displayName,
     })
     .from(agentRuns)
     .leftJoin(
@@ -565,10 +570,17 @@ async function getAgentNames(
       agentComposes,
       eq(agentComposeVersions.composeId, agentComposes.id),
     )
-    .where(and(eq(agentRuns.userId, userId), eq(agentRuns.orgId, orgId)));
+    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+    .where(
+      and(
+        inArray(agentRuns.id, runIds),
+        eq(agentRuns.userId, userId),
+        eq(agentRuns.orgId, orgId),
+      ),
+    );
 
   for (const row of rows) {
-    result.set(row.runId, row.composeName || "unknown");
+    result.set(row.runId, row.displayName ?? row.composeId ?? "unknown");
   }
 
   return result;
@@ -660,7 +672,7 @@ ${runIdFilter}
       }
     }
 
-    // Resolve agent names
+    // Resolve agent labels for the existing response field.
     const matchedRunIds = [
       ...new Set(
         matches.map((e) => {

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
@@ -13,10 +13,12 @@ import { server } from "../../../../mocks/server";
 import { listCommand } from "../list";
 import chalk from "chalk";
 
+const AGENT_ID = "11111111-1111-4111-8111-111111111111";
+
 const mockLogEntry = {
   id: "abc12345-1234-1234-1234-123456789abc",
   sessionId: null,
-  agentId: "my-agent",
+  agentId: AGENT_ID,
   displayName: "My Agent",
   framework: "claude",
   triggerSource: "cli",
@@ -105,9 +107,9 @@ describe("zero logs list command", () => {
       }),
     );
 
-    await listCommand.parseAsync(["node", "cli", "--agent", "my-agent"]);
+    await listCommand.parseAsync(["node", "cli", "--agent", AGENT_ID]);
 
-    expect(capturedUrl?.searchParams.get("agent")).toBe("my-agent");
+    expect(capturedUrl?.searchParams.get("agent")).toBe(AGENT_ID);
   });
 
   it("should pass status filter to API", async () => {
@@ -200,6 +202,6 @@ describe("zero logs list command", () => {
     await listCommand.parseAsync(["node", "cli"]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("my-agent");
+    expect(logCalls).toContain(AGENT_ID);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
@@ -12,6 +12,8 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server";
 import { searchCommand } from "../search";
 
+const AGENT_ID = "11111111-1111-4111-8111-111111111111";
+
 function makeEvent(
   sequenceNumber: number,
   text: string,
@@ -143,12 +145,12 @@ describe("zero logs search command", () => {
       "cli",
       "deploy",
       "--agent",
-      "zero",
+      AGENT_ID,
       "--run",
       "abc12345-1234-1234-1234-123456789abc",
     ]);
 
-    expect(capturedUrl?.searchParams.get("agent")).toBe("zero");
+    expect(capturedUrl?.searchParams.get("agent")).toBe(AGENT_ID);
     expect(capturedUrl?.searchParams.get("runId")).toBe(
       "abc12345-1234-1234-1234-123456789abc",
     );

--- a/turbo/apps/cli/src/commands/zero/logs/list.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/list.ts
@@ -30,7 +30,7 @@ export const listCommand = new Command()
   .name("list")
   .alias("ls")
   .description("List agent run logs")
-  .option("--agent <name>", "Filter by agent name")
+  .option("--agent <id>", "Filter by Zero agent ID")
   .option(
     "--status <status>",
     "Filter by status (queued|pending|running|completed|failed|timeout|cancelled)",
@@ -45,7 +45,7 @@ export const listCommand = new Command()
     `
 Examples:
   zero logs list
-  zero logs list --agent my-agent
+  zero logs list --agent 123e4567-e89b-12d3-a456-426614174000
   zero logs list --status completed --limit 10
   zero logs list --since 1h
   zero logs list --since 1d --status completed`,

--- a/turbo/apps/cli/src/commands/zero/logs/search.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/search.ts
@@ -177,7 +177,7 @@ export const searchCommand = new Command()
   .option("-A, --after-context <n>", "Show n events after each match")
   .option("-B, --before-context <n>", "Show n events before each match")
   .option("-C, --context <n>", "Show n events before and after each match")
-  .option("--agent <name>", "Filter by agent name")
+  .option("--agent <id>", "Filter by Zero agent ID")
   .option("--run <id>", "Filter by specific run ID")
   .option("--since <time>", "Search logs since (default: 7d)")
   .option("--limit <n>", "Maximum number of matches (default: 20)")
@@ -186,7 +186,7 @@ export const searchCommand = new Command()
     `
 Examples:
   zero logs search "error"
-  zero logs search "timeout" --agent my-agent -C 2
+  zero logs search "timeout" --agent 123e4567-e89b-12d3-a456-426614174000 -C 2
   zero logs search "failed" --since 30d --limit 50`,
   )
   .action(

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
@@ -12,6 +12,8 @@ import { server } from "../../../../mocks/server";
 import { zeroSearchCommand } from "../index";
 import { searchCommand } from "../../logs/search";
 
+const AGENT_ID = "11111111-1111-4111-8111-111111111111";
+
 function stubResponse() {
   return HttpResponse.json({
     results: [
@@ -78,7 +80,7 @@ describe("zero search --source logs parity with zero logs search", () => {
       "--source",
       "logs",
       "--agent",
-      "my-agent",
+      AGENT_ID,
       "--limit",
       "5",
       "-C",
@@ -92,7 +94,7 @@ describe("zero search --source logs parity with zero logs search", () => {
       "cli",
       "OOM",
       "--agent",
-      "my-agent",
+      AGENT_ID,
       "--limit",
       "5",
       "-C",
@@ -119,7 +121,7 @@ describe("zero search --source logs parity with zero logs search", () => {
       "--source",
       "logs",
       "--agent",
-      "zero",
+      AGENT_ID,
       "--run",
       "abc12345-1234-1234-1234-123456789abc",
       "--since",
@@ -135,7 +137,7 @@ describe("zero search --source logs parity with zero logs search", () => {
     expect(captured).toHaveLength(1);
     const url = captured[0]!;
     expect(url.searchParams.get("keyword")).toBe("error");
-    expect(url.searchParams.get("agent")).toBe("zero");
+    expect(url.searchParams.get("agent")).toBe(AGENT_ID);
     expect(url.searchParams.get("runId")).toBe(
       "abc12345-1234-1234-1234-123456789abc",
     );

--- a/turbo/apps/cli/src/commands/zero/search/index.ts
+++ b/turbo/apps/cli/src/commands/zero/search/index.ts
@@ -200,7 +200,7 @@ export const zeroSearchCommand = new Command()
     collectSource,
     [] as string[],
   )
-  .option("--agent <name>", "Filter by agent name")
+  .option("--agent <agent>", "Filter by agent (logs use ID; chat uses name)")
   .option("--run <id>", "Filter by run ID")
   .option("--since <time>", "Time window (e.g., 7d, 2h)")
   .option("--limit <n>", "Maximum number of matches")

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
@@ -16,6 +16,19 @@ import { http } from "../../../../../src/__tests__/msw";
 import { server } from "../../../../../src/mocks/server";
 
 const context = testContext();
+const testCronNow = Date.parse("2000-01-01T00:10:00.000Z");
+const staleCreatedAt = new Date(testCronNow - 6 * 60 * 1000);
+
+async function runCleanup(
+  request: Parameters<typeof GET>[0],
+): Promise<Response> {
+  const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(testCronNow);
+  try {
+    return await GET(request);
+  } finally {
+    dateNowSpy.mockRestore();
+  }
+}
 
 describe("GET /api/cron/cleanup-sandboxes", () => {
   const cronSecret = "test-cron-secret";
@@ -30,10 +43,8 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     vi.stubEnv("CRON_SECRET", cronSecret);
     reloadEnv();
 
-    // The cron is intentionally global and may sweep stale runs left by
-    // previously executed tests. Keep callback dispatch at the HTTP boundary
-    // mocked so suite stability does not depend on the whole test DB being
-    // pristine.
+    // Keep callback dispatch at the HTTP boundary mocked so suite stability
+    // does not depend on external callback routes.
     server.use(
       http.post(/.*\/api\/internal\/callbacks\/.*/, () => {
         return HttpResponse.json({ success: true });
@@ -54,7 +65,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
         "http://localhost:3000/api/cron/cleanup-sandboxes",
       );
 
-      const response = await GET(request);
+      const response = await runCleanup(request);
 
       expect(response.status).toBe(401);
       const data = await response.json();
@@ -71,7 +82,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
         },
       );
 
-      const response = await GET(request);
+      const response = await runCleanup(request);
 
       expect(response.status).toBe(401);
     });
@@ -86,7 +97,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
         },
       );
 
-      const response = await GET(request);
+      const response = await runCleanup(request);
 
       expect(response.status).toBe(200);
     });
@@ -103,7 +114,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
         },
       );
 
-      const response = await GET(request);
+      const response = await runCleanup(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -130,7 +141,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
         },
       );
 
-      const response = await GET(request);
+      const response = await runCleanup(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -143,10 +154,8 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     });
 
     it("should cleanup expired sandbox after heartbeat timeout", async () => {
-      // Create only this run as stale. Moving global Date.now forward causes
-      // the cron to sweep unrelated pending runs from other tests in the shard.
       const { runId } = await seedTestRun(user.userId, testComposeId, {
-        createdAt: new Date(Date.now() - 6 * 60 * 1000),
+        createdAt: staleCreatedAt,
       });
 
       const request = createTestRequest(
@@ -158,7 +167,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
         },
       );
 
-      const response = await GET(request);
+      const response = await runCleanup(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -175,7 +184,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       // Create a completed run older than the timeout window.
       const { runId } = await seedTestRun(user.userId, testComposeId, {
         status: "completed",
-        createdAt: new Date(Date.now() - 10 * 60 * 1000),
+        createdAt: staleCreatedAt,
       });
 
       const request = createTestRequest(
@@ -187,7 +196,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
         },
       );
 
-      const response = await GET(request);
+      const response = await runCleanup(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -200,8 +209,6 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     });
 
     it("should cleanup multiple expired sandboxes from different users", async () => {
-      const staleCreatedAt = new Date(Date.now() - 6 * 60 * 1000);
-
       // Create run for first user directly in pending state
       const { runId: runId1 } = await seedTestRun(user.userId, testComposeId, {
         createdAt: staleCreatedAt,
@@ -229,7 +236,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
         },
       );
 
-      const response = await GET(request);
+      const response = await runCleanup(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -243,9 +250,8 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     });
 
     it("should set run status to timeout with appropriate reason", async () => {
-      // Create only this run as stale; keep the cron's global clock real.
       const { runId } = await seedTestRun(user.userId, testComposeId, {
-        createdAt: new Date(Date.now() - 6 * 60 * 1000),
+        createdAt: staleCreatedAt,
       });
 
       const request = createTestRequest(
@@ -257,7 +263,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
         },
       );
 
-      const response = await GET(request);
+      const response = await runCleanup(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();

--- a/turbo/apps/web/app/api/cron/telegram-cleanup/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/telegram-cleanup/__tests__/route.test.ts
@@ -36,12 +36,17 @@ describe("GET /api/cron/telegram-cleanup", () => {
     expect(body.error.code).toBe("UNAUTHORIZED");
   });
 
-  it("should return zero deleted when no old messages exist", async () => {
+  it("should preserve recent messages and return deleted count", async () => {
+    const installationId = await createTestTelegramInstallation();
+    const recentDate = new Date();
+    await insertTestTelegramMessages(installationId, 2, recentDate);
+
     const response = await GET(cronRequest("test-cron-secret"));
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body.deleted).toBe(0);
+    expect(typeof body.deleted).toBe("number");
+    expect(await countTestTelegramMessages(installationId)).toBe(2);
   });
 
   it("should delete messages older than 30 days", async () => {
@@ -60,7 +65,7 @@ describe("GET /api/cron/telegram-cleanup", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body.deleted).toBe(3);
+    expect(body.deleted).toBeGreaterThanOrEqual(3);
     expect(await countTestTelegramMessages(installationId)).toBe(2);
   });
 
@@ -75,7 +80,7 @@ describe("GET /api/cron/telegram-cleanup", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body.deleted).toBe(0);
+    expect(typeof body.deleted).toBe("number");
     expect(await countTestTelegramMessages(installationId)).toBe(5);
   });
 });

--- a/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
@@ -6,6 +6,7 @@ import { DELETE, GET, POST } from "../route";
 import {
   testContext,
   uniqueId,
+  uniqueNumericId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { server } from "../../../../../../src/mocks/server";
@@ -452,7 +453,7 @@ describe("/api/integrations/telegram/link", () => {
     it("links the official bot account via telegramAuth", async () => {
       setupOfficialTelegramEnv();
       const user = await context.setupUser();
-      const telegramUserId = 99301;
+      const telegramUserId = Number(uniqueNumericId());
       const telegramAuth = makeTelegramAuth(
         telegramUserId,
         "official_tg",
@@ -487,7 +488,7 @@ describe("/api/integrations/telegram/link", () => {
       setupOfficialTelegramEnv();
       await context.setupUser();
       const otherOrgId = uniqueId("org");
-      const telegramUserId = 99302;
+      const telegramUserId = Number(uniqueNumericId());
       await insertTestOfficialTelegramUserLink({
         telegramUserId: String(telegramUserId),
         vm0UserId: uniqueId("other-user"),

--- a/turbo/apps/web/app/api/logs/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/logs/search/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { randomUUID } from "crypto";
 import { GET } from "../route";
 import {
   createTestRequest,
@@ -40,13 +41,17 @@ function createAxiomAgentEvent(
 }
 
 describe("GET /api/logs/search", () => {
+  let testComposeId: string;
   let testRunId: string;
 
   beforeEach(async () => {
     context.setupMocks();
     await context.setupUser();
 
-    const { composeId } = await createTestCompose(`test-search-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `test-search-${randomUUID().slice(0, 8)}`,
+    );
+    testComposeId = composeId;
 
     const { runId } = await createTestRun(composeId, "Test prompt");
     testRunId = runId;
@@ -110,6 +115,7 @@ describe("GET /api/logs/search", () => {
     const data = await response.json();
     expect(data.results).toHaveLength(1);
     expect(data.results[0].runId).toBe(testRunId);
+    expect(data.results[0].agentName).toBe(testComposeId);
     expect(data.results[0].matchedEvent.sequenceNumber).toBe(3);
     expect(data.results[0].contextBefore).toEqual([]);
     expect(data.results[0].contextAfter).toEqual([]);
@@ -206,9 +212,29 @@ describe("GET /api/logs/search", () => {
     expect(aplQuery).toContain('search "*deploy failed*"');
   });
 
-  it("should filter by agent name via database lookup", async () => {
+  it("should filter by agent ID via database lookup", async () => {
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      createAxiomAgentEvent(testRunId, 1, "Found it"),
+    ]);
+
     const request = createTestRequest(
-      "http://localhost:3000/api/logs/search?keyword=test&agent=nonexistent-agent",
+      `http://localhost:3000/api/logs/search?keyword=Found&agent=${testComposeId}`,
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].runId).toBe(testRunId);
+
+    const aplQuery = context.mocks.axiom.queryAxiom.mock.calls[0]![0] as string;
+    expect(aplQuery).toContain(`runId == "${testRunId}"`);
+  });
+
+  it("should return empty when agent ID has no runs", async () => {
+    const request = createTestRequest(
+      `http://localhost:3000/api/logs/search?keyword=test&agent=${randomUUID()}`,
     );
 
     const response = await GET(request);

--- a/turbo/apps/web/app/api/telegram/setup-status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/setup-status/__tests__/route.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { HttpResponse, http as mswHttp } from "msw";
 import { POST } from "../route";
-import { testContext } from "../../../../../src/__tests__/test-helpers";
+import {
+  testContext,
+  uniqueNumericId,
+} from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
@@ -91,8 +94,9 @@ describe("POST /api/telegram/setup-status", () => {
 
   it("returns BotFather domain and privacy setup status", async () => {
     await context.setupUser();
+    const botId = uniqueNumericId();
     const getMeHandler = telegramGetMe({
-      botId: "123456",
+      botId,
       username: "setup_bot",
       privacyDisabled: true,
     });
@@ -108,7 +112,7 @@ describe("POST /api/telegram/setup-status", () => {
 
     expect(response.status).toBe(200);
     expect(body).toEqual({
-      id: "123456",
+      id: botId,
       username: "setup_bot",
       domainConfigured: true,
       privacyDisabled: true,
@@ -118,7 +122,7 @@ describe("POST /api/telegram/setup-status", () => {
 
   it("returns 409 when the bot is already installed", async () => {
     const user = await context.setupUser();
-    const botId = "123456";
+    const botId = uniqueNumericId();
     await createTestTelegramInstallation({
       telegramBotId: botId,
       orgId: user.orgId,

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import { OFFICIAL_TELEGRAM_BOT_ID } from "@vm0/api-contracts/contracts/zero-inte
 import {
   testContext,
   uniqueId,
+  uniqueNumericId,
 } from "../../../../../src/__tests__/test-helpers";
 import {
   createTestCompose,
@@ -287,7 +288,7 @@ describe("POST /api/telegram/webhook/[telegramBotId]", () => {
       const user = await context.setupUser();
       const { composeId } = await createTestCompose(uniqueId("agent"));
       await setDefaultAgentByComposeId(user.orgId, composeId);
-      const telegramUserId = 456777;
+      const telegramUserId = Number(uniqueNumericId());
       const officialLink = await insertTestOfficialTelegramUserLink({
         telegramUserId: String(telegramUserId),
         telegramUsername: "official_user",

--- a/turbo/apps/web/app/api/zero/integrations/telegram/bots/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/bots/__tests__/route.test.ts
@@ -9,6 +9,7 @@ import {
 import { createTestTelegramInstallation } from "../../../../../../../src/__tests__/db-test-seeders/telegram";
 import {
   testContext,
+  uniqueNumericId,
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
@@ -63,19 +64,22 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
   });
 
   it("lists the official bot and custom Telegram bots in the active org", async () => {
+    const ownedBotId = uniqueNumericId();
+    const orgBotId = uniqueNumericId();
+    const otherOrgBotId = uniqueNumericId();
     const botId = await createTestTelegramInstallation({
-      telegramBotId: "123456789",
+      telegramBotId: ownedBotId,
       ownerUserId: user.userId,
       vm0UserId: user.userId,
       orgId: user.orgId,
     });
     await createTestTelegramInstallation({
-      telegramBotId: "987654321",
+      telegramBotId: orgBotId,
       ownerUserId: "other-owner",
       orgId: user.orgId,
     });
     await createTestTelegramInstallation({
-      telegramBotId: "555555555",
+      telegramBotId: otherOrgBotId,
       ownerUserId: user.userId,
     });
 
@@ -84,7 +88,7 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
         return HttpResponse.json({
           ok: true,
           result: {
-            id: 123456789,
+            id: Number(ownedBotId),
             is_bot: true,
             first_name: "Bot",
             username: "alerts_bot",
@@ -103,14 +107,14 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
         officialBotExpectation,
         expect.objectContaining({
           id: botId,
-          username: "bot_123456789",
+          username: `bot_${ownedBotId}`,
           isOwner: true,
           isConnected: true,
           tokenStatus: "valid",
           agent: expect.objectContaining({ id: expect.any(String) }),
         }),
         expect.objectContaining({
-          id: "987654321",
+          id: orgBotId,
           isOwner: false,
           isConnected: false,
         }),
@@ -118,7 +122,7 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
     );
     expect(
       data.bots.some((bot: { id: string }) => {
-        return bot.id === "555555555";
+        return bot.id === otherOrgBotId;
       }),
     ).toBe(false);
   });

--- a/turbo/apps/web/app/api/zero/integrations/telegram/download-file/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/download-file/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
 import { createTestTelegramInstallation } from "../../../../../../../src/__tests__/db-test-seeders/telegram";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
@@ -109,7 +110,7 @@ describe("GET /api/zero/integrations/telegram/download-file", () => {
 
   it("streams Telegram file bytes with content-type header", async () => {
     const botId = await createTestTelegramInstallation({
-      telegramBotId: "tg-bot-ok",
+      telegramBotId: uniqueId("tg-bot-ok"),
       orgId: user.orgId,
       ownerUserId: user.userId,
     });
@@ -160,7 +161,7 @@ describe("GET /api/zero/integrations/telegram/download-file", () => {
 
   it("returns 413 when Telegram reports a file over the proxy limit", async () => {
     const botId = await createTestTelegramInstallation({
-      telegramBotId: "tg-bot-big",
+      telegramBotId: uniqueId("tg-bot-big"),
       orgId: user.orgId,
       ownerUserId: user.userId,
     });
@@ -189,7 +190,7 @@ describe("GET /api/zero/integrations/telegram/download-file", () => {
 
   it("returns 413 when download content-length exceeds the proxy limit", async () => {
     const botId = await createTestTelegramInstallation({
-      telegramBotId: "tg-bot-huge-response",
+      telegramBotId: uniqueId("tg-bot-huge-response"),
       orgId: user.orgId,
       ownerUserId: user.userId,
     });

--- a/turbo/apps/web/app/api/zero/integrations/telegram/upload-file/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/upload-file/complete/__tests__/route.test.ts
@@ -64,11 +64,12 @@ describe("POST /api/zero/integrations/telegram/upload-file/complete", () => {
   it("sends the uploaded file URL through the requested Telegram bot", async () => {
     const { token, runId } = await zeroTokenWithRun();
     const botId = await createTestTelegramInstallation({
-      telegramBotId: "tg-bot-upload",
+      telegramBotId: uniqueId("tg-bot-upload"),
       orgId: user.orgId,
       ownerUserId: user.userId,
     });
     const uploadId = randomUUID();
+    const telegramFileId = uniqueId("tg-doc-file");
     const s3Key = `uploads/${user.userId}/${uploadId}/report.pdf`;
     const fileUrl = `http://localhost:3000/f/${encodeURIComponent(user.userId)}/${uploadId}/report.pdf`;
 
@@ -88,7 +89,7 @@ describe("POST /api/zero/integrations/telegram/upload-file/complete", () => {
               message_id: 321,
               chat: { id: -1001234567890 },
               document: {
-                file_id: "tg-doc-file-id",
+                file_id: telegramFileId,
                 file_unique_id: "tg-doc-unique",
                 file_name: "report.pdf",
                 mime_type: "application/pdf",
@@ -124,19 +125,19 @@ describe("POST /api/zero/integrations/telegram/upload-file/complete", () => {
     expect(await response.json()).toMatchObject({
       messageId: 321,
       chatId: "-1001234567890",
-      fileId: "tg-doc-file-id",
+      fileId: telegramFileId,
       filename: "report.pdf",
       mimetype: "application/pdf",
       size: 1234,
       url: fileUrl,
     });
 
-    const rows = await findTestRunUploadedFiles("telegram", "tg-doc-file-id");
+    const rows = await findTestRunUploadedFiles("telegram", telegramFileId);
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
       runId,
       source: "telegram",
-      externalId: "tg-doc-file-id",
+      externalId: telegramFileId,
       userId: user.userId,
       orgId: user.orgId,
       filename: "report.pdf",
@@ -152,7 +153,7 @@ describe("POST /api/zero/integrations/telegram/upload-file/complete", () => {
         messageThreadId: 42,
         telegramMessage: {
           id: 321,
-          fileId: "tg-doc-file-id",
+          fileId: telegramFileId,
         },
       },
     });
@@ -181,7 +182,7 @@ describe("POST /api/zero/integrations/telegram/upload-file/complete", () => {
   it("returns 400 when Telegram rejects the sendDocument call", async () => {
     const { token } = await zeroTokenWithRun();
     const botId = await createTestTelegramInstallation({
-      telegramBotId: "tg-bot-reject",
+      telegramBotId: uniqueId("tg-bot-reject"),
       orgId: user.orgId,
       ownerUserId: user.userId,
     });

--- a/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
@@ -206,9 +206,9 @@ describe("GET /api/zero/logs", () => {
       await completeTestRun(user.userId, run2);
     });
 
-    it("should filter by exact agent name", async () => {
+    it("should filter by exact agent ID", async () => {
       const request = createTestRequest(
-        `http://localhost:3000/api/zero/logs?agent=${alphaName}`,
+        `http://localhost:3000/api/zero/logs?agent=${alphaComposeId}`,
       );
       const response = await GET(request);
       const data = await response.json();
@@ -220,7 +220,7 @@ describe("GET /api/zero/logs", () => {
 
     it("should return empty list when agent has no runs", async () => {
       const request = createTestRequest(
-        "http://localhost:3000/api/zero/logs?agent=nonexistent-agent",
+        `http://localhost:3000/api/zero/logs?agent=${randomUUID()}`,
       );
       const response = await GET(request);
       const data = await response.json();
@@ -229,21 +229,20 @@ describe("GET /api/zero/logs", () => {
       expect(data.data).toEqual([]);
     });
 
-    it("should use exact match, not fuzzy", async () => {
-      // Search for partial name should return nothing with agent filter
+    it("should reject agent names for the agent filter", async () => {
       const request = createTestRequest(
-        `http://localhost:3000/api/zero/logs?agent=agent-alpha`,
+        `http://localhost:3000/api/zero/logs?agent=${alphaName}`,
       );
       const response = await GET(request);
       const data = await response.json();
 
-      expect(response.status).toBe(200);
-      expect(data.data).toEqual([]);
+      expect(response.status).toBe(400);
+      expect(data.error.code).toBe("BAD_REQUEST");
     });
 
     it("should take precedence over search param", async () => {
       const request = createTestRequest(
-        `http://localhost:3000/api/zero/logs?agent=${alphaName}&search=beta`,
+        `http://localhost:3000/api/zero/logs?agent=${alphaComposeId}&search=beta`,
       );
       const response = await GET(request);
       const data = await response.json();
@@ -314,7 +313,7 @@ describe("GET /api/zero/logs", () => {
 
     it("name param should take precedence over agent param", async () => {
       const request = createTestRequest(
-        `http://localhost:3000/api/zero/logs?name=${agentName}&agent=nonexistent`,
+        `http://localhost:3000/api/zero/logs?name=${agentName}&agent=${randomUUID()}`,
       );
       const response = await GET(request);
       const data = await response.json();
@@ -589,7 +588,7 @@ describe("GET /api/zero/logs", () => {
 
       // Filter for slack source + the other agent
       const request = createTestRequest(
-        `http://localhost:3000/api/zero/logs?triggerSource=slack&agent=${otherName}`,
+        `http://localhost:3000/api/zero/logs?triggerSource=slack&agent=${otherComposeId}`,
       );
       const response = await GET(request);
       const data = await response.json();
@@ -679,7 +678,7 @@ describe("GET /api/zero/logs", () => {
       expect(data.filters.sources).toContain("web");
     });
 
-    it("should return available agent names from user's runs", async () => {
+    it("should return available agent IDs from user's runs", async () => {
       const agentA = `filter-agent-a-${randomUUID().slice(0, 8)}`;
       const agentB = `filter-agent-b-${randomUUID().slice(0, 8)}`;
       const { composeId: composeA } = await createTestCompose(agentA);
@@ -701,8 +700,8 @@ describe("GET /api/zero/logs", () => {
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.filters.agents).toContain(agentA);
-      expect(data.filters.agents).toContain(agentB);
+      expect(data.filters.agents).toContain(composeA);
+      expect(data.filters.agents).toContain(composeB);
     });
 
     it("should not include null trigger sources in filters", async () => {

--- a/turbo/apps/web/app/api/zero/logs/route.ts
+++ b/turbo/apps/web/app/api/zero/logs/route.ts
@@ -66,8 +66,9 @@ interface LogsQuery {
 }
 
 /**
- * Build agent name filter conditions from query params.
- * name takes precedence over legacy agent param, which takes precedence over search.
+ * Build agent filter conditions from query params.
+ * name keeps the explicit compose-name filter, agent is the canonical Zero agent ID,
+ * and search remains a fuzzy compose-name filter.
  */
 function buildAgentFilterConditions(query: LogsQuery): SQL[] {
   const conditions: SQL[] = [];
@@ -75,7 +76,7 @@ function buildAgentFilterConditions(query: LogsQuery): SQL[] {
   if (query.name) {
     conditions.push(eq(agentComposes.name, query.name));
   } else if (query.agent) {
-    conditions.push(eq(agentComposes.name, query.agent));
+    conditions.push(eq(zeroAgents.id, query.agent));
   } else if (query.search) {
     conditions.push(ilike(agentComposes.name, `%${query.search}%`));
   }
@@ -139,6 +140,7 @@ async function getTotalCount(
       agentComposes,
       eq(agentComposeVersions.composeId, agentComposes.id),
     )
+    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
     .where(and(...conditions));
 
   return result?.count ?? 0;
@@ -156,7 +158,7 @@ function extractFramework(composeContent: unknown): string | null {
 }
 
 /**
- * Get distinct statuses, trigger sources, and agent names for filter dropdowns.
+ * Get distinct statuses, trigger sources, and agent IDs for filter dropdowns.
  */
 async function getAvailableFilters(
   userId: string,
@@ -183,7 +185,7 @@ async function getAvailableFilters(
       .innerJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
       .where(and(...baseConditions)),
     db
-      .selectDistinct({ name: agentComposes.name })
+      .selectDistinct({ id: zeroAgents.id })
       .from(agentRuns)
       .leftJoin(
         agentComposeVersions,
@@ -193,7 +195,8 @@ async function getAvailableFilters(
         agentComposes,
         eq(agentComposeVersions.composeId, agentComposes.id),
       )
-      .where(and(...baseConditions, isNotNull(agentComposes.name))),
+      .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+      .where(and(...baseConditions, isNotNull(zeroAgents.id))),
   ]);
 
   const statuses = statusRows
@@ -220,10 +223,10 @@ async function getAvailableFilters(
 
   const agents = agentRows
     .map((r) => {
-      return r.name;
+      return r.id;
     })
-    .filter((name): name is string => {
-      return name !== null;
+    .filter((id): id is string => {
+      return id !== null;
     });
 
   return { statuses, sources, agents };

--- a/turbo/apps/web/app/api/zero/logs/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/search/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { randomUUID } from "crypto";
 import { GET } from "../route";
 import {
   createTestRequest,
@@ -49,6 +50,7 @@ function createAxiomAgentEvent(
 
 describe("GET /api/zero/logs/search", () => {
   let user: UserContext;
+  let testComposeId: string;
   let testRunId: string;
   let zeroToken: string;
 
@@ -56,7 +58,10 @@ describe("GET /api/zero/logs/search", () => {
     context.setupMocks();
     user = await context.setupUser();
 
-    const { composeId } = await createTestCompose(`test-search-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `test-search-${randomUUID().slice(0, 8)}`,
+    );
+    testComposeId = composeId;
     const { runId } = await createTestRun(composeId, "Test prompt");
     testRunId = runId;
 
@@ -134,6 +139,7 @@ describe("GET /api/zero/logs/search", () => {
     const data = await response.json();
     expect(data.results).toHaveLength(1);
     expect(data.results[0].runId).toBe(testRunId);
+    expect(data.results[0].agentName).toBe(testComposeId);
     expect(data.results[0].matchedEvent.sequenceNumber).toBe(3);
     expect(data.results[0].contextBefore).toEqual([]);
     expect(data.results[0].contextAfter).toEqual([]);
@@ -232,9 +238,30 @@ describe("GET /api/zero/logs/search", () => {
     expect(aplQuery).toContain('search "*deploy failed*"');
   });
 
-  it("should filter by agent name via database lookup", async () => {
+  it("should filter by agent ID via database lookup", async () => {
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      createAxiomAgentEvent(testRunId, 1, "Found it"),
+    ]);
+
     const request = createTestRequest(
-      "http://localhost:3000/api/zero/logs/search?keyword=test&agent=nonexistent-agent",
+      `http://localhost:3000/api/zero/logs/search?keyword=Found&agent=${testComposeId}`,
+      { headers: { Authorization: `Bearer ${zeroToken}` } },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].runId).toBe(testRunId);
+
+    const aplQuery = context.mocks.axiom.queryAxiom.mock.calls[0]![0] as string;
+    expect(aplQuery).toContain(`runId == "${testRunId}"`);
+  });
+
+  it("should return empty when agent ID has no runs", async () => {
+    const request = createTestRequest(
+      `http://localhost:3000/api/zero/logs/search?keyword=test&agent=${randomUUID()}`,
       { headers: { Authorization: `Bearer ${zeroToken}` } },
     );
 

--- a/turbo/apps/web/src/lib/infra/run/log-search-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/log-search-service.ts
@@ -4,6 +4,7 @@ import {
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { and, eq, inArray, gte } from "drizzle-orm";
 import { queryAxiom, getDatasetName, DATASETS } from "../../shared/axiom";
 
@@ -33,7 +34,8 @@ async function getAgentNames(
   const rows = await globalThis.services.db
     .select({
       runId: agentRuns.id,
-      composeName: agentComposes.name,
+      composeId: agentComposes.id,
+      displayName: zeroAgents.displayName,
     })
     .from(agentRuns)
     .leftJoin(
@@ -44,6 +46,7 @@ async function getAgentNames(
       agentComposes,
       eq(agentComposeVersions.composeId, agentComposes.id),
     )
+    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
     .where(
       and(
         inArray(agentRuns.id, runIds),
@@ -53,7 +56,7 @@ async function getAgentNames(
     );
 
   for (const row of rows) {
-    result.set(row.runId, row.composeName || "unknown");
+    result.set(row.runId, row.displayName ?? row.composeId ?? "unknown");
   }
 
   return result;
@@ -63,7 +66,7 @@ async function getUserRunIds(
   userId: string,
   orgId: string,
   since: Date,
-  agentName?: string,
+  agentId?: string,
 ): Promise<string[]> {
   const conditions = [
     eq(agentRuns.userId, userId),
@@ -71,7 +74,7 @@ async function getUserRunIds(
     gte(agentRuns.createdAt, since),
   ];
 
-  if (agentName) {
+  if (agentId) {
     const rows = await globalThis.services.db
       .select({ runId: agentRuns.id })
       .from(agentRuns)
@@ -83,7 +86,8 @@ async function getUserRunIds(
         agentComposes,
         eq(agentComposeVersions.composeId, agentComposes.id),
       )
-      .where(and(...conditions, eq(agentComposes.name, agentName)));
+      .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+      .where(and(...conditions, eq(zeroAgents.id, agentId)));
 
     return rows.map((r) => {
       return r.runId;

--- a/turbo/packages/api-contracts/src/contracts/logs.ts
+++ b/turbo/packages/api-contracts/src/contracts/logs.ts
@@ -74,7 +74,8 @@ const logEntrySchema = z.object({
 });
 
 /**
- * Available filter values returned by the list endpoint
+ * Available filter values returned by the list endpoint.
+ * agents contains canonical Zero agent IDs.
  */
 const logsFiltersSchema = z.object({
   statuses: z.array(logStatusSchema),
@@ -136,7 +137,7 @@ export const logsListContract = c.router({
     headers: authHeadersSchema,
     query: listQuerySchema.extend({
       search: z.string().optional(),
-      agent: z.string().optional(),
+      agent: z.string().uuid().optional(), // canonical Zero agent ID
       name: z.string().optional(),
       since: z.coerce.number().optional(),
 

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -620,7 +620,7 @@ export const logsSearchContract = c.router({
     headers: authHeadersSchema,
     query: z.object({
       keyword: z.string().min(1),
-      agent: z.string().optional(),
+      agent: z.string().uuid().optional(), // canonical Zero agent ID
       runId: z.string().optional(),
       since: z.coerce.number().optional(),
       limit: z.coerce.number().min(1).max(50).default(20),

--- a/turbo/packages/api-contracts/src/contracts/zero-runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-runs.ts
@@ -292,7 +292,7 @@ export const zeroLogsSearchContract = c.router({
     headers: authHeadersSchema,
     query: z.object({
       keyword: z.string().min(1),
-      agent: z.string().optional(),
+      agent: z.string().uuid().optional(), // canonical Zero agent ID
       runId: z.string().optional(),
       since: z.coerce.number().optional(),
       limit: z.coerce.number().min(1).max(50).default(20),


### PR DESCRIPTION
## Summary
- Align Zero log list/search `agent` filters with the canonical Zero agent ID (`zero_agents.id`), matching the ID injected as `ZERO_AGENT_ID` and used by Zero Agent View.
- Keep `name` as the explicit compose-name filter and fuzzy `search` name matching, but make `agent` UUID-only in the relevant contracts.
- Render log search result labels from Zero agent metadata (`displayName ?? id`) instead of compose names.
- Update CLI help/tests for `zero logs` and `zero search --source logs`.
- Harden cron and Telegram tests that were failing in repeated full local runs against a persistent test DB.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm -F web db:migrate`
- `pnpm -F web exec vitest run app/api/zero/logs/__tests__/route.test.ts app/api/zero/logs/search/__tests__/route.test.ts app/api/logs/search/__tests__/route.test.ts`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/logs/__tests__/list.test.ts src/commands/zero/logs/__tests__/search.test.ts src/commands/zero/search/__tests__/logs-source.test.ts src/commands/zero/search/__tests__/chat-source.test.ts`
- `pnpm format`
- `pnpm lint`
- `pnpm check-types`
- `pnpm test` (832 files, 8746 tests)
- `pnpm knip`
- `git diff --check`