### PR TITLE
fix: render artifact text previews consistently

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -909,7 +909,80 @@ describe("zero chat thread page display - artifacts drawer", () => {
     expect(screen.getByText("Artifacts")).toBeInTheDocument();
 
     await user.click(screen.getByLabelText("Select data.csv"));
-    expect(screen.getByTitle("Preview data.csv")).toBeInTheDocument();
+    await waitFor(() => {
+      const table = screen.getByRole("table");
+      expect(within(table).getByText("label")).toBeInTheDocument();
+      expect(within(table).getByText("value")).toBeInTheDocument();
+      expect(within(table).getByText("alpha")).toBeInTheDocument();
+      expect(within(table).getByText("1")).toBeInTheDocument();
+    });
+  });
+
+  it("renders markdown artifacts through the text loader instead of an iframe", async () => {
+    const user = userEvent.setup();
+    let requestedUrl = "";
+    let requestedRange = "";
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: "Create markdown",
+          runId: "run-markdown-artifact",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      http.get("https://example.com/readme.md", ({ request }) => {
+        requestedUrl = request.url;
+        requestedRange = request.headers.get("Range") ?? "";
+        return HttpResponse.text("# 发布说明\n\n这里是中文内容");
+      }),
+      mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
+        return respond(200, {
+          runs: [
+            {
+              runId: "run-markdown-artifact",
+              files: [
+                {
+                  id: "file-md",
+                  filename: "readme.md",
+                  contentType: "text/markdown",
+                  size: 1024,
+                  url: "https://example.com/readme.md",
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+              ],
+            },
+          ],
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Open artifacts");
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("发布说明")).toBeInTheDocument();
+      expect(screen.getByText("这里是中文内容")).toBeInTheDocument();
+    });
+    expect(new URL(requestedUrl).searchParams.get("raw")).toBe("1");
+    expect(requestedRange).toBe("bytes=0-65535");
+    expect(
+      document.querySelector('iframe[title="Preview readme.md"]'),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Open preview for readme.md"));
+    const lightbox = await screen.findByTestId("attachment-lightbox");
+    expect(within(lightbox).getByText("发布说明")).toBeInTheDocument();
   });
 
   it("refreshes uploaded files from the artifacts Ably signal while the drawer is open", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -149,7 +149,7 @@ function triggerDirectDownload(url: string, filename: string): void {
   a.remove();
 }
 
-function TextPreviewLoader({
+export function TextPreviewLoader({
   url,
   children,
 }: {
@@ -190,7 +190,7 @@ function formatPlainPreviewText(
   return text;
 }
 
-function parseCsvRows(text: string): string[][] {
+export function parseCsvRows(text: string): string[][] {
   return text
     .split(/\r?\n/)
     .map((line) => {
@@ -204,6 +204,51 @@ function parseCsvRows(text: string): string[][] {
         return cell.trim();
       });
     });
+}
+
+export function CsvPreviewTable({ rows }: { rows: string[][] }) {
+  const [header, ...body] = rows;
+
+  return (
+    <div className="overflow-auto rounded-lg border border-foreground/10">
+      <table className="min-w-full divide-y divide-foreground/10 text-sm">
+        <thead className="bg-muted/40">
+          <tr>
+            {header.map((cell) => {
+              return (
+                <th
+                  key={`header-${cell}`}
+                  className="whitespace-nowrap px-3 py-2 text-left font-medium text-foreground"
+                >
+                  {cell}
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-foreground/10 bg-background">
+          {body.map((row) => {
+            const rowKey = `row-${row.join("\u0001")}`;
+            return (
+              <tr key={rowKey}>
+                {header.map((column, cellIndex) => {
+                  const value = row[cellIndex] ?? "";
+                  return (
+                    <td
+                      key={`${rowKey}-${column}-${value}`}
+                      className="whitespace-nowrap px-3 py-2 text-foreground"
+                    >
+                      {value}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
 }
 
 function triggerBlobDownload(blob: Blob, filename: string): void {
@@ -677,48 +722,9 @@ function CsvLightboxBody({
           );
         }
 
-        const [header, ...body] = rows;
-
         return (
           <div className="h-[min(78vh,900px)] overflow-auto p-6">
-            <div className="overflow-auto rounded-lg border border-foreground/10">
-              <table className="min-w-full divide-y divide-foreground/10 text-sm">
-                <thead className="bg-muted/40">
-                  <tr>
-                    {header.map((cell) => {
-                      return (
-                        <th
-                          key={`header-${cell}`}
-                          className="whitespace-nowrap px-3 py-2 text-left font-medium text-foreground"
-                        >
-                          {cell}
-                        </th>
-                      );
-                    })}
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-foreground/10 bg-background">
-                  {body.map((row) => {
-                    const rowKey = `row-${row.join("\u0001")}`;
-                    return (
-                      <tr key={rowKey}>
-                        {header.map((column, cellIndex) => {
-                          const value = row[cellIndex] ?? "";
-                          return (
-                            <td
-                              key={`${rowKey}-${column}-${value}`}
-                              className="whitespace-nowrap px-3 py-2 text-foreground"
-                            >
-                              {value}
-                            </td>
-                          );
-                        })}
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
+            <CsvPreviewTable rows={rows} />
           </div>
         );
       }}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -26,7 +26,6 @@ import {
   IconArrowBarToUp,
   IconBrandGoogleDrive,
   IconDownload,
-  IconEye,
   IconFile,
   IconLink,
   IconLoader2,
@@ -71,14 +70,22 @@ import {
   toggleAutoRead$,
 } from "../../signals/voice-io/voice-io-settings.ts";
 import { Markdown } from "../components/markdown.tsx";
-import { detach, Reason, onDomEventFn } from "../../signals/utils.ts";
+import {
+  detach,
+  jsonParseOr,
+  Reason,
+  onDomEventFn,
+} from "../../signals/utils.ts";
 import { zeroClient$ } from "../../signals/api-client.ts";
 import {
   AttachmentLightbox,
+  CsvPreviewTable,
   downloadAttachmentUrl,
   FileAttachmentChip,
   getAttachmentRawUrl,
+  parseCsvRows,
   PreviewableFileAttachmentChip,
+  TextPreviewLoader,
 } from "./zero-attachment-chips.tsx";
 import {
   classifyChatAttachment,
@@ -90,6 +97,7 @@ import {
 import { AttachmentPreview } from "./zero-attachment-preview.tsx";
 import {
   lightboxUrl$ as attachmentLightboxUrl$,
+  openDocumentLightbox$ as openAttachmentDocumentLightbox$,
   openImageLightbox$ as openAttachmentImageLightbox$,
 } from "../../signals/zero-page/zero-attachment-chips.ts";
 import {
@@ -506,6 +514,167 @@ function ArtifactPreviewBadge({ file }: { file: ChatThreadArtifactFile }) {
   }
 
   return <ArtifactFileIcon file={file} />;
+}
+
+type ArtifactTextPreviewKind = "markdown" | "text" | "json" | "csv";
+type ArtifactDocumentPreviewKind = ArtifactTextPreviewKind | "pdf";
+
+function getArtifactTextPreviewKind(
+  file: ChatThreadArtifactFile,
+): ArtifactTextPreviewKind | null {
+  const kind = classifyChatAttachment({
+    filename: file.filename,
+    url: file.url,
+    contentType: file.contentType,
+  });
+
+  if (
+    kind === "markdown" ||
+    kind === "text" ||
+    kind === "json" ||
+    kind === "csv"
+  ) {
+    return kind;
+  }
+
+  if (/\.log$/i.test(file.filename)) {
+    return "text";
+  }
+
+  return null;
+}
+
+function formatArtifactTextPreview(
+  kind: Exclude<ArtifactTextPreviewKind, "markdown">,
+  text: string,
+): string {
+  if (kind === "json") {
+    const parsed = jsonParseOr<unknown>(text, null);
+    return parsed === null ? text : JSON.stringify(parsed, null, 2);
+  }
+  return text;
+}
+
+function getArtifactDocumentPreviewKind(
+  file: ChatThreadArtifactFile,
+): ArtifactDocumentPreviewKind | null {
+  const textKind = getArtifactTextPreviewKind(file);
+  if (textKind) {
+    return textKind;
+  }
+
+  const contentType = file.contentType.toLowerCase();
+  const filename = file.filename.toLowerCase();
+  if (contentType === "application/pdf" || filename.endsWith(".pdf")) {
+    return "pdf";
+  }
+
+  return null;
+}
+
+function ArtifactTextDocumentPreviewFrame({
+  file,
+  kind,
+}: {
+  file: ChatThreadArtifactFile;
+  kind: ArtifactTextPreviewKind;
+}) {
+  const pageSignal = useGet(pageSignal$);
+
+  return (
+    <TextPreviewLoader url={file.url} signal={pageSignal}>
+      {({ status, text }) => {
+        if (status === "loading") {
+          return (
+            <div className="flex h-full w-full items-center justify-center bg-muted/40 text-muted-foreground">
+              <IconLoader2 size={18} className="animate-spin" />
+            </div>
+          );
+        }
+
+        if (status === "error") {
+          return (
+            <div className="flex h-full w-full items-center justify-center bg-muted/40 px-6 text-center text-sm text-muted-foreground">
+              {kind === "markdown"
+                ? "Markdown"
+                : kind === "json"
+                  ? "JSON"
+                  : kind === "csv"
+                    ? "CSV"
+                    : "Text"}{" "}
+              preview unavailable.
+            </div>
+          );
+        }
+
+        if (kind === "csv") {
+          const rows = parseCsvRows(text);
+          if (rows.length === 0) {
+            return (
+              <div className="flex h-full w-full items-center justify-center bg-muted/40 px-6 text-center text-sm text-muted-foreground">
+                CSV preview unavailable.
+              </div>
+            );
+          }
+
+          return (
+            <div className="h-full w-full overflow-auto bg-background p-4">
+              <CsvPreviewTable rows={rows} />
+            </div>
+          );
+        }
+
+        if (kind !== "markdown") {
+          const display = formatArtifactTextPreview(kind, text);
+          return (
+            <div className="h-full w-full overflow-auto bg-background p-4">
+              <pre className="whitespace-pre-wrap break-words text-xs text-foreground">
+                {display.length > 16_000
+                  ? `${display.slice(0, 16_000)}\n\n…`
+                  : display}
+              </pre>
+            </div>
+          );
+        }
+
+        return (
+          <div className="h-full w-full overflow-auto bg-background p-4 text-sm">
+            <Markdown source={text} />
+          </div>
+        );
+      }}
+    </TextPreviewLoader>
+  );
+}
+
+function ArtifactPreviewOpenOverlay({
+  children,
+  filename,
+  onOpen,
+}: {
+  children: ReactNode;
+  filename: string;
+  onOpen: () => void;
+}) {
+  return (
+    <div className="group/artifact-preview relative h-full w-full">
+      {children}
+      <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-150 group-hover/artifact-preview:bg-black/30 group-hover/artifact-preview:opacity-100 group-focus-within/artifact-preview:bg-black/30 group-focus-within/artifact-preview:opacity-100">
+        <button
+          type="button"
+          onClick={onOpen}
+          aria-label={`Open preview for ${filename}`}
+          className="pointer-events-auto flex h-16 w-16 items-center justify-center rounded-lg text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+        >
+          <IconFile
+            size={24}
+            stroke={1.8}
+            className="drop-shadow transition-opacity"
+          />
+        </button>
+      </div>
+    </div>
+  );
 }
 
 async function copyArtifactLinkToClipboard(
@@ -945,7 +1114,6 @@ type ChatImagePreviewButtonProps = {
   buttonClassName: string;
   imageClassName: string;
   onPreview: () => void;
-  overlayIcon?: "eye" | "photo";
   placeholderClassName: string;
   url: string;
 };
@@ -956,7 +1124,6 @@ function ChatImagePreviewButton({
   buttonClassName,
   imageClassName,
   onPreview,
-  overlayIcon = "photo",
   placeholderClassName,
   url,
 }: ChatImagePreviewButtonProps) {
@@ -1012,16 +1179,10 @@ function ChatImagePreviewButton({
         )}
       />
       <span className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-150 group-hover/image-preview:bg-black/30 group-hover/image-preview:opacity-100">
-        {overlayIcon === "eye" ? (
-          <span className="flex h-9 w-9 items-center justify-center rounded-full bg-black/50 text-white shadow-lg">
-            <IconEye size={18} stroke={1.8} />
-          </span>
-        ) : (
-          <IconPhoto
-            size={18}
-            className="text-white opacity-0 drop-shadow transition-opacity group-hover/image-preview:opacity-100"
-          />
-        )}
+        <IconPhoto
+          size={18}
+          className="text-white opacity-0 drop-shadow transition-opacity group-hover/image-preview:opacity-100"
+        />
       </span>
     </button>
   );
@@ -1029,6 +1190,7 @@ function ChatImagePreviewButton({
 
 function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
   const openImageLightbox = useSet(openAttachmentImageLightbox$);
+  const openDocumentLightbox = useSet(openAttachmentDocumentLightbox$);
   const previewKind = getArtifactPreviewKind(file);
 
   if (previewKind === "image") {
@@ -1041,7 +1203,6 @@ function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
         onPreview={() => {
           openImageLightbox(file.url);
         }}
-        overlayIcon="eye"
         placeholderClassName="h-full w-full"
         url={file.url}
       />
@@ -1074,12 +1235,45 @@ function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
   }
 
   if (previewKind === "document") {
+    const documentPreviewKind = getArtifactDocumentPreviewKind(file);
+    if (!documentPreviewKind) {
+      return (
+        <div className="flex h-full w-full items-center justify-center bg-muted/40">
+          <ArtifactFileIcon file={file} className="h-10 w-10" />
+        </div>
+      );
+    }
+
+    const openPreview = () => {
+      openDocumentLightbox({
+        kind: documentPreviewKind,
+        url: file.url,
+        filename: file.filename,
+      });
+    };
+
+    if (documentPreviewKind !== "pdf") {
+      return (
+        <ArtifactPreviewOpenOverlay
+          filename={file.filename}
+          onOpen={openPreview}
+        >
+          <ArtifactTextDocumentPreviewFrame
+            file={file}
+            kind={documentPreviewKind}
+          />
+        </ArtifactPreviewOpenOverlay>
+      );
+    }
+
     return (
-      <iframe
-        src={file.url}
-        title={`Preview ${file.filename}`}
-        className="h-full w-full bg-background"
-      />
+      <ArtifactPreviewOpenOverlay filename={file.filename} onOpen={openPreview}>
+        <iframe
+          src={file.url}
+          title={`Preview ${file.filename}`}
+          className="h-full w-full bg-background"
+        />
+      </ArtifactPreviewOpenOverlay>
     );
   }
 


### PR DESCRIPTION
## Summary
- load artifact markdown/text/json/csv previews through the raw text loader to avoid browser charset issues
- render artifact CSV previews with the same table component used by the full preview
- make artifact preview hover affordances match chat preview styling while preserving click-to-open preview

## Tests
- pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
- pnpm --filter @vm0/app exec oxlint src/views/zero-page/zero-attachment-chips.tsx src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
- pnpm --filter @vm0/app exec oxlint --type-aware src/views/zero-page/zero-attachment-chips.tsx src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
- pnpm --filter @vm0/app exec eslint src/views/zero-page/zero-attachment-chips.tsx src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx src/views/zero-page/__tests__/zero-attachment-preview.test.tsx --max-warnings 0
- pnpm --filter @vm0/app check-types
- git diff --check