### PR TITLE
fix: stabilize chatgpt oauth feature-off e2e

### DIFF
--- a/e2e/helpers/chatgpt-oauth-setup.bash
+++ b/e2e/helpers/chatgpt-oauth-setup.bash
@@ -90,31 +90,60 @@ _chatgpt_oauth_token() {
     fi
 }
 
-# Enable the chatgptOauthProvider feature switch for the current test user.
-# Required so isChatgptOauthEligible(orgId, userId) returns true and the
-# OAuth connect/callback routes don't 404. The switch is staff-only by
-# default, so production users see no surface.
-enable_chatgpt_oauth_provider() {
-    local token
-    token=$(_chatgpt_oauth_token)
+# Prefer the serial E2E token for the feature-off probe so runner chunks do
+# not race each other by mutating the shared runner user's feature switches.
+chatgpt_oauth_feature_off_token() {
+    local config="${CHATGPT_OAUTH_FEATURE_OFF_TOKEN_CONFIG:-/tmp/e2e-token-serial.json}"
+    if [ -f "$config" ]; then
+        jq -r '.token // empty' "$config"
+        return
+    fi
+    _chatgpt_oauth_token
+}
+
+# Set the chatgptOauthProvider feature switch override for the current test user.
+_set_chatgpt_oauth_provider() {
+    local enabled="$1"
+    local token="${2:-}"
     if [ -z "$token" ]; then
-        echo "enable_chatgpt_oauth_provider: no auth token (env or ~/.vm0/config.json)" >&2
+        token=$(_chatgpt_oauth_token)
+    fi
+    if [ -z "$token" ]; then
+        echo "_set_chatgpt_oauth_provider: no auth token (env or ~/.vm0/config.json)" >&2
         return 1
     fi
+    local body
+    body=$(jq -n --argjson enabled "$enabled" '{switches:{chatgptOauthProvider:$enabled}}')
     local curl_args=(-fsS -X POST -H "Content-Type: application/json"
         -H "Authorization: Bearer $token"
-        -d '{"switches":{"chatgptOauthProvider":true}}')
+        -d "$body")
     if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
         curl_args+=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
     fi
     curl "${curl_args[@]}" "${VM0_API_URL}/api/zero/feature-switches" >/dev/null
 }
 
+# Enable the chatgptOauthProvider feature switch for the current test user.
+# Required so isChatgptOauthEligible(orgId, userId) returns true and the
+# OAuth connect/callback routes don't 404. The switch is staff-only by
+# default, so production users see no surface.
+enable_chatgpt_oauth_provider() {
+    _set_chatgpt_oauth_provider true "$@"
+}
+
+# Force the chatgptOauthProvider feature switch off for the current test user.
+# Clearing overrides is not enough when the static registry enables staff orgs.
+force_disable_chatgpt_oauth_provider() {
+    _set_chatgpt_oauth_provider false "$@"
+}
+
 # Best-effort cleanup of feature-switch overrides — DELETE clears all
 # overrides for the user (test_user_id resolved server-side).
 disable_chatgpt_oauth_provider() {
-    local token
-    token=$(_chatgpt_oauth_token)
+    local token="${1:-}"
+    if [ -z "$token" ]; then
+        token=$(_chatgpt_oauth_token)
+    fi
     if [ -z "$token" ]; then
         return 0
     fi

--- a/e2e/tests/03-runner/t57-chatgpt-oauth-failure-modes.bats
+++ b/e2e/tests/03-runner/t57-chatgpt-oauth-failure-modes.bats
@@ -25,15 +25,17 @@ setup_file() {
 }
 
 @test "t57-1: connect endpoint returns 404 when feature switch off" {
-    # No enable_chatgpt_oauth_provider call — switch defaults to off.
-    # disable_* (best-effort cleanup; safe even if nothing to delete).
-    disable_chatgpt_oauth_provider
-
     local token
-    token=$(_chatgpt_oauth_token)
+    token=$(chatgpt_oauth_feature_off_token)
     if [ -z "$token" ]; then
         skip "no auth token available — VM0_TEST_TOKEN/ZERO_TOKEN/VM0_TOKEN not set and ~/.vm0/config.json absent"
     fi
+
+    # The registry can enable staff orgs by identity hash; write an explicit
+    # false override against the serial E2E user when available. Runner E2E
+    # chunks run in parallel, so this negative-path probe must not flip the
+    # shared runner user's switch while t54/t55 may be using it.
+    force_disable_chatgpt_oauth_provider "$token"
 
     local curl_args=(-s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $token")
     if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
@@ -47,9 +49,12 @@ setup_file() {
     # isChatgptOauthEligible returns false, route emits NotFound. This
     # keeps the entire surface hidden from production users.
     if [ "$code" != "404" ]; then
+        disable_chatgpt_oauth_provider "$token"
         echo "Expected 404, got $code" >&2
         return 1
     fi
+
+    disable_chatgpt_oauth_provider "$token"
 }
 
 # Test 4 server-side portion. Requires Wave 3 (#11932): the runner guard


### PR DESCRIPTION
## Summary
- make the ChatGPT OAuth feature-off E2E test write an explicit false override instead of assuming DELETE means disabled
- use the serial E2E token for the negative-path probe so parallel runner chunks do not mutate the shared runner user
- keep existing cleanup semantics by deleting overrides after the probe

## Tests
- bash -n e2e/helpers/chatgpt-oauth-setup.bash
- git diff --check
- helper token-selection smoke test

Note: local Bats could not run because this checkout is missing e2e/test/libs/bats-support/load.