### PR TITLE
fix: keep personal provider model defaults compatible

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/model-provider-default.ts
+++ b/turbo/apps/platform/src/signals/zero-page/model-provider-default.ts
@@ -1,5 +1,7 @@
 import {
+  allowsCustomModel,
   getDefaultModel,
+  getModels,
   type ModelProviderResponse,
 } from "@vm0/api-contracts/contracts/model-providers";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
@@ -12,6 +14,19 @@ interface AgentModelDefaultSource {
   preferPersonalProvider?: boolean;
 }
 
+function canProviderUseModel(
+  provider: ModelProviderResponse,
+  model: string | null | undefined,
+): model is string {
+  if (!model) {
+    return false;
+  }
+  if (allowsCustomModel(provider.type)) {
+    return true;
+  }
+  return getModels(provider.type)?.includes(model) ?? false;
+}
+
 function resolveProviderSelection(
   provider: ModelProviderResponse | undefined,
   fallbackSelectedModel?: string | null,
@@ -19,9 +34,15 @@ function resolveProviderSelection(
   if (!provider) {
     return null;
   }
+  const compatibleFallback = canProviderUseModel(
+    provider,
+    fallbackSelectedModel,
+  )
+    ? fallbackSelectedModel
+    : undefined;
   const selectedModel =
     provider.selectedModel ??
-    fallbackSelectedModel ??
+    compatibleFallback ??
     getDefaultModel(provider.type);
   if (!selectedModel) {
     return null;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
@@ -65,6 +65,8 @@ const ANTHROPIC_PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
 const MOONSHOT_PROVIDER_ID = "00000000-0000-4000-a000-000000000002";
 const ZAI_PROVIDER_ID = "00000000-0000-4000-a000-000000000003";
 const PERSONAL_OPENAI_PROVIDER_ID = "00000000-0000-4000-a000-000000000004";
+const VM0_PROVIDER_ID = "00000000-0000-4000-a000-000000000005";
+const PERSONAL_CODEX_PROVIDER_ID = "00000000-0000-4000-a000-000000000006";
 
 const THREAD_ID = "thread-default-model-1";
 
@@ -353,6 +355,46 @@ describe("chat composer — default model resolution", () => {
     await expectAgentChatLoaded();
 
     await expectComposerShowsModel("gpt-5.4");
+  });
+
+  it("uses the personal provider default when the agent model is incompatible", async () => {
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.PersonalModelProvider]: true,
+    });
+    setMockOrgModelProviders([
+      buildProvider({
+        id: VM0_PROVIDER_ID,
+        type: "vm0",
+        framework: "claude-code",
+        secretName: null,
+        isDefault: true,
+        selectedModel: "deepseek-v4-pro",
+      }),
+    ]);
+    setMockPersonalModelProviders([
+      buildProvider({
+        id: PERSONAL_CODEX_PROVIDER_ID,
+        type: "codex-oauth-token",
+        framework: "codex",
+        secretName: null,
+        authMethod: "auth_json",
+        isDefault: true,
+        selectedModel: null,
+      }),
+    ]);
+    mockAgent({
+      modelProviderId: VM0_PROVIDER_ID,
+      selectedModel: "deepseek-v4-pro",
+      preferPersonalProvider: true,
+    });
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+    await expectAgentChatLoaded();
+
+    await expectComposerShowsModel("gpt-5.5");
+    expect(
+      screen.queryByRole("combobox", { name: "DeepSeek V4 Pro" }),
+    ).not.toBeInTheDocument();
   });
 
   // CHAT-DM-004: When the agent is reset to "use org default" (both fields

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -1399,17 +1399,23 @@ describe("POST /api/zero/chat/messages", () => {
         expect(job!.executionContext.cliAgentType).toBe("codex");
       });
 
-      it("falls back to agent's selectedModel when personal row has none", async () => {
-        // Personal default has no selectedModel — precedence is
-        // user > agent > null, so the agent's selectedModel surfaces.
+      it("uses the personal provider default when the agent model is incompatible", async () => {
+        // Personal default has no selectedModel. The agent is pinned to a
+        // DeepSeek VM0 model, which must not be paired with the user's
+        // OpenAI provider. Fall back to the provider's default model instead.
+        await insertOrgNonDefaultModelProvider(
+          user.orgId,
+          "vm0",
+          "deepseek-v4-pro",
+        );
         const orgProviderId = await getTestModelProviderIdByType(
           user.orgId,
-          "anthropic-api-key",
+          "vm0",
         );
         await setTestZeroAgentModelProvider(
           agentId,
           orgProviderId,
-          "claude-opus-4-7",
+          "deepseek-v4-pro",
         );
         await setTestZeroAgentPreferPersonalProvider(agentId, true);
         await enablePersonalModelProviderForUser(user.orgId, user.userId);
@@ -1432,7 +1438,7 @@ describe("POST /api/zero/chat/messages", () => {
 
         const override = await getTestChatThreadModelOverride(threadId);
         expect(override.modelProviderId).toBe(personalProviderId);
-        expect(override.selectedModel).toBe("claude-opus-4-7");
+        expect(override.selectedModel).toBe("gpt-5.5");
       });
 
       it("falls through to agent's pin when user has no personal providers", async () => {

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -6,6 +6,12 @@ import {
   chatMessagesContract,
   type AttachFile,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  allowsCustomModel,
+  getDefaultModel,
+  getModels,
+  type ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -276,8 +282,39 @@ async function computeEagerPin(
   }
   return {
     modelProviderId: userRow.id,
-    selectedModel: userRow.selectedModel ?? agent.selectedModel ?? null,
+    selectedModel: resolveProviderSelectedModel(
+      userRow.type,
+      userRow.selectedModel,
+      agent.selectedModel,
+    ),
   };
+}
+
+function canProviderUseModel(
+  type: ModelProviderType,
+  model: string | null | undefined,
+): model is string {
+  if (!model) {
+    return false;
+  }
+  if (allowsCustomModel(type)) {
+    return true;
+  }
+  return getModels(type)?.includes(model) ?? false;
+}
+
+function resolveProviderSelectedModel(
+  type: ModelProviderType,
+  selectedModel: string | null,
+  fallbackSelectedModel: string | null,
+): string | null {
+  if (selectedModel) {
+    return selectedModel;
+  }
+  if (canProviderUseModel(type, fallbackSelectedModel)) {
+    return fallbackSelectedModel;
+  }
+  return getDefaultModel(type) ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- prevent agent selected models from being reused with incompatible personal default providers
- align chat eager pin creation with frontend model default resolution
- add frontend and backend regressions for the DeepSeek label with OpenAI/Codex provider icon mismatch

Closes #12087

## Tests
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
- pnpm -F web exec vitest app/api/zero/chat/messages/__tests__/route.test.ts
- pnpm format
- pnpm turbo run lint
- pnpm check-types
