### PR TITLE
feat(platform): unify codex auth.json paste flow across personal + org contexts

### DIFF
--- a/turbo/apps/platform/src/signals/external/personal-model-providers.ts
+++ b/turbo/apps/platform/src/signals/external/personal-model-providers.ts
@@ -96,3 +96,15 @@ export const deletePersonalModelProvider$ = command(
     });
   },
 );
+
+/**
+ * Force-refresh `personalModelProviders$` — used by the codex auth.json
+ * paste flow after a successful (re-)connect so the stale-provider banner
+ * unmounts. Mirrors `reloadOrgModelProviders$` in
+ * `external/org-model-providers.ts`.
+ */
+export const reloadPersonalModelProviders$ = command(({ set }) => {
+  set(internalReloadPersonalModelProviders$, (x) => {
+    return x + 1;
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-model-providers.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-model-providers.ts
@@ -380,6 +380,11 @@ export const orgSubmitDialog$ = command(
       );
       if (secretsConfig) {
         for (const [key, config] of Object.entries(secretsConfig)) {
+          // Derived secrets are populated by a server-side parser, not the
+          // form. Skip required-field validation for them (#12024).
+          if (config.derived) {
+            continue;
+          }
           if (config.required && !formValues.secrets[key]?.trim()) {
             errors[key] = `${config.label} is required`;
           }

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
@@ -289,6 +289,11 @@ export const personalSubmitDialog$ = command(
       );
       if (secretsConfig) {
         for (const [key, config] of Object.entries(secretsConfig)) {
+          // Derived secrets are populated by a server-side parser, not the
+          // form. Skip required-field validation for them (#12024).
+          if (config.derived) {
+            continue;
+          }
           if (config.required && !formValues.secrets[key]?.trim()) {
             errors[key] = `${config.label} is required`;
           }

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
@@ -15,8 +15,12 @@ import {
   createPersonalModelProvider$,
   deletePersonalModelProvider$,
   personalModelProviders$,
+  reloadPersonalModelProviders$,
   setDefaultPersonalModelProvider$,
 } from "../../external/personal-model-providers.ts";
+import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+import { zeroClient$ } from "../../api-client.ts";
+import { accept } from "../../../lib/accept.ts";
 
 // ---------------------------------------------------------------------------
 // Add provider dialog (list of provider type cards)
@@ -29,6 +33,83 @@ export const personalAddProviderDialogOpen$ = computed((get) => {
 export const setPersonalAddProviderDialogOpen$ = command(
   ({ set }, open: boolean) => {
     set(internalPersonalAddProviderDialogOpen$, open);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Codex auth.json paste dialog (personal scope, mirrors org-side dialog from
+// #11980; unified with org via #12024).
+// ---------------------------------------------------------------------------
+
+type CodexPasteDialogMode = "connect" | "reconnect";
+
+interface CodexPasteDialogState {
+  open: boolean;
+  mode: CodexPasteDialogMode;
+}
+
+const internalCodexPasteDialogStatePersonal$ = state<CodexPasteDialogState>({
+  open: false,
+  mode: "connect",
+});
+
+const internalCodexPasteContentPersonal$ = state<string>("");
+
+export const codexPasteDialogStatePersonal$ = computed((get) => {
+  return get(internalCodexPasteDialogStatePersonal$);
+});
+
+export const codexPasteContentPersonal$ = computed((get) => {
+  return get(internalCodexPasteContentPersonal$);
+});
+
+export const setCodexPasteDialogStatePersonal$ = command(
+  ({ set }, next: CodexPasteDialogState) => {
+    set(internalCodexPasteDialogStatePersonal$, next);
+    if (!next.open) {
+      set(internalCodexPasteContentPersonal$, "");
+    }
+  },
+);
+
+export const updateCodexPasteContentPersonal$ = command(
+  ({ set }, paste: string) => {
+    set(internalCodexPasteContentPersonal$, paste);
+  },
+);
+
+/**
+ * Submit the current personal codex paste content as `~/.codex/auth.json`
+ * via the `auth_json` authMethod. Same semantics as the org-side
+ * `submitCodexAuthJson$` — server parses, derives 4 CHATGPT_* secrets,
+ * persists; toast suppressed so dialog renders typed errors inline.
+ */
+export const submitCodexAuthJsonPersonal$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const rawJson = get(internalCodexPasteContentPersonal$).trim();
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroPersonalModelProvidersMainContract);
+    const result = await accept(
+      client.upsert({
+        body: {
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: rawJson },
+        },
+        fetchOptions: { signal },
+      }),
+      [200, 201],
+      { toast: false },
+    );
+    signal.throwIfAborted();
+
+    set(reloadPersonalModelProviders$);
+    set(internalCodexPasteContentPersonal$, "");
+    set(internalCodexPasteDialogStatePersonal$, (prev) => {
+      return { ...prev, open: false };
+    });
+
+    return result.body;
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
@@ -222,3 +222,156 @@ describe("personal-providers-tab — provider list rendering", () => {
     expect(screen.getByRole("combobox")).toHaveTextContent(/Anthropic/i);
   });
 });
+
+// ===========================================================================
+// codex-oauth-token paste flow on personal scope (#12024)
+//
+// Mirrors the org-side coverage in zero-page/__tests__/
+// org-add-provider-dialog-codex.test.tsx. Verifies:
+// - The Codex card is gated on FeatureSwitchKey.CodexOauthProvider
+// - Clicking the Codex card opens the paste dialog (not the generic form)
+// - The stale-provider banner appears when needsReconnect=true
+// - Banner button opens the paste dialog in reconnect mode
+// ===========================================================================
+
+describe("personal-providers-tab — codex paste flow", () => {
+  function makeStaleCodexProvider(): ModelProviderResponse {
+    const now = new Date().toISOString();
+    return {
+      id: "00000000-0000-4000-a000-000000000020",
+      type: "codex-oauth-token",
+      framework: "codex",
+      secretName: "CHATGPT_ACCESS_TOKEN",
+      authMethod: "auth_json",
+      secretNames: [
+        "CHATGPT_ACCESS_TOKEN",
+        "CHATGPT_REFRESH_TOKEN",
+        "CHATGPT_ACCOUNT_ID",
+        "CHATGPT_ID_TOKEN",
+      ],
+      isDefault: false,
+      selectedModel: null,
+      createdAt: now,
+      updatedAt: now,
+      needsReconnect: true,
+      lastRefreshErrorCode: "refresh_token_expired",
+      workspaceName: "Personal Acme",
+      planType: "plus",
+    };
+  }
+
+  it("hides the Codex card when the codexOauthProvider feature switch is off", async () => {
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.PersonalModelProvider]: true,
+      // CodexOauthProvider deliberately omitted → defaults to off
+    });
+    mockPreferences();
+    setMockPersonalModelProviders([]);
+    detachedSetupPage({ context, path: "/settings" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Model Providers")).toBeInTheDocument();
+    });
+    click(screen.getByText("Model Providers"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("personal-add-provider-button"),
+      ).toBeInTheDocument();
+    });
+    click(screen.getByTestId("personal-add-provider-button"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Add personal model provider"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("personal-provider-card-codex-oauth-token"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clicking the Codex card opens the paste dialog (not the generic form)", async () => {
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.PersonalModelProvider]: true,
+      [FeatureSwitchKey.CodexOauthProvider]: true,
+    });
+    mockPreferences();
+    setMockPersonalModelProviders([]);
+    detachedSetupPage({ context, path: "/settings" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Model Providers")).toBeInTheDocument();
+    });
+    click(screen.getByText("Model Providers"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("personal-add-provider-button"),
+      ).toBeInTheDocument();
+    });
+    click(screen.getByTestId("personal-add-provider-button"));
+
+    const codexCard = await screen.findByTestId(
+      "personal-provider-card-codex-oauth-token",
+    );
+    click(codexCard);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: /Connect Codex/i }),
+      ).toBeInTheDocument();
+    });
+
+    // The textarea is present (paste-modal UX), not a 5-field generic form
+    expect(screen.getByTestId("codex-paste-textarea")).toBeInTheDocument();
+  });
+
+  it("renders the stale-provider banner when a personal codex provider needs reconnection", async () => {
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.PersonalModelProvider]: true,
+      [FeatureSwitchKey.CodexOauthProvider]: true,
+    });
+    mockPreferences();
+    setMockPersonalModelProviders([makeStaleCodexProvider()]);
+    detachedSetupPage({ context, path: "/settings" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Model Providers")).toBeInTheDocument();
+    });
+    click(screen.getByText("Model Providers"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("ChatGPT session needs reconnection"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("Your ChatGPT session expired. Re-connect to continue."),
+    ).toBeInTheDocument();
+  });
+
+  it("re-paste auth.json banner button opens the paste dialog in reconnect mode", async () => {
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.PersonalModelProvider]: true,
+      [FeatureSwitchKey.CodexOauthProvider]: true,
+    });
+    mockPreferences();
+    setMockPersonalModelProviders([makeStaleCodexProvider()]);
+    detachedSetupPage({ context, path: "/settings" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Model Providers")).toBeInTheDocument();
+    });
+    click(screen.getByText("Model Providers"));
+
+    const reconnectBtn = await screen.findByText("Re-paste auth.json");
+    click(reconnectBtn);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: /Re-connect Codex/i }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -35,7 +35,7 @@ import { ProviderIcon } from "../settings/provider-icons.tsx";
 import { PersonalAddProviderDialog } from "../settings/personal-add-provider-dialog.tsx";
 import { PersonalProviderDialog } from "../settings/personal-provider-dialog.tsx";
 import { PersonalDeleteProviderDialog } from "../settings/personal-delete-provider-dialog.tsx";
