### PR TITLE
fix: restore compact attachment chips

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -54,7 +54,7 @@ describe("chat-d-056: file type icon renders based on getFileTypeIcon", () => {
     });
   });
 
-  it("renders a thumbnail preview block for unknown file extension", async () => {
+  it("renders a compact download chip for unknown file extension", async () => {
     mockChatLifecycle({
       chatMessages: [
         {
@@ -72,13 +72,12 @@ describe("chat-d-056: file type icon renders based on getFileTypeIcon", () => {
     });
 
     await waitFor(() => {
-      const link = document.querySelector('a[download="archive.zip"]');
+      const link = screen.getByLabelText("Download archive.zip");
       expect(link).toBeInTheDocument();
-      expect(link).toHaveAttribute("data-testid", "attachment-preview-file");
       expect(
-        within(link as HTMLElement).getByTestId("attachment-preview-file-icon"),
+        within(link).getByTestId("attachment-chip-file-icon"),
       ).toBeInTheDocument();
-      expect(within(link as HTMLElement).getByText("ZIP")).toBeInTheDocument();
+      expect(within(link).getByText("ZIP")).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -93,8 +93,8 @@ describe("zero chat thread page display - attachment image preview", () => {
   });
 });
 
-describe("zero chat thread page display - attachment audio preview", () => {
-  it("renders audio attachment preview with controls", async () => {
+describe("zero chat thread page display - attachment audio chip", () => {
+  it("renders audio attachment as a compact download chip", async () => {
     mockChatLifecycle({
       chatMessages: [
         {
@@ -116,11 +116,13 @@ describe("zero chat thread page display - attachment audio preview", () => {
 
     detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
-    const audio = await waitFor(() => {
-      return screen.getByLabelText("Audio preview for clip.mp3");
+    const download = await waitFor(() => {
+      return screen.getByLabelText("Download clip.mp3");
     });
-    expect(audio).toHaveAttribute("src", "https://example.com/clip.mp3");
-    expect(audio).toHaveAttribute("controls");
+    expect(download).toHaveAttribute("href", "https://example.com/clip.mp3");
+    expect(
+      within(download).getByTestId("attachment-chip-file-icon"),
+    ).toBeInTheDocument();
   });
 });
 
@@ -763,7 +765,7 @@ describe("zero chat thread page display - body link document preview", () => {
     });
   });
 
-  it("renders structured non-inline attached files as thumbnail preview blocks", async () => {
+  it("renders structured non-inline attached files as compact download chips", async () => {
     const fileUrl =
       "https://www.vm0.ai/f/user_123/3a474c61-ffe4-4e56-b9e7-0185b3dba9f7/budget.xlsx";
     mockChatLifecycle({
@@ -789,16 +791,15 @@ describe("zero chat thread page display - body link document preview", () => {
     detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
     await waitFor(() => {
-      const preview = screen.getByTestId("attachment-preview-file");
-      expect(preview).toBeInTheDocument();
+      const preview = screen.getByLabelText("Download budget.xlsx");
       expect(
-        within(preview).getByTestId("attachment-preview-file-icon"),
+        within(preview).queryByTestId("attachment-preview-file-icon"),
+      ).not.toBeInTheDocument();
+      expect(
+        within(preview).getByTestId("attachment-chip-file-icon"),
       ).toBeInTheDocument();
       expect(within(preview).getByText("XLSX")).toBeInTheDocument();
-      expect(screen.getByLabelText("Download budget.xlsx")).toHaveAttribute(
-        "href",
-        `${fileUrl}?download=1`,
-      );
+      expect(preview).toHaveAttribute("href", `${fileUrl}?download=1`);
     });
   });
 
@@ -856,10 +857,9 @@ describe("zero chat thread page display - body link document preview", () => {
   });
 });
 
-// CHAT-D-065: Video attachments render an inline <video controls> player.
-// Covers isVideoFilename + video branch added to PagedUserMessage in #9662.
-describe("zero chat thread page display - attachment video preview", () => {
-  it("renders a video element with controls for mp4 attachments", async () => {
+// CHAT-D-065: Video attachments render as compact download chips.
+describe("zero chat thread page display - attachment video chip", () => {
+  it("renders a compact download chip for mp4 attachments", async () => {
     const videoUrl = "https://example.com/clip.mp4";
     mockChatLifecycle({
       chatMessages: [
@@ -873,21 +873,19 @@ describe("zero chat thread page display - attachment video preview", () => {
 
     detachedSetupPage({ context, path: "/chats/thread-test-1" });
 
-    const video = await waitFor(() => {
-      const el = document.querySelector<HTMLVideoElement>(
-        `video[src="${videoUrl}"]`,
-      );
-      expect(el).toBeInTheDocument();
-      return el;
+    const download = await waitFor(() => {
+      return screen.getByLabelText("Download clip.mp4");
     });
 
-    expect(video?.hasAttribute("controls")).toBeTruthy();
-    // Must not fall through to the image or download branches.
+    expect(download).toHaveAttribute("href", videoUrl);
+    expect(
+      within(download).getByTestId("attachment-chip-file-icon"),
+    ).toBeInTheDocument();
     expect(
       document.querySelector(`img[src="${videoUrl}"]`),
     ).not.toBeInTheDocument();
     expect(
-      document.querySelector('a[download="clip.mp4"]'),
+      document.querySelector(`video[src="${videoUrl}"]`),
     ).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -697,9 +697,11 @@ function CsvLightboxBody({
 // ---------------------------------------------------------------------------
 
 export function FileAttachmentChip({
+  contentType,
   filename,
   url,
 }: {
+  contentType?: string;
   filename: string;
   url: string;
 }) {
@@ -708,10 +710,12 @@ export function FileAttachmentChip({
       href={getAttachmentDownloadUrl(url)}
       download={filename}
       title={filename}
+      aria-label={`Download ${filename}`}
       className="inline-flex items-center justify-center rounded-lg hover:bg-foreground/10 transition-colors p-0.5"
     >
       <FilePreviewIcon
         filename={filename}
+        contentType={contentType}
         className="h-9 w-9"
         testId="attachment-chip-file-icon"
       />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2241,14 +2241,6 @@ function isImageFilename(filename: string): boolean {
   );
 }
 
-function isVideoFilename(filename: string): boolean {
-  return /\.(mp4|webm|mov|ogv)$/i.test(filename);
-}
-
-function isAudioFilename(filename: string): boolean {
-  return /\.(mp3|wav|wave|m4a|aac|ogg|oga|opus|flac|mpga)$/i.test(filename);
-}
-
 function AssistantErrorContent({ error }: { error: string }) {
   const setOrgManageOpen = useSet(setOrgManageDialogOpen$);
   const setTab = useSet(setActiveOrgManageTab$);
@@ -2437,8 +2429,6 @@ function resolveAttachments(
       url: f.url,
       contentType,
       isImage: kind === "image" || isImageFilename(f.filename),
-      isVideo: kind === "video" || isVideoFilename(f.filename),
-      isAudio: kind === "audio" || isAudioFilename(f.filename),
       kind,
     };
   });
@@ -2626,47 +2616,14 @@ function UserMessageAttachments({
             />
           );
         }
-        if (a.isVideo) {
-          return (
-            <video
-              key={a.url}
-              src={a.url}
-              controls
-              className="max-h-48 max-w-full rounded-lg border border-foreground/10"
-            />
-          );
-        }
-        if (a.isAudio) {
-          return (
-            <audio
-              key={a.url}
-              src={a.url}
-              controls
-              preload="metadata"
-              className="w-full max-w-md"
-              aria-label={`Audio preview for ${a.filename}`}
-            />
-          );
-        }
         if (
           a.kind === "markdown" ||
+          a.kind === "text" ||
+          a.kind === "json" ||
           a.kind === "csv" ||
           a.kind === "pdf" ||
-          a.kind === "html" ||
-          a.kind === "file"
+          a.kind === "html"
         ) {
-          return (
-            <AttachmentPreview
-              key={a.url}
-              attachment={{
-                filename: a.filename,
-                url: a.url,
-                contentType: a.contentType,
-              }}
-            />
-          );
-        }
-        if (a.kind === "text" || a.kind === "json") {
           return (
             <PreviewableFileAttachmentChip
               key={a.url}
@@ -2677,7 +2634,12 @@ function UserMessageAttachments({
           );
         }
         return (
-          <FileAttachmentChip key={a.url} filename={a.filename} url={a.url} />
+          <FileAttachmentChip
+            key={a.url}
+            filename={a.filename}
+            url={a.url}
+            contentType={a.contentType}
+          />
         );
       })}
     </div>
@@ -2809,8 +2771,6 @@ function persistedAttachmentsToResolved(
       url: a.url,
       contentType: a.contentType,
       isImage: kind === "image" || isImageFilename(a.filename),
-      isVideo: kind === "video" || isVideoFilename(a.filename),
-      isAudio: kind === "audio" || isAudioFilename(a.filename),
       kind,
     };
   });


### PR DESCRIPTION
## Summary
- Render non-image chat attachments as compact file chips instead of inline preview blocks
- Keep image attachments rendered as thumbnails that open the preview lightbox
- Update platform chat attachment tests for compact chip behavior

## Verification
- pnpm exec vitest run src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
- pnpm exec eslint src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/zero-attachment-chips.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
- pnpm exec oxlint src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/zero-attachment-chips.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
- git diff --check

## Notes
- Pre-commit full check-types is currently blocked by unrelated existing apps/web type errors, including app/api/runners/poll/route.ts and several connector route implicit-any errors.