### PR TITLE
docs: document nbd-cow error types

### DIFF
--- a/crates/nbd-cow/src/error.rs
+++ b/crates/nbd-cow/src/error.rs
@@ -5,6 +5,7 @@
 
 use crate::protocol::ProtocolError;
 
+/// Error type returned by `nbd-cow` operations.
 #[derive(Debug, thiserror::Error)]
 pub enum NbdCowError {
     #[error("protocol error: {0}")]
@@ -30,4 +31,5 @@ pub enum NbdCowError {
     NoFreeDevice,
 }
 
+/// Result type used by `nbd-cow` APIs.
 pub type Result<T> = std::result::Result<T, NbdCowError>;

--- a/crates/nbd-cow/src/error.rs
+++ b/crates/nbd-cow/src/error.rs
@@ -31,5 +31,5 @@ pub enum NbdCowError {
     NoFreeDevice,
 }
 
-/// Result type used by `nbd-cow` APIs.
+/// Convenience result type for fallible `nbd-cow` APIs using [`NbdCowError`].
 pub type Result<T> = std::result::Result<T, NbdCowError>;


### PR DESCRIPTION
## Summary
- add item-level docs for public `NbdCowError`
- document the public `Result<T>` alias in the same module

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p nbd-cow --no-deps`
- lefthook pre-commit (`cargo-fmt`, `cargo-clippy`, `cargo-doc`)

Closes #12038
Closes #12039