### PR TITLE
fix: validate compose ids before lookup

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/__tests__/route.test.ts
@@ -126,6 +126,20 @@ describe("GET /api/agent/composes/[id]", () => {
     testComposeId = composeId;
   });
 
+  it("should return 400 for malformed compose id", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/composes/91fc0bd84bba673393d9adfc1a0f4dec",
+      { method: "GET" },
+    );
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.code).toBe("BAD_REQUEST");
+    expect(data.error.message).toContain("valid UUID");
+  });
+
   describe("Cross-User Access Control", () => {
     // Note: API returns 404 (not 403) for unauthorized access to prevent
     // information leakage about existence of private agents

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
@@ -30,11 +30,23 @@ describe("GET /api/agent/composes/:id/instructions", () => {
     user = await context.setupUser();
   });
 
+  it("should return 400 for malformed compose id", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/composes/91fc0bd84bba673393d9adfc1a0f4dec/instructions",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.code).toBe("BAD_REQUEST");
+    expect(data.error.message).toContain("valid UUID");
+  });
+
   it("should return 401 when not authenticated", async () => {
     mockClerk({ userId: null });
 
     const request = createTestRequest(
-      "http://localhost:3000/api/agent/composes/some-id/instructions",
+      "http://localhost:3000/api/agent/composes/00000000-0000-0000-0000-000000000000/instructions",
     );
     const response = await GET(request);
     const data = await response.json();

--- a/turbo/apps/web/app/api/zero/composes/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/composes/[id]/__tests__/route.test.ts
@@ -54,10 +54,24 @@ describe("GET /api/zero/composes/:id", () => {
     expect(response.status).toBe(404);
   });
 
+  it("should return 400 for malformed compose id", async () => {
+    const userId = uniqueId("zcompid-bad-id");
+    await setupOrg(userId);
+
+    const response = await GET(
+      createTestRequest(composeIdUrl("91fc0bd84bba673393d9adfc1a0f4dec")),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.code).toBe("BAD_REQUEST");
+    expect(data.error.message).toContain("valid UUID");
+  });
+
   it("should return 401 when not authenticated", async () => {
     mockClerk({ userId: null });
 
-    const response = await GET(createTestRequest(composeIdUrl("some-id")));
+    const response = await GET(createTestRequest(composeIdUrl(randomUUID())));
     expect(response.status).toBe(401);
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/composes.ts
+++ b/turbo/packages/api-contracts/src/contracts/composes.ts
@@ -347,10 +347,11 @@ export const composesByIdContract = c.router({
     path: "/api/agent/composes/:id",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Compose ID is required"),
+      id: z.string().uuid("Compose ID must be a valid UUID"),
     }),
     responses: {
       200: composeResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
@@ -508,10 +509,11 @@ export const composesInstructionsContract = c.router({
     path: "/api/agent/composes/:id/instructions",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Compose ID is required"),
+      id: z.string().uuid("Compose ID must be a valid UUID"),
     }),
     responses: {
       200: composeInstructionsResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,

--- a/turbo/packages/api-contracts/src/contracts/zero-composes.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-composes.ts
@@ -38,10 +38,11 @@ export const zeroComposesByIdContract = c.router({
     path: "/api/zero/composes/:id",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().min(1, "Compose ID is required"),
+      id: z.string().uuid("Compose ID must be a valid UUID"),
     }),
     responses: {
       200: composeResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,


### PR DESCRIPTION
## Summary

- Require UUID path params for agent compose detail, instructions, and zero compose detail routes before handler/database lookup.
- Declare 400 validation responses in the affected compose contracts.
- Add route regression coverage for malformed compose IDs on all affected GET endpoints.

Closes #12113

## Tests

- `pnpm -C turbo -F web exec vitest run 'app/api/agent/composes/[id]/__tests__/route.test.ts' 'app/api/agent/composes/[id]/instructions/__tests__/route.test.ts'`
- `pnpm -C turbo -F web exec vitest run 'app/api/agent/composes/[id]/__tests__/route.test.ts' 'app/api/agent/composes/[id]/instructions/__tests__/route.test.ts' 'app/api/zero/composes/[id]/__tests__/route.test.ts'`
- `pnpm -C turbo format`
- `pnpm -C turbo exec prettier --write --ignore-unknown 'packages/api-contracts/src/contracts/zero-composes.ts' 'apps/web/app/api/zero/composes/[id]/__tests__/route.test.ts' 'packages/api-contracts/src/contracts/composes.ts' 'apps/web/app/api/agent/composes/[id]/__tests__/route.test.ts' 'apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts'`
- `pnpm -C turbo -F web lint`
- `pnpm -C turbo -F @vm0/api-contracts lint`
- `pnpm -C turbo -F web check-types`
- `pnpm -C turbo -F @vm0/api-contracts check-types`
- pre-commit hook: `prettier`, `knip`, repo `check-types`, `commitlint`
