### PR TITLE
fix: resolve preferred personal agent defaults

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -28,18 +28,15 @@ import {
   type ModelSelectionRequest,
   type PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import {
-  getDefaultModel,
-  type ModelProviderResponse,
-} from "@vm0/api-contracts/contracts/model-providers";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { orgModelProviders$ } from "../external/org-model-providers.ts";
 import { agentById } from "../agent.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { pinnedAgentIds$ } from "../zero-page/zero-pinned-agents.ts";
+import { composerModelProviders$ } from "../zero-page/composer-model-providers.ts";
+import { resolveEffectiveAgentDefaultSelection } from "../zero-page/model-provider-default.ts";
 import {
   writeChatMessageToClipboard,
   type ChatClipboardPayload,
@@ -269,32 +266,22 @@ function createModelSelection(
           selectedModel: thread.selectedModel,
         };
       }
-      // No thread override → fall back to the agent's default, then to the
-      // org default. Seeding here (rather than letting the picker show its
-      // null-value fallback) keeps the picker's displayed model identical
-      // to what the send body carries. Without this seed, the backend
-      // would receive `modelSelection: null` while the UI advertised a
-      // specific model, producing a display/run mismatch.
-      if (thread?.agentId) {
-        const agent = await get(agentById(thread.agentId));
-        if (agent?.modelProviderId && agent.selectedModel) {
-          return {
-            modelProviderId: agent.modelProviderId,
-            selectedModel: agent.selectedModel,
-          };
-        }
-      }
-      const { modelProviders } = await get(orgModelProviders$);
-      const defaultProvider = modelProviders.find((p) => {
-        return p.isDefault;
+      // No thread override → fall back to preferred personal default, then
+      // the agent's default, then the workspace default. Seeding here
+      // (rather than letting the picker show its null-value fallback) keeps
+      // the picker's displayed model identical to what the send body carries.
+      // Without this seed, the backend would receive `modelSelection: null`
+      // while the UI advertised a specific model, producing a display/run
+      // mismatch.
+      const agent = thread?.agentId
+        ? await get(agentById(thread.agentId))
+        : null;
+      const composerProviders = await get(composerModelProviders$);
+      return resolveEffectiveAgentDefaultSelection({
+        agent,
+        providers: composerProviders.providers,
+        tiers: composerProviders.tiers,
       });
-      if (defaultProvider?.selectedModel) {
-        return {
-          modelProviderId: defaultProvider.id,
-          selectedModel: defaultProvider.selectedModel,
-        };
-      }
-      return null;
     },
   );
 
@@ -375,13 +362,12 @@ function createAgentInfoSignals(
         return null;
       }
       const agent = await get(agentById(agentId));
-      if (!agent?.modelProviderId || !agent.selectedModel) {
-        return null;
-      }
-      return {
-        modelProviderId: agent.modelProviderId,
-        selectedModel: agent.selectedModel,
-      };
+      const composerProviders = await get(composerModelProviders$);
+      return resolveEffectiveAgentDefaultSelection({
+        agent,
+        providers: composerProviders.providers,
+        tiers: composerProviders.tiers,
+      });
     },
   );
 
