### PR TITLE
refactor(platform): swap checkbox to switch for prefer_personal_provider toggle

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
@@ -5,13 +5,13 @@ import { createPortal } from "react-dom";
 import { IconX } from "@tabler/icons-react";
 import {
   Button,
-  Checkbox,
   Input,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Switch,
 } from "@vm0/ui";
 import {
   Dialog,
@@ -788,11 +788,11 @@ function ScheduleFormDialogInner({
 
           {personalProviderEnabled && (
             <div className="flex items-start gap-2">
-              <Checkbox
+              <Switch
                 id="schedule-prefer-personal"
                 checked={form.preferPersonalProvider}
                 onCheckedChange={(v) => {
-                  updateForm({ preferPersonalProvider: v === true });
+                  updateForm({ preferPersonalProvider: v });
                 }}
                 aria-label="Use personal provider"
                 className="mt-0.5"

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
@@ -22,7 +22,6 @@ import {
   Button,
   Card,
   CardContent,
-  Checkbox,
   cn,
   Dialog,
   DialogContent,
@@ -36,6 +35,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Switch,
   Tabs,
   TabsList,
   TabsTrigger,
@@ -524,10 +524,10 @@ function ScheduleSettingsForm({
               description="Use the caller's personal provider when available, fall back to the selected one above."
               alignControls="center"
             >
-              <Checkbox
+              <Switch
                 checked={form.preferPersonalProvider}
                 onCheckedChange={(v) => {
-                  updateForm({ preferPersonalProvider: v === true });
+                  updateForm({ preferPersonalProvider: v });
                 }}
                 aria-label="Use personal provider"
               />

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -7,7 +7,6 @@ import {
   Button,
   Card,
   CardContent,
-  Checkbox,
   Dialog,
   DialogClose,
   DialogContent,
@@ -17,6 +16,7 @@ import {
   DialogTitle,
   DialogTrigger,
   Input,
+  Switch,
   cn,
 } from "@vm0/ui";
 import { IconTrash } from "@tabler/icons-react";
@@ -350,11 +350,9 @@ export function ZeroSettingsTab({
                 description="Use the caller's personal provider when available, fall back to the selected one above."
                 alignControls="center"
               >
-                <Checkbox
+                <Switch
                   checked={preferPersonalProvider}
-                  onCheckedChange={(v) => {
-                    setPreferPersonalProvider(v === true);
-                  }}
+                  onCheckedChange={setPreferPersonalProvider}
                   aria-label="Use personal provider"
                 />
               </InlineSettingsRow>


### PR DESCRIPTION
## Summary

- Switch is the project convention for boolean toggles (`lab-page`, `billing-dialog`, `provider-dialog-fields`, `model-provider-picker` inherit row, etc).
- Aligns three Wave 3 surfaces from #11973 (agent settings tab, schedule create/edit dialog, schedule detail page) with that pattern.
- Drops the `(v) => v === true` guard since `Switch`'s `onCheckedChange` always emits boolean (no `\"indeterminate\"` state Checkbox has).
- `aria-label=\"Use personal provider\"` preserved so the 9 existing round-trip tests still locate the control via `getByLabelText`.

## Test plan

- [ ] CI passes (lint / types / test / knip)
- [ ] Manually verify in agent profile (the surface user pointed out): https://app.vm0.ai/agents/4f189ea8-ada2-416d-83a9-9c25ddb960c9?tab=profile — toggle reads/writes correctly, save persists
- [ ] Manually verify in schedule create dialog and schedule detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)