### PR TITLE
docs(runner): document local command entrypoints

### DIFF
--- a/crates/runner/src/cmd/local/mod.rs
+++ b/crates/runner/src/cmd/local/mod.rs
@@ -9,6 +9,7 @@ use clap::{Args, Subcommand};
 
 use crate::error::RunnerResult;
 
+/// Arguments for the `runner local` subcommand group.
 #[derive(Args)]
 pub struct LocalArgs {
     #[command(subcommand)]
@@ -23,6 +24,7 @@ enum LocalCommand {
     Cancel(cancel::CancelArgs),
 }
 
+/// Dispatch `runner local` to the selected local file-queue subcommand.
 pub async fn run_local(args: LocalArgs) -> RunnerResult<ExitCode> {
     match args.command {
         LocalCommand::Submit(args) => submit::run_submit(args).await,


### PR DESCRIPTION
## Summary
- document the runner local CLI args wrapper
- document the runner local dispatcher entrypoint

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps
- git diff --check
- pre-commit lefthook: cargo-fmt, cargo-clippy, cargo-doc, check-file-size

Closes #11934