### PR TITLE
chore: mount codex switch config in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,6 +44,7 @@
     "source=certs,target=/home/vscode/.local/certs",
     "source=claude,target=/home/vscode/.local/share/claude",
     "source=codex,target=/home/vscode/.codex",
+    "source=codex-switch,target=/home/vscode/.codex-switch",
     "source=pki,target=/home/vscode/.pki",
     "source=cloudflared,target=/home/vscode/.cloudflared",
     "source=agent-browser,target=/home/vscode/.local/share/agent-browser"


### PR DESCRIPTION
## Summary
- add a persistent devcontainer mount for /home/vscode/.codex-switch

## Tests
- node -e "JSON.parse(require('fs').readFileSync('.devcontainer/devcontainer.json','utf8')); console.log('ok')"
- pre-commit: check-file-size
