### PR TITLE
refactor(runner): extract local file publish helper

### DIFF
--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -666,13 +666,15 @@ async fn ensure_rootfs_under_lock(
     input: RootfsBuildInput<'_>,
     mut release_template_lock: TemplateLockRelease,
 ) -> RunnerResult<()> {
+    let publish = LocalFilePublish::for_rootfs(input.rootfs_paths);
+
     // Clear any `rootfs.ext4.staging` residue from a previous crashed or
     // failed build. Holding the rootfs flock means the previous writer has
     // already exited (kernel releases flocks on process death), so any
     // staging file on disk is guaranteed to be stale — never a concurrent
     // writer's work-in-progress. This is the recovery arm of the
     // staging-rename contract; see `RootfsPaths::rootfs_staging`.
-    clear_rootfs_staging(input.rootfs_paths).await;
+    publish.cleanup_stale_staging_best_effort().await;
 
     let need_rootfs = !is_rootfs_present(input.rootfs_paths).await?;
     let mut scripts = RootfsScripts::new();
@@ -687,15 +689,12 @@ async fn ensure_rootfs_under_lock(
             // Commit the rootfs. Same-filesystem rename is POSIX-atomic, so
             // `rootfs.ext4` only becomes visible once customization and
             // verification have fully succeeded.
-            commit_staging(input.rootfs_paths).await?;
-            tracing::info!(
-                "rootfs committed: {}",
-                input.rootfs_paths.rootfs().display()
-            );
+            publish.commit().await?;
+            tracing::info!("rootfs committed: {}", publish.stable().display());
             Ok(())
         }
         .await;
-        finish_rootfs_staging_result(input.rootfs_paths, result).await?;
+        publish.finish_after_result(result).await?;
     } else {
         tracing::info!(
             "[OK] rootfs already present: {}",
@@ -705,28 +704,6 @@ async fn ensure_rootfs_under_lock(
     }
 
     Ok(())
-}
-
-async fn finish_rootfs_staging_result(
-    rootfs_paths: &RootfsPaths,
-    result: RunnerResult<()>,
-) -> RunnerResult<()> {
-    match result {
-        Ok(()) => Ok(()),
-        Err(original_err) => {
-            let staging = rootfs_paths.rootfs_staging();
-            match remove_file_if_exists(&staging, "failed rootfs staging file").await {
-                Ok(()) => Err(original_err),
-                Err(cleanup_err) => {
-                    tracing::warn!(
-                        "failed to remove rootfs staging {} after an earlier error: {cleanup_err}",
-                        staging.display()
-                    );
-                    Err(original_err)
-                }
-            }
-        }
-    }
 }
 
 async fn ensure_template_cached_under_lock(input: &TemplateInput<'_>) -> RunnerResult<()> {
@@ -1202,65 +1179,96 @@ async fn is_rootfs_present(rootfs: &RootfsPaths) -> RunnerResult<bool> {
         .map_err(|e| RunnerError::Internal(format!("check {}: {e}", rootfs.rootfs().display())))
 }
 
-/// Delete any `rootfs.ext4.staging` left behind by a previous build.
-///
-/// Called under the rootfs flock before rootfs work continues. Because
-/// holding the flock implies the previous writer has exited (the kernel
-/// releases flocks on process death), any staging file we see here is
-/// guaranteed to be crash residue — not a live writer's in-progress file.
-/// A committed `rootfs.ext4`, if present, is left untouched.
-///
-/// Non-existence is the common case and not logged. Removal is best
-/// effort: an error here just means the next step (writing new staging)
-/// will overwrite the file anyway.
-async fn clear_rootfs_staging(rootfs: &RootfsPaths) {
-    let staging = rootfs.rootfs_staging();
-    match tokio::fs::try_exists(&staging).await {
-        Ok(true) => {
-            tracing::warn!(
-                "removing stale rootfs staging file from a previous failed build: {}",
-                staging.display()
-            );
-            if let Err(e) = tokio::fs::remove_file(&staging).await {
-                if e.kind() == std::io::ErrorKind::IsADirectory {
-                    if let Err(dir_err) = tokio::fs::remove_dir_all(&staging).await {
+struct LocalFilePublish {
+    staging: PathBuf,
+    stable: PathBuf,
+}
+
+impl LocalFilePublish {
+    fn new(staging: PathBuf, stable: PathBuf) -> Self {
+        Self { staging, stable }
+    }
+
+    fn for_rootfs(rootfs: &RootfsPaths) -> Self {
+        Self::new(rootfs.rootfs_staging(), rootfs.rootfs())
+    }
+
+    fn stable(&self) -> &Path {
+        &self.stable
+    }
+
+    /// Delete any staging file left behind by a previous publish attempt.
+    ///
+    /// For rootfs this is called under the rootfs flock before work continues,
+    /// so any staging file is crash residue, not a live writer's in-progress
+    /// file. Non-existence is the common case and not logged. Removal is best
+    /// effort: a failure here leaves the next write step to fail or overwrite.
+    async fn cleanup_stale_staging_best_effort(&self) {
+        match tokio::fs::try_exists(&self.staging).await {
+            Ok(true) => {
+                tracing::warn!(
+                    "removing stale rootfs staging file from a previous failed build: {}",
+                    self.staging.display()
+                );
+                if let Err(e) = tokio::fs::remove_file(&self.staging).await {
+                    if e.kind() == std::io::ErrorKind::IsADirectory {
+                        if let Err(dir_err) = tokio::fs::remove_dir_all(&self.staging).await {
+                            tracing::warn!(
+                                "failed to remove stale staging directory {}: {dir_err}",
+                                self.staging.display()
+                            );
+                        }
+                    } else {
                         tracing::warn!(
-                            "failed to remove stale staging directory {}: {dir_err}",
-                            staging.display()
+                            "failed to remove stale staging file {}: {e}",
+                            self.staging.display()
                         );
                     }
-                } else {
-                    tracing::warn!(
-                        "failed to remove stale staging file {}: {e}",
-                        staging.display()
-                    );
+                }
+            }
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(
+                    "check staging {}: {e} (continuing; any residue will be overwritten)",
+                    self.staging.display()
+                );
+            }
+        }
+    }
+
+    /// Atomic commit: rename staging to stable.
+    ///
+    /// Same-filesystem rename is POSIX-atomic, so this is the single step
+    /// that makes the published file visible to future presence checks.
+    async fn commit(&self) -> RunnerResult<()> {
+        tokio::fs::rename(&self.staging, &self.stable)
+            .await
+            .map_err(|e| {
+                RunnerError::Internal(format!(
+                    "commit rootfs {} → {}: {e}",
+                    self.staging.display(),
+                    self.stable.display()
+                ))
+            })
+    }
+
+    async fn finish_after_result(&self, result: RunnerResult<()>) -> RunnerResult<()> {
+        match result {
+            Ok(()) => Ok(()),
+            Err(original_err) => {
+                match remove_file_if_exists(&self.staging, "failed rootfs staging file").await {
+                    Ok(()) => Err(original_err),
+                    Err(cleanup_err) => {
+                        tracing::warn!(
+                            "failed to remove rootfs staging {} after an earlier error: {cleanup_err}",
+                            self.staging.display()
+                        );
+                        Err(original_err)
+                    }
                 }
             }
         }
-        Ok(false) => {}
-        Err(e) => {
-            tracing::warn!(
-                "check staging {}: {e} (continuing; any residue will be overwritten)",
-                staging.display()
-            );
-        }
     }
-}
-
-/// Atomic commit: rename `rootfs.ext4.staging → rootfs.ext4`.
-///
-/// Same-filesystem rename is POSIX-atomic, so this is the single step
-/// that makes the rootfs visible to future `is_rootfs_present` checks.
-async fn commit_staging(rootfs: &RootfsPaths) -> RunnerResult<()> {
-    let from = rootfs.rootfs_staging();
-    let to = rootfs.rootfs();
-    tokio::fs::rename(&from, &to).await.map_err(|e| {
-        RunnerError::Internal(format!(
-            "commit rootfs {} → {}: {e}",
-            from.display(),
-            to.display()
-        ))
-    })
 }
 
 /// Compute a template hash for shared R2 image caching.
@@ -2205,10 +2213,11 @@ exit 1
     }
 
     #[tokio::test]
-    async fn clear_rootfs_staging_removes_residue() {
+    async fn local_file_publish_removes_stale_file_residue() {
         let dir = tempfile::tempdir().unwrap();
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
         let rootfs = RootfsPaths::new(&home, "cleanup-hash");
+        let publish = LocalFilePublish::for_rootfs(&rootfs);
         tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
 
         tokio::fs::write(rootfs.rootfs_staging(), b"crash-residue")
@@ -2216,15 +2225,16 @@ exit 1
             .unwrap();
         assert!(rootfs.rootfs_staging().exists());
 
-        clear_rootfs_staging(&rootfs).await;
+        publish.cleanup_stale_staging_best_effort().await;
         assert!(!rootfs.rootfs_staging().exists());
     }
 
     #[tokio::test]
-    async fn clear_rootfs_staging_removes_directory_residue() {
+    async fn local_file_publish_removes_stale_directory_residue() {
         let dir = tempfile::tempdir().unwrap();
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
         let rootfs = RootfsPaths::new(&home, "cleanup-dir-hash");
+        let publish = LocalFilePublish::for_rootfs(&rootfs);
 
         tokio::fs::create_dir_all(rootfs.rootfs_staging().join("nested"))
             .await
@@ -2236,27 +2246,29 @@ exit 1
         .await
         .unwrap();
 
-        clear_rootfs_staging(&rootfs).await;
+        publish.cleanup_stale_staging_best_effort().await;
         assert!(!rootfs.rootfs_staging().exists());
     }
 
     #[tokio::test]
-    async fn clear_rootfs_staging_noop_when_absent() {
+    async fn local_file_publish_stale_cleanup_noop_when_absent() {
         let dir = tempfile::tempdir().unwrap();
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
         let rootfs = RootfsPaths::new(&home, "noop-hash");
+        let publish = LocalFilePublish::for_rootfs(&rootfs);
         tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
 
         // No staging file — must not error.
-        clear_rootfs_staging(&rootfs).await;
+        publish.cleanup_stale_staging_best_effort().await;
         assert!(!rootfs.rootfs_staging().exists());
     }
 
     #[tokio::test]
-    async fn clear_rootfs_staging_leaves_committed_rootfs_alone() {
+    async fn local_file_publish_stale_cleanup_leaves_committed_rootfs_alone() {
         let dir = tempfile::tempdir().unwrap();
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
         let rootfs = RootfsPaths::new(&home, "preserve-hash");
+        let publish = LocalFilePublish::for_rootfs(&rootfs);
         tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
 
         tokio::fs::write(rootfs.rootfs(), b"real-rootfs")
@@ -2266,47 +2278,45 @@ exit 1
             .await
             .unwrap();
 
-        clear_rootfs_staging(&rootfs).await;
+        publish.cleanup_stale_staging_best_effort().await;
         assert!(rootfs.rootfs().exists(), "committed rootfs must survive");
         assert!(!rootfs.rootfs_staging().exists());
     }
 
     #[tokio::test]
-    async fn finish_rootfs_staging_result_removes_staging_after_error() {
+    async fn local_file_publish_finish_removes_staging_after_error() {
         let dir = tempfile::tempdir().unwrap();
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
         let rootfs = RootfsPaths::new(&home, "failed-cleanup-hash");
+        let publish = LocalFilePublish::for_rootfs(&rootfs);
         tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
         tokio::fs::write(rootfs.rootfs_staging(), b"partial-rootfs")
             .await
             .unwrap();
 
-        let err = finish_rootfs_staging_result(
-            &rootfs,
-            Err(RunnerError::Internal("customize failed".into())),
-        )
-        .await
-        .unwrap_err();
+        let err = publish
+            .finish_after_result(Err(RunnerError::Internal("customize failed".into())))
+            .await
+            .unwrap_err();
 
         assert!(err.to_string().contains("customize failed"));
         assert!(!rootfs.rootfs_staging().exists());
     }
 
     #[tokio::test]
-    async fn finish_rootfs_staging_result_preserves_original_error_when_cleanup_fails() {
+    async fn local_file_publish_finish_preserves_original_error_when_cleanup_fails() {
         let dir = tempfile::tempdir().unwrap();
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
         let rootfs = RootfsPaths::new(&home, "failed-cleanup-dir-hash");
+        let publish = LocalFilePublish::for_rootfs(&rootfs);
         tokio::fs::create_dir_all(rootfs.rootfs_staging())
             .await
             .unwrap();
 
-        let err = finish_rootfs_staging_result(
-            &rootfs,
-            Err(RunnerError::Internal("verify failed".into())),
-        )
-        .await
-        .unwrap_err();
+        let err = publish
+            .finish_after_result(Err(RunnerError::Internal("verify failed".into())))
+            .await
+            .unwrap_err();
 
         assert!(err.to_string().contains("verify failed"));
         assert!(
@@ -2316,17 +2326,18 @@ exit 1
     }
 
     #[tokio::test]
-    async fn commit_staging_renames_to_rootfs() {
+    async fn local_file_publish_commit_renames_to_rootfs() {
         let dir = tempfile::tempdir().unwrap();
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
         let rootfs = RootfsPaths::new(&home, "commit-hash");
+        let publish = LocalFilePublish::for_rootfs(&rootfs);
         tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
 
         tokio::fs::write(rootfs.rootfs_staging(), b"customized")
             .await
             .unwrap();
 
-        commit_staging(&rootfs).await.unwrap();
+        publish.commit().await.unwrap();
 
         assert!(!rootfs.rootfs_staging().exists());
         assert!(rootfs.rootfs().exists());
@@ -2342,6 +2353,7 @@ exit 1
         let dir = tempfile::tempdir().unwrap();
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
         let rootfs = RootfsPaths::new(&home, "happy-hash");
+        let publish = LocalFilePublish::for_rootfs(&rootfs);
         tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
 
         // Simulate template R2 download directly into staging.
@@ -2353,7 +2365,7 @@ exit 1
         tokio::fs::write(rootfs.rootfs_staging(), b"customized")
             .await
             .unwrap();
-        commit_staging(&rootfs).await.unwrap();
+        publish.commit().await.unwrap();
 
         assert!(rootfs.rootfs().exists());
         assert!(!rootfs.rootfs_staging().exists());
@@ -2362,12 +2374,13 @@ exit 1
 
     /// Crash simulation: template download succeeded, but the process died before
     /// normal error cleanup could run. The next build must see no committed
-    /// rootfs and `clear_rootfs_staging` must wipe the partial file.
+    /// rootfs and stale staging cleanup must wipe the partial file.
     #[tokio::test]
     async fn staging_contract_crash_leaves_recoverable_state() {
         let dir = tempfile::tempdir().unwrap();
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
         let rootfs = RootfsPaths::new(&home, "fail-hash");
+        let publish = LocalFilePublish::for_rootfs(&rootfs);
         tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
 
         tokio::fs::write(rootfs.rootfs_staging(), b"template-download")
@@ -2379,7 +2392,7 @@ exit 1
         assert!(rootfs.rootfs_staging().exists());
 
         // Next build's cleanup step.
-        clear_rootfs_staging(&rootfs).await;
+        publish.cleanup_stale_staging_best_effort().await;
         assert!(!rootfs.rootfs_staging().exists());
         assert!(!is_rootfs_present(&rootfs).await.unwrap());
     }


### PR DESCRIPTION
## Summary
- Add a private `LocalFilePublish` helper for staged local file cleanup, commit, and returned-error finalization.
- Migrate rootfs staging publish flow to the helper without changing rootfs lock, R2, snapshot, path, fsync, or cancellation behavior.
- Update existing rootfs staging behavior tests to exercise the helper directly.

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::build::tests::local_file_publish`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::build::tests::staging_contract`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::build::tests::is_rootfs_present_ignores_staging_file`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::build`

Closes #12020