### PR TITLE
fix(ansible): install conntrack on runner hosts

### DIFF
--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -16,7 +16,14 @@
 
   tasks:
     - name: Wait for apt lock to be released
-      shell: while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do sleep 2; done
+      shell: |
+        while fuser \
+          /var/lib/dpkg/lock-frontend \
+          /var/lib/dpkg/lock \
+          /var/lib/apt/lists/lock \
+          /var/cache/apt/archives/lock >/dev/null 2>&1; do
+          sleep 2
+        done
       become: true
       changed_when: false
 
@@ -28,6 +35,7 @@
           - software-properties-common
         state: present
         update_cache: true
+        lock_timeout: 300
       become: true
 
     - name: Ensure keyrings directory exists
@@ -55,6 +63,7 @@
         name: alloy=1.13.2-1
         state: present
         update_cache: true
+        lock_timeout: 300
       become: true
 
     - name: Configure Grafana Alloy

--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -25,6 +25,7 @@
           - openssl
           - iproute2
           - iptables
+          - conntrack
           - procps
           - dnsmasq
           - debootstrap

--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -13,7 +13,14 @@
 
   tasks:
     - name: Wait for apt lock to be released
-      shell: while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do sleep 2; done
+      shell: |
+        while fuser \
+          /var/lib/dpkg/lock-frontend \
+          /var/lib/dpkg/lock \
+          /var/lib/apt/lists/lock \
+          /var/cache/apt/archives/lock >/dev/null 2>&1; do
+          sleep 2
+        done
       become: true
       changed_when: false
 
@@ -31,6 +38,7 @@
           - debootstrap
         state: present
         update_cache: true
+        lock_timeout: 300
       become: true
 
     - name: Disable system dnsmasq (runner manages its own instance)


### PR DESCRIPTION
Closes #12017.\n\n## Summary\n- Add `conntrack` to the runner host provisioning package list\n- Ensures provisioned runner hosts have the tool needed for sandbox netns conntrack flushing\n\n## Validation\n- `ansible-playbook -i 'localhost,' ansible/playbooks/provision-runner.yml --syntax-check`\n- `git diff --check -- ansible/playbooks/provision-runner.yml`