### PR TITLE
fix: suppress handled schedule validation logs

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/utils.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/utils.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import {
   Reason,
+  clearAllDetached,
   detach,
+  markDetachedErrorHandled,
   resetSignal,
   createDeferredPromise,
   geometryStyle,
@@ -9,6 +11,11 @@ import {
   MAX_LOOP_COUNT_IN_TEST,
 } from "../utils.ts";
 import { createStore } from "ccstate";
+import { resetLoggerForTest, setLogErrorHandler } from "../log.ts";
+
+afterEach(() => {
+  resetLoggerForTest();
+});
 
 describe("utils", () => {
   describe("reason enum", () => {
@@ -31,6 +38,34 @@ describe("utils", () => {
       expect(() => {
         return detach(Promise.resolve("value"), Reason.Entrance);
       }).not.toThrow();
+    });
+
+    it("should log unhandled promise rejections", async () => {
+      const handler = vi.fn();
+      const error = new Error("boom");
+      setLogErrorHandler(handler);
+
+      detach(Promise.reject(error), Reason.DomCallback);
+      await clearAllDetached();
+
+      expect(handler).toHaveBeenCalledWith("Promise", [
+        "Detached promise rejected [dom_callback]",
+        error,
+      ]);
+    });
+
+    it("should not log handled promise rejections", async () => {
+      const handler = vi.fn();
+      const error = new Error("handled");
+      setLogErrorHandler(handler);
+
+      detach(
+        Promise.reject(markDetachedErrorHandled(error)),
+        Reason.DomCallback,
+      );
+      await clearAllDetached();
+
+      expect(handler).not.toHaveBeenCalled();
     });
   });
 

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -17,9 +17,25 @@ class PromiseTracker {
   collected = new Set<Promise<unknown>>();
   reasons = new Map<Promise<unknown>, Reason>();
   descriptions = new Map<Promise<unknown>, string>();
+  handledErrors = new WeakSet<object>();
 }
 
 const tracker = new PromiseTracker();
+
+export function markDetachedErrorHandled(error: unknown): unknown {
+  if ((typeof error === "object" || typeof error === "function") && error) {
+    tracker.handledErrors.add(error);
+  }
+  return error;
+}
+
+function isHandledDetachedError(error: unknown): boolean {
+  return (
+    (typeof error === "object" || typeof error === "function") &&
+    error !== null &&
+    tracker.handledErrors.has(error)
+  );
+}
 
 export function detach<T>(
   promise: T | Promise<T>,
@@ -38,7 +54,7 @@ export function detach<T>(
     silencePromise = Promise.resolve(promise).then(
       () => {},
       (error: unknown) => {
-        if (!isAbortError(error)) {
+        if (!isAbortError(error) && !isHandledDetachedError(error)) {
           L.error(`Detached promise rejected [${reason}]`, error);
         }
       },

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
@@ -18,6 +18,8 @@ import {
   zeroScheduleRunContract,
   type ScheduleResponse,
 } from "@vm0/api-contracts/contracts/zero-schedules";
+import { clearAllDetached, detach, Reason } from "../../utils.ts";
+import { resetLoggerForTest, setLogErrorHandler } from "../../log.ts";
 import {
   fetchZeroSchedules$,
   zeroScheduleEntries$,
@@ -34,6 +36,10 @@ import {
 
 const context = testContext();
 const mockApi = createMockApi(context);
+
+afterEach(() => {
+  resetLoggerForTest();
+});
 
 function mockScheduleResponse(): ScheduleResponse {
   return createMockScheduleResponse({
@@ -897,6 +903,41 @@ describe("org schedule signals", () => {
       expect(errorSpy).toHaveBeenCalledWith(
         "Scheduled time must be in the future",
       );
+    });
+
+    it("should not log detached pre-API validation errors after toast", async () => {
+      const errorSpy = vi.spyOn(toast, "error").mockImplementation(() => {
+        return "" as unknown as ReturnType<typeof toast.error>;
+      });
+      const logHandler = vi.fn();
+
+      await setup();
+      await clearAllDetached();
+      setLogErrorHandler(logHandler);
+
+      detach(
+        context.store.set(
+          saveOrgSchedule$,
+          {
+            prompt: "One-time task in the past",
+            freq: "once",
+            date: "2000-01-01",
+            hour: 9,
+            minute: 0,
+            timezone: "UTC",
+            intervalSeconds: 0,
+            agentId: "e0000000-0000-4000-a000-000000000010",
+          },
+          context.signal,
+        ),
+        Reason.DomCallback,
+      );
+      await clearAllDetached();
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Scheduled time must be in the future",
+      );
+      expect(logHandler).not.toHaveBeenCalled();
     });
   });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -23,8 +23,10 @@ import {
   type CronTimeOption,
 } from "./cron.ts";
 import { accept, ApiError } from "../../lib/accept.ts";
-import { throwIfAbort } from "../utils.ts";
+import { markDetachedErrorHandled, throwIfAbort } from "../utils.ts";
 import { defaultAgentId$ } from "../agent.ts";
+
+const SCHEDULE_TIME_PAST_MESSAGE = "Scheduled time must be in the future";
 
 // ---------------------------------------------------------------------------
 // State
@@ -213,7 +215,7 @@ function buildScheduleBody(
 
   if (params.freq === "once") {
     if (isAtTimePast(params.date, String(params.hour), String(params.minute))) {
-      throw new Error("Scheduled time must be in the future");
+      throw new Error(SCHEDULE_TIME_PAST_MESSAGE);
     }
     const atTime = buildAtTime(
       params.date,
@@ -440,6 +442,9 @@ export const saveOrgSchedule$ = command(
       if (!(error instanceof ApiError)) {
         const message = error instanceof Error ? error.message : "Save failed";
         toast.error(message);
+        if (message === SCHEDULE_TIME_PAST_MESSAGE) {
+          throw markDetachedErrorHandled(error);
+        }
       }
       throw error;
     }


### PR DESCRIPTION
## Summary
- add an explicit handled-detached-error marker for detached promises
- mark the one-time schedule past-time validation error as handled after showing the toast
- cover detached logging behavior and org schedule validation with regression tests

Fixes #10731

## Verification
- pnpm format
- pnpm -F @vm0/app exec vitest src/signals/zero-page/__tests__/zero-schedule.test.ts src/signals/__tests__/utils.test.ts
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app exec vitest
- pnpm check-types
- pnpm turbo run lint
- pnpm vitest
- pnpm knip

Note: the first full `pnpm vitest` run failed because the local dev database schema was stale. I ran `pnpm -F web db:migrate` after resolving a duplicate local index state, then reran `pnpm vitest` successfully.