### PR TITLE
feat(vsock): add bounded exec protocol messages

### DIFF
--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -32,6 +32,14 @@
 //! | 0x0E | G→H       | bounded_exec_result | `[1B termination][1B flags][4B exit_code][8B duration_ms][4B stdout_len][stdout][4B stderr_len][stderr]` |
 //! | 0x0F | G→H       | bounded_exec_output_chunk | `[1B stream][1B flags][4B sequence][4B chunk_len][chunk]` |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
+//!
+//! Bounded exec output chunks are request-scoped: they use the same non-zero
+//! `seq` as the bounded exec request. They are separate from pid-scoped
+//! `MSG_STDOUT_CHUNK` messages used by `spawn_watch`.
+//!
+//! Bounded exec stream tags are `0 = stdout` and `1 = stderr`. Termination
+//! tags are `0 = exited`, `1 = timed_out`, `2 = cancelled`,
+//! `3 = start_failed`, and `4 = wait_failed`.
 
 /// Header size (4-byte length prefix).
 pub const HEADER_SIZE: usize = 4;
@@ -324,6 +332,27 @@ fn append_len_prefixed_bytes(
     Ok(())
 }
 
+fn add_payload_capacity(
+    capacity: &mut usize,
+    field: &'static str,
+    amount: usize,
+) -> Result<(), ProtocolError> {
+    *capacity = capacity
+        .checked_add(amount)
+        .ok_or(ProtocolError::PayloadTooLarge(field, usize::MAX))?;
+    Ok(())
+}
+
+fn add_len_prefixed_capacity(
+    capacity: &mut usize,
+    field: &'static str,
+    bytes: &[u8],
+) -> Result<(), ProtocolError> {
+    checked_u32_len(field, bytes.len())?;
+    add_payload_capacity(capacity, field, 4)?;
+    add_payload_capacity(capacity, field, bytes.len())
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct BoundedExecRequest<'a> {
     pub timeout_ms: u32,
@@ -355,8 +384,23 @@ pub struct BoundedExecRequest<'a> {
 /// `[4B stream_chunk_limit][4B stdout_stream_limit][4B stderr_stream_limit]`
 /// `[4B cmd_len][command][4B env_count]([4B key_len][key][4B val_len][value])*`
 /// `[4B stdin_len][stdin]`.
+///
+/// This encoder preserves protocol fields as provided. Execution policy, such
+/// as whether non-zero stream limits are valid when a stream flag is disabled,
+/// belongs in the host/guest execution layers.
 pub fn encode_bounded_exec(request: &BoundedExecRequest<'_>) -> Result<Vec<u8>, ProtocolError> {
-    let mut p = Vec::new();
+    let command = request.command.as_bytes();
+    let stdin = request.stdin.unwrap_or_default();
+    let mut capacity = 25;
+    add_len_prefixed_capacity(&mut capacity, "command", command)?;
+    add_payload_capacity(&mut capacity, "env", 4)?;
+    for (key, val) in request.env {
+        add_len_prefixed_capacity(&mut capacity, "env key", key.as_bytes())?;
+        add_len_prefixed_capacity(&mut capacity, "env value", val.as_bytes())?;
+    }
+    add_len_prefixed_capacity(&mut capacity, "stdin", stdin)?;
+
+    let mut p = Vec::with_capacity(capacity);
     p.extend_from_slice(&request.timeout_ms.to_be_bytes());
     let mut flags = 0u8;
     if request.sudo {
@@ -377,13 +421,13 @@ pub fn encode_bounded_exec(request: &BoundedExecRequest<'_>) -> Result<Vec<u8>, 
     p.extend_from_slice(&request.stream_chunk_limit_bytes.to_be_bytes());
     p.extend_from_slice(&request.stdout_stream_limit_bytes.to_be_bytes());
     p.extend_from_slice(&request.stderr_stream_limit_bytes.to_be_bytes());
-    append_len_prefixed_bytes(&mut p, "command", request.command.as_bytes())?;
+    append_len_prefixed_bytes(&mut p, "command", command)?;
     p.extend_from_slice(&checked_u32_len("env", request.env.len())?.to_be_bytes());
     for (key, val) in request.env {
         append_len_prefixed_bytes(&mut p, "env key", key.as_bytes())?;
         append_len_prefixed_bytes(&mut p, "env value", val.as_bytes())?;
     }
-    append_len_prefixed_bytes(&mut p, "stdin", request.stdin.unwrap_or_default())?;
+    append_len_prefixed_bytes(&mut p, "stdin", stdin)?;
     Ok(p)
 }
 
@@ -424,7 +468,11 @@ pub fn encode_bounded_exec_result(
         flags |= BOUNDED_EXEC_RESULT_FLAG_STDERR_TRUNCATED;
     }
 
-    let mut p = Vec::new();
+    let mut capacity = 14;
+    add_len_prefixed_capacity(&mut capacity, "stdout", stdout)?;
+    add_len_prefixed_capacity(&mut capacity, "stderr", stderr)?;
+
+    let mut p = Vec::with_capacity(capacity);
     p.push(termination_tag);
     p.push(flags);
     p.extend_from_slice(&exit_code.to_be_bytes());
@@ -445,7 +493,10 @@ pub fn encode_bounded_exec_output_chunk(
     chunk: &[u8],
     truncated: bool,
 ) -> Result<Vec<u8>, ProtocolError> {
-    let mut p = Vec::new();
+    let mut capacity = 6;
+    add_len_prefixed_capacity(&mut capacity, "chunk", chunk)?;
+
+    let mut p = Vec::with_capacity(capacity);
     p.push(bounded_exec_stream_tag(stream));
     p.push(if truncated {
         BOUNDED_EXEC_OUTPUT_CHUNK_FLAG_TRUNCATED

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -28,6 +28,9 @@
 //! | 0x0A | H→G       | shutdown          | (empty) |
 //! | 0x0B | G→H       | shutdown_ack      | (empty) |
 //! | 0x0C | G→H       | stdout_chunk      | `[4B pid][data]` |
+//! | 0x0D | H→G       | bounded_exec      | `[4B timeout_ms][1B flags][4B stdout_limit][4B stderr_limit][4B stream_chunk_limit][4B stdout_stream_limit][4B stderr_stream_limit][4B cmd_len][command][4B env_count]([4B key_len][key][4B val_len][value])*[4B stdin_len][stdin]` |
+//! | 0x0E | G→H       | bounded_exec_result | `[1B termination][1B flags][4B exit_code][8B duration_ms][4B stdout_len][stdout][4B stderr_len][stderr]` |
+//! | 0x0F | G→H       | bounded_exec_output_chunk | `[1B stream][1B flags][4B sequence][4B chunk_len][chunk]` |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 
 /// Header size (4-byte length prefix).
@@ -53,6 +56,9 @@ pub const MSG_PROCESS_EXIT: u8 = 0x09;
 pub const MSG_SHUTDOWN: u8 = 0x0A;
 pub const MSG_SHUTDOWN_ACK: u8 = 0x0B;
 pub const MSG_STDOUT_CHUNK: u8 = 0x0C;
+pub const MSG_BOUNDED_EXEC: u8 = 0x0D;
+pub const MSG_BOUNDED_EXEC_RESULT: u8 = 0x0E;
+pub const MSG_BOUNDED_EXEC_OUTPUT_CHUNK: u8 = 0x0F;
 pub const MSG_ERROR: u8 = 0xFF;
 
 /// Default vsock port for host-guest communication.
@@ -68,6 +74,51 @@ pub const SPAWN_WATCH_FLAG_STREAM_STDOUT: u8 = 0x02;
 // Write-file payload flags.
 pub const WRITE_FILE_FLAG_SUDO: u8 = 0x01;
 pub const WRITE_FILE_FLAG_APPEND: u8 = 0x02;
+
+// Bounded-exec payload flags.
+pub const BOUNDED_EXEC_FLAG_SUDO: u8 = 0x01;
+pub const BOUNDED_EXEC_FLAG_STREAM_STDOUT: u8 = 0x02;
+pub const BOUNDED_EXEC_FLAG_STREAM_STDERR: u8 = 0x04;
+pub const BOUNDED_EXEC_FLAG_STDIN_PRESENT: u8 = 0x08;
+
+// Bounded-exec-result payload flags.
+pub const BOUNDED_EXEC_RESULT_FLAG_STDOUT_TRUNCATED: u8 = 0x01;
+pub const BOUNDED_EXEC_RESULT_FLAG_STDERR_TRUNCATED: u8 = 0x02;
+
+// Bounded-exec-output-chunk payload flags.
+pub const BOUNDED_EXEC_OUTPUT_CHUNK_FLAG_TRUNCATED: u8 = 0x01;
+
+const BOUNDED_EXEC_KNOWN_FLAGS: u8 = BOUNDED_EXEC_FLAG_SUDO
+    | BOUNDED_EXEC_FLAG_STREAM_STDOUT
+    | BOUNDED_EXEC_FLAG_STREAM_STDERR
+    | BOUNDED_EXEC_FLAG_STDIN_PRESENT;
+const BOUNDED_EXEC_RESULT_KNOWN_FLAGS: u8 =
+    BOUNDED_EXEC_RESULT_FLAG_STDOUT_TRUNCATED | BOUNDED_EXEC_RESULT_FLAG_STDERR_TRUNCATED;
+const BOUNDED_EXEC_OUTPUT_CHUNK_KNOWN_FLAGS: u8 = BOUNDED_EXEC_OUTPUT_CHUNK_FLAG_TRUNCATED;
+
+const BOUNDED_EXEC_STREAM_STDOUT: u8 = 0;
+const BOUNDED_EXEC_STREAM_STDERR: u8 = 1;
+
+const BOUNDED_EXEC_TERMINATION_EXITED: u8 = 0;
+const BOUNDED_EXEC_TERMINATION_TIMED_OUT: u8 = 1;
+const BOUNDED_EXEC_TERMINATION_CANCELLED: u8 = 2;
+const BOUNDED_EXEC_TERMINATION_START_FAILED: u8 = 3;
+const BOUNDED_EXEC_TERMINATION_WAIT_FAILED: u8 = 4;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum BoundedExecStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum BoundedExecTermination {
+    Exited { exit_code: i32 },
+    TimedOut,
+    Cancelled,
+    StartFailed,
+    WaitFailed,
+}
 
 /// Protocol error.
 #[derive(Debug, Clone)]
@@ -114,6 +165,12 @@ fn read_u32_at(data: &[u8], offset: usize) -> Option<u32> {
 fn read_i32_at(data: &[u8], offset: usize) -> Option<i32> {
     let bytes: [u8; 4] = data.get(offset..offset + 4)?.try_into().ok()?;
     Some(i32::from_be_bytes(bytes))
+}
+
+/// Read a `u64` from `data` at `offset`. Returns `None` if out of bounds.
+fn read_u64_at(data: &[u8], offset: usize) -> Option<u64> {
+    let bytes: [u8; 8] = data.get(offset..offset + 8)?.try_into().ok()?;
+    Some(u64::from_be_bytes(bytes))
 }
 
 /// A raw decoded message.
@@ -251,6 +308,141 @@ fn append_output_pair(p: &mut Vec<u8>, stdout: &[u8], stderr: &[u8]) {
     p.extend_from_slice(stdout);
     p.extend_from_slice(&(stderr.len() as u32).to_be_bytes());
     p.extend_from_slice(stderr);
+}
+
+fn checked_u32_len(field: &'static str, len: usize) -> Result<u32, ProtocolError> {
+    u32::try_from(len).map_err(|_| ProtocolError::PayloadTooLarge(field, len))
+}
+
+fn append_len_prefixed_bytes(
+    p: &mut Vec<u8>,
+    field: &'static str,
+    bytes: &[u8],
+) -> Result<(), ProtocolError> {
+    p.extend_from_slice(&checked_u32_len(field, bytes.len())?.to_be_bytes());
+    p.extend_from_slice(bytes);
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BoundedExecRequest<'a> {
+    pub timeout_ms: u32,
+    pub command: &'a str,
+    pub env: &'a [(&'a str, &'a str)],
+    pub sudo: bool,
+    pub stdin: Option<&'a [u8]>,
+    pub stdout_limit_bytes: u32,
+    pub stderr_limit_bytes: u32,
+    pub stream_stdout: bool,
+    pub stream_stderr: bool,
+    pub stream_chunk_limit_bytes: u32,
+    pub stdout_stream_limit_bytes: u32,
+    pub stderr_stream_limit_bytes: u32,
+}
+
+/// Encode bounded_exec payload.
+///
+/// Wire format:
+/// `[4B timeout_ms][1B flags][4B stdout_limit][4B stderr_limit]`
+/// `[4B stream_chunk_limit][4B stdout_stream_limit][4B stderr_stream_limit]`
+/// `[4B cmd_len][command][4B env_count]([4B key_len][key][4B val_len][value])*`
+/// `[4B stdin_len][stdin]`.
+pub fn encode_bounded_exec(request: &BoundedExecRequest<'_>) -> Result<Vec<u8>, ProtocolError> {
+    let mut p = Vec::new();
+    p.extend_from_slice(&request.timeout_ms.to_be_bytes());
+    let mut flags = 0u8;
+    if request.sudo {
+        flags |= BOUNDED_EXEC_FLAG_SUDO;
+    }
+    if request.stream_stdout {
+        flags |= BOUNDED_EXEC_FLAG_STREAM_STDOUT;
+    }
+    if request.stream_stderr {
+        flags |= BOUNDED_EXEC_FLAG_STREAM_STDERR;
+    }
+    if request.stdin.is_some() {
+        flags |= BOUNDED_EXEC_FLAG_STDIN_PRESENT;
+    }
+    p.push(flags);
+    p.extend_from_slice(&request.stdout_limit_bytes.to_be_bytes());
+    p.extend_from_slice(&request.stderr_limit_bytes.to_be_bytes());
+    p.extend_from_slice(&request.stream_chunk_limit_bytes.to_be_bytes());
+    p.extend_from_slice(&request.stdout_stream_limit_bytes.to_be_bytes());
+    p.extend_from_slice(&request.stderr_stream_limit_bytes.to_be_bytes());
+    append_len_prefixed_bytes(&mut p, "command", request.command.as_bytes())?;
+    p.extend_from_slice(&checked_u32_len("env", request.env.len())?.to_be_bytes());
+    for (key, val) in request.env {
+        append_len_prefixed_bytes(&mut p, "env key", key.as_bytes())?;
+        append_len_prefixed_bytes(&mut p, "env value", val.as_bytes())?;
+    }
+    append_len_prefixed_bytes(&mut p, "stdin", request.stdin.unwrap_or_default())?;
+    Ok(p)
+}
+
+fn bounded_exec_stream_tag(stream: BoundedExecStream) -> u8 {
+    match stream {
+        BoundedExecStream::Stdout => BOUNDED_EXEC_STREAM_STDOUT,
+        BoundedExecStream::Stderr => BOUNDED_EXEC_STREAM_STDERR,
+    }
+}
+
+fn bounded_exec_termination_tag(termination: BoundedExecTermination) -> (u8, i32) {
+    match termination {
+        BoundedExecTermination::Exited { exit_code } => {
+            (BOUNDED_EXEC_TERMINATION_EXITED, exit_code)
+        }
+        BoundedExecTermination::TimedOut => (BOUNDED_EXEC_TERMINATION_TIMED_OUT, 0),
+        BoundedExecTermination::Cancelled => (BOUNDED_EXEC_TERMINATION_CANCELLED, 0),
+        BoundedExecTermination::StartFailed => (BOUNDED_EXEC_TERMINATION_START_FAILED, 0),
+        BoundedExecTermination::WaitFailed => (BOUNDED_EXEC_TERMINATION_WAIT_FAILED, 0),
+    }
+}
+
+/// Encode bounded_exec_result payload.
+pub fn encode_bounded_exec_result(
+    termination: BoundedExecTermination,
+    duration_ms: u64,
+    stdout: &[u8],
+    stderr: &[u8],
+    stdout_truncated: bool,
+    stderr_truncated: bool,
+) -> Result<Vec<u8>, ProtocolError> {
+    let (termination_tag, exit_code) = bounded_exec_termination_tag(termination);
+    let mut flags = 0u8;
+    if stdout_truncated {
+        flags |= BOUNDED_EXEC_RESULT_FLAG_STDOUT_TRUNCATED;
+    }
+    if stderr_truncated {
+        flags |= BOUNDED_EXEC_RESULT_FLAG_STDERR_TRUNCATED;
+    }
+
+    let mut p = Vec::new();
+    p.push(termination_tag);
+    p.push(flags);
+    p.extend_from_slice(&exit_code.to_be_bytes());
+    p.extend_from_slice(&duration_ms.to_be_bytes());
+    append_len_prefixed_bytes(&mut p, "stdout", stdout)?;
+    append_len_prefixed_bytes(&mut p, "stderr", stderr)?;
+    Ok(p)
+}
+
+/// Encode bounded_exec_output_chunk payload.
+pub fn encode_bounded_exec_output_chunk(
+    stream: BoundedExecStream,
+    sequence: u32,
+    chunk: &[u8],
+    truncated: bool,
+) -> Result<Vec<u8>, ProtocolError> {
+    let mut p = Vec::new();
+    p.push(bounded_exec_stream_tag(stream));
+    p.push(if truncated {
+        BOUNDED_EXEC_OUTPUT_CHUNK_FLAG_TRUNCATED
+    } else {
+        0
+    });
+    p.extend_from_slice(&sequence.to_be_bytes());
+    append_len_prefixed_bytes(&mut p, "chunk", chunk)?;
+    Ok(p)
 }
 
 /// Encode write_file payload: `[2B path_len][path][1B flags][4B content_len][content]`.
@@ -612,6 +804,357 @@ pub struct DecodedSpawnWatch<'a> {
     pub stdout_log_path: Option<&'a str>,
 }
 
+#[derive(Debug)]
+pub struct DecodedBoundedExec<'a> {
+    pub timeout_ms: u32,
+    pub command: &'a str,
+    pub env: Vec<(&'a str, &'a str)>,
+    pub sudo: bool,
+    pub stdin: Option<&'a [u8]>,
+    pub stdout_limit_bytes: u32,
+    pub stderr_limit_bytes: u32,
+    pub stream_stdout: bool,
+    pub stream_stderr: bool,
+    pub stream_chunk_limit_bytes: u32,
+    pub stdout_stream_limit_bytes: u32,
+    pub stderr_stream_limit_bytes: u32,
+}
+
+#[derive(Debug)]
+pub struct DecodedBoundedExecResult<'a> {
+    pub termination: BoundedExecTermination,
+    pub duration_ms: u64,
+    pub stdout: &'a [u8],
+    pub stderr: &'a [u8],
+    pub stdout_truncated: bool,
+    pub stderr_truncated: bool,
+}
+
+#[derive(Debug)]
+pub struct DecodedBoundedExecOutputChunk<'a> {
+    pub stream: BoundedExecStream,
+    pub sequence: u32,
+    pub chunk: &'a [u8],
+    pub truncated: bool,
+}
+
+fn advance_offset(
+    offset: &mut usize,
+    amount: usize,
+    truncated_msg: &'static str,
+) -> Result<usize, ProtocolError> {
+    let start = *offset;
+    *offset = offset
+        .checked_add(amount)
+        .ok_or(ProtocolError::InvalidPayload(truncated_msg))?;
+    Ok(start)
+}
+
+fn read_u8_cursor(
+    payload: &[u8],
+    offset: &mut usize,
+    msg: &'static str,
+) -> Result<u8, ProtocolError> {
+    let start = advance_offset(offset, 1, msg)?;
+    read_u8_at(payload, start).ok_or(ProtocolError::InvalidPayload(msg))
+}
+
+fn read_u32_cursor(
+    payload: &[u8],
+    offset: &mut usize,
+    msg: &'static str,
+) -> Result<u32, ProtocolError> {
+    let start = advance_offset(offset, 4, msg)?;
+    read_u32_at(payload, start).ok_or(ProtocolError::InvalidPayload(msg))
+}
+
+fn read_i32_cursor(
+    payload: &[u8],
+    offset: &mut usize,
+    msg: &'static str,
+) -> Result<i32, ProtocolError> {
+    let start = advance_offset(offset, 4, msg)?;
+    read_i32_at(payload, start).ok_or(ProtocolError::InvalidPayload(msg))
+}
+
+fn read_u64_cursor(
+    payload: &[u8],
+    offset: &mut usize,
+    msg: &'static str,
+) -> Result<u64, ProtocolError> {
+    let start = advance_offset(offset, 8, msg)?;
+    read_u64_at(payload, start).ok_or(ProtocolError::InvalidPayload(msg))
+}
+
+fn read_bytes_cursor<'a>(
+    payload: &'a [u8],
+    offset: &mut usize,
+    len: usize,
+    msg: &'static str,
+) -> Result<&'a [u8], ProtocolError> {
+    let start = advance_offset(offset, len, msg)?;
+    payload
+        .get(start..start + len)
+        .ok_or(ProtocolError::InvalidPayload(msg))
+}
+
+fn read_len_prefixed_bytes_cursor<'a>(
+    payload: &'a [u8],
+    offset: &mut usize,
+    len_msg: &'static str,
+    truncated_msg: &'static str,
+) -> Result<&'a [u8], ProtocolError> {
+    let len = read_u32_cursor(payload, offset, len_msg)? as usize;
+    read_bytes_cursor(payload, offset, len, truncated_msg)
+}
+
+fn read_len_prefixed_str_cursor<'a>(
+    payload: &'a [u8],
+    offset: &mut usize,
+    len_msg: &'static str,
+    truncated_msg: &'static str,
+    utf8_msg: &'static str,
+) -> Result<&'a str, ProtocolError> {
+    std::str::from_utf8(read_len_prefixed_bytes_cursor(
+        payload,
+        offset,
+        len_msg,
+        truncated_msg,
+    )?)
+    .map_err(|_| ProtocolError::InvalidPayload(utf8_msg))
+}
+
+fn ensure_no_trailing_bytes(
+    payload: &[u8],
+    offset: usize,
+    msg: &'static str,
+) -> Result<(), ProtocolError> {
+    if offset == payload.len() {
+        Ok(())
+    } else {
+        Err(ProtocolError::InvalidPayload(msg))
+    }
+}
+
+fn reject_unknown_flags(
+    flags: u8,
+    known_flags: u8,
+    msg: &'static str,
+) -> Result<(), ProtocolError> {
+    if flags & !known_flags == 0 {
+        Ok(())
+    } else {
+        Err(ProtocolError::InvalidPayload(msg))
+    }
+}
+
+fn decode_bounded_exec_termination(
+    tag: u8,
+    exit_code: i32,
+) -> Result<BoundedExecTermination, ProtocolError> {
+    match tag {
+        BOUNDED_EXEC_TERMINATION_EXITED => Ok(BoundedExecTermination::Exited { exit_code }),
+        BOUNDED_EXEC_TERMINATION_TIMED_OUT => Ok(BoundedExecTermination::TimedOut),
+        BOUNDED_EXEC_TERMINATION_CANCELLED => Ok(BoundedExecTermination::Cancelled),
+        BOUNDED_EXEC_TERMINATION_START_FAILED => Ok(BoundedExecTermination::StartFailed),
+        BOUNDED_EXEC_TERMINATION_WAIT_FAILED => Ok(BoundedExecTermination::WaitFailed),
+        _ => Err(ProtocolError::InvalidPayload(
+            "bounded_exec_result invalid termination tag",
+        )),
+    }
+}
+
+fn decode_bounded_exec_stream(tag: u8) -> Result<BoundedExecStream, ProtocolError> {
+    match tag {
+        BOUNDED_EXEC_STREAM_STDOUT => Ok(BoundedExecStream::Stdout),
+        BOUNDED_EXEC_STREAM_STDERR => Ok(BoundedExecStream::Stderr),
+        _ => Err(ProtocolError::InvalidPayload(
+            "bounded_exec_output_chunk invalid stream tag",
+        )),
+    }
+}
+
+/// Decode bounded_exec payload into a [`DecodedBoundedExec`] struct.
+pub fn decode_bounded_exec(payload: &[u8]) -> Result<DecodedBoundedExec<'_>, ProtocolError> {
+    let mut offset = 0usize;
+    let timeout_ms = read_u32_cursor(payload, &mut offset, "bounded_exec payload too short")?;
+    let flags = read_u8_cursor(payload, &mut offset, "bounded_exec payload too short")?;
+    reject_unknown_flags(
+        flags,
+        BOUNDED_EXEC_KNOWN_FLAGS,
+        "bounded_exec unknown flags",
+    )?;
+    let stdout_limit_bytes =
+        read_u32_cursor(payload, &mut offset, "bounded_exec stdout_limit truncated")?;
+    let stderr_limit_bytes =
+        read_u32_cursor(payload, &mut offset, "bounded_exec stderr_limit truncated")?;
+    let stream_chunk_limit_bytes = read_u32_cursor(
+        payload,
+        &mut offset,
+        "bounded_exec stream_chunk_limit truncated",
+    )?;
+    let stdout_stream_limit_bytes = read_u32_cursor(
+        payload,
+        &mut offset,
+        "bounded_exec stdout_stream_limit truncated",
+    )?;
+    let stderr_stream_limit_bytes = read_u32_cursor(
+        payload,
+        &mut offset,
+        "bounded_exec stderr_stream_limit truncated",
+    )?;
+    let command = read_len_prefixed_str_cursor(
+        payload,
+        &mut offset,
+        "bounded_exec command_len truncated",
+        "bounded_exec command truncated",
+        "invalid UTF-8 in bounded_exec command",
+    )?;
+    let env_count =
+        read_u32_cursor(payload, &mut offset, "bounded_exec env count truncated")? as usize;
+    let mut env = Vec::new();
+    for _ in 0..env_count {
+        let key = read_len_prefixed_str_cursor(
+            payload,
+            &mut offset,
+            "bounded_exec env key_len truncated",
+            "bounded_exec env key truncated",
+            "invalid UTF-8 in bounded_exec env key",
+        )?;
+        let value = read_len_prefixed_str_cursor(
+            payload,
+            &mut offset,
+            "bounded_exec env value_len truncated",
+            "bounded_exec env value truncated",
+            "invalid UTF-8 in bounded_exec env value",
+        )?;
+        env.push((key, value));
+    }
+    let stdin_bytes = read_len_prefixed_bytes_cursor(
+        payload,
+        &mut offset,
+        "bounded_exec stdin_len truncated",
+        "bounded_exec stdin truncated",
+    )?;
+    let stdin_present = flags & BOUNDED_EXEC_FLAG_STDIN_PRESENT != 0;
+    if !stdin_present && !stdin_bytes.is_empty() {
+        return Err(ProtocolError::InvalidPayload(
+            "bounded_exec stdin bytes without stdin flag",
+        ));
+    }
+    ensure_no_trailing_bytes(payload, offset, "bounded_exec trailing bytes")?;
+
+    Ok(DecodedBoundedExec {
+        timeout_ms,
+        command,
+        env,
+        sudo: flags & BOUNDED_EXEC_FLAG_SUDO != 0,
+        stdin: stdin_present.then_some(stdin_bytes),
+        stdout_limit_bytes,
+        stderr_limit_bytes,
+        stream_stdout: flags & BOUNDED_EXEC_FLAG_STREAM_STDOUT != 0,
+        stream_stderr: flags & BOUNDED_EXEC_FLAG_STREAM_STDERR != 0,
+        stream_chunk_limit_bytes,
+        stdout_stream_limit_bytes,
+        stderr_stream_limit_bytes,
+    })
+}
+
+/// Decode bounded_exec_result payload.
+pub fn decode_bounded_exec_result(
+    payload: &[u8],
+) -> Result<DecodedBoundedExecResult<'_>, ProtocolError> {
+    let mut offset = 0usize;
+    let termination_tag = read_u8_cursor(
+        payload,
+        &mut offset,
+        "bounded_exec_result payload too short",
+    )?;
+    let flags = read_u8_cursor(
+        payload,
+        &mut offset,
+        "bounded_exec_result payload too short",
+    )?;
+    reject_unknown_flags(
+        flags,
+        BOUNDED_EXEC_RESULT_KNOWN_FLAGS,
+        "bounded_exec_result unknown flags",
+    )?;
+    let exit_code = read_i32_cursor(
+        payload,
+        &mut offset,
+        "bounded_exec_result exit_code truncated",
+    )?;
+    let duration_ms = read_u64_cursor(
+        payload,
+        &mut offset,
+        "bounded_exec_result duration_ms truncated",
+    )?;
+    let stdout = read_len_prefixed_bytes_cursor(
+        payload,
+        &mut offset,
+        "bounded_exec_result stdout_len truncated",
+        "bounded_exec_result stdout truncated",
+    )?;
+    let stderr = read_len_prefixed_bytes_cursor(
+        payload,
+        &mut offset,
+        "bounded_exec_result stderr_len truncated",
+        "bounded_exec_result stderr truncated",
+    )?;
+    ensure_no_trailing_bytes(payload, offset, "bounded_exec_result trailing bytes")?;
+
+    Ok(DecodedBoundedExecResult {
+        termination: decode_bounded_exec_termination(termination_tag, exit_code)?,
+        duration_ms,
+        stdout,
+        stderr,
+        stdout_truncated: flags & BOUNDED_EXEC_RESULT_FLAG_STDOUT_TRUNCATED != 0,
+        stderr_truncated: flags & BOUNDED_EXEC_RESULT_FLAG_STDERR_TRUNCATED != 0,
+    })
+}
+
+/// Decode bounded_exec_output_chunk payload.
+pub fn decode_bounded_exec_output_chunk(
+    payload: &[u8],
+) -> Result<DecodedBoundedExecOutputChunk<'_>, ProtocolError> {
+    let mut offset = 0usize;
+    let stream_tag = read_u8_cursor(
+        payload,
+        &mut offset,
+        "bounded_exec_output_chunk payload too short",
+    )?;
+    let flags = read_u8_cursor(
+        payload,
+        &mut offset,
+        "bounded_exec_output_chunk payload too short",
+    )?;
+    reject_unknown_flags(
+        flags,
+        BOUNDED_EXEC_OUTPUT_CHUNK_KNOWN_FLAGS,
+        "bounded_exec_output_chunk unknown flags",
+    )?;
+    let sequence = read_u32_cursor(
+        payload,
+        &mut offset,
+        "bounded_exec_output_chunk sequence truncated",
+    )?;
+    let chunk = read_len_prefixed_bytes_cursor(
+        payload,
+        &mut offset,
+        "bounded_exec_output_chunk chunk_len truncated",
+        "bounded_exec_output_chunk chunk truncated",
+    )?;
+    ensure_no_trailing_bytes(payload, offset, "bounded_exec_output_chunk trailing bytes")?;
+
+    Ok(DecodedBoundedExecOutputChunk {
+        stream: decode_bounded_exec_stream(stream_tag)?,
+        sequence,
+        chunk,
+        truncated: flags & BOUNDED_EXEC_OUTPUT_CHUNK_FLAG_TRUNCATED != 0,
+    })
+}
+
 /// Decoded process_exit fields: `(pid, exit_code, stdout, stderr)`.
 pub type ProcessExit<'a> = (u32, i32, &'a [u8], &'a [u8]);
 
