### PR TITLE
test(e2e): retarget t54/t55/t57 + Playwright to drive codex auth.json paste flow

### DIFF
--- a/e2e/fixtures/audit-runner.sh
+++ b/e2e/fixtures/audit-runner.sh
@@ -21,7 +21,19 @@
 #   - CODEX_REFRESH_TOKEN_URL_OVERRIDE env var (must be the no-op localhost URL)
 #
 # Usage:
-#   audit-runner.sh <real_access_token> <real_refresh_token> <real_account_id> <real_id_token>
+#   audit-runner.sh <real_access_token> <real_refresh_token> <real_account_id> <real_id_token> [<auth_json_blob_prefix>] [<workspace_name>]
+#
+# auth_json_blob_prefix: optional. First ~50 chars of the raw codex auth.json
+#   used to seed the provider via the paste flow. Catches "entire blob got
+#   logged" leaks that the per-token scans would still pass (since they only
+#   match individual claim values). Pass an empty string to skip.
+# workspace_name: optional. Synthetic high-entropy workspace_name claim from
+#   the id_token. Catches leaks of derived metadata. Pass an empty string to
+#   skip.
+#
+# plan_type is intentionally NOT scanned — its values ("plus", "pro",
+# "enterprise") are low-entropy English words that would false-positive on
+# any unrelated env or file content.
 #
 # Exit code: always 0 (the bats test makes the assertion on the JSON output
 # so a failed audit is a test failure, not a script failure).
@@ -32,6 +44,8 @@ real_access="$1"
 real_refresh="$2"
 real_account="$3"
 real_id="$4"
+auth_json_blob_prefix="${5:-}"
+workspace_name="${6:-}"
 
 auth_json_path="$HOME/.codex/auth.json"
 auth_mode="missing"
@@ -103,6 +117,8 @@ scan_for_value "$real_access" "access_token"
 scan_for_value "$real_refresh" "refresh_token"
 scan_for_value "$real_account" "account_id"
 scan_for_value "$real_id" "id_token"
+scan_for_value "$auth_json_blob_prefix" "auth_json_blob"
+scan_for_value "$workspace_name" "workspace_name"
 
 # Emit single-line compact JSON (small + easier to extract from agent output).
 jq -nc \

--- a/e2e/helpers/codex-oauth-setup.bash
+++ b/e2e/helpers/codex-oauth-setup.bash
@@ -154,6 +154,90 @@ disable_codex_oauth_provider() {
     curl "${curl_args[@]}" "${VM0_API_URL}/api/zero/feature-switches" >/dev/null 2>&1 || true
 }
 
+# Common POST helper for /api/cli/auth/test-codex-oauth. Takes a JSON body
+# string on stdin or as $1; returns curl exit + sets http_code via a
+# nameref-style global. Centralizes email encoding + Vercel bypass header.
+_post_test_codex_oauth() {
+    local body="$1"
+    local encoded_email
+    encoded_email=$(_codex_encode_email) || return 1
+
+    local curl_args=(-s -w "\n%{http_code}" -X POST -H "Content-Type: application/json")
+    if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
+        curl_args+=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
+    fi
+    curl_args+=(-d "$body")
+
+    curl "${curl_args[@]}" "${VM0_API_URL}/api/cli/auth/test-codex-oauth?email=${encoded_email}"
+}
+
+# Seed a codex-oauth-token model provider via the new auth_json paste path.
+#
+# Usage:
+#   seed_codex_oauth_via_authjson <raw_auth_json> [expires_in] [needs_reconnect] [last_refresh_error_code]
+#
+# raw_auth_json: the codex CLI's auth.json contents (JSON string).
+# expires_in: seconds from now until token expiry (default 600; negative pre-expires).
+# needs_reconnect: "true" or "false" (default "false").
+# last_refresh_error_code: optional refresh-error code for stale-state simulation.
+#
+# Returns nonzero if HTTP != 200. Used by the *-paste tests under
+# E2E_PASTE_FLOW_ENABLED.
+seed_codex_oauth_via_authjson() {
+    local raw_json="$1"
+    local expires_in="${2:-600}"
+    local needs_reconnect="${3:-false}"
+    local last_refresh_error_code="${4:-}"
+
+    local body
+    if [ -n "$last_refresh_error_code" ]; then
+        body=$(jq -n \
+            --arg aj "$raw_json" \
+            --argjson ei "$expires_in" \
+            --argjson nr "$needs_reconnect" \
+            --arg lrec "$last_refresh_error_code" \
+            '{kind: "auth_json", authJson: $aj, expiresIn: $ei, needsReconnect: $nr, lastRefreshErrorCode: $lrec}')
+    else
+        body=$(jq -n \
+            --arg aj "$raw_json" \
+            --argjson ei "$expires_in" \
+            --argjson nr "$needs_reconnect" \
+            '{kind: "auth_json", authJson: $aj, expiresIn: $ei, needsReconnect: $nr}')
+    fi
+
+    local resp http_code resp_body
+    resp=$(_post_test_codex_oauth "$body")
+    http_code=$(echo "$resp" | tail -n1)
+    resp_body=$(echo "$resp" | head -n-1)
+
+    if [ "$http_code" != "200" ]; then
+        echo "test-codex-oauth seed via authJson failed: HTTP $http_code" >&2
+        echo "Response: $resp_body" >&2
+        return 1
+    fi
+}
+
+# Probe whether the paste flow (#11978 + #11980) is wired in the running
+# server. Used to gate the *-paste tests so this PR can ship before
+# dependencies merge.
+#
+# Returns 0 if the test endpoint accepts the auth_json variant and does
+# NOT return paste_flow_not_wired. Returns 1 otherwise.
+#
+# Implementation: POST a clearly-invalid authJson and inspect the error
+# code. If the parser is wired we get auth_json_shape_invalid (400); if
+# not, we get paste_flow_not_wired (503).
+codex_oauth_paste_supported() {
+    local body='{"kind":"auth_json","authJson":"not json"}'
+    local resp http_code resp_body
+    resp=$(_post_test_codex_oauth "$body" 2>/dev/null)
+    http_code=$(echo "$resp" | tail -n1)
+    resp_body=$(echo "$resp" | head -n-1)
+
+    [ "$http_code" = "400" ] && \
+        echo "$resp_body" | jq -e '.error == "auth_json_shape_invalid"' >/dev/null 2>&1
+}
+
 # Probe whether Wave 3 (#11932) features are present. Used to gate Test 4
 # (stale recovery) tests so this PR can ship before #11932 merges.
 #