-import { CodexAuthPasteDialog } from "../settings/codex-auth-paste-dialog.tsx";
+import { PersonalCodexAuthPasteDialog } from "../settings/codex-auth-paste-dialog.tsx";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 
@@ -47,7 +47,7 @@ export function PersonalProvidersTab() {
       <ProviderListSection />
       <PersonalDeleteProviderDialog />
       <PersonalProviderDialog />
-      <CodexAuthPasteDialog scope="personal" />
+      <PersonalCodexAuthPasteDialog />
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -4,6 +4,7 @@ import { useGet, useSet, useLoadable } from "ccstate-react";
 import { IconDotsVertical, IconPlus } from "@tabler/icons-react";
 import {
   MODEL_PROVIDER_TYPES,
+  type ModelProviderResponse,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import {
@@ -27,12 +28,14 @@ import {
   personalSetDefaultProvider$,
   personalOpenEditDialog$,
   personalOpenDeleteDialog$,
+  setCodexPasteDialogStatePersonal$,
 } from "../../../../signals/zero-page/settings/personal-model-providers.ts";
 import { getUILabel } from "../settings/provider-ui-config.ts";
 import { ProviderIcon } from "../settings/provider-icons.tsx";
 import { PersonalAddProviderDialog } from "../settings/personal-add-provider-dialog.tsx";
 import { PersonalProviderDialog } from "../settings/personal-provider-dialog.tsx";
 import { PersonalDeleteProviderDialog } from "../settings/personal-delete-provider-dialog.tsx";
+import { CodexAuthPasteDialog } from "../settings/codex-auth-paste-dialog.tsx";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 
@@ -40,11 +43,82 @@ export function PersonalProvidersTab() {
   return (
     <div className="flex flex-col gap-8">
       <DefaultProviderSection />
+      <StaleBannerSection />
       <ProviderListSection />
       <PersonalDeleteProviderDialog />
       <PersonalProviderDialog />
+      <CodexAuthPasteDialog scope="personal" />
     </div>
   );
+}
+
+/**
+ * Render the re-connect banner above the personal provider list when any
+ * codex-oauth-token provider has flipped to needsReconnect=true (the
+ * firewall refresh pipeline writes this on refresh failure). Mirrors the
+ * org-side banner from `org-providers-tab.tsx` so personal + org have
+ * identical recovery UX (#12024).
+ */
+function StaleBannerSection() {
+  const providersLoadable = useLoadable(personalConfiguredProviders$);
+  const providers =
+    providersLoadable.state === "hasData" ? providersLoadable.data : [];
+  return <StaleProviderBanner providers={providers} />;
+}
+
+function StaleProviderBanner({
+  providers,
+}: {
+  providers: ModelProviderResponse[];
+}) {
+  const setPasteDialog = useSet(setCodexPasteDialogStatePersonal$);
+  const stale = providers.find((p) => {
+    return p.type === "codex-oauth-token" && p.needsReconnect;
+  });
+  if (!stale) {
+    return null;
+  }
+  return (
+    <section
+      className="flex items-center gap-3 rounded-xl border border-destructive/40 bg-destructive/5 p-4"
+      role="alert"
+    >
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-foreground">
+          ChatGPT session needs reconnection
+        </p>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {staleMessage(stale.lastRefreshErrorCode)}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          return setPasteDialog({ open: true, mode: "reconnect" });
+        }}
+        className="shrink-0 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+      >
+        Re-paste auth.json
+      </button>
+    </section>
+  );
+}
+
+function staleMessage(code: string | null): string {
+  switch (code) {
+    case "refresh_token_expired": {
+      return "Your ChatGPT session expired. Re-connect to continue.";
+    }
+    case "refresh_token_reused": {
+      return "Your ChatGPT session was used elsewhere. Re-connect.";
+    }
+    case "refresh_token_invalidated": {
+      return "Your ChatGPT session was revoked. Re-connect.";
+    }
+    default: {
+      return "ChatGPT refresh failed. Re-connect to retry.";
+    }
+  }
 }
 
 function DefaultProviderSection() {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/codex-auth-paste-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/codex-auth-paste-dialog.tsx
@@ -33,17 +33,17 @@ type CodexPasteDialogState = {
 };
 
 /**
- * Loadable state read by the dialog. Mirrors the shape exported by
- * `ccstate-react/experimental` — the dialog only inspects `state` and
- * `error`, so the data shape is intentionally `unknown` (both org and
- * personal commands resolve to a non-void payload, and we don't want the
- * bundle interface to bake one scope's payload into the other's signature).
+ * Loadable state read by the dialog. Derived from `useLoadableSet`'s actual
+ * return tuple so the discriminator union here cannot drift from
+ * `ccstate-react/experimental` — if the upstream library renames/adds a
+ * state, this type updates with it. `unknown` for the data type because the
+ * dialog only inspects `state` and `error` (both org and personal commands
+ * resolve to a non-void payload, and we don't want the bundle interface to
+ * bake one scope's payload into the other's signature).
  */
-type SubmitLoadable =
-  | { state: "idle" }
-  | { state: "loading" }
-  | { state: "hasData"; data: unknown }
-  | { state: "hasError"; error: unknown };
+type SubmitLoadable = ReturnType<
+  typeof useLoadableSet<unknown, [AbortSignal]>
+>[0];
 
 /**
  * The set of signals the paste dialog reads/writes for one scope. Both the

--- a/turbo/apps/platform/src/views/zero-page/components/settings/codex-auth-paste-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/codex-auth-paste-dialog.tsx
@@ -16,33 +16,65 @@ import {
   submitCodexAuthJson$,
   updateCodexPasteContent$,
 } from "../../../../signals/zero-page/settings/org-model-providers.ts";
+import {
+  codexPasteContentPersonal$,
+  codexPasteDialogStatePersonal$,
+  setCodexPasteDialogStatePersonal$,
+  submitCodexAuthJsonPersonal$,
+  updateCodexPasteContentPersonal$,
+} from "../../../../signals/zero-page/settings/personal-model-providers.ts";
 import { ApiError } from "../../../../lib/accept.ts";
 import { detach, isValidJson, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
+
+type CodexPasteScope = "org" | "personal";
 
 /**
  * Paste-based connection dialog for the codex-oauth-token provider.
  *
  * Replaces the broken cross-origin `window.location.assign` redirect that
- * shipped in #11909 (the platform SPA on app.vm0.ai resolved the relative
- * /api/zero/chatgpt/oauth/connect path against itself instead of www.vm0.ai).
- * Same component handles first-time connect and re-paste recovery from a
- * stale session — only the title differs by mode.
+ * shipped in #11909. Same component handles first-time connect and re-paste
+ * recovery from a stale session — only the title differs by mode. The
+ * `scope` prop selects between org-tier (`/api/zero/model-providers`) and
+ * personal-tier (`/api/zero/me/model-providers`) signal bundles so a single
+ * UI component drives both contexts (#12024).
  *
  * Submit POSTs `{ type: 'codex-oauth-token', authMethod: 'auth_json',
- * secrets: { CODEX_AUTH_JSON: <raw> } }` to /api/zero/model-providers; the
- * server-side parser lands in #11978. Typed error codes
- * (`CODEX_AUTH_JSON_SHAPE_INVALID`, `CODEX_FREE_PLAN_REJECTED`) surface
- * inline rather than via toast — the user is staring at the textarea, an
- * inline message keeps cause-and-effect close.
+ * secrets: { CODEX_AUTH_JSON: <raw> } }` to the scope-appropriate endpoint.
+ * Typed error codes (`CODEX_AUTH_JSON_SHAPE_INVALID`,
+ * `CODEX_FREE_PLAN_REJECTED`) surface inline rather than via toast — the
+ * user is staring at the textarea, an inline message keeps cause-and-effect
+ * close.
  */
-export function CodexAuthPasteDialog() {
-  const dialog = useGet(codexPasteDialogState$);
-  const paste = useGet(codexPasteContent$);
-  const setDialog = useSet(setCodexPasteDialogState$);
-  const updatePaste = useSet(updateCodexPasteContent$);
+export function CodexAuthPasteDialog({
+  scope = "org",
+}: {
+  scope?: CodexPasteScope;
+}) {
+  // Both bundles must be subscribed unconditionally to keep hook order
+  // stable; the unused side is read but its value isn't acted on.
+  const orgDialog = useGet(codexPasteDialogState$);
+  const orgPaste = useGet(codexPasteContent$);
+  const personalDialog = useGet(codexPasteDialogStatePersonal$);
+  const personalPaste = useGet(codexPasteContentPersonal$);
+  const setOrgDialog = useSet(setCodexPasteDialogState$);
+  const updateOrgPaste = useSet(updateCodexPasteContent$);
+  const setPersonalDialog = useSet(setCodexPasteDialogStatePersonal$);
+  const updatePersonalPaste = useSet(updateCodexPasteContentPersonal$);
   const pageSignal = useGet(pageSignal$);
-  const [submitLoadable, submit] = useLoadableSet(submitCodexAuthJson$);
+  const [orgSubmitLoadable, orgSubmit] = useLoadableSet(submitCodexAuthJson$);
+  const [personalSubmitLoadable, personalSubmit] = useLoadableSet(
+    submitCodexAuthJsonPersonal$,
+  );
+
+  const dialog = scope === "personal" ? personalDialog : orgDialog;
+  const paste = scope === "personal" ? personalPaste : orgPaste;
+  const setDialog = scope === "personal" ? setPersonalDialog : setOrgDialog;
+  const updatePaste =
+    scope === "personal" ? updatePersonalPaste : updateOrgPaste;
+  const submitLoadable =
+    scope === "personal" ? personalSubmitLoadable : orgSubmitLoadable;
+  const submit = scope === "personal" ? personalSubmit : orgSubmit;
 
   const submitting = submitLoadable.state === "loading";
   const serverError =

--- a/turbo/apps/platform/src/views/zero-page/components/settings/codex-auth-paste-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/codex-auth-paste-dialog.tsx
@@ -27,7 +27,75 @@ import { ApiError } from "../../../../lib/accept.ts";
 import { detach, isValidJson, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 
-type CodexPasteScope = "org" | "personal";
+type CodexPasteDialogState = {
+  open: boolean;
+  mode: "connect" | "reconnect";
+};
+
+/**
+ * Loadable state read by the dialog. Mirrors the shape exported by
+ * `ccstate-react/experimental` — the dialog only inspects `state` and
+ * `error`, so the data shape is intentionally `unknown` (both org and
+ * personal commands resolve to a non-void payload, and we don't want the
+ * bundle interface to bake one scope's payload into the other's signature).
+ */
+type SubmitLoadable =
+  | { state: "idle" }
+  | { state: "loading" }
+  | { state: "hasData"; data: unknown }
+  | { state: "hasError"; error: unknown };
+
+/**
+ * The set of signals the paste dialog reads/writes for one scope. Both the
+ * org and personal variants conform to this shape, so the inner presentational
+ * `CodexAuthPasteDialogView` can be agnostic of which scope it is rendering
+ * — only the wrapper (`Org…` / `Personal…`) subscribes to the right bundle.
+ */
+interface CodexPasteScopeBundle {
+  dialog: CodexPasteDialogState;
+  paste: string;
+  setDialog: (next: CodexPasteDialogState) => void;
+  updatePaste: (next: string) => void;
+  submitLoadable: SubmitLoadable;
+  submit: (signal: AbortSignal) => Promise<unknown>;
+}
+
+/**
+ * Org-tier wrapper. Subscribes only to the org signal bundle so the personal
+ * bundle is not evaluated on this render path. Used from `org-providers-tab`.
+ */
+export function CodexAuthPasteDialog() {
+  const bundle = useOrgCodexPasteBundle();
+  return <CodexAuthPasteDialogView bundle={bundle} />;
+}
+
+/**
+ * Personal-tier wrapper. Subscribes only to the personal signal bundle so
+ * the org bundle is not evaluated on this render path. Used from
+ * `personal-providers-tab`.
+ */
+export function PersonalCodexAuthPasteDialog() {
+  const bundle = usePersonalCodexPasteBundle();
+  return <CodexAuthPasteDialogView bundle={bundle} />;
+}
+
+function useOrgCodexPasteBundle(): CodexPasteScopeBundle {
+  const dialog = useGet(codexPasteDialogState$);
+  const paste = useGet(codexPasteContent$);
+  const setDialog = useSet(setCodexPasteDialogState$);
+  const updatePaste = useSet(updateCodexPasteContent$);
+  const [submitLoadable, submit] = useLoadableSet(submitCodexAuthJson$);
+  return { dialog, paste, setDialog, updatePaste, submitLoadable, submit };
+}
+
+function usePersonalCodexPasteBundle(): CodexPasteScopeBundle {
+  const dialog = useGet(codexPasteDialogStatePersonal$);
+  const paste = useGet(codexPasteContentPersonal$);
+  const setDialog = useSet(setCodexPasteDialogStatePersonal$);
+  const updatePaste = useSet(updateCodexPasteContentPersonal$);
+  const [submitLoadable, submit] = useLoadableSet(submitCodexAuthJsonPersonal$);
+  return { dialog, paste, setDialog, updatePaste, submitLoadable, submit };
+}
 
 /**
  * Paste-based connection dialog for the codex-oauth-token provider.
@@ -35,9 +103,8 @@ type CodexPasteScope = "org" | "personal";
  * Replaces the broken cross-origin `window.location.assign` redirect that
  * shipped in #11909. Same component handles first-time connect and re-paste
  * recovery from a stale session — only the title differs by mode. The
- * `scope` prop selects between org-tier (`/api/zero/model-providers`) and
- * personal-tier (`/api/zero/me/model-providers`) signal bundles so a single
- * UI component drives both contexts (#12024).
+ * scope-specific signal bundle is supplied by the wrapper component so this
+ * presentational layer is agnostic of org vs personal tier (#12024).
  *
  * Submit POSTs `{ type: 'codex-oauth-token', authMethod: 'auth_json',
  * secrets: { CODEX_AUTH_JSON: <raw> } }` to the scope-appropriate endpoint.
@@ -46,35 +113,14 @@ type CodexPasteScope = "org" | "personal";
  * user is staring at the textarea, an inline message keeps cause-and-effect
  * close.
  */
-export function CodexAuthPasteDialog({
-  scope = "org",
+function CodexAuthPasteDialogView({
+  bundle,
 }: {
-  scope?: CodexPasteScope;
+  bundle: CodexPasteScopeBundle;
 }) {
-  // Both bundles must be subscribed unconditionally to keep hook order
-  // stable; the unused side is read but its value isn't acted on.
-  const orgDialog = useGet(codexPasteDialogState$);
-  const orgPaste = useGet(codexPasteContent$);
-  const personalDialog = useGet(codexPasteDialogStatePersonal$);
-  const personalPaste = useGet(codexPasteContentPersonal$);
-  const setOrgDialog = useSet(setCodexPasteDialogState$);
-  const updateOrgPaste = useSet(updateCodexPasteContent$);
-  const setPersonalDialog = useSet(setCodexPasteDialogStatePersonal$);
-  const updatePersonalPaste = useSet(updateCodexPasteContentPersonal$);
+  const { dialog, paste, setDialog, updatePaste, submitLoadable, submit } =
+    bundle;
   const pageSignal = useGet(pageSignal$);
-  const [orgSubmitLoadable, orgSubmit] = useLoadableSet(submitCodexAuthJson$);
-  const [personalSubmitLoadable, personalSubmit] = useLoadableSet(
-    submitCodexAuthJsonPersonal$,
-  );
-
-  const dialog = scope === "personal" ? personalDialog : orgDialog;
-  const paste = scope === "personal" ? personalPaste : orgPaste;
-  const setDialog = scope === "personal" ? setPersonalDialog : setOrgDialog;
-  const updatePaste =
-    scope === "personal" ? updatePersonalPaste : updateOrgPaste;
-  const submitLoadable =
-    scope === "personal" ? personalSubmitLoadable : orgSubmitLoadable;
-  const submit = scope === "personal" ? personalSubmit : orgSubmit;
 
   const submitting = submitLoadable.state === "loading";
   const serverError =

--- a/turbo/apps/platform/src/views/zero-page/components/settings/personal-add-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/personal-add-provider-dialog.tsx
@@ -15,6 +15,7 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   personalConfiguredProviders$,
   personalOpenAddDialog$,
+  setCodexPasteDialogStatePersonal$,
 } from "../../../../signals/zero-page/settings/personal-model-providers.ts";
 import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import { getUILabel, getUIDescription } from "./provider-ui-config.ts";
@@ -78,7 +79,10 @@ export function PersonalAddProviderDialog({
   const configuredProviders = useLastResolved(personalConfiguredProviders$);
   const features = useLastResolved(featureSwitch$);
   const codexBetaEnabled = features?.[FeatureSwitchKey.CodexBeta] ?? false;
+  const codexOauthEnabled =
+    features?.[FeatureSwitchKey.CodexOauthProvider] ?? false;
   const openAdd = useSet(personalOpenAddDialog$);
+  const openCodexPaste = useSet(setCodexPasteDialogStatePersonal$);
   const configuredSet = new Set(
     configuredProviders?.map((p) => {
       return p.type;
@@ -86,6 +90,15 @@ export function PersonalAddProviderDialog({
   );
 
   const handleAdd = (type: ModelProviderType) => {
+    if (type === "codex-oauth-token") {
+      // Mirror the org-side behavior from #11980: open the paste dialog
+      // (textarea-only) instead of the generic form-based dialog. Close the
+      // picker so only the paste dialog is visible — stacking two dialogs
+      // is confusing (#12024).
+      openCodexPaste({ open: true, mode: "connect" });
+      onOpenChange(false);
+      return;
+    }
     openAdd(type);
   };
 
@@ -94,6 +107,9 @@ export function PersonalAddProviderDialog({
       return false;
     }
     if (type === "openai-api-key" && !codexBetaEnabled) {
+      return false;
+    }
+    if (type === "codex-oauth-token" && !codexOauthEnabled) {
       return false;
     }
     return true;

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
@@ -204,6 +204,14 @@ export function MultiAuthFields({
 
       {currentSecrets &&
         Object.entries(currentSecrets).map(([key, coreFieldConfig]) => {
+          // Skip derived secrets — these are populated by a server-side parser
+          // from another secret in the same authMethod (e.g., the four
+          // CHATGPT_* fields under codex-oauth-token / auth_json are derived
+          // from the user-pasted CODEX_AUTH_JSON). Rendering them as input
+          // fields would expose internal storage to the user (#12024).
+          if (coreFieldConfig.derived) {
+            return null;
+          }
           const field = getUISecretField(type, key, coreFieldConfig);
           return (
             <div key={key} className="flex flex-col gap-2">

--- a/turbo/apps/web/app/api/zero/me/model-providers/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/me/model-providers/__tests__/route.test.ts
@@ -386,6 +386,142 @@ describe("Personal-tier (BYOK) model provider routes", () => {
       expect(response.status).toBe(404);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // codex-oauth-token auth_json paste flow (#12024) — mirrors the org-side
+  // suite in app/api/zero/model-providers/__tests__/route.test.ts.
+  // ---------------------------------------------------------------------------
+
+  describe("codex-oauth-token auth_json paste flow (personal scope)", () => {
+    function base64UrlEncode(input: string): string {
+      return Buffer.from(input, "utf-8")
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+    }
+
+    function makeJwt(payload: Record<string, unknown>): string {
+      const header = base64UrlEncode(
+        JSON.stringify({ alg: "RS256", typ: "JWT" }),
+      );
+      const body = base64UrlEncode(JSON.stringify(payload));
+      return `${header}.${body}.fake-signature`;
+    }
+
+    function makeIdToken(opts: {
+      accountId: string;
+      planType: string;
+      workspaceName?: string;
+    }): string {
+      const auth: Record<string, unknown> = {
+        chatgpt_account_id: opts.accountId,
+        chatgpt_plan_type: opts.planType,
+      };
+      if (opts.workspaceName !== undefined) {
+        auth.organization = { title: opts.workspaceName };
+      }
+      return makeJwt({
+        "https://api.openai.com/auth": auth,
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      });
+    }
+
+    function makeAuthJson(overrides?: { planType?: string }): string {
+      const accessExp = Math.floor(Date.now() / 1000) + 7200;
+      return JSON.stringify({
+        OPENAI_API_KEY: null,
+        tokens: {
+          access_token: makeJwt({ exp: accessExp }),
+          refresh_token: "rt_personal_synthetic_high_entropy",
+          account_id: "ws_acct_plain",
+          id_token: makeIdToken({
+            accountId: "ws_acct_from_id_token_personal",
+            planType: overrides?.planType ?? "plus",
+            workspaceName: "Personal Acme",
+          }),
+        },
+      });
+    }
+
+    async function pasteAuthJson(rawJson: string): Promise<Response> {
+      const request = createTestRequest(upsertUrl(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: rawJson },
+        }),
+      });
+      return POST(request);
+    }
+
+    it("happy path: paste valid auth.json persists derived secrets + metadata", async () => {
+      const response = await pasteAuthJson(makeAuthJson());
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.provider.type).toBe("codex-oauth-token");
+      expect(data.provider.authMethod).toBe("auth_json");
+      expect(data.provider.workspaceName).toBe("Personal Acme");
+      expect(data.provider.planType).toBe("plus");
+      expect(data.provider.needsReconnect).toBe(false);
+    });
+
+    it("returns 400 CODEX_AUTH_JSON_SHAPE_INVALID on malformed JSON", async () => {
+      const response = await pasteAuthJson("{ not json");
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("CODEX_AUTH_JSON_SHAPE_INVALID");
+    });
+
+    it("returns 400 CODEX_AUTH_JSON_SHAPE_INVALID when tokens.refresh_token missing", async () => {
+      const incomplete = JSON.stringify({
+        tokens: {
+          access_token: makeJwt({ exp: Date.now() }),
+          // refresh_token omitted
+          account_id: "ws_acct",
+          id_token: makeIdToken({ accountId: "ws_acct", planType: "plus" }),
+        },
+      });
+      const response = await pasteAuthJson(incomplete);
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("CODEX_AUTH_JSON_SHAPE_INVALID");
+    });
+
+    it("returns 400 CODEX_FREE_PLAN_REJECTED for free-plan accounts", async () => {
+      const response = await pasteAuthJson(makeAuthJson({ planType: "free" }));
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("CODEX_FREE_PLAN_REJECTED");
+    });
+
+    it("returns 400 BAD_REQUEST when CODEX_AUTH_JSON is missing from secrets", async () => {
+      const request = createTestRequest(upsertUrl(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: {},
+        }),
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("BAD_REQUEST");
+    });
+
+    it("returns 404 when CodexOauthProvider feature switch is off", async () => {
+      mockIsFeatureEnabled.mockImplementation((key: FeatureSwitchKey) => {
+        // PersonalModelProvider stays on; only CodexOauthProvider gates this branch
+        return key !== FeatureSwitchKey.CodexOauthProvider;
+      });
+      const response = await pasteAuthJson(makeAuthJson());
+      expect(response.status).toBe(404);
+    });
+  });
 });
 
 // ===========================================================================

--- a/turbo/apps/web/app/api/zero/me/model-providers/route.ts
+++ b/turbo/apps/web/app/api/zero/me/model-providers/route.ts
@@ -1,10 +1,6 @@
 import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
-import {
-  hasAuthMethods,
-  type ModelProviderType,
-  type ModelProviderFramework,
-} from "@vm0/api-contracts/contracts/model-providers";
+import { hasAuthMethods } from "@vm0/api-contracts/contracts/model-providers";
 import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
@@ -20,123 +16,14 @@ import {
   upsertUserMultiAuthModelProvider,
 } from "../../../../../src/lib/zero/model-provider/model-provider-service";
 import {
-  parseCodexAuthJson,
-  isCodexAuthJsonShapeError,
-  isCodexAuthJsonFreePlanError,
-} from "../../../../../src/lib/zero/model-provider/codex-auth-json-parser";
+  handleCodexAuthJsonPaste,
+  serializeUpsertedProvider,
+} from "../../../../../src/lib/zero/model-provider/codex-auth-json-paste-handler";
 import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
 import { logger } from "../../../../../src/lib/shared/logger";
 import { isBadRequest } from "@vm0/api-services/errors";
 
 const log = logger("api:zero-me-model-providers");
-
-interface UpsertedProvider {
-  id: string;
-  type: ModelProviderType;
-  framework: ModelProviderFramework;
-  secretName: string | null;
-  authMethod?: string | null;
-  secretNames?: string[] | null;
-  isDefault: boolean;
-  selectedModel: string | null;
-  workspaceName: string | null;
-  planType: string | null;
-  needsReconnect: boolean;
-  lastRefreshErrorCode: string | null;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-function serializeProvider(provider: UpsertedProvider) {
-  return {
-    id: provider.id,
-    type: provider.type,
-    framework: provider.framework,
-    secretName: provider.secretName,
-    authMethod: provider.authMethod ?? null,
-    secretNames: provider.secretNames ?? null,
-    isDefault: provider.isDefault,
-    selectedModel: provider.selectedModel,
-    workspaceName: provider.workspaceName,
-    planType: provider.planType,
-    needsReconnect: provider.needsReconnect,
-    lastRefreshErrorCode: provider.lastRefreshErrorCode,
-    createdAt: provider.createdAt.toISOString(),
-    updatedAt: provider.updatedAt.toISOString(),
-  };
-}
-
-/**
- * Handle the codex-oauth-token + auth_json paste-based connect flow for the
- * personal scope. Mirrors the org-side `handleCodexAuthJsonPaste` in
- * `app/api/zero/model-providers/route.ts` — parses the raw ~/.codex/auth.json
- * server-side and persists the four derived CHATGPT_* fields. The raw
- * CODEX_AUTH_JSON blob is NEVER persisted (per Epic #11974 / #7365).
- */
-async function handleCodexAuthJsonPastePersonal(args: {
-  orgId: string;
-  userId: string;
-  rawAuthJson: string;
-  selectedModel: string | undefined;
-}) {
-  try {
-    const parsed = parseCodexAuthJson(args.rawAuthJson);
-
-    const { provider, created } = await upsertUserMultiAuthModelProvider(
-      args.orgId,
-      args.userId,
-      "codex-oauth-token",
-      "auth_json",
-      {
-        CHATGPT_ACCESS_TOKEN: parsed.accessToken,
-        CHATGPT_REFRESH_TOKEN: parsed.refreshToken,
-        CHATGPT_ACCOUNT_ID: parsed.accountId,
-        CHATGPT_ID_TOKEN: parsed.idToken,
-      },
-      args.selectedModel,
-      {
-        tokenExpiresAt: parsed.tokenExpiresAt,
-        workspaceName: parsed.workspaceName,
-        planType: parsed.planType,
-      },
-    );
-
-    log.info("personal codex provider connected via auth_json paste", {
-      orgId: args.orgId,
-      userId: args.userId,
-      workspaceName: parsed.workspaceName,
-      planType: parsed.planType,
-    });
-
-    return {
-      status: (created ? 201 : 200) as 200 | 201,
-      body: { provider: serializeProvider(provider), created },
-    };
-  } catch (error) {
-    if (isCodexAuthJsonFreePlanError(error)) {
-      log.info("rejected personal codex auth_json paste: free plan", {
-        orgId: args.orgId,
-        userId: args.userId,
-      });
-      return createErrorResponse(
-        "CODEX_FREE_PLAN_REJECTED",
-        "ChatGPT free plan is not supported — upgrade to Plus or higher.",
-      );
-    }
-    if (isCodexAuthJsonShapeError(error)) {
-      log.warn("rejected personal codex auth_json paste: shape", {
-        orgId: args.orgId,
-        userId: args.userId,
-        errorMessage: error.message,
-      });
-      return createErrorResponse(
-        "CODEX_AUTH_JSON_SHAPE_INVALID",
-        error.message,
-      );
-    }
-    throw error;
-  }
-}
 
 const router = tsr.router(zeroPersonalModelProvidersMainContract, {
   list: async ({ headers }) => {
@@ -235,11 +122,28 @@ const router = tsr.router(zeroPersonalModelProvidersMainContract, {
           "Missing CODEX_AUTH_JSON secret",
         );
       }
-      return handleCodexAuthJsonPastePersonal({
+      return handleCodexAuthJsonPaste({
+        scope: "personal",
         orgId: org.orgId,
         userId: authCtx.userId,
         rawAuthJson: raw,
         selectedModel,
+        upsert: ({
+          authMethod: pasteAuthMethod,
+          secretValues,
+          selectedModel: model,
+          metadata,
+        }) => {
+          return upsertUserMultiAuthModelProvider(
+            org.orgId,
+            authCtx.userId,
+            "codex-oauth-token",
+            pasteAuthMethod,
+            secretValues,
+            model,
+            metadata,
+          );
+        },
       });
     }
 
@@ -292,22 +196,7 @@ const router = tsr.router(zeroPersonalModelProvidersMainContract, {
       return {
         status: (created ? 201 : 200) as 200 | 201,
         body: {
-          provider: {
-            id: provider.id,
-            type: provider.type,
-            framework: provider.framework,
-            secretName: provider.secretName,
-            authMethod: provider.authMethod ?? null,
-            secretNames: provider.secretNames ?? null,
-            isDefault: provider.isDefault,
-            selectedModel: provider.selectedModel,
-            workspaceName: provider.workspaceName,
-            planType: provider.planType,
-            needsReconnect: provider.needsReconnect,
-            lastRefreshErrorCode: provider.lastRefreshErrorCode,
-            createdAt: provider.createdAt.toISOString(),
-            updatedAt: provider.updatedAt.toISOString(),
-          },
+          provider: serializeUpsertedProvider(provider),
           created,
         },
       };

--- a/turbo/apps/web/app/api/zero/me/model-providers/route.ts
+++ b/turbo/apps/web/app/api/zero/me/model-providers/route.ts
@@ -1,6 +1,10 @@
 import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
-import { hasAuthMethods } from "@vm0/api-contracts/contracts/model-providers";
+import {
+  hasAuthMethods,
+  type ModelProviderType,
+  type ModelProviderFramework,
+} from "@vm0/api-contracts/contracts/model-providers";
 import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
@@ -15,11 +19,124 @@ import {
   upsertUserModelProvider,
   upsertUserMultiAuthModelProvider,
 } from "../../../../../src/lib/zero/model-provider/model-provider-service";
+import {
+  parseCodexAuthJson,
+  isCodexAuthJsonShapeError,
+  isCodexAuthJsonFreePlanError,
+} from "../../../../../src/lib/zero/model-provider/codex-auth-json-parser";
 import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
 import { logger } from "../../../../../src/lib/shared/logger";
 import { isBadRequest } from "@vm0/api-services/errors";
 
 const log = logger("api:zero-me-model-providers");
+
+interface UpsertedProvider {
+  id: string;
+  type: ModelProviderType;
+  framework: ModelProviderFramework;
+  secretName: string | null;
+  authMethod?: string | null;
+  secretNames?: string[] | null;
+  isDefault: boolean;
+  selectedModel: string | null;
+  workspaceName: string | null;
+  planType: string | null;
+  needsReconnect: boolean;
+  lastRefreshErrorCode: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function serializeProvider(provider: UpsertedProvider) {
+  return {
+    id: provider.id,
+    type: provider.type,
+    framework: provider.framework,
+    secretName: provider.secretName,
+    authMethod: provider.authMethod ?? null,
+    secretNames: provider.secretNames ?? null,
+    isDefault: provider.isDefault,
+    selectedModel: provider.selectedModel,
+    workspaceName: provider.workspaceName,
+    planType: provider.planType,
+    needsReconnect: provider.needsReconnect,
+    lastRefreshErrorCode: provider.lastRefreshErrorCode,
+    createdAt: provider.createdAt.toISOString(),
+    updatedAt: provider.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Handle the codex-oauth-token + auth_json paste-based connect flow for the
+ * personal scope. Mirrors the org-side `handleCodexAuthJsonPaste` in
+ * `app/api/zero/model-providers/route.ts` — parses the raw ~/.codex/auth.json
+ * server-side and persists the four derived CHATGPT_* fields. The raw
+ * CODEX_AUTH_JSON blob is NEVER persisted (per Epic #11974 / #7365).
+ */
+async function handleCodexAuthJsonPastePersonal(args: {
+  orgId: string;
+  userId: string;
+  rawAuthJson: string;
+  selectedModel: string | undefined;
+}) {
+  try {
+    const parsed = parseCodexAuthJson(args.rawAuthJson);
+
+    const { provider, created } = await upsertUserMultiAuthModelProvider(
+      args.orgId,
+      args.userId,
+      "codex-oauth-token",
+      "auth_json",
+      {
+        CHATGPT_ACCESS_TOKEN: parsed.accessToken,
+        CHATGPT_REFRESH_TOKEN: parsed.refreshToken,
+        CHATGPT_ACCOUNT_ID: parsed.accountId,
+        CHATGPT_ID_TOKEN: parsed.idToken,
+      },
+      args.selectedModel,
+      {
+        tokenExpiresAt: parsed.tokenExpiresAt,
+        workspaceName: parsed.workspaceName,
+        planType: parsed.planType,
+      },
+    );
+
+    log.info("personal codex provider connected via auth_json paste", {
+      orgId: args.orgId,
+      userId: args.userId,
+      workspaceName: parsed.workspaceName,
+      planType: parsed.planType,
+    });
+
+    return {
+      status: (created ? 201 : 200) as 200 | 201,
+      body: { provider: serializeProvider(provider), created },
+    };
+  } catch (error) {
+    if (isCodexAuthJsonFreePlanError(error)) {
+      log.info("rejected personal codex auth_json paste: free plan", {
+        orgId: args.orgId,
+        userId: args.userId,
+      });
+      return createErrorResponse(
+        "CODEX_FREE_PLAN_REJECTED",
+        "ChatGPT free plan is not supported — upgrade to Plus or higher.",
+      );
+    }
+    if (isCodexAuthJsonShapeError(error)) {
+      log.warn("rejected personal codex auth_json paste: shape", {
+        orgId: args.orgId,
+        userId: args.userId,
+        errorMessage: error.message,
+      });
+      return createErrorResponse(
+        "CODEX_AUTH_JSON_SHAPE_INVALID",
+        error.message,
+      );
+    }
+    throw error;
+  }
+}
 
 const router = tsr.router(zeroPersonalModelProvidersMainContract, {
   list: async ({ headers }) => {
@@ -100,6 +217,30 @@ const router = tsr.router(zeroPersonalModelProvidersMainContract, {
       if (!codexBetaEnabled) {
         return createErrorResponse("NOT_FOUND", `Provider "${type}" not found`);
       }
+    }
+
+    if (type === "codex-oauth-token" && authMethod === "auth_json") {
+      const eligible = isFeatureEnabled(FeatureSwitchKey.CodexOauthProvider, {
+        orgId: org.orgId,
+        userId: authCtx.userId,
+        overrides,
+      });
+      if (!eligible) {
+        return createErrorResponse("NOT_FOUND", `Provider "${type}" not found`);
+      }
+      const raw = secrets?.CODEX_AUTH_JSON;
+      if (!raw) {
+        return createErrorResponse(
+          "BAD_REQUEST",
+          "Missing CODEX_AUTH_JSON secret",
+        );
+      }
+      return handleCodexAuthJsonPastePersonal({
+        orgId: org.orgId,
+        userId: authCtx.userId,
+        rawAuthJson: raw,
+        selectedModel,
+      });
     }
 
     log.debug("upserting personal model provider", {

--- a/turbo/apps/web/app/api/zero/model-providers/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/route.ts
@@ -1,10 +1,6 @@
 import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
-import {
-  hasAuthMethods,
-  type ModelProviderType,
-  type ModelProviderFramework,
-} from "@vm0/api-contracts/contracts/model-providers";
+import { hasAuthMethods } from "@vm0/api-contracts/contracts/model-providers";
 import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
@@ -21,122 +17,14 @@ import {
   upsertOrgNoSecretModelProvider,
 } from "../../../../src/lib/zero/model-provider/model-provider-service";
 import {
-  parseCodexAuthJson,
-  isCodexAuthJsonShapeError,
-  isCodexAuthJsonFreePlanError,
-} from "../../../../src/lib/zero/model-provider/codex-auth-json-parser";
+  handleCodexAuthJsonPaste,
+  serializeUpsertedProvider,
+} from "../../../../src/lib/zero/model-provider/codex-auth-json-paste-handler";
 import { loadFeatureSwitchOverrides } from "../../../../src/lib/zero/user/feature-switches-service";
 import { logger } from "../../../../src/lib/shared/logger";
 import { isBadRequest } from "@vm0/api-services/errors";
 
 const log = logger("api:zero-model-providers");
-
-interface UpsertedProvider {
-  id: string;
-  type: ModelProviderType;
-  framework: ModelProviderFramework;
-  secretName: string | null;
-  authMethod?: string | null;
-  secretNames?: string[] | null;
-  isDefault: boolean;
-  selectedModel: string | null;
-  workspaceName: string | null;
-  planType: string | null;
-  needsReconnect: boolean;
-  lastRefreshErrorCode: string | null;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-/**
- * Handle the codex-oauth-token + auth_json paste-based connect flow.
- * Parses the raw ~/.codex/auth.json server-side and persists the four derived
- * CHATGPT_* fields via the canonical `oauth` storage path. The raw
- * CODEX_AUTH_JSON blob is NEVER persisted (per Epic #11974 / #7365).
- *
- * Extracted from the upsert handler to keep complexity below 20 — the typed
- * error catch-and-translate adds three branches that pushed the parent past
- * the per-function ceiling.
- */
-async function handleCodexAuthJsonPaste(args: {
-  orgId: string;
-  userId: string;
-  rawAuthJson: string;
-  selectedModel: string | undefined;
-}) {
-  try {
-    const parsed = parseCodexAuthJson(args.rawAuthJson);
-
-    const { provider, created } = await upsertOrgMultiAuthModelProvider(
-      args.orgId,
-      "codex-oauth-token",
-      "auth_json",
-      {
-        CHATGPT_ACCESS_TOKEN: parsed.accessToken,
-        CHATGPT_REFRESH_TOKEN: parsed.refreshToken,
-        CHATGPT_ACCOUNT_ID: parsed.accountId,
-        CHATGPT_ID_TOKEN: parsed.idToken,
-      },
-      args.selectedModel,
-      {
-        tokenExpiresAt: parsed.tokenExpiresAt,
-        workspaceName: parsed.workspaceName,
-        planType: parsed.planType,
-      },
-    );
-
-    log.info("codex provider connected via auth_json paste", {
-      orgId: args.orgId,
-      workspaceName: parsed.workspaceName,
-      planType: parsed.planType,
-    });
-
-    return {
-      status: (created ? 201 : 200) as 200 | 201,
-      body: { provider: serializeProvider(provider), created },
-    };
-  } catch (error) {
-    if (isCodexAuthJsonFreePlanError(error)) {
-      log.info("rejected codex auth_json paste: free plan", {
-        orgId: args.orgId,
-      });
-      return createErrorResponse(
-        "CODEX_FREE_PLAN_REJECTED",
-        "ChatGPT free plan is not supported — upgrade to Plus or higher.",
-      );
-    }
-    if (isCodexAuthJsonShapeError(error)) {
-      log.warn("rejected codex auth_json paste: shape", {
-        orgId: args.orgId,
-        errorMessage: error.message,
-      });
-      return createErrorResponse(
-        "CODEX_AUTH_JSON_SHAPE_INVALID",
-        error.message,
-      );
-    }
-    throw error;
-  }
-}
-
-function serializeProvider(provider: UpsertedProvider) {
-  return {
-    id: provider.id,
-    type: provider.type,
-    framework: provider.framework,
-    secretName: provider.secretName,
-    authMethod: provider.authMethod ?? null,
-    secretNames: provider.secretNames ?? null,
-    isDefault: provider.isDefault,
-    selectedModel: provider.selectedModel,
-    workspaceName: provider.workspaceName,
-    planType: provider.planType,
-    needsReconnect: provider.needsReconnect,
-    lastRefreshErrorCode: provider.lastRefreshErrorCode,
-    createdAt: provider.createdAt.toISOString(),
-    updatedAt: provider.updatedAt.toISOString(),
-  };
-}
 
 const router = tsr.router(zeroModelProvidersMainContract, {
   list: async ({ headers }) => {
@@ -226,10 +114,25 @@ const router = tsr.router(zeroModelProvidersMainContract, {
         );
       }
       return handleCodexAuthJsonPaste({
+        scope: "org",
         orgId: org.orgId,
-        userId: authCtx.userId,
         rawAuthJson: raw,
         selectedModel,
+        upsert: ({
+          authMethod: pasteAuthMethod,
+          secretValues,
+          selectedModel: model,
+          metadata,
+        }) => {
+          return upsertOrgMultiAuthModelProvider(
+            org.orgId,
+            "codex-oauth-token",
+            pasteAuthMethod,
+            secretValues,
+            model,
+            metadata,
+          );
+        },
       });
     }
 
@@ -286,7 +189,7 @@ const router = tsr.router(zeroModelProvidersMainContract, {
 
       return {
         status: (created ? 201 : 200) as 200 | 201,
-        body: { provider: serializeProvider(provider), created },
+        body: { provider: serializeUpsertedProvider(provider), created },
       };
     } catch (error) {
       if (isBadRequest(error)) {

--- a/turbo/apps/web/src/lib/zero/model-provider/codex-auth-json-paste-handler.ts
+++ b/turbo/apps/web/src/lib/zero/model-provider/codex-auth-json-paste-handler.ts
@@ -79,6 +79,31 @@ type UpsertCodexProvider = (args: {
 }) => Promise<{ provider: UpsertedProvider; created: boolean }>;
 
 /**
+ * Common args shared by both scopes. Split out so the discriminated union
+ * below can intersect each scope's identity fields onto the same payload
+ * without repeating the paste-flow inputs.
+ */
+interface CodexAuthJsonPasteCommonArgs {
+  rawAuthJson: string;
+  selectedModel: string | undefined;
+  upsert: UpsertCodexProvider;
+}
+
+/**
+ * Discriminated union over the calling scope. The org variant carries only
+ * `orgId`; the personal variant additionally requires `userId`. Encoded in
+ * the type system (rather than as a doc-comment on a `userId?: string`) so
+ * the personal call site cannot compile without a real userId.
+ */
+type CodexAuthJsonPasteArgs =
+  | ({ scope: "org"; orgId: string } & CodexAuthJsonPasteCommonArgs)
+  | ({
+      scope: "personal";
+      orgId: string;
+      userId: string;
+    } & CodexAuthJsonPasteCommonArgs);
+
+/**
  * Handle the codex-oauth-token + auth_json paste-based connect flow.
  *
  * Parses the raw `~/.codex/auth.json` server-side and persists the four
@@ -89,16 +114,7 @@ type UpsertCodexProvider = (args: {
  * route (`/api/zero/me/model-providers`) so the paste contract — error codes,
  * log fields, response shape — cannot drift between the two scopes.
  */
-export async function handleCodexAuthJsonPaste(args: {
-  /** `"org" | "personal"` — drives the log namespace and the log payload. */
-  scope: "org" | "personal";
-  orgId: string;
-  /** Required for personal scope, omitted for org scope. */
-  userId?: string;
-  rawAuthJson: string;
-  selectedModel: string | undefined;
-  upsert: UpsertCodexProvider;
-}) {
+export async function handleCodexAuthJsonPaste(args: CodexAuthJsonPasteArgs) {
   const log = logger(
     args.scope === "personal"
       ? "api:zero-me-model-providers"

--- a/turbo/apps/web/src/lib/zero/model-provider/codex-auth-json-paste-handler.ts
+++ b/turbo/apps/web/src/lib/zero/model-provider/codex-auth-json-paste-handler.ts
@@ -1,0 +1,173 @@
+import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
+import type {
+  ModelProviderType,
+  ModelProviderFramework,
+} from "@vm0/api-contracts/contracts/model-providers";
+import {
+  parseCodexAuthJson,
+  isCodexAuthJsonShapeError,
+  isCodexAuthJsonFreePlanError,
+} from "./codex-auth-json-parser";
+import { logger } from "../../shared/logger";
+
+/**
+ * Shape of an upserted provider row that the paste handler serializes into the
+ * REST response. Subset of the internal `ModelProviderInfo` (drops `userId`,
+ * `tokenExpiresAt`) — kept here so both org and personal routes share one DTO.
+ */
+interface UpsertedProvider {
+  id: string;
+  type: ModelProviderType;
+  framework: ModelProviderFramework;
+  secretName: string | null;
+  authMethod?: string | null;
+  secretNames?: string[] | null;
+  isDefault: boolean;
+  selectedModel: string | null;
+  workspaceName: string | null;
+  planType: string | null;
+  needsReconnect: boolean;
+  lastRefreshErrorCode: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Serialize an upserted model-provider row into the REST DTO shape (Date →
+ * ISO string). Shared between org and personal paste handlers so the wire
+ * format cannot drift.
+ */
+export function serializeUpsertedProvider(provider: UpsertedProvider) {
+  return {
+    id: provider.id,
+    type: provider.type,
+    framework: provider.framework,
+    secretName: provider.secretName,
+    authMethod: provider.authMethod ?? null,
+    secretNames: provider.secretNames ?? null,
+    isDefault: provider.isDefault,
+    selectedModel: provider.selectedModel,
+    workspaceName: provider.workspaceName,
+    planType: provider.planType,
+    needsReconnect: provider.needsReconnect,
+    lastRefreshErrorCode: provider.lastRefreshErrorCode,
+    createdAt: provider.createdAt.toISOString(),
+    updatedAt: provider.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Caller-supplied upsert. Org route binds this to
+ * `upsertOrgMultiAuthModelProvider`, personal route binds it to a closure
+ * over `upsertUserMultiAuthModelProvider(orgId, userId, ...)`. Both signatures
+ * normalize to the same shape from the handler's perspective.
+ */
+type UpsertCodexProvider = (args: {
+  authMethod: "auth_json";
+  secretValues: {
+    CHATGPT_ACCESS_TOKEN: string;
+    CHATGPT_REFRESH_TOKEN: string;
+    CHATGPT_ACCOUNT_ID: string;
+    CHATGPT_ID_TOKEN: string;
+  };
+  selectedModel: string | undefined;
+  metadata: {
+    tokenExpiresAt: Date | null;
+    workspaceName: string | null;
+    planType: string | null;
+  };
+}) => Promise<{ provider: UpsertedProvider; created: boolean }>;
+
+/**
+ * Handle the codex-oauth-token + auth_json paste-based connect flow.
+ *
+ * Parses the raw `~/.codex/auth.json` server-side and persists the four
+ * derived `CHATGPT_*` fields via the caller-supplied upsert. The raw
+ * `CODEX_AUTH_JSON` blob is NEVER persisted (per Epic #11974 / #7365).
+ *
+ * Shared between the org route (`/api/zero/model-providers`) and the personal
+ * route (`/api/zero/me/model-providers`) so the paste contract — error codes,
+ * log fields, response shape — cannot drift between the two scopes.
+ */
+export async function handleCodexAuthJsonPaste(args: {
+  /** `"org" | "personal"` — drives the log namespace and the log payload. */
+  scope: "org" | "personal";
+  orgId: string;
+  /** Required for personal scope, omitted for org scope. */
+  userId?: string;
+  rawAuthJson: string;
+  selectedModel: string | undefined;
+  upsert: UpsertCodexProvider;
+}) {
+  const log = logger(
+    args.scope === "personal"
+      ? "api:zero-me-model-providers"
+      : "api:zero-model-providers",
+  );
+  const logContext =
+    args.scope === "personal"
+      ? { orgId: args.orgId, userId: args.userId }
+      : { orgId: args.orgId };
+
+  try {
+    const parsed = parseCodexAuthJson(args.rawAuthJson);
+
+    const { provider, created } = await args.upsert({
+      authMethod: "auth_json",
+      secretValues: {
+        CHATGPT_ACCESS_TOKEN: parsed.accessToken,
+        CHATGPT_REFRESH_TOKEN: parsed.refreshToken,
+        CHATGPT_ACCOUNT_ID: parsed.accountId,
+        CHATGPT_ID_TOKEN: parsed.idToken,
+      },
+      selectedModel: args.selectedModel,
+      metadata: {
+        tokenExpiresAt: parsed.tokenExpiresAt,
+        workspaceName: parsed.workspaceName,
+        planType: parsed.planType,
+      },
+    });
+
+    log.info(
+      args.scope === "personal"
+        ? "personal codex provider connected via auth_json paste"
+        : "codex provider connected via auth_json paste",
+      {
+        ...logContext,
+        workspaceName: parsed.workspaceName,
+        planType: parsed.planType,
+      },
+    );
+
+    return {
+      status: (created ? 201 : 200) as 200 | 201,
+      body: { provider: serializeUpsertedProvider(provider), created },
+    };
+  } catch (error) {
+    if (isCodexAuthJsonFreePlanError(error)) {
+      log.info(
+        args.scope === "personal"
+          ? "rejected personal codex auth_json paste: free plan"
+          : "rejected codex auth_json paste: free plan",
+        logContext,
+      );
+      return createErrorResponse(
+        "CODEX_FREE_PLAN_REJECTED",
+        "ChatGPT free plan is not supported — upgrade to Plus or higher.",
+      );
+    }
+    if (isCodexAuthJsonShapeError(error)) {
+      log.warn(
+        args.scope === "personal"
+          ? "rejected personal codex auth_json paste: shape"
+          : "rejected codex auth_json paste: shape",
+        { ...logContext, errorMessage: error.message },
+      );
+      return createErrorResponse(
+        "CODEX_AUTH_JSON_SHAPE_INVALID",
+        error.message,
+      );
+    }
+    throw error;
+  }
+}

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -18,6 +18,17 @@ export interface SecretFieldConfig {
    * never see (per #7365). Honored by `resolveMultiAuthProviderSecrets`.
    */
   serverOnly?: boolean;
+  /**
+   * When true, this secret is populated by a server-side parser from another
+   * secret in the same authMethod (typically a single user-input field whose
+   * raw value is exploded into multiple stored fields). UI MUST NOT render an
+   * input for this secret; the storage validation layer still uses it.
+   *
+   * Example: `codex-oauth-token` / `auth_json` — user pastes `CODEX_AUTH_JSON`,
+   * server parser writes `CHATGPT_ACCESS_TOKEN` / `_REFRESH_TOKEN` /
+   * `_ACCOUNT_ID` / `_ID_TOKEN`. Those four are `derived: true`.
+   */
+  derived?: boolean;
 }
 
 /**
@@ -447,23 +458,31 @@ export const MODEL_PROVIDER_TYPES = {
           // layer at egress) — keeping them non-serverOnly preserves the
           // placeholder injection path. CHATGPT_REFRESH_TOKEN and
           // CHATGPT_ID_TOKEN stay serverOnly per the #7365 invariant.
+          //
+          // All four are `derived: true` — the server-side parser populates
+          // them from the user-pasted CODEX_AUTH_JSON. The UI MUST NOT render
+          // them as input fields (per #12024).
           CHATGPT_ACCESS_TOKEN: {
             label: "CHATGPT_ACCESS_TOKEN",
             required: true,
+            derived: true,
           },
           CHATGPT_REFRESH_TOKEN: {
             label: "CHATGPT_REFRESH_TOKEN",
             required: true,
             serverOnly: true,
+            derived: true,
           },
           CHATGPT_ACCOUNT_ID: {
             label: "CHATGPT_ACCOUNT_ID",
             required: true,
+            derived: true,
           },
           CHATGPT_ID_TOKEN: {
             label: "CHATGPT_ID_TOKEN",
             required: true,
             serverOnly: true,
+            derived: true,
           },
         },
       },


### PR DESCRIPTION
## Summary

Mirror the org-side codex-oauth-token paste flow (#11980 / Epic #11974) to the personal-tier preferences tab so adding/reconnecting a Codex provider has identical UX in both scopes.

Closes #12024.

## What was broken

User report (2026-05-07): clicking the Codex card under Personal "Add provider" rendered a generic form with **five** input fields — one textarea for \`CODEX_AUTH_JSON\` plus four more for \`CHATGPT_ACCESS_TOKEN\` / \`_REFRESH_TOKEN\` / \`_ACCOUNT_ID\` / \`_ID_TOKEN\`. The four CHATGPT_* fields are server-derived from the pasted auth.json and should never be user input. The custom paste modal (textarea-only) only existed on the org-add path.

Two underlying gaps:
1. **Schema**: \`auth_json\` authMethod declared all 5 secrets together. The generic form-based dialog iterates \`secrets\` and renders an input for each.
2. **Personal-side missing**: \`personal-add-provider-dialog.tsx\` had no codex special-case, \`personal-providers-tab.tsx\` had no stale-provider banner, and \`/api/zero/me/model-providers\` POST had no \`auth_json\` parser branch — so personal-side submits would have failed even if the UI worked.

## Changes

### Foundational schema fix
- New \`derived?: boolean\` flag on \`SecretFieldConfig\`. Marks secrets that the server-side parser populates from another secret in the same authMethod.
- Four CHATGPT_* fields under \`codex-oauth-token\` / \`auth_json\` now have \`derived: true\`.
- \`provider-dialog-fields.tsx\` skips input rendering for derived secrets.
- Form-validation logic in both org and personal signal modules skips required-field checks for derived secrets.

### Server-side
- \`/api/zero/me/model-providers\` POST handler gains a \`type === 'codex-oauth-token' && authMethod === 'auth_json'\` branch. Routes through \`parseCodexAuthJson()\` (shared with org route), persists the four derived secrets via \`upsertUserMultiAuthModelProvider\` with metadata (tokenExpiresAt / workspaceName / planType). Same typed errors (\`CODEX_AUTH_JSON_SHAPE_INVALID\`, \`CODEX_FREE_PLAN_REJECTED\`).

### Platform-side
- \`CodexAuthPasteDialog\` accepts \`scope: 'org' | 'personal'\` prop. Internally selects the right signal bundle. Default scope \`'org'\` keeps the existing org call sites unchanged.
- New personal codex paste signals: \`codexPasteDialogStatePersonal\$\` / \`setCodexPasteDialogStatePersonal\$\` / \`codexPasteContentPersonal\$\` / \`updateCodexPasteContentPersonal\$\` / \`submitCodexAuthJsonPersonal\$\`.
- New \`reloadPersonalModelProviders\$\` exported from \`signals/external/personal-model-providers.ts\` (mirrors org-side reload).
- \`PersonalAddProviderDialog\`: codex card click now opens paste dialog (mode='connect', scope='personal'). Card gated on \`FeatureSwitchKey.CodexOauthProvider\`.
- \`PersonalProvidersTab\`: adds StaleBannerSection / StaleProviderBanner / staleMessage helpers wholly mirroring the org-side equivalents. Mounts \`<CodexAuthPasteDialog scope=\"personal\" />\`.

## Test plan

- [x] \`pnpm turbo run lint\` clean (10 workspaces)
- [x] \`pnpm check-types\` clean (11 workspaces)
- [x] \`pnpm -F @vm0/app exec vitest run\` — 264 files / 2348 tests pass (4 new for personal codex paste)
- [x] \`pnpm -F web exec vitest run app/api/zero/me/model-providers\` — 32 tests pass (6 new for auth_json branch)
- [x] \`pnpm knip\` clean (no orphaned exports introduced)

## Test coverage added

**Server (\`web/app/api/zero/me/model-providers/__tests__/route.test.ts\`)**:
- happy path: paste valid auth.json → 201, provider visible in response with workspaceName/planType/needsReconnect=false
- malformed JSON → 400 \`CODEX_AUTH_JSON_SHAPE_INVALID\`
- missing tokens.refresh_token → 400 \`CODEX_AUTH_JSON_SHAPE_INVALID\`
- free-plan id_token → 400 \`CODEX_FREE_PLAN_REJECTED\`
- missing \`CODEX_AUTH_JSON\` from secrets → 400 \`BAD_REQUEST\`
- \`CodexOauthProvider\` feature switch off → 404

**Platform (\`apps/platform/.../personal-providers-tab.test.tsx\`)**:
- Codex card hidden when CodexOauthProvider feature switch is off
- Codex card click opens paste dialog with \`codex-paste-textarea\` visible (regression on the bug)
- Stale-provider banner appears when needsReconnect=true
- Banner Re-paste button opens dialog in reconnect mode

## Rollback

Revert the PR. Org-side flow is unchanged (paste modal still works). Personal-side regresses to the current broken state (5-field form), no worse than today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)