### PR TITLE
feat(api-contracts,web): add auth_json authMethod and CODEX_AUTH_JSON parser

### DIFF
--- a/turbo/apps/web/app/api/cli/auth/test-codex-oauth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-codex-oauth/__tests__/route.test.ts
@@ -155,4 +155,90 @@ describe("/api/cli/auth/test-codex-oauth", () => {
     expect(state!.needsReconnect).toBe(true);
     expect(state!.lastRefreshErrorCode).toBe("refresh_token_expired");
   });
+
+  describe("authJson variant", () => {
+    function base64UrlEncode(input: string): string {
+      return Buffer.from(input, "utf-8")
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+    }
+
+    function makeJwt(payload: Record<string, unknown>): string {
+      const header = base64UrlEncode(
+        JSON.stringify({ alg: "RS256", typ: "JWT" }),
+      );
+      const body = base64UrlEncode(JSON.stringify(payload));
+      return `${header}.${body}.fake-signature`;
+    }
+
+    function makeAuthJson(): string {
+      const accessExp = Math.floor(Date.now() / 1000) + 7200;
+      const idToken = makeJwt({
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "ws_acct_id_token",
+          chatgpt_plan_type: "plus",
+          organization: { title: "Acme" },
+        },
+        exp: accessExp,
+      });
+      return JSON.stringify({
+        OPENAI_API_KEY: null,
+        tokens: {
+          access_token: makeJwt({ exp: accessExp }),
+          refresh_token: "rt_synthetic_authjson_seed",
+          account_id: "ws_acct_plain",
+          id_token: idToken,
+        },
+      });
+    }
+
+    it("seeds codex-oauth-token via auth_json paste path", async () => {
+      const response = await POST(makeRequest({ authJson: makeAuthJson() }));
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.orgId).toBe(TEST_ORG_ID);
+
+      const state = await findTestModelProviderTokenState(
+        TEST_ORG_ID,
+        ORG_SENTINEL_USER_ID,
+        "codex-oauth-token",
+      );
+      expect(state).not.toBeNull();
+      expect(state!.tokenExpiresAt).toBeInstanceOf(Date);
+      expect(state!.tokenExpiresAt!.getTime()).toBeGreaterThan(Date.now());
+      expect(state!.workspaceName).toBe("Acme");
+      expect(state!.planType).toBe("plus");
+      expect(state!.needsReconnect).toBe(false);
+      expect(state!.lastRefreshErrorCode).toBeNull();
+
+      // Account id sourced from id_token claim, not tokens.account_id
+      const accountId = await findTestConnectorSecret(
+        TEST_ORG_ID,
+        "CHATGPT_ACCOUNT_ID",
+        "model-provider",
+      );
+      expect(accountId).toBe("ws_acct_id_token");
+
+      // Refresh token persisted; raw blob NOT persisted
+      const refresh = await findTestConnectorSecret(
+        TEST_ORG_ID,
+        "CHATGPT_REFRESH_TOKEN",
+        "model-provider",
+      );
+      expect(refresh).toBe("rt_synthetic_authjson_seed");
+      const rawBlob = await findTestConnectorSecret(
+        TEST_ORG_ID,
+        "CODEX_AUTH_JSON",
+        "model-provider",
+      );
+      expect(rawBlob).toBeUndefined();
+    });
+
+    it("rejects malformed authJson with 400", async () => {
+      const response = await POST(makeRequest({ authJson: "{ not json" }));
+      expect(response.status).toBe(400);
+    });
+  });
 });