--- a/e2e/helpers/codex-oauth-setup.bash
+++ b/e2e/helpers/codex-oauth-setup.bash
@@ -171,39 +171,22 @@ _post_test_codex_oauth() {
     curl "${curl_args[@]}" "${VM0_API_URL}/api/cli/auth/test-codex-oauth?email=${encoded_email}"
 }
 
-# Seed a codex-oauth-token model provider via the new auth_json paste path.
+# Seed a codex-oauth-token model provider via the auth_json paste path.
 #
 # Usage:
-#   seed_codex_oauth_via_authjson <raw_auth_json> [expires_in] [needs_reconnect] [last_refresh_error_code]
+#   seed_codex_oauth_via_authjson <raw_auth_json>
 #
-# raw_auth_json: the codex CLI's auth.json contents (JSON string).
-# expires_in: seconds from now until token expiry (default 600; negative pre-expires).
-# needs_reconnect: "true" or "false" (default "false").
-# last_refresh_error_code: optional refresh-error code for stale-state simulation.
+# raw_auth_json: the codex CLI's auth.json contents (JSON string). The
+# server-side parser derives tokenExpiresAt, needsReconnect=false from
+# the parsed claims; the legacy seed_codex_oauth helper is the way to
+# inject explicit metadata (pre-expired tokens, stale state, etc.).
 #
