### PR TITLE
feat(vsock-guest): implement bounded exec

### DIFF
--- a/crates/vsock-guest/src/bounded_exec.rs
+++ b/crates/vsock-guest/src/bounded_exec.rs
@@ -1,0 +1,668 @@
+use std::io::{self, Write};
+use std::process::{Child, ChildStdin};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::thread::JoinHandle;
+use std::time::Instant;
+
+use vsock_proto::{
+    self, BoundedExecStream, BoundedExecTermination, MSG_BOUNDED_EXEC_OUTPUT_CHUNK,
+    MSG_BOUNDED_EXEC_RESULT,
+};
+
+use crate::drain::{BoundedDrainResult, BoundedStreamConfig, drain_bounded_cancellable};
+use crate::error::to_io_error;
+use crate::exec::{format_env_diagnostics, spawn_bounded_exec_command, truncate_preview};
+use crate::log::log;
+use crate::process::kill_and_reap_child;
+use crate::threading::{SystemThreadSpawner, ThreadSpawner};
+use crate::wait::{
+    DRAIN_DEADLINE_SECS, WaitOutcome, await_drain_deadline,
+    wait_with_kill_timeout_or_cancelled_either,
+};
+use crate::writer::GuestWriter;
+
+const THREAD_BOUNDED_EXEC_WORKER: &str = "vsock-bounded-exec-worker";
+const THREAD_BOUNDED_STDOUT: &str = "vsock-bounded-stdout";
+const THREAD_BOUNDED_STDERR: &str = "vsock-bounded-stderr";
+const THREAD_BOUNDED_STDIN: &str = "vsock-bounded-stdin";
+
+// MSG frame overhead (type + seq) plus bounded_exec_result fixed payload.
+const RESULT_FRAME_OVERHEAD_BYTES: usize = 1 + 4 + 22;
+const MAX_RESULT_OUTPUT_BYTES: usize = vsock_proto::MAX_MESSAGE_SIZE - RESULT_FRAME_OVERHEAD_BYTES;
+// MSG frame overhead (type + seq) plus bounded_exec_output_chunk fixed payload.
+const OUTPUT_CHUNK_FRAME_OVERHEAD_BYTES: usize = 1 + 4 + 10;
+const MAX_OUTPUT_CHUNK_BYTES: usize =
+    vsock_proto::MAX_MESSAGE_SIZE - OUTPUT_CHUNK_FRAME_OVERHEAD_BYTES;
+
+pub(crate) struct BoundedExecWorkerRequest {
+    pub(crate) seq: u32,
+    pub(crate) timeout_ms: u32,
+    pub(crate) command: String,
+    pub(crate) env: Vec<(String, String)>,
+    pub(crate) sudo: bool,
+    pub(crate) stdin: Option<Vec<u8>>,
+    pub(crate) stdout_limit_bytes: u32,
+    pub(crate) stderr_limit_bytes: u32,
+    pub(crate) stream_stdout: bool,
+    pub(crate) stream_stderr: bool,
+    pub(crate) stream_chunk_limit_bytes: u32,
+    pub(crate) stdout_stream_limit_bytes: u32,
+    pub(crate) stderr_stream_limit_bytes: u32,
+}
+
+impl BoundedExecWorkerRequest {
+    pub(crate) fn from_decoded(seq: u32, decoded: vsock_proto::DecodedBoundedExec<'_>) -> Self {
+        Self {
+            seq,
+            timeout_ms: decoded.timeout_ms,
+            command: decoded.command.to_owned(),
+            env: decoded
+                .env
+                .iter()
+                .map(|(key, value)| ((*key).to_owned(), (*value).to_owned()))
+                .collect(),
+            sudo: decoded.sudo,
+            stdin: decoded.stdin.map(<[u8]>::to_vec),
+            stdout_limit_bytes: decoded.stdout_limit_bytes,
+            stderr_limit_bytes: decoded.stderr_limit_bytes,
+            stream_stdout: decoded.stream_stdout,
+            stream_stderr: decoded.stream_stderr,
+            stream_chunk_limit_bytes: decoded.stream_chunk_limit_bytes,
+            stdout_stream_limit_bytes: decoded.stdout_stream_limit_bytes,
+            stderr_stream_limit_bytes: decoded.stderr_stream_limit_bytes,
+        }
+    }
+}
+
+struct BoundedDrainWorker {
+    seq: u32,
+    stream: BoundedExecStream,
+    final_limit_bytes: usize,
+    stream_config: Option<BoundedStreamConfig>,
+    writer: GuestWriter,
+    drain_cancel: Arc<AtomicBool>,
+    command_cancel: Arc<AtomicBool>,
+    drain_done_tx: mpsc::Sender<()>,
+}
+
+struct BoundedExecResultFrame<'a> {
+    seq: u32,
+    termination: BoundedExecTermination,
+    duration_ms: u64,
+    stdout: &'a [u8],
+    stderr: &'a [u8],
+    stdout_truncated: bool,
+    stderr_truncated: bool,
+}
+
+pub(crate) fn spawn_bounded_exec_worker(
+    request: BoundedExecWorkerRequest,
+    writer: GuestWriter,
+    connection_cancel: Arc<AtomicBool>,
+) -> io::Result<()> {
+    spawn_bounded_exec_worker_with_spawner(request, writer, connection_cancel, SystemThreadSpawner)
+}
+
+fn spawn_bounded_exec_worker_with_spawner<S>(
+    request: BoundedExecWorkerRequest,
+    writer: GuestWriter,
+    connection_cancel: Arc<AtomicBool>,
+    spawner: S,
+) -> io::Result<()>
+where
+    S: ThreadSpawner,
+{
+    let seq = request.seq;
+    let worker_writer = writer.clone();
+    let worker_spawner = spawner.clone();
+    let result = spawner.spawn_unit(
+        THREAD_BOUNDED_EXEC_WORKER,
+        Box::new(move || {
+            run_bounded_exec(request, worker_writer, connection_cancel, worker_spawner);
+        }),
+    );
+
+    match result {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let stderr = format!("Failed to spawn bounded exec worker thread: {e}");
+            send_bounded_exec_result(
+                BoundedExecResultFrame {
+                    seq,
+                    termination: BoundedExecTermination::StartFailed,
+                    duration_ms: 0,
+                    stdout: &[],
+                    stderr: stderr.as_bytes(),
+                    stdout_truncated: false,
+                    stderr_truncated: false,
+                },
+                &writer,
+            )
+        }
+    }
+}
+
+fn run_bounded_exec<S>(
+    request: BoundedExecWorkerRequest,
+    writer: GuestWriter,
+    connection_cancel: Arc<AtomicBool>,
+    spawner: S,
+) where
+    S: ThreadSpawner,
+{
+    log(
+        "INFO",
+        &format!(
+            "bounded_exec: {} (timeout={}ms, sudo={}, stdin={}, stdout_limit={}, stderr_limit={}, stream_stdout={}, stream_stderr={}, {})",
+            truncate_preview(&request.command),
+            request.timeout_ms,
+            request.sudo,
+            request.stdin.as_ref().map_or(0, Vec::len),
+            request.stdout_limit_bytes,
+            request.stderr_limit_bytes,
+            request.stream_stdout,
+            request.stream_stderr,
+            format_env_diagnostics(&request.command, &env_refs(&request.env)),
+        ),
+    );
+
+    let started = Instant::now();
+    if let Err(error) = validate_request(&request) {
+        send_final_best_effort(
+            request.seq,
+            BoundedExecTermination::StartFailed,
+            duration_ms(started),
+            &BoundedDrainResult::default(),
+            &BoundedDrainResult {
+                output: error.into_bytes(),
+                truncated: false,
+            },
+            &writer,
+        );
+        return;
+    }
+
+    let env_refs = env_refs(&request.env);
+    let spawned = match spawn_bounded_exec_command(
+        &request.command,
+        &env_refs,
+        request.sudo,
+        request.stdin.is_some(),
+    ) {
+        Ok(spawned) => spawned,
+        Err(e) => {
+            let stderr = format!(
+                "Failed to execute: {e} ({})",
+                format_env_diagnostics(&request.command, &env_refs)
+            );
+            let _ = send_bounded_exec_result(
+                BoundedExecResultFrame {
+                    seq: request.seq,
+                    termination: BoundedExecTermination::StartFailed,
+                    duration_ms: duration_ms(started),
+                    stdout: &[],
+                    stderr: stderr.as_bytes(),
+                    stdout_truncated: false,
+                    stderr_truncated: false,
+                },
+                &writer,
+            );
+            return;
+        }
+    };
+
+    let crate::exec::SpawnedCommand {
+        mut child,
+        env_script,
+    } = spawned;
+    let _env_script = env_script;
+
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            kill_and_send_wait_failed(request.seq, started, child, "missing stdout pipe", &writer);
+            return;
+        }
+    };
+    let stderr = match child.stderr.take() {
+        Some(stderr) => stderr,
+        None => {
+            kill_and_send_wait_failed(request.seq, started, child, "missing stderr pipe", &writer);
+            return;
+        }
+    };
+    let stdin = if request.stdin.is_some() {
+        match child.stdin.take() {
+            Some(stdin) => Some(stdin),
+            None => {
+                kill_and_send_wait_failed(
+                    request.seq,
+                    started,
+                    child,
+                    "missing stdin pipe",
+                    &writer,
+                );
+                return;
+            }
+        }
+    } else {
+        None
+    };
+
+    let drain_cancel = Arc::new(AtomicBool::new(false));
+    let command_cancel = Arc::new(AtomicBool::new(false));
+    let (drain_done_tx, drain_done_rx) = mpsc::channel::<()>();
+
+    let stdout_rx = spawn_bounded_drain(
+        stdout,
+        BoundedDrainWorker {
+            seq: request.seq,
+            stream: BoundedExecStream::Stdout,
+            final_limit_bytes: request.stdout_limit_bytes as usize,
+            stream_config: stream_config(
+                request.stream_stdout,
+                request.stream_chunk_limit_bytes,
+                request.stdout_stream_limit_bytes,
+            ),
+            writer: writer.clone(),
+            drain_cancel: drain_cancel.clone(),
+            command_cancel: command_cancel.clone(),
+            drain_done_tx: drain_done_tx.clone(),
+        },
+        spawner.clone(),
+    );
+    let (stdout_handle, stdout_result_rx) = match stdout_rx {
+        Ok(parts) => parts,
+        Err(e) => {
+            drain_cancel.store(true, Ordering::Release);
+            kill_and_send_wait_failed(
+                request.seq,
+                started,
+                child,
+                &format!("failed to spawn stdout drain thread: {e}"),
+                &writer,
+            );
+            return;
+        }
+    };
+
+    let stderr_rx = spawn_bounded_drain(
+        stderr,
+        BoundedDrainWorker {
+            seq: request.seq,
+            stream: BoundedExecStream::Stderr,
+            final_limit_bytes: request.stderr_limit_bytes as usize,
+            stream_config: stream_config(
+                request.stream_stderr,
+                request.stream_chunk_limit_bytes,
+                request.stderr_stream_limit_bytes,
+            ),
+            writer: writer.clone(),
+            drain_cancel: drain_cancel.clone(),
+            command_cancel: command_cancel.clone(),
+            drain_done_tx: drain_done_tx.clone(),
+        },
+        spawner.clone(),
+    );
+    let (stderr_handle, stderr_result_rx) = match stderr_rx {
+        Ok(parts) => parts,
+        Err(e) => {
+            drain_cancel.store(true, Ordering::Release);
+            kill_and_reap_child(child);
+            let _ = stdout_handle.join();
+            let _ = send_bounded_exec_result(
+                BoundedExecResultFrame {
+                    seq: request.seq,
+                    termination: BoundedExecTermination::WaitFailed,
+                    duration_ms: duration_ms(started),
+                    stdout: &[],
+                    stderr: format!("failed to spawn stderr drain thread: {e}").as_bytes(),
+                    stdout_truncated: false,
+                    stderr_truncated: false,
+                },
+                &writer,
+            );
+            return;
+        }
+    };
+
+    let stdin_worker = match (stdin, request.stdin) {
+        (Some(stdin), Some(stdin_bytes)) => {
+            match spawn_stdin_writer(stdin, stdin_bytes, command_cancel.clone(), spawner.clone()) {
+                Ok(worker) => Some(worker),
+                Err(e) => {
+                    drain_cancel.store(true, Ordering::Release);
+                    command_cancel.store(true, Ordering::Release);
+                    kill_and_reap_child(child);
+                    let _ = stdout_handle.join();
+                    let _ = stderr_handle.join();
+                    let _ = send_bounded_exec_result(
+                        BoundedExecResultFrame {
+                            seq: request.seq,
+                            termination: BoundedExecTermination::WaitFailed,
+                            duration_ms: duration_ms(started),
+                            stdout: &[],
+                            stderr: format!("failed to spawn stdin writer thread: {e}").as_bytes(),
+                            stdout_truncated: false,
+                            stderr_truncated: false,
+                        },
+                        &writer,
+                    );
+                    return;
+                }
+            }
+        }
+        _ => None,
+    };
+    drop(drain_done_tx);
+
+    let outcome = wait_with_kill_timeout_or_cancelled_either(
+        child,
+        request.timeout_ms,
+        &connection_cancel,
+        &command_cancel,
+    );
+    if matches!(outcome, WaitOutcome::Cancelled)
+        || connection_cancel.load(Ordering::Acquire)
+        || command_cancel.load(Ordering::Acquire)
+    {
+        drain_cancel.store(true, Ordering::Release);
+    }
+
+    let completed = await_drain_deadline(&drain_done_rx, 2, &drain_cancel);
+    if completed < 2 {
+        log(
+            "WARN",
+            &format!("bounded_exec: drain deadline reached after {DRAIN_DEADLINE_SECS}s",),
+        );
+    }
+
+    let _ = stdout_handle.join();
+    let _ = stderr_handle.join();
+    let stdin_error_rx = stdin_worker.map(|(stdin_handle, stdin_error_rx)| {
+        let _ = stdin_handle.join();
+        stdin_error_rx
+    });
+    let stdout_result = stdout_result_rx.recv().unwrap_or_default();
+    let mut stderr_result = stderr_result_rx.recv().unwrap_or_default();
+
+    let mut termination = match outcome {
+        WaitOutcome::Exited(status) => BoundedExecTermination::Exited {
+            exit_code: crate::process::extract_exit_code(status),
+        },
+        WaitOutcome::TimedOut => BoundedExecTermination::TimedOut,
+        WaitOutcome::Cancelled => BoundedExecTermination::Cancelled,
+        WaitOutcome::WaitFailed(msg) => {
+            if stderr_result.output.is_empty() {
+                stderr_result.output = format!("Failed to wait: {msg}").into_bytes();
+                stderr_result.truncated = false;
+            }
+            BoundedExecTermination::WaitFailed
+        }
+    };
+
+    if let Some(stdin_error_rx) = stdin_error_rx
+        && let Ok(stdin_error) = stdin_error_rx.try_recv()
+    {
+        termination = BoundedExecTermination::WaitFailed;
+        stderr_result.output = format!("Failed to write stdin: {stdin_error}").into_bytes();
+        stderr_result.truncated = false;
+    }
+
+    log(
+        "INFO",
+        &format!(
+            "bounded_exec result: termination={termination:?}, stdout_len={}, stderr_len={}, stdout_truncated={}, stderr_truncated={}",
+            stdout_result.output.len(),
+            stderr_result.output.len(),
+            stdout_result.truncated,
+            stderr_result.truncated,
+        ),
+    );
+
+    send_final_best_effort(
+        request.seq,
+        termination,
+        duration_ms(started),
+        &stdout_result,
+        &stderr_result,
+        &writer,
+    );
+}
+
+fn validate_request(request: &BoundedExecWorkerRequest) -> Result<(), String> {
+    let stdout_limit = request.stdout_limit_bytes as usize;
+    let stderr_limit = request.stderr_limit_bytes as usize;
+    let total_limit = stdout_limit
+        .checked_add(stderr_limit)
+        .ok_or_else(|| "bounded exec final output limits overflow".to_string())?;
+    if total_limit > MAX_RESULT_OUTPUT_BYTES {
+        return Err(format!(
+            "bounded exec final output limits exceed protocol result frame: {} > {}",
+            total_limit, MAX_RESULT_OUTPUT_BYTES
+        ));
+    }
+
+    if (request.stream_stdout || request.stream_stderr)
+        && request.stream_chunk_limit_bytes as usize > MAX_OUTPUT_CHUNK_BYTES
+    {
+        return Err(format!(
+            "bounded exec stream chunk limit exceeds protocol frame: {} > {}",
+            request.stream_chunk_limit_bytes, MAX_OUTPUT_CHUNK_BYTES
+        ));
+    }
+
+    Ok(())
+}
+
+fn env_refs(env: &[(String, String)]) -> Vec<(&str, &str)> {
+    env.iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect()
+}
+
+fn stream_config(
+    enabled: bool,
+    chunk_limit_bytes: u32,
+    stream_limit_bytes: u32,
+) -> Option<BoundedStreamConfig> {
+    enabled.then_some(BoundedStreamConfig {
+        chunk_limit_bytes: chunk_limit_bytes as usize,
+        stream_limit_bytes: stream_limit_bytes as usize,
+    })
+}
+
+fn spawn_bounded_drain<R, S>(
+    pipe: R,
+    worker: BoundedDrainWorker,
+    spawner: S,
+) -> io::Result<(JoinHandle<()>, mpsc::Receiver<BoundedDrainResult>)>
+where
+    R: std::os::unix::io::AsRawFd + Send + 'static,
+    S: ThreadSpawner,
+{
+    let BoundedDrainWorker {
+        seq,
+        stream,
+        final_limit_bytes,
+        stream_config,
+        writer,
+        drain_cancel,
+        command_cancel,
+        drain_done_tx,
+    } = worker;
+    let (result_tx, result_rx) = mpsc::channel();
+    let thread_name = match stream {
+        BoundedExecStream::Stdout => THREAD_BOUNDED_STDOUT,
+        BoundedExecStream::Stderr => THREAD_BOUNDED_STDERR,
+    };
+    let handle = spawner.spawn_unit(
+        thread_name,
+        Box::new(move || {
+            let mut sequence = 0u32;
+            let result = drain_bounded_cancellable(
+                pipe,
+                &drain_cancel,
+                final_limit_bytes,
+                stream_config,
+                |chunk, truncated| {
+                    let send_result = send_bounded_exec_output_chunk(
+                        seq, stream, sequence, chunk, truncated, &writer,
+                    );
+                    sequence = sequence.wrapping_add(1);
+                    if let Err(e) = send_result {
+                        log(
+                            "WARN",
+                            &format!("bounded_exec: failed to send output chunk: {e}"),
+                        );
+                        command_cancel.store(true, Ordering::Release);
+                        drain_cancel.store(true, Ordering::Release);
+                        return false;
+                    }
+                    true
+                },
+            );
+            let _ = result_tx.send(result);
+            let _ = drain_done_tx.send(());
+        }),
+    )?;
+    Ok((handle, result_rx))
+}
+
+fn spawn_stdin_writer<S>(
+    mut stdin: ChildStdin,
+    stdin_bytes: Vec<u8>,
+    command_cancel: Arc<AtomicBool>,
+    spawner: S,
+) -> io::Result<(JoinHandle<()>, mpsc::Receiver<String>)>
+where
+    S: ThreadSpawner,
+{
+    let (error_tx, error_rx) = mpsc::channel();
+    let handle = spawner.spawn_unit(
+        THREAD_BOUNDED_STDIN,
+        Box::new(move || {
+            let write_result = stdin.write_all(&stdin_bytes);
+            drop(stdin);
+            if let Err(e) = write_result {
+                if e.kind() == io::ErrorKind::BrokenPipe {
+                    return;
+                }
+                let _ = error_tx.send(e.to_string());
+                command_cancel.store(true, Ordering::Release);
+            }
+        }),
+    )?;
+    Ok((handle, error_rx))
+}
+
+fn kill_and_send_wait_failed(
+    seq: u32,
+    started: Instant,
+    child: Child,
+    error: &str,
+    writer: &GuestWriter,
+) {
+    kill_and_reap_child(child);
+    let _ = send_bounded_exec_result(
+        BoundedExecResultFrame {
+            seq,
+            termination: BoundedExecTermination::WaitFailed,
+            duration_ms: duration_ms(started),
+            stdout: &[],
+            stderr: error.as_bytes(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        },
+        writer,
+    );
+}
+
+fn send_final_best_effort(
+    seq: u32,
+    termination: BoundedExecTermination,
+    duration_ms: u64,
+    stdout: &BoundedDrainResult,
+    stderr: &BoundedDrainResult,
+    writer: &GuestWriter,
+) {
+    if let Err(e) = send_bounded_exec_result(
+        BoundedExecResultFrame {
+            seq,
+            termination,
+            duration_ms,
+            stdout: &stdout.output,
+            stderr: &stderr.output,
+            stdout_truncated: stdout.truncated,
+            stderr_truncated: stderr.truncated,
+        },
+        writer,
+    ) {
+        log("ERROR", &format!("Failed to send bounded_exec_result: {e}"));
+    }
+}
+
+fn send_bounded_exec_result(
+    frame: BoundedExecResultFrame<'_>,
+    writer: &GuestWriter,
+) -> io::Result<()> {
+    let BoundedExecResultFrame {
+        seq,
+        termination,
+        duration_ms,
+        stdout,
+        stderr,
+        stdout_truncated,
+        stderr_truncated,
+    } = frame;
+    let payload = match vsock_proto::encode_bounded_exec_result(
+        termination,
+        duration_ms,
+        stdout,
+        stderr,
+        stdout_truncated,
+        stderr_truncated,
+    ) {
+        Ok(payload) => payload,
+        Err(e) => {
+            log(
+                "ERROR",
+                &format!("Failed to encode bounded_exec_result: {e}"),
+            );
+            let diagnostic = format!("Failed to encode bounded exec result: {e}");
+            vsock_proto::encode_bounded_exec_result(
+                BoundedExecTermination::WaitFailed,
+                duration_ms,
+                &[],
+                diagnostic.as_bytes(),
+                false,
+                false,
+            )
+            .map_err(to_io_error)?
+        }
+    };
+    let encoded =
+        vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, seq, &payload).map_err(to_io_error)?;
+    writer.write_frame(&encoded)
+}
+
+fn send_bounded_exec_output_chunk(
+    seq: u32,
+    stream: BoundedExecStream,
+    sequence: u32,
+    chunk: &[u8],
+    truncated: bool,
+    writer: &GuestWriter,
+) -> io::Result<()> {
+    let payload = vsock_proto::encode_bounded_exec_output_chunk(stream, sequence, chunk, truncated)
+        .map_err(to_io_error)?;
+    let encoded =
+        vsock_proto::encode(MSG_BOUNDED_EXEC_OUTPUT_CHUNK, seq, &payload).map_err(to_io_error)?;
+    writer.write_frame(&encoded)
+}
+
+fn duration_ms(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
+}

