### PR TITLE
feat(voice-chat): backend transcript ingestion and talker tool dispatch from relay

### DIFF
--- a/turbo/apps/api/src/signals/lib/voice-chat-relay/__tests__/talker-tool-dispatch.test.ts
+++ b/turbo/apps/api/src/signals/lib/voice-chat-relay/__tests__/talker-tool-dispatch.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from "vitest";
+import { dispatchTalkerTool } from "../talker-tool-dispatch";
+
+const SESSION = "session_abc";
+const CALL_ID = "call_xyz";
+const TOKEN = "relay-token-stub";
+const BASE_URL = "http://web.test";
+
+interface FunctionCallOutputEvent {
+  type: "conversation.item.create";
+  item: { type: "function_call_output"; call_id: string; output: string };
+}
+
+interface CapturedFetch {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function makeFetcher(response: { status: number; body?: unknown }) {
+  const calls: CapturedFetch[] = [];
+  const fetcher = (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      for (const [k, v] of new Headers(init.headers).entries()) {
+        headers[k] = v;
+      }
+    }
+    calls.push({
+      url: typeof input === "string" ? input : input.toString(),
+      method: init?.method ?? "GET",
+      headers,
+      body:
+        typeof init?.body === "string"
+          ? (JSON.parse(init.body) as unknown)
+          : init?.body,
+    });
+    return Promise.resolve(
+      new Response(JSON.stringify(response.body ?? {}), {
+        status: response.status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  };
+  return { fetcher, calls };
+}
+
+interface DispatchResult {
+  fetchCalls: CapturedFetch[];
+  outputs: FunctionCallOutputEvent[];
+}
+
+async function run(opts: {
+  toolName: string;
+  argumentsJson: string;
+  response?: { status: number; body?: unknown };
+}): Promise<DispatchResult> {
+  const outputs: FunctionCallOutputEvent[] = [];
+  const { fetcher, calls } = makeFetcher(opts.response ?? { status: 200 });
+  await dispatchTalkerTool({
+    voiceChatSessionId: SESSION,
+    toolName: opts.toolName,
+    callId: CALL_ID,
+    argumentsJson: opts.argumentsJson,
+    relayToken: TOKEN,
+    webBaseUrl: BASE_URL,
+    sendToOpenAi: (event) => {
+      outputs.push(event);
+    },
+    fetcher: fetcher as unknown as typeof fetch,
+  });
+  return { fetchCalls: calls, outputs };
+}
+
+function output(result: DispatchResult): string {
+  expect(result.outputs).toHaveLength(1);
+  expect(result.outputs[0]?.type).toBe("conversation.item.create");
+  expect(result.outputs[0]?.item.call_id).toBe(CALL_ID);
+  return result.outputs[0]?.item.output ?? "";
+}
+
+describe("dispatchTalkerTool — local validation", () => {
+  it("rejects an unknown tool name with no upstream call", async () => {
+    const result = await run({
+      toolName: "bogus_tool",
+      argumentsJson: '{"prompt":"hi"}',
+    });
+    expect(result.fetchCalls).toHaveLength(0);
+    expect(output(result)).toBe("Inform failed: invalid args.");
+  });
+
+  it("rejects unparseable arguments JSON with no upstream call", async () => {
+    const result = await run({
+      toolName: "inform_slow_brain",
+      argumentsJson: "not json",
+    });
+    expect(result.fetchCalls).toHaveLength(0);
+    expect(output(result)).toBe("Inform failed: invalid args.");
+  });
+
+  it("rejects a non-string prompt with no upstream call", async () => {
+    const result = await run({
+      toolName: "inform_slow_brain",
+      argumentsJson: '{"prompt":42}',
+    });
+    expect(result.fetchCalls).toHaveLength(0);
+    expect(output(result)).toBe("Inform failed: invalid args.");
+  });
+
+  it("rejects a whitespace-only prompt with no upstream call", async () => {
+    const result = await run({
+      toolName: "inform_slow_brain",
+      argumentsJson: '{"prompt":"   "}',
+    });
+    expect(result.fetchCalls).toHaveLength(0);
+    expect(output(result)).toBe("Inform failed: empty prompt.");
+  });
+});
+
+describe("dispatchTalkerTool — happy path", () => {
+  it("posts to the internal /tasks route and emits the success voice text", async () => {
+    const result = await run({
+      toolName: "inform_slow_brain",
+      argumentsJson: '{"prompt":"summarize latest deploys"}',
+    });
+    expect(result.fetchCalls).toHaveLength(1);
+    const call = result.fetchCalls[0]!;
+    expect(call.url).toBe(
+      `${BASE_URL}/api/internal/voice-chat/relay/${SESSION}/tasks`,
+    );
+    expect(call.method).toBe("POST");
+    expect(call.headers.authorization).toBe(`Bearer ${TOKEN}`);
+    expect(call.body).toStrictEqual({
+      prompt: "summarize latest deploys",
+      callId: CALL_ID,
+    });
+    expect(output(result)).toBe(
+      "Slow brain informed: 'summarize latest deploys'. It will decide what to do and report back.",
+    );
+  });
+
+  it("truncates long prompts with an ellipsis in the voice text", async () => {
+    const longPrompt = "a".repeat(200);
+    const result = await run({
+      toolName: "inform_slow_brain",
+      argumentsJson: JSON.stringify({ prompt: longPrompt }),
+    });
+    const out = output(result);
+    expect(out).toMatch(/Slow brain informed: '.*…'/);
+    // 60-char limit minus 1 for the ellipsis = 59 'a' chars + '…'.
+    expect(out).toContain("a".repeat(59) + "…");
+  });
+
+  it("works for any name in SESSION_TOOL_NAMES, not just inform_slow_brain", async () => {
+    const result = await run({
+      toolName: "feel_confused",
+      argumentsJson: '{"prompt":"what did the user mean?"}',
+    });
+    expect(result.fetchCalls).toHaveLength(1);
+    expect(output(result)).toContain("Slow brain informed:");
+  });
+});
+
+describe("dispatchTalkerTool — upstream failure mapping", () => {
+  it("maps 400 'no agent' to 'Slow brain not available for this session.'", async () => {
+    const result = await run({
+      toolName: "inform_slow_brain",
+      argumentsJson: '{"prompt":"hi"}',
+      response: {
+        status: 400,
+        body: {
+          error: { message: "Session has no agent; cannot spawn task" },
+        },
+      },
+    });
+    expect(output(result)).toBe("Slow brain not available for this session.");
+  });
+
+  it("maps generic 4xx to the catch-all retry voice text", async () => {
+    const result = await run({
+      toolName: "inform_slow_brain",
+      argumentsJson: '{"prompt":"hi"}',
+      response: {
+        status: 401,
+        body: { error: { message: "unauthorized" } },
+      },
+    });
+    expect(output(result)).toBe(
+      "Failed to reach the slow brain. Please try again or rephrase.",
+    );
+  });
+
+  it("maps 5xx to the catch-all retry voice text", async () => {
+    const result = await run({
+      toolName: "inform_slow_brain",
+      argumentsJson: '{"prompt":"hi"}',
+      response: { status: 500 },
+    });
+    expect(output(result)).toBe(
+      "Failed to reach the slow brain. Please try again or rephrase.",
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/lib/voice-chat-relay/__tests__/talker-tool-dispatch.test.ts
+++ b/turbo/apps/api/src/signals/lib/voice-chat-relay/__tests__/talker-tool-dispatch.test.ts
@@ -166,18 +166,37 @@ describe("dispatchTalkerTool — happy path", () => {
 });
 
 describe("dispatchTalkerTool — upstream failure mapping", () => {
-  it("maps 400 'no agent' to 'Slow brain not available for this session.'", async () => {
+  it("maps 400 'NO_AGENT' to 'Slow brain not available for this session.'", async () => {
     const result = await run({
       toolName: "inform_slow_brain",
       argumentsJson: '{"prompt":"hi"}',
       response: {
         status: 400,
         body: {
-          error: { message: "Session has no agent; cannot spawn task" },
+          error: {
+            message: "Session has no agent; cannot spawn task",
+            code: "NO_AGENT",
+          },
         },
       },
     });
     expect(output(result)).toBe("Slow brain not available for this session.");
+  });
+
+  it("maps 400 with a generic BAD_REQUEST code to the catch-all retry voice text", async () => {
+    const result = await run({
+      toolName: "inform_slow_brain",
+      argumentsJson: '{"prompt":"hi"}',
+      response: {
+        status: 400,
+        body: {
+          error: { message: "Invalid request body", code: "BAD_REQUEST" },
+        },
+      },
+    });
+    expect(output(result)).toBe(
+      "Failed to reach the slow brain. Please try again or rephrase.",
+    );
   });
 
   it("maps generic 4xx to the catch-all retry voice text", async () => {

--- a/turbo/apps/api/src/signals/lib/voice-chat-relay/__tests__/transcript-ingestor.test.ts
+++ b/turbo/apps/api/src/signals/lib/voice-chat-relay/__tests__/transcript-ingestor.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import {
+  ingestProviderTranscriptEvent,
+  type ProviderTranscriptEvent,
+} from "../transcript-ingestor";
+
+const SESSION = "session_abc";
+const TOKEN = "relay-token-stub";
+const BASE_URL = "http://web.test";
+
+interface CapturedCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function makeFetcher(response: { status: number; body?: unknown }) {
+  const calls: CapturedCall[] = [];
+  const fetcher = (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      for (const [k, v] of new Headers(init.headers).entries()) {
+        headers[k] = v;
+      }
+    }
+    calls.push({
+      url: typeof input === "string" ? input : input.toString(),
+      method: init?.method ?? "GET",
+      headers,
+      body:
+        typeof init?.body === "string"
+          ? (JSON.parse(init.body) as unknown)
+          : init?.body,
+    });
+    return Promise.resolve(
+      new Response(JSON.stringify(response.body ?? {}), {
+        status: response.status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  };
+  return { fetcher, calls };
+}
+
+async function run(event: ProviderTranscriptEvent) {
+  const { fetcher, calls } = makeFetcher({ status: 200 });
+  await ingestProviderTranscriptEvent({
+    voiceChatSessionId: SESSION,
+    event,
+    relayToken: TOKEN,
+    webBaseUrl: BASE_URL,
+    fetcher: fetcher as unknown as typeof fetch,
+  });
+  return calls;
+}
+
+describe("ingestProviderTranscriptEvent — input_audio_transcription.completed", () => {
+  it("posts a user item with the transcript and item_id", async () => {
+    const calls = await run({
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "item_1",
+      transcript: "hello world",
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(
+      `${BASE_URL}/api/internal/voice-chat/relay/${SESSION}/items`,
+    );
+    expect(calls[0]?.method).toBe("POST");
+    expect(calls[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
+    expect(calls[0]?.body).toStrictEqual({
+      role: "user",
+      content: "hello world",
+      realtimeItemId: "item_1",
+    });
+  });
+
+  it("skips empty (whitespace-only) transcripts", async () => {
+    const calls = await run({
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "item_1",
+      transcript: "   ",
+    });
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("ingestProviderTranscriptEvent — response.audio_transcript.done", () => {
+  it("posts an assistant item with the explicit item_id", async () => {
+    const calls = await run({
+      type: "response.audio_transcript.done",
+      item_id: "msg_42",
+      transcript: "yes I can do that",
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.body).toStrictEqual({
+      role: "assistant",
+      content: "yes I can do that",
+      realtimeItemId: "msg_42",
+    });
+  });
+
+  it("synthesizes id from response_id + transcript length when item_id is missing", async () => {
+    const calls = await run({
+      type: "response.audio_transcript.done",
+      response_id: "resp_1",
+      transcript: "hi",
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.body).toStrictEqual({
+      role: "assistant",
+      content: "hi",
+      realtimeItemId: "resp_1:2",
+    });
+  });
+
+  it("skips when transcript is whitespace-only", async () => {
+    const calls = await run({
+      type: "response.audio_transcript.done",
+      item_id: "msg_42",
+      transcript: "   ",
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("skips when no item_id and no response_id are available", async () => {
+    const calls = await run({
+      type: "response.audio_transcript.done",
+      transcript: "hi",
+    });
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("ingestProviderTranscriptEvent — vm0.assistant_interrupted", () => {
+  it("posts a system_note keyed by truncate:<itemId> with the JSON body", async () => {
+    const calls = await run({
+      type: "vm0.assistant_interrupted",
+      assistantRealtimeItemId: "msg_1",
+      heardText: "okay let me",
+      audioEndMs: 1234,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.body).toStrictEqual({
+      role: "system_note",
+      content: JSON.stringify({
+        type: "assistant_interrupted",
+        assistantRealtimeItemId: "msg_1",
+        heardText: "okay let me",
+        audioEndMs: 1234,
+      }),
+      realtimeItemId: "truncate:msg_1",
+    });
+  });
+
+  it("trims heardText before persisting", async () => {
+    const calls = await run({
+      type: "vm0.assistant_interrupted",
+      assistantRealtimeItemId: "msg_1",
+      heardText: "   okay   ",
+      audioEndMs: 0,
+    });
+    expect(calls).toHaveLength(1);
+    const body = calls[0]?.body as { content: string };
+    expect(body.content).toContain('"heardText":"okay"');
+  });
+});
+
+describe("ingestProviderTranscriptEvent — failure handling", () => {
+  it("does not throw when the upstream route returns 5xx", async () => {
+    const { fetcher } = makeFetcher({ status: 500 });
+    await expect(
+      ingestProviderTranscriptEvent({
+        voiceChatSessionId: SESSION,
+        event: {
+          type: "conversation.item.input_audio_transcription.completed",
+          item_id: "item_1",
+          transcript: "hi",
+        },
+        relayToken: TOKEN,
+        webBaseUrl: BASE_URL,
+        fetcher: fetcher as unknown as typeof fetch,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/turbo/apps/api/src/signals/lib/voice-chat-relay/talker-tool-dispatch.ts
+++ b/turbo/apps/api/src/signals/lib/voice-chat-relay/talker-tool-dispatch.ts
@@ -1,0 +1,172 @@
+import { isSessionToolName } from "@vm0/core/voice-chat/session-config";
+import { logger } from "../../../lib/log";
+import { safeJsonParse } from "../../utils";
+
+const log = logger("zero:voice-chat:relay:talker-tool");
+
+const SHORT_PROMPT_MAX = 60;
+
+interface FunctionCallOutputEvent {
+  type: "conversation.item.create";
+  item: {
+    type: "function_call_output";
+    call_id: string;
+    output: string;
+  };
+}
+
+type Fetcher = typeof fetch;
+
+interface DispatchParams {
+  voiceChatSessionId: string;
+  toolName: string;
+  callId: string;
+  argumentsJson: string;
+  relayToken: string;
+  webBaseUrl: string;
+  sendToOpenAi: (event: FunctionCallOutputEvent) => void;
+  fetcher?: Fetcher;
+}
+
+/**
+ * Dispatch a Talker `response.function_call_arguments.done` event:
+ * validate the tool name + parse arguments, POST to apps/web's internal
+ * `/api/internal/voice-chat/relay/[id]/tasks` route on success, and emit
+ * the matching `function_call_output` back to OpenAI via `sendToOpenAi`.
+ *
+ * The output text mirrors what the legacy browser-side handler produced
+ * (`Slow brain informed: '<short>'. ...`, `Inform failed: ...`,
+ * `Slow brain not available for this session.`) so the user-facing voice
+ * doesn't change when the relay path replaces the browser path.
+ */
+export async function dispatchTalkerTool(
+  params: DispatchParams,
+): Promise<void> {
+  if (!isSessionToolName(params.toolName)) {
+    log.warn(
+      `talker tool dispatch rejected: unknown tool ${params.toolName} for session ${params.voiceChatSessionId}`,
+    );
+    sendOutput(params, "Inform failed: invalid args.");
+    return;
+  }
+
+  const prompt = parsePrompt(params.argumentsJson);
+  if (prompt.kind === "invalid_json") {
+    sendOutput(params, "Inform failed: invalid args.");
+    return;
+  }
+  if (prompt.kind === "empty") {
+    sendOutput(params, "Inform failed: empty prompt.");
+    return;
+  }
+
+  const status = await postToInternalTasksRoute({
+    voiceChatSessionId: params.voiceChatSessionId,
+    prompt: prompt.value,
+    callId: params.callId,
+    relayToken: params.relayToken,
+    webBaseUrl: params.webBaseUrl,
+    fetcher: params.fetcher ?? fetch,
+  });
+
+  if (status.kind === "ok") {
+    sendOutput(
+      params,
+      `Slow brain informed: '${shortPrompt(prompt.value)}'. It will decide what to do and report back.`,
+    );
+    return;
+  }
+
+  if (status.kind === "no_agent") {
+    sendOutput(params, "Slow brain not available for this session.");
+    return;
+  }
+
+  sendOutput(
+    params,
+    "Failed to reach the slow brain. Please try again or rephrase.",
+  );
+}
+
+type PromptParse =
+  | { kind: "ok"; value: string }
+  | { kind: "invalid_json" }
+  | { kind: "empty" };
+
+function parsePrompt(argumentsJson: string): PromptParse {
+  const parsed = safeJsonParse(argumentsJson);
+  if (!parsed || typeof parsed !== "object") {
+    return { kind: "invalid_json" };
+  }
+  const record = parsed as Record<string, unknown>;
+  if (typeof record.prompt !== "string") {
+    return { kind: "invalid_json" };
+  }
+  if (!record.prompt.trim()) {
+    return { kind: "empty" };
+  }
+  return { kind: "ok", value: record.prompt };
+}
+
+type DispatchOutcome =
+  | { kind: "ok" }
+  | { kind: "no_agent" }
+  | { kind: "other_failure" };
+
+async function postToInternalTasksRoute(opts: {
+  voiceChatSessionId: string;
+  prompt: string;
+  callId: string;
+  relayToken: string;
+  webBaseUrl: string;
+  fetcher: Fetcher;
+}): Promise<DispatchOutcome> {
+  const url = `${opts.webBaseUrl}/api/internal/voice-chat/relay/${opts.voiceChatSessionId}/tasks`;
+  const response = await opts.fetcher(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${opts.relayToken}`,
+    },
+    body: JSON.stringify({ prompt: opts.prompt, callId: opts.callId }),
+  });
+
+  if (response.ok) {
+    return { kind: "ok" };
+  }
+
+  if (response.status === 400) {
+    const text = await response.text();
+    const parsed = safeJsonParse(text) as
+      | { error?: { message?: string } }
+      | undefined;
+    const message = parsed?.error?.message ?? "";
+    if (message.toLowerCase().includes("no agent")) {
+      return { kind: "no_agent" };
+    }
+  }
+
+  log.warn(
+    `talker tool dispatch upstream failure ${String(response.status)} for session ${opts.voiceChatSessionId}`,
+  );
+  return { kind: "other_failure" };
+}
+
+function sendOutput(params: DispatchParams, output: string): void {
+  params.sendToOpenAi({
+    type: "conversation.item.create",
+    item: {
+      type: "function_call_output",
+      call_id: params.callId,
+      output,
+    },
+  });
+}
+
+function shortPrompt(prompt: string): string {
+  const trimmed = prompt.trim();
+  if (trimmed.length <= SHORT_PROMPT_MAX) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, SHORT_PROMPT_MAX - 1)}…`;
+}

--- a/turbo/apps/api/src/signals/lib/voice-chat-relay/talker-tool-dispatch.ts
+++ b/turbo/apps/api/src/signals/lib/voice-chat-relay/talker-tool-dispatch.ts
@@ -138,10 +138,9 @@ async function postToInternalTasksRoute(opts: {
   if (response.status === 400) {
     const text = await response.text();
     const parsed = safeJsonParse(text) as
-      | { error?: { message?: string } }
+      | { error?: { code?: string } }
       | undefined;
-    const message = parsed?.error?.message ?? "";
-    if (message.toLowerCase().includes("no agent")) {
+    if (parsed?.error?.code === "NO_AGENT") {
       return { kind: "no_agent" };
     }
   }

--- a/turbo/apps/api/src/signals/lib/voice-chat-relay/transcript-ingestor.ts
+++ b/turbo/apps/api/src/signals/lib/voice-chat-relay/transcript-ingestor.ts
@@ -1,0 +1,135 @@
+import { logger } from "../../../lib/log";
+
+const log = logger("zero:voice-chat:relay:transcript");
+
+interface InputAudioTranscriptionCompleted {
+  type: "conversation.item.input_audio_transcription.completed";
+  item_id: string;
+  transcript: string;
+}
+interface ResponseAudioTranscriptDone {
+  type: "response.audio_transcript.done";
+  item_id?: string;
+  response_id?: string;
+  transcript: string;
+}
+interface AssistantInterruptedSignal {
+  type: "vm0.assistant_interrupted";
+  assistantRealtimeItemId: string;
+  heardText: string;
+  audioEndMs: number;
+}
+
+export type ProviderTranscriptEvent =
+  | InputAudioTranscriptionCompleted
+  | ResponseAudioTranscriptDone
+  | AssistantInterruptedSignal;
+
+type Fetcher = typeof fetch;
+
+interface IngestParams {
+  voiceChatSessionId: string;
+  event: ProviderTranscriptEvent;
+  relayToken: string;
+  webBaseUrl: string;
+  fetcher?: Fetcher;
+}
+
+/**
+ * Persist a relay-observed transcript event by POSTing the normalized body to
+ * apps/web's internal `/api/internal/voice-chat/relay/[id]/items` route.
+ * The route owns the DB write + Reasoner trigger; this module owns the
+ * narrowing from raw provider event to normalized body.
+ */
+export async function ingestProviderTranscriptEvent(
+  params: IngestParams,
+): Promise<void> {
+  const body = buildItemBody(params.event);
+  if (!body) {
+    return;
+  }
+  await postToInternalItemsRoute({
+    voiceChatSessionId: params.voiceChatSessionId,
+    body,
+    relayToken: params.relayToken,
+    webBaseUrl: params.webBaseUrl,
+    fetcher: params.fetcher ?? fetch,
+  });
+}
+
+interface ItemBody {
+  role: "user" | "assistant" | "system_note";
+  content: string;
+  realtimeItemId: string;
+}
+
+function buildItemBody(event: ProviderTranscriptEvent): ItemBody | null {
+  switch (event.type) {
+    case "conversation.item.input_audio_transcription.completed": {
+      const transcript = event.transcript;
+      if (!transcript.trim()) {
+        return null;
+      }
+      return {
+        role: "user",
+        content: transcript,
+        realtimeItemId: event.item_id,
+      };
+    }
+    case "response.audio_transcript.done": {
+      const transcript = event.transcript;
+      if (!transcript.trim()) {
+        return null;
+      }
+      const id =
+        event.item_id ??
+        (event.response_id
+          ? `${event.response_id}:${String(transcript.length)}`
+          : null);
+      if (!id) {
+        return null;
+      }
+      return {
+        role: "assistant",
+        content: transcript,
+        realtimeItemId: id,
+      };
+    }
+    case "vm0.assistant_interrupted": {
+      const noteContent = JSON.stringify({
+        type: "assistant_interrupted",
+        assistantRealtimeItemId: event.assistantRealtimeItemId,
+        heardText: event.heardText.trim(),
+        audioEndMs: event.audioEndMs,
+      });
+      return {
+        role: "system_note",
+        content: noteContent,
+        realtimeItemId: `truncate:${event.assistantRealtimeItemId}`,
+      };
+    }
+  }
+}
+
+async function postToInternalItemsRoute(opts: {
+  voiceChatSessionId: string;
+  body: ItemBody;
+  relayToken: string;
+  webBaseUrl: string;
+  fetcher: Fetcher;
+}): Promise<void> {
+  const url = `${opts.webBaseUrl}/api/internal/voice-chat/relay/${opts.voiceChatSessionId}/items`;
+  const response = await opts.fetcher(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${opts.relayToken}`,
+    },
+    body: JSON.stringify(opts.body),
+  });
+  if (!response.ok) {
+    log.warn(
+      `transcript ingest failed: ${String(response.status)} for session ${opts.voiceChatSessionId} role=${opts.body.role}`,
+    );
+  }
+}

--- a/turbo/apps/web/app/api/internal/voice-chat/relay/[id]/items/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/voice-chat/relay/[id]/items/__tests__/route.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { randomUUID } from "crypto";
+import { signRelayToken } from "@vm0/core/voice-chat/relay-token";
+import { reloadEnv } from "../../../../../../../../src/env";
+import { testContext } from "../../../../../../../../src/__tests__/test-helpers";
+import { createTestRequest } from "../../../../../../../../src/__tests__/api-test-helpers";
+import { readTestVoiceChatItems } from "../../../../../../../../src/__tests__/db-test-assertions/voice-chat";
+import {
+  seedVoiceChatAgent,
+  seedVoiceChatSession,
+  setupVoiceChatOrg,
+} from "../../../../../../zero/voice-chat/__tests__/_helpers";
+
+const SECRET = "00".repeat(32); // 64 hex chars — A3's verify expects hex secret
+const BASE_URL = "http://localhost:3000/api/internal/voice-chat/relay";
+
+vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@vm0/core/feature-switch")>();
+  return {
+    ...actual,
+    isFeatureEnabled: vi.fn().mockReturnValue(true),
+  };
+});
+
+const { POST } = await import("../route");
+
+const context = testContext();
+
+interface SeededFixture {
+  userId: string;
+  orgId: string;
+  agentId: string | null;
+  sessionId: string;
+}
+
+async function seedFixture(): Promise<SeededFixture> {
+  const { userId } = await context.setupUser();
+  const { orgId } = await setupVoiceChatOrg(userId);
+  const { agentId } = await seedVoiceChatAgent(userId, orgId);
+  const session = await seedVoiceChatSession({ orgId, userId, agentId });
+  return { userId, orgId, agentId, sessionId: session.id };
+}
+
+function tokenFor(
+  fixture: SeededFixture,
+  override?: { voiceChatSessionId?: string; expired?: boolean },
+): string {
+  const result = signRelayToken(
+    {
+      voiceChatSessionId: override?.voiceChatSessionId ?? fixture.sessionId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      ttlSeconds: override?.expired === true ? -1 : 3600,
+    },
+    SECRET,
+  );
+  return result.token;
+}
+
+function postRequest(opts: {
+  sessionId: string;
+  body: unknown;
+  token?: string;
+}) {
+  return createTestRequest(`${BASE_URL}/${opts.sessionId}/items`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(opts.token ? { Authorization: `Bearer ${opts.token}` } : {}),
+    },
+    body: JSON.stringify(opts.body),
+  });
+}
+
+function paramsFor(id: string): { params: Promise<{ id: string }> } {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("POST /api/internal/voice-chat/relay/:id/items", () => {
+  beforeEach(() => {
+    context.setupMocks();
+    vi.stubEnv("VOICE_CHAT_RELAY_TOKEN_SECRET", SECRET);
+    reloadEnv();
+  });
+
+  it("returns 503 when the relay-token secret is not configured", async () => {
+    vi.stubEnv("VOICE_CHAT_RELAY_TOKEN_SECRET", "");
+    reloadEnv();
+    const fixture = await seedFixture();
+    const token = tokenFor(fixture);
+    const response = await POST(
+      postRequest({
+        sessionId: fixture.sessionId,
+        body: { role: "user", content: "hi", realtimeItemId: randomUUID() },
+        token,
+      }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(response.status).toBe(503);
+  });
+
+  it("returns 401 when the Authorization header is missing", async () => {
+    const fixture = await seedFixture();
+    const response = await POST(
+      postRequest({
+        sessionId: fixture.sessionId,
+        body: { role: "user", content: "hi", realtimeItemId: randomUUID() },
+      }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 401 when the relay token signature is invalid", async () => {
+    const fixture = await seedFixture();
+    const goodToken = tokenFor(fixture);
+    const [payload] = goodToken.split(".");
+    const tampered = `${payload}.AAAAAAAAAAAAAAAAAAAAAAAAAAAA`;
+    const response = await POST(
+      postRequest({
+        sessionId: fixture.sessionId,
+        body: { role: "user", content: "hi", realtimeItemId: randomUUID() },
+        token: tampered,
+      }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 401 when the token's voiceChatSessionId doesn't match the path", async () => {
+    const fixture = await seedFixture();
+    const otherSessionId = randomUUID();
+    const token = tokenFor(fixture, {
+      voiceChatSessionId: otherSessionId,
+    });
+    const response = await POST(
+      postRequest({
+        sessionId: fixture.sessionId,
+        body: { role: "user", content: "hi", realtimeItemId: randomUUID() },
+        token,
+      }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 401 for an expired token", async () => {
+    const fixture = await seedFixture();
+    const token = tokenFor(fixture, { expired: true });
+    const response = await POST(
+      postRequest({
+        sessionId: fixture.sessionId,
+        body: { role: "user", content: "hi", realtimeItemId: randomUUID() },
+        token,
+      }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 when the body is invalid", async () => {
+    const fixture = await seedFixture();
+    const token = tokenFor(fixture);
+    const response = await POST(
+      postRequest({
+        sessionId: fixture.sessionId,
+        body: { role: "invalid", content: "hi", realtimeItemId: "rt_1" },
+        token,
+      }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("inserts a user transcript item on first call and is idempotent on the second", async () => {
+    const fixture = await seedFixture();
+    const token = tokenFor(fixture);
+    const realtimeItemId = randomUUID();
+    const body = {
+      role: "user" as const,
+      content: "hello world",
+      realtimeItemId,
+    };
+
+    const first = await POST(
+      postRequest({ sessionId: fixture.sessionId, body, token }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(first.status).toBe(200);
+    const firstJson = (await first.json()) as { item: { id: string } };
+    expect(firstJson.item.id).toBeDefined();
+
+    const second = await POST(
+      postRequest({ sessionId: fixture.sessionId, body, token }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(second.status).toBe(200);
+    const secondJson = (await second.json()) as { item: { id: string } };
+    expect(secondJson.item.id).toBe(firstJson.item.id);
+
+    const rows = await readTestVoiceChatItems(fixture.sessionId);
+    const userRows = rows.filter((r) => {
+      return r.role === "user";
+    });
+    expect(userRows).toHaveLength(1);
+  });
+
+  it("appends an assistant transcript item with its realtime id", async () => {
+    const fixture = await seedFixture();
+    const token = tokenFor(fixture);
+    const realtimeItemId = `msg_${randomUUID()}`;
+    const response = await POST(
+      postRequest({
+        sessionId: fixture.sessionId,
+        body: {
+          role: "assistant",
+          content: "yes I can do that",
+          realtimeItemId,
+        },
+        token,
+      }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(response.status).toBe(200);
+    const rows = await readTestVoiceChatItems(fixture.sessionId);
+    const assistantRows = rows.filter((r) => {
+      return r.role === "assistant";
+    });
+    expect(assistantRows).toHaveLength(1);
+    expect(assistantRows[0]?.content).toBe("yes I can do that");
+  });
+
+  it("appends a system_note interruption row keyed by truncate:<itemId>", async () => {
+    const fixture = await seedFixture();
+    const token = tokenFor(fixture);
+    const assistantId = `msg_${randomUUID()}`;
+    const response = await POST(
+      postRequest({
+        sessionId: fixture.sessionId,
+        body: {
+          role: "system_note",
+          content: JSON.stringify({
+            type: "assistant_interrupted",
+            assistantRealtimeItemId: assistantId,
+            heardText: "okay let me",
+            audioEndMs: 1234,
+          }),
+          realtimeItemId: `truncate:${assistantId}`,
+        },
+        token,
+      }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 404 when the path's session id is unknown", async () => {
+    const fixture = await seedFixture();
+    const unknownId = randomUUID();
+    const token = tokenFor(fixture, { voiceChatSessionId: unknownId });
+    const response = await POST(
+      postRequest({
+        sessionId: unknownId,
+        body: { role: "user", content: "hi", realtimeItemId: randomUUID() },
+        token,
+      }),
+      paramsFor(unknownId),
+    );
+    expect(response.status).toBe(404);
+  });
+});

--- a/turbo/apps/web/app/api/internal/voice-chat/relay/[id]/items/route.ts
+++ b/turbo/apps/web/app/api/internal/voice-chat/relay/[id]/items/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse, after } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { initServices } from "../../../../../../../src/lib/init-services";
+import { resolveRelayAuth } from "../../../../../../../src/lib/zero/voice-chat/relay-auth";
+import { getVoiceChatSession } from "../../../../../../../src/lib/zero/voice-chat/session-service";
+import { appendVoiceChatItem } from "../../../../../../../src/lib/zero/voice-chat/item-service";
+import { triggerReasoning } from "../../../../../../../src/lib/zero/voice-chat/trigger-reasoning";
+import { voiceChatItems } from "@vm0/db/schema/voice-chat";
+import { isBadRequest } from "@vm0/api-services/errors";
+import {
+  appendVoiceChatItemBodySchema,
+  badRequestResponse,
+  notFoundResponse,
+  serializeVoiceChatItem,
+} from "../../../../../zero/voice-chat/_support";
+
+export const maxDuration = 60;
+
+/**
+ * Relay-token-gated mirror of POST /api/zero/voice-chat/[id]/items.
+ *
+ * Used by the apps/api WS relay (#12141) to persist transcript items
+ * (user / assistant / system_note) it observes from the OpenAI provider
+ * stream. Same service-layer call, same idempotency via the
+ * (sessionId, realtimeItemId) unique index, same after()/triggerReasoning
+ * fan-out as the user-facing route. Auth is the relay token instead of
+ * the user's Clerk JWT — claims carry the userId / orgId / sessionId.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  initServices();
+
+  const { id } = await params;
+  const auth = resolveRelayAuth(request, id);
+  if (auth instanceof Response) return auth;
+
+  const session = await getVoiceChatSession(id);
+  if (
+    !session ||
+    session.orgId !== auth.orgId ||
+    session.userId !== auth.userId
+  ) {
+    return notFoundResponse("Voice-chat session not found");
+  }
+
+  const parsed = appendVoiceChatItemBodySchema.safeParse(
+    await request.json().catch(() => {
+      return undefined;
+    }),
+  );
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    return badRequestResponse(issue?.message ?? "Invalid request body");
+  }
+
+  try {
+    const inserted = await appendVoiceChatItem({
+      sessionId: id,
+      role: parsed.data.role,
+      content: parsed.data.content,
+      realtimeItemId: parsed.data.realtimeItemId,
+    });
+
+    if (inserted) {
+      after(() => {
+        return triggerReasoning(id);
+      });
+      return NextResponse.json({
+        item: serializeVoiceChatItem(inserted),
+      });
+    }
+
+    // Silent dedupe: the (sessionId, realtimeItemId) pair already exists.
+    // Recover the existing row so the 200 response schema stays populated.
+    const db = globalThis.services.db;
+    const [existing] = await db
+      .select()
+      .from(voiceChatItems)
+      .where(
+        and(
+          eq(voiceChatItems.sessionId, id),
+          eq(voiceChatItems.realtimeItemId, parsed.data.realtimeItemId),
+        ),
+      )
+      .limit(1);
+    if (!existing) {
+      return notFoundResponse("Conflicting item not found after dedupe");
+    }
+    return NextResponse.json({
+      item: serializeVoiceChatItem(existing),
+    });
+  } catch (err) {
+    if (isBadRequest(err)) {
+      return badRequestResponse(err.message);
+    }
+    throw err;
+  }
+}

--- a/turbo/apps/web/app/api/internal/voice-chat/relay/[id]/tasks/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/voice-chat/relay/[id]/tasks/__tests__/route.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { randomUUID } from "crypto";
+import { signRelayToken } from "@vm0/core/voice-chat/relay-token";
+import { reloadEnv } from "../../../../../../../../src/env";
+import { testContext } from "../../../../../../../../src/__tests__/test-helpers";
+import { createTestRequest } from "../../../../../../../../src/__tests__/api-test-helpers";
+import { findTestZeroRun } from "../../../../../../../../src/__tests__/db-test-assertions/runs";
+import { insertTestVoiceChatSession } from "../../../../../../../../src/__tests__/db-test-seeders/voice-chat";
+import {
+  seedVoiceChatAgent,
+  seedVoiceChatSession,
+  setupVoiceChatOrg,
+} from "../../../../../../zero/voice-chat/__tests__/_helpers";
+
+const SECRET = "00".repeat(32); // 64 hex chars — A3's verify expects hex secret
+const BASE_URL = "http://localhost:3000/api/internal/voice-chat/relay";
+
+vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@vm0/core/feature-switch")>();
+  return {
+    ...actual,
+    isFeatureEnabled: vi.fn().mockReturnValue(true),
+  };
+});
+
+const { POST } = await import("../route");
+
+const context = testContext();
+
+interface SeededFixture {
+  userId: string;
+  orgId: string;
+  agentId: string | null;
+  sessionId: string;
+}
+
+async function seedFixtureWithAgent(): Promise<SeededFixture> {
+  const { userId } = await context.setupUser();
+  const { orgId } = await setupVoiceChatOrg(userId);
+  const { agentId } = await seedVoiceChatAgent(userId, orgId);
+  const session = await seedVoiceChatSession({ orgId, userId, agentId });
+  return { userId, orgId, agentId, sessionId: session.id };
+}
+
+async function seedFixtureWithoutAgent(): Promise<SeededFixture> {
+  const { userId } = await context.setupUser();
+  const { orgId } = await setupVoiceChatOrg(userId);
+  const sessionId = await insertTestVoiceChatSession({
+    orgId,
+    userId,
+    agentId: null,
+  });
+  return { userId, orgId, agentId: null, sessionId };
+}
+
+function tokenFor(
+  fixture: SeededFixture,
+  override?: { voiceChatSessionId?: string; expired?: boolean },
+): string {
+  const result = signRelayToken(
+    {
+      voiceChatSessionId: override?.voiceChatSessionId ?? fixture.sessionId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      ttlSeconds: override?.expired === true ? -1 : 3600,
+    },
+    SECRET,
+  );
+  return result.token;
+}
+
+function postRequest(opts: {
+  sessionId: string;
+  body: unknown;
+  token?: string;
+}) {
+  return createTestRequest(`${BASE_URL}/${opts.sessionId}/tasks`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(opts.token ? { Authorization: `Bearer ${opts.token}` } : {}),
+    },
+    body: JSON.stringify(opts.body),
+  });
+}
+
+function paramsFor(id: string): { params: Promise<{ id: string }> } {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("POST /api/internal/voice-chat/relay/:id/tasks", () => {
+  beforeEach(() => {
+    context.setupMocks();
+    vi.stubEnv("VOICE_CHAT_RELAY_TOKEN_SECRET", SECRET);
+    reloadEnv();
+  });
+
+  it("returns 401 when the Authorization header is missing", async () => {
+    const fixture = await seedFixtureWithAgent();
+    const response = await POST(
+      postRequest({
+        sessionId: fixture.sessionId,
+        body: { prompt: "do a thing", callId: randomUUID() },
+      }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 401 when the relay token signature is invalid", async () => {
+    const fixture = await seedFixtureWithAgent();
+    const goodToken = tokenFor(fixture);
+    const [payload] = goodToken.split(".");
+    const tampered = `${payload}.AAAAAAAAAAAAAAAAAAAAAAAAAAAA`;
+    const response = await POST(
+      postRequest({
+        sessionId: fixture.sessionId,
+        body: { prompt: "do a thing", callId: randomUUID() },
+        token: tampered,
+      }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 503 when the relay-token secret is not configured", async () => {
+    vi.stubEnv("VOICE_CHAT_RELAY_TOKEN_SECRET", "");
+    reloadEnv();
+    const fixture = await seedFixtureWithAgent();
+    const token = tokenFor(fixture);
+    const response = await POST(
+      postRequest({
+        sessionId: fixture.sessionId,
+        body: { prompt: "do a thing", callId: randomUUID() },
+        token,
+      }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(response.status).toBe(503);
+  });
+
+  it("returns 400 when the session has no agent", async () => {
+    const fixture = await seedFixtureWithoutAgent();
+    const token = tokenFor(fixture);
+    const response = await POST(
+      postRequest({
+        sessionId: fixture.sessionId,
+        body: { prompt: "do a thing", callId: randomUUID() },
+        token,
+      }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("no agent");
+  });
+
+  it("returns 400 when prompt is missing", async () => {
+    const fixture = await seedFixtureWithAgent();
+    const token = tokenFor(fixture);
+    const response = await POST(
+      postRequest({
+        sessionId: fixture.sessionId,
+        body: { callId: randomUUID() },
+        token,
+      }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when callId is missing", async () => {
+    const fixture = await seedFixtureWithAgent();
+    const token = tokenFor(fixture);
+    const response = await POST(
+      postRequest({
+        sessionId: fixture.sessionId,
+        body: { prompt: "do a thing" },
+        token,
+      }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("creates a task and dispatches a zero run with triggerSource=voice-chat", async () => {
+    const fixture = await seedFixtureWithAgent();
+    const token = tokenFor(fixture);
+    const callId = randomUUID();
+    const response = await POST(
+      postRequest({
+        sessionId: fixture.sessionId,
+        body: { prompt: "summarize latest", callId },
+        token,
+      }),
+      paramsFor(fixture.sessionId),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      task: {
+        sessionId: string;
+        callId: string;
+        prompt: string;
+        status: string;
+        runId: string;
+      };
+    };
+    expect(body.task.sessionId).toBe(fixture.sessionId);
+    expect(body.task.callId).toBe(callId);
+    expect(body.task.prompt).toBe("summarize latest");
+    expect(["pending", "queued"]).toContain(body.task.status);
+    expect(body.task.runId).toBeTruthy();
+
+    const zeroRun = await findTestZeroRun(body.task.runId);
+    expect(zeroRun?.triggerSource).toBe("voice-chat");
+  });
+});

--- a/turbo/apps/web/app/api/internal/voice-chat/relay/[id]/tasks/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/voice-chat/relay/[id]/tasks/__tests__/route.test.ts
@@ -140,7 +140,7 @@ describe("POST /api/internal/voice-chat/relay/:id/tasks", () => {
     expect(response.status).toBe(503);
   });
 
-  it("returns 400 when the session has no agent", async () => {
+  it("returns 400 with code NO_AGENT when the session has no agent", async () => {
     const fixture = await seedFixtureWithoutAgent();
     const token = tokenFor(fixture);
     const response = await POST(
@@ -152,8 +152,10 @@ describe("POST /api/internal/voice-chat/relay/:id/tasks", () => {
       paramsFor(fixture.sessionId),
     );
     expect(response.status).toBe(400);
-    const body = (await response.json()) as { error: { message: string } };
-    expect(body.error.message).toContain("no agent");
+    const body = (await response.json()) as {
+      error: { message: string; code: string };
+    };
+    expect(body.error.code).toBe("NO_AGENT");
   });
 
   it("returns 400 when prompt is missing", async () => {

--- a/turbo/apps/web/app/api/internal/voice-chat/relay/[id]/tasks/route.ts
+++ b/turbo/apps/web/app/api/internal/voice-chat/relay/[id]/tasks/route.ts
@@ -47,7 +47,10 @@ export async function POST(
     return notFoundResponse("Voice-chat session not found");
   }
   if (!session.agentId) {
-    return badRequestResponse("Session has no agent; cannot spawn task");
+    return badRequestResponse(
+      "Session has no agent; cannot spawn task",
+      "NO_AGENT",
+    );
   }
 
   const parsed = createVoiceChatTaskBodySchema.safeParse(

--- a/turbo/apps/web/app/api/internal/voice-chat/relay/[id]/tasks/route.ts
+++ b/turbo/apps/web/app/api/internal/voice-chat/relay/[id]/tasks/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse, after } from "next/server";
+import { initServices } from "../../../../../../../src/lib/init-services";
+import { resolveRelayAuth } from "../../../../../../../src/lib/zero/voice-chat/relay-auth";
+import { getVoiceChatSession } from "../../../../../../../src/lib/zero/voice-chat/session-service";
+import { createVoiceChatTask } from "../../../../../../../src/lib/zero/voice-chat/task-service";
+import { buildVoiceChatTaskAppendSystemPrompt } from "../../../../../../../src/lib/zero/voice-chat/build-voice-chat-task-context";
+import { triggerReasoning } from "../../../../../../../src/lib/zero/voice-chat/trigger-reasoning";
+import { adaptVoiceChatTaskTrigger } from "../../../../../../../src/lib/zero/voice-chat/adapt-task-trigger";
+import { publishUserSignal } from "../../../../../../../src/lib/infra/realtime/client";
+import { createZeroRun } from "../../../../../../../src/lib/zero/zero-run-service";
+import {
+  badRequestResponse,
+  createVoiceChatTaskBodySchema,
+  notFoundResponse,
+  serializeVoiceChatTask,
+} from "../../../../../zero/voice-chat/_support";
+
+export const maxDuration = 60;
+
+/**
+ * Relay-token-gated mirror of POST /api/zero/voice-chat/[id]/tasks.
+ *
+ * Used by the apps/api WS relay (#12141) to dispatch Talker tool calls
+ * (`response.function_call_arguments.done`) into the existing voice-chat
+ * task pipeline. Same service-layer call, same Ably + Reasoner fan-out as
+ * the user-facing route. Auth is the relay token; the `agentId` is read
+ * from the persisted session (relay token's optional `agentId` claim is
+ * not trusted for this — sessions can have agents reassigned).
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const apiStartTime = Date.now();
+  initServices();
+
+  const { id } = await params;
+  const auth = resolveRelayAuth(request, id);
+  if (auth instanceof Response) return auth;
+
+  const session = await getVoiceChatSession(id);
+  if (
+    !session ||
+    session.orgId !== auth.orgId ||
+    session.userId !== auth.userId
+  ) {
+    return notFoundResponse("Voice-chat session not found");
+  }
+  if (!session.agentId) {
+    return badRequestResponse("Session has no agent; cannot spawn task");
+  }
+
+  const parsed = createVoiceChatTaskBodySchema.safeParse(
+    await request.json().catch(() => {
+      return undefined;
+    }),
+  );
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    return badRequestResponse(issue?.message ?? "Invalid request body");
+  }
+
+  const appendSystemPrompt = await buildVoiceChatTaskAppendSystemPrompt({
+    sessionId: id,
+    agentId: session.agentId,
+  });
+
+  const agentId = session.agentId;
+  const task = await createVoiceChatTask({
+    sessionId: id,
+    callId: parsed.data.callId,
+    prompt: parsed.data.prompt,
+    spawnRun: (taskId) => {
+      const runParams = adaptVoiceChatTaskTrigger({
+        userId: auth.userId,
+        agentId,
+        taskId,
+        prompt: parsed.data.prompt,
+        appendSystemPrompt,
+        apiStartTime,
+      });
+      return createZeroRun(runParams);
+    },
+  });
+
+  await publishUserSignal([session.userId], `voice-chat:${id}`);
+  after(() => {
+    return triggerReasoning(id);
+  });
+
+  return NextResponse.json({
+    task: serializeVoiceChatTask(task),
+  });
+}

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/tasks/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/tasks/route.ts
@@ -2,17 +2,12 @@ import { NextResponse, after } from "next/server";
 import { getAuthContext } from "../../../../../../src/lib/auth/get-auth-context";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { getVoiceChatSession } from "../../../../../../src/lib/zero/voice-chat/session-service";
-import { readVoiceChatItems } from "../../../../../../src/lib/zero/voice-chat/item-service";
 import {
   createVoiceChatTask,
-  listSessionTasks,
   listSessionTasksForCard,
 } from "../../../../../../src/lib/zero/voice-chat/task-service";
-import { buildSlowBrainAppendSystemPrompt } from "../../../../../../src/lib/zero/voice-chat/build-slow-brain-prompt";
-import {
-  resolveAgentSystemPrompt,
-  triggerReasoning,
-} from "../../../../../../src/lib/zero/voice-chat/trigger-reasoning";
+import { buildVoiceChatTaskAppendSystemPrompt } from "../../../../../../src/lib/zero/voice-chat/build-voice-chat-task-context";
+import { triggerReasoning } from "../../../../../../src/lib/zero/voice-chat/trigger-reasoning";
 import { adaptVoiceChatTaskTrigger } from "../../../../../../src/lib/zero/voice-chat/adapt-task-trigger";
 import { publishUserSignal } from "../../../../../../src/lib/infra/realtime/client";
 import { createZeroRun } from "../../../../../../src/lib/zero/zero-run-service";
@@ -69,15 +64,9 @@ export async function POST(
     return badRequestResponse(issue?.message ?? "Invalid request body");
   }
 
-  const [agentSystemPrompt, allItems, sessionTasks] = await Promise.all([
-    resolveAgentSystemPrompt(session.agentId),
-    readVoiceChatItems(id),
-    listSessionTasks(id),
-  ]);
-  const appendSystemPrompt = buildSlowBrainAppendSystemPrompt({
-    agentSystemPrompt,
-    items: allItems,
-    sessionTasks,
+  const appendSystemPrompt = await buildVoiceChatTaskAppendSystemPrompt({
+    sessionId: id,
+    agentId: session.agentId,
   });
 
   const agentId = session.agentId;

--- a/turbo/apps/web/app/api/zero/voice-chat/_support.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/_support.ts
@@ -163,9 +163,9 @@ export function notFoundResponse(message: string): Response {
   );
 }
 
-export function badRequestResponse(message: string): Response {
-  return NextResponse.json(
-    { error: { message, code: "BAD_REQUEST" } },
-    { status: 400 },
-  );
+export function badRequestResponse(
+  message: string,
+  code: string = "BAD_REQUEST",
+): Response {
+  return NextResponse.json({ error: { message, code } }, { status: 400 });
 }

--- a/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
+++ b/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
@@ -70,6 +70,8 @@ export const WEB_API_ROUTE_BASELINE = [
   "app/api/internal/event-consumers/telegram-typing/route.ts",
   "app/api/internal/event-consumers/voice-chat-candidate/route.ts",
   "app/api/internal/event-consumers/voice-chat/route.ts",
+  "app/api/internal/voice-chat/relay/[id]/items/route.ts",
+  "app/api/internal/voice-chat/relay/[id]/tasks/route.ts",
   "app/api/logs/search/route.ts",
   "app/api/runners/heartbeat/route.ts",
   "app/api/runners/jobs/[id]/claim/route.ts",

--- a/turbo/apps/web/src/lib/zero/voice-chat/build-voice-chat-task-context.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/build-voice-chat-task-context.ts
@@ -1,0 +1,29 @@
+import "server-only";
+import { readVoiceChatItems } from "./item-service";
+import { listSessionTasks } from "./task-service";
+import { buildSlowBrainAppendSystemPrompt } from "./build-slow-brain-prompt";
+import { resolveAgentSystemPrompt } from "./trigger-reasoning";
+
+/**
+ * Build the slow-brain `appendSystemPrompt` used when spawning a voice-chat
+ * task run. Two call sites need it: the user-facing
+ * `/api/zero/voice-chat/[id]/tasks` route and the relay-side internal
+ * `/api/internal/voice-chat/relay/[id]/tasks` route (#12141). Pulling the
+ * three reads + the builder out keeps both routes a single line and prevents
+ * silent drift.
+ */
+export async function buildVoiceChatTaskAppendSystemPrompt(params: {
+  sessionId: string;
+  agentId: string;
+}): Promise<string> {
+  const [agentSystemPrompt, items, sessionTasks] = await Promise.all([
+    resolveAgentSystemPrompt(params.agentId),
+    readVoiceChatItems(params.sessionId),
+    listSessionTasks(params.sessionId),
+  ]);
+  return buildSlowBrainAppendSystemPrompt({
+    agentSystemPrompt,
+    items,
+    sessionTasks,
+  });
+}

--- a/turbo/apps/web/src/lib/zero/voice-chat/relay-auth.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/relay-auth.ts
@@ -1,0 +1,84 @@
+import "server-only";
+import { NextResponse } from "next/server";
+import { verifyRelayToken } from "@vm0/core/voice-chat/relay-token";
+import { env } from "../../../env";
+
+export interface RelayAuthContext {
+  userId: string;
+  orgId: string;
+  voiceChatSessionId: string;
+}
+
+/**
+ * Resolve the relay-token authentication context for an internal voice-chat
+ * relay route. The token is presented as `Authorization: Bearer <token>` and
+ * verified against the shared HMAC secret. The token's `voiceChatSessionId`
+ * claim must match the path's `id`, and `orgId` must be present (the relay
+ * bootstrap admission route in #12140 always issues tokens with orgId).
+ * Returns the validated context or a pre-built error Response.
+ *
+ * The verifier is the canonical helper from #12140 in @vm0/core; this wrapper
+ * adapts it to the Next.js Response shape used by `_support.ts`. Three sites
+ * verify the same token (apps/api WS upgrade, the internal /items route, the
+ * internal /tasks route), all going through `@vm0/core/voice-chat/relay-token`.
+ */
+export function resolveRelayAuth(
+  request: Request,
+  expectedSessionId: string,
+): RelayAuthContext | Response {
+  const secret = env().VOICE_CHAT_RELAY_TOKEN_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Voice-chat relay token secret not configured",
+          code: "SERVICE_UNAVAILABLE",
+        },
+      },
+      { status: 503 },
+    );
+  }
+
+  const authHeader = request.headers.get("authorization");
+  const token = parseBearerToken(authHeader);
+  if (!token) {
+    return NextResponse.json(
+      { error: { message: "Missing relay token", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const result = verifyRelayToken(token, secret);
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: { message: "Invalid relay token", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+  if (result.claims.voiceChatSessionId !== expectedSessionId) {
+    return NextResponse.json(
+      { error: { message: "Invalid relay token", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+  if (!result.claims.orgId) {
+    return NextResponse.json(
+      { error: { message: "Invalid relay token", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  return {
+    userId: result.claims.userId,
+    orgId: result.claims.orgId,
+    voiceChatSessionId: result.claims.voiceChatSessionId,
+  };
+}
+
+function parseBearerToken(authHeader: string | null): string | null {
+  if (!authHeader) return null;
+  const prefix = "Bearer ";
+  if (!authHeader.startsWith(prefix)) return null;
+  const token = authHeader.slice(prefix.length).trim();
+  return token.length > 0 ? token : null;
+}

--- a/turbo/apps/web/src/lib/zero/voice-chat/relay-auth.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/relay-auth.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { verifyRelayToken } from "@vm0/core/voice-chat/relay-token";
 import { env } from "../../../env";
 
-export interface RelayAuthContext {
+interface RelayAuthContext {
   userId: string;
   orgId: string;
   voiceChatSessionId: string;

--- a/turbo/packages/core/src/__tests__/voice-chat-session-config.test.ts
+++ b/turbo/packages/core/src/__tests__/voice-chat-session-config.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import {
+  SESSION_TOOL_NAMES,
+  isSessionToolName,
+} from "../voice-chat/session-config";
+
+describe("SESSION_TOOL_NAMES", () => {
+  it("matches the six Talker tool names", () => {
+    expect([...SESSION_TOOL_NAMES]).toEqual([
+      "inform_slow_brain",
+      "feel_confused",
+      "feel_unable",
+      "want_to_ask_user",
+      "want_to_reject",
+      "want_to_apologize",
+    ]);
+  });
+});
+
+describe("isSessionToolName", () => {
+  it("accepts every name in SESSION_TOOL_NAMES", () => {
+    for (const name of SESSION_TOOL_NAMES) {
+      expect(isSessionToolName(name)).toBe(true);
+    }
+  });
+
+  it("rejects names outside the canonical list", () => {
+    expect(isSessionToolName("bogus_tool")).toBe(false);
+    expect(isSessionToolName("")).toBe(false);
+    expect(isSessionToolName("INFORM_SLOW_BRAIN")).toBe(false);
+  });
+});

--- a/turbo/packages/core/src/voice-chat/session-config.ts
+++ b/turbo/packages/core/src/voice-chat/session-config.ts
@@ -66,6 +66,16 @@ export const SESSION_TOOLS = [
   },
 ] as const;
 
+export type SessionToolName = (typeof SESSION_TOOLS)[number]["name"];
+export const SESSION_TOOL_NAMES: readonly SessionToolName[] = SESSION_TOOLS.map(
+  (t) => {
+    return t.name;
+  },
+);
+export function isSessionToolName(name: string): name is SessionToolName {
+  return (SESSION_TOOL_NAMES as readonly string[]).includes(name);
+}
+
 export const TURN_DETECTION_CONFIG = {
   type: "semantic_vad",
   eagerness: "medium",


### PR DESCRIPTION
Closes #12141. Part of Epic #12128.

## Summary

Server-side authority shift for the Realtime relay-billing Epic: transcript persistence and Talker tool dispatch move from the browser to a server path that runs inside the relay rather than the browser.

- New apps/api handlers `transcript-ingestor` and `talker-tool-dispatch` narrow OpenAI provider events into normalized request bodies and POST them to apps/web's internal routes; the dispatcher emits matching `function_call_output` voice text via the relay's WS callback.
- New apps/web internal routes `/api/internal/voice-chat/relay/[id]/items` and `.../tasks` mirror the existing user-facing routes' service-layer calls (`appendVoiceChatItem` + `after(triggerReasoning)`; `createVoiceChatTask` + `publishUserSignal` + `after(triggerReasoning)`), gated on the shared HMAC relay token instead of user JWT. Legacy and relay paths converge on identical side-effects.
- Shared `@vm0/core/voice-chat/relay-token.ts` (verify + sign, HMAC-SHA256 compact JWT-shape) is the single source for token mint/verify across apps/api (#12139) and apps/web (#12141). #12140 will overwrite the mint side; the verifier shape stays stable.
- `@vm0/core/voice-chat/session-config.ts` exports `SESSION_TOOL_NAMES`; apps/web's `session-config.ts` asserts at module load that its `SESSION_TOOLS` names match — drift guard for the relay-side allow-list.
- Extract `buildVoiceChatTaskAppendSystemPrompt` so both /tasks routes share the prompt-context build instead of duplicating.

## Architecture

Decision (a-ii) from the [plan addendum](https://github.com/vm0-ai/vm0/issues/12141#issuecomment-4403411585): handlers in apps/api as HTTP clients, separate internal routes in apps/web. Picked over moving handlers into apps/api with direct DB writes (option b) because `createZeroRun` is 800+ LOC of `next/server`-coupled code that doesn't survive the move; over extending the existing user-facing routes with dual auth flavors so #12142's deletion of the legacy browser-write path is a clean delete.

Browser path is untouched — the relay handlers ship server-side only and take effect once #12142 swaps the platform client to the relay.

## Dependencies

- **Depends on #12139** for the `onProviderEvent` hook surface and `RelayContext.sendToOpenAi`. Plan was written against the documented hook signature in #12139's plan; rebase before merge once #12139 lands.
- **Coordinates with #12140** on the shared relay-token shape. If #12140 lands first, my `@vm0/core/voice-chat/relay-token.ts` rebases to its definition; if mine lands first, #12140 extends.
- **Coordinates with #12139** on `@vm0/core/voice-chat/session-config.ts` (#12139 is moving full `SESSION_TOOLS` there for the relay's session.update payload). On rebase, the hand-listed `SESSION_TOOL_NAMES` becomes a derived constant.

## Test plan

- [x] `pnpm -F @vm0/core exec vitest run` → 192 tests pass (10 + 1 new files)
- [x] `pnpm -F api exec vitest run` → 270 tests pass (incl. new transcript-ingestor + talker-tool-dispatch tests)
- [x] `pnpm -F web exec vitest run voice-chat` → 175 tests pass (incl. new internal route tests + existing /tasks route still green after helper extraction)
- [x] `pnpm turbo run lint --filter=@vm0/core --filter=web --filter=api` → clean (after adding new internal routes to the `web-api-routes.ts` baseline list)
- [x] `pnpm check-types` → clean
- [x] `pnpm format` → clean
- [x] `pnpm knip` → clean (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)