### PR TITLE
feat(ui): swap tabler icons for hugeicons (rounded, friendlier weight)

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -21,7 +21,6 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@sentry/react": "^10.38.0",
     "@sentry/vite-plugin": "^4.9.0",
-    "@tabler/icons-react": "^3.36.1",
     "@tiptap/core": "3.21.0",
     "@tiptap/markdown": "3.21.0",
     "@tiptap/pm": "3.21.0",

--- a/turbo/apps/platform/src/views/activity-page/activity-inspect-page.tsx
+++ b/turbo/apps/platform/src/views/activity-page/activity-inspect-page.tsx
@@ -1,7 +1,7 @@
 import { useGet, useSet, useLastResolved } from "ccstate-react";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
-import { IconSearch, IconChartLine, IconUpload } from "@tabler/icons-react";
+import { IconSearch, IconChartLine, IconUpload } from "@vm0/ui/icons";
 import { Button, Input, Tabs, TabsList, TabsTrigger } from "@vm0/ui";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type {

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -7,7 +7,7 @@ import {
   IconLoader2,
   IconPlus,
   IconWand,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import {
   Card,
   CardContent,

--- a/turbo/apps/platform/src/views/components/loading-switch.tsx
+++ b/turbo/apps/platform/src/views/components/loading-switch.tsx
@@ -1,4 +1,4 @@
-import { IconLoader2 } from "@tabler/icons-react";
+import { IconLoader2 } from "@vm0/ui/icons";
 import { Switch, cn } from "@vm0/ui";
 
 /** Track/thumb sizing shared with plain `Switch` when toggles must align (e.g. settings rows). */

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -1,7 +1,7 @@
 import MarkdownPreview, {
   type MarkdownPreviewProps,
 } from "@uiw/react-markdown-preview";
-import { IconLoader2, IconPhoto } from "@tabler/icons-react";
+import { IconLoader2, IconPhoto } from "@vm0/ui/icons";
 import { useGet, useSet } from "ccstate-react";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { theme$ } from "../../signals/theme.ts";

--- a/turbo/apps/platform/src/views/components/pagination.tsx
+++ b/turbo/apps/platform/src/views/components/pagination.tsx
@@ -3,7 +3,7 @@ import {
   IconChevronRight,
   IconChevronsLeft,
   IconChevronsRight,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import {
   Button,
   Select,

--- a/turbo/apps/platform/src/views/device-bb0/bb0-device-page.tsx
+++ b/turbo/apps/platform/src/views/device-bb0/bb0-device-page.tsx
@@ -8,7 +8,7 @@ import {
   IconPlugConnected,
   IconRefresh,
   IconWifi,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { Button } from "@vm0/ui/components/ui/button";
 import { Input } from "@vm0/ui/components/ui/input";
 import { detach, Reason } from "../../signals/utils.ts";

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -3,7 +3,7 @@ import {
   IconChevronDown,
   IconChevronLeft,
   IconChevronRight,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import emptyInsightsImg from "../zero-page/assets/empty-insights.webp";
 import {
   Skeleton,

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -11,7 +11,7 @@ import {
   IconAlertTriangle,
   IconLoader2,
   IconX,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import {
   isFirewallConnectorType,
   resolveFirewallPolicies,

--- a/turbo/apps/platform/src/views/pwa-install/install-banner.tsx
+++ b/turbo/apps/platform/src/views/pwa-install/install-banner.tsx
@@ -1,10 +1,5 @@
 import { useGet, useSet } from "ccstate-react";
-import {
-  IconDownload,
-  IconShare2,
-  IconSquarePlus,
-  IconX,
-} from "@tabler/icons-react";
+import { IconDownload, IconShare2, IconSquarePlus, IconX } from "@vm0/ui/icons";
 import {
   Dialog,
   DialogContent,

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -8,7 +8,7 @@ import {
   SheetTitle,
   Button,
 } from "@vm0/ui";
-import { IconCrown } from "@tabler/icons-react";
+import { IconCrown } from "@vm0/ui/icons";
 import {
   queueDrawerOpen$,
   setQueueDrawerOpen$,

--- a/turbo/apps/platform/src/views/redeem-campaign-page/redeem-campaign-page.tsx
+++ b/turbo/apps/platform/src/views/redeem-campaign-page/redeem-campaign-page.tsx
@@ -6,7 +6,7 @@ import {
   IconLoader2,
   IconLock,
   IconX,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { Button } from "@vm0/ui";
 import type { RedeemResponse } from "@vm0/api-contracts/contracts/zero-billing";
 import {

--- a/turbo/apps/platform/src/views/report-error/report-error-page.tsx
+++ b/turbo/apps/platform/src/views/report-error/report-error-page.tsx
@@ -5,7 +5,7 @@ import {
   IconCheck,
   IconLoader2,
   IconX,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   reportErrorRun$,

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -20,7 +20,7 @@ import {
   IconX,
   IconMessageCircle,
   IconWand,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import {
   Button,
   Tabs,

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -15,7 +15,7 @@ import {
   IconPin,
   IconPlus,
   IconUserPlus,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import {
   Button,

--- a/turbo/apps/platform/src/views/zero-page/api-keys-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/api-keys-page.tsx
@@ -1,6 +1,6 @@
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import { IconKey, IconTrash, IconLoader2, IconPlus } from "@tabler/icons-react";
+import { IconKey, IconTrash, IconLoader2, IconPlus } from "@vm0/ui/icons";
 import type { ApiKeyItem } from "@vm0/api-contracts/contracts/api-keys";
 import { Button } from "@vm0/ui/components/ui/button";
 import { Input } from "@vm0/ui/components/ui/input";

--- a/turbo/apps/platform/src/views/zero-page/avatar-maker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-maker.tsx
@@ -17,7 +17,7 @@ import {
   IconChevronLeft,
   IconChevronRight,
   IconDice,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import type { AvatarSvgConfig } from "./avatar-svg-utils.ts";
 import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
 import {

--- a/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
@@ -17,7 +17,7 @@ import {
   DialogDescription,
 } from "@vm0/ui/components/ui/dialog";
 import { Input, Switch } from "@vm0/ui";
-import { IconCheck } from "@tabler/icons-react";
+import { IconCheck } from "@vm0/ui/icons";
 import {
   type BillingTier,
   apiTierToBillingTier,

--- a/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
@@ -1,4 +1,4 @@
-import { IconChevronRight } from "@tabler/icons-react";
+import { IconChevronRight } from "@vm0/ui/icons";
 import { CopyButton } from "@vm0/ui";
 import type { NetworkLogEntry } from "@vm0/api-contracts/contracts/runs";
 import { formatSize, InlineBadge } from "./network-badge.tsx";

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/event-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/event-card.tsx
@@ -4,7 +4,7 @@ import {
   IconTool,
   IconRobot,
   IconTerminal,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { Markdown } from "../../../components/markdown.tsx";
 import { Popover, PopoverContent, PopoverTrigger } from "@vm0/ui";
 

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
@@ -1,4 +1,4 @@
-import { IconCheck, IconCircleDashed, IconLoader } from "@tabler/icons-react";
+import { IconCheck, IconCircleDashed, IconLoader } from "@vm0/ui/icons";
 import { Markdown } from "../../../components/markdown.tsx";
 import {
   isTaskEventData,

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-table.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-table.tsx
@@ -1,4 +1,4 @@
-import { IconChevronRight, IconClock, IconLoader2 } from "@tabler/icons-react";
+import { IconChevronRight, IconClock, IconLoader2 } from "@vm0/ui/icons";
 import { cn } from "@vm0/ui";
 import {
   getTriggerSourceLabel,

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/status-badge.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/status-badge.tsx
@@ -5,7 +5,7 @@ import {
   IconCircleX,
   IconClockExclamation,
   IconBan,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import type { LogStatus } from "../../../../signals/zero-page/log-types.ts";
 
 interface StatusBadgeConfig {

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -1,6 +1,6 @@
 import type { MouseEvent, ReactNode } from "react";
 import { useGet, useSet } from "ccstate-react";
-import { IconCpu } from "@tabler/icons-react";
+import { IconCpu } from "@vm0/ui/icons";
 import {
   Select,
   SelectContent,

--- a/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
@@ -3,7 +3,7 @@ import {
   IconChevronDown,
   IconFilter,
   IconLoader2,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { useGet, useSet } from "ccstate-react";
 import {
   DropdownMenu,

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -8,7 +8,7 @@ import {
   IconArrowLeft,
   IconChevronRight,
   IconCoins,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import {
   billingStatusAsync$,

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-domains-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-domains-tab.tsx
@@ -11,7 +11,7 @@ import {
   IconDots,
   IconShieldCheck,
   IconShieldOff,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import {
   cn,
   Button,

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
@@ -1,7 +1,7 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
 import { useLoadable, useGet, useSet } from "ccstate-react";
-import { IconUpload } from "@tabler/icons-react";
+import { IconUpload } from "@vm0/ui/icons";
 import {
   Input,
   Button,

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
@@ -1,5 +1,5 @@
 import { useLastLoadable } from "ccstate-react";
-import { IconCircleCheck, IconDownload } from "@tabler/icons-react";
+import { IconCircleCheck, IconDownload } from "@vm0/ui/icons";
 import {
   cn,
   Tooltip,

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
@@ -22,7 +22,7 @@ import {
   IconCoins,
   IconFileInvoice,
   IconWorldWww,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 
 import { OrgGeneralTab } from "./org-general-tab.tsx";
 import { OrgProvidersTab } from "./org-providers-tab.tsx";

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -11,7 +11,7 @@ import {
   IconCheck,
   IconX,
   IconUserPlus,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import {
   cn,
   Input,

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
@@ -1,7 +1,7 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
 import { useGet, useSet, useLoadable } from "ccstate-react";
-import { IconDotsVertical, IconPlus } from "@tabler/icons-react";
+import { IconDotsVertical, IconPlus } from "@vm0/ui/icons";
 import {
   MODEL_PROVIDER_TYPES,
   type ModelProviderResponse,

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -3,7 +3,7 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import type { OrgMember } from "@vm0/api-contracts/contracts/org-members";
 import type { BillingStatusResponse } from "@vm0/api-contracts/contracts/zero-billing";
 import type { MemberUsage } from "@vm0/api-contracts/contracts/zero-usage";
-import { IconChevronRight, IconUsers } from "@tabler/icons-react";
+import { IconChevronRight, IconUsers } from "@vm0/ui/icons";
 import { Input } from "@vm0/ui";
 import {
   Tooltip,

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/unsaved-bar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/unsaved-bar.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from "react-dom";
-import { IconPencil, IconLoader2 } from "@tabler/icons-react";
+import { IconPencil, IconLoader2 } from "@vm0/ui/icons";
 import { Button } from "@vm0/ui";
 
 export function UnsavedBar({

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -1,7 +1,7 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
 import { useGet, useSet, useLoadable } from "ccstate-react";
-import { IconDotsVertical, IconPlus } from "@tabler/icons-react";
+import { IconDotsVertical, IconPlus } from "@vm0/ui/icons";
 import {
   MODEL_PROVIDER_TYPES,
   type ModelProviderResponse,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-permission-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-permission-dialog.tsx
@@ -2,7 +2,7 @@
 // oxlint-disable max-lines-per-function
 import { useLastResolved, useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import { IconSearch, IconCircleCheckFilled } from "@tabler/icons-react";
+import { IconSearch, IconCircleCheckFilled } from "@vm0/ui/icons";
 import {
   Dialog,
   DialogContent,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
@@ -1,5 +1,5 @@
 import { useGet, useLastResolved, useSet } from "ccstate-react";
-import { IconDotsVertical } from "@tabler/icons-react";
+import { IconDotsVertical } from "@vm0/ui/icons";
 import {
   Button,
   DropdownMenu,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
@@ -1,5 +1,5 @@
 import { useLastResolved, useSet } from "ccstate-react";
-import { IconPlus } from "@tabler/icons-react";
+import { IconPlus } from "@vm0/ui/icons";
 import {
   Dialog,
   DialogContent,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -41,7 +41,7 @@ import {
   permissionUnknownPolicy$,
   setPermissionUnknownPolicy$,
 } from "../../../../signals/zero-page/settings/permissions-dialog.ts";
-import { IconCheck, IconBan, IconChevronRight } from "@tabler/icons-react";
+import { IconCheck, IconBan, IconChevronRight } from "@vm0/ui/icons";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/personal-add-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/personal-add-provider-dialog.tsx
@@ -1,5 +1,5 @@
 import { useLastResolved, useSet } from "ccstate-react";
-import { IconPlus } from "@tabler/icons-react";
+import { IconPlus } from "@vm0/ui/icons";
 import {
   Dialog,
   DialogContent,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
@@ -9,7 +9,7 @@ import {
   SelectValue,
 } from "@vm0/ui/components/ui/select";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
-import { IconClock, IconLoader2 } from "@tabler/icons-react";
+import { IconClock, IconLoader2 } from "@vm0/ui/icons";
 import {
   userPreferences$,
   updateUserPreference$,

--- a/turbo/apps/platform/src/views/zero-page/schedule-calendar-view.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-calendar-view.tsx
@@ -1,11 +1,7 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
 import { useGet, useSet } from "ccstate-react";
-import {
-  IconChevronLeft,
-  IconChevronRight,
-  IconPencil,
-} from "@tabler/icons-react";
+import { IconChevronLeft, IconChevronRight, IconPencil } from "@vm0/ui/icons";
 import {
   cn,
   Tooltip,

--- a/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
@@ -2,7 +2,7 @@
 // oxlint-disable max-lines-per-function
 import { useGet, useSet, useLastResolved } from "ccstate-react";
 import { createPortal } from "react-dom";
-import { IconX } from "@tabler/icons-react";
+import { IconX } from "@vm0/ui/icons";
 import {
   Button,
   Input,

--- a/turbo/apps/platform/src/views/zero-page/schedule-list-view.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-list-view.tsx
@@ -6,7 +6,7 @@ import {
   IconPlus,
   IconPlayerPlay,
   IconDotsVertical,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import {
   Button,
   cn,

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -6,12 +6,7 @@ import {
   useLastResolved,
   useResolved,
 } from "ccstate-react";
-import {
-  IconMenu2,
-  IconPlus,
-  IconUserPlus,
-  IconVolume2,
-} from "@tabler/icons-react";
+import { IconMenu2, IconPlus, IconUserPlus, IconVolume2 } from "@vm0/ui/icons";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type { RouteKey } from "../../signals/route-paths.ts";
 import { cn } from "@vm0/ui";

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -14,7 +14,7 @@ import {
   IconDots,
   IconPin,
   IconPinnedOff,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import type { ChatThreadListItem } from "@vm0/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { useChatThreadsTitleLabels } from "./zero-sidebar-shared.tsx";

--- a/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
@@ -20,7 +20,7 @@ import {
   IconListNumbers,
   IconBlockquote,
   IconCode,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import "highlight.js/styles/github.css";
 
 function getLowlight() {

--- a/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
@@ -9,7 +9,7 @@ import {
   IconKeyboard,
   IconLoader2,
   IconBug,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import { Switch } from "@vm0/ui/components/ui/switch";
 import { cn } from "@vm0/ui";

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -11,7 +11,7 @@ import {
   IconLoader2,
   IconDownload,
   IconChartLine,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import {
   Button,
   Input,

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
@@ -2,11 +2,7 @@
 // oxlint-disable max-lines-per-function
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import {
-  IconUsers,
-  IconCircleDot,
-  IconPlugConnected,
-} from "@tabler/icons-react";
+import { IconUsers, IconCircleDot, IconPlugConnected } from "@vm0/ui/icons";
 import {
   Select,
   SelectContent,

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -11,7 +11,7 @@ import {
   IconZoomOut,
   IconZoomReset,
   IconX,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import type { ZeroChatAttachment } from "../../signals/chat-page/chat-message.ts";
 import { logger } from "../../signals/log.ts";
 import { detach, jsonParseOr, Reason } from "../../signals/utils.ts";

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -6,7 +6,7 @@ import {
   IconEye,
   IconFileMusic,
   IconLoader2,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { useGet, useLastResolved, useSet } from "ccstate-react";
 import type { Computed } from "ccstate";
 import { jsonParseOr } from "../../signals/utils.ts";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -17,7 +17,7 @@ import {
   IconPlayerStop,
   IconPlug,
   IconPlus,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import {
   Dialog,
   DialogContent,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
@@ -6,7 +6,7 @@ import {
   useLastLoadable,
   useLastResolved,
 } from "ccstate-react";
-import { IconPlus, IconSearch, IconX, IconTrash } from "@tabler/icons-react";
+import { IconPlus, IconSearch, IconX, IconTrash } from "@vm0/ui/icons";
 import {
   Button,
   Dialog,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -31,7 +31,7 @@ import {
   IconLink,
   IconLoader2,
   IconPackage,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import {
   cn,
   isEditableTarget,

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -14,7 +14,7 @@ import {
   IconPlus,
   IconLoader2,
   IconDotsVertical,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import {
   CONNECTOR_TYPES,
   type ConnectorType,

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -21,7 +21,7 @@ import {
   authorizeConnector$,
 } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { IconCheck, IconLoader2 } from "@tabler/icons-react";
+import { IconCheck, IconLoader2 } from "@vm0/ui/icons";
 import { Vm0LogoLink, GoogleOAuthNotice } from "./zero-directed-shared.tsx";
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -40,7 +40,7 @@ import {
 } from "../../signals/connectors-page/directed-connect-type.ts";
 import { authorizeConnector$ } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { IconCheck, IconLoader2 } from "@tabler/icons-react";
+import { IconCheck, IconLoader2 } from "@vm0/ui/icons";
 import { Vm0LogoLink, GoogleOAuthNotice } from "./zero-directed-shared.tsx";
 
 function runDirectedConnect(params: {

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -1,11 +1,7 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
 import { useGet, useLastResolved, useSet } from "ccstate-react";
-import {
-  IconArrowUpRight,
-  IconMessageCircle,
-  IconSearch,
-} from "@tabler/icons-react";
+import { IconArrowUpRight, IconMessageCircle, IconSearch } from "@vm0/ui/icons";
 import { Card, CardContent, cn, Input } from "@vm0/ui";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { getCategories } from "./zero-ideation-data.ts";

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -62,7 +62,7 @@ import {
   IconCircleCheckFilled,
   IconLoader,
   IconSearch,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { detach, Reason } from "../../signals/utils.ts";
 import { AccountDropdown } from "./zero-sidebar.tsx";
 import { handleZeroAccountAction$ } from "../../signals/zero-page/zero-nav.ts";

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -16,7 +16,7 @@ import {
   IconSettings,
   IconPlus,
   IconMail,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { clerk$, currentOrgInfo$ } from "../../signals/auth.ts";
 import {
   bestEffort,

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -22,7 +22,7 @@ import {
   deletingSchedule$,
   setDeletingSchedule$,
 } from "../../signals/zero-page/schedule-card.ts";
-import { IconPlus, IconList, IconLayoutGrid } from "@tabler/icons-react";
+import { IconPlus, IconList, IconLayoutGrid } from "@vm0/ui/icons";
 import {
   Card,
   CardContent,

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
@@ -16,7 +16,7 @@ import {
   IconRotateClockwise2,
   IconSettings,
   IconTrash,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { LoadingSwitch } from "../components/loading-switch.tsx";
 import {
   Button,

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -3,7 +3,7 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { IconList, IconLayoutGrid, IconPlus } from "@tabler/icons-react";
+import { IconList, IconLayoutGrid, IconPlus } from "@vm0/ui/icons";
 import {
   Tabs,
   TabsList,

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -19,7 +19,7 @@ import {
   Switch,
   cn,
 } from "@vm0/ui";
-import { IconTrash } from "@tabler/icons-react";
+import { IconTrash } from "@vm0/ui/icons";
 import {
   type Tone,
   TONE_OPTIONS,

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -11,7 +11,7 @@ import {
   IconDatabaseExport,
   IconKey,
   IconChartBar,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   DropdownMenu,

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -9,7 +9,7 @@ import {
   IconPin,
   IconLoader2,
   IconCrown,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import {
   DndContext,
   closestCenter,

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -7,7 +7,7 @@ import {
   useLastLoadable,
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import { IconPlus, IconChevronRight, IconX } from "@tabler/icons-react";
+import { IconPlus, IconChevronRight, IconX } from "@vm0/ui/icons";
 import {
   Tooltip,
   TooltipContent,

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -21,7 +21,7 @@ import {
   IconFlask,
   IconSparkles,
   IconMenu2,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   Tooltip,

--- a/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
@@ -7,7 +7,7 @@ import {
   IconAlertCircle,
   IconCircleCheck,
   IconArrowLeft,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { Button } from "@vm0/ui";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
@@ -6,7 +6,7 @@ import {
   IconArrowLeft,
   IconCircleCheck,
   IconLoader2,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { Button, CopyButton } from "@vm0/ui";
 import { clerk$, resolveWebOrigin } from "../../signals/auth.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
@@ -17,7 +17,7 @@ import {
   IconPlus,
   IconRefresh,
   IconRobot,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import {
   type TelegramBot,
   type TelegramBotStatus,

--- a/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from "react-dom";
-import { IconPencil, IconLoader2 } from "@tabler/icons-react";
+import { IconPencil, IconLoader2 } from "@vm0/ui/icons";
 import { Button } from "@vm0/ui";
 
 interface ZeroUnsavedBarProps {

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -7,7 +7,7 @@ import {
   IconDotsVertical,
   IconDownload,
   IconSettings,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { Button } from "@vm0/ui";
 import {
   Popover,

--- a/turbo/apps/web/app/[locale]/models/[slug]/ModelDetailClient.tsx
+++ b/turbo/apps/web/app/[locale]/models/[slug]/ModelDetailClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { IconArrowRight } from "@tabler/icons-react";
+import { IconArrowRight } from "@vm0/ui/icons";
 import { useTranslations } from "next-intl";
 import { Link } from "../../../../navigation";
 import { Footer } from "../../../components/Footer";

--- a/turbo/apps/web/app/[locale]/use-cases/[slug]/UseCaseDetailClient.tsx
+++ b/turbo/apps/web/app/[locale]/use-cases/[slug]/UseCaseDetailClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import { IconArrowUpRight } from "@tabler/icons-react";
+import { IconArrowUpRight } from "@vm0/ui/icons";
 import { useTranslations } from "next-intl";
 import { Link } from "../../../../navigation";
 import { Footer } from "../../../components/Footer";

--- a/turbo/apps/web/app/cli-auth/success/page.tsx
+++ b/turbo/apps/web/app/cli-auth/success/page.tsx
@@ -2,7 +2,7 @@
 
 import { useTheme } from "../../components/ThemeProvider";
 import Image from "next/image";
-import { IconCheck } from "@tabler/icons-react";
+import { IconCheck } from "@vm0/ui/icons";
 
 export default function CliAuthSuccessPage(): React.JSX.Element {
   const { theme, toggleTheme } = useTheme();

--- a/turbo/apps/web/app/components/NavMenu.tsx
+++ b/turbo/apps/web/app/components/NavMenu.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import Image from "next/image";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
-import { IconArrowUpRight, IconChevronDown } from "@tabler/icons-react";
+import { IconArrowUpRight, IconChevronDown } from "@vm0/ui/icons";
 import { Link } from "../../navigation";
 
 export interface NavMenuItem {

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -10,7 +10,7 @@ import {
   IconArrowRight,
   IconArrowUpRight,
   IconChevronDown,
-} from "@tabler/icons-react";
+} from "@vm0/ui/icons";
 import { ThemeToggle } from "./ThemeToggle";
 import { LanguageSwitcher } from "./LanguageSwitcher";
 import { NavMenu, type NavMenuItem } from "./NavMenu";

--- a/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
+++ b/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
@@ -91,15 +91,14 @@ vi.mock("next/image", () => {
   };
 });
 
-// External: @tabler/icons-react (used by Navbar)
-vi.mock("@tabler/icons-react", () => {
+// External: @vm0/ui/icons (used by Navbar)
+vi.mock("@vm0/ui/icons", () => {
   const Icon = () => {
     return <span />;
   };
   return {
     IconArrowRight: Icon,
     IconArrowUpRight: Icon,
-    IconBrandGithub: Icon,
     IconChevronDown: Icon,
   };
 });

--- a/turbo/apps/web/app/connector/[status]/page.tsx
+++ b/turbo/apps/web/app/connector/[status]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useTheme } from "../../components/ThemeProvider";
 import Image from "next/image";
-import { IconCheck, IconX } from "@tabler/icons-react";
+import { IconCheck, IconX } from "@vm0/ui/icons";
 import { useSearchParams } from "next/navigation";
 import { use } from "react";
 

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -32,7 +32,6 @@
     "@sentry/nextjs": "^10.38.0",
     "@slack/web-api": "^7.13.0",
     "@t3-oss/env-nextjs": "^0.13.8",
-    "@tabler/icons-react": "^3.36.1",
     "@team-plain/typescript-sdk": "^5.12.1",
     "@ts-rest/core": "3.53.0-rc.1",
     "@ts-rest/serverless": "3.53.0-rc.1",

--- a/turbo/packages/ui/package.json
+++ b/turbo/packages/ui/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./components/ui/*": "./src/components/ui/*.tsx",
+    "./icons": "./src/icons.tsx",
     "./lib/utils": "./src/lib/utils.ts",
     "./styles/globals.css": "./src/styles/globals.css"
   },
@@ -46,7 +47,8 @@
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.2.8",
-    "@tabler/icons-react": "^3.31.0",
+    "@hugeicons/core-free-icons": "^4.1.2",
+    "@hugeicons/react": "^1.1.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "react": "^19.1.2",

--- a/turbo/packages/ui/src/components/ui/checkbox.tsx
+++ b/turbo/packages/ui/src/components/ui/checkbox.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
-import { IconCheck } from "@tabler/icons-react";
+import { IconCheck } from "@vm0/ui/icons";
 
 import { cn } from "../../lib/utils";
 

--- a/turbo/packages/ui/src/components/ui/copy-button.tsx
+++ b/turbo/packages/ui/src/components/ui/copy-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { IconCopy, IconCheck } from "@tabler/icons-react";
+import { IconCopy, IconCheck } from "@vm0/ui/icons";
 import { cn } from "../../lib/utils";
 import {
   Tooltip,

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { IconX } from "@tabler/icons-react";
+import { IconX } from "@vm0/ui/icons";
 
 import { cn } from "../../lib/utils";
 

--- a/turbo/packages/ui/src/components/ui/multi-select-combobox.tsx
+++ b/turbo/packages/ui/src/components/ui/multi-select-combobox.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import * as React from "react";
-import {
-  IconChevronDown,
-  IconCheck,
-  IconX,
-  IconSearch,
-} from "@tabler/icons-react";
+import { IconChevronDown, IconCheck, IconX, IconSearch } from "@vm0/ui/icons";
 
 import { cn } from "../../lib/utils";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";

--- a/turbo/packages/ui/src/components/ui/select.tsx
+++ b/turbo/packages/ui/src/components/ui/select.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
-import { IconCheck, IconChevronDown, IconChevronUp } from "@tabler/icons-react";
+import { IconCheck, IconChevronDown, IconChevronUp } from "@vm0/ui/icons";
 
 import { cn } from "../../lib/utils";
 

--- a/turbo/packages/ui/src/components/ui/sheet.tsx
+++ b/turbo/packages/ui/src/components/ui/sheet.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { IconX } from "@tabler/icons-react";
+import { IconX } from "@vm0/ui/icons";
 
 import { cn } from "../../lib/utils";
 

--- a/turbo/packages/ui/src/icons.tsx
+++ b/turbo/packages/ui/src/icons.tsx
@@ -1,0 +1,322 @@
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
+import {
+  AlarmClockIcon,
+  Alert01Icon,
+  AlertDiamondIcon,
+  ArrowDataTransferHorizontalIcon,
+  ArrowDown01Icon,
+  ArrowLeft01Icon,
+  ArrowLeft02Icon,
+  ArrowLeftDoubleIcon,
+  ArrowRight01Icon,
+  ArrowRight02Icon,
+  ArrowRightDoubleIcon,
+  ArrowTurnBackwardIcon,
+  ArrowUp01Icon,
+  ArrowUp02Icon,
+  ArrowUpDoubleIcon,
+  ArrowUpRight01Icon,
+  AttachmentIcon,
+  BluetoothIcon,
+  BubbleChatIcon,
+  Bug01Icon,
+  Building01Icon,
+  Calendar03Icon,
+  Cancel01Icon,
+  ChartBarLineIcon,
+  ChartLineData01Icon,
+  CheckmarkCircle01Icon,
+  CheckmarkCircle02Icon,
+  Chemistry01Icon,
+  CircleArrowDataTransferDiagonalIcon,
+  Clock01Icon,
+  Coins01Icon,
+  ComputerIcon,
+  ComputerTerminal01Icon,
+  Copy01Icon,
+  CpuIcon,
+  CreditCardIcon,
+  CrownIcon,
+  DatabaseExportIcon,
+  Delete02Icon,
+  DiceIcon,
+  Download01Icon,
+  File01Icon,
+  FileEditIcon,
+  FileMusicIcon,
+  FilterHorizontalIcon,
+  FilterIcon,
+  GiftIcon,
+  Globe02Icon,
+  GoogleDriveIcon,
+  GridIcon,
+  HandGripIcon,
+  Image01Icon,
+  InvoiceIcon,
+  Key01Icon,
+  KeyboardIcon,
+  LeftToRightListBulletIcon,
+  LeftToRightListNumberIcon,
+  Link01Icon,
+  LinkSquare01Icon,
+  Loading02Icon,
+  Loading03Icon,
+  LockIcon,
+  Logout01Icon,
+  MagicWand01Icon,
+  Mail01Icon,
+  Menu01Icon,
+  Mic01Icon,
+  Moon01Icon,
+  MoreHorizontalIcon,
+  MoreVerticalIcon,
+  Move01Icon,
+  PackageIcon,
+  PaintBoardIcon,
+  PencilEdit01Icon,
+  PencilEdit02Icon,
+  PinIcon,
+  PinOffIcon,
+  PlayIcon,
+  PlugSocketIcon,
+  PlusSignIcon,
+  QuoteUpIcon,
+  RecordIcon,
+  RefreshIcon,
+  ReloadIcon,
+  RepeatIcon,
+  RoboticIcon,
+  Search01Icon,
+  SecurityBlockIcon,
+  SecurityCheckIcon,
+  Settings01Icon,
+  Share01Icon,
+  Shield01Icon,
+  SidebarLeftIcon,
+  SlackIcon,
+  SourceCodeIcon,
+  SparklesIcon,
+  SquareArrowExpand01Icon,
+  StopIcon,
+  Sun01Icon,
+  TextBoldIcon,
+  TextItalicIcon,
+  TextNumberSignIcon,
+  TextStrikethroughIcon,
+  Tick02Icon,
+  ToolsIcon,
+  Upload01Icon,
+  UserAdd01Icon,
+  UserCircleIcon,
+  UserGroupIcon,
+  UserIcon,
+  VideoReplayIcon,
+  ViewIcon,
+  VolumeHighIcon,
+  Wifi01Icon,
+  ZoomInAreaIcon,
+  ZoomOutAreaIcon,
+} from "@hugeicons/core-free-icons";
+import { forwardRef, type SVGProps } from "react";
+
+type IconProps = Omit<SVGProps<SVGSVGElement>, "stroke" | "strokeWidth"> & {
+  size?: number | string;
+  strokeWidth?: number;
+  /** tabler-compat alias for strokeWidth */
+  stroke?: number;
+};
+
+function makeIcon(svg: IconSvgElement, displayName: string) {
+  const Component = forwardRef<SVGSVGElement, IconProps>(
+    ({ stroke, strokeWidth, size, ...rest }, ref) => {
+      return (
+        <HugeiconsIcon
+          ref={ref}
+          icon={svg}
+          size={size}
+          strokeWidth={strokeWidth ?? stroke}
+          {...rest}
+        />
+      );
+    },
+  );
+  Component.displayName = displayName;
+  return Component;
+}
+
+export const IconAdjustmentsHorizontal = makeIcon(
+  FilterHorizontalIcon,
+  "IconAdjustmentsHorizontal",
+);
+export const IconAlertCircle = makeIcon(Alert01Icon, "IconAlertCircle");
+export const IconAlertTriangle = makeIcon(
+  AlertDiamondIcon,
+  "IconAlertTriangle",
+);
+export const IconArrowBackUp = makeIcon(
+  ArrowTurnBackwardIcon,
+  "IconArrowBackUp",
+);
+export const IconArrowBarToUp = makeIcon(ArrowUpDoubleIcon, "IconArrowBarToUp");
+export const IconArrowLeft = makeIcon(ArrowLeft02Icon, "IconArrowLeft");
+export const IconArrowRight = makeIcon(ArrowRight02Icon, "IconArrowRight");
+export const IconArrowUp = makeIcon(ArrowUp02Icon, "IconArrowUp");
+export const IconArrowUpRight = makeIcon(
+  ArrowUpRight01Icon,
+  "IconArrowUpRight",
+);
+export const IconArrowsMove = makeIcon(Move01Icon, "IconArrowsMove");
+export const IconBan = makeIcon(Cancel01Icon, "IconBan");
+export const IconBlockquote = makeIcon(QuoteUpIcon, "IconBlockquote");
+export const IconBluetooth = makeIcon(BluetoothIcon, "IconBluetooth");
+export const IconBold = makeIcon(TextBoldIcon, "IconBold");
+export const IconBrandGoogleDrive = makeIcon(
+  GoogleDriveIcon,
+  "IconBrandGoogleDrive",
+);
+export const IconBrandSlack = makeIcon(SlackIcon, "IconBrandSlack");
+export const IconBug = makeIcon(Bug01Icon, "IconBug");
+export const IconBuilding = makeIcon(Building01Icon, "IconBuilding");
+export const IconCalendar = makeIcon(Calendar03Icon, "IconCalendar");
+export const IconChartBar = makeIcon(ChartBarLineIcon, "IconChartBar");
+export const IconChartLine = makeIcon(ChartLineData01Icon, "IconChartLine");
+export const IconCheck = makeIcon(Tick02Icon, "IconCheck");
+export const IconChevronDown = makeIcon(ArrowDown01Icon, "IconChevronDown");
+export const IconChevronLeft = makeIcon(ArrowLeft01Icon, "IconChevronLeft");
+export const IconChevronRight = makeIcon(ArrowRight01Icon, "IconChevronRight");
+export const IconChevronUp = makeIcon(ArrowUp01Icon, "IconChevronUp");
+export const IconChevronsLeft = makeIcon(
+  ArrowLeftDoubleIcon,
+  "IconChevronsLeft",
+);
+export const IconChevronsRight = makeIcon(
+  ArrowRightDoubleIcon,
+  "IconChevronsRight",
+);
+export const IconCircleCheck = makeIcon(
+  CheckmarkCircle01Icon,
+  "IconCircleCheck",
+);
+export const IconCircleCheckFilled = makeIcon(
+  CheckmarkCircle02Icon,
+  "IconCircleCheckFilled",
+);
+export const IconCircleDashed = makeIcon(
+  CircleArrowDataTransferDiagonalIcon,
+  "IconCircleDashed",
+);
+export const IconCircleDot = makeIcon(RecordIcon, "IconCircleDot");
+export const IconCircleX = makeIcon(Cancel01Icon, "IconCircleX");
+export const IconClock = makeIcon(Clock01Icon, "IconClock");
+export const IconClockExclamation = makeIcon(
+  AlarmClockIcon,
+  "IconClockExclamation",
+);
+export const IconCode = makeIcon(SourceCodeIcon, "IconCode");
+export const IconCoins = makeIcon(Coins01Icon, "IconCoins");
+export const IconCopy = makeIcon(Copy01Icon, "IconCopy");
+export const IconCpu = makeIcon(CpuIcon, "IconCpu");
+export const IconCreditCard = makeIcon(CreditCardIcon, "IconCreditCard");
+export const IconCrown = makeIcon(CrownIcon, "IconCrown");
+export const IconDatabaseExport = makeIcon(
+  DatabaseExportIcon,
+  "IconDatabaseExport",
+);
+export const IconDeviceDesktop = makeIcon(ComputerIcon, "IconDeviceDesktop");
+export const IconDice = makeIcon(DiceIcon, "IconDice");
+export const IconDots = makeIcon(MoreHorizontalIcon, "IconDots");
+export const IconDotsVertical = makeIcon(MoreVerticalIcon, "IconDotsVertical");
+export const IconDownload = makeIcon(Download01Icon, "IconDownload");
+export const IconEdit = makeIcon(PencilEdit01Icon, "IconEdit");
+export const IconExternalLink = makeIcon(LinkSquare01Icon, "IconExternalLink");
+export const IconEye = makeIcon(ViewIcon, "IconEye");
+export const IconFile = makeIcon(File01Icon, "IconFile");
+export const IconFileInvoice = makeIcon(InvoiceIcon, "IconFileInvoice");
+export const IconFileMusic = makeIcon(FileMusicIcon, "IconFileMusic");
+export const IconFileText = makeIcon(FileEditIcon, "IconFileText");
+export const IconFilter = makeIcon(FilterIcon, "IconFilter");
+export const IconFlask = makeIcon(Chemistry01Icon, "IconFlask");
+export const IconGift = makeIcon(GiftIcon, "IconGift");
+export const IconH1 = makeIcon(TextNumberSignIcon, "IconH1");
+export const IconH2 = makeIcon(TextNumberSignIcon, "IconH2");
+export const IconH3 = makeIcon(TextNumberSignIcon, "IconH3");
+export const IconHandStop = makeIcon(HandGripIcon, "IconHandStop");
+export const IconItalic = makeIcon(TextItalicIcon, "IconItalic");
+export const IconKey = makeIcon(Key01Icon, "IconKey");
+export const IconKeyboard = makeIcon(KeyboardIcon, "IconKeyboard");
+export const IconLayoutGrid = makeIcon(GridIcon, "IconLayoutGrid");
+export const IconLayoutSidebarLeftCollapse = makeIcon(
+  SidebarLeftIcon,
+  "IconLayoutSidebarLeftCollapse",
+);
+export const IconLink = makeIcon(Link01Icon, "IconLink");
+export const IconList = makeIcon(LeftToRightListBulletIcon, "IconList");
+export const IconListNumbers = makeIcon(
+  LeftToRightListNumberIcon,
+  "IconListNumbers",
+);
+export const IconLoader = makeIcon(Loading02Icon, "IconLoader");
+export const IconLoader2 = makeIcon(Loading03Icon, "IconLoader2");
+export const IconLock = makeIcon(LockIcon, "IconLock");
+export const IconLogout = makeIcon(Logout01Icon, "IconLogout");
+export const IconMail = makeIcon(Mail01Icon, "IconMail");
+export const IconMenu2 = makeIcon(Menu01Icon, "IconMenu2");
+export const IconMessageCircle = makeIcon(BubbleChatIcon, "IconMessageCircle");
+export const IconMicrophone = makeIcon(Mic01Icon, "IconMicrophone");
+export const IconMoon = makeIcon(Moon01Icon, "IconMoon");
+export const IconPackage = makeIcon(PackageIcon, "IconPackage");
+export const IconPalette = makeIcon(PaintBoardIcon, "IconPalette");
+export const IconPaperclip = makeIcon(AttachmentIcon, "IconPaperclip");
+export const IconPencil = makeIcon(PencilEdit02Icon, "IconPencil");
+export const IconPhoto = makeIcon(Image01Icon, "IconPhoto");
+export const IconPin = makeIcon(PinIcon, "IconPin");
+export const IconPinnedOff = makeIcon(PinOffIcon, "IconPinnedOff");
+export const IconPlayerPlay = makeIcon(PlayIcon, "IconPlayerPlay");
+export const IconPlayerStop = makeIcon(StopIcon, "IconPlayerStop");
+export const IconPlug = makeIcon(PlugSocketIcon, "IconPlug");
+export const IconPlugConnected = makeIcon(PlugSocketIcon, "IconPlugConnected");
+export const IconPlus = makeIcon(PlusSignIcon, "IconPlus");
+export const IconRefresh = makeIcon(RefreshIcon, "IconRefresh");
+export const IconRepeat = makeIcon(RepeatIcon, "IconRepeat");
+export const IconRobot = makeIcon(RoboticIcon, "IconRobot");
+export const IconRotateClockwise2 = makeIcon(
+  ReloadIcon,
+  "IconRotateClockwise2",
+);
+export const IconSearch = makeIcon(Search01Icon, "IconSearch");
+export const IconSettings = makeIcon(Settings01Icon, "IconSettings");
+export const IconShare2 = makeIcon(Share01Icon, "IconShare2");
+export const IconShield = makeIcon(Shield01Icon, "IconShield");
+export const IconShieldCheck = makeIcon(SecurityCheckIcon, "IconShieldCheck");
+export const IconShieldOff = makeIcon(SecurityBlockIcon, "IconShieldOff");
+export const IconSparkles = makeIcon(SparklesIcon, "IconSparkles");
+export const IconSquarePlus = makeIcon(
+  SquareArrowExpand01Icon,
+  "IconSquarePlus",
+);
+export const IconStrikethrough = makeIcon(
+  TextStrikethroughIcon,
+  "IconStrikethrough",
+);
+export const IconSun = makeIcon(Sun01Icon, "IconSun");
+export const IconSwitchHorizontal = makeIcon(
+  ArrowDataTransferHorizontalIcon,
+  "IconSwitchHorizontal",
+);
+export const IconTerminal = makeIcon(ComputerTerminal01Icon, "IconTerminal");
+export const IconTool = makeIcon(ToolsIcon, "IconTool");
+export const IconTrash = makeIcon(Delete02Icon, "IconTrash");
+export const IconUpload = makeIcon(Upload01Icon, "IconUpload");
+export const IconUser = makeIcon(UserIcon, "IconUser");
+export const IconUserCircle = makeIcon(UserCircleIcon, "IconUserCircle");
+export const IconUserPlus = makeIcon(UserAdd01Icon, "IconUserPlus");
+export const IconUsers = makeIcon(UserGroupIcon, "IconUsers");
+export const IconVideo = makeIcon(VideoReplayIcon, "IconVideo");
+export const IconVolume2 = makeIcon(VolumeHighIcon, "IconVolume2");
+export const IconWand = makeIcon(MagicWand01Icon, "IconWand");
+export const IconWifi = makeIcon(Wifi01Icon, "IconWifi");
+export const IconWorldWww = makeIcon(Globe02Icon, "IconWorldWww");
+export const IconX = makeIcon(Cancel01Icon, "IconX");
+export const IconZoomIn = makeIcon(ZoomInAreaIcon, "IconZoomIn");
+export const IconZoomOut = makeIcon(ZoomOutAreaIcon, "IconZoomOut");
+export const IconZoomReset = makeIcon(Search01Icon, "IconZoomReset");

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/api:
     dependencies:
@@ -218,7 +218,7 @@ importers:
         version: 8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/cli:
     dependencies:
@@ -297,7 +297,7 @@ importers:
         version: 6.24.1
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -328,9 +328,6 @@ importers:
       '@sentry/vite-plugin':
         specifier: ^4.9.0
         version: 4.9.1
-      '@tabler/icons-react':
-        specifier: ^3.36.1
-        version: 3.41.0(react@19.2.4)
       '@tiptap/core':
         specifier: 3.21.0
         version: 3.21.0(@tiptap/pm@3.21.0)
@@ -478,7 +475,7 @@ importers:
         version: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/web:
     dependencies:
@@ -524,9 +521,6 @@ importers:
       '@t3-oss/env-nextjs':
         specifier: ^0.13.8
         version: 0.13.11(typescript@5.9.3)(zod@4.3.6)
-      '@tabler/icons-react':
-        specifier: ^3.36.1
-        version: 3.41.0(react@19.2.4)
       '@team-plain/typescript-sdk':
         specifier: ^5.12.1
         version: 5.12.1
@@ -722,7 +716,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/api-contracts:
     dependencies:
@@ -762,7 +756,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/api-services:
     devDependencies:
@@ -786,7 +780,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/connectors:
     dependencies:
@@ -817,7 +811,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/core:
     dependencies:
@@ -851,7 +845,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/db:
     dependencies:
@@ -888,7 +882,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/eslint-config:
     devDependencies:
@@ -942,7 +936,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -953,6 +947,12 @@ importers:
 
   packages/ui:
     dependencies:
+      '@hugeicons/core-free-icons':
+        specifier: ^4.1.2
+        version: 4.1.2
+      '@hugeicons/react':
+        specifier: ^1.1.6
+        version: 1.1.6(react@19.2.4)
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -974,9 +974,6 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@tabler/icons-react':
-        specifier: ^3.31.0
-        version: 3.41.0(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1052,7 +1049,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -2004,6 +2001,14 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: '*'
+
+  '@hugeicons/core-free-icons@4.1.2':
+    resolution: {integrity: sha512-7PfGYaUyExpAMA8ZC7gfXykttrBDIUutU/yQHIBgz0L61ENSM73mqg/9hCTZemiEUVtj2raRRjhoJMGdAFwetQ==}
+
+  '@hugeicons/react@1.1.6':
+    resolution: {integrity: sha512-c2LhXJMAW5wN1pC/smBXG0YPqUON6ceR/ZdXHCjEI9KvB+hjtqYjmzIxok5hAQOeXGz0WtORgCQMzqewFKAZwg==}
+    peerDependencies:
+      react: '>=16.0.0'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -4773,14 +4778,6 @@ packages:
         optional: true
       zod:
         optional: true
-
-  '@tabler/icons-react@3.41.0':
-    resolution: {integrity: sha512-8XKc3wZKf1icxqwIPSOO61M+dtf8yJPwAE/rtFAVzc5Ros+OjCqowfcoI5IpKK09RSo8s0hHrWvydGgnXqYILg==}
-    peerDependencies:
-      react: '>= 16'
-
-  '@tabler/icons@3.41.0':
-    resolution: {integrity: sha512-arlig0nkaC9UGqTZuT1MMZepX29t3Ysx5HSy2UvmR+CZrhlNxZrCM6Z4qYBoaIO+2ICZykttjBCSpf+p/t0H3w==}
 
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
@@ -9069,6 +9066,7 @@ packages:
       '@vitest/ui': 4.1.5
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -10559,6 +10557,12 @@ snapshots:
   '@hono/vite-build@1.11.1(hono@4.12.16)':
     dependencies:
       hono: 4.12.16
+
+  '@hugeicons/core-free-icons@4.1.2': {}
+
+  '@hugeicons/react@1.1.6(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
 
   '@humanfs/core@0.19.1': {}
 
@@ -13278,13 +13282,6 @@ snapshots:
       typescript: 5.9.3
       zod: 4.3.6
 
-  '@tabler/icons-react@3.41.0(react@19.2.4)':
-    dependencies:
-      '@tabler/icons': 3.41.0
-      react: 19.2.4
-
-  '@tabler/icons@3.41.0': {}
-
   '@tailwindcss/node@4.2.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -13946,7 +13943,7 @@ snapshots:
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -13960,7 +13957,7 @@ snapshots:
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -13976,7 +13973,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -13994,7 +13991,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -14014,7 +14011,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       '@vitest/browser': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
 
@@ -14072,7 +14069,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -18293,7 +18290,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -18323,18 +18320,39 @@ snapshots:
       '@vitest/ui': 4.1.5(vitest@4.1.5)
       happy-dom: 20.9.0
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
+
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.3.0
+      '@vitest/browser-playwright': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/coverage-v8': 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
+      '@vitest/ui': 4.1.5(vitest@4.1.5)
+      happy-dom: 20.9.0
+    transitivePeerDependencies:
+      - msw
 
   vscode-languageserver-textdocument@1.0.12: {}
 


### PR DESCRIPTION
## Summary

Replace `@tabler/icons-react` with **Hugeicons** across the monorepo to give icons a rounder, slightly thicker weight (Ming felt the Tabler set read as too thin).

- New shim at `turbo/packages/ui/src/icons.tsx` exposes 122 `IconXxx` named components that wrap `@hugeicons/react`'s `<HugeiconsIcon>` and forward the Tabler-shaped `stroke` / `size` / `className` API. Only the import path needed to change at call sites.
- `@tabler/icons-react` removed from `apps/web`, `apps/platform`, and `packages/ui`.
- 86 files re-pointed from `@tabler/icons-react` to `@vm0/ui/icons`.
- One test mock (`navbar-blog.test.tsx`) updated to mock the new module path.

## Mapping highlights

A few notable mappings (Tabler → Hugeicons):
- `IconCheck` → `Tick02Icon`
- `IconX` / `IconCircleX` / `IconBan` → `Cancel01Icon`
- `IconChevronDown/Up/Left/Right` → `ArrowDown/Up/Left/Right01Icon`
- `IconArrowLeft/Right/Up` → `ArrowLeft/Right/Up02Icon`
- `IconSettings` → `Settings01Icon`
- `IconTrash` → `Delete02Icon`
- `IconEdit` → `PencilEdit01Icon`
- `IconExternalLink` → `LinkSquare01Icon`
- `IconBrandSlack` / `IconBrandGoogleDrive` → `SlackIcon` / `GoogleDriveIcon`

Some icons don't have a perfect 1:1 (`IconHandStop` → `HandGripIcon`, `IconCircleDashed` → `CircleArrowDataTransferDiagonalIcon`, `IconZoomReset` → `Search01Icon`). Please flag any that read wrong in the preview deploy and I'll swap them.

## Test plan

- [x] `pnpm -F @vm0/ui check-types`
- [x] `pnpm -F @vm0/app check-types`
- [x] `pnpm -F web check-types`
- [x] `pnpm -F @vm0/ui lint` / `pnpm -F @vm0/app lint` / `pnpm -F web lint`
- [x] `pnpm -F @vm0/ui test` (32 passing)
- [x] Targeted `pnpm exec vitest run` for every platform directory whose files were edited (~190 tests passing across `activity`, `conn`, `device-bb0`, `network-insights`, `preferences-page`, `pwa-install`, `schedule-page`, `zero-page/components/preferences`, `zero-page/components/org-manage`, root `__tests__`)
- [x] `pnpm knip` clean
- [ ] Visually inspect Vercel preview, flag any icons that look wrong
- [ ] Web vitest needs a Postgres globalSetup not available in the sandbox — CI will run it

🤖 Generated with [Claude Code](https://claude.com/claude-code)