### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -107,7 +107,7 @@ ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.2"
-CLAUDE_CODE_VERSION="2.1.128"
+CLAUDE_CODE_VERSION="2.1.132"
 CODEX_CLI_VERSION="0.128.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Summary

Bump pinned package versions in `crates/runner/scripts/build-template.sh`.

## Updates

| Package | Old | New |
|---------|-----|-----|
| Claude Code CLI | 2.1.128 | 2.1.132 |

All other pinned versions (Go 1.26.2, Codex CLI 0.128.0, @googleworkspace/cli 0.22.5, @xdevplatform/xurl 1.0.3, agent-browser 0.26.0) are already at their latest releases.

## Test plan

- [ ] CI builds the runner template successfully
- [ ] Rootfs verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)