### PR TITLE
fix: allow codex oauth backend routes

### DIFF
--- a/turbo/apps/web/src/lib/zero/context/__tests__/resolve-permissions.test.ts
+++ b/turbo/apps/web/src/lib/zero/context/__tests__/resolve-permissions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 
+import { MODEL_PROVIDER_FIREWALL_CONFIGS } from "@vm0/api-contracts/contracts/model-providers";
 import type { ExpandedFirewallConfig } from "@vm0/connectors/firewall-types";
 
 import { mergePermissions } from "../resolve-permissions";
@@ -72,6 +73,21 @@ describe("mergePermissions — defaultPolicies on model-provider firewall", () =
       "a",
     ]);
     expect(result?.networkPolicies["model-provider:test"]?.ask).toEqual(["b"]);
+  });
+
+  it("allows codex-oauth-token API permission while keeping unknown endpoints denied", () => {
+    const firewall = MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"];
+
+    const result = mergePermissions(firewall, []);
+
+    expect(result?.networkPolicies["model-provider:codex-oauth-token"]).toEqual(
+      {
+        allow: ["codex:api"],
+        deny: ["denied"],
+        ask: [],
+        unknownPolicy: "deny",
+      },
+    );
   });
 
   it("returns undefined when there are no firewalls at all", () => {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -374,10 +374,27 @@ describe("codex-oauth-token codex provider", () => {
     });
   });
 
+  it("firewall allows the known ChatGPT Codex backend routes", () => {
+    const config = MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"];
+    expect(config.apis[0]!.permissions).toEqual([
+      {
+        name: "codex:api",
+        rules: [
+          "GET /models",
+          "GET /responses",
+          "POST /responses",
+          "POST /analytics-events/events",
+        ],
+      },
+    ]);
+  });
+
   it("firewall denies auth.openai.com via defaultPolicies + permission rule", () => {
     const config = MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"];
-    expect(config.defaultPolicies?.deny).toContain("denied");
-    expect(config.defaultPolicies?.unknownPolicy).toBe("deny");
+    expect(config.defaultPolicies).toEqual({
+      deny: ["denied"],
+      unknownPolicy: "deny",
+    });
     expect(config.apis[1]!.permissions).toEqual([
       { name: "denied", rules: ["ANY /*"] },
     ]);

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -823,7 +823,17 @@ export const MODEL_PROVIDER_FIREWALL_CONFIGS: Record<
             "ChatGPT-Account-ID": "${{ secrets.CHATGPT_ACCOUNT_ID }}",
           },
         },
-        permissions: [],
+        permissions: [
+          {
+            name: "codex:api",
+            rules: [
+              "GET /models",
+              "GET /responses",
+              "POST /responses",
+              "POST /analytics-events/events",
+            ],
+          },
+        ],
       },
       {
         base: "https://auth.openai.com",


### PR DESCRIPTION
## Summary
- Add explicit codex:api firewall rules for ChatGPT Codex backend endpoints used by codex-cli OAuth token flows.
- Keep auth.openai.com denied and unknown ChatGPT Codex backend endpoints denied.
- Add contract and permission-merge regression coverage.

## Validation
- ./scripts/sync-env.sh
- ./scripts/prepare.sh
- pnpm -F @vm0/api-contracts exec vitest src/contracts/__tests__/model-providers.test.ts
- pnpm -F web exec vitest src/lib/zero/context/__tests__/resolve-permissions.test.ts
- pnpm check-types
- pnpm format
- pnpm turbo run lint
- pnpm vitest
- pnpm knip
- git diff --check

Fixes #12089