-# Returns nonzero if HTTP != 200. Used by the *-paste tests under
-# E2E_PASTE_FLOW_ENABLED.
+# Returns nonzero if HTTP != 200. Used by the *-paste tests.
 seed_codex_oauth_via_authjson() {
     local raw_json="$1"
-    local expires_in="${2:-600}"
-    local needs_reconnect="${3:-false}"
-    local last_refresh_error_code="${4:-}"
 
     local body
-    if [ -n "$last_refresh_error_code" ]; then
-        body=$(jq -n \
-            --arg aj "$raw_json" \
-            --argjson ei "$expires_in" \
-            --argjson nr "$needs_reconnect" \
-            --arg lrec "$last_refresh_error_code" \
-            '{kind: "auth_json", authJson: $aj, expiresIn: $ei, needsReconnect: $nr, lastRefreshErrorCode: $lrec}')
-    else
-        body=$(jq -n \
-            --arg aj "$raw_json" \
-            --argjson ei "$expires_in" \
-            --argjson nr "$needs_reconnect" \
-            '{kind: "auth_json", authJson: $aj, expiresIn: $ei, needsReconnect: $nr}')
-    fi
+    body=$(jq -n --arg aj "$raw_json" '{authJson: $aj}')
 
     local resp http_code resp_body
     resp=$(_post_test_codex_oauth "$body")
@@ -217,25 +200,19 @@ seed_codex_oauth_via_authjson() {
     fi
 }
 
-# Probe whether the paste flow (#11978 + #11980) is wired in the running
-# server. Used to gate the *-paste tests so this PR can ship before
-# dependencies merge.
+# Probe whether the paste flow (#11978's parser) is wired in the running
+# server. Mostly redundant after #11978 merged into main — kept as a
+# robust runtime probe so the tests gracefully skip if the test endpoint
+# regresses.
 #
-# Returns 0 if the test endpoint accepts the auth_json variant and does
-# NOT return paste_flow_not_wired. Returns 1 otherwise.
-#
-# Implementation: POST a clearly-invalid authJson and inspect the error
-# code. If the parser is wired we get auth_json_shape_invalid (400); if
-# not, we get paste_flow_not_wired (503).
+# Returns 0 if a clearly-invalid authJson POST yields a 400 response.
 codex_oauth_paste_supported() {
-    local body='{"kind":"auth_json","authJson":"not json"}'
-    local resp http_code resp_body
+    local body='{"authJson":"{ not json"}'
+    local resp http_code
     resp=$(_post_test_codex_oauth "$body" 2>/dev/null)
     http_code=$(echo "$resp" | tail -n1)
-    resp_body=$(echo "$resp" | head -n-1)
 
-    [ "$http_code" = "400" ] && \
-        echo "$resp_body" | jq -e '.error == "auth_json_shape_invalid"' >/dev/null 2>&1
+    [ "$http_code" = "400" ]
 }
 
 # Probe whether Wave 3 (#11932) features are present. Used to gate Test 4

--- a/e2e/playwright/tests/codex-oauth-paste-dialog.spec.ts
+++ b/e2e/playwright/tests/codex-oauth-paste-dialog.spec.ts
@@ -1,0 +1,232 @@
+import { clerk, clerkSetup } from "@clerk/testing/playwright";
+import { expect, test } from "@playwright/test";
+import { deriveAppUrl } from "../playwright.config";
+
+/**
+ * Paste-modal happy path + error paths for the codex-oauth-token provider.
+ *
+ * Wave 2 contract (post-#11978 + #11980):
+ *   - Paste modal data-testid="codex-paste-modal"
+ *   - Textarea data-testid="codex-paste-modal-textarea"
+ *   - Submit button data-testid="codex-paste-modal-submit"
+ *   - Inline error data-testid="codex-paste-modal-error" with text
+ *     content matching the typed error code (auth_json_shape_invalid /
+ *     free_plan_rejected)
+ *
+ * Skips via runtime probe when paste flow is not yet wired (server-side
+ * parser absent OR modal testid absent in DOM).
+ */
+
+const VALID_AUTH_JSON = JSON.stringify({
+  OPENAI_API_KEY: null,
+  tokens: {
+    access_token:
+      "REAL-AT-pw-7f3a82d1-9b4c-4e5f-a1b2-c3d4e5f60718-DO-NOT-LEAK",
+    refresh_token:
+      "REAL-RT-pw-1a2b3c4d-5e6f-7g8h-9i0j-k1l2m3n4o5p6-DO-NOT-LEAK",
+    account_id: "ws_REAL_ACCOUNT_pw_DO_NOT_LEAK",
+    id_token: "hdr-REAL-IDTOK-pw.body-payload.sig",
+  },
+  last_refresh: "2026-05-06T00:00:00Z",
+});
+
+async function pasteFlowSupported(
+  request: import("@playwright/test").APIRequestContext,
+  apiUrl: string,
+  email: string,
+  bypassSecret: string | undefined,
+): Promise<boolean> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (bypassSecret) {
+    headers["x-vercel-protection-bypass"] = bypassSecret;
+  }
+  const encodedEmail = email.replace(/\+/g, "%2B").replace(/@/g, "%40");
+  const resp = await request.post(
+    `${apiUrl}/api/cli/auth/test-codex-oauth?email=${encodedEmail}`,
+    {
+      headers,
+      data: { kind: "auth_json", authJson: "not json" },
+    },
+  );
+  if (resp.status() !== 400) {
+    return false;
+  }
+  const body = await resp.json();
+  return body.error === "auth_json_shape_invalid";
+}
+
+async function ensurePasteModalAvailable(
+  page: import("@playwright/test").Page,
+  appUrl: string,
+  email: string,
+): Promise<boolean> {
+  await clerkSetup();
+  await page.goto(appUrl, { waitUntil: "domcontentloaded" });
+  await clerk.signIn({ page, emailAddress: email });
+  await page.goto(`${appUrl}/settings/model-providers`, {
+    waitUntil: "domcontentloaded",
+    timeout: 60_000,
+  });
+
+  const addButton = page.getByRole("button", { name: /add provider/i });
+  if ((await addButton.count()) === 0) {
+    return false;
+  }
+  await addButton.click();
+
+  const codexCard = page.locator("[data-testid='provider-card-codex-oauth-token']");
+  if ((await codexCard.count()) === 0) {
+    return false;
+  }
+  await codexCard.click();
+
+  const modal = page.locator("[data-testid='codex-paste-modal']");
+  return (await modal.count()) > 0;
+}
+
+test.describe("codex-oauth paste flow", () => {
+  test("happy path: paste valid auth.json → modal closes, provider in list", async ({
+    page,
+    request,
+  }) => {
+    const apiUrl = process.env.VM0_API_URL;
+    const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+    const email = process.env.E2E_CLERK_USER_EMAIL;
+    if (!apiUrl || !email) {
+      test.skip(true, "VM0_API_URL or E2E_CLERK_USER_EMAIL not set");
+      return;
+    }
+    if (!(await pasteFlowSupported(request, apiUrl, email, bypassSecret))) {
+      test.skip(true, "Paste flow not yet wired (sub-issue #11978 pending)");
+      return;
+    }
+
+    const appUrl = deriveAppUrl(apiUrl);
+    if (!(await ensurePasteModalAvailable(page, appUrl, email))) {
+      test.skip(
+        true,
+        "Paste modal not yet shipped (sub-issue #11980 pending)",
+      );
+      return;
+    }
+
+    const modal = page.locator("[data-testid='codex-paste-modal']");
+    const textarea = modal.locator("[data-testid='codex-paste-modal-textarea']");
+    const submit = modal.locator("[data-testid='codex-paste-modal-submit']");
+
+    // Submit disabled with empty textarea
+    await expect(submit).toBeDisabled();
+
+    // Paste valid auth.json
+    await textarea.fill(VALID_AUTH_JSON);
+    await expect(submit).toBeEnabled();
+
+    await submit.click();
+
+    // Modal closes
+    await expect(modal).toBeHidden({ timeout: 10_000 });
+
+    // Provider row appears in the list
+    const providerRow = page.locator(
+      "[data-testid='provider-row-codex-oauth-token']",
+    );
+    await expect(providerRow).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("rejects malformed JSON inline", async ({ page, request }) => {
+    const apiUrl = process.env.VM0_API_URL;
+    const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+    const email = process.env.E2E_CLERK_USER_EMAIL;
+    if (!apiUrl || !email) {
+      test.skip(true, "VM0_API_URL or E2E_CLERK_USER_EMAIL not set");
+      return;
+    }
+    if (!(await pasteFlowSupported(request, apiUrl, email, bypassSecret))) {
+      test.skip(true, "Paste flow not yet wired (sub-issue #11978 pending)");
+      return;
+    }
+
+    const appUrl = deriveAppUrl(apiUrl);
+    if (!(await ensurePasteModalAvailable(page, appUrl, email))) {
+      test.skip(
+        true,
+        "Paste modal not yet shipped (sub-issue #11980 pending)",
+      );
+      return;
+    }
+
+    const modal = page.locator("[data-testid='codex-paste-modal']");
+    const textarea = modal.locator("[data-testid='codex-paste-modal-textarea']");
+    const submit = modal.locator("[data-testid='codex-paste-modal-submit']");
+
+    await textarea.fill("not valid json {");
+    await submit.click();
+
+    const error = modal.locator("[data-testid='codex-paste-modal-error']");
+    await expect(error).toBeVisible({ timeout: 10_000 });
+    await expect(error).toContainText(/auth_json_shape_invalid|invalid/i);
+    await expect(modal).toBeVisible();
+  });
+
+  test("rejects free plan inline", async ({ page, request }) => {
+    const apiUrl = process.env.VM0_API_URL;
+    const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+    const email = process.env.E2E_CLERK_USER_EMAIL;
+    if (!apiUrl || !email) {
+      test.skip(true, "VM0_API_URL or E2E_CLERK_USER_EMAIL not set");
+      return;
+    }
+    if (!(await pasteFlowSupported(request, apiUrl, email, bypassSecret))) {
+      test.skip(true, "Paste flow not yet wired (sub-issue #11978 pending)");
+      return;
+    }
+
+    const appUrl = deriveAppUrl(apiUrl);
+    if (!(await ensurePasteModalAvailable(page, appUrl, email))) {
+      test.skip(
+        true,
+        "Paste modal not yet shipped (sub-issue #11980 pending)",
+      );
+      return;
+    }
+
+    // Build an id_token with chatgpt_plan_type="free". Uses btoa (browser-
+    // and node-native) instead of Buffer to avoid pulling Node types into
+    // the Playwright spec (which runs in a node context but has no
+    // @types/node at the e2e workspace level).
+    const claims = {
+      "https://api.openai.com/auth": {
+        chatgpt_plan_type: "free",
+        chatgpt_account_id: "test-acc",
+      },
+    };
+    const payloadB64 = btoa(JSON.stringify(claims))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/g, "");
+    const freePlanIdToken = `hdr.${payloadB64}.sig`;
+
+    const freePlanAuthJson = JSON.stringify({
+      OPENAI_API_KEY: null,
+      tokens: {
+        access_token: "at",
+        refresh_token: "rt",
+        account_id: "ai",
+        id_token: freePlanIdToken,
+      },
+      last_refresh: "2026-05-06T00:00:00Z",
+    });
+
+    const modal = page.locator("[data-testid='codex-paste-modal']");
+    const textarea = modal.locator("[data-testid='codex-paste-modal-textarea']");
+    const submit = modal.locator("[data-testid='codex-paste-modal-submit']");
+
+    await textarea.fill(freePlanAuthJson);
+    await submit.click();
+
+    const error = modal.locator("[data-testid='codex-paste-modal-error']");
+    await expect(error).toBeVisible({ timeout: 10_000 });
+    await expect(error).toContainText(/free_plan_rejected|free plan/i);
+    await expect(modal).toBeVisible();
+  });
+});

--- a/e2e/playwright/tests/codex-oauth-paste-dialog.spec.ts
+++ b/e2e/playwright/tests/codex-oauth-paste-dialog.spec.ts
@@ -10,8 +10,8 @@ import { deriveAppUrl } from "../playwright.config";
  *   - Textarea data-testid="codex-paste-modal-textarea"
  *   - Submit button data-testid="codex-paste-modal-submit"
  *   - Inline error data-testid="codex-paste-modal-error" with text
- *     content matching the typed error code (auth_json_shape_invalid /
- *     free_plan_rejected)
+ *     content matching the parser's typed-error message (shape error /
+ *     free-plan rejection — assertions tolerant to wording shifts)
  *
  * Skips via runtime probe when paste flow is not yet wired (server-side
  * parser absent OR modal testid absent in DOM).
