### PR TITLE
fix: mention doctor generate in agent tools

### DIFF
--- a/turbo/apps/web/src/lib/zero/__tests__/agent-prompt.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/agent-prompt.test.ts
@@ -21,6 +21,10 @@ describe("buildAgentPrompt", () => {
     expect(prompt).toContain("zero telegram bot list");
     expect(prompt).toContain("explicitly choose the bot with `--bot-id`");
     expect(prompt).toContain(
+      "When the user asks to generate anything (for example, image, video, audio, or website)",
+    );
+    expect(prompt).toContain("run `zero doctor generate -h`");
+    expect(prompt).toContain(
       "Do not present a local path as something the user can open",
     );
   });

--- a/turbo/apps/web/src/lib/zero/agent-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/agent-prompt.ts
@@ -83,6 +83,7 @@ function buildAgentToolsPrompt(): string {
     "- The user cannot see files on your local filesystem. If the user needs to view or download a local file, upload it through the appropriate integration first: use `zero web upload-file` for web chat, `zero slack upload-file` for Slack, or `zero telegram upload-file` for Telegram, then share the returned URL or platform file reference. Do not present a local path as something the user can open.",
     "- Third-party services (GitHub, Slack, Notion, 100+ more) are accessed via connectors that expose env vars like `GH_TOKEN`. Find: `zero connector search <keyword>`. List connected: `zero connector list`. Inspect: `zero connector status <type>`.",
     "- Diagnose connector health (token presence, firewall rules, permission policies): `zero doctor check-connector --help`.",
+    "- When the user asks to generate anything (for example, image, video, audio, or website), run `zero doctor generate -h`.",
     "- Troubleshoot permission denials: `zero doctor permission-deny --help` to identify which permission covers a blocked request.",
     "- Request permission changes: `zero doctor permission-change --help` to enable or disable a permission.",
     "- Inspect yourself: `zero whoami` for identity and permissions, `zero agent view $ZERO_AGENT_ID --instructions` for your current settings.",


### PR DESCRIPTION
## Summary
- add zero doctor generate guidance to the Zero agent tools system prompt
- cover the new guidance in the agent prompt test

## Tests
- pnpm --filter web exec vitest run src/lib/zero/__tests__/agent-prompt.test.ts
- pnpm --filter web exec oxlint src/lib/zero/agent-prompt.ts src/lib/zero/__tests__/agent-prompt.test.ts
- pnpm --filter web exec oxlint --type-aware src/lib/zero/agent-prompt.ts src/lib/zero/__tests__/agent-prompt.test.ts
- pnpm --filter web exec eslint src/lib/zero/agent-prompt.ts src/lib/zero/__tests__/agent-prompt.test.ts --max-warnings 0
- pnpm --filter web check-types
- git diff --check

Pre-commit also ran full repository check-types.