### PR TITLE
fix(platform): preserve optimistic messages across thread resolution handoff

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -120,6 +120,20 @@ const resolvePaneThread$ = command(
     const { spec, thread, isNew, matchingOptimistic } = args;
 
     if (matchingOptimistic) {
+      // Transfer optimistic messages from the local pending thread to the
+      // remote-backed thread's delta so messages sent during the optimistic
+      // window survive the handoff. On a new thread the remote initial page
+      // may not yet include the server-committed message (waitUntil race),
+      // and fetchNextPage$ exits early when sinceId is undefined.
+      const optimisticGroups = await get(
+        matchingOptimistic.pendingThread.groupedChatMessages$,
+      );
+      for (const group of optimisticGroups) {
+        for (const msg of group.messages) {
+          set(thread.insertOptimisticMessage$, msg);
+        }
+      }
+
       await get(thread.groupedChatMessages$);
       signal.throwIfAborted();
       set(thread.hideSkeleton$);

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -128,6 +128,7 @@ const resolvePaneThread$ = command(
       const optimisticGroups = await get(
         matchingOptimistic.pendingThread.groupedChatMessages$,
       );
+      signal.throwIfAborted();
       for (const group of optimisticGroups) {
         for (const msg of group.messages) {
           set(thread.insertOptimisticMessage$, msg);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
@@ -292,5 +293,61 @@ describe("talk navigation", () => {
     await waitFor(() => {
       expect(pathname()).toBe(`/agents/${MOCK_AGENT_ID}/chat`);
     });
+  });
+});
+
+describe("optimistic message preservation on thread resolution", () => {
+  it("preserves messages sent during the optimistic window after the thread resolves", async () => {
+    const user = userEvent.setup();
+    const createDeferred = createDeferredPromise<void>(context.signal);
+
+    mockChatAPIs();
+    server.use(
+      mockApi(chatThreadsContract.create, async ({ body, respond }) => {
+        await createDeferred.promise;
+        return respond(201, {
+          id: body.clientThreadId ?? "fallback",
+          title: null,
+          createdAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/agents/c0000000-0000-4000-a000-000000000001/chat",
+      featureSwitches: { [FeatureSwitchKey.ChatHeaderNewButton]: true },
+    });
+
+    const newButton = await waitFor(() => {
+      return screen.getByTestId("chat-header-new-button");
+    });
+    await user.click(newButton);
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+
+    await fill(textarea, "Message during optimistic window");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Message during optimistic window"),
+      ).toBeInTheDocument();
+    });
+
+    // Resolve the thread creation, triggering the optimistic→remote handoff
+    // in resolvePaneThread$. The message must survive the transition.
+    await act(async () => {
+      createDeferred.resolve();
+      for (let i = 0; i < 30; i++) {
+        await Promise.resolve();
+      }
+    });
+
+    expect(
+      screen.getByText("Message during optimistic window"),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Fixes a bug where a chat message sent during the optimistic thread window disappears from the UI when the thread resolves.

## Root Cause

In `resolvePaneThread$` (`chat-thread-panes.ts`), when the pane switches from the local optimistic data source to the remote-backed (IDB-cached) data source, the optimistic messages that were inserted into the local delta are lost — the remote data source has its own separate `deltaMessages$`.

Additionally, `fetchNextPage$` exits early when `sinceId` is undefined (new thread with no messages yet), and the Ably `chatThreadRunCreated` event may race with subscription setup (server inserts the message in `waitUntil` after the 201 response).

## Fix

Before switching the pane, transfer all messages from the optimistic thread's data source into the remote thread's delta via `insertOptimisticMessage$`. The existing deduplication in `mergeIntoGroups` and `appendDeltaMessages$` handles the case where the server later delivers the same message by `clientMessageId`.

## Test Plan

- [ ] Manual: click New Thread, send a message before the thread resolves — message should persist after resolution
- [ ] Manual: send multiple rapid messages on a new optimistic thread — all should persist
- [ ] Existing CI tests pass (chat-page setup, optimistic-chat-thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)