### PR TITLE
fix: reject codex oauth authorize requests

### DIFF
--- a/turbo/apps/web/app/api/connectors/[type]/authorize/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/authorize/__tests__/route.test.ts
@@ -132,6 +132,21 @@ describe("GET /api/connectors/:type/authorize - OAuth Authorize", () => {
     expect(sessionCookie).toBeUndefined();
   });
 
+  it("should return 400 for refresh-only codex-oauth connector", async () => {
+    await context.setupUser();
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/connectors/codex-oauth/authorize",
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ type: "codex-oauth" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("auth.json paste flow");
+  });
+
   describe("Slack connector", () => {
     it("should redirect to Slack OAuth with correct parameters", async () => {
       await context.setupUser();

--- a/turbo/apps/web/app/api/connectors/[type]/authorize/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/authorize/route.ts
@@ -29,6 +29,7 @@ const STATE_COOKIE_NAME = "connector_oauth_state";
 const SESSION_COOKIE_NAME = "connector_oauth_session";
 const PKCE_COOKIE_NAME = "connector_oauth_pkce";
 const COOKIE_MAX_AGE = 15 * 60; // 15 minutes
+const REFRESH_ONLY_CONNECTOR_TYPES = new Set<string>(["codex-oauth"]);
 
 /**
  * Generate a random state string for CSRF protection
@@ -99,6 +100,16 @@ export async function GET(
   if (connectorType === "computer") {
     return NextResponse.json(
       { error: "Computer connector does not use OAuth" },
+      { status: 400 },
+    );
+  }
+
+  if (REFRESH_ONLY_CONNECTOR_TYPES.has(connectorType)) {
+    return NextResponse.json(
+      {
+        error:
+          "codex-oauth does not use browser OAuth authorization; use the codex auth.json paste flow",
+      },
       { status: 400 },
     );
   }


### PR DESCRIPTION
## Summary

- Return a client-facing 400 for `codex-oauth` browser authorize requests before the refresh-only provider handler is invoked.
- Add route regression coverage for `/api/connectors/codex-oauth/authorize`.

Closes #12112

## Tests

- `pnpm -C turbo -F web exec vitest run --dir 'app/api/connectors/[type]/authorize/__tests__'`
- `pnpm -C turbo -F web lint`
- `pnpm -C turbo -F web check-types`
- pre-commit hook: `prettier`, `knip`, repo `check-types`, `commitlint`