@@ -45,14 +45,18 @@ async function pasteFlowSupported(
     `${apiUrl}/api/cli/auth/test-codex-oauth?email=${encodedEmail}`,
     {
       headers,
-      data: { kind: "auth_json", authJson: "not json" },
+      data: { authJson: "{ not json" },
     },
   );
+  // #11978's parser returns 400 for any malformed authJson. If the test
+  // endpoint hasn't accepted the authJson variant (which would manifest
+  // as a 400 from zod with "Invalid body shape"), the body has an
+  // `issues` array; the parser path returns `error` only.
   if (resp.status() !== 400) {
     return false;
   }
   const body = await resp.json();
-  return body.error === "auth_json_shape_invalid";
+  return typeof body.error === "string" && !("issues" in body);
 }
 
 async function ensurePasteModalAvailable(
@@ -164,7 +168,7 @@ test.describe("codex-oauth paste flow", () => {
 
     const error = modal.locator("[data-testid='codex-paste-modal-error']");
     await expect(error).toBeVisible({ timeout: 10_000 });
-    await expect(error).toContainText(/auth_json_shape_invalid|invalid/i);
+    await expect(error).toContainText(/shape invalid|invalid/i);
     await expect(modal).toBeVisible();
   });
 
@@ -226,7 +230,7 @@ test.describe("codex-oauth paste flow", () => {
 
     const error = modal.locator("[data-testid='codex-paste-modal-error']");
     await expect(error).toBeVisible({ timeout: 10_000 });
-    await expect(error).toContainText(/free_plan_rejected|free plan/i);
+    await expect(error).toContainText(/free plan/i);
     await expect(modal).toBeVisible();
   });
 });

--- a/e2e/playwright/tests/codex-oauth-stale-banner.spec.ts
+++ b/e2e/playwright/tests/codex-oauth-stale-banner.spec.ts
@@ -3,21 +3,24 @@ import { expect, test } from "@playwright/test";
 import { deriveAppUrl } from "../playwright.config";
 
 /**
- * Test 4 (UI portion) for issue #11941: stale-provider banner + re-connect
- * CTA in OrgProvidersTab when a codex-oauth-token provider has
- * needsReconnect=true.
+ * Stale-provider banner + re-paste CTA in OrgProvidersTab when a
+ * codex-oauth-token provider has needsReconnect=true.
  *
- * REQUIRES Wave 3 (#11932). The probe at the top of the test skips when
- * Wave 3's API surface (modelProviderResponseSchema with needsReconnect
- * field) hasn't shipped — keeps this PR mergeable before #11932 lands.
+ * Wave 2 paste-flow target state (post-#11978 + #11980):
+ *   - Banner DOM element: data-testid="codex-stale-banner"
+ *   - Re-paste CTA inside the banner: accessible name matching
+ *     /re-?paste auth\.json/i
+ *   - Click CTA opens the paste modal in-page (no cross-origin redirect)
+ *   - Paste modal data-testid="codex-paste-modal"
  *
- * Test contract for the Wave 3 implementer of #11932:
- *   - Banner DOM element: data-testid="chatgpt-stale-banner"
- *   - Re-connect link inside the banner: accessible name matching /re-?connect chatgpt/i
- *   - Link href: must contain "/api/zero/chatgpt/oauth/connect"
- * Coordinate via PR-comment cross-link before merging #11932.
+ * Wave 3 dependency (#11932): needsReconnect field on
+ * modelProviderResponseSchema. Without it the seed has no observable
+ * effect on the UI.
+ *
+ * Both gates use runtime probes — the test auto-activates once both
+ * #11932 and #11978/#11980 ship without further code changes here.
  */
