### PR TITLE
perf(chat): dedupe vm0 credit admission org metadata read

### DIFF
--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -734,6 +734,31 @@ describe("POST /api/zero/chat/messages", () => {
           counter.restore();
         }
       });
+
+      it("reads zero_agents once and org_metadata once for vm0-managed credit admission", async () => {
+        await insertOrgDefaultModelProvider(user.orgId, "vm0");
+        await setOrgCredits(user.orgId, 10_000);
+
+        const counter = createQueryCounter();
+        try {
+          const response = await POST(
+            createTestRequest(URL, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                agentId,
+                prompt: "dedup with vm0 credit admission",
+              }),
+            }),
+          );
+
+          expect(response.status).toBe(201);
+          expect(counter.countMatching(/from\s+"?zero_agents"?/i)).toBe(1);
+          expect(counter.countMatching(/from\s+"?org_metadata"?/i)).toBe(1);
+        } finally {
+          counter.restore();
+        }
+      });
     });
 
     describe("per-run model selection (composer picker)", () => {

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -16,7 +16,7 @@ import {
   createZeroRun,
   fetchZeroAgentForRun,
 } from "../../../../../src/lib/zero/zero-run-service";
-import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
+import { resolveOrgWithMetadata } from "../../../../../src/lib/zero/org/resolve-org";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import {
@@ -84,6 +84,29 @@ function buildFullPrompt(
 ): string {
   if (!attachFiles || attachFiles.length === 0) return prompt;
   return `${prompt}\n\n${buildWebAttachFilesPrompt(attachFiles)}`;
+}
+
+interface PreloadedOrgMetadataForRun {
+  orgId: string;
+  tier: string;
+  credits?: number;
+}
+
+function buildPreloadedOrgMetadata(params: {
+  org: { orgId: string; tier: string };
+  orgMeta: { credits: number } | undefined;
+}): PreloadedOrgMetadataForRun {
+  if (!params.orgMeta) {
+    return {
+      orgId: params.org.orgId,
+      tier: params.org.tier,
+    };
+  }
+  return {
+    orgId: params.org.orgId,
+    tier: params.org.tier,
+    credits: params.orgMeta.credits,
+  };
 }
 
 interface ResolvedThread {
@@ -413,16 +436,17 @@ const router = tsr.router(chatMessagesContract, {
       };
     }
 
-    // resolveOrg already fetches org_metadata — capture the tier here so the
-    // service's Round 2 can skip its duplicate getOrgMetadata call. Resolved
-    // up front (rather than only inside the modelSelection branch) so the
-    // orphan-pin detection in resolveRunModelOverride can scope its provider
-    // lookup to the caller's org.
-    const { org: callerOrg } = await resolveOrg(authCtx);
-    const preloadedOrgTier: { orgId: string; tier: string } = {
-      orgId: callerOrg.orgId,
-      tier: callerOrg.tier,
-    };
+    // resolveOrgWithMetadata already fetches org_metadata — capture the tier
+    // and DB-backed credits here so createZeroRun can skip duplicate reads.
+    // Resolved up front (rather than only inside the modelSelection branch) so
+    // the orphan-pin detection in resolveRunModelOverride can scope its
+    // provider lookup to the caller's org.
+    const { org: callerOrg, orgMeta: callerOrgMeta } =
+      await resolveOrgWithMetadata(authCtx);
+    const preloadedOrgMetadata = buildPreloadedOrgMetadata({
+      org: callerOrg,
+      orgMeta: callerOrgMeta,
+    });
 
     // Validate per-run model selection belongs to the caller's org before
     // we trust it to write onto the thread or override the agent's default.
@@ -599,7 +623,7 @@ const router = tsr.router(chatMessagesContract, {
         callbacks: [chatCallback],
         chatThreadId: threadId,
         preloadedAgent: agent,
-        preloadedOrgTier,
+        preloadedOrgMetadata,
         spanDims: dims,
         userProfile: userProfileFromClaims(authCtx),
       });

--- a/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
@@ -424,6 +424,36 @@ describe("checkOrgCredits (general vm0 credit gate)", () => {
     });
   });
 
+  it("throws with preloaded credits when member creditEnabled is false", async () => {
+    await insertOrgMembersEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+      creditEnabled: false,
+    });
+
+    await expectInsufficientCredits(() => {
+      return checkOrgCredits(user.orgId, user.userId, {
+        preloadedOrgCredits: { orgId: user.orgId, credits: 10_000 },
+      });
+    });
+  });
+
+  it("throws with preloaded credits when unsettled expired credits exhaust spendable balance", async () => {
+    await insertCreditExpiresRecord({
+      orgId: user.orgId,
+      source: "subscription_renewal",
+      amount: 5000,
+      remaining: 5000,
+      expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    });
+
+    await expectInsufficientCredits(() => {
+      return checkOrgCredits(user.orgId, user.userId, {
+        preloadedOrgCredits: { orgId: user.orgId, credits: 5000 },
+      });
+    });
+  });
+
   it("throws when org_metadata row is missing", async () => {
     await deleteOrgRow(user.orgId);
     await expectInsufficientCredits(() => {

--- a/turbo/apps/web/src/lib/zero/credit/check-org-credits.ts
+++ b/turbo/apps/web/src/lib/zero/credit/check-org-credits.ts
@@ -2,6 +2,28 @@ import { sql } from "drizzle-orm";
 import { insufficientCredits } from "@vm0/api-services/errors";
 import type { Database } from "../../../types/global";
 
+export interface CheckOrgCreditsOptions {
+  preloadedOrgCredits?: {
+    orgId: string;
+    credits: number;
+  };
+}
+
+interface CreditCheckRow extends Record<string, unknown> {
+  credit_enabled: boolean | null;
+  credits: string | null;
+  unsettled_expired: string | null;
+}
+
+function isDatabase(value: unknown): value is Database {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "execute" in value &&
+    typeof value.execute === "function"
+  );
+}
+
 /**
  * Pre-flight check: ensure the member can spend vm0-bundled credits for this org.
  *
@@ -20,39 +42,61 @@ import type { Database } from "../../../types/global";
  *
  * Accepts an optional `db` so callers inside a transaction (e.g. queue drain
  * under `pg_advisory_xact_lock`) can keep the read within the same boundary.
+ * Callers that already fetched org_metadata may pass preloaded credits either
+ * as the third argument or after the db handle.
  */
 export async function checkOrgCredits(
   orgId: string,
   userId: string,
-  db: Database = globalThis.services.db,
+  dbOrOptions: Database | CheckOrgCreditsOptions = globalThis.services.db,
+  options: CheckOrgCreditsOptions = {},
 ): Promise<void> {
-  const { rows } = await db.execute<{
-    credit_enabled: boolean | null;
-    credits: string | null;
-    unsettled_expired: string | null;
-  }>(sql`
-    WITH member AS (
-      SELECT credit_enabled FROM org_members_metadata
-      WHERE org_id = ${orgId} AND user_id = ${userId}
-      LIMIT 1
-    ),
-    org AS (
-      SELECT credits FROM org_metadata
-      WHERE org_id = ${orgId}
-      LIMIT 1
-    ),
-    expired AS (
-      SELECT COALESCE(SUM(remaining), 0)::bigint AS total
-      FROM credit_expires_record
-      WHERE org_id = ${orgId}
-        AND expires_at <= now()
-        AND remaining > 0
-    )
-    SELECT
-      (SELECT credit_enabled FROM member) AS credit_enabled,
-      (SELECT credits FROM org) AS credits,
-      (SELECT total FROM expired) AS unsettled_expired
-  `);
+  const db = isDatabase(dbOrOptions) ? dbOrOptions : globalThis.services.db;
+  const resolvedOptions = isDatabase(dbOrOptions) ? options : dbOrOptions;
+  const preloaded = resolvedOptions.preloadedOrgCredits;
+  const { rows } =
+    preloaded && preloaded.orgId === orgId
+      ? await db.execute<CreditCheckRow>(sql`
+          WITH member AS (
+            SELECT credit_enabled FROM org_members_metadata
+            WHERE org_id = ${orgId} AND user_id = ${userId}
+            LIMIT 1
+          ),
+          expired AS (
+            SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+            FROM credit_expires_record
+            WHERE org_id = ${orgId}
+              AND expires_at <= now()
+              AND remaining > 0
+          )
+          SELECT
+            (SELECT credit_enabled FROM member) AS credit_enabled,
+            ${preloaded.credits}::bigint AS credits,
+            (SELECT total FROM expired) AS unsettled_expired
+        `)
+      : await db.execute<CreditCheckRow>(sql`
+          WITH member AS (
+            SELECT credit_enabled FROM org_members_metadata
+            WHERE org_id = ${orgId} AND user_id = ${userId}
+            LIMIT 1
+          ),
+          org AS (
+            SELECT credits FROM org_metadata
+            WHERE org_id = ${orgId}
+            LIMIT 1
+          ),
+          expired AS (
+            SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+            FROM credit_expires_record
+            WHERE org_id = ${orgId}
+              AND expires_at <= now()
+              AND remaining > 0
+          )
+          SELECT
+            (SELECT credit_enabled FROM member) AS credit_enabled,
+            (SELECT credits FROM org) AS credits,
+            (SELECT total FROM expired) AS unsettled_expired
+        `);
 
   const row = rows[0];
   if (!row) throw insufficientCredits();

--- a/turbo/apps/web/src/lib/zero/org/resolve-org.ts
+++ b/turbo/apps/web/src/lib/zero/org/resolve-org.ts
@@ -30,6 +30,15 @@ type ResolvedMember = {
   userId: string;
 };
 
+interface ResolvedOrgResult {
+  org: ResolvedOrg;
+  member: ResolvedMember;
+}
+
+interface ResolvedOrgWithMetadataResult extends ResolvedOrgResult {
+  orgMeta?: OrgMetadata;
+}
+
 /**
  * Verify a user's membership in a Clerk organization.
  *
@@ -73,7 +82,21 @@ async function verifyMembership(
  */
 export async function resolveOrg(
   authCtx: AuthContext,
-): Promise<{ org: ResolvedOrg; member: ResolvedMember }> {
+): Promise<ResolvedOrgResult> {
+  const { org, member } = await resolveOrgWithMetadata(authCtx);
+  return { org, member };
+}
+
+/**
+ * Resolve org and return the DB-backed org metadata when it exists.
+ *
+ * Brand-new orgs can resolve from JWT claims before onboarding creates
+ * org_metadata; in that fallback case `orgMeta` is omitted so callers do not
+ * mistake synthetic credits=0 for a fresh database read.
+ */
+export async function resolveOrgWithMetadata(
+  authCtx: AuthContext,
+): Promise<ResolvedOrgWithMetadataResult> {
   const orgId = authCtx.orgId ?? null;
   if (!orgId) {
     throw badRequest(
@@ -82,8 +105,10 @@ export async function resolveOrg(
   }
 
   let orgMeta: OrgMetadata;
+  let dbOrgMeta: OrgMetadata | undefined;
   try {
     orgMeta = await getOrgMetadata(orgId);
+    dbOrgMeta = orgMeta;
   } catch (error) {
     if (!isNotFound(error)) throw error;
     // Brand-new org: JWT proves existence, org_metadata row not yet created
@@ -95,7 +120,7 @@ export async function resolveOrg(
     defaultAgentId: orgMeta.defaultAgentId,
   };
   const member = await verifyMembership(resolved, authCtx);
-  return { org: resolved, member };
+  return { org: resolved, member, orgMeta: dbOrgMeta };
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -14,7 +14,10 @@ import { canAccessCompose } from "../infra/agent/compose-access";
 import { validateFrameworkApiKey } from "../infra/run/utils";
 import { logger } from "../shared/logger";
 import { MODEL_PROVIDER_ENV_VARS } from "./context/resolve-model-provider";
-import { checkOrgCredits } from "./credit/check-org-credits";
+import {
+  checkOrgCredits,
+  type CheckOrgCreditsOptions,
+} from "./credit/check-org-credits";
 import {
   getOrgDefaultModelProvider,
   getOrgDefaultModelProviderType,
@@ -232,10 +235,11 @@ export async function resolveRunAdmissionContext(params: {
 export async function checkOrgCreditsForRunAdmission(
   context: RunAdmissionContext,
   db: Database = globalThis.services.db,
+  options: CheckOrgCreditsOptions = {},
 ): Promise<void> {
   if (context.providerType !== "vm0") return;
 
-  await checkOrgCredits(context.orgId, context.userId, db);
+  await checkOrgCredits(context.orgId, context.userId, db, options);
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -111,6 +111,10 @@ export interface ZeroAgentForRun {
   preferPersonalProvider: boolean;
 }
 
+type OrgAdmissionMetadata = Pick<OrgMetadata, "orgId" | "tier"> & {
+  credits?: number;
+};
+
 /**
  * Fetch the union projection of zero_agents needed to create a run. Shared by
  * the web chat route (404 check + model override fields) and the service's
@@ -191,13 +195,12 @@ export interface CreateZeroRunParams {
    */
   preloadedAgent?: ZeroAgentForRun;
   /**
-   * Pre-fetched org tier scoped to the caller's active org. Round 2 uses it
-   * only when resolved.orgId === preloadedOrgTier.orgId (cross-org composes
-   * still read fresh org_metadata). Typed as a structural Pick so that the
-   * caller cannot accidentally populate a fake .credits — and so future code
-   * cannot read .credits via this preload.
+   * Pre-fetched org metadata scoped to the caller's active org. Round 2 uses it
+   * only when resolved.orgId === preloadedOrgMetadata.orgId (cross-org composes
+   * still read fresh org_metadata). `credits` is optional because brand-new org
+   * fallback metadata is synthetic and should not bypass the credit row read.
    */
-  preloadedOrgTier?: Pick<OrgMetadata, "orgId" | "tier">;
+  preloadedOrgMetadata?: OrgAdmissionMetadata;
   /**
    * When present, each Phase-1 sub-stage emits a span to the `sandbox-op-log`
    * Axiom dataset with `source: "web-chat"`, carrying these dimensions. The
@@ -245,10 +248,10 @@ function loadZeroAgentForRun(
   return preloaded ? Promise.resolve(preloaded) : fetchZeroAgentForRun(agentId);
 }
 
-function loadOrgTier(
-  preloaded: Pick<OrgMetadata, "orgId" | "tier"> | undefined,
+function loadOrgAdmissionMetadata(
+  preloaded: OrgAdmissionMetadata | undefined,
   orgId: string,
-): Promise<Pick<OrgMetadata, "orgId" | "tier">> {
+): Promise<OrgAdmissionMetadata> {
   if (preloaded && preloaded.orgId === orgId) {
     return Promise.resolve(preloaded);
   }
@@ -577,7 +580,10 @@ async function createZeroRunRecord(
   // composes (rare; also caught by authorizeCompose below) fall through to
   // a fresh SELECT because the preload's tier is scoped to authCtx.orgId.
   const round2OrgMeta = timed(async () => {
-    return loadOrgTier(params.preloadedOrgTier, resolved.orgId);
+    return loadOrgAdmissionMetadata(
+      params.preloadedOrgMetadata,
+      resolved.orgId,
+    );
   });
   const round2UserContext = timed(async () => {
     return loadRunUserContext(resolved.orgId, params.userId);
@@ -712,7 +718,12 @@ async function createZeroRunRecord(
   }
 
   const round3Credits = timed(async () => {
-    return checkOrgCreditsForRunAdmission(admissionContext);
+    if (orgMeta.credits === undefined) {
+      return checkOrgCreditsForRunAdmission(admissionContext, db);
+    }
+    return checkOrgCreditsForRunAdmission(admissionContext, db, {
+      preloadedOrgCredits: { orgId: orgMeta.orgId, credits: orgMeta.credits },
+    });
   });
   const round3ModelProvider = timed(async () => {
     return checkModelProviderConfigured(


### PR DESCRIPTION
## Summary
- reuse DB-backed org credits already read by chat org resolution and createZeroRun Round 2
- keep member credit cap and unsettled expired credit checks in the vm0 credit gate
- add vm0-managed provider query-count coverage for chat POST

Closes #10613

## Tests
- pnpm -F web exec vitest run app/api/zero/chat/messages/__tests__/route.test.ts src/lib/zero/__tests__/credit-check.test.ts -t "deduplicates per-request reads|credit check with modelSelection|checkOrgCredits"
- pnpm -F web lint
- pnpm -F web check-types
- pnpm knip --workspace web