### PR TITLE
fix: strip user prefix from file urls

### DIFF
--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/messages/__tests__/route.test.ts
@@ -353,7 +353,7 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
     expect(userMsg.attachFiles[0].id).toBe("paged-resolve-uuid");
     expect(userMsg.attachFiles[0].filename).toBe("data.csv");
     expect(userMsg.attachFiles[0].url).toBe(
-      `http://localhost:3000/f/${encodeURIComponent(testUserId)}/paged-resolve-uuid/data.csv`,
+      `http://localhost:3000/f/${encodeURIComponent(testUserId.replace(/^user_/, ""))}/paged-resolve-uuid/data.csv`,
     );
   });
 

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -672,7 +672,7 @@ describe("POST /api/zero/chat/messages", () => {
       expect(userMsg.attachFiles[0].id).toBe("resolve-uuid-1");
       expect(userMsg.attachFiles[0].filename).toBe("data.csv");
       expect(userMsg.attachFiles[0].url).toBe(
-        `http://localhost:3000/f/${encodeURIComponent(user.userId)}/resolve-uuid-1/data.csv`,
+        `http://localhost:3000/f/${encodeURIComponent(user.userId.replace(/^user_/, ""))}/resolve-uuid-1/data.csv`,
       );
     });
 

--- a/turbo/apps/web/app/api/zero/image-io/generate/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/image-io/generate/__tests__/route.test.ts
@@ -268,7 +268,7 @@ describe("POST /api/zero/image-io/generate", () => {
     });
     expect(body.id).toEqual(expect.any(String));
     expect(body.url).toBe(
-      `http://localhost:3000/f/${encodeURIComponent(userId)}/${body.id}/${body.filename}`,
+      `http://localhost:3000/f/${encodeURIComponent(userId.replace(/^user_/, ""))}/${body.id}/${body.filename}`,
     );
 
     expect(context.mocks.s3.uploadS3Buffer).toHaveBeenCalledTimes(1);

