### PR TITLE
fix(ably-subscriber): require exact localhost match

### DIFF
--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -1915,35 +1915,63 @@ mod tests {
         assert_eq!(result, data);
     }
 
+    fn assert_websocket_endpoint(
+        url: &str,
+        scheme: &str,
+        expected_host: url::Host<&str>,
+        expected_port: Option<u16>,
+    ) {
+        let parsed = url::Url::parse(url).unwrap();
+        assert_eq!(parsed.scheme(), scheme);
+        assert_eq!(parsed.host(), Some(expected_host));
+        assert_eq!(parsed.port(), expected_port);
+    }
+
     #[test]
     fn build_ws_url_localhost_uses_ws() {
         let url = build_ws_url("127.0.0.1:9000", "tok", None).unwrap();
-        assert!(url.starts_with("ws://127.0.0.1:9000/"));
+        assert_websocket_endpoint(
+            &url,
+            "ws",
+            url::Host::Ipv4(std::net::Ipv4Addr::LOCALHOST),
+            Some(9000),
+        );
 
         let url = build_ws_url("localhost:9000", "tok", None).unwrap();
-        assert!(url.starts_with("ws://localhost:9000/"));
+        assert_websocket_endpoint(&url, "ws", url::Host::Domain("localhost"), Some(9000));
 
         let url = build_ws_url("LOCALHOST:9000", "tok", None).unwrap();
-        assert!(url.starts_with("ws://localhost:9000/"));
+        assert_websocket_endpoint(&url, "ws", url::Host::Domain("localhost"), Some(9000));
 
         let url = build_ws_url("[::1]:9000", "tok", None).unwrap();
-        assert!(url.starts_with("ws://[::1]:9000/"));
+        assert_websocket_endpoint(
+            &url,
+            "ws",
+            url::Host::Ipv6(std::net::Ipv6Addr::LOCALHOST),
+            Some(9000),
+        );
     }
 
     #[test]
     fn build_ws_url_localhost_prefixes_use_wss() {
         let cases = [
-            ("localhost.evil.com", "wss://localhost.evil.com/"),
-            ("127.0.0.1.attacker.com", "wss://127.0.0.1.attacker.com/"),
-            ("127.0.0.10", "wss://127.0.0.10/"),
+            (
+                "localhost.evil.com",
+                url::Host::Domain("localhost.evil.com"),
+            ),
+            (
+                "127.0.0.1.attacker.com",
+                url::Host::Domain("127.0.0.1.attacker.com"),
+            ),
+            (
+                "127.0.0.10",
+                url::Host::Ipv4(std::net::Ipv4Addr::new(127, 0, 0, 10)),
+            ),
         ];
 
-        for (host, expected_prefix) in cases {
+        for (host, expected_host) in cases {
             let url = build_ws_url(host, "tok", None).unwrap();
-            assert!(
-                url.starts_with(expected_prefix),
-                "host {host} unexpectedly used plaintext URL {url}",
-            );
+            assert_websocket_endpoint(&url, "wss", expected_host, None);
         }
     }
 }

--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -27,7 +27,16 @@ const PROTOCOL_VERSION: &str = "5";
 const AGENT_STRING: &str = concat!("ably-subscriber-rs/", env!("CARGO_PKG_VERSION"));
 
 fn is_localhost(host: &str) -> bool {
-    host.starts_with("127.0.0.1") || host.starts_with("localhost")
+    let Ok(url) = url::Url::parse(&format!("http://{host}/")) else {
+        return false;
+    };
+
+    match url.host() {
+        Some(url::Host::Domain(host)) if host.eq_ignore_ascii_case("localhost") => true,
+        Some(url::Host::Ipv4(addr)) if addr == std::net::Ipv4Addr::LOCALHOST => true,
+        Some(url::Host::Ipv6(addr)) if addr == std::net::Ipv6Addr::LOCALHOST => true,
+        _ => false,
+    }
 }
 
 fn error_or_unknown(error: Option<ErrorInfo>) -> ErrorInfo {
@@ -1913,5 +1922,28 @@ mod tests {
 
         let url = build_ws_url("localhost:9000", "tok", None).unwrap();
         assert!(url.starts_with("ws://localhost:9000/"));
+
+        let url = build_ws_url("LOCALHOST:9000", "tok", None).unwrap();
+        assert!(url.starts_with("ws://localhost:9000/"));
+
+        let url = build_ws_url("[::1]:9000", "tok", None).unwrap();
+        assert!(url.starts_with("ws://[::1]:9000/"));
+    }
+
+    #[test]
+    fn build_ws_url_localhost_prefixes_use_wss() {
+        let cases = [
+            ("localhost.evil.com", "wss://localhost.evil.com/"),
+            ("127.0.0.1.attacker.com", "wss://127.0.0.1.attacker.com/"),
+            ("127.0.0.10", "wss://127.0.0.10/"),
+        ];
+
+        for (host, expected_prefix) in cases {
+            let url = build_ws_url(host, "tok", None).unwrap();
+            assert!(
+                url.starts_with(expected_prefix),
+                "host {host} unexpectedly used plaintext URL {url}",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- parse the configured realtime host and only treat exact localhost, 127.0.0.1, or ::1 as plaintext development endpoints
- keep TLS for localhost-prefix lookalikes such as localhost.evil.com, 127.0.0.1.attacker.com, and 127.0.0.10
- add regression coverage for IPv6 localhost, uppercase localhost, and prefix spoofing cases

Closes #12042

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p ably-subscriber
- cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets --all-features -- -D warnings
- git diff --check