### PR TITLE
fix: restore codex sessions as jsonl

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1325,7 +1325,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "uuid",
- "zstd",
 ]
 
 [[package]]

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -1,5 +1,5 @@
 //! Session-history reader — abstracts over Claude (literal jsonl path) and
-//! codex (`CODEX_SEARCH:{dir}:{id}` marker → recursive scan + zstd decode).
+//! codex (`CODEX_SEARCH:{dir}:{id}` marker → recursive scan + optional zstd decode).
 //!
 //! `events::extract_session_id` writes one of two payloads to
 //! `paths::session_history_path_file()`:
@@ -10,7 +10,7 @@
 //!   defer resolution until checkpoint time when the file is on disk.
 //!
 //! `read_session_history` is the single entry point used by `checkpoint.rs`.
-//! It returns the decompressed bytes regardless of the source format.
+//! It returns the history bytes, decompressing legacy `.zst` files when needed.
 //!
 //! See parent epic #11386, sub-issue #11419 for the design rationale.
 //!
@@ -112,7 +112,7 @@ where
     }
 }
 
-/// Read the bytes at `path`, decompressing zstd if the extension is `.zst`.
+/// Read the bytes at `path`, decompressing legacy zstd files if the extension is `.zst`.
 fn read_history_bytes(path: &Path) -> Result<Vec<u8>, AgentError> {
     let raw = std::fs::read(path).map_err(|e| {
         AgentError::Checkpoint(format!(

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -19,8 +19,8 @@
 //!
 //! - End-to-end `send_event` → `extract_session_id` → marker write for the
 //!   codex `thread.started` event shape.
-//! - `session_history::read_session_history` decodes the marker, walks the
-//!   `YYYY/MM/DD/` codex layout, and zstd-decompresses the result.
+//! - `session_history::read_session_history` decodes the marker and walks the
+//!   `YYYY/MM/DD/` codex layout.
 //! - Claude literal-path resolution through the same public entry,
 //!   exercised by passing a literal `.jsonl` path through the
 //!   history-path file.
@@ -181,8 +181,40 @@ async fn read_session_history_resolves_codex_marker_end_to_end() {
     let _guard = TEST_MUTEX.lock().unwrap();
     reset_session_files();
 
-    // Set up a fake codex sessions tree under a temp dir, with a zstd-
-    // compressed jsonl at the canonical YYYY/MM/DD/ depth.
+    // Set up a fake codex sessions tree under a temp dir, with a jsonl file
+    // at the canonical YYYY/MM/DD/ depth.
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    let history = b"{\"type\":\"thread.started\",\"thread_id\":\"x\"}\n";
+    write_session_file(
+        &sessions_dir,
+        &["2026", "04", "28"],
+        &format!("{thread_id}.jsonl"),
+        history,
+    )
+    .unwrap();
+
+    // Drive the public entry exactly the way `checkpoint.rs` does:
+    // a marker file pointing at the sessions dir + thread id.
+    let path_file = tmp.path().join("path.txt");
+    let marker = format!(
+        "CODEX_SEARCH:{}:{thread_id}",
+        sessions_dir.to_string_lossy()
+    );
+    std::fs::write(&path_file, marker.as_bytes()).unwrap();
+
+    let bytes =
+        guest_agent::session_history::read_session_history(path_file.to_str().unwrap()).unwrap();
+    assert_eq!(bytes, history);
+}
+
+#[tokio::test]
+async fn read_session_history_decodes_legacy_zstd_session() {
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
     let tmp = tempfile::tempdir().unwrap();
     let sessions_dir = tmp.path().join("sessions");
     let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
@@ -196,8 +228,6 @@ async fn read_session_history_resolves_codex_marker_end_to_end() {
     )
     .unwrap();
 
-    // Drive the public entry exactly the way `checkpoint.rs` does:
-    // a marker file pointing at the sessions dir + thread id.
     let path_file = tmp.path().join("path.txt");
     let marker = format!(
         "CODEX_SEARCH:{}:{thread_id}",
@@ -224,12 +254,11 @@ async fn read_session_history_resolves_dash_stripped_filename() {
     let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
     let id_no_dashes = thread_id.replace('-', "");
     let history = b"line1\nline2\n";
-    let compressed = zstd::encode_all(history.as_slice(), 0).unwrap();
     write_session_file(
         &sessions_dir,
         &["2026", "04", "28"],
-        &format!("rollout-2026-04-28T11-22-37-{id_no_dashes}.jsonl.zst"),
-        &compressed,
+        &format!("rollout-2026-04-28T11-22-37-{id_no_dashes}.jsonl"),
+        history,
     )
     .unwrap();
 

--- a/crates/guest-mock-codex/Cargo.toml
+++ b/crates/guest-mock-codex/Cargo.toml
@@ -8,7 +8,6 @@ chrono = { workspace = true, features = ["clock"] }
 clap = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 uuid = { workspace = true, features = ["v7"] }
-zstd.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -1,8 +1,8 @@
 //! Mock Codex CLI for testing.
 //!
-//! Emits Codex `exec --json` protocol events on stdout and persists a
-//! zstd-compressed JSONL session file at the same path layout the real
-//! Codex CLI uses (`$CODEX_HOME/sessions/YYYY/MM/DD/<thread_id>.jsonl.zst`).
+//! Emits Codex `exec --json` protocol events on stdout and persists a JSONL
+//! session file at the same path layout the real Codex CLI uses
+//! (`$CODEX_HOME/sessions/YYYY/MM/DD/<thread_id>.jsonl`).
 //!
 //! Activated in guest VMs via `USE_MOCK_CODEX=true` (handled by guest-agent).
 //! This binary itself runs whenever it's invoked — the env-var dispatch lives
@@ -20,7 +20,7 @@
 //! synthetic 3-event sequence is replaced with a baked JSONL fixture by
 //! that name (see `FIXTURES`). The thread id is taken from the fixture's
 //! `thread.started` event; the fixture's bytes are written verbatim to
-//! stdout and to the zstd session file. Used by
+//! stdout and to the session file. Used by
 //! `e2e/tests/03-runner/t-codex-event-mapping.bats` to exercise the
 //! codex-event-parser branches that the synthetic sequence cannot reach.
 
@@ -28,7 +28,7 @@ use chrono::{NaiveDate, Utc};
 use clap::{Parser, Subcommand};
 use serde_json::{Value, json};
 use std::fs;
-use std::io::{self, Read, Write};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
@@ -151,7 +151,7 @@ fn lookup_fixture(name: &str) -> Option<&'static str> {
 }
 
 /// Run a fixture: parse JSONL, extract thread id from `thread.started`,
-/// emit events to stdout, and persist the zstd session file under
+/// emit events to stdout, and persist the session file under
 /// `$CODEX_HOME` so checkpoint reads see the same content the CLI saw.
 fn run_fixture(content: &str) -> io::Result<()> {
     let events = parse_fixture_events(content)?;
@@ -216,7 +216,7 @@ fn codex_home() -> PathBuf {
 
 /// Build the session file path, with `today` injected for testability.
 ///
-/// Layout: `<codex_home>/sessions/YYYY/MM/DD/<thread_id>.jsonl.zst`
+/// Layout: `<codex_home>/sessions/YYYY/MM/DD/<thread_id>.jsonl`
 fn build_session_path(codex_home: &Path, today: NaiveDate, thread_id: &str) -> PathBuf {
     let yyyy = today.format("%Y").to_string();
     let mm = today.format("%m").to_string();
@@ -226,7 +226,7 @@ fn build_session_path(codex_home: &Path, today: NaiveDate, thread_id: &str) -> P
         .join(yyyy)
         .join(mm)
         .join(dd)
-        .join(format!("{thread_id}.jsonl.zst"))
+        .join(format!("{thread_id}.jsonl"))
 }
 
 /// Build the three-event sequence the mock emits for a single turn.
@@ -252,8 +252,8 @@ fn emit_events<W: Write>(out: &mut W, events: &[Value]) -> io::Result<()> {
     out.flush()
 }
 
-/// Encode events as zstd-compressed JSONL and atomically write to `path`,
-/// creating parent directories as needed.
+/// Encode events as JSONL and atomically write to `path`, creating parent
+/// directories as needed.
 fn write_session_file(path: &Path, events: &[Value]) -> io::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -262,19 +262,15 @@ fn write_session_file(path: &Path, events: &[Value]) -> io::Result<()> {
     for ev in events {
         writeln!(buf, "{ev}")?;
     }
-    let compressed = zstd::encode_all(buf.as_slice(), 3)?;
-    let tmp = path.with_extension("zst.tmp");
-    fs::write(&tmp, compressed)?;
+    let tmp = path.with_extension("jsonl.tmp");
+    fs::write(&tmp, buf)?;
     fs::rename(&tmp, path)
 }
 
-/// Read a zstd-compressed JSONL session file into parsed `Value` events.
+/// Read a JSONL session file into parsed `Value` events.
 /// Used both by `append_session_file` (read-modify-write) and tests.
 fn read_session_file(path: &Path) -> io::Result<Vec<Value>> {
-    let bytes = fs::read(path)?;
-    let mut decoder = zstd::Decoder::new(bytes.as_slice())?;
-    let mut decoded = String::new();
-    decoder.read_to_string(&mut decoded)?;
+    let decoded = fs::read_to_string(path)?;
     let mut out = Vec::new();
     for line in decoded.lines() {
         if line.is_empty() {
@@ -287,9 +283,9 @@ fn read_session_file(path: &Path) -> io::Result<Vec<Value>> {
     Ok(out)
 }
 
-/// Append `new_events` to an existing session file by reading, decompressing,
-/// extending, recompressing, and atomically renaming. If the file does not
-/// exist, falls back to `write_session_file` so the resume call does not fail.
+/// Append `new_events` to an existing session file by reading, extending, and
+/// atomically renaming. If the file does not exist, falls back to
+/// `write_session_file` so the resume call does not fail.
 fn append_session_file(path: &Path, new_events: &[Value]) -> io::Result<()> {
     let mut existing = match read_session_file(path) {
         Ok(events) => events,
@@ -350,7 +346,7 @@ mod tests {
         let p = build_session_path(home, day, "abc");
         assert_eq!(
             p,
-            PathBuf::from("/tmp/.codex/sessions/2026/01/05/abc.jsonl.zst")
+            PathBuf::from("/tmp/.codex/sessions/2026/01/05/abc.jsonl")
         );
     }
 
@@ -361,7 +357,7 @@ mod tests {
         let p = build_session_path(home, day, "xyz-uuid");
         assert_eq!(
             p,
-            PathBuf::from("/var/codex/sessions/2026/12/31/xyz-uuid.jsonl.zst")
+            PathBuf::from("/var/codex/sessions/2026/12/31/xyz-uuid.jsonl")
         );
     }
 
@@ -394,7 +390,7 @@ mod tests {
     #[test]
     fn write_then_read_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("nested/deep/file.jsonl.zst");
+        let path = dir.path().join("nested/deep/file.jsonl");
         let evs = build_events("rt-1", "hi");
         write_session_file(&path, &evs).unwrap();
         let read_back = read_session_file(&path).unwrap();
@@ -405,7 +401,7 @@ mod tests {
     #[test]
     fn append_to_missing_file_creates_it() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("appended.jsonl.zst");
+        let path = dir.path().join("appended.jsonl");
         let evs = build_events("a-1", "first");
         append_session_file(&path, &evs).unwrap();
         let read_back = read_session_file(&path).unwrap();
@@ -415,7 +411,7 @@ mod tests {
     #[test]
     fn append_to_existing_file_extends() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("extend.jsonl.zst");
+        let path = dir.path().join("extend.jsonl");
         let first = build_events("e-1", "turn-1");
         write_session_file(&path, &first).unwrap();
         let second = build_events("e-1", "turn-2");

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -4,7 +4,6 @@
 //! Cover the contract guest-agent will rely on: stdout JSONL shape, the
 //! on-disk session file path / format, and resume semantics.
 
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -54,10 +53,7 @@ fn run_with_env(
 }
 
 fn read_session_file(path: &Path) -> std::io::Result<Vec<Value>> {
-    let bytes = std::fs::read(path)?;
-    let mut decoder = zstd::Decoder::new(bytes.as_slice())?;
-    let mut decoded = String::new();
-    decoder.read_to_string(&mut decoded)?;
+    let decoded = std::fs::read_to_string(path)?;
     let mut out = Vec::new();
     for line in decoded.lines() {
         if line.is_empty() {
@@ -73,7 +69,7 @@ fn read_session_file(path: &Path) -> std::io::Result<Vec<Value>> {
 fn find_session_file(codex_home: &Path) -> Option<PathBuf> {
     let mut found = None;
     walk(&codex_home.join("sessions"), &mut |p| {
-        if p.extension().and_then(|s| s.to_str()) == Some("zst") {
+        if p.extension().and_then(|s| s.to_str()) == Some("jsonl") {
             found = Some(p.to_path_buf());
         }
     });
@@ -95,7 +91,7 @@ fn walk(dir: &Path, f: &mut dyn FnMut(&Path)) {
 }
 
 #[test]
-fn happy_path_emits_three_events_and_persists_zstd() {
+fn happy_path_emits_three_events_and_persists_jsonl() {
     let dir = TempDir::new().unwrap();
     let out = run(dir.path(), &["exec", "--json", "--", "hello"]).unwrap();
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1142,7 +1142,7 @@ async fn download_storages(
 ///
 /// Dispatches on `cli_agent_type`:
 /// - `claude-code` (or empty, the default) → plain `.jsonl` under `~/.claude/projects/-{project}/`.
-/// - `codex` → zstd-compressed `.jsonl.zst` under `~/.codex/sessions/YYYY/MM/DD/`.
+/// - `codex` → plain `.jsonl` under `~/.codex/sessions/YYYY/MM/DD/`.
 /// - anything else → skipped with a warning (forward-compatible with future agents).
 async fn restore_session(
     sandbox: &dyn Sandbox,
@@ -1202,20 +1202,19 @@ async fn restore_claude_session(
     Ok(())
 }
 
-/// Write a Codex session history file as zstd-compressed JSONL at
-/// `~/.codex/sessions/YYYY/MM/DD/{thread_id}.jsonl.zst`.
+/// Write a Codex session history file as plain JSONL at
+/// `~/.codex/sessions/YYYY/MM/DD/{thread_id}.jsonl`.
 ///
 /// The date partition uses today's UTC date — `codex exec resume` walks the
 /// `sessions/` tree and resolves files by thread_id, so the partition is a
-/// hint, not a lookup key. Compression level 3 matches `guest-mock-codex`
-/// fixtures so round-trips are byte-stable across host and guest.
+/// hint, not a lookup key.
 async fn restore_codex_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     session: &ResumeSession,
 ) -> RunnerResult<()> {
     // Layout matches the real codex CLI (and `guest-mock-codex`):
-    // `/home/user/.codex/sessions/YYYY/MM/DD/{thread_id}.jsonl.zst`.
+    // `/home/user/.codex/sessions/YYYY/MM/DD/{thread_id}.jsonl`.
     let today = chrono::Utc::now().date_naive();
     let session_dir = format!(
         "/home/user/.codex/sessions/{}/{}/{}",
@@ -1223,7 +1222,7 @@ async fn restore_codex_session(
         today.format("%m"),
         today.format("%d"),
     );
-    let session_path = format!("{session_dir}/{}.jsonl.zst", session.session_id);
+    let session_path = format!("{session_dir}/{}.jsonl", session.session_id);
 
     let mkdir_cmd = format!("mkdir -p '{}'", session_dir.replace('\'', "'\\''"));
     sandbox
@@ -1235,15 +1234,14 @@ async fn restore_codex_session(
         })
         .await?;
 
-    let compressed = zstd::encode_all(session.session_history.as_bytes(), 3)
-        .map_err(|e| RunnerError::Internal(format!("zstd encode failed: {e}")))?;
-    sandbox.write_file(&session_path, &compressed).await?;
+    sandbox
+        .write_file(&session_path, session.session_history.as_bytes())
+        .await?;
 
     info!(
         run_id = %context.run_id,
         path = %session_path,
         bytes_in = session.session_history.len(),
-        bytes_out = compressed.len(),
         "restored codex session history",
     );
     Ok(())
@@ -2479,10 +2477,16 @@ mod tests {
             session_id: "01jzm-thread-id".into(),
             session_history: "{\"type\":\"thread.started\"}\n".into(),
         };
-        // mkdir exec + write_file — both succeed by default. The codex branch
-        // performs an additional zstd::encode_all call before write_file; this
-        // test fails fast if that path errors out.
+        // mkdir exec + write_file — both succeed by default.
         restore_session(&sandbox, &ctx, &session).await.unwrap();
+        let writes = sandbox.write_file_calls();
+        assert_eq!(writes.len(), 1);
+        assert!(
+            writes[0].path.ends_with("/01jzm-thread-id.jsonl"),
+            "codex resume history must be restored as plain jsonl, got {}",
+            writes[0].path
+        );
+        assert_eq!(writes[0].content, session.session_history.as_bytes());
     }
 
     #[tokio::test]
@@ -2498,16 +2502,6 @@ mod tests {
         };
         let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
         assert!(err.to_string().contains("invalid session_id"));
-    }
-
-    #[test]
-    fn codex_session_zstd_round_trip_recovers_bytes() {
-        // The runner compresses session bytes before write; the guest decompresses
-        // on read. This guards against a level/header drift between the two ends.
-        let input = "{\"type\":\"thread.started\",\"thread_id\":\"x\"}\n";
-        let compressed = zstd::encode_all(input.as_bytes(), 3).unwrap();
-        let decoded = zstd::decode_all(compressed.as_slice()).unwrap();
-        assert_eq!(decoded, input.as_bytes());
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -56,6 +56,12 @@ pub struct SpawnWatchCall {
     pub guest_log_path: Option<String>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WriteFileCall {
+    pub path: String,
+    pub content: Vec<u8>,
+}
+
 enum LifecycleBehavior {
     Result(Result<()>),
     Panic(String),
@@ -290,6 +296,7 @@ pub struct MockSandbox {
     source_ip: String,
     exec_results: Mutex<VecDeque<Result<ExecResult>>>,
     write_file_results: Mutex<VecDeque<Result<()>>>,
+    write_file_calls: Mutex<Vec<WriteFileCall>>,
     overrides: Option<Arc<MockSandboxOverrides>>,
     /// Holds the stdout channel sender alive when simulating a non-closing
     /// channel (e.g. wait_exit_error override). Without this, the sender is
@@ -304,6 +311,7 @@ impl MockSandbox {
             source_ip: "10.0.0.1".into(),
             exec_results: Mutex::new(VecDeque::new()),
             write_file_results: Mutex::new(VecDeque::new()),
+            write_file_calls: Mutex::new(Vec::new()),
             overrides: None,
             stdout_tx: Mutex::new(None),
         }
@@ -315,6 +323,7 @@ impl MockSandbox {
             source_ip: "10.0.0.1".into(),
             exec_results: Mutex::new(VecDeque::new()),
             write_file_results: Mutex::new(VecDeque::new()),
+            write_file_calls: Mutex::new(Vec::new()),
             overrides: Some(overrides),
             stdout_tx: Mutex::new(None),
         }
@@ -336,6 +345,10 @@ impl MockSandbox {
         self.write_file_results
             .lock_ignoring_poison()
             .push_back(result);
+    }
+
+    pub fn write_file_calls(&self) -> Vec<WriteFileCall> {
+        self.write_file_calls.lock_ignoring_poison().clone()
     }
 }
 
@@ -442,7 +455,13 @@ impl Sandbox for MockSandbox {
             .unwrap_or_else(|| Ok(default_exec_result()))
     }
 
-    async fn write_file(&self, _path: &str, _content: &[u8]) -> Result<()> {
+    async fn write_file(&self, path: &str, content: &[u8]) -> Result<()> {
+        self.write_file_calls
+            .lock_ignoring_poison()
+            .push(WriteFileCall {
+                path: path.to_string(),
+                content: content.to_vec(),
+            });
         self.write_file_results
             .lock_ignoring_poison()
             .pop_front()


### PR DESCRIPTION
## Summary
- restore Codex resume history as plain .jsonl files so codex-cli can read them as UTF-8
- update guest-mock-codex to match the current Codex session-store format
- keep guest-agent checkpoint reading compatible with legacy .jsonl.zst files and add coverage for both formats

## Root Cause
Prod resume runs restored Codex session history to /home/user/.codex/sessions/.../<thread_id>.jsonl.zst. codex-cli 0.128 reads thread-store files as UTF-8 JSONL, so it failed before model execution with: stream did not contain valid UTF-8.

## Tests
- cargo test -p runner restore_session
- cargo test -p guest-agent --test codex_session_resume
- cargo test -p guest-mock-codex
- cargo test -p sandbox-mock
- git diff --check
- pre-commit: cargo fmt, cargo clippy, cargo doc