--- a/crates/vsock-guest/src/bounded_exec.rs
+++ b/crates/vsock-guest/src/bounded_exec.rs
@@ -28,13 +28,7 @@ const THREAD_BOUNDED_STDOUT: &str = "vsock-bounded-stdout";
 const THREAD_BOUNDED_STDERR: &str = "vsock-bounded-stderr";
 const THREAD_BOUNDED_STDIN: &str = "vsock-bounded-stdin";
 
-// MSG frame overhead (type + seq) plus bounded_exec_result fixed payload.
-const RESULT_FRAME_OVERHEAD_BYTES: usize = 1 + 4 + 22;
-const MAX_RESULT_OUTPUT_BYTES: usize = vsock_proto::MAX_MESSAGE_SIZE - RESULT_FRAME_OVERHEAD_BYTES;
-// MSG frame overhead (type + seq) plus bounded_exec_output_chunk fixed payload.
-const OUTPUT_CHUNK_FRAME_OVERHEAD_BYTES: usize = 1 + 4 + 10;
-const MAX_OUTPUT_CHUNK_BYTES: usize =
-    vsock_proto::MAX_MESSAGE_SIZE - OUTPUT_CHUNK_FRAME_OVERHEAD_BYTES;
+const MIN_STREAM_CHUNK_LIMIT_BYTES: usize = 1024;
 
 pub(crate) struct BoundedExecWorkerRequest {
     pub(crate) seq: u32,
@@ -438,20 +432,29 @@ fn validate_request(request: &BoundedExecWorkerRequest) -> Result<(), String> {
     let total_limit = stdout_limit
         .checked_add(stderr_limit)
         .ok_or_else(|| "bounded exec final output limits overflow".to_string())?;
-    if total_limit > MAX_RESULT_OUTPUT_BYTES {
+    if total_limit > vsock_proto::MAX_BOUNDED_EXEC_RESULT_OUTPUT_BYTES {
         return Err(format!(
             "bounded exec final output limits exceed protocol result frame: {} > {}",
-            total_limit, MAX_RESULT_OUTPUT_BYTES
+            total_limit,
+            vsock_proto::MAX_BOUNDED_EXEC_RESULT_OUTPUT_BYTES
         ));
     }
 
-    if (request.stream_stdout || request.stream_stderr)
-        && request.stream_chunk_limit_bytes as usize > MAX_OUTPUT_CHUNK_BYTES
-    {
-        return Err(format!(
-            "bounded exec stream chunk limit exceeds protocol frame: {} > {}",
-            request.stream_chunk_limit_bytes, MAX_OUTPUT_CHUNK_BYTES
-        ));
+    if request.stream_stdout || request.stream_stderr {
+        let stream_chunk_limit = request.stream_chunk_limit_bytes as usize;
+        if stream_chunk_limit < MIN_STREAM_CHUNK_LIMIT_BYTES {
+            return Err(format!(
+                "bounded exec stream chunk limit below minimum: {} < {}",
+                request.stream_chunk_limit_bytes, MIN_STREAM_CHUNK_LIMIT_BYTES
+            ));
+        }
+        if stream_chunk_limit > vsock_proto::MAX_BOUNDED_EXEC_OUTPUT_CHUNK_BYTES {
+            return Err(format!(
+                "bounded exec stream chunk limit exceeds protocol frame: {} > {}",
+                request.stream_chunk_limit_bytes,
+                vsock_proto::MAX_BOUNDED_EXEC_OUTPUT_CHUNK_BYTES
+            ));
+        }
     }
 
     Ok(())

--- a/crates/vsock-guest/src/bounded_exec.rs
+++ b/crates/vsock-guest/src/bounded_exec.rs
@@ -28,8 +28,6 @@ const THREAD_BOUNDED_STDOUT: &str = "vsock-bounded-stdout";
 const THREAD_BOUNDED_STDERR: &str = "vsock-bounded-stderr";
 const THREAD_BOUNDED_STDIN: &str = "vsock-bounded-stdin";
 
-const MIN_STREAM_CHUNK_LIMIT_BYTES: usize = 1024;
-
 pub(crate) struct BoundedExecWorkerRequest {
     pub(crate) seq: u32,
     pub(crate) timeout_ms: u32,
@@ -442,10 +440,11 @@ fn validate_request(request: &BoundedExecWorkerRequest) -> Result<(), String> {
 
     if request.stream_stdout || request.stream_stderr {
         let stream_chunk_limit = request.stream_chunk_limit_bytes as usize;
-        if stream_chunk_limit < MIN_STREAM_CHUNK_LIMIT_BYTES {
+        if stream_chunk_limit < vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES {
             return Err(format!(
                 "bounded exec stream chunk limit below minimum: {} < {}",
-                request.stream_chunk_limit_bytes, MIN_STREAM_CHUNK_LIMIT_BYTES
+                request.stream_chunk_limit_bytes,
+                vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES
             ));
         }
         if stream_chunk_limit > vsock_proto::MAX_BOUNDED_EXEC_OUTPUT_CHUNK_BYTES {

--- a/crates/vsock-guest/src/bounded_exec.rs
+++ b/crates/vsock-guest/src/bounded_exec.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::thread::JoinHandle;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use vsock_proto::{
     self, BoundedExecStream, BoundedExecTermination, MSG_BOUNDED_EXEC_OUTPUT_CHUNK,
@@ -27,6 +27,7 @@ const THREAD_BOUNDED_EXEC_WORKER: &str = "vsock-bounded-exec-worker";
 const THREAD_BOUNDED_STDOUT: &str = "vsock-bounded-stdout";
 const THREAD_BOUNDED_STDERR: &str = "vsock-bounded-stderr";
 const THREAD_BOUNDED_STDIN: &str = "vsock-bounded-stdin";
+const STREAM_CHUNK_WRITE_DEADLINE: Duration = Duration::from_secs(2);
 
 pub(crate) struct BoundedExecWorkerRequest {
     pub(crate) seq: u32,
@@ -662,7 +663,7 @@ fn send_bounded_exec_output_chunk(
         .map_err(to_io_error)?;
     let encoded =
         vsock_proto::encode(MSG_BOUNDED_EXEC_OUTPUT_CHUNK, seq, &payload).map_err(to_io_error)?;
-    writer.write_frame(&encoded)
+    writer.write_frame_with_deadline(&encoded, STREAM_CHUNK_WRITE_DEADLINE)
 }
 
 fn duration_ms(started: Instant) -> u64 {

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -5,8 +5,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
-use vsock_proto::{self, MSG_EXEC, MSG_EXEC_RESULT, MSG_READY, MSG_SPAWN_WATCH};
+use vsock_proto::{self, MSG_BOUNDED_EXEC, MSG_EXEC, MSG_EXEC_RESULT, MSG_READY, MSG_SPAWN_WATCH};
 
+use crate::bounded_exec::{BoundedExecWorkerRequest, spawn_bounded_exec_worker};
 use crate::error::to_io_error;
 use crate::handlers::{MessageOutcome, handle_exec, handle_message};
 use crate::log::log;
@@ -137,7 +138,7 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
             .decode(buf.get(..n).unwrap_or_default())
             .map_err(to_io_error)?
         {
-            // MSG_EXEC and MSG_SPAWN_WATCH run in background threads to avoid
+            // Command-style messages run in background threads to avoid
             // blocking the event loop. A blocking child process (e.g. reading a
             // pipe fd) would otherwise stall all subsequent messages.
             if msg.msg_type == MSG_SPAWN_WATCH {
@@ -155,6 +156,18 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                         stdout_log_path: d.stdout_log_path,
                     },
                     msg.seq,
+                    writer.clone(),
+                    connection_cancel.clone(),
+                )?;
+            } else if msg.msg_type == MSG_BOUNDED_EXEC {
+                log(
+                    "INFO",
+                    &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),
+                );
+                let decoded =
+                    vsock_proto::decode_bounded_exec(&msg.payload).map_err(to_io_error)?;
+                spawn_bounded_exec_worker(
+                    BoundedExecWorkerRequest::from_decoded(msg.seq, decoded),
                     writer.clone(),
                     connection_cancel.clone(),
                 )?;

--- a/crates/vsock-guest/src/drain.rs
+++ b/crates/vsock-guest/src/drain.rs
@@ -5,6 +5,18 @@ use std::sync::atomic::{AtomicBool, Ordering};
 const STDOUT_CHUNK_SIZE: usize = 8 * 1024;
 const DRAIN_POLL_TIMEOUT_MS: libc::c_int = 100;
 
+#[derive(Clone, Copy)]
+pub(crate) struct BoundedStreamConfig {
+    pub(crate) chunk_limit_bytes: usize,
+    pub(crate) stream_limit_bytes: usize,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct BoundedDrainResult {
+    pub(crate) output: Vec<u8>,
+    pub(crate) truncated: bool,
+}
+
 /// Drain `pipe` until EOF or `cancel` is set, calling `on_chunk` for each
 /// non-empty read.
 ///
@@ -87,6 +99,75 @@ where
     buf
 }
 
+/// Bounded variant of [`drain_until_eof_or_cancelled`].
+///
+/// The returned final buffer retains only the first `final_limit_bytes` bytes,
+/// but the helper continues reading after truncation so the child cannot block
+/// on a full pipe. When `stream` is set, early bytes are additionally forwarded
+/// through `on_stream_chunk` up to the configured stream budget. Returning
+/// `false` from the callback disables further stream forwarding, but draining
+/// still continues until EOF or cancellation.
+pub(crate) fn drain_bounded_cancellable<R>(
+    pipe: R,
+    cancel: &AtomicBool,
+    final_limit_bytes: usize,
+    stream: Option<BoundedStreamConfig>,
+    mut on_stream_chunk: impl FnMut(&[u8], bool) -> bool,
+) -> BoundedDrainResult
+where
+    R: std::os::unix::io::AsRawFd,
+{
+    let mut output = Vec::with_capacity(final_limit_bytes.min(STDOUT_CHUNK_SIZE));
+    let mut truncated = false;
+    let mut stream_emitted = 0usize;
+    let mut stream_truncated = false;
+    let mut stream_enabled = stream.is_some();
+
+    drain_until_eof_or_cancelled(pipe, cancel, |chunk| {
+        if output.len() < final_limit_bytes {
+            let remaining = final_limit_bytes - output.len();
+            let keep = remaining.min(chunk.len());
+            output.extend_from_slice(chunk.get(..keep).unwrap_or_default());
+            if keep < chunk.len() {
+                truncated = true;
+            }
+        } else if !chunk.is_empty() {
+            truncated = true;
+        }
+
+        let Some(config) = stream else {
+            return;
+        };
+        if !stream_enabled || stream_truncated || chunk.is_empty() {
+            return;
+        }
+
+        if stream_emitted >= config.stream_limit_bytes || config.chunk_limit_bytes == 0 {
+            stream_truncated = true;
+            stream_enabled = on_stream_chunk(&[], true);
+            return;
+        }
+
+        let remaining_stream = config.stream_limit_bytes - stream_emitted;
+        let emit_total = remaining_stream.min(chunk.len());
+        let emit = chunk.get(..emit_total).unwrap_or_default();
+        for part in emit.chunks(config.chunk_limit_bytes) {
+            if !on_stream_chunk(part, false) {
+                stream_enabled = false;
+                return;
+            }
+            stream_emitted += part.len();
+        }
+
+        if emit_total < chunk.len() {
+            stream_truncated = true;
+            stream_enabled = on_stream_chunk(&[], true);
+        }
+    });
+
+    BoundedDrainResult { output, truncated }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -158,5 +239,91 @@ mod tests {
         });
 
         assert!(output.is_empty());
+    }
+
+    #[test]
+    fn bounded_drain_retains_limit_and_reports_truncation() {
+        let (reader, mut writer) = pipe_pair();
+        writer.write_all(b"abcdef").unwrap();
+        drop(writer);
+
+        let cancel = AtomicBool::new(false);
+        let result = drain_bounded_cancellable(reader, &cancel, 3, None, |_, _| true);
+
+        assert_eq!(result.output, b"abc".to_vec());
+        assert!(result.truncated);
+    }
+
+    #[test]
+    fn bounded_drain_zero_limit_stores_no_bytes_but_truncates() {
+        let (reader, mut writer) = pipe_pair();
+        writer.write_all(b"abc").unwrap();
+        drop(writer);
+
+        let cancel = AtomicBool::new(false);
+        let result = drain_bounded_cancellable(reader, &cancel, 0, None, |_, _| true);
+
+        assert!(result.output.is_empty());
+        assert!(result.truncated);
+    }
+
+    #[test]
+    fn bounded_drain_splits_stream_chunks_and_marks_stream_truncation() {
+        let (reader, mut writer) = pipe_pair();
+        writer.write_all(b"abcdef").unwrap();
+        drop(writer);
+
+        let cancel = AtomicBool::new(false);
+        let mut chunks = Vec::new();
+        let result = drain_bounded_cancellable(
+            reader,
+            &cancel,
+            10,
+            Some(BoundedStreamConfig {
+                chunk_limit_bytes: 2,
+                stream_limit_bytes: 5,
+            }),
+            |chunk, truncated| {
+                chunks.push((chunk.to_vec(), truncated));
+                true
+            },
+        );
+
+        assert_eq!(result.output, b"abcdef".to_vec());
+        assert!(!result.truncated);
+        assert_eq!(
+            chunks,
+            vec![
+                (b"ab".to_vec(), false),
+                (b"cd".to_vec(), false),
+                (b"e".to_vec(), false),
+                (Vec::new(), true),
+            ]
+        );
+    }
+
+    #[test]
+    fn bounded_drain_cancel_exits_while_writer_fd_remains_open() {
+        let (reader, mut writer) = pipe_pair();
+        let cancel = AtomicBool::new(false);
+        writer.write_all(b"hello").unwrap();
+
+        let result = drain_bounded_cancellable(
+            reader,
+            &cancel,
+            10,
+            Some(BoundedStreamConfig {
+                chunk_limit_bytes: 10,
+                stream_limit_bytes: 10,
+            }),
+            |_, _| {
+                cancel.store(true, Ordering::Release);
+                true
+            },
+        );
+
+        assert_eq!(result.output, b"hello".to_vec());
+        assert!(!result.truncated);
+        drop(writer);
     }
 }

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -623,6 +623,29 @@ pub(crate) fn spawn_with_pipes(
     Ok(SpawnedCommand { child, env_script })
 }
 
+/// Spawn `command` for bounded exec with stdout/stderr piped and caller-selected
+/// stdin behavior. Existing legacy exec/spawn_watch keep using
+/// [`spawn_with_pipes`] so their stdin semantics stay unchanged.
+pub(crate) fn spawn_bounded_exec_command(
+    command: &str,
+    env: &[(&str, &str)],
+    sudo: bool,
+    pipe_stdin: bool,
+) -> io::Result<SpawnedCommand> {
+    let PreparedExecCommand {
+        mut command,
+        env_script,
+    } = build_exec_command_with_env(command, env, sudo)?;
+    if pipe_stdin {
+        command.stdin(Stdio::piped());
+    } else {
+        command.stdin(Stdio::null());
+    }
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let child = spawn_in_own_process_group(&mut command)?;
+    Ok(SpawnedCommand { child, env_script })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! Protocol encoding/decoding is handled by the `vsock-proto` crate.
 
+mod bounded_exec;
 mod connection;
 mod drain;
 mod error;

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -92,9 +92,31 @@ pub(crate) fn wait_with_kill_timeout(mut child: Child, timeout_ms: u32) -> WaitO
 /// work tied to a disconnected host connection cannot outlive that connection
 /// indefinitely.
 pub(crate) fn wait_with_kill_timeout_or_cancelled(
-    mut child: Child,
+    child: Child,
     timeout_ms: u32,
     cancel: &AtomicBool,
+) -> WaitOutcome {
+    wait_with_kill_timeout_or_cancelled_by(child, timeout_ms, || cancel.load(Ordering::Acquire))
+}
+
+/// Like [`wait_with_kill_timeout_or_cancelled`], but observes either cancel
+/// flag. Used by bounded exec, which has both connection-level cancellation
+/// and local cancellation from stream write failures.
+pub(crate) fn wait_with_kill_timeout_or_cancelled_either(
+    child: Child,
+    timeout_ms: u32,
+    first_cancel: &AtomicBool,
+    second_cancel: &AtomicBool,
+) -> WaitOutcome {
+    wait_with_kill_timeout_or_cancelled_by(child, timeout_ms, || {
+        first_cancel.load(Ordering::Acquire) || second_cancel.load(Ordering::Acquire)
+    })
+}
+
+fn wait_with_kill_timeout_or_cancelled_by(
+    mut child: Child,
+    timeout_ms: u32,
+    is_cancelled: impl Fn() -> bool + Copy + Send + Sync,
 ) -> WaitOutcome {
     let child_id = child.id();
     let deadline = if timeout_ms > 0 {
@@ -110,7 +132,7 @@ pub(crate) fn wait_with_kill_timeout_or_cancelled(
     thread::scope(|scope| {
         let (done_tx, done_rx) = mpsc::channel::<()>();
         let watchdog = match spawn_scoped_named(scope, THREAD_WAIT_WATCHDOG, move || {
-            wait_for_done_timeout_or_cancelled(done_rx, deadline, cancel, child_id)
+            wait_for_done_timeout_or_cancelled(done_rx, deadline, is_cancelled, child_id)
         }) {
             Ok(watchdog) => watchdog,
             Err(e) => {
@@ -148,7 +170,7 @@ pub(crate) fn wait_with_kill_timeout_or_cancelled(
 fn wait_for_done_timeout_or_cancelled(
     done_rx: mpsc::Receiver<()>,
     deadline: Option<Instant>,
-    cancel: &AtomicBool,
+    is_cancelled: impl Fn() -> bool,
     child_id: u32,
 ) -> Option<WatchdogKill> {
     let poll_interval = Duration::from_millis(WATCHDOG_CANCEL_POLL_INTERVAL_MS);
@@ -170,7 +192,7 @@ fn wait_for_done_timeout_or_cancelled(
             None => poll_interval,
         };
 
-        if cancel.load(Ordering::Acquire) {
+        if is_cancelled() {
             return kill_child_unless_done(&done_rx, child_id, KillReason::Cancelled);
         }
 
@@ -513,7 +535,7 @@ mod tests {
         let outcome = wait_for_done_timeout_or_cancelled(
             done_rx,
             Some(Instant::now()),
-            &cancel,
+            || cancel.load(Ordering::Acquire),
             i32::MAX as u32,
         );
 
@@ -526,7 +548,12 @@ mod tests {
         let (done_tx, done_rx) = mpsc::channel::<()>();
         done_tx.send(()).unwrap();
 
-        let outcome = wait_for_done_timeout_or_cancelled(done_rx, None, &cancel, i32::MAX as u32);
+        let outcome = wait_for_done_timeout_or_cancelled(
+            done_rx,
+            None,
+            || cancel.load(Ordering::Acquire),
+            i32::MAX as u32,
+        );
 
         assert!(outcome.is_none());
     }

--- a/crates/vsock-guest/src/writer.rs
+++ b/crates/vsock-guest/src/writer.rs
@@ -28,7 +28,11 @@ impl GuestWriter {
         self.write_frame_with_deadline(frame, WRITE_DEADLINE)
     }
 
-    fn write_frame_with_deadline(&self, frame: &[u8], deadline: Duration) -> io::Result<()> {
+    pub(crate) fn write_frame_with_deadline(
+        &self,
+        frame: &[u8],
+        deadline: Duration,
+    ) -> io::Result<()> {
         let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
         let result = send_frame(stream.as_raw_fd(), frame, deadline);
         if result.is_err() {

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -603,6 +603,32 @@ fn bounded_exec_zero_final_limits_return_empty_truncated_output() {
 }
 
 #[test]
+fn bounded_exec_ignores_stream_limits_when_streaming_is_disabled() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request("printf no-stream", &[], None);
+    request.stream_stdout = false;
+    request.stream_stderr = false;
+    request.stream_chunk_limit_bytes = 0;
+    request.stdout_stream_limit_bytes = 0;
+    request.stderr_stream_limit_bytes = 0;
+    send_bounded_exec(&mut host_stream, 26, &request);
+    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 26);
+
+    assert!(chunks.is_empty());
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, b"no-stream");
+    assert_eq!(result.stderr, b"");
+    assert!(!result.stdout_truncated);
+    assert!(!result.stderr_truncated);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn bounded_exec_zero_stream_budget_emits_truncation_marker_only() {
     let (handle, mut host_stream) = start_guest_connection();
 
@@ -610,8 +636,8 @@ fn bounded_exec_zero_stream_budget_emits_truncation_marker_only() {
     request.stream_stdout = true;
     request.stream_chunk_limit_bytes = vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32;
     request.stdout_stream_limit_bytes = 0;
-    send_bounded_exec(&mut host_stream, 26, &request);
-    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 26);
+    send_bounded_exec(&mut host_stream, 27, &request);
+    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 27);
 
     assert_eq!(
         result.termination,
@@ -628,6 +654,73 @@ fn bounded_exec_zero_stream_budget_emits_truncation_marker_only() {
 }
 
 #[test]
+fn bounded_exec_stream_limit_emits_data_then_truncation_marker() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request("head -c 2500 /dev/zero | tr '\\0' S", &[], None);
+    request.stream_stdout = true;
+    request.stream_chunk_limit_bytes = vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32;
+    request.stdout_stream_limit_bytes = 1500;
+    send_bounded_exec(&mut host_stream, 28, &request);
+    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 28);
+
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, vec![b'S'; 2500]);
+    assert!(!result.stdout_truncated);
+    assert!(!result.stderr_truncated);
+
+    assert!(
+        chunks.len() >= 2,
+        "expected streamed data and a truncation marker, got {} chunks",
+        chunks.len()
+    );
+    for (expected_sequence, chunk) in chunks.iter().enumerate() {
+        assert_eq!(chunk.stream, BoundedExecStream::Stdout);
+        assert_eq!(chunk.sequence, expected_sequence as u32);
+    }
+    let (marker, data_chunks) = chunks.split_last().expect("chunks are not empty");
+    assert!(marker.truncated);
+    assert!(marker.chunk.is_empty());
+    assert!(data_chunks.iter().all(|chunk| !chunk.truncated));
+    assert!(data_chunks.iter().all(|chunk| !chunk.chunk.is_empty()));
+    let max_stream_chunk_len = vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES;
+    assert!(
+        data_chunks
+            .iter()
+            .all(|chunk| chunk.chunk.len() <= max_stream_chunk_len)
+    );
+    let streamed = data_chunks
+        .iter()
+        .flat_map(|chunk| chunk.chunk.iter().copied())
+        .collect::<Vec<_>>();
+    assert_eq!(streamed, vec![b'S'; 1500]);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_rejects_stream_chunk_limit_that_cannot_fit_frame() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request("echo should-not-run", &[], None);
+    request.stream_stdout = true;
+    request.stream_chunk_limit_bytes =
+        (vsock_proto::MAX_BOUNDED_EXEC_OUTPUT_CHUNK_BYTES + 1) as u32;
+    send_bounded_exec(&mut host_stream, 29, &request);
+    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 29);
+    let stderr = String::from_utf8_lossy(&result.stderr);
+
+    assert!(chunks.is_empty());
+    assert_eq!(result.termination, BoundedExecTermination::StartFailed);
+    assert!(stderr.contains("stream chunk limit exceeds protocol frame"));
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn bounded_exec_slow_request_does_not_block_fast_request() {
     let (handle, mut host_stream) = start_guest_connection();
 
@@ -635,9 +728,9 @@ fn bounded_exec_slow_request_does_not_block_fast_request() {
     slow_request.timeout_ms = 0;
     let fast_request = bounded_request("printf fast", &[], None);
 
-    send_bounded_exec(&mut host_stream, 27, &slow_request);
-    send_bounded_exec(&mut host_stream, 28, &fast_request);
-    let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 28);
+    send_bounded_exec(&mut host_stream, 30, &slow_request);
+    send_bounded_exec(&mut host_stream, 31, &fast_request);
+    let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 31);
 
     assert_eq!(
         result.termination,

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -562,6 +562,93 @@ fn bounded_exec_rejects_tiny_stream_chunk_limit() {
     finish_guest_connection(handle, host_stream);
 }
 
+#[test]
+fn bounded_exec_rejects_final_output_limits_that_cannot_fit_result_frame() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request("echo should-not-run", &[], None);
+    request.stdout_limit_bytes = vsock_proto::MAX_BOUNDED_EXEC_RESULT_OUTPUT_BYTES as u32;
+    request.stderr_limit_bytes = 1;
+    send_bounded_exec(&mut host_stream, 24, &request);
+    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 24);
+    let stderr = String::from_utf8_lossy(&result.stderr);
+
+    assert!(chunks.is_empty());
+    assert_eq!(result.termination, BoundedExecTermination::StartFailed);
+    assert!(stderr.contains("final output limits exceed protocol result frame"));
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_zero_final_limits_return_empty_truncated_output() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request("printf stdout; printf stderr >&2", &[], None);
+    request.stdout_limit_bytes = 0;
+    request.stderr_limit_bytes = 0;
+    send_bounded_exec(&mut host_stream, 25, &request);
+    let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 25);
+
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    assert!(result.stdout.is_empty());
+    assert!(result.stderr.is_empty());
+    assert!(result.stdout_truncated);
+    assert!(result.stderr_truncated);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_zero_stream_budget_emits_truncation_marker_only() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request("printf streamed", &[], None);
+    request.stream_stdout = true;
+    request.stream_chunk_limit_bytes = vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32;
+    request.stdout_stream_limit_bytes = 0;
+    send_bounded_exec(&mut host_stream, 26, &request);
+    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 26);
+
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, b"streamed");
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks[0].stream, BoundedExecStream::Stdout);
+    assert_eq!(chunks[0].sequence, 0);
+    assert!(chunks[0].chunk.is_empty());
+    assert!(chunks[0].truncated);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_slow_request_does_not_block_fast_request() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut slow_request = bounded_request("sleep 60", &[], None);
+    slow_request.timeout_ms = 0;
+    let fast_request = bounded_request("printf fast", &[], None);
+
+    send_bounded_exec(&mut host_stream, 27, &slow_request);
+    send_bounded_exec(&mut host_stream, 28, &fast_request);
+    let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 28);
+
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, b"fast");
+    assert_eq!(result.stderr, b"");
+
+    finish_guest_connection(handle, host_stream);
+}
+
 /// Verify that a slow exec does not block a fast exec that arrives later.
 /// This is the core regression test for the non-blocking exec fix.
 #[test]

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -360,9 +360,9 @@ fn bounded_exec_broken_pipe_stdin_keeps_child_exit_status() {
 fn bounded_exec_streams_stdout_before_final_result() {
     let (handle, mut host_stream) = start_guest_connection();
 
-    let mut request = bounded_request("printf login-url; sleep 0.2; printf done", &[], None);
+    let mut request = bounded_request("printf login-url; printf done", &[], None);
     request.stream_stdout = true;
-    request.stream_chunk_limit_bytes = 1024;
+    request.stream_chunk_limit_bytes = vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32;
     request.stdout_stream_limit_bytes = 64;
     send_bounded_exec(&mut host_stream, 15, &request);
     let (chunks, result) = read_bounded_exec_result(&mut host_stream, 15);
@@ -395,7 +395,7 @@ fn bounded_exec_streams_stdout_and_stderr_independently() {
     let mut request = bounded_request("printf out; printf err >&2", &[], None);
     request.stream_stdout = true;
     request.stream_stderr = true;
-    request.stream_chunk_limit_bytes = 1024;
+    request.stream_chunk_limit_bytes = vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32;
     send_bounded_exec(&mut host_stream, 16, &request);
     let (chunks, result) = read_bounded_exec_result(&mut host_stream, 16);
 

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -362,7 +362,7 @@ fn bounded_exec_streams_stdout_before_final_result() {
 
     let mut request = bounded_request("printf login-url; sleep 0.2; printf done", &[], None);
     request.stream_stdout = true;
-    request.stream_chunk_limit_bytes = 4;
+    request.stream_chunk_limit_bytes = 1024;
     request.stdout_stream_limit_bytes = 64;
     send_bounded_exec(&mut host_stream, 15, &request);
     let (chunks, result) = read_bounded_exec_result(&mut host_stream, 15);
@@ -540,6 +540,24 @@ fn bounded_exec_invalid_env_payload_returns_start_failed_without_leaking_value()
     assert_eq!(result.termination, BoundedExecTermination::StartFailed);
     assert!(stderr.contains("invalid environment variable name"));
     assert!(!stderr.contains(secret));
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_rejects_tiny_stream_chunk_limit() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request("echo should-not-run", &[], None);
+    request.stream_stdout = true;
+    request.stream_chunk_limit_bytes = 1;
+    send_bounded_exec(&mut host_stream, 23, &request);
+    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 23);
+    let stderr = String::from_utf8_lossy(&result.stderr);
+
+    assert!(chunks.is_empty());
+    assert_eq!(result.termination, BoundedExecTermination::StartFailed);
+    assert!(stderr.contains("stream chunk limit below minimum"));
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -11,8 +11,10 @@ use std::time::Duration;
 
 use vsock_guest::{handle_connection, run};
 use vsock_proto::{
-    self, MSG_ERROR, MSG_EXEC, MSG_EXEC_RESULT, MSG_PROCESS_EXIT, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
-    MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK,
+    self, BoundedExecRequest, BoundedExecStream, BoundedExecTermination, MSG_BOUNDED_EXEC,
+    MSG_BOUNDED_EXEC_OUTPUT_CHUNK, MSG_BOUNDED_EXEC_RESULT, MSG_ERROR, MSG_EXEC, MSG_EXEC_RESULT,
+    MSG_PROCESS_EXIT, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT,
+    MSG_STDOUT_CHUNK,
 };
 
 const EXIT_CODE_TIMEOUT: i32 = 124;
@@ -165,6 +167,381 @@ fn send_exec_and_read_result_with_env(
     vsock_proto::decode_exec_result(&msgs[0].payload)
         .map(|(code, out, err)| (code, out.to_vec(), err.to_vec()))
         .unwrap()
+}
+
+struct BoundedChunk {
+    stream: BoundedExecStream,
+    sequence: u32,
+    chunk: Vec<u8>,
+    truncated: bool,
+}
+
+struct BoundedResult {
+    termination: BoundedExecTermination,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    stdout_truncated: bool,
+    stderr_truncated: bool,
+}
+
+fn bounded_request<'a>(
+    command: &'a str,
+    env: &'a [(&'a str, &'a str)],
+    stdin: Option<&'a [u8]>,
+) -> BoundedExecRequest<'a> {
+    BoundedExecRequest {
+        timeout_ms: 5000,
+        command,
+        env,
+        sudo: false,
+        stdin,
+        stdout_limit_bytes: 1024 * 1024,
+        stderr_limit_bytes: 1024 * 1024,
+        stream_stdout: false,
+        stream_stderr: false,
+        stream_chunk_limit_bytes: 8192,
+        stdout_stream_limit_bytes: 1024 * 1024,
+        stderr_stream_limit_bytes: 1024 * 1024,
+    }
+}
+
+fn send_bounded_exec(stream: &mut impl std::io::Write, seq: u32, request: &BoundedExecRequest<'_>) {
+    let payload = vsock_proto::encode_bounded_exec(request).unwrap();
+    let msg = vsock_proto::encode(MSG_BOUNDED_EXEC, seq, &payload).unwrap();
+    stream.write_all(&msg).unwrap();
+}
+
+fn read_bounded_exec_result(
+    stream: &mut impl std::io::Read,
+    seq: u32,
+) -> (Vec<BoundedChunk>, BoundedResult) {
+    let mut decoder = vsock_proto::Decoder::new();
+    let mut buf = [0u8; 4096];
+    let mut chunks = Vec::new();
+    loop {
+        let n = read_retry_eintr(stream, &mut buf).unwrap();
+        assert!(n > 0, "unexpected EOF waiting for bounded exec result");
+        for msg in decoder.decode(buf.get(..n).unwrap_or_default()).unwrap() {
+            if msg.seq != seq {
+                continue;
+            }
+            match msg.msg_type {
+                MSG_BOUNDED_EXEC_OUTPUT_CHUNK => {
+                    let decoded =
+                        vsock_proto::decode_bounded_exec_output_chunk(&msg.payload).unwrap();
+                    chunks.push(BoundedChunk {
+                        stream: decoded.stream,
+                        sequence: decoded.sequence,
+                        chunk: decoded.chunk.to_vec(),
+                        truncated: decoded.truncated,
+                    });
+                }
+                MSG_BOUNDED_EXEC_RESULT => {
+                    let decoded = vsock_proto::decode_bounded_exec_result(&msg.payload).unwrap();
+                    return (
+                        chunks,
+                        BoundedResult {
+                            termination: decoded.termination,
+                            stdout: decoded.stdout.to_vec(),
+                            stderr: decoded.stderr.to_vec(),
+                            stdout_truncated: decoded.stdout_truncated,
+                            stderr_truncated: decoded.stderr_truncated,
+                        },
+                    );
+                }
+                other => panic!("unexpected bounded exec response type: 0x{other:02X}"),
+            }
+        }
+    }
+}
+
+fn start_guest_connection() -> (thread::JoinHandle<()>, std::os::unix::net::UnixStream) {
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    let (guest_stream, mut host_stream) = StdUnixStream::pair().unwrap();
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+    read_and_discard_message(&mut host_stream);
+    host_stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+    (handle, host_stream)
+}
+
+fn finish_guest_connection(
+    handle: thread::JoinHandle<()>,
+    host_stream: std::os::unix::net::UnixStream,
+) {
+    drop(host_stream);
+    let _ = handle.join();
+}
+
+#[test]
+fn bounded_exec_stdout_stderr_success() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let request = bounded_request("printf stdout; printf stderr >&2", &[], None);
+    send_bounded_exec(&mut host_stream, 11, &request);
+    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 11);
+
+    assert!(chunks.is_empty());
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, b"stdout");
+    assert_eq!(result.stderr, b"stderr");
+    assert!(!result.stdout_truncated);
+    assert!(!result.stderr_truncated);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_nonzero_exit_is_exited() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let request = bounded_request("printf failed >&2; exit 42", &[], None);
+    send_bounded_exec(&mut host_stream, 12, &request);
+    let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 12);
+
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 42 }
+    );
+    assert_eq!(result.stdout, b"");
+    assert_eq!(result.stderr, b"failed");
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_stdin_is_written_and_closed() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let stdin = b"hello from stdin";
+    let request = bounded_request(
+        "cat; read extra || printf ':eof'",
+        &[],
+        Some(stdin.as_slice()),
+    );
+    send_bounded_exec(&mut host_stream, 13, &request);
+    let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 13);
+
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, b"hello from stdin:eof");
+    assert_eq!(result.stderr, b"");
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_broken_pipe_stdin_keeps_child_exit_status() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let stdin = vec![b'x'; 1024 * 1024];
+    let request = bounded_request("exit 7", &[], Some(stdin.as_slice()));
+    send_bounded_exec(&mut host_stream, 14, &request);
+    let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 14);
+
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 7 }
+    );
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_streams_stdout_before_final_result() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request("printf login-url; sleep 0.2; printf done", &[], None);
+    request.stream_stdout = true;
+    request.stream_chunk_limit_bytes = 4;
+    request.stdout_stream_limit_bytes = 64;
+    send_bounded_exec(&mut host_stream, 15, &request);
+    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 15);
+
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, b"login-urldone");
+    assert!(
+        !chunks.is_empty(),
+        "expected stream chunks before final result"
+    );
+    let streamed = chunks
+        .iter()
+        .filter(|chunk| chunk.stream == BoundedExecStream::Stdout)
+        .flat_map(|chunk| chunk.chunk.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(streamed, b"login-urldone");
+    assert_eq!(chunks[0].sequence, 0);
+    assert!(chunks.iter().all(|chunk| !chunk.truncated));
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_streams_stdout_and_stderr_independently() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request("printf out; printf err >&2", &[], None);
+    request.stream_stdout = true;
+    request.stream_stderr = true;
+    request.stream_chunk_limit_bytes = 1024;
+    send_bounded_exec(&mut host_stream, 16, &request);
+    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 16);
+
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    let stdout_chunks = chunks
+        .iter()
+        .filter(|chunk| chunk.stream == BoundedExecStream::Stdout)
+        .collect::<Vec<_>>();
+    let stderr_chunks = chunks
+        .iter()
+        .filter(|chunk| chunk.stream == BoundedExecStream::Stderr)
+        .collect::<Vec<_>>();
+    assert_eq!(stdout_chunks.len(), 1);
+    assert_eq!(stderr_chunks.len(), 1);
+    assert_eq!(stdout_chunks[0].sequence, 0);
+    assert_eq!(stderr_chunks[0].sequence, 0);
+    assert_eq!(stdout_chunks[0].chunk, b"out");
+    assert_eq!(stderr_chunks[0].chunk, b"err");
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_timeout_returns_timed_out_with_partial_output() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request("printf before; sleep 60", &[], None);
+    request.timeout_ms = 200;
+    send_bounded_exec(&mut host_stream, 17, &request);
+    let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 17);
+
+    assert_eq!(result.termination, BoundedExecTermination::TimedOut);
+    assert_eq!(result.stdout, b"before");
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_tracks_stdout_stderr_truncation_independently() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request("printf abcdefghij; printf err >&2", &[], None);
+    request.stdout_limit_bytes = 4;
+    request.stderr_limit_bytes = 10;
+    send_bounded_exec(&mut host_stream, 18, &request);
+    let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 18);
+
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, b"abcd");
+    assert_eq!(result.stderr, b"err");
+    assert!(result.stdout_truncated);
+    assert!(!result.stderr_truncated);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_over_cap_output_continues_draining() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request(
+        "head -c 200000 /dev/zero | tr '\\0' A; head -c 200000 /dev/zero | tr '\\0' B >&2",
+        &[],
+        None,
+    );
+    request.stdout_limit_bytes = 32;
+    request.stderr_limit_bytes = 32;
+    send_bounded_exec(&mut host_stream, 19, &request);
+    let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 19);
+
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, vec![b'A'; 32]);
+    assert_eq!(result.stderr, vec![b'B'; 32]);
+    assert!(result.stdout_truncated);
+    assert!(result.stderr_truncated);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_timeout_zero_silent_child_is_cancelled_on_host_disconnect() {
+    let pid_path = unique_pid_path("bounded-exec-cancel");
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let command = format!("echo $$ > '{}'; sleep 60", pid_path.as_str());
+    let mut request = bounded_request(&command, &[], None);
+    request.timeout_ms = 0;
+    send_bounded_exec(&mut host_stream, 20, &request);
+
+    let pid = read_pid_file(pid_path.as_str());
+    assert!(
+        pid_alive(pid),
+        "child should still be running before disconnect",
+    );
+
+    drop(host_stream);
+    let _ = handle.join();
+    wait_for_pid_exit(pid, "bounded exec host disconnect");
+}
+
+#[test]
+fn bounded_exec_large_env_payload_succeeds() {
+    let values = large_env_values();
+    let env = large_env_entries(&values);
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let request = bounded_request(LARGE_ENV_COMMAND, &env, None);
+    send_bounded_exec(&mut host_stream, 21, &request);
+    let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 21);
+
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 },
+        "stderr: {}",
+        String::from_utf8_lossy(&result.stderr),
+    );
+    assert_large_env_stdout(&result.stdout);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_invalid_env_payload_returns_start_failed_without_leaking_value() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let secret = "do-not-print-this-secret";
+    let env = [("BAD;KEY", secret)];
+    let request = bounded_request("echo should-not-run", &env, None);
+    send_bounded_exec(&mut host_stream, 22, &request);
+    let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 22);
+    let stderr = String::from_utf8_lossy(&result.stderr);
+
+    assert_eq!(result.termination, BoundedExecTermination::StartFailed);
+    assert!(stderr.contains("invalid environment variable name"));
+    assert!(!stderr.contains(secret));
+
+    finish_guest_connection(handle, host_stream);
 }
 
 /// Verify that a slow exec does not block a fast exec that arrives later.

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -50,6 +50,17 @@ pub const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
 /// Minimum body size: type (1) + seq (4).
 pub const MIN_BODY_SIZE: usize = 5;
 
