### PR TITLE
fix: initialize codex-switch volume permissions

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -56,6 +56,7 @@ sudo mkdir -p \
   /home/vscode/.local/lib \
   /home/vscode/.pki \
   /home/vscode/.codex \
+  /home/vscode/.codex-switch \
   /home/vscode/.npm
 sudo chown -R vscode:vscode \
   /home/vscode/.config \
@@ -64,6 +65,7 @@ sudo chown -R vscode:vscode \
   /home/vscode/.pki \
   /home/vscode/.cloudflared \
   /home/vscode/.codex \
+  /home/vscode/.codex-switch \
   /home/vscode/.npm
 echo "✓ User-local npm/Codex directories ready"
 


### PR DESCRIPTION
## Summary
- add /home/vscode/.codex-switch to devcontainer setup mkdir/chown list
- keep the mounted codex-switch volume writable by the vscode user

## Testing
- bash -n .devcontainer/setup.sh