### PR TITLE
fix(runner): select usage parser from cli agent type

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -171,6 +171,7 @@ async def request(flow: http.HTTPFlow) -> None:
         flow.metadata["vm_proxy_log_path"] = vm_info.get("proxyLogPath", "")
         flow.metadata["capture_body"] = vm_info.get("captureNetworkBodies", False)
         flow.metadata["vm_sandbox_token"] = vm_info.get("sandboxToken", "")
+        flow.metadata["cli_agent_type"] = vm_info.get("cliAgentType") or "claude-code"
 
         # Get target hostname
         hostname = flow.request.pretty_host.lower()
@@ -407,7 +408,7 @@ def response(flow: http.HTTPFlow) -> None:
         if firewall_name.startswith("model-provider:") and flow.metadata.get(
             "firewall_billable", False
         ):
-            if firewall_name == "model-provider:openai-api-key":
+            if response_streaming.uses_openai_responses_usage_protocol(flow):
                 json_usage = usage.extract_openai_responses_usage_from_json(
                     bytes(stream_buf),
                     flow.response.headers if flow.response else None,

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -20,8 +20,8 @@ _RESPONSE_STREAM_CALLBACK = "_vm0_response_stream_callback"
 _X_JSON_RESPONSE_FINISH = "x_json_response_finish"
 
 
-def _is_openai_responses_provider(firewall_name: str) -> bool:
-    return firewall_name == "model-provider:openai-api-key"
+def uses_openai_responses_usage_protocol(flow: http.HTTPFlow) -> bool:
+    return flow.metadata.get("cli_agent_type") == "codex"
 
 
 def configure_response_stream(flow: http.HTTPFlow) -> None:
@@ -86,7 +86,7 @@ def configure_response_stream(flow: http.HTTPFlow) -> None:
     if is_billable_model_provider:
         content_type = flow.response.headers.get("content-type", "").lower()
         if "text/event-stream" in content_type:
-            if _is_openai_responses_provider(firewall_name):
+            if uses_openai_responses_usage_protocol(flow):
                 parser_fn, usage_dict = usage.create_openai_responses_sse_usage_extractor()
             else:
                 parser_fn, usage_dict = usage.create_anthropic_messages_sse_usage_extractor()
@@ -95,7 +95,7 @@ def configure_response_stream(flow: http.HTTPFlow) -> None:
             flow.metadata[_MODEL_SSE_USAGE_FINISH] = parser_fn.finish
             sse_decompressor = body_utils.create_stream_decompressor(flow.response.headers)
         else:
-            if _is_openai_responses_provider(firewall_name):
+            if uses_openai_responses_usage_protocol(flow):
                 extractor = usage.create_openai_responses_json_usage_extractor()
             else:
                 extractor = usage.create_anthropic_messages_json_usage_extractor()

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -674,6 +674,7 @@ class TestRequestHandler:
                 await mitm_addon.request(flow)
 
             assert flow.metadata["firewall_name"] == "model-provider:anthropic-api-key"
+            assert flow.metadata["cli_agent_type"] == "claude-code"
             assert flow.metadata["firewall_billable"] is False
             assert "_usage_flow_tracked" not in flow.metadata
             assert usage.counters._in_flight_flows == 0
@@ -695,6 +696,7 @@ class TestRequestHandler:
             "vms": {
                 "10.200.0.5": {
                     "runId": "run-model-1",
+                    "cliAgentType": "codex",
                     "billableFirewalls": [firewall_name],
                     "modelUsageProvider": "claude-opus-4-6",
                     "sandboxToken": "tok-model",
@@ -745,6 +747,7 @@ class TestRequestHandler:
                 await mitm_addon.request(flow)
 
             assert flow.metadata["firewall_name"] == firewall_name
+            assert flow.metadata["cli_agent_type"] == "codex"
             assert flow.metadata["firewall_billable"] is True
             assert flow.metadata["model_usage_provider"] == "claude-opus-4-6"
             assert flow.metadata["_usage_flow_tracked"] is True
@@ -1326,6 +1329,7 @@ class TestResponseHeadersHandler:
         ).encode()
         flow = real_flow(with_response=False, host="api.openai.com")
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
         flow.response = tutils.tresp(
             status_code=200,
@@ -2308,6 +2312,7 @@ class TestResponseHeadersSseParser:
             headers=http.Headers(**{"content-type": "Text/Event-Stream"}),
         )
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
 
         mitm_addon.responseheaders(flow)
@@ -2329,6 +2334,7 @@ class TestResponseHeadersSseParser:
             headers=http.Headers(**{"content-type": "text/event-stream"}),
         )
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
 
         mitm_addon.responseheaders(flow)
@@ -2353,6 +2359,7 @@ class TestResponseHeadersSseParser:
             headers=http.Headers(**{"content-type": "text/event-stream"}),
         )
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
 
         mitm_addon.responseheaders(flow)
