### PR TITLE
fix: support upload file previews

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -51,6 +51,8 @@ type ExtractedPreviewUrl = {
 // ---------------------------------------------------------------------------
 
 const TEXT_PREVIEW_MAX_BYTES = 65_536;
+const PLATFORM_FILE_PATH_PATTERN = /^\/f\/[^/]+\/[^/]+\/[^/]+$/;
+const PLATFORM_FILE_HOST_SUFFIXES = ["vm0.ai", "vm6.ai", "vm7.ai"] as const;
 
 // ---------------------------------------------------------------------------
 // classifyChatAttachment helpers
@@ -211,13 +213,74 @@ export function contentTypeForBodyPreviewKind(kind: BodyPreviewKind): string {
 // URL / line parsing
 // ---------------------------------------------------------------------------
 
+type PlatformHostTarget = "api" | "www" | "app" | "platform";
+
+function browserHost(): string | null {
+  if (typeof location === "undefined" || !location.host) {
+    return null;
+  }
+  return location.host;
+}
+
+function rewritePlatformHostname(
+  hostname: string,
+  target: PlatformHostTarget,
+): string {
+  return hostname.replace(/(^|-)(platform|app|www|api)\./, `$1${target}.`);
+}
+
+function addPlatformFileHostVariants(hosts: Set<string>, host: string | null) {
+  if (!host) {
+    return;
+  }
+
+  hosts.add(host);
+
+  const hostUrl = `https://${host}`;
+  if (!URL.canParse(hostUrl)) {
+    return;
+  }
+
+  const parsed = new URL(hostUrl);
+  for (const target of ["api", "www", "app", "platform"] as const) {
+    parsed.hostname = rewritePlatformHostname(parsed.hostname, target);
+    hosts.add(parsed.host);
+  }
+}
+
+function platformFileHosts(): Set<string> {
+  const hosts = new Set<string>();
+  addPlatformFileHostVariants(hosts, browserHost());
+  return hosts;
+}
+
+function isPlatformFileHostname(hostname: string): boolean {
+  return PLATFORM_FILE_HOST_SUFFIXES.some((suffix) => {
+    return hostname === suffix || hostname.endsWith(`.${suffix}`);
+  });
+}
+
+function hasExplicitUrlOrigin(url: string): boolean {
+  return /^[a-z][a-z\d+\-.]*:\/\//i.test(url);
+}
+
 function isPlatformFileUrl(url: string): boolean {
-  const baseUrl = "https://vm0.local";
+  const host = browserHost();
+  const baseUrl = host ? `https://${host}` : "https://vm0.local";
   if (!URL.canParse(url, baseUrl)) {
     return false;
   }
   const parsed = new URL(url, baseUrl);
-  return /^\/f\/[^/]+\/[^/]+\/[^/]+$/.test(parsed.pathname);
+  if (!PLATFORM_FILE_PATH_PATTERN.test(parsed.pathname)) {
+    return false;
+  }
+  if (!hasExplicitUrlOrigin(url)) {
+    return true;
+  }
+  return (
+    platformFileHosts().has(parsed.host) ||
+    isPlatformFileHostname(parsed.hostname)
+  );
 }
 
 function stripMarkdownLineDecorations(value: string): string {
@@ -305,6 +368,87 @@ function extractPreviewUrlFromLine(line: string): ExtractedPreviewUrl | null {
   return null;
 }
 
+function splitMarkdownTableRow(line: string): string[] | null {
+  const trimmed = line.trim();
+  if (!trimmed.includes("|")) {
+    return null;
+  }
+
+  const cells: string[] = [];
+  let current = "";
+  let escaped = false;
+  for (const char of trimmed) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      current += char;
+      escaped = true;
+      continue;
+    }
+    if (char === "|") {
+      cells.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  cells.push(current.trim());
+
+  if (cells[0] === "") {
+    cells.shift();
+  }
+  if (cells.at(-1) === "") {
+    cells.pop();
+  }
+
+  return cells.length >= 2 ? cells : null;
+}
+
+function isMarkdownTableSeparator(line: string): boolean {
+  const cells = splitMarkdownTableRow(line);
+  return (
+    cells !== null &&
+    cells.every((cell) => {
+      return /^:?-{3,}:?$/.test(cell.replace(/\s+/g, ""));
+    })
+  );
+}
+
+function isMarkdownTableContentRow(line: string): boolean {
+  const cells = splitMarkdownTableRow(line);
+  return (
+    cells !== null &&
+    cells.some((cell) => {
+      return cell.length > 0;
+    })
+  );
+}
+
+function markdownTableRowIndexes(lines: string[]): Set<number> {
+  const indexes = new Set<number>();
+  for (let index = 0; index < lines.length - 1; index += 1) {
+    if (
+      isMarkdownTableContentRow(lines[index]!) &&
+      isMarkdownTableSeparator(lines[index + 1]!)
+    ) {
+      indexes.add(index);
+      indexes.add(index + 1);
+
+      for (
+        let rowIndex = index + 2;
+        rowIndex < lines.length && isMarkdownTableContentRow(lines[rowIndex]!);
+        rowIndex += 1
+      ) {
+        indexes.add(rowIndex);
+      }
+    }
+  }
+  return indexes;
+}
+
 // ---------------------------------------------------------------------------
 // Block parsing (pure — no computeds)
 // ---------------------------------------------------------------------------
@@ -315,6 +459,7 @@ export function parseBodyRenderBlocks(content: string): {
 } {
   const blocks: BodyRenderBlock[] = [];
   const lines = content.split("\n");
+  const tableRowIndexes = markdownTableRowIndexes(lines);
   const keptLines: string[] = [];
   const markdownBuffer: string[] = [];
   let blockSequence = 0;
@@ -339,7 +484,7 @@ export function parseBodyRenderBlocks(content: string): {
     markdownBuffer.length = 0;
   };
 
-  for (const line of lines) {
+  for (const [lineIndex, line] of lines.entries()) {
     const trimmedLine = line.trim();
     const fenceMatch = trimmedLine.match(/^(`{3,}|~{3,})/);
     if (fenceMatch) {
@@ -360,6 +505,12 @@ export function parseBodyRenderBlocks(content: string): {
     }
 
     if (openFence) {
+      markdownBuffer.push(line);
+      keptLines.push(line);
+      continue;
+    }
+
+    if (tableRowIndexes.has(lineIndex)) {
       markdownBuffer.push(line);
       keptLines.push(line);
       continue;

--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -13,7 +13,8 @@ export type BodyPreviewKind =
   | "json"
   | "csv"
   | "pdf"
-  | "html";
+  | "html"
+  | "file";
 
 export type BodyRenderBlock =
   | {
@@ -32,17 +33,7 @@ export type BodyRenderBlock =
       };
     };
 
-type ChatAttachmentKind =
-  | "image"
-  | "video"
-  | "audio"
-  | "markdown"
-  | "text"
-  | "json"
-  | "csv"
-  | "pdf"
-  | "html"
-  | "file";
+type ChatAttachmentKind = BodyPreviewKind;
 
 interface ChatAttachmentDescriptor {
   filename: string;
@@ -73,12 +64,66 @@ function normalizeType(contentType?: string): string {
   return (contentType ?? "").split(";")[0]?.trim().toLowerCase();
 }
 
-export function classifyChatAttachment(
-  attachment: ChatAttachmentDescriptor,
-): ChatAttachmentKind {
-  const type = normalizeType(attachment.contentType);
-  const ext = fileExt(attachment.filename);
+const CHAT_KIND_BY_CONTENT_TYPE: Readonly<Record<string, BodyPreviewKind>> = {
+  "text/markdown": "markdown",
+  "text/x-markdown": "markdown",
+  "text/plain": "text",
+  "text/tab-separated-values": "text",
+  "text/xml": "text",
+  "text/yaml": "text",
+  "text/x-yaml": "text",
+  "application/xml": "text",
+  "application/yaml": "text",
+  "application/x-yaml": "text",
+  "application/json": "json",
+  "text/csv": "csv",
+  "application/pdf": "pdf",
+  "text/html": "html",
+} as const;
 
+const CHAT_KIND_BY_EXTENSION: Readonly<Record<string, BodyPreviewKind>> = {
+  md: "markdown",
+  txt: "text",
+  log: "text",
+  xml: "text",
+  yaml: "text",
+  yml: "text",
+  tsv: "text",
+  json: "json",
+  csv: "csv",
+  pdf: "pdf",
+  html: "html",
+  htm: "html",
+  png: "image",
+  jpg: "image",
+  jpeg: "image",
+  gif: "image",
+  webp: "image",
+  svg: "image",
+  bmp: "image",
+  avif: "image",
+  heic: "image",
+  heif: "image",
+  tif: "image",
+  tiff: "image",
+  psd: "image",
+  mp4: "video",
+  webm: "video",
+  mov: "video",
+  ogv: "video",
+  mp3: "audio",
+  wav: "audio",
+  wave: "audio",
+  m4a: "audio",
+  aac: "audio",
+  ogg: "audio",
+  oga: "audio",
+  opus: "audio",
+  flac: "audio",
+  mpga: "audio",
+} as const;
+
+function mediaKindFromContentType(type: string): BodyPreviewKind | null {
   if (type.startsWith("image/")) {
     return "image";
   }
@@ -88,43 +133,23 @@ export function classifyChatAttachment(
   if (type.startsWith("audio/")) {
     return "audio";
   }
+  return null;
+}
 
-  if (type === "text/markdown" || ext === "md") {
-    return "markdown";
-  }
-  if (type === "text/plain" || ext === "txt") {
-    return "text";
-  }
-  if (type === "application/json" || ext === "json") {
-    return "json";
-  }
-  if (type === "text/csv" || ext === "csv") {
-    return "csv";
-  }
-  if (type === "application/pdf" || ext === "pdf") {
-    return "pdf";
-  }
-  if (type === "text/html" || ext === "html" || ext === "htm") {
-    return "html";
+export function classifyChatAttachment(
+  attachment: ChatAttachmentDescriptor,
+): ChatAttachmentKind {
+  const type = normalizeType(attachment.contentType);
+  const ext = fileExt(attachment.filename);
+  const mediaKind = mediaKindFromContentType(type);
+
+  if (mediaKind) {
+    return mediaKind;
   }
 
-  if (
-    ["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "avif"].includes(ext)
-  ) {
-    return "image";
-  }
-  if (["mp4", "webm", "mov", "ogv"].includes(ext)) {
-    return "video";
-  }
-  if (
-    ["mp3", "wav", "m4a", "aac", "ogg", "oga", "opus", "flac", "mpga"].includes(
-      ext,
-    )
-  ) {
-    return "audio";
-  }
-
-  return "file";
+  return (
+    CHAT_KIND_BY_CONTENT_TYPE[type] ?? CHAT_KIND_BY_EXTENSION[ext] ?? "file"
+  );
 }
 
 function filenameFromUrl(url: string): string {
@@ -146,7 +171,8 @@ function isBodyPreviewKind(kind: string): kind is BodyPreviewKind {
     kind === "json" ||
     kind === "csv" ||
     kind === "pdf" ||
-    kind === "html"
+    kind === "html" ||
+    kind === "file"
   );
 }
 
@@ -174,6 +200,9 @@ export function contentTypeForBodyPreviewKind(kind: BodyPreviewKind): string {
   }
   if (kind === "audio") {
     return "audio/*";
+  }
+  if (kind === "file") {
+    return "application/octet-stream";
   }
   return "video/*";
 }

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -11,6 +11,10 @@ import {
   setImageLoadStatus$,
 } from "../../signals/view-component-state.ts";
 
+type MarkdownNodeProp = { node?: unknown };
+type MarkdownAnchorProps = ComponentPropsWithoutRef<"a"> & MarkdownNodeProp;
+type MarkdownImageProps = ComponentPropsWithoutRef<"img"> & MarkdownNodeProp;
+
 type RewriteArgs = Parameters<
   NonNullable<MarkdownPreviewProps["rehypeRewrite"]>
 >;
@@ -205,9 +209,18 @@ function isSafeMediaUrl(href: string): boolean {
   return /^https?:\/\//i.test(href);
 }
 
-function PlainLink({ href, children, ...rest }: ComponentPropsWithoutRef<"a">) {
+function omitMarkdownNodeProp<Props extends object>(
+  props: Props,
+): Omit<Props, "node"> {
+  const cleanProps = { ...props };
+  delete (cleanProps as Partial<MarkdownNodeProp>).node;
+  return cleanProps;
+}
+
+function PlainLink({ href, children, ...rest }: MarkdownAnchorProps) {
+  const linkProps = omitMarkdownNodeProp(rest);
   return (
-    <a {...rest} href={href} target="_blank" rel="noopener noreferrer">
+    <a {...linkProps} href={href} target="_blank" rel="noopener noreferrer">
       {children}
     </a>
   );
@@ -272,7 +285,7 @@ function MediaLink({
   children,
   onImageClick,
   ...rest
-}: ComponentPropsWithoutRef<"a"> & {
+}: MarkdownAnchorProps & {
   onImageClick?: (url: string) => void;
 }) {
   if (!href || !isSafeMediaUrl(href)) {
@@ -306,7 +319,7 @@ function MediaLink({
 }
 
 function MarkdownLinkRenderer(
-  props: { children?: ReactNode } & ComponentPropsWithoutRef<"a"> & {
+  props: { children?: ReactNode } & MarkdownAnchorProps & {
       mediaPreview: boolean;
       onImageClick: ((url: string) => void) | undefined;
     },
@@ -323,17 +336,18 @@ function MarkdownLinkRenderer(
 }
 
 function MarkdownImageRenderer(
-  props: ComponentPropsWithoutRef<"img"> & {
+  props: MarkdownImageProps & {
     mediaPreview: boolean;
     onImageClick: ((url: string) => void) | undefined;
   },
 ) {
   const { mediaPreview, onImageClick, src, alt, ...rest } = props;
+  const imageProps = omitMarkdownNodeProp(rest);
   const hasSafeSrc = typeof src === "string" && isSafeMediaUrl(src);
   if (mediaPreview && hasSafeSrc) {
     return <MediaImage src={src} alt={alt ?? ""} onImageClick={onImageClick} />;
   }
-  return <img {...rest} src={src} alt={alt} />;
+  return <img {...imageProps} src={src} alt={alt} />;
 }
 
 export function Markdown({
@@ -348,7 +362,7 @@ export function Markdown({
 }) {
   const theme = useGet(theme$);
   const renderLink = (
-    props: { children?: ReactNode } & ComponentPropsWithoutRef<"a">,
+    props: { children?: ReactNode } & MarkdownAnchorProps,
   ) => {
     return (
       <MarkdownLinkRenderer
@@ -358,7 +372,7 @@ export function Markdown({
       />
     );
   };
-  const renderImage = (props: ComponentPropsWithoutRef<"img">) => {
+  const renderImage = (props: MarkdownImageProps) => {
     return (
       <MarkdownImageRenderer
         {...props}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { chatMessagesContract } from "@vm0/api-contracts/contracts/chat-threads";
@@ -54,7 +54,7 @@ describe("chat-d-056: file type icon renders based on getFileTypeIcon", () => {
     });
   });
 
-  it("renders generic file icon for unknown file extension", async () => {
+  it("renders a thumbnail preview block for unknown file extension", async () => {
     mockChatLifecycle({
       chatMessages: [
         {
@@ -74,9 +74,11 @@ describe("chat-d-056: file type icon renders based on getFileTypeIcon", () => {
     await waitFor(() => {
       const link = document.querySelector('a[download="archive.zip"]');
       expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("data-testid", "attachment-preview-file");
       expect(
-        link?.querySelector('img[aria-hidden="true"]'),
-      ).not.toBeInTheDocument();
+        within(link as HTMLElement).getByTestId("attachment-preview-file-icon"),
+      ).toBeInTheDocument();
+      expect(within(link as HTMLElement).getByText("ZIP")).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
@@ -57,6 +57,17 @@ describe("attachment preview component", () => {
     expect(screen.getByTestId("attachment-preview-text")).toBeInTheDocument();
   });
 
+  it.each(["config.xml", "settings.yaml", "table.tsv"])(
+    "should render text preview for %s files",
+    (filename) => {
+      renderPreview({
+        filename,
+        url: `https://example.com/${filename}`,
+      });
+      expect(screen.getByTestId("attachment-preview-text")).toBeInTheDocument();
+    },
+  );
+
   it("should render json preview for .json files", () => {
     renderPreview({
       filename: "data.json",
@@ -126,12 +137,16 @@ describe("attachment preview component", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("should render null for unknown file types (.zip)", () => {
-    const { container } = renderPreview({
+  it("should render generic file preview for non-inline upload file types (.zip)", () => {
+    renderPreview({
       filename: "archive.zip",
       url: "https://example.com/archive.zip",
     });
-    expect(container).toBeEmptyDOMElement();
+    expect(screen.getByTestId("attachment-preview-file")).toBeInTheDocument();
+    expect(screen.getByLabelText("Download archive.zip")).toHaveAttribute(
+      "href",
+      "https://example.com/archive.zip?download=1",
+    );
   });
 
   // Content-type fallback (filename has no extension)
@@ -183,6 +198,22 @@ describe("attachment preview component", () => {
     });
     expect(screen.getByTestId("attachment-preview-html")).toBeInTheDocument();
   });
+
+  it.each([
+    ["application/xml", "xml-file"],
+    ["application/yaml", "yaml-file"],
+    ["text/tab-separated-values", "tsv-file"],
+  ])(
+    "should classify by content-type %s as text preview",
+    (contentType, filename) => {
+      renderPreview({
+        filename,
+        url: `https://example.com/${filename}`,
+        contentType,
+      });
+      expect(screen.getByTestId("attachment-preview-text")).toBeInTheDocument();
+    },
+  );
 
   it("should classify by content-type audio/mpeg when filename has no extension", () => {
     renderPreview({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx
@@ -7,7 +7,13 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { StoreProvider } from "ccstate-react";
 import { computed } from "ccstate";
 import { server } from "../../../mocks/server.ts";
@@ -137,15 +143,20 @@ describe("attachment preview component", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("should render generic file preview for non-inline upload file types (.zip)", () => {
+  it("should render a thumbnail preview block for non-inline upload file types", () => {
     renderPreview({
-      filename: "archive.zip",
-      url: "https://example.com/archive.zip",
+      filename: "budget.xlsx",
+      url: "https://example.com/budget.xlsx",
     });
-    expect(screen.getByTestId("attachment-preview-file")).toBeInTheDocument();
-    expect(screen.getByLabelText("Download archive.zip")).toHaveAttribute(
+    const preview = screen.getByTestId("attachment-preview-file");
+    expect(preview).toBeInTheDocument();
+    expect(
+      within(preview).getByTestId("attachment-preview-file-icon"),
+    ).toBeInTheDocument();
+    expect(within(preview).getByText("XLSX")).toBeInTheDocument();
+    expect(screen.getByLabelText("Download budget.xlsx")).toHaveAttribute(
       "href",
-      "https://example.com/archive.zip?download=1",
+      "https://example.com/budget.xlsx?download=1",
     );
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -723,10 +723,13 @@ describe("zero chat thread page display - body link document preview", () => {
       detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
       await waitFor(() => {
+        const textPreview = screen.getByTestId("attachment-preview-text");
+        expect(textPreview).toBeInTheDocument();
         expect(
-          screen.getByTestId("attachment-preview-text"),
+          within(textPreview).getByText((content) => {
+            return content.includes(expectedText);
+          }),
         ).toBeInTheDocument();
-        expect(screen.getByText(new RegExp(expectedText))).toBeInTheDocument();
       });
     },
   );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -170,9 +170,16 @@ describe("zero chat thread page display - attachment document preview", () => {
 });
 
 describe("zero chat thread page display - body link document preview", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "location",
+      new URL("https://app.vm0.ai/chats/thread-test-1"),
+    );
+  });
+
   it("renders markdown body links inline for platform file urls", async () => {
     const docUrl =
-      "https://www.vm0.ai/f/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/notes.md";
+      "https://api.vm0.ai/f/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/notes.md";
     server.use(
       http.get(docUrl, () => {
         return HttpResponse.text("# Linked PRD\n\nPreview body");
@@ -232,6 +239,117 @@ describe("zero chat thread page display - body link document preview", () => {
     expect(
       screen.queryByTestId("attachment-preview-markdown"),
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps external /f links as plain links and does not render preview cards", async () => {
+    const docUrl =
+      "https://example.com/f/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/notes.md";
+
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content: `[notes](${docUrl})`,
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    await waitFor(() => {
+      expect(screen.getByText("notes").closest("a")).toHaveAttribute(
+        "href",
+        docUrl,
+      );
+    });
+
+    expect(
+      screen.queryByTestId("attachment-preview-markdown"),
+    ).not.toBeInTheDocument();
+  });
+
+  it.each(["vm0.ai", "vm6.ai", "vm7.ai"])(
+    "renders %s file host links as thumbnail preview blocks",
+    async (host) => {
+      const fileUrl = `https://www.${host}/f/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/test_files.zip`;
+
+      mockChatLifecycle({
+        chatMessages: [
+          {
+            role: "assistant",
+            content: `[test_files.zip](${fileUrl})`,
+            createdAt: "2026-03-10T00:00:00Z",
+          },
+        ],
+      });
+
+      detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+      const preview = await screen.findByTestId("attachment-preview-file");
+      expect(
+        within(preview).getByTestId("attachment-preview-file-icon"),
+      ).toBeInTheDocument();
+      expect(within(preview).getByText("ZIP")).toBeInTheDocument();
+    },
+  );
+
+  it("renders matching tunnel host file links as thumbnail preview blocks", async () => {
+    vi.stubGlobal(
+      "location",
+      new URL("https://tunnel-yuma-vm0-app.vm7.ai/chats/thread-test-1"),
+    );
+    const fileUrl =
+      "https://tunnel-yuma-vm0-www.vm7.ai/f/user_3BennfUepyJwP3OaiYD0rK8CZKs/bce0a522-aed9-4d72-a86c-3164177fb44c/test_files.zip";
+
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content: `[test_files.zip](${fileUrl})`,
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    const preview = await screen.findByTestId("attachment-preview-file");
+    expect(
+      within(preview).getByTestId("attachment-preview-file-icon"),
+    ).toBeInTheDocument();
+    expect(within(preview).getByText("ZIP")).toBeInTheDocument();
+    expect(screen.getByLabelText("Download test_files.zip")).toHaveAttribute(
+      "href",
+      `${fileUrl}?download=1`,
+    );
+  });
+
+  it("keeps platform file links inside markdown tables as table links", async () => {
+    const docUrl =
+      "https://www.vm0.ai/f/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/budget.xlsx";
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content: [
+            "| File | Link |",
+            "| --- | --- |",
+            `| Budget | [budget.xlsx](${docUrl}) |`,
+          ].join("\n"),
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    const table = await screen.findByRole("table");
+    expect(within(table).getByText("budget.xlsx").closest("a")).toHaveAttribute(
+      "href",
+      docUrl,
+    );
+    expect(screen.queryByTestId("attachment-preview-file")).toBeNull();
   });
 
   it("renders html body links as preview cards for platform file urls", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -613,7 +613,7 @@ describe("zero chat thread page display - body link document preview", () => {
     },
   );
 
-  it("renders non-inline platform file links as generic file previews", async () => {
+  it("renders non-inline platform file links as thumbnail preview blocks", async () => {
     const docUrl =
       "https://www.vm0.ai/f/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/budget.xlsx";
     mockChatLifecycle({
@@ -629,10 +629,54 @@ describe("zero chat thread page display - body link document preview", () => {
     detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
     await waitFor(() => {
-      expect(screen.getByTestId("attachment-preview-file")).toBeInTheDocument();
+      const preview = screen.getByTestId("attachment-preview-file");
+      expect(preview).toBeInTheDocument();
+      expect(
+        within(preview).getByTestId("attachment-preview-file-icon"),
+      ).toBeInTheDocument();
+      expect(within(preview).getByText("XLSX")).toBeInTheDocument();
       expect(screen.getByLabelText("Download budget.xlsx")).toHaveAttribute(
         "href",
         `${docUrl}?download=1`,
+      );
+    });
+  });
+
+  it("renders structured non-inline attached files as thumbnail preview blocks", async () => {
+    const fileUrl =
+      "https://www.vm0.ai/f/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/budget.xlsx";
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: "Please review",
+          createdAt: "2026-03-10T00:00:00Z",
+          attachFiles: [
+            {
+              id: "file-budget",
+              filename: "budget.xlsx",
+              contentType:
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+              size: 2048,
+              url: fileUrl,
+            },
+          ],
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    await waitFor(() => {
+      const preview = screen.getByTestId("attachment-preview-file");
+      expect(preview).toBeInTheDocument();
+      expect(
+        within(preview).getByTestId("attachment-preview-file-icon"),
+      ).toBeInTheDocument();
+      expect(within(preview).getByText("XLSX")).toBeInTheDocument();
+      expect(screen.getByLabelText("Download budget.xlsx")).toHaveAttribute(
+        "href",
+        `${fileUrl}?download=1`,
       );
     });
   });
@@ -888,6 +932,19 @@ describe("zero chat thread page display - artifacts drawer", () => {
           headers: { "Content-Type": "text/csv" },
         });
       }),
+      http.get("https://example.com/deck.pptx", () => {
+        return new HttpResponse(
+          new Blob(["ppt"], {
+            type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          }),
+          {
+            headers: {
+              "Content-Type":
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            },
+          },
+        );
+      }),
       mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
         artifactsRequests += 1;
         return respond(200, {
@@ -909,6 +966,15 @@ describe("zero chat thread page display - artifacts drawer", () => {
                   contentType: "text/csv",
                   size: 2048,
                   url: "https://example.com/data.csv",
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+                {
+                  id: "file-3",
+                  filename: "deck.pptx",
+                  contentType:
+                    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                  size: 3072,
+                  url: "https://example.com/deck.pptx",
                   createdAt: "2026-03-10T00:00:00Z",
                 },
               ],
@@ -966,6 +1032,9 @@ describe("zero chat thread page display - artifacts drawer", () => {
     expect(zipText).toContain("data.csv");
     expect(screen.getAllByText("chart.png").length).toBeGreaterThan(0);
     expect(screen.getByText("data.csv")).toBeInTheDocument();
+    const deckButton = screen.getByLabelText("Select deck.pptx");
+    expect(deckButton).toBeInTheDocument();
+    expect(within(deckButton).getByText("PPTX")).toBeInTheDocument();
 
     await user.click(screen.getByLabelText("Preview chart.png"));
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -566,6 +566,77 @@ describe("zero chat thread page display - body link document preview", () => {
     });
   });
 
+  it.each([
+    {
+      filename: "config.xml",
+      content: "<settings><enabled>true</enabled></settings>",
+      expectedText: "settings",
+    },
+    {
+      filename: "deploy.yaml",
+      content: "enabled: true\nregion: us-east-1",
+      expectedText: "region: us-east-1",
+    },
+    {
+      filename: "table.tsv",
+      content: "name\tvalue\nalpha\t1",
+      expectedText: "alpha",
+    },
+  ])(
+    "renders $filename body links as text previews for platform file urls",
+    async ({ filename, content, expectedText }) => {
+      const fileUrl = `https://www.vm0.ai/f/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/${filename}`;
+      server.use(
+        http.get(fileUrl, () => {
+          return HttpResponse.text(content);
+        }),
+      );
+
+      mockChatLifecycle({
+        chatMessages: [
+          {
+            role: "assistant",
+            content: `[file](${fileUrl})`,
+            createdAt: "2026-03-10T00:00:00Z",
+          },
+        ],
+      });
+
+      detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("attachment-preview-text"),
+        ).toBeInTheDocument();
+        expect(screen.getByText(new RegExp(expectedText))).toBeInTheDocument();
+      });
+    },
+  );
+
+  it("renders non-inline platform file links as generic file previews", async () => {
+    const docUrl =
+      "https://www.vm0.ai/f/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/budget.xlsx";
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "assistant",
+          content: `[budget](${docUrl})`,
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-preview-file")).toBeInTheDocument();
+      expect(screen.getByLabelText("Download budget.xlsx")).toHaveAttribute(
+        "href",
+        `${docUrl}?download=1`,
+      );
+    });
+  });
+
   it("preserves assistant soft line breaks without forcing hard breaks", async () => {
     mockChatLifecycle({
       chatMessages: [
@@ -983,6 +1054,128 @@ describe("zero chat thread page display - artifacts drawer", () => {
     await user.click(screen.getByLabelText("Open preview for readme.md"));
     const lightbox = await screen.findByTestId("attachment-lightbox");
     expect(within(lightbox).getByText("发布说明")).toBeInTheDocument();
+  });
+
+  it("renders xml artifacts through the text loader instead of an iframe", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: "Create XML",
+          runId: "run-xml-artifact",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      http.get("https://example.com/config.xml", () => {
+        return HttpResponse.text("<config><enabled>true</enabled></config>");
+      }),
+      mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
+        return respond(200, {
+          runs: [
+            {
+              runId: "run-xml-artifact",
+              files: [
+                {
+                  id: "file-xml",
+                  filename: "config.xml",
+                  contentType: "application/xml",
+                  size: 512,
+                  url: "https://example.com/config.xml",
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+              ],
+            },
+          ],
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Open artifacts");
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/<config>/)).toBeInTheDocument();
+    });
+    expect(
+      document.querySelector('iframe[title="Preview config.xml"]'),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Open preview for config.xml"));
+    const lightbox = await screen.findByTestId("attachment-lightbox");
+    expect(within(lightbox).getByText(/<config>/)).toBeInTheDocument();
+  });
+
+  it("renders html artifacts as document iframe previews", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle({
+      chatMessages: [
+        {
+          role: "user",
+          content: "Create HTML",
+          runId: "run-html-artifact",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    server.use(
+      http.get("https://example.com/report.html", () => {
+        return HttpResponse.html("<html><body>report preview</body></html>");
+      }),
+      mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
+        return respond(200, {
+          runs: [
+            {
+              runId: "run-html-artifact",
+              files: [
+                {
+                  id: "file-html",
+                  filename: "report.html",
+                  contentType: "text/html",
+                  size: 1024,
+                  url: "https://example.com/report.html",
+                  createdAt: "2026-03-10T00:00:00Z",
+                },
+              ],
+            },
+          ],
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-test-1",
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Open artifacts");
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('iframe[title="Preview report.html"]'),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText("Open preview for report.html"));
+    const lightbox = await screen.findByTestId("attachment-lightbox");
+    expect(within(lightbox).getByTitle("report.html preview")).toHaveAttribute(
+      "src",
+      "https://example.com/report.html",
+    );
   });
 
   it("refreshes uploaded files from the artifacts Ably signal while the drawer is open", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -48,51 +48,162 @@ import docCsvIcon from "./assets/doc-csv.svg";
 import docTxtIcon from "./assets/doc-txt.svg";
 import docJsonIcon from "./assets/doc-json.svg";
 import docHtmlIcon from "./assets/doc-html.svg";
+import docAudioIcon from "./assets/doc-audio.svg";
+import docVideoIcon from "./assets/doc-video.svg";
 
 const log = logger("zero-attachment-chips");
+
+const FILE_ICON_BY_EXTENSION: Readonly<Record<string, string>> = {
+  pdf: docPdfIcon,
+  doc: docDocIcon,
+  docx: docDocIcon,
+  docm: docDocIcon,
+  dotm: docDocIcon,
+  dotx: docDocIcon,
+  odt: docDocIcon,
+  rtf: docDocIcon,
+  pages: docDocIcon,
+  epub: docDocIcon,
+  ai: docDocIcon,
+  eps: docDocIcon,
+  ps: docDocIcon,
+  md: docDocIcon,
+  txt: docTxtIcon,
+  log: docTxtIcon,
+  xml: docTxtIcon,
+  yaml: docTxtIcon,
+  yml: docTxtIcon,
+  json: docJsonIcon,
+  html: docHtmlIcon,
+  htm: docHtmlIcon,
+  csv: docCsvIcon,
+  tsv: docCsvIcon,
+  xls: docCsvIcon,
+  xlsx: docCsvIcon,
+  xlsb: docCsvIcon,
+  xlsm: docCsvIcon,
+  xltm: docCsvIcon,
+  xltx: docCsvIcon,
+  numbers: docCsvIcon,
+  ods: docCsvIcon,
+  ppt: docDocIcon,
+  pptx: docDocIcon,
+  pptm: docDocIcon,
+  potm: docDocIcon,
+  potx: docDocIcon,
+  ppsx: docDocIcon,
+  ppsm: docDocIcon,
+  key: docDocIcon,
+  odp: docDocIcon,
+  mp3: docAudioIcon,
+  mpga: docAudioIcon,
+  wav: docAudioIcon,
+  wave: docAudioIcon,
+  m4a: docAudioIcon,
+  aac: docAudioIcon,
+  ogg: docAudioIcon,
+  oga: docAudioIcon,
+  opus: docAudioIcon,
+  flac: docAudioIcon,
+  mp4: docVideoIcon,
+  webm: docVideoIcon,
+  mov: docVideoIcon,
+  ogv: docVideoIcon,
+  parquet: docCsvIcon,
+  sqlite: docCsvIcon,
+  sqlite3: docCsvIcon,
+  db: docCsvIcon,
+} as const;
+
+const FILE_ICON_BY_CONTENT_TYPE: Readonly<Record<string, string>> = {
+  "application/pdf": docPdfIcon,
+  "application/json": docJsonIcon,
+  "text/html": docHtmlIcon,
+  "text/csv": docCsvIcon,
+  "text/tab-separated-values": docCsvIcon,
+  "text/plain": docTxtIcon,
+  "text/xml": docTxtIcon,
+  "text/yaml": docTxtIcon,
+  "text/x-yaml": docTxtIcon,
+  "application/xml": docTxtIcon,
+  "application/yaml": docTxtIcon,
+  "application/x-yaml": docTxtIcon,
+  "text/markdown": docDocIcon,
+  "text/x-markdown": docDocIcon,
+  "application/msword": docDocIcon,
+  "application/rtf": docDocIcon,
+  "text/rtf": docDocIcon,
+  "application/postscript": docDocIcon,
+  "application/illustrator": docDocIcon,
+  "application/vnd.adobe.illustrator": docDocIcon,
+  "application/epub+zip": docDocIcon,
+  "application/vnd.apple.pages": docDocIcon,
+  "application/x-iwork-pages-sffpages": docDocIcon,
+  "application/vnd.oasis.opendocument.text": docDocIcon,
+  "application/vnd.ms-excel": docCsvIcon,
+  "application/vnd.apple.numbers": docCsvIcon,
+  "application/x-iwork-numbers-sffnumbers": docCsvIcon,
+  "application/vnd.oasis.opendocument.spreadsheet": docCsvIcon,
+  "application/vnd.apache.parquet": docCsvIcon,
+  "application/x-parquet": docCsvIcon,
+  "application/vnd.sqlite3": docCsvIcon,
+  "application/x-sqlite3": docCsvIcon,
+  "application/vnd.ms-powerpoint": docDocIcon,
+  "application/vnd.apple.keynote": docDocIcon,
+  "application/x-iwork-keynote-sffkey": docDocIcon,
+  "application/vnd.oasis.opendocument.presentation": docDocIcon,
+} as const;
+
+const FILE_ICON_CONTENT_TYPE_PREFIXES = [
+  { prefix: "audio/", icon: docAudioIcon },
+  { prefix: "video/", icon: docVideoIcon },
+  { prefix: "application/vnd.ms-word", icon: docDocIcon },
+  {
+    prefix: "application/vnd.openxmlformats-officedocument.wordprocessingml.",
+    icon: docDocIcon,
+  },
+  { prefix: "application/vnd.ms-excel.", icon: docCsvIcon },
+  {
+    prefix: "application/vnd.openxmlformats-officedocument.spreadsheetml.",
+    icon: docCsvIcon,
+  },
+  { prefix: "application/vnd.ms-powerpoint.", icon: docDocIcon },
+  {
+    prefix: "application/vnd.openxmlformats-officedocument.presentationml.",
+    icon: docDocIcon,
+  },
+] as const satisfies readonly {
+  readonly prefix: string;
+  readonly icon: string;
+}[];
+
+function getFileTypeIconByContentType(contentType: string): string | null {
+  const exactIcon = FILE_ICON_BY_CONTENT_TYPE[contentType];
+  if (exactIcon) {
+    return exactIcon;
+  }
+  return (
+    FILE_ICON_CONTENT_TYPE_PREFIXES.find(({ prefix }) => {
+      return contentType.startsWith(prefix);
+    })?.icon ?? null
+  );
+}
 
 /**
  * Return the icon path for a known file extension, or null for unknown types.
  */
-function getFileTypeIcon(filename: string): string | null {
+export function getFileTypeIcon(
+  filename: string,
+  contentType?: string,
+): string | null {
+  const type = (contentType ?? "").split(";")[0]?.trim().toLowerCase();
   const ext = filename.split(".").pop()?.toLowerCase();
-  switch (ext) {
-    case "pdf": {
-      return docPdfIcon;
-    }
-    case "doc":
-    case "docx":
-    case "odt":
-    case "rtf":
-    case "md": {
-      return docDocIcon;
-    }
-    case "txt": {
-      return docTxtIcon;
-    }
-    case "json": {
-      return docJsonIcon;
-    }
-    case "html": {
-      return docHtmlIcon;
-    }
-    case "csv": {
-      return docCsvIcon;
-    }
-    case "xls":
-    case "xlsx":
-    case "ods": {
-      return docCsvIcon;
-    }
-    case "ppt":
-    case "pptx":
-    case "odp": {
-      return docDocIcon;
-    }
-    default: {
-      return null;
-    }
+  const extensionIcon = ext ? FILE_ICON_BY_EXTENSION[ext] : undefined;
+  if (extensionIcon) {
+    return extensionIcon;
   }
+
+  return type ? getFileTypeIconByContentType(type) : null;
 }
 
 function getPreviewIconSrc(preview: {
@@ -906,7 +1017,9 @@ function AttachmentChip({
   const isVideo = attachment.contentType.startsWith("video/");
   const isAudio = attachment.contentType.startsWith("audio/");
   const iconSrc =
-    isImage || isVideo || isAudio ? null : getFileTypeIcon(attachment.filename);
+    isImage || isVideo || isAudio
+      ? null
+      : getFileTypeIcon(attachment.filename, attachment.contentType);
   return (
     <>
       <div

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -3,7 +3,6 @@ import { useGet, useSet, useLoadable } from "ccstate-react";
 import { createPortal } from "react-dom";
 import {
   IconDownload,
-  IconFile,
   IconFileMusic,
   IconPhoto,
   IconVideo,
@@ -42,178 +41,37 @@ import {
   openImageLightbox$,
   lightboxDialogRef$,
 } from "../../signals/zero-page/zero-attachment-chips.ts";
-import docPdfIcon from "./assets/doc-pdf.svg";
-import docDocIcon from "./assets/doc-doc.svg";
-import docCsvIcon from "./assets/doc-csv.svg";
-import docTxtIcon from "./assets/doc-txt.svg";
-import docJsonIcon from "./assets/doc-json.svg";
-import docHtmlIcon from "./assets/doc-html.svg";
-import docAudioIcon from "./assets/doc-audio.svg";
-import docVideoIcon from "./assets/doc-video.svg";
+import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
 
 const log = logger("zero-attachment-chips");
 
-const FILE_ICON_BY_EXTENSION: Readonly<Record<string, string>> = {
-  pdf: docPdfIcon,
-  doc: docDocIcon,
-  docx: docDocIcon,
-  docm: docDocIcon,
-  dotm: docDocIcon,
-  dotx: docDocIcon,
-  odt: docDocIcon,
-  rtf: docDocIcon,
-  pages: docDocIcon,
-  epub: docDocIcon,
-  ai: docDocIcon,
-  eps: docDocIcon,
-  ps: docDocIcon,
-  md: docDocIcon,
-  txt: docTxtIcon,
-  log: docTxtIcon,
-  xml: docTxtIcon,
-  yaml: docTxtIcon,
-  yml: docTxtIcon,
-  json: docJsonIcon,
-  html: docHtmlIcon,
-  htm: docHtmlIcon,
-  csv: docCsvIcon,
-  tsv: docCsvIcon,
-  xls: docCsvIcon,
-  xlsx: docCsvIcon,
-  xlsb: docCsvIcon,
-  xlsm: docCsvIcon,
-  xltm: docCsvIcon,
-  xltx: docCsvIcon,
-  numbers: docCsvIcon,
-  ods: docCsvIcon,
-  ppt: docDocIcon,
-  pptx: docDocIcon,
-  pptm: docDocIcon,
-  potm: docDocIcon,
-  potx: docDocIcon,
-  ppsx: docDocIcon,
-  ppsm: docDocIcon,
-  key: docDocIcon,
-  odp: docDocIcon,
-  mp3: docAudioIcon,
-  mpga: docAudioIcon,
-  wav: docAudioIcon,
-  wave: docAudioIcon,
-  m4a: docAudioIcon,
-  aac: docAudioIcon,
-  ogg: docAudioIcon,
-  oga: docAudioIcon,
-  opus: docAudioIcon,
-  flac: docAudioIcon,
-  mp4: docVideoIcon,
-  webm: docVideoIcon,
-  mov: docVideoIcon,
-  ogv: docVideoIcon,
-  parquet: docCsvIcon,
-  sqlite: docCsvIcon,
-  sqlite3: docCsvIcon,
-  db: docCsvIcon,
-} as const;
+type DocumentAttachmentPreviewKind =
+  | "markdown"
+  | "text"
+  | "json"
+  | "csv"
+  | "html"
+  | "pdf";
 
-const FILE_ICON_BY_CONTENT_TYPE: Readonly<Record<string, string>> = {
-  "application/pdf": docPdfIcon,
-  "application/json": docJsonIcon,
-  "text/html": docHtmlIcon,
-  "text/csv": docCsvIcon,
-  "text/tab-separated-values": docCsvIcon,
-  "text/plain": docTxtIcon,
-  "text/xml": docTxtIcon,
-  "text/yaml": docTxtIcon,
-  "text/x-yaml": docTxtIcon,
-  "application/xml": docTxtIcon,
-  "application/yaml": docTxtIcon,
-  "application/x-yaml": docTxtIcon,
-  "text/markdown": docDocIcon,
-  "text/x-markdown": docDocIcon,
-  "application/msword": docDocIcon,
-  "application/rtf": docDocIcon,
-  "text/rtf": docDocIcon,
-  "application/postscript": docDocIcon,
-  "application/illustrator": docDocIcon,
-  "application/vnd.adobe.illustrator": docDocIcon,
-  "application/epub+zip": docDocIcon,
-  "application/vnd.apple.pages": docDocIcon,
-  "application/x-iwork-pages-sffpages": docDocIcon,
-  "application/vnd.oasis.opendocument.text": docDocIcon,
-  "application/vnd.ms-excel": docCsvIcon,
-  "application/vnd.apple.numbers": docCsvIcon,
-  "application/x-iwork-numbers-sffnumbers": docCsvIcon,
-  "application/vnd.oasis.opendocument.spreadsheet": docCsvIcon,
-  "application/vnd.apache.parquet": docCsvIcon,
-  "application/x-parquet": docCsvIcon,
-  "application/vnd.sqlite3": docCsvIcon,
-  "application/x-sqlite3": docCsvIcon,
-  "application/vnd.ms-powerpoint": docDocIcon,
-  "application/vnd.apple.keynote": docDocIcon,
-  "application/x-iwork-keynote-sffkey": docDocIcon,
-  "application/vnd.oasis.opendocument.presentation": docDocIcon,
-} as const;
-
-const FILE_ICON_CONTENT_TYPE_PREFIXES = [
-  { prefix: "audio/", icon: docAudioIcon },
-  { prefix: "video/", icon: docVideoIcon },
-  { prefix: "application/vnd.ms-word", icon: docDocIcon },
-  {
-    prefix: "application/vnd.openxmlformats-officedocument.wordprocessingml.",
-    icon: docDocIcon,
-  },
-  { prefix: "application/vnd.ms-excel.", icon: docCsvIcon },
-  {
-    prefix: "application/vnd.openxmlformats-officedocument.spreadsheetml.",
-    icon: docCsvIcon,
-  },
-  { prefix: "application/vnd.ms-powerpoint.", icon: docDocIcon },
-  {
-    prefix: "application/vnd.openxmlformats-officedocument.presentationml.",
-    icon: docDocIcon,
-  },
-] as const satisfies readonly {
-  readonly prefix: string;
-  readonly icon: string;
-}[];
-
-function getFileTypeIconByContentType(contentType: string): string | null {
-  const exactIcon = FILE_ICON_BY_CONTENT_TYPE[contentType];
-  if (exactIcon) {
-    return exactIcon;
+function contentTypeForDocumentAttachmentPreviewKind(
+  kind: DocumentAttachmentPreviewKind,
+): string {
+  if (kind === "csv") {
+    return "text/csv";
   }
-  return (
-    FILE_ICON_CONTENT_TYPE_PREFIXES.find(({ prefix }) => {
-      return contentType.startsWith(prefix);
-    })?.icon ?? null
-  );
-}
-
-/**
- * Return the icon path for a known file extension, or null for unknown types.
- */
-function getFileTypeIcon(
-  filename: string,
-  contentType?: string,
-): string | null {
-  const type = (contentType ?? "").split(";")[0]?.trim().toLowerCase();
-  const ext = filename.split(".").pop()?.toLowerCase();
-  const extensionIcon = ext ? FILE_ICON_BY_EXTENSION[ext] : undefined;
-  if (extensionIcon) {
-    return extensionIcon;
+  if (kind === "markdown") {
+    return "text/markdown";
   }
-
-  return type ? getFileTypeIconByContentType(type) : null;
-}
-
-function getPreviewIconSrc(preview: {
-  kind: "markdown" | "text" | "json" | "csv" | "html" | "pdf";
-  filename: string;
-}): string | null {
-  if (preview.kind === "csv") {
-    return docCsvIcon;
+  if (kind === "text") {
+    return "text/plain";
   }
-  return getFileTypeIcon(preview.filename);
+  if (kind === "json") {
+    return "application/json";
+  }
+  if (kind === "html") {
+    return "text/html";
+  }
+  return "application/pdf";
 }
 
 // ---------------------------------------------------------------------------
@@ -619,8 +477,6 @@ export function AttachmentLightbox() {
     return <ImageLightbox url={preview.url} />;
   }
 
-  const iconSrc = getPreviewIconSrc(preview);
-
   const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) {
       closeLightbox();
@@ -667,20 +523,13 @@ export function AttachmentLightbox() {
       <div className="w-[min(92vw,1100px)] rounded-2xl bg-background shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200">
         <div className="flex items-center gap-3 border-b border-foreground/10 px-4 py-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-muted">
-            {iconSrc ? (
-              <img
-                alt=""
-                aria-hidden="true"
-                src={iconSrc}
-                className="h-7 w-7 object-contain opacity-90"
-              />
-            ) : (
-              <IconFile
-                size={22}
-                stroke={1.8}
-                className="text-muted-foreground"
-              />
-            )}
+            <FilePreviewIcon
+              filename={preview.filename}
+              contentType={contentTypeForDocumentAttachmentPreviewKind(
+                preview.kind,
+              )}
+              testId="attachment-lightbox-file-icon"
+            />
           </div>
           <div className="min-w-0">
             <div className="truncate text-sm font-medium text-foreground">
@@ -854,7 +703,6 @@ export function FileAttachmentChip({
   filename: string;
   url: string;
 }) {
-  const iconSrc = getFileTypeIcon(filename);
   return (
     <a
       href={getAttachmentDownloadUrl(url)}
@@ -862,16 +710,11 @@ export function FileAttachmentChip({
       title={filename}
       className="inline-flex items-center justify-center rounded-lg hover:bg-foreground/10 transition-colors p-0.5"
     >
-      {iconSrc ? (
-        <img
-          alt=""
-          className="h-9 w-9 object-contain opacity-80"
-          aria-hidden="true"
-          src={iconSrc}
-        />
-      ) : (
-        <IconFile size={28} stroke={1.5} className="text-muted-foreground" />
-      )}
+      <FilePreviewIcon
+        filename={filename}
+        className="h-9 w-9"
+        testId="attachment-chip-file-icon"
+      />
     </a>
   );
 }
@@ -885,7 +728,6 @@ export function PreviewableFileAttachmentChip({
   url: string;
   kind: "markdown" | "text" | "json" | "csv" | "pdf" | "html";
 }) {
-  const iconSrc = getFileTypeIcon(filename);
   const openDocumentLightbox = useSet(openDocumentLightbox$);
 
   return (
@@ -898,16 +740,12 @@ export function PreviewableFileAttachmentChip({
       aria-label={`Open ${kind} preview for ${filename}`}
       className="inline-flex items-center justify-center rounded-lg hover:bg-foreground/10 transition-colors p-0.5"
     >
-      {iconSrc ? (
-        <img
-          alt=""
-          className="h-9 w-9 object-contain opacity-80"
-          aria-hidden="true"
-          src={iconSrc}
-        />
-      ) : (
-        <IconFile size={28} stroke={1.5} className="text-muted-foreground" />
-      )}
+      <FilePreviewIcon
+        filename={filename}
+        contentType={contentTypeForDocumentAttachmentPreviewKind(kind)}
+        className="h-9 w-9"
+        testId="attachment-chip-file-icon"
+      />
     </button>
   );
 }
@@ -1016,10 +854,6 @@ function AttachmentChip({
   const isImage = attachment.contentType.startsWith("image/");
   const isVideo = attachment.contentType.startsWith("video/");
   const isAudio = attachment.contentType.startsWith("audio/");
-  const iconSrc =
-    isImage || isVideo || isAudio
-      ? null
-      : getFileTypeIcon(attachment.filename, attachment.contentType);
   return (
     <>
       <div
@@ -1040,15 +874,13 @@ function AttachmentChip({
             stroke={1.5}
             className="text-muted-foreground"
           />
-        ) : iconSrc ? (
-          <img
-            alt=""
-            className="h-9 w-9 object-contain opacity-80"
-            aria-hidden="true"
-            src={iconSrc}
-          />
         ) : (
-          <IconFile size={28} stroke={1.5} className="text-muted-foreground" />
+          <FilePreviewIcon
+            filename={attachment.filename}
+            contentType={attachment.contentType}
+            className="h-9 w-9"
+            testId="composer-attachment-file-icon"
+          />
         )}
         {uploading && (
           <span className="absolute -top-1 -left-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background">

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -192,7 +192,7 @@ function getFileTypeIconByContentType(contentType: string): string | null {
 /**
  * Return the icon path for a known file extension, or null for unknown types.
  */
-export function getFileTypeIcon(
+function getFileTypeIcon(
   filename: string,
   contentType?: string,
 ): string | null {

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -23,12 +23,6 @@ import {
   FilePreviewIcon,
   getFilePreviewAccentClass,
 } from "./zero-file-preview-icon.tsx";
-import docPdfIcon from "./assets/doc-pdf.svg";
-import docDocIcon from "./assets/doc-doc.svg";
-import docCsvIcon from "./assets/doc-csv.svg";
-import docTxtIcon from "./assets/doc-txt.svg";
-import docJsonIcon from "./assets/doc-json.svg";
-import docHtmlIcon from "./assets/doc-html.svg";
 
 interface ChatAttachmentDescriptor {
   filename: string;
@@ -36,25 +30,31 @@ interface ChatAttachmentDescriptor {
   contentType?: string;
 }
 
-function getPreviewIconSrc(
-  kind: "markdown" | "text" | "json" | "csv" | "pdf" | "html",
-): string {
-  if (kind === "pdf") {
-    return docPdfIcon;
-  }
-  if (kind === "csv") {
-    return docCsvIcon;
+type DocumentPreviewKind =
+  | "markdown"
+  | "text"
+  | "json"
+  | "csv"
+  | "pdf"
+  | "html";
+
+function contentTypeForDocumentPreviewKind(kind: DocumentPreviewKind): string {
+  if (kind === "markdown") {
+    return "text/markdown";
   }
   if (kind === "text") {
-    return docTxtIcon;
+    return "text/plain";
   }
   if (kind === "json") {
-    return docJsonIcon;
+    return "application/json";
   }
-  if (kind === "html") {
-    return docHtmlIcon;
+  if (kind === "csv") {
+    return "text/csv";
   }
-  return docDocIcon;
+  if (kind === "pdf") {
+    return "application/pdf";
+  }
+  return "text/html";
 }
 
 function normalizePlatformFileUrl(url: string): string {
@@ -106,7 +106,6 @@ function TextPreview({ filename, url, kind, text$ }: TextPreviewProps) {
   const collapsedKey = `attachment-preview:${kind}:${filename}:${url}`;
   const text = useLastResolved(text$ ?? EMPTY_TEXT$);
   const collapsed = textPreviewCollapsedByKey[collapsedKey] ?? false;
-  const iconSrc = getPreviewIconSrc(kind);
 
   let content: ReactNode = (
     <div className="mt-3 flex items-center justify-center rounded-lg bg-muted/30 p-3 text-muted-foreground">
@@ -148,11 +147,10 @@ function TextPreview({ filename, url, kind, text$ }: TextPreviewProps) {
         aria-label={`${collapsed ? "Expand" : "Collapse"} ${kind} preview for ${filename}`}
       >
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-muted/60">
-          <img
-            alt=""
-            aria-hidden="true"
-            src={iconSrc}
-            className="h-7 w-7 object-contain opacity-90"
+          <FilePreviewIcon
+            filename={filename}
+            contentType={contentTypeForDocumentPreviewKind(kind)}
+            testId={`attachment-preview-${kind}-icon`}
           />
         </div>
         <div className="min-w-0 flex-1 pr-16">
@@ -183,7 +181,6 @@ function DocumentThumbnailPreview({
   kind: "markdown" | "csv" | "pdf" | "html";
 }) {
   const openDocumentLightbox = useSet(openDocumentLightbox$);
-  const iconSrc = getPreviewIconSrc(kind);
   const accentClass =
     kind === "markdown"
       ? "from-emerald-500/15 via-lime-500/10 to-background"
@@ -210,11 +207,10 @@ function DocumentThumbnailPreview({
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.45),transparent_55%)] dark:bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.08),transparent_55%)]" />
         <div className="absolute inset-x-0 top-0 h-10 bg-gradient-to-b from-black/10 to-transparent" />
         <div className="relative flex h-16 w-16 items-center justify-center rounded-2xl border border-foreground/10 bg-background/90 shadow-sm transition-transform duration-200 group-hover/doc-preview:scale-105">
-          <img
-            alt=""
-            aria-hidden="true"
-            src={iconSrc}
-            className="h-10 w-10 object-contain opacity-95"
+          <FilePreviewIcon
+            filename={filename}
+            contentType={contentTypeForDocumentPreviewKind(kind)}
+            testId={`attachment-preview-${kind}-icon`}
           />
         </div>
         <div className="absolute right-2 top-2 inline-flex items-center gap-1 rounded-full bg-background/85 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground opacity-0 transition-opacity duration-200 group-hover/doc-preview:opacity-100">

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -4,6 +4,7 @@ import {
   IconChevronUp,
   IconDownload,
   IconEye,
+  IconFile,
   IconFileMusic,
   IconLoader2,
 } from "@tabler/icons-react";
@@ -19,6 +20,7 @@ import {
   classifyChatAttachment,
   EMPTY_TEXT$,
 } from "../../signals/chat-page/parse-body-blocks.ts";
+import { getFileTypeIcon } from "./zero-attachment-chips.tsx";
 import docPdfIcon from "./assets/doc-pdf.svg";
 import docDocIcon from "./assets/doc-doc.svg";
 import docCsvIcon from "./assets/doc-csv.svg";
@@ -263,6 +265,52 @@ function AudioPreview({ filename, url }: { filename: string; url: string }) {
   );
 }
 
+function GenericFilePreview({
+  filename,
+  url,
+  contentType,
+}: {
+  filename: string;
+  url: string;
+  contentType?: string;
+}) {
+  const iconSrc = getFileTypeIcon(filename, contentType);
+
+  return (
+    <div
+      className="relative flex w-full max-w-md items-center gap-3 rounded-xl border border-foreground/10 bg-background/60 p-3"
+      data-testid="attachment-preview-file"
+    >
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-muted/60 text-muted-foreground">
+        {iconSrc ? (
+          <img
+            alt=""
+            aria-hidden="true"
+            src={iconSrc}
+            className="h-7 w-7 object-contain opacity-90"
+          />
+        ) : (
+          <IconFile size={22} stroke={1.6} />
+        )}
+      </div>
+      <div className="min-w-0 flex-1 pr-10">
+        <div className="truncate text-sm font-medium text-foreground">
+          {filename}
+        </div>
+      </div>
+      <a
+        href={toDownloadUrl(url)}
+        download={filename}
+        title={filename}
+        aria-label={`Download ${filename}`}
+        className="absolute right-3 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-background/90 text-muted-foreground hover:text-foreground"
+      >
+        <IconDownload size={12} />
+      </a>
+    </div>
+  );
+}
+
 export function AttachmentPreview({
   attachment,
   text$,
@@ -332,6 +380,15 @@ export function AttachmentPreview({
     case "audio": {
       return (
         <AudioPreview filename={attachment.filename} url={attachment.url} />
+      );
+    }
+    case "file": {
+      return (
+        <GenericFilePreview
+          filename={attachment.filename}
+          url={attachment.url}
+          contentType={attachment.contentType}
+        />
       );
     }
     default: {

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -4,7 +4,6 @@ import {
   IconChevronUp,
   IconDownload,
   IconEye,
-  IconFile,
   IconFileMusic,
   IconLoader2,
 } from "@tabler/icons-react";
@@ -20,7 +19,10 @@ import {
   classifyChatAttachment,
   EMPTY_TEXT$,
 } from "../../signals/chat-page/parse-body-blocks.ts";
-import { getFileTypeIcon } from "./zero-attachment-chips.tsx";
+import {
+  FilePreviewIcon,
+  getFilePreviewAccentClass,
+} from "./zero-file-preview-icon.tsx";
 import docPdfIcon from "./assets/doc-pdf.svg";
 import docDocIcon from "./assets/doc-doc.svg";
 import docCsvIcon from "./assets/doc-csv.svg";
@@ -229,6 +231,52 @@ function DocumentThumbnailPreview({
   );
 }
 
+function FileThumbnailPreview({
+  filename,
+  url,
+  contentType,
+}: {
+  filename: string;
+  url: string;
+  contentType?: string;
+}) {
+  const accentClass = getFilePreviewAccentClass(filename, contentType);
+
+  return (
+    <a
+      href={toDownloadUrl(url)}
+      download={filename}
+      title={filename}
+      data-testid="attachment-preview-file"
+      aria-label={`Download ${filename}`}
+      className="group/doc-preview inline-flex w-fit self-start align-top text-left"
+    >
+      <div
+        className={`relative flex aspect-[4/3] w-[144px] items-center justify-center overflow-hidden rounded-xl bg-gradient-to-br sm:w-[168px] ${accentClass}`}
+      >
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.45),transparent_55%)] dark:bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.08),transparent_55%)]" />
+        <div className="absolute inset-x-0 top-0 h-10 bg-gradient-to-b from-black/10 to-transparent" />
+        <div className="relative flex h-16 w-16 items-center justify-center rounded-2xl border border-foreground/10 bg-background/90 shadow-sm transition-transform duration-200 group-hover/doc-preview:scale-105">
+          <FilePreviewIcon
+            filename={filename}
+            contentType={contentType}
+            testId="attachment-preview-file-icon"
+          />
+        </div>
+        <div className="absolute right-2 top-2 inline-flex items-center gap-1 rounded-full bg-background/85 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground opacity-0 transition-opacity duration-200 group-hover/doc-preview:opacity-100">
+          <IconDownload size={10} />
+          Download
+        </div>
+        <div className="absolute inset-x-0 bottom-0 flex items-end justify-between gap-2 bg-gradient-to-t from-black/55 via-black/15 to-transparent px-2.5 py-2.5 text-white opacity-0 transition-opacity duration-200 group-hover/doc-preview:opacity-100">
+          <div className="min-w-0">
+            <div className="truncate text-xs font-medium">{filename}</div>
+          </div>
+        </div>
+      </div>
+    </a>
+  );
+}
+
 function AudioPreview({ filename, url }: { filename: string; url: string }) {
   return (
     <div
@@ -261,52 +309,6 @@ function AudioPreview({ filename, url }: { filename: string; url: string }) {
         className="block w-full"
         aria-label={`Audio preview for ${filename}`}
       />
-    </div>
-  );
-}
-
-function GenericFilePreview({
-  filename,
-  url,
-  contentType,
-}: {
-  filename: string;
-  url: string;
-  contentType?: string;
-}) {
-  const iconSrc = getFileTypeIcon(filename, contentType);
-
-  return (
-    <div
-      className="relative flex w-full max-w-md items-center gap-3 rounded-xl border border-foreground/10 bg-background/60 p-3"
-      data-testid="attachment-preview-file"
-    >
-      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-muted/60 text-muted-foreground">
-        {iconSrc ? (
-          <img
-            alt=""
-            aria-hidden="true"
-            src={iconSrc}
-            className="h-7 w-7 object-contain opacity-90"
-          />
-        ) : (
-          <IconFile size={22} stroke={1.6} />
-        )}
-      </div>
-      <div className="min-w-0 flex-1 pr-10">
-        <div className="truncate text-sm font-medium text-foreground">
-          {filename}
-        </div>
-      </div>
-      <a
-        href={toDownloadUrl(url)}
-        download={filename}
-        title={filename}
-        aria-label={`Download ${filename}`}
-        className="absolute right-3 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-background/90 text-muted-foreground hover:text-foreground"
-      >
-        <IconDownload size={12} />
-      </a>
     </div>
   );
 }
@@ -384,7 +386,7 @@ export function AttachmentPreview({
     }
     case "file": {
       return (
-        <GenericFilePreview
+        <FileThumbnailPreview
           filename={attachment.filename}
           url={attachment.url}
           contentType={attachment.contentType}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -54,14 +54,6 @@ import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
 import type { ChatThreadArtifactFile } from "@vm0/api-contracts/contracts/chat-threads";
 import emptyChatImg from "./assets/empty-chat.webp";
 import emptyArtifactImg from "./assets/empty-artifact.webp";
-import docAudioIcon from "./assets/doc-audio.svg";
-import docCsvIcon from "./assets/doc-csv.svg";
-import docDocIcon from "./assets/doc-doc.svg";
-import docHtmlIcon from "./assets/doc-html.svg";
-import docJsonIcon from "./assets/doc-json.svg";
-import docPdfIcon from "./assets/doc-pdf.svg";
-import docTxtIcon from "./assets/doc-txt.svg";
-import docVideoIcon from "./assets/doc-video.svg";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { playTts$, stopTts$ } from "../../signals/voice-io/voice-io-tts.ts";
@@ -82,6 +74,7 @@ import {
   CsvPreviewTable,
   downloadAttachmentUrl,
   FileAttachmentChip,
+  getFileTypeIcon,
   getAttachmentRawUrl,
   parseCsvRows,
   PreviewableFileAttachmentChip,
@@ -407,24 +400,28 @@ function getFileExtension(filename: string): string {
 function getArtifactPreviewKind(
   file: ChatThreadArtifactFile,
 ): ArtifactPreviewKind {
-  const contentType = file.contentType.toLowerCase();
-  const filename = file.filename.toLowerCase();
+  const kind = classifyChatAttachment({
+    filename: file.filename,
+    url: file.url,
+    contentType: file.contentType,
+  });
 
-  if (contentType.startsWith("image/") || isImageFilename(filename)) {
+  if (kind === "image") {
     return "image";
   }
-  if (contentType.startsWith("video/") || isVideoFilename(filename)) {
+  if (kind === "video") {
     return "video";
   }
-  if (contentType.startsWith("audio/") || isAudioFilename(filename)) {
+  if (kind === "audio") {
     return "audio";
   }
   if (
-    contentType === "application/pdf" ||
-    contentType === "application/json" ||
-    contentType === "text/csv" ||
-    (contentType.startsWith("text/") && contentType !== "text/html") ||
-    /\.(pdf|txt|md|csv|json|log)$/i.test(filename)
+    kind === "markdown" ||
+    kind === "text" ||
+    kind === "json" ||
+    kind === "csv" ||
+    kind === "pdf" ||
+    kind === "html"
   ) {
     return "document";
   }
@@ -442,37 +439,7 @@ function flattenArtifactRuns(
 }
 
 function getArtifactFileIconSrc(file: ChatThreadArtifactFile): string | null {
-  const kind = classifyChatAttachment({
-    filename: file.filename,
-    url: file.url,
-    contentType: file.contentType,
-  });
-
-  if (kind === "pdf") {
-    return docPdfIcon;
-  }
-  if (kind === "html") {
-    return docHtmlIcon;
-  }
-  if (kind === "csv") {
-    return docCsvIcon;
-  }
-  if (kind === "json") {
-    return docJsonIcon;
-  }
-  if (kind === "text") {
-    return docTxtIcon;
-  }
-  if (kind === "markdown") {
-    return docDocIcon;
-  }
-  if (kind === "video") {
-    return docVideoIcon;
-  }
-  if (kind === "audio") {
-    return docAudioIcon;
-  }
-  return null;
+  return getFileTypeIcon(file.filename, file.contentType);
 }
 
 function ArtifactFileIcon({
@@ -517,7 +484,7 @@ function ArtifactPreviewBadge({ file }: { file: ChatThreadArtifactFile }) {
 }
 
 type ArtifactTextPreviewKind = "markdown" | "text" | "json" | "csv";
-type ArtifactDocumentPreviewKind = ArtifactTextPreviewKind | "pdf";
+type ArtifactDocumentPreviewKind = ArtifactTextPreviewKind | "pdf" | "html";
 
 function getArtifactTextPreviewKind(
   file: ChatThreadArtifactFile,
@@ -567,6 +534,13 @@ function getArtifactDocumentPreviewKind(
   const filename = file.filename.toLowerCase();
   if (contentType === "application/pdf" || filename.endsWith(".pdf")) {
     return "pdf";
+  }
+  if (
+    contentType === "text/html" ||
+    filename.endsWith(".html") ||
+    filename.endsWith(".htm")
+  ) {
+    return "html";
   }
 
   return null;
@@ -1252,7 +1226,7 @@ function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
       });
     };
 
-    if (documentPreviewKind !== "pdf") {
+    if (documentPreviewKind !== "pdf" && documentPreviewKind !== "html") {
       return (
         <ArtifactPreviewOpenOverlay
           filename={file.filename}
@@ -2229,15 +2203,17 @@ function BodyContentBlocks({
 }
 
 function isImageFilename(filename: string): boolean {
-  return /\.(png|jpe?g|gif|webp|svg)$/i.test(filename);
+  return /\.(png|jpe?g|gif|webp|svg|bmp|avif|heic|heif|tiff?|psd)$/i.test(
+    filename,
+  );
 }
 
 function isVideoFilename(filename: string): boolean {
-  return /\.(mp4|webm|mov)$/i.test(filename);
+  return /\.(mp4|webm|mov|ogv)$/i.test(filename);
 }
 
 function isAudioFilename(filename: string): boolean {
-  return /\.(mp3|wav|m4a|aac|ogg|oga|opus|flac|mpga)$/i.test(filename);
+  return /\.(mp3|wav|wave|m4a|aac|ogg|oga|opus|flac|mpga)$/i.test(filename);
 }
 
 function AssistantErrorContent({ error }: { error: string }) {
@@ -2452,18 +2428,77 @@ function inferAttachmentContentType(filename: string, kind: string): string {
     gif: "image/gif",
     webp: "image/webp",
     svg: "image/svg+xml",
+    bmp: "image/bmp",
+    avif: "image/avif",
+    heic: "image/heic",
+    heif: "image/heif",
+    tif: "image/tiff",
+    tiff: "image/tiff",
+    psd: "image/vnd.adobe.photoshop",
     mp4: "video/mp4",
     webm: "video/webm",
     mov: "video/quicktime",
     mp3: "audio/mpeg",
     mpga: "audio/mpeg",
     wav: "audio/wav",
+    wave: "audio/wave",
     m4a: "audio/mp4",
     aac: "audio/aac",
     ogg: "audio/ogg",
     oga: "audio/ogg",
     opus: "audio/opus",
     flac: "audio/flac",
+    pdf: "application/pdf",
+    txt: "text/plain",
+    log: "text/plain",
+    csv: "text/csv",
+    md: "text/markdown",
+    html: "text/html",
+    htm: "text/html",
+    json: "application/json",
+    xml: "application/xml",
+    yaml: "application/yaml",
+    yml: "application/yaml",
+    tsv: "text/tab-separated-values",
+    doc: "application/msword",
+    docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    docm: "application/vnd.ms-word.document.macroenabled.12",
+    dotm: "application/vnd.ms-word.template.macroenabled.12",
+    dotx: "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+    odt: "application/vnd.oasis.opendocument.text",
+    rtf: "application/rtf",
+    xls: "application/vnd.ms-excel",
+    xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    xlsb: "application/vnd.ms-excel.sheet.binary.macroenabled.12",
+    xlsm: "application/vnd.ms-excel.sheet.macroenabled.12",
+    xltm: "application/vnd.ms-excel.template.macroenabled.12",
+    xltx: "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+    ods: "application/vnd.oasis.opendocument.spreadsheet",
+    ppt: "application/vnd.ms-powerpoint",
+    pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    potm: "application/vnd.ms-powerpoint.template.macroenabled.12",
+    potx: "application/vnd.openxmlformats-officedocument.presentationml.template",
+    odp: "application/vnd.oasis.opendocument.presentation",
+    ppsx: "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+    ppsm: "application/vnd.ms-powerpoint.slideshow.macroenabled.12",
+    pptm: "application/vnd.ms-powerpoint.presentation.macroenabled.12",
+    zip: "application/zip",
+    rar: "application/vnd.rar",
+    "7z": "application/x-7z-compressed",
+    tar: "application/x-tar",
+    gz: "application/gzip",
+    tgz: "application/gzip",
+    bz2: "application/x-bzip2",
+    xz: "application/x-xz",
+    pages: "application/vnd.apple.pages",
+    numbers: "application/vnd.apple.numbers",
+    key: "application/vnd.apple.keynote",
+    parquet: "application/vnd.apache.parquet",
+    sqlite: "application/vnd.sqlite3",
+    sqlite3: "application/vnd.sqlite3",
+    db: "application/vnd.sqlite3",
+    epub: "application/epub+zip",
+    ai: "application/postscript",
   };
   const lower = filename.toLowerCase();
   const extension = lower.includes(".") ? lower.split(".").pop() : undefined;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -74,7 +74,6 @@ import {
   CsvPreviewTable,
   downloadAttachmentUrl,
   FileAttachmentChip,
-  getFileTypeIcon,
   getAttachmentRawUrl,
   parseCsvRows,
   PreviewableFileAttachmentChip,
@@ -88,6 +87,7 @@ import {
   type BodyRenderBlock,
 } from "../../signals/chat-page/parse-body-blocks.ts";
 import { AttachmentPreview } from "./zero-attachment-preview.tsx";
+import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
 import {
   lightboxUrl$ as attachmentLightboxUrl$,
   openDocumentLightbox$ as openAttachmentDocumentLightbox$,
@@ -392,11 +392,6 @@ function artifactItemKey(item: ChatArtifactItem): string {
   return `${item.runId}:${item.file.id}:${item.file.url}`;
 }
 
-function getFileExtension(filename: string): string {
-  const ext = filename.split(".").pop();
-  return ext && ext !== filename ? ext.toUpperCase() : "FILE";
-}
-
 function getArtifactPreviewKind(
   file: ChatThreadArtifactFile,
 ): ArtifactPreviewKind {
@@ -438,34 +433,21 @@ function flattenArtifactRuns(
   });
 }
 
-function getArtifactFileIconSrc(file: ChatThreadArtifactFile): string | null {
-  return getFileTypeIcon(file.filename, file.contentType);
-}
-
 function ArtifactFileIcon({
   file,
-  className,
+  size = "sm",
 }: {
   file: ChatThreadArtifactFile;
-  className?: string;
+  size?: "sm" | "md";
 }) {
-  const iconSrc = getArtifactFileIconSrc(file);
-  if (iconSrc) {
-    return (
-      <img
-        alt=""
-        aria-hidden="true"
-        src={iconSrc}
-        className={cn("h-5 w-5 object-contain opacity-90", className)}
-      />
-    );
-  }
-
-  const previewKind = getArtifactPreviewKind(file);
-  if (previewKind === "image") {
-    return <IconPhoto size={18} stroke={1.5} />;
-  }
-  return <IconFile size={18} stroke={1.5} />;
+  return (
+    <FilePreviewIcon
+      filename={file.filename}
+      contentType={file.contentType}
+      size={size}
+      testId="artifact-file-icon"
+    />
+  );
 }
 
 function ArtifactPreviewBadge({ file }: { file: ChatThreadArtifactFile }) {
@@ -1213,7 +1195,7 @@ function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
     if (!documentPreviewKind) {
       return (
         <div className="flex h-full w-full items-center justify-center bg-muted/40">
-          <ArtifactFileIcon file={file} className="h-10 w-10" />
+          <ArtifactFileIcon file={file} size="md" />
         </div>
       );
     }
@@ -1254,13 +1236,10 @@ function ArtifactPreviewFrame({ file }: { file: ChatThreadArtifactFile }) {
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-3 bg-muted/40 p-8 text-center">
       <span className="flex h-16 w-16 items-center justify-center rounded-lg border border-border/70 bg-background text-muted-foreground shadow-sm">
-        <ArtifactFileIcon file={file} className="h-10 w-10" />
+        <ArtifactFileIcon file={file} size="md" />
       </span>
       <div className="min-w-0">
-        <p className="text-xs font-medium uppercase text-muted-foreground">
-          {getFileExtension(file.filename)}
-        </p>
-        <p className="mt-1 max-w-[260px] truncate text-sm text-foreground">
+        <p className="max-w-[260px] truncate text-sm text-foreground">
           {file.filename}
         </p>
       </div>
@@ -1298,8 +1277,6 @@ function ArtifactPreviewPanel({
           </p>
           <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
             <span>{formatBytes(file.size)}</span>
-            <span aria-hidden>·</span>
-            <span>{getFileExtension(file.filename)}</span>
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
@@ -1338,12 +1315,7 @@ function ArtifactThumbnail({
       {previewKind === "image" ? (
         <ArtifactThumbnailImage url={file.url} />
       ) : (
-        <span className="flex flex-col items-center gap-0.5 text-muted-foreground">
-          <ArtifactFileIcon file={file} />
-          <span className="max-w-14 truncate text-[10px] font-medium">
-            {getFileExtension(file.filename)}
-          </span>
-        </span>
+        <ArtifactFileIcon file={file} />
       )}
     </div>
   );
@@ -1428,8 +1400,6 @@ function ArtifactFileRow({
           </span>
           <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
             <span>{formatBytes(file.size)}</span>
-            <span aria-hidden>·</span>
-            <span>{getFileExtension(file.filename)}</span>
             <span aria-hidden>·</span>
             <span>{formatArtifactTime(file.createdAt)}</span>
           </div>
@@ -2617,12 +2587,23 @@ function UserMessageAttachments({
         }
         if (
           a.kind === "markdown" ||
-          a.kind === "text" ||
-          a.kind === "json" ||
           a.kind === "csv" ||
           a.kind === "pdf" ||
-          a.kind === "html"
+          a.kind === "html" ||
+          a.kind === "file"
         ) {
+          return (
+            <AttachmentPreview
+              key={a.url}
+              attachment={{
+                filename: a.filename,
+                url: a.url,
+                contentType: a.contentType,
+              }}
+            />
+          );
+        }
+        if (a.kind === "text" || a.kind === "json") {
           return (
             <PreviewableFileAttachmentChip
               key={a.url}

--- a/turbo/apps/platform/src/views/zero-page/zero-file-preview-icon.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-file-preview-icon.tsx
@@ -1,0 +1,308 @@
+const SPREADSHEET_FILE_RE =
+  /\.(csv|tsv|xls|xlsx|xlsm|xlsb|xltx|xltm|ods|numbers|parquet)$/i;
+const DATABASE_FILE_RE = /\.(sqlite|sqlite3|db)$/i;
+const PRESENTATION_FILE_RE = /\.(ppt|pptx|pptm|potx|potm|ppsx|ppsm|odp|key)$/i;
+const ARCHIVE_FILE_RE = /\.(zip|rar|7z|tar|gz|tgz|bz2|xz)$/i;
+const ARTWORK_FILE_RE = /\.(psd|ai|eps)$/i;
+const DOCUMENT_FILE_RE = /\.(doc|docx|docm|dotx|dotm|odt|rtf|pages|epub)$/i;
+const PDF_FILE_RE = /\.pdf$/i;
+const MARKDOWN_FILE_RE = /\.(md|markdown|mdx)$/i;
+const TEXT_FILE_RE = /\.(txt|log|xml|yaml|yml)$/i;
+const JSON_FILE_RE = /\.json$/i;
+const HTML_FILE_RE = /\.(html|htm)$/i;
+const AUDIO_FILE_RE = /\.(mp3|mpga|wav|wave|m4a|aac|ogg|oga|opus|flac)$/i;
+const VIDEO_FILE_RE = /\.(mp4|webm|mov|ogv)$/i;
+const SPREADSHEET_EXTENSION_RE =
+  /^(CSV|TSV|XLS|XLSX|XLSM|XLSB|XLTX|XLTM|ODS|NUMBERS|PARQUET)$/;
+const DATABASE_EXTENSION_RE = /^(SQLITE|SQLITE3|DB)$/;
+const PRESENTATION_EXTENSION_RE =
+  /^(PPT|PPTX|PPTM|POTX|POTM|PPSX|PPSM|ODP|KEY)$/;
+const ARCHIVE_EXTENSION_RE = /^(ZIP|RAR|7Z|TAR|GZ|TGZ|BZ2|XZ)$/;
+const ARTWORK_EXTENSION_RE = /^(PSD|AI|EPS)$/;
+const DOCUMENT_EXTENSION_RE = /^(DOC|DOCX|DOCM|DOTX|DOTM|ODT|RTF|PAGES|EPUB)$/;
+
+type FilePreviewIconMeta = {
+  label: string;
+  bandClassName: string;
+};
+
+type FilePreviewIconSize = "sm" | "md";
+
+function filePreviewIconSizeClass(size: FilePreviewIconSize) {
+  if (size === "sm") {
+    return {
+      root: "h-5 w-5 rounded-[5px]",
+      top: "h-2.5",
+      band: "h-2.5 px-0.5 text-[5px] tracking-[0.02em]",
+    };
+  }
+
+  return {
+    root: "h-10 w-10 rounded-[10px]",
+    top: "h-5",
+    band: "h-5 px-1 text-[8px] tracking-[0.04em]",
+  };
+}
+
+function normalizeContentType(contentType?: string): string {
+  return (contentType ?? "").split(";")[0]?.trim().toLowerCase();
+}
+
+function matchesFilePreviewType(
+  lowerFilename: string,
+  lowerContentType: string,
+  filenamePattern: RegExp,
+  contentTypeFragments: string[],
+) {
+  return (
+    filenamePattern.test(lowerFilename) ||
+    contentTypeFragments.some((fragment) => {
+      return lowerContentType.includes(fragment);
+    })
+  );
+}
+
+function isSpreadsheetPreviewFile(
+  lowerFilename: string,
+  lowerContentType: string,
+) {
+  return matchesFilePreviewType(
+    lowerFilename,
+    lowerContentType,
+    SPREADSHEET_FILE_RE,
+    ["spreadsheet", "excel", "csv", "parquet"],
+  );
+}
+
+function isDatabasePreviewFile(
+  lowerFilename: string,
+  lowerContentType: string,
+) {
+  return matchesFilePreviewType(
+    lowerFilename,
+    lowerContentType,
+    DATABASE_FILE_RE,
+    ["sqlite"],
+  );
+}
+
+function isPresentationPreviewFile(
+  lowerFilename: string,
+  lowerContentType: string,
+) {
+  return matchesFilePreviewType(
+    lowerFilename,
+    lowerContentType,
+    PRESENTATION_FILE_RE,
+    ["presentation", "powerpoint", "keynote"],
+  );
+}
+
+function isArchivePreviewFile(lowerFilename: string, lowerContentType: string) {
+  return matchesFilePreviewType(
+    lowerFilename,
+    lowerContentType,
+    ARCHIVE_FILE_RE,
+    ["zip", "compressed", "gzip"],
+  );
+}
+
+export function getFilePreviewAccentClass(
+  filename: string,
+  contentType?: string,
+) {
+  const lower = filename.toLowerCase();
+  const type = normalizeContentType(contentType);
+
+  if (
+    isSpreadsheetPreviewFile(lower, type) ||
+    isDatabasePreviewFile(lower, type)
+  ) {
+    return "from-teal-500/15 via-emerald-500/10 to-background";
+  }
+
+  if (isPresentationPreviewFile(lower, type)) {
+    return "from-blue-500/15 via-cyan-500/10 to-background";
+  }
+
+  if (isArchivePreviewFile(lower, type)) {
+    return "from-amber-500/15 via-orange-500/10 to-background";
+  }
+
+  return "from-slate-500/15 via-cyan-500/10 to-background";
+}
+
+function filePreviewExtension(filename: string): string {
+  const ext = filename.split(".").pop()?.toUpperCase();
+  return ext && ext !== filename.toUpperCase() ? ext : "";
+}
+
+function spreadsheetFilePreviewLabel(ext: string) {
+  return ext ? ext.slice(0, 4) : "XLS";
+}
+
+function presentationFilePreviewLabel(ext: string) {
+  return ext ? ext.slice(0, 4) : "PPT";
+}
+
+function archiveFilePreviewLabel(ext: string) {
+  return ext ? ext.slice(0, 4) : "ZIP";
+}
+
+function documentFilePreviewLabel(ext: string) {
+  return ext ? ext.slice(0, 4) : "DOC";
+}
+
+function getTextDocumentPreviewIconMeta(
+  lower: string,
+  type: string,
+  ext: string,
+): FilePreviewIconMeta | null {
+  if (PDF_FILE_RE.test(lower) || type === "application/pdf") {
+    return { label: "PDF", bandClassName: "bg-[#D73527]" };
+  }
+
+  if (HTML_FILE_RE.test(lower) || type === "text/html") {
+    return { label: "HTML", bandClassName: "bg-[#D84E1F]" };
+  }
+
+  if (JSON_FILE_RE.test(lower) || type === "application/json") {
+    return { label: "JSON", bandClassName: "bg-[#8A6D00]" };
+  }
+
+  if (MARKDOWN_FILE_RE.test(lower) || type.includes("markdown")) {
+    return { label: "MD", bandClassName: "bg-[#395BFF]" };
+  }
+
+  if (
+    TEXT_FILE_RE.test(lower) ||
+    type.startsWith("text/") ||
+    type.includes("xml") ||
+    type.includes("yaml")
+  ) {
+    return { label: ext || "TXT", bandClassName: "bg-[#64748B]" };
+  }
+
+  if (AUDIO_FILE_RE.test(lower) || type.startsWith("audio/")) {
+    return { label: ext || "AUD", bandClassName: "bg-[#7C3AED]" };
+  }
+
+  if (VIDEO_FILE_RE.test(lower) || type.startsWith("video/")) {
+    return { label: ext || "VID", bandClassName: "bg-[#E11D48]" };
+  }
+
+  return null;
+}
+
+function getStructuredFilePreviewIconMeta(
+  lower: string,
+  type: string,
+  ext: string,
+): FilePreviewIconMeta | null {
+  if (
+    SPREADSHEET_EXTENSION_RE.test(ext) ||
+    isSpreadsheetPreviewFile(lower, type)
+  ) {
+    return {
+      label: spreadsheetFilePreviewLabel(ext),
+      bandClassName: "bg-[#E47412]",
+    };
+  }
+
+  if (DATABASE_EXTENSION_RE.test(ext) || isDatabasePreviewFile(lower, type)) {
+    return { label: "DB", bandClassName: "bg-[#0F766E]" };
+  }
+
+  if (
+    PRESENTATION_EXTENSION_RE.test(ext) ||
+    isPresentationPreviewFile(lower, type)
+  ) {
+    return {
+      label: presentationFilePreviewLabel(ext),
+      bandClassName: "bg-[#2563EB]",
+    };
+  }
+
+  if (ARCHIVE_EXTENSION_RE.test(ext) || isArchivePreviewFile(lower, type)) {
+    return {
+      label: archiveFilePreviewLabel(ext),
+      bandClassName: "bg-[#D97706]",
+    };
+  }
+
+  if (
+    ARTWORK_EXTENSION_RE.test(ext) ||
+    matchesFilePreviewType(lower, type, ARTWORK_FILE_RE, ["illustrator"])
+  ) {
+    return { label: ext || "ART", bandClassName: "bg-[#D84E1F]" };
+  }
+
+  if (DOCUMENT_EXTENSION_RE.test(ext) || DOCUMENT_FILE_RE.test(lower)) {
+    return {
+      label: documentFilePreviewLabel(ext),
+      bandClassName: "bg-[#395BFF]",
+    };
+  }
+
+  return null;
+}
+
+function getFilePreviewIconMeta(
+  filename: string,
+  contentType?: string,
+): FilePreviewIconMeta {
+  const lower = filename.toLowerCase();
+  const type = normalizeContentType(contentType);
+  const ext = filePreviewExtension(filename);
+  const knownMeta =
+    getTextDocumentPreviewIconMeta(lower, type, ext) ??
+    getStructuredFilePreviewIconMeta(lower, type, ext);
+
+  if (knownMeta) {
+    return knownMeta;
+  }
+
+  return {
+    label: ext ? ext.slice(0, 4) : "FILE",
+    bandClassName: "bg-[#64748B]",
+  };
+}
+
+export function FilePreviewIcon({
+  filename,
+  contentType,
+  className,
+  size = "md",
+  testId,
+}: {
+  filename: string;
+  contentType?: string;
+  className?: string;
+  size?: FilePreviewIconSize;
+  testId?: string;
+}) {
+  const { label, bandClassName } = getFilePreviewIconMeta(
+    filename,
+    contentType,
+  );
+  const sizeClass = filePreviewIconSizeClass(size);
+
+  return (
+    <span
+      aria-hidden="true"
+      data-testid={testId}
+      className={`relative flex overflow-hidden border border-[#E1DBD5] bg-white shadow-sm ${sizeClass.root}${
+        className ? ` ${className}` : ""
+      }`}
+    >
+      <span
+        className={`absolute inset-x-0 top-0 bg-[#F0EBE5] ${sizeClass.top}`}
+      />
+      <span
+        className={`absolute inset-x-0 bottom-0 flex items-center justify-center font-bold text-white ${sizeClass.band} ${bandClassName}`}
+      >
+        {label}
+      </span>
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- align chat-thread attachment classification with web upload file types
- add generic file preview cards for non-inline uploaded files
- reuse the shared preview classification in artifact previews, including XML/YAML/TSV text previews and HTML artifact iframe previews

## Verification
- pnpm exec prettier --write apps/platform/src/signals/chat-page/parse-body-blocks.ts apps/platform/src/views/zero-page/zero-attachment-chips.tsx apps/platform/src/views/zero-page/zero-attachment-preview.tsx apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/zero-attachment-preview.test.tsx apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
- pnpm -F @vm0/app exec oxlint src/signals/chat-page/parse-body-blocks.ts src/views/zero-page/zero-attachment-chips.tsx src/views/zero-page/zero-attachment-preview.tsx src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/__tests__/zero-attachment-preview.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
- pnpm -F @vm0/app exec eslint src/signals/chat-page/parse-body-blocks.ts src/views/zero-page/zero-attachment-chips.tsx src/views/zero-page/zero-attachment-preview.tsx src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/__tests__/zero-attachment-preview.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx --max-warnings 0
- pnpm -F @vm0/app exec tsc --noEmit --pretty false 2>&1 | rg "(parse-body-blocks|zero-attachment-chips|zero-attachment-preview|zero-chat-thread-page|zero-attachment-preview\.test|zero-chat-thread-page-display\.test)" || true

## Notes
- Targeted Vitest commands timed out locally with no test output in this runner.
- Full pre-commit check-types is currently blocked by existing unrelated api test typing errors like `Property 'body' does not exist on type 'never'`.