+/// Fixed bytes in a bounded_exec_result payload before stdout/stderr contents.
+pub const BOUNDED_EXEC_RESULT_FIXED_PAYLOAD_BYTES: usize = 1 + 1 + 4 + 8 + 4 + 4;
+/// Fixed bytes in a bounded_exec_output_chunk payload before chunk contents.
+pub const BOUNDED_EXEC_OUTPUT_CHUNK_FIXED_PAYLOAD_BYTES: usize = 1 + 1 + 4 + 4;
+/// Maximum combined stdout+stderr bytes that fit in one bounded_exec_result frame.
+pub const MAX_BOUNDED_EXEC_RESULT_OUTPUT_BYTES: usize =
+    MAX_MESSAGE_SIZE - MIN_BODY_SIZE - BOUNDED_EXEC_RESULT_FIXED_PAYLOAD_BYTES;
+/// Maximum chunk bytes that fit in one bounded_exec_output_chunk frame.
+pub const MAX_BOUNDED_EXEC_OUTPUT_CHUNK_BYTES: usize =
+    MAX_MESSAGE_SIZE - MIN_BODY_SIZE - BOUNDED_EXEC_OUTPUT_CHUNK_FIXED_PAYLOAD_BYTES;
+
 // Message type constants.
 pub const MSG_READY: u8 = 0x00;
 pub const MSG_PING: u8 = 0x01;

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -60,6 +60,8 @@ pub const MAX_BOUNDED_EXEC_RESULT_OUTPUT_BYTES: usize =
 /// Maximum chunk bytes that fit in one bounded_exec_output_chunk frame.
 pub const MAX_BOUNDED_EXEC_OUTPUT_CHUNK_BYTES: usize =
     MAX_MESSAGE_SIZE - MIN_BODY_SIZE - BOUNDED_EXEC_OUTPUT_CHUNK_FIXED_PAYLOAD_BYTES;
+/// Minimum stream chunk limit accepted by bounded exec implementations.
+pub const MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES: usize = 1024;
 
 // Message type constants.
 pub const MSG_READY: u8 = 0x00;


### PR DESCRIPTION
Closes #12108

## Summary
- add guest-side `MSG_BOUNDED_EXEC` dispatch and dedicated bounded exec worker
- add bounded stdout/stderr draining with final caps, truncation flags, optional request-scoped stream chunks, and one-shot stdin
- preserve env-script spawning, process-group timeout/cancel cleanup, and legacy exec/spawn_watch behavior
- add bounded exec integration tests and focused drain tests

## Verification
- `cargo fmt --manifest-path crates/Cargo.toml --package vsock-guest`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --all-targets`
- pre-commit: check-file-size, crates cargo-fmt, crates cargo-doc, crates cargo-clippy
