### PR TITLE
fix(web): accept multi-auth providers as authoritative for codex framework

### DIFF
--- a/turbo/apps/web/src/lib/infra/run/utils/__tests__/validate-framework-api-key.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/utils/__tests__/validate-framework-api-key.test.ts
@@ -93,6 +93,34 @@ describe("validateFrameworkApiKey", () => {
         );
       }).not.toThrow();
     });
+
+    // Regression: #12045 — codex-oauth-token is a multi-auth provider, so
+    // getSecretNameForType returns undefined and the openai-api-key match
+    // path can't see it. Its framework IS codex though — the firewall
+    // replacement layer + sandbox-side placeholder auth.json self-provision
+    // ChatGPT-mode auth without using OPENAI_API_KEY (Epic #11974). The
+    // multi-auth fallback in the validator must accept it.
+    it("accepts codex compose when codex-oauth-token provider is configured", () => {
+      expect(() => {
+        validateFrameworkApiKey(
+          makeCompose("codex", {}),
+          "codex-oauth-token" as ModelProviderType,
+        );
+      }).not.toThrow();
+    });
+
+    it("accepts compose=claude-code + provider=codex-oauth-token (provider's codex framework wins)", () => {
+      // Mirrors the openai-api-key Epic #11520 case below: thread pinned to
+      // a codex-oauth-token provider while the compose still says
+      // claude-code. Resolved framework = codex (provider's), and the
+      // codex-oauth-token multi-auth fallback must accept the run.
+      expect(() => {
+        validateFrameworkApiKey(
+          makeCompose("claude-code", {}),
+          "codex-oauth-token" as ModelProviderType,
+        );
+      }).not.toThrow();
+    });
   });
 
   describe("provider framework wins over compose framework (Epic #11520)", () => {

--- a/turbo/apps/web/src/lib/infra/run/utils/validate-framework-api-key.ts
+++ b/turbo/apps/web/src/lib/infra/run/utils/validate-framework-api-key.ts
@@ -16,14 +16,21 @@ import type { AgentComposeYaml } from "../../agent-compose/types";
  * claude-code is exempt: the org-level model-provider system
  * (`checkModelProviderConfigured`) already gates runs that lack
  * `ANTHROPIC_API_KEY`. Other frameworks (codex today) are satisfied when
- * either:
+ * any of:
  *   (a) compose `environment` declares the framework's key (literal or
  *       `${{ secrets.X }}` placeholder), OR
- *   (b) a configured `providerType`'s `secretName` matches the framework's
- *       required env var — runtime injection from the provider supplies the
- *       key without compose-level declaration.
+ *   (b) a configured single-secret `providerType`'s `secretName` matches
+ *       the framework's required env var — runtime injection from the
+ *       provider supplies the key without compose-level declaration
+ *       (e.g., openai-api-key → OPENAI_API_KEY), OR
+ *   (c) a configured multi-auth `providerType` is registered with the
+ *       resolved framework. Multi-auth providers self-provision auth via
+ *       firewall-replaced injection rather than the framework's canonical
+ *       env var, so the env-var requirement does not apply
+ *       (e.g., codex-oauth-token → ChatGPT mode placeholder auth.json,
+ *       per Epic #11974).
  *
- * @throws BadRequestError when neither path is satisfied.
+ * @throws BadRequestError when none of the paths are satisfied.
  */
 export function validateFrameworkApiKey(
   compose: AgentComposeYaml,
@@ -48,6 +55,16 @@ export function validateFrameworkApiKey(
   if (requiredVar in env) return;
 
   if (providerType && getSecretNameForType(providerType) === requiredVar) {
+    return;
+  }
+
+  // Multi-auth providers (e.g., codex-oauth-token) don't expose a single
+  // top-level `secretName`, so the previous check returns false. Their
+  // authoritative path is the firewall-replacement layer + sandbox-side
+  // placeholder bootstrap — the framework's env var is intentionally NOT
+  // populated. Accept them when their framework matches the run's
+  // resolved framework.
+  if (providerType && getFrameworkForType(providerType) === framework) {
     return;
   }
 


### PR DESCRIPTION
## Summary

P0 production fix for #12045. Composing a run with \`framework: codex\` while using the codex-oauth-token provider was rejected with:

\`\`\`
Compose with framework "codex" requires OPENAI_API_KEY in agent environment.
\`\`\`

The validator only matched single-secret providers (whose top-level \`secretName\` equals the framework's required env var). Multi-auth providers like codex-oauth-token declare \`authMethods\` and have no top-level \`secretName\`, so the openai-api-key match path could not see them.

This entirely blocked the codex-oauth-token paste flow that Epic #11974 shipped today (release \`app-v0.330.0\` / \`web-v12.337.0\`).

## Fix

Accept a configured provider when its \`framework\` matches the resolved framework, in addition to the existing single-secret name match. Comment in code explains the rationale.

\`codex-oauth-token\` self-provisions ChatGPT auth via the firewall replacement layer + sandbox placeholder \`~/.codex/auth.json\` (ChatGPT mode), so the framework's canonical \`OPENAI_API_KEY\` env var is intentionally NOT populated by this path.

## Regression Tests

- codex compose + codex-oauth-token provider passes validation (was throwing)
- compose=claude-code + provider=codex-oauth-token passes (Epic #11520 framework-override path now works for paste-flow too)
- All existing cases still pass (no negative-path regression for openai-api-key, claude-code, missing-provider)

## Test Plan

- [x] \`pnpm -F web exec vitest run src/lib/infra/run/utils/__tests__/validate-framework-api-key\` — 16/16 pass
- [x] \`pnpm turbo run lint\` clean
- [x] \`pnpm check-types\` clean

Closes #12045.

🤖 Generated with [Claude Code](https://claude.com/claude-code)