### PR TITLE
feat(platform): replace oauth button with codex auth.json paste modal

### DIFF
--- a/turbo/apps/platform/src/signals/external/org-model-providers.ts
+++ b/turbo/apps/platform/src/signals/external/org-model-providers.ts
@@ -7,6 +7,7 @@ import {
 import type {
   UpsertModelProviderRequest,
   ModelProviderType,
+  UpsertModelProviderResponse,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
@@ -73,6 +74,42 @@ export const setDefaultOrgModelProvider$ = command(
     set(internalReloadOrgModelProviders$, (x) => {
       return x + 1;
     });
+  },
+);
+
+/**
+ * Submit a raw `~/.codex/auth.json` payload for the codex-oauth-token
+ * provider via the `auth_json` authMethod (server-side parser lives in
+ * #11978). Suppresses the default toast on error so the paste dialog can
+ * render typed error codes inline (e.g. `auth_json_shape_invalid`,
+ * `free_plan_rejected`); callers handle the thrown ApiError.
+ */
+export const submitCodexAuthJson$ = command(
+  async (
+    { get, set },
+    rawJson: string,
+    signal: AbortSignal,
+  ): Promise<UpsertModelProviderResponse> => {
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroModelProvidersMainContract);
+    const result = await accept(
+      client.upsert({
+        body: {
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: rawJson },
+        },
+        fetchOptions: { signal },
+      }),
+      [200, 201],
+      { toast: false },
+    );
+
+    set(internalReloadOrgModelProviders$, (x) => {
+      return x + 1;
+    });
+
+    return result.body;
   },
 );
 

