### PR TITLE
Scale down inline blog illustrations

### DIFF
--- a/turbo/apps/web/app/blog.css
+++ b/turbo/apps/web/app/blog.css
@@ -782,10 +782,12 @@
 
 /* Images in content */
 .blog-post-content img {
-  max-width: 100%;
+  display: block;
+  width: 100%;
+  max-width: 400px;
   height: auto;
   border-radius: 8px;
-  margin: 32px 0;
+  margin: 32px auto;
 }
 
 /* Task lists (GFM support) */


### PR DESCRIPTION
## Summary
- Inline `![alt](url)` images in blog post bodies were rendering at the full 800 px column width.
- Cap them at 400 px and center them — they're spot illustrations, not hero images. Cover images are unaffected (rendered separately via Next.js `Image`).

Triggered by review of `/en/blog/posts/how-i-automate-blog-production-with-zero` where the illustrations felt oversized.

## Test plan
- [ ] Inline illustrations on `how-i-automate-blog-production-with-zero` render at ~400 px and centered
- [ ] Cover image and author avatar unaffected
- [ ] Mobile layout still responsive (image shrinks below 400 px on narrow viewports)