### PR TITLE
docs(sandbox-fc): document guest network invariant

### DIFF
--- a/crates/sandbox-fc/src/network/guest.rs
+++ b/crates/sandbox-fc/src/network/guest.rs
@@ -2,7 +2,7 @@
 ///
 /// Every namespace uses the same values — isolation guarantees no conflicts.
 /// These must match the Firecracker VM's network configuration.
-pub struct GuestNetwork {
+pub(crate) struct GuestNetwork {
     /// TAP device name inside namespace (must match Firecracker config).
     pub tap_name: &'static str,
     /// Fixed MAC for the TAP device (host-side, locally administered).
@@ -22,7 +22,12 @@ pub struct GuestNetwork {
     pub prefix_len: u8,
 }
 
-pub const GUEST_NETWORK: GuestNetwork = GuestNetwork {
+/// Canonical guest-facing network values for Firecracker VM namespaces.
+///
+/// Boot arguments, Firecracker network configuration, and namespace TAP setup
+/// all read these values. Keep them compatible with the guest network state
+/// baked into snapshots, including deterministic MAC addresses and IPs.
+pub(crate) const GUEST_NETWORK: GuestNetwork = GuestNetwork {
     tap_name: "vm0-tap",
     tap_mac: "02:00:00:00:00:02",
     guest_mac: "02:00:00:00:00:01",
@@ -41,7 +46,7 @@ pub(crate) fn generate_guest_network_boot_args() -> String {
 }
 
 /// Generate the full kernel boot args string (base flags + network config).
-pub fn generate_boot_args() -> String {
+pub(crate) fn generate_boot_args() -> String {
     format!(
         "console=ttyS0 reboot=k panic=1 pci=off nomodules random.trust_cpu=on \
          quiet loglevel=0 nokaslr audit=0 numa=off mitigations=off noresume \

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -2,6 +2,6 @@ mod error;
 mod guest;
 mod pool;
 
-pub use guest::generate_boot_args;
-pub use guest::{GUEST_NETWORK, GuestNetwork};
+pub(crate) use guest::generate_boot_args;
+pub(crate) use guest::{GUEST_NETWORK, GuestNetwork};
 pub use pool::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, NetnsPoolHandle};


### PR DESCRIPTION
## Summary
- add a doc comment to `GUEST_NETWORK` describing the shared guest network invariant
- narrow guest-network helper exports to `pub(crate)` because they are crate-internal, not crate public API
- keep the external `sandbox-fc` API unchanged

Closes #12037

## Verification
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo check --manifest-path crates/Cargo.toml -p sandbox-fc
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc network::guest
- git diff --check
- pre-commit: cargo-clippy, cargo-doc