### PR TITLE
fix: support chat arrow key scrolling

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
@@ -4,6 +4,25 @@ import { createScrollSignals } from "../auto-scroll.ts";
 
 const context = testContext();
 
+function setScrollableSize(
+  container: HTMLElement,
+  scrollHeight: number,
+  clientHeight: number,
+) {
+  Object.defineProperty(container, "scrollHeight", {
+    get: () => {
+      return scrollHeight;
+    },
+    configurable: true,
+  });
+  Object.defineProperty(container, "clientHeight", {
+    get: () => {
+      return clientHeight;
+    },
+    configurable: true,
+  });
+}
+
 // VC-SCROLL-001: ResizeObserver observes firstElementChild, not the container
 describe("createScrollSignals - ResizeObserver targets inner content", () => {
   it("observes firstElementChild when it exists (VC-SCROLL-001)", () => {
@@ -169,6 +188,69 @@ describe("createScrollSignals - browser-initiated scroll does not disable auto-s
     // autoScroll$ should still execute — auto-scroll was NOT disabled
     context.store.set(autoScroll$);
     expect(container.scrollTop).toBe(1000);
+  });
+});
+
+describe("createScrollSignals - keyboard step scrolling", () => {
+  it("scrollBy$ scrolls upward and disables auto-scroll", () => {
+    const container = document.createElement("div");
+    const inner = document.createElement("div");
+    container.appendChild(inner);
+    document.body.appendChild(container);
+    setScrollableSize(container, 1000, 300);
+
+    const { setScrollContainer$, scrollBy$, autoScroll$ } =
+      createScrollSignals();
+    context.store.set(setScrollContainer$, container);
+
+    container.scrollTop = 500;
+    container.dispatchEvent(new Event("scroll"));
+
+    expect(context.store.set(scrollBy$, "up")).toBeTruthy();
+    expect(container.scrollTop).toBe(428);
+
+    context.store.set(autoScroll$);
+    expect(container.scrollTop).toBe(428);
+  });
+
+  it("scrollBy$ scrolls downward and re-enables auto-scroll at the bottom", () => {
+    const container = document.createElement("div");
+    const inner = document.createElement("div");
+    container.appendChild(inner);
+    document.body.appendChild(container);
+    setScrollableSize(container, 1000, 300);
+
+    const { setScrollContainer$, scrollBy$, autoScroll$ } =
+      createScrollSignals();
+    context.store.set(setScrollContainer$, container);
+
+    container.scrollTop = 500;
+    container.dispatchEvent(new Event("scroll"));
+    container.dispatchEvent(new Event("wheel"));
+    container.scrollTop = 300;
+    container.dispatchEvent(new Event("scroll"));
+
+    container.scrollTop = 650;
+    expect(context.store.set(scrollBy$, "down")).toBeTruthy();
+    expect(container.scrollTop).toBe(700);
+
+    context.store.set(autoScroll$);
+    expect(container.scrollTop).toBe(1000);
+  });
+
+  it("scrollBy$ is a no-op when the container cannot scroll further", () => {
+    const container = document.createElement("div");
+    const inner = document.createElement("div");
+    container.appendChild(inner);
+    document.body.appendChild(container);
+    setScrollableSize(container, 1000, 300);
+
+    const { setScrollContainer$, scrollBy$ } = createScrollSignals();
+    context.store.set(setScrollContainer$, container);
+
+    container.scrollTop = 0;
+    expect(context.store.set(scrollBy$, "up")).toBeFalsy();
+    expect(container.scrollTop).toBe(0);
   });
 });
 

--- a/turbo/apps/platform/src/signals/auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/auto-scroll.ts
@@ -1,10 +1,13 @@
-import { command, state } from "ccstate";
+import { command, state, type State } from "ccstate";
 import { onRef } from "./utils.ts";
 import { logger } from "./log.ts";
 
 const L = logger("AutoScroll");
 const AT_BOTTOM_THRESHOLD = 10;
 const USER_INPUT_WINDOW_MS = 200;
+const KEY_SCROLL_STEP_PX = 72;
+
+export type ScrollStepDirection = "up" | "down";
 
 // Persists a user's last non-bottom scroll position across container
 // re-binds (e.g. when switching between parallel chat threads). Keyed by
@@ -43,6 +46,11 @@ function isUserScrollKey(key: string): boolean {
     key === "End" ||
     key === " "
   );
+}
+
+function clampScrollTop(el: HTMLElement, scrollTop: number): number {
+  const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+  return Math.max(0, Math.min(scrollTop, maxScrollTop));
 }
 
 function scrollInfo(el: HTMLElement) {
@@ -188,6 +196,49 @@ function buildResizeHandler(ctx: ResizeHandlerContext) {
   };
 }
 
