### PR TITLE
fix(vsock-guest): avoid env argv blowup

### DIFF
--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -4,19 +4,18 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, SystemTime};
 
-use std::os::fd::AsRawFd;
-use std::os::unix::ffi::OsStrExt;
+use std::os::fd::{AsRawFd, RawFd};
 use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 
 /// Maximum length for command preview in logs
 const COMMAND_PREVIEW_MAX_LEN: usize = 100;
 #[cfg(not(debug_assertions))]
 const SANDBOX_USER: &str = "user";
-const SANDBOX_UID: libc::uid_t = 1000;
 const SANDBOX_GID: libc::gid_t = 1000;
 const ENV_SCRIPT_PREFIX: &str = "vm0-env-";
 const ENV_SCRIPT_SUFFIX: &str = ".sh";
 const ENV_SCRIPT_STALE_AFTER: Duration = Duration::from_secs(60 * 60);
+const CHOWN_UNCHANGED_UID: libc::uid_t = !0;
 
 fn get_exec_user() -> Option<&'static str> {
     #[cfg(debug_assertions)]
@@ -252,7 +251,7 @@ fn build_env_script_content(
     script.push_str("script_path=");
     script.push_str(&shell_escape_value(script_path));
     script.push('\n');
-    script.push_str("rm -f -- \"$script_path\"\n");
+    script.push_str("rm -f -- \"$script_path\" 2>/dev/null || true\n");
     script.push_str("rmdir -- \"$script_dir\" 2>/dev/null || true\n");
     for (key, value) in env {
         script.push_str("export ");
@@ -328,14 +327,10 @@ fn ensure_env_script_dir(dir: &Path) -> io::Result<()> {
     Ok(())
 }
 
-fn chown_path(path: &Path, uid: libc::uid_t, gid: libc::gid_t) -> io::Result<()> {
-    let path = std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "env script path must not contain NUL bytes",
-        )
-    })?;
-    let ret = unsafe { libc::chown(path.as_ptr(), uid, gid) };
+fn fchown_group(fd: RawFd, gid: libc::gid_t) -> io::Result<()> {
+    // SAFETY: `fd` comes from an open file/directory descriptor and `-1`
+    // as uid asks fchown to leave the owner unchanged.
+    let ret = unsafe { libc::fchown(fd, CHOWN_UNCHANGED_UID, gid) };
     if ret != 0 {
         return Err(io::Error::last_os_error());
     }
@@ -443,14 +438,19 @@ fn create_env_script_in_dir(
         let result = (|| -> io::Result<()> {
             file.write_all(script.as_bytes())?;
             if effective_uid() == 0 && !sudo && get_exec_user().is_some() {
-                file.set_permissions(fs::Permissions::from_mode(0o000))?;
-                chown_path(&script_dir, SANDBOX_UID, SANDBOX_GID)?;
-                let ret = unsafe { libc::fchown(file.as_raw_fd(), SANDBOX_UID, SANDBOX_GID) };
-                if ret != 0 {
-                    return Err(io::Error::last_os_error());
-                }
+                // Keep the per-run directory and script root-owned. The
+                // sandbox user only gets group read/traverse access; if it
+                // owned either path, an existing same-UID process could
+                // chmod/replace run.sh after the path appears in argv but
+                // before bash opens it.
+                let script_dir_file = File::open(&script_dir)?;
+                fchown_group(file.as_raw_fd(), SANDBOX_GID)?;
+                file.set_permissions(fs::Permissions::from_mode(0o440))?;
+                fchown_group(script_dir_file.as_raw_fd(), SANDBOX_GID)?;
+                fs::set_permissions(&script_dir, fs::Permissions::from_mode(0o710))?;
+            } else {
+                file.set_permissions(fs::Permissions::from_mode(0o400))?;
             }
-            file.set_permissions(fs::Permissions::from_mode(0o400))?;
             Ok(())
         })();
 
@@ -626,7 +626,8 @@ mod tests {
         assert!(rm_pos < export_pos);
         assert!(script.contains("script_dir='/run/vm0-exec/vm0-env-test'"));
         assert!(script.contains("script_path='/run/vm0-exec/vm0-env-test/run.sh'"));
-        assert!(script.contains("rmdir -- \"$script_dir\""));
+        assert!(script.contains("rm -f -- \"$script_path\" 2>/dev/null || true"));
+        assert!(script.contains("rmdir -- \"$script_dir\" 2>/dev/null || true"));
         assert!(script.contains("export FOO='it'\\''s a \"test\"'"));
         assert!(script.contains("exec /bin/bash -c 'echo \"$FOO\"'"));
     }

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -391,11 +391,21 @@ fn create_env_script_in_dir(
             Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
             Err(e) => return Err(e),
         }
-        fs::set_permissions(&script_dir, fs::Permissions::from_mode(0o700))?;
 
         let path = script_dir.join(format!("run{ENV_SCRIPT_SUFFIX}"));
-        let script = build_env_script_content(&script_dir, &path, command, env)?;
         let mut guard = EnvScriptGuard::new(path.clone(), script_dir.clone());
+        if let Err(e) = fs::set_permissions(&script_dir, fs::Permissions::from_mode(0o700)) {
+            guard.cleanup();
+            return Err(e);
+        }
+
+        let script = match build_env_script_content(&script_dir, &path, command, env) {
+            Ok(script) => script,
+            Err(e) => {
+                guard.cleanup();
+                return Err(e);
+            }
+        };
 
         let mut options = OpenOptions::new();
         options
@@ -405,8 +415,14 @@ fn create_env_script_in_dir(
             .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
         let mut file = match options.open(&path) {
             Ok(file) => file,
-            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
-            Err(e) => return Err(e),
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                guard.cleanup();
+                continue;
+            }
+            Err(e) => {
+                guard.cleanup();
+                return Err(e);
+            }
         };
 
         let result = (|| -> io::Result<()> {
@@ -638,6 +654,25 @@ mod tests {
         );
         assert!(!err.to_string().contains("before"));
         assert!(!err.to_string().contains("after"));
+    }
+
+    #[test]
+    fn create_env_script_cleans_dir_on_script_build_failure() {
+        let (dir, _guard) = temp_dir("build-failure-cleanup");
+        let err = match create_env_script_in_dir(&dir, "echo hi", &[("BAD;KEY", "x")], true) {
+            Ok(_) => panic!("invalid env key unexpectedly created an env script"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        let entries = std::fs::read_dir(&dir)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(
+            entries.is_empty(),
+            "env script entries leaked after build failure: {entries:?}"
+        );
     }
 
     #[test]

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -1,7 +1,9 @@
+use std::ffi::{CStr, CString};
 use std::fs::{self, DirBuilder, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::OnceLock;
 use std::time::{Duration, SystemTime};
 
 use std::os::fd::{AsRawFd, RawFd};
@@ -9,13 +11,13 @@ use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsE
 
 /// Maximum length for command preview in logs
 const COMMAND_PREVIEW_MAX_LEN: usize = 100;
-#[cfg(not(debug_assertions))]
 const SANDBOX_USER: &str = "user";
-const SANDBOX_GID: libc::gid_t = 1000;
 const ENV_SCRIPT_PREFIX: &str = "vm0-env-";
 const ENV_SCRIPT_SUFFIX: &str = ".sh";
 const ENV_SCRIPT_STALE_AFTER: Duration = Duration::from_secs(60 * 60);
 const CHOWN_UNCHANGED_UID: libc::uid_t = !0;
+const PASSWD_BUFFER_MAX_LEN: usize = 1024 * 1024;
+static SANDBOX_USER_GID: OnceLock<libc::gid_t> = OnceLock::new();
 
 fn get_exec_user() -> Option<&'static str> {
     #[cfg(debug_assertions)]
@@ -327,6 +329,70 @@ fn ensure_env_script_dir(dir: &Path) -> io::Result<()> {
     Ok(())
 }
 
+fn initial_passwd_buffer_len() -> usize {
+    // SAFETY: sysconf is read-only for this process setting.
+    let len = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
+    if len > 0 {
+        (len as usize).min(PASSWD_BUFFER_MAX_LEN)
+    } else {
+        16 * 1024
+    }
+}
+
+fn lookup_user_gid_cstr(user: &CStr) -> io::Result<libc::gid_t> {
+    let mut buffer = vec![0_u8; initial_passwd_buffer_len()];
+    loop {
+        // SAFETY: zero is a valid initial state for passwd before getpwnam_r
+        // fills it with pointers into `buffer`.
+        let mut passwd: libc::passwd = unsafe { std::mem::zeroed() };
+        let mut result: *mut libc::passwd = std::ptr::null_mut();
+        // SAFETY: all pointers are valid for the duration of the call, and
+        // `buffer` is writable with the length supplied to getpwnam_r.
+        let ret = unsafe {
+            libc::getpwnam_r(
+                user.as_ptr(),
+                &mut passwd,
+                buffer.as_mut_ptr().cast(),
+                buffer.len(),
+                &mut result,
+            )
+        };
+        if ret == 0 {
+            if result.is_null() {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("sandbox user not found: {}", user.to_string_lossy()),
+                ));
+            }
+            return Ok(passwd.pw_gid);
+        }
+        if ret == libc::ERANGE && buffer.len() < PASSWD_BUFFER_MAX_LEN {
+            buffer.resize((buffer.len() * 2).min(PASSWD_BUFFER_MAX_LEN), 0);
+            continue;
+        }
+        return Err(io::Error::from_raw_os_error(ret));
+    }
+}
+
+fn lookup_user_gid(user: &str) -> io::Result<libc::gid_t> {
+    let user = CString::new(user).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "sandbox user name must not contain NUL bytes",
+        )
+    })?;
+    lookup_user_gid_cstr(&user)
+}
+
+fn sandbox_user_gid() -> io::Result<libc::gid_t> {
+    if let Some(gid) = SANDBOX_USER_GID.get() {
+        return Ok(*gid);
+    }
+    let gid = lookup_user_gid(SANDBOX_USER)?;
+    let _ = SANDBOX_USER_GID.set(gid);
+    Ok(*SANDBOX_USER_GID.get().unwrap_or(&gid))
+}
+
 fn fchown_group(fd: RawFd, gid: libc::gid_t) -> io::Result<()> {
     // SAFETY: `fd` comes from an open file/directory descriptor and `-1`
     // as uid asks fchown to leave the owner unchanged.
@@ -443,10 +509,11 @@ fn create_env_script_in_dir(
                 // owned either path, an existing same-UID process could
                 // chmod/replace run.sh after the path appears in argv but
                 // before bash opens it.
+                let sandbox_gid = sandbox_user_gid()?;
                 let script_dir_file = File::open(&script_dir)?;
-                fchown_group(file.as_raw_fd(), SANDBOX_GID)?;
+                fchown_group(file.as_raw_fd(), sandbox_gid)?;
                 file.set_permissions(fs::Permissions::from_mode(0o440))?;
-                fchown_group(script_dir_file.as_raw_fd(), SANDBOX_GID)?;
+                fchown_group(script_dir_file.as_raw_fd(), sandbox_gid)?;
                 fs::set_permissions(&script_dir, fs::Permissions::from_mode(0o710))?;
             } else {
                 file.set_permissions(fs::Permissions::from_mode(0o400))?;
@@ -596,6 +663,23 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let guard = TempDirGuard(dir.clone());
         (dir, guard)
+    }
+
+    #[test]
+    fn lookup_user_gid_reads_system_group() {
+        let root = std::ffi::CString::new("root").unwrap();
+
+        assert_eq!(lookup_user_gid_cstr(&root).unwrap(), 0);
+    }
+
+    #[test]
+    fn lookup_user_gid_reports_missing_user() {
+        let user =
+            std::ffi::CString::new(format!("vm0-missing-user-{}", std::process::id())).unwrap();
+
+        let err = lookup_user_gid_cstr(&user).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
     }
 
     #[test]

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -782,6 +782,30 @@ mod tests {
     }
 
     #[test]
+    fn env_script_dir_rejects_existing_file() {
+        let (base, _guard) = temp_dir("dir-file");
+        let path = base.join("vm0-exec");
+        std::fs::write(&path, "not a directory").unwrap();
+
+        let err = ensure_env_script_dir(&path).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        assert!(path.is_file());
+    }
+
+    #[test]
+    fn env_script_dir_rejects_group_or_world_writable_directory() {
+        let (base, _guard) = temp_dir("dir-mode");
+        let dir = base.join("vm0-exec");
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        let err = ensure_env_script_dir(&dir).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
     fn stale_env_script_cleanup_only_removes_matching_entries() {
         let (dir, _guard) = temp_dir("stale");
         let stale = dir.join(format!("{ENV_SCRIPT_PREFIX}stale{ENV_SCRIPT_SUFFIX}"));
@@ -795,6 +819,21 @@ mod tests {
         assert_eq!(removed, 1);
         assert!(!stale.exists());
         assert!(other.exists());
+    }
+
+    #[test]
+    fn stale_env_script_cleanup_preserves_recent_directories() {
+        let (dir, _guard) = temp_dir("recent-dir");
+        let active = dir.join(format!("{ENV_SCRIPT_PREFIX}active"));
+        std::fs::create_dir(&active).unwrap();
+        std::fs::write(active.join("run.sh"), "secret").unwrap();
+
+        let removed =
+            cleanup_stale_env_scripts_in(&dir, SystemTime::now(), Duration::from_secs(60 * 60))
+                .unwrap();
+
+        assert_eq!(removed, 0);
+        assert!(active.exists());
     }
 
     #[test]

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -262,39 +262,49 @@ fn random_hex(bytes: usize) -> io::Result<String> {
     Ok(out)
 }
 
+fn validate_env_script_dir(dir: &Path, euid: libc::uid_t) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(dir)?;
+    if !metadata.file_type().is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("env script path is not a directory: {}", dir.display()),
+        ));
+    }
+    let expected_owner = if euid == 0 { 0 } else { euid };
+    if metadata.uid() != expected_owner {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "env script directory has unexpected owner: {}",
+                dir.display()
+            ),
+        ));
+    }
+    if metadata.permissions().mode() & 0o022 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "env script directory is writable by group/other: {}",
+                dir.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
 fn ensure_env_script_dir(dir: &Path) -> io::Result<()> {
     let euid = effective_uid();
     let mode = if euid == 0 { 0o711 } else { 0o700 };
-    match fs::symlink_metadata(dir) {
-        Ok(metadata) => {
-            if !metadata.file_type().is_dir() {
-                return Err(io::Error::new(
-                    io::ErrorKind::AlreadyExists,
-                    format!("env script path is not a directory: {}", dir.display()),
-                ));
-            }
-            let expected_owner = if euid == 0 { 0 } else { euid };
-            if metadata.uid() != expected_owner {
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    format!(
-                        "env script directory has unexpected owner: {}",
-                        dir.display()
-                    ),
-                ));
-            }
-            if metadata.permissions().mode() & 0o022 != 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    format!(
-                        "env script directory is writable by group/other: {}",
-                        dir.display()
-                    ),
-                ));
-            }
-        }
+    match validate_env_script_dir(dir, euid) {
+        Ok(()) => {}
         Err(e) if e.kind() == io::ErrorKind::NotFound => {
-            DirBuilder::new().mode(mode).create(dir)?;
+            match DirBuilder::new().mode(mode).create(dir) {
+                Ok(()) => {}
+                Err(create_err) if create_err.kind() == io::ErrorKind::AlreadyExists => {
+                    validate_env_script_dir(dir, euid)?;
+                }
+                Err(create_err) => return Err(create_err),
+            }
         }
         Err(e) => return Err(e),
     }
