### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -110,12 +110,12 @@ ROOTFS_DIR=""
 CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
-GO_VERSION="1.26.2"
-CLAUDE_CODE_VERSION="2.1.132"
-CODEX_CLI_VERSION="0.128.0"
+GO_VERSION="1.26.3"
+CLAUDE_CODE_VERSION="2.1.133"
+CODEX_CLI_VERSION="0.129.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
-AGENT_BROWSER_VERSION="0.26.0"
+AGENT_BROWSER_VERSION="0.27.0"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

Update pinned tool versions in `crates/runner/scripts/build-template.sh`.

| Package | Old | New |
|---|---|---|
| Go | 1.26.2 | 1.26.3 |
| Claude Code | 2.1.132 | 2.1.133 |
| Codex CLI | 0.128.0 | 0.129.0 |
| agent-browser | 0.26.0 | 0.27.0 |

`GWS_CLI_VERSION` (0.22.5) and `XURL_VERSION` (1.0.3) are already at the latest published version — no change.

## Test plan

- [ ] CI green (template build picks up new versions and rebuilds rootfs)