+interface ScrollByCommandDeps {
+  internalScrollContainer$: State<HTMLElement | null>;
+  autoScrollDisabled$: State<boolean>;
+  id: string | undefined;
+  lastKnownScrollTop: { v: number };
+  markUserInput: () => void;
+}
+
+function createScrollByCommand(deps: ScrollByCommandDeps) {
+  return command(({ get, set }, direction: ScrollStepDirection) => {
+    const scrollEl = get(deps.internalScrollContainer$);
+    if (!scrollEl) {
+      return false;
+    }
+    const delta = direction === "up" ? -KEY_SCROLL_STEP_PX : KEY_SCROLL_STEP_PX;
+    const nextScrollTop = clampScrollTop(scrollEl, scrollEl.scrollTop + delta);
+    if (nextScrollTop === scrollEl.scrollTop) {
+      return false;
+    }
+
+    deps.markUserInput();
+    scrollEl.scrollTop = nextScrollTop;
+
+    const distanceFromBottom =
+      scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight;
+    if (distanceFromBottom <= AT_BOTTOM_THRESHOLD) {
+      set(deps.autoScrollDisabled$, false);
+      if (deps.id !== undefined) {
+        set(clearCachedScrollTop$, deps.id);
+      }
+    } else if (direction === "up") {
+      set(deps.autoScrollDisabled$, true);
+      if (deps.id !== undefined) {
+        set(setCachedScrollTop$, deps.id, scrollEl.scrollTop);
+      }
+    } else if (deps.id !== undefined && get(deps.autoScrollDisabled$)) {
+      set(setCachedScrollTop$, deps.id, scrollEl.scrollTop);
+    }
+    deps.lastKnownScrollTop.v = scrollEl.scrollTop;
+    return true;
+  });
+}
+
 /**
  * Factory that creates scroll-management signals for a scrollable container.
  *
@@ -219,6 +270,13 @@ export function createScrollSignals(id?: string) {
     suppressNextScrollToBottom: false,
     pendingPrependScrollHeight: null,
   };
+  const lastKnownScrollTop = { v: 0 };
+  const lastUserInputAt = { v: 0 };
+
+  const markUserInput = () => {
+    lastUserInputAt.v = performance.now();
+    restoreState.suppressNextScrollToBottom = false;
+  };
 
   const setScrollContainer$ = onRef(
     command(({ get, set }, el: HTMLElement, signal: AbortSignal) => {
@@ -235,13 +293,8 @@ export function createScrollSignals(id?: string) {
         L.debug("container bound → restoring", `id=${id}`, `saved=${saved}`);
       }
 
-      const lastKnownScrollTop = { v: el.scrollTop };
-      const lastUserInputAt = { v: 0 };
-
-      const markUserInput = () => {
-        lastUserInputAt.v = performance.now();
-        restoreState.suppressNextScrollToBottom = false;
-      };
+      lastKnownScrollTop.v = el.scrollTop;
+      lastUserInputAt.v = 0;
 
       const ctx: ScrollHandlerContext = {
         el,
@@ -311,6 +364,14 @@ export function createScrollSignals(id?: string) {
     scrollEl.scrollTop = scrollEl.scrollHeight;
   });
 
+  const scrollBy$ = createScrollByCommand({
+    internalScrollContainer$,
+    autoScrollDisabled$,
+    id,
+    lastKnownScrollTop,
+    markUserInput,
+  });
+
   // Snapshot the container's current scrollHeight before prepending messages.
   // The ResizeObserver callback will detect the resulting height increase and
   // compensate scrollTop so the viewport stays anchored on the same content.
@@ -342,6 +403,7 @@ export function createScrollSignals(id?: string) {
     autoScroll$,
     scrollToBottom$,
     scrollToTop$,
+    scrollBy$,
     recordScrollHeightForPrepend$,
   };
 }

--- a/turbo/apps/platform/src/signals/auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/auto-scroll.ts
@@ -239,6 +239,66 @@ function createScrollByCommand(deps: ScrollByCommandDeps) {
   });
 }
 
+interface PrepareKeyboardScrollCommandDeps {
+  internalScrollContainer$: State<HTMLElement | null>;
+  markUserInput: () => void;
+}
+
+function createPrepareKeyboardScrollCommand(
+  deps: PrepareKeyboardScrollCommandDeps,
+) {
+  return command(({ get }) => {
+    const scrollEl = get(deps.internalScrollContainer$);
+    if (!scrollEl) {
+      return false;
+    }
+    deps.markUserInput();
+    if (!scrollEl.contains(scrollEl.ownerDocument.activeElement)) {
+      scrollEl.focus({ preventScroll: true });
+    }
+    return true;
+  });
+}
+
+interface RecordScrollHeightForPrependCommandDeps {
+  internalScrollContainer$: State<HTMLElement | null>;
+  restoreState: RestoreState;
+}
+
+function createRecordScrollHeightForPrependCommand(
+  deps: RecordScrollHeightForPrependCommandDeps,
+) {
+  return command(({ get }) => {
+    const el = get(deps.internalScrollContainer$);
+    if (el) {
+      deps.restoreState.pendingPrependScrollHeight = el.scrollHeight;
+      L.debug("recordScrollHeightForPrepend$", `height=${el.scrollHeight}`);
+    }
+  });
+}
+
+interface ScrollToTopCommandDeps {
+  internalScrollContainer$: State<HTMLElement | null>;
+  autoScrollDisabled$: State<boolean>;
+  restoreState: RestoreState;
+  id: string | undefined;
+}
+
+function createScrollToTopCommand(deps: ScrollToTopCommandDeps) {
+  return command(({ get, set }) => {
+    const scrollEl = get(deps.internalScrollContainer$);
+    if (!scrollEl) {
+      return;
+    }
+    set(deps.autoScrollDisabled$, true);
+    deps.restoreState.suppressNextScrollToBottom = false;
+    if (deps.id !== undefined) {
+      set(setCachedScrollTop$, deps.id, 0);
+    }
+    scrollEl.scrollTop = 0;
+  });
+}
+
 /**
  * Factory that creates scroll-management signals for a scrollable container.
  *
@@ -372,30 +432,22 @@ export function createScrollSignals(id?: string) {
     markUserInput,
   });
 
-  // Snapshot the container's current scrollHeight before prepending messages.
-  // The ResizeObserver callback will detect the resulting height increase and
-  // compensate scrollTop so the viewport stays anchored on the same content.
-  const recordScrollHeightForPrepend$ = command(({ get }) => {
-    const el = get(internalScrollContainer$);
-    if (el) {
-      restoreState.pendingPrependScrollHeight = el.scrollHeight;
-      L.debug("recordScrollHeightForPrepend$", `height=${el.scrollHeight}`);
-    }
+  const prepareKeyboardScroll$ = createPrepareKeyboardScrollCommand({
+    internalScrollContainer$,
+    markUserInput,
   });
 
-  // Scrolling to top is an explicit opt-out of auto-scroll — disable it so
-  // ResizeObserver doesn't snap back to the bottom when new messages arrive.
-  const scrollToTop$ = command(({ get, set }) => {
-    const scrollEl = get(internalScrollContainer$);
-    if (!scrollEl) {
-      return;
-    }
-    set(autoScrollDisabled$, true);
-    restoreState.suppressNextScrollToBottom = false;
-    if (id !== undefined) {
-      set(setCachedScrollTop$, id, 0);
-    }
-    scrollEl.scrollTop = 0;
+  const recordScrollHeightForPrepend$ =
+    createRecordScrollHeightForPrependCommand({
+      internalScrollContainer$,
+      restoreState,
+    });
+
+  const scrollToTop$ = createScrollToTopCommand({
+    internalScrollContainer$,
+    autoScrollDisabled$,
+    restoreState,
+    id,
   });
 
   return {
@@ -404,6 +456,7 @@ export function createScrollSignals(id?: string) {
     scrollToBottom$,
     scrollToTop$,
     scrollBy$,
+    prepareKeyboardScroll$,
     recordScrollHeightForPrepend$,
   };
 }

--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -91,8 +91,8 @@ export const setChatKeyboardScrollRoot$ = onRef(
         get(currentRightThread$),
         targetThreadId ?? activeThreadId,
       );
-      if (thread && set(thread.scrollBy$, direction)) {
-        event.preventDefault();
+      if (thread) {
+        set(thread.prepareKeyboardScroll$);
       }
     };
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -55,6 +55,26 @@ function isKeyboardScrollBlockedTarget(target: EventTarget | null): boolean {
   return target.closest('[role="dialog"]') !== null;
 }
 
+function isDocumentScrollTarget(root: HTMLElement, target: EventTarget | null) {
+  const doc = root.ownerDocument;
+  return (
+    target === doc || target === doc.body || target === doc.documentElement
+  );
+}
+
+function isKeyboardScrollAllowedTarget(
+  root: HTMLElement,
+  target: EventTarget | null,
+): boolean {
+  if (isKeyboardScrollBlockedTarget(target)) {
+    return false;
+  }
+  return (
+    isDocumentScrollTarget(root, target) ||
+    (target instanceof Node && root.contains(target))
+  );
+}
+
 function resolveKeyboardScrollThread(
   leftThread: ChatThreadSignals | null,
   rightThread: ChatThreadSignals | null,
@@ -82,7 +102,7 @@ export const setChatKeyboardScrollRoot$ = onRef(
         return;
       }
       const direction = plainArrowScrollDirection(event);
-      if (!direction || isKeyboardScrollBlockedTarget(event.target)) {
+      if (!direction || !isKeyboardScrollAllowedTarget(el, event.target)) {
         return;
       }
       const targetThreadId = chatThreadIdForKeyboardTarget(event.target);

--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -1,4 +1,5 @@
 import { command } from "ccstate";
+import { isEditableTarget, matchShortcut } from "@vm0/ui";
 import {
   currentLeftThread$,
   currentRightThread$,
@@ -7,6 +8,8 @@ import {
 } from "./chat-thread-panes.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import type { ChatThreadSignals } from "./create-chat-thread.ts";
+import type { ScrollStepDirection } from "../auto-scroll.ts";
+import { onRef } from "../utils.ts";
 
 /**
  * Snapshot row shape consumed by `navigateToAdjacentThread$`. The caller
@@ -19,6 +22,86 @@ interface NavigableThread {
   readonly id: string;
   readonly agent: { readonly id: string };
 }
+
+function plainArrowScrollDirection(
+  event: KeyboardEvent,
+): ScrollStepDirection | null {
+  if (matchShortcut("arrowup", event)) {
+    return "up";
+  }
+  if (matchShortcut("arrowdown", event)) {
+    return "down";
+  }
+  return null;
+}
+
+function chatThreadIdForKeyboardTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return null;
+  }
+  const threadContainer = target.closest<HTMLElement>(
+    "[data-chat-thread-container-id]",
+  );
+  return threadContainer?.dataset.chatThreadContainerId ?? null;
+}
+
+function isKeyboardScrollBlockedTarget(target: EventTarget | null): boolean {
+  if (isEditableTarget(target)) {
+    return true;
+  }
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  return target.closest('[role="dialog"]') !== null;
+}
+
+function resolveKeyboardScrollThread(
+  leftThread: ChatThreadSignals | null,
+  rightThread: ChatThreadSignals | null,
+  threadId: string | null,
+): ChatThreadSignals | null {
+  if (threadId === rightThread?.threadId) {
+    return rightThread;
+  }
+  if (threadId === leftThread?.threadId) {
+    return leftThread;
+  }
+  return leftThread;
+}
+
+export const setChatKeyboardScrollRoot$ = onRef(
+  command(({ get, set }, el: HTMLElement, signal: AbortSignal) => {
+    let activeThreadId: string | null = null;
+
+    const markActiveThread = (event: Event) => {
+      activeThreadId = chatThreadIdForKeyboardTarget(event.target);
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+      const direction = plainArrowScrollDirection(event);
+      if (!direction || isKeyboardScrollBlockedTarget(event.target)) {
+        return;
+      }
+      const targetThreadId = chatThreadIdForKeyboardTarget(event.target);
+      const thread = resolveKeyboardScrollThread(
+        get(currentLeftThread$),
+        get(currentRightThread$),
+        targetThreadId ?? activeThreadId,
+      );
+      if (thread && set(thread.scrollBy$, direction)) {
+        event.preventDefault();
+      }
+    };
+
+    el.addEventListener("focusin", markActiveThread, { signal });
+    el.addEventListener("pointerdown", markActiveThread, { signal });
+    el.addEventListener("pointerover", markActiveThread, { signal });
+    document.addEventListener("keydown", onKeyDown, { signal });
+  }),
+);
 
 export const navigateToAdjacentThread$ = command(
   async (
@@ -73,11 +156,19 @@ export const navigateToAdjacentThread$ = command(
 );
 
 export const scrollCurrentThread$ = command(
-  ({ set }, thread: ChatThreadSignals, position: "top" | "bottom") => {
+  (
+    { set },
+    thread: ChatThreadSignals,
+    position: "top" | "bottom" | ScrollStepDirection,
+  ): boolean => {
     if (position === "top") {
       set(thread.scrollToTop$);
-    } else {
-      set(thread.scrollToBottom$);
+      return true;
     }
+    if (position === "bottom") {
+      set(thread.scrollToBottom$);
+      return true;
+    }
+    return set(thread.scrollBy$, position);
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -174,6 +174,7 @@ export interface ChatThreadSignals {
   scrollToBottom$: Command<void, []>;
   scrollToTop$: Command<void, []>;
   scrollBy$: Command<boolean, [ScrollStepDirection]>;
+  prepareKeyboardScroll$: Command<boolean, []>;
   // ── Initial-load skeleton ────────────────────────────────────────────────
   // Starts hidden — `setupChatThreadInitScroll$` flips it on only when the
   // IDB cache misses, so cache hits skip the skeleton entirely. Flipped off

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -9,7 +9,10 @@ import {
 import { animationFrame, delay } from "signal-timers";
 import { onRef, resetSignal, setLoop } from "../utils.ts";
 import { setAblyLoop$ } from "../realtime.ts";
-import { createScrollSignals } from "../auto-scroll.ts";
+import {
+  createScrollSignals,
+  type ScrollStepDirection,
+} from "../auto-scroll.ts";
 import {
   createDraftSignals,
   createRestoredAttachment,
@@ -170,6 +173,7 @@ export interface ChatThreadSignals {
   autoScroll$: Command<void, []>;
   scrollToBottom$: Command<void, []>;
   scrollToTop$: Command<void, []>;
+  scrollBy$: Command<boolean, [ScrollStepDirection]>;
   // ── Initial-load skeleton ────────────────────────────────────────────────
   // Starts hidden — `setupChatThreadInitScroll$` flips it on only when the
   // IDB cache misses, so cache hits skip the skeleton entirely. Flipped off
@@ -1483,13 +1487,8 @@ export function createChatThreadSignals(
   const { threadData$, reloadThread$ } = createThreadData(dataSource);
   const { modelSelection$, setModelSelection$ } =
     createModelSelection(threadData$);
-  const {
-    setScrollContainer$,
-    autoScroll$,
-    scrollToBottom$,
-    scrollToTop$,
-    recordScrollHeightForPrepend$,
-  } = createScrollSignals(threadId);
+  const { recordScrollHeightForPrepend$, ...scrollSignals } =
+    createScrollSignals(threadId);
   const { skeletonVisible$, showSkeleton$, hideSkeleton$ } =
     createSkeletonSignals();
   const { composerFileInput$, setComposerFileInput$ } =
@@ -1525,7 +1524,7 @@ export function createChatThreadSignals(
     threadData$,
     latestChatMessageId$,
     fetchNextPage$,
-    autoScroll$,
+    autoScroll$: scrollSignals.autoScroll$,
     dataSource,
   });
 
@@ -1537,7 +1536,7 @@ export function createChatThreadSignals(
     cancelDraftSync$,
     flushDraftClear$,
     insertOptimisticMessage$,
-    scrollToBottom$,
+    scrollToBottom$: scrollSignals.scrollToBottom$,
     reloadThread$,
     dataSource,
   });
@@ -1563,10 +1562,7 @@ export function createChatThreadSignals(
     setModelSelection$,
     ...messageCommands,
     cancelRun$,
-    setScrollContainer$,
-    autoScroll$,
-    scrollToBottom$,
-    scrollToTop$,
+    ...scrollSignals,
     skeletonVisible$,
     showSkeleton$,
     hideSkeleton$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
@@ -440,5 +440,12 @@ describe("chat page keyboard shortcuts", () => {
     composer!.focus();
     fireEvent.keyDown(composer!, { key: "ArrowDown" });
     expect(document.activeElement).toBe(composer);
+
+    const outsideButton = document.createElement("button");
+    document.body.appendChild(outsideButton);
+    outsideButton.focus();
+    fireEvent.keyDown(outsideButton, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(outsideButton);
+    outsideButton.remove();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
@@ -370,4 +370,74 @@ describe("chat page keyboard shortcuts", () => {
       expect(scrollContainer!.scrollTop).toBe(0);
     });
   });
+
+  it("plain up/down keys scroll the message list outside the composer", async () => {
+    mockThreadList([{ id: "thread-arrow-scroll", title: "Arrow scroll test" }]);
+    server.use(
+      mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {
+        if (query.sinceId) {
+          return respond(200, { messages: [] });
+        }
+        return respond(200, {
+          messages: [
+            {
+              id: "msg-1",
+              role: "user",
+              content: "Plain arrow scroll test",
+              createdAt: "2026-03-10T00:00:00Z",
+            },
+          ],
+        });
+      }),
+      mockApi(chatThreadByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          id: "thread-arrow-scroll",
+          title: "Arrow scroll test",
+          agentId: AGENT_ID,
+          chatMessages: [],
+          latestSessionId: null,
+          activeRunIds: [],
+          draftContent: null,
+          draftAttachments: null,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-arrow-scroll" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Plain arrow scroll test")).toBeInTheDocument();
+    });
+
+    const scrollContainer = document.querySelector<HTMLElement>(
+      "[data-scroll-container]",
+    );
+    expect(scrollContainer).not.toBeNull();
+    Object.defineProperty(scrollContainer, "scrollHeight", {
+      get: () => {
+        return 1200;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(scrollContainer, "clientHeight", {
+      get: () => {
+        return 300;
+      },
+      configurable: true,
+    });
+
+    scrollContainer!.scrollTop = 100;
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    expect(scrollContainer!.scrollTop).toBe(172);
+
+    fireEvent.keyDown(document, { key: "ArrowUp" });
+    expect(scrollContainer!.scrollTop).toBe(100);
+
+    const composer = document.querySelector("textarea");
+    expect(composer).not.toBeNull();
+    fireEvent.keyDown(composer!, { key: "ArrowDown" });
+    expect(scrollContainer!.scrollTop).toBe(100);
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
@@ -371,7 +371,7 @@ describe("chat page keyboard shortcuts", () => {
     });
   });
 
-  it("plain up/down keys scroll the message list outside the composer", async () => {
+  it("plain up/down keys hand off to native message-list scrolling outside the composer", async () => {
     mockThreadList([{ id: "thread-arrow-scroll", title: "Arrow scroll test" }]);
     server.use(
       mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {
@@ -428,16 +428,17 @@ describe("chat page keyboard shortcuts", () => {
       configurable: true,
     });
 
-    scrollContainer!.scrollTop = 100;
-    fireEvent.keyDown(document, { key: "ArrowDown" });
-    expect(scrollContainer!.scrollTop).toBe(172);
+    expect(fireEvent.keyDown(document, { key: "ArrowDown" })).toBeTruthy();
+    expect(document.activeElement).toBe(scrollContainer);
 
-    fireEvent.keyDown(document, { key: "ArrowUp" });
-    expect(scrollContainer!.scrollTop).toBe(100);
+    const activeBeforeUp = document.activeElement;
+    expect(fireEvent.keyDown(document, { key: "ArrowUp" })).toBeTruthy();
+    expect(document.activeElement).toBe(activeBeforeUp);
 
     const composer = document.querySelector("textarea");
     expect(composer).not.toBeNull();
+    composer!.focus();
     fireEvent.keyDown(composer!, { key: "ArrowDown" });
-    expect(scrollContainer!.scrollTop).toBe(100);
+    expect(document.activeElement).toBe(composer);
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1739,7 +1739,8 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
         <div
           ref={setScrollContainer}
           data-scroll-container
-          className="absolute inset-0 overflow-y-auto [scrollbar-gutter:stable]"
+          tabIndex={-1}
+          className="absolute inset-0 overflow-y-auto focus:outline-none [scrollbar-gutter:stable]"
         >
           <main className="px-4 sm:px-6 py-4 items-center @container">
             <div

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -136,6 +136,7 @@ import {
 import {
   navigateToAdjacentThread$,
   scrollCurrentThread$,
+  setChatKeyboardScrollRoot$,
 } from "../../signals/chat-page/chat-keyboard.ts";
 import { sidebarChatThreads$ } from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 import {
@@ -1591,10 +1592,14 @@ export function ZeroChatThreadPage() {
   const leftThread = useGet(currentLeftThread$);
   const rightThread = useGet(currentRightThread$);
   const lightboxUrl = useGet(attachmentLightboxUrl$);
+  const setKeyboardScrollRoot = useSet(setChatKeyboardScrollRoot$);
 
   return (
     <>
-      <div className="flex flex-1 min-h-0 bg-transparent">
+      <div
+        ref={setKeyboardScrollRoot}
+        className="flex flex-1 min-h-0 bg-transparent"
+      >
         {leftThread && (
           <ChatThread key={leftThread.threadId} thread={leftThread} />
         )}


### PR DESCRIPTION
## Summary
- add chat thread step scrolling through ArrowUp/ArrowDown on web
- route plain arrow keys to the active chat pane while preserving composer/input behavior
- keep keyboard scrolling integrated with existing auto-scroll disable/cache logic

## Tests
- pnpm -C turbo/apps/platform exec vitest run src/signals/__tests__/auto-scroll.test.ts src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
- pnpm -C turbo/apps/platform exec oxlint src/signals/auto-scroll.ts src/signals/chat-page/chat-keyboard.ts src/signals/chat-page/create-chat-thread.ts src/views/zero-page/zero-chat-thread-page.tsx src/signals/__tests__/auto-scroll.test.ts src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
- pnpm -C turbo/apps/platform exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json src/signals/auto-scroll.ts src/signals/chat-page/chat-keyboard.ts src/signals/chat-page/create-chat-thread.ts src/views/zero-page/zero-chat-thread-page.tsx src/signals/__tests__/auto-scroll.test.ts src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx
- pnpm -C turbo/apps/platform exec eslint src/signals/auto-scroll.ts src/signals/chat-page/chat-keyboard.ts src/signals/chat-page/create-chat-thread.ts src/views/zero-page/zero-chat-thread-page.tsx src/signals/__tests__/auto-scroll.test.ts src/views/zero-page/__tests__/chat-keyboard-shortcuts.test.tsx --max-warnings 0

## Notes
- Full pre-commit check-types is currently blocked by existing web package type errors on main, including app/api/runners/poll/route.ts and several app/api/zero routes.