### PR TITLE
refactor(vsock-guest): handle thread spawn failures

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -11,6 +11,7 @@ use crate::error::to_io_error;
 use crate::handlers::{MessageOutcome, handle_exec, handle_message};
 use crate::log::log;
 use crate::monitor::{SpawnWatchRequest, handle_spawn_watch};
+use crate::threading::{SystemThreadSpawner, ThreadSpawner};
 use crate::writer::GuestWriter;
 
 // Vsock constants (only used on Linux)
@@ -19,10 +20,19 @@ const VSOCK_CID_HOST: u32 = 2;
 
 /// Read buffer size for the connection event loop (local tuning constant).
 const READ_BUFFER_SIZE: usize = 64 * 1024; // 64KB
+const THREAD_EXEC_WORKER: &str = "vsock-exec-worker";
 
 enum ConnectionEnd {
     Closed,
     Shutdown,
+}
+
+struct ExecWorkerRequest {
+    timeout_ms: u32,
+    command: String,
+    env: Vec<(String, String)>,
+    sudo: bool,
+    seq: u32,
 }
 
 /// Signals all command work spawned for this host connection when the
@@ -163,25 +173,17 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                     .collect();
                 let sudo = d.sudo;
                 let seq = msg.seq;
-                let w = writer.clone();
-                let connection_cancel = connection_cancel.clone();
-                thread::spawn(move || {
-                    let env_refs: Vec<(&str, &str)> =
-                        env.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
-                    let (exit_code, stdout, stderr) =
-                        handle_exec(timeout_ms, &command, &env_refs, sudo, &connection_cancel);
-                    let payload = vsock_proto::encode_exec_result(exit_code, &stdout, &stderr);
-                    let encoded = match vsock_proto::encode(MSG_EXEC_RESULT, seq, &payload) {
-                        Ok(msg) => msg,
-                        Err(e) => {
-                            log("ERROR", &format!("Failed to encode exec_result: {}", e));
-                            return;
-                        }
-                    };
-                    if let Err(e) = w.write_frame(&encoded) {
-                        log("ERROR", &format!("Failed to send exec_result: {}", e));
-                    }
-                });
+                spawn_exec_worker(
+                    ExecWorkerRequest {
+                        timeout_ms,
+                        command,
+                        env,
+                        sudo,
+                        seq,
+                    },
+                    writer.clone(),
+                    connection_cancel.clone(),
+                )?;
             } else {
                 match handle_message(&msg)? {
                     MessageOutcome::Response(response) => {
@@ -201,6 +203,71 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
 
     log("INFO", "Host disconnected");
     Ok(ConnectionEnd::Closed)
+}
+
+fn spawn_exec_worker(
+    request: ExecWorkerRequest,
+    writer: GuestWriter,
+    connection_cancel: Arc<AtomicBool>,
+) -> io::Result<()> {
+    spawn_exec_worker_with_spawner(request, writer, connection_cancel, SystemThreadSpawner)
+}
+
+fn spawn_exec_worker_with_spawner<S>(
+    request: ExecWorkerRequest,
+    writer: GuestWriter,
+    connection_cancel: Arc<AtomicBool>,
+    spawner: S,
+) -> io::Result<()>
+where
+    S: ThreadSpawner,
+{
+    let worker_writer = writer.clone();
+    let seq = request.seq;
+    let result = spawner.spawn_unit(
+        THREAD_EXEC_WORKER,
+        Box::new(move || {
+            let env_refs: Vec<(&str, &str)> = request
+                .env
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+            let (exit_code, stdout, stderr) = handle_exec(
+                request.timeout_ms,
+                &request.command,
+                &env_refs,
+                request.sudo,
+                &connection_cancel,
+            );
+            if let Err(e) = send_exec_result(seq, exit_code, &stdout, &stderr, &worker_writer) {
+                log("ERROR", &format!("Failed to send exec_result: {e}"));
+            }
+        }),
+    );
+
+    match result {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let stderr = format!("Failed to spawn exec worker thread: {e}");
+            send_exec_result(seq, 1, &[], stderr.as_bytes(), &writer)
+        }
+    }
+}
+
+fn send_exec_result(
+    seq: u32,
+    exit_code: i32,
+    stdout: &[u8],
+    stderr: &[u8],
+    writer: &GuestWriter,
+) -> io::Result<()> {
+    let payload = vsock_proto::encode_exec_result(exit_code, stdout, stderr);
+    let encoded = vsock_proto::encode(MSG_EXEC_RESULT, seq, &payload).map_err(to_io_error)?;
+    if let Err(e) = writer.write_frame(&encoded) {
+        log("ERROR", &format!("Failed to send exec_result: {}", e));
+        return Err(e);
+    }
+    Ok(())
 }
 
 /// Maximum reconnection attempts before giving up
@@ -285,5 +352,63 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                 thread::sleep(Duration::from_millis(RECONNECT_DELAY_MS));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::threading::test_support::FailingThreadSpawner;
+    use std::io::Read;
+    use std::os::unix::net::UnixStream;
+    use std::time::Duration;
+
+    fn read_message(stream: &mut UnixStream) -> vsock_proto::RawMessage {
+        let mut hdr = [0u8; 4];
+        stream.read_exact(&mut hdr).unwrap();
+        let body_len = u32::from_be_bytes(hdr) as usize;
+        let mut body = vec![0u8; body_len];
+        stream.read_exact(&mut body).unwrap();
+
+        let mut full = Vec::with_capacity(4 + body_len);
+        full.extend_from_slice(&hdr);
+        full.extend_from_slice(&body);
+        let mut decoder = vsock_proto::Decoder::new();
+        let mut messages = decoder.decode(&full).unwrap();
+        assert_eq!(messages.len(), 1);
+        messages.remove(0)
+    }
+
+    #[test]
+    fn exec_worker_spawn_failure_returns_exec_result() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let writer = GuestWriter::new(guest);
+
+        spawn_exec_worker_with_spawner(
+            ExecWorkerRequest {
+                timeout_ms: 0,
+                command: "echo should-not-run".to_string(),
+                env: Vec::new(),
+                sudo: false,
+                seq: 42,
+            },
+            writer,
+            Arc::new(AtomicBool::new(false)),
+            FailingThreadSpawner::fail_once(THREAD_EXEC_WORKER),
+        )
+        .unwrap();
+
+        let msg = read_message(&mut host);
+        assert_eq!(msg.msg_type, MSG_EXEC_RESULT);
+        assert_eq!(msg.seq, 42);
+        let (code, stdout, stderr) = vsock_proto::decode_exec_result(&msg.payload).unwrap();
+        assert_eq!(code, 1);
+        assert!(stdout.is_empty());
+        assert!(
+            String::from_utf8_lossy(stderr).contains("exec worker thread"),
+            "unexpected stderr: {:?}",
+            String::from_utf8_lossy(stderr),
+        );
     }
 }

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -2,7 +2,6 @@ use std::io::{self, Write};
 use std::process::{Child, Stdio};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::thread;
 
 use vsock_proto::{
     self, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
@@ -15,12 +14,16 @@ use crate::exec::{
     build_exec_command, prepend_env, spawn_in_own_process_group, spawn_with_pipes, truncate_preview,
 };
 use crate::log::log;
-use crate::process::extract_exit_code;
+use crate::process::{extract_exit_code, kill_and_reap_child};
 use crate::shutdown::handle_shutdown;
+use crate::threading::{SystemThreadSpawner, ThreadSpawner};
 use crate::wait::{
     WaitOutcome, await_drain_deadline, finalize_buffered_result,
     wait_with_drain_and_timeout_or_cancelled, wait_with_kill_timeout,
 };
+
+const THREAD_WRITE_STDERR: &str = "vsock-write-stderr";
+const WRITE_TIMEOUT_MS: u32 = 30_000;
 
 pub(crate) enum MessageOutcome {
     Response(Vec<u8>),
@@ -89,8 +92,6 @@ fn handle_write_file(path: &str, content: &[u8], use_sudo: bool, append: bool) -
 
     // Execute as 'user' (UID 1000) to match E2B sandbox behavior
     // Use subprocess instead of direct fs::write to run as user
-    const WRITE_TIMEOUT_MS: u32 = 30_000;
-
     let escaped_path = path.replace('\'', "'\\''");
 
     // Build the write command: tee for privileged writes (build_exec_command
@@ -126,12 +127,18 @@ fn handle_write_file(path: &str, content: &[u8], use_sudo: bool, append: bool) -
     if let Some(mut stdin) = child.stdin.take()
         && let Err(e) = stdin.write_all(content)
     {
-        let _ = child.kill();
-        let _ = child.wait(); // Prevent zombie process
+        kill_and_reap_child(child);
         return (false, format!("Failed to write to stdin: {e}"));
     }
     // stdin is dropped here, closing the pipe
 
+    wait_write_file_child(child, SystemThreadSpawner)
+}
+
+fn wait_write_file_child<S>(mut child: Child, spawner: S) -> (bool, String)
+where
+    S: ThreadSpawner,
+{
     // Drain stderr concurrently with wait via the cancellable helper. Stdout
     // is `Stdio::null()` so there's no orphan-fd hazard there. After the
     // child exits, the drain thread either reaches EOF naturally or — if a
@@ -142,20 +149,29 @@ fn handle_write_file(path: &str, content: &[u8], use_sudo: bool, append: bool) -
     let stderr_pipe = match child.stderr.take() {
         Some(p) => p,
         None => {
-            let _ = child.kill();
-            let _ = child.wait();
+            kill_and_reap_child(child);
             return (false, "missing stderr pipe".to_string());
         }
     };
     let cancel = Arc::new(AtomicBool::new(false));
     let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
     let stderr_handle = {
-        let cancel = cancel.clone();
-        thread::spawn(move || {
-            let buf = drain_into_vec_cancellable(stderr_pipe, &cancel);
-            let _ = done_tx.send(());
-            buf
-        })
+        let drain_cancel = cancel.clone();
+        match spawner.spawn_vec(
+            THREAD_WRITE_STDERR,
+            Box::new(move || {
+                let buf = drain_into_vec_cancellable(stderr_pipe, &drain_cancel);
+                let _ = done_tx.send(());
+                buf
+            }),
+        ) {
+            Ok(handle) => handle,
+            Err(e) => {
+                cancel.store(true, std::sync::atomic::Ordering::Release);
+                kill_and_reap_child(child);
+                return (false, format!("Failed to spawn stderr drain thread: {e}"));
+            }
+        }
     };
 
     let outcome = wait_with_kill_timeout(child, WRITE_TIMEOUT_MS);
@@ -225,6 +241,12 @@ pub(crate) fn handle_message(msg: &RawMessage) -> io::Result<MessageOutcome> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::threading::test_support::FailingThreadSpawner;
+
+    fn pid_alive(pid: u32) -> bool {
+        // SAFETY: kill(pid, 0) is the standard process-existence check.
+        unsafe { libc::kill(pid as i32, 0) == 0 }
+    }
 
     #[cfg(unix)]
     #[test]
@@ -237,5 +259,18 @@ mod tests {
         let _ = child.wait();
 
         assert_eq!(pgid, pid as libc::pid_t);
+    }
+
+    #[test]
+    fn write_file_stderr_drain_spawn_failure_kills_and_reaps_child() {
+        let child = spawn_write_file_command("sleep 60", false).unwrap();
+        let pid = child.id();
+
+        let (success, error) =
+            wait_write_file_child(child, FailingThreadSpawner::fail_once(THREAD_WRITE_STDERR));
+
+        assert!(!success);
+        assert!(error.contains("stderr drain thread"));
+        assert!(!pid_alive(pid), "child pid {pid} should have been reaped");
     }
 }

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -15,6 +15,7 @@ mod log;
 mod monitor;
 mod process;
 mod shutdown;
+mod threading;
 mod wait;
 mod writer;
 

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -620,7 +620,7 @@ mod tests {
     }
 
     #[test]
-    fn streaming_monitor_drain_spawn_failure_reports_process_exit_and_reaps_child() {
+    fn streaming_monitor_stdout_drain_spawn_failure_reports_process_exit_and_reaps_child() {
         let (guest, mut host) = UnixStream::pair().unwrap();
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
         let writer = GuestWriter::new(guest);
@@ -656,6 +656,49 @@ mod tests {
         assert!(stdout.is_empty());
         assert!(
             String::from_utf8_lossy(stderr).contains("stdout drain thread"),
+            "unexpected stderr: {:?}",
+            String::from_utf8_lossy(stderr),
+        );
+        assert!(!pid_alive(pid), "child pid {pid} should have been reaped");
+    }
+
+    #[test]
+    fn streaming_monitor_stderr_drain_spawn_failure_reports_process_exit_and_reaps_child() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let writer = GuestWriter::new(guest);
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        handle_spawn_watch_with_spawner(
+            SpawnWatchRequest {
+                timeout_ms: 0,
+                command: "sleep 60",
+                env: &[],
+                sudo: false,
+                stream_stdout: true,
+                stdout_log_path: None,
+            },
+            10,
+            writer,
+            cancel,
+            FailingThreadSpawner::fail_once(THREAD_STREAM_STDERR),
+        )
+        .unwrap();
+
+        let result = read_message(&mut host);
+        assert_eq!(result.msg_type, MSG_SPAWN_WATCH_RESULT);
+        assert_eq!(result.seq, 10);
+        let pid = vsock_proto::decode_spawn_watch_result(&result.payload).unwrap();
+
+        let exit = read_message(&mut host);
+        assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
+        let (exit_pid, code, stdout, stderr) =
+            vsock_proto::decode_process_exit(&exit.payload).unwrap();
+        assert_eq!(exit_pid, pid);
+        assert_eq!(code, 1);
+        assert!(stdout.is_empty());
+        assert!(
+            String::from_utf8_lossy(stderr).contains("stderr drain thread"),
             "unexpected stderr: {:?}",
             String::from_utf8_lossy(stderr),
         );

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -14,7 +14,7 @@ use crate::process::{ChildReapGuard, kill_and_reap_child};
 use crate::threading::{SystemThreadSpawner, ThreadSpawner};
 use crate::wait::{
     DRAIN_DEADLINE_SECS, await_drain_deadline, finalize_buffered_result, finalize_wait_outcome,
-    wait_with_drain_and_timeout_or_cancelled, wait_with_kill_timeout_or_cancelled,
+    wait_with_drain_and_timeout_or_cancelled_with_spawner, wait_with_kill_timeout_or_cancelled,
 };
 use crate::writer::GuestWriter;
 
@@ -492,6 +492,7 @@ where
     } = request;
     let child_guard = ChildReapGuard::new(child);
     let exit_writer = writer.clone();
+    let monitor_spawner = spawner.clone();
     let result = spawner.spawn_unit(
         THREAD_BUFFERED_MONITOR,
         Box::new(move || {
@@ -503,7 +504,12 @@ where
                 return;
             };
             let (outcome, stdout, stderr_buf) =
-                wait_with_drain_and_timeout_or_cancelled(child, timeout_ms, &connection_cancel);
+                wait_with_drain_and_timeout_or_cancelled_with_spawner(
+                    child,
+                    timeout_ms,
+                    &connection_cancel,
+                    monitor_spawner,
+                );
             let (exit_code, stdout, stderr) = finalize_buffered_result(outcome, stdout, stderr_buf);
 
             log(
@@ -551,6 +557,7 @@ fn send_process_exit(pid: u32, exit_code: i32, stdout: &[u8], stderr: &[u8], wri
 mod tests {
     use super::*;
     use crate::threading::test_support::FailingThreadSpawner;
+    use crate::wait::THREAD_DRAIN_STDOUT;
     use std::io::Read;
     use std::os::unix::net::UnixStream;
     use std::time::Duration;
@@ -742,6 +749,49 @@ mod tests {
         assert!(stdout.is_empty());
         assert!(
             String::from_utf8_lossy(stderr).contains("buffered monitor thread"),
+            "unexpected stderr: {:?}",
+            String::from_utf8_lossy(stderr),
+        );
+        assert!(!pid_alive(pid), "child pid {pid} should have been reaped");
+    }
+
+    #[test]
+    fn buffered_monitor_drain_spawn_failure_reports_process_exit_and_reaps_child() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let writer = GuestWriter::new(guest);
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        handle_spawn_watch_with_spawner(
+            SpawnWatchRequest {
+                timeout_ms: 0,
+                command: "sleep 60",
+                env: &[],
+                sudo: false,
+                stream_stdout: false,
+                stdout_log_path: None,
+            },
+            11,
+            writer,
+            cancel,
+            FailingThreadSpawner::fail_once(THREAD_DRAIN_STDOUT),
+        )
+        .unwrap();
+
+        let result = read_message(&mut host);
+        assert_eq!(result.msg_type, MSG_SPAWN_WATCH_RESULT);
+        assert_eq!(result.seq, 11);
+        let pid = vsock_proto::decode_spawn_watch_result(&result.payload).unwrap();
+
+        let exit = read_message(&mut host);
+        assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
+        let (exit_pid, code, stdout, stderr) =
+            vsock_proto::decode_process_exit(&exit.payload).unwrap();
+        assert_eq!(exit_pid, pid);
+        assert_eq!(code, 1);
+        assert!(stdout.is_empty());
+        assert!(
+            String::from_utf8_lossy(stderr).contains("stdout drain thread"),
             "unexpected stderr: {:?}",
             String::from_utf8_lossy(stderr),
         );

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -1,7 +1,8 @@
 use std::io::{self, Write};
+use std::process::{Child, ChildStdout};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::thread;
+use std::thread::JoinHandle;
 
 use vsock_proto::{self, MSG_ERROR, MSG_PROCESS_EXIT, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK};
 
@@ -9,11 +10,47 @@ use crate::drain::{drain_into_vec_cancellable, drain_until_eof_or_cancelled};
 use crate::error::to_io_error;
 use crate::exec::{prepend_env, spawn_with_pipes, truncate_preview};
 use crate::log::log;
+use crate::process::{ChildReapGuard, kill_and_reap_child};
+use crate::threading::{SystemThreadSpawner, ThreadSpawner};
 use crate::wait::{
     DRAIN_DEADLINE_SECS, await_drain_deadline, finalize_buffered_result, finalize_wait_outcome,
     wait_with_drain_and_timeout_or_cancelled, wait_with_kill_timeout_or_cancelled,
 };
 use crate::writer::GuestWriter;
+
+const THREAD_STREAM_MONITOR: &str = "vsock-stream-monitor";
+const THREAD_BUFFERED_MONITOR: &str = "vsock-buffered-monitor";
+const THREAD_STREAM_STDERR: &str = "vsock-stream-stderr";
+const THREAD_STREAM_STDOUT: &str = "vsock-stream-stdout";
+
+struct StreamingMonitorRequest {
+    pid: u32,
+    child: Child,
+    timeout_ms: u32,
+    stdout_pipe: Option<ChildStdout>,
+    log_path: Option<String>,
+    writer: GuestWriter,
+    connection_cancel: Arc<AtomicBool>,
+}
+
+struct BufferedMonitorRequest {
+    pid: u32,
+    child: Child,
+    timeout_ms: u32,
+    writer: GuestWriter,
+    connection_cancel: Arc<AtomicBool>,
+}
+
+struct StreamingSetupFailure {
+    pid: u32,
+    child: Child,
+    cancel: Arc<AtomicBool>,
+    drain_done_tx: std::sync::mpsc::Sender<()>,
+    stderr_handle: Option<JoinHandle<Vec<u8>>>,
+    stdout_handle: Option<JoinHandle<()>>,
+    writer: GuestWriter,
+    error: String,
+}
 
 pub(crate) struct SpawnWatchRequest<'a> {
     pub(crate) timeout_ms: u32,
@@ -44,6 +81,19 @@ pub(crate) fn handle_spawn_watch(
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
 ) -> io::Result<()> {
+    handle_spawn_watch_with_spawner(request, seq, writer, connection_cancel, SystemThreadSpawner)
+}
+
+fn handle_spawn_watch_with_spawner<S>(
+    request: SpawnWatchRequest<'_>,
+    seq: u32,
+    writer: GuestWriter,
+    connection_cancel: Arc<AtomicBool>,
+    spawner: S,
+) -> io::Result<()>
+where
+    S: ThreadSpawner,
+{
     log(
         "INFO",
         &format!(
@@ -83,14 +133,12 @@ pub(crate) fn handle_spawn_watch(
     let response = match vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, seq, &payload) {
         Ok(r) => r,
         Err(e) => {
-            let _ = child.kill();
-            let _ = child.wait();
+            kill_and_reap_child(child);
             return Err(to_io_error(e));
         }
     };
     if let Err(e) = writer.write_frame(&response) {
-        let _ = child.kill();
-        let _ = child.wait();
+        kill_and_reap_child(child);
         return Err(e);
     }
 
@@ -98,19 +146,41 @@ pub(crate) fn handle_spawn_watch(
         // Streaming mode: stream stdout to vsock chunks, optionally teeing to a guest file.
         // Take stdout from child so we can read it in a separate thread.
         let stdout_pipe = child.stdout.take();
-        spawn_streaming_monitor(
-            pid,
-            child,
-            request.timeout_ms,
-            stdout_pipe,
-            request.stdout_log_path.map(str::to_owned),
-            writer,
-            connection_cancel,
-        );
+        if let Err(e) = spawn_streaming_monitor(
+            StreamingMonitorRequest {
+                pid,
+                child,
+                timeout_ms: request.timeout_ms,
+                stdout_pipe,
+                log_path: request.stdout_log_path.map(str::to_owned),
+                writer,
+                connection_cancel,
+            },
+            spawner,
+        ) {
+            log(
+                "ERROR",
+                &format!("spawn_watch: failed to spawn streaming monitor for pid={pid}: {e}"),
+            );
+        }
     } else {
         // Buffered mode: stdout/stderr drained via cancellable helper, sent
         // in a single MSG_PROCESS_EXIT after wait.
-        spawn_buffered_monitor(pid, child, request.timeout_ms, writer, connection_cancel);
+        if let Err(e) = spawn_buffered_monitor(
+            BufferedMonitorRequest {
+                pid,
+                child,
+                timeout_ms: request.timeout_ms,
+                writer,
+                connection_cancel,
+            },
+            spawner,
+        ) {
+            log(
+                "ERROR",
+                &format!("spawn_watch: failed to spawn buffered monitor for pid={pid}: {e}"),
+            );
+        }
     }
 
     Ok(())
@@ -133,43 +203,128 @@ pub(crate) fn handle_spawn_watch(
 /// `MSG_STDOUT_CHUNK` for an already-exited pid (or grow our stderr buffer
 /// indefinitely).
 fn spawn_streaming_monitor(
-    pid: u32,
-    mut child: std::process::Child,
-    timeout_ms: u32,
-    stdout_pipe: Option<std::process::ChildStdout>,
-    log_path: Option<String>,
-    writer: GuestWriter,
-    connection_cancel: Arc<AtomicBool>,
-) {
-    thread::spawn(move || {
-        let cancel = Arc::new(AtomicBool::new(false));
-        let (drain_done_tx, drain_done_rx) = std::sync::mpsc::channel::<()>();
+    request: StreamingMonitorRequest,
+    spawner: impl ThreadSpawner,
+) -> io::Result<()> {
+    spawn_streaming_monitor_with_spawner(request, spawner)
+}
 
-        // Spawn both drain threads BEFORE `child.wait()`. They run
-        // concurrently with the child, so neither pipe (~64 KB) can fill
-        // and block the child. If we instead waited on the child first
-        // and drained after, a chatty child would deadlock on its next
-        // write to a full pipe and never exit. Order between the two
-        // spawn calls is irrelevant — both happen before wait, and they
-        // run in parallel.
-        let stderr_handle = if let Some(stderr) = child.stderr.take() {
-            let cancel = cancel.clone();
-            let tx = drain_done_tx.clone();
-            Some(thread::spawn(move || {
-                let buf = drain_into_vec_cancellable(stderr, &cancel);
+fn spawn_streaming_monitor_with_spawner<S>(
+    request: StreamingMonitorRequest,
+    spawner: S,
+) -> io::Result<()>
+where
+    S: ThreadSpawner,
+{
+    let StreamingMonitorRequest {
+        pid,
+        child,
+        timeout_ms,
+        stdout_pipe,
+        log_path,
+        writer,
+        connection_cancel,
+    } = request;
+    let child_guard = ChildReapGuard::new(child);
+    let monitor_spawner = spawner.clone();
+    let exit_writer = writer.clone();
+    let result = spawner.spawn_unit(
+        THREAD_STREAM_MONITOR,
+        Box::new(move || {
+            let Some(child) = child_guard.into_child() else {
+                log(
+                    "ERROR",
+                    "spawn_watch: streaming monitor child guard was empty",
+                );
+                return;
+            };
+            run_streaming_monitor(
+                StreamingMonitorRequest {
+                    pid,
+                    child,
+                    timeout_ms,
+                    stdout_pipe,
+                    log_path,
+                    writer,
+                    connection_cancel,
+                },
+                monitor_spawner,
+            );
+        }),
+    );
+    if let Err(e) = &result {
+        send_process_exit(
+            pid,
+            1,
+            &[],
+            format!("Failed to spawn streaming monitor thread: {e}").as_bytes(),
+            &exit_writer,
+        );
+    }
+    result.map(|_| ())
+}
+
+fn run_streaming_monitor<S>(request: StreamingMonitorRequest, spawner: S)
+where
+    S: ThreadSpawner,
+{
+    let StreamingMonitorRequest {
+        pid,
+        mut child,
+        timeout_ms,
+        stdout_pipe,
+        log_path,
+        writer,
+        connection_cancel,
+    } = request;
+    let cancel = Arc::new(AtomicBool::new(false));
+    let (drain_done_tx, drain_done_rx) = std::sync::mpsc::channel::<()>();
+
+    // Spawn both drain threads BEFORE `child.wait()`. They run
+    // concurrently with the child, so neither pipe (~64 KB) can fill
+    // and block the child. If we instead waited on the child first
+    // and drained after, a chatty child would deadlock on its next
+    // write to a full pipe and never exit. Order between the two
+    // spawn calls is irrelevant — both happen before wait, and they
+    // run in parallel.
+    let stderr_handle = if let Some(stderr) = child.stderr.take() {
+        let drain_cancel = cancel.clone();
+        let tx = drain_done_tx.clone();
+        match spawner.spawn_vec(
+            THREAD_STREAM_STDERR,
+            Box::new(move || {
+                let buf = drain_into_vec_cancellable(stderr, &drain_cancel);
                 let _ = tx.send(());
                 buf
-            }))
-        } else {
-            None
-        };
+            }),
+        ) {
+            Ok(handle) => Some(handle),
+            Err(e) => {
+                finish_streaming_setup_failure(StreamingSetupFailure {
+                    pid,
+                    child,
+                    cancel,
+                    drain_done_tx,
+                    stderr_handle: None,
+                    stdout_handle: None,
+                    writer,
+                    error: format!("Failed to spawn stderr drain thread: {e}"),
+                });
+                return;
+            }
+        }
+    } else {
+        None
+    };
 
-        // Stream stdout to file + vsock in a dedicated thread.
-        let stdout_handle = if let Some(stdout) = stdout_pipe {
-            let cancel = cancel.clone();
-            let tx = drain_done_tx.clone();
-            let stdout_writer = writer.clone();
-            Some(thread::spawn(move || {
+    // Stream stdout to file + vsock in a dedicated thread.
+    let stdout_handle = if let Some(stdout) = stdout_pipe {
+        let drain_cancel = cancel.clone();
+        let tx = drain_done_tx.clone();
+        let stdout_writer = writer.clone();
+        match spawner.spawn_unit(
+            THREAD_STREAM_STDOUT,
+            Box::new(move || {
                 let mut log_file = match log_path.as_deref() {
                     Some(path) => match std::fs::OpenOptions::new()
                         .create(true)
@@ -188,7 +343,7 @@ fn spawn_streaming_monitor(
                     None => None,
                 };
 
-                drain_until_eof_or_cancelled(stdout, &cancel, |chunk| {
+                drain_until_eof_or_cancelled(stdout, &drain_cancel, |chunk| {
                     // Write to log file (best-effort)
                     if let Some(ref mut f) = log_file {
                         let _ = f.write_all(chunk);
@@ -216,91 +371,165 @@ fn spawn_streaming_monitor(
                             "WARN",
                             &format!("spawn_watch: failed to send stdout chunk: {e}"),
                         );
-                        cancel.store(true, Ordering::Release);
+                        drain_cancel.store(true, Ordering::Release);
                     }
                 });
                 let _ = tx.send(());
-            }))
-        } else {
-            None
-        };
-        drop(drain_done_tx); // so recv returns Disconnected when both threads die
-
-        // child wait is now UNBLOCKED — no pipe fds are held by this thread.
-        let outcome = wait_with_kill_timeout_or_cancelled(child, timeout_ms, &connection_cancel);
-        if matches!(outcome, crate::wait::WaitOutcome::Cancelled)
-            || connection_cancel.load(Ordering::Acquire)
-        {
-            cancel.store(true, Ordering::Release);
+            }),
+        ) {
+            Ok(handle) => Some(handle),
+            Err(e) => {
+                finish_streaming_setup_failure(StreamingSetupFailure {
+                    pid,
+                    child,
+                    cancel,
+                    drain_done_tx,
+                    stderr_handle,
+                    stdout_handle: None,
+                    writer,
+                    error: format!("Failed to spawn stdout drain thread: {e}"),
+                });
+                return;
+            }
         }
+    } else {
+        None
+    };
+    drop(drain_done_tx); // so recv returns Disconnected when both threads die
 
-        // Shared drain deadline: stdout + stderr share a single budget.
-        // This matches guest-agent's 5s drain behavior.
-        let expected = stdout_handle.is_some() as usize + stderr_handle.is_some() as usize;
-        let completed = await_drain_deadline(&drain_done_rx, expected, &cancel);
-        // await_drain_deadline cancels either side that's still draining. The
-        // thread observes the flag within ~100 ms (poll cadence), drops its fd,
-        // and grandchild writes start failing with EPIPE.
-        if completed < expected {
-            log(
-                "WARN",
-                &format!(
-                    "spawn_watch: pid={pid} drain deadline reached after \
-                     {DRAIN_DEADLINE_SECS}s, possible orphaned child process",
-                ),
-            );
-        }
+    // child wait is now UNBLOCKED — no pipe fds are held by this thread.
+    let outcome = wait_with_kill_timeout_or_cancelled(child, timeout_ms, &connection_cancel);
+    if matches!(outcome, crate::wait::WaitOutcome::Cancelled)
+        || connection_cancel.load(Ordering::Acquire)
+    {
+        cancel.store(true, Ordering::Release);
+    }
 
-        let stderr = stderr_handle
-            .map(|h| h.join().unwrap_or_default())
-            .unwrap_or_default();
-        if let Some(h) = stdout_handle {
-            let _ = h.join();
-        }
-
-        let (exit_code, stderr) = finalize_wait_outcome(outcome, stderr);
-
+    // Shared drain deadline: stdout + stderr share a single budget.
+    // This matches guest-agent's 5s drain behavior.
+    let expected = stdout_handle.is_some() as usize + stderr_handle.is_some() as usize;
+    let completed = await_drain_deadline(&drain_done_rx, expected, &cancel);
+    // await_drain_deadline cancels either side that's still draining. The
+    // thread observes the flag within ~100 ms (poll cadence), drops its fd,
+    // and grandchild writes start failing with EPIPE.
+    if completed < expected {
         log(
-            "INFO",
+            "WARN",
             &format!(
-                "spawn_watch: pid={} exited with code={}, stderr_len={} (streamed)",
-                pid,
-                exit_code,
-                stderr.len()
+                "spawn_watch: pid={pid} drain deadline reached after \
+                     {DRAIN_DEADLINE_SECS}s, possible orphaned child process",
             ),
         );
+    }
 
-        send_process_exit(pid, exit_code, &[], &stderr, &writer);
-    });
+    let stderr = stderr_handle
+        .map(|h| h.join().unwrap_or_default())
+        .unwrap_or_default();
+    if let Some(h) = stdout_handle {
+        let _ = h.join();
+    }
+
+    let (exit_code, stderr) = finalize_wait_outcome(outcome, stderr);
+
+    log(
+        "INFO",
+        &format!(
+            "spawn_watch: pid={} exited with code={}, stderr_len={} (streamed)",
+            pid,
+            exit_code,
+            stderr.len()
+        ),
+    );
+
+    send_process_exit(pid, exit_code, &[], &stderr, &writer);
+}
+
+fn finish_streaming_setup_failure(failure: StreamingSetupFailure) {
+    let StreamingSetupFailure {
+        pid,
+        child,
+        cancel,
+        drain_done_tx,
+        stderr_handle,
+        stdout_handle,
+        writer,
+        error,
+    } = failure;
+    cancel.store(true, Ordering::Release);
+    drop(drain_done_tx);
+    kill_and_reap_child(child);
+    if let Some(handle) = stderr_handle {
+        let _ = handle.join();
+    }
+    if let Some(handle) = stdout_handle {
+        let _ = handle.join();
+    }
+    send_process_exit(pid, 1, &[], error.as_bytes(), &writer);
 }
 
 /// Buffered monitor: waits for process exit while concurrently draining
 /// stdout/stderr via the cancellable helper, then sends `MSG_PROCESS_EXIT`.
 fn spawn_buffered_monitor(
-    pid: u32,
-    child: std::process::Child,
-    timeout_ms: u32,
-    writer: GuestWriter,
-    connection_cancel: Arc<AtomicBool>,
-) {
-    thread::spawn(move || {
-        let (outcome, stdout, stderr_buf) =
-            wait_with_drain_and_timeout_or_cancelled(child, timeout_ms, &connection_cancel);
-        let (exit_code, stdout, stderr) = finalize_buffered_result(outcome, stdout, stderr_buf);
+    request: BufferedMonitorRequest,
+    spawner: impl ThreadSpawner,
+) -> io::Result<()> {
+    spawn_buffered_monitor_with_spawner(request, spawner)
+}
 
-        log(
-            "INFO",
-            &format!(
-                "spawn_watch: pid={} exited with code={}, stdout_len={}, stderr_len={}",
-                pid,
-                exit_code,
-                stdout.len(),
-                stderr.len()
-            ),
+fn spawn_buffered_monitor_with_spawner<S>(
+    request: BufferedMonitorRequest,
+    spawner: S,
+) -> io::Result<()>
+where
+    S: ThreadSpawner,
+{
+    let BufferedMonitorRequest {
+        pid,
+        child,
+        timeout_ms,
+        writer,
+        connection_cancel,
+    } = request;
+    let child_guard = ChildReapGuard::new(child);
+    let exit_writer = writer.clone();
+    let result = spawner.spawn_unit(
+        THREAD_BUFFERED_MONITOR,
+        Box::new(move || {
+            let Some(child) = child_guard.into_child() else {
+                log(
+                    "ERROR",
+                    "spawn_watch: buffered monitor child guard was empty",
+                );
+                return;
+            };
+            let (outcome, stdout, stderr_buf) =
+                wait_with_drain_and_timeout_or_cancelled(child, timeout_ms, &connection_cancel);
+            let (exit_code, stdout, stderr) = finalize_buffered_result(outcome, stdout, stderr_buf);
+
+            log(
+                "INFO",
+                &format!(
+                    "spawn_watch: pid={} exited with code={}, stdout_len={}, stderr_len={}",
+                    pid,
+                    exit_code,
+                    stdout.len(),
+                    stderr.len()
+                ),
+            );
+
+            send_process_exit(pid, exit_code, &stdout, &stderr, &writer);
+        }),
+    );
+    if let Err(e) = &result {
+        send_process_exit(
+            pid,
+            1,
+            &[],
+            format!("Failed to spawn buffered monitor thread: {e}").as_bytes(),
+            &exit_writer,
         );
-
-        send_process_exit(pid, exit_code, &stdout, &stderr, &writer);
-    });
+    }
+    result.map(|_| ())
 }
 
 /// Send a process_exit notification over vsock (best-effort).
@@ -315,5 +544,164 @@ fn send_process_exit(pid: u32, exit_code: i32, stdout: &[u8], stderr: &[u8], wri
     };
     if let Err(e) = writer.write_frame(&exit_msg) {
         log("ERROR", &format!("Failed to send process_exit: {}", e));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::threading::test_support::FailingThreadSpawner;
+    use std::io::Read;
+    use std::os::unix::net::UnixStream;
+    use std::time::Duration;
+
+    fn pid_alive(pid: u32) -> bool {
+        // SAFETY: kill(pid, 0) is the standard process-existence check.
+        unsafe { libc::kill(pid as i32, 0) == 0 }
+    }
+
+    fn read_message(stream: &mut UnixStream) -> vsock_proto::RawMessage {
+        let mut hdr = [0u8; 4];
+        stream.read_exact(&mut hdr).unwrap();
+        let body_len = u32::from_be_bytes(hdr) as usize;
+        let mut body = vec![0u8; body_len];
+        stream.read_exact(&mut body).unwrap();
+
+        let mut full = Vec::with_capacity(4 + body_len);
+        full.extend_from_slice(&hdr);
+        full.extend_from_slice(&body);
+        let mut decoder = vsock_proto::Decoder::new();
+        let mut messages = decoder.decode(&full).unwrap();
+        assert_eq!(messages.len(), 1);
+        messages.remove(0)
+    }
+
+    #[test]
+    fn spawn_watch_outer_monitor_spawn_failure_reports_process_exit_and_reaps_child() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let writer = GuestWriter::new(guest);
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        handle_spawn_watch_with_spawner(
+            SpawnWatchRequest {
+                timeout_ms: 0,
+                command: "sleep 60",
+                env: &[],
+                sudo: false,
+                stream_stdout: true,
+                stdout_log_path: None,
+            },
+            7,
+            writer,
+            cancel,
+            FailingThreadSpawner::fail_once(THREAD_STREAM_MONITOR),
+        )
+        .unwrap();
+
+        let result = read_message(&mut host);
+        assert_eq!(result.msg_type, MSG_SPAWN_WATCH_RESULT);
+        assert_eq!(result.seq, 7);
+        let pid = vsock_proto::decode_spawn_watch_result(&result.payload).unwrap();
+
+        let exit = read_message(&mut host);
+        assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
+        let (exit_pid, code, stdout, stderr) =
+            vsock_proto::decode_process_exit(&exit.payload).unwrap();
+        assert_eq!(exit_pid, pid);
+        assert_eq!(code, 1);
+        assert!(stdout.is_empty());
+        assert!(
+            String::from_utf8_lossy(stderr).contains("streaming monitor thread"),
+            "unexpected stderr: {:?}",
+            String::from_utf8_lossy(stderr),
+        );
+        assert!(!pid_alive(pid), "child pid {pid} should have been reaped");
+    }
+
+    #[test]
+    fn streaming_monitor_drain_spawn_failure_reports_process_exit_and_reaps_child() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let writer = GuestWriter::new(guest);
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        handle_spawn_watch_with_spawner(
+            SpawnWatchRequest {
+                timeout_ms: 0,
+                command: "sleep 60",
+                env: &[],
+                sudo: false,
+                stream_stdout: true,
+                stdout_log_path: None,
+            },
+            8,
+            writer,
+            cancel,
+            FailingThreadSpawner::fail_once(THREAD_STREAM_STDOUT),
+        )
+        .unwrap();
+
+        let result = read_message(&mut host);
+        assert_eq!(result.msg_type, MSG_SPAWN_WATCH_RESULT);
+        assert_eq!(result.seq, 8);
+        let pid = vsock_proto::decode_spawn_watch_result(&result.payload).unwrap();
+
+        let exit = read_message(&mut host);
+        assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
+        let (exit_pid, code, stdout, stderr) =
+            vsock_proto::decode_process_exit(&exit.payload).unwrap();
+        assert_eq!(exit_pid, pid);
+        assert_eq!(code, 1);
+        assert!(stdout.is_empty());
+        assert!(
+            String::from_utf8_lossy(stderr).contains("stdout drain thread"),
+            "unexpected stderr: {:?}",
+            String::from_utf8_lossy(stderr),
+        );
+        assert!(!pid_alive(pid), "child pid {pid} should have been reaped");
+    }
+
+    #[test]
+    fn buffered_spawn_watch_outer_monitor_spawn_failure_reports_process_exit_and_reaps_child() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let writer = GuestWriter::new(guest);
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        handle_spawn_watch_with_spawner(
+            SpawnWatchRequest {
+                timeout_ms: 0,
+                command: "sleep 60",
+                env: &[],
+                sudo: false,
+                stream_stdout: false,
+                stdout_log_path: None,
+            },
+            9,
+            writer,
+            cancel,
+            FailingThreadSpawner::fail_once(THREAD_BUFFERED_MONITOR),
+        )
+        .unwrap();
+
+        let result = read_message(&mut host);
+        assert_eq!(result.msg_type, MSG_SPAWN_WATCH_RESULT);
+        assert_eq!(result.seq, 9);
+        let pid = vsock_proto::decode_spawn_watch_result(&result.payload).unwrap();
+
+        let exit = read_message(&mut host);
+        assert_eq!(exit.msg_type, MSG_PROCESS_EXIT);
+        let (exit_pid, code, stdout, stderr) =
+            vsock_proto::decode_process_exit(&exit.payload).unwrap();
+        assert_eq!(exit_pid, pid);
+        assert_eq!(code, 1);
+        assert!(stdout.is_empty());
+        assert!(
+            String::from_utf8_lossy(stderr).contains("buffered monitor thread"),
+            "unexpected stderr: {:?}",
+            String::from_utf8_lossy(stderr),
+        );
+        assert!(!pid_alive(pid), "child pid {pid} should have been reaped");
     }
 }

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -112,17 +112,10 @@ pub(crate) unsafe fn kill_process_tree(child_id: u32) -> bool {
 /// Kill the process tree for a spawned child and reap the direct child.
 pub(crate) fn kill_and_reap_child(mut child: Child) {
     let child_id = child.id();
-    match child.try_wait() {
-        Ok(Some(_)) => return,
-        Ok(None) => {}
-        Err(e) => {
-            log(
-                "WARN",
-                &format!("failed to check child pid={child_id} before kill: {e}"),
-            );
-        }
-    }
 
+    // Signal before waiting. The direct child may already be a zombie while
+    // descendants still live in its process group; reaping first would release
+    // the child PID and lose the stable PGID we need for group cleanup.
     // SAFETY: child_id comes from a live `Child` returned by Command::spawn.
     let killed = unsafe { kill_process_tree(child_id) } || child.kill().is_ok();
     if !killed {
@@ -241,5 +234,60 @@ mod tests {
     #[test]
     fn parse_stat_ppid_pgid_no_closing_paren() {
         assert_eq!(parse_stat_ppid_pgid("1 bash S 10 42 42"), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    fn process_is_gone_or_zombie(pid: i32) -> bool {
+        match std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+            Ok(stat) => {
+                let close_paren = stat.rfind(')').unwrap_or(0);
+                stat.get(close_paren + 2..)
+                    .and_then(|fields| fields.split_whitespace().next())
+                    == Some("Z")
+            }
+            Err(_) => true,
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn wait_until_process_is_gone_or_zombie(pid: i32) -> bool {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+        while std::time::Instant::now() < deadline {
+            if process_is_gone_or_zombie(pid) {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        process_is_gone_or_zombie(pid)
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn kill_and_reap_child_kills_group_after_direct_child_exits() {
+        use std::io::{BufRead, BufReader};
+        use std::os::unix::process::CommandExt;
+        use std::process::Stdio;
+
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("sleep 60 & echo $!")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        command.process_group(0);
+
+        let mut child = command.spawn().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let mut line = String::new();
+        BufReader::new(stdout).read_line(&mut line).unwrap();
+        let background_pid: i32 = line.trim().parse().unwrap();
+
+        assert_eq!(unsafe { libc::kill(background_pid, 0) }, 0);
+        kill_and_reap_child(child);
+
+        if !wait_until_process_is_gone_or_zombie(background_pid) {
+            let _ = unsafe { libc::kill(background_pid, libc::SIGKILL) };
+            panic!("background pid {background_pid} should have been killed");
+        }
     }
 }

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -1,4 +1,4 @@
-use std::process::ExitStatus;
+use std::process::{Child, ExitStatus};
 
 use crate::log::log;
 
@@ -107,6 +107,56 @@ pub(crate) unsafe fn kill_process_tree(child_id: u32) -> bool {
     }
 
     true
+}
+
+/// Kill the process tree for a spawned child and reap the direct child.
+pub(crate) fn kill_and_reap_child(mut child: Child) {
+    let child_id = child.id();
+    match child.try_wait() {
+        Ok(Some(_)) => return,
+        Ok(None) => {}
+        Err(e) => {
+            log(
+                "WARN",
+                &format!("failed to check child pid={child_id} before kill: {e}"),
+            );
+        }
+    }
+
+    // SAFETY: child_id comes from a live `Child` returned by Command::spawn.
+    let killed = unsafe { kill_process_tree(child_id) } || child.kill().is_ok();
+    if !killed {
+        log(
+            "WARN",
+            &format!("failed to signal process tree for child pid={child_id}"),
+        );
+    }
+
+    if let Err(e) = child.wait() {
+        log("WARN", &format!("failed to reap child pid={child_id}: {e}"));
+    }
+}
+
+pub(crate) struct ChildReapGuard {
+    child: Option<Child>,
+}
+
+impl ChildReapGuard {
+    pub(crate) fn new(child: Child) -> Self {
+        Self { child: Some(child) }
+    }
+
+    pub(crate) fn into_child(mut self) -> Option<Child> {
+        self.child.take()
+    }
+}
+
+impl Drop for ChildReapGuard {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.take() {
+            kill_and_reap_child(child);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/vsock-guest/src/threading.rs
+++ b/crates/vsock-guest/src/threading.rs
@@ -1,0 +1,99 @@
+use std::io;
+use std::thread::{self, JoinHandle, ScopedJoinHandle};
+
+pub(crate) type UnitTask = Box<dyn FnOnce() + Send + 'static>;
+pub(crate) type VecTask = Box<dyn FnOnce() -> Vec<u8> + Send + 'static>;
+
+pub(crate) trait ThreadSpawner: Clone + Send + Sync + 'static {
+    fn spawn_unit(&self, name: &'static str, task: UnitTask) -> io::Result<JoinHandle<()>>;
+
+    fn spawn_vec(&self, name: &'static str, task: VecTask) -> io::Result<JoinHandle<Vec<u8>>>;
+}
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct SystemThreadSpawner;
+
+impl ThreadSpawner for SystemThreadSpawner {
+    fn spawn_unit(&self, name: &'static str, task: UnitTask) -> io::Result<JoinHandle<()>> {
+        thread::Builder::new().name(name.to_string()).spawn(task)
+    }
+
+    fn spawn_vec(&self, name: &'static str, task: VecTask) -> io::Result<JoinHandle<Vec<u8>>> {
+        thread::Builder::new().name(name.to_string()).spawn(task)
+    }
+}
+
+pub(crate) fn spawn_scoped_named<'scope, 'env, T, F>(
+    scope: &'scope thread::Scope<'scope, 'env>,
+    name: &'static str,
+    f: F,
+) -> io::Result<ScopedJoinHandle<'scope, T>>
+where
+    T: Send + 'scope,
+    F: FnOnce() -> T + Send + 'scope,
+{
+    thread::Builder::new()
+        .name(name.to_string())
+        .spawn_scoped(scope, f)
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::collections::VecDeque;
+    use std::io;
+    use std::sync::{Arc, Mutex};
+    use std::thread::JoinHandle;
+
+    use super::{SystemThreadSpawner, ThreadSpawner, UnitTask, VecTask};
+
+    #[derive(Clone)]
+    pub(crate) struct FailingThreadSpawner {
+        failures: Arc<Mutex<VecDeque<&'static str>>>,
+    }
+
+    impl FailingThreadSpawner {
+        pub(crate) fn fail_once(name: &'static str) -> Self {
+            Self::fail_sequence([name])
+        }
+
+        pub(crate) fn fail_sequence(names: impl IntoIterator<Item = &'static str>) -> Self {
+            Self {
+                failures: Arc::new(Mutex::new(names.into_iter().collect())),
+            }
+        }
+
+        fn should_fail(&self, name: &'static str) -> bool {
+            let mut failures = self.failures.lock().unwrap_or_else(|e| e.into_inner());
+            if failures.front().is_some_and(|next| *next == name) {
+                failures.pop_front();
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    impl ThreadSpawner for FailingThreadSpawner {
+        fn spawn_unit(&self, name: &'static str, task: UnitTask) -> io::Result<JoinHandle<()>> {
+            if self.should_fail(name) {
+                drop(task);
+                Err(io::Error::other(format!(
+                    "injected thread spawn failure for {name}",
+                )))
+            } else {
+                SystemThreadSpawner.spawn_unit(name, task)
+            }
+        }
+
+        fn spawn_vec(&self, name: &'static str, task: VecTask) -> io::Result<JoinHandle<Vec<u8>>> {
+            if self.should_fail(name) {
+                drop(task);
+                Err(io::Error::other(format!(
+                    "injected thread spawn failure for {name}",
+                )))
+            } else {
+                SystemThreadSpawner.spawn_vec(name, task)
+            }
+        }
+    }
+}

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -371,6 +371,23 @@ mod tests {
         unsafe { libc::kill(pid as i32, 0) == 0 }
     }
 
+    fn spawn_sleeping_child_with_pipes() -> (Child, u32) {
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("echo stdout-ready; sleep 60")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+        let child = command.spawn().unwrap();
+        let pid = child.id();
+        (child, pid)
+    }
+
     #[test]
     fn fast_exit_wait_does_not_pay_cancel_poll_interval_per_child() {
         let iterations = 20;
@@ -448,19 +465,7 @@ mod tests {
     #[test]
     fn drain_spawn_failure_kills_and_reaps_child_after_first_drain_starts() {
         let cancel = AtomicBool::new(false);
-        let mut command = Command::new("sh");
-        command
-            .arg("-c")
-            .arg("echo stdout-ready; sleep 60")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        #[cfg(unix)]
-        {
-            use std::os::unix::process::CommandExt;
-            command.process_group(0);
-        }
-        let child = command.spawn().unwrap();
-        let pid = child.id();
+        let (child, pid) = spawn_sleeping_child_with_pipes();
 
         let (outcome, stdout, stderr) = wait_with_drain_and_timeout_or_cancelled_with_spawner(
             child,
@@ -471,6 +476,27 @@ mod tests {
 
         assert!(
             matches!(outcome, WaitOutcome::WaitFailed(msg) if msg.contains("stderr drain thread")),
+            "unexpected wait outcome"
+        );
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+        assert!(!pid_alive(pid), "child pid {pid} should have been reaped");
+    }
+
+    #[test]
+    fn drain_spawn_failure_kills_and_reaps_child_before_any_drain_starts() {
+        let cancel = AtomicBool::new(false);
+        let (child, pid) = spawn_sleeping_child_with_pipes();
+
+        let (outcome, stdout, stderr) = wait_with_drain_and_timeout_or_cancelled_with_spawner(
+            child,
+            0,
+            &cancel,
+            FailingThreadSpawner::fail_once(THREAD_DRAIN_STDOUT),
+        );
+
+        assert!(
+            matches!(outcome, WaitOutcome::WaitFailed(msg) if msg.contains("stdout drain thread")),
             "unexpected wait outcome"
         );
         assert!(stdout.is_empty());

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -5,7 +5,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::drain::drain_into_vec_cancellable;
-use crate::process::{extract_exit_code, kill_process_tree};
+use crate::process::{extract_exit_code, kill_and_reap_child, kill_process_tree};
+use crate::threading::{SystemThreadSpawner, ThreadSpawner, spawn_scoped_named};
 
 /// Exit code returned when command times out (same as bash/Python)
 pub(crate) const EXIT_CODE_TIMEOUT: i32 = 124;
@@ -16,6 +17,9 @@ pub(crate) const EXIT_CODE_TIMEOUT: i32 = 124;
 /// child processes hold pipe fds open.
 pub(crate) const DRAIN_DEADLINE_SECS: u64 = 5;
 const WATCHDOG_CANCEL_POLL_INTERVAL_MS: u64 = 50;
+const THREAD_WAIT_WATCHDOG: &str = "vsock-wait-watchdog";
+const THREAD_DRAIN_STDOUT: &str = "vsock-drain-stdout";
+const THREAD_DRAIN_STDERR: &str = "vsock-drain-stderr";
 
 /// Outcome of child wait helpers.
 pub(crate) enum WaitOutcome {
@@ -105,19 +109,15 @@ pub(crate) fn wait_with_kill_timeout_or_cancelled(
 
     thread::scope(|scope| {
         let (done_tx, done_rx) = mpsc::channel::<()>();
-        let watchdog = match thread::Builder::new()
-            .name("vsock-wait-watchdog".to_string())
-            .spawn_scoped(scope, move || {
-                wait_for_done_timeout_or_cancelled(done_rx, deadline, cancel, child_id)
-            }) {
+        let watchdog = match spawn_scoped_named(scope, THREAD_WAIT_WATCHDOG, move || {
+            wait_for_done_timeout_or_cancelled(done_rx, deadline, cancel, child_id)
+        }) {
             Ok(watchdog) => watchdog,
             Err(e) => {
                 // If the watchdog cannot be created, timeout/cancel can no
                 // longer be enforced. Kill and reap the child instead of
                 // letting it outlive the failed wait helper.
-                // SAFETY: child_id is a valid PID from Command::spawn.
-                let _ = unsafe { kill_process_tree(child_id) } || child.kill().is_ok();
-                let _ = child.wait();
+                kill_and_reap_child(child);
                 return WaitOutcome::WaitFailed(format!("failed to spawn wait watchdog: {e}"));
             }
         };
@@ -220,18 +220,34 @@ fn kill_child(child_id: u32, reason: KillReason) -> WatchdogKill {
 /// EPIPE / SIGPIPE, so neither kernel pipe buffers nor our heap accumulate
 /// further bytes.
 pub(crate) fn wait_with_drain_and_timeout_or_cancelled(
-    mut child: Child,
+    child: Child,
     timeout_ms: u32,
     external_cancel: &AtomicBool,
 ) -> (WaitOutcome, Vec<u8>, Vec<u8>) {
+    wait_with_drain_and_timeout_or_cancelled_with_spawner(
+        child,
+        timeout_ms,
+        external_cancel,
+        SystemThreadSpawner,
+    )
+}
+
+fn wait_with_drain_and_timeout_or_cancelled_with_spawner<S>(
+    mut child: Child,
+    timeout_ms: u32,
+    external_cancel: &AtomicBool,
+    spawner: S,
+) -> (WaitOutcome, Vec<u8>, Vec<u8>)
+where
+    S: ThreadSpawner,
+{
     // Defensive: if either pipe is missing the caller broke the
     // `spawn_with_pipes` invariant. Reap the child before returning so we
     // don't leave a zombie — `Child`'s `Drop` doesn't wait.
     let stdout = match child.stdout.take() {
         Some(s) => s,
         None => {
-            let _ = child.kill();
-            let _ = child.wait();
+            kill_and_reap_child(child);
             return (
                 WaitOutcome::WaitFailed("missing stdout pipe".to_string()),
                 Vec::new(),
@@ -242,8 +258,7 @@ pub(crate) fn wait_with_drain_and_timeout_or_cancelled(
     let stderr = match child.stderr.take() {
         Some(s) => s,
         None => {
-            let _ = child.kill();
-            let _ = child.wait();
+            kill_and_reap_child(child);
             return (
                 WaitOutcome::WaitFailed("missing stderr pipe".to_string()),
                 Vec::new(),
@@ -256,22 +271,54 @@ pub(crate) fn wait_with_drain_and_timeout_or_cancelled(
     let (done_tx, done_rx) = mpsc::channel::<()>();
 
     let stdout_handle = {
-        let cancel = cancel.clone();
+        let drain_cancel = cancel.clone();
         let tx = done_tx.clone();
-        thread::spawn(move || {
-            let buf = drain_into_vec_cancellable(stdout, &cancel);
-            let _ = tx.send(());
-            buf
-        })
+        match spawner.spawn_vec(
+            THREAD_DRAIN_STDOUT,
+            Box::new(move || {
+                let buf = drain_into_vec_cancellable(stdout, &drain_cancel);
+                let _ = tx.send(());
+                buf
+            }),
+        ) {
+            Ok(handle) => handle,
+            Err(e) => {
+                cancel.store(true, Ordering::Release);
+                drop(stderr);
+                drop(done_tx);
+                kill_and_reap_child(child);
+                return (
+                    WaitOutcome::WaitFailed(format!("failed to spawn stdout drain thread: {e}")),
+                    Vec::new(),
+                    Vec::new(),
+                );
+            }
+        }
     };
     let stderr_handle = {
-        let cancel = cancel.clone();
+        let drain_cancel = cancel.clone();
         let tx = done_tx.clone();
-        thread::spawn(move || {
-            let buf = drain_into_vec_cancellable(stderr, &cancel);
-            let _ = tx.send(());
-            buf
-        })
+        match spawner.spawn_vec(
+            THREAD_DRAIN_STDERR,
+            Box::new(move || {
+                let buf = drain_into_vec_cancellable(stderr, &drain_cancel);
+                let _ = tx.send(());
+                buf
+            }),
+        ) {
+            Ok(handle) => handle,
+            Err(e) => {
+                cancel.store(true, Ordering::Release);
+                drop(done_tx);
+                kill_and_reap_child(child);
+                let _ = stdout_handle.join();
+                return (
+                    WaitOutcome::WaitFailed(format!("failed to spawn stderr drain thread: {e}")),
+                    Vec::new(),
+                    Vec::new(),
+                );
+            }
+        }
     };
     drop(done_tx); // so recv returns Disconnected if both drain threads die
 
@@ -312,10 +359,16 @@ pub(crate) fn finalize_buffered_result(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::threading::test_support::FailingThreadSpawner;
     use std::process::{Command, Stdio};
 
     fn successful_status() -> ExitStatus {
         Command::new("true").status().unwrap()
+    }
+
+    fn pid_alive(pid: u32) -> bool {
+        // SAFETY: kill(pid, 0) is the standard process-existence check.
+        unsafe { libc::kill(pid as i32, 0) == 0 }
     }
 
     #[test]
@@ -390,6 +443,39 @@ mod tests {
         let outcome = wait_with_kill_timeout_or_cancelled(child, 30_000, &cancel);
 
         assert!(matches!(outcome, WaitOutcome::Cancelled));
+    }
+
+    #[test]
+    fn drain_spawn_failure_kills_and_reaps_child_after_first_drain_starts() {
+        let cancel = AtomicBool::new(false);
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("echo stdout-ready; sleep 60")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+        let child = command.spawn().unwrap();
+        let pid = child.id();
+
+        let (outcome, stdout, stderr) = wait_with_drain_and_timeout_or_cancelled_with_spawner(
+            child,
+            0,
+            &cancel,
+            FailingThreadSpawner::fail_once(THREAD_DRAIN_STDERR),
+        );
+
+        assert!(
+            matches!(outcome, WaitOutcome::WaitFailed(msg) if msg.contains("stderr drain thread")),
+            "unexpected wait outcome"
+        );
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+        assert!(!pid_alive(pid), "child pid {pid} should have been reaped");
     }
 
     #[test]

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -18,7 +18,7 @@ pub(crate) const EXIT_CODE_TIMEOUT: i32 = 124;
 pub(crate) const DRAIN_DEADLINE_SECS: u64 = 5;
 const WATCHDOG_CANCEL_POLL_INTERVAL_MS: u64 = 50;
 const THREAD_WAIT_WATCHDOG: &str = "vsock-wait-watchdog";
-const THREAD_DRAIN_STDOUT: &str = "vsock-drain-stdout";
+pub(crate) const THREAD_DRAIN_STDOUT: &str = "vsock-drain-stdout";
 const THREAD_DRAIN_STDERR: &str = "vsock-drain-stderr";
 
 /// Outcome of child wait helpers.
@@ -232,7 +232,7 @@ pub(crate) fn wait_with_drain_and_timeout_or_cancelled(
     )
 }
 
-fn wait_with_drain_and_timeout_or_cancelled_with_spawner<S>(
+pub(crate) fn wait_with_drain_and_timeout_or_cancelled_with_spawner<S>(
     mut child: Child,
     timeout_ms: u32,
     external_cancel: &AtomicBool,


### PR DESCRIPTION
## Summary
- add a fallible vsock-guest thread spawner and child reap guard
- convert exec, write_file, wait drain, and spawn_watch monitor/drain thread setup to explicit spawn failure paths
- add deterministic failure-injection coverage for cleanup and fallback responses

## Tests
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest -- -D warnings
- cargo fmt --manifest-path crates/Cargo.toml --all
- git diff --check

Closes #12093