### PR TITLE
fix(platform): suppress Ably Connection closed Sentry noise and guard subscribe

### DIFF
--- a/turbo/apps/platform/src/lib/sentry.ts
+++ b/turbo/apps/platform/src/lib/sentry.ts
@@ -72,6 +72,10 @@ export function initSentry(): void {
       "Insufficient credits",
       // Third-party scripts (we don't use axios — any AxiosError is external noise)
       "AxiosError",
+      // Ably SDK internal rejections — when the WebSocket connection closes
+      // during an in-flight channel attach, Ably's internal promises reject
+      // before our try/catch in realtime.ts can suppress them.
+      "Connection closed",
     ],
 
     // Filter out errors from browser extension and third-party scripts

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -58,6 +58,7 @@ async function runWithChannel({
   // run the body themselves before calling this. Chat / queue / slack
   // subscribers don't need a baseline because their data is fetched through
   // separate computeds.
+  signal.throwIfAborted();
   let deferred = createDeferredPromise(signal);
 
   const pokeLoop = () => {


### PR DESCRIPTION
## Summary
- Add `"Connection closed"` to Sentry's `ignoreErrors` to filter out Ably SDK internal promise rejections that surface before our try/catch in `realtime.ts` can suppress them
- Add `signal.throwIfAborted()` at the start of `runWithChannel` to avoid calling `channel.subscribe()` when the signal is already aborted (and `ably.close()` has been called)

## Root Cause
When `ably.close()` is called during app teardown while a `channel.subscribe()` is in flight, the real Ably SDK (v2.21.0) creates internal Promises (timer, message queue, re-attach) that reject with `"Connection closed"` in macro tasks — outside the reach of our existing try/catch suppression.

## Fixes
Closes #11053

## Test Plan
- [x] Existing realtime tests pass (mock covers the synchronous suppression path)
- [ ] Deploy to staging, verify Sentry stops reporting `Connection closed` for platform app
- [ ] Confirm no regressions in realtime updates (thread list, run status, connector changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)