--- a/turbo/apps/web/app/api/cli/auth/test-codex-oauth/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-codex-oauth/route.ts
@@ -5,6 +5,11 @@ import { modelProviders } from "@vm0/db/schema/model-provider";
 import { initServices } from "../../../../../src/lib/init-services";
 import { upsertOrgMultiAuthModelProvider } from "../../../../../src/lib/zero/model-provider/model-provider-service";
 import {
+  parseCodexAuthJson,
+  isCodexAuthJsonShapeError,
+  isCodexAuthJsonFreePlanError,
+} from "../../../../../src/lib/zero/model-provider/codex-auth-json-parser";
+import {
   resolveTestUserId,
   resolveTestUserOrg,
   DEFAULT_TEST_EMAIL,
@@ -12,7 +17,7 @@ import {
 import { isTestEndpointAllowed } from "../../../../../src/lib/auth/test-endpoint-guard";
 import { ORG_SENTINEL_USER_ID } from "../../../../../src/lib/zero/org/org-sentinel";
 
-const bodySchema = z.object({
+const legacyBodySchema = z.object({
   /** Real-shaped (but synthetic) tokens. The audit grep asserts these
    *  strings never appear in any sandbox env / file / log. Use high-entropy
    *  values to avoid grep false-positives. */
@@ -31,18 +36,37 @@ const bodySchema = z.object({
   lastRefreshErrorCode: z.string().nullable().optional(),
 });
 
+/**
+ * The auth_json variant exercises the production parser path so e2e tests
+ * cover the same code as the public POST /api/zero/model-providers route.
+ * Use this variant when verifying paste-flow changes; use the legacy variant
+ * when seeding a synthetic state directly (e.g. pre-stale provider for
+ * stale-recovery tests).
+ */
+const authJsonBodySchema = z.object({
+  authJson: z.string().min(1),
+});
+
+const bodySchema = z.union([authJsonBodySchema, legacyBodySchema]);
+
 const DEFAULT_EXPIRES_IN_SECS = 600;
 
 /**
  * POST /api/cli/auth/test-codex-oauth?email=<email>
  *
- * Test-only endpoint for E2E tests of the ChatGPT-OAuth Codex flow.
+ * Test-only endpoint for E2E tests of the codex-oauth-token paste flow.
  * Seeds a `codex-oauth-token` model_providers row + the four secrets
  * (CHATGPT_ACCESS_TOKEN, CHATGPT_REFRESH_TOKEN, CHATGPT_ACCOUNT_ID,
  * CHATGPT_ID_TOKEN) under the org-sentinel user, bypassing the browser
  * OAuth dance.
  *
- * Body: see bodySchema above.
+ * Body accepts one of two shapes:
+ *  - `{ authJson }` — exercises the production parser (matches the user-facing
+ *    POST /api/zero/model-providers paste path).
+ *  - legacy fields — direct seed of synthetic state, useful for stale-recovery
+ *    probes (sets `needsReconnect`, `lastRefreshErrorCode`, negative
+ *    `expiresIn`).
+ *
  * Query: ?email=<email> (default: DEFAULT_TEST_EMAIL).
  *
  * Gated by isTestEndpointAllowed — returns 404 in production.
@@ -81,17 +105,70 @@ export async function POST(request: Request) {
     );
   }
 
+  if ("authJson" in body) {
+    return seedFromAuthJson(org.orgId, body.authJson);
+  }
+  return seedFromLegacyFields(org.orgId, body);
+}
+
+async function seedFromAuthJson(
+  orgId: string,
+  authJson: string,
+): Promise<NextResponse> {
+  let parsed;
+  try {
+    parsed = parseCodexAuthJson(authJson);
+  } catch (err) {
+    if (isCodexAuthJsonFreePlanError(err)) {
+      return NextResponse.json(
+        { error: "Free plan rejected by parser" },
+        { status: 400 },
+      );
+    }
+    if (isCodexAuthJsonShapeError(err)) {
+      return NextResponse.json(
+        { error: `auth.json shape invalid: ${err.message}` },
+        { status: 400 },
+      );
+    }
+    throw err;
+  }
+
   await upsertOrgMultiAuthModelProvider(
-    org.orgId,
+    orgId,
     "codex-oauth-token",
     "oauth",
     {
-      CHATGPT_ACCESS_TOKEN: body.accessToken,
-      CHATGPT_REFRESH_TOKEN: body.refreshToken,
-      CHATGPT_ACCOUNT_ID: body.accountId,
-      CHATGPT_ID_TOKEN: body.idToken,
+      CHATGPT_ACCESS_TOKEN: parsed.accessToken,
+      CHATGPT_REFRESH_TOKEN: parsed.refreshToken,
+      CHATGPT_ACCOUNT_ID: parsed.accountId,
+      CHATGPT_ID_TOKEN: parsed.idToken,
+    },
+    undefined,
+    {
+      tokenExpiresAt: parsed.tokenExpiresAt,
+      workspaceName: parsed.workspaceName,
+      planType: parsed.planType,
     },
   );
+
+  return NextResponse.json({
+    ok: true,
+    orgId,
+    tokenExpiresAt: parsed.tokenExpiresAt.toISOString(),
+  });
+}
+
+async function seedFromLegacyFields(
+  orgId: string,
+  body: z.infer<typeof legacyBodySchema>,
+): Promise<NextResponse> {
+  await upsertOrgMultiAuthModelProvider(orgId, "codex-oauth-token", "oauth", {
+    CHATGPT_ACCESS_TOKEN: body.accessToken,
+    CHATGPT_REFRESH_TOKEN: body.refreshToken,
+    CHATGPT_ACCOUNT_ID: body.accountId,
+    CHATGPT_ID_TOKEN: body.idToken,
+  });
 
   // Set token state directly — `upsertOrgMultiAuthModelProvider` doesn't
   // accept these fields today (Wave 3 / #11932 widens the signature).
@@ -108,7 +185,7 @@ export async function POST(request: Request) {
     })
     .where(
       and(
-        eq(modelProviders.orgId, org.orgId),
+        eq(modelProviders.orgId, orgId),
         eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
         eq(modelProviders.type, "codex-oauth-token"),
       ),
@@ -116,7 +193,7 @@ export async function POST(request: Request) {
 
   return NextResponse.json({
     ok: true,
-    orgId: org.orgId,
+    orgId,
     tokenExpiresAt: tokenExpiresAt.toISOString(),
   });
 }

--- a/turbo/apps/web/app/api/zero/model-providers/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/__tests__/route.test.ts
@@ -6,6 +6,8 @@ import { POST as setDefaultPOST } from "../[type]/default/route";
 import {
   createTestRequest,
   setTestModelProviderNeedsReconnect,
+  findTestConnectorSecret,
+  findTestModelProviderTokenState,
   ORG_SENTINEL_USER_ID,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
@@ -482,6 +484,264 @@ describe("Org-level model provider routes", () => {
       expect(stale).toBeDefined();
       expect(stale?.needsReconnect).toBe(true);
       expect(stale?.lastRefreshErrorCode).toBe("refresh_token_expired");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // codex-oauth-token auth_json paste flow
+  // ---------------------------------------------------------------------------
+
+  describe("codex-oauth-token auth_json paste flow", () => {
+    function base64UrlEncode(input: string): string {
+      return Buffer.from(input, "utf-8")
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+    }
+
+    function makeJwt(payload: Record<string, unknown>): string {
+      const header = base64UrlEncode(
+        JSON.stringify({ alg: "RS256", typ: "JWT" }),
+      );
+      const body = base64UrlEncode(JSON.stringify(payload));
+      return `${header}.${body}.fake-signature`;
+    }
+
+    function makeIdToken(opts: {
+      accountId: string;
+      planType: string;
+      workspaceName?: string;
+      exp?: number;
+    }): string {
+      const auth: Record<string, unknown> = {
+        chatgpt_account_id: opts.accountId,
+        chatgpt_plan_type: opts.planType,
+      };
+      if (opts.workspaceName !== undefined) {
+        auth.organization = { title: opts.workspaceName };
+      }
+      return makeJwt({
+        "https://api.openai.com/auth": auth,
+        exp: opts.exp ?? Math.floor(Date.now() / 1000) + 3600,
+      });
+    }
+
+    function makeAuthJson(overrides?: {
+      accessToken?: string;
+      refreshToken?: string;
+      idToken?: string;
+      planType?: string;
+    }): string {
+      const accessExp = Math.floor(Date.now() / 1000) + 7200;
+      return JSON.stringify({
+        OPENAI_API_KEY: null,
+        tokens: {
+          access_token: overrides?.accessToken ?? makeJwt({ exp: accessExp }),
+          refresh_token:
+            overrides?.refreshToken ?? "rt_synthetic_test_high_entropy",
+          account_id: "ws_acct_plain",
+          id_token:
+            overrides?.idToken ??
+            makeIdToken({
+              accountId: "ws_acct_from_id_token",
+              planType: overrides?.planType ?? "plus",
+              workspaceName: "Acme Corp",
+            }),
+        },
+      });
+    }
+
+    async function pasteAuthJson(rawJson: string): Promise<Response> {
+      const request = createTestRequest(upsertUrl(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: rawJson },
+        }),
+      });
+      return POST(request);
+    }
+
+    it("happy path: paste valid auth.json persists 4 derived secrets and metadata", async () => {
+      const response = await pasteAuthJson(makeAuthJson());
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.provider.type).toBe("codex-oauth-token");
+      expect(data.provider.authMethod).toBe("oauth");
+      expect(data.provider.workspaceName).toBe("Acme Corp");
+      expect(data.provider.planType).toBe("plus");
+      expect(data.provider.needsReconnect).toBe(false);
+
+      // The four derived CHATGPT_* fields are persisted
+      const access = await findTestConnectorSecret(
+        user.orgId,
+        "CHATGPT_ACCESS_TOKEN",
+        "model-provider",
+      );
+      const refresh = await findTestConnectorSecret(
+        user.orgId,
+        "CHATGPT_REFRESH_TOKEN",
+        "model-provider",
+      );
+      const accountId = await findTestConnectorSecret(
+        user.orgId,
+        "CHATGPT_ACCOUNT_ID",
+        "model-provider",
+      );
+      const idToken = await findTestConnectorSecret(
+        user.orgId,
+        "CHATGPT_ID_TOKEN",
+        "model-provider",
+      );
+      expect(access).toBeTypeOf("string");
+      expect(refresh).toBe("rt_synthetic_test_high_entropy");
+      // accountId comes from id_token claim, NOT tokens.account_id
+      expect(accountId).toBe("ws_acct_from_id_token");
+      expect(accountId).not.toBe("ws_acct_plain");
+      expect(idToken).toBeTypeOf("string");
+
+      // Metadata persisted on the row
+      const state = await findTestModelProviderTokenState(
+        user.orgId,
+        ORG_SENTINEL_USER_ID,
+        "codex-oauth-token",
+      );
+      expect(state).not.toBeNull();
+      expect(state!.tokenExpiresAt).toBeInstanceOf(Date);
+      expect(state!.tokenExpiresAt!.getTime()).toBeGreaterThan(Date.now());
+      expect(state!.workspaceName).toBe("Acme Corp");
+      expect(state!.planType).toBe("plus");
+      expect(state!.needsReconnect).toBe(false);
+      expect(state!.lastRefreshErrorCode).toBeNull();
+    });
+
+    it("never persists the raw CODEX_AUTH_JSON blob", async () => {
+      const response = await pasteAuthJson(makeAuthJson());
+      expect(response.status).toBe(201);
+
+      // Defense-in-depth: the raw blob must not appear under the wire-shape key
+      const rawUpper = await findTestConnectorSecret(
+        user.orgId,
+        "CODEX_AUTH_JSON",
+        "model-provider",
+      );
+      const rawLower = await findTestConnectorSecret(
+        user.orgId,
+        "codex_auth_json",
+        "model-provider",
+      );
+      expect(rawUpper).toBeUndefined();
+      expect(rawLower).toBeUndefined();
+    });
+
+    it("returns 400 CODEX_AUTH_JSON_SHAPE_INVALID on malformed JSON", async () => {
+      const response = await pasteAuthJson("{ not json");
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("CODEX_AUTH_JSON_SHAPE_INVALID");
+    });
+
+    it("returns 400 CODEX_AUTH_JSON_SHAPE_INVALID when tokens.refresh_token is missing", async () => {
+      const incomplete = JSON.stringify({
+        tokens: {
+          access_token: makeJwt({ exp: Date.now() }),
+          // refresh_token omitted
+          account_id: "ws_acct",
+          id_token: makeIdToken({ accountId: "ws_acct", planType: "plus" }),
+        },
+      });
+      const response = await pasteAuthJson(incomplete);
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("CODEX_AUTH_JSON_SHAPE_INVALID");
+    });
+
+    it("returns 400 CODEX_FREE_PLAN_REJECTED for free-plan accounts", async () => {
+      const response = await pasteAuthJson(makeAuthJson({ planType: "free" }));
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("CODEX_FREE_PLAN_REJECTED");
+    });
+
+    it("returns 400 BAD_REQUEST when CODEX_AUTH_JSON is missing from secrets", async () => {
+      const request = createTestRequest(upsertUrl(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: {},
+        }),
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("BAD_REQUEST");
+    });
+
+    it("re-paste atomically clears needsReconnect and lastRefreshErrorCode", async () => {
+      // First paste — provider becomes healthy
+      await pasteAuthJson(makeAuthJson());
+
+      // Pretend the firewall refresh pipeline marked it stale
+      await setTestModelProviderNeedsReconnect(
+        user.orgId,
+        ORG_SENTINEL_USER_ID,
+        "codex-oauth-token",
+        true,
+        "refresh_token_expired",
+      );
+
+      const beforeReset = await findTestModelProviderTokenState(
+        user.orgId,
+        ORG_SENTINEL_USER_ID,
+        "codex-oauth-token",
+      );
+      expect(beforeReset?.needsReconnect).toBe(true);
+      expect(beforeReset?.lastRefreshErrorCode).toBe("refresh_token_expired");
+
+      // User re-pastes a fresh auth.json
+      const newAccess = makeJwt({
+        exp: Math.floor(Date.now() / 1000) + 7200,
+        sub: "fresh",
+      });
+      const response = await pasteAuthJson(
+        makeAuthJson({ accessToken: newAccess, refreshToken: "rt_fresh" }),
+      );
+      expect(response.status).toBe(200);
+
+      const afterReset = await findTestModelProviderTokenState(
+        user.orgId,
+        ORG_SENTINEL_USER_ID,
+        "codex-oauth-token",
+      );
+      expect(afterReset?.needsReconnect).toBe(false);
+      expect(afterReset?.lastRefreshErrorCode).toBeNull();
+
+      // The new refresh token replaced the old one
+      const refresh = await findTestConnectorSecret(
+        user.orgId,
+        "CHATGPT_REFRESH_TOKEN",
+        "model-provider",
+      );
+      expect(refresh).toBe("rt_fresh");
+    });
+
+    it("returns 404 when codexOauthProvider feature switch is disabled", async () => {
+      // Default mock returns true; flip to false for this single call only.
+      mockIsFeatureEnabled.mockImplementationOnce(
+        (key: { name?: string } | string) => {
+          const keyName = typeof key === "string" ? key : key.name;
+          return keyName !== "codexOauthProvider";
+        },
+      );
+      const response = await pasteAuthJson(makeAuthJson());
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error.code).toBe("NOT_FOUND");
     });
   });
 });

--- a/turbo/apps/web/app/api/zero/model-providers/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/route.ts
@@ -1,6 +1,10 @@
 import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
-import { hasAuthMethods } from "@vm0/api-contracts/contracts/model-providers";
+import {
+  hasAuthMethods,
+  type ModelProviderType,
+  type ModelProviderFramework,
+} from "@vm0/api-contracts/contracts/model-providers";
 import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
@@ -16,11 +20,127 @@ import {
   upsertOrgMultiAuthModelProvider,
   upsertOrgNoSecretModelProvider,
 } from "../../../../src/lib/zero/model-provider/model-provider-service";
+import { isCodexOauthEligible } from "../../../../src/lib/zero/model-provider/codex-oauth-eligibility";
+import {
+  parseCodexAuthJson,
+  isCodexAuthJsonShapeError,
+  isCodexAuthJsonFreePlanError,
+} from "../../../../src/lib/zero/model-provider/codex-auth-json-parser";
 import { loadFeatureSwitchOverrides } from "../../../../src/lib/zero/user/feature-switches-service";
 import { logger } from "../../../../src/lib/shared/logger";
 import { isBadRequest } from "@vm0/api-services/errors";
 
 const log = logger("api:zero-model-providers");
+
+interface UpsertedProvider {
+  id: string;
+  type: ModelProviderType;
+  framework: ModelProviderFramework;
+  secretName: string | null;
+  authMethod?: string | null;
+  secretNames?: string[] | null;
+  isDefault: boolean;
+  selectedModel: string | null;
+  workspaceName: string | null;
+  planType: string | null;
+  needsReconnect: boolean;
+  lastRefreshErrorCode: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Handle the codex-oauth-token + auth_json paste-based connect flow.
+ * Parses the raw ~/.codex/auth.json server-side and persists the four derived
+ * CHATGPT_* fields via the canonical `oauth` storage path. The raw
+ * CODEX_AUTH_JSON blob is NEVER persisted (per Epic #11974 / #7365).
+ *
+ * Extracted from the upsert handler to keep complexity below 20 — the typed
+ * error catch-and-translate adds three branches that pushed the parent past
+ * the per-function ceiling.
+ */
+async function handleCodexAuthJsonPaste(args: {
+  orgId: string;
+  userId: string;
+  rawAuthJson: string;
+  selectedModel: string | undefined;
+}) {
+  try {
+    const parsed = parseCodexAuthJson(args.rawAuthJson);
+
+    const { provider, created } = await upsertOrgMultiAuthModelProvider(
+      args.orgId,
+      "codex-oauth-token",
+      // Storage stays on the canonical `oauth` authMethod with the four
+      // derived CHATGPT_* secrets — that's what the firewall layer reads.
+      // Wave 3 (#11979) collapses oauth + auth_json onto the four fields.
+      "oauth",
+      {
+        CHATGPT_ACCESS_TOKEN: parsed.accessToken,
+        CHATGPT_REFRESH_TOKEN: parsed.refreshToken,
+        CHATGPT_ACCOUNT_ID: parsed.accountId,
+        CHATGPT_ID_TOKEN: parsed.idToken,
+      },
+      args.selectedModel,
+      {
+        tokenExpiresAt: parsed.tokenExpiresAt,
+        workspaceName: parsed.workspaceName,
+        planType: parsed.planType,
+      },
+    );
+
+    log.info("codex provider connected via auth_json paste", {
+      orgId: args.orgId,
+      workspaceName: parsed.workspaceName,
+      planType: parsed.planType,
+    });
+
+    return {
+      status: (created ? 201 : 200) as 200 | 201,
+      body: { provider: serializeProvider(provider), created },
+    };
+  } catch (error) {
+    if (isCodexAuthJsonFreePlanError(error)) {
+      log.info("rejected codex auth_json paste: free plan", {
+        orgId: args.orgId,
+      });
+      return createErrorResponse(
+        "CODEX_FREE_PLAN_REJECTED",
+        "ChatGPT free plan is not supported — upgrade to Plus or higher.",
+      );
+    }
+    if (isCodexAuthJsonShapeError(error)) {
+      log.warn("rejected codex auth_json paste: shape", {
+        orgId: args.orgId,
+        errorMessage: error.message,
+      });
+      return createErrorResponse(
+        "CODEX_AUTH_JSON_SHAPE_INVALID",
+        error.message,
+      );
+    }
+    throw error;
+  }
+}
+
+function serializeProvider(provider: UpsertedProvider) {
+  return {
+    id: provider.id,
+    type: provider.type,
+    framework: provider.framework,
+    secretName: provider.secretName,
+    authMethod: provider.authMethod ?? null,
+    secretNames: provider.secretNames ?? null,
+    isDefault: provider.isDefault,
+    selectedModel: provider.selectedModel,
+    workspaceName: provider.workspaceName,
+    planType: provider.planType,
+    needsReconnect: provider.needsReconnect,
+    lastRefreshErrorCode: provider.lastRefreshErrorCode,
+    createdAt: provider.createdAt.toISOString(),
+    updatedAt: provider.updatedAt.toISOString(),
+  };
+}
 
 const router = tsr.router(zeroModelProvidersMainContract, {
   list: async ({ headers }) => {
@@ -89,6 +209,26 @@ const router = tsr.router(zeroModelProvidersMainContract, {
       }
     }
 
+    if (type === "codex-oauth-token" && authMethod === "auth_json") {
+      const eligible = await isCodexOauthEligible(org.orgId, authCtx.userId);
+      if (!eligible) {
+        return createErrorResponse("NOT_FOUND", `Provider "${type}" not found`);
+      }
+      const raw = secrets?.CODEX_AUTH_JSON;
+      if (!raw) {
+        return createErrorResponse(
+          "BAD_REQUEST",
+          "Missing CODEX_AUTH_JSON secret",
+        );
+      }
+      return handleCodexAuthJsonPaste({
+        orgId: org.orgId,
+        userId: authCtx.userId,
+        rawAuthJson: raw,
+        selectedModel,
+      });
+    }
+
     log.debug("upserting org model provider", {
       orgId: org.orgId,
       type,
@@ -142,25 +282,7 @@ const router = tsr.router(zeroModelProvidersMainContract, {
 
       return {
         status: (created ? 201 : 200) as 200 | 201,
-        body: {
-          provider: {
-            id: provider.id,
-            type: provider.type,
-            framework: provider.framework,
-            secretName: provider.secretName,
-            authMethod: provider.authMethod ?? null,
-            secretNames: provider.secretNames ?? null,
-            isDefault: provider.isDefault,
-            selectedModel: provider.selectedModel,
-            workspaceName: provider.workspaceName,
-            planType: provider.planType,
-            needsReconnect: provider.needsReconnect,
-            lastRefreshErrorCode: provider.lastRefreshErrorCode,
-            createdAt: provider.createdAt.toISOString(),
-            updatedAt: provider.updatedAt.toISOString(),
-          },
-          created,
-        },
+        body: { provider: serializeProvider(provider), created },
       };
     } catch (error) {
       if (isBadRequest(error)) {

--- a/turbo/apps/web/src/lib/zero/model-provider/__tests__/codex-auth-json-parser.test.ts
+++ b/turbo/apps/web/src/lib/zero/model-provider/__tests__/codex-auth-json-parser.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseCodexAuthJson,
+  isCodexAuthJsonShapeError,
+  isCodexAuthJsonFreePlanError,
+} from "../codex-auth-json-parser";
+
+function expectShapeError(fn: () => unknown): void {
+  let caught: unknown;
+  try {
+    fn();
+  } catch (err) {
+    caught = err;
+  }
+  expect(isCodexAuthJsonShapeError(caught)).toBe(true);
+}
+
+function expectFreePlanError(fn: () => unknown): void {
+  let caught: unknown;
+  try {
+    fn();
+  } catch (err) {
+    caught = err;
+  }
+  expect(isCodexAuthJsonFreePlanError(caught)).toBe(true);
+}
+
+function base64UrlEncode(input: string): string {
+  return Buffer.from(input, "utf-8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = base64UrlEncode(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const body = base64UrlEncode(JSON.stringify(payload));
+  return `${header}.${body}.fake-signature`;
+}
+
+interface IdTokenOpts {
+  accountId?: string | null;
+  planType?: string | null;
+  workspaceName?: string;
+  workspaceClaim?:
+    | "organization.title"
+    | "workspace.name"
+    | "chatgpt_workspace_name";
+  exp?: number;
+  omitAuth?: boolean;
+}
+
+function makeIdToken(opts: IdTokenOpts = {}): string {
+  if (opts.omitAuth) {
+    return makeJwt({ exp: opts.exp ?? Math.floor(Date.now() / 1000) + 3600 });
+  }
+  const auth: Record<string, unknown> = {};
+  if (opts.accountId !== null && opts.accountId !== undefined) {
+    auth.chatgpt_account_id = opts.accountId;
+  }
+  if (opts.planType !== null && opts.planType !== undefined) {
+    auth.chatgpt_plan_type = opts.planType;
+  }
+  if (opts.workspaceName !== undefined) {
+    if (opts.workspaceClaim === "organization.title") {
+      auth.organization = { title: opts.workspaceName };
+    } else if (opts.workspaceClaim === "workspace.name") {
+      auth.workspace = { name: opts.workspaceName };
+    } else {
+      auth.chatgpt_workspace_name = opts.workspaceName;
+    }
+  }
+  return makeJwt({
+    "https://api.openai.com/auth": auth,
+    exp: opts.exp ?? Math.floor(Date.now() / 1000) + 3600,
+  });
+}
+
+interface AuthJsonOpts {
+  accessToken?: string;
+  refreshToken?: string;
+  accountId?: string;
+  idToken?: string;
+  /** Add OPENAI_API_KEY field to the outer object (passthrough). */
+  withApiKey?: boolean;
+}
+
+function makeAuthJson(opts: AuthJsonOpts = {}): string {
+  const accessTokenExp = Math.floor(Date.now() / 1000) + 3600;
+  return JSON.stringify({
+    OPENAI_API_KEY: opts.withApiKey ? "sk-test" : null,
+    tokens: {
+      access_token:
+        opts.accessToken ?? makeJwt({ exp: accessTokenExp, sub: "user" }),
+      refresh_token: opts.refreshToken ?? "rt_synthetic_high_entropy_value",
+      account_id: opts.accountId ?? "ws_acct_synthetic",
+      id_token:
+        opts.idToken ??
+        makeIdToken({
+          accountId: "ws_acct_from_id_token",
+          planType: "plus",
+          workspaceName: "Acme",
+          workspaceClaim: "organization.title",
+        }),
+    },
+    last_refresh: "2026-05-06T08:30:00Z",
+  });
+}
+
+describe("parseCodexAuthJson", () => {
+  describe("happy path", () => {
+    it("parses a valid auth.json and returns ParsedCodexAuth", () => {
+      const accessExp = Math.floor(Date.now() / 1000) + 7200;
+      const accessToken = makeJwt({ exp: accessExp, sub: "user_abc" });
+      const idToken = makeIdToken({
+        accountId: "ws_acct_from_id_token",
+        planType: "plus",
+        workspaceName: "Acme",
+        workspaceClaim: "organization.title",
+      });
+      const result = parseCodexAuthJson(
+        makeAuthJson({ accessToken, idToken, accountId: "ws_acct_plain" }),
+      );
+
+      expect(result.accessToken).toBe(accessToken);
+      expect(result.idToken).toBe(idToken);
+      expect(result.refreshToken).toMatch(/^rt_/);
+      // Critical: account_id sourced from id_token claim, not tokens.account_id
+      expect(result.accountId).toBe("ws_acct_from_id_token");
+      expect(result.accountId).not.toBe("ws_acct_plain");
+      expect(result.planType).toBe("plus");
+      expect(result.workspaceName).toBe("Acme");
+      expect(result.tokenExpiresAt.getTime()).toBe(accessExp * 1000);
+    });
+
+    it("ignores OPENAI_API_KEY field in outer object (passthrough)", () => {
+      expect(() => {
+        parseCodexAuthJson(makeAuthJson({ withApiKey: true }));
+      }).not.toThrow();
+    });
+
+    it.each(["plus", "pro", "business", "edu", "enterprise"])(
+      "accepts plan_type %s",
+      (planType) => {
+        const idToken = makeIdToken({
+          accountId: "ws_acct",
+          planType,
+          workspaceName: "W",
+        });
+        const result = parseCodexAuthJson(makeAuthJson({ idToken }));
+        expect(result.planType).toBe(planType);
+      },
+    );
+  });
+
+  describe("tokenExpiresAt derivation", () => {
+    it("derives tokenExpiresAt from access_token.exp", () => {
+      const accessExp = 2_000_000_000; // far future
+      const idExp = 1_999_000_000;
+      const accessToken = makeJwt({ exp: accessExp });
+      const idToken = makeIdToken({
+        accountId: "ws_acct",
+        planType: "plus",
+        exp: idExp,
+      });
+      const result = parseCodexAuthJson(makeAuthJson({ accessToken, idToken }));
+      expect(result.tokenExpiresAt.getTime()).toBe(accessExp * 1000);
+    });
+
+    it("falls back to id_token.exp when access_token is opaque (not a JWT)", () => {
+      const idExp = 2_000_000_000;
+      const idToken = makeIdToken({
+        accountId: "ws_acct",
+        planType: "plus",
+        exp: idExp,
+      });
+      const result = parseCodexAuthJson(
+        makeAuthJson({
+          accessToken: "opaque-not-a-jwt-token",
+          idToken,
+        }),
+      );
+      expect(result.tokenExpiresAt.getTime()).toBe(idExp * 1000);
+    });
+
+    it("throws when both access_token and id_token lack exp", () => {
+      const accessTokenNoExp = makeJwt({ sub: "user" });
+      const idTokenNoExp = makeJwt({
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "ws_acct",
+          chatgpt_plan_type: "plus",
+        },
+        // intentionally no `exp`
+      });
+      expectShapeError(() => {
+        return parseCodexAuthJson(
+          makeAuthJson({
+            accessToken: accessTokenNoExp,
+            idToken: idTokenNoExp,
+          }),
+        );
+      });
+    });
+  });
+
+  describe("workspace name extraction", () => {
+    it.each(["organization.title", "workspace.name", "chatgpt_workspace_name"])(
+      "extracts workspaceName from %s claim shape",
+      (claimShape) => {
+        const idToken = makeIdToken({
+          accountId: "ws_acct",
+          planType: "plus",
+          workspaceName: "Acme",
+          workspaceClaim: claimShape as
+            | "organization.title"
+            | "workspace.name"
+            | "chatgpt_workspace_name",
+        });
+        const result = parseCodexAuthJson(makeAuthJson({ idToken }));
+        expect(result.workspaceName).toBe("Acme");
+      },
+    );
+
+    it("returns null workspaceName when no workspace claim is present", () => {
+      const idToken = makeIdToken({ accountId: "ws_acct", planType: "plus" });
+      const result = parseCodexAuthJson(makeAuthJson({ idToken }));
+      expect(result.workspaceName).toBeNull();
+    });
+  });
+
+  describe("shape errors", () => {
+    it("throws on malformed JSON", () => {
+      expectShapeError(() => {
+        return parseCodexAuthJson("{ not valid json");
+      });
+    });
+
+    it("throws on missing tokens key (API-key-mode auth.json)", () => {
+      const raw = JSON.stringify({ OPENAI_API_KEY: "sk-test" });
+      expectShapeError(() => {
+        return parseCodexAuthJson(raw);
+      });
+    });
+
+    it("throws on missing tokens.refresh_token", () => {
+      const raw = JSON.stringify({
+        tokens: {
+          access_token: makeJwt({ exp: Date.now() }),
+          // refresh_token omitted
+          account_id: "ws_acct",
+          id_token: makeIdToken({
+            accountId: "ws_acct",
+            planType: "plus",
+          }),
+        },
+      });
+      expectShapeError(() => {
+        return parseCodexAuthJson(raw);
+      });
+    });
+
+    it("throws on empty tokens.access_token", () => {
+      const raw = JSON.stringify({
+        tokens: {
+          access_token: "",
+          refresh_token: "rt",
+          account_id: "ws",
+          id_token: makeIdToken({ accountId: "ws", planType: "plus" }),
+        },
+      });
+      expectShapeError(() => {
+        return parseCodexAuthJson(raw);
+      });
+    });
+
+    it("throws when id_token has no required claims (omitAuth)", () => {
+      const idToken = makeIdToken({ omitAuth: true });
+      expectShapeError(() => {
+        return parseCodexAuthJson(makeAuthJson({ idToken }));
+      });
+    });
+
+    it("throws when id_token is missing chatgpt_account_id", () => {
+      const idToken = makeIdToken({ accountId: null, planType: "plus" });
+      expectShapeError(() => {
+        return parseCodexAuthJson(makeAuthJson({ idToken }));
+      });
+    });
+
+    it("throws when id_token is missing chatgpt_plan_type", () => {
+      const idToken = makeIdToken({ accountId: "ws", planType: null });
+      expectShapeError(() => {
+        return parseCodexAuthJson(makeAuthJson({ idToken }));
+      });
+    });
+
+    it("throws when id_token is not a parsable JWT", () => {
+      expectShapeError(() => {
+        return parseCodexAuthJson(
+          makeAuthJson({ idToken: "not-a-jwt-at-all" }),
+        );
+      });
+    });
+
+    it("throws when raw blob exceeds 16 KiB", () => {
+      const oversized = " ".repeat(17 * 1024) + makeAuthJson();
+      expectShapeError(() => {
+        return parseCodexAuthJson(oversized);
+      });
+    });
+  });
+
+  describe("free-plan rejection", () => {
+    it("throws when plan_type is 'free'", () => {
+      const idToken = makeIdToken({ accountId: "ws", planType: "free" });
+      expectFreePlanError(() => {
+        return parseCodexAuthJson(makeAuthJson({ idToken }));
+      });
+    });
+
+    it("free-plan error is distinct from shape error (type guards)", () => {
+      const idToken = makeIdToken({ accountId: "ws", planType: "free" });
+      let caught: unknown;
+      try {
+        parseCodexAuthJson(makeAuthJson({ idToken }));
+      } catch (err) {
+        caught = err;
+      }
+      expect(isCodexAuthJsonFreePlanError(caught)).toBe(true);
+      expect(isCodexAuthJsonShapeError(caught)).toBe(false);
+    });
+
+    it("shape error matches its own type guard but not free-plan guard", () => {
+      let caught: unknown;
+      try {
+        parseCodexAuthJson("malformed");
+      } catch (err) {
+        caught = err;
+      }
+      expect(isCodexAuthJsonShapeError(caught)).toBe(true);
+      expect(isCodexAuthJsonFreePlanError(caught)).toBe(false);
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/zero/model-provider/codex-auth-json-parser.ts
+++ b/turbo/apps/web/src/lib/zero/model-provider/codex-auth-json-parser.ts
@@ -1,0 +1,211 @@
+import { z } from "zod";
+
+/**
+ * Server-side parser for the contents of `~/.codex/auth.json` produced by
+ * `codex login`. Validates shape via zod, decodes the access_token + id_token
+ * JWTs to derive `tokenExpiresAt`, `accountId`, `planType`, and
+ * `workspaceName`, and rejects free-plan accounts with a typed error.
+ *
+ * The raw `CODEX_AUTH_JSON` blob this parser consumes is NEVER persisted —
+ * the route handler discards it after parsing and only the four derived
+ * `CHATGPT_*` fields are stored as secrets (per #7365 / Epic #11974).
+ *
+ * The JWT/claims helpers and zod schemas below are intentionally inlined
+ * here (rather than imported from connector/providers/codex-oauth.ts) so that
+ * #11979's deletion of the OAuth-flow code can drop those duplicates without
+ * a cross-PR coupling. This file owns its dependencies.
+ */
+
+// JWT payload decode without signature verification: the access_token and
+// id_token are validated cryptographically by the upstream ChatGPT backend
+// and the user's TLS-secured `codex login` flow. Codex CLI itself does not
+// verify locally either.
+function decodeJwtPayload(token: string): unknown {
+  const parts = token.split(".");
+  const payload = parts[1];
+  if (parts.length !== 3 || !payload) {
+    throw new Error("Invalid JWT structure");
+  }
+  const padded = payload.replace(/-/g, "+").replace(/_/g, "/");
+  const padding =
+    padded.length % 4 === 0 ? "" : "=".repeat(4 - (padded.length % 4));
+  const json = Buffer.from(padded + padding, "base64").toString("utf-8");
+  return JSON.parse(json);
+}
+
+const chatgptAuthClaimsSchema = z
+  .object({
+    chatgpt_account_id: z.string().optional(),
+    chatgpt_plan_type: z.string().optional(),
+    organization: z
+      .object({ title: z.string().optional() })
+      .partial()
+      .optional(),
+    workspace: z.object({ name: z.string().optional() }).partial().optional(),
+    chatgpt_workspace_name: z.string().optional(),
+  })
+  .passthrough();
+
+const chatgptIdTokenClaimsSchema = z
+  .object({
+    exp: z.number().optional(),
+    "https://api.openai.com/auth": chatgptAuthClaimsSchema.optional(),
+  })
+  .passthrough();
+
+type ChatgptAuthClaims = z.infer<typeof chatgptAuthClaimsSchema>;
+
+function extractWorkspaceName(authClaims: ChatgptAuthClaims): string | null {
+  return (
+    authClaims.organization?.title ??
+    authClaims.workspace?.name ??
+    authClaims.chatgpt_workspace_name ??
+    null
+  );
+}
+
+const MAX_AUTH_JSON_BYTES = 16 * 1024;
+
+const codexAuthJsonSchema = z
+  .object({
+    tokens: z.object({
+      access_token: z.string().min(1),
+      refresh_token: z.string().min(1),
+      account_id: z.string().min(1),
+      id_token: z.string().min(1),
+    }),
+  })
+  .passthrough();
+
+const expSchema = z.object({ exp: z.number() }).passthrough();
+
+/**
+ * Typed error thrown when the pasted auth.json is malformed JSON, fails the
+ * shape schema, or omits required claims. Matches the project pattern
+ * (Error with `name`-tagged narrowing) from `codex-oauth.ts`. Not exported —
+ * callers narrow via the `isCodexAuthJsonShapeError` type guard.
+ */
+interface CodexAuthJsonShapeError extends Error {
+  readonly name: "CodexAuthJsonShapeError";
+}
+
+interface CodexAuthJsonFreePlanError extends Error {
+  readonly name: "CodexAuthJsonFreePlanError";
+}
+
+function createCodexAuthJsonShapeError(
+  message: string,
+): CodexAuthJsonShapeError {
+  const err = new Error(message);
+  err.name = "CodexAuthJsonShapeError";
+  return err as CodexAuthJsonShapeError;
+}
+
+function createCodexAuthJsonFreePlanError(): CodexAuthJsonFreePlanError {
+  const err = new Error(
+    "ChatGPT free plan is not supported — upgrade to Plus, Pro, Business, Edu, or Enterprise",
+  );
+  err.name = "CodexAuthJsonFreePlanError";
+  return err as CodexAuthJsonFreePlanError;
+}
+
+export function isCodexAuthJsonShapeError(
+  v: unknown,
+): v is CodexAuthJsonShapeError {
+  return v instanceof Error && v.name === "CodexAuthJsonShapeError";
+}
+
+export function isCodexAuthJsonFreePlanError(
+  v: unknown,
+): v is CodexAuthJsonFreePlanError {
+  return v instanceof Error && v.name === "CodexAuthJsonFreePlanError";
+}
+
+interface ParsedCodexAuth {
+  accessToken: string;
+  refreshToken: string;
+  /**
+   * Always sourced from `id_token`'s `chatgpt_account_id` claim — NOT from the
+   * plain `tokens.account_id` field. The id_token claim is cryptographically
+   * tied to the upstream session; the plain JSON field is informational.
+   */
+  accountId: string;
+  idToken: string;
+  tokenExpiresAt: Date;
+  workspaceName: string | null;
+  planType: string;
+}
+
+function readJwtExp(token: string): number | null {
+  let payload: unknown;
+  try {
+    payload = decodeJwtPayload(token);
+  } catch {
+    return null;
+  }
+  const parsed = expSchema.safeParse(payload);
+  return parsed.success ? parsed.data.exp : null;
+}
+
+export function parseCodexAuthJson(raw: string): ParsedCodexAuth {
+  if (raw.length > MAX_AUTH_JSON_BYTES) {
+    throw createCodexAuthJsonShapeError(
+      "auth.json is unexpectedly large — paste only the contents of ~/.codex/auth.json",
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw createCodexAuthJsonShapeError("auth.json is not valid JSON");
+  }
+
+  const shape = codexAuthJsonSchema.safeParse(parsed);
+  if (!shape.success) {
+    throw createCodexAuthJsonShapeError(
+      "auth.json shape unrecognized — your codex CLI may need updating",
+    );
+  }
+  const { tokens } = shape.data;
+
+  // Decode id_token first — its claims drive both account_id (cryptographically
+  // signed source of truth) and the plan-type rejection. Match the OAuth
+  // callback's ordering: shape errors win over free-plan errors.
+  let idClaims: z.infer<typeof chatgptIdTokenClaimsSchema>;
+  try {
+    idClaims = chatgptIdTokenClaimsSchema.parse(
+      decodeJwtPayload(tokens.id_token),
+    );
+  } catch {
+    throw createCodexAuthJsonShapeError("auth.json id_token claims unparsable");
+  }
+  const auth = idClaims["https://api.openai.com/auth"];
+  if (!auth?.chatgpt_account_id || !auth.chatgpt_plan_type) {
+    throw createCodexAuthJsonShapeError(
+      "auth.json id_token missing required claims",
+    );
+  }
+  if (auth.chatgpt_plan_type === "free") {
+    throw createCodexAuthJsonFreePlanError();
+  }
+
+  // tokenExpiresAt: prefer access_token.exp (the artifact that actually expires
+  // for inference), fall back to id_token.exp if the access_token is opaque.
+  const tokenExp = readJwtExp(tokens.access_token) ?? idClaims.exp ?? null;
+  if (tokenExp === null) {
+    throw createCodexAuthJsonShapeError(
+      "auth.json access_token has no exp claim",
+    );
+  }
+
+  return {
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+    accountId: auth.chatgpt_account_id,
+    idToken: tokens.id_token,
+    tokenExpiresAt: new Date(tokenExp * 1000),
+    workspaceName: extractWorkspaceName(auth),
+    planType: auth.chatgpt_plan_type,
+  };
+}

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -292,17 +292,19 @@ describe("codex-oauth-token codex provider", () => {
     expect(getSelectableProviderTypes()).toContain("codex-oauth-token");
   });
 
-  it("uses multi-auth shape with oauth method and four secrets", () => {
+  it("uses multi-auth shape with oauth and auth_json methods", () => {
     const methods = getAuthMethodsForType("codex-oauth-token");
     expect(methods).toBeDefined();
-    expect(Object.keys(methods!)).toEqual(["oauth"]);
-    const secrets = methods!.oauth!.secrets;
-    expect(Object.keys(secrets).sort()).toEqual([
+    expect(Object.keys(methods!).sort()).toEqual(["auth_json", "oauth"]);
+    const oauthSecrets = methods!.oauth!.secrets;
+    expect(Object.keys(oauthSecrets).sort()).toEqual([
       "CHATGPT_ACCESS_TOKEN",
       "CHATGPT_ACCOUNT_ID",
       "CHATGPT_ID_TOKEN",
       "CHATGPT_REFRESH_TOKEN",
     ]);
+    const authJsonSecrets = methods!.auth_json!.secrets;
+    expect(Object.keys(authJsonSecrets)).toEqual(["CODEX_AUTH_JSON"]);
   });
 
   it("marks refresh and id tokens as serverOnly", () => {
@@ -312,6 +314,12 @@ describe("codex-oauth-token codex provider", () => {
     // Access token + account ID are NOT server-only — they reach the sandbox
     expect(secrets.CHATGPT_ACCESS_TOKEN!.serverOnly).not.toBe(true);
     expect(secrets.CHATGPT_ACCOUNT_ID!.serverOnly).not.toBe(true);
+  });
+
+  it("auth_json secret CODEX_AUTH_JSON is serverOnly (raw blob never leaves server)", () => {
+    const secrets = getSecretsForAuthMethod("codex-oauth-token", "auth_json")!;
+    expect(secrets.CODEX_AUTH_JSON!.serverOnly).toBe(true);
+    expect(secrets.CODEX_AUTH_JSON!.required).toBe(true);
   });
 
   it("environmentMapping does NOT reference refresh or id tokens", () => {

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -32,6 +32,14 @@ export const ApiError = {
     status: 422 as const,
     code: "PROVIDER_DELETED",
   },
+  CODEX_AUTH_JSON_SHAPE_INVALID: {
+    status: 400 as const,
+    code: "CODEX_AUTH_JSON_SHAPE_INVALID",
+  },
+  CODEX_FREE_PLAN_REJECTED: {
+    status: 400 as const,
+    code: "CODEX_FREE_PLAN_REJECTED",
+  },
   INTERNAL_SERVER_ERROR: {
     status: 500 as const,
     code: "INTERNAL_SERVER_ERROR",

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -446,6 +446,28 @@ export const MODEL_PROVIDER_TYPES = {
           },
         },
       },
+      // Paste-based auth: user runs `codex login` locally, then pastes the
+      // resulting ~/.codex/auth.json. The server-side parser (codex-auth-json-
+      // parser.ts) extracts the four CHATGPT_* fields from the raw blob and
+      // persists them via the `oauth` authMethod path; the raw CODEX_AUTH_JSON
+      // blob itself is NEVER stored. The auth_json secret declaration here
+      // exists for the wire-shape and UI rendering (see #11980); storage stays
+      // canonical until #11979 collapses oauth + auth_json onto the four
+      // CHATGPT_* fields.
+      auth_json: {
+        label: "Codex auth.json",
+        helpText:
+          "Run `codex login` locally, then paste the contents of ~/.codex/auth.json below.",
+        secrets: {
+          CODEX_AUTH_JSON: {
+            label: "auth.json contents",
+            required: true,
+            serverOnly: true,
+            placeholder: '{"OPENAI_API_KEY":null,"tokens":{...}}',
+            helpText: "Paste the entire contents of ~/.codex/auth.json",
+          },
+        },
+      },
     } as Record<string, AuthMethodConfig>,
     defaultAuthMethod: "oauth",
     environmentMapping: {


### PR DESCRIPTION
## Summary

Sub-issue **#11978** of Epic #11974 (Wave 2). Adds the server-side parser and API wiring for the new codex auth.json paste flow, alongside the existing OAuth path. The OAuth flow stays in place for now — Wave 3 (#11979) will collapse oauth + auth_json onto the four CHATGPT_* fields after this PR and #11980 (UI) are wired through.

### What this PR does

- **api-contracts**: adds `auth_json` auth method to `codex-oauth-token` (sibling to `oauth`), declaring a single `CODEX_AUTH_JSON` `serverOnly` secret. Adds two typed error codes: `CODEX_AUTH_JSON_SHAPE_INVALID`, `CODEX_FREE_PLAN_REJECTED`.
- **parser** (`turbo/apps/web/src/lib/zero/model-provider/codex-auth-json-parser.ts`): validates JSON shape via zod, decodes `access_token` and `id_token` JWTs to derive `tokenExpiresAt`/`accountId`/`planType`/`workspaceName`, rejects free-plan accounts. JWT/claims helpers inlined (not imported from `codex-oauth.ts`) so #11979 can drop the OAuth-flow code without cross-PR coupling.
- **route handler** (`POST /api/zero/model-providers`): branches on `type=codex-oauth-token, authMethod=auth_json`, gates on `isCodexOauthEligible`, parses, and persists the four derived `CHATGPT_*` secrets via the canonical `oauth` storage path. Passes metadata so the atomic upsert clears `needsReconnect` / `lastRefreshErrorCode` on re-paste.
- **e2e seed endpoint** (`POST /api/cli/auth/test-codex-oauth`): adds an `authJson` body variant that exercises the production parser path; legacy synthetic-fields shape preserved for stale-recovery probes.

### Key invariants

- Raw `CODEX_AUTH_JSON` blob is **never** persisted — the route handler builds the secrets map explicitly from parser output. Integration test verifies this directly with a query for `CODEX_AUTH_JSON` and `codex_auth_json` under the model-provider type.
- `accountId` always sourced from the cryptographically-tied `id_token` claim, not the plain `tokens.account_id` field.
- `tokenExpiresAt` prefers `access_token.exp`, falls back to `id_token.exp`.
- 16 KiB body cap on the raw paste blob.
- Re-paste atomically clears stale flags — same recovery path as re-OAuth (mirrors `model-provider-service.ts` `buildMultiAuthConflictSet`).

### Test plan

- [x] 26 parser unit tests in `__tests__/codex-auth-json-parser.test.ts` (happy path, exp derivation, workspace shapes, shape errors, free-plan rejection)
- [x] 8 new integration tests in `app/api/zero/model-providers/__tests__/route.test.ts` (happy path, raw-blob audit, malformed JSON, missing refresh token, free plan, missing CODEX_AUTH_JSON, stale-clear on re-paste, feature switch off)
- [x] 2 new tests in `app/api/cli/auth/test-codex-oauth/__tests__/route.test.ts` (auth_json seed happy path + malformed)
- [x] All existing model-providers route tests still pass (23/23)
- [x] All existing test-codex-oauth tests still pass (5/5)
- [x] api-contracts tests pass (147/147)
- [x] `pnpm turbo run lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm knip` clean

### Cross-PR coordination

| PR | Status | Notes |
|---|---|---|
| #11990 (Wave 1, #11977) | merged | rename chatgpt-oauth-token → codex-oauth-token |
| **this PR** (#11978) | review | adds auth_json wire + parser; storage stays on `oauth` |
| #11980 | parallel | platform UI paste modal — calls this PR's endpoint |
| #11979 | depends-on | deletes OAuth flow + collapses oauth/auth_json onto 4 fields |

Closes #11978

🤖 Generated with [Claude Code](https://claude.com/claude-code)