### PR TITLE
perf(chat): persist zero run metadata in transactions

### DIFF
--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -431,15 +431,14 @@ describe("POST /api/zero/chat/messages", () => {
           });
           expect(round2ConnectorsSpan?.org_id).toBeTruthy();
 
-          // run_id is stamped after the tx commits — only post-commit spans
-          // carry it.
+          // run_id is stamped after agent_runs insert returns; spans emitted
+          // after that point carry it even while still inside the tx.
           const persistSpan = chatSpanEvents.find((e) => {
             return e.op_type === "api_chat_send_persist_zero_run_metadata";
           });
           expect(persistSpan?.run_id).toBe(data.runId);
 
-          // insert_run_record happens inside the tx, before commit — emits
-          // with run_id absent.
+          // insert_run_record emits before the inserted run id is stamped.
           const insertRunRecordSpan = chatSpanEvents.find((e) => {
             return e.op_type === "api_chat_send_create_run_insert_run_record";
           });

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { randomUUID } from "crypto";
 import {
   testContext,
   uniqueId,
@@ -8,6 +9,7 @@ import {
   createTestCompose,
   createTestSchedule,
   findTestRunRecord,
+  findTestRunsByUserAndPrompt,
   findTestRunnerJobEntry,
   findTestZeroRun,
   findTestRunCallbacks,
@@ -373,6 +375,46 @@ describe("createZeroRun() — service-only parameters", () => {
       const zeroRun = await findTestZeroRun(result.runId);
       expect(zeroRun).toBeDefined();
       expect(zeroRun!.triggerSource).toBe("web");
+    });
+
+    it("should persist zero_runs row before returning for queued runs", async () => {
+      await createZeroRun(baseParams({ prompt: uniqueId("occupying-run") }));
+      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+      reloadEnv();
+
+      const result = await createZeroRun(
+        baseParams({ prompt: uniqueId("queued-run"), triggerSource: "web" }),
+      );
+
+      expect(result.status).toBe("queued");
+      const zeroRun = await findTestZeroRun(result.runId);
+      expect(zeroRun).toBeDefined();
+      expect(zeroRun!.triggerSource).toBe("web");
+    });
+
+    it("should roll back the agent run if zero_runs metadata fails", async () => {
+      const prompt = uniqueId("metadata-failure");
+
+      await expect(
+        createZeroRun(baseParams({ prompt, chatThreadId: randomUUID() })),
+      ).rejects.toThrow();
+
+      const runs = await findTestRunsByUserAndPrompt(user.userId, prompt);
+      expect(runs).toHaveLength(0);
+    });
+
+    it("should roll back the queued run if zero_runs metadata fails", async () => {
+      await createZeroRun(baseParams({ prompt: uniqueId("occupying-run") }));
+      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+      reloadEnv();
+      const prompt = uniqueId("queued-metadata-failure");
+
+      await expect(
+        createZeroRun(baseParams({ prompt, chatThreadId: randomUUID() })),
+      ).rejects.toThrow();
+
+      const runs = await findTestRunsByUserAndPrompt(user.userId, prompt);
+      expect(runs).toHaveLength(0);
     });
 
     it("should persist triggerSource for all sources before dispatch", async () => {

--- a/turbo/apps/web/src/lib/zero/zero-run-metadata.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-metadata.ts
@@ -1,0 +1,28 @@
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
+import type { Database } from "../../types/global";
+
+export interface ZeroRunMetadataValues {
+  triggerSource: TriggerSource;
+  scheduleId?: string;
+  triggerAgentId?: string;
+  chatThreadId?: string;
+  modelProvider?: string;
+  selectedModel?: string;
+}
+
+export async function persistZeroRunMetadata(
+  db: Database,
+  runId: string,
+  metadata: ZeroRunMetadataValues,
+): Promise<void> {
+  await db.insert(zeroRuns).values({
+    id: runId,
+    triggerSource: metadata.triggerSource,
+    scheduleId: metadata.scheduleId ?? null,
+    triggerAgentId: metadata.triggerAgentId ?? null,
+    chatThreadId: metadata.chatThreadId ?? null,
+    modelProvider: metadata.modelProvider ?? null,
+    selectedModel: metadata.selectedModel ?? null,
+  });
+}

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -49,6 +49,10 @@ import { loadFeatureSwitchOverrides } from "./user/feature-switches-service";
 import { buildZeroExecutionContext } from "./build-zero-context";
 import { buildAutoMemoryArtifact } from "./memory";
 import {
+  persistZeroRunMetadata,
+  type ZeroRunMetadataValues,
+} from "./zero-run-metadata";
+import {
   encryptSecretsMap,
   decryptSecretsMap,
 } from "../shared/crypto/secrets-encryption";
@@ -77,6 +81,11 @@ type QueuedRunDispatcher = (
   params: CreateRunParams,
 ) => Promise<void>;
 
+interface EnqueueRunOptions {
+  zeroRunMetadata?: ZeroRunMetadataValues;
+  onZeroRunMetadataPersisted?: (durationMs: number) => void;
+}
+
 // ─── Queue Operations (moved from run-queue-service.ts) ─────────────────────
 
 /**
@@ -88,6 +97,7 @@ type QueuedRunDispatcher = (
  */
 export async function enqueueRun(
   params: CreateRunParams,
+  options: EnqueueRunOptions = {},
 ): Promise<CreateRunResult> {
   const { userId, agentComposeVersionId, prompt } = params;
 
@@ -112,6 +122,7 @@ export async function enqueueRun(
   // Eagerly create the agent_sessions row too so sessionId is known on the
   // POST response even for queued runs (same promise as synchronous runs).
   const expiresAt = new Date(Date.now() + QUEUE_TTL_MS);
+  let zeroRunMetadataDurationMs: number | undefined;
 
   const run = await globalThis.services.db.transaction(async (tx) => {
     let sessionId: string;
@@ -157,6 +168,12 @@ export async function enqueueRun(
       throw new Error("Failed to create queued run record");
     }
 
+    if (options.zeroRunMetadata) {
+      const zeroRunMetadataStartedAt = Date.now();
+      await persistZeroRunMetadata(tx, inserted.id, options.zeroRunMetadata);
+      zeroRunMetadataDurationMs = Date.now() - zeroRunMetadataStartedAt;
+    }
+
     await tx.insert(agentRunQueue).values({
       runId: inserted.id,
       userId,
@@ -181,6 +198,10 @@ export async function enqueueRun(
       queueDepth: Number(depthRow?.depth ?? 0),
     };
   });
+
+  if (zeroRunMetadataDurationMs !== undefined) {
+    options.onZeroRunMetadataPersisted?.(zeroRunMetadataDurationMs);
+  }
 
   log.debug(`Enqueued run ${run.id} for user ${userId}`);
 
@@ -619,7 +640,8 @@ export async function dispatchQueuedZeroRun(
 
   // Update zero_runs with resolved model fields before dispatch so metadata
   // is recorded even if dispatch succeeds but a later step fails.
-  // Row already exists (created at enqueue time), so UPDATE is safe.
+  // Zero callers create the row at enqueue time; direct low-level test enqueues
+  // may omit it, in which case this UPDATE is a no-op.
   await globalThis.services.db
     .update(zeroRuns)
     .set({

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -44,6 +44,10 @@ import {
 } from "./zero-run-queue-service";
 import { generateZeroToken, generateSandboxToken } from "../auth/sandbox-token";
 import { buildZeroExecutionContext } from "./build-zero-context";
+import {
+  persistZeroRunMetadata,
+  type ZeroRunMetadataValues,
+} from "./zero-run-metadata";
 import { buildAutoMemoryArtifact } from "./memory";
 import { getOrgMetadata, type OrgMetadata } from "./org/org-metadata-service";
 import { isConcurrentRunLimit } from "@vm0/api-services/errors";
@@ -299,6 +303,20 @@ function resolveEffectiveModel(
   };
 }
 
+function buildZeroRunMetadata(
+  params: CreateZeroRunParams,
+  runParams: CreateRunParams,
+): ZeroRunMetadataValues {
+  return {
+    triggerSource: params.triggerSource,
+    scheduleId: params.scheduleId,
+    triggerAgentId: params.triggerAgentId,
+    chatThreadId: params.chatThreadId,
+    modelProvider: params.modelProvider,
+    selectedModel: runParams.selectedModelOverride,
+  };
+}
+
 /** Context needed by insertRunWithAdvisoryLock — carved out of createZeroRunRecord. */
 interface InsertRunWithAdvisoryLockParams {
   resolved: Awaited<ReturnType<typeof resolveStartRunCompose>>;
@@ -334,6 +352,7 @@ async function insertRunWithAdvisoryLock(
     emit,
     stamp,
   } = ctx;
+  const zeroRunMetadata = buildZeroRunMetadata(params, runParams);
 
   let run;
   try {
@@ -366,21 +385,29 @@ async function insertRunWithAdvisoryLock(
         });
       });
       emit(CHAT_REQUEST_OPS.create_run_insert_run_record, insertT.ms);
+
+      stamp({ run_id: insertT.result.id });
+      const persistT = await timed(async () => {
+        return persistZeroRunMetadata(tx, insertT.result.id, zeroRunMetadata);
+      });
+      emit(CHAT_REQUEST_OPS.persist_zero_run_metadata, persistT.ms);
+
       return insertT.result;
     });
   } catch (error) {
     if (isConcurrentRunLimit(error)) {
-      const queueResult = await enqueueRun(runParams);
+      let persistDurationMs: number | undefined;
+      const queueResult = await enqueueRun(runParams, {
+        zeroRunMetadata,
+        onZeroRunMetadataPersisted: (durationMs) => {
+          persistDurationMs = durationMs;
+        },
+      });
 
       stamp({ run_id: queueResult.runId });
-
-      const persistT = await timed(async () => {
-        return persistZeroRunMetadata(queueResult.runId, params, {
-          selectedModelOverride: runParams.selectedModelOverride,
-          modelProviderId: runParams.modelProviderId,
-        });
-      });
-      emit(CHAT_REQUEST_OPS.persist_zero_run_metadata, persistT.ms);
+      if (persistDurationMs !== undefined) {
+        emit(CHAT_REQUEST_OPS.persist_zero_run_metadata, persistDurationMs);
+      }
 
       return {
         runId: queueResult.runId,
@@ -393,16 +420,6 @@ async function insertRunWithAdvisoryLock(
   }
 
   const transactionTime = Date.now();
-
-  stamp({ run_id: run.id });
-
-  const persistT = await timed(async () => {
-    return persistZeroRunMetadata(run.id, params, {
-      selectedModelOverride: runParams.selectedModelOverride,
-      modelProviderId: runParams.modelProviderId,
-    });
-  });
-  emit(CHAT_REQUEST_OPS.persist_zero_run_metadata, persistT.ms);
 
   const record: CreateRunRecordResult = {
     run: { id: run.id, createdAt: run.createdAt },
@@ -942,27 +959,6 @@ export async function createZeroRun(
     sessionId: result.sessionId,
     markResponseReady,
   };
-}
-
-/**
- * Persist zero-layer metadata to zero_runs table.
- * Called eagerly during createZeroRunRecord so that activity queries see the
- * correct triggerSource immediately (before dispatch completes).
- */
-async function persistZeroRunMetadata(
-  runId: string,
-  params: CreateZeroRunParams,
-  modelOverride?: { selectedModelOverride?: string; modelProviderId?: string },
-): Promise<void> {
-  await globalThis.services.db.insert(zeroRuns).values({
-    id: runId,
-    triggerSource: params.triggerSource,
-    scheduleId: params.scheduleId ?? null,
-    triggerAgentId: params.triggerAgentId ?? null,
-    chatThreadId: params.chatThreadId ?? null,
-    modelProvider: params.modelProvider ?? null,
-    selectedModel: modelOverride?.selectedModelOverride ?? null,
-  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Move zero run metadata insertion into the existing run creation transaction for direct chat runs.
- Persist queued run metadata inside `enqueueRun`'s transaction without using `after()`.
- Add regression coverage for queued metadata visibility and rollback when zero_run metadata insertion fails.

Closes #10595.

## Test plan
- `pnpm -F web db:migrate`
- `pnpm -F web exec vitest run src/lib/zero/__tests__/zero-run-service.test.ts`
- `pnpm -F web exec vitest run src/lib/zero/__tests__/run-queue-service.test.ts`
- `pnpm -F web exec vitest run app/api/zero/chat/messages/__tests__/route.test.ts src/lib/zero/__tests__/zero-run-service.test.ts src/lib/zero/__tests__/run-queue-service.test.ts`
- `pnpm -F web run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm turbo run lint`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-chat-page.test.tsx src/views/zero-page/__tests__/zero-instructions-tab.test.tsx`

Note: full `pnpm test` completed 837/839 files and 8835/8835 tests, then failed while loading two platform suites with `ENOMEM`; both suites passed when rerun directly in isolation.