### PR TITLE
Add run startup diagnostic spans

### DIFF
--- a/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
@@ -21,6 +21,23 @@ import type { PreparedContext, ExecutorResult } from "./types";
 
 const log = logger("executor:runner");
 
+function recordRunnerDispatchSpan(attrs: {
+  runId: string;
+  actionType: string;
+  durationMs: number;
+  success?: boolean;
+  dimensions?: Record<string, unknown>;
+}): void {
+  recordSandboxOperation({
+    sandboxType: "runner",
+    actionType: attrs.actionType,
+    durationMs: attrs.durationMs,
+    success: attrs.success ?? true,
+    runId: attrs.runId,
+    dimensions: attrs.dimensions,
+  });
+}
+
 /**
  * Queue an agent run for execution by a self-hosted runner
  *
@@ -60,14 +77,27 @@ export async function executeRunnerJob(
     throw forbidden("Only vm0/* runner groups are supported");
   }
 
+  const buildStoredContextStart = Date.now();
   const storedContext = buildStoredContext(context, profile);
+  recordRunnerDispatchSpan({
+    runId: context.runId,
+    actionType: "api_dispatch_build_stored_context",
+    durationMs: Date.now() - buildStoredContextStart,
+  });
 
   // Ingest sanitized context snapshot to Axiom for debugging
+  const ingestContextSnapshotStart = Date.now();
   ingestRunContext(buildRunContextSnapshot(context));
+  recordRunnerDispatchSpan({
+    runId: context.runId,
+    actionType: "api_dispatch_ingest_context_snapshot",
+    durationMs: Date.now() - ingestContextSnapshotStart,
+  });
 
   // Insert into runner job queue
   // TTL: 2 hours for job expiration
   const expiresAt = new Date(Date.now() + 2 * 60 * 60 * 1000);
+  const insertRunnerJobStart = Date.now();
   await globalThis.services.db.insert(runnerJobQueue).values({
     runId: context.runId,
     runnerGroup,
@@ -76,23 +106,45 @@ export async function executeRunnerJob(
     executionContext: storedContext,
     expiresAt,
   });
+  recordRunnerDispatchSpan({
+    runId: context.runId,
+    actionType: "api_dispatch_insert_runner_job",
+    durationMs: Date.now() - insertRunnerJobStart,
+  });
 
   // Store runner group on agent_runs for cancel routing (runner_job_queue
   // is deleted after claim, so we need a durable reference).
+  const updateRunnerGroupStart = Date.now();
   await globalThis.services.db
     .update(agentRuns)
     .set({ runnerGroup })
     .where(eq(agentRuns.id, context.runId));
+  recordRunnerDispatchSpan({
+    runId: context.runId,
+    actionType: "api_dispatch_update_runner_group",
+    durationMs: Date.now() - updateRunnerGroupStart,
+  });
 
   log.debug(`Run ${context.runId} queued for runner group: ${runnerGroup}`);
 
   // Notify runners via Ably with optional targeted dispatch
-  await notifyRunners(
+  const notifyRunnersStart = Date.now();
+  const notifyResult = await notifyRunners(
     runnerGroup,
     context.runId,
     profile,
     context.resumeSession?.sessionId ?? null,
   );
+  recordRunnerDispatchSpan({
+    runId: context.runId,
+    actionType: "api_dispatch_notify_runners",
+    durationMs: Date.now() - notifyRunnersStart,
+    dimensions: {
+      notification_published: notifyResult.published,
+      targeted_runner: notifyResult.targetRunnerId !== null,
+      find_best_runner_failed: notifyResult.findBestRunnerFailed,
+    },
+  });
 
   return {
     runId: context.runId,
@@ -111,24 +163,53 @@ async function notifyRunners(
   runId: string,
   profile: string,
   sessionId: string | null,
-): Promise<void> {
+): Promise<{
+  targetRunnerId: string | null;
+  published: boolean;
+  findBestRunnerFailed: boolean;
+}> {
   let targetRunnerId: string | null = null;
+  let findBestRunnerFailed = false;
+  const findBestRunnerStart = Date.now();
   try {
     const target = await findBestRunner(runnerGroup, profile, sessionId);
     targetRunnerId = target?.runnerId ?? null;
   } catch (e) {
+    findBestRunnerFailed = true;
     log.warn(`findBestRunner failed for run ${runId}, using broadcast`, e);
+  } finally {
+    recordRunnerDispatchSpan({
+      runId,
+      actionType: "api_dispatch_find_best_runner",
+      durationMs: Date.now() - findBestRunnerStart,
+      success: !findBestRunnerFailed,
+      dimensions: {
+        targeted_runner: targetRunnerId !== null,
+        session_resume: sessionId !== null,
+      },
+    });
   }
 
+  const publishJobNotificationStart = Date.now();
   const published = await publishJobNotification(
     runnerGroup,
     runId,
     profile,
     targetRunnerId,
   );
+  recordRunnerDispatchSpan({
+    runId,
+    actionType: "api_dispatch_publish_job_notification",
+    durationMs: Date.now() - publishJobNotificationStart,
+    dimensions: {
+      notification_published: published,
+      targeted_runner: targetRunnerId !== null,
+    },
+  });
   if (published) {
     log.debug(`Job notification published for run ${runId}`);
   }
+  return { targetRunnerId, published, findBestRunnerFailed };
 }
 
 /**

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -19,6 +19,7 @@ import { executeRunnerJob } from "./executors/runner-executor";
 import type { ExecutorResult, PreparedContext } from "./executors/types";
 import type {
   ContextArtifact,
+  DispatchDiagnosticSpan,
   ExecutionContext,
   DispatchTimings,
 } from "./types";
@@ -347,7 +348,7 @@ export async function buildAndDispatchRun(opts: {
     // below start from timings.authorize because the route-entry → authorize
     // segment covers many heterogeneous call paths (auth, resolve, pre-flight)
     // whose aggregate is not a meaningful single metric.
-    const steps = [
+    const steps: DispatchDiagnosticSpan[] = [
       {
         op: "api_step_validate_and_insert",
         ms: timings.transaction - timings.authorize,
@@ -424,6 +425,7 @@ export async function buildAndDispatchRun(opts: {
         op: "api_prepare_storage_manifest",
         ms: prepareResult.timings.storageManifest,
       },
+      ...(timings.diagnosticSpans ?? []),
     ];
     for (const step of steps) {
       recordSandboxOperation({
@@ -432,6 +434,7 @@ export async function buildAndDispatchRun(opts: {
         durationMs: step.ms,
         success: true,
         runId,
+        dimensions: step.dimensions,
       });
     }
 

--- a/turbo/apps/web/src/lib/infra/run/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/types.ts
@@ -183,4 +183,11 @@ export interface DispatchTimings {
   token: number;
   resolveSourceDuration?: number;
   resolveSecretsDuration?: number;
+  diagnosticSpans?: DispatchDiagnosticSpan[];
+}
+
+export interface DispatchDiagnosticSpan {
+  op: string;
+  ms: number;
+  dimensions?: Record<string, unknown>;
 }

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -21,6 +21,7 @@ import { badRequest, notFound } from "@vm0/api-services/errors";
 import { logger } from "../shared/logger";
 import type {
   ContextArtifact,
+  DispatchDiagnosticSpan,
   ExecutionContext,
   ResumeSession,
 } from "../infra/run/types";
@@ -32,6 +33,7 @@ import { getUserPreferences } from "./user/user-preferences-service";
 import { getApiTokenConnectorTypes } from "./connector/connector-service";
 import {
   MODEL_PROVIDER_ENV_VARS,
+  type ResolveModelProviderSecretTimings,
   resolveModelProviderSecrets,
 } from "./context/resolve-model-provider";
 import { resolveOauthConnectorSecrets } from "./context/resolve-connectors";
@@ -63,6 +65,14 @@ export {
 } from "./context/resolve-permissions";
 
 const log = logger("zero:build-context");
+
+async function captureDuration<T>(
+  operation: () => Promise<T>,
+): Promise<{ value: T; durationMs: number }> {
+  const start = Date.now();
+  const value = await operation();
+  return { value, durationMs: Date.now() - start };
+}
 
 /**
  * Append the auto-memory artifact when this is a new run. On resume paths
@@ -130,6 +140,20 @@ function withRuntimeRunEnvironment(
     ...(environment ?? {}),
     VM0_RUN_SOURCE: triggerSource,
   };
+}
+
+interface ResolveSecretsAndEnvironmentTimings {
+  fetchReferencedSecrets: number;
+  resolveModelProvider: number;
+  resolveOauthConnectors: number;
+  getApiTokenConnectorTypes: number;
+  fetchAndMergeVariables: number;
+  resolveCustomConnectors: number;
+  filterSecretsAndMaps: number;
+  buildFirewallConfigs: number;
+  expandEnvironment: number;
+  billableFirewalls: number;
+  modelProvider?: ResolveModelProviderSecretTimings;
 }
 
 /**
@@ -236,6 +260,7 @@ async function resolveSecretsAndEnvironment(
   mergedVars: Record<string, string> | undefined;
   billableFirewalls: string[];
   modelUsageProvider: string | undefined;
+  timings: ResolveSecretsAndEnvironmentTimings;
 }> {
   // Model provider secret injection
   const hasExplicitModelProviderConfig = MODEL_PROVIDER_ENV_VARS.some((v) => {
@@ -247,30 +272,66 @@ async function resolveSecretsAndEnvironment(
   // The three resolve functions have independent DB queries (different secret types),
   // so there is no data dependency between them.
   const [
-    dbSecrets,
+    dbSecretsResult,
     modelProviderResult,
     oauthResult,
-    apiTokenTypes,
-    mergedVars,
+    apiTokenTypesResult,
+    mergedVarsResult,
     customConnectorResult,
   ] = await Promise.all([
-    fetchReferencedSecrets(orgId, userId, firstAgent?.environment),
-    resolveModelProviderSecrets(
-      orgId,
-      userId,
-      framework,
-      hasExplicitModelProviderConfig,
-      modelProvider,
-      modelProviderId,
-      selectedModelOverride,
-      preferPersonalProvider,
-    ),
-    resolveOauthConnectorSecrets(orgId, userId, allowedConnectorTypes),
-    getApiTokenConnectorTypes(orgId, userId),
-    fetchAndMergeVariables(orgId, userId, vars),
-    resolveCustomConnectorFirewalls(orgId, userId, allowedCustomConnectorIds),
+    captureDuration(() => {
+      return fetchReferencedSecrets(orgId, userId, firstAgent?.environment);
+    }),
+    captureDuration(() => {
+      return resolveModelProviderSecrets(
+        orgId,
+        userId,
+        framework,
+        hasExplicitModelProviderConfig,
+        modelProvider,
+        modelProviderId,
+        selectedModelOverride,
+        preferPersonalProvider,
+      );
+    }),
+    captureDuration(() => {
+      return resolveOauthConnectorSecrets(orgId, userId, allowedConnectorTypes);
+    }),
+    captureDuration(() => {
+      return getApiTokenConnectorTypes(orgId, userId);
+    }),
+    captureDuration(() => {
+      return fetchAndMergeVariables(orgId, userId, vars);
+    }),
+    captureDuration(() => {
+      return resolveCustomConnectorFirewalls(
+        orgId,
+        userId,
+        allowedCustomConnectorIds,
+      );
+    }),
   ]);
+  const dbSecrets = dbSecretsResult.value;
+  const resolvedModelProviderResult = modelProviderResult.value;
+  const oauthConnectors = oauthResult.value;
+  const apiTokenTypes = apiTokenTypesResult.value;
+  const mergedVars = mergedVarsResult.value;
+  const customConnectors = customConnectorResult.value;
+  const timings: ResolveSecretsAndEnvironmentTimings = {
+    fetchReferencedSecrets: dbSecretsResult.durationMs,
+    resolveModelProvider: modelProviderResult.durationMs,
+    resolveOauthConnectors: oauthResult.durationMs,
+    getApiTokenConnectorTypes: apiTokenTypesResult.durationMs,
+    fetchAndMergeVariables: mergedVarsResult.durationMs,
+    resolveCustomConnectors: customConnectorResult.durationMs,
+    filterSecretsAndMaps: 0,
+    buildFirewallConfigs: 0,
+    expandEnvironment: 0,
+    billableFirewalls: 0,
+    modelProvider: resolvedModelProviderResult.timings,
+  };
 
+  const filterSecretsStart = Date.now();
   const rawApiTokenTypes = allowedConnectorTypes
     ? apiTokenTypes.filter((t) => {
         return allowedConnectorTypes.includes(t);
@@ -278,7 +339,7 @@ async function resolveSecretsAndEnvironment(
     : apiTokenTypes;
 
   const connectorTypes = [
-    ...new Set([...oauthResult.connectorTypes, ...rawApiTokenTypes]),
+    ...new Set([...oauthConnectors.connectorTypes, ...rawApiTokenTypes]),
   ];
 
   // Filter dbSecrets: strip env vars that belong to disallowed connectors.
@@ -300,20 +361,20 @@ async function resolveSecretsAndEnvironment(
   const envSecrets = injectPlatformEnvSecrets(connectorTypes);
 
   const hasCustomConnectorSecrets =
-    Object.keys(customConnectorResult.secrets).length > 0;
+    Object.keys(customConnectors.secrets).length > 0;
   const hasSecrets =
-    oauthResult.resolvedSecrets ||
-    modelProviderResult.secrets ||
+    oauthConnectors.resolvedSecrets ||
+    resolvedModelProviderResult.secrets ||
     filteredDbSecrets ||
     cliSecrets ||
     hasCustomConnectorSecrets ||
     envSecrets;
   const secrets: Record<string, string> | undefined = hasSecrets
     ? {
-        ...oauthResult.resolvedSecrets, // connector env mappings (e.g. GITHUB_TOKEN)
-        ...modelProviderResult.secrets, // model provider
+        ...oauthConnectors.resolvedSecrets, // connector env mappings (e.g. GITHUB_TOKEN)
+        ...resolvedModelProviderResult.secrets, // model provider
         ...filteredDbSecrets, // DB user secrets (connector secrets filtered)
-        ...customConnectorResult.secrets, // org custom connector per-user secrets
+        ...customConnectors.secrets, // org custom connector per-user secrets
         ...envSecrets, // platform env secrets (e.g. GOOGLE_ADS_DEVELOPER_TOKEN)
         ...cliSecrets, // highest: CLI --secrets
       }
@@ -325,22 +386,24 @@ async function resolveSecretsAndEnvironment(
   // filter because they share names with `modelProviderResult.secrets` — those secrets
   // ARE the source of the OAuth refresh, not an override target.
   const filteredOauthMap = filterSecretConnectorMap(
-    oauthResult.secretConnectorMap,
-    [modelProviderResult.secrets, dbSecrets, cliSecrets],
+    oauthConnectors.secretConnectorMap,
+    [resolvedModelProviderResult.secrets, dbSecrets, cliSecrets],
   );
   const secretConnectorMap = mergeSecretConnectorMaps(
     filteredOauthMap,
-    modelProviderResult.secretConnectorMap,
+    resolvedModelProviderResult.secretConnectorMap,
   );
   const secretConnectorMetadataMap = mergeSecretConnectorMetadataMaps(
-    modelProviderResult.secretConnectorMetadataMap,
+    resolvedModelProviderResult.secretConnectorMetadataMap,
   );
+  timings.filterSecretsAndMaps = Date.now() - filterSecretsStart;
 
+  const buildFirewallConfigsStart = Date.now();
   // Auto-generate config entry for model provider (if applicable).
   // For meta-providers like "vm0", use the concrete provider type for lookup.
   const modelProviderFirewallType =
-    modelProviderResult.concreteProviderType ??
-    modelProviderResult.resolvedModelProvider;
+    resolvedModelProviderResult.concreteProviderType ??
+    resolvedModelProviderResult.resolvedModelProvider;
   const modelProviderConfig = modelProviderFirewallType
     ? getModelProviderFirewall(modelProviderFirewallType)
     : undefined;
@@ -359,9 +422,11 @@ async function resolveSecretsAndEnvironment(
     ...connectorTypes.filter(isFirewallConnectorType).map((type) => {
       return { ...getConnectorFirewall(type) };
     }),
-    ...customConnectorResult.firewalls,
+    ...customConnectors.firewalls,
   ];
+  timings.buildFirewallConfigs = Date.now() - buildFirewallConfigsStart;
 
+  const expandEnvironmentStart = Date.now();
   // Expand environment variables from compose config.
   // All permission configs (model provider, connector) are passed via the
   // `firewalls` param for unified placeholder injection.
@@ -369,13 +434,15 @@ async function resolveSecretsAndEnvironment(
     agentCompose,
     mergedVars,
     secrets,
-    modelProviderResult.injectedEnvironment,
+    resolvedModelProviderResult.injectedEnvironment,
     [
       ...(modelProviderConfig ? [modelProviderConfig] : []),
       ...connectorPermissionConfigs,
     ],
   );
+  timings.expandEnvironment = Date.now() - expandEnvironmentStart;
 
+  const billableFirewallsStart = Date.now();
   // Billable firewalls feed flow.metadata["firewall_billable"] in mitm-addon,
   // gating platform-side billing webhooks and full-body response buffering:
   // - vm0 meta-provider: platform-paid model tokens (user didn't supply a key).
@@ -383,12 +450,13 @@ async function resolveSecretsAndEnvironment(
   //   where the platform covers the upstream cost and bills the user.
   const billableFirewalls: string[] = [];
   const vm0ManagedModelProviderConfig =
-    modelProviderResult.resolvedModelProvider === "vm0" && modelProviderConfig;
+    resolvedModelProviderResult.resolvedModelProvider === "vm0" &&
+    modelProviderConfig;
   if (vm0ManagedModelProviderConfig) {
     billableFirewalls.push(vm0ManagedModelProviderConfig.name);
   }
   const modelUsageProvider = vm0ManagedModelProviderConfig
-    ? modelProviderResult.selectedModel
+    ? resolvedModelProviderResult.selectedModel
     : undefined;
   const billableConnectorSet = new Set<string>(BILLABLE_CONNECTORS);
   for (const fw of connectorPermissionConfigs) {
@@ -396,28 +464,36 @@ async function resolveSecretsAndEnvironment(
       billableFirewalls.push(fw.name);
     }
   }
+  timings.billableFirewalls = Date.now() - billableFirewallsStart;
 
   return {
     secrets,
     environment,
     secretConnectorMap,
     secretConnectorMetadataMap,
-    resolvedModelProvider: modelProviderResult.resolvedModelProvider,
+    resolvedModelProvider: resolvedModelProviderResult.resolvedModelProvider,
     // Provider-derived framework when resolution ran; otherwise the compose
     // framework. Source-of-truth for downstream framework-aware logic.
-    resolvedFramework: modelProviderResult.framework ?? framework,
+    resolvedFramework: resolvedModelProviderResult.framework ?? framework,
     modelProviderConfig,
-    selectedModel: modelProviderResult.selectedModel,
+    selectedModel: resolvedModelProviderResult.selectedModel,
     connectorPermissionConfigs,
     mergedVars,
     billableFirewalls,
     modelUsageProvider,
+    timings,
   };
 }
 
 interface BuildZeroContextTimings {
   resolveSourceAndOrg: number;
   resolveSecrets: number;
+  userPreferences: number;
+  previousRunModelProvider: number;
+  compatibilityChecks: number;
+  mergePermissions: number;
+  resolveSecretsDetails: ResolveSecretsAndEnvironmentTimings;
+  diagnosticSpans: DispatchDiagnosticSpan[];
 }
 
 interface BuildZeroContextResult {
@@ -429,6 +505,99 @@ interface BuildZeroContextResult {
   resolvedFramework: string;
   /** The logical model name selected by the user, for model usage billing. */
   selectedModel: string | undefined;