@@ -519,6 +529,7 @@ pub(crate) fn spawn_with_pipes(
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use std::sync::{Arc, Barrier};
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use crate::wait::{WaitOutcome, wait_with_kill_timeout};
@@ -710,6 +721,29 @@ mod tests {
 
         assert!(!path.exists());
         assert!(!script_dir.exists());
+    }
+
+    #[test]
+    fn env_script_dir_creation_tolerates_concurrent_first_use() {
+        let (base, _guard) = temp_dir("dir-race");
+        let dir = base.join("vm0-exec");
+        let thread_count = 8;
+        let barrier = Arc::new(Barrier::new(thread_count));
+        let handles = (0..thread_count)
+            .map(|_| {
+                let dir = dir.clone();
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    ensure_env_script_dir(&dir)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            handle.join().unwrap().unwrap();
+        }
+        assert!(dir.is_dir());
     }
 
     #[test]

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -1,8 +1,22 @@
-use std::io;
+use std::fs::{self, DirBuilder, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::time::{Duration, SystemTime};
+
+use std::os::fd::AsRawFd;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 
 /// Maximum length for command preview in logs
 const COMMAND_PREVIEW_MAX_LEN: usize = 100;
+#[cfg(not(debug_assertions))]
+const SANDBOX_USER: &str = "user";
+const SANDBOX_UID: libc::uid_t = 1000;
+const SANDBOX_GID: libc::gid_t = 1000;
+const ENV_SCRIPT_PREFIX: &str = "vm0-env-";
+const ENV_SCRIPT_SUFFIX: &str = ".sh";
+const ENV_SCRIPT_STALE_AFTER: Duration = Duration::from_secs(60 * 60);
 
 fn get_exec_user() -> Option<&'static str> {
     #[cfg(debug_assertions)]
@@ -13,36 +27,13 @@ fn get_exec_user() -> Option<&'static str> {
     #[cfg(not(debug_assertions))]
     {
         // Default user for command execution (UID 1000, matching E2B sandbox)
-        Some("user")
+        Some(SANDBOX_USER)
     }
 }
 
 /// Shell-escape a value by wrapping in single quotes and escaping embedded `'`.
 fn shell_escape_value(val: &str) -> String {
     format!("'{}'", val.replace('\'', "'\\''"))
-}
-
-/// Prepend environment variable exports to a command string.
-///
-/// Returns the command unchanged when `env` is empty. Otherwise produces
-/// `export KEY='value' KEY2='value2'; command` so the variables are
-/// available for shell expansion in the command.
-pub(crate) fn prepend_env(command: &str, env: &[(&str, &str)]) -> String {
-    if env.is_empty() {
-        return command.to_string();
-    }
-    let mut parts = String::from("export ");
-    for (i, (key, val)) in env.iter().enumerate() {
-        if i > 0 {
-            parts.push(' ');
-        }
-        parts.push_str(key);
-        parts.push('=');
-        parts.push_str(&shell_escape_value(val));
-    }
-    parts.push_str("; ");
-    parts.push_str(command);
-    parts
 }
 
 /// Build a Command to execute a shell command as the appropriate user.
@@ -82,6 +73,379 @@ pub(crate) fn build_exec_command(command: &str, sudo: bool) -> Command {
     }
 }
 
+pub(crate) struct EnvScriptGuard {
+    path: Option<PathBuf>,
+    dir: Option<PathBuf>,
+}
+
+impl EnvScriptGuard {
+    fn new(path: PathBuf, dir: PathBuf) -> Self {
+        Self {
+            path: Some(path),
+            dir: Some(dir),
+        }
+    }
+
+    pub(crate) fn path(&self) -> Option<&Path> {
+        self.path.as_deref()
+    }
+
+    pub(crate) fn cleanup(&mut self) {
+        if let Some(path) = self.path.take() {
+            let _ = fs::remove_file(path);
+        }
+        if let Some(dir) = self.dir.take() {
+            let _ = fs::remove_dir(dir);
+        }
+    }
+}
+
+impl Drop for EnvScriptGuard {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}
+
+pub(crate) struct PreparedExecCommand {
+    pub(crate) command: Command,
+    pub(crate) env_script: Option<EnvScriptGuard>,
+}
+
+pub(crate) struct SpawnedCommand {
+    pub(crate) child: Child,
+    pub(crate) env_script: Option<EnvScriptGuard>,
+}
+
+fn effective_uid() -> libc::uid_t {
+    // SAFETY: `geteuid` is a simple libc getter with no preconditions.
+    unsafe { libc::geteuid() }
+}
+
+fn default_env_script_dir() -> PathBuf {
+    if effective_uid() == 0 {
+        PathBuf::from("/run/vm0-exec")
+    } else if Path::new("/dev/shm").is_dir() {
+        PathBuf::from("/dev/shm/vm0-exec")
+    } else {
+        std::env::temp_dir().join("vm0-exec")
+    }
+}
+
+fn format_env_key_for_log(key: &str) -> String {
+    truncate_preview(&key.escape_debug().to_string())
+}
+
+pub(crate) fn format_env_diagnostics(command: &str, env: &[(&str, &str)]) -> String {
+    let env_bytes: usize = env.iter().map(|(key, value)| key.len() + value.len()).sum();
+    let mut largest: Vec<(&str, usize)> =
+        env.iter().map(|(key, value)| (*key, value.len())).collect();
+    largest.sort_by(|(left_key, left_len), (right_key, right_len)| {
+        right_len
+            .cmp(left_len)
+            .then_with(|| left_key.cmp(right_key))
+    });
+    let largest = largest
+        .into_iter()
+        .take(5)
+        .map(|(key, len)| format!("{}:{len}", format_env_key_for_log(key)))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    format!(
+        "command_bytes={}, env_count={}, env_bytes={}, largest_env=[{}]",
+        command.len(),
+        env.len(),
+        env_bytes,
+        largest,
+    )
+}
+
+fn is_shell_identifier(key: &str) -> bool {
+    let mut chars = key.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
+fn validate_env_keys(env: &[(&str, &str)]) -> io::Result<()> {
+    for (key, _) in env {
+        if !is_shell_identifier(key) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "invalid environment variable name: {}",
+                    format_env_key_for_log(key)
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn build_env_script_content(
+    script_dir: &Path,
+    script_path: &Path,
+    command: &str,
+    env: &[(&str, &str)],
+) -> io::Result<String> {
+    validate_env_keys(env)?;
+    let script_dir = script_dir.to_str().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "env script directory path must be valid UTF-8",
+        )
+    })?;
+    let script_path = script_path.to_str().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "env script path must be valid UTF-8",
+        )
+    })?;
+
+    let mut script = String::new();
+    script.push_str("#!/bin/bash\n");
+    script.push_str("set +e\n");
+    script.push_str("script_dir=");
+    script.push_str(&shell_escape_value(script_dir));
+    script.push('\n');
+    script.push_str("script_path=");
+    script.push_str(&shell_escape_value(script_path));
+    script.push('\n');
+    script.push_str("rm -f -- \"$script_path\"\n");
+    script.push_str("rmdir -- \"$script_dir\" 2>/dev/null || true\n");
+    for (key, value) in env {
+        script.push_str("export ");
+        script.push_str(key);
+        script.push('=');
+        script.push_str(&shell_escape_value(value));
+        script.push('\n');
+    }
+    script.push_str("exec /bin/bash -c ");
+    script.push_str(&shell_escape_value(command));
+    script.push('\n');
+    Ok(script)
+}
+
+fn random_hex(bytes: usize) -> io::Result<String> {
+    let mut raw = vec![0_u8; bytes];
+    File::open("/dev/urandom")?.read_exact(&mut raw)?;
+    let mut out = String::with_capacity(bytes * 2);
+    for byte in raw {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    Ok(out)
+}
+
+fn ensure_env_script_dir(dir: &Path) -> io::Result<()> {
+    let euid = effective_uid();
+    let mode = if euid == 0 { 0o711 } else { 0o700 };
+    match fs::symlink_metadata(dir) {
+        Ok(metadata) => {
+            if !metadata.file_type().is_dir() {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    format!("env script path is not a directory: {}", dir.display()),
+                ));
+            }
+            let expected_owner = if euid == 0 { 0 } else { euid };
+            if metadata.uid() != expected_owner {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!(
+                        "env script directory has unexpected owner: {}",
+                        dir.display()
+                    ),
+                ));
+            }
+            if metadata.permissions().mode() & 0o022 != 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!(
+                        "env script directory is writable by group/other: {}",
+                        dir.display()
+                    ),
+                ));
+            }
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            DirBuilder::new().mode(mode).create(dir)?;
+        }
+        Err(e) => return Err(e),
+    }
+
+    fs::set_permissions(dir, fs::Permissions::from_mode(mode))?;
+    Ok(())
+}
+
+fn chown_path(path: &Path, uid: libc::uid_t, gid: libc::gid_t) -> io::Result<()> {
+    let path = std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "env script path must not contain NUL bytes",
+        )
+    })?;
+    let ret = unsafe { libc::chown(path.as_ptr(), uid, gid) };
+    if ret != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn cleanup_stale_env_scripts_in(
+    dir: &Path,
+    now: SystemTime,
+    stale_after: Duration,
+) -> io::Result<usize> {
+    let mut removed = 0;
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Ok(0);
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with(ENV_SCRIPT_PREFIX) {
+            continue;
+        }
+        let path = entry.path();
+        let Ok(metadata) = fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if !metadata.file_type().is_dir() && !name.ends_with(ENV_SCRIPT_SUFFIX) {
+            continue;
+        }
+        if !metadata.file_type().is_file()
+            && !metadata.file_type().is_symlink()
+            && !metadata.file_type().is_dir()
+        {
+            continue;
+        }
+        let Ok(modified) = metadata.modified() else {
+            continue;
+        };
+        if now
+            .duration_since(modified)
+            .is_ok_and(|age| age >= stale_after)
+        {
+            let removed_entry = if metadata.file_type().is_dir() {
+                fs::remove_dir_all(&path).is_ok()
+            } else {
+                fs::remove_file(&path).is_ok()
+            };
+            if removed_entry {
+                removed += 1;
+            }
+        }
+    }
+    Ok(removed)
+}
+
+fn create_env_script_in_dir(
+    dir: &Path,
+    command: &str,
+    env: &[(&str, &str)],
+    sudo: bool,
+) -> io::Result<EnvScriptGuard> {
+    ensure_env_script_dir(dir)?;
+    let _ = cleanup_stale_env_scripts_in(dir, SystemTime::now(), ENV_SCRIPT_STALE_AFTER);
+
+    for _ in 0..16 {
+        let script_dir = dir.join(format!("{}{}", ENV_SCRIPT_PREFIX, random_hex(16)?));
+        match DirBuilder::new().mode(0o700).create(&script_dir) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e),
+        }
+        fs::set_permissions(&script_dir, fs::Permissions::from_mode(0o700))?;
+
+        let path = script_dir.join(format!("run{ENV_SCRIPT_SUFFIX}"));
+        let script = build_env_script_content(&script_dir, &path, command, env)?;
+        let mut guard = EnvScriptGuard::new(path.clone(), script_dir.clone());
+
+        let mut options = OpenOptions::new();
+        options
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+        let mut file = match options.open(&path) {
+            Ok(file) => file,
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e),
+        };
+
+        let result = (|| -> io::Result<()> {
+            file.write_all(script.as_bytes())?;
+            if effective_uid() == 0 && !sudo && get_exec_user().is_some() {
+                file.set_permissions(fs::Permissions::from_mode(0o000))?;
+                chown_path(&script_dir, SANDBOX_UID, SANDBOX_GID)?;
+                let ret = unsafe { libc::fchown(file.as_raw_fd(), SANDBOX_UID, SANDBOX_GID) };
+                if ret != 0 {
+                    return Err(io::Error::last_os_error());
+                }
+            }
+            file.set_permissions(fs::Permissions::from_mode(0o400))?;
+            Ok(())
+        })();
+
+        if let Err(e) = result {
+            guard.cleanup();
+            return Err(e);
+        }
+        drop(file);
+        return Ok(guard);
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "failed to allocate a unique env script path",
+    ))
+}
+
+fn create_env_script(
+    command: &str,
+    env: &[(&str, &str)],
+    sudo: bool,
+) -> io::Result<EnvScriptGuard> {
+    create_env_script_in_dir(&default_env_script_dir(), command, env, sudo)
+}
+
+fn script_invocation(path: &Path) -> io::Result<String> {
+    let path = path.to_str().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "env script path must be valid UTF-8",
+        )
+    })?;
+    Ok(format!("/bin/bash {}", shell_escape_value(path)))
+}
+
+pub(crate) fn build_exec_command_with_env(
+    command: &str,
+    env: &[(&str, &str)],
+    sudo: bool,
+) -> io::Result<PreparedExecCommand> {
+    if env.is_empty() {
+        return Ok(PreparedExecCommand {
+            command: build_exec_command(command, sudo),
+            env_script: None,
+        });
+    }
+
+    let env_script = create_env_script(command, env, sudo)?;
+    let script_path = env_script
+        .path()
+        .ok_or_else(|| io::Error::other("env script path missing"))?;
+    let invocation = script_invocation(script_path)?;
+    Ok(PreparedExecCommand {
+        command: build_exec_command(&invocation, sudo),
+        env_script: Some(env_script),
+    })
+}
+
 /// Truncate a command string for logging, preserving UTF-8 boundaries
 pub(crate) fn truncate_preview(s: &str) -> String {
     if s.len() <= COMMAND_PREVIEW_MAX_LEN {
@@ -115,10 +479,18 @@ pub(crate) fn spawn_in_own_process_group(command: &mut Command) -> io::Result<Ch
 
 /// Spawn `command` with stdout/stderr piped — used by both buffered exec and
 /// streaming spawn-watch.
-pub(crate) fn spawn_with_pipes(command: &str, sudo: bool) -> io::Result<Child> {
-    let mut command = build_exec_command(command, sudo);
+pub(crate) fn spawn_with_pipes(
+    command: &str,
+    env: &[(&str, &str)],
+    sudo: bool,
+) -> io::Result<SpawnedCommand> {
+    let PreparedExecCommand {
+        mut command,
+        env_script,
+    } = build_exec_command_with_env(command, env, sudo)?;
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    spawn_in_own_process_group(&mut command)
+    let child = spawn_in_own_process_group(&mut command)?;
+    Ok(SpawnedCommand { child, env_script })
 }
 
 #[cfg(test)]
@@ -148,6 +520,20 @@ mod tests {
         path.exists()
     }
 
+    fn temp_dir(label: &str) -> (PathBuf, TempDirGuard) {
+        let dir = std::env::temp_dir().join(format!(
+            "vsock-guest-{label}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let guard = TempDirGuard(dir.clone());
+        (dir, guard)
+    }
+
     #[test]
     fn shell_escape_simple() {
         assert_eq!(shell_escape_value("hello"), "'hello'");
@@ -164,28 +550,165 @@ mod tests {
     }
 
     #[test]
-    fn prepend_env_empty() {
-        assert_eq!(prepend_env("echo hi", &[]), "echo hi");
+    fn env_script_content_self_removes_before_exports() {
+        let dir = Path::new("/run/vm0-exec/vm0-env-test");
+        let path = dir.join("run.sh");
+        let script =
+            build_env_script_content(dir, &path, "echo \"$FOO\"", &[("FOO", "it's a \"test\"")])
+                .unwrap();
+
+        let rm_pos = script.find("rm -f -- \"$script_path\"").unwrap();
+        let export_pos = script.find("export FOO=").unwrap();
+        assert!(rm_pos < export_pos);
+        assert!(script.contains("script_dir='/run/vm0-exec/vm0-env-test'"));
+        assert!(script.contains("script_path='/run/vm0-exec/vm0-env-test/run.sh'"));
+        assert!(script.contains("rmdir -- \"$script_dir\""));
+        assert!(script.contains("export FOO='it'\\''s a \"test\"'"));
+        assert!(script.contains("exec /bin/bash -c 'echo \"$FOO\"'"));
     }
 
     #[test]
-    fn prepend_env_single() {
-        assert_eq!(
-            prepend_env("echo hi", &[("FOO", "bar")]),
-            "export FOO='bar'; echo hi"
+    fn env_script_content_rejects_invalid_env_key() {
+        let dir = Path::new("/run/vm0-exec/vm0-env-test");
+        let path = dir.join("run.sh");
+        let err = build_env_script_content(dir, &path, "echo hi", &[("BAD;touch /tmp/pwned", "x")])
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(
+            err.to_string()
+                .contains("invalid environment variable name")
         );
     }
 
     #[test]
-    fn prepend_env_multiple() {
-        let result = prepend_env("cmd", &[("A", "1"), ("B", "2")]);
-        assert_eq!(result, "export A='1' B='2'; cmd");
+    fn env_script_invocation_keeps_secret_out_of_argv() {
+        let (dir, _guard) = temp_dir("argv");
+        let secret = "secret-value-that-must-not-be-in-argv";
+        let script =
+            create_env_script_in_dir(&dir, "echo \"$FOO\"", &[("FOO", secret)], true).unwrap();
+        let invocation = script_invocation(script.path().unwrap()).unwrap();
+        let command = build_exec_command(&invocation, true);
+        let argv = std::iter::once(command.get_program().to_string_lossy().to_string())
+            .chain(
+                command
+                    .get_args()
+                    .map(|arg| arg.to_string_lossy().into_owned()),
+            )
+            .collect::<Vec<_>>()
+            .join("\0");
+
+        assert!(!argv.contains(secret));
+        assert!(argv.contains("/bin/bash"));
+        assert!(argv.contains(script.path().unwrap().to_str().unwrap()));
     }
 
     #[test]
-    fn prepend_env_with_special_chars() {
-        let result = prepend_env("cmd", &[("KEY", "it's a \"test\"")]);
-        assert_eq!(result, "export KEY='it'\\''s a \"test\"'; cmd");
+    fn env_script_removes_file_and_directory_when_started() {
+        let (dir, _guard) = temp_dir("self-remove");
+        let output = dir.join("output");
+        let output_arg = shell_escape_value(output.to_str().unwrap());
+        let script = create_env_script_in_dir(
+            &dir,
+            &format!("printf \"$FOO\" > {output_arg}"),
+            &[("FOO", "done")],
+            true,
+        )
+        .unwrap();
+        let path = script.path().unwrap().to_path_buf();
+        let script_dir = path.parent().unwrap().to_path_buf();
+        let invocation = script_invocation(&path).unwrap();
+
+        let status = Command::new("sh")
+            .arg("-c")
+            .arg(invocation)
+            .status()
+            .unwrap();
+
+        assert!(status.success());
+        assert_eq!(std::fs::read_to_string(output).unwrap(), "done");
+        assert!(!path.exists());
+        assert!(!script_dir.exists());
+    }
+
+    #[test]
+    fn env_diagnostics_do_not_include_values() {
+        let diagnostics = format_env_diagnostics(
+            "echo hi",
+            &[
+                ("SMALL", "ok"),
+                ("BIG", "secret-value-that-must-not-appear"),
+            ],
+        );
+
+        assert!(diagnostics.contains("command_bytes=7"));
+        assert!(diagnostics.contains("env_count=2"));
+        assert!(diagnostics.contains("BIG:33"));
+        assert!(!diagnostics.contains("secret-value"));
+        assert!(!diagnostics.contains("ok"));
+    }
+
+    #[test]
+    fn env_script_guard_cleanup_is_idempotent() {
+        let (dir, _guard) = temp_dir("cleanup");
+        let script_dir = dir.join("vm0-env-cleanup");
+        std::fs::create_dir(&script_dir).unwrap();
+        let path = script_dir.join("run.sh");
+        std::fs::write(&path, "secret").unwrap();
+        let mut guard = EnvScriptGuard::new(path.clone(), script_dir.clone());
+
+        guard.cleanup();
+        guard.cleanup();
+
+        assert!(!path.exists());
+        assert!(!script_dir.exists());
+    }
+
+    #[test]
+    fn stale_env_script_cleanup_only_removes_matching_entries() {
+        let (dir, _guard) = temp_dir("stale");
+        let stale = dir.join(format!("{ENV_SCRIPT_PREFIX}stale{ENV_SCRIPT_SUFFIX}"));
+        let other = dir.join("other.sh");
+        std::fs::write(&stale, "secret").unwrap();
+        std::fs::write(&other, "not ours").unwrap();
+
+        let removed =
+            cleanup_stale_env_scripts_in(&dir, SystemTime::now(), Duration::ZERO).unwrap();
+
+        assert_eq!(removed, 1);
+        assert!(!stale.exists());
+        assert!(other.exists());
+    }
+
+    #[test]
+    fn stale_env_script_cleanup_removes_matching_directories() {
+        let (dir, _guard) = temp_dir("stale-dir");
+        let stale = dir.join(format!("{ENV_SCRIPT_PREFIX}stale-dir"));
+        let nested = stale.join("run.sh");
+        std::fs::create_dir(&stale).unwrap();
+        std::fs::write(&nested, "secret").unwrap();
+
+        let removed =
+            cleanup_stale_env_scripts_in(&dir, SystemTime::now(), Duration::ZERO).unwrap();
+
+        assert_eq!(removed, 1);
+        assert!(!stale.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stale_env_script_cleanup_removes_symlink_without_following_it() {
+        let (dir, _guard) = temp_dir("stale-symlink");
+        let target = dir.join("target");
+        let link = dir.join(format!("{ENV_SCRIPT_PREFIX}link{ENV_SCRIPT_SUFFIX}"));
+        std::fs::write(&target, "keep").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let removed =
+            cleanup_stale_env_scripts_in(&dir, SystemTime::now(), Duration::ZERO).unwrap();
+
+        assert_eq!(removed, 1);
+        assert!(std::fs::symlink_metadata(&link).is_err());
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "keep");
     }
 
     #[test]

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -186,13 +186,35 @@ fn validate_env_keys(env: &[(&str, &str)]) -> io::Result<()> {
     Ok(())
 }
 
+fn validate_env_values(env: &[(&str, &str)]) -> io::Result<()> {
+    for (key, value) in env {
+        if value.as_bytes().contains(&0) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "environment variable value contains NUL bytes: {}",
+                    format_env_key_for_log(key)
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn build_env_script_content(
     script_dir: &Path,
     script_path: &Path,
     command: &str,
     env: &[(&str, &str)],
 ) -> io::Result<String> {
+    if command.as_bytes().contains(&0) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "command contains NUL bytes",
+        ));
+    }
     validate_env_keys(env)?;
+    validate_env_values(env)?;
     let script_dir = script_dir.to_str().ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -578,6 +600,33 @@ mod tests {
             err.to_string()
                 .contains("invalid environment variable name")
         );
+    }
+
+    #[test]
+    fn env_script_content_rejects_nul_command() {
+        let dir = Path::new("/run/vm0-exec/vm0-env-test");
+        let path = dir.join("run.sh");
+        let err = build_env_script_content(dir, &path, "echo before\0after", &[("FOO", "x")])
+            .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("command contains NUL bytes"));
+    }
+
+    #[test]
+    fn env_script_content_rejects_nul_env_value() {
+        let dir = Path::new("/run/vm0-exec/vm0-env-test");
+        let path = dir.join("run.sh");
+        let err = build_env_script_content(dir, &path, "echo hi", &[("SECRET", "before\0after")])
+            .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(
+            err.to_string()
+                .contains("environment variable value contains NUL bytes: SECRET")
+        );
+        assert!(!err.to_string().contains("before"));
+        assert!(!err.to_string().contains("after"));
     }
 
     #[test]

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -135,18 +135,33 @@ fn format_env_key_for_log(key: &str) -> String {
     truncate_preview(&key.escape_debug().to_string())
 }
 
+fn compare_env_diagnostic_entries(
+    left: &(&str, usize),
+    right: &(&str, usize),
+) -> std::cmp::Ordering {
+    right.1.cmp(&left.1).then_with(|| left.0.cmp(right.0))
+}
+
 pub(crate) fn format_env_diagnostics(command: &str, env: &[(&str, &str)]) -> String {
-    let env_bytes: usize = env.iter().map(|(key, value)| key.len() + value.len()).sum();
-    let mut largest: Vec<(&str, usize)> =
-        env.iter().map(|(key, value)| (*key, value.len())).collect();
-    largest.sort_by(|(left_key, left_len), (right_key, right_len)| {
-        right_len
-            .cmp(left_len)
-            .then_with(|| left_key.cmp(right_key))
-    });
+    let mut env_bytes = 0;
+    let mut largest: Vec<(&str, usize)> = Vec::with_capacity(env.len().min(5));
+    for (key, value) in env {
+        env_bytes += key.len() + value.len();
+        let entry = (*key, value.len());
+        match largest
+            .iter()
+            .position(|existing| compare_env_diagnostic_entries(&entry, existing).is_lt())
+        {
+            Some(index) => largest.insert(index, entry),
+            None if largest.len() < 5 => largest.push(entry),
+            None => {}
+        }
+        if largest.len() > 5 {
+            largest.pop();
+        }
+    }
     let largest = largest
         .into_iter()
-        .take(5)
         .map(|(key, len)| format!("{}:{len}", format_env_key_for_log(key)))
         .collect::<Vec<_>>()
         .join(",");
@@ -740,6 +755,25 @@ mod tests {
         assert!(diagnostics.contains("BIG:33"));
         assert!(!diagnostics.contains("secret-value"));
         assert!(!diagnostics.contains("ok"));
+    }
+
+    #[test]
+    fn env_diagnostics_reports_largest_five_in_stable_order() {
+        let diagnostics = format_env_diagnostics(
+            "cmd",
+            &[
+                ("Z", "1"),
+                ("B", "22"),
+                ("A", "22"),
+                ("C", "333"),
+                ("D", "4444"),
+                ("E", "55555"),
+                ("F", "666666"),
+            ],
+        );
+
+        assert!(diagnostics.contains("env_count=7"));
+        assert!(diagnostics.contains("largest_env=[F:6,E:5,D:4,C:3,A:2]"));
     }
 
     #[test]

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -11,7 +11,8 @@ use vsock_proto::{
 use crate::drain::drain_into_vec_cancellable;
 use crate::error::to_io_error;
 use crate::exec::{
-    build_exec_command, prepend_env, spawn_in_own_process_group, spawn_with_pipes, truncate_preview,
+    build_exec_command, format_env_diagnostics, spawn_in_own_process_group, spawn_with_pipes,
+    truncate_preview,
 };
 use crate::log::log;
 use crate::process::{extract_exit_code, kill_and_reap_child};
@@ -41,25 +42,32 @@ pub(crate) fn handle_exec(
     log(
         "INFO",
         &format!(
-            "exec: {} (timeout={}ms, sudo={}, env_count={})",
+            "exec: {} (timeout={}ms, sudo={}, {})",
             truncate_preview(command),
             timeout_ms,
             sudo,
-            env.len(),
+            format_env_diagnostics(command, env),
         ),
     );
-    let command = prepend_env(command, env);
 
-    let child = match spawn_with_pipes(&command, sudo) {
+    let spawned = match spawn_with_pipes(command, env, sudo) {
         Ok(c) => c,
         Err(e) => {
             return (
                 1,
                 Vec::new(),
-                format!("Failed to execute: {e}").into_bytes(),
+                format!(
+                    "Failed to execute: {e} ({})",
+                    format_env_diagnostics(command, env)
+                )
+                .into_bytes(),
             );
         }
     };
+    let crate::exec::SpawnedCommand {
+        child,
+        env_script: _env_script,
+    } = spawned;
 
     let (outcome, stdout, stderr_buf) =
         wait_with_drain_and_timeout_or_cancelled(child, timeout_ms, connection_cancel);

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -8,7 +8,7 @@ use vsock_proto::{self, MSG_ERROR, MSG_PROCESS_EXIT, MSG_SPAWN_WATCH_RESULT, MSG
 
 use crate::drain::{drain_into_vec_cancellable, drain_until_eof_or_cancelled};
 use crate::error::to_io_error;
-use crate::exec::{prepend_env, spawn_with_pipes, truncate_preview};
+use crate::exec::{EnvScriptGuard, format_env_diagnostics, spawn_with_pipes, truncate_preview};
 use crate::log::log;
 use crate::process::{ChildReapGuard, kill_and_reap_child};
 use crate::threading::{SystemThreadSpawner, ThreadSpawner};
@@ -29,6 +29,7 @@ struct StreamingMonitorRequest {
     timeout_ms: u32,
     stdout_pipe: Option<ChildStdout>,
     log_path: Option<String>,
+    env_script: Option<EnvScriptGuard>,
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
 }
@@ -37,6 +38,7 @@ struct BufferedMonitorRequest {
     pid: u32,
     child: Child,
     timeout_ms: u32,
+    env_script: Option<EnvScriptGuard>,
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
 }
@@ -48,6 +50,7 @@ struct StreamingSetupFailure {
     drain_done_tx: std::sync::mpsc::Sender<()>,
     stderr_handle: Option<JoinHandle<Vec<u8>>>,
     stdout_handle: Option<JoinHandle<()>>,
+    env_script: Option<EnvScriptGuard>,
     writer: GuestWriter,
     error: String,
 }
@@ -97,25 +100,31 @@ where
     log(
         "INFO",
         &format!(
-            "spawn_watch: {} (timeout={}ms, sudo={}, env_count={}, stream={})",
+            "spawn_watch: {} (timeout={}ms, sudo={}, stream={}, {})",
             truncate_preview(request.command),
             request.timeout_ms,
             request.sudo,
-            request.env.len(),
             request.stream_stdout,
+            format_env_diagnostics(request.command, request.env),
         ),
     );
-    let command = prepend_env(request.command, request.env);
 
-    let mut child = match spawn_with_pipes(&command, request.sudo) {
+    let spawned = match spawn_with_pipes(request.command, request.env, request.sudo) {
         Ok(c) => c,
         Err(e) => {
-            let payload = vsock_proto::encode_error(&format!("Failed to spawn: {e}"));
+            let payload = vsock_proto::encode_error(&format!(
+                "Failed to spawn: {e} ({})",
+                format_env_diagnostics(request.command, request.env)
+            ));
             let response = vsock_proto::encode(MSG_ERROR, seq, &payload).map_err(to_io_error)?;
             writer.write_frame(&response)?;
             return Ok(());
         }
     };
+    let crate::exec::SpawnedCommand {
+        mut child,
+        env_script,
+    } = spawned;
 
     let pid = child.id();
     log("INFO", &format!("spawn_watch: started pid={pid}"));
@@ -153,6 +162,7 @@ where
                 timeout_ms: request.timeout_ms,
                 stdout_pipe,
                 log_path: request.stdout_log_path.map(str::to_owned),
+                env_script,
                 writer,
                 connection_cancel,
             },
@@ -171,6 +181,7 @@ where
                 pid,
                 child,
                 timeout_ms: request.timeout_ms,
+                env_script,
                 writer,
                 connection_cancel,
             },
@@ -222,6 +233,7 @@ where
         timeout_ms,
         stdout_pipe,
         log_path,
+        env_script,
         writer,
         connection_cancel,
     } = request;
@@ -245,6 +257,7 @@ where
                     timeout_ms,
                     stdout_pipe,
                     log_path,
+                    env_script,
                     writer,
                     connection_cancel,
                 },
@@ -274,9 +287,11 @@ where
         timeout_ms,
         stdout_pipe,
         log_path,
+        env_script,
         writer,
         connection_cancel,
     } = request;
+    let _env_script = env_script;
     let cancel = Arc::new(AtomicBool::new(false));
     let (drain_done_tx, drain_done_rx) = std::sync::mpsc::channel::<()>();
 
@@ -307,6 +322,7 @@ where
                     drain_done_tx,
                     stderr_handle: None,
                     stdout_handle: None,
+                    env_script: _env_script,
                     writer,
                     error: format!("Failed to spawn stderr drain thread: {e}"),
                 });
@@ -386,6 +402,7 @@ where
                     drain_done_tx,
                     stderr_handle,
                     stdout_handle: None,
+                    env_script: _env_script,
                     writer,
                     error: format!("Failed to spawn stdout drain thread: {e}"),
                 });
@@ -452,9 +469,11 @@ fn finish_streaming_setup_failure(failure: StreamingSetupFailure) {
         drain_done_tx,
         stderr_handle,
         stdout_handle,
+        env_script,
         writer,
         error,
     } = failure;
+    let _env_script = env_script;
     cancel.store(true, Ordering::Release);
     drop(drain_done_tx);
     kill_and_reap_child(child);
@@ -487,6 +506,7 @@ where
         pid,
         child,
         timeout_ms,
+        env_script,
         writer,
         connection_cancel,
     } = request;
@@ -524,6 +544,7 @@ where
             );
 
             send_process_exit(pid, exit_code, &stdout, &stderr, &writer);
+            drop(env_script);
         }),
     );
     if let Err(e) = &result {

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use vsock_guest::{handle_connection, run};
 use vsock_proto::{
-    self, MSG_EXEC, MSG_EXEC_RESULT, MSG_PROCESS_EXIT, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
+    self, MSG_ERROR, MSG_EXEC, MSG_EXEC_RESULT, MSG_PROCESS_EXIT, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
     MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK,
 };
 
@@ -308,6 +308,43 @@ fn exec_large_env_payload_succeeds() {
 
     assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
     assert_large_env_stdout(&stdout);
+
+    drop(host_writer);
+    drop(host_reader);
+    let _ = handle.join();
+}
+
+#[test]
+fn exec_invalid_env_payload_returns_error_without_leaking_value() {
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    let (guest_stream, host_stream) = StdUnixStream::pair().unwrap();
+    let mut host_writer = host_stream.try_clone().unwrap();
+    let mut host_reader = host_stream;
+
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+    read_and_discard_message(&mut host_reader); // MSG_READY
+    host_reader
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    let secret = "do-not-print-this-secret";
+    let (code, stdout, stderr) = send_exec_and_read_result_with_env(
+        &mut host_writer,
+        &mut host_reader,
+        1,
+        "echo should-not-run",
+        5000,
+        &[("BAD;KEY", secret)],
+    );
+    let stderr = String::from_utf8_lossy(&stderr);
+
+    assert_eq!(code, 1);
+    assert!(stdout.is_empty());
+    assert!(stderr.contains("invalid environment variable name"));
+    assert!(!stderr.contains(secret));
 
     drop(host_writer);
     drop(host_reader);
@@ -623,6 +660,40 @@ fn streaming_spawn_watch_large_env_payload_succeeds() {
 
     assert_eq!(exit_code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
     assert_large_env_stdout(&stdout_data);
+
+    drop(host_stream);
+    let _ = handle.join();
+}
+
+#[test]
+fn streaming_spawn_watch_invalid_env_payload_returns_error_without_leaking_value() {
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+    read_and_discard_message(&mut host_stream); // MSG_READY
+    host_stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    let secret = "do-not-print-this-secret";
+    send_spawn_watch_with_env(
+        &mut host_stream,
+        1,
+        "echo should-not-run",
+        &[("BAD;KEY", secret)],
+        None,
+        5000,
+    );
+
+    let msg = read_message(&mut host_stream);
+    assert_eq!(msg.msg_type, MSG_ERROR);
+    assert_eq!(msg.seq, 1);
+    let error = vsock_proto::decode_error(&msg.payload).unwrap();
+    assert!(error.contains("invalid environment variable name"));
+    assert!(!error.contains(secret));
 
     drop(host_stream);
     let _ = handle.join();

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -103,7 +103,18 @@ fn send_exec_and_read_result(
     command: &str,
     timeout_ms: u32,
 ) -> (i32, Vec<u8>, Vec<u8>) {
-    let payload = vsock_proto::encode_exec(timeout_ms, command, &[], false);
+    send_exec_and_read_result_with_env(writer, reader, seq, command, timeout_ms, &[])
+}
+
+fn send_exec_and_read_result_with_env(
+    writer: &mut impl std::io::Write,
+    reader: &mut impl std::io::Read,
+    seq: u32,
+    command: &str,
+    timeout_ms: u32,
+    env: &[(&str, &str)],
+) -> (i32, Vec<u8>, Vec<u8>) {
+    let payload = vsock_proto::encode_exec(timeout_ms, command, env, false);
     let msg = vsock_proto::encode(MSG_EXEC, seq, &payload).unwrap();
     writer.write_all(&msg).unwrap();
 
@@ -233,6 +244,54 @@ fn exec_returns_correct_result() {
         send_exec_and_read_result(&mut host_writer, &mut host_reader, 1, "echo hello", 5000);
     assert_eq!(code, 0);
     assert_eq!(String::from_utf8_lossy(&stdout).trim(), "hello");
+
+    drop(host_writer);
+    drop(host_reader);
+    let _ = handle.join();
+}
+
+#[test]
+fn exec_large_env_payload_succeeds() {
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    let big_a = "A".repeat(40 * 1024);
+    let big_b = "B".repeat(40 * 1024);
+    let big_c = "C".repeat(40 * 1024);
+    let big_d = "D".repeat(40 * 1024);
+    let env = [
+        ("SMALL", "ok"),
+        ("BIG_A", big_a.as_str()),
+        ("BIG_B", big_b.as_str()),
+        ("BIG_C", big_c.as_str()),
+        ("BIG_D", big_d.as_str()),
+    ];
+
+    let (guest_stream, host_stream) = StdUnixStream::pair().unwrap();
+    let mut host_writer = host_stream.try_clone().unwrap();
+    let mut host_reader = host_stream;
+
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+    read_and_discard_message(&mut host_reader); // MSG_READY
+    host_reader
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    let (code, stdout, stderr) = send_exec_and_read_result_with_env(
+        &mut host_writer,
+        &mut host_reader,
+        1,
+        "printf '%s:%s:%s:%s:%s\\n' \"$SMALL\" \"${#BIG_A}\" \"${#BIG_B}\" \"${#BIG_C}\" \"${#BIG_D}\"",
+        5000,
+        &env,
+    );
+
+    assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
+    assert_eq!(
+        String::from_utf8_lossy(&stdout),
+        "ok:40960:40960:40960:40960\n"
+    );
 
     drop(host_writer);
     drop(host_reader);
@@ -430,8 +489,19 @@ fn send_spawn_watch(
     log_path: Option<&str>,
     timeout_ms: u32,
 ) {
+    send_spawn_watch_with_env(stream, seq, command, &[], log_path, timeout_ms);
+}
+
+fn send_spawn_watch_with_env(
+    stream: &mut impl std::io::Write,
+    seq: u32,
+    command: &str,
+    env: &[(&str, &str)],
+    log_path: Option<&str>,
+    timeout_ms: u32,
+) {
     let payload =
-        vsock_proto::encode_spawn_watch(timeout_ms, command, &[], false, true, log_path).unwrap();
+        vsock_proto::encode_spawn_watch(timeout_ms, command, env, false, true, log_path).unwrap();
     let msg = vsock_proto::encode(MSG_SPAWN_WATCH, seq, &payload).unwrap();
     stream.write_all(&msg).unwrap();
 }
@@ -511,6 +581,51 @@ fn streaming_monitor_normal_exit() {
     assert!(pid > 0);
     assert_eq!(exit_code, 0);
     assert_eq!(String::from_utf8_lossy(&stdout_data).trim(), "hello");
+
+    drop(host_stream);
+    let _ = handle.join();
+}
+
+#[test]
+fn streaming_spawn_watch_large_env_payload_succeeds() {
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    let big_a = "A".repeat(40 * 1024);
+    let big_b = "B".repeat(40 * 1024);
+    let big_c = "C".repeat(40 * 1024);
+    let big_d = "D".repeat(40 * 1024);
+    let env = [
+        ("SMALL", "ok"),
+        ("BIG_A", big_a.as_str()),
+        ("BIG_B", big_b.as_str()),
+        ("BIG_C", big_c.as_str()),
+        ("BIG_D", big_d.as_str()),
+    ];
+
+    let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+    read_and_discard_message(&mut host_stream); // MSG_READY
+    host_stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    send_spawn_watch_with_env(
+        &mut host_stream,
+        1,
+        "printf '%s:%s:%s:%s:%s\\n' \"$SMALL\" \"${#BIG_A}\" \"${#BIG_B}\" \"${#BIG_C}\" \"${#BIG_D}\"",
+        &env,
+        None,
+        5000,
+    );
+    let (_pid, stdout_data, exit_code, stderr) = read_streaming_result(&mut host_stream, 1);
+
+    assert_eq!(exit_code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
+    assert_eq!(
+        String::from_utf8_lossy(&stdout_data),
+        "ok:40960:40960:40960:40960\n"
+    );
 
     drop(host_stream);
     let _ = handle.join();

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -17,6 +17,8 @@ use vsock_proto::{
 
 const EXIT_CODE_TIMEOUT: i32 = 124;
 const DRAIN_DEADLINE_SECS: u64 = 5;
+const LARGE_ENV_COMMAND: &str =
+    "printf '%s:%s:%s:%s:%s\\n' \"$SMALL\" \"${#BIG_A}\" \"${#BIG_B}\" \"${#BIG_C}\" \"${#BIG_D}\"";
 
 struct TempPathGuard(String);
 
@@ -54,6 +56,32 @@ fn unique_socket_path(label: &str) -> TempPathGuard {
 
 fn unique_pid_path(label: &str) -> TempPathGuard {
     unique_tmp_path(label, ".pid")
+}
+
+fn large_env_values() -> [String; 4] {
+    [
+        "A".repeat(40 * 1024),
+        "B".repeat(40 * 1024),
+        "C".repeat(40 * 1024),
+        "D".repeat(40 * 1024),
+    ]
+}
+
+fn large_env_entries(values: &[String; 4]) -> [(&'static str, &str); 5] {
+    [
+        ("SMALL", "ok"),
+        ("BIG_A", values[0].as_str()),
+        ("BIG_B", values[1].as_str()),
+        ("BIG_C", values[2].as_str()),
+        ("BIG_D", values[3].as_str()),
+    ]
+}
+
+fn assert_large_env_stdout(stdout: &[u8]) {
+    assert_eq!(
+        String::from_utf8_lossy(stdout),
+        "ok:40960:40960:40960:40960\n"
+    );
 }
 
 struct OrphanProcessGuard {
@@ -254,17 +282,8 @@ fn exec_returns_correct_result() {
 fn exec_large_env_payload_succeeds() {
     use std::os::unix::net::UnixStream as StdUnixStream;
 
-    let big_a = "A".repeat(40 * 1024);
-    let big_b = "B".repeat(40 * 1024);
-    let big_c = "C".repeat(40 * 1024);
-    let big_d = "D".repeat(40 * 1024);
-    let env = [
-        ("SMALL", "ok"),
-        ("BIG_A", big_a.as_str()),
-        ("BIG_B", big_b.as_str()),
-        ("BIG_C", big_c.as_str()),
-        ("BIG_D", big_d.as_str()),
-    ];
+    let values = large_env_values();
+    let env = large_env_entries(&values);
 
     let (guest_stream, host_stream) = StdUnixStream::pair().unwrap();
     let mut host_writer = host_stream.try_clone().unwrap();
@@ -282,16 +301,13 @@ fn exec_large_env_payload_succeeds() {
         &mut host_writer,
         &mut host_reader,
         1,
-        "printf '%s:%s:%s:%s:%s\\n' \"$SMALL\" \"${#BIG_A}\" \"${#BIG_B}\" \"${#BIG_C}\" \"${#BIG_D}\"",
+        LARGE_ENV_COMMAND,
         5000,
         &env,
     );
 
     assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
-    assert_eq!(
-        String::from_utf8_lossy(&stdout),
-        "ok:40960:40960:40960:40960\n"
-    );
+    assert_large_env_stdout(&stdout);
 
     drop(host_writer);
     drop(host_reader);
@@ -590,17 +606,8 @@ fn streaming_monitor_normal_exit() {
 fn streaming_spawn_watch_large_env_payload_succeeds() {
     use std::os::unix::net::UnixStream as StdUnixStream;
 
-    let big_a = "A".repeat(40 * 1024);
-    let big_b = "B".repeat(40 * 1024);
-    let big_c = "C".repeat(40 * 1024);
-    let big_d = "D".repeat(40 * 1024);
-    let env = [
-        ("SMALL", "ok"),
-        ("BIG_A", big_a.as_str()),
-        ("BIG_B", big_b.as_str()),
-        ("BIG_C", big_c.as_str()),
-        ("BIG_D", big_d.as_str()),
-    ];
+    let values = large_env_values();
+    let env = large_env_entries(&values);
 
     let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
     let handle = thread::spawn(move || {
@@ -611,21 +618,11 @@ fn streaming_spawn_watch_large_env_payload_succeeds() {
         .set_read_timeout(Some(Duration::from_secs(5)))
         .unwrap();
 
-    send_spawn_watch_with_env(
-        &mut host_stream,
-        1,
-        "printf '%s:%s:%s:%s:%s\\n' \"$SMALL\" \"${#BIG_A}\" \"${#BIG_B}\" \"${#BIG_C}\" \"${#BIG_D}\"",
-        &env,
-        None,
-        5000,
-    );
+    send_spawn_watch_with_env(&mut host_stream, 1, LARGE_ENV_COMMAND, &env, None, 5000);
     let (_pid, stdout_data, exit_code, stderr) = read_streaming_result(&mut host_stream, 1);
 
     assert_eq!(exit_code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
-    assert_eq!(
-        String::from_utf8_lossy(&stdout_data),
-        "ok:40960:40960:40960:40960\n"
-    );
+    assert_large_env_stdout(&stdout_data);
 
     drop(host_stream);
     let _ = handle.join();
@@ -886,8 +883,18 @@ fn send_spawn_watch_buffered(
     command: &str,
     timeout_ms: u32,
 ) {
+    send_spawn_watch_buffered_with_env(stream, seq, command, &[], timeout_ms);
+}
+
+fn send_spawn_watch_buffered_with_env(
+    stream: &mut impl std::io::Write,
+    seq: u32,
+    command: &str,
+    env: &[(&str, &str)],
+    timeout_ms: u32,
+) {
     let payload =
-        vsock_proto::encode_spawn_watch(timeout_ms, command, &[], false, false, None).unwrap();
+        vsock_proto::encode_spawn_watch(timeout_ms, command, env, false, false, None).unwrap();
     let msg = vsock_proto::encode(MSG_SPAWN_WATCH, seq, &payload).unwrap();
     stream.write_all(&msg).unwrap();
 }
@@ -1163,6 +1170,32 @@ fn spawn_watch_buffered_timeout_zero_silent_child_is_cancelled_on_host_disconnec
     drop(host_stream);
     let _ = handle.join();
     wait_for_pid_exit(pid, "buffered spawn_watch host disconnect");
+}
+
+#[test]
+fn buffered_spawn_watch_large_env_payload_succeeds() {
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    let values = large_env_values();
+    let env = large_env_entries(&values);
+
+    let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+    read_and_discard_message(&mut host_stream); // MSG_READY
+    host_stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    send_spawn_watch_buffered_with_env(&mut host_stream, 1, LARGE_ENV_COMMAND, &env, 5000);
+    let (_pid, code, stdout, stderr) = read_buffered_spawn_watch_result(&mut host_stream, 1);
+
+    assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
+    assert_large_env_stdout(&stdout);
+
+    drop(host_stream);
+    let _ = handle.join();
 }
 
 /// Regression for #11077: when the host drops the vsock connection


### PR DESCRIPTION
## Summary
- route env-bearing exec/spawn_watch through a short-lived tmpfs script instead of expanding env into the shell argv
- keep empty-env commands on the existing direct path and preserve su - user / sudo behavior
- add safe env size diagnostics plus cleanup tests for script lifecycle and large-env behavior tests

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets -- -D warnings
- cargo test --manifest-path crates/Cargo.toml

Closes #12117