### PR TITLE
fix: tolerate stale chat callbacks

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
@@ -14,6 +14,7 @@ import {
   getPushSubscriptionsByEndpoint,
   createSignedCallbackRequest,
   addTestRunToThread,
+  deleteTestChatThread,
   getTestChatMessagesByThread,
   insertTestAssistantEventMessages,
   insertOrgDefaultModelProvider,
@@ -275,6 +276,117 @@ describe("POST /api/internal/callbacks/chat", () => {
     );
 
     expect(response.status).toBe(400);
+  });
+
+  describe("Stale Thread Callbacks", () => {
+    it("should no-op completed callbacks after the chat thread is deleted", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread();
+      await deleteTestChatThread(threadId);
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "completed",
+            payload: { threadId, agentId },
+          },
+          secret,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      const chatMessages = await getTestChatMessagesByThread(threadId);
+      expect(chatMessages).toHaveLength(0);
+      expect(context.mocks.axiom.queryAxiom).not.toHaveBeenCalled();
+      expect(mockAblyPublish).not.toHaveBeenCalledWith(
+        expect.stringMatching(/^chatThread/),
+        null,
+      );
+    });
+
+    it("should no-op failed callbacks after the chat thread is deleted", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread({
+        status: "failed",
+      });
+      await deleteTestChatThread(threadId);
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "failed",
+            error: "boom",
+            payload: { threadId, agentId },
+          },
+          secret,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      const chatMessages = await getTestChatMessagesByThread(threadId);
+      expect(chatMessages).toHaveLength(0);
+      expect(mockAblyPublish).not.toHaveBeenCalledWith(
+        expect.stringMatching(/^chatThread/),
+        null,
+      );
+    });
+
+    it("should use the run's chat thread when callback payload thread is stale", async () => {
+      const { threadId, runId, secret } = await setupRunAndThread();
+      const staleThreadId = "00000000-0000-0000-0000-000000000001";
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        {
+          sequenceNumber: 0,
+          eventData: {
+            message: {
+              content: [{ type: "text", text: "Authoritative thread reply" }],
+            },
+          },
+        },
+      ]);
+
+      const response = await POST(
+        createSignedCallbackRequest(
+          "http://localhost/api/internal/callbacks/chat",
+          {
+            runId,
+            status: "completed",
+            payload: { threadId: staleThreadId, agentId },
+          },
+          secret,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+
+      const messages = await getTestChatMessagesByThread(threadId);
+      const assistant = messages.find((m) => {
+        return m.role === "assistant" && m.sequenceNumber !== null;
+      });
+      expect(assistant).toBeDefined();
+      expect(assistant!.content).toBe("Authoritative thread reply");
+
+      expect(mockAblyPublish).toHaveBeenCalledWith(
+        `chatThreadMessageCreated:${threadId}`,
+        null,
+      );
+      expect(mockAblyPublish).toHaveBeenCalledWith(
+        `chatThreadRunUpdated:${threadId}`,
+        null,
+      );
+      expect(mockAblyPublish).not.toHaveBeenCalledWith(
+        `chatThreadRunUpdated:${staleThreadId}`,
+        null,
+      );
+    });
   });
 
   describe("Chat Persistence", () => {

--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -10,6 +10,7 @@ import {
   insertAssistantEventMessages,
   publishChatThreadRunUpdated,
   getLatestMessagesByThreadId,
+  getChatThreadIdForRun,
   PREVIOUS_CONTEXT_MESSAGES,
 } from "../../../../../src/lib/zero/chat-thread/chat-message-service";
 import { autoSendPendingMessageOnRunComplete } from "../../../../../src/lib/zero/chat-thread/auto-send-pending-message";
@@ -388,10 +389,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ success: true });
   }
 
-  // Fetch the run record for userId, prompt, error
+  // Fetch the run record for prompt and terminal error details.
   const [run] = await globalThis.services.db
     .select({
-      userId: agentRuns.userId,
       prompt: agentRuns.prompt,
       error: agentRuns.error,
     })
@@ -403,15 +403,38 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ success: true });
   }
 
+  const chatThread = await getChatThreadIdForRun(runId);
+  if (!chatThread) {
+    log.info("Skipping terminal chat callback for missing chat thread", {
+      runId,
+      status,
+      payloadThreadId: payload.threadId,
+    });
+    return NextResponse.json({ success: true });
+  }
+
+  if (chatThread.chatThreadId !== payload.threadId) {
+    log.warn("Chat callback payload thread does not match run mapping", {
+      runId,
+      payloadThreadId: payload.threadId,
+      chatThreadId: chatThread.chatThreadId,
+    });
+  }
+
   if (status === "completed") {
-    await handleCompleted(runId, run.prompt, payload.threadId, run.userId);
+    await handleCompleted(
+      runId,
+      run.prompt,
+      chatThread.chatThreadId,
+      chatThread.userId,
+    );
   } else if (status === "failed") {
     const errorMessage = error ?? run.error ?? "Run failed";
     await handleFailed(
       runId,
       run.prompt,
-      payload.threadId,
-      run.userId,
+      chatThread.chatThreadId,
+      chatThread.userId,
       errorMessage,
     );
   }

--- a/turbo/apps/web/src/__tests__/api-test-helpers/agents.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/agents.ts
@@ -30,6 +30,7 @@ export {
   createTestAgentSession,
   createTestSessionWithConversation,
   insertTestChatThread,
+  deleteTestChatThread,
   insertTestChatMessage,
   getTestChatMessagesByThread,
   addTestRunToThread,

--- a/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
@@ -55,6 +55,7 @@ export {
   createTestAgentSession,
   createTestSessionWithConversation,
   insertTestChatThread,
+  deleteTestChatThread,
   insertTestChatMessage,
   getTestChatMessagesByThread,
   addTestRunToThread,

--- a/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/agents.ts
@@ -578,6 +578,19 @@ export async function insertTestChatThread(
   return threadId;
 }
 
+/**
+ * Delete a chat thread directly in the database.
+ *
+ * @why-db-direct Tests need to model stale callbacks arriving after the
+ * user-facing thread row has already been deleted.
+ */
+export async function deleteTestChatThread(threadId: string): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .delete(chatThreads)
+    .where(eq(chatThreads.id, threadId));
+}
+
 // ---------------------------------------------------------------------------
 // Chat message seeders (service wrappers for test data setup)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Resolve chat callbacks through the authoritative `zero_runs` to `chat_threads` mapping before terminal side effects.
- Treat callbacks for deleted/missing chat threads as stale success/no-ops instead of inserting into `chat_messages` with a missing FK.
- Add regression coverage for completed/failed callbacks after thread deletion and stale payload thread IDs.

Closes #12114

## Tests

- `pnpm -C turbo -F web exec vitest run 'app/api/internal/callbacks/chat/__tests__/route.test.ts'`
- `pnpm -C turbo -F web lint`
- `pnpm -C turbo -F web check-types`
- pre-commit: prettier, knip, repo `pnpm check-types`