+}
+
+function optionalDiagnosticSpan(
+  op: string,
+  ms: number | undefined,
+): DispatchDiagnosticSpan[] {
+  return ms === undefined ? [] : [{ op, ms }];
+}
+
+function buildDiagnosticSpans(
+  timings: Omit<BuildZeroContextTimings, "diagnosticSpans">,
+): DispatchDiagnosticSpan[] {
+  const modelProvider = timings.resolveSecretsDetails.modelProvider;
+  return [
+    {
+      op: "api_build_resolve_secrets_fetch_secrets",
+      ms: timings.resolveSecretsDetails.fetchReferencedSecrets,
+    },
+    {
+      op: "api_build_resolve_secrets_model_provider",
+      ms: timings.resolveSecretsDetails.resolveModelProvider,
+    },
+    {
+      op: "api_build_resolve_secrets_oauth_connectors",
+      ms: timings.resolveSecretsDetails.resolveOauthConnectors,
+    },
+    {
+      op: "api_build_resolve_secrets_api_token_types",
+      ms: timings.resolveSecretsDetails.getApiTokenConnectorTypes,
+    },
+    {
+      op: "api_build_resolve_secrets_variables",
+      ms: timings.resolveSecretsDetails.fetchAndMergeVariables,
+    },
+    {
+      op: "api_build_resolve_secrets_custom_connectors",
+      ms: timings.resolveSecretsDetails.resolveCustomConnectors,
+    },
+    {
+      op: "api_build_resolve_secrets_maps",
+      ms: timings.resolveSecretsDetails.filterSecretsAndMaps,
+    },
+    {
+      op: "api_build_resolve_secrets_firewall_configs",
+      ms: timings.resolveSecretsDetails.buildFirewallConfigs,
+    },
+    {
+      op: "api_build_resolve_secrets_expand_environment",
+      ms: timings.resolveSecretsDetails.expandEnvironment,
+    },
+    {
+      op: "api_build_resolve_secrets_billable_firewalls",
+      ms: timings.resolveSecretsDetails.billableFirewalls,
+    },
+    { op: "api_build_user_preferences", ms: timings.userPreferences },
+    {
+      op: "api_build_previous_model_provider",
+      ms: timings.previousRunModelProvider,
+    },
+    {
+      op: "api_build_compatibility_checks",
+      ms: timings.compatibilityChecks,
+    },
+    { op: "api_build_merge_permissions", ms: timings.mergePermissions },
+    ...optionalDiagnosticSpan(
+      "api_build_model_provider_personal_eligibility",
+      modelProvider?.personalEligibility,
+    ),
+    ...optionalDiagnosticSpan(
+      "api_build_model_provider_default_lookup",
+      modelProvider?.defaultProviderLookup,
+    ),
+    ...optionalDiagnosticSpan(
+      "api_build_model_provider_matching_lookup",
+      modelProvider?.matchingProviderLookup,
+    ),
+    ...optionalDiagnosticSpan(
+      "api_build_model_provider_vm0_resolution",
+      modelProvider?.vm0ProviderResolution,
+    ),
+    ...optionalDiagnosticSpan(
+      "api_build_model_provider_multi_auth_resolution",
+      modelProvider?.multiAuthSecretResolution,
+    ),
+    ...optionalDiagnosticSpan(
+      "api_build_model_provider_single_secret_fetch",
+      modelProvider?.singleSecretFetch,
+    ),
+    ...optionalDiagnosticSpan(
+      "api_build_model_provider_environment_mapping",
+      modelProvider?.environmentMapping,
+    ),
+  ];
 }
 
 /**
@@ -770,39 +939,49 @@ export async function buildZeroExecutionContext(
   // When preloadedUserTimezone is provided (from Phase 1), skip getUserPreferences
   // to avoid the duplicate DB query.
   const resolveSecretsStart = Date.now();
-  const [secretsResult, userPrefs, originalModelProvider] = await Promise.all([
-    resolveSecretsAndEnvironment(
-      params.orgId,
-      agentCompose,
-      firstAgent,
-      vars,
-      params.secrets,
-      params.modelProvider,
-      params.userId,
-      params.allowedConnectorTypes,
-      params.allowedCustomConnectorIds,
-      params.modelProviderId,
-      params.selectedModelOverride,
-      params.preferPersonalProvider,
-    ),
-    params.preloadedUserTimezone !== undefined
-      ? Promise.resolve(null)
-      : params.userId
-        ? getUserPreferences(params.orgId, params.userId)
-        : Promise.resolve(null),
-    // Zero-layer concern: fetch previous run's model provider for compatibility check
-    resolution?.previousRunId
-      ? globalThis.services.db
-          .select({ modelProvider: zeroRuns.modelProvider })
-          .from(zeroRuns)
-          .where(eq(zeroRuns.id, resolution.previousRunId))
-          .limit(1)
-          .then(([row]) => {
-            return row?.modelProvider ?? undefined;
-          })
-      : Promise.resolve(undefined),
-  ]);
+  const [secretsResultTimed, userPrefsTimed, originalModelProviderTimed] =
+    await Promise.all([
+      captureDuration(() => {
+        return resolveSecretsAndEnvironment(
+          params.orgId,
+          agentCompose,
+          firstAgent,
+          vars,
+          params.secrets,
+          params.modelProvider,
+          params.userId,
+          params.allowedConnectorTypes,
+          params.allowedCustomConnectorIds,
+          params.modelProviderId,
+          params.selectedModelOverride,
+          params.preferPersonalProvider,
+        );
+      }),
+      captureDuration(() => {
+        return params.preloadedUserTimezone !== undefined
+          ? Promise.resolve(null)
+          : params.userId
+            ? getUserPreferences(params.orgId, params.userId)
+            : Promise.resolve(null);
+      }),
+      // Zero-layer concern: fetch previous run's model provider for compatibility check
+      captureDuration(() => {
+        return resolution?.previousRunId
+          ? globalThis.services.db
+              .select({ modelProvider: zeroRuns.modelProvider })
+              .from(zeroRuns)
+              .where(eq(zeroRuns.id, resolution.previousRunId))
+              .limit(1)
+              .then(([row]) => {
+                return row?.modelProvider ?? undefined;
+              })
+          : Promise.resolve(undefined);
+      }),
+    ]);
   const resolveSecretsEnd = Date.now();
+  const secretsResult = secretsResultTimed.value;
+  const userPrefs = userPrefsTimed.value;
+  const originalModelProvider = originalModelProviderTimed.value;
 
   const {
     secrets,
@@ -831,16 +1010,30 @@ export async function buildZeroExecutionContext(
   //   framework's format; switching binaries mid-thread can't replay it.
   //   resolvedFramework is the source of truth (provider-derived since
   //   #11649); the compose's `framework` field is no longer authoritative.
+  const compatibilityChecksStart = Date.now();
   checkProviderCompatibility(originalModelProvider, resolvedModelProvider);
   checkFrameworkCompatibility(resolution?.sessionFramework, resolvedFramework);
+  const compatibilityChecksEnd = Date.now();
 
   // Build permission manifest (base + auth entries for the runner).
+  const mergePermissionsStart = Date.now();
   const permissionResult = mergePermissions(
     modelProviderConfig,
     connectorPermissionConfigs,
     params.permissionPolicies,
     mergedVars,
   );
+  const mergePermissionsEnd = Date.now();
+
+  const timingDetails: Omit<BuildZeroContextTimings, "diagnosticSpans"> = {
+    resolveSourceAndOrg: resolveEnd - resolveStart,
+    resolveSecrets: resolveSecretsEnd - resolveSecretsStart,
+    userPreferences: userPrefsTimed.durationMs,
+    previousRunModelProvider: originalModelProviderTimed.durationMs,
+    compatibilityChecks: compatibilityChecksEnd - compatibilityChecksStart,
+    mergePermissions: mergePermissionsEnd - mergePermissionsStart,
+    resolveSecretsDetails: secretsResult.timings,
+  };
 
   // Build final execution context
   return {
@@ -887,8 +1080,8 @@ export async function buildZeroExecutionContext(
       resolvedFramework,
     },
     timings: {
-      resolveSourceAndOrg: resolveEnd - resolveStart,
-      resolveSecrets: resolveSecretsEnd - resolveSecretsStart,
+      ...timingDetails,
+      diagnosticSpans: buildDiagnosticSpans(timingDetails),
     },
     resolvedModelProvider,
     resolvedFramework,

--- a/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
@@ -146,6 +146,16 @@ function resolveEnvironmentMapping(
   return result;
 }
 
+export interface ResolveModelProviderSecretTimings {
+  personalEligibility: number;
+  defaultProviderLookup: number;
+  matchingProviderLookup: number;
+  vm0ProviderResolution?: number;
+  multiAuthSecretResolution?: number;
+  singleSecretFetch?: number;
+  environmentMapping?: number;
+}
+
 /**
  * Result of model provider secret resolution
  */