@@ -2368,6 +2375,54 @@ class TestResponseHeadersSseParser:
         assert flow.metadata["model_provider_usage"]["model"] == "gpt-5.5"
         assert flow.metadata["model_provider_usage"]["tokens.input"] == 30
         assert flow.metadata["model_provider_usage"]["tokens.cache_read"] == 12
+
+    def test_codex_oauth_model_provider_uses_openai_sse_parser(self, real_flow):
+        flow = real_flow(with_response=False, host="chatgpt.com")
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "text/event-stream"}),
+        )
+        flow.metadata["firewall_name"] = "model-provider:codex-oauth-token"
+        flow.metadata["cli_agent_type"] = "codex"
+        flow.metadata["firewall_billable"] = True
+
+        mitm_addon.responseheaders(flow)
+
+        assert "model_provider_usage" in flow.metadata
+        callback = flow.response.stream
+        callback(
+            b"event: response.completed\n"
+            b'data: {"response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":42,'
+            b'"input_tokens_details":{"cached_tokens":12}}}}\n\n'
+        )
+        assert flow.metadata["model_provider_usage"]["model"] == "gpt-5.5"
+        assert flow.metadata["model_provider_usage"]["tokens.input"] == 30
+        assert flow.metadata["model_provider_usage"]["tokens.cache_read"] == 12
+
+    @pytest.mark.parametrize("cli_agent_type", [None, ""])
+    def test_default_cli_agent_type_uses_anthropic_sse_parser(self, real_flow, cli_agent_type):
+        flow = real_flow(with_response=False, host="chatgpt.com")
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(**{"content-type": "text/event-stream"}),
+        )
+        flow.metadata["firewall_name"] = "model-provider:codex-oauth-token"
+        if cli_agent_type is not None:
+            flow.metadata["cli_agent_type"] = cli_agent_type
+        flow.metadata["firewall_billable"] = True
+
+        mitm_addon.responseheaders(flow)
+
+        callback = flow.response.stream
+        callback(
+            b"event: message_start\n"
+            b'data: {"type":"message_start","message":'
+            b'{"model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":42}}}\n\n'
+        )
+        assert flow.metadata["model_provider_usage"]["model"] == "claude-sonnet-4-6"
+        assert flow.metadata["model_provider_usage"]["tokens.input"] == 42
 
     def test_decompresses_gzip_sse_before_parsing(self, real_flow, headers):
         """Compressed SSE streams must be decompressed before usage extraction."""
