### PR TITLE
fix(guest-agent): checkpoint recoverable abnormal exits

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -12,19 +12,53 @@ use crate::session_history;
 use crate::urls;
 use bytes::Bytes;
 use guest_common::telemetry::record_sandbox_op;
-use guest_common::{log_error, log_info};
+use guest_common::{log_error, log_info, log_warn};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::io::ErrorKind;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
+#[derive(Clone, Copy)]
+enum CheckpointMode {
+    Success,
+    Recovery,
+}
+
+impl CheckpointMode {
+    fn total_op(self) -> &'static str {
+        match self {
+            Self::Success => "checkpoint_total",
+            Self::Recovery => "recovery_checkpoint_total",
+        }
+    }
+
+    fn log_label(self) -> &'static str {
+        match self {
+            Self::Success => "checkpoint",
+            Self::Recovery => "recovery checkpoint",
+        }
+    }
+
+    fn validate_history(self) -> bool {
+        matches!(self, Self::Recovery)
+    }
+}
+
 /// Log the message, record a failed `sandbox_op`, and build a matching
-/// `Checkpoint` error — all three channels share the same message so
-/// telemetry and logs stay in sync.
-fn fail(op: &str, start: std::time::Instant, msg: impl Into<String>) -> AgentError {
+/// `Checkpoint` error. Success-path checkpoint failures are run-fatal and
+/// logged as errors; recovery checkpoint skips are best-effort and stay warn.
+fn fail(
+    mode: CheckpointMode,
+    op: &str,
+    start: std::time::Instant,
+    msg: impl Into<String>,
+) -> AgentError {
     let msg = msg.into();
-    log_error!(LOG_TAG, "{msg}");
+    match mode {
+        CheckpointMode::Success => log_error!(LOG_TAG, "{msg}"),
+        CheckpointMode::Recovery => log_warn!(LOG_TAG, "{msg}"),
+    }
     record_sandbox_op(op, start.elapsed(), false, Some(&msg));
     AgentError::Checkpoint(msg)
 }
@@ -216,13 +250,31 @@ async fn snapshot_artifacts(http: &HttpClient) -> Result<Option<serde_json::Valu
 /// Create a checkpoint after a successful run.
 pub async fn create_checkpoint(http: &HttpClient) -> Result<(), AgentError> {
     let start = std::time::Instant::now();
-    let result = create_checkpoint_impl(http).await;
-    record_sandbox_op("checkpoint_total", start.elapsed(), result.is_ok(), None);
+    let result = create_checkpoint_impl(http, CheckpointMode::Success).await;
+    record_sandbox_op(
+        CheckpointMode::Success.total_op(),
+        start.elapsed(),
+        result.is_ok(),
+        None,
+    );
     result
 }
 
-async fn create_checkpoint_impl(http: &HttpClient) -> Result<(), AgentError> {
-    log_info!(LOG_TAG, "Creating checkpoint...");
+/// Create a best-effort recovery checkpoint after an abnormal CLI exit.
+pub async fn create_recovery_checkpoint(http: &HttpClient) -> Result<(), AgentError> {
+    let start = std::time::Instant::now();
+    let result = create_checkpoint_impl(http, CheckpointMode::Recovery).await;
+    record_sandbox_op(
+        CheckpointMode::Recovery.total_op(),
+        start.elapsed(),
+        result.is_ok(),
+        None,
+    );
+    result
+}
+
+async fn create_checkpoint_impl(http: &HttpClient, mode: CheckpointMode) -> Result<(), AgentError> {
+    log_info!(LOG_TAG, "Creating {}...", mode.log_label());
 
     // Read session ID. Let `read_to_string` surface `NotFound` directly — an
     // explicit `exists()` check would be a redundant stat plus a TOCTOU race
@@ -232,6 +284,7 @@ async fn create_checkpoint_impl(http: &HttpClient) -> Result<(), AgentError> {
         Ok(s) => s.trim().to_string(),
         Err(e) if e.kind() == ErrorKind::NotFound => {
             return Err(fail(
+                mode,
                 "session_id_read",
                 session_id_start,
                 "No session ID found",
@@ -239,6 +292,7 @@ async fn create_checkpoint_impl(http: &HttpClient) -> Result<(), AgentError> {
         }
         Err(e) => {
             return Err(fail(
+                mode,
                 "session_id_read",
                 session_id_start,
                 format!("Failed to read session ID: {e}"),
@@ -247,6 +301,7 @@ async fn create_checkpoint_impl(http: &HttpClient) -> Result<(), AgentError> {
     };
     if session_id.is_empty() {
         return Err(fail(
+            mode,
             "session_id_read",
             session_id_start,
             "Session ID is empty",
@@ -264,6 +319,7 @@ async fn create_checkpoint_impl(http: &HttpClient) -> Result<(), AgentError> {
             Ok(b) => b,
             Err(e) => {
                 return Err(fail(
+                    mode,
                     "session_history_read",
                     history_read_start,
                     e.to_string(),
@@ -275,6 +331,7 @@ async fn create_checkpoint_impl(http: &HttpClient) -> Result<(), AgentError> {
         Ok(s) => s,
         Err(e) => {
             return Err(fail(
+                mode,
                 "session_history_read",
                 history_read_start,
                 format!("Session history is not valid UTF-8: {e}"),
@@ -284,10 +341,16 @@ async fn create_checkpoint_impl(http: &HttpClient) -> Result<(), AgentError> {
 
     if session_history.trim().is_empty() {
         return Err(fail(
+            mode,
             "session_history_read",
             history_read_start,
             "Session history is empty",
         ));
+    }
+
+    if mode.validate_history() {
+        validate_recoverable_session_history(&session_history)
+            .map_err(|msg| fail(mode, "session_history_validate", history_read_start, msg))?;
     }
 
     let line_count = session_history.lines().count();
@@ -365,21 +428,42 @@ async fn create_checkpoint_impl(http: &HttpClient) -> Result<(), AgentError> {
         .and_then(|v| v.as_str());
 
     if let Some(id) = checkpoint_id {
-        log_info!(LOG_TAG, "Checkpoint created successfully: {id}");
+        log_info!(LOG_TAG, "{} created successfully: {id}", mode.log_label());
         record_sandbox_op("checkpoint_api_call", api_start.elapsed(), true, None);
         Ok(())
     } else {
-        log_error!(LOG_TAG, "Checkpoint API returned invalid response");
-        record_sandbox_op(
+        Err(fail(
+            mode,
             "checkpoint_api_call",
-            api_start.elapsed(),
-            false,
-            Some("Invalid response"),
-        );
-        Err(AgentError::Checkpoint(
-            "Invalid checkpoint API response".into(),
+            api_start,
+            "Invalid checkpoint API response",
         ))
     }
+}
+
+fn validate_recoverable_session_history(session_history: &str) -> Result<(), String> {
+    let mut line_count = 0usize;
+    for (index, line) in session_history.lines().enumerate() {
+        if line.trim().is_empty() {
+            return Err(format!(
+                "Session history line {} is empty; recovery checkpoint skipped",
+                index + 1
+            ));
+        }
+        serde_json::from_str::<serde_json::Value>(line).map_err(|e| {
+            format!(
+                "Session history line {} is not valid JSON; recovery checkpoint skipped: {e}",
+                index + 1
+            )
+        })?;
+        line_count += 1;
+    }
+
+    if line_count == 0 {
+        return Err("Session history has no JSONL entries; recovery checkpoint skipped".into());
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -410,5 +494,30 @@ mod tests {
         assert!(obj.contains_key("version"));
         assert!(obj.contains_key("mountPath"));
         assert!(!obj.contains_key("mount_path"));
+    }
+
+    #[test]
+    fn recoverable_session_history_accepts_valid_jsonl() {
+        let history = r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant"}"#;
+
+        assert!(validate_recoverable_session_history(&history).is_ok());
+    }
+
+    #[test]
+    fn recoverable_session_history_rejects_partial_trailing_json() {
+        let history = r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant""#;
+
+        let err = validate_recoverable_session_history(&history).unwrap_err();
+
+        assert!(err.contains("line 2"));
+    }
+
+    #[test]
+    fn recoverable_session_history_rejects_blank_lines() {
+        let history = r#"{"type":"system"}"#.to_string() + "\n\n" + r#"{"type":"assistant"}"#;
+
+        let err = validate_recoverable_session_history(&history).unwrap_err();
+
+        assert!(err.contains("line 2"));
     }
 }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -14,7 +14,7 @@ use guest_agent::paths;
 use guest_agent::telemetry::{Telemetry, UploadMode};
 
 use guest_common::telemetry::record_sandbox_op;
-use guest_common::{log_error, log_info};
+use guest_common::{log_error, log_info, log_warn};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio_util::sync::CancellationToken;
@@ -301,6 +301,15 @@ async fn execute(
         } else if cli_exit_code != 0 {
             log_info!(LOG_TAG, "claude-code failed with exit code {cli_exit_code}");
         }
+
+        if env::has_api() {
+            log_info!(LOG_TAG, "Attempting best-effort recovery checkpoint");
+            match checkpoint::create_recovery_checkpoint(&http).await {
+                Ok(()) => log_info!(LOG_TAG, "Recovery checkpoint created"),
+                Err(e) => log_warn!(LOG_TAG, "Recovery checkpoint skipped: {e}"),
+            }
+        }
+
         log_info!(LOG_TAG, "▷ Cleanup");
         final_telemetry(telemetry).await;
     }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -16,7 +16,7 @@ use guest_agent::telemetry::{Telemetry, UploadMode};
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
@@ -177,7 +177,7 @@ async fn execute(
     log_info!(LOG_TAG, "▷ Execution");
     let cli_start = Instant::now();
     let mut last_event_sequence = None;
-    let (mut exit_code, error_message) =
+    let (exit_code, error_message) =
         match cli::execute_cli(masker, heartbeat_handle, http.clone()).await {
             Ok(cli_result) => {
                 last_event_sequence = cli_result.last_event_sequence;
@@ -217,6 +217,25 @@ async fn execute(
         },
     );
 
+    complete_execution(
+        cli_exit_code,
+        exit_code,
+        cli_elapsed,
+        last_event_sequence,
+        telemetry,
+        &http,
+    )
+    .await
+}
+
+async fn complete_execution(
+    cli_exit_code: i32,
+    mut exit_code: i32,
+    cli_elapsed: Duration,
+    last_event_sequence: Option<u32>,
+    telemetry: &Telemetry,
+    http: &HttpClient,
+) -> i32 {
     // Check if any events failed to send (before logging execution result)
     if std::path::Path::new(paths::event_error_flag()).exists() {
         log_error!(LOG_TAG, "Some events failed to send, marking run as failed");
@@ -242,7 +261,7 @@ async fn execute(
         log_info!(LOG_TAG, "▷ Checkpoint");
         let cp_start = Instant::now();
         let (cp_result, _) = tokio::join!(
-            checkpoint::create_checkpoint(&http),
+            checkpoint::create_checkpoint(http),
             telemetry.flush(UploadMode::Live),
         );
         match cp_result {
@@ -269,7 +288,7 @@ async fn execute(
                 // returned.
                 log_info!(LOG_TAG, "▷ Cleanup");
                 complete::report_success(
-                    &http,
+                    http,
                     env::sandbox_id(),
                     env::sandbox_reuse_result(),
                     last_event_sequence,
@@ -304,7 +323,7 @@ async fn execute(
 
         if env::has_api() {
             log_info!(LOG_TAG, "Attempting best-effort recovery checkpoint");
-            match checkpoint::create_recovery_checkpoint(&http).await {
+            match checkpoint::create_recovery_checkpoint(http).await {
                 Ok(()) => log_info!(LOG_TAG, "Recovery checkpoint created"),
                 Err(e) => log_warn!(LOG_TAG, "Recovery checkpoint skipped: {e}"),
             }
@@ -332,4 +351,99 @@ async fn final_telemetry(telemetry: &Telemetry) {
         telemetry_ok,
         None,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::prelude::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn complete_execution_creates_recovery_checkpoint_after_cli_failure() {
+        let server = MockServer::start();
+        unsafe {
+            std::env::set_var("VM0_API_URL", server.base_url());
+            std::env::set_var("VM0_API_TOKEN", "test-token");
+            std::env::set_var("VM0_RUN_ID", "main-recovery-checkpoint");
+            std::env::set_var("VM0_WORKING_DIR", "/tmp/main-recovery-checkpoint");
+        }
+
+        let cleanup_paths = [
+            paths::session_id_file().to_string(),
+            paths::session_history_path_file().to_string(),
+            paths::checkpoint_error_file().to_string(),
+            paths::event_error_flag().to_string(),
+            paths::sandbox_ops_file().to_string(),
+            paths::telemetry_system_log_pos_file().to_string(),
+            paths::telemetry_metrics_pos_file().to_string(),
+            paths::telemetry_sandbox_ops_pos_file().to_string(),
+        ];
+        for path in &cleanup_paths {
+            let _ = std::fs::remove_file(path);
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let history_path = dir.path().join("history.jsonl");
+        let history = r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant"}"# + "\n";
+        std::fs::write(&history_path, &history).unwrap();
+        std::fs::write(paths::session_id_file(), "recovery-session-from-main").unwrap();
+        std::fs::write(
+            paths::session_history_path_file(),
+            history_path.to_string_lossy().as_ref(),
+        )
+        .unwrap();
+
+        let prepare_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/checkpoints/prepare-history")
+                .json_body_includes(r#"{"runId":"main-recovery-checkpoint"}"#);
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(json!({
+                    "presignedUrl": server.url("/test/main-recovery-history-upload"),
+                    "existing": false
+                }));
+        });
+        let upload_mock = server.mock(|when, then| {
+            when.method(PUT)
+                .path("/test/main-recovery-history-upload")
+                .body(history.as_str());
+            then.status(200);
+        });
+        let checkpoint_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/checkpoints")
+                .json_body_includes(r#"{"cliAgentSessionId":"recovery-session-from-main"}"#);
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(json!({"checkpointId": "checkpoint-from-main"}));
+        });
+        let telemetry_mock = server.mock(|when, then| {
+            when.method(POST).path("/api/webhooks/agent/telemetry");
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(json!({}));
+        });
+
+        let masker = Arc::new(masker::SecretMasker::from_env());
+        let http = HttpClient::new().unwrap();
+        let telemetry = Telemetry::spawn(masker, http.clone());
+        let exit_code = complete_execution(1, 1, Duration::ZERO, None, &telemetry, &http).await;
+        telemetry.shutdown().await;
+
+        assert_eq!(exit_code, 1);
+        assert!(
+            !std::path::Path::new(paths::checkpoint_error_file()).exists(),
+            "recovery checkpoint failure must not write the success-path checkpoint error file"
+        );
+        prepare_mock.assert_calls_async(1).await;
+        upload_mock.assert_calls_async(1).await;
+        checkpoint_mock.assert_calls_async(1).await;
+        telemetry_mock.assert_calls_async(1).await;
+
+        for path in cleanup_paths {
+            let _ = std::fs::remove_file(path);
+        }
+    }
 }

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -54,6 +54,27 @@ impl Drop for SystemLogOverrideGuard {
     }
 }
 
+fn cleanup_session_checkpoint_files() {
+    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
+    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
+    let _ = std::fs::remove_file(guest_agent::paths::checkpoint_error_file());
+}
+
+struct SessionCheckpointFilesGuard;
+
+impl SessionCheckpointFilesGuard {
+    fn new() -> Self {
+        cleanup_session_checkpoint_files();
+        Self
+    }
+}
+
+impl Drop for SessionCheckpointFilesGuard {
+    fn drop(&mut self) {
+        cleanup_session_checkpoint_files();
+    }
+}
+
 // =========================================================================
 // Group 1: post_json core
 // =========================================================================
@@ -995,6 +1016,169 @@ async fn send_event_skips_session_id_for_non_init() {
     );
 
     mock.delete_async().await;
+}
+
+// =========================================================================
+// Group 6b: Recovery checkpoint
+// =========================================================================
+
+#[tokio::test]
+async fn recovery_checkpoint_uploads_valid_session_history() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let dir = tempfile::tempdir().unwrap();
+    let history_path = dir.path().join("history.jsonl");
+    let history = r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant"}"# + "\n";
+    std::fs::write(&history_path, &history).unwrap();
+    std::fs::write(guest_agent::paths::session_id_file(), "recovery-session").unwrap();
+    std::fs::write(
+        guest_agent::paths::session_history_path_file(),
+        history_path.to_string_lossy().as_ref(),
+    )
+    .unwrap();
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(r#"{"runId":"test-run-001"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url("/test/recovery-history-upload"),
+                "existing": false
+            }));
+    });
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT)
+            .path("/test/recovery-history-upload")
+            .header("Content-Type", "application/octet-stream")
+            .body(history.as_str());
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(r#"{"cliAgentSessionId":"recovery-session"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "checkpoint-recovery"}));
+    });
+
+    let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
+
+    assert!(result.is_ok());
+    prepare_mock.assert_calls_async(1).await;
+    upload_mock.assert_calls_async(1).await;
+    checkpoint_mock.assert_calls_async(1).await;
+    prepare_mock.delete_async().await;
+    upload_mock.delete_async().await;
+    checkpoint_mock.delete_async().await;
+}
+
+#[tokio::test]
+async fn recovery_checkpoint_rejects_partial_jsonl_without_error_file() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let dir = tempfile::tempdir().unwrap();
+    let history_path = dir.path().join("partial.jsonl");
+    std::fs::write(
+        &history_path,
+        r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant""#,
+    )
+    .unwrap();
+    std::fs::write(guest_agent::paths::session_id_file(), "partial-session").unwrap();
+    std::fs::write(
+        guest_agent::paths::session_history_path_file(),
+        history_path.to_string_lossy().as_ref(),
+    )
+    .unwrap();
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200);
+    });
+
+    let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
+
+    assert!(result.is_err());
+    assert!(
+        !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
+        "recovery checkpoint must not write the success-path checkpoint error file"
+    );
+    prepare_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(0).await;
+    prepare_mock.delete_async().await;
+    checkpoint_mock.delete_async().await;
+}
+
+#[tokio::test]
+async fn recovery_checkpoint_skips_when_session_id_is_missing() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    let _files_guard = SessionCheckpointFilesGuard::new();
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200);
+    });
+
+    let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
+
+    assert!(result.is_err());
+    assert!(
+        !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
+        "recovery checkpoint must not write the success-path checkpoint error file"
+    );
+    prepare_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(0).await;
+    prepare_mock.delete_async().await;
+    checkpoint_mock.delete_async().await;
+}
+
+#[tokio::test]
+async fn recovery_checkpoint_skips_when_history_marker_is_missing() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    std::fs::write(guest_agent::paths::session_id_file(), "missing-history").unwrap();
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200);
+    });
+
+    let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
+
+    assert!(result.is_err());
+    assert!(
+        !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
+        "recovery checkpoint must not write the success-path checkpoint error file"
+    );
+    prepare_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(0).await;
+    prepare_mock.delete_async().await;
+    checkpoint_mock.delete_async().await;
 }
 
 // =========================================================================

--- a/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
@@ -3,6 +3,7 @@ import { POST as createRunRoute } from "../../../app/api/agent/runs/route";
 import { GET as getRunByIdRoute } from "../../../app/api/agent/runs/[id]/route";
 import { POST as checkpointWebhook } from "../../../app/api/webhooks/agent/checkpoints/route";
 import { POST as completeWebhook } from "../../../app/api/webhooks/agent/complete/route";
+import type { VolumeVersionsSnapshot } from "../../lib/infra/checkpoint/types";
 import { createTestRequest } from "./core";
 
 // Re-exports: DB-direct seeders
@@ -110,7 +111,7 @@ export async function createTestCheckpoint(
   userId: string,
   runId: string,
   options?: {
-    volumeVersionsSnapshot?: { versions: Record<string, string> };
+    volumeVersionsSnapshot?: VolumeVersionsSnapshot;
   },
 ): Promise<{
   checkpointId: string;

--- a/turbo/apps/web/src/lib/infra/checkpoint/additional-volumes.ts
+++ b/turbo/apps/web/src/lib/infra/checkpoint/additional-volumes.ts
@@ -1,0 +1,14 @@
+import type { AdditionalVolume } from "../storage/types";
+import type { VolumeVersionsSnapshot } from "./types";
+
+export function additionalVolumesFromSnapshot(
+  snapshot: VolumeVersionsSnapshot | null | undefined,
+): AdditionalVolume[] | undefined {
+  return snapshot?.additionalVolumes?.map((volume) => {
+    return {
+      name: volume.name,
+      version: volume.versionId,
+      mountPath: volume.mountPath,
+    };
+  });
+}

--- a/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { resolveSession } from "../resolve-session";
 import {
-  completeTestRun,
+  createTestCheckpoint,
   createTestCompose,
   createTestRun,
+  setTestRunStatus,
 } from "../../../../../__tests__/api-test-helpers";
 import {
+  createTestSessionWithConversation,
   setTestSessionArtifacts,
   setTestSessionFramework,
 } from "../../../../../__tests__/db-test-seeders/agents";
+import { setTestCheckpointArtifactSnapshots } from "../../../../../__tests__/db-test-seeders/runs";
 import {
   testContext,
   uniqueId,
@@ -22,18 +25,23 @@ const WORKING_DIR = "/home/user/workspace";
 describe("resolveSession — artifacts passthrough", () => {
   let user: UserContext;
   let composeId: string;
+  let composeVersionId: string;
 
   beforeEach(async () => {
     context.setupMocks();
     user = await context.setupUser();
     const compose = await createTestCompose(uniqueId("sess-resolver"));
     composeId = compose.composeId;
+    composeVersionId = compose.versionId;
   });
 
   it("returns session.artifacts verbatim from the DB", async () => {
-    const { runId } = await createTestRun(composeId, "session expansion run");
-    const { agentSessionId } = await completeTestRun(user.userId, runId);
-    await setTestSessionFramework(agentSessionId, "claude-code");
+    const { id: agentSessionId } = await createTestSessionWithConversation(
+      user.userId,
+      composeId,
+      composeVersionId,
+      "claude-code",
+    );
     const entries = [
       { name: "mem", version: "latest", mountPath: "/opt/mem" },
       { name: "ctx", version: "latest", mountPath: WORKING_DIR },
@@ -46,9 +54,12 @@ describe("resolveSession — artifacts passthrough", () => {
   });
 
   it("returns empty artifact list when session has no artifacts", async () => {
-    const { runId } = await createTestRun(composeId, "empty session run");
-    const { agentSessionId } = await completeTestRun(user.userId, runId);
-    await setTestSessionFramework(agentSessionId, "claude-code");
+    const { id: agentSessionId } = await createTestSessionWithConversation(
+      user.userId,
+      composeId,
+      composeVersionId,
+      "claude-code",
+    );
     await setTestSessionArtifacts(agentSessionId, []);
 
     const resolution = await resolveSession(agentSessionId, user.userId);
@@ -57,12 +68,77 @@ describe("resolveSession — artifacts passthrough", () => {
   });
 
   it("populates sessionFramework from conversation.cliAgentType", async () => {
-    const { runId } = await createTestRun(composeId, "framework field run");
-    const { agentSessionId } = await completeTestRun(user.userId, runId);
+    const { id: agentSessionId } = await createTestSessionWithConversation(
+      user.userId,
+      composeId,
+      composeVersionId,
+      "claude-code",
+    );
     await setTestSessionFramework(agentSessionId, "codex");
 
     const resolution = await resolveSession(agentSessionId, user.userId);
 
     expect(resolution.sessionFramework).toBe("codex");
+  });
+
+  it("uses checkpoint artifacts when continuing a recoverable failed session", async () => {
+    const { runId } = await createTestRun(composeId, "failed recovery run", {
+      additionalVolumes: [
+        {
+          name: "memory",
+          version: "mem-base",
+          mountPath: "/home/user/.claude/projects/-home-user-workspace/memory",
+        },
+      ],
+    });
+    const { agentSessionId, checkpointId } = await createTestCheckpoint(
+      user.userId,
+      runId,
+      {
+        volumeVersionsSnapshot: {
+          versions: { workspace: "vol-failed", memory: "mem-failed" },
+        },
+      },
+    );
+    await setTestRunStatus(runId, "failed");
+    await setTestSessionFramework(agentSessionId, "claude-code");
+    await setTestSessionArtifacts(agentSessionId, [
+      { name: "stale", version: "latest", mountPath: WORKING_DIR },
+    ]);
+
+    const checkpointArtifacts = [
+      { name: "workspace", version: "snap-failed", mountPath: WORKING_DIR },
+    ];
+    await setTestCheckpointArtifactSnapshots(checkpointId, checkpointArtifacts);
+
+    const resolution = await resolveSession(agentSessionId, user.userId);
+
+    expect(resolution.artifacts).toEqual(checkpointArtifacts);
+    expect(resolution.volumeVersions).toEqual({
+      workspace: "vol-failed",
+      memory: "mem-failed",
+    });
+    expect(resolution.additionalVolumes).toBeUndefined();
+  });
+
+  it("does not use checkpoint artifacts while the linked run is still running", async () => {
+    const { runId } = await createTestRun(composeId, "in-flight recovery run");
+    const { agentSessionId, checkpointId } = await createTestCheckpoint(
+      user.userId,
+      runId,
+    );
+    await setTestSessionFramework(agentSessionId, "claude-code");
+    const sessionArtifacts = [
+      { name: "session", version: "latest", mountPath: WORKING_DIR },
+    ];
+    await setTestSessionArtifacts(agentSessionId, sessionArtifacts);
+    await setTestCheckpointArtifactSnapshots(checkpointId, [
+      { name: "checkpoint", version: "snap", mountPath: WORKING_DIR },
+    ]);
+
+    const resolution = await resolveSession(agentSessionId, user.userId);
+
+    expect(resolution.artifacts).toEqual(sessionArtifacts);
+    expect(resolution.volumeVersions).toBeUndefined();
   });
 });

--- a/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
@@ -82,12 +82,14 @@ describe("resolveSession — artifacts passthrough", () => {
   });
 
   it("uses checkpoint artifacts when continuing a recoverable failed session", async () => {
+    const additionalVolumeMountPath =
+      "/home/user/.claude/projects/-home-user-workspace/memory";
     const { runId } = await createTestRun(composeId, "failed recovery run", {
       additionalVolumes: [
         {
           name: "memory",
           version: "mem-base",
-          mountPath: "/home/user/.claude/projects/-home-user-workspace/memory",
+          mountPath: additionalVolumeMountPath,
         },
       ],
     });
@@ -97,6 +99,13 @@ describe("resolveSession — artifacts passthrough", () => {
       {
         volumeVersionsSnapshot: {
           versions: { workspace: "vol-failed", memory: "mem-failed" },
+          additionalVolumes: [
+            {
+              name: "memory",
+              versionId: "mem-failed",
+              mountPath: additionalVolumeMountPath,
+            },
+          ],
         },
       },
     );
@@ -118,7 +127,13 @@ describe("resolveSession — artifacts passthrough", () => {
       workspace: "vol-failed",
       memory: "mem-failed",
     });
-    expect(resolution.additionalVolumes).toBeUndefined();
+    expect(resolution.additionalVolumes).toEqual([
+      {
+        name: "memory",
+        version: "mem-failed",
+        mountPath: additionalVolumeMountPath,
+      },
+    ]);
   });
 
   it("does not use checkpoint artifacts while the linked run is still running", async () => {

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-checkpoint.ts
@@ -10,6 +10,7 @@ import type {
   VolumeVersionsSnapshot,
 } from "../../checkpoint/types";
 import { decodeToContextArtifacts } from "../../checkpoint/decode-artifact-snapshots";
+import { additionalVolumesFromSnapshot } from "../../checkpoint/additional-volumes";
 import type { AgentComposeYaml } from "../../agent-compose/types";
 import type { ConversationResolution } from "./types";
 import { extractWorkingDir } from "../utils";
@@ -52,16 +53,9 @@ export async function resolveCheckpoint(
   const rawArtifacts: unknown = checkpoint.artifactSnapshots;
   const checkpointVolumeVersions =
     checkpoint.volumeVersionsSnapshot as VolumeVersionsSnapshot | null;
-
-  // Extract additional volumes from enriched snapshot (pinned versions from checkpoint)
-  const checkpointAdditionalVolumes =
-    checkpointVolumeVersions?.additionalVolumes?.map((vol) => {
-      return {
-        name: vol.name,
-        version: vol.versionId,
-        mountPath: vol.mountPath,
-      };
-    });
+  const checkpointAdditionalVolumes = additionalVolumesFromSnapshot(
+    checkpointVolumeVersions,
+  );
 
   // Get version ID from snapshot
   const agentComposeVersionId = agentComposeSnapshot.agentComposeVersionId;

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-session.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-session.ts
@@ -4,14 +4,22 @@ import {
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { checkpoints } from "@vm0/db/schema/checkpoint";
 import { notFound, unauthorized, badRequest } from "@vm0/api-services/errors";
 import { logger } from "../../../shared/logger";
 import { getAgentSessionWithConversation } from "../../agent-session";
 import type { ConversationResolution } from "./types";
 import { extractWorkingDir } from "../utils";
 import { resolveSessionHistory } from "./resolve-session-history";
+import type { VolumeVersionsSnapshot } from "../../checkpoint/types";
+import { decodeToContextArtifacts } from "../../checkpoint/decode-artifact-snapshots";
 
 const log = logger("run:resolve-session");
+const RECOVERABLE_FAILED_RUN_STATUSES = new Set([
+  "failed",
+  "timeout",
+  "cancelled",
+]);
 
 /**
  * Resolve session to ConversationResolution
@@ -57,8 +65,9 @@ export async function resolveSession(
   // Run independent operations in parallel:
   // - Compose → version chain (needs session.agentComposeId)
   // - Session history from R2 (needs session.conversation)
-  // - Last run vars (needs conversation.runId)
-  const [composeResult, sessionHistory, lastRunResult] = await Promise.all([
+  // - Last run vars and optional failed-run checkpoint snapshot
+  //   (needs conversation.runId)
+  const [composeResult, sessionHistory, runSnapshotResult] = await Promise.all([
     // Compose → version (serial chain)
     (async () => {
       const [compose] = await globalThis.services.db
@@ -96,20 +105,42 @@ export async function resolveSession(
       conversation.cliAgentSessionHistoryHash,
       conversation.cliAgentSessionHistory,
     ),
-    // Last run vars as fallback for continue operations
+    // Last run vars as fallback for continue operations. When the linked
+    // conversation belongs to a failed terminal run with a checkpoint, the
+    // checkpoint snapshot is the durable workspace state left after VM teardown,
+    // so session continue restores artifacts and compose volumes from it.
     globalThis.services.db
       .select({
         vars: agentRuns.vars,
+        status: agentRuns.status,
+        checkpointId: checkpoints.id,
+        artifactSnapshots: checkpoints.artifactSnapshots,
+        volumeVersionsSnapshot: checkpoints.volumeVersionsSnapshot,
       })
       .from(agentRuns)
+      .leftJoin(checkpoints, eq(checkpoints.runId, agentRuns.id))
       .where(eq(agentRuns.id, conversation.runId))
       .limit(1),
   ]);
 
   const { versionId, version } = composeResult;
-  const [lastRun] = lastRunResult;
+  const [lastRun] = runSnapshotResult;
   const lastRunVars =
     (lastRun?.vars as Record<string, string> | null) ?? undefined;
+  const failedRecoverableCheckpoint = Boolean(
+    lastRun?.checkpointId &&
+    RECOVERABLE_FAILED_RUN_STATUSES.has(lastRun.status),
+  );
+  const checkpointVolumeVersions = failedRecoverableCheckpoint
+    ? (lastRun?.volumeVersionsSnapshot as VolumeVersionsSnapshot | null)
+    : null;
+  const checkpointArtifacts = failedRecoverableCheckpoint
+    ? lastRun?.artifactSnapshots
+    : null;
+  const artifacts =
+    failedRecoverableCheckpoint && checkpointArtifacts != null
+      ? decodeToContextArtifacts(checkpointArtifacts)
+      : session.artifacts;
   const workingDir = extractWorkingDir(version.content);
 
   return {
@@ -121,9 +152,9 @@ export async function resolveSession(
       cliAgentSessionId: conversation.cliAgentSessionId,
       cliAgentSessionHistory: sessionHistory,
     },
-    artifacts: session.artifacts,
+    artifacts,
     vars: lastRunVars,
-    volumeVersions: undefined,
+    volumeVersions: checkpointVolumeVersions?.versions,
     previousRunId: conversation.runId,
     sessionFramework: conversation.cliAgentType,
   };

--- a/turbo/apps/web/src/lib/infra/run/resolvers/resolve-session.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/resolve-session.ts
@@ -13,6 +13,7 @@ import { extractWorkingDir } from "../utils";
 import { resolveSessionHistory } from "./resolve-session-history";
 import type { VolumeVersionsSnapshot } from "../../checkpoint/types";
 import { decodeToContextArtifacts } from "../../checkpoint/decode-artifact-snapshots";
+import { additionalVolumesFromSnapshot } from "../../checkpoint/additional-volumes";
 
 const log = logger("run:resolve-session");
 const RECOVERABLE_FAILED_RUN_STATUSES = new Set([
@@ -137,6 +138,9 @@ export async function resolveSession(
   const checkpointArtifacts = failedRecoverableCheckpoint
     ? lastRun?.artifactSnapshots
     : null;
+  const checkpointAdditionalVolumes = failedRecoverableCheckpoint
+    ? additionalVolumesFromSnapshot(checkpointVolumeVersions)
+    : undefined;
   const artifacts =
     failedRecoverableCheckpoint && checkpointArtifacts != null
       ? decodeToContextArtifacts(checkpointArtifacts)
@@ -155,6 +159,7 @@ export async function resolveSession(
     artifacts,
     vars: lastRunVars,
     volumeVersions: checkpointVolumeVersions?.versions,
+    additionalVolumes: checkpointAdditionalVolumes,
     previousRunId: conversation.runId,
     sessionFramework: conversation.cliAgentType,
   };

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -143,7 +143,7 @@ export const webhookCompleteContract = c.router({
 export const webhookCheckpointsContract = c.router({
   /**
    * POST /api/webhooks/agent/checkpoints
-   * Create checkpoint for completed agent run
+   * Create a recoverable checkpoint for an agent run.
    */
   create: {
     method: "POST",


### PR DESCRIPTION
## Summary
- add a best-effort guest-agent recovery checkpoint path for abnormal exits with valid CLI session history
- keep recovery checkpoint failures non-fatal so the original abnormal exit is preserved
- make sessionId continue restore checkpoint artifact/volume snapshots for failed/timeout/cancelled runs with a checkpoint

## Scope
This is the scoped replacement for #11931. It intentionally does not change run events, callbacks, complete/result persistence, blob ref-count hardening, or completed-session behavior.

## Tests
- cargo test -p guest-agent recovery_checkpoint
- cargo test -p guest-agent recoverable_session_history
- pnpm exec vitest run apps/web/src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts
- pnpm --filter web exec eslint src/lib/infra/run/resolvers/resolve-session.ts src/lib/infra/run/resolvers/__tests__/resolve-session.test.ts --max-warnings 0
- pnpm check-types
- pnpm knip
- git diff --check

Fixes #11805