### PR TITLE
feat: move ApiBackend feature switch to organization level

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -268,6 +268,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Route platform API traffic to the api backend host instead of the www backend host. Unported endpoints continue through the api backend's web fallback proxy.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ConnectorCategories]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

Changed the `ApiBackend` feature switch from global-only to organization-level gating by adding `enabledOrgIdHashes: STAFF_ORG_ID_HASHES`. Follows the same pattern used by `ConnectorCategories`, `PlatformConnectors`, `CodexBeta`, etc.

## Change

`turbo/packages/core/src/feature-switch.ts` — 1 line added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)