@@ -846,6 +1389,462 @@ mod tests {
         assert_eq!(code, 1);
         assert!(stdout.is_empty());
         assert!(stderr.is_empty());
+    }
+
+    fn full_bounded_exec_request<'a>() -> BoundedExecRequest<'a> {
+        BoundedExecRequest {
+            timeout_ms: 12_345,
+            command: "printf hello",
+            env: &[("TOKEN", "secret"), ("HOME", "/home/user")],
+            sudo: true,
+            stdin: Some(b"input"),
+            stdout_limit_bytes: 1024,
+            stderr_limit_bytes: 2048,
+            stream_stdout: true,
+            stream_stderr: true,
+            stream_chunk_limit_bytes: 256,
+            stdout_stream_limit_bytes: 4096,
+            stderr_stream_limit_bytes: 8192,
+        }
+    }
+
+    #[test]
+    fn bounded_exec_payload_roundtrip_with_env_stdin_and_streaming() {
+        let request = full_bounded_exec_request();
+        let payload = encode_bounded_exec(&request).unwrap();
+        let d = decode_bounded_exec(&payload).unwrap();
+
+        assert_eq!(d.timeout_ms, request.timeout_ms);
+        assert_eq!(d.command, request.command);
+        assert_eq!(d.env, request.env);
+        assert!(d.sudo);
+        assert_eq!(d.stdin, Some(b"input".as_slice()));
+        assert_eq!(d.stdout_limit_bytes, 1024);
+        assert_eq!(d.stderr_limit_bytes, 2048);
+        assert!(d.stream_stdout);
+        assert!(d.stream_stderr);
+        assert_eq!(d.stream_chunk_limit_bytes, 256);
+        assert_eq!(d.stdout_stream_limit_bytes, 4096);
+        assert_eq!(d.stderr_stream_limit_bytes, 8192);
+    }
+
+    #[test]
+    fn bounded_exec_payload_roundtrip_without_stdin_or_streaming() {
+        let request = BoundedExecRequest {
+            timeout_ms: 1,
+            command: "true",
+            env: &[],
+            sudo: false,
+            stdin: None,
+            stdout_limit_bytes: 0,
+            stderr_limit_bytes: 0,
+            stream_stdout: false,
+            stream_stderr: false,
+            stream_chunk_limit_bytes: 0,
+            stdout_stream_limit_bytes: 0,
+            stderr_stream_limit_bytes: 0,
+        };
+        let payload = encode_bounded_exec(&request).unwrap();
+        let d = decode_bounded_exec(&payload).unwrap();
+
+        assert_eq!(d.timeout_ms, 1);
+        assert_eq!(d.command, "true");
+        assert!(d.env.is_empty());
+        assert!(!d.sudo);
+        assert_eq!(d.stdin, None);
+        assert!(!d.stream_stdout);
+        assert!(!d.stream_stderr);
+    }
+
+    #[test]
+    fn bounded_exec_payload_distinguishes_explicit_empty_stdin() {
+        let request = BoundedExecRequest {
+            stdin: Some(b""),
+            ..full_bounded_exec_request()
+        };
+        let payload = encode_bounded_exec(&request).unwrap();
+        let d = decode_bounded_exec(&payload).unwrap();
+
+        assert_eq!(d.stdin, Some(b"".as_slice()));
+    }
+
+    #[test]
+    fn decode_bounded_exec_rejects_stdin_bytes_without_stdin_flag() {
+        let mut payload = encode_bounded_exec(&full_bounded_exec_request()).unwrap();
+        payload[4] &= !BOUNDED_EXEC_FLAG_STDIN_PRESENT;
+
+        let err = decode_bounded_exec(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec stdin bytes without stdin flag")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_rejects_unknown_flags() {
+        let mut payload = encode_bounded_exec(&full_bounded_exec_request()).unwrap();
+        payload[4] |= 0x80;
+
+        let err = decode_bounded_exec(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec unknown flags")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_rejects_truncated_command() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&1_u32.to_be_bytes());
+        payload.push(0);
+        for _ in 0..5 {
+            payload.extend_from_slice(&0_u32.to_be_bytes());
+        }
+        payload.extend_from_slice(&3_u32.to_be_bytes());
+        payload.extend_from_slice(b"ab");
+
+        let err = decode_bounded_exec(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec command truncated")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_rejects_truncated_env_value() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&1_u32.to_be_bytes());
+        payload.push(0);
+        for _ in 0..5 {
+            payload.extend_from_slice(&0_u32.to_be_bytes());
+        }
+        payload.extend_from_slice(&0_u32.to_be_bytes()); // empty command
+        payload.extend_from_slice(&1_u32.to_be_bytes()); // one env pair
+        payload.extend_from_slice(&1_u32.to_be_bytes()); // key len
+        payload.push(b'K');
+        payload.extend_from_slice(&3_u32.to_be_bytes()); // value len
+        payload.extend_from_slice(b"xy");
+
+        let err = decode_bounded_exec(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec env value truncated")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_rejects_invalid_utf8_command() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&1_u32.to_be_bytes());
+        payload.push(0);
+        for _ in 0..5 {
+            payload.extend_from_slice(&0_u32.to_be_bytes());
+        }
+        payload.extend_from_slice(&1_u32.to_be_bytes());
+        payload.push(0xFF);
+        payload.extend_from_slice(&0_u32.to_be_bytes());
+        payload.extend_from_slice(&0_u32.to_be_bytes());
+
+        let err = decode_bounded_exec(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("invalid UTF-8 in bounded_exec command")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_rejects_invalid_utf8_env_key() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&1_u32.to_be_bytes());
+        payload.push(0);
+        for _ in 0..5 {
+            payload.extend_from_slice(&0_u32.to_be_bytes());
+        }
+        payload.extend_from_slice(&0_u32.to_be_bytes()); // empty command
+        payload.extend_from_slice(&1_u32.to_be_bytes()); // one env pair
+        payload.extend_from_slice(&1_u32.to_be_bytes()); // key len
+        payload.push(0xFF);
+        payload.extend_from_slice(&0_u32.to_be_bytes()); // empty value
+        payload.extend_from_slice(&0_u32.to_be_bytes()); // no stdin
+
+        let err = decode_bounded_exec(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("invalid UTF-8 in bounded_exec env key")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_rejects_oversized_env_count_without_large_allocation() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&1_u32.to_be_bytes());
+        payload.push(0);
+        for _ in 0..5 {
+            payload.extend_from_slice(&0_u32.to_be_bytes());
+        }
+        payload.extend_from_slice(&0_u32.to_be_bytes()); // empty command
+        payload.extend_from_slice(&u32::MAX.to_be_bytes());
+
+        let err = decode_bounded_exec(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec env key_len truncated")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_rejects_trailing_bytes() {
+        let mut payload = encode_bounded_exec(&full_bounded_exec_request()).unwrap();
+        payload.push(0xFF);
+
+        let err = decode_bounded_exec(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec trailing bytes")
+        ));
+    }
+
+    #[test]
+    fn bounded_exec_result_roundtrip_exited() {
+        let payload = encode_bounded_exec_result(
+            BoundedExecTermination::Exited { exit_code: 42 },
+            123,
+            b"out",
+            b"err",
+            false,
+            true,
+        )
+        .unwrap();
+        let d = decode_bounded_exec_result(&payload).unwrap();
+
+        assert_eq!(
+            d.termination,
+            BoundedExecTermination::Exited { exit_code: 42 }
+        );
+        assert_eq!(d.duration_ms, 123);
+        assert_eq!(d.stdout, b"out");
+        assert_eq!(d.stderr, b"err");
+        assert!(!d.stdout_truncated);
+        assert!(d.stderr_truncated);
+    }
+
+    #[test]
+    fn bounded_exec_result_roundtrip_non_exit_terminations() {
+        for termination in [
+            BoundedExecTermination::TimedOut,
+            BoundedExecTermination::Cancelled,
+            BoundedExecTermination::StartFailed,
+            BoundedExecTermination::WaitFailed,
+        ] {
+            let payload =
+                encode_bounded_exec_result(termination, 999, b"partial", b"diagnostic", true, true)
+                    .unwrap();
+            let d = decode_bounded_exec_result(&payload).unwrap();
+
+            assert_eq!(d.termination, termination);
+            assert_eq!(d.duration_ms, 999);
+            assert_eq!(d.stdout, b"partial");
+            assert_eq!(d.stderr, b"diagnostic");
+            assert!(d.stdout_truncated);
+            assert!(d.stderr_truncated);
+        }
+    }
+
+    #[test]
+    fn decode_bounded_exec_result_rejects_invalid_termination_tag() {
+        let mut payload =
+            encode_bounded_exec_result(BoundedExecTermination::TimedOut, 0, b"", b"", false, false)
+                .unwrap();
+        payload[0] = 0xFF;
+
+        let err = decode_bounded_exec_result(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_result invalid termination tag")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_result_rejects_unknown_flags() {
+        let mut payload =
+            encode_bounded_exec_result(BoundedExecTermination::TimedOut, 0, b"", b"", false, false)
+                .unwrap();
+        payload[1] = 0x80;
+
+        let err = decode_bounded_exec_result(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_result unknown flags")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_result_rejects_truncated_stdout() {
+        let mut payload = Vec::new();
+        payload.push(BOUNDED_EXEC_TERMINATION_EXITED);
+        payload.push(0);
+        payload.extend_from_slice(&0_i32.to_be_bytes());
+        payload.extend_from_slice(&0_u64.to_be_bytes());
+        payload.extend_from_slice(&3_u32.to_be_bytes());
+        payload.extend_from_slice(b"ab");
+
+        let err = decode_bounded_exec_result(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_result stdout truncated")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_result_rejects_truncated_stderr() {
+        let mut payload = encode_bounded_exec_result(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            0,
+            b"out",
+            b"err",
+            false,
+            false,
+        )
+        .unwrap();
+        payload.pop();
+
+        let err = decode_bounded_exec_result(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_result stderr truncated")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_result_rejects_trailing_bytes() {
+        let mut payload = encode_bounded_exec_result(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            0,
+            b"out",
+            b"err",
+            false,
+            false,
+        )
+        .unwrap();
+        payload.push(0);
+
+        let err = decode_bounded_exec_result(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_result trailing bytes")
+        ));
+    }
+
+    #[test]
+    fn bounded_exec_output_chunk_roundtrip_stdout_and_stderr() {
+        for stream in [BoundedExecStream::Stdout, BoundedExecStream::Stderr] {
+            let payload = encode_bounded_exec_output_chunk(stream, 7, b"chunk", true).unwrap();
+            let d = decode_bounded_exec_output_chunk(&payload).unwrap();
+
+            assert_eq!(d.stream, stream);
+            assert_eq!(d.sequence, 7);
+            assert_eq!(d.chunk, b"chunk");
+            assert!(d.truncated);
+        }
+    }
+
+    #[test]
+    fn decode_bounded_exec_output_chunk_rejects_invalid_stream_tag() {
+        let mut payload =
+            encode_bounded_exec_output_chunk(BoundedExecStream::Stdout, 0, b"", false).unwrap();
+        payload[0] = 0xFF;
+
+        let err = decode_bounded_exec_output_chunk(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_output_chunk invalid stream tag")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_output_chunk_rejects_unknown_flags() {
+        let mut payload =
+            encode_bounded_exec_output_chunk(BoundedExecStream::Stdout, 0, b"", false).unwrap();
+        payload[1] = 0x80;
+
+        let err = decode_bounded_exec_output_chunk(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_output_chunk unknown flags")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_output_chunk_rejects_truncated_chunk() {
+        let mut payload = Vec::new();
+        payload.push(BOUNDED_EXEC_STREAM_STDOUT);
+        payload.push(0);
+        payload.extend_from_slice(&0_u32.to_be_bytes());
+        payload.extend_from_slice(&3_u32.to_be_bytes());
+        payload.extend_from_slice(b"ab");
+
+        let err = decode_bounded_exec_output_chunk(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_output_chunk chunk truncated")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_output_chunk_rejects_trailing_bytes() {
+        let mut payload =
+            encode_bounded_exec_output_chunk(BoundedExecStream::Stdout, 0, b"ok", false).unwrap();
+        payload.push(0);
+
+        let err = decode_bounded_exec_output_chunk(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_output_chunk trailing bytes")
+        ));
+    }
+
+    #[test]
+    fn full_message_bounded_exec_roundtrip() {
+        let request_payload = encode_bounded_exec(&full_bounded_exec_request()).unwrap();
+        let result_payload = encode_bounded_exec_result(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            15,
+            b"out",
+            b"err",
+            false,
+            false,
+        )
+        .unwrap();
+        let chunk_payload =
+            encode_bounded_exec_output_chunk(BoundedExecStream::Stderr, 3, b"warn", false).unwrap();
+
+        let mut data = encode(MSG_BOUNDED_EXEC, 10, &request_payload).unwrap();
+        data.extend_from_slice(&encode(MSG_BOUNDED_EXEC_RESULT, 10, &result_payload).unwrap());
+        data.extend_from_slice(&encode(MSG_BOUNDED_EXEC_OUTPUT_CHUNK, 10, &chunk_payload).unwrap());
+
+        let mut dec = Decoder::new();
+        let msgs = dec.decode(&data).unwrap();
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+        assert_eq!(msgs[1].msg_type, MSG_BOUNDED_EXEC_RESULT);
+        assert_eq!(msgs[2].msg_type, MSG_BOUNDED_EXEC_OUTPUT_CHUNK);
+        assert_eq!(msgs[0].seq, 10);
+        assert_eq!(
+            decode_bounded_exec(&msgs[0].payload).unwrap().command,
+            "printf hello"
+        );
+        assert_eq!(
+            decode_bounded_exec_result(&msgs[1].payload)
+                .unwrap()
+                .termination,
+            BoundedExecTermination::Exited { exit_code: 0 }
+        );
+        assert_eq!(
+            decode_bounded_exec_output_chunk(&msgs[2].payload)
+                .unwrap()
+                .stream,
+            BoundedExecStream::Stderr
+        );
     }
 
     #[test]

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -333,10 +333,18 @@ pub struct BoundedExecRequest<'a> {
     pub stdin: Option<&'a [u8]>,
     pub stdout_limit_bytes: u32,
     pub stderr_limit_bytes: u32,
+    /// Whether stdout should be emitted through request-scoped
+    /// `MSG_BOUNDED_EXEC_OUTPUT_CHUNK` messages.
     pub stream_stdout: bool,
+    /// Whether stderr should be emitted through request-scoped
+    /// `MSG_BOUNDED_EXEC_OUTPUT_CHUNK` messages.
     pub stream_stderr: bool,
     pub stream_chunk_limit_bytes: u32,
+    /// Maximum emitted stdout bytes when `stream_stdout` is enabled.
+    /// Execution layers should ignore this field when stdout streaming is off.
     pub stdout_stream_limit_bytes: u32,
+    /// Maximum emitted stderr bytes when `stream_stderr` is enabled.
+    /// Execution layers should ignore this field when stderr streaming is off.
     pub stderr_stream_limit_bytes: u32,
 }
 
@@ -427,6 +435,10 @@ pub fn encode_bounded_exec_result(
 }
 
 /// Encode bounded_exec_output_chunk payload.
+///
+/// This message is scoped to a bounded exec request: callers should send it
+/// with the same non-zero `seq` as the request it belongs to. It is not a
+/// pid-scoped `MSG_STDOUT_CHUNK` replacement.
 pub fn encode_bounded_exec_output_chunk(
     stream: BoundedExecStream,
     sequence: u32,
@@ -964,6 +976,19 @@ fn decode_bounded_exec_termination(
     }
 }
 
+fn validate_bounded_exec_termination_tag(tag: u8) -> Result<(), ProtocolError> {
+    match tag {
+        BOUNDED_EXEC_TERMINATION_EXITED
+        | BOUNDED_EXEC_TERMINATION_TIMED_OUT
+        | BOUNDED_EXEC_TERMINATION_CANCELLED
+        | BOUNDED_EXEC_TERMINATION_START_FAILED
+        | BOUNDED_EXEC_TERMINATION_WAIT_FAILED => Ok(()),
+        _ => Err(ProtocolError::InvalidPayload(
+            "bounded_exec_result invalid termination tag",
+        )),
+    }
+}
+
 fn decode_bounded_exec_stream(tag: u8) -> Result<BoundedExecStream, ProtocolError> {
     match tag {
         BOUNDED_EXEC_STREAM_STDOUT => Ok(BoundedExecStream::Stdout),
@@ -1080,6 +1105,7 @@ pub fn decode_bounded_exec_result(
         BOUNDED_EXEC_RESULT_KNOWN_FLAGS,
         "bounded_exec_result unknown flags",
     )?;
+    validate_bounded_exec_termination_tag(termination_tag)?;
     let exit_code = read_i32_cursor(
         payload,
         &mut offset,
@@ -1134,6 +1160,7 @@ pub fn decode_bounded_exec_output_chunk(
         BOUNDED_EXEC_OUTPUT_CHUNK_KNOWN_FLAGS,
         "bounded_exec_output_chunk unknown flags",
     )?;
+    let stream = decode_bounded_exec_stream(stream_tag)?;
     let sequence = read_u32_cursor(
         payload,
         &mut offset,
@@ -1148,7 +1175,7 @@ pub fn decode_bounded_exec_output_chunk(
     ensure_no_trailing_bytes(payload, offset, "bounded_exec_output_chunk trailing bytes")?;
 
     Ok(DecodedBoundedExecOutputChunk {
-        stream: decode_bounded_exec_stream(stream_tag)?,
+        stream,
         sequence,
         chunk,
         truncated: flags & BOUNDED_EXEC_OUTPUT_CHUNK_FLAG_TRUNCATED != 0,
@@ -1481,6 +1508,18 @@ mod tests {
     }
 
     #[test]
+    fn decode_bounded_exec_rejects_truncated_stdin() {
+        let mut payload = encode_bounded_exec(&full_bounded_exec_request()).unwrap();
+        payload.pop();
+
+        let err = decode_bounded_exec(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec stdin truncated")
+        ));
+    }
+
+    #[test]
     fn decode_bounded_exec_rejects_unknown_flags() {
         let mut payload = encode_bounded_exec(&full_bounded_exec_request()).unwrap();
         payload[4] |= 0x80;
@@ -1575,6 +1614,29 @@ mod tests {
     }
 
     #[test]
+    fn decode_bounded_exec_rejects_invalid_utf8_env_value() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&1_u32.to_be_bytes());
+        payload.push(0);
+        for _ in 0..5 {
+            payload.extend_from_slice(&0_u32.to_be_bytes());
+        }
+        payload.extend_from_slice(&0_u32.to_be_bytes()); // empty command
+        payload.extend_from_slice(&1_u32.to_be_bytes()); // one env pair
+        payload.extend_from_slice(&1_u32.to_be_bytes()); // key len
+        payload.push(b'K');
+        payload.extend_from_slice(&1_u32.to_be_bytes()); // value len
+        payload.push(0xFF);
+        payload.extend_from_slice(&0_u32.to_be_bytes()); // no stdin
+
+        let err = decode_bounded_exec(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("invalid UTF-8 in bounded_exec env value")
+        ));
+    }
+
+    #[test]
     fn decode_bounded_exec_rejects_oversized_env_count_without_large_allocation() {
         let mut payload = Vec::new();
         payload.extend_from_slice(&1_u32.to_be_bytes());
@@ -1629,6 +1691,27 @@ mod tests {
     }
 
     #[test]
+    fn bounded_exec_result_truncation_flags_roundtrip_independently() {
+        for (stdout_truncated, stderr_truncated) in
+            [(false, false), (true, false), (false, true), (true, true)]
+        {
+            let payload = encode_bounded_exec_result(
+                BoundedExecTermination::Exited { exit_code: 0 },
+                1,
+                b"out",
+                b"err",
+                stdout_truncated,
+                stderr_truncated,
+            )
+            .unwrap();
+            let d = decode_bounded_exec_result(&payload).unwrap();
+
+            assert_eq!(d.stdout_truncated, stdout_truncated);
+            assert_eq!(d.stderr_truncated, stderr_truncated);
+        }
+    }
+
+    #[test]
     fn bounded_exec_result_roundtrip_non_exit_terminations() {
         for termination in [
             BoundedExecTermination::TimedOut,
@@ -1658,6 +1741,15 @@ mod tests {
         payload[0] = 0xFF;
 
         let err = decode_bounded_exec_result(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_result invalid termination tag")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_result_rejects_invalid_termination_tag_before_body() {
+        let err = decode_bounded_exec_result(&[0xFF, 0]).unwrap_err();
         assert!(matches!(
             err,
             ProtocolError::InvalidPayload("bounded_exec_result invalid termination tag")
@@ -1755,6 +1847,15 @@ mod tests {
         payload[0] = 0xFF;
 
         let err = decode_bounded_exec_output_chunk(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_output_chunk invalid stream tag")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_output_chunk_rejects_invalid_stream_tag_before_body() {
+        let err = decode_bounded_exec_output_chunk(&[0xFF, 0]).unwrap_err();
         assert!(matches!(
             err,
             ProtocolError::InvalidPayload("bounded_exec_output_chunk invalid stream tag")

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -1535,6 +1535,18 @@ mod tests {
     }
 
     #[test]
+    fn bounded_exec_payload_roundtrip_with_empty_env_value() {
+        let request = BoundedExecRequest {
+            env: &[("EMPTY", "")],
+            ..full_bounded_exec_request()
+        };
+        let payload = encode_bounded_exec(&request).unwrap();
+        let d = decode_bounded_exec(&payload).unwrap();
+
+        assert_eq!(d.env, vec![("EMPTY", "")]);
+    }
+
+    #[test]
     fn bounded_exec_payload_distinguishes_explicit_empty_stdin() {
         let request = BoundedExecRequest {
             stdin: Some(b""),
@@ -1567,6 +1579,24 @@ mod tests {
         assert!(matches!(
             err,
             ProtocolError::InvalidPayload("bounded_exec stdin truncated")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_rejects_missing_stdin_len_after_env() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&1_u32.to_be_bytes());
+        payload.push(0);
+        for _ in 0..5 {
+            payload.extend_from_slice(&0_u32.to_be_bytes());
+        }
+        payload.extend_from_slice(&0_u32.to_be_bytes()); // empty command
+        payload.extend_from_slice(&0_u32.to_be_bytes()); // empty env
+
+        let err = decode_bounded_exec(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec stdin_len truncated")
         ));
     }
 
@@ -1742,6 +1772,30 @@ mod tests {
     }
 
     #[test]
+    fn bounded_exec_result_empty_output_roundtrip() {
+        let payload = encode_bounded_exec_result(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            0,
+            b"",
+            b"",
+            false,
+            false,
+        )
+        .unwrap();
+        let d = decode_bounded_exec_result(&payload).unwrap();
+
+        assert_eq!(
+            d.termination,
+            BoundedExecTermination::Exited { exit_code: 0 }
+        );
+        assert_eq!(d.duration_ms, 0);
+        assert!(d.stdout.is_empty());
+        assert!(d.stderr.is_empty());
+        assert!(!d.stdout_truncated);
+        assert!(!d.stderr_truncated);
+    }
+
+    #[test]
     fn bounded_exec_result_truncation_flags_roundtrip_independently() {
         for (stdout_truncated, stderr_truncated) in
             [(false, false), (true, false), (false, true), (true, true)]
@@ -1822,6 +1876,32 @@ mod tests {
     }
 
     #[test]
+    fn decode_bounded_exec_result_rejects_truncated_exit_code() {
+        let payload = [BOUNDED_EXEC_TERMINATION_EXITED, 0, 0, 0, 0];
+
+        let err = decode_bounded_exec_result(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_result exit_code truncated")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_result_rejects_truncated_duration() {
+        let mut payload = Vec::new();
+        payload.push(BOUNDED_EXEC_TERMINATION_EXITED);
+        payload.push(0);
+        payload.extend_from_slice(&0_i32.to_be_bytes());
+        payload.extend_from_slice(&0_u64.to_be_bytes()[..7]);
+
+        let err = decode_bounded_exec_result(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_result duration_ms truncated")
+        ));
+    }
+
+    #[test]
     fn decode_bounded_exec_result_rejects_truncated_stdout() {
         let mut payload = Vec::new();
         payload.push(BOUNDED_EXEC_TERMINATION_EXITED);
@@ -1892,6 +1972,18 @@ mod tests {
     }
 
     #[test]
+    fn bounded_exec_output_chunk_empty_chunk_roundtrip() {
+        let payload =
+            encode_bounded_exec_output_chunk(BoundedExecStream::Stdout, 0, b"", false).unwrap();
+        let d = decode_bounded_exec_output_chunk(&payload).unwrap();
+
+        assert_eq!(d.stream, BoundedExecStream::Stdout);
+        assert_eq!(d.sequence, 0);
+        assert!(d.chunk.is_empty());
+        assert!(!d.truncated);
+    }
+
+    #[test]
     fn decode_bounded_exec_output_chunk_rejects_invalid_stream_tag() {
         let mut payload =
             encode_bounded_exec_output_chunk(BoundedExecStream::Stdout, 0, b"", false).unwrap();
@@ -1923,6 +2015,17 @@ mod tests {
         assert!(matches!(
             err,
             ProtocolError::InvalidPayload("bounded_exec_output_chunk unknown flags")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_output_chunk_rejects_truncated_sequence() {
+        let payload = [BOUNDED_EXEC_STREAM_STDOUT, 0, 0, 0, 0];
+
+        let err = decode_bounded_exec_output_chunk(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_output_chunk sequence truncated")
         ));
     }
 


### PR DESCRIPTION
Closes #12110

## Summary
- add bounded exec request/result/output chunk message types to vsock-proto
- add typed request/result/chunk encoders and strict decoders with checked length handling
- cover round trips and malformed payload cases for stdin flags, UTF-8, truncation, unknown flags/tags, trailing bytes, and framed messages

## Tests
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto --all-targets -- -D warnings

Pre-commit also ran workspace cargo-fmt, cargo-clippy, and cargo-doc.