### PR TITLE
fix: add og-image route to public routes in clerk middleware

### DIFF
--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -27,6 +27,7 @@ const isPublicRoute = createRouteMatcher([
   "/use-cases/:slug",
   "/:locale/use-cases",
   "/:locale/use-cases/:slug",
+  "/:locale/use-cases/:slug/opengraph-image",
   "/rankings",
   "/:locale/rankings",
   "/terms-of-use",


### PR DESCRIPTION
## Summary
- Fixes 404 on use case OG image endpoints (`/en/use-cases/:slug/opengraph-image`)
- Root cause: Clerk middleware's `isPublicRoute` matcher had the use case page route but not the OG image sub-route, causing `auth.protect()` to intercept before Next.js could serve the image
- Added `/:locale/use-cases/:slug/opengraph-image` to `isPublicRoute` in `proxy.ts`

## Test plan
- [ ] Visit any use case page and verify `og:image` meta tag resolves to a valid PNG image
- [ ] Verify the OG image is visually correct with title, description, connectors, and Zero avatar
- [ ] Confirm OG images work across locales (en, de, ja, es)

🤖 Generated with [Claude Code](https://claude.com/claude-code)