### PR TITLE
refactor(guest-agent): initialize http client explicitly

### DIFF
--- a/crates/guest-agent/src/artifact.rs
+++ b/crates/guest-agent/src/artifact.rs
@@ -11,7 +11,7 @@
 
 use crate::constants;
 use crate::error::AgentError;
-use crate::http;
+use crate::http::HttpClient;
 use crate::urls;
 use api_contracts::generated::types::webhooks::agent::storages::{
     commit as storage_commit, prepare as storage_prepare,
@@ -39,6 +39,16 @@ pub(crate) struct FileEntry {
 
 pub(crate) struct SnapshotResult {
     pub(crate) version_id: String,
+}
+
+pub(crate) struct CreateSnapshotRequest<'a> {
+    pub(crate) mount_path: &'a str,
+    pub(crate) files: Vec<FileEntry>,
+    pub(crate) storage_name: &'a str,
+    pub(crate) storage_type: &'a str,
+    pub(crate) run_id: &'a str,
+    pub(crate) message: &'a str,
+    pub(crate) parent_version_id: &'a str,
 }
 
 fn non_empty_string(value: &str) -> Option<String> {
@@ -91,14 +101,19 @@ pub(crate) async fn walk_files(mount_path: &str) -> Result<Vec<FileEntry>, Agent
 /// pre-walked file list (see [`walk_files`]) — this lets the checkpoint step
 /// share one walk between its skip-check fingerprint and the snapshot upload.
 pub(crate) async fn create_snapshot(
-    mount_path: &str,
-    files: Vec<FileEntry>,
-    storage_name: &str,
-    storage_type: &str,
-    run_id: &str,
-    message: &str,
-    parent_version_id: &str,
+    http: &HttpClient,
+    request: CreateSnapshotRequest<'_>,
 ) -> Result<SnapshotResult, AgentError> {
+    let CreateSnapshotRequest {
+        mount_path,
+        files,
+        storage_name,
+        storage_type,
+        run_id,
+        message,
+        parent_version_id,
+    } = request;
+
     log_info!(
         LOG_TAG,
         "Creating direct upload snapshot for '{storage_name}'"
@@ -118,12 +133,13 @@ pub(crate) async fn create_snapshot(
         changes: None,
     };
 
-    let prep_result = http::post_json(
-        urls::storage_prepare_url(),
-        &prep_payload,
-        constants::HTTP_MAX_RETRIES,
-    )
-    .await;
+    let prep_result = http
+        .post_json(
+            urls::storage_prepare_url(),
+            &prep_payload,
+            constants::HTTP_MAX_RETRIES,
+        )
+        .await;
     let prep_resp = match prep_result {
         Ok(Some(v)) => v,
         Ok(None) => {
@@ -208,12 +224,13 @@ pub(crate) async fn create_snapshot(
             files: to_commit_files(&files),
             message: None,
         };
-        let resp = http::post_json(
-            urls::storage_commit_url(),
-            &commit_payload,
-            constants::HTTP_MAX_RETRIES,
-        )
-        .await?;
+        let resp = http
+            .post_json(
+                urls::storage_commit_url(),
+                &commit_payload,
+                constants::HTTP_MAX_RETRIES,
+            )
+            .await?;
         let commit_success = resp
             .map(|v| {
                 serde_json::from_value::<storage_commit::Response>(v)
@@ -275,7 +292,9 @@ pub(crate) async fn create_snapshot(
     // Step 5: Upload to S3
     log_info!(LOG_TAG, "Uploading archive to S3...");
     let s3_start = std::time::Instant::now();
-    if let Err(e) = http::put_presigned_file(&archive_url, &archive_path, "application/gzip").await
+    if let Err(e) = http
+        .put_presigned_file(&archive_url, &archive_path, "application/gzip")
+        .await
     {
         record_sandbox_op("artifact_s3_upload", s3_start.elapsed(), false, None);
         return Err(e);
@@ -283,8 +302,9 @@ pub(crate) async fn create_snapshot(
 
     log_info!(LOG_TAG, "Uploading manifest to S3...");
     let manifest_data = tokio::fs::read(&manifest_path).await?;
-    if let Err(e) =
-        http::put_presigned(&manifest_url, manifest_data.into(), "application/json").await
+    if let Err(e) = http
+        .put_presigned(&manifest_url, manifest_data.into(), "application/json")
+        .await
     {
         record_sandbox_op("artifact_s3_upload", s3_start.elapsed(), false, None);
         return Err(e);
@@ -303,12 +323,13 @@ pub(crate) async fn create_snapshot(
         files: to_commit_files(&files),
         message: Some(message.to_string()),
     };
-    let resp = match http::post_json(
-        urls::storage_commit_url(),
-        &commit_payload,
-        constants::HTTP_MAX_RETRIES,
-    )
-    .await
+    let resp = match http
+        .post_json(
+            urls::storage_commit_url(),
+            &commit_payload,
+            constants::HTTP_MAX_RETRIES,
+        )
+        .await
     {
         Ok(v) => v,
         Err(e) => {
@@ -1226,14 +1247,18 @@ mod tests {
                 .json_body(serde_json::json!({ "success": true }));
         });
 
+        let http = HttpClient::new().unwrap();
         let result = create_snapshot(
-            root.to_str().unwrap(),
-            files,
-            "storage",
-            "artifact",
-            "run-id",
-            "message",
-            "",
+            &http,
+            CreateSnapshotRequest {
+                mount_path: root.to_str().unwrap(),
+                files,
+                storage_name: "storage",
+                storage_type: "artifact",
+                run_id: "run-id",
+                message: "message",
+                parent_version_id: "",
+            },
         )
         .await;
 

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -6,7 +6,7 @@ use crate::content_hash;
 use crate::env;
 use crate::env::Framework;
 use crate::error::AgentError;
-use crate::http;
+use crate::http::HttpClient;
 use crate::paths;
 use crate::session_history;
 use crate::urls;
@@ -44,21 +44,23 @@ fn build_artifact_snapshot_entry(name: &str, version: &str, mount_path: &str) ->
 /// dedup). Telemetry is recorded under `session_history_prepare` and
 /// `session_history_s3_upload` to match the pre-parallelization op names.
 async fn upload_session_history(
+    http: &HttpClient,
     history_hash: &str,
     history_size: u64,
     history_bytes: Vec<u8>,
 ) -> Result<(), AgentError> {
     let prep_start = std::time::Instant::now();
-    let prep_resp = match http::post_json(
-        urls::checkpoint_prepare_history_url(),
-        &json!({
-            "runId": env::run_id(),
-            "hash": history_hash,
-            "size": history_size,
-        }),
-        constants::HTTP_MAX_RETRIES,
-    )
-    .await
+    let prep_resp = match http
+        .post_json(
+            urls::checkpoint_prepare_history_url(),
+            &json!({
+                "runId": env::run_id(),
+                "hash": history_hash,
+                "size": history_size,
+            }),
+            constants::HTTP_MAX_RETRIES,
+        )
+        .await
     {
         Ok(Some(v)) => {
             record_sandbox_op("session_history_prepare", prep_start.elapsed(), true, None);
@@ -97,12 +99,13 @@ async fn upload_session_history(
 
     log_info!(LOG_TAG, "Uploading session history to S3...");
     let upload_start = std::time::Instant::now();
-    if let Err(e) = http::put_presigned(
-        presigned_url,
-        Bytes::from(history_bytes),
-        "application/octet-stream",
-    )
-    .await
+    if let Err(e) = http
+        .put_presigned(
+            presigned_url,
+            Bytes::from(history_bytes),
+            "application/octet-stream",
+        )
+        .await
     {
         record_sandbox_op(
             "session_history_s3_upload",
@@ -126,7 +129,7 @@ async fn upload_session_history(
 /// post-#10602, so there is no longer a separate memory arm. Payload shape is
 /// `Array<{name, version, mountPath}>` per #10911 — the receiver tolerates the
 /// legacy `Record<name, version>` form too (#10919).
-async fn snapshot_artifacts() -> Result<Option<serde_json::Value>, AgentError> {
+async fn snapshot_artifacts(http: &HttpClient) -> Result<Option<serde_json::Value>, AgentError> {
     let entries = env::artifacts();
     if entries.is_empty() {
         log_info!(
@@ -181,14 +184,18 @@ async fn snapshot_artifacts() -> Result<Option<serde_json::Value>, AgentError> {
             "Creating VAS snapshot for artifact '{}'",
             entry.name
         );
+        let message = format!("Checkpoint from run {}", env::run_id());
         let snapshot = artifact::create_snapshot(
-            &entry.mount_path,
-            files,
-            &entry.name,
-            "artifact",
-            env::run_id(),
-            &format!("Checkpoint from run {}", env::run_id()),
-            &entry.version_id,
+            http,
+            artifact::CreateSnapshotRequest {
+                mount_path: &entry.mount_path,
+                files,
+                storage_name: &entry.name,
+                storage_type: "artifact",
+                run_id: env::run_id(),
+                message: &message,
+                parent_version_id: &entry.version_id,
+            },
         )
         .await?;
         log_info!(
@@ -207,14 +214,14 @@ async fn snapshot_artifacts() -> Result<Option<serde_json::Value>, AgentError> {
 }
 
 /// Create a checkpoint after a successful run.
-pub async fn create_checkpoint() -> Result<(), AgentError> {
+pub async fn create_checkpoint(http: &HttpClient) -> Result<(), AgentError> {
     let start = std::time::Instant::now();
-    let result = create_checkpoint_impl().await;
+    let result = create_checkpoint_impl(http).await;
     record_sandbox_op("checkpoint_total", start.elapsed(), result.is_ok(), None);
     result
 }
 
-async fn create_checkpoint_impl() -> Result<(), AgentError> {
+async fn create_checkpoint_impl(http: &HttpClient) -> Result<(), AgentError> {
     log_info!(LOG_TAG, "Creating checkpoint...");
 
     // Read session ID. Let `read_to_string` surface `NotFound` directly — an
@@ -307,8 +314,13 @@ async fn create_checkpoint_impl() -> Result<(), AgentError> {
     // (prepare + HEAD update). Serial, wall time was dominated by whichever
     // was longer plus the other; concurrent, it's just the longer one.
     let (_, artifact_snapshots) = tokio::try_join!(
-        upload_session_history(&history_hash, history_size, session_history.into_bytes()),
-        snapshot_artifacts(),
+        upload_session_history(
+            http,
+            &history_hash,
+            history_size,
+            session_history.into_bytes()
+        ),
+        snapshot_artifacts(http),
     )?;
 
     // Build and send checkpoint payload (session history hash only, content uploaded to S3)
@@ -331,12 +343,13 @@ async fn create_checkpoint_impl() -> Result<(), AgentError> {
 
     log_info!(LOG_TAG, "Calling checkpoint API...");
     let api_start = std::time::Instant::now();
-    let result = match http::post_json(
-        urls::checkpoint_url(),
-        &payload,
-        constants::HTTP_MAX_RETRIES,
-    )
-    .await
+    let result = match http
+        .post_json(
+            urls::checkpoint_url(),
+            &payload,
+            constants::HTTP_MAX_RETRIES,
+        )
+        .await
     {
         Ok(v) => v,
         Err(e) => {

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -4,6 +4,7 @@ use crate::constants;
 use crate::env;
 use crate::error::AgentError;
 use crate::events;
+use crate::http::HttpClient;
 use crate::masker::SecretMasker;
 use crate::paths;
 use crate::timing;
@@ -360,6 +361,7 @@ pub struct CliExecutionResult {
 pub async fn execute_cli(
     masker: &SecretMasker,
     mut heartbeat_handle: tokio::task::JoinHandle<Result<(), AgentError>>,
+    http: HttpClient,
 ) -> Result<CliExecutionResult, AgentError> {
     log_info!(LOG_TAG, "Starting claude-code execution...");
 
@@ -478,10 +480,11 @@ pub async fn execute_cli(
     // stdout reading loop.  Unbounded channel because events are small
     // and CLI lifetime is bounded by JOB_TIMEOUT.
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<PreparedEvent>();
+    let event_http = http.clone();
     let event_sender = tokio::spawn(async move {
         let mut acked_prefix = AckedEventPrefix::default();
         while let Some(event) = event_rx.recv().await {
-            match events::post_event(&event.payload).await {
+            match events::post_event(&event_http, &event.payload).await {
                 Ok(()) => {
                     acked_prefix.record_success(event.sequence);
                 }

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -375,7 +375,10 @@ pub async fn execute_cli(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .process_group(0);
+        .process_group(0)
+        // If setup fails after spawn (for example agent-log file creation),
+        // dropping `Child` must not leave a CLI process running in the VM.
+        .kill_on_drop(true);
 
     match env::Framework::from_env() {
         env::Framework::ClaudeCode => {

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -404,6 +404,10 @@ pub async fn execute_cli(
         }
     }
 
+    // Open the run log before spawning the CLI. If the run-id-scoped path is
+    // invalid or unavailable, fail without starting a child process.
+    let mut log_file = tokio::fs::File::create(paths::agent_log_file()).await?;
+
     let mut child = cmd.spawn()?;
 
     let stdout = child
@@ -424,9 +428,6 @@ pub async fn execute_cli(
         }
         lines
     });
-
-    // Open agent log file
-    let mut log_file = tokio::fs::File::create(paths::agent_log_file()).await?;
 
     // Stream stdout JSONL, racing against heartbeat and process exit.
     //

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -376,8 +376,8 @@ pub async fn execute_cli(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .process_group(0)
-        // If setup fails after spawn (for example agent-log file creation),
-        // dropping `Child` must not leave a CLI process running in the VM.
+        // If a future setup step fails after spawn, dropping `Child` must not
+        // leave a CLI process running in the VM.
         .kill_on_drop(true);
 
     match env::Framework::from_env() {

--- a/crates/guest-agent/src/complete.rs
+++ b/crates/guest-agent/src/complete.rs
@@ -19,6 +19,7 @@
 //! not treat either field as authoritative for security decisions.
 
 use crate::env;
+use crate::http::HttpClient;
 use crate::urls;
 use guest_common::{log_info, log_warn};
 use serde::Serialize;
@@ -57,6 +58,7 @@ fn as_optional(value: &str) -> Option<&str> {
 /// Fire-and-forget. Returns `()` and never propagates errors — the runner's
 /// fallback call covers any failure here.
 pub async fn report_success(
+    http: &HttpClient,
     sandbox_id: &str,
     sandbox_reuse_result: &str,
     last_event_sequence: Option<u32>,
@@ -75,7 +77,7 @@ pub async fn report_success(
 
     // 1 attempt — the runner's fallback is the safety net. Retrying from the
     // guest just delays VM exit without improving the outcome.
-    match crate::http::post_json(urls::complete_url(), &payload, 1).await {
+    match http.post_json(urls::complete_url(), &payload, 1).await {
         Ok(_) => log_info!(LOG_TAG, "Complete webhook acknowledged"),
         Err(e) => log_warn!(LOG_TAG, "Complete webhook failed (runner will retry): {e}"),
     }

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -7,7 +7,7 @@ use crate::constants;
 use crate::env;
 use crate::env::Framework;
 use crate::error::AgentError;
-use crate::http;
+use crate::http::HttpClient;
 use crate::masker::SecretMasker;
 use crate::paths;
 use crate::urls;
@@ -21,6 +21,7 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 /// On the init event, extracts and persists the session ID and
 /// session history path.
 pub async fn send_event(
+    http: &HttpClient,
     event: &mut Value,
     seq: u32,
     masker: &SecretMasker,
@@ -28,7 +29,7 @@ pub async fn send_event(
     let Some(payload) = prepare_event(event, seq, masker) else {
         return Ok(());
     };
-    post_event(&payload).await
+    post_event(http, &payload).await
 }
 
 /// Prepare an event for sending: extract session ID, add sequence number,
@@ -62,8 +63,11 @@ pub fn prepare_event(event: &mut Value, seq: u32, masker: &SecretMasker) -> Opti
 }
 
 /// POST a prepared event payload to the webhook endpoint.
-pub async fn post_event(payload: &Value) -> Result<(), AgentError> {
-    match http::post_json(urls::events_url(), payload, constants::HTTP_MAX_RETRIES).await {
+pub async fn post_event(http: &HttpClient, payload: &Value) -> Result<(), AgentError> {
+    match http
+        .post_json(urls::events_url(), payload, constants::HTTP_MAX_RETRIES)
+        .await
+    {
         Ok(_) => Ok(()),
         Err(e) => {
             log_error!(LOG_TAG, "Failed to send event after retries");

--- a/crates/guest-agent/src/heartbeat.rs
+++ b/crates/guest-agent/src/heartbeat.rs
@@ -7,7 +7,7 @@
 use crate::constants;
 use crate::env;
 use crate::error::AgentError;
-use crate::http;
+use crate::http::HttpClient;
 use crate::urls;
 use guest_common::{log_error, log_info, log_warn};
 use serde_json::json;
@@ -23,12 +23,16 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 ///
 /// The caller should race this against CLI execution so that a network
 /// failure terminates the run early.
-pub async fn heartbeat_loop(shutdown: CancellationToken) -> Result<(), AgentError> {
-    heartbeat_loop_with_interval(shutdown, constants::HEARTBEAT_INTERVAL_SECS).await
+pub async fn heartbeat_loop(
+    http: HttpClient,
+    shutdown: CancellationToken,
+) -> Result<(), AgentError> {
+    heartbeat_loop_with_interval(http, shutdown, constants::HEARTBEAT_INTERVAL_SECS).await
 }
 
 /// Like [`heartbeat_loop`] but with a configurable interval (for testing).
 pub async fn heartbeat_loop_with_interval(
+    http: HttpClient,
     shutdown: CancellationToken,
     interval_secs: u64,
 ) -> Result<(), AgentError> {
@@ -47,7 +51,7 @@ pub async fn heartbeat_loop_with_interval(
             _ = shutdown.cancelled() => return Ok(()),
             _ = interval.tick() => {
                 let payload = json!({ "runId": env::run_id() });
-                match http::post_json(urls::heartbeat_url(), &payload, constants::HTTP_MAX_RETRIES).await {
+                match http.post_json(urls::heartbeat_url(), &payload, constants::HTTP_MAX_RETRIES).await {
                     Ok(_) => {
                         if is_first {
                             log_info!(LOG_TAG, "Heartbeat sent (initial)");

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -408,6 +408,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn disabled_client_raw_upload_fails_before_request_build() {
+        let client = HttpClient { inner: None };
+        let result = client
+            .put_presigned(
+                "http://127.0.0.1:1/upload",
+                Bytes::from_static(b"manifest"),
+                "application/json",
+            )
+            .await;
+
+        let Err(AgentError::Http(message)) = result else {
+            panic!("expected disabled HTTP client error");
+        };
+        assert!(message.contains("HTTP client is disabled"));
+    }
+
+    #[tokio::test]
     async fn disabled_client_stream_upload_fails_before_file_open() {
         let client = HttpClient { inner: None };
         let result = client

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -331,9 +331,9 @@ impl HttpClient {
         content_type: &str,
     ) -> Result<(), AgentError> {
         let max_retries = constants::HTTP_MAX_RETRIES;
+        let client = self.inner()?;
         let source_file = Arc::new(tokio::fs::File::open(path).await?);
         let file_len = source_file.metadata().await?.len();
-        let client = self.inner()?;
 
         send_with_retry(
             "PUT presigned",
@@ -399,6 +399,23 @@ mod tests {
         let client = HttpClient { inner: None };
         let result = client
             .post_json("http://127.0.0.1:1/test", &serde_json::json!({}), 1)
+            .await;
+
+        let Err(AgentError::Http(message)) = result else {
+            panic!("expected disabled HTTP client error");
+        };
+        assert!(message.contains("HTTP client is disabled"));
+    }
+
+    #[tokio::test]
+    async fn disabled_client_stream_upload_fails_before_file_open() {
+        let client = HttpClient { inner: None };
+        let result = client
+            .put_presigned_file(
+                "http://127.0.0.1:1/upload",
+                Path::new("/definitely/missing/source.bin"),
+                "application/octet-stream",
+            )
             .await;
 
         let Err(AgentError::Http(message)) = result else {

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncSeekExt, ReadBuf};
@@ -21,13 +21,29 @@ use tokio::io::{AsyncRead, AsyncSeekExt, ReadBuf};
 const LOG_TAG: &str = "sandbox:guest-agent";
 const HTTP_TOO_MANY_REQUESTS: u16 = 429;
 
-static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
-    Client::builder()
-        .connect_timeout(Duration::from_secs(constants::HTTP_CONNECT_TIMEOUT_SECS))
-        .timeout(Duration::from_secs(constants::HTTP_TIMEOUT_SECS))
-        .build()
-        .unwrap_or_else(|_| Client::new())
-});
+/// Shared guest-agent HTTP client.
+///
+/// Build this during initialization and pass cheap clones to background tasks.
+/// That keeps webhook/S3 timeout configuration consistent across all HTTP
+/// calls and makes client-construction failures explicit at startup.
+#[derive(Clone)]
+pub struct HttpClient {
+    inner: Client,
+}
+
+impl HttpClient {
+    pub fn new() -> Result<Self, AgentError> {
+        let inner = Client::builder()
+            .connect_timeout(Duration::from_secs(constants::HTTP_CONNECT_TIMEOUT_SECS))
+            .timeout(Duration::from_secs(constants::HTTP_TIMEOUT_SECS))
+            .build()
+            .map_err(|e| {
+                AgentError::Http(format!("failed to build guest-agent HTTP client: {e}"))
+            })?;
+
+        Ok(Self { inner })
+    }
+}
 
 async fn send_with_retry<BuildRequest, BuildRequestFuture, BuildClientError, ClientErrorFuture>(
     label: &str,
@@ -72,105 +88,116 @@ where
     Err(AgentError::Http(final_error))
 }
 
-/// POST JSON to a webhook endpoint with Bearer auth, Vercel bypass, and retry.
-///
-/// Returns the parsed JSON response on success, or `None` if the response body
-/// is empty. Returns `Err` immediately on non-retriable 4xx errors (except 429),
-/// or after all retries are exhausted for 5xx / 429 / network errors.
-pub async fn post_json(
-    url: &str,
-    body: &impl Serialize,
-    max_retries: u32,
-) -> Result<Option<Value>, AgentError> {
-    let resp = send_with_retry(
-        "POST",
-        max_retries,
-        format!("POST failed after {max_retries} attempts to {url}"),
-        || {
-            let mut req = HTTP_CLIENT
-                .post(url)
-                .header("Authorization", format!("Bearer {}", env::api_token()))
-                .json(body);
+impl HttpClient {
+    /// POST JSON to a webhook endpoint with Bearer auth, Vercel bypass, and retry.
+    ///
+    /// Returns the parsed JSON response on success, or `None` if the response body
+    /// is empty. Returns `Err` immediately on non-retriable 4xx errors (except 429),
+    /// or after all retries are exhausted for 5xx / 429 / network errors.
+    pub async fn post_json(
+        &self,
+        url: &str,
+        body: &impl Serialize,
+        max_retries: u32,
+    ) -> Result<Option<Value>, AgentError> {
+        let resp = send_with_retry(
+            "POST",
+            max_retries,
+            format!("POST failed after {max_retries} attempts to {url}"),
+            || {
+                let mut req = self
+                    .inner
+                    .post(url)
+                    .header("Authorization", format!("Bearer {}", env::api_token()))
+                    .json(body);
 
-            let bypass = env::vercel_bypass();
-            if !bypass.is_empty() {
-                req = req.header("x-vercel-protection-bypass", bypass);
-            }
+                let bypass = env::vercel_bypass();
+                if !bypass.is_empty() {
+                    req = req.header("x-vercel-protection-bypass", bypass);
+                }
 
-            std::future::ready(Ok(req))
-        },
-        |resp, attempt, max_retries| {
-            let url = url.to_owned();
-            async move {
-                let status = resp.status();
-                let error_msg = resp
-                    .text()
-                    .await
-                    .ok()
-                    .and_then(|body| serde_json::from_str::<Value>(&body).ok())
-                    .and_then(|v| v.get("error")?.get("message")?.as_str().map(String::from));
+                std::future::ready(Ok(req))
+            },
+            |resp, attempt, max_retries| {
+                let url = url.to_owned();
+                async move {
+                    let status = resp.status();
+                    let error_msg = resp
+                        .text()
+                        .await
+                        .ok()
+                        .and_then(|body| serde_json::from_str::<Value>(&body).ok())
+                        .and_then(|v| v.get("error")?.get("message")?.as_str().map(String::from));
 
-                match error_msg {
-                    Some(msg) => {
-                        log_warn!(LOG_TAG, "HTTP POST failed: HTTP {status} — {msg}",);
-                        AgentError::Http(format!("POST {url}: {msg}"))
-                    }
-                    None => {
-                        log_warn!(
-                            LOG_TAG,
-                            "HTTP POST failed (attempt {attempt}/{max_retries}): HTTP {status}",
-                        );
-                        AgentError::Http(format!("POST {url}: HTTP {status}"))
+                    match error_msg {
+                        Some(msg) => {
+                            log_warn!(LOG_TAG, "HTTP POST failed: HTTP {status} — {msg}",);
+                            AgentError::Http(format!("POST {url}: {msg}"))
+                        }
+                        None => {
+                            log_warn!(
+                                LOG_TAG,
+                                "HTTP POST failed (attempt {attempt}/{max_retries}): HTTP {status}",
+                            );
+                            AgentError::Http(format!("POST {url}: HTTP {status}"))
+                        }
                     }
                 }
-            }
-        },
-    )
-    .await?;
+            },
+        )
+        .await?;
 
-    let text = resp
-        .text()
-        .await
-        .map_err(|e| AgentError::Http(e.to_string()))?;
-    if text.is_empty() {
-        return Ok(None);
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| AgentError::Http(e.to_string()))?;
+        if text.is_empty() {
+            return Ok(None);
+        }
+        let val: Value =
+            serde_json::from_str(&text).map_err(|e| AgentError::Http(e.to_string()))?;
+        Ok(Some(val))
     }
-    let val: Value = serde_json::from_str(&text).map_err(|e| AgentError::Http(e.to_string()))?;
-    Ok(Some(val))
-}
 
-/// PUT raw bytes to a presigned S3 URL with retry.
-///
-/// No auth headers — the URL itself carries the authorization.
-/// Uses a per-request timeout override for longer uploads.
-/// Accepts `Bytes` for O(1) clone on retry.
-pub async fn put_presigned(url: &str, data: Bytes, content_type: &str) -> Result<(), AgentError> {
-    let max_retries = constants::HTTP_MAX_RETRIES;
+    /// PUT raw bytes to a presigned S3 URL with retry.
+    ///
+    /// No auth headers — the URL itself carries the authorization.
+    /// Uses a per-request timeout override for longer uploads.
+    /// Accepts `Bytes` for O(1) clone on retry.
+    pub async fn put_presigned(
+        &self,
+        url: &str,
+        data: Bytes,
+        content_type: &str,
+    ) -> Result<(), AgentError> {
+        let max_retries = constants::HTTP_MAX_RETRIES;
 
-    send_with_retry(
-        "PUT presigned",
-        max_retries,
-        format!("PUT presigned failed after {max_retries} attempts"),
-        move || {
-            let data = data.clone();
-            std::future::ready(Ok(HTTP_CLIENT
-                .put(url)
-                .timeout(Duration::from_secs(constants::HTTP_UPLOAD_TIMEOUT_SECS))
-                .header("Content-Type", content_type)
-                .body(data)))
-        },
-        |resp, attempt, max_retries| async move {
-            let status = resp.status();
-            log_warn!(
-                LOG_TAG,
-                "HTTP PUT presigned failed (attempt {attempt}/{max_retries}): HTTP {status}",
-            );
-            AgentError::Http(format!("PUT presigned: HTTP {status}"))
-        },
-    )
-    .await?;
+        send_with_retry(
+            "PUT presigned",
+            max_retries,
+            format!("PUT presigned failed after {max_retries} attempts"),
+            move || {
+                let data = data.clone();
+                std::future::ready(Ok(self
+                    .inner
+                    .put(url)
+                    .timeout(Duration::from_secs(constants::HTTP_UPLOAD_TIMEOUT_SECS))
+                    .header("Content-Type", content_type)
+                    .body(data)))
+            },
+            |resp, attempt, max_retries| async move {
+                let status = resp.status();
+                log_warn!(
+                    LOG_TAG,
+                    "HTTP PUT presigned failed (attempt {attempt}/{max_retries}): HTTP {status}",
+                );
+                AgentError::Http(format!("PUT presigned: HTTP {status}"))
+            },
+        )
+        .await?;
 
-    Ok(())
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -271,52 +298,56 @@ impl http_body::Body for SizedBody {
     }
 }
 
-/// PUT a file to a presigned S3 URL by streaming from disk.
-///
-/// Unlike [`put_presigned`], this avoids loading the entire file into memory.
-/// A `SizedBody` streams bounded chunks and reports the file size via
-/// `size_hint`, so hyper sets `Content-Length` automatically.
-/// On each retry the original file handle is cloned, producing a fresh body
-/// with stable file identity and length.
-pub async fn put_presigned_file(
-    url: &str,
-    path: &Path,
-    content_type: &str,
-) -> Result<(), AgentError> {
-    let max_retries = constants::HTTP_MAX_RETRIES;
-    let source_file = Arc::new(tokio::fs::File::open(path).await?);
-    let file_len = source_file.metadata().await?.len();
+impl HttpClient {
+    /// PUT a file to a presigned S3 URL by streaming from disk.
+    ///
+    /// Unlike [`Self::put_presigned`], this avoids loading the entire file into
+    /// memory. A `SizedBody` streams bounded chunks and reports the file size via
+    /// `size_hint`, so hyper sets `Content-Length` automatically. On each retry the
+    /// original file handle is cloned, producing a fresh body with stable file
+    /// identity and length.
+    pub async fn put_presigned_file(
+        &self,
+        url: &str,
+        path: &Path,
+        content_type: &str,
+    ) -> Result<(), AgentError> {
+        let max_retries = constants::HTTP_MAX_RETRIES;
+        let source_file = Arc::new(tokio::fs::File::open(path).await?);
+        let file_len = source_file.metadata().await?.len();
 
-    send_with_retry(
-        "PUT presigned",
-        max_retries,
-        format!("PUT presigned failed after {max_retries} attempts"),
-        move || {
-            let source_file = Arc::clone(&source_file);
-            async move {
-                let mut file = source_file.try_clone().await?;
-                file.seek(std::io::SeekFrom::Start(0)).await?;
-                let body = reqwest::Body::wrap(SizedBody::new(file, file_len));
+        send_with_retry(
+            "PUT presigned",
+            max_retries,
+            format!("PUT presigned failed after {max_retries} attempts"),
+            move || {
+                let source_file = Arc::clone(&source_file);
+                async move {
+                    let mut file = source_file.try_clone().await?;
+                    file.seek(std::io::SeekFrom::Start(0)).await?;
+                    let body = reqwest::Body::wrap(SizedBody::new(file, file_len));
 
-                Ok(HTTP_CLIENT
-                    .put(url)
-                    .timeout(Duration::from_secs(constants::HTTP_UPLOAD_TIMEOUT_SECS))
-                    .header("Content-Type", content_type)
-                    .body(body))
-            }
-        },
-        |resp, attempt, max_retries| async move {
-            let status = resp.status();
-            log_warn!(
-                LOG_TAG,
-                "HTTP PUT presigned failed (attempt {attempt}/{max_retries}): HTTP {status}",
-            );
-            AgentError::Http(format!("PUT presigned: HTTP {status}"))
-        },
-    )
-    .await?;
+                    Ok(self
+                        .inner
+                        .put(url)
+                        .timeout(Duration::from_secs(constants::HTTP_UPLOAD_TIMEOUT_SECS))
+                        .header("Content-Type", content_type)
+                        .body(body))
+                }
+            },
+            |resp, attempt, max_retries| async move {
+                let status = resp.status();
+                log_warn!(
+                    LOG_TAG,
+                    "HTTP PUT presigned failed (attempt {attempt}/{max_retries}): HTTP {status}",
+                );
+                AgentError::Http(format!("PUT presigned: HTTP {status}"))
+            },
+        )
+        .await?;
 
-    Ok(())
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -23,12 +23,14 @@ const HTTP_TOO_MANY_REQUESTS: u16 = 429;
 
 /// Shared guest-agent HTTP client.
 ///
-/// Build this during initialization and pass cheap clones to background tasks.
-/// That keeps webhook/S3 timeout configuration consistent across all HTTP
-/// calls and makes client-construction failures explicit at startup.
+/// API-enabled runs build this during initialization and pass cheap clones to
+/// background tasks. That keeps webhook/S3 timeout configuration consistent
+/// across all HTTP calls and makes client-construction failures explicit at
+/// startup. Local/test runs without `VM0_API_TOKEN` use a disabled client so
+/// they do not fail on HTTP stack setup they will never use.
 #[derive(Clone)]
 pub struct HttpClient {
-    inner: Client,
+    inner: Option<Client>,
 }
 
 impl HttpClient {
@@ -41,7 +43,23 @@ impl HttpClient {
                 AgentError::Http(format!("failed to build guest-agent HTTP client: {e}"))
             })?;
 
-        Ok(Self { inner })
+        Ok(Self { inner: Some(inner) })
+    }
+
+    pub fn for_current_env() -> Result<Self, AgentError> {
+        if env::has_api() {
+            Self::new()
+        } else {
+            Ok(Self { inner: None })
+        }
+    }
+
+    fn inner(&self) -> Result<&Client, AgentError> {
+        self.inner.as_ref().ok_or_else(|| {
+            AgentError::Http(
+                "guest-agent HTTP client is disabled because VM0_API_TOKEN is unset".into(),
+            )
+        })
     }
 }
 
@@ -100,13 +118,13 @@ impl HttpClient {
         body: &impl Serialize,
         max_retries: u32,
     ) -> Result<Option<Value>, AgentError> {
+        let client = self.inner()?;
         let resp = send_with_retry(
             "POST",
             max_retries,
             format!("POST failed after {max_retries} attempts to {url}"),
             || {
-                let mut req = self
-                    .inner
+                let mut req = client
                     .post(url)
                     .header("Authorization", format!("Bearer {}", env::api_token()))
                     .json(body);
@@ -171,6 +189,7 @@ impl HttpClient {
         content_type: &str,
     ) -> Result<(), AgentError> {
         let max_retries = constants::HTTP_MAX_RETRIES;
+        let client = self.inner()?;
 
         send_with_retry(
             "PUT presigned",
@@ -178,8 +197,7 @@ impl HttpClient {
             format!("PUT presigned failed after {max_retries} attempts"),
             move || {
                 let data = data.clone();
-                std::future::ready(Ok(self
-                    .inner
+                std::future::ready(Ok(client
                     .put(url)
                     .timeout(Duration::from_secs(constants::HTTP_UPLOAD_TIMEOUT_SECS))
                     .header("Content-Type", content_type)
@@ -315,6 +333,7 @@ impl HttpClient {
         let max_retries = constants::HTTP_MAX_RETRIES;
         let source_file = Arc::new(tokio::fs::File::open(path).await?);
         let file_len = source_file.metadata().await?.len();
+        let client = self.inner()?;
 
         send_with_retry(
             "PUT presigned",
@@ -327,8 +346,7 @@ impl HttpClient {
                     file.seek(std::io::SeekFrom::Start(0)).await?;
                     let body = reqwest::Body::wrap(SizedBody::new(file, file_len));
 
-                    Ok(self
-                        .inner
+                    Ok(client
                         .put(url)
                         .timeout(Duration::from_secs(constants::HTTP_UPLOAD_TIMEOUT_SECS))
                         .header("Content-Type", content_type)
@@ -374,6 +392,19 @@ mod tests {
             Ok(data) => Some(data),
             Err(_) => panic!("expected data frame"),
         }
+    }
+
+    #[tokio::test]
+    async fn disabled_client_fails_before_request_build() {
+        let client = HttpClient { inner: None };
+        let result = client
+            .post_json("http://127.0.0.1:1/test", &serde_json::json!({}), 1)
+            .await;
+
+        let Err(AgentError::Http(message)) = result else {
+            panic!("expected disabled HTTP client error");
+        };
+        assert!(message.contains("HTTP client is disabled"));
     }
 
     #[tokio::test]

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -29,7 +29,8 @@ async fn main() {
 }
 
 /// Top-level orchestrator. Returns exit code directly (never panics/errors out).
-/// Final telemetry upload is guaranteed to run on every code path.
+/// Final telemetry upload is attempted on all paths where the HTTP client can
+/// be initialized; when no API token is configured, that upload is a no-op.
 async fn run() -> i32 {
     // Record API-to-agent E2E time (as early as possible)
     guest_agent::timing::record_e2e_from_api("api_to_agent_start");

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -38,7 +38,7 @@ async fn run() -> i32 {
     if env::working_dir().is_empty() {
         log_error!(LOG_TAG, "Fatal: VM0_WORKING_DIR is required but not set");
         let masker = Arc::new(masker::SecretMasker::from_env());
-        let telemetry = match HttpClient::new() {
+        let telemetry = match HttpClient::for_current_env() {
             Ok(http) => Some(Telemetry::spawn(masker, http)),
             Err(e) => {
                 log_error!(LOG_TAG, "Final telemetry unavailable: {e}");
@@ -55,7 +55,7 @@ async fn run() -> i32 {
         return 1;
     }
 
-    let http = match HttpClient::new() {
+    let http = match HttpClient::for_current_env() {
         Ok(http) => http,
         Err(e) => {
             log_error!(LOG_TAG, "Fatal: {e}");

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -7,6 +7,7 @@ use guest_agent::complete;
 use guest_agent::env;
 use guest_agent::error;
 use guest_agent::heartbeat;
+use guest_agent::http::HttpClient;
 use guest_agent::masker;
 use guest_agent::metrics;
 use guest_agent::paths;
@@ -37,14 +38,31 @@ async fn run() -> i32 {
     if env::working_dir().is_empty() {
         log_error!(LOG_TAG, "Fatal: VM0_WORKING_DIR is required but not set");
         let masker = Arc::new(masker::SecretMasker::from_env());
-        let telemetry = Telemetry::spawn(masker);
+        let telemetry = match HttpClient::new() {
+            Ok(http) => Some(Telemetry::spawn(masker, http)),
+            Err(e) => {
+                log_error!(LOG_TAG, "Final telemetry unavailable: {e}");
+                None
+            }
+        };
         log_info!(LOG_TAG, "▷ Cleanup");
-        final_telemetry(&telemetry).await;
-        telemetry.shutdown().await;
+        if let Some(telemetry) = telemetry {
+            final_telemetry(&telemetry).await;
+            telemetry.shutdown().await;
+        }
         log_info!(LOG_TAG, "Background processes stopped");
         log_info!(LOG_TAG, "✗ Sandbox failed (exit code 1)");
         return 1;
     }
+
+    let http = match HttpClient::new() {
+        Ok(http) => http,
+        Err(e) => {
+            log_error!(LOG_TAG, "Fatal: {e}");
+            log_info!(LOG_TAG, "✗ Sandbox failed (exit code 1)");
+            return 1;
+        }
+    };
 
     // Lifecycle: Header
     log_info!(LOG_TAG, "▶ VM0 Sandbox {}", env::run_id());
@@ -61,7 +79,8 @@ async fn run() -> i32 {
     let t = Instant::now();
     let heartbeat_handle = tokio::spawn({
         let shutdown = shutdown.clone();
-        async move { heartbeat::heartbeat_loop(shutdown).await }
+        let http = http.clone();
+        async move { heartbeat::heartbeat_loop(http, shutdown).await }
     });
     log_info!(LOG_TAG, "Heartbeat started");
     record_sandbox_op("heartbeat_start", t.elapsed(), true, None);
@@ -75,7 +94,7 @@ async fn run() -> i32 {
     record_sandbox_op("metrics_collector_start", t.elapsed(), true, None);
 
     let t = Instant::now();
-    let telemetry = Telemetry::spawn(masker.clone());
+    let telemetry = Telemetry::spawn(masker.clone(), http.clone());
     log_info!(LOG_TAG, "Telemetry upload started");
     record_sandbox_op("telemetry_upload_start", t.elapsed(), true, None);
 
@@ -83,7 +102,7 @@ async fn run() -> i32 {
     // `execute` owns the final telemetry upload — on the success path it's run
     // in parallel with `checkpoint` so the ~1s upload doesn't serialize behind
     // the ~4s snapshot work.
-    let exit_code = execute(&masker, start, heartbeat_handle, &telemetry).await;
+    let exit_code = execute(&masker, start, heartbeat_handle, &telemetry, http).await;
 
     // Stop all background processes. Telemetry uses its own command
     // channel; `shutdown` only covers heartbeat/metrics.
@@ -108,6 +127,7 @@ async fn execute(
     start: Instant,
     heartbeat_handle: tokio::task::JoinHandle<Result<(), error::AgentError>>,
     telemetry: &Telemetry,
+    http: HttpClient,
 ) -> i32 {
     // Pre-warm kernel DNS cache for the CLI's API endpoint.
     // Fire-and-forget: runs in background so the cache is populated by the
@@ -155,32 +175,33 @@ async fn execute(
     log_info!(LOG_TAG, "▷ Execution");
     let cli_start = Instant::now();
     let mut last_event_sequence = None;
-    let (mut exit_code, error_message) = match cli::execute_cli(masker, heartbeat_handle).await {
-        Ok(cli_result) => {
-            last_event_sequence = cli_result.last_event_sequence;
-            let code = cli_result.exit_code;
-            if code != 0 {
-                let msg = if cli_result.stderr_lines.is_empty() {
-                    format!("Agent exited with code {code}")
+    let (mut exit_code, error_message) =
+        match cli::execute_cli(masker, heartbeat_handle, http.clone()).await {
+            Ok(cli_result) => {
+                last_event_sequence = cli_result.last_event_sequence;
+                let code = cli_result.exit_code;
+                if code != 0 {
+                    let msg = if cli_result.stderr_lines.is_empty() {
+                        format!("Agent exited with code {code}")
+                    } else {
+                        log_info!(
+                            LOG_TAG,
+                            "Captured {} stderr lines",
+                            cli_result.stderr_lines.len()
+                        );
+                        cli_result.stderr_lines.join(" ")
+                    };
+                    (code, msg)
                 } else {
-                    log_info!(
-                        LOG_TAG,
-                        "Captured {} stderr lines",
-                        cli_result.stderr_lines.len()
-                    );
-                    cli_result.stderr_lines.join(" ")
-                };
-                (code, msg)
-            } else {
-                (0, String::new())
+                    (0, String::new())
+                }
             }
-        }
-        Err(e) => {
-            let msg = e.to_string();
-            log_error!(LOG_TAG, "CLI execution failed: {msg}");
-            (1, msg)
-        }
-    };
+            Err(e) => {
+                let msg = e.to_string();
+                log_error!(LOG_TAG, "CLI execution failed: {msg}");
+                (1, msg)
+            }
+        };
     let cli_exit_code = exit_code;
     let cli_elapsed = cli_start.elapsed();
     record_sandbox_op(
@@ -219,7 +240,7 @@ async fn execute(
         log_info!(LOG_TAG, "▷ Checkpoint");
         let cp_start = Instant::now();
         let (cp_result, _) = tokio::join!(
-            checkpoint::create_checkpoint(),
+            checkpoint::create_checkpoint(&http),
             telemetry.flush(UploadMode::Live),
         );
         match cp_result {
@@ -246,6 +267,7 @@ async fn execute(
                 // returned.
                 log_info!(LOG_TAG, "▷ Cleanup");
                 complete::report_success(
+                    &http,
                     env::sandbox_id(),
                     env::sandbox_reuse_result(),
                     last_event_sequence,

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -99,10 +99,10 @@ async fn run() -> i32 {
     log_info!(LOG_TAG, "Telemetry upload started");
     record_sandbox_op("telemetry_upload_start", t.elapsed(), true, None);
 
-    // Execute main logic (init + CLI + checkpoint + final telemetry).
-    // `execute` owns the final telemetry upload — on the success path it's run
-    // in parallel with `checkpoint` so the ~1s upload doesn't serialize behind
-    // the ~4s snapshot work.
+    // Execute main logic (init + CLI + checkpoint + cleanup telemetry).
+    // On the success path, `execute` overlaps the pre-checkpoint telemetry
+    // flush with checkpoint creation; the final flush still runs after
+    // `/complete` so the acknowledgement log line is uploaded.
     let exit_code = execute(&masker, start, heartbeat_handle, &telemetry, http).await;
 
     // Stop all background processes. Telemetry uses its own command

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -121,8 +121,9 @@ async fn run() -> i32 {
     exit_code
 }
 
-/// Main execution logic: working dir, CLI, checkpoint, and final telemetry
-/// upload (parallel with checkpoint on the success path; serial otherwise).
+/// Main execution logic: working dir, CLI, checkpoint, and cleanup telemetry.
+/// The success path overlaps the pre-checkpoint telemetry flush with
+/// checkpoint creation, then runs the final flush after `/complete`.
 async fn execute(
     masker: &masker::SecretMasker,
     start: Instant,

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -13,7 +13,7 @@
 use crate::constants;
 use crate::env;
 use crate::error::AgentError;
-use crate::http;
+use crate::http::HttpClient;
 use crate::masker::SecretMasker;
 use crate::paths;
 use crate::urls;
@@ -140,7 +140,11 @@ fn save_position(pos_path: &str, pos: u64) {
 /// pre-checkpoint `flush(UploadMode::Live)`) must use `UploadMode::Live`
 /// so a later pass can safely pick up the tail once the producer
 /// completes the line.
-async fn upload_telemetry(masker: &SecretMasker, mode: UploadMode) -> Result<(), AgentError> {
+async fn upload_telemetry(
+    http: &HttpClient,
+    masker: &SecretMasker,
+    mode: UploadMode,
+) -> Result<(), AgentError> {
     // Read deltas
     let (system_log, log_pos) = read_file_delta(
         paths::system_log_file(),
@@ -178,7 +182,7 @@ async fn upload_telemetry(masker: &SecretMasker, mode: UploadMode) -> Result<(),
     });
 
     // Use 1 attempt for telemetry (non-critical, best-effort)
-    match http::post_json(urls::telemetry_url(), &payload, 1).await {
+    match http.post_json(urls::telemetry_url(), &payload, 1).await {
         Ok(_) => {
             save_position(paths::telemetry_system_log_pos_file(), log_pos);
             save_position(paths::telemetry_metrics_pos_file(), metrics_pos);
@@ -223,9 +227,9 @@ impl Telemetry {
     /// reintroducing the multi-writer race that the channel was built
     /// to eliminate (#11008). The type system can't enforce this — the
     /// constraint is the shared pos paths, not the channel.
-    pub fn spawn(masker: Arc<SecretMasker>) -> Self {
+    pub fn spawn(masker: Arc<SecretMasker>, http: HttpClient) -> Self {
         let (tx, rx) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
-        let handle = tokio::spawn(run(rx, masker));
+        let handle = tokio::spawn(run(rx, masker, http));
         Self { tx, handle }
     }
 
@@ -266,7 +270,7 @@ impl Telemetry {
 /// select boundary, so a caller-driven flush is never blocked behind a
 /// tick that hasn't started yet. (A tick already in its `await` cannot
 /// be preempted; the worst-case wait for a flush is one in-flight tick.)
-async fn run(mut rx: mpsc::Receiver<Cmd>, masker: Arc<SecretMasker>) {
+async fn run(mut rx: mpsc::Receiver<Cmd>, masker: Arc<SecretMasker>, http: HttpClient) {
     if !env::has_api() {
         // Drain commands so callers don't block on `reply_rx`. Flushes
         // are a no-op (no API to upload to); Shutdown ends the loop.
@@ -294,13 +298,13 @@ async fn run(mut rx: mpsc::Receiver<Cmd>, masker: Arc<SecretMasker>) {
             biased;
             cmd = rx.recv() => match cmd {
                 Some(Cmd::Flush { mode, reply }) => {
-                    let result = upload_telemetry(&masker, mode).await;
+                    let result = upload_telemetry(&http, &masker, mode).await;
                     let _ = reply.send(result);
                 }
                 Some(Cmd::Shutdown) | None => break,
             },
             _ = interval.tick() => {
-                let _ = upload_telemetry(&masker, UploadMode::Live).await;
+                let _ = upload_telemetry(&http, &masker, UploadMode::Live).await;
             }
         }
     }

--- a/crates/guest-agent/tests/cli_setup_failure.rs
+++ b/crates/guest-agent/tests/cli_setup_failure.rs
@@ -1,0 +1,54 @@
+//! CLI setup should fail before spawning the agent when local log setup fails.
+//!
+//! This test lives in its own binary because `guest_agent::env` and
+//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+
+use guest_agent::error::AgentError;
+use std::io::ErrorKind;
+use std::time::Duration;
+
+#[tokio::test]
+async fn agent_log_open_failure_happens_before_cli_spawn() -> Result<(), Box<dyn std::error::Error>>
+{
+    let tmp = tempfile::tempdir()?;
+    let run_prefix = format!("cli-log-parent-file-{}", std::process::id());
+    let parent_file = std::env::temp_dir().join(format!("vm0-agent-{run_prefix}"));
+    std::fs::write(&parent_file, b"not a directory")?;
+
+    unsafe {
+        std::env::set_var("VM0_RUN_ID", format!("{run_prefix}/child"));
+        std::env::set_var("VM0_WORKING_DIR", tmp.path());
+        std::env::set_var("VM0_PROMPT", "@exit-after-result");
+        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var("USE_MOCK_CLAUDE", "true");
+        std::env::set_var(
+            "VM0_MOCK_CLAUDE_PATH",
+            "/definitely/missing/guest-mock-claude",
+        );
+        std::env::set_var("HOME", tmp.path());
+    }
+
+    let masker = guest_agent::masker::SecretMasker::from_raw("");
+    let heartbeat = tokio::spawn(async { Ok(()) });
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(1),
+        guest_agent::cli::execute_cli(
+            &masker,
+            heartbeat,
+            guest_agent::http::HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("log setup failure should return promptly");
+
+    match result {
+        Err(AgentError::Io(err)) => assert_eq!(err.kind(), ErrorKind::NotADirectory),
+        Err(err) => return Err(format!("expected IO error from agent log setup, got {err}").into()),
+        Ok(_) => return Err("expected execute_cli to fail before spawning CLI".into()),
+    }
+
+    let _ = std::fs::remove_file(parent_file);
+    Ok(())
+}

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -66,6 +66,12 @@ fn setup_env_once() {
 /// `/tmp/vm0-session-*.txt` files written by `extract_session_id`.
 static TEST_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
+macro_rules! http_client {
+    () => {
+        guest_agent::http::HttpClient::new().unwrap()
+    };
+}
+
 /// Wipe the per-run session-id / history-path files so each test starts
 /// from a clean slate. `extract_session_id` is idempotent (first id wins),
 /// so leaving stale files would mask real failures.
@@ -109,7 +115,7 @@ async fn send_event_extracts_codex_thread_id_and_writes_marker() {
 
     // No API token → send_event skips the HTTP POST but still runs
     // extract_session_id, which is the part we want to assert.
-    let result = guest_agent::events::send_event(&mut event, 1, &masker).await;
+    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
     assert!(
         result.is_ok(),
         "send_event should succeed when no API token"
@@ -143,7 +149,7 @@ async fn send_event_codex_ignores_non_thread_started_event() {
 
     let masker = SecretMasker::from_raw("");
     let mut event = json!({"type": "turn.completed"});
-    let result = guest_agent::events::send_event(&mut event, 1, &masker).await;
+    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
     assert!(result.is_ok());
 
     assert!(
@@ -160,7 +166,7 @@ async fn send_event_codex_ignores_empty_thread_id() {
 
     let masker = SecretMasker::from_raw("");
     let mut event = json!({"type": "thread.started", "thread_id": ""});
-    let result = guest_agent::events::send_event(&mut event, 1, &masker).await;
+    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
     assert!(result.is_ok());
 
     assert!(

--- a/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
@@ -42,7 +42,11 @@ async fn heartbeat_panic_reap_escalates_to_sigkill_when_sigterm_ignored()
     // + sigkill grace (1s, unignorable) + stdout drain (5s) + slack.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(&masker, heartbeat),
+        guest_agent::cli::execute_cli(
+            &masker,
+            heartbeat,
+            guest_agent::http::HttpClient::new().unwrap(),
+        ),
     )
     .await
     .expect("execute_cli did not return within 15s - heartbeat panic reap likely broken");

--- a/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
@@ -40,7 +40,11 @@ async fn heartbeat_failure_reap_escalates_to_sigkill_when_sigterm_ignored()
     // + sigkill grace (1s, unignorable) + stdout drain (5s) + slack.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(&masker, heartbeat),
+        guest_agent::cli::execute_cli(
+            &masker,
+            heartbeat,
+            guest_agent::http::HttpClient::new().unwrap(),
+        ),
     )
     .await
     .expect("execute_cli did not return within 15s - heartbeat reap escalation likely broken");

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -82,6 +82,30 @@ async fn post_json_success_json_response() {
 }
 
 #[tokio::test]
+async fn for_current_env_uses_enabled_client_when_api_token_is_set()
+-> Result<(), Box<dyn std::error::Error>> {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/test/for-current-env")
+            .header("Authorization", "Bearer test-token-abc123");
+        then.status(200).json_body(json!({"status": "ok"}));
+    });
+
+    let url = format!("{}/test/for-current-env", server.base_url());
+    let result = guest_agent::http::HttpClient::for_current_env()?
+        .post_json(&url, &json!({}), 1)
+        .await?;
+
+    mock.assert_calls_async(1).await;
+    assert_eq!(result.unwrap()["status"], "ok");
+    mock.delete_async().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn post_json_success_empty_response() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -33,6 +33,12 @@ static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
 /// Serialize all tests — they share one mock server and process-wide env vars.
 static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
+macro_rules! http_client {
+    () => {
+        guest_agent::http::HttpClient::new().unwrap()
+    };
+}
+
 struct SystemLogOverrideGuard;
 
 impl SystemLogOverrideGuard {
@@ -65,7 +71,9 @@ async fn post_json_success_json_response() {
     });
 
     let url = format!("{}/test/success", server.base_url());
-    let result = guest_agent::http::post_json(&url, &json!({"key": "val"}), 1).await;
+    let result = http_client!()
+        .post_json(&url, &json!({"key": "val"}), 1)
+        .await;
 
     mock.assert_calls_async(1).await;
     let val = result.unwrap().unwrap();
@@ -84,7 +92,9 @@ async fn post_json_success_empty_response() {
     });
 
     let url = format!("{}/test/empty", server.base_url());
-    let result = guest_agent::http::post_json(&url, &json!({"key": "val"}), 1).await;
+    let result = http_client!()
+        .post_json(&url, &json!({"key": "val"}), 1)
+        .await;
 
     mock.assert_calls_async(1).await;
     assert!(result.unwrap().is_none());
@@ -110,8 +120,7 @@ async fn post_json_retry_then_succeed() {
     });
 
     let url = format!("{}/test/retry-succeed", server.base_url());
-    let handle =
-        tokio::spawn(async move { guest_agent::http::post_json(&url, &json!({}), 3).await });
+    let handle = tokio::spawn(async move { http_client!().post_json(&url, &json!({}), 3).await });
 
     // Wait until the failure mock has been hit twice, then remove it so
     // the third attempt falls through to the success mock.
@@ -141,7 +150,7 @@ async fn post_json_retry_exhausted() {
     });
 
     let url = format!("{}/test/exhaust", server.base_url());
-    let result = guest_agent::http::post_json(&url, &json!({}), 3).await;
+    let result = http_client!().post_json(&url, &json!({}), 3).await;
 
     mock.assert_calls_async(3).await;
     assert!(result.is_err());
@@ -163,7 +172,7 @@ async fn post_json_4xx_returns_immediately_no_retry() {
     });
 
     let url = format!("{}/test/post-400", server.base_url());
-    let result = guest_agent::http::post_json(&url, &json!({}), 3).await;
+    let result = http_client!().post_json(&url, &json!({}), 3).await;
 
     // Should fail immediately — only 1 call, no retries.
     mock.assert_calls_async(1).await;
@@ -182,7 +191,7 @@ async fn post_json_429_retries() {
     });
 
     let url = format!("{}/test/post-429", server.base_url());
-    let result = guest_agent::http::post_json(&url, &json!({}), 3).await;
+    let result = http_client!().post_json(&url, &json!({}), 3).await;
 
     // 429 is retriable — should exhaust all retries.
     mock.assert_calls_async(3).await;
@@ -207,7 +216,7 @@ async fn post_json_sends_bearer_token() {
     });
 
     let url = format!("{}/test/auth", server.base_url());
-    let result = guest_agent::http::post_json(&url, &json!({}), 1).await;
+    let result = http_client!().post_json(&url, &json!({}), 1).await;
 
     mock.assert_calls_async(1).await;
     assert!(result.is_ok());
@@ -227,7 +236,7 @@ async fn post_json_sends_vercel_bypass_header() {
     });
 
     let url = format!("{}/test/bypass", server.base_url());
-    let result = guest_agent::http::post_json(&url, &json!({}), 1).await;
+    let result = http_client!().post_json(&url, &json!({}), 1).await;
 
     mock.assert_calls_async(1).await;
     assert!(result.is_ok());
@@ -252,7 +261,9 @@ async fn put_presigned_success() {
 
     let url = format!("{}/test/put-success", server.base_url());
     let data = Bytes::from_static(b"test data");
-    let result = guest_agent::http::put_presigned(&url, data, "application/octet-stream").await;
+    let result = http_client!()
+        .put_presigned(&url, data, "application/octet-stream")
+        .await;
 
     mock.assert_calls_async(1).await;
     assert!(result.is_ok());
@@ -277,7 +288,9 @@ async fn put_presigned_retry_then_succeed() {
     let url = format!("{}/test/put-retry", server.base_url());
     let data = Bytes::from_static(b"retry data");
     let handle = tokio::spawn(async move {
-        guest_agent::http::put_presigned(&url, data, "application/octet-stream").await
+        http_client!()
+            .put_presigned(&url, data, "application/octet-stream")
+            .await
     });
 
     loop {
@@ -310,7 +323,9 @@ async fn put_presigned_4xx_returns_immediately_no_retry() {
 
     let url = format!("{}/test/put-403", server.base_url());
     let data = Bytes::from_static(b"forbidden data");
-    let result = guest_agent::http::put_presigned(&url, data, "application/octet-stream").await;
+    let result = http_client!()
+        .put_presigned(&url, data, "application/octet-stream")
+        .await;
 
     // Should fail immediately — only 1 call, no retries.
     mock.assert_calls_async(1).await;
@@ -330,7 +345,9 @@ async fn put_presigned_429_retries() {
 
     let url = format!("{}/test/put-429", server.base_url());
     let data = Bytes::from_static(b"rate limited data");
-    let result = guest_agent::http::put_presigned(&url, data, "application/octet-stream").await;
+    let result = http_client!()
+        .put_presigned(&url, data, "application/octet-stream")
+        .await;
 
     // 429 is retriable — should exhaust all retries.
     mock.assert_calls_async(3).await;
@@ -360,7 +377,9 @@ async fn put_presigned_file_success() {
     });
 
     let url = format!("{}/test/put-file-success", server.base_url());
-    let result = guest_agent::http::put_presigned_file(&url, &file_path, "application/gzip").await;
+    let result = http_client!()
+        .put_presigned_file(&url, &file_path, "application/gzip")
+        .await;
 
     mock.assert_calls_async(1).await;
     assert!(result.is_ok());
@@ -385,7 +404,9 @@ async fn put_presigned_file_sets_content_length() {
     });
 
     let url = format!("{}/test/put-file-content-length", server.base_url());
-    let result = guest_agent::http::put_presigned_file(&url, &file_path, "application/gzip").await;
+    let result = http_client!()
+        .put_presigned_file(&url, &file_path, "application/gzip")
+        .await;
 
     mock.assert_calls_async(1).await;
     assert!(result.is_ok());
@@ -413,7 +434,9 @@ async fn put_presigned_file_retry_then_succeed() {
     let url = format!("{}/test/put-file-retry", server.base_url());
     let path = file_path.clone();
     let handle = tokio::spawn(async move {
-        guest_agent::http::put_presigned_file(&url, &path, "application/gzip").await
+        http_client!()
+            .put_presigned_file(&url, &path, "application/gzip")
+            .await
     });
 
     loop {
@@ -453,7 +476,9 @@ async fn put_presigned_file_retry_fails_if_source_shrinks() {
     let url = format!("{}/test/put-file-retry-shrunk", server.base_url());
     let path = file_path.clone();
     let handle = tokio::spawn(async move {
-        guest_agent::http::put_presigned_file(&url, &path, "application/gzip").await
+        http_client!()
+            .put_presigned_file(&url, &path, "application/gzip")
+            .await
     });
 
     loop {
@@ -495,7 +520,9 @@ async fn put_presigned_file_retry_uses_original_length_if_source_grows() {
     let url = format!("{}/test/put-file-retry-grown", server.base_url());
     let path = file_path.clone();
     let handle = tokio::spawn(async move {
-        guest_agent::http::put_presigned_file(&url, &path, "application/gzip").await
+        http_client!()
+            .put_presigned_file(&url, &path, "application/gzip")
+            .await
     });
 
     loop {
@@ -539,7 +566,9 @@ async fn put_presigned_file_retry_uses_original_handle_if_path_is_replaced() {
     let url = format!("{}/test/put-file-retry-replaced", server.base_url());
     let path = file_path.clone();
     let handle = tokio::spawn(async move {
-        guest_agent::http::put_presigned_file(&url, &path, "application/gzip").await
+        http_client!()
+            .put_presigned_file(&url, &path, "application/gzip")
+            .await
     });
 
     loop {
@@ -576,7 +605,9 @@ async fn put_presigned_file_large_multi_chunk() {
     });
 
     let url = format!("{}/test/put-file-large", server.base_url());
-    let result = guest_agent::http::put_presigned_file(&url, &file_path, "application/gzip").await;
+    let result = http_client!()
+        .put_presigned_file(&url, &file_path, "application/gzip")
+        .await;
 
     mock.assert_calls_async(1).await;
     assert!(result.is_ok());
@@ -598,7 +629,9 @@ async fn put_presigned_file_4xx_no_retry() {
     });
 
     let url = format!("{}/test/put-file-403", server.base_url());
-    let result = guest_agent::http::put_presigned_file(&url, &file_path, "application/gzip").await;
+    let result = http_client!()
+        .put_presigned_file(&url, &file_path, "application/gzip")
+        .await;
 
     mock.assert_calls_async(1).await;
     assert!(result.is_err());
@@ -621,8 +654,9 @@ async fn heartbeat_first_success() {
 
     let shutdown = CancellationToken::new();
     let shutdown_clone = shutdown.clone();
-    let handle =
-        tokio::spawn(async move { guest_agent::heartbeat::heartbeat_loop(shutdown_clone).await });
+    let handle = tokio::spawn(async move {
+        guest_agent::heartbeat::heartbeat_loop(http_client!(), shutdown_clone).await
+    });
 
     // Wait for the first heartbeat to land, then shut down.
     loop {
@@ -649,7 +683,7 @@ async fn heartbeat_first_failure_fatal() {
     });
 
     let shutdown = CancellationToken::new();
-    let result = guest_agent::heartbeat::heartbeat_loop(shutdown).await;
+    let result = guest_agent::heartbeat::heartbeat_loop(http_client!(), shutdown).await;
 
     assert!(result.is_err());
     mock.assert_calls_async(3).await;
@@ -673,7 +707,12 @@ async fn heartbeat_consecutive_failures_fatal() {
     let shutdown = CancellationToken::new();
     let shutdown_clone = shutdown.clone();
     let handle = tokio::spawn(async move {
-        guest_agent::heartbeat::heartbeat_loop_with_interval(shutdown_clone, TEST_INTERVAL).await
+        guest_agent::heartbeat::heartbeat_loop_with_interval(
+            http_client!(),
+            shutdown_clone,
+            TEST_INTERVAL,
+        )
+        .await
     });
 
     // Wait for first successful heartbeat.
@@ -734,7 +773,12 @@ async fn heartbeat_recovery_resets_counter() {
     let shutdown = CancellationToken::new();
     let shutdown_clone = shutdown.clone();
     let handle = tokio::spawn(async move {
-        guest_agent::heartbeat::heartbeat_loop_with_interval(shutdown_clone, TEST_INTERVAL).await
+        guest_agent::heartbeat::heartbeat_loop_with_interval(
+            http_client!(),
+            shutdown_clone,
+            TEST_INTERVAL,
+        )
+        .await
     });
 
     // Wait for first successful heartbeat.
@@ -815,7 +859,7 @@ async fn send_event_correct_payload() {
 
     let masker = SecretMasker::from_raw("");
     let mut event = json!({"type": "test", "data": "hello"});
-    let result = guest_agent::events::send_event(&mut event, 42, &masker).await;
+    let result = guest_agent::events::send_event(&http_client!(), &mut event, 42, &masker).await;
 
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
@@ -838,7 +882,7 @@ async fn send_event_masks_secrets() {
     let masker = SecretMasker::from_raw(&encoded_secret);
 
     let mut event = json!({"type": "test", "data": "contains super-secret-value here"});
-    let result = guest_agent::events::send_event(&mut event, 1, &masker).await;
+    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
 
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
@@ -875,7 +919,7 @@ async fn send_event_extracts_claude_session_id() {
         "subtype": "init",
         "session_id": "ses-abc-123"
     });
-    let result = guest_agent::events::send_event(&mut event, 1, &masker).await;
+    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
 
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
@@ -916,7 +960,7 @@ async fn send_event_skips_session_id_for_non_init() {
 
     let masker = SecretMasker::from_raw("");
     let mut event = json!({"type": "assistant", "data": "hello"});
-    let result = guest_agent::events::send_event(&mut event, 1, &masker).await;
+    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
 
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
@@ -945,7 +989,9 @@ async fn put_presigned_retry_exhausted() {
 
     let url = format!("{}/test/put-exhaust", server.base_url());
     let data = Bytes::from_static(b"exhaust data");
-    let result = guest_agent::http::put_presigned(&url, data, "application/octet-stream").await;
+    let result = http_client!()
+        .put_presigned(&url, data, "application/octet-stream")
+        .await;
 
     mock.assert_calls_async(3).await;
     assert!(result.is_err());
@@ -965,7 +1011,7 @@ async fn post_json_malformed_json_response() {
     });
 
     let url = format!("{}/test/malformed", server.base_url());
-    let result = guest_agent::http::post_json(&url, &json!({}), 3).await;
+    let result = http_client!().post_json(&url, &json!({}), 3).await;
 
     mock.assert_calls_async(1).await;
     assert!(result.is_err());
@@ -987,7 +1033,7 @@ async fn send_event_failure_writes_error_flag() {
 
     let masker = SecretMasker::from_raw("");
     let mut event = json!({"type": "test"});
-    let result = guest_agent::events::send_event(&mut event, 1, &masker).await;
+    let result = guest_agent::events::send_event(&http_client!(), &mut event, 1, &masker).await;
 
     assert!(result.is_err());
     assert!(
@@ -1041,7 +1087,7 @@ async fn flush_is_incremental_between_calls() {
     });
 
     let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
-    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker);
+    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker, http_client!());
 
     // Pre-checkpoint record → first flush captures it.
     guest_common::telemetry::record_sandbox_op("first_op", Duration::from_millis(10), true, None);
@@ -1093,7 +1139,7 @@ async fn final_flush_uploads_log_emitted_immediately_before_it() {
 
     let system_log_guard = SystemLogOverrideGuard::set(system_log);
     let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
-    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker);
+    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker, http_client!());
 
     guest_common::log_warn!("sandbox:guest-agent", "{marker}");
     telemetry
@@ -1143,7 +1189,7 @@ async fn concurrent_flushes_do_not_regress_pos_file() {
     });
 
     let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
-    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker);
+    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker, http_client!());
 
     // Record one op, then fire several concurrent flushes. Pre-refactor a
     // tick + final could both read the same pos and race on save_position;
@@ -1198,7 +1244,7 @@ async fn flush_propagates_error_then_loop_recovers() {
     let _ = std::fs::remove_file(pos_file);
 
     let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
-    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker);
+    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker, http_client!());
 
     // Force upload_telemetry to fire HTTP by writing a delta.
     guest_common::telemetry::record_sandbox_op(
@@ -1280,6 +1326,7 @@ async fn complete_report_success_posts_full_payload_when_metadata_present() {
     });
 
     guest_agent::complete::report_success(
+        &http_client!(),
         guest_agent::env::sandbox_id(),
         guest_agent::env::sandbox_reuse_result(),
         Some(7),
@@ -1310,7 +1357,7 @@ async fn complete_report_success_omits_metadata_when_env_absent() {
         then.status(200).json_body(json!({"success": true}));
     });
 
-    guest_agent::complete::report_success("", "", None).await;
+    guest_agent::complete::report_success(&http_client!(), "", "", None).await;
 
     mock.assert_calls_async(1).await;
     mock.delete_async().await;
@@ -1329,6 +1376,7 @@ async fn complete_report_success_swallows_server_error() {
     // 1 attempt — no retry, no panic. Fire-and-forget semantics mean the
     // runner fallback is the correctness guarantee.
     guest_agent::complete::report_success(
+        &http_client!(),
         guest_agent::env::sandbox_id(),
         guest_agent::env::sandbox_reuse_result(),
         None,
@@ -1357,6 +1405,7 @@ async fn complete_report_success_swallows_4xx_auth_error() {
     });
 
     guest_agent::complete::report_success(
+        &http_client!(),
         guest_agent::env::sandbox_id(),
         guest_agent::env::sandbox_reuse_result(),
         None,

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -3,6 +3,8 @@
 //! This test lives in its own binary because `guest_agent::env` caches
 //! environment values in process-wide `LazyLock`s.
 
+mod common;
+
 use guest_agent::error::AgentError;
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
@@ -29,18 +31,16 @@ impl Drop for SystemLogOverrideGuard {
 #[tokio::test]
 async fn no_api_mode_drains_background_webhook_users_without_network_client()
 -> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
-    let run_id = format!("no-api-mode-{}", std::process::id());
     unsafe {
-        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
-        std::env::set_var("VM0_API_TOKEN", "");
-        std::env::set_var("VM0_RUN_ID", &run_id);
-        std::env::set_var("VM0_WORKING_DIR", tmp.path());
-        std::env::set_var("VM0_PROMPT", "no api mode");
-        std::env::set_var("HOME", tmp.path());
+        common::setup_env(&mock, tmp.path(), "@exit-after-result", 3, 1)?;
     }
 
     let http = HttpClient::for_current_env()?;
+    let _ = std::fs::remove_file(guest_agent::paths::event_error_flag());
+    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
+    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
 
     let disabled = http
         .post_json("http://127.0.0.1:1/should-not-send", &json!({}), 1)
@@ -90,6 +90,23 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
         "no-API complete path must return before touching the disabled HTTP client: {complete_log}"
     );
 
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(&masker, common::spawn_dummy_heartbeat(), http.clone()),
+    )
+    .await
+    .expect("no-API execute_cli should return promptly with disabled HTTP client")?;
+    assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
+    assert_eq!(
+        cli_result.last_event_sequence, None,
+        "no-API execute_cli must not enqueue webhook events"
+    );
+    assert!(
+        !std::path::Path::new(guest_agent::paths::event_error_flag()).exists(),
+        "no-API execute_cli must not write event error flag"
+    );
+
+    let _ = std::fs::remove_file(guest_agent::paths::event_error_flag());
     let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
     let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
     Ok(())

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -11,6 +11,21 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
+struct SystemLogOverrideGuard;
+
+impl SystemLogOverrideGuard {
+    fn set(path: &std::path::Path) -> Self {
+        guest_common::log::set_system_log_file(path.to_string_lossy().as_ref());
+        Self
+    }
+}
+
+impl Drop for SystemLogOverrideGuard {
+    fn drop(&mut self) {
+        guest_common::log::clear_system_log_file();
+    }
+}
+
 #[tokio::test]
 async fn no_api_mode_drains_background_webhook_users_without_network_client()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -65,7 +80,15 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
         "session-no-api"
     );
 
+    let complete_log_path = tmp.path().join("complete-system.log");
+    let complete_log_guard = SystemLogOverrideGuard::set(&complete_log_path);
     guest_agent::complete::report_success(&http, "sandbox-no-api", "reused", Some(1)).await;
+    drop(complete_log_guard);
+    let complete_log = std::fs::read_to_string(&complete_log_path).unwrap_or_default();
+    assert!(
+        !complete_log.contains("Complete webhook failed"),
+        "no-API complete path must return before touching the disabled HTTP client: {complete_log}"
+    );
 
     let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
     let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -1,0 +1,73 @@
+//! No-API mode is used by local/reap tests and skips all webhook calls.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches
+//! environment values in process-wide `LazyLock`s.
+
+use guest_agent::error::AgentError;
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+async fn no_api_mode_drains_background_webhook_users_without_network_client()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let run_id = format!("no-api-mode-{}", std::process::id());
+    unsafe {
+        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var("VM0_RUN_ID", &run_id);
+        std::env::set_var("VM0_WORKING_DIR", tmp.path());
+        std::env::set_var("VM0_PROMPT", "no api mode");
+        std::env::set_var("HOME", tmp.path());
+    }
+
+    let http = HttpClient::for_current_env()?;
+
+    let disabled = http
+        .post_json("http://127.0.0.1:1/should-not-send", &json!({}), 1)
+        .await;
+    let Err(AgentError::Http(message)) = disabled else {
+        return Err("direct HTTP use should fail when no API token is configured".into());
+    };
+    assert!(message.contains("HTTP client is disabled"));
+
+    let masker = Arc::new(SecretMasker::from_raw(""));
+    let telemetry = guest_agent::telemetry::Telemetry::spawn(Arc::clone(&masker), http.clone());
+    telemetry
+        .flush(guest_agent::telemetry::UploadMode::Final)
+        .await?;
+    telemetry.shutdown().await;
+
+    let shutdown = CancellationToken::new();
+    let heartbeat = tokio::spawn(guest_agent::heartbeat::heartbeat_loop(
+        http.clone(),
+        shutdown.clone(),
+    ));
+    shutdown.cancel();
+    tokio::time::timeout(Duration::from_secs(1), heartbeat)
+        .await
+        .expect("heartbeat should exit promptly after shutdown in no-API mode")
+        .expect("heartbeat task should not panic")?;
+
+    let mut event = json!({
+        "type": "system",
+        "subtype": "init",
+        "session_id": "session-no-api",
+        "cwd": tmp.path().to_string_lossy(),
+    });
+    guest_agent::events::send_event(&http, &mut event, 1, &masker).await?;
+    assert_eq!(
+        std::fs::read_to_string(guest_agent::paths::session_id_file())?,
+        "session-no-api"
+    );
+
+    guest_agent::complete::report_success(&http, "sandbox-no-api", "reused", Some(1)).await;
+
+    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
+    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
+    Ok(())
+}

--- a/crates/guest-agent/tests/post_result_reap.rs
+++ b/crates/guest-agent/tests/post_result_reap.rs
@@ -25,7 +25,11 @@ async fn post_result_reap_sigterm_kills_hung_cli() -> Result<(), Box<dyn std::er
     // reap. Locally runs in ~1s.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(&masker, heartbeat),
+        guest_agent::cli::execute_cli(
+            &masker,
+            heartbeat,
+            guest_agent::http::HttpClient::new().unwrap(),
+        ),
     )
     .await
     .expect("execute_cli did not return within 15s — reap likely broken");

--- a/crates/guest-agent/tests/post_result_reap_happy.rs
+++ b/crates/guest-agent/tests/post_result_reap_happy.rs
@@ -34,7 +34,11 @@ async fn post_result_reap_stays_silent_on_clean_exit() -> Result<(), Box<dyn std
     let started = Instant::now();
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(&masker, heartbeat),
+        guest_agent::cli::execute_cli(
+            &masker,
+            heartbeat,
+            guest_agent::http::HttpClient::new().unwrap(),
+        ),
     )
     .await
     .expect("execute_cli did not return within 15s on the happy path");

--- a/crates/guest-agent/tests/post_result_reap_sigkill.rs
+++ b/crates/guest-agent/tests/post_result_reap_sigkill.rs
@@ -29,7 +29,11 @@ async fn post_result_reap_escalates_to_sigkill_when_sigterm_ignored()
     // stdout drain (5s) + slack = 15s.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(&masker, heartbeat),
+        guest_agent::cli::execute_cli(
+            &masker,
+            heartbeat,
+            guest_agent::http::HttpClient::new().unwrap(),
+        ),
     )
     .await
     .expect("execute_cli did not return within 15s — sigkill escalation likely broken");

--- a/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
@@ -25,7 +25,11 @@ async fn stuck_tool_reap_escalates_to_sigkill_when_sigterm_ignored()
     // + slack.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(&masker, heartbeat),
+        guest_agent::cli::execute_cli(
+            &masker,
+            heartbeat,
+            guest_agent::http::HttpClient::new().unwrap(),
+        ),
     )
     .await
     .expect("execute_cli did not return within 15s - forced SIGKILL escalation likely broken");

--- a/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
@@ -24,7 +24,11 @@ async fn stuck_tool_reap_survives_stdout_eof_before_child_exit()
     // + sigkill grace (1s, unignorable) + slack.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(&masker, heartbeat),
+        guest_agent::cli::execute_cli(
+            &masker,
+            heartbeat,
+            guest_agent::http::HttpClient::new().unwrap(),
+        ),
     )
     .await
     .expect("execute_cli did not return within 15s - stdout EOF forced reap likely broken");


### PR DESCRIPTION
## Summary
- replace the guest-agent global lazy reqwest client with an explicit `HttpClient` constructed during startup
- pass the shared client through heartbeat, telemetry, event posting, checkpoint/artifact upload, and complete reporting
- keep timeout configuration on all guest-agent HTTP paths and surface client build failures at initialization

Closes #11936

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `git diff --check`