### PR TITLE
feat(voice-chat): upgrade Talker model from gpt-realtime-mini to gpt-realtime-2

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
@@ -32,7 +32,7 @@ type BargeInMode = "speech_started" | "transcript_confirmed";
 
 // Model used for the SDP exchange URL. Session config (tools / VAD / etc.) is
 // preset server-side in createEphemeralToken — keep this file free of it.
-const TALKER_MODEL = "gpt-realtime-mini";
+const TALKER_MODEL = "gpt-realtime-2";
 
 const OPENAI_REALTIME_BASE_URL = "https://api.openai.com/v1/realtime";
 

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -27,7 +27,7 @@ type BargeInMode = "speech_started" | "transcript_confirmed";
 
 // Model used for the SDP exchange URL. Session config (tools / VAD / etc.) is
 // preset server-side in createEphemeralToken — keep this file free of it.
-const TALKER_MODEL = "gpt-realtime-mini";
+const TALKER_MODEL = "gpt-realtime-2";
 
 const OPENAI_REALTIME_BASE_URL = "https://api.openai.com/v1/realtime";
 

--- a/turbo/apps/web/app/api/zero/voice-chat-candidate/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat-candidate/token/__tests__/route.test.ts
@@ -120,7 +120,7 @@ describe("POST /api/zero/voice-chat-candidate/token", () => {
     const body = await response.json();
     expect(response.status).toBe(200);
     expect(body.client_secret.value).toBe("ek_test_value");
-    expect(received?.model).toBe("gpt-realtime-mini");
+    expect(received?.model).toBe("gpt-realtime-2");
     expect(received?.modalities).toEqual(["text", "audio"]);
     expect(typeof received?.instructions).toBe("string");
     expect(received?.instructions?.length ?? 0).toBeGreaterThan(0);

--- a/turbo/apps/web/app/api/zero/voice-chat/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/token/__tests__/route.test.ts
@@ -117,7 +117,7 @@ describe("POST /api/zero/voice-chat/token", () => {
     const body = await response.json();
     expect(response.status).toBe(200);
     expect(body.client_secret.value).toBe("ek_test_value");
-    expect(received?.model).toBe("gpt-realtime-mini");
+    expect(received?.model).toBe("gpt-realtime-2");
     expect(received?.modalities).toEqual(["text", "audio"]);
     expect(typeof received?.instructions).toBe("string");
     expect(received?.instructions?.length ?? 0).toBeGreaterThan(0);

--- a/turbo/apps/web/src/lib/zero/voice-chat-candidate/openai-token.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat-candidate/openai-token.ts
@@ -10,7 +10,7 @@ import {
 
 const OPENAI_REALTIME_URL = "https://api.openai.com/v1/realtime/sessions";
 
-const TALKER_MODEL = "gpt-realtime-mini";
+const TALKER_MODEL = "gpt-realtime-2";
 
 interface EphemeralTokenResponse {
   client_secret: {

--- a/turbo/apps/web/src/lib/zero/voice-chat/openai-token.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/openai-token.ts
@@ -10,7 +10,7 @@ import {
 
 const OPENAI_REALTIME_URL = "https://api.openai.com/v1/realtime/sessions";
 
-const TALKER_MODEL = "gpt-realtime-mini";
+const TALKER_MODEL = "gpt-realtime-2";
 
 interface EphemeralTokenResponse {
   client_secret: {


### PR DESCRIPTION
## Summary

Upgrade the Talker model from `gpt-realtime-mini` to `gpt-realtime-2`, the new speech-to-speech model OpenAI shipped on May 7, 2026.

Per [@kwindla](https://x.com/kwindla/status/2052521318688739811), this is "the first speech-to-speech model good enough to use in voice agents that do real work" — it handles complex system instructions and frequent tool calls with low latency.

## Changes

- 4 `TALKER_MODEL` constants: `"gpt-realtime-mini"` → `"gpt-realtime-2"`
  - `turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts`
  - `turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts`
  - `turbo/apps/web/src/lib/zero/voice-chat/openai-token.ts`
  - `turbo/apps/web/src/lib/zero/voice-chat-candidate/openai-token.ts`
- 2 test assertions updated to match

## Test plan

- [ ] Verify voice-chat Talker starts and connects successfully with the new model
- [ ] Verify voice-chat-candidate Talker starts and connects successfully with the new model
- [ ] Confirm tool calling (Slow Brain dispatch) works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)