### PR TITLE
fix(platform): polyfill promise withresolvers

### DIFF
--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -164,12 +164,11 @@ export default [
       "ccstate/no-direct-local-storage": "off",
     },
   },
-  // Allow new Promise() in the dedicated helper that wraps a one-shot
-  // browser DOM event pair (<img> load/error). No ambient signal exists at
-  // the DOM layer; isolating the pattern to a single-purpose file keeps the
-  // rule active for the rest of org-general-tab.tsx.
+  // Allow new Promise() in dedicated infrastructure helpers that wrap browser
+  // primitives. App code should continue using createDeferredPromise().
   {
     files: [
+      "src/polyfill.ts",
       "src/views/zero-page/components/org-manage/read-image-dimensions.ts",
     ],
     rules: {

--- a/turbo/apps/platform/src/__tests__/polyfill.test.ts
+++ b/turbo/apps/platform/src/__tests__/polyfill.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import "../polyfill.ts";
 
 describe("abortSignal.any polyfill", () => {
@@ -90,5 +90,37 @@ describe("abortSignal.any polyfill", () => {
       expect(abortHandler).toHaveBeenCalledTimes(1);
       expect(combined.reason).toBe("first");
     });
+  });
+});
+
+describe("promise withResolvers polyfill", () => {
+  const originalWithResolvers = Promise.withResolvers;
+
+  afterEach(() => {
+    Object.defineProperty(Promise, "withResolvers", {
+      configurable: true,
+      value: originalWithResolvers,
+      writable: true,
+    });
+  });
+
+  it("should have Promise.withResolvers available", () => {
+    expect(typeof Promise.withResolvers).toBe("function");
+  });
+
+  it("should install a fallback when the browser lacks Promise.withResolvers", async () => {
+    Object.defineProperty(Promise, "withResolvers", {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
+    vi.resetModules();
+
+    await import("../polyfill.ts");
+
+    const deferred = Promise.withResolvers<string>();
+    deferred.resolve("ok");
+
+    await expect(deferred.promise).resolves.toBe("ok");
   });
 });

--- a/turbo/apps/platform/src/polyfill.ts
+++ b/turbo/apps/platform/src/polyfill.ts
@@ -30,3 +30,20 @@ if (typeof AbortSignal.any !== "function") {
 
   AbortSignal.any = anySignal;
 }
+
+if (typeof Promise.withResolvers !== "function") {
+  Promise.withResolvers = function withResolvers<T>(): PromiseWithResolvers<T> {
+    let resolveDeferred: (value: T | PromiseLike<T>) => void = () => {
+      throw new Error("Promise resolver was not initialized");
+    };
+    let rejectDeferred: (reason?: unknown) => void = () => {
+      throw new Error("Promise rejecter was not initialized");
+    };
+    const promise = new Promise<T>((resolve, reject) => {
+      resolveDeferred = resolve;
+      rejectDeferred = reject;
+    });
+
+    return { promise, resolve: resolveDeferred, reject: rejectDeferred };
+  };
+}


### PR DESCRIPTION
## Summary\n- add a Promise.withResolvers fallback in the platform polyfill for browsers that do not implement it\n- cover the missing-native path in the existing polyfill tests\n\n## Sentry\n- Fixes PLATFORM-3J (Promise.withResolvers is not a function)\n\n## Tests\n- pnpm -F @vm0/app exec vitest run src/__tests__/polyfill.test.ts\n- pnpm -F @vm0/app lint\n- pnpm -F @vm0/app check-types\n- pre-commit: prettier, knip, pnpm check-types