### PR TITLE
refactor(runner): split snapshot publish boundary

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -28,7 +28,7 @@
 #   bash build-template.sh \
 #     --output-dir /path/to/output \
 #     --debootstrap-dir /path/to/cache \
-#     --debootstrap-lock /path/to/locks/debootstrap.lock \
+#     --debootstrap-lock /path/to/cache/.lock \
 #     --hash <input-hash> \
 #     --disk-mb 16384 \
 #     [--mirror http://archive.ubuntu.com/ubuntu]

--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -104,6 +104,7 @@ TMP_TEMPLATE="${TEMPLATE_FILE}.tmp.$$"
 TEMPLATE_PATH="${OUTPUT_DIR}/${TEMPLATE_FILE}"
 TMP_TEMPLATE_PATH="${OUTPUT_DIR}/${TMP_TEMPLATE}"
 ROOTFS_DIR=""
+CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.2"
@@ -209,6 +210,9 @@ cleanup() {
   if ! rm -f "$TMP_TEMPLATE_PATH"; then
     cleanup_failed=1
   fi
+  if [[ -n "$CACHE_TMP_TAR" ]] && ! rm -f "$CACHE_TMP_TAR"; then
+    cleanup_failed=1
+  fi
 
   if [[ "$cleanup_failed" -ne 0 && "$status" -eq 0 ]]; then
     echo "error: template build cleanup failed" >&2
@@ -241,13 +245,19 @@ debootstrap_build() {
   else
     # --make-tarball downloads packages into a tarball without extracting.
     # It always exits non-zero ("cannot exec ...") because it skips the
-    # second stage, so we check the tarball was created instead.
-    sudo debootstrap --make-tarball="$cache_tar" noble "$ROOTFS_DIR" "$MIRROR" || true
-    if [[ ! -s "$cache_tar" ]]; then
-      echo "error: debootstrap --make-tarball failed to create $cache_tar" >&2
+    # second stage, so we check the tarball was created instead. Write to a
+    # process-scoped temp file first: a cancelled build must not publish a
+    # partial tarball under the stable cache name that another runner may reuse.
+    CACHE_TMP_TAR="${cache_tar}.tmp.$$"
+    rm -f "$CACHE_TMP_TAR"
+    sudo debootstrap --make-tarball="$CACHE_TMP_TAR" noble "$ROOTFS_DIR" "$MIRROR" || true
+    if [[ ! -s "$CACHE_TMP_TAR" ]]; then
+      echo "error: debootstrap --make-tarball failed to create $CACHE_TMP_TAR" >&2
       exit 1
     fi
-    sudo debootstrap --unpack-tarball="$(realpath "$cache_tar")" noble "$ROOTFS_DIR" "$MIRROR"
+    sudo debootstrap --unpack-tarball="$(realpath "$CACHE_TMP_TAR")" noble "$ROOTFS_DIR" "$MIRROR"
+    mv -f "$CACHE_TMP_TAR" "$cache_tar"
+    CACHE_TMP_TAR=""
   fi
 
   # Mount virtual filesystems for chroot operations.

--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -28,6 +28,7 @@
 #   bash build-template.sh \
 #     --output-dir /path/to/output \
 #     --debootstrap-dir /path/to/cache \
+#     --debootstrap-lock /path/to/locks/debootstrap.lock \
 #     --hash <input-hash> \
 #     --disk-mb 16384 \
 #     [--mirror http://archive.ubuntu.com/ubuntu]
@@ -60,6 +61,7 @@ shift
 
 OUTPUT_DIR=""
 DEBOOTSTRAP_DIR=""
+DEBOOTSTRAP_LOCK=""
 INPUT_HASH=""
 DISK_MB=""
 # Default mirror: archive.ubuntu.com only hosts amd64/i386;
@@ -74,6 +76,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --output-dir)        OUTPUT_DIR="$2";        shift 2 ;;
     --debootstrap-dir)   DEBOOTSTRAP_DIR="$2";   shift 2 ;;
+    --debootstrap-lock)  DEBOOTSTRAP_LOCK="$2";  shift 2 ;;
     --hash)              INPUT_HASH="$2";        shift 2 ;;
     --disk-mb)           DISK_MB="$2";           shift 2 ;;
     --mirror)            MIRROR="$2";            shift 2 ;;
@@ -81,7 +84,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-for var in OUTPUT_DIR DEBOOTSTRAP_DIR INPUT_HASH DISK_MB; do
+for var in OUTPUT_DIR DEBOOTSTRAP_DIR DEBOOTSTRAP_LOCK INPUT_HASH DISK_MB; do
   if [[ -z "${!var}" ]]; then
     echo "error: --$(echo "$var" | tr '_' '-' | tr '[:upper:]' '[:lower:]') is required" >&2
     exit 1
