### PR TITLE
fix: avoid codex e2e feature switch cleanup race

### DIFF
--- a/e2e/helpers/codex-oauth-setup.bash
+++ b/e2e/helpers/codex-oauth-setup.bash
@@ -134,24 +134,20 @@ enable_codex_oauth_provider() {
 # Force the codexOauthProvider feature switch off for the current test user.
 # Clearing overrides is not enough when the static registry enables staff orgs.
 force_disable_codex_oauth_provider() {
-    _set_codex_oauth_provider false "$@"
-}
-
-# Best-effort cleanup of feature-switch overrides — DELETE clears all
-# overrides for the user (test_user_id resolved server-side).
-disable_codex_oauth_provider() {
     local token="${1:-}"
     if [ -z "$token" ]; then
-        token=$(_codex_oauth_token)
+        token=$(codex_oauth_feature_off_token)
     fi
-    if [ -z "$token" ]; then
-        return 0
-    fi
-    local curl_args=(-fsS -X DELETE -H "Authorization: Bearer $token")
-    if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
-        curl_args+=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
-    fi
-    curl "${curl_args[@]}" "${VM0_API_URL}/api/zero/feature-switches" >/dev/null 2>&1 || true
+    _set_codex_oauth_provider false "$token"
+}
+
+# No-op cleanup for the shared runner user. Runner E2E files run in parallel;
+# deleting feature-switch overrides here would clear every switch for the
+# shared authenticated user, including codexBeta or codexOauthProvider that
+# another file may have enabled moments earlier. Feature-off probes should use
+# force_disable_codex_oauth_provider with an isolated token.
+disable_codex_oauth_provider() {
+    return 0
 }
 
 # Common POST helper for /api/cli/auth/test-codex-oauth. Takes a JSON body

--- a/e2e/helpers/codex-zero.bash
+++ b/e2e/helpers/codex-zero.bash
@@ -60,14 +60,16 @@ enable_codex_beta() {
         >/dev/null
 }
 
-# Clear all of the current test user's feature-switch overrides (best-effort
-# cleanup). Using DELETE rather than POST-flip-to-false avoids leaking the
-# override to subsequent serial-layer tests sharing E2E_SERIAL_EMAIL if the
-# request 5xxs.
+# Do not clear feature-switch overrides in teardown. Runner E2E files execute
+# in parallel and share the same authenticated runner user; DELETE
+# /api/zero/feature-switches removes every override for that shared user, which
+# can race another file between enable_codex_beta and its gated API call.
+#
+# Leaving codexBeta enabled is intentional for the shared E2E runner user.
+# Tests that need feature-off behavior must use a dedicated token/user and
+# explicitly force the switch off for that isolated identity.
 disable_codex_beta() {
-    _codex_zero_curl "/api/zero/feature-switches" \
-        -X DELETE \
-        >/dev/null 2>&1 || true
+    return 0
 }
 
 # Poll /api/zero/chat-threads/:id/messages until the newest assistant row


### PR DESCRIPTION
## Summary
- stop Codex E2E teardown helpers from deleting all feature-switch overrides for the shared runner user
- keep feature-off helper isolated by defaulting forced disable to the serial/dedicated token path

## Tests
- bash -n e2e/helpers/codex-zero.bash e2e/helpers/codex-oauth-setup.bash e2e/tests/03-runner/t-codex-zero-byok-smoke.bats e2e/tests/03-runner/t54-codex-oauth-sandbox.bats e2e/tests/03-runner/t55-codex-oauth-refresh.bats e2e/tests/03-runner/t57-codex-oauth-failure-modes.bats
- git diff --check