### PR TITLE
test: clean up info and migration test hygiene

### DIFF
--- a/turbo/apps/cli/src/commands/info/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/info/__tests__/index.test.ts
@@ -9,20 +9,12 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
-import { tmpdir } from "os";
 import { join } from "path";
 import chalk from "chalk";
 import * as os from "os";
 import { infoCommand } from "../index";
 
-// Mock os.homedir to point to temp directory for isolated testing
-vi.mock("os", async () => {
-  const actual = await vi.importActual<typeof os>("os");
-  return {
-    ...actual,
-    homedir: vi.fn(),
-  };
-});
+vi.mock("os", { spy: true });
 
 describe("info command", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -36,7 +28,7 @@ describe("info command", () => {
     vi.stubEnv("VM0_API_URL", testApiUrl);
 
     // Create temp directory for each test
-    tempDir = mkdtempSync(join(tmpdir(), "vm0-info-test-"));
+    tempDir = mkdtempSync(join(os.tmpdir(), "vm0-info-test-"));
     mockHomedir.mockReturnValue(tempDir);
   });
 

--- a/turbo/apps/cli/src/commands/info/index.ts
+++ b/turbo/apps/cli/src/commands/info/index.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { existsSync } from "fs";
-import { homedir, release, type } from "os";
+import * as os from "os";
 import { join } from "path";
 import { getApiUrl, loadConfig } from "../../lib/api/config";
 import { detectPackageManager } from "../../lib/utils/update-checker";
@@ -9,7 +9,7 @@ import { detectPackageManager } from "../../lib/utils/update-checker";
 declare const __CLI_VERSION__: string;
 
 function getConfigPath() {
-  return join(homedir(), ".vm0", "config.json");
+  return join(os.homedir(), ".vm0", "config.json");
 }
 
 export const infoCommand = new Command()
@@ -51,7 +51,7 @@ export const infoCommand = new Command()
     console.log(chalk.bold("System:"));
     console.log(`  Node: ${process.version}`);
     console.log(`  Platform: ${process.platform} (${process.arch})`);
-    console.log(`  OS: ${type()} ${release()}`);
+    console.log(`  OS: ${os.type()} ${os.release()}`);
     console.log(`  Shell: ${process.env.SHELL ?? "unknown"}`);
     console.log(`  Package Manager: ${detectPackageManager()}`);
   });

--- a/turbo/apps/web/src/db/migrations/__tests__/0284_starter_credit_expiry.test.ts
+++ b/turbo/apps/web/src/db/migrations/__tests__/0284_starter_credit_expiry.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable web/no-direct-db-in-tests -- migration tests exercise pre-migration SQL before API exists */
+
 import { describe, it, expect, beforeEach } from "vitest";
 import { and, eq, sql } from "drizzle-orm";
 import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
@@ -21,7 +23,6 @@ async function seedOrg(
   tier: "free" | "pro",
   credits: number,
 ): Promise<void> {
-  // eslint-disable-next-line web/no-direct-db-in-tests -- Migration test: raw row seeding
   await globalThis.services.db
     .insert(orgMetadata)
     .values({ orgId, tier, credits })
@@ -32,7 +33,6 @@ async function seedOrg(
 }
 
 async function clearStarterGrants(orgId: string): Promise<void> {
-  // eslint-disable-next-line web/no-direct-db-in-tests -- Migration test: isolates each run
   await globalThis.services.db
     .delete(creditExpiresRecord)
     .where(
@@ -44,7 +44,6 @@ async function clearStarterGrants(orgId: string): Promise<void> {
 }
 
 async function readStarterGrants(orgId: string) {
-  // eslint-disable-next-line web/no-direct-db-in-tests -- Migration test: read-back assertion
   return globalThis.services.db
     .select()
     .from(creditExpiresRecord)
@@ -57,7 +56,6 @@ async function readStarterGrants(orgId: string) {
 }
 
 async function runBackfill(): Promise<void> {
-  // eslint-disable-next-line web/no-direct-db-in-tests -- Migration test: executes the verbatim backfill body
   await globalThis.services.db.execute(sql`
     INSERT INTO "credit_expires_record" (
       id, org_id, source, stripe_invoice_id, amount, remaining, expires_at, created_at
@@ -85,7 +83,6 @@ async function runBackfill(): Promise<void> {
 describe("migration 0284 backfill body", () => {
   beforeEach(() => {
     context.setupMocks();
-    // eslint-disable-next-line web/no-direct-db-in-tests -- Migration test: needs services initialised to run raw SQL
     initServices();
   });
 


### PR DESCRIPTION
## Summary
- replace the info command test's vi.importActual partial mock with a Vitest spy mock for os
- route info command OS access through the os namespace so homedir can be controlled by the spy mock
- consolidate the 0284 migration test's direct-DB lint suppressions into one file-level migration-test exception

## Verification
- pnpm -F @vm0/cli exec vitest run src/commands/info/__tests__/index.test.ts
- pnpm -F web exec vitest run src/db/migrations/__tests__/0284_starter_credit_expiry.test.ts
- pnpm exec prettier --check apps/web/src/db/migrations/__tests__/0284_starter_credit_expiry.test.ts
- pnpm -F @vm0/cli lint
- pnpm -F web lint
- pnpm -F @vm0/cli check-types
- lefthook pre-commit: prettier, knip, pnpm check-types

Closes #10531