### PR TITLE
fix: fix two api shadow divergence sources — slack environment and connector timestamps

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
@@ -2,9 +2,14 @@ import { randomUUID } from "node:crypto";
 import { createStore } from "ccstate";
 import { zeroIntegrationsSlackContract } from "@vm0/api-contracts/contracts/zero-integrations-slack";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { agentComposes } from "@vm0/db/schema/agent-compose";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgCache } from "@vm0/db/schema/org-cache";
+import { secrets } from "@vm0/db/schema/secret";
+import { variables } from "@vm0/db/schema/variable";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { eq } from "drizzle-orm";
@@ -185,5 +190,143 @@ describe("GET /api/zero/integrations/slack", () => {
     expect(response.body.isConnected).toBeFalsy();
     expect(response.body.isInstalled).toBeTruthy();
     expect(response.body.isAdmin).toBeTruthy();
+  });
+
+  describe("environment field", () => {
+    afterEach(async () => {
+      await writeDb.delete(variables).where(eq(variables.orgId, fixture.orgId));
+      await writeDb.delete(secrets).where(eq(secrets.orgId, fixture.orgId));
+    });
+
+    const dol = "\x24";
+    const composeContent = JSON.parse(
+      `{"settings":{"api_key":"${dol}{{ secrets.SEC_A }}","region":"${dol}{{ vars.VAR_A }}"}}`,
+    ) as Record<string, unknown>;
+
+    async function seedEnvironmentVersion(): Promise<void> {
+      const versionId = randomUUID();
+      await writeDb.insert(agentComposeVersions).values({
+        id: versionId,
+        composeId: fixture.composeId,
+        content: composeContent,
+        createdBy: fixture.userId,
+      });
+      await writeDb
+        .update(agentComposes)
+        .set({ headVersionId: versionId })
+        .where(eq(agentComposes.id, fixture.composeId));
+    }
+
+    async function seedUserSecret(name: string): Promise<void> {
+      await writeDb.insert(secrets).values({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name,
+        encryptedValue: `encrypted_${name}`,
+        type: "user",
+      });
+    }
+
+    async function seedUserVariable(
+      name: string,
+      value: string,
+    ): Promise<void> {
+      await writeDb.insert(variables).values({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name,
+        value,
+      });
+    }
+
+    function mockAdminAuth(): void {
+      context.mocks.clerk.authenticateRequest.mockResolvedValue({
+        isAuthenticated: true,
+        toAuth: () => {
+          return {
+            userId: fixture.userId,
+            orgId: fixture.orgId,
+            orgRole: "org:admin",
+          };
+        },
+      });
+    }
+
+    it("includes environment when connected with head version and secrets/vars present", async () => {
+      await seedEnvironmentVersion();
+      await seedUserSecret("SEC_A");
+      await seedUserVariable("VAR_A", "us-east-1");
+
+      mockAdminAuth();
+      mockApiShadowCompareRoutes([zeroIntegrationsSlackContract.getStatus]);
+
+      const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+      const response = await accept(
+        client.getStatus({
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      );
+
+      expect(response.body.environment).toBeDefined();
+      expect(response.body.environment!.requiredSecrets).toStrictEqual([
+        "SEC_A",
+      ]);
+      expect(response.body.environment!.requiredVars).toStrictEqual(["VAR_A"]);
+      expect(response.body.environment!.missingSecrets).toStrictEqual([]);
+      expect(response.body.environment!.missingVars).toStrictEqual([]);
+    });
+
+    it("reports missing secrets and vars in environment", async () => {
+      await seedEnvironmentVersion();
+
+      mockAdminAuth();
+      mockApiShadowCompareRoutes([zeroIntegrationsSlackContract.getStatus]);
+
+      const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+      const response = await accept(
+        client.getStatus({
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      );
+
+      expect(response.body.environment).toBeDefined();
+      expect(response.body.environment!.requiredSecrets).toStrictEqual([
+        "SEC_A",
+      ]);
+      expect(response.body.environment!.requiredVars).toStrictEqual(["VAR_A"]);
+      expect(response.body.environment!.missingSecrets).toStrictEqual([
+        "SEC_A",
+      ]);
+      expect(response.body.environment!.missingVars).toStrictEqual(["VAR_A"]);
+    });
+
+    it("omits environment when isConnected is false", async () => {
+      await writeDb
+        .delete(slackOrgConnections)
+        .where(eq(slackOrgConnections.slackWorkspaceId, fixture.workspaceId));
+
+      await seedEnvironmentVersion();
+      await seedUserSecret("SEC_A");
+      await seedUserVariable("VAR_A", "us-east-1");
+
+      mockAdminAuth();
+      mockApiShadowCompareRoutes([zeroIntegrationsSlackContract.getStatus]);
+
+      const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+      const response = await accept(
+        client.getStatus({
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      );
+
+      expect(response.body.isConnected).toBeFalsy();
+      expect(response.body.environment).toBeUndefined();
+    });
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
@@ -60,7 +60,8 @@ const getSlackEnvironment$ = computed(
     const auth = get(organizationAuthContext$);
     const db = get(db$);
 
-    // Find the default agent via org metadata
+    // Three sequential queries to resolve default-agent → compose → version
+    // (each depends on the prior result, so a single JOIN is not straightforward).
     const [meta] = await db
       .select({ defaultAgentId: orgMetadata.defaultAgentId })
       .from(orgMetadata)

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
@@ -7,6 +7,14 @@ import {
 } from "@vm0/api-contracts/contracts/zero-integrations-slack";
 import { authHeadersSchema } from "@vm0/api-contracts/contracts/base";
 import { apiErrorSchema } from "@vm0/api-contracts/contracts/errors";
+import { extractAndGroupVariables } from "@vm0/core/variable-expander";
+import { getConnectorProvidedSecretNames } from "@vm0/connectors/connector-utils";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { eq } from "drizzle-orm";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -18,6 +26,9 @@ import {
 } from "../services/zero-slack-data.service";
 import { getFileInfo } from "../../lib/slack-client";
 import { fetchSlackFile } from "../external/slack-file-fetcher";
+import { db$ } from "../external/db";
+import { zeroConnectorList } from "../services/zero-connector-data.service";
+import { userSecrets, userVariables } from "../services/zero-user-data.service";
 import type { RouteEntry } from "../route";
 
 const c = initContract();
@@ -44,6 +55,79 @@ const slackDownloadFileContract = c.router({
   },
 });
 
+const getSlackEnvironment$ = computed(
+  async (get): Promise<z.infer<typeof slackOrgStatusSchema>["environment"]> => {
+    const auth = get(organizationAuthContext$);
+    const db = get(db$);
+
+    // Find the default agent via org metadata
+    const [meta] = await db
+      .select({ defaultAgentId: orgMetadata.defaultAgentId })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, auth.orgId))
+      .limit(1);
+
+    if (!meta?.defaultAgentId) {
+      return undefined;
+    }
+
+    const [compose] = await db
+      .select({ headVersionId: agentComposes.headVersionId })
+      .from(agentComposes)
+      .where(eq(agentComposes.id, meta.defaultAgentId))
+      .limit(1);
+
+    if (!compose?.headVersionId) {
+      return undefined;
+    }
+
+    const [version] = await db
+      .select({ content: agentComposeVersions.content })
+      .from(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, compose.headVersionId))
+      .limit(1);
+
+    if (!version) {
+      return undefined;
+    }
+
+    const grouped = extractAndGroupVariables(version.content);
+    const requiredSecrets = grouped.secrets.map((s) => s.name);
+    const requiredVars = grouped.vars.map((v) => v.name);
+
+    const [userSecretList, userVarList, userConnectors] = await Promise.all([
+      get(userSecrets({ orgId: auth.orgId, userId: auth.userId })),
+      get(userVariables({ orgId: auth.orgId, userId: auth.userId })),
+      get(zeroConnectorList({ orgId: auth.orgId, userId: auth.userId })),
+    ]);
+
+    const connectorProvided = getConnectorProvidedSecretNames(
+      userConnectors.connectors.map((c) => c.type),
+    );
+    const existingSecretNames = new Set([
+      ...userSecretList.secrets.map((s) => s.name),
+      ...connectorProvided,
+    ]);
+    const existingVarNames = new Set(
+      userVarList.variables.map((v) => v.name),
+    );
+
+    const missingSecrets = requiredSecrets.filter(
+      (name) => !existingSecretNames.has(name),
+    );
+    const missingVars = requiredVars.filter(
+      (name) => !existingVarNames.has(name),
+    );
+
+    return {
+      requiredSecrets,
+      requiredVars,
+      missingSecrets,
+      missingVars,
+    };
+  },
+);
+
 const getSlackStatusInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const status = await get(
@@ -54,6 +138,10 @@ const getSlackStatusInner$ = computed(async (get) => {
     }),
   );
 
+  const environment = status.isConnected
+    ? await get(getSlackEnvironment$)
+    : undefined;
+
   const body: z.infer<typeof slackOrgStatusSchema> = {
     isConnected: status.isConnected,
     isInstalled: status.isInstalled,
@@ -63,6 +151,7 @@ const getSlackStatusInner$ = computed(async (get) => {
     connectUrl: status.connectUrl,
     defaultAgentName: status.defaultAgentName,
     agentOrgSlug: status.agentOrgSlug,
+    ...(environment !== undefined && { environment }),
   };
 
   return { status: 200 as const, body };

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
@@ -92,8 +92,12 @@ const getSlackEnvironment$ = computed(
     }
 
     const grouped = extractAndGroupVariables(version.content);
-    const requiredSecrets = grouped.secrets.map((s) => s.name);
-    const requiredVars = grouped.vars.map((v) => v.name);
+    const requiredSecrets = grouped.secrets.map((s) => {
+      return s.name;
+    });
+    const requiredVars = grouped.vars.map((v) => {
+      return v.name;
+    });
 
     const [userSecretList, userVarList, userConnectors] = await Promise.all([
       get(userSecrets({ orgId: auth.orgId, userId: auth.userId })),
@@ -102,22 +106,28 @@ const getSlackEnvironment$ = computed(
     ]);
 
     const connectorProvided = getConnectorProvidedSecretNames(
-      userConnectors.connectors.map((c) => c.type),
+      userConnectors.connectors.map((c) => {
+        return c.type;
+      }),
     );
     const existingSecretNames = new Set([
-      ...userSecretList.secrets.map((s) => s.name),
+      ...userSecretList.secrets.map((s) => {
+        return s.name;
+      }),
       ...connectorProvided,
     ]);
     const existingVarNames = new Set(
-      userVarList.variables.map((v) => v.name),
+      userVarList.variables.map((v) => {
+        return v.name;
+      }),
     );
 
-    const missingSecrets = requiredSecrets.filter(
-      (name) => !existingSecretNames.has(name),
-    );
-    const missingVars = requiredVars.filter(
-      (name) => !existingVarNames.has(name),
-    );
+    const missingSecrets = requiredSecrets.filter((name) => {
+      return !existingSecretNames.has(name);
+    });
+    const missingVars = requiredVars.filter((name) => {
+      return !existingVarNames.has(name);
+    });
 
     return {
       requiredSecrets,

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -1,0 +1,36 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { secrets } from "@vm0/db/schema/secret";
+import { writeDb$ } from "../../external/db";
+import { zeroConnectorList } from "../zero-connector-data.service";
+
+const store = createStore();
+const writeDb = store.set(writeDb$);
+
+describe("zeroConnectorList", () => {
+  it("assigns fixed sentinel timestamps to derived api-token connectors", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+
+    // Seed OPENAI_TOKEN so openai is derived as a connected api-token connector
+    await writeDb.insert(secrets).values({
+      orgId,
+      userId,
+      name: "OPENAI_TOKEN",
+      encryptedValue: "encrypted_openai_token",
+      type: "user",
+    });
+
+    const list = await store.get(zeroConnectorList({ orgId, userId }));
+    const openai = list.connectors.find((c) => {
+      return c.type === "openai";
+    });
+
+    expect(openai).toBeDefined();
+    if (openai) {
+      expect(openai.createdAt).toBe("1970-01-01T00:00:00.000Z");
+      expect(openai.updatedAt).toBe("1970-01-01T00:00:00.000Z");
+    }
+  });
+});

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -26,7 +26,6 @@ import { variables } from "@vm0/db/schema/variable";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
-import { nowDate } from "../../lib/time";
 import { db$ } from "../external/db";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
@@ -200,7 +199,9 @@ export function zeroConnectorList(args: {
         return connector.type;
       }),
     );
-    const now = nowDate().toISOString();
+    // Use a fixed timestamp for derived connectors — they are inferred from
+    // secrets/variables rather than explicitly created, so a stable sentinel
+    // value keeps shadow comparisons deterministic.
     const derivedConnectors: ConnectorResponse[] = derivedTypes
       .filter((type) => {
         return !dbTypes.has(type);
@@ -215,8 +216,8 @@ export function zeroConnectorList(args: {
           externalEmail: null,
           oauthScopes: null,
           needsReconnect: false,
-          createdAt: now,
-          updatedAt: now,
+          createdAt: "1970-01-01T00:00:00.000Z",
+          updatedAt: "1970-01-01T00:00:00.000Z",
         };
       });
 
@@ -357,7 +358,7 @@ function apiTokenConnectorByType(args: {
       return null;
     }
 
-    const now = nowDate().toISOString();
+    // Use a fixed timestamp — this connector is inferred, not explicitly created.
     return {
       id: null,
       type: args.type,
@@ -367,8 +368,8 @@ function apiTokenConnectorByType(args: {
       externalEmail: null,
       oauthScopes: null,
       needsReconnect: false,
-      createdAt: now,
-      updatedAt: now,
+      createdAt: "1970-01-01T00:00:00.000Z",
+      updatedAt: "1970-01-01T00:00:00.000Z",
     };
   });
 }

--- a/turbo/apps/web/src/lib/zero/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/connector/connector-service.ts
@@ -218,7 +218,9 @@ export async function listConnectors(
       return c.type;
     }),
   );
-  const now = new Date().toISOString();
+  // Use a fixed timestamp for derived connectors — they are inferred from
+  // secrets/variables rather than explicitly created, so a stable sentinel
+  // value keeps shadow comparisons deterministic.
   const derivedConnectors: ConnectorResponse[] = derivedTypes
     .filter((type) => {
       return !dbTypeSet.has(type);
@@ -233,8 +235,8 @@ export async function listConnectors(
         externalEmail: null,
         oauthScopes: null,
         needsReconnect: false,
-        createdAt: now,
-        updatedAt: now,
+        createdAt: "1970-01-01T00:00:00.000Z",
+        updatedAt: "1970-01-01T00:00:00.000Z",
       };
     });
 
@@ -358,7 +360,7 @@ export async function getConnector(
   });
   if (!secretsOk || !variablesOk) return null;
 
-  const now = new Date().toISOString();
+  // Use a fixed timestamp — this connector is inferred, not explicitly created.
   return {
     id: null,
     type,
@@ -368,8 +370,8 @@ export async function getConnector(
     externalEmail: null,
     oauthScopes: null,
     needsReconnect: false,
-    createdAt: now,
-    updatedAt: now,
+    createdAt: "1970-01-01T00:00:00.000Z",
+    updatedAt: "1970-01-01T00:00:00.000Z",
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes two remaining sources of `response shadow divergence` warnings observed in production Axiom logs (~443 events/day):

- **`GET /api/zero/integrations/slack`** — The API handler was missing the `environment` field entirely. Added full environment computation (resolve agent compose → extract `requiredSecrets`/`requiredVars` from YAML → check user secrets/vars/connectors → compute `missingSecrets`/`missingVars`), matching the web handler's behavior.
- **`GET /api/zero/connectors`** — Derived api-token connectors (inferred from secrets, not stored in DB) used `nowDate().toISOString()` for `createdAt`/`updatedAt`, causing millisecond-level differences between API and web calls. Changed to a fixed epoch timestamp (`"1970-01-01T00:00:00.000Z"`) since these connectors were never explicitly created.

## Changes

| File | Change |
|------|--------|
| `apps/api/src/signals/routes/zero-integrations-slack.ts` | Added `getSlackEnvironment$` computed and include `environment` in response when connected (+89 lines) |
| `apps/api/src/signals/services/zero-connector-data.service.ts` | Fixed epoch timestamp for derived connectors; removed unused `nowDate` import |
| `apps/web/src/lib/zero/connector/connector-service.ts` | Same fix for web side to keep both implementations in sync |

## Remaining

Two additional divergence sources (`/api/zero/chat-threads` updatedAt, `/api/zero/chat-threads/:id` title/status) are race conditions inherent to the shadow compare design — the API handler and web fetch run at different times, so title renames and run status transitions naturally differ. These would need shadow-compare-level tolerance rather than handler-level fixes.

## Test plan

- [x] All 245 API tests pass (32 test files)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [ ] Deploy and verify in Axiom — expects 0 events for `/api/zero/integrations/slack` and `/api/zero/connectors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)