### PR TITLE
refactor(runner): centralize ownership transitions

### DIFF
--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -5,8 +5,9 @@ use std::sync::atomic::{AtomicU8, Ordering};
 use crate::ids::RunId;
 use crate::provider::JobProvider;
 use crate::resource_budget::BudgetLease;
-use crate::status::StatusTracker;
 use crate::types::SandboxReuseResult;
+
+use super::ownership::{OwnershipTransitions, RunSandbox};
 
 /// Ownership facts known by the outer runner task for panic cleanup.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -152,7 +153,7 @@ impl CompletionReady {
     pub(super) async fn complete_and_release(
         self,
         provider: &dyn JobProvider,
-        status: &StatusTracker,
+        ownership: &OwnershipTransitions<'_>,
         cleanup_state: &RunCleanupState,
     ) {
         let Self { payload, budget } = self;
@@ -173,7 +174,9 @@ impl CompletionReady {
                 Some(reuse_result),
             )
             .await;
-        status.remove_run_if_matching(run_id, sandbox_id).await;
+        ownership
+            .active_completed(RunSandbox::new(run_id, sandbox_id))
+            .await;
         cleanup_state.mark_status_removed();
         budget.release();
     }
@@ -193,6 +196,8 @@ mod tests {
     use crate::resource_budget::{BudgetLease, ResourceBudget};
     use crate::status::StatusTracker;
     use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
+
+    use super::super::ownership::OwnershipTransitions;
 
     fn test_budget_lease() -> (Arc<ResourceBudget>, BudgetLease) {
         let budget = Arc::new(ResourceBudget::new(8, 32768, 1.0, 0));
@@ -271,6 +276,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let status_path = dir.path().join("status.json");
         let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let ownership = OwnershipTransitions::new(&status);
         let provider = CompletionOrderProvider {
             budget: Arc::clone(&budget),
             budget_count_at_complete: Arc::clone(&budget_count_at_complete),
@@ -286,7 +292,7 @@ mod tests {
             test_completion_payload(run_id, sandbox_id),
             BudgetOwnership::active(ActiveBudgetLease::new(lease)),
         )
-        .complete_and_release(&provider, &status, &cleanup_state)
+        .complete_and_release(&provider, &ownership, &cleanup_state)
         .await;
 
         assert_eq!(
@@ -320,6 +326,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let status_path = dir.path().join("status.json");
         let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let ownership = OwnershipTransitions::new(&status);
         let provider = CompletionOrderProvider {
             budget: Arc::clone(&budget),
             budget_count_at_complete,
@@ -335,7 +342,7 @@ mod tests {
             test_completion_payload(run_id, sandbox_id),
             BudgetOwnership::idle_owned(),
         )
-        .complete_and_release(&provider, &status, &cleanup_state)
+        .complete_and_release(&provider, &ownership, &cleanup_state)
         .await;
 
         assert_eq!(
@@ -359,6 +366,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let status_path = dir.path().join("status.json");
         let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let ownership = OwnershipTransitions::new(&status);
         let provider = CompletionOrderProvider {
             budget: Arc::clone(&budget),
             budget_count_at_complete,
@@ -376,7 +384,7 @@ mod tests {
             test_completion_payload(run_id, completed_sandbox_id),
             BudgetOwnership::active(ActiveBudgetLease::new(lease)),
         )
-        .complete_and_release(&provider, &status, &cleanup_state)
+        .complete_and_release(&provider, &ownership, &cleanup_state)
         .await;
 
         assert_eq!(
@@ -398,6 +406,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let status_path = dir.path().join("status.json");
         let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let ownership = OwnershipTransitions::new(&status);
         let provider = CompletionOrderProvider {
             budget: Arc::clone(&budget),
             budget_count_at_complete: Arc::clone(&budget_count_at_complete),
@@ -413,7 +422,7 @@ mod tests {
             test_completion_payload(run_id, sandbox_id),
             BudgetOwnership::active(ActiveBudgetLease::from_rejected_park(lease)),
         )
-        .complete_and_release(&provider, &status, &cleanup_state)
+        .complete_and_release(&provider, &ownership, &cleanup_state)
         .await;
 
         assert_eq!(

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -15,11 +15,12 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use super::factory_lifecycle::SharedFactory;
-use super::idle_lifecycle::{SharedIdlePool, set_idle_status_snapshot};
+use super::idle_lifecycle::SharedIdlePool;
 use super::job_lifecycle::{
     ActiveBudgetLease, CompletionPayload, RunCleanupDisposition, RunCleanupState,
 };
 use super::orphan_reap::OrphanedActiveRuns;
+use super::ownership::{OwnershipTransitions, RunSandbox};
 use super::sandbox_finalization::{FinalizeContext, finalize_sandbox_for_completion};
 #[cfg(test)]
 use super::{OuterJobPanicPoint, maybe_panic_outer_job};
@@ -252,8 +253,9 @@ pub(super) fn spawn_job(
             .await;
 
             // Structural guarantee: claim (in provider) is always paired with complete.
+            let ownership = OwnershipTransitions::new(status.as_ref());
             completion_ready
-                .complete_and_release(provider.as_ref(), status.as_ref(), &cleanup_state_for_body)
+                .complete_and_release(provider.as_ref(), &ownership, &cleanup_state_for_body)
                 .await;
 
             // Best-effort telemetry, deferred past `provider.complete` so the
@@ -318,16 +320,17 @@ pub(super) async fn cleanup_panicked_job(
     orphaned_active_runs: OrphanedActiveRuns,
 ) {
     cancel_tokens.lock().await.remove(&run_id);
+    let ownership = OwnershipTransitions::new(status.as_ref());
+    let run = RunSandbox::new(run_id, sandbox_id);
 
     match cleanup_state.disposition() {
         RunCleanupDisposition::StatusRemoved => {}
         RunCleanupDisposition::DestroyCompleted => {
-            status.remove_run_if_matching(run_id, sandbox_id).await;
+            ownership.active_destroy_completed(run).await;
         }
         RunCleanupDisposition::IdlePoolOwned => {
             let snapshot = idle_pool.lock().await.status_snapshot();
-            set_idle_status_snapshot(&status, snapshot).await;
-            status.remove_run_if_matching(run_id, sandbox_id).await;
+            ownership.active_idle_pool_owned(run, snapshot).await;
         }
         RunCleanupDisposition::ActiveOrUnknown => {
             warn!(
@@ -335,7 +338,9 @@ pub(super) async fn cleanup_panicked_job(
                 sandbox_id = %sandbox_id,
                 "outer job task panicked before sandbox ownership was proven; leaving active run visible for orphan reconciliation"
             );
-            orphaned_active_runs.insert(run_id, sandbox_id).await;
+            ownership
+                .active_ownership_unknown(&orphaned_active_runs, run)
+                .await;
         }
     }
 }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -15,6 +15,7 @@
 //! - `job_spawn`: claimed job task spawning, completion, and panic cleanup.
 //! - `mitm_restart`: mitmproxy crash restart and backoff.
 //! - `orphan_reap`: orphan active-run reconciliation.
+//! - `ownership`: active/idle/orphan ownership transition ordering.
 //! - `sandbox_finalization`: post-executor sandbox park/destroy finalization.
 //! - `signals`: lifecycle signal registration and mode transitions.
 //!
@@ -68,6 +69,7 @@ mod job_lifecycle;
 mod job_spawn;
 mod mitm_restart;
 mod orphan_reap;
+mod ownership;
 mod sandbox_finalization;
 mod signals;
 

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 use sandbox::SandboxId;
 use tracing::{info, warn};
 
-use super::idle_lifecycle::{SharedIdlePool, set_idle_status_snapshot};
+use super::idle_lifecycle::SharedIdlePool;
+use super::ownership::{OwnershipTransitions, RunSandbox};
 use crate::ids::RunId;
 use crate::process;
 use crate::status::StatusTracker;
@@ -61,7 +62,7 @@ impl OrphanedActiveRuns {
         }
     }
 
-    async fn remove_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) -> bool {
+    pub(super) async fn remove_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) -> bool {
         let mut runs = self.inner.lock().await;
         let removed =
             matches!(runs.get(&run_id), Some(current) if current.sandbox_id == sandbox_id);
@@ -171,27 +172,24 @@ async fn reap_orphaned_active_run_records(
         .collect();
     drop(pool);
     let mut non_idle_records = Vec::new();
-    let mut refreshed_idle_status = false;
+    let ownership = OwnershipTransitions::new(status);
+    let idle_owned_runs = idle_owned_records
+        .iter()
+        .copied()
+        .map(|record| RunSandbox::new(record.run_id, record.sandbox_id));
+    let reconciled_idle_runs = ownership
+        .orphan_reconciled_idle_owned(orphaned_active_runs, idle_owned_runs, idle_snapshot)
+        .await;
+    for run in reconciled_idle_runs {
+        info!(
+            run_id = %run.run_id(),
+            sandbox_id = %run.sandbox_id(),
+            "orphaned active run reconciled as idle-pool owned"
+        );
+    }
     for record in records {
         if idle_owned_records.contains(&record) {
-            if !orphaned_active_runs
-                .remove_if_matching(record.run_id, record.sandbox_id)
-                .await
-            {
-                continue;
-            }
-            if !refreshed_idle_status {
-                set_idle_status_snapshot(status, idle_snapshot.clone()).await;
-                refreshed_idle_status = true;
-            }
-            status
-                .remove_run_if_matching(record.run_id, record.sandbox_id)
-                .await;
-            info!(
-                run_id = %record.run_id,
-                sandbox_id = %record.sandbox_id,
-                "orphaned active run reconciled as idle-pool owned"
-            );
+            continue;
         } else {
             non_idle_records.push(record);
         }
@@ -304,15 +302,16 @@ async fn reap_orphaned_active_runs_with_firecrackers(
             continue;
         }
 
-        if !orphaned_active_runs
-            .remove_if_matching(record.run_id, record.sandbox_id)
+        let ownership = OwnershipTransitions::new(status);
+        if !ownership
+            .orphan_confirmed_absent(
+                orphaned_active_runs,
+                RunSandbox::new(record.run_id, record.sandbox_id),
+            )
             .await
         {
             continue;
         }
-        status
-            .remove_run_if_matching(record.run_id, record.sandbox_id)
-            .await;
         info!(
             run_id = %record.run_id,
             sandbox_id = %record.sandbox_id,

--- a/crates/runner/src/cmd/start/ownership.rs
+++ b/crates/runner/src/cmd/start/ownership.rs
@@ -225,6 +225,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn active_idle_pool_owned_preserves_reinserted_active_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let transitions = OwnershipTransitions::new(&status);
+        let run_id = RunId::new_v4();
+        let stale_sandbox_id = SandboxId::new_v4();
+        let current_sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, stale_sandbox_id).await;
+        status.add_run(run_id, current_sandbox_id).await;
+
+        assert!(
+            !transitions
+                .active_idle_pool_owned(
+                    RunSandbox::new(run_id, stale_sandbox_id),
+                    idle_snapshot("sess-stale", stale_sandbox_id),
+                )
+                .await
+        );
+
+        let (idle_sessions, active_runs) = status_idle_sessions_and_active_runs(&status_path).await;
+        assert_eq!(idle_sessions, vec!["sess-stale"]);
+        assert_eq!(
+            active_runs,
+            vec![(run_id.to_string(), current_sandbox_id.to_string())]
+        );
+    }
+
+    #[tokio::test]
     async fn active_ownership_unknown_registers_orphan_and_keeps_active_visible() {
         let dir = tempfile::tempdir().unwrap();
         let status_path = dir.path().join("status.json");
@@ -279,6 +308,35 @@ mod tests {
             vec![(run_id.to_string(), current_sandbox_id.to_string())]
         );
         assert_eq!(orphans.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn orphan_absent_clears_stale_orphan_without_removing_reinserted_active_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let transitions = OwnershipTransitions::new(&status);
+        let orphans = OrphanedActiveRuns::new();
+        let run_id = RunId::new_v4();
+        let stale_sandbox_id = SandboxId::new_v4();
+        let current_sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, stale_sandbox_id).await;
+        orphans.insert(run_id, stale_sandbox_id).await;
+        status.add_run(run_id, current_sandbox_id).await;
+
+        assert!(
+            !transitions
+                .orphan_confirmed_absent(&orphans, RunSandbox::new(run_id, stale_sandbox_id))
+                .await
+        );
+
+        let (_idle_sessions, active_runs) =
+            status_idle_sessions_and_active_runs(&status_path).await;
+        assert_eq!(
+            active_runs,
+            vec![(run_id.to_string(), current_sandbox_id.to_string())]
+        );
+        assert_eq!(orphans.len().await, 0);
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/ownership.rs
+++ b/crates/runner/src/cmd/start/ownership.rs
@@ -88,8 +88,9 @@ impl<'a> OwnershipTransitions<'a> {
 
     /// Idle pool now proves ownership for these orphan records.
     ///
-    /// The idle snapshot is published once, before the first matching active
-    /// removal. Stale orphan records are skipped by `(run_id, sandbox_id)`.
+    /// Only runs present in `idle_snapshot` are eligible. The idle snapshot is
+    /// published once, before the first matching active removal. Stale orphan
+    /// records are skipped by `(run_id, sandbox_id)`.
     pub(super) async fn orphan_reconciled_idle_owned(
         &self,
         orphaned_active_runs: &OrphanedActiveRuns,
@@ -118,7 +119,11 @@ impl<'a> OwnershipTransitions<'a> {
         reconciled
     }
 
-    /// Process discovery confirmed the orphan sandbox absent; clear orphan and active status.
+    /// Process discovery confirmed the orphan sandbox absent; clear orphan state.
+    ///
+    /// Returns whether matching active status was also removed. A stale orphan
+    /// can still be cleared when active status is already gone or points at a
+    /// different sandbox.
     pub(super) async fn orphan_confirmed_absent(
         &self,
         orphaned_active_runs: &OrphanedActiveRuns,

--- a/crates/runner/src/cmd/start/ownership.rs
+++ b/crates/runner/src/cmd/start/ownership.rs
@@ -54,10 +54,12 @@ impl<'a> OwnershipTransitions<'a> {
         self.remove_matching_active(run).await
     }
 
-    /// Active sandbox was accepted by the idle pool; publish idle status.
-    pub(super) async fn active_parked_to_idle(
+    /// Publish the idle-pool state after a caller transferred sandbox ownership.
+    ///
+    /// This intentionally does not remove active status; normal completion does
+    /// that after `provider.complete`.
+    pub(super) async fn publish_idle_status_after_pool_transfer(
         &self,
-        _run: RunSandbox,
         idle_snapshot: IdlePoolSnapshot,
     ) {
         set_idle_status_snapshot(self.status, idle_snapshot).await;
@@ -97,6 +99,9 @@ impl<'a> OwnershipTransitions<'a> {
         let mut reconciled = Vec::new();
         let mut refreshed_idle_status = false;
         for run in runs {
+            if !idle_snapshot_contains_sandbox_id(&idle_snapshot, run.sandbox_id) {
+                continue;
+            }
             if !orphaned_active_runs
                 .remove_if_matching(run.run_id, run.sandbox_id)
                 .await
@@ -133,6 +138,16 @@ impl<'a> OwnershipTransitions<'a> {
             .remove_run_if_matching(run.run_id, run.sandbox_id)
             .await
     }
+}
+
+fn idle_snapshot_contains_sandbox_id(
+    idle_snapshot: &IdlePoolSnapshot,
+    sandbox_id: SandboxId,
+) -> bool {
+    idle_snapshot
+        .idle_vms
+        .iter()
+        .any(|idle_vm| idle_vm.sandbox_id == sandbox_id)
 }
 
 #[cfg(test)]
@@ -262,6 +277,37 @@ mod tests {
         assert_eq!(
             active_runs,
             vec![(run_id.to_string(), current_sandbox_id.to_string())]
+        );
+        assert_eq!(orphans.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn orphan_idle_owned_requires_idle_snapshot_membership() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let transitions = OwnershipTransitions::new(&status);
+        let orphans = OrphanedActiveRuns::new();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let idle_sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, sandbox_id).await;
+        orphans.insert(run_id, sandbox_id).await;
+
+        let reconciled = transitions
+            .orphan_reconciled_idle_owned(
+                &orphans,
+                [RunSandbox::new(run_id, sandbox_id)],
+                idle_snapshot("sess-different", idle_sandbox_id),
+            )
+            .await;
+
+        assert!(reconciled.is_empty());
+        let (idle_sessions, active_runs) = status_idle_sessions_and_active_runs(&status_path).await;
+        assert!(idle_sessions.is_empty());
+        assert_eq!(
+            active_runs,
+            vec![(run_id.to_string(), sandbox_id.to_string())]
         );
         assert_eq!(orphans.len().await, 1);
     }

--- a/crates/runner/src/cmd/start/ownership.rs
+++ b/crates/runner/src/cmd/start/ownership.rs
@@ -1,0 +1,268 @@
+//! Active, idle, and orphan ownership transitions for `runner start`.
+//!
+//! This module owns the ordering of cross-structure transitions. It delegates
+//! persisted status to [`StatusTracker`], orphan record storage to
+//! [`OrphanedActiveRuns`], and idle-pool mutation to callers that already hold
+//! the right pool context. Slow sandbox operations stay outside this module.
+
+use sandbox::SandboxId;
+
+use super::idle_lifecycle::set_idle_status_snapshot;
+use super::orphan_reap::OrphanedActiveRuns;
+use crate::idle_pool::IdlePoolSnapshot;
+use crate::ids::RunId;
+use crate::status::StatusTracker;
+
+/// Identity proving which sandbox a run cleanup path is allowed to affect.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct RunSandbox {
+    run_id: RunId,
+    sandbox_id: SandboxId,
+}
+
+impl RunSandbox {
+    pub(super) fn new(run_id: RunId, sandbox_id: SandboxId) -> Self {
+        Self { run_id, sandbox_id }
+    }
+
+    pub(super) fn run_id(self) -> RunId {
+        self.run_id
+    }
+
+    pub(super) fn sandbox_id(self) -> SandboxId {
+        self.sandbox_id
+    }
+}
+
+/// Narrow facade for the ownership transitions that touch multiple structures.
+pub(super) struct OwnershipTransitions<'a> {
+    status: &'a StatusTracker,
+}
+
+impl<'a> OwnershipTransitions<'a> {
+    pub(super) fn new(status: &'a StatusTracker) -> Self {
+        Self { status }
+    }
+
+    /// Normal provider completion has been reported; remove matching active status.
+    pub(super) async fn active_completed(&self, run: RunSandbox) -> bool {
+        self.remove_matching_active(run).await
+    }
+
+    /// Active sandbox destruction completed; remove matching active status.
+    pub(super) async fn active_destroy_completed(&self, run: RunSandbox) -> bool {
+        self.remove_matching_active(run).await
+    }
+
+    /// Active sandbox was accepted by the idle pool; publish idle status.
+    pub(super) async fn active_parked_to_idle(
+        &self,
+        _run: RunSandbox,
+        idle_snapshot: IdlePoolSnapshot,
+    ) {
+        set_idle_status_snapshot(self.status, idle_snapshot).await;
+    }
+
+    /// Idle pool owns this sandbox; publish idle status before removing active status.
+    pub(super) async fn active_idle_pool_owned(
+        &self,
+        run: RunSandbox,
+        idle_snapshot: IdlePoolSnapshot,
+    ) -> bool {
+        set_idle_status_snapshot(self.status, idle_snapshot).await;
+        self.remove_matching_active(run).await
+    }
+
+    /// Ownership is uncertain after panic; keep active status visible and track as orphan.
+    pub(super) async fn active_ownership_unknown(
+        &self,
+        orphaned_active_runs: &OrphanedActiveRuns,
+        run: RunSandbox,
+    ) {
+        orphaned_active_runs
+            .insert(run.run_id, run.sandbox_id)
+            .await;
+    }
+
+    /// Idle pool now proves ownership for these orphan records.
+    ///
+    /// The idle snapshot is published once, before the first matching active
+    /// removal. Stale orphan records are skipped by `(run_id, sandbox_id)`.
+    pub(super) async fn orphan_reconciled_idle_owned(
+        &self,
+        orphaned_active_runs: &OrphanedActiveRuns,
+        runs: impl IntoIterator<Item = RunSandbox>,
+        idle_snapshot: IdlePoolSnapshot,
+    ) -> Vec<RunSandbox> {
+        let mut reconciled = Vec::new();
+        let mut refreshed_idle_status = false;
+        for run in runs {
+            if !orphaned_active_runs
+                .remove_if_matching(run.run_id, run.sandbox_id)
+                .await
+            {
+                continue;
+            }
+            if !refreshed_idle_status {
+                set_idle_status_snapshot(self.status, idle_snapshot.clone()).await;
+                refreshed_idle_status = true;
+            }
+            self.remove_matching_active(run).await;
+            reconciled.push(run);
+        }
+        reconciled
+    }
+
+    /// Process discovery confirmed the orphan sandbox absent; clear orphan and active status.
+    pub(super) async fn orphan_confirmed_absent(
+        &self,
+        orphaned_active_runs: &OrphanedActiveRuns,
+        run: RunSandbox,
+    ) -> bool {
+        if !orphaned_active_runs
+            .remove_if_matching(run.run_id, run.sandbox_id)
+            .await
+        {
+            return false;
+        }
+        self.remove_matching_active(run).await
+    }
+
+    async fn remove_matching_active(&self, run: RunSandbox) -> bool {
+        self.status
+            .remove_run_if_matching(run.run_id, run.sandbox_id)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::status::IdleVm;
+
+    async fn status_idle_sessions_and_active_runs(
+        status_path: &std::path::Path,
+    ) -> (Vec<String>, Vec<(String, String)>) {
+        let raw = tokio::fs::read_to_string(status_path).await.unwrap();
+        let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let mut sessions: Vec<String> = status
+            .get("idle_vms")
+            .and_then(|v| v.as_array())
+            .map(|idle_vms| {
+                idle_vms
+                    .iter()
+                    .filter_map(|vm| {
+                        vm.get("session_id")
+                            .and_then(|session| session.as_str())
+                            .map(str::to_string)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        sessions.sort_unstable();
+        let mut active_runs: Vec<(String, String)> = status["active_runs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|run| {
+                (
+                    run["run_id"].as_str().unwrap().to_string(),
+                    run["sandbox_id"].as_str().unwrap().to_string(),
+                )
+            })
+            .collect();
+        active_runs.sort_unstable();
+        (sessions, active_runs)
+    }
+
+    fn idle_snapshot(session_id: &str, sandbox_id: SandboxId) -> IdlePoolSnapshot {
+        IdlePoolSnapshot {
+            revision: 1,
+            idle_vms: vec![IdleVm {
+                session_id: session_id.to_string(),
+                sandbox_id,
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn active_idle_pool_owned_publishes_idle_status_and_removes_active() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let transitions = OwnershipTransitions::new(&status);
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, sandbox_id).await;
+
+        assert!(
+            transitions
+                .active_idle_pool_owned(
+                    RunSandbox::new(run_id, sandbox_id),
+                    idle_snapshot("sess-owned", sandbox_id),
+                )
+                .await
+        );
+
+        let (idle_sessions, active_runs) = status_idle_sessions_and_active_runs(&status_path).await;
+        assert_eq!(idle_sessions, vec!["sess-owned"]);
+        assert!(active_runs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn active_ownership_unknown_registers_orphan_and_keeps_active_visible() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let transitions = OwnershipTransitions::new(&status);
+        let orphans = OrphanedActiveRuns::new();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, sandbox_id).await;
+
+        transitions
+            .active_ownership_unknown(&orphans, RunSandbox::new(run_id, sandbox_id))
+            .await;
+
+        let (_idle_sessions, active_runs) =
+            status_idle_sessions_and_active_runs(&status_path).await;
+        assert_eq!(
+            active_runs,
+            vec![(run_id.to_string(), sandbox_id.to_string())]
+        );
+        assert_eq!(orphans.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn orphan_idle_owned_skips_stale_orphan_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+        let transitions = OwnershipTransitions::new(&status);
+        let orphans = OrphanedActiveRuns::new();
+        let run_id = RunId::new_v4();
+        let stale_sandbox_id = SandboxId::new_v4();
+        let current_sandbox_id = SandboxId::new_v4();
+        status.add_run(run_id, stale_sandbox_id).await;
+        orphans.insert(run_id, stale_sandbox_id).await;
+        status.add_run(run_id, current_sandbox_id).await;
+        orphans.insert(run_id, current_sandbox_id).await;
+
+        let reconciled = transitions
+            .orphan_reconciled_idle_owned(
+                &orphans,
+                [RunSandbox::new(run_id, stale_sandbox_id)],
+                idle_snapshot("sess-stale", stale_sandbox_id),
+            )
+            .await;
+
+        assert!(reconciled.is_empty());
+        let (idle_sessions, active_runs) = status_idle_sessions_and_active_runs(&status_path).await;
+        assert!(idle_sessions.is_empty());
+        assert_eq!(
+            active_runs,
+            vec![(run_id.to_string(), current_sandbox_id.to_string())]
+        );
+        assert_eq!(orphans.len().await, 1);
+    }
+}

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -14,11 +14,11 @@ use tracing::{info, warn};
 
 use super::idle_lifecycle::{
     SharedIdlePool, destroy_idle_jobs_and_wait, destroy_idle_payload_and_wait,
-    set_idle_status_snapshot,
 };
 use super::job_lifecycle::{
     ActiveBudgetLease, BudgetOwnership, CompletionPayload, CompletionReady, RunCleanupState,
 };
+use super::ownership::{OwnershipTransitions, RunSandbox};
 #[cfg(test)]
 use super::{OuterJobPanicPoint, maybe_panic_outer_job};
 use crate::idle_pool::{
@@ -228,7 +228,10 @@ pub(super) async fn finalize_sandbox_for_completion(
                     // FirecrackerNotInStatus warnings.
                     let snapshot = pool.status_snapshot();
                     drop(pool);
-                    set_idle_status_snapshot(&status, snapshot).await;
+                    let ownership = OwnershipTransitions::new(status.as_ref());
+                    ownership
+                        .active_parked_to_idle(RunSandbox::new(run_id, sandbox_id), snapshot)
+                        .await;
                     park_notify.notify_one();
                     BudgetOwnership::idle_owned()
                 }
@@ -243,7 +246,10 @@ pub(super) async fn finalize_sandbox_for_completion(
                     );
                     let snapshot = pool.status_snapshot();
                     drop(pool);
-                    set_idle_status_snapshot(&status, snapshot).await;
+                    let ownership = OwnershipTransitions::new(status.as_ref());
+                    ownership
+                        .active_parked_to_idle(RunSandbox::new(run_id, sandbox_id), snapshot)
+                        .await;
                     // Notify immediately — session is already in pool.
                     // Don't wait for stop_and_destroy which can be slow.
                     park_notify.notify_one();

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -18,7 +18,7 @@ use super::idle_lifecycle::{
 use super::job_lifecycle::{
     ActiveBudgetLease, BudgetOwnership, CompletionPayload, CompletionReady, RunCleanupState,
 };
-use super::ownership::{OwnershipTransitions, RunSandbox};
+use super::ownership::OwnershipTransitions;
 #[cfg(test)]
 use super::{OuterJobPanicPoint, maybe_panic_outer_job};
 use crate::idle_pool::{
@@ -230,7 +230,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                     drop(pool);
                     let ownership = OwnershipTransitions::new(status.as_ref());
                     ownership
-                        .active_parked_to_idle(RunSandbox::new(run_id, sandbox_id), snapshot)
+                        .publish_idle_status_after_pool_transfer(snapshot)
                         .await;
                     park_notify.notify_one();
                     BudgetOwnership::idle_owned()
@@ -248,7 +248,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                     drop(pool);
                     let ownership = OwnershipTransitions::new(status.as_ref());
                     ownership
-                        .active_parked_to_idle(RunSandbox::new(run_id, sandbox_id), snapshot)
+                        .publish_idle_status_after_pool_transfer(snapshot)
                         .await;
                     // Notify immediately — session is already in pool.
                     // Don't wait for stop_and_destroy which can be slow.


### PR DESCRIPTION
## Summary

- Add a narrow runner-start ownership transition coordinator in `start/ownership.rs`.
- Route normal completion, panic cleanup, parked-idle status publication, and orphan reconciliation through named ownership transitions.
- Preserve the existing safety invariants: active removal still requires `(run_id, sandbox_id)`, idle status is published before active removal, and unknown panic cleanup leaves active status visible while registering an orphan.

Closes #11427

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner ownership`
- `cargo test --manifest-path crates/Cargo.toml -p runner panic_cleanup`
- `cargo test --manifest-path crates/Cargo.toml -p runner orphan_reaper`
- `cargo test --manifest-path crates/Cargo.toml -p runner finalizer`
- `cargo test --manifest-path crates/Cargo.toml -p runner park`
- `cargo test --manifest-path crates/Cargo.toml -p runner cancel`
- `cargo test --manifest-path crates/Cargo.toml -p runner budget`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-features`