@@ -2512,6 +2567,65 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["cli_agent_type"] = "codex"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        body = json.dumps(
+            {
+                "id": "resp_1",
+                "model": "gpt-5.5",
+                "usage": {
+                    "input_tokens": 50,
+                    "output_tokens": 200,
+                    "input_tokens_details": {"cached_tokens": 10},
+                },
+            }
+        ).encode()
+        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=http.Headers(
+                **{"content-type": "application/json", "content-length": str(len(body))}
+            ),
+        )
+        mitm_addon._request_start_times[flow.id] = time.time()
+
+        with (
+            mitm_ctx(),
+            patch.object(usage.webhook, "_opener") as mock_opener,
+        ):
+            mock_opener.open.return_value = MagicMock()
+            mitm_addon.response(flow)
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        extracted = flow.metadata["model_provider_usage"]
+        assert extracted["message_id"] == "resp_1"
+        assert extracted["model"] == "gpt-5.5"
+        assert extracted["tokens.input"] == 40
+        assert extracted["tokens.output"] == 200
+        assert extracted["tokens.cache_read"] == 10
+        events = _usage_event_events_from_calls(mock_opener.open.call_args_list)
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert by_category == {
+            "tokens.input": 40,
+            "tokens.output": 200,
+            "tokens.cache_read": 10,
+        }
+
+    def test_codex_oauth_non_streaming_json_fallback(
+        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor
+    ):
+        """Codex OAuth model-provider fallback uses OpenAI Responses mapping."""
+        flow = real_flow(with_response=False, host="chatgpt.com")
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_client_ip"] = "10.200.0.1"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://chatgpt.com/backend-api/codex/responses"
+        flow.metadata["firewall_name"] = "model-provider:codex-oauth-token"
+        flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         body = json.dumps(
@@ -2573,6 +2687,7 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = False
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["stream_buffer"] = bytearray(body)
@@ -2605,6 +2720,7 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.response = tutils.tresp(
@@ -2648,6 +2764,7 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["model_provider_usage"] = {
@@ -2684,6 +2801,7 @@ class TestResponseUsageReporting:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["model_provider_usage"] = {"model": "gpt-5.5"}
@@ -2924,6 +3042,7 @@ class TestResponseUsageReporting:
         """Early-returning SSE flows should not retain parser closures."""
         flow = real_flow(with_response=False, host="api.openai.com")
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
         flow.response = tutils.tresp(
             status_code=200,

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -214,6 +214,7 @@ async fn run_sandbox(
     let proxy_log_path = std::path::PathBuf::from("/dev/null");
     let registration = proxy::VmRegistration {
         run_id: &run_id,
+        cli_agent_type: "claude-code",
         sandbox_token: "",
         network_log_path: &network_log_path,
         proxy_log_path: &proxy_log_path,

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -393,8 +393,10 @@ async fn register_proxy(
     let network_log_path = config.log_paths.network_log(context.run_id);
     let proxy_log_path = config.log_paths.proxy_log(context.run_id);
     let run_id_str = context.run_id.to_string();
+    let cli_agent_type = normalized_cli_agent_type(&context.cli_agent_type);
     let registration = proxy::VmRegistration {
         run_id: &run_id_str,
+        cli_agent_type,
         sandbox_token: &context.sandbox_token,
         network_log_path: &network_log_path,
         proxy_log_path: &proxy_log_path,
@@ -1314,11 +1316,7 @@ fn build_env_json(
     // The API omits cli_agent_type for claude-code agents (the default).
     env.insert(
         "CLI_AGENT_TYPE".into(),
-        if context.cli_agent_type.is_empty() {
-            "claude-code".into()
-        } else {
-            context.cli_agent_type.clone()
-        },
+        normalized_cli_agent_type(&context.cli_agent_type).into(),
     );
 
     // Vercel bypass
@@ -1434,6 +1432,14 @@ fn build_env_json(
     }
 
     env
+}
+
+fn normalized_cli_agent_type(cli_agent_type: &str) -> &str {
+    if cli_agent_type.is_empty() {
+        "claude-code"
+    } else {
+        cli_agent_type
+    }
 }
 
 #[cfg(test)]

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -25,6 +25,8 @@ struct ProxyRegistry {
 #[serde(rename_all = "camelCase")]
 struct VmEntry {
     run_id: String,
+    #[serde(default = "default_cli_agent_type")]
+    cli_agent_type: String,
     sandbox_token: String,
     registered_at: i64,
     network_log_path: String,
@@ -41,10 +43,15 @@ struct VmEntry {
     model_usage_provider: Option<String>,
 }
 
+fn default_cli_agent_type() -> String {
+    "claude-code".to_string()
+}
+
 /// Parameters for registering a VM in the proxy registry.
 #[derive(Debug)]
 pub struct VmRegistration<'a> {
     pub run_id: &'a str,
+    pub cli_agent_type: &'a str,
     pub sandbox_token: &'a str,
     pub network_log_path: &'a std::path::Path,
     pub proxy_log_path: &'a std::path::Path,
@@ -761,6 +768,7 @@ impl ProxyRegistryHandle {
             source_ip.to_string(),
             VmEntry {
                 run_id: registration.run_id.to_string(),
+                cli_agent_type: registration.cli_agent_type.to_string(),
                 sandbox_token: registration.sandbox_token.to_string(),
                 registered_at: now,
                 network_log_path: registration.network_log_path.to_string_lossy().into_owned(),
@@ -936,6 +944,7 @@ PY
             "10.200.0.2".to_string(),
             VmEntry {
                 run_id: "test-run".to_string(),
+                cli_agent_type: "claude-code".to_string(),
                 sandbox_token: String::new(),
                 registered_at: 1000,
                 network_log_path: "/tmp/network-test-run.jsonl".to_string(),
@@ -989,6 +998,7 @@ PY
         // Register via handle.
         let registration = VmRegistration {
             run_id: "run-1",
+            cli_agent_type: "claude-code",
             sandbox_token: "tok-1",
             network_log_path: std::path::Path::new("/tmp/network-run-1.jsonl"),
             proxy_log_path: std::path::Path::new("/tmp/proxy-run-1.jsonl"),
@@ -1013,6 +1023,7 @@ PY
         // Re-register same IP overwrites the entry.
         let registration2 = VmRegistration {
             run_id: "run-2",
+            cli_agent_type: "codex",
             sandbox_token: "tok-2",
             network_log_path: std::path::Path::new("/tmp/network-run-2.jsonl"),
             proxy_log_path: std::path::Path::new("/tmp/proxy-run-2.jsonl"),
@@ -1032,6 +1043,7 @@ PY
         let loaded = read_registry(&registry_path).await.unwrap();
         let vm = loaded.vms.get("10.200.0.2").unwrap();
         assert_eq!(vm.run_id, "run-2");
+        assert_eq!(vm.cli_agent_type, "codex");
 
         // Unregister via handle.
         handle.unregister_vm("10.200.0.2").await.unwrap();
@@ -1072,6 +1084,7 @@ PY
                     std::path::PathBuf::from(format!("/tmp/proxy-{run_id_owned}.jsonl"));
                 let registration = VmRegistration {
                     run_id: &run_id_owned,
+                    cli_agent_type: "claude-code",
                     sandbox_token: "",
                     network_log_path: &log_path,
                     proxy_log_path: &proxy_path,
@@ -1138,6 +1151,7 @@ PY
 
         let registration = VmRegistration {
             run_id: "run-fw",
+            cli_agent_type: "claude-code",
             sandbox_token: "tok",
             network_log_path: std::path::Path::new("/tmp/network-run-fw.jsonl"),
             proxy_log_path: std::path::Path::new("/tmp/proxy-run-fw.jsonl"),
@@ -1213,6 +1227,7 @@ PY
         let billable = ["model-provider:vm0".to_string()];
         let registration = VmRegistration {
             run_id: "run-billing",
+            cli_agent_type: "codex",
             sandbox_token: "tok",
             network_log_path: std::path::Path::new("/tmp/network-run-billing.jsonl"),
             proxy_log_path: std::path::Path::new("/tmp/proxy-run-billing.jsonl"),
@@ -1239,9 +1254,29 @@ PY
             serde_json::json!(["model-provider:vm0"])
         );
         assert_eq!(
+            value["vms"]["10.200.0.9"]["cliAgentType"],
+            serde_json::json!("codex")
+        );
+        assert_eq!(
             value["vms"]["10.200.0.9"]["modelUsageProvider"],
             serde_json::json!("claude-sonnet-4-6")
         );
+    }
+
+    #[tokio::test]
+    async fn registry_defaults_missing_cli_agent_type_to_claude_code() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        tokio::fs::write(
+            &registry_path,
+            r#"{"vms":{"10.200.0.2":{"runId":"run-legacy","sandboxToken":"tok","registeredAt":1000,"networkLogPath":"/tmp/network.jsonl","proxyLogPath":"/tmp/proxy.jsonl","firewalls":null,"networkPolicies":null,"encryptedSecrets":null,"secretConnectorMap":null,"vars":null,"captureNetworkBodies":false,"billableFirewalls":[]}},"updatedAt":1000}"#,
+        )
+        .await
+        .unwrap();
+
+        let loaded = read_registry(&registry_path).await.unwrap();
+        let vm = loaded.vms.get("10.200.0.2").unwrap();
+        assert_eq!(vm.cli_agent_type, "claude-code");
     }
 
     #[tokio::test]
@@ -1263,6 +1298,7 @@ PY
 
         let registration = VmRegistration {
             run_id: "run-enc",
+            cli_agent_type: "claude-code",
             sandbox_token: "tok",
             network_log_path: std::path::Path::new("/tmp/network-run-enc.jsonl"),
             proxy_log_path: std::path::Path::new("/tmp/proxy-run-enc.jsonl"),
@@ -1328,6 +1364,7 @@ PY
 
         let registration = VmRegistration {
             run_id: "run-webhook",
+            cli_agent_type: "claude-code",
             sandbox_token: "tok",
             network_log_path: std::path::Path::new("/tmp/network-run-webhook.jsonl"),
             proxy_log_path: std::path::Path::new("/tmp/proxy-run-webhook.jsonl"),
@@ -1393,6 +1430,7 @@ PY
 
         let registration = VmRegistration {
             run_id: "run-query-auth",
+            cli_agent_type: "claude-code",
             sandbox_token: "tok",
             network_log_path: std::path::Path::new("/tmp/network-run-query.jsonl"),
             proxy_log_path: std::path::Path::new("/tmp/proxy-run-query.jsonl"),

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -25,7 +25,6 @@ struct ProxyRegistry {
 #[serde(rename_all = "camelCase")]
 struct VmEntry {
     run_id: String,
-    #[serde(default = "default_cli_agent_type")]
     cli_agent_type: String,
     sandbox_token: String,
     registered_at: i64,
@@ -41,10 +40,6 @@ struct VmEntry {
     billable_firewalls: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     model_usage_provider: Option<String>,
-}
-
-fn default_cli_agent_type() -> String {
-    "claude-code".to_string()
 }
 
 /// Parameters for registering a VM in the proxy registry.
@@ -1261,22 +1256,6 @@ PY
             value["vms"]["10.200.0.9"]["modelUsageProvider"],
             serde_json::json!("claude-sonnet-4-6")
         );
-    }
-
-    #[tokio::test]
-    async fn registry_defaults_missing_cli_agent_type_to_claude_code() {
-        let dir = tempfile::tempdir().unwrap();
-        let registry_path = dir.path().join("proxy-registry.json");
-        tokio::fs::write(
-            &registry_path,
-            r#"{"vms":{"10.200.0.2":{"runId":"run-legacy","sandboxToken":"tok","registeredAt":1000,"networkLogPath":"/tmp/network.jsonl","proxyLogPath":"/tmp/proxy.jsonl","firewalls":null,"networkPolicies":null,"encryptedSecrets":null,"secretConnectorMap":null,"vars":null,"captureNetworkBodies":false,"billableFirewalls":[]}},"updatedAt":1000}"#,
-        )
-        .await
-        .unwrap();
-
-        let loaded = read_registry(&registry_path).await.unwrap();
-        let vm = loaded.vms.get("10.200.0.2").unwrap();
-        assert_eq!(vm.cli_agent_type, "claude-code");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add normalized `cliAgentType` to the runner proxy registry and mitmproxy flow metadata
- select model-provider usage parser from `cli_agent_type` instead of provider/firewall name
- cover Codex OAuth streaming and JSON fallback usage extraction

Closes #12026

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cd crates/runner/mitm-addon && python3 -m pytest`
- `cd crates/runner/mitm-addon && ruff check src tests`
- `git diff --check`
