### PR TITLE
fix: give ansible blocking stdin in provision action

### DIFF
--- a/.github/actions/provision/action.yml
+++ b/.github/actions/provision/action.yml
@@ -45,9 +45,28 @@ runs:
         fi
 
         ANSIBLE_HASH=$(git rev-parse HEAD:ansible)
+        ssh_with_retry() {
+          local host="$1"
+          shift
+          local attempt
+          for attempt in 1 2 3; do
+            if ssh "${METAL_USER}@${host}" "$@"; then
+              return 0
+            fi
+            echo "SSH command failed for ${host} (attempt ${attempt}/3)" >&2
+            if [ "$attempt" != "3" ]; then
+              sleep 2
+            fi
+          done
+          return 1
+        }
+
         STALE_HOSTS=""
         for HOST in $(echo "$HOSTS" | tr ',' ' '); do
-          REMOTE_HASH=$(ssh "${METAL_USER}@${HOST}" "cat ~/.vm0-provision-hash 2>/dev/null" || true)
+          if ! REMOTE_HASH=$(ssh_with_retry "${HOST}" "cat ~/.vm0-provision-hash 2>/dev/null || true"); then
+            echo "::error::Failed to read provision hash from ${HOST} after retries"
+            exit 1
+          fi
           if [ "$ANSIBLE_HASH" != "$REMOTE_HASH" ]; then
             echo "Host ${HOST} needs provisioning (${REMOTE_HASH:0:8} != ${ANSIBLE_HASH:0:8})"
             STALE_HOSTS="${STALE_HOSTS:+${STALE_HOSTS},}${HOST}"
@@ -86,5 +105,5 @@ runs:
           -e "env_label=${ENV_LABEL}" -v
 
         for HOST in $(echo "$STALE_HOSTS" | tr ',' ' '); do
-          ssh "${METAL_USER}@${HOST}" "echo ${ANSIBLE_HASH} > ~/.vm0-provision-hash"
+          ssh_with_retry "${HOST}" "echo ${ANSIBLE_HASH} > ~/.vm0-provision-hash"
         done

--- a/.github/actions/provision/action.yml
+++ b/.github/actions/provision/action.yml
@@ -48,9 +48,10 @@ runs:
         ssh_with_retry() {
           local host="$1"
           shift
-          local attempt
+          local attempt output
           for attempt in 1 2 3; do
-            if ssh "${METAL_USER}@${host}" "$@"; then
+            if output=$(ssh "${METAL_USER}@${host}" "$@"); then
+              printf '%s' "$output"
               return 0
             fi
             echo "SSH command failed for ${host} (attempt ${attempt}/3)" >&2

--- a/.github/actions/provision/action.yml
+++ b/.github/actions/provision/action.yml
@@ -67,10 +67,18 @@ runs:
           pip3 install ansible-core
         fi
 
-        ansible-playbook -i "${STALE_HOSTS}," ansible/playbooks/provision-runner.yml \
+        run_ansible_playbook() {
+          # GitHub's container step can expose stdin as a non-blocking fd.
+          # Ansible refuses to start with non-blocking stdio, even though these
+          # playbooks never read stdin. Give it a blocking input handle while
+          # preserving stdout/stderr in the Actions log.
+          ansible-playbook "$@" < /dev/null
+        }
+
+        run_ansible_playbook -i "${STALE_HOSTS}," ansible/playbooks/provision-runner.yml \
           -e "ansible_user=${METAL_USER}" -v
 
-        ansible-playbook -i "${STALE_HOSTS}," ansible/playbooks/provision-monitoring.yml \
+        run_ansible_playbook -i "${STALE_HOSTS}," ansible/playbooks/provision-monitoring.yml \
           -e "ansible_user=${METAL_USER}" \
           -e "grafana_cloud_prometheus_url=${GRAFANA_CLOUD_PROMETHEUS_URL}" \
           -e "grafana_cloud_prometheus_user=${GRAFANA_CLOUD_PROMETHEUS_USER}" \


### PR DESCRIPTION
## Summary
- wrap provision action ansible-playbook calls in a helper that redirects stdin from /dev/null
- avoid Ansible failing in GitHub container steps when inherited stdin is non-blocking

## Tests
- git diff --check
- pre-commit hooks via git commit

Note: actionlint is not installed in this workspace.