### PR TITLE
fix: remove vsock wait polling from fast exits

### DIFF
--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -110,7 +110,10 @@ pub(crate) fn wait_with_kill_timeout_or_cancelled(
 
         let status = child.wait();
         let _ = done_tx.send(());
-        let watchdog_kill = watchdog.join().unwrap_or(None);
+        let watchdog_kill = match watchdog.join() {
+            Ok(watchdog_kill) => watchdog_kill,
+            Err(panic) => std::panic::resume_unwind(panic),
+        };
 
         match status {
             Err(e) => WaitOutcome::WaitFailed(e.to_string()),
@@ -280,7 +283,7 @@ mod tests {
 
     #[test]
     fn fast_exit_wait_does_not_pay_cancel_poll_interval_per_child() {
-        let iterations = 12;
+        let iterations = 20;
         let start = Instant::now();
 
         for _ in 0..iterations {
@@ -299,7 +302,7 @@ mod tests {
 
         let elapsed = start.elapsed();
         assert!(
-            elapsed < Duration::from_millis(500),
+            elapsed < Duration::from_millis(800),
             "fast child exits should not accumulate the 50ms cancel poll interval per child; \
              {iterations} waits took {elapsed:?}",
         );

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -339,7 +339,7 @@ mod tests {
 
         let elapsed = start.elapsed();
         assert!(
-            elapsed < Duration::from_millis(800),
+            elapsed < Duration::from_millis(900),
             "fast child exits should not accumulate the 50ms cancel poll interval per child; \
              {iterations} waits took {elapsed:?}",
         );

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -140,12 +140,16 @@ fn wait_for_done_timeout_or_cancelled(
     let poll_interval = Duration::from_millis(WATCHDOG_CANCEL_POLL_INTERVAL_MS);
 
     loop {
+        if wait_done(&done_rx) {
+            return None;
+        }
+
         let now = Instant::now();
         let wait_for = match deadline {
             Some(deadline) => {
                 let remaining = deadline.saturating_duration_since(now);
                 if remaining.is_zero() {
-                    return Some(kill_child(child_id, KillReason::Timeout));
+                    return kill_child_unless_done(&done_rx, child_id, KillReason::Timeout);
                 }
                 remaining.min(poll_interval)
             }
@@ -153,13 +157,32 @@ fn wait_for_done_timeout_or_cancelled(
         };
 
         if cancel.load(Ordering::Acquire) {
-            return Some(kill_child(child_id, KillReason::Cancelled));
+            return kill_child_unless_done(&done_rx, child_id, KillReason::Cancelled);
         }
 
         match done_rx.recv_timeout(wait_for) {
             Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => return None,
             Err(mpsc::RecvTimeoutError::Timeout) => {}
         }
+    }
+}
+
+fn wait_done(done_rx: &mpsc::Receiver<()>) -> bool {
+    match done_rx.try_recv() {
+        Ok(()) | Err(mpsc::TryRecvError::Disconnected) => true,
+        Err(mpsc::TryRecvError::Empty) => false,
+    }
+}
+
+fn kill_child_unless_done(
+    done_rx: &mpsc::Receiver<()>,
+    child_id: u32,
+    reason: KillReason,
+) -> Option<WatchdogKill> {
+    if wait_done(done_rx) {
+        None
+    } else {
+        Some(kill_child(child_id, reason))
     }
 }
 
@@ -333,6 +356,22 @@ mod tests {
         cancel_thread.join().unwrap();
 
         assert!(matches!(outcome, WaitOutcome::Cancelled));
+    }
+
+    #[test]
+    fn watchdog_done_signal_wins_over_elapsed_deadline() {
+        let cancel = AtomicBool::new(false);
+        let (done_tx, done_rx) = mpsc::channel::<()>();
+        done_tx.send(()).unwrap();
+
+        let outcome = wait_for_done_timeout_or_cancelled(
+            done_rx,
+            Some(Instant::now()),
+            &cancel,
+            i32::MAX as u32,
+        );
+
+        assert!(outcome.is_none());
     }
 
     #[test]

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -373,6 +373,26 @@ mod tests {
     }
 
     #[test]
+    fn nonzero_timeout_child_is_cancelled_by_pre_signalled_cancel() {
+        let cancel = AtomicBool::new(true);
+        let mut command = Command::new("sleep");
+        command
+            .arg("60")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+        let child = command.spawn().unwrap();
+
+        let outcome = wait_with_kill_timeout_or_cancelled(child, 30_000, &cancel);
+
+        assert!(matches!(outcome, WaitOutcome::Cancelled));
+    }
+
+    #[test]
     fn watchdog_done_signal_wins_over_elapsed_deadline() {
         let cancel = AtomicBool::new(false);
         let (done_tx, done_rx) = mpsc::channel::<()>();
@@ -384,6 +404,17 @@ mod tests {
             &cancel,
             i32::MAX as u32,
         );
+
+        assert!(outcome.is_none());
+    }
+
+    #[test]
+    fn watchdog_done_signal_wins_over_pre_signalled_cancel() {
+        let cancel = AtomicBool::new(true);
+        let (done_tx, done_rx) = mpsc::channel::<()>();
+        done_tx.send(()).unwrap();
+
+        let outcome = wait_for_done_timeout_or_cancelled(done_rx, None, &cancel, i32::MAX as u32);
 
         assert!(outcome.is_none());
     }

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -105,8 +105,22 @@ pub(crate) fn wait_with_kill_timeout_or_cancelled(
 
     thread::scope(|scope| {
         let (done_tx, done_rx) = mpsc::channel::<()>();
-        let watchdog = scope
-            .spawn(move || wait_for_done_timeout_or_cancelled(done_rx, deadline, cancel, child_id));
+        let watchdog = match thread::Builder::new()
+            .name("vsock-wait-watchdog".to_string())
+            .spawn_scoped(scope, move || {
+                wait_for_done_timeout_or_cancelled(done_rx, deadline, cancel, child_id)
+            }) {
+            Ok(watchdog) => watchdog,
+            Err(e) => {
+                // If the watchdog cannot be created, timeout/cancel can no
+                // longer be enforced. Kill and reap the child instead of
+                // letting it outlive the failed wait helper.
+                // SAFETY: child_id is a valid PID from Command::spawn.
+                let _ = unsafe { kill_process_tree(child_id) } || child.kill().is_ok();
+                let _ = child.wait();
+                return WaitOutcome::WaitFailed(format!("failed to spawn wait watchdog: {e}"));
+            }
+        };
 
         let status = child.wait();
         let _ = done_tx.send(());

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -15,7 +15,7 @@ pub(crate) const EXIT_CODE_TIMEOUT: i32 = 124;
 /// `send_process_exit()` anyway to prevent indefinite hangs when orphaned
 /// child processes hold pipe fds open.
 pub(crate) const DRAIN_DEADLINE_SECS: u64 = 5;
-const WAIT_CANCEL_POLL_INTERVAL_MS: u64 = 50;
+const WATCHDOG_CANCEL_POLL_INTERVAL_MS: u64 = 50;
 
 /// Outcome of child wait helpers.
 pub(crate) enum WaitOutcome {
@@ -32,6 +32,11 @@ pub(crate) enum WaitOutcome {
 enum KillReason {
     Timeout,
     Cancelled,
+}
+
+struct WatchdogKill {
+    reason: KillReason,
+    killed: bool,
 }
 
 /// Wait for drain workers to complete within the shared drain deadline, then
@@ -97,44 +102,70 @@ pub(crate) fn wait_with_kill_timeout_or_cancelled(
     } else {
         None
     };
-    let poll_interval = Duration::from_millis(WAIT_CANCEL_POLL_INTERVAL_MS);
 
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => return WaitOutcome::Exited(status),
-            Ok(None) => {}
-            Err(e) => return WaitOutcome::WaitFailed(e.to_string()),
-        }
+    thread::scope(|scope| {
+        let (done_tx, done_rx) = mpsc::channel::<()>();
+        let watchdog = scope
+            .spawn(move || wait_for_done_timeout_or_cancelled(done_rx, deadline, cancel, child_id));
 
-        let now = Instant::now();
-        let reason = if deadline.is_some_and(|deadline| now >= deadline) {
-            Some(KillReason::Timeout)
-        } else if cancel.load(Ordering::Acquire) {
-            Some(KillReason::Cancelled)
-        } else {
-            None
-        };
+        let status = child.wait();
+        let _ = done_tx.send(());
+        let watchdog_kill = watchdog.join().unwrap_or(None);
 
-        if let Some(reason) = reason {
-            // SAFETY: child_id is a valid PID from Command::spawn.
-            let killed = unsafe { kill_process_tree(child_id) } || child.kill().is_ok();
-            return match child.wait() {
-                Err(e) => WaitOutcome::WaitFailed(e.to_string()),
-                Ok(status) if !killed => WaitOutcome::Exited(status),
-                Ok(_) => match reason {
+        match status {
+            Err(e) => WaitOutcome::WaitFailed(e.to_string()),
+            Ok(status) => match watchdog_kill {
+                Some(WatchdogKill {
+                    reason,
+                    killed: true,
+                }) => match reason {
                     KillReason::Timeout => WaitOutcome::TimedOut,
                     KillReason::Cancelled => WaitOutcome::Cancelled,
                 },
-            };
+                _ => WaitOutcome::Exited(status),
+            },
+        }
+    })
+}
+
+fn wait_for_done_timeout_or_cancelled(
+    done_rx: mpsc::Receiver<()>,
+    deadline: Option<Instant>,
+    cancel: &AtomicBool,
+    child_id: u32,
+) -> Option<WatchdogKill> {
+    let poll_interval = Duration::from_millis(WATCHDOG_CANCEL_POLL_INTERVAL_MS);
+
+    loop {
+        let now = Instant::now();
+        let wait_for = match deadline {
+            Some(deadline) => {
+                let remaining = deadline.saturating_duration_since(now);
+                if remaining.is_zero() {
+                    return Some(kill_child(child_id, KillReason::Timeout));
+                }
+                remaining.min(poll_interval)
+            }
+            None => poll_interval,
+        };
+
+        if cancel.load(Ordering::Acquire) {
+            return Some(kill_child(child_id, KillReason::Cancelled));
         }
 
-        let sleep_for = deadline
-            .map(|deadline| deadline.saturating_duration_since(now).min(poll_interval))
-            .unwrap_or(poll_interval);
-        if !sleep_for.is_zero() {
-            thread::sleep(sleep_for);
+        match done_rx.recv_timeout(wait_for) {
+            Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => return None,
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
         }
     }
+}
+
+fn kill_child(child_id: u32, reason: KillReason) -> WatchdogKill {
+    // SAFETY: child_id is a valid PID from Command::spawn.
+    let killed = unsafe { kill_process_tree(child_id) }
+        // SAFETY: child_id is a process id from Command::spawn.
+        || unsafe { libc::kill(child_id as i32, libc::SIGKILL) == 0 };
+    WatchdogKill { reason, killed }
 }
 
 /// Coordinate child wait + concurrent stdout/stderr drain + timeout-driven kill.
@@ -241,10 +272,64 @@ pub(crate) fn finalize_buffered_result(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::process::Command;
+    use std::process::{Command, Stdio};
 
     fn successful_status() -> ExitStatus {
         Command::new("true").status().unwrap()
+    }
+
+    #[test]
+    fn fast_exit_wait_does_not_pay_cancel_poll_interval_per_child() {
+        let iterations = 12;
+        let start = Instant::now();
+
+        for _ in 0..iterations {
+            let child = Command::new("sleep")
+                .arg("0.02")
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .unwrap();
+            let outcome = wait_with_kill_timeout(child, 30_000);
+            assert!(
+                matches!(outcome, WaitOutcome::Exited(status) if status.success()),
+                "unexpected wait outcome"
+            );
+        }
+
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "fast child exits should not accumulate the 50ms cancel poll interval per child; \
+             {iterations} waits took {elapsed:?}",
+        );
+    }
+
+    #[test]
+    fn timeout_zero_child_is_cancelled_by_external_cancel() {
+        let cancel = Arc::new(AtomicBool::new(false));
+        let cancel_for_thread = Arc::clone(&cancel);
+        let mut command = Command::new("sleep");
+        command
+            .arg("60")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+        let child = command.spawn().unwrap();
+
+        let cancel_thread = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(100));
+            cancel_for_thread.store(true, Ordering::Release);
+        });
+
+        let outcome = wait_with_kill_timeout_or_cancelled(child, 0, &cancel);
+        cancel_thread.join().unwrap();
+
+        assert!(matches!(outcome, WaitOutcome::Cancelled));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- restore `vsock-guest` normal child waits to blocking `child.wait()` so fast `write_file` children do not pay the 50ms cancel poll interval
- keep timeout and disconnect cancellation through a watchdog thread that kills the process tree and signals the original `TimedOut`/`Cancelled` outcomes
- add regression coverage for repeated fast child exits and timeout-zero external cancellation

## Evidence
- Closes #12081
- Prod sample from issue investigation: `d8175518-beb4-4e23-8182-e90576c0621a` spent `5597ms` in `storage_download` while staging only `503,753` bytes across `106` cache hits
- Local benchmark showed the regression is fixed-overhead dominated, matching the `try_wait() + 50ms` polling path introduced in the suspect release window

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest`
- `cargo clippy -p vsock-guest -- -D warnings`
- `git diff --check`
- pre-commit Rust doc/clippy hooks