@@ -178,6 +188,7 @@ interface ModelProviderSecretResult {
    *  The firewall refresh path uses this to refresh personal providers under
    *  the provider row owner instead of the org sentinel. */
   secretConnectorMetadataMap?: Record<string, SecretConnectorMetadata>;
+  timings?: ResolveModelProviderSecretTimings;
 }
 
 /**
@@ -455,6 +466,11 @@ export async function resolveModelProviderSecrets(
   preferPersonalProvider?: boolean,
 ): Promise<ModelProviderSecretResult> {
   const secrets: Record<string, string> | undefined = undefined;
+  const timings: ResolveModelProviderSecretTimings = {
+    personalEligibility: 0,
+    defaultProviderLookup: 0,
+    matchingProviderLookup: 0,
+  };
 
   // Skip if compose already declares the framework's auth env var directly.
   // Framework-agnostic: codex with explicit OPENAI_API_KEY short-circuits here
@@ -465,6 +481,7 @@ export async function resolveModelProviderSecrets(
       injectedEnvironment: undefined,
       resolvedModelProvider: undefined,
       framework,
+      timings,
     };
   }
 
@@ -478,11 +495,15 @@ export async function resolveModelProviderSecrets(
   // framework wins" rule at the dispatch boundary: an org with only a codex
   // provider still resolves secrets for a claude-code compose; the
   // provider's framework propagates downstream via `resolvedFramework`.
+  const personalEligibilityStart = Date.now();
   const personalEligible = await isPersonalTierEligible(
     orgId,
     userId,
     preferPersonalProvider,
   );
+  timings.personalEligibility = Date.now() - personalEligibilityStart;
+
+  const defaultProviderStart = Date.now();
   const defaultProvider = await resolveDefaultProviderRow({
     orgId,
     userId,
@@ -490,6 +511,7 @@ export async function resolveModelProviderSecrets(
     modelProviderId,
     personalEligible,
   });
+  timings.defaultProviderLookup = Date.now() - defaultProviderStart;
 
   const providerType = resolveProviderType(
     defaultProvider,
@@ -511,6 +533,7 @@ export async function resolveModelProviderSecrets(
   // their own secret + selectedModel even when their default is org-tier
   // (Epic #11868). Falls back to undefined when no row exists, in which case
   // `resolveEnvironmentMapping` uses `getDefaultModel(providerType)`.
+  const matchingProviderStart = Date.now();
   const matchingProvider = await resolveMatchingProviderForType({
     orgId,
     userId,
@@ -520,6 +543,7 @@ export async function resolveModelProviderSecrets(
     modelProviderId,
     personalEligible,
   });
+  timings.matchingProviderLookup = Date.now() - matchingProviderStart;
   // Derive `secretUserId` from the row whose secret we're about to fetch
   // (`matchingProvider`), not blindly from `defaultProvider`. They diverge
   // in the explicit-type-override path: an explicit `openai-api-key`
@@ -550,13 +574,17 @@ export async function resolveModelProviderSecrets(
     if (!selectedModel) {
       throw badRequest("VM0 provider requires a selected model");
     }
-    return resolveVm0Provider(selectedModel);
+    const vm0ProviderStart = Date.now();
+    const resolved = await resolveVm0Provider(selectedModel);
+    timings.vm0ProviderResolution = Date.now() - vm0ProviderStart;
+    return { ...resolved, timings };
   }
 
   const resolvedFramework = getFrameworkForType(providerType);
 
   // Handle multi-auth providers (like aws-bedrock)
   if (hasAuthMethods(providerType)) {
+    const multiAuthStart = Date.now();
     const resolved = await resolveMultiAuthProviderSecrets(
       orgId,
       secretUserId,
@@ -564,15 +592,17 @@ export async function resolveModelProviderSecrets(
       matchingProvider?.authMethod,
       selectedModel,
     );
-    return (
-      resolved ?? {
-        secrets,
-        injectedEnvironment: undefined,
-        resolvedModelProvider: providerType,
-        framework: resolvedFramework,
-        selectedModel,
-      }
-    );
+    timings.multiAuthSecretResolution = Date.now() - multiAuthStart;
+    return resolved
+      ? { ...resolved, timings }
+      : {
+          secrets,
+          injectedEnvironment: undefined,
+          resolvedModelProvider: providerType,
+          framework: resolvedFramework,
+          selectedModel,
+          timings,
+        };
   }
 
   // Handle single-secret providers
@@ -584,15 +614,18 @@ export async function resolveModelProviderSecrets(
       resolvedModelProvider: providerType,
       framework: resolvedFramework,
       selectedModel,
+      timings,
     };
   }
 
+  const secretFetchStart = Date.now();
   const secretValue = await getSecretValue(
     orgId,
     secretUserId,
     secretName,
     "model-provider",
   );
+  timings.singleSecretFetch = Date.now() - secretFetchStart;
 
   if (!secretValue) {
     return {
@@ -601,15 +634,18 @@ export async function resolveModelProviderSecrets(
       resolvedModelProvider: providerType,
       framework: resolvedFramework,
       selectedModel,
+      timings,
     };
   }
 
   // Resolve environment mapping as template references
+  const environmentMappingStart = Date.now();
   const injectedEnvironment = resolveEnvironmentMapping(
     providerType,
     secretName,
     selectedModel,
   );
+  timings.environmentMapping = Date.now() - environmentMappingStart;
 
   log.debug(
     `Resolved model provider env: ${Object.keys(injectedEnvironment).join(", ")}`,
@@ -621,5 +657,6 @@ export async function resolveModelProviderSecrets(
     resolvedModelProvider: providerType,
     framework: resolvedFramework,
     selectedModel,
+    timings,
   };
 }

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -660,6 +660,7 @@ export async function dispatchQueuedZeroRun(
       token: tokenTime,
       resolveSourceDuration: contextResult.timings.resolveSourceAndOrg,
       resolveSecretsDuration: contextResult.timings.resolveSecrets,
+      diagnosticSpans: contextResult.timings.diagnosticSpans,
     },
   });
 }

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -862,6 +862,7 @@ async function dispatchZeroRun(
         token: tokenTime,
         resolveSourceDuration: contextResult.timings.resolveSourceAndOrg,
         resolveSecretsDuration: contextResult.timings.resolveSecrets,
+        diagnosticSpans: contextResult.timings.diagnosticSpans,
       },
     });
 


### PR DESCRIPTION
## Summary
- add detailed Zero context diagnostic spans for secrets, model provider lookup, permissions, and compatibility checks
- add runner dispatch spans for context storage, queue insert, runner group update, and runner notification
- thread diagnostic spans through the shared run dispatch metric pipeline for issue #10796 follow-up

## Tests
- pnpm format
- pnpm -F web check-types
- pnpm -F web exec vitest run src/lib/zero/context/__tests__/resolve-model-provider.test.ts src/lib/zero/__tests__/build-zero-context.test.ts src/lib/zero/__tests__/run-queue-service.test.ts
- pnpm -F web lint
- pre-commit: pnpm knip
- pre-commit: pnpm check-types