--- a/turbo/apps/platform/src/signals/external/org-model-providers.ts
+++ b/turbo/apps/platform/src/signals/external/org-model-providers.ts
@@ -7,7 +7,6 @@ import {
 import type {
   UpsertModelProviderRequest,
   ModelProviderType,
-  UpsertModelProviderResponse,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
@@ -78,40 +77,16 @@ export const setDefaultOrgModelProvider$ = command(
 );
 
 /**
- * Submit a raw `~/.codex/auth.json` payload for the codex-oauth-token
- * provider via the `auth_json` authMethod (server-side parser lives in
- * #11978). Suppresses the default toast on error so the paste dialog can
- * render typed error codes inline (e.g. `auth_json_shape_invalid`,
- * `free_plan_rejected`); callers handle the thrown ApiError.
+ * Force a refetch of `orgModelProviders$`. Used by higher-level commands
+ * that mutate provider state through a different code path (e.g. the codex
+ * auth.json paste flow in #11980, which lives in settings/ to share dialog
+ * state with the paste dialog).
  */
-export const submitCodexAuthJson$ = command(
-  async (
-    { get, set },
-    rawJson: string,
-    signal: AbortSignal,
-  ): Promise<UpsertModelProviderResponse> => {
-    const createClient = get(zeroClient$);
-    const client = createClient(zeroModelProvidersMainContract);
-    const result = await accept(
-      client.upsert({
-        body: {
-          type: "codex-oauth-token",
-          authMethod: "auth_json",
-          secrets: { CODEX_AUTH_JSON: rawJson },
-        },
-        fetchOptions: { signal },
-      }),
-      [200, 201],
-      { toast: false },
-    );
-
-    set(internalReloadOrgModelProviders$, (x) => {
-      return x + 1;
-    });
-
-    return result.body;
-  },
-);
+export const reloadOrgModelProviders$ = command(({ set }) => {
+  set(internalReloadOrgModelProviders$, (x) => {
+    return x + 1;
+  });
+});
 
 /**
  * Delete an org model provider by type (admin only).

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -174,6 +174,21 @@ export function jsonParseOr<T>(value: string, fallback: T): T {
 }
 
 /**
+ * Boolean shape check for untrusted JSON strings — returns true when the
+ * value parses, false otherwise. Helps callers that just want a sanity
+ * gate (e.g. disabling a submit button until paste is parseable) without
+ * dealing with the sentinel pattern of `jsonParseOr`.
+ */
+export function isValidJson(value: string): boolean {
+  // Defer to the project's safe-parse utility with a unique fallback
+  // reference so we can detect failure without try/catch in the caller.
+  const SENTINEL: object = JSON_INVALID_SENTINEL;
+  return jsonParseOr<object>(value, SENTINEL) !== SENTINEL;
+}
+
+const JSON_INVALID_SENTINEL = Object.freeze({});
+
+/**
  * Best-effort wrapper: await `p` and swallow non-abort errors.
  * Use for prefetch or fire-and-forget operations where failure is acceptable.
  */

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-model-providers.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-model-providers.ts
@@ -11,12 +11,16 @@ import {
   type ModelProviderType,
   type ModelProviderResponse,
 } from "@vm0/api-contracts/contracts/model-providers";
+import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
 import {
   createOrgModelProvider$,
   deleteOrgModelProvider$,
   orgModelProviders$,
+  reloadOrgModelProviders$,
   setDefaultOrgModelProvider$,
 } from "../../external/org-model-providers.ts";
+import { zeroClient$ } from "../../api-client.ts";
+import { accept } from "../../../lib/accept.ts";
 
 // ---------------------------------------------------------------------------
 // Add provider dialog (list of provider type cards)
@@ -36,6 +40,13 @@ export const setOrgAddProviderDialogOpen$ = command(
 // Codex auth.json paste dialog (replaces broken cross-origin OAuth redirect;
 // see #11980). Same dialog handles both first-time connect and re-paste
 // recovery from a stale session — only the title differs by mode.
+//
+// Submit goes through `submitCodexAuthJson$` below. The dialog component
+// drives that command via `useLoadableSet`, which gives it loading + error
+// state for inline rendering. The command itself closes the dialog and
+// resets the paste textarea on success — the bidirectional flow keeps the
+// component free of try/catch (banned by no-restricted-syntax) and useState
+// (banned by no-restricted-imports).
 // ---------------------------------------------------------------------------
 
 type CodexPasteDialogMode = "connect" | "reconnect";
@@ -50,13 +61,66 @@ const internalCodexPasteDialogState$ = state<CodexPasteDialogState>({
   mode: "connect",
 });
 
+const internalCodexPasteContent$ = state<string>("");
+
 export const codexPasteDialogState$ = computed((get) => {
   return get(internalCodexPasteDialogState$);
+});
+
+export const codexPasteContent$ = computed((get) => {
+  return get(internalCodexPasteContent$);
 });
 
 export const setCodexPasteDialogState$ = command(
   ({ set }, next: CodexPasteDialogState) => {
     set(internalCodexPasteDialogState$, next);
+    if (!next.open) {
+      set(internalCodexPasteContent$, "");
+    }
+  },
+);
+
+export const updateCodexPasteContent$ = command(({ set }, paste: string) => {
+  set(internalCodexPasteContent$, paste);
+});
+
+/**
+ * Submit the current codex paste content as `~/.codex/auth.json` via the
+ * `auth_json` authMethod. Server-side parser lives in #11978.
+ *
+ * Suppresses the default toast on error (`{ toast: false }`) so the paste
+ * dialog can render typed error codes inline (e.g. `auth_json_shape_invalid`,
+ * `free_plan_rejected`) — `useLoadableSet` in the component reads these
+ * codes off the rejected ApiError. On success, closes the dialog, resets
+ * the paste textarea, and triggers an org-providers refetch so the stale
+ * banner unmounts after a re-paste.
+ */
+export const submitCodexAuthJson$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const rawJson = get(internalCodexPasteContent$).trim();
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroModelProvidersMainContract);
+    const result = await accept(
+      client.upsert({
+        body: {
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: rawJson },
+        },
+        fetchOptions: { signal },
+      }),
+      [200, 201],
+      { toast: false },
+    );
+    signal.throwIfAborted();
+
+    set(reloadOrgModelProviders$);
+    set(internalCodexPasteContent$, "");
+    set(internalCodexPasteDialogState$, (prev) => {
+      return { ...prev, open: false };
+    });
+
+    return result.body;
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-model-providers.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-model-providers.ts
@@ -89,8 +89,9 @@ export const updateCodexPasteContent$ = command(({ set }, paste: string) => {
  * `auth_json` authMethod. Server-side parser lives in #11978.
  *
  * Suppresses the default toast on error (`{ toast: false }`) so the paste
- * dialog can render typed error codes inline (e.g. `auth_json_shape_invalid`,
- * `free_plan_rejected`) — `useLoadableSet` in the component reads these
+ * dialog can render typed error codes inline (e.g.
+ * `CODEX_AUTH_JSON_SHAPE_INVALID`, `CODEX_FREE_PLAN_REJECTED`) —
+ * `useLoadableSet` in the component reads these
  * codes off the rejected ApiError. On success, closes the dialog, resets
  * the paste textarea, and triggers an org-providers refetch so the stale
  * banner unmounts after a re-paste.

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-model-providers.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-model-providers.ts
@@ -33,6 +33,34 @@ export const setOrgAddProviderDialogOpen$ = command(
 );
 
 // ---------------------------------------------------------------------------
+// Codex auth.json paste dialog (replaces broken cross-origin OAuth redirect;
+// see #11980). Same dialog handles both first-time connect and re-paste
+// recovery from a stale session — only the title differs by mode.
+// ---------------------------------------------------------------------------
+
+type CodexPasteDialogMode = "connect" | "reconnect";
+
+interface CodexPasteDialogState {
+  open: boolean;
+  mode: CodexPasteDialogMode;
+}
+
+const internalCodexPasteDialogState$ = state<CodexPasteDialogState>({
+  open: false,
+  mode: "connect",
+});
+
+export const codexPasteDialogState$ = computed((get) => {
+  return get(internalCodexPasteDialogState$);
+});
+
+export const setCodexPasteDialogState$ = command(
+  ({ set }, next: CodexPasteDialogState) => {
+    set(internalCodexPasteDialogState$, next);
+  },
+);
+
+// ---------------------------------------------------------------------------
 // Dialog state (add/edit single provider form)
 // ---------------------------------------------------------------------------
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/codex-auth-paste-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/codex-auth-paste-dialog.test.tsx
@@ -100,7 +100,7 @@ describe("codex paste dialog — local sanity", () => {
 });
 
 describe("codex paste dialog — submit happy path", () => {
-  it("POSTs auth_json shape and closes the dialog on success", async () => {
+  it("posts auth_json shape and closes the dialog on success", async () => {
     let receivedBody: unknown = null;
     server.use(
       mockApi(zeroModelProvidersMainContract.upsert, ({ body, respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/codex-auth-paste-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/codex-auth-paste-dialog.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * Tests for the codex auth.json paste dialog (#11980).
+ *
+ * Covers:
+ * - Empty paste / malformed JSON disables submit (client-side sanity check)
+ * - Happy path posts the auth_json shape and closes the dialog
+ * - Server-typed error codes (auth_json_shape_invalid, free_plan_rejected)
+ *   surface inline; toast.error is NOT fired (UX choice — see #11980 plan)
+ * - Reconnect mode renders a different title
+ * - Cancel resets transient state for the next open
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
+import { server } from "../../../mocks/server.ts";
+import { mockApi } from "../../../mocks/msw-contract.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import {
+  detachedSetupPage,
+  click,
+  fill,
+} from "../../../__tests__/page-helper.ts";
+import {
+  setCodexPasteDialogState$,
+  setOrgAddProviderDialogOpen$,
+} from "../../../signals/zero-page/settings/org-model-providers.ts";
+import { resetMockOrgModelProviders } from "../../../mocks/handlers/api-org-model-providers.ts";
+
+vi.mock("@vm0/ui/components/ui/sonner", async (importOriginal) => {
+  const actual =
+    (await importOriginal()) as typeof import("@vm0/ui/components/ui/sonner");
+  return {
+    ...actual,
+    toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+  };
+});
+
+const context = testContext();
+
+beforeEach(() => {
+  resetMockOrgModelProviders();
+  vi.mocked(toast.error).mockClear();
+  vi.mocked(toast.success).mockClear();
+});
+
+afterEach(() => {
+  // Make sure the dialog is closed between tests so leaked state doesn't
+  // bleed into the next case.
+  context.store.set(setCodexPasteDialogState$, {
+    open: false,
+    mode: "connect",
+  });
+  context.store.set(setOrgAddProviderDialogOpen$, false);
+});
+
+async function openPasteDialog(
+  mode: "connect" | "reconnect" = "connect",
+): Promise<void> {
+  detachedSetupPage({ context, path: "/?settings=providers" });
+  await waitFor(() => {
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+  context.store.set(setCodexPasteDialogState$, { open: true, mode });
+  await waitFor(() => {
+    expect(screen.getByTestId("codex-paste-textarea")).toBeInTheDocument();
+  });
+}
+
+const VALID_JSON = '{"OPENAI_API_KEY":"sk-test","tokens":{"access_token":"a"}}';
+
+describe("codex paste dialog — local sanity", () => {
+  it("disables submit when textarea is empty", async () => {
+    await openPasteDialog();
+    const submit = screen.getByTestId("codex-paste-submit");
+    expect(submit).toBeDisabled();
+  });
+
+  it("disables submit and shows hint when paste is not valid JSON", async () => {
+    await openPasteDialog();
+    const textarea = screen.getByTestId("codex-paste-textarea");
+    await fill(textarea, "not-json{");
+
+    const submit = screen.getByTestId("codex-paste-submit");
+    expect(submit).toBeDisabled();
+    expect(
+      screen.getByText(/Looks like the paste isn't valid JSON yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it("enables submit once paste parses as JSON", async () => {
+    await openPasteDialog();
+    const textarea = screen.getByTestId("codex-paste-textarea");
+    await fill(textarea, VALID_JSON);
+
+    const submit = screen.getByTestId("codex-paste-submit");
+    expect(submit).not.toBeDisabled();
+  });
+});
+
+describe("codex paste dialog — submit happy path", () => {
+  it("POSTs auth_json shape and closes the dialog on success", async () => {
+    let receivedBody: unknown = null;
+    server.use(
+      mockApi(zeroModelProvidersMainContract.upsert, ({ body, respond }) => {
+        receivedBody = body;
+        return respond(201, {
+          provider: {
+            id: "00000000-0000-4000-a000-000000000099",
+            type: "codex-oauth-token",
+            framework: "codex",
+            secretName: "CHATGPT_ACCESS_TOKEN",
+            authMethod: "auth_json",
+            secretNames: ["CODEX_AUTH_JSON"],
+            isDefault: true,
+            selectedModel: null,
+            needsReconnect: false,
+            lastRefreshErrorCode: null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+          created: true,
+        });
+      }),
+    );
+
+    await openPasteDialog();
+    const textarea = screen.getByTestId("codex-paste-textarea");
+    await fill(textarea, VALID_JSON);
+    click(screen.getByTestId("codex-paste-submit"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: /Connect Codex/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(receivedBody).toStrictEqual({
+      type: "codex-oauth-token",
+      authMethod: "auth_json",
+      secrets: { CODEX_AUTH_JSON: VALID_JSON },
+    });
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+  });
+});
+
+describe("codex paste dialog — server typed errors", () => {
+  it("renders friendly copy for auth_json_shape_invalid without firing toast", async () => {
+    server.use(
+      mockApi(zeroModelProvidersMainContract.upsert, ({ respond }) => {
+        return respond(400, {
+          error: {
+            code: "auth_json_shape_invalid",
+            message: "shape invalid",
+          },
+        });
+      }),
+    );
+
+    await openPasteDialog();
+    await fill(screen.getByTestId("codex-paste-textarea"), VALID_JSON);
+    click(screen.getByTestId("codex-paste-submit"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/auth\.json format unrecognized/i),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("dialog", { name: /Connect Codex/i }),
+    ).toBeInTheDocument();
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+  });
+
+  it("renders friendly copy for free_plan_rejected", async () => {
+    server.use(
+      mockApi(zeroModelProvidersMainContract.upsert, ({ respond }) => {
+        return respond(400, {
+          error: {
+            code: "free_plan_rejected",
+            message: "free plan",
+          },
+        });
+      }),
+    );
+
+    await openPasteDialog();
+    await fill(screen.getByTestId("codex-paste-textarea"), VALID_JSON);
+    click(screen.getByTestId("codex-paste-submit"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Free ChatGPT plans cannot use Codex/i),
+      ).toBeInTheDocument();
+    });
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+  });
+
+  it("falls back to server message for unknown error codes", async () => {
+    server.use(
+      mockApi(zeroModelProvidersMainContract.upsert, ({ respond }) => {
+        return respond(400, {
+          error: { code: "WHATEVER", message: "some other error from server" },
+        });
+      }),
+    );
+
+    await openPasteDialog();
+    await fill(screen.getByTestId("codex-paste-textarea"), VALID_JSON);
+    click(screen.getByTestId("codex-paste-submit"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/some other error from server/i),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("codex paste dialog — modes", () => {
+  it("renders Re-connect Codex title in reconnect mode", async () => {
+    await openPasteDialog("reconnect");
+    expect(
+      screen.getByRole("dialog", { name: /Re-connect Codex/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/codex-auth-paste-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/codex-auth-paste-dialog.test.tsx
@@ -4,8 +4,9 @@
  * Covers:
  * - Empty paste / malformed JSON disables submit (client-side sanity check)
  * - Happy path posts the auth_json shape and closes the dialog
- * - Server-typed error codes (auth_json_shape_invalid, free_plan_rejected)
- *   surface inline; toast.error is NOT fired (UX choice — see #11980 plan)
+ * - Server-typed error codes (CODEX_AUTH_JSON_SHAPE_INVALID,
+ *   CODEX_FREE_PLAN_REJECTED) surface inline; toast.error is NOT fired
+ *   (UX choice — see #11980 plan)
  * - Reconnect mode renders a different title
  * - Cancel resets transient state for the next open
  */
@@ -146,12 +147,12 @@ describe("codex paste dialog — submit happy path", () => {
 });
 
 describe("codex paste dialog — server typed errors", () => {
-  it("renders friendly copy for auth_json_shape_invalid without firing toast", async () => {
+  it("renders friendly copy for CODEX_AUTH_JSON_SHAPE_INVALID without firing toast", async () => {
     server.use(
       mockApi(zeroModelProvidersMainContract.upsert, ({ respond }) => {
         return respond(400, {
           error: {
-            code: "auth_json_shape_invalid",
+            code: "CODEX_AUTH_JSON_SHAPE_INVALID",
             message: "shape invalid",
           },
         });
@@ -174,12 +175,12 @@ describe("codex paste dialog — server typed errors", () => {
     expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
   });
 
-  it("renders friendly copy for free_plan_rejected", async () => {
+  it("renders friendly copy for CODEX_FREE_PLAN_REJECTED", async () => {
     server.use(
       mockApi(zeroModelProvidersMainContract.upsert, ({ respond }) => {
         return respond(400, {
           error: {
-            code: "free_plan_rejected",
+            code: "CODEX_FREE_PLAN_REJECTED",
             message: "free plan",
           },
         });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-add-provider-dialog-codex.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-add-provider-dialog-codex.test.tsx
@@ -1,15 +1,13 @@
 /**
- * Tests for the Connect ChatGPT entry on the model-providers settings tab.
+ * Tests for the Connect Codex entry on the model-providers settings tab.
  *
  * Covers:
  * - Card hidden when CodexOauthProvider feature switch is off (DoD: gate-off)
  * - Card visible when feature switch is on (DoD: gate-on)
- * - Click on the card redirects to /api/zero/chatgpt/oauth/connect (DoD: redirect)
+ * - Click on the card opens the codex auth.json paste dialog
+ *   (replaces the broken cross-origin OAuth redirect; #11980)
  * - Existing-provider row renders workspace name + plan pill when fields
  *   present on codex-oauth-token provider (DoD: post-OAuth display)
- *
- * Wave 2 sub-issue of Epic #11872 (issue #11907). Server-side OAuth route
- * delivered in #11909; this test mocks the redirect target.
  */
 
 import {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-add-provider-dialog-codex.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-add-provider-dialog-codex.test.tsx
@@ -10,15 +10,7 @@
  *   present on codex-oauth-token provider (DoD: post-OAuth display)
  */
 
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type Mock,
-} from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
@@ -107,33 +99,15 @@ describe("connect ChatGPT card — feature switch gating", () => {
   });
 });
 
-describe("connect ChatGPT card — click handler", () => {
-  let assignSpy: Mock;
-  let originalAssign: Location["assign"];
-
+describe("connect Codex card — click handler", () => {
   beforeEach(() => {
     setMockFeatureSwitches({
       [FeatureSwitchKey.CodexOauthProvider]: true,
     });
     resetMockOrgModelProviders();
-    // jsdom marks window.location.assign as non-configurable in some versions;
-    // replace it via defineProperty so we can spy without "Cannot redefine".
-    originalAssign = window.location.assign;
-    assignSpy = vi.fn();
-    Object.defineProperty(window.location, "assign", {
-      configurable: true,
-      value: assignSpy,
-    });
   });
 
-  afterEach(() => {
-    Object.defineProperty(window.location, "assign", {
-      configurable: true,
-      value: originalAssign,
-    });
-  });
-
-  it("redirects to /api/zero/chatgpt/oauth/connect when card is clicked", async () => {
+  it("opens the auth.json paste dialog when the codex card is clicked", async () => {
     await openProvidersPage();
     context.store.set(setOrgAddProviderDialogOpen$, true);
 
@@ -142,7 +116,11 @@ describe("connect ChatGPT card — click handler", () => {
     );
     click(card);
 
-    expect(assignSpy).toHaveBeenCalledWith("/api/zero/chatgpt/oauth/connect");
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: /Connect Codex/i }),
+      ).toBeInTheDocument();
+    });
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Tests for OrgProvidersTab — specifically the stale-session reconnect
+ * banner button (#11980 replaces the broken cross-origin <a href> with a
+ * button that opens the codex auth.json paste dialog in reconnect mode).
+ *
+ * Covers:
+ * - Re-paste button opens the paste dialog with reconnect title
+ * - Successful re-paste clears needsReconnect → banner unmounts
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
+import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
+import { server } from "../../../../../mocks/server.ts";
+import { mockApi } from "../../../../../mocks/msw-contract.ts";
+import { testContext } from "../../../../../signals/__tests__/test-helpers.ts";
+import {
+  detachedSetupPage,
+  click,
+  fill,
+} from "../../../../../__tests__/page-helper.ts";
+import {
+  setMockOrgModelProviders,
+  resetMockOrgModelProviders,
+} from "../../../../../mocks/handlers/api-org-model-providers.ts";
+import { setCodexPasteDialogState$ } from "../../../../../signals/zero-page/settings/org-model-providers.ts";
+
+vi.mock("@vm0/ui/components/ui/sonner", async (importOriginal) => {
+  const actual =
+    (await importOriginal()) as typeof import("@vm0/ui/components/ui/sonner");
+  return {
+    ...actual,
+    toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+  };
+});
+
+const context = testContext();
+
+function makeStaleProvider(): ModelProviderResponse {
+  return {
+    id: "00000000-0000-4000-a000-0000000000a1",
+    type: "codex-oauth-token",
+    framework: "codex",
+    secretName: "CHATGPT_ACCESS_TOKEN",
+    authMethod: "oauth",
+    secretNames: [
+      "CHATGPT_ACCESS_TOKEN",
+      "CHATGPT_REFRESH_TOKEN",
+      "CHATGPT_ACCOUNT_ID",
+      "CHATGPT_ID_TOKEN",
+    ],
+    isDefault: true,
+    selectedModel: null,
+    needsReconnect: true,
+    lastRefreshErrorCode: "refresh_token_expired",
+    createdAt: "2026-05-06T00:00:00Z",
+    updatedAt: "2026-05-06T00:00:00Z",
+  };
+}
+
+function makeFreshProvider(): ModelProviderResponse {
+  return {
+    ...makeStaleProvider(),
+    needsReconnect: false,
+    lastRefreshErrorCode: null,
+  };
+}
+
+beforeEach(() => {
+  resetMockOrgModelProviders();
+  vi.mocked(toast.error).mockClear();
+  vi.mocked(toast.success).mockClear();
+});
+
+afterEach(() => {
+  context.store.set(setCodexPasteDialogState$, {
+    open: false,
+    mode: "connect",
+  });
+});
+
+async function openProvidersPage(): Promise<void> {
+  detachedSetupPage({ context, path: "/?settings=providers" });
+  await waitFor(() => {
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+}
+
+describe("org-providers-tab — stale banner reconnect", () => {
+  it("opens the paste dialog in reconnect mode when Re-paste button is clicked", async () => {
+    setMockOrgModelProviders([makeStaleProvider()]);
+    await openProvidersPage();
+
+    const button = await screen.findByRole("button", {
+      name: /Re-paste auth\.json/i,
+    });
+    click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: /Re-connect Codex/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("clears the stale banner after a successful re-paste", async () => {
+    setMockOrgModelProviders([makeStaleProvider()]);
+    server.use(
+      mockApi(zeroModelProvidersMainContract.upsert, ({ respond }) => {
+        const fresh = makeFreshProvider();
+        // Reflect the post-submit state so the next list refresh sees a
+        // non-stale provider; the dialog drives the refresh via the
+        // internal reload counter inside submitCodexAuthJson$.
+        setMockOrgModelProviders([fresh]);
+        return respond(200, { provider: fresh, created: false });
+      }),
+    );
+
+    await openProvidersPage();
+
+    expect(
+      await screen.findByText(/ChatGPT session needs reconnection/i),
+    ).toBeInTheDocument();
+
+    click(await screen.findByRole("button", { name: /Re-paste auth\.json/i }));
+
+    await fill(
+      await screen.findByTestId("codex-paste-textarea"),
+      '{"OPENAI_API_KEY":"sk","tokens":{"access_token":"a"}}',
+    );
+    click(screen.getByTestId("codex-paste-submit"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/ChatGPT session needs reconnection/i),
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("dialog", { name: /Re-connect Codex/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
@@ -88,20 +88,23 @@ async function openProvidersPage(): Promise<void> {
   });
 }
 
+async function findRepasteButton(): Promise<HTMLElement> {
+  return await screen.findByText("Re-paste auth.json");
+}
+
+function findReconnectDialogTitle(): HTMLElement | null {
+  return screen.queryByText("Re-connect Codex");
+}
+
 describe("org-providers-tab — stale banner reconnect", () => {
   it("opens the paste dialog in reconnect mode when Re-paste button is clicked", async () => {
     setMockOrgModelProviders([makeStaleProvider()]);
     await openProvidersPage();
 
-    const button = await screen.findByRole("button", {
-      name: /Re-paste auth\.json/i,
-    });
-    click(button);
+    click(await findRepasteButton());
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("dialog", { name: /Re-connect Codex/i }),
-      ).toBeInTheDocument();
+      expect(findReconnectDialogTitle()).toBeInTheDocument();
     });
   });
 
@@ -120,11 +123,13 @@ describe("org-providers-tab — stale banner reconnect", () => {
 
     await openProvidersPage();
 
-    expect(
-      await screen.findByText(/ChatGPT session needs reconnection/i),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText(/ChatGPT session needs reconnection/i),
+      ).toBeInTheDocument();
+    });
 
-    click(await screen.findByRole("button", { name: /Re-paste auth\.json/i }));
+    click(await findRepasteButton());
 
     await fill(
       await screen.findByTestId("codex-paste-textarea"),
@@ -137,8 +142,6 @@ describe("org-providers-tab — stale banner reconnect", () => {
         screen.queryByText(/ChatGPT session needs reconnection/i),
       ).not.toBeInTheDocument();
     });
-    expect(
-      screen.queryByRole("dialog", { name: /Re-connect Codex/i }),
-    ).not.toBeInTheDocument();
+    expect(findReconnectDialogTitle()).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
@@ -28,6 +28,7 @@ import {
   orgSetDefaultProvider$,
   orgOpenEditDialog$,
   orgOpenDeleteDialog$,
+  setCodexPasteDialogState$,
 } from "../../../../signals/zero-page/settings/org-model-providers.ts";
 import { isOrgAdmin$ } from "../../../../signals/org.ts";
 import { getUILabel } from "../settings/provider-ui-config.ts";
@@ -35,6 +36,7 @@ import { ProviderIcon } from "../settings/provider-icons.tsx";
 import { OrgAddProviderDialog } from "../settings/org-add-provider-dialog.tsx";
 import { OrgProviderDialog } from "../settings/org-provider-dialog.tsx";
 import { OrgDeleteProviderDialog } from "../settings/org-delete-provider-dialog.tsx";
+import { CodexAuthPasteDialog } from "../settings/codex-auth-paste-dialog.tsx";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 
@@ -50,6 +52,7 @@ export function OrgProvidersTab() {
       <ProviderListSection isAdmin={isAdmin} />
       <OrgDeleteProviderDialog />
       <OrgProviderDialog />
+      <CodexAuthPasteDialog />
     </div>
   );
 }
@@ -73,6 +76,7 @@ function StaleProviderBanner({
 }: {
   providers: ModelProviderResponse[];
 }) {
+  const setPasteDialog = useSet(setCodexPasteDialogState$);
   const stale = providers.find((p) => {
     return p.type === "codex-oauth-token" && p.needsReconnect;
   });
@@ -92,12 +96,15 @@ function StaleProviderBanner({
           {staleMessage(stale.lastRefreshErrorCode)}
         </p>
       </div>
-      <a
-        href="/api/zero/chatgpt/oauth/connect"
+      <button
+        type="button"
+        onClick={() => {
+          return setPasteDialog({ open: true, mode: "reconnect" });
+        }}
         className="shrink-0 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
       >
-        Re-connect ChatGPT
-      </a>
+        Re-paste auth.json
+      </button>
     </section>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/codex-auth-paste-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/codex-auth-paste-dialog.tsx
@@ -1,5 +1,5 @@
 import { useGet, useSet } from "ccstate-react";
-import { useState } from "react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import {
   Dialog,
   DialogContent,
@@ -10,12 +10,14 @@ import {
 } from "@vm0/ui/components/ui/dialog";
 import { Button } from "@vm0/ui/components/ui/button";
 import {
+  codexPasteContent$,
   codexPasteDialogState$,
   setCodexPasteDialogState$,
+  submitCodexAuthJson$,
+  updateCodexPasteContent$,
 } from "../../../../signals/zero-page/settings/org-model-providers.ts";
-import { submitCodexAuthJson$ } from "../../../../signals/external/org-model-providers.ts";
 import { ApiError } from "../../../../lib/accept.ts";
-import { detach, Reason } from "../../../../signals/utils.ts";
+import { detach, isValidJson, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 
 /**
@@ -32,51 +34,29 @@ import { pageSignal$ } from "../../../../signals/page-signal.ts";
  * server-side parser lands in #11978. Typed error codes
  * (`auth_json_shape_invalid`, `free_plan_rejected`) surface inline rather
  * than via toast — the user is staring at the textarea, an inline message
- * keeps the cause-and-effect close.
+ * keeps cause-and-effect close.
  */
 export function CodexAuthPasteDialog() {
   const dialog = useGet(codexPasteDialogState$);
+  const paste = useGet(codexPasteContent$);
   const setDialog = useSet(setCodexPasteDialogState$);
-  const submit = useSet(submitCodexAuthJson$);
+  const updatePaste = useSet(updateCodexPasteContent$);
   const pageSignal = useGet(pageSignal$);
+  const [submitLoadable, submit] = useLoadableSet(submitCodexAuthJson$);
 
-  const [paste, setPaste] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [serverError, setServerError] = useState<ApiError | null>(null);
-
-  function resetTransientState(): void {
-    setPaste("");
-    setServerError(null);
-    setSubmitting(false);
-  }
-
-  function handleOpenChange(nextOpen: boolean): void {
-    if (!nextOpen) {
-      resetTransientState();
-    }
-    setDialog({ ...dialog, open: nextOpen });
-  }
+  const submitting = submitLoadable.state === "loading";
+  const serverError =
+    submitLoadable.state === "hasError" &&
+    submitLoadable.error instanceof ApiError
+      ? submitLoadable.error
+      : null;
 
   const trimmed = paste.trim();
   const localParseError = computeLocalParseError(trimmed);
   const canSubmit = trimmed !== "" && localParseError === null && !submitting;
 
-  async function handleSubmit(): Promise<void> {
-    setSubmitting(true);
-    setServerError(null);
-    try {
-      await submit(trimmed, pageSignal);
-      resetTransientState();
-      setDialog({ ...dialog, open: false });
-    } catch (error) {
-      if (error instanceof ApiError) {
-        setServerError(error);
-      } else {
-        throw error;
-      }
-    } finally {
-      setSubmitting(false);
-    }
+  function handleOpenChange(nextOpen: boolean): void {
+    setDialog({ ...dialog, open: nextOpen });
   }
 
   const title =
@@ -111,10 +91,7 @@ export function CodexAuthPasteDialog() {
         <textarea
           value={paste}
           onChange={(e) => {
-            setPaste(e.target.value);
-            if (serverError) {
-              setServerError(null);
-            }
+            return updatePaste(e.target.value);
           }}
           placeholder='{"OPENAI_API_KEY": "...", "tokens": {...}, ...}'
           rows={8}
@@ -137,7 +114,7 @@ export function CodexAuthPasteDialog() {
           <Button
             variant="outline"
             onClick={() => {
-              handleOpenChange(false);
+              return handleOpenChange(false);
             }}
             disabled={submitting}
           >
@@ -145,7 +122,7 @@ export function CodexAuthPasteDialog() {
           </Button>
           <Button
             onClick={() => {
-              detach(handleSubmit(), Reason.DomCallback);
+              detach(submit(pageSignal), Reason.DomCallback);
             }}
             disabled={!canSubmit}
             data-testid="codex-paste-submit"
@@ -162,12 +139,9 @@ function computeLocalParseError(trimmed: string): string | null {
   if (trimmed === "") {
     return null;
   }
-  try {
-    JSON.parse(trimmed);
-    return null;
-  } catch {
-    return "Looks like the paste isn't valid JSON yet.";
-  }
+  return isValidJson(trimmed)
+    ? null
+    : "Looks like the paste isn't valid JSON yet.";
 }
 
 function getErrorCopy(error: ApiError): string {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/codex-auth-paste-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/codex-auth-paste-dialog.tsx
@@ -32,9 +32,9 @@ import { pageSignal$ } from "../../../../signals/page-signal.ts";
  * Submit POSTs `{ type: 'codex-oauth-token', authMethod: 'auth_json',
  * secrets: { CODEX_AUTH_JSON: <raw> } }` to /api/zero/model-providers; the
  * server-side parser lands in #11978. Typed error codes
- * (`auth_json_shape_invalid`, `free_plan_rejected`) surface inline rather
- * than via toast — the user is staring at the textarea, an inline message
- * keeps cause-and-effect close.
+ * (`CODEX_AUTH_JSON_SHAPE_INVALID`, `CODEX_FREE_PLAN_REJECTED`) surface
+ * inline rather than via toast — the user is staring at the textarea, an
+ * inline message keeps cause-and-effect close.
  */
 export function CodexAuthPasteDialog() {
   const dialog = useGet(codexPasteDialogState$);
@@ -145,10 +145,10 @@ function computeLocalParseError(trimmed: string): string | null {
 }
 
 function getErrorCopy(error: ApiError): string {
-  if (error.code === "auth_json_shape_invalid") {
+  if (error.code === "CODEX_AUTH_JSON_SHAPE_INVALID") {
     return "auth.json format unrecognized — your codex CLI may need updating. Re-run `codex login` and try again.";
   }
-  if (error.code === "free_plan_rejected") {
+  if (error.code === "CODEX_FREE_PLAN_REJECTED") {
     return "Free ChatGPT plans cannot use Codex via vm0. Upgrade to Plus or Pro and re-run `codex login`.";
   }
   return error.message;

--- a/turbo/apps/platform/src/views/zero-page/components/settings/codex-auth-paste-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/codex-auth-paste-dialog.tsx
@@ -1,0 +1,181 @@
+import { useGet, useSet } from "ccstate-react";
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui/components/ui/dialog";
+import { Button } from "@vm0/ui/components/ui/button";
+import {
+  codexPasteDialogState$,
+  setCodexPasteDialogState$,
+} from "../../../../signals/zero-page/settings/org-model-providers.ts";
+import { submitCodexAuthJson$ } from "../../../../signals/external/org-model-providers.ts";
+import { ApiError } from "../../../../lib/accept.ts";
+import { detach, Reason } from "../../../../signals/utils.ts";
+import { pageSignal$ } from "../../../../signals/page-signal.ts";
+
+/**
+ * Paste-based connection dialog for the codex-oauth-token provider.
+ *
+ * Replaces the broken cross-origin `window.location.assign` redirect that
+ * shipped in #11909 (the platform SPA on app.vm0.ai resolved the relative
+ * /api/zero/chatgpt/oauth/connect path against itself instead of www.vm0.ai).
+ * Same component handles first-time connect and re-paste recovery from a
+ * stale session — only the title differs by mode.
+ *
+ * Submit POSTs `{ type: 'codex-oauth-token', authMethod: 'auth_json',
+ * secrets: { CODEX_AUTH_JSON: <raw> } }` to /api/zero/model-providers; the
+ * server-side parser lands in #11978. Typed error codes
+ * (`auth_json_shape_invalid`, `free_plan_rejected`) surface inline rather
+ * than via toast — the user is staring at the textarea, an inline message
+ * keeps the cause-and-effect close.
+ */
+export function CodexAuthPasteDialog() {
+  const dialog = useGet(codexPasteDialogState$);
+  const setDialog = useSet(setCodexPasteDialogState$);
+  const submit = useSet(submitCodexAuthJson$);
+  const pageSignal = useGet(pageSignal$);
+
+  const [paste, setPaste] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<ApiError | null>(null);
+
+  function resetTransientState(): void {
+    setPaste("");
+    setServerError(null);
+    setSubmitting(false);
+  }
+
+  function handleOpenChange(nextOpen: boolean): void {
+    if (!nextOpen) {
+      resetTransientState();
+    }
+    setDialog({ ...dialog, open: nextOpen });
+  }
+
+  const trimmed = paste.trim();
+  const localParseError = computeLocalParseError(trimmed);
+  const canSubmit = trimmed !== "" && localParseError === null && !submitting;
+
+  async function handleSubmit(): Promise<void> {
+    setSubmitting(true);
+    setServerError(null);
+    try {
+      await submit(trimmed, pageSignal);
+      resetTransientState();
+      setDialog({ ...dialog, open: false });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        setServerError(error);
+      } else {
+        throw error;
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const title =
+    dialog.mode === "reconnect" ? "Re-connect Codex" : "Connect Codex";
+  const submitLabel = submitting
+    ? "Connecting…"
+    : dialog.mode === "reconnect"
+      ? "Reconnect"
+      : "Connect";
+
+  return (
+    <Dialog open={dialog.open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            Paste the contents of <code>~/.codex/auth.json</code> from the
+            machine where you ran <code>codex login</code>.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ol className="text-xs text-muted-foreground space-y-1 list-decimal list-inside">
+          <li>
+            On your local machine, run <code>codex login</code>
+          </li>
+          <li>
+            After successful login, run <code>cat ~/.codex/auth.json</code>
+          </li>
+          <li>Paste the entire JSON output below</li>
+        </ol>
+
+        <textarea
+          value={paste}
+          onChange={(e) => {
+            setPaste(e.target.value);
+            if (serverError) {
+              setServerError(null);
+            }
+          }}
+          placeholder='{"OPENAI_API_KEY": "...", "tokens": {...}, ...}'
+          rows={8}
+          spellCheck={false}
+          aria-label="codex auth.json content"
+          data-testid="codex-paste-textarea"
+          className="w-full rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-xs font-mono whitespace-pre text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 resize-y min-h-[10rem]"
+        />
+
+        {localParseError && (
+          <p className="text-xs text-muted-foreground">{localParseError}</p>
+        )}
+        {serverError && (
+          <p className="text-xs text-destructive" role="alert">
+            {getErrorCopy(serverError)}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => {
+              handleOpenChange(false);
+            }}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              detach(handleSubmit(), Reason.DomCallback);
+            }}
+            disabled={!canSubmit}
+            data-testid="codex-paste-submit"
+          >
+            {submitLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function computeLocalParseError(trimmed: string): string | null {
+  if (trimmed === "") {
+    return null;
+  }
+  try {
+    JSON.parse(trimmed);
+    return null;
+  } catch {
+    return "Looks like the paste isn't valid JSON yet.";
+  }
+}
+
+function getErrorCopy(error: ApiError): string {
+  if (error.code === "auth_json_shape_invalid") {
+    return "auth.json format unrecognized — your codex CLI may need updating. Re-run `codex login` and try again.";
+  }
+  if (error.code === "free_plan_rejected") {
+    return "Free ChatGPT plans cannot use Codex via vm0. Upgrade to Plus or Pro and re-run `codex login`.";
+  }
+  return error.message;
+}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
@@ -15,6 +15,7 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   orgConfiguredProviders$,
   orgOpenAddDialog$,
+  setCodexPasteDialogState$,
 } from "../../../../signals/zero-page/settings/org-model-providers.ts";
 import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import { getUILabel, getUIDescription } from "./provider-ui-config.ts";
@@ -77,6 +78,7 @@ export function OrgAddProviderDialog({
   const codexOauthEnabled =
     features?.[FeatureSwitchKey.CodexOauthProvider] ?? false;
   const openAdd = useSet(orgOpenAddDialog$);
+  const openCodexPaste = useSet(setCodexPasteDialogState$);
   const configuredSet = new Set(
     configuredProviders?.map((p) => {
       return p.type;
@@ -85,10 +87,11 @@ export function OrgAddProviderDialog({
 
   const handleAdd = (type: ModelProviderType) => {
     if (type === "codex-oauth-token") {
-      // Server-side eligibility re-check happens in /api/zero/chatgpt/oauth/connect
-      // (delivered in #11909). The client gate above is a UX optimization to keep
-      // the card out of view; the route returns 404 when ineligible.
-      window.location.assign("/api/zero/chatgpt/oauth/connect");
+      // Open the auth.json paste dialog (#11980 replaces the broken
+      // cross-origin OAuth redirect). Close the picker so only the paste
+      // dialog is visible — stacking two dialogs is confusing.
+      openCodexPaste({ open: true, mode: "connect" });
+      onOpenChange(false);
       return;
     }
     openAdd(type);


### PR DESCRIPTION
## Summary

- Replaces the broken cross-origin \`window.location.assign("/api/zero/chatgpt/oauth/connect")\` (and the matching \`<a href>\` Reconnect CTA) with a same-origin paste dialog that POSTs the contents of \`~/.codex/auth.json\` via the \`auth_json\` authMethod.
- Single dialog handles both first-time connect (\"Connect Codex\") and re-paste recovery (\"Re-connect Codex\") via a \`mode\` flag.
- Typed server error codes (\`auth_json_shape_invalid\`, \`free_plan_rejected\`) surface inline rather than via toast — the user is staring at the textarea, an inline message keeps cause-and-effect close.

Closes sub-issue C of epic #11974: #11980.

## Coordination

The server-side parser for \`authMethod: "auth_json"\` lives in sub-issue **B (#11978)** and has not yet shipped. Production behavior:

- ✅ Card click opens modal (verifiable today)
- ✅ Banner click opens modal in reconnect mode (verifiable today)
- ⚠️ Submit will 400 from the existing oauth-only authMethod whitelist until #11978 lands; the dialog will render the server's \`error.message\` via the unknown-code fallback path

Test coverage uses MSW to mock the server-side surface, so this PR is fully testable in isolation.

## Notable trade-offs

- **Submit lives in \`settings/\` not \`external/\`.** \`submitCodexAuthJson\$\` reads the paste content signal and closes the dialog as a side effect on success — it needs access to dialog state signals defined in \`settings/\`. Exposes a new public \`reloadOrgModelProviders\$\` command from \`external/\` to keep the cache-invalidation counter private to that module.
- **No \`useState\` / no \`try/catch\`.** The dialog drives submit via \`useLoadableSet\` and reads \`submitting\` + error off the loadable. A new \`isValidJson\` helper in \`signals/utils.ts\` wraps \`jsonParseOr\` with a sentinel so the component never has to write a try/catch.
- **Renames \`-chatgpt.test.tsx\` → \`-codex.test.tsx\`** — followup of #11990 (the rename PR for sub-issue A) which missed this one file.

## Test plan
- [x] \`pnpm -F @vm0/app exec vitest run\` — 264 files / 2343 tests pass
- [x] \`pnpm turbo run lint\` — 10 workspaces clean
- [x] \`pnpm check-types\` — 11 workspaces clean
- [x] \`pnpm knip\` — clean (only configuration hints)
- [x] \`pnpm format\` — clean
- [x] Issue grep checks: 0 matches for \`/api/zero/chatgpt/oauth/connect\` (excluding docstring reference), 0 matches for the redirect / \`<a href>\` patterns
- [ ] Manual browser smoke after #11978 ships (covered by sub-issue **E #11981** e2e tests)

## Rollback

\`git revert\` the PR. The OAuth button reappears (still broken cross-origin in production — same state as pre-PR). No DB migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)