### PR TITLE
docs(sandbox): add crate-level docs

### DIFF
--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -1,3 +1,30 @@
+//! Firecracker-backed implementation of the `sandbox` provider traits.
+//!
+//! This crate wires Firecracker microVMs, host networking, COW rootfs devices,
+//! vsock control, and snapshot creation behind the provider-neutral traits from
+//! the `sandbox` crate. Most runner code should target those traits; use this
+//! crate directly when constructing the Firecracker provider or when a tool
+//! needs Firecracker-specific controls.
+//!
+//! The main entry points are:
+//!
+//! - [`FirecrackerRuntime`], which manages shared host resources and creates
+//!   [`FirecrackerFactory`] instances.
+//! - [`FirecrackerFactory`], which creates and destroys [`FirecrackerSandbox`]
+//!   instances for a configured rootfs, kernel, and profile.
+//! - [`FirecrackerSandbox`], the running microVM implementation of the
+//!   `sandbox::Sandbox` trait.
+//! - [`FirecrackerControl`], which exposes control-plane operations for a
+//!   running sandbox.
+//! - [`FirecrackerSnapshotProvider`], which creates snapshots compatible with
+//!   this provider.
+//! - [`NetnsPool`] and [`NetnsLease`], for code that must manage provider
+//!   network resources directly.
+//!
+//! Lower-level helpers such as [`ApiClient`] and the exported path/config types
+//! are public for runner integration and diagnostics, but they are not the
+//! preferred abstraction for normal sandbox lifecycle code.
+
 mod api;
 mod balloon;
 mod command;

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -1,3 +1,22 @@
+//! Provider-neutral sandbox traits and shared types.
+//!
+//! This crate defines the API used by runners and higher-level orchestration
+//! code to create, control, snapshot, and tear down isolated execution
+//! environments. It does not start a sandbox by itself; concrete providers
+//! implement these traits in separate crates.
+//!
+//! The main extension points are:
+//!
+//! - [`SandboxRuntime`], which owns provider-wide resources and creates
+//!   [`SandboxFactory`] instances.
+//! - [`SandboxFactory`], which creates and destroys [`Sandbox`] instances.
+//! - [`Sandbox`], which represents a running isolated environment.
+//! - [`SandboxControl`], which exposes host-side control operations.
+//! - [`SnapshotProvider`], which creates provider-specific snapshots.
+//!
+//! Configuration, result, and error types are shared here so provider crates
+//! can expose a consistent lifecycle and failure model.
+
 mod config;
 mod control;
 mod error;


### PR DESCRIPTION
Closes #11933.\n\n## Summary\n- Add provider-neutral crate docs to sandbox\n- Add Firecracker provider crate docs to sandbox-fc\n\n## Tests\n- cargo fmt --manifest-path crates/sandbox/Cargo.toml --check\n- cargo fmt --manifest-path crates/sandbox-fc/Cargo.toml --check\n- cargo doc --manifest-path crates/Cargo.toml -p sandbox -p sandbox-fc --no-deps\n- pre-commit: cargo-fmt, cargo-clippy, cargo-doc