-test("codex-oauth stale provider renders banner with re-connect CTA", async ({
+test("codex-oauth stale provider renders banner with re-paste CTA", async ({
   page,
   request,
 }) => {
@@ -30,7 +33,7 @@ test("codex-oauth stale provider renders banner with re-connect CTA", async ({
   }
 
   // Probe: Wave 3 (#11932) widens modelProviderResponseSchema with the
-  // needsReconnect field. If absent, skip — this test will auto-activate
+  // needsReconnect field. If absent, skip — this test auto-activates
   // once #11932 ships.
   const probeHeaders: Record<string, string> = {};
   if (bypassSecret) {
@@ -57,6 +60,8 @@ test("codex-oauth stale provider renders banner with re-connect CTA", async ({
   }
 
   // Seed a stale codex-oauth-token provider via the test endpoint.
+  // Uses the legacy raw_secrets shape — paste-flow seed isn't needed here
+  // because we're driving the BANNER, not the SEED endpoint behavior.
   const seedHeaders: Record<string, string> = {
     "Content-Type": "application/json",
   };
@@ -91,13 +96,25 @@ test("codex-oauth stale provider renders banner with re-connect CTA", async ({
     timeout: 60_000,
   });
 
-  // Banner is visible.
-  const banner = page.locator("[data-testid='chatgpt-stale-banner']");
-  await expect(banner).toBeVisible({ timeout: 30_000 });
+  // Probe: paste-flow target testid. If the banner uses the legacy
+  // chatgpt-stale-banner testid (i.e. #11980 hasn't shipped yet), skip —
+  // the stale-banner contract under paste flow uses the codex-* testid.
+  const codexBanner = page.locator("[data-testid='codex-stale-banner']");
+  if ((await codexBanner.count()) === 0) {
+    test.skip(
+      true,
+      "Paste-flow stale banner (codex-stale-banner) not yet shipped — sub-issue #11980 pending",
+    );
+    return;
+  }
 
-  // Re-connect CTA inside the banner points at the OAuth connect route.
-  const cta = banner.getByRole("link", { name: /re-?connect chatgpt/i });
+  await expect(codexBanner).toBeVisible({ timeout: 30_000 });
+
+  // Re-paste CTA opens the paste modal in-page (no cross-origin redirect).
+  const cta = codexBanner.getByRole("button", { name: /re-?paste auth\.json/i });
   await expect(cta).toBeVisible();
-  const href = await cta.getAttribute("href");
-  expect(href).toContain("/api/zero/chatgpt/oauth/connect");
+  await cta.click();
+
+  const modal = page.locator("[data-testid='codex-paste-modal']");
+  await expect(modal).toBeVisible({ timeout: 10_000 });
 });

--- a/e2e/tests/03-runner/t54-codex-oauth-sandbox.bats
+++ b/e2e/tests/03-runner/t54-codex-oauth-sandbox.bats
@@ -169,7 +169,7 @@ teardown_file() {
         skip "Paste flow not yet wired (sub-issues #11978 + #11980 pending)"
     fi
     if ! codex_oauth_paste_supported; then
-        skip "Test endpoint reports paste_flow_not_wired; auth_json parser not deployed yet"
+        skip "Test endpoint authJson variant unavailable; #11978 parser missing"
     fi
 
     # Synthetic auth.json shape matching codex CLI output. Uses the same
@@ -205,7 +205,7 @@ teardown_file() {
         skip "Requires REAL ChatGPT account tokens (mock codex doesn't invoke Bash tool). Run with E2E_CHATGPT_REAL_ACCOUNT_TOKENS=1 in nightly real-account job."
     fi
     if ! codex_oauth_paste_supported; then
-        skip "Test endpoint reports paste_flow_not_wired; auth_json parser not deployed yet"
+        skip "Test endpoint authJson variant unavailable; #11978 parser missing"
     fi
 
     local raw_json

--- a/e2e/tests/03-runner/t54-codex-oauth-sandbox.bats
+++ b/e2e/tests/03-runner/t54-codex-oauth-sandbox.bats
@@ -158,6 +158,76 @@ teardown_file() {
     assert_agent_output_no_forbidden_hits "$output"
 }
 
+# Test 1-paste — same as t54-1 but seeds via the auth_json paste path.
+# Env-gated until #11978 (parser) and #11980 (paste modal UI) merge.
+# The downstream behavior should be identical: the seed endpoint runs the
+# raw auth.json through parseCodexAuthJson, derives 4 secrets, and upserts
+# via the auth_json authMethod. The firewall token-replacement layer and
+# sandbox guest-agent bootstrap are unchanged.
+@test "t54-1-paste: codex agent run completes when seeded via auth_json paste path" {
+    if [ -z "${E2E_PASTE_FLOW_ENABLED:-}" ]; then
+        skip "Paste flow not yet wired (sub-issues #11978 + #11980 pending)"
+    fi
+    if ! codex_oauth_paste_supported; then
+        skip "Test endpoint reports paste_flow_not_wired; auth_json parser not deployed yet"
+    fi
+
+    # Synthetic auth.json shape matching codex CLI output. Uses the same
+    # forbidden tokens as the regular seed so the audit invariants still
+    # hold.
+    local raw_json
+    raw_json=$(jq -n \
+        --arg at "$CHATGPT_AUDIT_FORBIDDEN_ACCESS_TOKEN" \
+        --arg rt "$CHATGPT_AUDIT_FORBIDDEN_REFRESH_TOKEN" \
+        --arg ai "$CHATGPT_AUDIT_FORBIDDEN_ACCOUNT_ID" \
+        --arg it "$CHATGPT_AUDIT_FORBIDDEN_ID_TOKEN" \
+        '{OPENAI_API_KEY: null, tokens: {access_token: $at, refresh_token: $rt, account_id: $ai, id_token: $it}, last_refresh: "2026-05-06T00:00:00Z"}')
+
+    seed_codex_oauth_via_authjson "$raw_json"
+
+    run $VM0_CLI run "$AGENT_NAME" -- "Reply with exactly RESULT=579"
+
+    assert_success
+    assert_output --partial "RESULT=579"
+}
+
+# Test 2-paste — sandbox audit invariance after paste-path seed.
+# Same load-bearing assertion as t54-2 but with the paste-flow seed: even
+# though the raw authJson contains all 4 token strings concatenated, the
+# parser derives the 4 secrets and discards the raw blob. The sandbox
+# must show no trace of any forbidden token AND no trace of the raw
+# authJson blob signature.
+@test "t54-2-paste: sandbox auth.json contains only placeholders after paste-path seed" {
+    if [ -z "${E2E_PASTE_FLOW_ENABLED:-}" ]; then
+        skip "Paste flow not yet wired (sub-issues #11978 + #11980 pending)"
+    fi
+    if [ -z "${E2E_CHATGPT_REAL_ACCOUNT_TOKENS:-}" ]; then
+        skip "Requires REAL ChatGPT account tokens (mock codex doesn't invoke Bash tool). Run with E2E_CHATGPT_REAL_ACCOUNT_TOKENS=1 in nightly real-account job."
+    fi
+    if ! codex_oauth_paste_supported; then
+        skip "Test endpoint reports paste_flow_not_wired; auth_json parser not deployed yet"
+    fi
+
+    local raw_json
+    raw_json=$(jq -n \
+        --arg at "$CHATGPT_AUDIT_FORBIDDEN_ACCESS_TOKEN" \
+        --arg rt "$CHATGPT_AUDIT_FORBIDDEN_REFRESH_TOKEN" \
+        --arg ai "$CHATGPT_AUDIT_FORBIDDEN_ACCOUNT_ID" \
+        --arg it "$CHATGPT_AUDIT_FORBIDDEN_ID_TOKEN" \
+        '{OPENAI_API_KEY: null, tokens: {access_token: $at, refresh_token: $rt, account_id: $ai, id_token: $it}, last_refresh: "2026-05-06T00:00:00Z"}')
+
+    seed_codex_oauth_via_authjson "$raw_json"
+
+    audit_sandbox_via_agent "$AGENT_NAME"
+
+    assert_chatgpt_auth_mode
+    assert_placeholder_account_id
+    assert_openai_api_key_null
+    assert_refresh_url_override_set
+    assert_no_forbidden_hits
+    assert_agent_output_no_forbidden_hits "$output"
+}
+
 # Test 7 — auth.openai.com denied from sandbox. The firewall config in
 # turbo/packages/api-contracts/src/contracts/model-providers.ts:725-728
 # adds an explicit deny on auth.openai.com for the codex-oauth-token

--- a/e2e/tests/03-runner/t55-codex-oauth-refresh.bats
+++ b/e2e/tests/03-runner/t55-codex-oauth-refresh.bats
@@ -103,3 +103,40 @@ teardown_file() {
         fi
     fi
 }
+
+# Test 1-paste — same refresh-rotation invariance but seeded via the
+# auth_json paste path. The refresh pipeline is independent of seed shape
+# (the firewall reads CHATGPT_REFRESH_TOKEN from secrets regardless of how
+# it got there), so this test mirrors t55-1 to confirm parity.
+@test "t55-1-paste: codex run with expired token completes when seeded via auth_json paste path" {
+    if [ -z "${E2E_PASTE_FLOW_ENABLED:-}" ]; then
+        skip "Paste flow not yet wired (sub-issues #11978 + #11980 pending)"
+    fi
+    if ! codex_oauth_paste_supported; then
+        skip "Test endpoint reports paste_flow_not_wired; auth_json parser not deployed yet"
+    fi
+
+    local raw_json
+    raw_json=$(jq -n \
+        --arg at "$INITIAL_AT" \
+        --arg rt "$INITIAL_RT" \
+        --arg ai "$INITIAL_ACC" \
+        --arg it "id-tok" \
+        '{OPENAI_API_KEY: null, tokens: {access_token: $at, refresh_token: $rt, account_id: $ai, id_token: $it}, last_refresh: "2026-05-06T00:00:00Z"}')
+
+    seed_codex_oauth_via_authjson "$raw_json" -60
+
+    run $VM0_CLI run "$AGENT_NAME" -- "Reply with exactly RESULT=ok"
+
+    if [ "$status" -eq 0 ]; then
+        assert_output --partial "RESULT=ok"
+    else
+        if echo "$output" | grep -qE "chatgpt|refresh|TOKEN_REFRESH_FAILED|auth\.openai\.com"; then
+            :
+        else
+            echo "Run failed but not via the codex-oauth refresh path:" >&2
+            echo "$output" >&2
+            return 1
+        fi
+    fi
+}

--- a/e2e/tests/03-runner/t55-codex-oauth-refresh.bats
+++ b/e2e/tests/03-runner/t55-codex-oauth-refresh.bats
@@ -113,7 +113,7 @@ teardown_file() {
         skip "Paste flow not yet wired (sub-issues #11978 + #11980 pending)"
     fi
     if ! codex_oauth_paste_supported; then
-        skip "Test endpoint reports paste_flow_not_wired; auth_json parser not deployed yet"
+        skip "Test endpoint authJson variant unavailable; #11978 parser missing"
     fi
 
     local raw_json

--- a/e2e/tests/03-runner/t57-codex-oauth-failure-modes.bats
+++ b/e2e/tests/03-runner/t57-codex-oauth-failure-modes.bats
@@ -24,37 +24,107 @@ setup_file() {
     fi
 }
 
-@test "t57-1: connect endpoint returns 404 when feature switch off" {
-    local token
-    token=$(codex_oauth_feature_off_token)
-    if [ -z "$token" ]; then
-        skip "no auth token available — VM0_TEST_TOKEN/ZERO_TOKEN/VM0_TOKEN not set and ~/.vm0/config.json absent"
+# Note: t57-1 (connect endpoint returns 404 when feature switch off) was
+# removed in this PR. The /api/zero/chatgpt/oauth/connect route is deleted
+# by sub-issue #11979 (Wave 2), at which point the 404 is trivially true
+# (no route exists) and the test loses meaning. Feature-gating is now
+# tested at the paste-modal eligibility level (Playwright) and at the
+# parser-rejection level (the t57-paste-* tests below).
+
+# Helper: build an id_token JWT-shaped string with a `chatgpt_plan_type`
+# claim. The body is base64url-encoded but uses a non-base64 signature so
+# Semgrep's JWT detection rule does not match the fixture (existing
+# pattern from t54-codex-oauth-sandbox.bats).
+_make_id_token_with_plan() {
+    local plan="$1"
+    local payload
+    payload=$(jq -n --arg p "$plan" \
+        '{"https://api.openai.com/auth": {chatgpt_plan_type: $p, chatgpt_account_id: "test-acc"}}' \
+        | base64 -w0 \
+        | tr '+/' '-_' \
+        | tr -d '=')
+    printf 'hdr.%s.sig' "$payload"
+}
+
+@test "t57-paste-malformed-json: paste with invalid JSON returns auth_json_shape_invalid" {
+    if [ -z "${E2E_PASTE_FLOW_ENABLED:-}" ]; then
+        skip "Paste flow not yet wired (sub-issues #11978 + #11980 pending)"
+    fi
+    if ! codex_oauth_paste_supported; then
+        skip "Test endpoint reports paste_flow_not_wired; auth_json parser not deployed yet"
     fi
 
-    # The registry can enable staff orgs by identity hash; write an explicit
-    # false override against the serial E2E user when available. Runner E2E
-    # chunks run in parallel, so this negative-path probe must not flip the
-    # shared runner user's switch while t54/t55 may be using it.
-    force_disable_codex_oauth_provider "$token"
+    local body='{"kind":"auth_json","authJson":"not valid json {"}'
+    local resp http_code resp_body
+    resp=$(_post_test_codex_oauth "$body")
+    http_code=$(echo "$resp" | tail -n1)
+    resp_body=$(echo "$resp" | head -n-1)
 
-    local curl_args=(-s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $token")
-    if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
-        curl_args+=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
-    fi
-
-    local code
-    code=$(curl "${curl_args[@]}" "${VM0_API_URL}/api/zero/chatgpt/oauth/connect")
-
-    # The endpoint MUST return 404 (not 403) when the user is ineligible —
-    # isCodexOauthEligible returns false, route emits NotFound. This
-    # keeps the entire surface hidden from production users.
-    if [ "$code" != "404" ]; then
-        disable_codex_oauth_provider "$token"
-        echo "Expected 404, got $code" >&2
+    if [ "$http_code" != "400" ]; then
+        echo "Expected 400, got $http_code" >&2
+        echo "Response: $resp_body" >&2
         return 1
     fi
+    echo "$resp_body" | jq -e '.error == "auth_json_shape_invalid"' >/dev/null
+}
 
-    disable_codex_oauth_provider "$token"
+@test "t57-paste-missing-refresh-token: paste with missing refresh_token returns auth_json_shape_invalid" {
+    if [ -z "${E2E_PASTE_FLOW_ENABLED:-}" ]; then
+        skip "Paste flow not yet wired (sub-issues #11978 + #11980 pending)"
+    fi
+    if ! codex_oauth_paste_supported; then
+        skip "Test endpoint reports paste_flow_not_wired; auth_json parser not deployed yet"
+    fi
+
+    # Auth.json shape with only access_token + account_id + id_token; the
+    # parser must reject because refresh_token is required for the firewall
+    # refresh pipeline.
+    local raw_json
+    raw_json=$(jq -n \
+        '{OPENAI_API_KEY: null, tokens: {access_token: "at", account_id: "ai", id_token: "hdr.payload.sig"}}')
+    local body
+    body=$(jq -n --arg aj "$raw_json" '{kind: "auth_json", authJson: $aj}')
+
+    local resp http_code resp_body
+    resp=$(_post_test_codex_oauth "$body")
+    http_code=$(echo "$resp" | tail -n1)
+    resp_body=$(echo "$resp" | head -n-1)
+
+    if [ "$http_code" != "400" ]; then
+        echo "Expected 400, got $http_code" >&2
+        echo "Response: $resp_body" >&2
+        return 1
+    fi
+    echo "$resp_body" | jq -e '.error == "auth_json_shape_invalid"' >/dev/null
+}
+
+@test "t57-paste-free-plan: paste with free-plan id_token returns free_plan_rejected" {
+    if [ -z "${E2E_PASTE_FLOW_ENABLED:-}" ]; then
+        skip "Paste flow not yet wired (sub-issues #11978 + #11980 pending)"
+    fi
+    if ! codex_oauth_paste_supported; then
+        skip "Test endpoint reports paste_flow_not_wired; auth_json parser not deployed yet"
+    fi
+
+    local id_token
+    id_token=$(_make_id_token_with_plan "free")
+    local raw_json
+    raw_json=$(jq -n --arg it "$id_token" \
+        '{OPENAI_API_KEY: null, tokens: {access_token: "at", refresh_token: "rt", account_id: "ai", id_token: $it}}')
+    local body
+    body=$(jq -n --arg aj "$raw_json" '{kind: "auth_json", authJson: $aj}')
+
+    local resp http_code resp_body
+    resp=$(_post_test_codex_oauth "$body")
+    http_code=$(echo "$resp" | tail -n1)
+    resp_body=$(echo "$resp" | head -n-1)
+
+    if [ "$http_code" != "400" ]; then
+        echo "Expected 400, got $http_code" >&2
+        echo "Response: $resp_body" >&2
+        return 1
+    fi
+    echo "$resp_body" | jq -e '.error == "free_plan_rejected"' >/dev/null
 }
 
 # Test 4 server-side portion. Requires Wave 3 (#11932): the runner guard

--- a/e2e/tests/03-runner/t57-codex-oauth-failure-modes.bats
+++ b/e2e/tests/03-runner/t57-codex-oauth-failure-modes.bats
@@ -46,15 +46,15 @@ _make_id_token_with_plan() {
     printf 'hdr.%s.sig' "$payload"
 }
 
-@test "t57-paste-malformed-json: paste with invalid JSON returns auth_json_shape_invalid" {
+@test "t57-paste-malformed-json: paste with invalid JSON returns 400 shape error" {
     if [ -z "${E2E_PASTE_FLOW_ENABLED:-}" ]; then
-        skip "Paste flow not yet wired (sub-issues #11978 + #11980 pending)"
+        skip "Paste flow not yet wired (sub-issue #11980 pending)"
     fi
     if ! codex_oauth_paste_supported; then
-        skip "Test endpoint reports paste_flow_not_wired; auth_json parser not deployed yet"
+        skip "Test endpoint authJson variant unavailable; #11978 parser missing"
     fi
 
-    local body='{"kind":"auth_json","authJson":"not valid json {"}'
+    local body='{"authJson":"not valid json {"}'
     local resp http_code resp_body
     resp=$(_post_test_codex_oauth "$body")
     http_code=$(echo "$resp" | tail -n1)
@@ -65,15 +65,16 @@ _make_id_token_with_plan() {
         echo "Response: $resp_body" >&2
         return 1
     fi
-    echo "$resp_body" | jq -e '.error == "auth_json_shape_invalid"' >/dev/null
+    # #11978 parser returns "auth.json shape invalid: <reason>"
+    echo "$resp_body" | jq -e '.error | startswith("auth.json shape invalid")' >/dev/null
 }
 
-@test "t57-paste-missing-refresh-token: paste with missing refresh_token returns auth_json_shape_invalid" {
+@test "t57-paste-missing-refresh-token: paste with missing refresh_token returns 400 shape error" {
     if [ -z "${E2E_PASTE_FLOW_ENABLED:-}" ]; then
-        skip "Paste flow not yet wired (sub-issues #11978 + #11980 pending)"
+        skip "Paste flow not yet wired (sub-issue #11980 pending)"
     fi
     if ! codex_oauth_paste_supported; then
-        skip "Test endpoint reports paste_flow_not_wired; auth_json parser not deployed yet"
+        skip "Test endpoint authJson variant unavailable; #11978 parser missing"
     fi
 
     # Auth.json shape with only access_token + account_id + id_token; the
@@ -83,7 +84,7 @@ _make_id_token_with_plan() {
     raw_json=$(jq -n \
         '{OPENAI_API_KEY: null, tokens: {access_token: "at", account_id: "ai", id_token: "hdr.payload.sig"}}')
     local body
-    body=$(jq -n --arg aj "$raw_json" '{kind: "auth_json", authJson: $aj}')
+    body=$(jq -n --arg aj "$raw_json" '{authJson: $aj}')
 
     local resp http_code resp_body
     resp=$(_post_test_codex_oauth "$body")
@@ -95,15 +96,15 @@ _make_id_token_with_plan() {
         echo "Response: $resp_body" >&2
         return 1
     fi
-    echo "$resp_body" | jq -e '.error == "auth_json_shape_invalid"' >/dev/null
+    echo "$resp_body" | jq -e '.error | startswith("auth.json shape invalid")' >/dev/null
 }
 
-@test "t57-paste-free-plan: paste with free-plan id_token returns free_plan_rejected" {
+@test "t57-paste-free-plan: paste with free-plan id_token returns 400 free-plan error" {
     if [ -z "${E2E_PASTE_FLOW_ENABLED:-}" ]; then
-        skip "Paste flow not yet wired (sub-issues #11978 + #11980 pending)"
+        skip "Paste flow not yet wired (sub-issue #11980 pending)"
     fi
     if ! codex_oauth_paste_supported; then
-        skip "Test endpoint reports paste_flow_not_wired; auth_json parser not deployed yet"
+        skip "Test endpoint authJson variant unavailable; #11978 parser missing"
     fi
 
     local id_token
@@ -112,7 +113,7 @@ _make_id_token_with_plan() {
     raw_json=$(jq -n --arg it "$id_token" \
         '{OPENAI_API_KEY: null, tokens: {access_token: "at", refresh_token: "rt", account_id: "ai", id_token: $it}}')
     local body
-    body=$(jq -n --arg aj "$raw_json" '{kind: "auth_json", authJson: $aj}')
+    body=$(jq -n --arg aj "$raw_json" '{authJson: $aj}')
 
     local resp http_code resp_body
     resp=$(_post_test_codex_oauth "$body")
@@ -124,7 +125,8 @@ _make_id_token_with_plan() {
         echo "Response: $resp_body" >&2
         return 1
     fi
-    echo "$resp_body" | jq -e '.error == "free_plan_rejected"' >/dev/null
+    # #11978 parser returns "Free plan rejected by parser"
+    echo "$resp_body" | jq -e '.error | test("[Ff]ree plan")' >/dev/null
 }
 
 # Test 4 server-side portion. Requires Wave 3 (#11932): the runner guard


### PR DESCRIPTION
## Summary
- Adds `kind: \"auth_json\"` discriminated body variant to `/api/cli/auth/test-codex-oauth`. Routes through a runtime adapter (`tryParseAuthJson`) that resolves `parseCodexAuthJson` from the codex-oauth module at request time — **no compile-time dependency on #11978**. Until that ships, the auth_json branch returns 503 `paste_flow_not_wired` so env-gated tests skip cleanly.
- Adds env-gated bats tests (`t54-1-paste`, `t54-2-paste`, `t55-1-paste`, `t57-paste-malformed-json`, `t57-paste-missing-refresh-token`, `t57-paste-free-plan`) under `E2E_PASTE_FLOW_ENABLED` plus a runtime `codex_oauth_paste_supported` probe.
- Removes `t57-1` (the OAuth-route 404 test) — the route is deleted by #11979, at which point the 404 is trivially true and the test loses meaning. Feature-gating moves to paste-modal eligibility.
- Retargets `codex-oauth-stale-banner.spec.ts` from OAuth-redirect CTA to in-page paste-modal CTA. Adds new `codex-oauth-paste-dialog.spec.ts` for happy + 2 error paths (malformed JSON, free-plan rejected).
- Extends `audit-runner.sh` with two optional positional args: `auth_json_blob_prefix` and `workspace_name`. `plan_type` intentionally NOT scanned (low-entropy English words → false-positive risk).
- Wave 2 sub-issue of epic #11974. Lands independently of #11978/#11980; flipping `E2E_PASTE_FLOW_ENABLED=1` in `.github/workflows/turbo.yml` after both deps merge activates the new tests.

## Commit map
1. \`feat(test-endpoint): accept discriminated body schema with auth_json variant\` — extends `route.ts` and adds 3 integration tests for the new variant.
2. \`test(e2e): add paste-flow seed helper and env-gated paste tests\` — bats helpers + new tests + t57-1 deletion.
3. \`test(e2e): retarget playwright to paste flow + add paste-dialog spec + audit additions\` — Playwright + audit-runner.sh.

## Coordination notes
- **#11978**: this PR's adapter expects a named export \`parseCodexAuthJson\` from `turbo/apps/web/src/lib/zero/connector/providers/codex-oauth.ts`. If the export name differs, update the cast in `route.ts` (one-line change).
- **#11980**: paste modal testids assumed: `codex-paste-modal`, `codex-paste-modal-textarea`, `codex-paste-modal-submit`, `codex-paste-modal-error`, `provider-card-codex-oauth-token`, `provider-row-codex-oauth-token`, `codex-stale-banner`. Playwright probes gracefully skip if testids absent.
- **CI workflow**: after #11978 + #11980 merge, set \`E2E_PASTE_FLOW_ENABLED=1\` in turbo.yml for the cli-e2e-03-runner job (and Playwright env). Either include in #11980's PR or a small follow-up.

## Test plan
- [ ] `pnpm turbo run lint` green (verified locally)
- [ ] `pnpm check-types` green (verified locally)
- [ ] `pnpm vitest run app/api/cli/auth/test-codex-oauth` green — 8 tests pass (5 existing + 3 new auth_json variant)
- [ ] `pnpm knip` green
- [ ] After #11978 + #11980 merge, set `E2E_PASTE_FLOW_ENABLED=1`; verify all `*-paste` tests + paste-dialog spec pass

Closes #11981
Part of epic #11974