### PR TITLE
fix: make e2e default agent seeding race-safe

### DIFF
--- a/turbo/apps/web/app/api/test/telegram-state/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/test/telegram-state/__tests__/route.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { POST as slackPOST } from "../../slack-state/route";
+import { POST as telegramPOST } from "../route";
+import {
+  createTestRequest,
+  ensureOrgRow,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../src/__tests__/test-helpers";
+import { reloadEnv } from "../../../../../src/env";
+
+const mockGetUserList = vi.fn();
+const mockGetOrganizationMembershipList = vi.fn();
+vi.mock("@clerk/nextjs/server", () => {
+  return {
+    clerkClient: vi.fn(async () => {
+      return {
+        users: {
+          getUserList: mockGetUserList,
+          getOrganizationMembershipList: mockGetOrganizationMembershipList,
+        },
+      };
+    }),
+    auth: vi.fn(async () => {
+      return { userId: null, orgId: null, orgRole: null };
+    }),
+  };
+});
+
+const context = testContext();
+
+function postSlackState(body: Record<string, unknown>) {
+  return slackPOST(
+    createTestRequest("http://localhost:3000/api/test/slack-state", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+function postTelegramState(body: Record<string, unknown>) {
+  return telegramPOST(
+    createTestRequest("http://localhost:3000/api/test/telegram-state", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe("/api/test/telegram-state", () => {
+  let userId: string;
+  let orgId: string;
+  let email: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    vi.stubEnv("VERCEL_ENV", "");
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("CLERK_SECRET_KEY", "test-secret-key");
+    reloadEnv();
+
+    mockGetUserList.mockReset();
+    mockGetOrganizationMembershipList.mockReset();
+
+    userId = uniqueId("user-telegram-state");
+    orgId = uniqueId("org-telegram-state");
+    email = `${uniqueId("telegram-state")}@example.com`;
+
+    mockGetUserList.mockResolvedValue({ data: [{ id: userId }] });
+    mockGetOrganizationMembershipList.mockResolvedValue({
+      data: [
+        {
+          createdAt: Date.now(),
+          organization: {
+            id: orgId,
+            slug: "telegram-state-org",
+            name: "telegram-state-org",
+          },
+          role: "org:admin",
+          publicUserData: { userId },
+        },
+      ],
+    });
+    await ensureOrgRow(orgId);
+  });
+
+  it("seeds the shared default agent when Slack and Telegram preflights race", async () => {
+    const teamId = uniqueId("T_TELEGRAM_RACE");
+    const botId = uniqueId("123456_TELEGRAM_RACE");
+    const responses = await Promise.all(
+      Array.from({ length: 8 }, (_, index) => {
+        if (index % 2 === 0) {
+          return postSlackState({
+            team_id: teamId,
+            slack_user_id: "U_TELEGRAM_RACE",
+            email,
+            seed_connection: true,
+            seed_default_agent: true,
+          });
+        }
+        return postTelegramState({
+          bot_id: botId,
+          telegram_user_id: "99001",
+          email,
+          seed_link: true,
+        });
+      }),
+    );
+
+    const bodies = await Promise.all(
+      responses.map(async (response) => {
+        if (response.status !== 200) {
+          throw new Error(
+            `Expected 200, got ${response.status}: ${await response.text()}`,
+          );
+        }
+        return response.json() as Promise<{ default_agent_id: string }>;
+      }),
+    );
+
+    expect(
+      new Set(
+        bodies.map((body) => {
+          return body.default_agent_id;
+        }),
+      ).size,
+    ).toBe(1);
+  });
+});

--- a/turbo/apps/web/src/lib/test-endpoints/seed-default-agent.ts
+++ b/turbo/apps/web/src/lib/test-endpoints/seed-default-agent.ts
@@ -1,5 +1,5 @@
-import { randomBytes } from "crypto";
-import { and, eq } from "drizzle-orm";
+import { createHash } from "crypto";
+import { and, eq, isNull } from "drizzle-orm";
 import {
   agentComposes,
   agentComposeVersions,
@@ -19,13 +19,14 @@ interface SeedDefaultAgentInput {
 }
 
 /**
- * Seed the minimum state required for a Slack event dispatch to succeed:
+ * Seed the minimum state required for a Slack/Telegram event dispatch to succeed:
  * an agent compose with a head version, a matching zero_agents row, and
  * an org_metadata entry pointing `default_agent_id` at it.
  *
  * Idempotent per (orgId, name) — re-running reuses the existing compose.
- * Used by `/api/test/slack-state` so BATS e2e tests can drive the full
- * mention/DM dispatch path without going through the compose API.
+ * Used by `/api/test/slack-state` and `/api/test/telegram-state` so BATS e2e
+ * tests can drive the full mention/DM dispatch path without going through the
+ * compose API.
  */
 export async function seedDefaultAgent(
   services: Services,
@@ -33,41 +34,15 @@ export async function seedDefaultAgent(
 ): Promise<{ composeId: string; versionId: string; agentId: string }> {
   const { db } = services;
 
-  const [existingCompose] = await db
-    .select({
-      id: agentComposes.id,
-      headVersionId: agentComposes.headVersionId,
-    })
-    .from(agentComposes)
-    .where(
-      and(
-        eq(agentComposes.orgId, input.orgId),
-        eq(agentComposes.name, input.name),
-      ),
-    )
-    .limit(1);
-
-  let composeId: string;
-  let versionId: string;
-
-  if (existingCompose) {
-    composeId = existingCompose.id;
-    versionId =
-      existingCompose.headVersionId ??
-      (await insertComposeVersion(db, composeId, input.userId));
-  } else {
-    const [row] = await db
-      .insert(agentComposes)
-      .values({
-        userId: input.userId,
-        orgId: input.orgId,
-        name: input.name,
-      })
-      .returning({ id: agentComposes.id });
-    if (!row) throw new Error("Failed to insert agent compose");
-    composeId = row.id;
-    versionId = await insertComposeVersion(db, composeId, input.userId);
-  }
+  const compose = await getOrInsertCompose(db, input);
+  const composeId = compose.id;
+  const versionId = await ensureComposeVersion(
+    db,
+    composeId,
+    input.userId,
+    input.name,
+    compose.headVersionId,
+  );
 
   await db
     .insert(zeroAgents)
@@ -95,38 +70,103 @@ export async function seedDefaultAgent(
   return { composeId, versionId, agentId: composeId };
 }
 
-async function insertComposeVersion(
+async function getOrInsertCompose(
+  db: typeof globalThis.services.db,
+  input: SeedDefaultAgentInput,
+): Promise<{ id: string; headVersionId: string | null }> {
+  const [inserted] = await db
+    .insert(agentComposes)
+    .values({
+      userId: input.userId,
+      orgId: input.orgId,
+      name: input.name,
+    })
+    .onConflictDoNothing({
+      target: [agentComposes.orgId, agentComposes.name],
+    })
+    .returning({
+      id: agentComposes.id,
+      headVersionId: agentComposes.headVersionId,
+    });
+
+  if (inserted) return inserted;
+
+  const [existing] = await db
+    .select({
+      id: agentComposes.id,
+      headVersionId: agentComposes.headVersionId,
+    })
+    .from(agentComposes)
+    .where(
+      and(
+        eq(agentComposes.orgId, input.orgId),
+        eq(agentComposes.name, input.name),
+      ),
+    )
+    .limit(1);
+
+  if (!existing) {
+    throw new Error("Failed to resolve agent compose after conflict");
+  }
+  return existing;
+}
+
+async function ensureComposeVersion(
   db: typeof globalThis.services.db,
   composeId: string,
   userId: string,
+  name: string,
+  headVersionId: string | null,
 ): Promise<string> {
-  // agent_compose_versions.id is varchar(64) (content-addressed SHA-256).
-  // For the seed we use a random 64-char hex string — good enough for test
-  // isolation and never clashes with a real content hash.
-  const versionId = randomBytes(32).toString("hex");
-  await db.insert(agentComposeVersions).values({
-    id: versionId,
-    composeId,
-    content: {
-      version: "1.0",
-      agents: {
-        "e2e-slack-agent": {
-          framework: "claude-code",
-          // Explicit model-provider env var so validateComposeRequirements
-          // skips the org-default provider lookup (e2e previews don't have
-          // one configured). Value is a placeholder — USE_MOCK_CLAUDE on
-          // preview short-circuits actual Claude calls anyway.
-          environment: {
-            ANTHROPIC_API_KEY: "fake-e2e-anthropic-key",
-          },
+  if (headVersionId) return headVersionId;
+
+  const content = defaultAgentContent(name);
+  const versionId = createHash("sha256")
+    .update(JSON.stringify(content) + composeId)
+    .digest("hex");
+  await db
+    .insert(agentComposeVersions)
+    .values({
+      id: versionId,
+      composeId,
+      content,
+      createdBy: userId,
+    })
+    .onConflictDoNothing();
+
+  const [updated] = await db
+    .update(agentComposes)
+    .set({ headVersionId: versionId, updatedAt: new Date() })
+    .where(
+      and(eq(agentComposes.id, composeId), isNull(agentComposes.headVersionId)),
+    )
+    .returning({ headVersionId: agentComposes.headVersionId });
+  if (updated?.headVersionId) return updated.headVersionId;
+
+  const [compose] = await db
+    .select({ headVersionId: agentComposes.headVersionId })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+  if (compose?.headVersionId) return compose.headVersionId;
+
+  throw new Error("Failed to resolve agent compose head version");
+}
+
+function defaultAgentContent(name: string) {
+  return {
+    version: "1.0",
+    agents: {
+      [name]: {
+        framework: "claude-code",
+        // Explicit model-provider env var so validateComposeRequirements
+        // skips the org-default provider lookup (e2e previews don't have
+        // one configured). Value is a placeholder — USE_MOCK_CLAUDE on
+        // preview short-circuits actual Claude calls anyway.
+        environment: {
+          ANTHROPIC_API_KEY: "fake-e2e-anthropic-key",
         },
       },
     },
-    createdBy: userId,
-  });
-  await db
-    .update(agentComposes)
-    .set({ headVersionId: versionId })
-    .where(eq(agentComposes.id, composeId));
-  return versionId;
+  };
 }


### PR DESCRIPTION
## Summary
- make test endpoint default-agent seeding idempotent under concurrent Slack/Telegram preflights
- avoid duplicate compose/version inserts by using conflict-safe writes and deterministic version IDs
- add a route-level regression test for parallel Slack and Telegram state seeding

## Tests
- pnpm --filter web exec prettier --check app/api/test/telegram-state/__tests__/route.test.ts src/lib/test-endpoints/seed-default-agent.ts
- pnpm --filter web exec eslint app/api/test/telegram-state/__tests__/route.test.ts src/lib/test-endpoints/seed-default-agent.ts --max-warnings 0
- pnpm --filter web exec oxlint app/api/test/telegram-state/__tests__/route.test.ts src/lib/test-endpoints/seed-default-agent.ts
- pnpm --filter web exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json app/api/test/telegram-state/__tests__/route.test.ts src/lib/test-endpoints/seed-default-agent.ts
- git diff --check

Note: local targeted Vitest is blocked by the stale local test DB schema missing zero_agents.prefer_personal_provider.