@@ -121,7 +124,7 @@ AGENT_BROWSER_VERSION="0.26.0"
 check_dependencies() {
   local missing=()
 
-  for cmd in debootstrap sudo chroot mktemp stat mkfs.ext4 umount mountpoint unshare; do
+  for cmd in debootstrap flock sudo chroot mktemp stat mkfs.ext4 umount mountpoint unshare; do
     if ! command -v "$cmd" &> /dev/null; then
       missing+=("$cmd")
     fi
@@ -231,10 +234,7 @@ trap 'echo "error: command failed at line ${LINENO}: ${BASH_COMMAND}" >&2' ERR
 # Bootstrap Ubuntu 24.04 rootfs
 # ---------------------------------------------------------------------------
 
-debootstrap_build() {
-  echo "bootstrapping Ubuntu 24.04 rootfs..."
-  ROOTFS_DIR="$(mktemp -d)"
-
+debootstrap_cache_locked() {
   # Cache the base package tarball so repeated builds (e.g. after changing
   # a pinned version) skip the ~200 MB download from the Ubuntu mirror.
   local cache_tar="${DEBOOTSTRAP_DIR}/noble-$(dpkg --print-architecture).tar"
@@ -259,6 +259,21 @@ debootstrap_build() {
     mv -f "$CACHE_TMP_TAR" "$cache_tar"
     CACHE_TMP_TAR=""
   fi
+}
+
+debootstrap_build() {
+  echo "bootstrapping Ubuntu 24.04 rootfs..."
+  ROOTFS_DIR="$(mktemp -d)"
+
+  # Only the shared tarball cache needs fleet-wide serialization. Release the
+  # lock before package installation and mkfs so distinct template builds can
+  # run concurrently after they have their private unpacked rootfs.
+  local lock_fd
+  exec {lock_fd}>>"$DEBOOTSTRAP_LOCK"
+  flock "$lock_fd"
+  debootstrap_cache_locked
+  flock -u "$lock_fd"
+  exec {lock_fd}>&-
 
   # Mount virtual filesystems for chroot operations.
   # --bind /dev recursively brings in sub-mounts (pts, shm, etc.);

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -734,7 +734,7 @@ async fn ensure_template_cached_under_lock(input: &TemplateInput<'_>) -> RunnerR
     // filesystem. Even a cache hit downloads a full template for validation,
     // and /tmp may be much smaller than the runner data disk.
     let warm_parent = template_warm_parent_dir(input.paths, input.template_hash);
-    cleanup_stale_template_attempt_dirs(&warm_parent, TEMPLATE_WARM_ATTEMPT_DIR_PREFIX).await?;
+    cleanup_template_warm_parent(&warm_parent).await?;
     let warm_dir = template_attempt_dir(&warm_parent, TEMPLATE_WARM_ATTEMPT_DIR_PREFIX);
 
     let result = async {
@@ -835,6 +835,20 @@ async fn cleanup_stale_template_attempt_dirs(parent: &Path, prefix: &str) -> Run
     }
 
     Ok(())
+}
+
+async fn cleanup_template_warm_parent(parent: &Path) -> RunnerResult<()> {
+    match tokio::fs::symlink_metadata(parent).await {
+        Ok(metadata) if metadata.is_dir() => {
+            cleanup_stale_template_attempt_dirs(parent, TEMPLATE_WARM_ATTEMPT_DIR_PREFIX).await
+        }
+        Ok(_) => remove_path_if_exists(parent, "stale template warm parent").await,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(RunnerError::Internal(format!(
+            "stat template warm parent {}: {e}",
+            parent.display()
+        ))),
+    }
 }
 
 async fn remove_path_if_exists(path: &Path, label: &str) -> RunnerResult<()> {
@@ -2850,6 +2864,22 @@ exit 1
         assert!(
             other_dir.exists(),
             "template warm cleanup for one hash must not remove another hash's active attempt"
+        );
+    }
+
+    #[tokio::test]
+    async fn template_warm_parent_cleanup_removes_stale_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
+        let parent = template_warm_parent_dir(&home, "abc123");
+        tokio::fs::create_dir_all(home.images_dir()).await.unwrap();
+        tokio::fs::write(&parent, b"not a directory").await.unwrap();
+
+        cleanup_template_warm_parent(&parent).await.unwrap();
+
+        assert!(
+            !parent.exists(),
+            "malformed warm parent file must not block later warm attempts"
         );
     }
 

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -26,6 +26,11 @@ const GUEST_MOCK_CLAUDE_DEST: &str = "/usr/local/bin/guest-mock-claude";
 const GUEST_MOCK_CODEX_DEST: &str = "/usr/local/bin/guest-mock-codex";
 const ROOTFS_DNS_NAMESERVER: &str = "8.8.8.8";
 const TEMPLATE_FILE: &str = "template.ext4";
+const TEMPLATE_DOWNLOAD_FILE: &str = "downloaded-template.ext4";
+const TEMPLATE_WARM_DIR_PREFIX: &str = "template-warm-";
+const TEMPLATE_WARM_ATTEMPT_DIR_PREFIX: &str = "attempt-";
+const TEMPLATE_BUILD_DIR_PREFIX: &str = "template-build-";
+const TEMPLATE_ATTEMPT_DIR_SUFFIX: &str = ".tmp";
 
 /// Bump to invalidate all shared template images in R2.
 ///
@@ -728,8 +733,9 @@ async fn ensure_template_cached_under_lock(input: &TemplateInput<'_>) -> RunnerR
     // Keep warm-up staging on the runner image volume, not the system temp
     // filesystem. Even a cache hit downloads a full template for validation,
     // and /tmp may be much smaller than the runner data disk.
-    let warm_dir = warm_template_dir(input.paths, input.template_hash);
-    remove_path_if_exists(&warm_dir, "stale template warm dir").await?;
+    let warm_parent = template_warm_parent_dir(input.paths, input.template_hash);
+    cleanup_stale_template_attempt_dirs(&warm_parent, TEMPLATE_WARM_ATTEMPT_DIR_PREFIX).await?;
+    let warm_dir = template_attempt_dir(&warm_parent, TEMPLATE_WARM_ATTEMPT_DIR_PREFIX);
 
     let result = async {
         tokio::fs::create_dir_all(&warm_dir).await.map_err(|e| {
@@ -784,10 +790,51 @@ async fn ensure_template_cached_under_lock(input: &TemplateInput<'_>) -> RunnerR
     finish_temp_dir_result(&warm_dir, "template warm dir", result).await
 }
 
-fn warm_template_dir(paths: &HomePaths, template_hash: &str) -> PathBuf {
+fn template_attempt_dir(parent: &Path, prefix: &str) -> PathBuf {
+    parent.join(format!(
+        "{prefix}{}{TEMPLATE_ATTEMPT_DIR_SUFFIX}",
+        uuid::Uuid::new_v4()
+    ))
+}
+
+fn template_warm_parent_dir(paths: &HomePaths, template_hash: &str) -> PathBuf {
     paths
         .images_dir()
-        .join(format!("template-{template_hash}.warm.tmp"))
+        .join(format!("{TEMPLATE_WARM_DIR_PREFIX}{template_hash}"))
+}
+
+fn is_template_attempt_dir_name(name: &str, prefix: &str) -> bool {
+    name.starts_with(prefix) && name.ends_with(TEMPLATE_ATTEMPT_DIR_SUFFIX)
+}
+
+async fn cleanup_stale_template_attempt_dirs(parent: &Path, prefix: &str) -> RunnerResult<()> {
+    let mut entries = match tokio::fs::read_dir(parent).await {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(RunnerError::Internal(format!(
+                "read template attempt parent {}: {e}",
+                parent.display()
+            )));
+        }
+    };
+
+    while let Some(entry) = entries.next_entry().await.map_err(|e| {
+        RunnerError::Internal(format!(
+            "read template attempt entry in {}: {e}",
+            parent.display()
+        ))
+    })? {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if is_template_attempt_dir_name(name, prefix) {
+            remove_path_if_exists(&entry.path(), "stale template attempt dir").await?;
+        }
+    }
+
+    Ok(())
 }
 
 async fn remove_path_if_exists(path: &Path, label: &str) -> RunnerResult<()> {
@@ -845,80 +892,80 @@ async fn obtain_template_to_staging(
     scripts: &mut RootfsScripts,
 ) -> RunnerResult<()> {
     let staging = rootfs_paths.rootfs_staging();
-    let build_dir = template_build_dir(rootfs_paths);
-    remove_path_if_exists(&build_dir, "stale template build dir").await?;
+    cleanup_stale_template_attempt_dirs(rootfs_paths.dir(), TEMPLATE_BUILD_DIR_PREFIX).await?;
+    let attempt_dir = template_attempt_dir(rootfs_paths.dir(), TEMPLATE_BUILD_DIR_PREFIX);
+    let downloaded_template = attempt_dir.join(TEMPLATE_DOWNLOAD_FILE);
     let mut force_reupload = false;
 
-    if let Some(cache) = input.cache.as_cache() {
-        match cache
-            .try_download_template_to_file(input.template_hash, &staging)
-            .await
-        {
-            Ok(true) => {
-                let work_dir_path = scripts.path().await?;
-                if let Err(e) = verify_template_file(&staging, &work_dir_path).await {
-                    tracing::warn!(
-                        "R2 template object for {} failed validation ({e}) — \
-                         rebuilding locally and force-overwriting the bad object",
-                        input.template_hash
-                    );
-                    let _ = tokio::fs::remove_file(&staging).await;
-                    force_reupload = true;
-                } else {
-                    tracing::info!(
-                        "[OK] template downloaded from R2 into staging: {}",
-                        staging.display()
-                    );
-                    return Ok(());
+    let result = async {
+        if let Some(cache) = input.cache.as_cache() {
+            match cache
+                .try_download_template_to_file(input.template_hash, &downloaded_template)
+                .await
+            {
+                Ok(true) => {
+                    let work_dir_path = scripts.path().await?;
+                    if let Err(e) = verify_template_file(&downloaded_template, &work_dir_path).await
+                    {
+                        tracing::warn!(
+                            "R2 template object for {} failed validation ({e}) — \
+                             rebuilding locally and force-overwriting the bad object",
+                            input.template_hash
+                        );
+                        force_reupload = true;
+                    } else {
+                        move_file_sync(&downloaded_template, &staging, "materialize template")?;
+                        tracing::info!(
+                            "[OK] template downloaded from R2 into staging: {}",
+                            staging.display()
+                        );
+                        return Ok(());
+                    }
                 }
-            }
-            Ok(false) => tracing::info!(
-                "R2 template cache miss for {} — building locally",
-                input.template_hash
-            ),
-            Err(e) => {
-                if e.is_invalid_object() {
-                    tracing::warn!(
-                        "R2 template object for {} is invalid ({e}) — \
-                         rebuilding locally and force-overwriting the bad object",
-                        input.template_hash
-                    );
-                    force_reupload = true;
-                } else if input.cache.is_required() {
-                    return Err(RunnerError::Internal(format!(
-                        "R2 template download failed while warming cache: {e}"
-                    )));
-                } else {
-                    tracing::warn!(
-                        "R2 template download failed: {e} — falling back to local build"
-                    );
+                Ok(false) => tracing::info!(
+                    "R2 template cache miss for {} — building locally",
+                    input.template_hash
+                ),
+                Err(e) => {
+                    if e.is_invalid_object() {
+                        tracing::warn!(
+                            "R2 template object for {} is invalid ({e}) — \
+                             rebuilding locally and force-overwriting the bad object",
+                            input.template_hash
+                        );
+                        force_reupload = true;
+                    } else if input.cache.is_required() {
+                        return Err(RunnerError::Internal(format!(
+                            "R2 template download failed while warming cache: {e}"
+                        )));
+                    } else {
+                        tracing::warn!(
+                            "R2 template download failed: {e} — falling back to local build"
+                        );
+                    }
                 }
             }
         }
-    }
 
-    let work_dir_path = scripts.path().await?;
-    let result = async {
-        build_template_locally(input, &build_dir, &work_dir_path).await?;
-        let built_template = build_dir.join(TEMPLATE_FILE);
+        let work_dir_path = scripts.path().await?;
+        build_template_locally(input, &attempt_dir, &work_dir_path).await?;
+        let built_template = attempt_dir.join(TEMPLATE_FILE);
         upload_template_to_r2(input, &built_template, force_reupload).await?;
-        tokio::fs::rename(&built_template, &staging)
-            .await
-            .map_err(|e| {
-                RunnerError::Internal(format!(
-                    "move template {} → {}: {e}",
-                    built_template.display(),
-                    staging.display()
-                ))
-            })
+        move_file_sync(&built_template, &staging, "move template to staging")
     }
     .await;
 
-    finish_temp_dir_result(&build_dir, "template build dir", result).await
+    finish_temp_dir_result(&attempt_dir, "template build dir", result).await
 }
 
-fn template_build_dir(rootfs_paths: &RootfsPaths) -> PathBuf {
-    rootfs_paths.dir().join("template.tmp")
+fn move_file_sync(source: &Path, destination: &Path, label: &str) -> RunnerResult<()> {
+    std::fs::rename(source, destination).map_err(|e| {
+        RunnerError::Internal(format!(
+            "{label} {} → {}: {e}",
+            source.display(),
+            destination.display()
+        ))
+    })
 }
 
 struct RootfsScripts {
@@ -2104,17 +2151,25 @@ exit 1
     }
 
     #[test]
-    fn warm_template_dir_stays_on_runner_image_volume() {
+    fn warm_template_attempt_dir_stays_on_runner_image_volume() {
         let dir = tempfile::tempdir().unwrap();
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
+        let images_dir = home.images_dir();
+        let warm_parent = template_warm_parent_dir(&home, "abc123");
 
-        let warm_dir = warm_template_dir(&home, "abc123");
+        let warm_dir = template_attempt_dir(&warm_parent, TEMPLATE_WARM_ATTEMPT_DIR_PREFIX);
+        let file_name = warm_dir.file_name().and_then(|name| name.to_str()).unwrap();
 
-        assert!(warm_dir.starts_with(home.images_dir()));
-        assert_eq!(
-            warm_dir.file_name().and_then(|name| name.to_str()),
-            Some("template-abc123.warm.tmp")
-        );
+        assert!(warm_dir.starts_with(&images_dir));
+        assert!(warm_dir.starts_with(&warm_parent));
+        assert!(!is_template_attempt_dir_name(
+            file_name,
+            TEMPLATE_BUILD_DIR_PREFIX
+        ));
+        assert!(is_template_attempt_dir_name(
+            file_name,
+            TEMPLATE_WARM_ATTEMPT_DIR_PREFIX
+        ));
     }
 
     #[tokio::test]
@@ -2599,9 +2654,9 @@ exit 1
         assert_eq!(content, b"customized");
     }
 
-    /// End-to-end contract simulation for the template-download + customization
-    /// path: template arrives directly in staging, customization mutates
-    /// staging, and commit atomically publishes the rootfs.
+    /// End-to-end contract simulation for the template materialization +
+    /// customization path: the verified template is moved into staging,
+    /// customization mutates staging, and commit atomically publishes the rootfs.
     #[tokio::test]
     async fn staging_contract_happy_path() {
         let dir = tempfile::tempdir().unwrap();
@@ -2610,7 +2665,7 @@ exit 1
         let publish = LocalFilePublish::for_rootfs(&rootfs);
         tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
 
-        // Simulate template R2 download directly into staging.
+        // Simulate a verified template being moved into staging.
         tokio::fs::write(rootfs.rootfs_staging(), b"template-download")
             .await
             .unwrap();
@@ -2652,11 +2707,14 @@ exit 1
     }
 
     #[tokio::test]
-    async fn stale_template_build_dir_is_removed_before_reuse() {
+    async fn stale_template_attempt_dir_is_removed_before_reuse() {
         let dir = tempfile::tempdir().unwrap();
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
         let rootfs = RootfsPaths::new(&home, "template-build-residue-hash");
-        let build_dir = template_build_dir(&rootfs);
+        tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
+        let build_dir = rootfs.dir().join(format!(
+            "{TEMPLATE_BUILD_DIR_PREFIX}old{TEMPLATE_ATTEMPT_DIR_SUFFIX}"
+        ));
         tokio::fs::create_dir_all(build_dir.join("nested"))
             .await
             .unwrap();
@@ -2664,7 +2722,7 @@ exit 1
             .await
             .unwrap();
 
-        remove_path_if_exists(&build_dir, "stale template build dir")
+        cleanup_stale_template_attempt_dirs(rootfs.dir(), TEMPLATE_BUILD_DIR_PREFIX)
             .await
             .unwrap();
 
@@ -2675,23 +2733,47 @@ exit 1
     }
 
     #[tokio::test]
-    async fn stale_template_build_file_is_removed_before_reuse() {
+    async fn stale_template_attempt_file_is_removed_before_reuse() {
         let dir = tempfile::tempdir().unwrap();
         let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
         let rootfs = RootfsPaths::new(&home, "template-build-file-residue-hash");
-        let build_dir = template_build_dir(&rootfs);
         tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
+        let build_dir = rootfs.dir().join(format!(
+            "{TEMPLATE_BUILD_DIR_PREFIX}old{TEMPLATE_ATTEMPT_DIR_SUFFIX}"
+        ));
         tokio::fs::write(&build_dir, b"not a directory")
             .await
             .unwrap();
 
-        remove_path_if_exists(&build_dir, "stale template build dir")
+        cleanup_stale_template_attempt_dirs(rootfs.dir(), TEMPLATE_BUILD_DIR_PREFIX)
             .await
             .unwrap();
 
         assert!(
             !build_dir.exists(),
             "stale local template build file must not block later template materialization"
+        );
+    }
+
+    #[tokio::test]
+    async fn template_attempt_cleanup_preserves_other_hash_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
+        let this_parent = template_warm_parent_dir(&home, "this-hash");
+        let other_parent = template_warm_parent_dir(&home, "other-hash");
+        let this_dir = template_attempt_dir(&this_parent, TEMPLATE_WARM_ATTEMPT_DIR_PREFIX);
+        let other_dir = template_attempt_dir(&other_parent, TEMPLATE_WARM_ATTEMPT_DIR_PREFIX);
+        tokio::fs::create_dir_all(&this_dir).await.unwrap();
+        tokio::fs::create_dir_all(&other_dir).await.unwrap();
+
+        cleanup_stale_template_attempt_dirs(&this_parent, TEMPLATE_WARM_ATTEMPT_DIR_PREFIX)
+            .await
+            .unwrap();
+
+        assert!(!this_dir.exists());
+        assert!(
+            other_dir.exists(),
+            "template warm cleanup for one hash must not remove another hash's active attempt"
         );
     }
 

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -1121,16 +1121,16 @@ async fn build_template_locally(
         .map_err(|e| RunnerError::Internal(format!("create {}: {e}", output_dir.display())))?;
 
     // Local template build — the slow path (debootstrap + apt install).
-    let debootstrap_lock_path = input.paths.debootstrap_lock();
-    tracing::info!(
-        "acquiring exclusive debootstrap cache lock for template build: {}",
-        debootstrap_lock_path.display()
-    );
-    let _debootstrap_lock = lock::acquire(debootstrap_lock_path).await?;
     let debootstrap_dir = input.paths.debootstrap_dir();
     tokio::fs::create_dir_all(&debootstrap_dir)
         .await
         .map_err(|e| RunnerError::Internal(format!("create {}: {e}", debootstrap_dir.display())))?;
+    let locks_dir = input.paths.locks_dir();
+    tokio::fs::create_dir_all(&locks_dir)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("create {}: {e}", locks_dir.display())))?;
+    let debootstrap_lock_path = input.paths.debootstrap_lock();
+    drop(lock::open_lock_file(&debootstrap_lock_path)?);
     let disk_mb_str = input.disk_mb.to_string();
 
     let mut cmd = rootfs_script_command(&work_dir.join("build-template.sh"));
@@ -1138,6 +1138,8 @@ async fn build_template_locally(
         .arg(output_dir)
         .arg("--debootstrap-dir")
         .arg(&debootstrap_dir)
+        .arg("--debootstrap-lock")
+        .arg(&debootstrap_lock_path)
         .arg("--hash")
         .arg(input.template_hash)
         .arg("--disk-mb")
@@ -3067,6 +3069,30 @@ exit 1
         assert!(
             !TEMPLATE_BUILD_SCRIPT.contains(r#"--make-tarball="$cache_tar""#),
             "build-template.sh must not publish partial debootstrap cache tarballs on cancellation"
+        );
+    }
+
+    #[test]
+    fn build_script_locks_only_debootstrap_cache_access() {
+        assert!(
+            TEMPLATE_BUILD_SCRIPT.contains("--debootstrap-lock"),
+            "build-template.sh should receive the same debootstrap cache lock path used by GC"
+        );
+        assert!(
+            TEMPLATE_BUILD_SCRIPT.contains("flock \"$lock_fd\""),
+            "build-template.sh should lock shared debootstrap cache access"
+        );
+        assert!(
+            TEMPLATE_BUILD_SCRIPT.contains("exec {lock_fd}>>\"$DEBOOTSTRAP_LOCK\""),
+            "build-template.sh should open the pre-created lock file without truncating it"
+        );
+        assert!(
+            TEMPLATE_BUILD_SCRIPT.contains("flock -u \"$lock_fd\""),
+            "build-template.sh should release the debootstrap cache lock after unpack"
+        );
+        assert!(
+            TEMPLATE_BUILD_SCRIPT.contains("debootstrap_cache_locked\n  flock -u"),
+            "build-template.sh should release the cache lock before chroot package install and mkfs"
         );
     }
 

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -642,7 +642,8 @@ async fn build_snapshot(
         memory_mb: def.memory_mb,
     };
 
-    let output = provider.create_snapshot(create_config).await?;
+    let pending = provider.create_uncommitted_snapshot(create_config).await?;
+    let output = pending.commit().await?;
 
     let (snapshot_sz, memory_sz, cow_sz) = tokio::join!(
         file_sizes(&output.snapshot_path),
@@ -1414,6 +1415,10 @@ fn human_bytes(bytes: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
 
     #[derive(clap::Parser)]
     struct TestBuildCli {
@@ -1471,6 +1476,71 @@ mod tests {
             guest_mock_claude: guest.clone(),
             guest_mock_codex: guest.clone(),
             guest_reseed: guest,
+        }
+    }
+
+    struct RecordingPendingSnapshotPublish {
+        output_dir: PathBuf,
+        committed: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl sandbox::PendingSnapshotPublish for RecordingPendingSnapshotPublish {
+        async fn commit(
+            self: Box<Self>,
+        ) -> Result<sandbox::SnapshotOutput, sandbox::SnapshotError> {
+            self.committed.store(true, Ordering::SeqCst);
+            let output = sandbox::SnapshotOutput {
+                snapshot_path: self.output_dir.join("snapshot.bin"),
+                memory_path: self.output_dir.join("memory.bin"),
+                cow_path: self.output_dir.join("cow.img"),
+            };
+            tokio::fs::write(&output.snapshot_path, b"snapshot").await?;
+            tokio::fs::write(&output.memory_path, b"memory").await?;
+            tokio::fs::write(&output.cow_path, b"cow").await?;
+            Ok(output)
+        }
+
+        async fn discard(self: Box<Self>) -> Result<(), sandbox::SnapshotError> {
+            Ok(())
+        }
+    }
+
+    struct RecordingSnapshotProvider {
+        create_uncommitted_called: Arc<AtomicBool>,
+        create_snapshot_called: Arc<AtomicBool>,
+        committed: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl SnapshotProvider for RecordingSnapshotProvider {
+        async fn create_uncommitted_snapshot(
+            &self,
+            config: sandbox::SnapshotCreateConfig,
+        ) -> Result<Box<dyn sandbox::PendingSnapshotPublish>, sandbox::SnapshotError> {
+            self.create_uncommitted_called.store(true, Ordering::SeqCst);
+            Ok(Box::new(RecordingPendingSnapshotPublish {
+                output_dir: config.output_dir,
+                committed: Arc::clone(&self.committed),
+            }))
+        }
+
+        async fn create_snapshot(
+            &self,
+            _config: sandbox::SnapshotCreateConfig,
+        ) -> Result<sandbox::SnapshotOutput, sandbox::SnapshotError> {
+            self.create_snapshot_called.store(true, Ordering::SeqCst);
+            Err(sandbox::SnapshotError::Setup(
+                "build_snapshot should use create_uncommitted_snapshot".into(),
+            ))
+        }
+
+        fn config_hash(&self) -> String {
+            "recording-provider".into()
+        }
+
+        async fn is_complete(&self, _output_dir: &Path) -> Result<bool, sandbox::SnapshotError> {
+            Ok(false)
         }
     }
 
@@ -1691,6 +1761,52 @@ exit 1
 
         assert_eq!(resolved, tmp_dir.path().join("guest-agent"));
         assert_eq!(tokio::fs::read(&resolved).await.unwrap(), b"old-binary");
+    }
+
+    #[tokio::test]
+    async fn build_snapshot_uses_explicit_pending_publish_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        let rootfs_paths = RootfsPaths::new(&home, "rootfs-hash");
+        tokio::fs::create_dir_all(rootfs_paths.dir()).await.unwrap();
+        tokio::fs::write(rootfs_paths.rootfs(), b"rootfs")
+            .await
+            .unwrap();
+        let snapshot_dir = dir.path().join("snapshot");
+        let create_uncommitted_called = Arc::new(AtomicBool::new(false));
+        let create_snapshot_called = Arc::new(AtomicBool::new(false));
+        let committed = Arc::new(AtomicBool::new(false));
+        let provider = RecordingSnapshotProvider {
+            create_uncommitted_called: Arc::clone(&create_uncommitted_called),
+            create_snapshot_called: Arc::clone(&create_snapshot_called),
+            committed: Arc::clone(&committed),
+        };
+        let def = profile::ProfileDef {
+            vcpu: 1,
+            memory_mb: 128,
+            disk_mb: 16,
+        };
+
+        build_snapshot(
+            &home,
+            &rootfs_paths,
+            "snapshot-hash",
+            &snapshot_dir,
+            &def,
+            &provider,
+        )
+        .await
+        .unwrap();
+
+        assert!(create_uncommitted_called.load(Ordering::SeqCst));
+        assert!(committed.load(Ordering::SeqCst));
+        assert!(
+            !create_snapshot_called.load(Ordering::SeqCst),
+            "build_snapshot should not use the compatibility create_snapshot path"
+        );
+        assert!(snapshot_dir.join("snapshot.bin").exists());
+        assert!(snapshot_dir.join("memory.bin").exists());
+        assert!(snapshot_dir.join("cow.img").exists());
     }
 
     #[test]

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -1554,6 +1554,7 @@ mod tests {
 
     struct FailingPendingSnapshotPublish {
         discarded: Arc<AtomicBool>,
+        discard_error: Option<&'static str>,
     }
 
     #[async_trait::async_trait]
@@ -1564,12 +1565,16 @@ mod tests {
 
         async fn discard(&mut self) -> Result<(), sandbox::SnapshotError> {
             self.discarded.store(true, Ordering::SeqCst);
-            Ok(())
+            match self.discard_error {
+                Some(message) => Err(sandbox::SnapshotError::Teardown(message.into())),
+                None => Ok(()),
+            }
         }
     }
 
     struct FailingSnapshotProvider {
         discarded: Arc<AtomicBool>,
+        discard_error: Option<&'static str>,
     }
 
     #[async_trait::async_trait]
@@ -1580,6 +1585,7 @@ mod tests {
         ) -> Result<Box<dyn sandbox::PendingSnapshotPublish>, sandbox::SnapshotError> {
             Ok(Box::new(FailingPendingSnapshotPublish {
                 discarded: Arc::clone(&self.discarded),
+                discard_error: self.discard_error,
             }))
         }
 
@@ -1870,6 +1876,7 @@ exit 1
         let discarded = Arc::new(AtomicBool::new(false));
         let provider = FailingSnapshotProvider {
             discarded: Arc::clone(&discarded),
+            discard_error: None,
         };
         let def = profile::ProfileDef {
             vcpu: 1,
@@ -1895,6 +1902,48 @@ exit 1
         assert!(
             discarded.load(Ordering::SeqCst),
             "build_snapshot should explicitly discard after commit failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_snapshot_preserves_commit_error_when_discard_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        let rootfs_paths = RootfsPaths::new(&home, "rootfs-hash");
+        tokio::fs::create_dir_all(rootfs_paths.dir()).await.unwrap();
+        tokio::fs::write(rootfs_paths.rootfs(), b"rootfs")
+            .await
+            .unwrap();
+        let snapshot_dir = dir.path().join("snapshot");
+        let discarded = Arc::new(AtomicBool::new(false));
+        let provider = FailingSnapshotProvider {
+            discarded: Arc::clone(&discarded),
+            discard_error: Some("discard failed"),
+        };
+        let def = profile::ProfileDef {
+            vcpu: 1,
+            memory_mb: 128,
+            disk_mb: 16,
+        };
+
+        let err = build_snapshot(
+            &home,
+            &rootfs_paths,
+            "snapshot-hash",
+            &snapshot_dir,
+            &def,
+            &provider,
+        )
+        .await
+        .expect_err("snapshot publish should fail");
+
+        assert!(
+            matches!(err, RunnerError::Snapshot(sandbox::SnapshotError::Teardown(ref message)) if message == "publish failed"),
+            "discard failure must not mask the publish failure, got: {err:?}"
+        );
+        assert!(
+            discarded.load(Ordering::SeqCst),
+            "build_snapshot should still try discard after commit failure"
         );
     }
 

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -3060,6 +3060,11 @@ exit 1
             "build-template.sh should atomically publish the verified debootstrap cache tarball"
         );
         assert!(
+            TEMPLATE_BUILD_SCRIPT
+                .contains(r#"[[ -n "$CACHE_TMP_TAR" ]] && ! rm -f "$CACHE_TMP_TAR""#),
+            "build-template.sh should remove unpublished debootstrap cache temp files on cleanup"
+        );
+        assert!(
             !TEMPLATE_BUILD_SCRIPT.contains(r#"--make-tarball="$cache_tar""#),
             "build-template.sh must not publish partial debootstrap cache tarballs on cancellation"
         );

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -1125,10 +1125,6 @@ async fn build_template_locally(
     tokio::fs::create_dir_all(&debootstrap_dir)
         .await
         .map_err(|e| RunnerError::Internal(format!("create {}: {e}", debootstrap_dir.display())))?;
-    let locks_dir = input.paths.locks_dir();
-    tokio::fs::create_dir_all(&locks_dir)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("create {}: {e}", locks_dir.display())))?;
     let debootstrap_lock_path = input.paths.debootstrap_lock();
     drop(lock::open_lock_file(&debootstrap_lock_path)?);
     let disk_mb_str = input.disk_mb.to_string();

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -819,17 +819,6 @@ async fn remove_dir_all_if_exists(path: &Path, label: &str) -> RunnerResult<()> 
     }
 }
 
-async fn remove_file_if_exists(path: &Path, label: &str) -> RunnerResult<()> {
-    match tokio::fs::remove_file(path).await {
-        Ok(()) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(RunnerError::Internal(format!(
-            "remove {label} {}: {e}",
-            path.display()
-        ))),
-    }
-}
-
 async fn finish_temp_dir_result(
     path: &Path,
     label: &str,
@@ -1216,30 +1205,30 @@ impl LocalFilePublish {
     /// so any staging file is crash residue, not a live writer's in-progress
     /// file. Non-existence is the common case and not logged. Removal is best
     /// effort: a failure here leaves the next write step to fail or overwrite.
+    ///
+    /// Keep this synchronous while the caller owns the rootfs lock. A cancelled
+    /// Tokio fs operation can continue on the blocking pool after the lock is
+    /// dropped, which is not safe for the fixed staging path.
     async fn cleanup_stale_staging_best_effort(&self) {
-        match tokio::fs::try_exists(&self.staging).await {
-            Ok(true) => {
+        match std::fs::symlink_metadata(&self.staging) {
+            Ok(metadata) => {
                 tracing::warn!(
                     "removing stale rootfs staging file from a previous failed build: {}",
                     self.staging.display()
                 );
-                if let Err(e) = tokio::fs::remove_file(&self.staging).await {
-                    if e.kind() == std::io::ErrorKind::IsADirectory {
-                        if let Err(dir_err) = tokio::fs::remove_dir_all(&self.staging).await {
-                            tracing::warn!(
-                                "failed to remove stale staging directory {}: {dir_err}",
-                                self.staging.display()
-                            );
-                        }
-                    } else {
-                        tracing::warn!(
-                            "failed to remove stale staging file {}: {e}",
-                            self.staging.display()
-                        );
-                    }
+                let result = if metadata.file_type().is_dir() {
+                    std::fs::remove_dir_all(&self.staging)
+                } else {
+                    std::fs::remove_file(&self.staging)
+                };
+                if let Err(e) = result {
+                    tracing::warn!(
+                        "failed to remove stale staging path {}: {e}",
+                        self.staging.display()
+                    );
                 }
             }
-            Ok(false) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => {
                 tracing::warn!(
                     "check staging {}: {e} (continuing; any residue will be overwritten)",
@@ -1254,22 +1243,20 @@ impl LocalFilePublish {
     /// Same-filesystem rename is POSIX-atomic, so this is the single step
     /// that makes the published file visible to future presence checks.
     async fn commit(&self) -> RunnerResult<()> {
-        tokio::fs::rename(&self.staging, &self.stable)
-            .await
-            .map_err(|e| {
-                RunnerError::Internal(format!(
-                    "commit rootfs {} → {}: {e}",
-                    self.staging.display(),
-                    self.stable.display()
-                ))
-            })
+        std::fs::rename(&self.staging, &self.stable).map_err(|e| {
+            RunnerError::Internal(format!(
+                "commit rootfs {} → {}: {e}",
+                self.staging.display(),
+                self.stable.display()
+            ))
+        })
     }
 
     async fn finish_after_result(&self, result: RunnerResult<()>) -> RunnerResult<()> {
         match result {
             Ok(()) => Ok(()),
             Err(original_err) => {
-                match remove_file_if_exists(&self.staging, "failed rootfs staging file").await {
+                match remove_file_if_exists_sync(&self.staging, "failed rootfs staging file") {
                     Ok(()) => Err(original_err),
                     Err(cleanup_err) => {
                         tracing::warn!(
@@ -1281,6 +1268,17 @@ impl LocalFilePublish {
                 }
             }
         }
+    }
+}
+
+fn remove_file_if_exists_sync(path: &Path, label: &str) -> RunnerResult<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(RunnerError::Internal(format!(
+            "remove {label} {}: {e}",
+            path.display()
+        ))),
     }
 }
 

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -787,7 +787,7 @@ async fn ensure_template_cached_under_lock(input: &TemplateInput<'_>) -> RunnerR
     }
     .await;
 
-    finish_temp_dir_result(&warm_dir, "template warm dir", result).await
+    finish_template_warm_dir_result(&warm_parent, &warm_dir, result).await
 }
 
 fn template_attempt_dir(parent: &Path, prefix: &str) -> PathBuf {
@@ -883,6 +883,45 @@ async fn finish_temp_dir_result(
             );
             Err(original_err)
         }
+    }
+}
+
+async fn finish_template_warm_dir_result(
+    parent: &Path,
+    attempt: &Path,
+    result: RunnerResult<()>,
+) -> RunnerResult<()> {
+    let result = finish_temp_dir_result(attempt, "template warm dir", result).await;
+    match remove_empty_dir_if_exists(parent).await {
+        Ok(()) => result,
+        Err(parent_err) => match result {
+            Ok(()) => Err(parent_err),
+            Err(original_err) => {
+                tracing::warn!(
+                    "failed to remove template warm parent {} after an earlier error: {parent_err}",
+                    parent.display()
+                );
+                Err(original_err)
+            }
+        },
+    }
+}
+
+async fn remove_empty_dir_if_exists(path: &Path) -> RunnerResult<()> {
+    match tokio::fs::remove_dir(path).await {
+        Ok(()) => Ok(()),
+        Err(e)
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::DirectoryNotEmpty
+            ) =>
+        {
+            Ok(())
+        }
+        Err(e) => Err(RunnerError::Internal(format!(
+            "remove empty template warm parent {}: {e}",
+            path.display()
+        ))),
     }
 }
 
@@ -2210,6 +2249,43 @@ exit 1
             err.to_string().contains("original failure"),
             "original error should win when operation and cleanup both fail, got {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn template_warm_cleanup_removes_empty_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
+        let parent = template_warm_parent_dir(&home, "abc123");
+        let attempt = template_attempt_dir(&parent, TEMPLATE_WARM_ATTEMPT_DIR_PREFIX);
+        tokio::fs::create_dir_all(&attempt).await.unwrap();
+
+        finish_template_warm_dir_result(&parent, &attempt, Ok(()))
+            .await
+            .unwrap();
+
+        assert!(!attempt.exists());
+        assert!(
+            !parent.exists(),
+            "successful warm cleanup should not leave empty parent dirs"
+        );
+    }
+
+    #[tokio::test]
+    async fn template_warm_cleanup_preserves_original_error_when_parent_cleanup_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("not-a-dir");
+        let attempt = parent.join("attempt");
+        tokio::fs::write(&parent, b"file").await.unwrap();
+
+        let err = finish_template_warm_dir_result(
+            &parent,
+            &attempt,
+            Err(RunnerError::Internal("warm failed".into())),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.to_string().contains("warm failed"));
     }
 
     #[test]

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -1121,6 +1121,12 @@ async fn build_template_locally(
         .map_err(|e| RunnerError::Internal(format!("create {}: {e}", output_dir.display())))?;
 
     // Local template build — the slow path (debootstrap + apt install).
+    let debootstrap_lock_path = input.paths.debootstrap_lock();
+    tracing::info!(
+        "acquiring exclusive debootstrap cache lock for template build: {}",
+        debootstrap_lock_path.display()
+    );
+    let _debootstrap_lock = lock::acquire(debootstrap_lock_path).await?;
     let debootstrap_dir = input.paths.debootstrap_dir();
     tokio::fs::create_dir_all(&debootstrap_dir)
         .await

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -642,8 +642,20 @@ async fn build_snapshot(
         memory_mb: def.memory_mb,
     };
 
-    let pending = provider.create_uncommitted_snapshot(create_config).await?;
-    let output = pending.commit().await?;
+    let mut pending = provider.create_uncommitted_snapshot(create_config).await?;
+    let output = match pending.commit().await {
+        Ok(output) => output,
+        Err(err) => {
+            if let Err(discard_err) = pending.discard().await {
+                tracing::warn!(
+                    error = %discard_err,
+                    snapshot_dir = %snapshot_dir.display(),
+                    "failed to discard uncommitted snapshot after publish failure"
+                );
+            }
+            return Err(err.into());
+        }
+    };
 
     let (snapshot_sz, memory_sz, cow_sz) = tokio::join!(
         file_sizes(&output.snapshot_path),
@@ -1486,9 +1498,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl sandbox::PendingSnapshotPublish for RecordingPendingSnapshotPublish {
-        async fn commit(
-            self: Box<Self>,
-        ) -> Result<sandbox::SnapshotOutput, sandbox::SnapshotError> {
+        async fn commit(&mut self) -> Result<sandbox::SnapshotOutput, sandbox::SnapshotError> {
             self.committed.store(true, Ordering::SeqCst);
             let output = sandbox::SnapshotOutput {
                 snapshot_path: self.output_dir.join("snapshot.bin"),
@@ -1501,7 +1511,7 @@ mod tests {
             Ok(output)
         }
 
-        async fn discard(self: Box<Self>) -> Result<(), sandbox::SnapshotError> {
+        async fn discard(&mut self) -> Result<(), sandbox::SnapshotError> {
             Ok(())
         }
     }
@@ -1537,6 +1547,46 @@ mod tests {
 
         fn config_hash(&self) -> String {
             "recording-provider".into()
+        }
+
+        async fn is_complete(&self, _output_dir: &Path) -> Result<bool, sandbox::SnapshotError> {
+            Ok(false)
+        }
+    }
+
+    struct FailingPendingSnapshotPublish {
+        discarded: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl sandbox::PendingSnapshotPublish for FailingPendingSnapshotPublish {
+        async fn commit(&mut self) -> Result<sandbox::SnapshotOutput, sandbox::SnapshotError> {
+            Err(sandbox::SnapshotError::Teardown("publish failed".into()))
+        }
+
+        async fn discard(&mut self) -> Result<(), sandbox::SnapshotError> {
+            self.discarded.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    struct FailingSnapshotProvider {
+        discarded: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl SnapshotProvider for FailingSnapshotProvider {
+        async fn create_uncommitted_snapshot(
+            &self,
+            _config: sandbox::SnapshotCreateConfig,
+        ) -> Result<Box<dyn sandbox::PendingSnapshotPublish>, sandbox::SnapshotError> {
+            Ok(Box::new(FailingPendingSnapshotPublish {
+                discarded: Arc::clone(&self.discarded),
+            }))
+        }
+
+        fn config_hash(&self) -> String {
+            "failing-provider".into()
         }
 
         async fn is_complete(&self, _output_dir: &Path) -> Result<bool, sandbox::SnapshotError> {
@@ -1807,6 +1857,47 @@ exit 1
         assert!(snapshot_dir.join("snapshot.bin").exists());
         assert!(snapshot_dir.join("memory.bin").exists());
         assert!(snapshot_dir.join("cow.img").exists());
+    }
+
+    #[tokio::test]
+    async fn build_snapshot_discards_pending_publish_after_commit_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        let rootfs_paths = RootfsPaths::new(&home, "rootfs-hash");
+        tokio::fs::create_dir_all(rootfs_paths.dir()).await.unwrap();
+        tokio::fs::write(rootfs_paths.rootfs(), b"rootfs")
+            .await
+            .unwrap();
+        let snapshot_dir = dir.path().join("snapshot");
+        let discarded = Arc::new(AtomicBool::new(false));
+        let provider = FailingSnapshotProvider {
+            discarded: Arc::clone(&discarded),
+        };
+        let def = profile::ProfileDef {
+            vcpu: 1,
+            memory_mb: 128,
+            disk_mb: 16,
+        };
+
+        let err = build_snapshot(
+            &home,
+            &rootfs_paths,
+            "snapshot-hash",
+            &snapshot_dir,
+            &def,
+            &provider,
+        )
+        .await
+        .expect_err("snapshot publish should fail");
+
+        assert!(
+            matches!(err, RunnerError::Snapshot(sandbox::SnapshotError::Teardown(ref message)) if message == "publish failed"),
+            "got: {err:?}"
+        );
+        assert!(
+            discarded.load(Ordering::SeqCst),
+            "build_snapshot should explicitly discard after commit failure"
+        );
     }
 
     #[test]

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -3042,6 +3042,30 @@ exit 1
     }
 
     #[test]
+    fn build_script_publishes_debootstrap_cache_atomically() {
+        assert!(
+            TEMPLATE_BUILD_SCRIPT.contains(r#"CACHE_TMP_TAR="${cache_tar}.tmp.$$""#),
+            "build-template.sh should stage debootstrap cache writes in a process-scoped temp file"
+        );
+        assert!(
+            TEMPLATE_BUILD_SCRIPT.contains(r#"--make-tarball="$CACHE_TMP_TAR""#),
+            "build-template.sh must not write debootstrap output directly to the stable cache path"
+        );
+        assert!(
+            TEMPLATE_BUILD_SCRIPT.contains(r#"--unpack-tarball="$(realpath "$CACHE_TMP_TAR")""#),
+            "build-template.sh should validate the temp tarball before publishing it"
+        );
+        assert!(
+            TEMPLATE_BUILD_SCRIPT.contains(r#"mv -f "$CACHE_TMP_TAR" "$cache_tar""#),
+            "build-template.sh should atomically publish the verified debootstrap cache tarball"
+        );
+        assert!(
+            !TEMPLATE_BUILD_SCRIPT.contains(r#"--make-tarball="$cache_tar""#),
+            "build-template.sh must not publish partial debootstrap cache tarballs on cancellation"
+        );
+    }
+
+    #[test]
     fn rootfs_scripts_enter_private_mount_namespace() {
         for (name, script) in [
             ("build-template.sh", TEMPLATE_BUILD_SCRIPT),

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -2147,6 +2147,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gc_nested_images_keeps_recent_current_template_warm_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let warm_dir = home.images_dir().join("template-warm-abc123");
+        std::fs::create_dir_all(&warm_dir).unwrap();
+        std::fs::write(warm_dir.join("attempt-new.tmp"), b"partial").unwrap();
+
+        let freed = gc_nested_images(&home, Some(0), false).await.unwrap();
+
+        assert_eq!(freed, 0);
+        assert!(
+            warm_dir.exists(),
+            "recent warm rootfs dir must survive the GC grace window"
+        );
+    }
+
+    #[tokio::test]
     async fn gc_nested_images_removes_stale_template_warm_dir() {
         use std::fs::FileTimes;
 

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -1860,6 +1860,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gc_debootstrap_missing_cache_dir_does_not_create_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+
+        let freed = gc_debootstrap(&home, Some(0), false).await.unwrap();
+
+        assert_eq!(freed, 0);
+        assert!(
+            !home.debootstrap_dir().exists(),
+            "missing debootstrap cache dir should remain absent"
+        );
+        assert!(
+            !home.debootstrap_lock().exists(),
+            "GC must not create the debootstrap lock when there is no cache dir"
+        );
+    }
+
+    #[tokio::test]
     async fn gc_debootstrap_skips_when_cache_lock_is_held() {
         use std::fs::FileTimes;
 
@@ -1911,6 +1929,33 @@ mod tests {
         assert!(
             lock_path.exists(),
             "debootstrap GC must not remove its own lock file"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_debootstrap_ignores_non_cache_files() {
+        use std::fs::FileTimes;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let debootstrap_dir = home.debootstrap_dir();
+        std::fs::create_dir_all(&debootstrap_dir).unwrap();
+        let unrelated = debootstrap_dir.join("README");
+        std::fs::write(&unrelated, b"metadata").unwrap();
+        std::fs::File::open(&unrelated)
+            .unwrap()
+            .set_times(
+                FileTimes::new()
+                    .set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000)),
+            )
+            .unwrap();
+
+        let freed = gc_debootstrap(&home, Some(0), false).await.unwrap();
+
+        assert_eq!(freed, 0);
+        assert!(
+            unrelated.exists(),
+            "debootstrap GC should only remove cache tarballs"
         );
     }
 

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -1846,6 +1846,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gc_debootstrap_removes_stale_temp_tarballs_but_keeps_recent_ones() {
+        use std::fs::FileTimes;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let debootstrap_dir = home.debootstrap_dir();
+        std::fs::create_dir_all(&debootstrap_dir).unwrap();
+        let stale_tmp = debootstrap_dir.join("noble-amd64.tar.tmp.123");
+        let recent_tmp = debootstrap_dir.join("noble-amd64.tar.tmp.456");
+        std::fs::write(&stale_tmp, b"stale partial").unwrap();
+        std::fs::write(&recent_tmp, b"recent partial").unwrap();
+        let stale_size = std::fs::metadata(&stale_tmp).unwrap().len();
+        let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        std::fs::File::open(&stale_tmp)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(old_time))
+            .unwrap();
+
+        let freed = gc_debootstrap(&home, Some(0), false).await.unwrap();
+
+        assert_eq!(freed, stale_size);
+        assert!(
+            !stale_tmp.exists(),
+            "stale debootstrap temp tarball should be GC'd"
+        );
+        assert!(
+            recent_tmp.exists(),
+            "recent debootstrap temp tarball may still belong to an active build"
+        );
+    }
+
+    #[tokio::test]
     async fn gc_job_logs_deletes_stale() {
         use std::fs::FileTimes;
         use std::time::Duration;

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -629,6 +629,13 @@ async fn gc_debootstrap(
     keep_latest: Option<usize>,
     dry_run: bool,
 ) -> RunnerResult<u64> {
+    let dir = home.debootstrap_dir();
+    if !dir.try_exists().map_err(|e| {
+        RunnerError::Internal(format!("check debootstrap dir {}: {e}", dir.display()))
+    })? {
+        return Ok(0);
+    }
+
     let lock_path = home.debootstrap_lock();
     let _lock = match probe_lock(&lock_path) {
         LockProbe::Free(lock) => lock,
@@ -642,7 +649,6 @@ async fn gc_debootstrap(
         }
     };
 
-    let dir = home.debootstrap_dir();
     let Some(mut entries) = read_dir_or_missing(&dir).await? else {
         return Ok(0);
     };
@@ -657,13 +663,15 @@ async fn gc_debootstrap(
         if !meta.is_file() {
             continue;
         }
+        let Some(kind) = debootstrap_cache_file_kind(&path) else {
+            continue;
+        };
         let mtime = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
-        let is_temp = is_debootstrap_temp_tarball(&path);
         files.push(DeBootstrapCacheFile {
             path,
             size: meta.len(),
             mtime,
-            is_temp,
+            is_temp: matches!(kind, DeBootstrapCacheFileKind::Temp),
         });
     }
 
@@ -724,10 +732,20 @@ struct DeBootstrapCacheFile {
     is_temp: bool,
 }
 
-fn is_debootstrap_temp_tarball(path: &Path) -> bool {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name.contains(".tar.tmp."))
+enum DeBootstrapCacheFileKind {
+    Stable,
+    Temp,
+}
+
+fn debootstrap_cache_file_kind(path: &Path) -> Option<DeBootstrapCacheFileKind> {
+    let name = path.file_name().and_then(|name| name.to_str())?;
+    if name.contains(".tar.tmp.") {
+        Some(DeBootstrapCacheFileKind::Temp)
+    } else if name.ends_with(".tar") {
+        Some(DeBootstrapCacheFileKind::Stable)
+    } else {
+        None
+    }
 }
 
 /// Remove unused lock files. Any lock file that can be exclusively locked is
@@ -1868,6 +1886,31 @@ mod tests {
         assert!(
             cache_tar.exists(),
             "active debootstrap cache tarball must survive GC"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_debootstrap_keeps_its_lock_file() {
+        use std::fs::FileTimes;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let lock_path = home.debootstrap_lock();
+        drop(lock::open_lock_file(&lock_path).unwrap());
+        std::fs::File::open(&lock_path)
+            .unwrap()
+            .set_times(
+                FileTimes::new()
+                    .set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000)),
+            )
+            .unwrap();
+
+        let freed = gc_debootstrap(&home, Some(0), false).await.unwrap();
+
+        assert_eq!(freed, 0);
+        assert!(
+            lock_path.exists(),
+            "debootstrap GC must not remove its own lock file"
         );
     }
 

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -36,6 +36,7 @@ const STORAGE_CACHE_MAX_BYTES: u64 = 1 << 30; // 1 GiB
 /// bound many tiny storage versions, and each cached version also creates a
 /// lock file.
 const STORAGE_CACHE_MAX_ENTRIES: u64 = 5_000;
+const TEMPLATE_WARM_DIR_PREFIX: &str = "template-warm-";
 
 #[derive(Args)]
 pub struct GcArgs {
@@ -243,8 +244,11 @@ async fn try_delete_orphan_rootfs(rootfs_path: &Path, rootfs_hash: &str, dry_run
 }
 
 fn template_warm_hash(name: &str) -> Option<&str> {
-    name.strip_prefix("template-")
-        .and_then(|rest| rest.strip_suffix(".warm.tmp"))
+    name.strip_prefix(TEMPLATE_WARM_DIR_PREFIX)
+        .or_else(|| {
+            name.strip_prefix("template-")
+                .and_then(|rest| rest.strip_suffix(".warm.tmp"))
+        })
         .filter(|hash| !hash.is_empty())
 }
 
@@ -2064,6 +2068,42 @@ mod tests {
         assert_eq!(freed, 0);
     }
 
+    #[test]
+    fn template_warm_hash_accepts_current_and_legacy_names() {
+        assert_eq!(template_warm_hash("template-warm-abc123"), Some("abc123"));
+        assert_eq!(
+            template_warm_hash("template-abc123.warm.tmp"),
+            Some("abc123")
+        );
+        assert_eq!(template_warm_hash("template-warm-"), None);
+        assert_eq!(template_warm_hash("rootfs-hash"), None);
+    }
+
+    #[tokio::test]
+    async fn gc_nested_images_keeps_locked_current_template_warm_dir() {
+        use std::fs::FileTimes;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let warm_dir = home.images_dir().join("template-warm-abc123");
+        std::fs::create_dir_all(&warm_dir).unwrap();
+        std::fs::write(warm_dir.join("attempt-old.tmp"), b"partial").unwrap();
+
+        let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        std::fs::File::open(&warm_dir)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(old_time))
+            .unwrap();
+
+        let lock_file = lock::open_lock_file(&home.template_lock("abc123")).unwrap();
+        let _held = Flock::lock(lock_file, FlockArg::LockExclusive).unwrap();
+
+        let freed = gc_nested_images(&home, Some(0), false).await.unwrap();
+
+        assert_eq!(freed, 0);
+        assert!(warm_dir.exists(), "active warm rootfs dir must survive GC");
+    }
+
     #[tokio::test]
     async fn gc_nested_images_keeps_locked_template_warm_dir() {
         use std::fs::FileTimes;
@@ -2115,6 +2155,31 @@ mod tests {
         let warm_dir = home.images_dir().join("template-abc123.warm.tmp");
         std::fs::create_dir_all(&warm_dir).unwrap();
         std::fs::write(warm_dir.join("template.ext4"), b"partial").unwrap();
+
+        let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        std::fs::File::open(&warm_dir)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(old_time))
+            .unwrap();
+
+        let freed = gc_nested_images(&home, Some(0), false).await.unwrap();
+
+        assert!(
+            !warm_dir.exists(),
+            "stale warm rootfs dir should be removed"
+        );
+        assert!(freed > 0);
+    }
+
+    #[tokio::test]
+    async fn gc_nested_images_removes_stale_current_template_warm_dir() {
+        use std::fs::FileTimes;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let warm_dir = home.images_dir().join("template-warm-abc123");
+        std::fs::create_dir_all(&warm_dir).unwrap();
+        std::fs::write(warm_dir.join("attempt-old.tmp"), b"partial").unwrap();
 
         let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
         std::fs::File::open(&warm_dir)

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -629,6 +629,19 @@ async fn gc_debootstrap(
     keep_latest: Option<usize>,
     dry_run: bool,
 ) -> RunnerResult<u64> {
+    let lock_path = home.debootstrap_lock();
+    let _lock = match probe_lock(&lock_path) {
+        LockProbe::Free(lock) => lock,
+        LockProbe::Held => {
+            info!("debootstrap cache: in use, skipping");
+            return Ok(0);
+        }
+        LockProbe::Error(e) => {
+            info!("debootstrap cache: lock probe failed ({e}), skipping");
+            return Ok(0);
+        }
+    };
+
     let dir = home.debootstrap_dir();
     let Some(mut entries) = read_dir_or_missing(&dir).await? else {
         return Ok(0);
@@ -1800,6 +1813,36 @@ mod tests {
 
     fn test_home(root: &Path) -> HomePaths {
         HomePaths::with_root(root.to_path_buf())
+    }
+
+    #[tokio::test]
+    async fn gc_debootstrap_skips_when_cache_lock_is_held() {
+        use std::fs::FileTimes;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let debootstrap_dir = home.debootstrap_dir();
+        std::fs::create_dir_all(&debootstrap_dir).unwrap();
+        let cache_tar = debootstrap_dir.join("noble-amd64.tar");
+        std::fs::write(&cache_tar, b"cached").unwrap();
+        std::fs::File::open(&cache_tar)
+            .unwrap()
+            .set_times(
+                FileTimes::new()
+                    .set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000)),
+            )
+            .unwrap();
+
+        let lock_file = lock::open_lock_file(&home.debootstrap_lock()).unwrap();
+        let _held = Flock::lock(lock_file, FlockArg::LockExclusive).unwrap();
+
+        let freed = gc_debootstrap(&home, Some(0), false).await.unwrap();
+
+        assert_eq!(freed, 0);
+        assert!(
+            cache_tar.exists(),
+            "active debootstrap cache tarball must survive GC"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -647,7 +647,7 @@ async fn gc_debootstrap(
         return Ok(0);
     };
 
-    let mut files: Vec<(PathBuf, u64, SystemTime)> = Vec::new();
+    let mut files: Vec<DeBootstrapCacheFile> = Vec::new();
     while let Some(entry) = next_entry_warn(&mut entries, "gc_debootstrap", &dir).await {
         let path = entry.path();
         let meta = match tokio::fs::metadata(&path).await {
@@ -658,17 +658,23 @@ async fn gc_debootstrap(
             continue;
         }
         let mtime = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
-        files.push((path, meta.len(), mtime));
+        let is_temp = is_debootstrap_temp_tarball(&path);
+        files.push(DeBootstrapCacheFile {
+            path,
+            size: meta.len(),
+            mtime,
+            is_temp,
+        });
     }
 
     // Skip files touched recently (same GC_MIN_AGE as rootfs/snapshots).
     let now = SystemTime::now();
-    files.retain(|(path, _, mtime)| {
-        let age = now.duration_since(*mtime).unwrap_or_default();
+    files.retain(|file| {
+        let age = now.duration_since(file.mtime).unwrap_or_default();
         if age < GC_MIN_AGE {
             info!(
                 "debootstrap cache: {} too recent ({}s old), skipping",
-                path.display(),
+                file.path.display(),
                 age.as_secs()
             );
             false
@@ -677,31 +683,51 @@ async fn gc_debootstrap(
         }
     });
 
-    // Sort newest first, keep the N most recent.
-    files.sort_by_key(|f| std::cmp::Reverse(f.2));
+    // Sort newest first, keep the N most recent stable tarballs. Stale
+    // `*.tar.tmp.<pid>` files are cancellation residue and must not consume a
+    // keep_latest slot that would otherwise protect a usable cache tarball.
+    files.sort_by_key(|f| std::cmp::Reverse(f.mtime));
     let keep = keep_latest.unwrap_or(0);
+    let mut stable_seen = 0usize;
 
     let mut freed: u64 = 0;
-    for (path, size, _) in files.iter().skip(keep) {
+    for file in files.iter() {
+        if !file.is_temp && stable_seen < keep {
+            stable_seen += 1;
+            continue;
+        }
         if dry_run {
             info!(
                 "debootstrap cache: would remove {} ({})",
-                path.display(),
-                human_bytes(*size)
+                file.path.display(),
+                human_bytes(file.size)
             );
-        } else if let Err(e) = tokio::fs::remove_file(path).await {
-            tracing::warn!("remove {}: {e}", path.display());
+        } else if let Err(e) = tokio::fs::remove_file(&file.path).await {
+            tracing::warn!("remove {}: {e}", file.path.display());
             continue;
         } else {
             info!(
                 "debootstrap cache: removed {} ({})",
-                path.display(),
-                human_bytes(*size)
+                file.path.display(),
+                human_bytes(file.size)
             );
         }
-        freed += size;
+        freed += file.size;
     }
     Ok(freed)
+}
+
+struct DeBootstrapCacheFile {
+    path: PathBuf,
+    size: u64,
+    mtime: SystemTime,
+    is_temp: bool,
+}
+
+fn is_debootstrap_temp_tarball(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.contains(".tar.tmp."))
 }
 
 /// Remove unused lock files. Any lock file that can be exclusively locked is
@@ -1874,6 +1900,43 @@ mod tests {
         assert!(
             recent_tmp.exists(),
             "recent debootstrap temp tarball may still belong to an active build"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_debootstrap_temp_tarballs_do_not_consume_keep_latest_slots() {
+        use std::fs::FileTimes;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let debootstrap_dir = home.debootstrap_dir();
+        std::fs::create_dir_all(&debootstrap_dir).unwrap();
+        let stable_tar = debootstrap_dir.join("noble-amd64.tar");
+        let newer_tmp = debootstrap_dir.join("noble-amd64.tar.tmp.789");
+        std::fs::write(&stable_tar, b"stable").unwrap();
+        std::fs::write(&newer_tmp, b"newer partial").unwrap();
+        let temp_size = std::fs::metadata(&newer_tmp).unwrap().len();
+        let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let newer_time = old_time + Duration::from_secs(60);
+        std::fs::File::open(&stable_tar)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(old_time))
+            .unwrap();
+        std::fs::File::open(&newer_tmp)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(newer_time))
+            .unwrap();
+
+        let freed = gc_debootstrap(&home, Some(1), false).await.unwrap();
+
+        assert_eq!(freed, temp_size);
+        assert!(
+            stable_tar.exists(),
+            "keep_latest should protect the stable debootstrap tarball"
+        );
+        assert!(
+            !newer_tmp.exists(),
+            "stale temp tarballs must not consume keep_latest slots"
         );
     }
 

--- a/crates/runner/src/cmd/setup.rs
+++ b/crates/runner/src/cmd/setup.rs
@@ -68,7 +68,7 @@ fn check_system_dependencies() -> Vec<&'static str> {
     // Required by `runner start` (sandbox networking)
     let required = ["ip", "iptables", "iptables-save", "sysctl", "dnsmasq"];
     // Only needed by specific commands (rootfs, build, etc.)
-    let optional = ["pgrep", "mkfs.ext4", "debootstrap", "openssl"];
+    let optional = ["pgrep", "mkfs.ext4", "debootstrap", "flock", "openssl"];
 
     let missing_required: Vec<&str> = required
         .iter()

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -148,7 +148,7 @@ impl HomePaths {
     }
 
     pub fn debootstrap_lock(&self) -> PathBuf {
-        self.locks_dir().join("debootstrap.lock")
+        self.debootstrap_dir().join(".lock")
     }
 
     pub fn base_dir_lock(&self, base_dir: &Path) -> PathBuf {
@@ -411,10 +411,7 @@ mod tests {
         let ca_lock = home.ca_lock();
         assert_eq!(ca_lock, PathBuf::from("/test/locks/ca.lock"));
         let debootstrap_lock = home.debootstrap_lock();
-        assert_eq!(
-            debootstrap_lock,
-            PathBuf::from("/test/locks/debootstrap.lock")
-        );
+        assert_eq!(debootstrap_lock, PathBuf::from("/test/debootstrap/.lock"));
     }
 
     #[test]

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -147,6 +147,10 @@ impl HomePaths {
         self.root.join("locks")
     }
 
+    pub fn debootstrap_lock(&self) -> PathBuf {
+        self.locks_dir().join("debootstrap.lock")
+    }
+
     pub fn base_dir_lock(&self, base_dir: &Path) -> PathBuf {
         let hash = hex::encode(Sha256::digest(base_dir.as_os_str().as_encoded_bytes()));
         self.locks_dir().join(format!("base-dir-{hash}.lock"))
@@ -406,6 +410,11 @@ mod tests {
         assert!(template_lock.to_string_lossy().contains("template-def456"));
         let ca_lock = home.ca_lock();
         assert_eq!(ca_lock, PathBuf::from("/test/locks/ca.lock"));
+        let debootstrap_lock = home.debootstrap_lock();
+        assert_eq!(
+            debootstrap_lock,
+            PathBuf::from("/test/locks/debootstrap.lock")
+        );
     }
 
     #[test]

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -74,11 +74,9 @@
 //!   `*.download.tmp/` directory beside the destination. The next download
 //!   removes it as the first action, so the leak is bounded to one stale dir
 //!   per destination and self-heals on next attempt.
-//! - **R2 multipart upload session**: a cancelled `upload` after
-//!   `create_multipart_upload` returned but before `Complete` runs leaks
-//!   the `upload_id` server-side (Drop can't `.await` to call
-//!   `abort_multipart_upload`). R2's default 7-day lifecycle cleans
-//!   abandoned segments, capping the wasted storage cost.
+//! - **R2 multipart upload session**: once `create_multipart_upload` returns,
+//!   an owned guard aborts the upload on normal errors and schedules a
+//!   best-effort abort if the upload future is cancelled before disarm.
 //! - **`spawn_blocking` pack / unpack tasks**: tokio cannot cancel
 //!   blocking tasks. After parent cancellation, the producer/consumer
 //!   thread runs until it hits BrokenPipe or natural EOF — wasted CPU for
@@ -510,21 +508,25 @@ impl R2ImageCache {
             .upload_id()
             .ok_or_else(|| R2Error::S3("create_multipart_upload: no upload_id".into()))?
             .to_string();
+        let mut upload_guard = MultipartUploadGuard::new(
+            self.client.clone(),
+            self.bucket.clone(),
+            key.to_string(),
+            upload_id,
+        );
 
         // Run the full pack→stream→complete pipeline, then abort if anything
         // failed (including Complete itself — server-side validation errors
         // can fail Complete after all parts uploaded successfully).
-        let result = self.do_multipart_upload(key, &upload_id, files).await;
+        let result = self
+            .do_multipart_upload(key, upload_guard.upload_id(), files)
+            .await;
         if result.is_err() {
-            // Best-effort abort; R2's 7-day default lifecycle catches misses.
-            let _ = self
-                .client
-                .abort_multipart_upload()
-                .bucket(&self.bucket)
-                .key(key)
-                .upload_id(&upload_id)
-                .send()
-                .await;
+            // Best-effort abort; the guard remains armed if this await is
+            // cancelled so Drop can still schedule a detached abort.
+            upload_guard.abort().await;
+        } else {
+            upload_guard.disarm();
         }
         result
     }
@@ -787,6 +789,92 @@ impl R2ImageCache {
     }
 }
 
+struct MultipartUploadGuard {
+    client: aws_sdk_s3::Client,
+    bucket: String,
+    key: String,
+    upload_id: String,
+    runtime: tokio::runtime::Handle,
+    armed: bool,
+}
+
+impl MultipartUploadGuard {
+    fn new(client: aws_sdk_s3::Client, bucket: String, key: String, upload_id: String) -> Self {
+        Self {
+            client,
+            bucket,
+            key,
+            upload_id,
+            runtime: tokio::runtime::Handle::current(),
+            armed: true,
+        }
+    }
+
+    fn upload_id(&self) -> &str {
+        &self.upload_id
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    async fn abort(&mut self) {
+        if !self.armed {
+            return;
+        }
+        abort_multipart_upload(
+            self.client.clone(),
+            self.bucket.clone(),
+            self.key.clone(),
+            self.upload_id.clone(),
+            "failed multipart upload",
+        )
+        .await;
+        self.disarm();
+    }
+}
+
+impl Drop for MultipartUploadGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        drop(self.runtime.spawn(abort_multipart_upload(
+            self.client.clone(),
+            self.bucket.clone(),
+            self.key.clone(),
+            self.upload_id.clone(),
+            "cancelled multipart upload",
+        )));
+    }
+}
+
+async fn abort_multipart_upload(
+    client: aws_sdk_s3::Client,
+    bucket: String,
+    key: String,
+    upload_id: String,
+    reason: &'static str,
+) {
+    if let Err(e) = client
+        .abort_multipart_upload()
+        .bucket(bucket)
+        .key(&key)
+        .upload_id(&upload_id)
+        .send()
+        .await
+    {
+        tracing::warn!(
+            error = %e,
+            key,
+            upload_id,
+            reason,
+            "failed to abort R2 multipart upload"
+        );
+    }
+}
+
 #[cfg(test)]
 fn key_for_hash(hash: &str) -> String {
     format!("{LEGACY_ROOTFS_KEY_PREFIX}{hash}.tar.zst")
@@ -1045,6 +1133,19 @@ mod tests {
     fn mock_cache(bucket: &str, rules: &[&Rule]) -> R2ImageCache {
         let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, rules);
         R2ImageCache::with_client(client, bucket.to_string())
+    }
+
+    async fn wait_for_rule_calls(rule: &Rule, expected: usize) {
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if rule.num_calls() == expected {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {expected} mock call(s)"));
     }
 
     #[test]
@@ -1915,6 +2016,34 @@ mod tests {
         // even if the SDK retried `complete` internally — r2_cache issues
         // one best-effort abort per failed upload (not per retry).
         assert_eq!(abort.num_calls(), 1, "abort MUST run on Complete failure");
+    }
+
+    /// Dropping the upload future after `CreateMultipartUpload` must not leave
+    /// server-side multipart state behind until R2 lifecycle cleanup. The guard
+    /// schedules a detached abort on drop, which is the cancellation path that
+    /// normal error-return tests do not exercise.
+    #[tokio::test]
+    async fn multipart_upload_guard_aborts_on_drop() {
+        use aws_sdk_s3::Client;
+        use aws_sdk_s3::operation::abort_multipart_upload::AbortMultipartUploadOutput;
+
+        let abort = mock!(Client::abort_multipart_upload)
+            .match_requests(|req| {
+                req.bucket() == Some("test-bucket")
+                    && req.key() == Some("runner-templates/abc.tar.zst")
+                    && req.upload_id() == Some("test-upload-id")
+            })
+            .then_output(|| AbortMultipartUploadOutput::builder().build());
+        let cache = mock_cache("test-bucket", &[&abort]);
+
+        drop(MultipartUploadGuard::new(
+            cache.client.clone(),
+            cache.bucket.clone(),
+            key_for_template_hash("abc"),
+            "test-upload-id".to_string(),
+        ));
+
+        wait_for_rule_calls(&abort, 1).await;
     }
 
     /// Missing `e_tag` on `upload_part` response → `R2Error::S3` with the

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -95,7 +95,7 @@
 //!
 //! `cmd::build::run_build` defends by passing `force = true` to upload
 //! whenever template download classifies an object as invalid. That bypasses the
-//! dedup check and atomically overwrites the bad object in a single PUT.
+//! dedup check and atomically overwrites the bad object via multipart complete.
 //!
 //! ## Tar entry security
 //!
@@ -470,8 +470,8 @@ impl R2ImageCache {
     /// detecting a corrupt prior upload (download succeeded but template.ext4
     /// is missing). Going through `delete + dedup-upload` would deadlock the
     /// fleet's cache if `DeleteObject` permission is missing or transiently
-    /// failing — `force` is a single-round-trip atomic overwrite that doesn't
-    /// depend on `s3:DeleteObject`.
+    /// failing — `force` keeps the overwrite on the multipart upload path and
+    /// does not depend on `s3:DeleteObject`.
     ///
     /// The client is built from explicit R2 credentials, so it avoids AWS
     /// credential/endpoint discovery stalls. Outer call sites (CI/systemd)

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -30,10 +30,12 @@
 //! fatal `PartialConfig` error — almost certainly a typo'd secret rotation, and
 //! silently disabling cache fleet-wide is worse than failing the deploy.
 //!
-//! Streaming: both upload and download avoid temp files entirely. Upload uses a
-//! `tokio::io::duplex` pipe to couple the sync tar+zstd producer (on a blocking
-//! thread) to the async multipart consumer. Download uses `SyncIoBridge` to
-//! adapt the async S3 body into a sync `Read` for the blocking unpack thread.
+//! Streaming: upload avoids temp files by using a `tokio::io::duplex` pipe to
+//! couple the sync tar+zstd producer (on a blocking thread) to the async
+//! multipart consumer. Download streams the S3 body through `SyncIoBridge` into
+//! a sibling staging directory, then renames the extracted `template.ext4` to
+//! the caller's destination. Callers that coordinate shared output paths should
+//! pass an attempt-scoped destination and perform their own final publish step.
 //! Memory peak per upload ≈ `(2 + CONCURRENCY + 1) × PART_SIZE` — duplex buffer,
 //! in-flight upload chunks, and the part being read — bounded regardless of
 //! image size. Currently ~112 MiB with `PART_SIZE` = 16 MiB and `CONCURRENCY` = 4.

--- a/crates/runner/src/r2_cache.rs
+++ b/crates/runner/src/r2_cache.rs
@@ -12,9 +12,10 @@
 //! 1. `runner build` computes a `template_hash` for the shared R2 object and
 //!    a separate `rootfs_hash` for local images.
 //! 2. `--warm-rootfs-cache` ensures only the template R2 object exists.
-//! 3. Normal builds materialize the template object into `rootfs.ext4.staging`
-//!    (or build/upload it on miss), customize the staging image locally, verify
-//!    it, and then atomically commit the rootfs.
+//! 3. Normal builds materialize the template object into a per-attempt local
+//!    file (or build/upload it on miss), move the verified template into
+//!    `rootfs.ext4.staging`, customize the staging image locally, verify it,
+//!    and then atomically commit the rootfs.
 //!
 //! Atomicity guarantees:
 //! - Multipart upload is atomic from consumer POV (object only appears after

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -417,17 +417,11 @@ async fn cleanup_after_netns_pool_failure(
     device_pool: &DevicePoolHandle,
     sock_dir: &Path,
 ) {
-    let cow_file = cow_device.cow_file().to_path_buf();
-    if let Err(cleanup_err) = cow_device
-        .destroy_with_retries(cow_destroy_retry_policy())
-        .await
-    {
+    if let Err(cleanup_err) = destroy_snapshot_cow_and_cleanup_attempt_dir(cow_device).await {
         tracing::warn!(
             error = %cleanup_err,
             "failed to destroy COW device after netns pool failure"
         );
-    } else {
-        cleanup_snapshot_attempt_dir_for_cow(&cow_file).await;
     }
     device_pool.cleanup().await;
     cleanup_snapshot_sock_dir(
@@ -1528,15 +1522,8 @@ impl SnapshotCleanupFinalizer {
         let Some(cow_device) = self.cow_device.take() else {
             return true;
         };
-        let cow_file = cow_device.cow_file().to_path_buf();
-        match cow_device
-            .destroy_with_retries(cow_destroy_retry_policy())
-            .await
-        {
-            Ok(()) => {
-                cleanup_snapshot_attempt_dir_for_cow(&cow_file).await;
-                true
-            }
+        match destroy_snapshot_cow_and_cleanup_attempt_dir(cow_device).await {
+            Ok(()) => true,
             Err(e) => {
                 tracing::warn!(
                     error = %e,

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -469,7 +469,6 @@ enum SnapshotPublishState {
     HoldingDevice(PooledNbdCowDevice),
     KeepingCow(KeepCowFinalizer),
     KeptCow(KeptCow),
-    Committed,
     Empty,
 }
 
@@ -501,10 +500,7 @@ impl SnapshotPublishAttempt {
     }
 
     fn has_cleanup_work(&self) -> bool {
-        !matches!(
-            self.state,
-            SnapshotPublishState::Committed | SnapshotPublishState::Empty
-        )
+        !matches!(self.state, SnapshotPublishState::Empty)
     }
 
     fn start_keep_cow(&mut self) -> Result<(), SnapshotError> {
@@ -524,10 +520,6 @@ impl SnapshotPublishAttempt {
                 self.state = SnapshotPublishState::KeptCow(kept_cow);
                 Ok(())
             }
-            SnapshotPublishState::Committed => {
-                self.state = SnapshotPublishState::Committed;
-                Ok(())
-            }
             SnapshotPublishState::Empty => Err(SnapshotError::Teardown(
                 "snapshot publish attempt missing COW ownership".into(),
             )),
@@ -538,7 +530,7 @@ impl SnapshotPublishAttempt {
         self.start_keep_cow()?;
         let result = match &mut self.state {
             SnapshotPublishState::KeepingCow(finalizer) => finalizer.as_mut().await,
-            SnapshotPublishState::KeptCow(_) | SnapshotPublishState::Committed => return Ok(()),
+            SnapshotPublishState::KeptCow(_) => return Ok(()),
             SnapshotPublishState::HoldingDevice(_) | SnapshotPublishState::Empty => {
                 return Err(SnapshotError::Teardown(
                     "snapshot publish attempt did not start keep-COW finalizer".into(),
@@ -560,31 +552,16 @@ impl SnapshotPublishAttempt {
         }
     }
 
-    async fn commit_success(&mut self, output: &SnapshotOutputPaths) -> Result<(), SnapshotError> {
+    async fn resolve_into_kept_cow(&mut self) -> Result<KeptCow, SnapshotError> {
         self.resolve_keep_cow().await?;
 
         let state = std::mem::replace(&mut self.state, SnapshotPublishState::Empty);
         match state {
-            SnapshotPublishState::KeptCow(kept_cow) => {
-                match commit_snapshot_cow_output(&kept_cow, output) {
-                    Ok(()) => {
-                        self.state = SnapshotPublishState::Committed;
-                        Ok(())
-                    }
-                    Err(e) => {
-                        self.state = SnapshotPublishState::KeptCow(kept_cow);
-                        Err(e)
-                    }
-                }
-            }
-            SnapshotPublishState::Committed => {
-                self.state = SnapshotPublishState::Committed;
-                Ok(())
-            }
+            SnapshotPublishState::KeptCow(kept_cow) => Ok(kept_cow),
             other => {
                 self.state = other;
                 Err(SnapshotError::Teardown(
-                    "snapshot publish attempt reached commit without kept COW".into(),
+                    "snapshot publish attempt resolved without kept COW".into(),
                 ))
             }
         }
@@ -636,92 +613,130 @@ impl SnapshotPublishAttempt {
                 }
                 cleaned
             }
-            SnapshotPublishState::Committed | SnapshotPublishState::Empty => true,
+            SnapshotPublishState::Empty => true,
             other => {
                 self.state = other;
                 false
             }
         }
     }
+}
 
-    fn cleanup_resolved_kept_cow_sync(&mut self) -> bool {
-        let state = std::mem::replace(&mut self.state, SnapshotPublishState::Empty);
-        match state {
-            SnapshotPublishState::KeptCow(kept_cow) => {
-                let cleaned = cleanup_kept_cow_after_publish_drop(&kept_cow);
-                if !cleaned {
-                    self.state = SnapshotPublishState::KeptCow(kept_cow);
-                }
-                cleaned
-            }
-            SnapshotPublishState::Committed | SnapshotPublishState::Empty => true,
-            other => {
-                self.state = other;
-                false
-            }
-        }
-    }
+enum FirecrackerPendingSnapshotPublishState {
+    Pending(KeptCow),
+    Committed,
+    Discarded,
 }
 
 struct FirecrackerPendingSnapshotPublish {
     snapshot_config: SnapshotConfig,
     output: SnapshotOutputPaths,
-    publish_attempt: SnapshotPublishAttempt,
+    state: FirecrackerPendingSnapshotPublishState,
 }
 
 impl FirecrackerPendingSnapshotPublish {
-    async fn commit_config(mut self) -> Result<SnapshotConfig, SnapshotError> {
-        if let Err(err) = self.publish_attempt.commit_success(&self.output).await {
-            if !self.publish_attempt.cleanup_after_cancellation().await {
-                tracing::warn!(
-                    error = %err,
-                    output_dir = %self.output.dir().display(),
-                    "failed to cleanup uncommitted snapshot artifacts after publish failure"
-                );
-            }
-            return Err(err);
+    fn new(
+        snapshot_config: SnapshotConfig,
+        output: SnapshotOutputPaths,
+        kept_cow: KeptCow,
+    ) -> Self {
+        Self {
+            snapshot_config,
+            output,
+            state: FirecrackerPendingSnapshotPublishState::Pending(kept_cow),
         }
-
-        Ok(self.snapshot_config.clone())
     }
 
-    async fn discard_inner(mut self) -> Result<(), SnapshotError> {
-        if self.publish_attempt.cleanup_after_cancellation().await {
-            Ok(())
-        } else {
-            Err(SnapshotError::Teardown(
-                "failed to discard uncommitted snapshot artifacts".into(),
-            ))
+    async fn commit_config(&mut self) -> Result<SnapshotConfig, SnapshotError> {
+        let state = std::mem::replace(
+            &mut self.state,
+            FirecrackerPendingSnapshotPublishState::Discarded,
+        );
+        match state {
+            FirecrackerPendingSnapshotPublishState::Pending(kept_cow) => {
+                match commit_snapshot_cow_output(&kept_cow, &self.output) {
+                    Ok(()) => {
+                        self.state = FirecrackerPendingSnapshotPublishState::Committed;
+                        Ok(self.snapshot_config.clone())
+                    }
+                    Err(e) => {
+                        self.state = FirecrackerPendingSnapshotPublishState::Pending(kept_cow);
+                        Err(e)
+                    }
+                }
+            }
+            FirecrackerPendingSnapshotPublishState::Committed => {
+                self.state = FirecrackerPendingSnapshotPublishState::Committed;
+                Ok(self.snapshot_config.clone())
+            }
+            FirecrackerPendingSnapshotPublishState::Discarded => {
+                self.state = FirecrackerPendingSnapshotPublishState::Discarded;
+                Err(SnapshotError::Teardown(
+                    "pending snapshot publish was already discarded".into(),
+                ))
+            }
+        }
+    }
+
+    async fn discard_inner(&mut self) -> Result<(), SnapshotError> {
+        let state = std::mem::replace(
+            &mut self.state,
+            FirecrackerPendingSnapshotPublishState::Discarded,
+        );
+        match state {
+            FirecrackerPendingSnapshotPublishState::Pending(kept_cow) => {
+                if cleanup_kept_cow_after_publish_cancellation(&kept_cow).await {
+                    Ok(())
+                } else {
+                    self.state = FirecrackerPendingSnapshotPublishState::Pending(kept_cow);
+                    Err(SnapshotError::Teardown(
+                        "failed to discard uncommitted snapshot artifacts".into(),
+                    ))
+                }
+            }
+            FirecrackerPendingSnapshotPublishState::Committed
+            | FirecrackerPendingSnapshotPublishState::Discarded => {
+                self.state = state;
+                Ok(())
+            }
         }
     }
 }
 
 impl Drop for FirecrackerPendingSnapshotPublish {
     fn drop(&mut self) {
-        if self.publish_attempt.has_cleanup_work() {
-            let cleaned = self.publish_attempt.cleanup_resolved_kept_cow_sync();
+        let state = std::mem::replace(
+            &mut self.state,
+            FirecrackerPendingSnapshotPublishState::Discarded,
+        );
+        if let FirecrackerPendingSnapshotPublishState::Pending(kept_cow) = state {
+            let cleaned = cleanup_kept_cow_after_publish_drop(&kept_cow);
+            if !cleaned {
+                self.state = FirecrackerPendingSnapshotPublishState::Pending(kept_cow);
+            }
             tracing::warn!(
                 cleaned,
                 output_dir = %self.output.dir().display(),
                 "uncommitted snapshot publish dropped without commit or discard"
             );
+        } else {
+            self.state = state;
         }
     }
 }
 
 #[async_trait]
 impl PendingSnapshotPublish for FirecrackerPendingSnapshotPublish {
-    async fn commit(self: Box<Self>) -> Result<SnapshotOutput, sandbox::SnapshotError> {
-        let snapshot_config = (*self)
+    async fn commit(&mut self) -> Result<SnapshotOutput, sandbox::SnapshotError> {
+        let snapshot_config = self
             .commit_config()
             .await
             .map_err(SnapshotError::into_sandbox_error)?;
         Ok(snapshot_output_from_config(snapshot_config))
     }
 
-    async fn discard(self: Box<Self>) -> Result<(), sandbox::SnapshotError> {
-        (*self)
-            .discard_inner()
+    async fn discard(&mut self) -> Result<(), sandbox::SnapshotError> {
+        self.discard_inner()
             .await
             .map_err(SnapshotError::into_sandbox_error)
     }
@@ -1155,7 +1170,7 @@ impl SnapshotAttempt {
         }
     }
 
-    async fn prepare_success_publish(&mut self) -> Result<SnapshotPublishAttempt, SnapshotError> {
+    async fn prepare_success_publish(&mut self) -> Result<KeptCow, SnapshotError> {
         let cow_device = self.cow_device.take().ok_or_else(|| {
             SnapshotError::Teardown("snapshot attempt missing COW device before publish".into())
         })?;
@@ -1163,14 +1178,13 @@ impl SnapshotAttempt {
         self.resolve_success_publish().await
     }
 
-    async fn resolve_success_publish(&mut self) -> Result<SnapshotPublishAttempt, SnapshotError> {
+    async fn resolve_success_publish(&mut self) -> Result<KeptCow, SnapshotError> {
         let publish_attempt = self.publish_attempt.as_mut().ok_or_else(|| {
             SnapshotError::Teardown("snapshot publish attempt missing before publish".into())
         })?;
-        publish_attempt.resolve_keep_cow().await?;
-        self.publish_attempt.take().ok_or_else(|| {
-            SnapshotError::Teardown("snapshot publish attempt missing after prepare".into())
-        })
+        let kept_cow = publish_attempt.resolve_into_kept_cow().await?;
+        self.publish_attempt.take();
+        Ok(kept_cow)
     }
 
     async fn cleanup_failure(&mut self) {
@@ -1513,10 +1527,14 @@ impl Drop for SnapshotAttempt {
 pub async fn create_snapshot(
     config: SnapshotCreateConfig,
 ) -> Result<SnapshotConfig, SnapshotError> {
-    create_uncommitted_snapshot(config)
-        .await?
-        .commit_config()
-        .await
+    let mut pending = create_uncommitted_snapshot(config).await?;
+    match pending.commit_config().await {
+        Ok(config) => Ok(config),
+        Err(err) => {
+            let _ = pending.discard_inner().await;
+            Err(err)
+        }
+    }
 }
 
 async fn create_uncommitted_snapshot(
@@ -1607,14 +1625,13 @@ async fn create_uncommitted_snapshot(
     attempt_dir_guard.disarm();
     let result = run_snapshot_workflow(&config, &mut attempt).await;
     let result = match result {
-        Ok(snapshot_config) => match attempt.prepare_success_publish().await {
-            Ok(publish_attempt) => Ok(FirecrackerPendingSnapshotPublish {
+        Ok(snapshot_config) => attempt.prepare_success_publish().await.map(|kept_cow| {
+            FirecrackerPendingSnapshotPublish::new(
                 snapshot_config,
-                output: SnapshotOutputPaths::new(config.output_dir.clone()),
-                publish_attempt,
-            }),
-            Err(err) => Err(err),
-        },
+                SnapshotOutputPaths::new(config.output_dir.clone()),
+                kept_cow,
+            )
+        }),
         Err(err) => Err(err),
     };
 
@@ -2136,12 +2153,12 @@ mod tests {
         write_required_snapshot_artifacts(&output).await;
         let kept_cow = write_kept_cow_for_test(&output.work_dir(), "pending-commit").await;
 
-        let pending: Box<dyn PendingSnapshotPublish> =
-            Box::new(FirecrackerPendingSnapshotPublish {
-                snapshot_config: output.snapshot_config("pending-commit"),
-                output: SnapshotOutputPaths::new(output.dir().to_path_buf()),
-                publish_attempt: SnapshotPublishAttempt::new_with_kept_cow_for_test(kept_cow),
-            });
+        let mut pending: Box<dyn PendingSnapshotPublish> =
+            Box::new(FirecrackerPendingSnapshotPublish::new(
+                output.snapshot_config("pending-commit"),
+                SnapshotOutputPaths::new(output.dir().to_path_buf()),
+                kept_cow,
+            ));
 
         let published = pending.commit().await.expect("commit pending publish");
 
@@ -2168,18 +2185,22 @@ mod tests {
             .expect("create output dir");
         let kept_cow = write_kept_cow_for_test(&output.work_dir(), "pending-commit-fail").await;
 
-        let pending: Box<dyn PendingSnapshotPublish> =
-            Box::new(FirecrackerPendingSnapshotPublish {
-                snapshot_config: output.snapshot_config("pending-commit-fail"),
-                output: SnapshotOutputPaths::new(output.dir().to_path_buf()),
-                publish_attempt: SnapshotPublishAttempt::new_with_kept_cow_for_test(kept_cow),
-            });
+        let mut pending: Box<dyn PendingSnapshotPublish> =
+            Box::new(FirecrackerPendingSnapshotPublish::new(
+                output.snapshot_config("pending-commit-fail"),
+                SnapshotOutputPaths::new(output.dir().to_path_buf()),
+                kept_cow,
+            ));
 
         let err = pending
             .commit()
             .await
             .expect_err("pending commit should fail without snapshot and memory artifacts");
         assert!(matches!(err, sandbox::SnapshotError::Io(_)), "got: {err:?}");
+        pending
+            .discard()
+            .await
+            .expect("failed pending commit should keep cleanup state for discard");
         assert!(
             !tokio::fs::try_exists(output.complete_marker())
                 .await
@@ -2206,12 +2227,12 @@ mod tests {
             .expect("attempt dir")
             .to_path_buf();
 
-        let pending: Box<dyn PendingSnapshotPublish> =
-            Box::new(FirecrackerPendingSnapshotPublish {
-                snapshot_config: output.snapshot_config("pending-discard"),
-                output: SnapshotOutputPaths::new(output.dir().to_path_buf()),
-                publish_attempt: SnapshotPublishAttempt::new_with_kept_cow_for_test(kept_cow),
-            });
+        let mut pending: Box<dyn PendingSnapshotPublish> =
+            Box::new(FirecrackerPendingSnapshotPublish::new(
+                output.snapshot_config("pending-discard"),
+                SnapshotOutputPaths::new(output.dir().to_path_buf()),
+                kept_cow,
+            ));
 
         pending.discard().await.expect("discard pending publish");
 
@@ -2252,11 +2273,11 @@ mod tests {
         let cow_file = kept_cow.cow_file.clone();
         let bitmap_file = kept_cow.bitmap_file.clone();
 
-        let pending = FirecrackerPendingSnapshotPublish {
-            snapshot_config: output.snapshot_config("pending-drop"),
-            output: SnapshotOutputPaths::new(output.dir().to_path_buf()),
-            publish_attempt: SnapshotPublishAttempt::new_with_kept_cow_for_test(kept_cow),
-        };
+        let pending = FirecrackerPendingSnapshotPublish::new(
+            output.snapshot_config("pending-drop"),
+            SnapshotOutputPaths::new(output.dir().to_path_buf()),
+            kept_cow,
+        );
 
         drop(pending);
 
@@ -2317,17 +2338,17 @@ mod tests {
             .await
             .expect("create output dir");
         let kept_cow = write_kept_cow_for_test(&output.work_dir(), "commit-cleanup").await;
-        let mut publish_attempt = SnapshotPublishAttempt::new_with_kept_cow_for_test(kept_cow);
+        let mut pending = FirecrackerPendingSnapshotPublish::new(
+            output.snapshot_config("commit-cleanup"),
+            SnapshotOutputPaths::new(output.dir().to_path_buf()),
+            kept_cow,
+        );
 
-        let err = publish_attempt
-            .commit_success(&output)
+        let err = pending
+            .commit_config()
             .await
             .expect_err("commit should fail without snapshot and memory artifacts");
         assert!(matches!(err, SnapshotError::Io(_)), "got: {err:?}");
-        assert!(
-            publish_attempt.has_cleanup_work(),
-            "failed commit must keep publish state so cleanup can finish"
-        );
         assert!(
             tokio::fs::try_exists(output.cow()).await.unwrap(),
             "failed marker publication may leave partial stable cow"
@@ -2337,11 +2358,10 @@ mod tests {
             "failed marker publication may leave partial stable bitmap"
         );
 
-        assert!(publish_attempt.cleanup_after_cancellation().await);
-        assert!(
-            !publish_attempt.has_cleanup_work(),
-            "cleanup should resolve retained publish state"
-        );
+        pending
+            .discard_inner()
+            .await
+            .expect("failed commit should keep cleanup state for discard");
         assert!(
             !tokio::fs::try_exists(output.complete_marker())
                 .await

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -2402,6 +2402,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pending_snapshot_publish_discard_output_cleanup_failure_keeps_state_for_retry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = SnapshotOutputPaths::new(dir.path().join("output"));
+        write_required_snapshot_artifacts(&output).await;
+        tokio::fs::remove_file(output.snapshot())
+            .await
+            .expect("remove snapshot file");
+        tokio::fs::create_dir(output.snapshot())
+            .await
+            .expect("replace snapshot file with directory");
+        let kept_cow = write_kept_cow_for_test(&output.work_dir(), "pending-output-retry").await;
+        let cow_file = kept_cow.cow_file.clone();
+        let bitmap_file = kept_cow.bitmap_file.clone();
+        let mut pending = FirecrackerPendingSnapshotPublish::new(
+            output.snapshot_config("pending-output-retry"),
+            SnapshotOutputPaths::new(output.dir().to_path_buf()),
+            kept_cow,
+        );
+
+        pending
+            .discard_inner()
+            .await
+            .expect_err("discard should fail when an output artifact cannot be removed");
+
+        assert!(
+            tokio::fs::metadata(output.snapshot())
+                .await
+                .expect("snapshot directory should remain")
+                .is_dir(),
+            "failed output cleanup should leave the blocking artifact for retry"
+        );
+        assert!(
+            !tokio::fs::try_exists(&cow_file).await.unwrap(),
+            "failed output cleanup should still remove temporary cow"
+        );
+        assert!(
+            !tokio::fs::try_exists(&bitmap_file).await.unwrap(),
+            "failed output cleanup should still remove temporary bitmap"
+        );
+
+        tokio::fs::remove_dir(output.snapshot())
+            .await
+            .expect("remove blocking snapshot directory");
+        pending
+            .discard_inner()
+            .await
+            .expect("retry should clean retained pending publish state");
+
+        assert!(
+            !tokio::fs::try_exists(output.snapshot()).await.unwrap(),
+            "retry should leave no snapshot output"
+        );
+        assert!(
+            !tokio::fs::try_exists(output.memory()).await.unwrap(),
+            "retry should leave no memory output"
+        );
+        assert!(
+            !tokio::fs::try_exists(output.work_dir()).await.unwrap(),
+            "retry should leave no snapshot work dir"
+        );
+    }
+
+    #[tokio::test]
     async fn pending_snapshot_publish_drop_cleans_temp_without_publishing() {
         let dir = tempfile::tempdir().expect("tempdir");
         let output = SnapshotOutputPaths::new(dir.path().join("output"));
@@ -2434,6 +2497,14 @@ mod tests {
         assert!(
             !tokio::fs::try_exists(attempt_dir).await.unwrap(),
             "drop should cleanup temporary attempt dir"
+        );
+        assert!(
+            tokio::fs::try_exists(output.snapshot()).await.unwrap(),
+            "drop must not cleanup stable snapshot output without the caller's lock"
+        );
+        assert!(
+            tokio::fs::try_exists(output.memory()).await.unwrap(),
+            "drop must not cleanup stable memory output without the caller's lock"
         );
         assert!(
             !tokio::fs::try_exists(output.complete_marker())

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -41,6 +41,37 @@ fn cow_destroy_retry_policy() -> DestroyRetryPolicy {
     }
 }
 
+struct AbortOnDropTask<T> {
+    handle: JoinHandle<T>,
+}
+
+impl<T> AbortOnDropTask<T> {
+    fn new(handle: JoinHandle<T>) -> Self {
+        Self { handle }
+    }
+
+    fn abort(&self) {
+        self.handle.abort();
+    }
+}
+
+impl<T> Future for AbortOnDropTask<T> {
+    type Output = Result<T, tokio::task::JoinError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        Pin::new(&mut this.handle).poll(cx)
+    }
+}
+
+impl<T> Drop for AbortOnDropTask<T> {
+    fn drop(&mut self) {
+        if !self.handle.is_finished() {
+            self.handle.abort();
+        }
+    }
+}
+
 /// Non-cancellable cleanup for a snapshot COW and its token-scoped attempt dir.
 ///
 /// The NBD device finalizer already keeps running after cancellation; this
@@ -1943,15 +1974,16 @@ async fn run_with_firecracker(
 
     // 7. Bind vsock listener BEFORE starting the instance (race: guest connects ~300ms after boot).
     let vsock_path_for_listen = vsock_uds_str.clone();
-    let vsock_task = tokio::spawn(async move {
+    let vsock_task = AbortOnDropTask::new(tokio::spawn(async move {
         vsock_host::VsockHost::wait_for_connection(&vsock_path_for_listen, VSOCK_CONNECT_TIMEOUT)
             .await
-    });
+    }));
 
     // 8. Start instance.
     let start_result = client.start_instance().await;
     if let Err(e) = start_result {
         vsock_task.abort();
+        let _ = vsock_task.await;
         return Err(e.into());
     }
 
@@ -3045,6 +3077,37 @@ mod tests {
             .await
             .expect("dropped cleanup finalizer should continue")
             .expect("cleanup finalizer should finish");
+    }
+
+    #[tokio::test]
+    async fn abort_on_drop_task_aborts_vsock_listener() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let base = dir.path().join("snapshot-vsock");
+        let listener =
+            std::path::PathBuf::from(format!("{}_{}", base.display(), vsock_proto::VSOCK_PORT));
+        let base = base.display().to_string();
+
+        let task = AbortOnDropTask::new(tokio::spawn(async move {
+            vsock_host::VsockHost::wait_for_connection(&base, Duration::from_secs(30)).await
+        }));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !listener.exists() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("vsock listener should bind");
+
+        drop(task);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while listener.exists() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropped task should abort and remove vsock listener");
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -1159,9 +1159,18 @@ impl SnapshotAttempt {
         let cow_device = self.cow_device.take().ok_or_else(|| {
             SnapshotError::Teardown("snapshot attempt missing COW device before publish".into())
         })?;
-        let mut publish_attempt = SnapshotPublishAttempt::new(cow_device);
+        self.publish_attempt = Some(SnapshotPublishAttempt::new(cow_device));
+        self.resolve_success_publish().await
+    }
+
+    async fn resolve_success_publish(&mut self) -> Result<SnapshotPublishAttempt, SnapshotError> {
+        let publish_attempt = self.publish_attempt.as_mut().ok_or_else(|| {
+            SnapshotError::Teardown("snapshot publish attempt missing before publish".into())
+        })?;
         publish_attempt.resolve_keep_cow().await?;
-        Ok(publish_attempt)
+        self.publish_attempt.take().ok_or_else(|| {
+            SnapshotError::Teardown("snapshot publish attempt missing after prepare".into())
+        })
     }
 
     async fn cleanup_failure(&mut self) {
@@ -2481,6 +2490,57 @@ mod tests {
             report.cleanup_events,
             vec!["publish", "device_pool"],
             "publish cleanup must finish before device pool cleanup"
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_attempt_drop_handoff_cleans_publish_resolve_cancellation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (mut attempt, _sock_dir) = snapshot_attempt_for_test(&dir);
+        write_required_snapshot_artifacts(&attempt.output).await;
+        let kept_cow = write_kept_cow_for_test(&attempt.output.work_dir(), "cancel-resolve").await;
+        let cow_file = kept_cow.cow_file.clone();
+        let bitmap_file = kept_cow.bitmap_file.clone();
+        let output_dir = attempt.output.dir().to_path_buf();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (kept_tx, kept_rx) = tokio::sync::oneshot::channel();
+        let (cleanup_tx, cleanup_rx) = tokio::sync::oneshot::channel();
+
+        attempt.track_publish_attempt_for_test(
+            SnapshotPublishAttempt::new_with_keep_future_for_test(async move {
+                let _ = started_tx.send(());
+                kept_rx.await.map_err(|_| {
+                    nbd_cow::error::NbdCowError::Io(std::io::Error::other("test sender dropped"))
+                })
+            }),
+        );
+        attempt.notify_cleanup_complete_for_test(cleanup_tx);
+
+        let handle = tokio::spawn(async move { attempt.resolve_success_publish().await });
+        started_rx
+            .await
+            .expect("keep-COW finalizer should be polled");
+        handle.abort();
+        let _ = handle.await;
+
+        kept_tx.send(kept_cow).expect("send kept cow");
+        let report = wait_for_snapshot_cleanup(cleanup_rx).await;
+        let output = SnapshotOutputPaths::new(output_dir);
+
+        assert!(report.publish_cleaned);
+        assert!(
+            !tokio::fs::try_exists(&cow_file).await.unwrap(),
+            "cancellation cleanup should remove temporary cow"
+        );
+        assert!(
+            !tokio::fs::try_exists(&bitmap_file).await.unwrap(),
+            "cancellation cleanup should remove temporary bitmap"
+        );
+        assert!(
+            !tokio::fs::try_exists(output.complete_marker())
+                .await
+                .unwrap(),
+            "cancellation cleanup must not publish complete marker"
         );
     }
 

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -13,7 +13,7 @@ use tracing::info;
 
 use nbd_cow::pool::DevicePoolHandle;
 use nbd_cow::{DestroyRetryPolicy, KeptCow, PooledNbdCowDevice};
-use sandbox::{SnapshotCreateConfig, SnapshotOutput, SnapshotProvider};
+use sandbox::{PendingSnapshotPublish, SnapshotCreateConfig, SnapshotOutput, SnapshotProvider};
 
 use crate::api::{ApiClient, ApiError};
 use crate::config::SnapshotConfig;
@@ -643,6 +643,96 @@ impl SnapshotPublishAttempt {
             }
         }
     }
+
+    fn cleanup_resolved_kept_cow_sync(&mut self) -> bool {
+        let state = std::mem::replace(&mut self.state, SnapshotPublishState::Empty);
+        match state {
+            SnapshotPublishState::KeptCow(kept_cow) => {
+                let cleaned = cleanup_kept_cow_after_publish_drop(&kept_cow);
+                if !cleaned {
+                    self.state = SnapshotPublishState::KeptCow(kept_cow);
+                }
+                cleaned
+            }
+            SnapshotPublishState::Committed | SnapshotPublishState::Empty => true,
+            other => {
+                self.state = other;
+                false
+            }
+        }
+    }
+}
+
+struct FirecrackerPendingSnapshotPublish {
+    snapshot_config: SnapshotConfig,
+    output: SnapshotOutputPaths,
+    publish_attempt: SnapshotPublishAttempt,
+}
+
+impl FirecrackerPendingSnapshotPublish {
+    async fn commit_config(mut self) -> Result<SnapshotConfig, SnapshotError> {
+        if let Err(err) = self.publish_attempt.commit_success(&self.output).await {
+            if !self.publish_attempt.cleanup_after_cancellation().await {
+                tracing::warn!(
+                    error = %err,
+                    output_dir = %self.output.dir().display(),
+                    "failed to cleanup uncommitted snapshot artifacts after publish failure"
+                );
+            }
+            return Err(err);
+        }
+
+        Ok(self.snapshot_config.clone())
+    }
+
+    async fn discard_inner(mut self) -> Result<(), SnapshotError> {
+        if self.publish_attempt.cleanup_after_cancellation().await {
+            Ok(())
+        } else {
+            Err(SnapshotError::Teardown(
+                "failed to discard uncommitted snapshot artifacts".into(),
+            ))
+        }
+    }
+}
+
+impl Drop for FirecrackerPendingSnapshotPublish {
+    fn drop(&mut self) {
+        if self.publish_attempt.has_cleanup_work() {
+            let cleaned = self.publish_attempt.cleanup_resolved_kept_cow_sync();
+            tracing::warn!(
+                cleaned,
+                output_dir = %self.output.dir().display(),
+                "uncommitted snapshot publish dropped without commit or discard"
+            );
+        }
+    }
+}
+
+#[async_trait]
+impl PendingSnapshotPublish for FirecrackerPendingSnapshotPublish {
+    async fn commit(self: Box<Self>) -> Result<SnapshotOutput, sandbox::SnapshotError> {
+        let snapshot_config = (*self)
+            .commit_config()
+            .await
+            .map_err(SnapshotError::into_sandbox_error)?;
+        Ok(snapshot_output_from_config(snapshot_config))
+    }
+
+    async fn discard(self: Box<Self>) -> Result<(), sandbox::SnapshotError> {
+        (*self)
+            .discard_inner()
+            .await
+            .map_err(SnapshotError::into_sandbox_error)
+    }
+}
+
+fn snapshot_output_from_config(config: SnapshotConfig) -> SnapshotOutput {
+    SnapshotOutput {
+        snapshot_path: config.snapshot_path,
+        memory_path: config.memory_path,
+        cow_path: config.cow_path,
+    }
 }
 
 async fn cleanup_kept_cow_after_publish_cancellation(kept_cow: &KeptCow) -> bool {
@@ -662,6 +752,25 @@ async fn cleanup_kept_cow_after_publish_cancellation(kept_cow: &KeptCow) -> bool
         }
     }
     cleanup_snapshot_attempt_dir_for_cow(&kept_cow.cow_file).await && cleaned
+}
+
+fn cleanup_kept_cow_after_publish_drop(kept_cow: &KeptCow) -> bool {
+    let mut cleaned = true;
+    for path in [&kept_cow.bitmap_file, &kept_cow.cow_file] {
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    path = %path.display(),
+                    "failed to cleanup kept COW artifact after pending snapshot publish drop"
+                );
+                cleaned = false;
+            }
+        }
+    }
+    cleanup_snapshot_attempt_dir_for_cow_sync(&kept_cow.cow_file) && cleaned
 }
 
 fn commit_snapshot_cow_output(
@@ -707,8 +816,8 @@ async fn destroy_snapshot_cow_after_workflow_error(cow_device: PooledNbdCowDevic
 /// snapshot creation. It intentionally does not participate in the factory
 /// leak-cleaner path used by sandbox creation: a snapshot attempt owns a
 /// one-shot netns pool, a per-snapshot NBD device pool, a single COW device,
-/// and one Firecracker child only until `finish_workflow` and the outer pool /
-/// socket cleanup steps run.
+/// and one Firecracker child only until the workflow runtime cleanup and the
+/// outer pool / socket cleanup steps run.
 ///
 /// Drop never performs async cleanup inline. If cancellation drops the attempt
 /// while it still owns runtime resources, Drop moves them into a detached
@@ -971,7 +1080,7 @@ impl SnapshotAttempt {
         Ok(())
     }
 
-    async fn finish_workflow(
+    async fn finish_runtime_after_workflow(
         &mut self,
         result: Result<SnapshotConfig, SnapshotError>,
     ) -> Result<SnapshotConfig, SnapshotError> {
@@ -998,15 +1107,7 @@ impl SnapshotAttempt {
         // cleanup() only drains pool-owned namespaces, not checked-out leases.
         self.release_network("failed to release netns").await;
 
-        // Tear down NBD COW device.
-        //
-        // After kill_process_group + child.wait(), the kernel may still be
-        // releasing the NBD device fd. Retry destroy until all references are
-        // released. The COW-device bind mount lived inside the FC process's
-        // private mount namespace and was auto-cleaned when the process exited.
-        if result.is_ok() {
-            self.finalize_success().await?;
-        } else {
+        if result.is_err() {
             self.cleanup_failure().await;
         }
 
@@ -1054,17 +1155,13 @@ impl SnapshotAttempt {
         }
     }
 
-    async fn finalize_success(&mut self) -> Result<(), SnapshotError> {
+    async fn prepare_success_publish(&mut self) -> Result<SnapshotPublishAttempt, SnapshotError> {
         let cow_device = self.cow_device.take().ok_or_else(|| {
-            SnapshotError::Teardown("snapshot attempt missing COW device before finalize".into())
+            SnapshotError::Teardown("snapshot attempt missing COW device before publish".into())
         })?;
-        self.publish_attempt = Some(SnapshotPublishAttempt::new(cow_device));
-        let publish_attempt = self.publish_attempt.as_mut().ok_or_else(|| {
-            SnapshotError::Teardown("snapshot publish attempt missing before finalize".into())
-        })?;
-        publish_attempt.commit_success(&self.output).await?;
-        self.publish_attempt.take();
-        Ok(())
+        let mut publish_attempt = SnapshotPublishAttempt::new(cow_device);
+        publish_attempt.resolve_keep_cow().await?;
+        Ok(publish_attempt)
     }
 
     async fn cleanup_failure(&mut self) {
@@ -1402,11 +1499,20 @@ impl Drop for SnapshotAttempt {
 /// 10. Pre-warm guest caches (PAM/nsswitch, CLI modules)
 /// 11. Pause VM
 /// 12. Create snapshot
-/// 13. Move COW file + bitmap to output dir
-/// 14. Cleanup (kill Firecracker, destroy netns, release base image)
+/// 13. Cleanup Firecracker/netns/NBD runtime resources and keep the temporary COW
+/// 14. Move COW file + bitmap to output dir and publish the complete marker
 pub async fn create_snapshot(
     config: SnapshotCreateConfig,
 ) -> Result<SnapshotConfig, SnapshotError> {
+    create_uncommitted_snapshot(config)
+        .await?
+        .commit_config()
+        .await
+}
+
+async fn create_uncommitted_snapshot(
+    config: SnapshotCreateConfig,
+) -> Result<FirecrackerPendingSnapshotPublish, SnapshotError> {
     // Check prerequisites (binary, kernel, rootfs, kvm, runtime dir, etc.).
     prerequisites::check_prerequisites(&prerequisites::PrerequisiteConfig {
         binary_path: &config.binary_path,
@@ -1491,6 +1597,17 @@ pub async fn create_snapshot(
     );
     attempt_dir_guard.disarm();
     let result = run_snapshot_workflow(&config, &mut attempt).await;
+    let result = match result {
+        Ok(snapshot_config) => match attempt.prepare_success_publish().await {
+            Ok(publish_attempt) => Ok(FirecrackerPendingSnapshotPublish {
+                snapshot_config,
+                output: SnapshotOutputPaths::new(config.output_dir.clone()),
+                publish_attempt,
+            }),
+            Err(err) => Err(err),
+        },
+        Err(err) => Err(err),
+    };
 
     attempt.cleanup_device_pool().await;
     attempt.cleanup_netns_pool().await;
@@ -1601,7 +1718,7 @@ async fn run_snapshot_workflow(
     attempt.acquire_network().await?;
     attempt.spawn_firecracker(config).await?;
 
-    // Guard: ensure process and NBD cleanup on any explicit exit path.
+    // Guard: ensure Firecracker and netns cleanup on any explicit exit path.
     let result = run_with_firecracker(
         config,
         attempt.paths(),
@@ -1609,7 +1726,7 @@ async fn run_snapshot_workflow(
         attempt.output(),
     )
     .await;
-    attempt.finish_workflow(result).await
+    attempt.finish_runtime_after_workflow(result).await
 }
 
 /// Inner workflow that runs while Firecracker is alive.
@@ -1733,18 +1850,14 @@ pub struct FirecrackerSnapshotProvider;
 
 #[async_trait]
 impl SnapshotProvider for FirecrackerSnapshotProvider {
-    async fn create_snapshot(
+    async fn create_uncommitted_snapshot(
         &self,
         config: SnapshotCreateConfig,
-    ) -> Result<SnapshotOutput, sandbox::SnapshotError> {
-        let sc = create_snapshot(config)
+    ) -> Result<Box<dyn PendingSnapshotPublish>, sandbox::SnapshotError> {
+        let publish = create_uncommitted_snapshot(config)
             .await
             .map_err(SnapshotError::into_sandbox_error)?;
-        Ok(SnapshotOutput {
-            snapshot_path: sc.snapshot_path,
-            memory_path: sc.memory_path,
-            cow_path: sc.cow_path,
-        })
+        Ok(Box::new(publish))
     }
 
     fn config_hash(&self) -> String {
@@ -2005,6 +2118,126 @@ mod tests {
 
         let provider = FirecrackerSnapshotProvider;
         assert!(provider.is_complete(output.dir()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn pending_snapshot_publish_commit_writes_complete_marker() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = SnapshotOutputPaths::new(dir.path().join("output"));
+        write_required_snapshot_artifacts(&output).await;
+        let kept_cow = write_kept_cow_for_test(&output.work_dir(), "pending-commit").await;
+
+        let pending: Box<dyn PendingSnapshotPublish> =
+            Box::new(FirecrackerPendingSnapshotPublish {
+                snapshot_config: output.snapshot_config("pending-commit"),
+                output: SnapshotOutputPaths::new(output.dir().to_path_buf()),
+                publish_attempt: SnapshotPublishAttempt::new_with_kept_cow_for_test(kept_cow),
+            });
+
+        let published = pending.commit().await.expect("commit pending publish");
+
+        assert_eq!(published.snapshot_path, output.snapshot());
+        assert_eq!(published.memory_path, output.memory());
+        assert_eq!(published.cow_path, output.cow());
+        assert!(
+            tokio::fs::try_exists(output.complete_marker())
+                .await
+                .unwrap(),
+            "commit should write complete marker"
+        );
+
+        let provider = FirecrackerSnapshotProvider;
+        assert!(provider.is_complete(output.dir()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn pending_snapshot_publish_discard_does_not_publish_marker_or_stable_cow() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = SnapshotOutputPaths::new(dir.path().join("output"));
+        write_required_snapshot_artifacts(&output).await;
+        let kept_cow = write_kept_cow_for_test(&output.work_dir(), "pending-discard").await;
+        let attempt_dir = kept_cow
+            .cow_file
+            .parent()
+            .expect("attempt dir")
+            .to_path_buf();
+
+        let pending: Box<dyn PendingSnapshotPublish> =
+            Box::new(FirecrackerPendingSnapshotPublish {
+                snapshot_config: output.snapshot_config("pending-discard"),
+                output: SnapshotOutputPaths::new(output.dir().to_path_buf()),
+                publish_attempt: SnapshotPublishAttempt::new_with_kept_cow_for_test(kept_cow),
+            });
+
+        pending.discard().await.expect("discard pending publish");
+
+        assert!(
+            !tokio::fs::try_exists(output.cow()).await.unwrap(),
+            "discard should not publish stable cow"
+        );
+        assert!(
+            !tokio::fs::try_exists(output.cow_bitmap()).await.unwrap(),
+            "discard should not publish stable cow bitmap"
+        );
+        assert!(
+            !tokio::fs::try_exists(output.complete_marker())
+                .await
+                .unwrap(),
+            "discard should not write complete marker"
+        );
+        assert!(
+            !tokio::fs::try_exists(attempt_dir).await.unwrap(),
+            "discard should remove temporary attempt dir"
+        );
+
+        let provider = FirecrackerSnapshotProvider;
+        assert!(!provider.is_complete(output.dir()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn pending_snapshot_publish_drop_cleans_temp_without_publishing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = SnapshotOutputPaths::new(dir.path().join("output"));
+        write_required_snapshot_artifacts(&output).await;
+        let kept_cow = write_kept_cow_for_test(&output.work_dir(), "pending-drop").await;
+        let attempt_dir = kept_cow
+            .cow_file
+            .parent()
+            .expect("attempt dir")
+            .to_path_buf();
+        let cow_file = kept_cow.cow_file.clone();
+        let bitmap_file = kept_cow.bitmap_file.clone();
+
+        let pending = FirecrackerPendingSnapshotPublish {
+            snapshot_config: output.snapshot_config("pending-drop"),
+            output: SnapshotOutputPaths::new(output.dir().to_path_buf()),
+            publish_attempt: SnapshotPublishAttempt::new_with_kept_cow_for_test(kept_cow),
+        };
+
+        drop(pending);
+
+        assert!(
+            !tokio::fs::try_exists(&cow_file).await.unwrap(),
+            "drop should cleanup temporary cow"
+        );
+        assert!(
+            !tokio::fs::try_exists(&bitmap_file).await.unwrap(),
+            "drop should cleanup temporary bitmap"
+        );
+        assert!(
+            !tokio::fs::try_exists(attempt_dir).await.unwrap(),
+            "drop should cleanup temporary attempt dir"
+        );
+        assert!(
+            !tokio::fs::try_exists(output.complete_marker())
+                .await
+                .unwrap(),
+            "drop must not write complete marker"
+        );
+        assert!(
+            !tokio::fs::try_exists(output.cow()).await.unwrap(),
+            "drop must not publish stable cow"
+        );
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -2696,6 +2696,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pending_snapshot_publish_discard_recovers_after_partial_bitmap_publish() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = SnapshotOutputPaths::new(dir.path().join("output"));
+        write_required_snapshot_artifacts(&output).await;
+        tokio::fs::create_dir(output.cow())
+            .await
+            .expect("block cow rename with directory");
+        let kept_cow = write_kept_cow_for_test(&output.work_dir(), "partial-bitmap").await;
+        let cow_file = kept_cow.cow_file.clone();
+        let bitmap_file = kept_cow.bitmap_file.clone();
+        let mut pending = FirecrackerPendingSnapshotPublish::new(
+            output.snapshot_config("partial-bitmap"),
+            SnapshotOutputPaths::new(output.dir().to_path_buf()),
+            kept_cow,
+        );
+
+        let err = pending
+            .commit_config()
+            .await
+            .expect_err("commit should fail after publishing bitmap but before cow");
+        assert!(matches!(err, SnapshotError::Io(_)), "got: {err:?}");
+        assert!(
+            tokio::fs::try_exists(output.cow_bitmap()).await.unwrap(),
+            "failed commit should expose the partial stable bitmap"
+        );
+        assert!(
+            !tokio::fs::try_exists(&bitmap_file).await.unwrap(),
+            "bitmap rename should move the temp bitmap before commit fails"
+        );
+
+        pending
+            .discard_inner()
+            .await
+            .expect_err("discard should keep state when blocking output cow directory remains");
+        assert!(
+            !tokio::fs::try_exists(output.cow_bitmap()).await.unwrap(),
+            "discard should remove the partial stable bitmap"
+        );
+        assert!(
+            !tokio::fs::try_exists(&cow_file).await.unwrap(),
+            "discard should remove the remaining temp cow"
+        );
+
+        tokio::fs::remove_dir(output.cow())
+            .await
+            .expect("remove blocking cow directory");
+        pending
+            .discard_inner()
+            .await
+            .expect("retry should finish cleanup after blocking output is fixed");
+        assert!(
+            !tokio::fs::try_exists(output.complete_marker())
+                .await
+                .unwrap(),
+            "failed commit cleanup must not publish marker"
+        );
+        assert!(
+            !FirecrackerSnapshotProvider
+                .is_complete(output.dir())
+                .await
+                .unwrap(),
+            "partial bitmap publish must remain incomplete"
+        );
+    }
+
+    #[tokio::test]
     async fn snapshot_publish_cleanup_kept_cow_does_not_publish_stable_output() {
         let dir = tempfile::tempdir().expect("tempdir");
         let output = SnapshotOutputPaths::new(dir.path().join("output"));

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -604,21 +604,19 @@ impl SnapshotPublishAttempt {
     }
 
     async fn cleanup_resolved_kept_cow(&mut self) -> bool {
-        let state = std::mem::replace(&mut self.state, SnapshotPublishState::Empty);
-        match state {
-            SnapshotPublishState::KeptCow(kept_cow) => {
-                let cleaned = cleanup_kept_cow_after_publish_cancellation(&kept_cow).await;
-                if !cleaned {
-                    self.state = SnapshotPublishState::KeptCow(kept_cow);
-                }
-                cleaned
+        let cleanup_paths = match &self.state {
+            SnapshotPublishState::KeptCow(kept_cow) => KeptCowCleanupPaths::from_kept_cow(kept_cow),
+            SnapshotPublishState::Empty => return true,
+            SnapshotPublishState::HoldingDevice(_) | SnapshotPublishState::KeepingCow(_) => {
+                return false;
             }
-            SnapshotPublishState::Empty => true,
-            other => {
-                self.state = other;
-                false
-            }
+        };
+
+        let cleaned = cleanup_kept_cow_paths_after_publish_cancellation(&cleanup_paths).await;
+        if cleaned {
+            self.state = SnapshotPublishState::Empty;
         }
+        cleaned
     }
 }
 
@@ -626,6 +624,20 @@ enum FirecrackerPendingSnapshotPublishState {
     Pending(KeptCow),
     Committed,
     Discarded,
+}
+
+struct KeptCowCleanupPaths {
+    cow_file: PathBuf,
+    bitmap_file: PathBuf,
+}
+
+impl KeptCowCleanupPaths {
+    fn from_kept_cow(kept_cow: &KeptCow) -> Self {
+        Self {
+            cow_file: kept_cow.cow_file.clone(),
+            bitmap_file: kept_cow.bitmap_file.clone(),
+        }
+    }
 }
 
 struct FirecrackerPendingSnapshotPublish {
@@ -679,26 +691,21 @@ impl FirecrackerPendingSnapshotPublish {
     }
 
     async fn discard_inner(&mut self) -> Result<(), SnapshotError> {
-        let state = std::mem::replace(
-            &mut self.state,
-            FirecrackerPendingSnapshotPublishState::Discarded,
-        );
-        match state {
+        let cleanup_paths = match &self.state {
             FirecrackerPendingSnapshotPublishState::Pending(kept_cow) => {
-                if cleanup_kept_cow_after_publish_cancellation(&kept_cow).await {
-                    Ok(())
-                } else {
-                    self.state = FirecrackerPendingSnapshotPublishState::Pending(kept_cow);
-                    Err(SnapshotError::Teardown(
-                        "failed to discard uncommitted snapshot artifacts".into(),
-                    ))
-                }
+                KeptCowCleanupPaths::from_kept_cow(kept_cow)
             }
             FirecrackerPendingSnapshotPublishState::Committed
-            | FirecrackerPendingSnapshotPublishState::Discarded => {
-                self.state = state;
-                Ok(())
-            }
+            | FirecrackerPendingSnapshotPublishState::Discarded => return Ok(()),
+        };
+
+        if cleanup_kept_cow_paths_after_publish_cancellation(&cleanup_paths).await {
+            self.state = FirecrackerPendingSnapshotPublishState::Discarded;
+            Ok(())
+        } else {
+            Err(SnapshotError::Teardown(
+                "failed to discard uncommitted snapshot artifacts".into(),
+            ))
         }
     }
 }
@@ -750,9 +757,9 @@ fn snapshot_output_from_config(config: SnapshotConfig) -> SnapshotOutput {
     }
 }
 
-async fn cleanup_kept_cow_after_publish_cancellation(kept_cow: &KeptCow) -> bool {
+async fn cleanup_kept_cow_paths_after_publish_cancellation(paths: &KeptCowCleanupPaths) -> bool {
     let mut cleaned = true;
-    for path in [&kept_cow.bitmap_file, &kept_cow.cow_file] {
+    for path in [&paths.bitmap_file, &paths.cow_file] {
         match tokio::fs::remove_file(path).await {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -766,12 +773,16 @@ async fn cleanup_kept_cow_after_publish_cancellation(kept_cow: &KeptCow) -> bool
             }
         }
     }
-    cleanup_snapshot_attempt_dir_for_cow(&kept_cow.cow_file).await && cleaned
+    cleanup_snapshot_attempt_dir_for_cow(&paths.cow_file).await && cleaned
 }
 
 fn cleanup_kept_cow_after_publish_drop(kept_cow: &KeptCow) -> bool {
+    cleanup_kept_cow_paths_after_publish_drop(&KeptCowCleanupPaths::from_kept_cow(kept_cow))
+}
+
+fn cleanup_kept_cow_paths_after_publish_drop(paths: &KeptCowCleanupPaths) -> bool {
     let mut cleaned = true;
-    for path in [&kept_cow.bitmap_file, &kept_cow.cow_file] {
+    for path in [&paths.bitmap_file, &paths.cow_file] {
         match std::fs::remove_file(path) {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -785,7 +796,7 @@ fn cleanup_kept_cow_after_publish_drop(kept_cow: &KeptCow) -> bool {
             }
         }
     }
-    cleanup_snapshot_attempt_dir_for_cow_sync(&kept_cow.cow_file) && cleaned
+    cleanup_snapshot_attempt_dir_for_cow_sync(&paths.cow_file) && cleaned
 }
 
 fn commit_snapshot_cow_output(
@@ -2257,6 +2268,75 @@ mod tests {
 
         let provider = FirecrackerSnapshotProvider;
         assert!(!provider.is_complete(output.dir()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn pending_snapshot_publish_discard_failure_keeps_cleanup_state_for_retry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = SnapshotOutputPaths::new(dir.path().join("output"));
+        write_required_snapshot_artifacts(&output).await;
+        let cow_file = snapshot_attempt_cow_file(&output.work_dir(), "pending-discard-retry");
+        let attempt_dir = cow_file.parent().expect("attempt dir").to_path_buf();
+        tokio::fs::create_dir_all(&cow_file)
+            .await
+            .expect("create cow path as directory");
+        let bitmap_file = attempt_dir.join("cow.img.bitmap");
+        tokio::fs::write(&bitmap_file, b"bitmap")
+            .await
+            .expect("write bitmap");
+        let mut pending = FirecrackerPendingSnapshotPublish::new(
+            output.snapshot_config("pending-discard-retry"),
+            SnapshotOutputPaths::new(output.dir().to_path_buf()),
+            KeptCow {
+                cow_file: cow_file.clone(),
+                bitmap_file: bitmap_file.clone(),
+            },
+        );
+
+        pending
+            .discard_inner()
+            .await
+            .expect_err("discard should fail when a temp artifact cannot be removed");
+
+        assert!(
+            !tokio::fs::try_exists(&bitmap_file).await.unwrap(),
+            "failed discard should still remove cleanup work that succeeded"
+        );
+        assert!(
+            tokio::fs::try_exists(&cow_file).await.unwrap(),
+            "failed discard should leave the failed temp artifact for retry"
+        );
+        assert!(
+            !tokio::fs::try_exists(output.complete_marker())
+                .await
+                .unwrap(),
+            "failed discard must not publish marker"
+        );
+
+        tokio::fs::remove_dir(&cow_file)
+            .await
+            .expect("remove blocking cow directory");
+        tokio::fs::write(&cow_file, b"cow")
+            .await
+            .expect("write retryable cow file");
+
+        pending
+            .discard_inner()
+            .await
+            .expect("retry should clean retained pending publish state");
+
+        assert!(
+            !tokio::fs::try_exists(attempt_dir).await.unwrap(),
+            "retry should remove temporary attempt dir"
+        );
+        assert!(
+            !tokio::fs::try_exists(output.cow()).await.unwrap(),
+            "discard retry must not publish stable cow"
+        );
+        assert!(
+            !tokio::fs::try_exists(output.cow_bitmap()).await.unwrap(),
+            "discard retry must not publish stable cow bitmap"
+        );
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -131,42 +131,57 @@ impl SnapshotError {
     }
 }
 
+fn remove_file_if_exists_sync(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+fn remove_dir_all_if_exists_sync(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
 async fn prepare_snapshot_output(output: &SnapshotOutputPaths) -> Result<PathBuf, SnapshotError> {
     // Paths inside work_dir get baked into the snapshot and are used as
     // bind-mount targets during restore, so they must be deterministic.
     //
     // Only remove snapshot-specific artifacts, not the entire output directory.
+    //
+    // Use synchronous filesystem calls for shared snapshot-hash paths while the
+    // caller holds the snapshot lock. A cancelled Tokio fs operation can keep
+    // running on the blocking pool after the lock is dropped.
     let work = output.work_dir();
-    match tokio::fs::remove_file(output.complete_marker()).await {
-        Ok(()) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => return Err(e.into()),
-    }
-    let _ = tokio::fs::remove_dir_all(&work).await;
+    remove_file_if_exists_sync(&output.complete_marker())?;
+    let _ = remove_dir_all_if_exists_sync(&work);
     for stale in [
         output.snapshot(),
         output.memory(),
         output.cow(),
         output.cow_bitmap(),
     ] {
-        let _ = tokio::fs::remove_file(&stale).await;
+        let _ = remove_file_if_exists_sync(&stale);
     }
-    tokio::fs::create_dir_all(&work).await?;
+    std::fs::create_dir_all(&work)?;
     Ok(work)
 }
 
 async fn cleanup_existing_snapshot_sock_dir(sock_dir: &Path) {
     if sock_dir.exists()
-        && let Err(e) = tokio::fs::remove_dir_all(sock_dir).await
+        && let Err(e) = remove_dir_all_if_exists_sync(sock_dir)
     {
         tracing::warn!(error = %e, "failed to clean stale sock dir");
     }
 }
 
 async fn cleanup_snapshot_sock_dir(sock_dir: &Path, warning: &'static str) -> bool {
-    match tokio::fs::remove_dir_all(sock_dir).await {
+    match remove_dir_all_if_exists_sync(sock_dir) {
         Ok(()) => true,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
         Err(e) => {
             tracing::warn!(error = %e, "{warning}");
             false
@@ -699,11 +714,10 @@ impl FirecrackerPendingSnapshotPublish {
             | FirecrackerPendingSnapshotPublishState::Discarded => return Ok(()),
         };
 
-        let output_artifacts_cleaned =
-            cleanup_uncommitted_snapshot_output_artifacts(&self.output).await;
+        let output_artifacts_cleaned = cleanup_uncommitted_snapshot_output_artifacts(&self.output);
         let cow_cleaned = cleanup_kept_cow_paths_after_publish_cancellation(&cleanup_paths).await;
         let work_cleaned = if cow_cleaned {
-            cleanup_snapshot_work_dir(&self.output).await
+            cleanup_snapshot_work_dir(&self.output)
         } else {
             false
         };
@@ -785,7 +799,7 @@ async fn cleanup_kept_cow_paths_after_publish_cancellation(paths: &KeptCowCleanu
     cleanup_snapshot_attempt_dir_for_cow(&paths.cow_file).await && cleaned
 }
 
-async fn cleanup_uncommitted_snapshot_output_artifacts(output: &SnapshotOutputPaths) -> bool {
+fn cleanup_uncommitted_snapshot_output_artifacts(output: &SnapshotOutputPaths) -> bool {
     let mut cleaned = true;
     for path in [
         output.complete_marker(),
@@ -794,9 +808,8 @@ async fn cleanup_uncommitted_snapshot_output_artifacts(output: &SnapshotOutputPa
         output.cow(),
         output.cow_bitmap(),
     ] {
-        match tokio::fs::remove_file(&path).await {
+        match remove_file_if_exists_sync(&path) {
             Ok(()) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => {
                 tracing::warn!(
                     error = %e,
@@ -810,11 +823,10 @@ async fn cleanup_uncommitted_snapshot_output_artifacts(output: &SnapshotOutputPa
     cleaned
 }
 
-async fn cleanup_snapshot_work_dir(output: &SnapshotOutputPaths) -> bool {
+fn cleanup_snapshot_work_dir(output: &SnapshotOutputPaths) -> bool {
     let work_dir = output.work_dir();
-    match tokio::fs::remove_dir_all(&work_dir).await {
+    match remove_dir_all_if_exists_sync(&work_dir) {
         Ok(()) => true,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
         Err(e) => {
             tracing::warn!(
                 error = %e,

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -2160,6 +2160,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pending_snapshot_publish_commit_failure_does_not_publish_marker() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = SnapshotOutputPaths::new(dir.path().join("output"));
+        tokio::fs::create_dir_all(output.dir())
+            .await
+            .expect("create output dir");
+        let kept_cow = write_kept_cow_for_test(&output.work_dir(), "pending-commit-fail").await;
+
+        let pending: Box<dyn PendingSnapshotPublish> =
+            Box::new(FirecrackerPendingSnapshotPublish {
+                snapshot_config: output.snapshot_config("pending-commit-fail"),
+                output: SnapshotOutputPaths::new(output.dir().to_path_buf()),
+                publish_attempt: SnapshotPublishAttempt::new_with_kept_cow_for_test(kept_cow),
+            });
+
+        let err = pending
+            .commit()
+            .await
+            .expect_err("pending commit should fail without snapshot and memory artifacts");
+        assert!(matches!(err, sandbox::SnapshotError::Io(_)), "got: {err:?}");
+        assert!(
+            !tokio::fs::try_exists(output.complete_marker())
+                .await
+                .unwrap(),
+            "failed pending commit must not write complete marker"
+        );
+
+        let provider = FirecrackerSnapshotProvider;
+        assert!(
+            !provider.is_complete(output.dir()).await.unwrap(),
+            "failed pending commit must remain incomplete"
+        );
+    }
+
+    #[tokio::test]
     async fn pending_snapshot_publish_discard_does_not_publish_marker_or_stable_cow() {
         let dir = tempfile::tempdir().expect("tempdir");
         let output = SnapshotOutputPaths::new(dir.path().join("output"));

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -699,7 +699,16 @@ impl FirecrackerPendingSnapshotPublish {
             | FirecrackerPendingSnapshotPublishState::Discarded => return Ok(()),
         };
 
-        if cleanup_kept_cow_paths_after_publish_cancellation(&cleanup_paths).await {
+        let output_artifacts_cleaned =
+            cleanup_uncommitted_snapshot_output_artifacts(&self.output).await;
+        let cow_cleaned = cleanup_kept_cow_paths_after_publish_cancellation(&cleanup_paths).await;
+        let work_cleaned = if cow_cleaned {
+            cleanup_snapshot_work_dir(&self.output).await
+        } else {
+            false
+        };
+
+        if output_artifacts_cleaned && cow_cleaned && work_cleaned {
             self.state = FirecrackerPendingSnapshotPublishState::Discarded;
             Ok(())
         } else {
@@ -774,6 +783,47 @@ async fn cleanup_kept_cow_paths_after_publish_cancellation(paths: &KeptCowCleanu
         }
     }
     cleanup_snapshot_attempt_dir_for_cow(&paths.cow_file).await && cleaned
+}
+
+async fn cleanup_uncommitted_snapshot_output_artifacts(output: &SnapshotOutputPaths) -> bool {
+    let mut cleaned = true;
+    for path in [
+        output.complete_marker(),
+        output.snapshot(),
+        output.memory(),
+        output.cow(),
+        output.cow_bitmap(),
+    ] {
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    path = %path.display(),
+                    "failed to cleanup uncommitted snapshot output artifact"
+                );
+                cleaned = false;
+            }
+        }
+    }
+    cleaned
+}
+
+async fn cleanup_snapshot_work_dir(output: &SnapshotOutputPaths) -> bool {
+    let work_dir = output.work_dir();
+    match tokio::fs::remove_dir_all(&work_dir).await {
+        Ok(()) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                path = %work_dir.display(),
+                "failed to cleanup uncommitted snapshot work dir"
+            );
+            false
+        }
+    }
 }
 
 fn cleanup_kept_cow_after_publish_drop(kept_cow: &KeptCow) -> bool {
@@ -2248,6 +2298,14 @@ mod tests {
         pending.discard().await.expect("discard pending publish");
 
         assert!(
+            !tokio::fs::try_exists(output.snapshot()).await.unwrap(),
+            "discard should remove uncommitted snapshot file"
+        );
+        assert!(
+            !tokio::fs::try_exists(output.memory()).await.unwrap(),
+            "discard should remove uncommitted memory file"
+        );
+        assert!(
             !tokio::fs::try_exists(output.cow()).await.unwrap(),
             "discard should not publish stable cow"
         );
@@ -2264,6 +2322,10 @@ mod tests {
         assert!(
             !tokio::fs::try_exists(attempt_dir).await.unwrap(),
             "discard should remove temporary attempt dir"
+        );
+        assert!(
+            !tokio::fs::try_exists(output.work_dir()).await.unwrap(),
+            "discard should remove uncommitted snapshot work dir"
         );
 
         let provider = FirecrackerSnapshotProvider;
@@ -2442,6 +2504,14 @@ mod tests {
             .discard_inner()
             .await
             .expect("failed commit should keep cleanup state for discard");
+        assert!(
+            !tokio::fs::try_exists(output.cow()).await.unwrap(),
+            "cleanup should remove partial stable cow after failed commit"
+        );
+        assert!(
+            !tokio::fs::try_exists(output.cow_bitmap()).await.unwrap(),
+            "cleanup should remove partial stable bitmap after failed commit"
+        );
         assert!(
             !tokio::fs::try_exists(output.complete_marker())
                 .await

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -40,15 +41,100 @@ fn cow_destroy_retry_policy() -> DestroyRetryPolicy {
     }
 }
 
-async fn destroy_snapshot_cow_and_cleanup_attempt_dir(
-    cow_device: PooledNbdCowDevice,
+/// Non-cancellable cleanup for a snapshot COW and its token-scoped attempt dir.
+///
+/// The NBD device finalizer already keeps running after cancellation; this
+/// wrapper keeps the attempt-dir cleanup in the same detached task so a
+/// cancelled waiter cannot leave empty token directories behind.
+struct SnapshotCowCleanupFinalizer {
+    handle: Option<JoinHandle<nbd_cow::error::Result<()>>>,
+}
+
+impl SnapshotCowCleanupFinalizer {
+    fn new(handle: JoinHandle<nbd_cow::error::Result<()>>) -> Self {
+        Self {
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Future for SnapshotCowCleanupFinalizer {
+    type Output = nbd_cow::error::Result<()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let Some(handle) = this.handle.as_mut() else {
+            return Poll::Ready(Err(nbd_cow::error::NbdCowError::Io(std::io::Error::other(
+                "snapshot COW cleanup finalizer polled after completion",
+            ))));
+        };
+
+        match Pin::new(handle).poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(result) => {
+                this.handle.take();
+                Poll::Ready(finish_snapshot_cow_cleanup_join(result))
+            }
+        }
+    }
+}
+
+impl Drop for SnapshotCowCleanupFinalizer {
+    fn drop(&mut self) {
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+
+        match tokio::runtime::Handle::try_current() {
+            Ok(runtime) => {
+                runtime.spawn(observe_detached_snapshot_cow_cleanup(handle));
+            }
+            Err(e) => tracing::warn!(
+                error = %e,
+                "snapshot COW cleanup finalizer dropped outside Tokio runtime; continuing without observer"
+            ),
+        }
+    }
+}
+
+fn finish_snapshot_cow_cleanup_join(
+    result: std::result::Result<nbd_cow::error::Result<()>, tokio::task::JoinError>,
 ) -> nbd_cow::error::Result<()> {
+    match result {
+        Ok(result) => result,
+        Err(e) if e.is_panic() => std::panic::resume_unwind(e.into_panic()),
+        Err(e) => Err(nbd_cow::error::NbdCowError::Io(std::io::Error::other(
+            format!("snapshot COW cleanup finalizer task was cancelled: {e}"),
+        ))),
+    }
+}
+
+async fn observe_detached_snapshot_cow_cleanup(handle: JoinHandle<nbd_cow::error::Result<()>>) {
+    match handle.await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "detached snapshot COW cleanup finalizer failed");
+        }
+        Err(e) if e.is_panic() => {
+            tracing::error!(error = %e, "detached snapshot COW cleanup finalizer panicked");
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "detached snapshot COW cleanup finalizer task was cancelled");
+        }
+    }
+}
+
+fn destroy_snapshot_cow_and_cleanup_attempt_dir(
+    cow_device: PooledNbdCowDevice,
+) -> SnapshotCowCleanupFinalizer {
     let cow_file = cow_device.cow_file().to_path_buf();
-    cow_device
-        .destroy_with_retries(cow_destroy_retry_policy())
-        .await?;
-    cleanup_snapshot_attempt_dir_for_cow(&cow_file).await;
-    Ok(())
+    SnapshotCowCleanupFinalizer::new(tokio::spawn(async move {
+        cow_device
+            .destroy_with_retries(cow_destroy_retry_policy())
+            .await?;
+        cleanup_snapshot_attempt_dir_for_cow(&cow_file).await;
+        Ok(())
+    }))
 }
 
 async fn destroy_snapshot_cow_after_error(context: &'static str, cow_device: PooledNbdCowDevice) {
@@ -2878,6 +2964,34 @@ mod tests {
             attempt_dir.exists(),
             "disarmed attempt dir guard should leave the owned dir intact"
         );
+    }
+
+    #[tokio::test]
+    async fn snapshot_cow_cleanup_finalizer_continues_after_future_drop() {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+
+        let finalizer = SnapshotCowCleanupFinalizer::new(tokio::spawn(async move {
+            let _ = started_tx.send(());
+            finish_rx.await.map_err(|e| {
+                nbd_cow::error::NbdCowError::Io(std::io::Error::other(format!(
+                    "test cleanup finalizer release dropped: {e}"
+                )))
+            })?;
+            let _ = done_tx.send(());
+            Ok(())
+        }));
+
+        started_rx
+            .await
+            .expect("cleanup finalizer task should start");
+        drop(finalizer);
+        finish_tx.send(()).expect("release cleanup finalizer");
+        tokio::time::timeout(Duration::from_secs(1), done_rx)
+            .await
+            .expect("dropped cleanup finalizer should continue")
+            .expect("cleanup finalizer should finish");
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -3111,6 +3111,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn abort_on_drop_task_explicit_abort_removes_vsock_listener() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let base = dir.path().join("snapshot-vsock-explicit-abort");
+        let listener =
+            std::path::PathBuf::from(format!("{}_{}", base.display(), vsock_proto::VSOCK_PORT));
+        let base = base.display().to_string();
+
+        let task = AbortOnDropTask::new(tokio::spawn(async move {
+            vsock_host::VsockHost::wait_for_connection(&base, Duration::from_secs(30)).await
+        }));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !listener.exists() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("vsock listener should bind");
+
+        task.abort();
+        let join = task.await;
+        assert!(
+            join.is_err_and(|e| e.is_cancelled()),
+            "explicit abort should cancel the listener task"
+        );
+
+        assert!(
+            !listener.exists(),
+            "explicit abort should remove the vsock listener socket"
+        );
+    }
+
+    #[tokio::test]
     async fn cleanup_snapshot_attempt_dir_removes_empty_token_dir() {
         let dir = tempfile::tempdir().expect("tempdir");
         let work = dir.path().join("work");

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -656,7 +656,7 @@ struct MockPendingSnapshotPublish {
 
 #[async_trait]
 impl PendingSnapshotPublish for MockPendingSnapshotPublish {
-    async fn commit(self: Box<Self>) -> std::result::Result<SnapshotOutput, SnapshotError> {
+    async fn commit(&mut self) -> std::result::Result<SnapshotOutput, SnapshotError> {
         Ok(SnapshotOutput {
             snapshot_path: self.output_dir.join("snapshot.bin"),
             memory_path: self.output_dir.join("memory.bin"),
@@ -664,7 +664,7 @@ impl PendingSnapshotPublish for MockPendingSnapshotPublish {
         })
     }
 
-    async fn discard(self: Box<Self>) -> std::result::Result<(), SnapshotError> {
+    async fn discard(&mut self) -> std::result::Result<(), SnapshotError> {
         Ok(())
     }
 }
@@ -761,7 +761,10 @@ impl SandboxControl for MockSandboxControl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
 
     fn test_snapshot_config(output_dir: PathBuf) -> SnapshotCreateConfig {
         SnapshotCreateConfig {
@@ -793,7 +796,7 @@ mod tests {
             uuid::Uuid::new_v4().simple()
         ));
 
-        let pending = provider
+        let mut pending = provider
             .create_uncommitted_snapshot(test_snapshot_config(output_dir))
             .await
             .expect("create uncommitted snapshot");
@@ -841,6 +844,75 @@ mod tests {
         assert_eq!(output.snapshot_path, output_dir.join("snapshot.bin"));
         assert_eq!(output.memory_path, output_dir.join("memory.bin"));
         assert_eq!(output.cow_path, output_dir.join("cow.img"));
+    }
+
+    struct FailingPendingSnapshotPublish {
+        discarded: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl PendingSnapshotPublish for FailingPendingSnapshotPublish {
+        async fn commit(&mut self) -> std::result::Result<SnapshotOutput, SnapshotError> {
+            Err(SnapshotError::Teardown("commit failed".into()))
+        }
+
+        async fn discard(&mut self) -> std::result::Result<(), SnapshotError> {
+            self.discarded.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    struct FailingSnapshotProvider {
+        discarded: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl SnapshotProvider for FailingSnapshotProvider {
+        async fn create_uncommitted_snapshot(
+            &self,
+            _config: SnapshotCreateConfig,
+        ) -> std::result::Result<Box<dyn PendingSnapshotPublish>, SnapshotError> {
+            Ok(Box::new(FailingPendingSnapshotPublish {
+                discarded: Arc::clone(&self.discarded),
+            }))
+        }
+
+        fn config_hash(&self) -> String {
+            "failing-snapshot-config-hash".into()
+        }
+
+        async fn is_complete(
+            &self,
+            _output_dir: &std::path::Path,
+        ) -> std::result::Result<bool, SnapshotError> {
+            Ok(false)
+        }
+    }
+
+    #[tokio::test]
+    async fn snapshot_provider_default_create_snapshot_discards_after_commit_failure() {
+        let discarded = Arc::new(AtomicBool::new(false));
+        let provider = FailingSnapshotProvider {
+            discarded: Arc::clone(&discarded),
+        };
+        let output_dir = std::env::temp_dir().join(format!(
+            "sandbox-mock-snapshot-failure-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+
+        let err = provider
+            .create_snapshot(test_snapshot_config(output_dir))
+            .await
+            .expect_err("commit should fail");
+
+        assert!(
+            matches!(err, SnapshotError::Teardown(ref message) if message == "commit failed"),
+            "got: {err:?}"
+        );
+        assert!(
+            discarded.load(Ordering::SeqCst),
+            "default create_snapshot should discard after commit failure"
+        );
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -650,17 +650,34 @@ impl RuntimeProvider for MockRuntimeProvider {
 /// A mock [`SnapshotProvider`] that returns dummy paths.
 pub struct MockSnapshotProvider;
 
+struct MockPendingSnapshotPublish {
+    output_dir: PathBuf,
+}
+
+#[async_trait]
+impl PendingSnapshotPublish for MockPendingSnapshotPublish {
+    async fn commit(self: Box<Self>) -> std::result::Result<SnapshotOutput, SnapshotError> {
+        Ok(SnapshotOutput {
+            snapshot_path: self.output_dir.join("snapshot.bin"),
+            memory_path: self.output_dir.join("memory.bin"),
+            cow_path: self.output_dir.join("cow.img"),
+        })
+    }
+
+    async fn discard(self: Box<Self>) -> std::result::Result<(), SnapshotError> {
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl SnapshotProvider for MockSnapshotProvider {
-    async fn create_snapshot(
+    async fn create_uncommitted_snapshot(
         &self,
         config: SnapshotCreateConfig,
-    ) -> std::result::Result<SnapshotOutput, SnapshotError> {
-        Ok(SnapshotOutput {
-            snapshot_path: config.output_dir.join("snapshot.bin"),
-            memory_path: config.output_dir.join("memory.bin"),
-            cow_path: config.output_dir.join("cow.img"),
-        })
+    ) -> std::result::Result<Box<dyn PendingSnapshotPublish>, SnapshotError> {
+        Ok(Box::new(MockPendingSnapshotPublish {
+            output_dir: config.output_dir,
+        }))
     }
 
     fn config_hash(&self) -> String {
@@ -746,6 +763,18 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
+    fn test_snapshot_config(output_dir: PathBuf) -> SnapshotCreateConfig {
+        SnapshotCreateConfig {
+            id: "test-snapshot".into(),
+            binary_path: "/tmp/firecracker".into(),
+            kernel_path: "/tmp/kernel".into(),
+            rootfs_path: "/tmp/rootfs.ext4".into(),
+            output_dir,
+            vcpu_count: 2,
+            memory_mb: 1024,
+        }
+    }
+
     fn test_sandbox_config() -> SandboxConfig {
         SandboxConfig {
             id: sandbox::SandboxId::new_v4(),
@@ -754,6 +783,22 @@ mod tests {
                 memory_mb: 1024,
             },
         }
+    }
+
+    #[tokio::test]
+    async fn snapshot_provider_can_discard_uncommitted_snapshot() {
+        let provider = MockSnapshotProvider;
+        let output_dir = std::env::temp_dir().join(format!(
+            "sandbox-mock-snapshot-discard-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+
+        let pending = provider
+            .create_uncommitted_snapshot(test_snapshot_config(output_dir))
+            .await
+            .expect("create uncommitted snapshot");
+
+        pending.discard().await.expect("discard pending snapshot");
     }
 
     #[tokio::test]
@@ -770,6 +815,32 @@ mod tests {
         let exec = result.unwrap();
         assert_eq!(exec.exit_code, 0);
         assert!(exec.stdout.is_empty());
+    }
+
+    #[tokio::test]
+    async fn snapshot_provider_default_create_snapshot_commits_pending_publish() {
+        let provider = MockSnapshotProvider;
+        let output_dir = std::env::temp_dir().join(format!(
+            "sandbox-mock-snapshot-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+
+        let output = provider
+            .create_snapshot(SnapshotCreateConfig {
+                id: "snapshot-test".into(),
+                binary_path: "/tmp/firecracker".into(),
+                kernel_path: "/tmp/kernel".into(),
+                rootfs_path: "/tmp/rootfs.ext4".into(),
+                output_dir: output_dir.clone(),
+                vcpu_count: 1,
+                memory_mb: 128,
+            })
+            .await
+            .expect("create snapshot");
+
+        assert_eq!(output.snapshot_path, output_dir.join("snapshot.bin"));
+        assert_eq!(output.memory_path, output_dir.join("memory.bin"));
+        assert_eq!(output.cow_path, output_dir.join("cow.img"));
     }
 
     #[tokio::test]

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -37,5 +37,7 @@ pub use error::{
 pub use factory::SandboxFactory;
 pub use runtime::{RuntimeProvider, SandboxRuntime};
 pub use sandbox::Sandbox;
-pub use snapshot::{SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider};
+pub use snapshot::{
+    PendingSnapshotPublish, SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider,
+};
 pub use types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle, SpawnOutputMode};

--- a/crates/sandbox/src/snapshot.rs
+++ b/crates/sandbox/src/snapshot.rs
@@ -81,18 +81,49 @@ pub enum SnapshotError {
     Io(#[from] std::io::Error),
 }
 
+/// Pending provider-side publish step for a created snapshot.
+///
+/// A pending publish means the provider finished all live runtime work needed
+/// to create the snapshot, but has not yet made the output reusable. Call
+/// [`commit`](Self::commit) to publish the provider-specific completion marker
+/// and return the output paths, or [`discard`](Self::discard) to abandon the
+/// uncommitted artifacts. Dropping this object without an explicit call must
+/// not publish a usable snapshot.
+#[async_trait]
+pub trait PendingSnapshotPublish: Send {
+    /// Make the snapshot reusable and return the stable output paths.
+    async fn commit(self: Box<Self>) -> Result<SnapshotOutput, SnapshotError>;
+
+    /// Abandon the uncommitted snapshot artifacts.
+    async fn discard(self: Box<Self>) -> Result<(), SnapshotError>;
+}
+
 /// Creates snapshots for fast sandbox boot.
 ///
 /// This is a lightweight, stateless trait — it does not require a
 /// [`SandboxRuntime`](crate::SandboxRuntime) instance.
 #[async_trait]
 pub trait SnapshotProvider: Send + Sync {
+    /// Create a snapshot and return a pending provider-side publish step.
+    ///
+    /// The pending object represents the boundary after provider runtime
+    /// resources have been cleaned up and before the snapshot is made reusable.
+    async fn create_uncommitted_snapshot(
+        &self,
+        config: SnapshotCreateConfig,
+    ) -> Result<Box<dyn PendingSnapshotPublish>, SnapshotError>;
+
     /// Create a snapshot by booting a temporary VM, configuring it, and
     /// capturing its state to the output directory.
     async fn create_snapshot(
         &self,
         config: SnapshotCreateConfig,
-    ) -> Result<SnapshotOutput, SnapshotError>;
+    ) -> Result<SnapshotOutput, SnapshotError> {
+        self.create_uncommitted_snapshot(config)
+            .await?
+            .commit()
+            .await
+    }
 
     /// Content hash of all internal configuration that affects snapshot output.
     ///

--- a/crates/sandbox/src/snapshot.rs
+++ b/crates/sandbox/src/snapshot.rs
@@ -90,6 +90,12 @@ pub enum SnapshotError {
 /// uncommitted artifacts. Dropping this object without an explicit call must
 /// not publish a usable snapshot.
 ///
+/// `discard` is the deterministic cleanup path. Callers that coordinate access
+/// to the output directory should call it before releasing that exclusivity.
+/// Implementations may intentionally keep `Drop` narrower than `discard` so a
+/// late drop cannot remove a snapshot published by a later owner of the same
+/// output directory.
+///
 /// `commit` takes `&mut self` so a failed publish can preserve provider-owned
 /// cleanup state. Callers may then call `discard` best-effort before treating
 /// the output as incomplete.
@@ -99,6 +105,9 @@ pub trait PendingSnapshotPublish: Send {
     async fn commit(&mut self) -> Result<SnapshotOutput, SnapshotError>;
 
     /// Abandon the uncommitted snapshot artifacts.
+    ///
+    /// This should be called while the caller still owns any output-directory
+    /// lock or equivalent coordination needed by the provider.
     async fn discard(&mut self) -> Result<(), SnapshotError>;
 }
 

--- a/crates/sandbox/src/snapshot.rs
+++ b/crates/sandbox/src/snapshot.rs
@@ -89,13 +89,17 @@ pub enum SnapshotError {
 /// and return the output paths, or [`discard`](Self::discard) to abandon the
 /// uncommitted artifacts. Dropping this object without an explicit call must
 /// not publish a usable snapshot.
+///
+/// `commit` takes `&mut self` so a failed publish can preserve provider-owned
+/// cleanup state. Callers may then call `discard` best-effort before treating
+/// the output as incomplete.
 #[async_trait]
 pub trait PendingSnapshotPublish: Send {
     /// Make the snapshot reusable and return the stable output paths.
-    async fn commit(self: Box<Self>) -> Result<SnapshotOutput, SnapshotError>;
+    async fn commit(&mut self) -> Result<SnapshotOutput, SnapshotError>;
 
     /// Abandon the uncommitted snapshot artifacts.
-    async fn discard(self: Box<Self>) -> Result<(), SnapshotError>;
+    async fn discard(&mut self) -> Result<(), SnapshotError>;
 }
 
 /// Creates snapshots for fast sandbox boot.
@@ -119,10 +123,14 @@ pub trait SnapshotProvider: Send + Sync {
         &self,
         config: SnapshotCreateConfig,
     ) -> Result<SnapshotOutput, SnapshotError> {
-        self.create_uncommitted_snapshot(config)
-            .await?
-            .commit()
-            .await
+        let mut pending = self.create_uncommitted_snapshot(config).await?;
+        match pending.commit().await {
+            Ok(output) => Ok(output),
+            Err(err) => {
+                let _ = pending.discard().await;
+                Err(err)
+            }
+        }
     }
 
     /// Content hash of all internal configuration that affects snapshot output.


### PR DESCRIPTION
## Summary
- add provider-neutral pending snapshot publish API with mutable commit/discard lifecycle
- split Firecracker snapshot runtime cleanup from final marker publication, returning only finalized kept COW state to the pending publish handle
- make runner explicitly create, commit, and discard uncommitted snapshot publishes while it still owns the snapshot build flow

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p sandbox -p sandbox-mock`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc snapshot`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::build`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox -p sandbox-mock -p sandbox-fc -p runner --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`

Closes #12021
