### PR TITLE
feat(platform): add prefer_personal_provider checkbox to agent and schedule settings

### DIFF
--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -125,3 +125,7 @@ export const idbMessageEnabled$ = computed((get) => {
 export const pwaOfflineCacheEnabled$ = computed((get) => {
   return get(featureSwitch$)[FeatureSwitchKey.PwaOfflineCache] ?? false;
 });
+
+export const personalModelProviderEnabled$ = computed((get) => {
+  return get(featureSwitch$)[FeatureSwitchKey.PersonalModelProvider] ?? false;
+});

--- a/turbo/apps/platform/src/signals/schedule-page/schedule-form.ts
+++ b/turbo/apps/platform/src/signals/schedule-page/schedule-form.ts
@@ -20,6 +20,7 @@ export interface ScheduleFormData {
   prompt: string;
   modelProviderId: string | null;
   selectedModel: string | null;
+  preferPersonalProvider: boolean;
 }
 
 export function createDefaultFormData(): ScheduleFormData {
@@ -37,6 +38,7 @@ export function createDefaultFormData(): ScheduleFormData {
     prompt: "",
     modelProviderId: null,
     selectedModel: null,
+    preferPersonalProvider: false,
   };
 }
 

--- a/turbo/apps/platform/src/signals/schedule-page/schedule-save-flow.ts
+++ b/turbo/apps/platform/src/signals/schedule-page/schedule-save-flow.ts
@@ -39,6 +39,7 @@ export const createOrgScheduleFromForm$ = command(
         agentId: values.agentId,
         modelProviderId: values.modelProviderId,
         selectedModel: values.selectedModel,
+        preferPersonalProvider: values.preferPersonalProvider,
         ...(values.freq === "every_week"
           ? { dayOfWeek: values.dayOfWeek }
           : {}),

--- a/turbo/apps/platform/src/signals/zero-page/agent-types.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-types.ts
@@ -10,6 +10,7 @@ export interface AgentDetail {
   permissionPolicies: FirewallPolicies | null;
   modelProviderId: string | null;
   selectedModel: string | null;
+  preferPersonalProvider: boolean;
 }
 
 export interface AgentInstructions {

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/settings.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/settings.ts
@@ -16,6 +16,7 @@ interface AgentSettingsUpdate {
   avatarUrl?: string | null;
   modelProviderId?: string | null;
   selectedModel?: string | null;
+  preferPersonalProvider?: boolean;
 }
 
 export const updateAgentSettings$ = command(

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-tab.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-tab.ts
@@ -50,6 +50,16 @@ export const setSettingsModelSelection$ = command(
   },
 );
 
+const internalPreferPersonalProvider$ = state(false);
+export const settingsPreferPersonalProvider$ = computed((get) => {
+  return get(internalPreferPersonalProvider$);
+});
+export const setSettingsPreferPersonalProvider$ = command(
+  ({ set }, value: boolean) => {
+    set(internalPreferPersonalProvider$, value);
+  },
+);
+
 // ---------------------------------------------------------------------------
 // Saved settings state (for dirty detection)
 // ---------------------------------------------------------------------------
@@ -60,6 +70,7 @@ interface SavedSettings {
   tone: Tone;
   avatarUrl: string | null;
   modelSelection: ModelProviderSelection | null;
+  preferPersonalProvider: boolean;
 }
 
 const internalSavedSettings$ = state<SavedSettings>({
@@ -68,6 +79,7 @@ const internalSavedSettings$ = state<SavedSettings>({
   tone: "professional",
   avatarUrl: null,
   modelSelection: null,
+  preferPersonalProvider: false,
 });
 
 export const settingsDirty$ = computed((get) => {
@@ -82,7 +94,8 @@ export const settingsDirty$ = computed((get) => {
     get(internalDesc$) !== saved.description ||
     get(internalTone$) !== saved.tone ||
     get(internalAvatarUrl$) !== saved.avatarUrl ||
-    modelChanged
+    modelChanged ||
+    get(internalPreferPersonalProvider$) !== saved.preferPersonalProvider
   );
 });
 
@@ -96,6 +109,7 @@ interface FormSource {
   tone: Tone;
   avatarUrl: string | null;
   modelSelection: ModelProviderSelection | null;
+  preferPersonalProvider: boolean;
 }
 
 const internalFormSource$ = state<FormSource | null>(null);
@@ -114,7 +128,9 @@ export const initSettingsForm$ = command(({ get, set }, opts: FormSource) => {
     current.avatarUrl === opts.avatarUrl &&
     current.modelSelection?.modelProviderId ===
       opts.modelSelection?.modelProviderId &&
-    current.modelSelection?.selectedModel === opts.modelSelection?.selectedModel
+    current.modelSelection?.selectedModel ===
+      opts.modelSelection?.selectedModel &&
+    current.preferPersonalProvider === opts.preferPersonalProvider
   ) {
     return;
   }
@@ -124,12 +140,14 @@ export const initSettingsForm$ = command(({ get, set }, opts: FormSource) => {
   set(internalTone$, opts.tone);
   set(internalAvatarUrl$, opts.avatarUrl);
   set(internalModelSelection$, opts.modelSelection);
+  set(internalPreferPersonalProvider$, opts.preferPersonalProvider);
   set(internalSavedSettings$, {
     name: opts.name,
     description: opts.description,
     tone: opts.tone,
     avatarUrl: opts.avatarUrl,
     modelSelection: opts.modelSelection,
+    preferPersonalProvider: opts.preferPersonalProvider,
   });
 });
 
@@ -144,6 +162,7 @@ export const resetSettingsForm$ = command(({ get, set }) => {
   set(internalTone$, saved.tone);
   set(internalAvatarUrl$, saved.avatarUrl);
   set(internalModelSelection$, saved.modelSelection);
+  set(internalPreferPersonalProvider$, saved.preferPersonalProvider);
 });
 
 // ---------------------------------------------------------------------------
@@ -157,6 +176,7 @@ export const markSettingsSaved$ = command(({ get, set }) => {
     tone: get(internalTone$),
     avatarUrl: get(internalAvatarUrl$),
     modelSelection: get(internalModelSelection$),
+    preferPersonalProvider: get(internalPreferPersonalProvider$),
   });
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -205,6 +205,9 @@ function buildScheduleBody(
     ...(params.selectedModel !== undefined && {
       selectedModel: params.selectedModel,
     }),
+    ...(params.preferPersonalProvider !== undefined && {
+      preferPersonalProvider: params.preferPersonalProvider,
+    }),
   };
 
   if (params.freq === "every_n_minutes") {
@@ -262,6 +265,7 @@ export interface ZeroScheduleSaveParams {
   editName?: string;
   modelProviderId?: string | null;
   selectedModel?: string | null;
+  preferPersonalProvider?: boolean;
 }
 
 export const saveZeroSchedule$ = command(
@@ -370,6 +374,7 @@ export interface OrgScheduleEntry {
   lastRunAt: string | null;
   modelProviderId: string | null;
   selectedModel: string | null;
+  preferPersonalProvider: boolean;
 }
 
 const internalAllSchedules$ = state<ScheduleResponse[]>([]);
@@ -402,6 +407,7 @@ export const allOrgScheduleEntries$ = computed((get) => {
         lastRunAt: s.lastRunAt,
         modelProviderId: s.modelProviderId,
         selectedModel: s.selectedModel,
+        preferPersonalProvider: s.preferPersonalProvider,
       };
     });
 });

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -827,6 +827,7 @@ function AgentTabContent({
   ownerId,
   modelProviderId,
   selectedModel,
+  preferPersonalProvider,
 }: {
   activeTab: string;
   agentId: string;
@@ -838,6 +839,7 @@ function AgentTabContent({
   ownerId: string;
   modelProviderId: string | null;
   selectedModel: string | null;
+  preferPersonalProvider: boolean;
 }) {
   const deleteAgent = useSet(deleteAgent$);
   const nav = useSet(detachedNavigateTo$);
@@ -864,13 +866,14 @@ function AgentTabContent({
     case "profile": {
       return (
         <ZeroSettingsTab
-          key={`${displayName}\0${description}\0${resolvedSound}\0${avatarUrl}\0${modelProviderId ?? ""}\0${selectedModel ?? ""}`}
+          key={`${displayName}\0${description}\0${resolvedSound}\0${avatarUrl}\0${modelProviderId ?? ""}\0${selectedModel ?? ""}\0${preferPersonalProvider ? "1" : "0"}`}
           displayName={displayName}
           description={description}
           sound={resolvedSound}
           avatarUrl={avatarUrl}
           modelProviderId={modelProviderId}
           selectedModel={selectedModel}
+          preferPersonalProvider={preferPersonalProvider}
           updateSettings$={updateAgentSettings$}
           inputId="job-agent-name"
           isDefaultAgent={isDefaultAgent}
@@ -892,17 +895,31 @@ function useAgentFields() {
   const detail = useLastResolved(agentDetail$);
   // Both signals fetch from zeroAgentsByIdContract; pick whichever resolved first
   const source = agent ?? detail;
-  const agentId = source?.agentId ?? "";
+  if (!source) {
+    return {
+      detail: detail ?? null,
+      agentId: "",
+      displayName: "Agent",
+      description: "",
+      avatarUrl: null,
+      resolvedSound: resolveSound("professional"),
+      ownerId: "",
+      modelProviderId: null,
+      selectedModel: null,
+      preferPersonalProvider: false,
+    };
+  }
   return {
     detail: detail ?? null,
-    agentId,
-    displayName: source?.displayName ?? (agentId || "Agent"),
-    description: source?.description ?? "",
-    avatarUrl: source?.avatarUrl ?? null,
-    resolvedSound: resolveSound(source?.sound ?? "professional"),
-    ownerId: source?.ownerId ?? "",
-    modelProviderId: source?.modelProviderId ?? null,
-    selectedModel: source?.selectedModel ?? null,
+    agentId: source.agentId,
+    displayName: source.displayName ?? (source.agentId || "Agent"),
+    description: source.description ?? "",
+    avatarUrl: source.avatarUrl,
+    resolvedSound: resolveSound(source.sound ?? "professional"),
+    ownerId: source.ownerId,
+    modelProviderId: source.modelProviderId,
+    selectedModel: source.selectedModel,
+    preferPersonalProvider: source.preferPersonalProvider,
   };
 }
 
@@ -975,6 +992,7 @@ export function ZeroJobDetailPage() {
           ownerId={fields.ownerId}
           modelProviderId={fields.modelProviderId}
           selectedModel={fields.selectedModel}
+          preferPersonalProvider={fields.preferPersonalProvider}
         />
       </main>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/__tests__/build-combined-schedule.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/build-combined-schedule.test.ts
@@ -20,6 +20,7 @@ function makeEntry(
     lastRunAt: null,
     modelProviderId: null,
     selectedModel: null,
+    preferPersonalProvider: false,
     ...overrides,
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/schedule-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/schedule-dialog.test.tsx
@@ -25,6 +25,7 @@ import {
   setMockSchedules,
   createMockScheduleResponse,
 } from "../../../mocks/handlers/api-schedules.ts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -63,9 +64,19 @@ function mockCreateModeAPIs() {
   setMockSchedules([mockScheduleForList()]);
 }
 
-async function openCreateDialog() {
+async function openCreateDialog(
+  options: {
+    featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>;
+  } = {},
+) {
   mockCreateModeAPIs();
-  detachedSetupPage({ context, path: "/schedules" });
+  detachedSetupPage({
+    context,
+    path: "/schedules",
+    ...(options.featureSwitches && {
+      featureSwitches: options.featureSwitches,
+    }),
+  });
   await waitFor(() => {
     expect(screen.getByText(/Add schedule/i)).not.toBeDisabled();
   });
@@ -518,5 +529,47 @@ describe("schedule dialog - ESC with unsaved changes (SCHED-D-067)", () => {
       ).not.toBeInTheDocument();
     });
     expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("schedule dialog — personal provider checkbox", () => {
+  it("hides the checkbox when feature switch is off", async () => {
+    await openCreateDialog();
+    expect(
+      screen.queryByLabelText(/use personal provider/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the checkbox when feature switch is on", async () => {
+    await openCreateDialog({
+      featureSwitches: { [FeatureSwitchKey.PersonalModelProvider]: true },
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/use personal provider/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("includes preferPersonalProvider in the deploy body when checked", async () => {
+    let capturedBody: Record<string, unknown> | undefined;
+    server.use(
+      mockApi(zeroSchedulesMainContract.deploy, ({ body, respond }) => {
+        capturedBody = body as Record<string, unknown>;
+        return respond(201, mockDeployResponse());
+      }),
+    );
+
+    await openCreateDialog({
+      featureSwitches: { [FeatureSwitchKey.PersonalModelProvider]: true },
+    });
+
+    await fill(screen.getByLabelText("Prompt"), "Daily standup summary");
+    click(await screen.findByLabelText(/use personal provider/i));
+    click(screen.getByText(/^Create$/i));
+
+    await waitFor(() => {
+      expect(capturedBody?.preferPersonalProvider).toBeTruthy();
+    });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page.test.tsx
@@ -1,13 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { detachedSetupPage, click } from "../../../__tests__/page-helper.ts";
 import {
   setMockSchedules,
   createMockScheduleResponse,
 } from "../../../mocks/handlers/api-schedules.ts";
+import { server } from "../../../mocks/server.ts";
+import { createMockApi } from "../../../mocks/msw-contract.ts";
+import { zeroSchedulesMainContract } from "@vm0/api-contracts/contracts/zero-schedules";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const context = testContext();
+const mockApi = createMockApi(context);
 
 const SCHEDULE_ID = "f0000001-0000-4000-a000-000000000001";
 
@@ -48,6 +53,73 @@ describe("zero schedule detail page", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Schedule not found")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero schedule detail page — personal provider checkbox", () => {
+  it("hides the checkbox when feature switch is off", async () => {
+    mockAPIs();
+    detachedSetupPage({ context, path: `/schedules/${SCHEDULE_ID}` });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Daily morning briefing")[0],
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByLabelText(/use personal provider/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the checkbox when feature switch is on", async () => {
+    mockAPIs();
+    detachedSetupPage({
+      context,
+      path: `/schedules/${SCHEDULE_ID}`,
+      featureSwitches: { [FeatureSwitchKey.PersonalModelProvider]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/use personal provider/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("includes preferPersonalProvider in the deploy body when toggled and saved", async () => {
+    mockAPIs();
+    let capturedBody: Record<string, unknown> | undefined;
+    server.use(
+      mockApi(zeroSchedulesMainContract.deploy, ({ body, respond }) => {
+        capturedBody = body as Record<string, unknown>;
+        return respond(200, {
+          schedule: createMockScheduleResponse({
+            preferPersonalProvider: true,
+          }),
+          created: false,
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/schedules/${SCHEDULE_ID}`,
+      featureSwitches: { [FeatureSwitchKey.PersonalModelProvider]: true },
+    });
+
+    const checkbox = await screen.findByLabelText(/use personal provider/i);
+    click(checkbox);
+
+    await waitFor(() => {
+      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+    });
+
+    click(screen.getByText(/^Save$/i));
+
+    await waitFor(() => {
+      expect(capturedBody?.preferPersonalProvider).toBeTruthy();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
@@ -19,6 +19,7 @@ import {
   zeroAgentInstructionsContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
 import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -81,8 +82,18 @@ function mockAPIs(detailOverrides: Record<string, unknown> = {}) {
   );
 }
 
-async function openProfileTab() {
-  detachedSetupPage({ context, path: "/agents/my-agent" });
+async function openProfileTab(
+  options: {
+    featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>;
+  } = {},
+) {
+  detachedSetupPage({
+    context,
+    path: "/agents/my-agent",
+    ...(options.featureSwitches && {
+      featureSwitches: options.featureSwitches,
+    }),
+  });
   await waitFor(() => {
     expect(
       screen.getByRole("heading", { name: "My Agent" }),
@@ -416,6 +427,57 @@ describe("zero settings tab - interaction", () => {
 
     await waitFor(() => {
       expect(pathname()).toBe("/agents");
+    });
+  });
+});
+
+describe("zero settings tab — personal provider checkbox", () => {
+  it("hides the checkbox when feature switch is off", async () => {
+    mockAPIs();
+    await openProfileTab();
+
+    expect(
+      screen.queryByLabelText(/use personal provider/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the checkbox when feature switch is on", async () => {
+    mockAPIs();
+    await openProfileTab({
+      featureSwitches: { [FeatureSwitchKey.PersonalModelProvider]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/use personal provider/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("persists the toggle on save (PATCH includes preferPersonalProvider: true)", async () => {
+    mockAPIs();
+    let captured: ZeroAgentMetadataRequest | undefined;
+    server.use(
+      mockApi(zeroAgentsByIdContract.updateMetadata, ({ body, respond }) => {
+        captured = body as ZeroAgentMetadataRequest;
+        return respond(200, agentDetail({ preferPersonalProvider: true }));
+      }),
+    );
+    await openProfileTab({
+      featureSwitches: { [FeatureSwitchKey.PersonalModelProvider]: true },
+    });
+
+    const checkbox = await screen.findByLabelText(/use personal provider/i);
+    click(checkbox);
+
+    await waitFor(() => {
+      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+    });
+
+    click(screen.getByText(/^Save$/i));
+
+    await waitFor(() => {
+      expect(captured?.preferPersonalProvider).toBeTruthy();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import { IconX } from "@tabler/icons-react";
 import {
   Button,
+  Checkbox,
   Input,
   Select,
   SelectContent,
@@ -34,6 +35,7 @@ import {
   dialogAgentModelDefault$,
 } from "../../signals/schedule-page/schedule-form.ts";
 import { orgModelProviders$ } from "../../signals/external/org-model-providers.ts";
+import { personalModelProviderEnabled$ } from "../../signals/external/feature-switch.ts";
 import {
   ModelProviderPicker,
   type ModelProviderSelection,
@@ -124,6 +126,7 @@ export interface ScheduleFormValues {
   dayOfMonth: string;
   modelProviderId: string | null;
   selectedModel: string | null;
+  preferPersonalProvider: boolean;
 }
 
 interface ScheduleFormDialogProps {
@@ -502,6 +505,7 @@ function buildDefaults(
     dayOfMonth: "1",
     modelProviderId: null,
     selectedModel: null,
+    preferPersonalProvider: false,
   };
   return { ...defaults, ...initialValues };
 }
@@ -528,6 +532,7 @@ function checkDirty(
     current.dayOfMonth !== init.dayOfMonth ||
     current.modelProviderId !== init.modelProviderId ||
     current.selectedModel !== init.selectedModel ||
+    current.preferPersonalProvider !== init.preferPersonalProvider ||
     (opts.hasAgents && current.agentId !== init.agentId)
   );
 }
@@ -565,6 +570,8 @@ function ScheduleFormDialogInner({
 
   const agentModelDefault = useLastResolved(dialogAgentModelDefault$) ?? null;
 
+  const personalProviderEnabled = useGet(personalModelProviderEnabled$);
+
   const current: ScheduleFormValues = {
     prompt: form.prompt,
     description: form.description,
@@ -579,6 +586,7 @@ function ScheduleFormDialogInner({
     dayOfMonth: form.dayOfMonth,
     modelProviderId: form.modelProviderId,
     selectedModel: form.selectedModel,
+    preferPersonalProvider: form.preferPersonalProvider,
   };
 
   const isDirty = checkDirty(current, init, mode, {
@@ -775,6 +783,27 @@ function ScheduleFormDialogInner({
                 agentDefault={agentModelDefault}
                 inheritLabel="agent"
               />
+            </div>
+          )}
+
+          {personalProviderEnabled && (
+            <div className="flex items-start gap-2">
+              <Checkbox
+                id="schedule-prefer-personal"
+                checked={form.preferPersonalProvider}
+                onCheckedChange={(v) => {
+                  updateForm({ preferPersonalProvider: v === true });
+                }}
+                aria-label="Use personal provider"
+                className="mt-0.5"
+              />
+              <label
+                htmlFor="schedule-prefer-personal"
+                className="text-sm text-muted-foreground leading-snug"
+              >
+                Use the caller&apos;s personal provider when available, fall
+                back to the selected one above.
+              </label>
             </div>
           )}
         </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -318,6 +318,7 @@ export function ZeroScheduleCard({
           dayOfMonth: "1",
           modelProviderId: null,
           selectedModel: null,
+          preferPersonalProvider: false,
         },
         signal,
       ),

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
@@ -22,6 +22,7 @@ import {
   Button,
   Card,
   CardContent,
+  Checkbox,
   cn,
   Dialog,
   DialogContent,
@@ -102,6 +103,7 @@ import {
   type ScheduleSettingsSnapshot,
 } from "../../signals/schedule-page/schedule-form.ts";
 import { orgModelProviders$ } from "../../signals/external/org-model-providers.ts";
+import { personalModelProviderEnabled$ } from "../../signals/external/feature-switch.ts";
 import {
   ModelProviderPicker,
   type ModelProviderSelection,
@@ -267,6 +269,7 @@ function buildSettingsSnapshot(
     dayOfMonth: parsed.dayOfMonth ?? "1",
     modelProviderId: entry.modelProviderId,
     selectedModel: entry.selectedModel,
+    preferPersonalProvider: entry.preferPersonalProvider,
   };
 }
 
@@ -284,7 +287,8 @@ function isSettingsChanged(
     a.agentId !== b.agentId ||
     a.description !== b.description ||
     a.modelProviderId !== b.modelProviderId ||
-    a.selectedModel !== b.selectedModel
+    a.selectedModel !== b.selectedModel ||
+    a.preferPersonalProvider !== b.preferPersonalProvider
   );
 }
 
@@ -321,6 +325,8 @@ function ScheduleSettingsForm({
 
   const agentModelDefault = useLastResolved(scheduleAgentModelDefault$) ?? null;
 
+  const personalProviderEnabled = useGet(personalModelProviderEnabled$);
+
   // Reset form when entry changes (component is keyed by entry.id)
   useSet(syncSettingsFormEntry$)(entry.id, entry.prompt, initial);
 
@@ -337,6 +343,7 @@ function ScheduleSettingsForm({
     dayOfMonth: form.dayOfMonth,
     modelProviderId: form.modelProviderId,
     selectedModel: form.selectedModel,
+    preferPersonalProvider: form.preferPersonalProvider,
   };
   const isDirty = savedState ? isSettingsChanged(current, savedState) : false;
 
@@ -355,6 +362,7 @@ function ScheduleSettingsForm({
       description: savedState.description,
       modelProviderId: savedState.modelProviderId,
       selectedModel: savedState.selectedModel,
+      preferPersonalProvider: savedState.preferPersonalProvider,
     });
   };
 
@@ -375,6 +383,7 @@ function ScheduleSettingsForm({
       agentId: form.agentId,
       modelProviderId: form.modelProviderId,
       selectedModel: form.selectedModel,
+      preferPersonalProvider: form.preferPersonalProvider,
       ...(form.freq === "every_week" ? { dayOfWeek: form.dayOfWeek } : {}),
       ...(form.freq === "every_month" ? { dayOfMonth: form.dayOfMonth } : {}),
     });
@@ -507,6 +516,21 @@ function ScheduleSettingsForm({
                   inheritLabel="agent"
                 />
               </div>
+            </InlineSettingsRow>
+          )}
+          {personalProviderEnabled && (
+            <InlineSettingsRow
+              label="Personal provider"
+              description="Use the caller's personal provider when available, fall back to the selected one above."
+              alignControls="center"
+            >
+              <Checkbox
+                checked={form.preferPersonalProvider}
+                onCheckedChange={(v) => {
+                  updateForm({ preferPersonalProvider: v === true });
+                }}
+                aria-label="Use personal provider"
+              />
             </InlineSettingsRow>
           )}
         </CardContent>

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -78,6 +78,7 @@ export type CombinedEntry = ScheduleEntry & {
   lastRunAt: string | null;
   modelProviderId: string | null;
   selectedModel: string | null;
+  preferPersonalProvider: boolean;
 };
 
 export function buildCombinedSchedule(
@@ -99,6 +100,7 @@ export function buildCombinedSchedule(
       lastRunAt: e.lastRunAt,
       modelProviderId: e.modelProviderId,
       selectedModel: e.selectedModel,
+      preferPersonalProvider: e.preferPersonalProvider,
     };
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Card,
   CardContent,
+  Checkbox,
   Dialog,
   DialogClose,
   DialogContent,
@@ -51,8 +52,11 @@ import {
   deleteAgent$,
   settingsModelSelection$,
   setSettingsModelSelection$,
+  settingsPreferPersonalProvider$,
+  setSettingsPreferPersonalProvider$,
 } from "../../signals/zero-page/settings/settings-tab.ts";
 import { orgModelProviders$ } from "../../signals/external/org-model-providers.ts";
+import { personalModelProviderEnabled$ } from "../../signals/external/feature-switch.ts";
 import {
   ModelProviderPicker,
   type ModelProviderSelection,
@@ -65,6 +69,7 @@ interface ZeroSettingsTabProps {
   avatarUrl: string | null;
   modelProviderId?: string | null;
   selectedModel?: string | null;
+  preferPersonalProvider?: boolean;
   updateSettings$: Command<
     Promise<void>,
     [
@@ -75,6 +80,7 @@ interface ZeroSettingsTabProps {
         avatarUrl?: string | null;
         modelProviderId?: string | null;
         selectedModel?: string | null;
+        preferPersonalProvider?: boolean;
       },
       AbortSignal,
     ]
@@ -93,6 +99,7 @@ export function ZeroSettingsTab({
   avatarUrl: initialAvatarUrl,
   modelProviderId: initialModelProviderId,
   selectedModel: initialSelectedModel,
+  preferPersonalProvider: initialPreferPersonalProvider = false,
   updateSettings$,
   inputId = "zero-agent-name",
   isDefaultAgent = false,
@@ -112,6 +119,7 @@ export function ZeroSettingsTab({
     tone: initialSound,
     avatarUrl: initialAvatarUrl,
     modelSelection: initialModelSelection,
+    preferPersonalProvider: initialPreferPersonalProvider,
   });
 
   const agentName = useGet(settingsAgentName$);
@@ -124,6 +132,9 @@ export function ZeroSettingsTab({
   const setAvatarUrl = useSet(setSettingsAvatarUrl$);
   const modelSelection = useGet(settingsModelSelection$);
   const setModelSelection = useSet(setSettingsModelSelection$);
+  const preferPersonalProvider = useGet(settingsPreferPersonalProvider$);
+  const setPreferPersonalProvider = useSet(setSettingsPreferPersonalProvider$);
+  const personalProviderEnabled = useGet(personalModelProviderEnabled$);
   const isSettingsDirty = useGet(settingsDirty$);
   const resetForm = useSet(resetSettingsForm$);
   const markSaved = useSet(markSettingsSaved$);
@@ -154,6 +165,7 @@ export function ZeroSettingsTab({
             avatarUrl,
             modelProviderId: modelSelection?.modelProviderId ?? null,
             selectedModel: modelSelection?.selectedModel ?? null,
+            preferPersonalProvider,
           },
           pageSignal,
         );
@@ -210,6 +222,7 @@ export function ZeroSettingsTab({
                           modelProviderId:
                             modelSelection?.modelProviderId ?? null,
                           selectedModel: modelSelection?.selectedModel ?? null,
+                          preferPersonalProvider,
                         },
                         pageSignal,
                       ).then(() => {
@@ -328,6 +341,21 @@ export function ZeroSettingsTab({
                   providers={orgProviders.modelProviders}
                   value={modelSelection}
                   onChange={setModelSelection}
+                />
+              </InlineSettingsRow>
+            )}
+            {personalProviderEnabled && (
+              <InlineSettingsRow
+                label="Personal provider"
+                description="Use the caller's personal provider when available, fall back to the selected one above."
+                alignControls="center"
+              >
+                <Checkbox
+                  checked={preferPersonalProvider}
+                  onCheckedChange={(v) => {
+                    setPreferPersonalProvider(v === true);
+                  }}
+                  aria-label="Use personal provider"
                 />
               </InlineSettingsRow>
             )}


### PR DESCRIPTION
## Summary

Wave 3 sub-issue of epic #11868. Surfaces the `prefer_personal_provider` boolean (added in #11873, plumbed in #11886, honored by the resolver in #11899, used by eager-pin in #11918) as a checkbox UI on three surfaces, gated on the `personalModelProvider` feature switch (off by default, staff-rollout via `STAFF_ORG_ID_HASHES`).

- Agent settings tab (`zero-settings-tab.tsx`)
- Schedule create/edit dialog (`schedule-dialog.tsx`)
- Schedule detail page (`zero-schedule-detail-page.tsx`)

When the switch is off, all three checkboxes are absent. When on, toggling them writes through the existing PATCH / schedule deploy endpoints — no new backend code in this PR.

Closes #11926

## Refactor note

Adding `source?.preferPersonalProvider ?? false` to `useAgentFields` in `zero-job-detail-page.tsx` pushed cyclomatic complexity from 20 to 22 (each `?.` + `??` chain adds 2). Refactored to short-circuit on null `source` with a literal-default object, mirroring the `agentResponseBody` cleanup from PR #11903. Same observable behavior, lower complexity.

## UI deviation from issue body

Issue body's example used `label=""` for the new `InlineSettingsRow`. Reading `InlineSettingsRow` (`zero-inline-settings-row.tsx:24`) shows it always renders the label `<p>`, so an empty string produces a blank left-column paragraph. Used `label="Personal provider"` instead — the description text carries the verbatim explanation copy. Reviewers can object if they prefer the empty-label spec; it's a one-line change.

## Test plan

- [x] `pnpm format` — clean
- [x] `pnpm turbo run lint` — pass (after one cycle: refactored complexity, switched 3 `toBe(true)` to `toBeTruthy()` per oxlint)
- [x] `pnpm check-types` — pass (11/11 packages)
- [x] `pnpm -F @vm0/app exec vitest run` — full platform suite passes (2263/2263, 9 new tests)
- [x] `pnpm knip` — no new findings (only pre-existing config hints)

## Test cases (3 per surface)

| Surface | Default-hidden | Gated-visible | Save round-trip |
| --- | --- | --- | --- |
| Agent settings tab | feature off → no checkbox | feature on → checkbox visible | toggle → save → PATCH body has `preferPersonalProvider: true` |
| Schedule dialog | feature off → no checkbox | feature on → checkbox visible | toggle → create → deploy body has `preferPersonalProvider: true` |
| Schedule detail page | feature off → no checkbox | feature on → checkbox visible | toggle → save → deploy body has `preferPersonalProvider: true` |

## Out of scope (deferred)

- Personal model provider Preferences tab — separate Wave 3 sibling sub-issue
- Composer chat picker merge — separate Wave 3 sibling sub-issue
- CLI flag — out of scope per epic Decision 8 (web-UI-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)