--- a/turbo/apps/web/app/api/zero/integrations/telegram/upload-file/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/upload-file/complete/__tests__/route.test.ts
@@ -73,7 +73,7 @@ describe("POST /api/zero/integrations/telegram/upload-file/complete", () => {
     const uploadId = randomUUID();
     const telegramFileId = uniqueId("tg-doc-file-id");
     const s3Key = `uploads/${user.userId}/${uploadId}/report.pdf`;
-    const fileUrl = `http://localhost:3000/f/${encodeURIComponent(user.userId)}/${uploadId}/report.pdf`;
+    const fileUrl = `http://localhost:3000/f/${encodeURIComponent(user.userId.replace(/^user_/, ""))}/${uploadId}/report.pdf`;
 
     context.mocks.s3.listS3Objects.mockResolvedValueOnce([
       { key: s3Key, size: 1234 },

--- a/turbo/apps/web/app/api/zero/integrations/telegram/upload-file/init/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/upload-file/init/__tests__/route.test.ts
@@ -85,7 +85,7 @@ describe("POST /api/zero/integrations/telegram/upload-file/init", () => {
     expect(body.uploadId).toMatch(/^[0-9a-f-]{36}$/);
     expect(body.uploadUrl).toBeTypeOf("string");
     expect(body.fileUrl).toContain(
-      `/f/${encodeURIComponent(user.userId)}/${body.uploadId}/daily_report.pdf`,
+      `/f/${encodeURIComponent(user.userId.replace(/^user_/, ""))}/${body.uploadId}/daily_report.pdf`,
     );
 
     const putCall = context.mocks.s3.generatePresignedPutUrl.mock.calls[0];

--- a/turbo/apps/web/app/api/zero/uploads/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/uploads/complete/__tests__/route.test.ts
@@ -110,7 +110,7 @@ describe("POST /api/zero/uploads/complete", () => {
       filename: "report.pdf",
       contentType: "application/pdf",
       sizeBytes: 1234,
-      url: `http://localhost:3000/f/${encodeURIComponent(user.userId)}/${fileId}/report.pdf`,
+      url: `http://localhost:3000/f/${encodeURIComponent(user.userId.replace(/^user_/, ""))}/${fileId}/report.pdf`,
       metadata: { s3Key },
     });
   });

--- a/turbo/apps/web/app/api/zero/uploads/prepare/route.ts
+++ b/turbo/apps/web/app/api/zero/uploads/prepare/route.ts
@@ -22,10 +22,10 @@ const log = logger("api:zero:uploads:prepare");
  * this path is not constrained by Vercel's ~4.5 MB serverless body cap.
  *
  * The GET-side URL returned to the caller is a permanent
- * `/f/{userId}/{id}/{filename}` redirect served by the app — callers may
- * persist it in messages, drafts, or external channels. The short-lived
- * presigned signature is materialized per-request inside that route, on
- * each individual access.
+ * `/f/{publicUserId}/{id}/{filename}` redirect served by the app — callers
+ * may persist it in messages, drafts, or external channels. The public user
+ * segment omits Clerk's `user_` prefix; the short-lived presigned signature
+ * is materialized per-request inside that route, on each individual access.
  */
 
 const PUT_URL_TTL_SECONDS = 3600; // 1 hour to finish the upload

--- a/turbo/apps/web/app/api/zero/voice-io/speech/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/speech/__tests__/route.test.ts
@@ -295,7 +295,7 @@ describe("POST /api/zero/voice-io/speech", () => {
     });
     expect(body.id).toEqual(expect.any(String));
     expect(body.url).toBe(
-      `http://localhost:3000/f/${encodeURIComponent(userId)}/${body.id}/${body.filename}`,
+      `http://localhost:3000/f/${encodeURIComponent(userId.replace(/^user_/, ""))}/${body.id}/${body.filename}`,
     );
 
     expect(context.mocks.s3.uploadS3Buffer).toHaveBeenCalledTimes(1);

--- a/turbo/apps/web/app/f/[userId]/[id]/[filename]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/f/[userId]/[id]/[filename]/__tests__/route.test.ts
@@ -50,6 +50,30 @@ describe("GET /f/[userId]/[id]/[filename]", () => {
     expect(contentDisposition).toBeUndefined();
   });
 
+  it("maps prefixless public user IDs back to Clerk user IDs", async () => {
+    context.mocks.s3.generatePresignedUrl.mockResolvedValue(
+      "https://signed.example.com/doc.pdf?sig=abc",
+    );
+
+    const res = await invoke("alice", "file-id", "doc.pdf");
+
+    expect(res.status).toBe(302);
+
+    const [, key] = context.mocks.s3.generatePresignedUrl.mock.calls[0] ?? [];
+    expect(key).toBe("uploads/user_alice/file-id/doc.pdf");
+  });
+
+  it("keeps non-Clerk user-like URL segments unchanged", async () => {
+    context.mocks.s3.generatePresignedUrl.mockResolvedValue(
+      "https://signed.example.com/doc.pdf?sig=abc",
+    );
+
+    await invoke("user-1", "file-id", "doc.pdf");
+
+    const [, key] = context.mocks.s3.generatePresignedUrl.mock.calls[0] ?? [];
+    expect(key).toBe("uploads/user-1/file-id/doc.pdf");
+  });
+
   it("forces attachment download when ?download=1 is present", async () => {
     context.mocks.s3.generatePresignedUrl.mockResolvedValue(
       "https://signed.example.com/report.pdf",

--- a/turbo/apps/web/app/f/[userId]/[id]/[filename]/route.ts
+++ b/turbo/apps/web/app/f/[userId]/[id]/[filename]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { initServices } from "../../../../../src/lib/init-services";
 import { generatePresignedUrl } from "../../../../../src/lib/infra/s3/s3-client";
+import { storageUserIdFromFileUrlSegment } from "../../../../../src/lib/zero/uploads/file-url";
 import { env } from "../../../../../src/env";
 import { applyCorsHeaders } from "../../../../../proxy.cors";
 
@@ -8,12 +9,13 @@ import { applyCorsHeaders } from "../../../../../proxy.cors";
  * Permanent file URL resolver.
  *
  * Callers (chat messages, drafts, Slack unfurls, external share links) hold
- * a stable `/f/{userId}/{id}/{filename}` URL returned by
- * /api/zero/uploads/prepare. The three path segments rebuild the full S3
- * key (`uploads/{userId}/{id}/{filename}`) — the same convention the
- * prepare route uses — so this route needs no database or S3 listing to
- * resolve the object. It mints a short-lived presigned URL per request and
- * 302-redirects the browser.
+ * a stable `/f/{publicUserId}/{id}/{filename}` URL returned by
+ * /api/zero/uploads/prepare. New URLs omit the Clerk `user_` prefix from the
+ * user segment, but old `/f/user_...` links remain valid. The three path
+ * segments rebuild the full S3 key (`uploads/{userId}/{id}/{filename}`) —
+ * the same convention the prepare route uses — so this route needs no
+ * database or S3 listing to resolve the object. It mints a short-lived
+ * presigned URL per request and 302-redirects the browser.
  *
  * Access model: share-by-link. The path itself is the capability — any
  * caller that knows it may fetch the file, matching the semantics of the
@@ -83,9 +85,10 @@ export async function GET(
 ) {
   initServices();
   const { userId, id, filename } = await params;
+  const storageUserId = storageUserIdFromFileUrlSegment(userId);
 
   const bucket = env().R2_USER_STORAGES_BUCKET_NAME;
-  const s3Key = `uploads/${userId}/${id}/${filename}`;
+  const s3Key = `uploads/${storageUserId}/${id}/${filename}`;
 
   const wantDownload = request.nextUrl.searchParams.get("download") === "1";
   const wantRaw = request.nextUrl.searchParams.get("raw") === "1";

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
@@ -462,9 +462,9 @@ type ChatMessage = {
  * Resolve file IDs to permanent file URLs with metadata for the frontend.
  *
  * Lists S3 objects at each file's prefix to recover filename and size, then
- * constructs the permanent `${APP_URL}/f/{userId}/{id}/{filename}` URL. The
- * short-lived presigned signature is materialized per-request inside the /f
- * route, not here — the value returned to the frontend is stable and safe
+ * constructs the permanent `${APP_URL}/f/{publicUserId}/{id}/{filename}` URL.
+ * The short-lived presigned signature is materialized per-request inside the
+ * /f route, not here — the value returned to the frontend is stable and safe
  * to persist in markdown or share over external channels.
  */
 export async function resolveAttachFileUrls(

--- a/turbo/apps/web/src/lib/zero/uploads/file-url.test.ts
+++ b/turbo/apps/web/src/lib/zero/uploads/file-url.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFileUrl,
+  publicFileUserIdSegment,
+  storageUserIdFromFileUrlSegment,
+} from "./file-url";
+
+describe("file URL user ID segments", () => {
+  it("omits the Clerk user_ prefix from generated /f URLs", () => {
+    expect(buildFileUrl("user_alice", "file-id", "report.pdf")).toBe(
+      "http://localhost:3000/f/alice/file-id/report.pdf",
+    );
+  });
+
+  it("leaves non-Clerk user IDs unchanged in generated /f URLs", () => {
+    expect(buildFileUrl("user-1", "file-id", "report.pdf")).toBe(
+      "http://localhost:3000/f/user-1/file-id/report.pdf",
+    );
+  });
+
+  it("maps public URL segments back to storage user IDs", () => {
+    expect(publicFileUserIdSegment("user_alice")).toBe("alice");
+    expect(storageUserIdFromFileUrlSegment("alice")).toBe("user_alice");
+    expect(storageUserIdFromFileUrlSegment("user_alice")).toBe("user_alice");
+    expect(storageUserIdFromFileUrlSegment("user-1")).toBe("user-1");
+  });
+});

--- a/turbo/apps/web/src/lib/zero/uploads/file-url.ts
+++ b/turbo/apps/web/src/lib/zero/uploads/file-url.ts
@@ -3,23 +3,43 @@ import { getApiUrl } from "../../infra/callback/dispatcher";
 /**
  * Build the permanent URL for an uploaded attachment.
  *
- * The three path segments together reconstruct the S3 key
- * `uploads/{userId}/{id}/{filename}`, so the /f route can generate a
- * presigned GET without any database or listing lookup. Because the URL
- * embeds only stable identifiers (no signature, no expiry), callers may
- * persist it in chat message content, draft rows, Slack unfurls, or CLI
- * output — the short-lived signature is materialized per-request inside
- * the /f route on each access.
+ * The three path segments together reconstruct the S3 key, so the /f route
+ * can generate a presigned GET without any database or listing lookup.
+ * Because the URL embeds only stable identifiers (no signature, no expiry),
+ * callers may persist it in chat message content, draft rows, Slack unfurls,
+ * or CLI output — the short-lived signature is materialized per-request
+ * inside the /f route on each access.
  *
  * Uses VM0_API_URL (public host) rather than NEXT_PUBLIC_APP_URL so the
  * URL is reachable by anonymous share-by-link consumers (Slack unfurl
  * bots, email clients, external viewers) that never sign in to the app
  * domain.
  */
+const CLERK_USER_ID_PREFIX = "user_";
+
+export function publicFileUserIdSegment(userId: string): string {
+  return userId.startsWith(CLERK_USER_ID_PREFIX)
+    ? userId.slice(CLERK_USER_ID_PREFIX.length)
+    : userId;
+}
+
+export function storageUserIdFromFileUrlSegment(userIdSegment: string): string {
+  // Preserve old `/f/user_...` links and non-Clerk/dev IDs such as `user-1`.
+  if (
+    userIdSegment === "user" ||
+    userIdSegment.startsWith(CLERK_USER_ID_PREFIX) ||
+    userIdSegment.startsWith("user-")
+  ) {
+    return userIdSegment;
+  }
+  return `${CLERK_USER_ID_PREFIX}${userIdSegment}`;
+}
+
 export function buildFileUrl(
   userId: string,
   id: string,
   filename: string,
 ): string {
-  return `${getApiUrl()}/f/${encodeURIComponent(userId)}/${id}/${encodeURIComponent(filename)}`;
+  const publicUserId = publicFileUserIdSegment(userId);
+  return `${getApiUrl()}/f/${encodeURIComponent(publicUserId)}/${id}/${encodeURIComponent(filename)}`;
 }

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -19,10 +19,10 @@ const attachFileSchema = z.object({
 
 /**
  * Attach file returned to the frontend with a resolved URL.
- * `url` is the permanent `${APP_URL}/f/{userId}/{id}/{filename}` redirect
- * served by the app — consumers may render, cache, or share it freely; the
- * underlying short-lived presigned signature is materialized per-request
- * inside the /f route.
+ * `url` is the permanent `${APP_URL}/f/{publicUserId}/{id}/{filename}`
+ * redirect served by the app — consumers may render, cache, or share it
+ * freely; the underlying short-lived presigned signature is materialized
+ * per-request inside the /f route.
  */
 const resolvedAttachFileSchema = attachFileSchema.extend({
   url: z.string(),
@@ -53,9 +53,9 @@ const chatThreadArtifactRunSchema = z.object({
 /**
  * Attachment metadata persisted in chat_threads.draft_attachments.
  *
- * `url` is the permanent `/f/{userId}/{id}/{filename}` form. Historically
- * this stored a 7-day presigned URL that could silently expire while
- * drafts sat in the DB; the permanent redirect removes that footgun.
+ * `url` is the permanent `/f/{publicUserId}/{id}/{filename}` form.
+ * Historically this stored a 7-day presigned URL that could silently expire
+ * while drafts sat in the DB; the permanent redirect removes that footgun.
  */
 const persistedAttachmentSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
## Summary
- omit the Clerk `user_` prefix when generating permanent `/f/` file URLs
- map prefixless `/f/` URL segments back to existing `uploads/user_...` storage keys
- keep existing `/f/user_...` links and non-Clerk dev/test IDs working

## Testing
- `pnpm format`
- `pnpm vitest apps/web/src/lib/zero/uploads/file-url.test.ts 'apps/web/app/f/[userId]/[id]/[filename]/__tests__/route.test.ts'`
- `pnpm turbo run lint --filter=web`
- `pnpm turbo run check-types --filter=web`
- `git diff --check`
- pre-commit: prettier, knip, check-types, commitlint