### PR TITLE
fix: make mobile breadcrumb title match desktop on works page

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-mobile-breadcrumb.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-mobile-breadcrumb.ts
@@ -193,11 +193,18 @@ export const mobileBreadcrumb$ = computed(
       return await get(activityDetailBreadcrumb$);
     }
 
+    if (route === "works") {
+      const displayName = await get(currentChatAgentDisplayName$);
+      return {
+        section: `Where ${displayName ?? "Zero"} works`,
+        sectionPath: ROUTES.works,
+      };
+    }
+
     // Static labels for other non-chat sections
     const nonChatSections: Partial<
       Record<string, { label: string; path: RoutePath }>
     > = {
-      works: { label: "Works", path: ROUTES.works },
       settings: { label: "Settings", path: ROUTES.settings },
       connectors: { label: "Connectors", path: ROUTES.connectors },
     };


### PR DESCRIPTION
## Summary
The mobile breadcrumb title for the Works page showed a static "Works" label, while the desktop page header dynamically renders "Where {displayName} works". This PR makes the mobile breadcrumb resolve the agent display name dynamically, matching the desktop behavior.

Before: mobile top bar shows **Works**
After: mobile top bar shows **Where Zero works** (or the current agent's display name)

## Fix
In `zero-mobile-breadcrumb.ts`, the `works` route is now handled before the static `nonChatSections` block, resolving `currentChatAgentDisplayName$` to build the section string dynamically — the same pattern the desktop `zero-works-page.tsx` already uses.

Closes #11611

🤖 Generated with [Claude Code](https://claude.com/claude-code)