@@ -1144,23 +1130,14 @@ function createSendMessage(deps: SendMessageDeps) {
       if (!effectiveSelectedModel) {
         const agent = await get(agentById(agentId));
         signal.throwIfAborted();
-        if (agent?.modelProviderId && agent.selectedModel) {
-          effectiveSelectedModel = agent.selectedModel;
-        }
-      }
-      if (!effectiveSelectedModel) {
-        const { modelProviders } = await get(orgModelProviders$);
+        const composerProviders = await get(composerModelProviders$);
         signal.throwIfAborted();
-        const defaultProvider = (
-          modelProviders as ModelProviderResponse[]
-        ).find((provider) => {
-          return provider.isDefault;
-        });
-        const defaultModel = defaultProvider
-          ? getDefaultModel(defaultProvider.type)
-          : undefined;
         effectiveSelectedModel =
-          defaultProvider?.selectedModel ?? defaultModel ?? undefined;
+          resolveEffectiveAgentDefaultSelection({
+            agent,
+            providers: composerProviders.providers,
+            tiers: composerProviders.tiers,
+          })?.selectedModel ?? undefined;
       }
 
       const result = await set(

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -8,10 +8,6 @@ import {
   type ChatThreadListItem,
   type ModelSelectionRequest,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import {
-  getDefaultModel,
-  type ModelProviderResponse,
-} from "@vm0/api-contracts/contracts/model-providers";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
 import {
@@ -42,7 +38,8 @@ import {
 } from "./optimistic-chat-thread-state.ts";
 import { toVoid } from "../utils.ts";
 import { agentById } from "../agent.ts";
-import { orgModelProviders$ } from "../external/org-model-providers.ts";
+import { composerModelProviders$ } from "../zero-page/composer-model-providers.ts";
+import { resolveEffectiveAgentDefaultSelection } from "../zero-page/model-provider-default.ts";
 
 export type { OptimisticChatPane };
 export { optimisticChatThread$ };
@@ -351,23 +348,14 @@ const sendNewThreadMessage$ = command(
     if (!effectiveSelectedModel) {
       const agent = await get(agentById(agentId));
       signal.throwIfAborted();
-      if (agent?.modelProviderId && agent.selectedModel) {
-        effectiveSelectedModel = agent.selectedModel;
-      }
-    }
-    if (!effectiveSelectedModel) {
-      const { modelProviders } = await get(orgModelProviders$);
+      const composerProviders = await get(composerModelProviders$);
       signal.throwIfAborted();
-      const defaultProvider = (modelProviders as ModelProviderResponse[]).find(
-        (provider) => {
-          return provider.isDefault;
-        },
-      );
-      const defaultModel = defaultProvider
-        ? getDefaultModel(defaultProvider.type)
-        : undefined;
       effectiveSelectedModel =
-        defaultProvider?.selectedModel ?? defaultModel ?? undefined;
+        resolveEffectiveAgentDefaultSelection({
+          agent,
+          providers: composerProviders.providers,
+          tiers: composerProviders.tiers,
+        })?.selectedModel ?? undefined;
     }
     const prepared = await set(
       prepareUserMessageFromDraft$,

--- a/turbo/apps/platform/src/signals/zero-page/model-provider-default.ts
+++ b/turbo/apps/platform/src/signals/zero-page/model-provider-default.ts
@@ -1,0 +1,81 @@
+import {
+  getDefaultModel,
+  type ModelProviderResponse,
+} from "@vm0/api-contracts/contracts/model-providers";
+import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
+
+type ProviderTier = "personal" | "org";
+
+interface AgentModelDefaultSource {
+  modelProviderId: string | null;
+  selectedModel: string | null;
+  preferPersonalProvider?: boolean;
+}
+
+function resolveProviderSelection(
+  provider: ModelProviderResponse | undefined,
+  fallbackSelectedModel?: string | null,
+): ModelProviderSelection | null {
+  if (!provider) {
+    return null;
+  }
+  const selectedModel =
+    provider.selectedModel ??
+    fallbackSelectedModel ??
+    getDefaultModel(provider.type);
+  if (!selectedModel) {
+    return null;
+  }
+  return {
+    modelProviderId: provider.id,
+    selectedModel,
+  };
+}
+
+export function resolveWorkspaceDefaultSelection(
+  providers: ModelProviderResponse[],
+  tiers?: Map<string, ProviderTier>,
+): ModelProviderSelection | null {
+  const defaultProvider = providers.find((provider) => {
+    return provider.isDefault && tiers?.get(provider.id) !== "personal";
+  });
+  return resolveProviderSelection(defaultProvider);
+}
+
+function resolvePersonalDefaultSelection(
+  agent: AgentModelDefaultSource | null | undefined,
+  providers: ModelProviderResponse[],
+  tiers?: Map<string, ProviderTier>,
+): ModelProviderSelection | null {
+  if (!agent?.preferPersonalProvider || !tiers) {
+    return null;
+  }
+  const personalDefault = providers.find((provider) => {
+    return provider.isDefault && tiers.get(provider.id) === "personal";
+  });
+  return resolveProviderSelection(personalDefault, agent.selectedModel);
+}
+
+export function resolveEffectiveAgentDefaultSelection(params: {
+  agent: AgentModelDefaultSource | null | undefined;
+  providers: ModelProviderResponse[];
+  tiers?: Map<string, ProviderTier>;
+}): ModelProviderSelection | null {
+  const personalDefault = resolvePersonalDefaultSelection(
+    params.agent,
+    params.providers,
+    params.tiers,
+  );
+  if (personalDefault) {
+    return personalDefault;
+  }
+
+  if (params.agent?.modelProviderId && params.agent.selectedModel) {
+    return {
+      modelProviderId: params.agent.modelProviderId,
+      selectedModel: params.agent.selectedModel,
+    };
+  }
+
+  return resolveWorkspaceDefaultSelection(params.providers, params.tiers);
+}

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -3,8 +3,9 @@ import { talkDraft$ } from "./chat-draft.ts";
 import { getRandomPrompts } from "../../views/zero-page/zero-ideation-data.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
-import { orgModelProviders$ } from "../external/org-model-providers.ts";
 import { currentChatAgent$ } from "../agent-chat.ts";
+import { composerModelProviders$ } from "./composer-model-providers.ts";
+import { resolveEffectiveAgentDefaultSelection } from "./model-provider-default.ts";
 
 // ---------------------------------------------------------------------------
 // Landing page local UI state for ZeroChatPage
@@ -52,29 +53,19 @@ export const chatPageModelSelection$ = computed(
     if (user.kind === "set") {
       return user.value;
     }
-    // Priority: agent default > org default. Seed here (rather than letting
-    // the picker fall back to its null-value display) so the model shown
-    // next to Send is the exact model the send body will carry. See the
-    // matching note in `createModelSelection` (create-chat-thread.ts) for
-    // the full display/run mismatch reasoning.
+    // Priority: preferred personal default > agent default > workspace
+    // default. Seed here (rather than letting the picker fall back to its
+    // null-value display) so the model shown next to Send is the exact
+    // model the send body will carry. See the matching note in
+    // `createModelSelection` (create-chat-thread.ts) for the full
+    // display/run mismatch reasoning.
     const agent = await get(currentChatAgent$);
-    if (agent?.modelProviderId && agent.selectedModel) {
-      return {
-        modelProviderId: agent.modelProviderId,
-        selectedModel: agent.selectedModel,
-      };
-    }
-    const { modelProviders } = await get(orgModelProviders$);
-    const defaultProvider = modelProviders.find((p) => {
-      return p.isDefault;
+    const composerProviders = await get(composerModelProviders$);
+    return resolveEffectiveAgentDefaultSelection({
+      agent,
+      providers: composerProviders.providers,
+      tiers: composerProviders.tiers,
     });
-    if (defaultProvider?.selectedModel) {
-      return {
-        modelProviderId: defaultProvider.id,
-        selectedModel: defaultProvider.selectedModel,
-      };
-    }
-    return null;
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-send.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-send.test.tsx
@@ -24,6 +24,8 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { chatMessagesContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -32,6 +34,10 @@ import {
   setMockOrgModelProviders,
   resetMockOrgModelProviders,
 } from "../../../mocks/handlers/api-org-model-providers.ts";
+import {
+  setMockPersonalModelProviders,
+  resetMockPersonalModelProviders,
+} from "../../../mocks/handlers/api-personal-model-providers.ts";
 import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.helpers.ts";
 import {
   mockChatLifecycle,
@@ -42,10 +48,12 @@ import {
 const context = testContext();
 const mockApi = createMockApi(context);
 const THREAD_ID = "thread-test-1";
+const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 
 describe("chat composer — model picker display vs. send body", () => {
   beforeEach(() => {
     resetMockOrgModelProviders();
+    resetMockPersonalModelProviders();
   });
 
   // CHAT-MSEL-001: picker display and send body agree on org default
@@ -125,6 +133,111 @@ describe("chat composer — model picker display vs. send body", () => {
     expect(capturedBody?.modelSelection).toStrictEqual({
       modelProviderId: PROVIDER_ID,
       selectedModel: DEFAULT_MODEL,
+    });
+  });
+
+  it("sends the personal default when the agent prefers personal providers", async () => {
+    const user = userEvent.setup();
+
+    const AGENT_PROVIDER_ID = "00000000-0000-4000-a000-000000000011";
+    const PERSONAL_PROVIDER_ID = "00000000-0000-4000-a000-000000000012";
+
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.PersonalModelProvider]: true,
+    });
+    setMockOrgModelProviders([
+      {
+        id: AGENT_PROVIDER_ID,
+        type: "anthropic-api-key",
+        framework: "claude-code",
+        secretName: "ANTHROPIC_API_KEY",
+        authMethod: null,
+        secretNames: null,
+        isDefault: true,
+        selectedModel: "claude-opus-4-7",
+        needsReconnect: false,
+        lastRefreshErrorCode: null,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+    setMockPersonalModelProviders([
+      {
+        id: PERSONAL_PROVIDER_ID,
+        type: "openai-api-key",
+        framework: "codex",
+        secretName: "OPENAI_API_KEY",
+        authMethod: null,
+        secretNames: null,
+        isDefault: true,
+        selectedModel: "gpt-5.4",
+        needsReconnect: false,
+        lastRefreshErrorCode: null,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+    server.use(
+      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          agentId: DEFAULT_AGENT_ID,
+          ownerId: "test-user-123",
+          displayName: "Zero",
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: null,
+          customSkills: [] as string[],
+          modelProviderId: AGENT_PROVIDER_ID,
+          selectedModel: "claude-opus-4-7",
+          preferPersonalProvider: true,
+        });
+      }),
+    );
+
+    mockChatLifecycle({ threadId: THREAD_ID });
+
+    let capturedBody:
+      | {
+          modelSelection?: {
+            modelProviderId: string;
+            selectedModel: string;
+          } | null;
+        }
+      | undefined;
+    server.use(
+      mockApi(chatMessagesContract.send, ({ body, respond }) => {
+        capturedBody = body;
+        return respond(201, {
+          runId: "run-test-1",
+          threadId: THREAD_ID,
+          status: "pending",
+          createdAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+    );
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: "gpt-5.4" }),
+      ).toBeInTheDocument();
+    });
+
+    await sendMessageInUI(user, textarea, "Hello");
+
+    await waitFor(() => {
+      expect(capturedBody).toBeDefined();
+    });
+
+    expect(capturedBody?.modelSelection).toStrictEqual({
+      modelProviderId: PERSONAL_PROVIDER_ID,
+      selectedModel: "gpt-5.4",
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
@@ -34,6 +34,7 @@ import {
   zeroAgentInstructionsContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
 import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -44,6 +45,10 @@ import {
   setMockOrgModelProviders,
   resetMockOrgModelProviders,
 } from "../../../mocks/handlers/api-org-model-providers.ts";
+import {
+  setMockPersonalModelProviders,
+  resetMockPersonalModelProviders,
+} from "../../../mocks/handlers/api-personal-model-providers.ts";
 import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.helpers.ts";
 import {
   setMockOnboardingStatus,
@@ -59,6 +64,7 @@ const AGENT_ID = "e0000000-0000-4000-a000-000000000010";
 const ANTHROPIC_PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
 const MOONSHOT_PROVIDER_ID = "00000000-0000-4000-a000-000000000002";
 const ZAI_PROVIDER_ID = "00000000-0000-4000-a000-000000000003";
+const PERSONAL_OPENAI_PROVIDER_ID = "00000000-0000-4000-a000-000000000004";
 
 const THREAD_ID = "thread-default-model-1";
 
@@ -69,6 +75,7 @@ const THREAD_ID = "thread-default-model-1";
 interface AgentModelConfig {
   modelProviderId: string | null;
   selectedModel: string | null;
+  preferPersonalProvider?: boolean;
 }
 
 function mockAgent(config: AgentModelConfig) {
@@ -96,6 +103,7 @@ function mockAgent(config: AgentModelConfig) {
         customSkills: [] as string[],
         modelProviderId: config.modelProviderId,
         selectedModel: config.selectedModel,
+        preferPersonalProvider: config.preferPersonalProvider ?? false,
       });
     }),
     mockApi(zeroAgentInstructionsContract.get, ({ respond }) => {
@@ -248,6 +256,7 @@ async function expectAgentChatLoaded(): Promise<void> {
 describe("chat composer — default model resolution", () => {
   beforeEach(() => {
     resetMockOrgModelProviders();
+    resetMockPersonalModelProviders();
     resetMockOnboardingStatus();
     setMockFeatureSwitches({});
     // Align onboarding default with the test agent so currentChatAgentId$
@@ -314,6 +323,36 @@ describe("chat composer — default model resolution", () => {
     await expectAgentChatLoaded();
 
     await expectComposerShowsModel("Claude Opus 4.6");
+  });
+
+  it("shows the personal default when the agent prefers personal providers", async () => {
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.PersonalModelProvider]: true,
+    });
+    mockOrgProviders({
+      defaultProviderId: MOONSHOT_PROVIDER_ID,
+      defaultSelectedModel: "kimi-k2.5",
+    });
+    setMockPersonalModelProviders([
+      buildProvider({
+        id: PERSONAL_OPENAI_PROVIDER_ID,
+        type: "openai-api-key",
+        framework: "codex",
+        secretName: "OPENAI_API_KEY",
+        isDefault: true,
+        selectedModel: "gpt-5.4",
+      }),
+    ]);
+    mockAgent({
+      modelProviderId: ANTHROPIC_PROVIDER_ID,
+      selectedModel: "claude-opus-4-7",
+      preferPersonalProvider: true,
+    });
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+    await expectAgentChatLoaded();
+
+    await expectComposerShowsModel("gpt-5.4");
   });
 
   // CHAT-DM-004: When the agent is reset to "use org default" (both fields

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -50,6 +50,7 @@ import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-ma
 import { ZeroChatComposer } from "./zero-chat-composer.tsx";
 import { AttachmentLightbox } from "./zero-attachment-chips.tsx";
 import { composerModelProviders$ } from "../../signals/zero-page/composer-model-providers.ts";
+import { resolveEffectiveAgentDefaultSelection } from "../../signals/zero-page/model-provider-default.ts";
 import {
   chatPageInput$,
   chatPageModelSelection$,
@@ -476,13 +477,13 @@ export function AgentChatPage() {
   const setModelSelection = useSet(setChatPageModelSelection$);
   const resetModelSelection = useSet(resetChatPageModelSelection$);
   const currentAgent = useLastResolved(currentChatAgent$);
-  const agentModelDefault =
-    currentAgent?.modelProviderId && currentAgent?.selectedModel
-      ? {
-          modelProviderId: currentAgent.modelProviderId,
-          selectedModel: currentAgent.selectedModel,
-        }
-      : null;
+  const agentModelDefault = composerProviders
+    ? resolveEffectiveAgentDefaultSelection({
+        agent: currentAgent,
+        providers: composerProviders.providers,
+        tiers: composerProviders.tiers,
+      })
+    : null;
 
   const handleSendMessage = (message: string) => {
     if (!currentChatAgentId) {

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -814,10 +814,10 @@ export function ModelProviderPicker({
     );
   }
 
-  // Workspace default for the inherit toggle row resolves against org-tier
-  // rows only when tiers are provided — the user's personal default is a
-  // separate concept, picked explicitly via the Personal section, not
-  // inherited via the agent → workspace chain (Wave 3, Epic #11868).
+  // Workspace fallback for the inherit toggle resolves against org-tier rows
+  // only when tiers are provided. Callers that want "agent default" to mean a
+  // preferred personal provider pass that resolved personal row as
+  // `agentDefault`; otherwise personal defaults stay out of workspace fallback.
   const inheritScope = tiers
     ? providers.filter((p) => {
         return tiers.get(p.id) !== "personal";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -74,7 +74,6 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  getDefaultModel,
   getModelImageInputSupport,
   type ModelProviderResponse,
   type ModelProviderType,
@@ -104,6 +103,7 @@ import {
   authorizeConnector$,
   deauthorizeConnector$,
 } from "../../signals/zero-page/zero-connectors.ts";
+import { resolveWorkspaceDefaultSelection } from "../../signals/zero-page/model-provider-default.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   showAddDialog$,
@@ -245,32 +245,10 @@ function resolveConnectorLabel(
   return connectorMap.get(type as ConnectorType)?.label ?? type;
 }
 
-interface ResolvedComposerModel {
-  modelProviderId: string;
-  selectedModel: string;
-}
-
-function resolveProviderSelection(
-  provider: ModelProviderResponse | undefined,
-): ResolvedComposerModel | null {
-  if (!provider) {
-    return null;
-  }
-  const selectedModel =
-    provider.selectedModel ?? getDefaultModel(provider.type);
-  if (!selectedModel) {
-    return null;
-  }
-  return {
-    modelProviderId: provider.id,
-    selectedModel,
-  };
-}
-
 function resolveComposerModelForSelection(
   modelPicker: ComposerModelPicker | undefined,
   selection: ModelProviderSelection | null,
-): ResolvedComposerModel | null {
+): ModelProviderSelection | null {
   if (!modelPicker) {
     return null;
   }
@@ -280,10 +258,10 @@ function resolveComposerModelForSelection(
   if (modelPicker.agentDefault) {
     return modelPicker.agentDefault;
   }
-  const defaultProvider = modelPicker.providers.find((provider) => {
-    return provider.isDefault;
-  });
-  return resolveProviderSelection(defaultProvider);
+  return resolveWorkspaceDefaultSelection(
+    modelPicker.providers,
+    modelPicker.tiers,
+  );
 }
 
 interface VisualAttachmentUnsupportedState {

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -1324,6 +1324,56 @@ describe("POST /api/zero/chat/messages", () => {
         expect(override.selectedModel).toBe("gpt-5.4");
       });
 
+      it("runs the personal default when the request explicitly inherits modelSelection null", async () => {
+        // The web picker sends `modelSelection: null` when the user chooses
+        // "Use agent default". That must inherit the newly created thread's
+        // eager pin, not fall back to the agent's org-tier provider.
+        const { agentId: composeAgentId } = await createTestCompose(
+          uniqueId("personal-null-inherit"),
+          { noEnvironmentBlock: true },
+        );
+        const orgProviderId = await getTestModelProviderIdByType(
+          user.orgId,
+          "anthropic-api-key",
+        );
+        await setTestZeroAgentModelProvider(
+          composeAgentId,
+          orgProviderId,
+          "claude-opus-4-7",
+        );
+        await setTestZeroAgentPreferPersonalProvider(composeAgentId, true);
+        await enablePersonalModelProviderForUser(user.orgId, user.userId);
+        const personalProviderId = await insertUserDefaultModelProvider(
+          user.orgId,
+          user.userId,
+          "openai-api-key",
+          "gpt-5.4",
+        );
+
+        const response = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId: composeAgentId,
+              prompt: "explicit inherit personal pin",
+              modelSelection: null,
+            }),
+          }),
+        );
+        expect(response.status).toBe(201);
+        const { runId, threadId } = await response.json();
+        await context.mocks.flushAfter();
+
+        const override = await getTestChatThreadModelOverride(threadId);
+        expect(override.modelProviderId).toBe(personalProviderId);
+        expect(override.selectedModel).toBe("gpt-5.4");
+
+        const job = await findTestRunnerJobEntry(runId);
+        expect(job).toBeDefined();
+        expect(job!.executionContext.cliAgentType).toBe("codex");
+      });
+
       it("falls back to agent's selectedModel when personal row has none", async () => {
         // Personal default has no selectedModel — precedence is
         // user > agent > null, so the agent's selectedModel surfaces.

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -96,8 +96,9 @@ interface ResolvedThread {
 /**
  * Persist the composer's per-run override onto the thread row and return the
  * effective override to use for this run (precedence: per-run > thread > agent).
- * `undefined` for `modelSelection` means "leave thread row as-is" — older
- * clients that never saw the field still get the thread/agent fall-through.
+ * `null` or `undefined` for `modelSelection` means "inherit" — older clients
+ * that never saw the field and newer clients explicitly choosing "Use default"
+ * both get the thread/agent fall-through.
  *
  * When the thread carries an eager-pinned provider but that provider has since
  * been deleted, this throws `providerDeleted()` rather than silently falling
@@ -127,7 +128,7 @@ async function resolveRunModelOverride(
       providerId: modelSelection.modelProviderId,
       selectedModel: modelSelection.selectedModel,
     };
-  } else if (modelSelection === undefined) {
+  } else {
     const [thread] = await globalThis.services.db
       .select({
         modelProviderId: chatThreads.modelProviderId,


### PR DESCRIPTION
## Summary
- centralize effective "Use agent default" model resolution so an agent that prefers personal providers resolves to the user's personal default provider first
- apply the same resolution across Zero chat entry points, existing chat composer state, visual attachment fallback, and picker display
- preserve the backend eager personal pin when the composer sends `modelSelection: null` for inherited defaults

## Tests
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx src/views/zero-page/__tests__/chat-composer-model-selection-send.test.tsx`
- `pnpm -F web exec vitest run app/api/zero/chat/messages/__tests__/route.test.ts`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `pnpm knip --cache`
- pre-commit hook: prettier, knip, and `turbo run check-types --concurrency=1`
