### PR TITLE
fix(web): prevent agent reply email markdown crashes

### DIFF
--- a/turbo/apps/web/src/lib/zero/email/__tests__/outbox-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/email/__tests__/outbox-service.test.ts
@@ -312,6 +312,40 @@ describe("outbox-service", () => {
       expect(html).toContain("<strong");
       expect(html).toContain("<code");
     });
+
+    it("renders fenced code blocks inside list items", async () => {
+      const { id } = await insertTestOutboxItem({
+        fromAddress: "agent@vm7.bot",
+        toAddresses: "user@example.com",
+        subject: "Markdown list code test",
+        template: {
+          template: "agent-reply",
+          props: {
+            agentName: "test-agent",
+            output:
+              "- item\n  ```ts\n  const x = 1;\n  ```\n\n<script>alert('x')</script>",
+            logsUrl: "https://example.com/logs",
+          },
+        },
+      });
+
+      await drainById(id);
+
+      const sentCall = mockResend.emails.send.mock.calls[0];
+      expect(sentCall).toBeDefined();
+      const payload: CreateEmailOptions = sentCall![0];
+      expect(payload).toHaveProperty("react");
+      if (!("react" in payload) || payload.react == null) {
+        throw new Error("Expected react property on email payload");
+      }
+      const html = await render(payload.react);
+
+      expect(html).toContain("<li");
+      expect(html).toContain("<pre");
+      expect(html).toContain("<code");
+      expect(html).toContain("const x = 1");
+      expect(html).not.toContain("<script>");
+    });
   });
 
   describe("post-send actions", () => {

--- a/turbo/apps/web/src/lib/zero/email/templates/agent-reply.tsx
+++ b/turbo/apps/web/src/lib/zero/email/templates/agent-reply.tsx
@@ -3,12 +3,12 @@ import {
   Head,
   Body,
   Container,
-  Markdown,
   Text,
   Link,
   Hr,
 } from "@react-email/components";
 import { UnsubscribeFooter } from "./unsubscribe-footer";
+import { EmailMarkdown } from "./email-markdown";
 
 interface AgentReplyEmailProps {
   agentName: string;
@@ -28,12 +28,7 @@ export function AgentReplyEmail({
       <Head />
       <Body style={bodyStyle}>
         <Container align="left" style={containerStyle}>
-          <Markdown
-            markdownContainerStyles={markdownContainerStyle}
-            markdownCustomStyles={markdownCustomStyles}
-          >
-            {output}
-          </Markdown>
+          <EmailMarkdown>{output}</EmailMarkdown>
           <Hr style={hrStyle} />
           <Text style={signatureStyle}>{agentName} from VM0</Text>
           <Text style={footerStyle}>
@@ -64,48 +59,6 @@ const bodyStyle = {
 const containerStyle = {
   margin: "0",
   padding: "0 24px",
-};
-
-const markdownContainerStyle = {
-  fontSize: "14px",
-  color: "#222222",
-  lineHeight: "1.5",
-  fontFamily,
-};
-
-const markdownCustomStyles = {
-  h1: { fontSize: "18px", fontWeight: "bold" as const, margin: "16px 0 8px" },
-  h2: { fontSize: "16px", fontWeight: "bold" as const, margin: "14px 0 6px" },
-  h3: { fontSize: "15px", fontWeight: "bold" as const, margin: "12px 0 4px" },
-  p: { margin: "0 0 10px", lineHeight: "1.5" },
-  link: { color: "#1a73e8" },
-  bold: { fontWeight: "bold" as const },
-  codeInline: {
-    fontFamily: "monospace",
-    fontSize: "13px",
-    backgroundColor: "#f1f3f4",
-    padding: "1px 4px",
-    borderRadius: "3px",
-  },
-  codeBlock: {
-    fontFamily: "monospace",
-    fontSize: "13px",
-    backgroundColor: "#f1f3f4",
-    padding: "12px",
-    borderRadius: "4px",
-    overflowX: "auto" as const,
-    lineHeight: "1.4",
-  },
-  blockQuote: {
-    borderLeft: "3px solid #dadce0",
-    margin: "8px 0",
-    paddingLeft: "12px",
-    color: "#5f6368",
-  },
-  ul: { margin: "0 0 10px", paddingLeft: "24px" },
-  ol: { margin: "0 0 10px", paddingLeft: "24px" },
-  li: { margin: "2px 0" },
-  hr: { borderColor: "#dadce0", margin: "16px 0" },
 };
 
 const hrStyle = {

--- a/turbo/apps/web/src/lib/zero/email/templates/email-markdown.tsx
+++ b/turbo/apps/web/src/lib/zero/email/templates/email-markdown.tsx
@@ -1,0 +1,160 @@
+import type { CSSProperties } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+interface EmailMarkdownProps {
+  children: string;
+}
+
+export function EmailMarkdown({ children }: EmailMarkdownProps) {
+  return (
+    <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+      {children}
+    </ReactMarkdown>
+  );
+}
+
+const components = {
+  p({ children }) {
+    return <p style={paragraphStyle}>{children}</p>;
+  },
+  h1({ children }) {
+    return <h1 style={h1Style}>{children}</h1>;
+  },
+  h2({ children }) {
+    return <h2 style={h2Style}>{children}</h2>;
+  },
+  h3({ children }) {
+    return <h3 style={h3Style}>{children}</h3>;
+  },
+  a({ href, title, children }) {
+    return (
+      <a
+        href={href}
+        title={title}
+        target="_blank"
+        rel="noreferrer"
+        style={linkStyle}
+      >
+        {children}
+      </a>
+    );
+  },
+  strong({ children }) {
+    return <strong style={boldStyle}>{children}</strong>;
+  },
+  em({ children }) {
+    return <em style={italicStyle}>{children}</em>;
+  },
+  code({ children }) {
+    return <code style={codeInlineStyle}>{children}</code>;
+  },
+  pre({ children }) {
+    return <pre style={codeBlockStyle}>{children}</pre>;
+  },
+  blockquote({ children }) {
+    return <blockquote style={blockQuoteStyle}>{children}</blockquote>;
+  },
+  ul({ children }) {
+    return <ul style={listStyle}>{children}</ul>;
+  },
+  ol({ start, children }) {
+    return (
+      <ol start={start} style={listStyle}>
+        {children}
+      </ol>
+    );
+  },
+  li({ children }) {
+    return <li style={listItemStyle}>{children}</li>;
+  },
+  hr() {
+    return <hr style={ruleStyle} />;
+  },
+} satisfies Components;
+
+const fontFamily = "Arial, Helvetica, sans-serif";
+
+const paragraphStyle = {
+  margin: "0 0 10px",
+  lineHeight: "1.5",
+  fontSize: "14px",
+  color: "#222222",
+  fontFamily,
+} satisfies CSSProperties;
+
+const headerBaseStyle = {
+  fontWeight: "bold",
+  color: "#222222",
+  fontFamily,
+} satisfies CSSProperties;
+
+const h1Style = {
+  ...headerBaseStyle,
+  fontSize: "18px",
+  margin: "16px 0 8px",
+} satisfies CSSProperties;
+
+const h2Style = {
+  ...headerBaseStyle,
+  fontSize: "16px",
+  margin: "14px 0 6px",
+} satisfies CSSProperties;
+
+const h3Style = {
+  ...headerBaseStyle,
+  fontSize: "15px",
+  margin: "12px 0 4px",
+} satisfies CSSProperties;
+
+const linkStyle = {
+  color: "#1a73e8",
+  textDecoration: "underline",
+} satisfies CSSProperties;
+
+const boldStyle = {
+  fontWeight: "bold",
+} satisfies CSSProperties;
+
+const italicStyle = {
+  fontStyle: "italic",
+} satisfies CSSProperties;
+
+const codeInlineStyle = {
+  fontFamily: "monospace",
+  fontSize: "13px",
+  backgroundColor: "#f1f3f4",
+  padding: "1px 4px",
+  borderRadius: "3px",
+} satisfies CSSProperties;
+
+const codeBlockStyle = {
+  ...codeInlineStyle,
+  display: "block",
+  padding: "12px",
+  borderRadius: "4px",
+  overflowX: "auto",
+  lineHeight: "1.4",
+  whiteSpace: "pre-wrap",
+} satisfies CSSProperties;
+
+const blockQuoteStyle = {
+  borderLeft: "3px solid #dadce0",
+  margin: "8px 0",
+  paddingLeft: "12px",
+  color: "#5f6368",
+} satisfies CSSProperties;
+
+const listStyle = {
+  margin: "0 0 10px",
+  paddingLeft: "24px",
+} satisfies CSSProperties;
+
+const listItemStyle = {
+  margin: "2px 0",
+} satisfies CSSProperties;
+
+const ruleStyle = {
+  borderColor: "#dadce0",
+  margin: "16px 0",
+} satisfies CSSProperties;


### PR DESCRIPTION
## Summary
- replace React Email Markdown in agent reply emails with a local ReactMarkdown-based email renderer
- keep raw HTML inert while preserving common markdown email elements, including fenced code blocks in list items
- add a regression test for the Sentry failure shape from WEB-3J

## Validation
- pnpm -C turbo -F web exec vitest src/lib/zero/email/__tests__/outbox-service.test.ts
- pnpm -C turbo -F web check-types
- pnpm -C turbo -F web lint
- pre-commit hook: prettier, knip, full check-types, commitlint

Closes #12086