### PR TITLE
fix: close mobile sidebar overlay on account actions

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -115,6 +115,7 @@ export type ZeroAccountAction =
 
 export const handleZeroAccountAction$ = command(
   ({ set }, action: ZeroAccountAction) => {
+    set(internalSidebarExpanded$, false);
     if (action === "signout" || action === "manage") {
       return;
     }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -509,6 +509,33 @@ describe("zero sidebar - collapse button closes mobile overlay (SIDEBAR-M-023)",
   });
 });
 
+describe("zero sidebar - preferences click closes mobile overlay (SIDEBAR-M-030)", () => {
+  it("sets sidebarExpanded to false when Preferences is clicked from account dropdown while sidebar is open as mobile overlay", async () => {
+    mockBaseAPIs();
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Test User")).toBeInTheDocument();
+    });
+
+    // Simulate mobile sidebar expanded state (as if "Open menu" was tapped)
+    context.store.set(setSidebarExpanded$, true);
+    expect(context.store.get(sidebarExpanded$)).toBeTruthy();
+
+    // Open account dropdown
+    click(screen.getByText("Test User"));
+
+    // Click Preferences
+    const preferencesItem = await waitFor(() => {
+      return screen.getByText("Preferences");
+    });
+    click(preferencesItem);
+
+    // The sidebar overlay should close when navigating to settings
+    expect(context.store.get(sidebarExpanded$)).toBeFalsy();
+  });
+});
+
 describe("zero sidebar - agent action menu opens (SIDEBAR-D-066)", () => {
   it("reveals the remove action button on a pinned agent card", async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary
- Mobile sidebar overlay now closes when navigating via account dropdown actions (Preferences, API Keys, Usage)
- Regular sidebar nav items already closed the overlay — account actions were the missing case

## Root Cause
`handleZeroAccountAction$` in `zero-nav.ts` navigated but never called `set(internalSidebarExpanded$, false)`, unlike the `onSelect` callback in `zero-sidebar.tsx` which calls both navigation and `setExpanded(false)`.

## Test Plan
- [x] Added `SIDEBAR-M-030`: sidebar closes when Preferences is clicked from account dropdown on mobile
- [x] All 31 existing sidebar/layout tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)