### PR TITLE
fix: publish realtime signals before 201 response in chat send routes

### DIFF
--- a/turbo/apps/web/app/api/v1/chat-threads/messages/route.ts
+++ b/turbo/apps/web/app/api/v1/chat-threads/messages/route.ts
@@ -1,4 +1,3 @@
-import { after } from "next/server";
 import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { chatThreadV1SendContract } from "@vm0/api-contracts/contracts/chat-threads-v1";
 import { initServices } from "../../../../../src/lib/init-services";
@@ -107,13 +106,13 @@ const router = tsr.router(chatThreadV1SendContract, {
         runId: result.runId,
       });
 
-      after(async () => {
-        await publishUserSignal(
-          [authCtx.userId],
-          `chatThreadRunCreated:${threadId}`,
-        );
-        await publishThreadListChanged(authCtx.userId);
-      });
+      // Publish realtime signals before returning the 201 so the client's
+      // realtime subscription can update before the send command resolves.
+      await publishUserSignal(
+        [authCtx.userId],
+        `chatThreadRunCreated:${threadId}`,
+      );
+      await publishThreadListChanged(authCtx.userId);
 
       return {
         status: 201 as const,

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -500,16 +500,11 @@ describe("POST /api/zero/chat/messages", () => {
           expect(byOp.has("api_after_schedule_to_closure")).toBe(true);
           expect(byOp.has("api_after_closure_to_dispatch")).toBe(true);
 
-          // The signals-path after() callback emits its own closure-entry
-          // offset against the same responseReady anchor.
-          expect(byOp.has("api_after_signals_enter_offset")).toBe(true);
-
           const phase1 = byOp.get("api_phase1_post_tx_sync")!;
           const gap = byOp.get("api_after_scheduling_gap")!;
           const phase2 = byOp.get("api_phase2_callbacks_token_pure")!;
           const scheduleToClosure = byOp.get("api_after_schedule_to_closure")!;
           const closureToDispatch = byOp.get("api_after_closure_to_dispatch")!;
-          const signalsOffset = byOp.get("api_after_signals_enter_offset")!;
 
           for (const span of [
             phase1,
@@ -517,7 +512,6 @@ describe("POST /api/zero/chat/messages", () => {
             phase2,
             scheduleToClosure,
             closureToDispatch,
-            signalsOffset,
           ]) {
             expect(typeof span.duration_ms).toBe("number");
             expect(span.duration_ms).toBeGreaterThanOrEqual(0);

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -1,6 +1,5 @@
 import { and, eq } from "drizzle-orm";
 import { after } from "next/server";
-import { waitUntil } from "@vercel/functions";
 import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import {
   chatMessagesContract,
@@ -63,7 +62,6 @@ import { publishUserSignal } from "../../../../../src/lib/infra/realtime/client"
 import { logger } from "../../../../../src/lib/shared/logger";
 import {
   recordChatSpan,
-  recordSandboxOperation,
   type ChatSpanDimensions,
 } from "../../../../../src/lib/infra/metrics";
 import {
@@ -666,64 +664,39 @@ const router = tsr.router(chatMessagesContract, {
         userProfile: userProfileFromClaims(authCtx),
       });
 
-      // Stamp response-ready for the Phase-2 instrumentation split before
-      // registering the signals waitUntil() so we can measure its closure-entry
-      // offset against the same responseReady anchor used by dispatchZeroRun.
-      const responseReadyAt = result.markResponseReady();
-
-      // Persist user message to chat_messages in waitUntil() so the 201
-      // response flushes before the INSERT (+ internal chatThreadMessageCreated
-      // publish) runs. The response body omits the row id and the client
-      // renders optimistically via clientMessageId, so no caller blocks.
+      // Persist user message and publish realtime signals before returning the
+      // 201 so the client's realtime subscription can update thread state before
+      // the send command resolves, keeping the cancel button visible for pending
+      // runs.
       //
       // Ordering: insertChatMessage MUST complete before publishUserSignal /
       // publishThreadListChanged fire — those signals tell other devices to
       // refetch the thread list / paged-messages view, and they must see the
-      // new row on refetch. The `await`s below preserve that ordering.
-      waitUntil(
-        (async () => {
-          const signalsEnterAt = Date.now();
-          try {
-            // Stamp with the runId so the callback's prior-context filter can
-            // exclude this message structurally (by runId) instead of by content.
-            await insertChatMessage({
-              chatThreadId: threadId,
-              userId: authCtx.userId,
-              role: "user",
-              content: body.prompt,
-              runId: result.runId,
-              attachFiles: body.attachFiles?.map((f: AttachFile) => {
-                return f.id;
-              }),
-              id: body.clientMessageId,
-              spanDims: dims,
-            });
-          } catch (err: unknown) {
-            log.error("Deferred insertChatMessage failed", {
-              runId: result.runId,
-              err,
-            });
-          }
-          await publishUserSignal(
-            [authCtx.userId],
-            `chatThreadRunCreated:${threadId}`,
-          );
-          await publishThreadListChanged(authCtx.userId);
-          // Cross-referenced with api_after_schedule_to_closure in Axiom to
-          // infer whether Vercel fires waitUntil() and after() callbacks in
-          // parallel or serial: near-equal durations imply parallel, a large
-          // gap implies serial.
-          if (responseReadyAt !== undefined) {
-            recordSandboxOperation({
-              sandboxType: "chat",
-              actionType: "api_after_signals_enter_offset",
-              durationMs: signalsEnterAt - responseReadyAt,
-              success: true,
-              runId: result.runId,
-            });
-          }
-        })(),
+      // new row on refetch.
+      try {
+        await insertChatMessage({
+          chatThreadId: threadId,
+          userId: authCtx.userId,
+          role: "user",
+          content: body.prompt,
+          runId: result.runId,
+          attachFiles: body.attachFiles?.map((f: AttachFile) => {
+            return f.id;
+          }),
+          id: body.clientMessageId,
+          spanDims: dims,
+        });
+      } catch (err: unknown) {
+        log.error("insertChatMessage failed", {
+          runId: result.runId,
+          err,
+        });
+      }
+      await publishUserSignal(
+        [authCtx.userId],
+        `chatThreadRunCreated:${threadId}`,
       );
+      await publishThreadListChanged(authCtx.userId);
 
       return {
         status: 201 as const,


### PR DESCRIPTION
## Summary
- Moves `publishUserSignal(chatThreadRunCreated)` and `publishThreadListChanged` from `waitUntil()` / `after()` to before the 201 response in both chat send routes (`zero/chat/messages` and `v1/chat-threads/messages`)
- Also moves `insertChatMessage` onto the critical path (was inside `waitUntil`) to preserve the ordering constraint
- Removes the `api_after_signals_enter_offset` diagnostic span that tracked the now-eliminated closure-entry gap

## Root Cause
The web chat cancel button was disappearing for pending runs (#11962). When `sendMessage$` POST returned 201, `sendLoadable.state` flipped to `"hasData"` and `allFinished$` was evaluated. But `threadData$` was stale (`activeRunIds = []`) because the `chatThreadRunCreated` Ably event was deferred inside `waitUntil()` — it fired *after* the response was sent.

By publishing the realtime signals before the 201 return, the client's Ably subscription (`onRunChanged$` → `reloadThread$`) can update `threadData$` before `allFinished$` is re-evaluated, keeping the cancel button visible.

## Test Plan
- [ ] Send a message and verify cancel button appears immediately (no flash)
- [ ] Verify sidebar thread list updates correctly
- [ ] Verify other devices receive realtime updates

Fixes #11962

🤖 Generated with [Claude Code](https://claude.com/claude-code)