### PR TITLE
fix: reconcile stale billing entitlements

### DIFF
--- a/turbo/apps/web/app/api/cron/reconcile-billing-entitlements/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/reconcile-billing-entitlements/__tests__/route.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GET } from "../route";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
+import {
+  getOrgBillingFields,
+  updateOrgStripeFields,
+} from "../../../../../src/__tests__/api-test-helpers";
+import { reloadEnv } from "../../../../../src/env";
+
+vi.hoisted(() => {
+  vi.stubEnv("CRON_SECRET", "test-cron-secret");
+});
+
+const context = testContext();
+
+function cronRequest(secret?: string) {
+  return new Request(
+    "http://localhost:3000/api/cron/reconcile-billing-entitlements",
+    {
+      method: "GET",
+      headers: secret ? { authorization: `Bearer ${secret}` } : {},
+    },
+  );
+}
+
+function hoursAgo(hours: number): Date {
+  return new Date(Date.now() - hours * 60 * 60 * 1000);
+}
+
+describe("GET /api/cron/reconcile-billing-entitlements", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    vi.stubEnv("CRON_SECRET", "test-cron-secret");
+    reloadEnv();
+    user = await context.setupUser();
+  });
+
+  it("rejects requests without the cron secret", async () => {
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("downgrades stale past_due paid subscriptions without paid-through", async () => {
+    const subId = uniqueId("sub-stale-past-due");
+
+    await updateOrgStripeFields(user.orgId, {
+      stripeCustomerId: uniqueId("cus-stale-past-due"),
+      stripeSubscriptionId: subId,
+      subscriptionStatus: "past_due",
+      currentPeriodEnd: null,
+      tier: "pro",
+      updatedAt: hoursAgo(48),
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.downgraded).toBeGreaterThanOrEqual(1);
+
+    const billing = await getOrgBillingFields(user.orgId);
+    expect(billing?.tier).toBe("free");
+    expect(billing?.subscriptionStatus).toBe("past_due");
+    expect(billing?.stripeSubscriptionId).toBe(subId);
+  });
+
+  it("downgrades stale unpaid subscriptions after paid-through expires", async () => {
+    await updateOrgStripeFields(user.orgId, {
+      stripeCustomerId: uniqueId("cus-stale-unpaid"),
+      stripeSubscriptionId: uniqueId("sub-stale-unpaid"),
+      subscriptionStatus: "unpaid",
+      currentPeriodEnd: hoursAgo(48),
+      tier: "team",
+      updatedAt: hoursAgo(48),
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+
+    expect(response.status).toBe(200);
+
+    const billing = await getOrgBillingFields(user.orgId);
+    expect(billing?.tier).toBe("free");
+    expect(billing?.subscriptionStatus).toBe("unpaid");
+  });
+
+  it("downgrades expired paid-through even if org metadata was recently updated", async () => {
+    await updateOrgStripeFields(user.orgId, {
+      stripeCustomerId: uniqueId("cus-expired-recent-update"),
+      stripeSubscriptionId: uniqueId("sub-expired-recent-update"),
+      subscriptionStatus: "past_due",
+      currentPeriodEnd: hoursAgo(48),
+      tier: "pro",
+      updatedAt: hoursAgo(1),
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+
+    expect(response.status).toBe(200);
+
+    const billing = await getOrgBillingFields(user.orgId);
+    expect(billing?.tier).toBe("free");
+  });
+
+  it("keeps stale past_due subscriptions with future paid-through", async () => {
+    const paidThrough = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+    await updateOrgStripeFields(user.orgId, {
+      stripeCustomerId: uniqueId("cus-future-past-due"),
+      stripeSubscriptionId: uniqueId("sub-future-past-due"),
+      subscriptionStatus: "past_due",
+      currentPeriodEnd: paidThrough,
+      tier: "pro",
+      updatedAt: hoursAgo(48),
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+
+    expect(response.status).toBe(200);
+
+    const billing = await getOrgBillingFields(user.orgId);
+    expect(billing?.tier).toBe("pro");
+    expect(billing?.currentPeriodEnd).toEqual(paidThrough);
+  });
+
+  it("keeps fresh past_due subscriptions within the grace window", async () => {
+    await updateOrgStripeFields(user.orgId, {
+      stripeCustomerId: uniqueId("cus-fresh-past-due"),
+      stripeSubscriptionId: uniqueId("sub-fresh-past-due"),
+      subscriptionStatus: "past_due",
+      currentPeriodEnd: null,
+      tier: "pro",
+      updatedAt: hoursAgo(1),
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+
+    expect(response.status).toBe(200);
+
+    const billing = await getOrgBillingFields(user.orgId);
+    expect(billing?.tier).toBe("pro");
+  });
+});

--- a/turbo/apps/web/app/api/cron/reconcile-billing-entitlements/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/reconcile-billing-entitlements/__tests__/route.test.ts
@@ -80,7 +80,7 @@ function stripeSubscription(
   subscriptionId: string,
   options: {
     status: string;
-    periodEnd: Date;
+    periodEnd?: Date | null;
     priceId?: string;
     cancelAtPeriodEnd?: boolean;
   },
@@ -93,7 +93,13 @@ function stripeSubscription(
       data: [
         {
           price: { id: options.priceId ?? TEST_PRICE_PRO },
-          current_period_end: Math.floor(options.periodEnd.getTime() / 1000),
+          ...(options.periodEnd
+            ? {
+                current_period_end: Math.floor(
+                  options.periodEnd.getTime() / 1000,
+                ),
+              }
+            : {}),
         },
       ],
     },
@@ -151,6 +157,42 @@ describe("GET /api/cron/reconcile-billing-entitlements", () => {
     expect(billing?.tier).toBe("free");
     expect(billing?.subscriptionStatus).toBe("past_due");
     expect(billing?.stripeSubscriptionId).toBe(subId);
+  });
+
+  it("downgrades payment-failed subscriptions when Stripe has no paid-through", async () => {
+    const subId = uniqueId("sub-no-stripe-paid-through");
+
+    stripeMocks.subscriptionsRetrieve.mockImplementation(
+      async (subscriptionId: string) => {
+        if (subscriptionId === subId) {
+          return stripeSubscription(subscriptionId, {
+            status: "past_due",
+            periodEnd: null,
+          });
+        }
+        return stripeSubscription(subscriptionId, {
+          status: "past_due",
+          periodEnd: hoursAgo(48),
+        });
+      },
+    );
+
+    await updateOrgStripeFields(user.orgId, {
+      stripeCustomerId: uniqueId("cus-no-stripe-paid-through"),
+      stripeSubscriptionId: subId,
+      subscriptionStatus: "past_due",
+      currentPeriodEnd: null,
+      tier: "pro",
+      updatedAt: hoursAgo(48),
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+
+    expect(response.status).toBe(200);
+
+    const billing = await getOrgBillingFields(user.orgId);
+    expect(billing?.tier).toBe("free");
+    expect(billing?.subscriptionStatus).toBe("past_due");
   });
 
   it("repairs missing local paid-through from Stripe instead of downgrading", async () => {

--- a/turbo/apps/web/app/api/cron/reconcile-billing-entitlements/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/reconcile-billing-entitlements/__tests__/route.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { GET } from "../route";
 import {
   testContext,
   uniqueId,
@@ -10,12 +9,58 @@ import {
   updateOrgStripeFields,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { reloadEnv } from "../../../../../src/env";
+import type { StripeMockFns } from "../../../../../src/__tests__/stripe-mock";
+import { GET } from "../route";
+
+const stripeMocks = vi.hoisted<StripeMockFns>(() => {
+  return {
+    subscriptionsRetrieve: vi.fn(),
+    subscriptionsUpdate: vi.fn(),
+    subscriptionsCancel: vi.fn(),
+    invoicesRetrieve: vi.fn(),
+    invoicesList: vi.fn(),
+    customersCreate: vi.fn(),
+    checkoutSessionsCreate: vi.fn(),
+    billingPortalSessionsCreate: vi.fn(),
+    constructEvent: vi.fn(),
+  };
+});
+
+vi.mock("stripe", () => {
+  return {
+    default: function MockStripe() {
+      return {
+        subscriptions: {
+          retrieve: stripeMocks.subscriptionsRetrieve,
+          update: stripeMocks.subscriptionsUpdate,
+          cancel: stripeMocks.subscriptionsCancel,
+        },
+        invoices: {
+          retrieve: stripeMocks.invoicesRetrieve,
+          list: stripeMocks.invoicesList,
+        },
+        customers: { create: stripeMocks.customersCreate },
+        checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
+        billingPortal: {
+          sessions: { create: stripeMocks.billingPortalSessionsCreate },
+        },
+        webhooks: { constructEvent: stripeMocks.constructEvent },
+      };
+    },
+  };
+});
 
 vi.hoisted(() => {
   vi.stubEnv("CRON_SECRET", "test-cron-secret");
 });
 
 const context = testContext();
+const TEST_PRICE_PRO = "price_test_pro";
+const TEST_PRICE_TEAM = "price_test_team";
+const TEST_ZERO_PRICE = JSON.stringify({
+  pro: [TEST_PRICE_PRO],
+  team: [TEST_PRICE_TEAM],
+});
 
 function cronRequest(secret?: string) {
   return new Request(
@@ -31,14 +76,49 @@ function hoursAgo(hours: number): Date {
   return new Date(Date.now() - hours * 60 * 60 * 1000);
 }
 
+function stripeSubscription(
+  subscriptionId: string,
+  options: {
+    status: string;
+    periodEnd: Date;
+    priceId?: string;
+    cancelAtPeriodEnd?: boolean;
+  },
+) {
+  return {
+    id: subscriptionId,
+    status: options.status,
+    cancel_at_period_end: options.cancelAtPeriodEnd ?? false,
+    items: {
+      data: [
+        {
+          price: { id: options.priceId ?? TEST_PRICE_PRO },
+          current_period_end: Math.floor(options.periodEnd.getTime() / 1000),
+        },
+      ],
+    },
+  };
+}
+
 describe("GET /api/cron/reconcile-billing-entitlements", () => {
   let user: UserContext;
 
   beforeEach(async () => {
     context.setupMocks();
     vi.stubEnv("CRON_SECRET", "test-cron-secret");
+    vi.stubEnv("ZERO_PRICE", TEST_ZERO_PRICE);
     reloadEnv();
     user = await context.setupUser();
+
+    stripeMocks.subscriptionsRetrieve.mockReset();
+    stripeMocks.subscriptionsRetrieve.mockImplementation(
+      async (subscriptionId: string) => {
+        return stripeSubscription(subscriptionId, {
+          status: "past_due",
+          periodEnd: hoursAgo(48),
+        });
+      },
+    );
   });
 
   it("rejects requests without the cron secret", async () => {
@@ -73,10 +153,145 @@ describe("GET /api/cron/reconcile-billing-entitlements", () => {
     expect(billing?.stripeSubscriptionId).toBe(subId);
   });
 
+  it("repairs missing local paid-through from Stripe instead of downgrading", async () => {
+    const subId = uniqueId("sub-repair-paid-through");
+    const stripePaidThroughUnix =
+      Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60;
+    const stripePaidThrough = new Date(stripePaidThroughUnix * 1000);
+
+    stripeMocks.subscriptionsRetrieve.mockImplementation(
+      async (subscriptionId: string) => {
+        if (subscriptionId === subId) {
+          return stripeSubscription(subscriptionId, {
+            status: "past_due",
+            periodEnd: stripePaidThrough,
+          });
+        }
+        return stripeSubscription(subscriptionId, {
+          status: "past_due",
+          periodEnd: hoursAgo(48),
+        });
+      },
+    );
+
+    await updateOrgStripeFields(user.orgId, {
+      stripeCustomerId: uniqueId("cus-repair-paid-through"),
+      stripeSubscriptionId: subId,
+      subscriptionStatus: "past_due",
+      currentPeriodEnd: null,
+      tier: "pro",
+      updatedAt: hoursAgo(48),
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+
+    expect(response.status).toBe(200);
+    expect(stripeMocks.subscriptionsRetrieve).toHaveBeenCalledWith(subId);
+
+    const billing = await getOrgBillingFields(user.orgId);
+    expect(billing?.tier).toBe("pro");
+    expect(billing?.subscriptionStatus).toBe("past_due");
+    expect(billing?.currentPeriodEnd).toEqual(stripePaidThrough);
+  });
+
+  it("repairs recovered Stripe subscriptions instead of downgrading", async () => {
+    const subId = uniqueId("sub-recovered");
+    const stripePaidThroughUnix =
+      Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
+    const stripePaidThrough = new Date(stripePaidThroughUnix * 1000);
+
+    stripeMocks.subscriptionsRetrieve.mockImplementation(
+      async (subscriptionId: string) => {
+        if (subscriptionId === subId) {
+          return stripeSubscription(subscriptionId, {
+            status: "active",
+            periodEnd: stripePaidThrough,
+            priceId: TEST_PRICE_TEAM,
+          });
+        }
+        return stripeSubscription(subscriptionId, {
+          status: "past_due",
+          periodEnd: hoursAgo(48),
+        });
+      },
+    );
+
+    await updateOrgStripeFields(user.orgId, {
+      stripeCustomerId: uniqueId("cus-recovered"),
+      stripeSubscriptionId: subId,
+      subscriptionStatus: "past_due",
+      currentPeriodEnd: null,
+      tier: "pro",
+      updatedAt: hoursAgo(48),
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+
+    expect(response.status).toBe(200);
+
+    const billing = await getOrgBillingFields(user.orgId);
+    expect(billing?.tier).toBe("team");
+    expect(billing?.subscriptionStatus).toBe("active");
+    expect(billing?.currentPeriodEnd).toEqual(stripePaidThrough);
+  });
+
+  it("downgrades canceled Stripe subscriptions as missed deleted hooks", async () => {
+    const subId = uniqueId("sub-canceled");
+
+    stripeMocks.subscriptionsRetrieve.mockImplementation(
+      async (subscriptionId: string) => {
+        if (subscriptionId === subId) {
+          return stripeSubscription(subscriptionId, {
+            status: "canceled",
+            periodEnd: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+          });
+        }
+        return stripeSubscription(subscriptionId, {
+          status: "past_due",
+          periodEnd: hoursAgo(48),
+        });
+      },
+    );
+
+    await updateOrgStripeFields(user.orgId, {
+      stripeCustomerId: uniqueId("cus-canceled"),
+      stripeSubscriptionId: subId,
+      subscriptionStatus: "past_due",
+      currentPeriodEnd: null,
+      tier: "pro",
+      updatedAt: hoursAgo(48),
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+
+    expect(response.status).toBe(200);
+
+    const billing = await getOrgBillingFields(user.orgId);
+    expect(billing?.tier).toBe("free");
+    expect(billing?.subscriptionStatus).toBe("canceled");
+    expect(billing?.stripeSubscriptionId).toBeNull();
+  });
+
   it("downgrades stale unpaid subscriptions after paid-through expires", async () => {
+    const subId = uniqueId("sub-stale-unpaid");
+    stripeMocks.subscriptionsRetrieve.mockImplementation(
+      async (subscriptionId: string) => {
+        if (subscriptionId === subId) {
+          return stripeSubscription(subscriptionId, {
+            status: "unpaid",
+            periodEnd: hoursAgo(48),
+          });
+        }
+        return stripeSubscription(subscriptionId, {
+          status: "past_due",
+          periodEnd: hoursAgo(48),
+        });
+      },
+    );
+
     await updateOrgStripeFields(user.orgId, {
       stripeCustomerId: uniqueId("cus-stale-unpaid"),
-      stripeSubscriptionId: uniqueId("sub-stale-unpaid"),
+      stripeSubscriptionId: subId,
       subscriptionStatus: "unpaid",
       currentPeriodEnd: hoursAgo(48),
       tier: "team",

--- a/turbo/apps/web/app/api/cron/reconcile-billing-entitlements/route.ts
+++ b/turbo/apps/web/app/api/cron/reconcile-billing-entitlements/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { initServices } from "../../../../src/lib/init-services";
+import { downgradeStalePaymentFailedSubscriptions } from "../../../../src/lib/zero/billing/billing-service";
+import { logger } from "../../../../src/lib/shared/logger";
+import { env } from "../../../../src/env";
+
+const log = logger("cron:reconcile-billing-entitlements");
+
+export async function GET(request: Request): Promise<Response> {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = env().CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json(
+      { error: { message: "Invalid cron secret", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const result = await downgradeStalePaymentFailedSubscriptions();
+
+  if (result.downgraded > 0) {
+    log.info("Billing entitlement reconciliation completed", result);
+  }
+
+  return NextResponse.json({ success: true, ...result });
+}

--- a/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
@@ -520,7 +520,7 @@ describe("POST /api/webhooks/stripe", () => {
   });
 
   describe("customer.subscription.updated", () => {
-    it("syncs status and tier", async () => {
+    it("syncs failed payment status without restoring paid entitlement from price", async () => {
       const cusId = uniqueId("cus-update");
       const subId = uniqueId("sub-update");
 
@@ -542,7 +542,7 @@ describe("POST /api/webhooks/stripe", () => {
 
       const billing = await getOrgBillingFields(user.orgId);
       expect(billing?.subscriptionStatus).toBe("past_due");
-      expect(billing?.tier).toBe("team");
+      expect(billing?.tier).toBe("pro");
     });
 
     it("downgrades tier from team to pro when price changes", async () => {
@@ -641,6 +641,72 @@ describe("POST /api/webhooks/stripe", () => {
 
       const billing = await getOrgBillingFields(user.orgId);
       expect(billing?.cancelAtPeriodEnd).toBe(false);
+    });
+
+    it("refreshes current period end for active subscriptions", async () => {
+      const cusId = uniqueId("cus-period-refresh");
+      const subId = uniqueId("sub-period-refresh");
+      const periodEnd = Math.floor(Date.now() / 1000) + 30 * 86400;
+
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+        stripeSubscriptionId: subId,
+        subscriptionStatus: "active",
+        tier: "pro",
+      });
+
+      const response = await sendWebhookEvent("customer.subscription.updated", {
+        id: subId,
+        status: "active",
+        cancel_at_period_end: false,
+        items: {
+          data: [
+            { price: { id: TEST_PRICE_PRO }, current_period_end: periodEnd },
+          ],
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const billing = await getOrgBillingFields(user.orgId);
+      expect(billing?.currentPeriodEnd).toEqual(new Date(periodEnd * 1000));
+    });
+
+    it("does not extend paid-through from a failed payment update", async () => {
+      const cusId = uniqueId("cus-past-due-period");
+      const subId = uniqueId("sub-past-due-period");
+      const paidThrough = new Date(Date.now() + 7 * 86400 * 1000);
+      const subscriptionItemPeriodEnd =
+        Math.floor(Date.now() / 1000) + 30 * 86400;
+
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+        stripeSubscriptionId: subId,
+        subscriptionStatus: "active",
+        currentPeriodEnd: paidThrough,
+        tier: "pro",
+      });
+
+      const response = await sendWebhookEvent("customer.subscription.updated", {
+        id: subId,
+        status: "past_due",
+        cancel_at_period_end: false,
+        items: {
+          data: [
+            {
+              price: { id: TEST_PRICE_PRO },
+              current_period_end: subscriptionItemPeriodEnd,
+            },
+          ],
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const billing = await getOrgBillingFields(user.orgId);
+      expect(billing?.tier).toBe("pro");
+      expect(billing?.subscriptionStatus).toBe("past_due");
+      expect(billing?.currentPeriodEnd).toEqual(paidThrough);
     });
   });
 

--- a/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
+++ b/turbo/apps/web/custom-eslint/baselines/web-api-routes.ts
@@ -41,6 +41,7 @@ export const WEB_API_ROUTE_BASELINE = [
   "app/api/cron/drain-email-outbox/route.ts",
   "app/api/cron/execute-schedules/route.ts",
   "app/api/cron/process-usage-events/route.ts",
+  "app/api/cron/reconcile-billing-entitlements/route.ts",
   "app/api/cron/sync-skills/route.ts",
   "app/api/cron/telegram-cleanup/route.ts",
   "app/api/cron/voice-chat-cleanup/route.ts",

--- a/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
@@ -46,12 +46,14 @@ export async function updateOrgStripeFields(
     cancelAtPeriodEnd?: boolean;
     lastProcessedInvoiceId?: string | null;
     tier?: string;
+    updatedAt?: Date;
   },
 ): Promise<void> {
   initServices();
+  const { updatedAt, ...billingFields } = fields;
   await globalThis.services.db
     .update(orgMetadata)
-    .set({ ...fields, updatedAt: new Date() })
+    .set({ ...billingFields, updatedAt: updatedAt ?? new Date() })
     .where(eq(orgMetadata.orgId, orgId));
 }
 

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -93,6 +93,12 @@ function subscriptionCanRefreshPaidThrough(
   return ENTITLEMENT_PERIOD_REFRESH_STATUSES.has(subscription.status);
 }
 
+function subscriptionIsPaymentFailed(subscription: SubscriptionInput): boolean {
+  return PAYMENT_FAILED_SUBSCRIPTION_STATUSES.includes(
+    subscription.status as (typeof PAYMENT_FAILED_SUBSCRIPTION_STATUSES)[number],
+  );
+}
+
 function tierFromPriceId(priceId: string): OrgTier {
   const priceMap = env().ZERO_PRICE;
   if (priceMap) {
@@ -617,24 +623,25 @@ export async function handleSubscriptionDeleted(
 /**
  * Local billing entitlement reconciliation for the known webhook gap where an
  * org can stay on a paid tier after Stripe moves the subscription to a failed
- * payment state. This intentionally avoids Stripe API calls and only touches
- * rows that no longer have a future paid-through timestamp locally.
+ * payment state. Local stale candidates are verified against Stripe before
+ * downgrade; if Stripe shows fresher billing state, the local row is repaired.
  */
 export async function downgradeStalePaymentFailedSubscriptions(options?: {
   now?: Date;
 }): Promise<{ downgraded: number }> {
   const db = globalThis.services.db;
+  const stripe = getStripe();
   const now = options?.now ?? new Date();
   const staleBefore = new Date(
     now.getTime() - PAYMENT_FAILURE_DOWNGRADE_GRACE_MS,
   );
 
-  const downgraded = await db
-    .update(orgMetadata)
-    .set({
-      tier: "free",
-      updatedAt: now,
+  const candidates = await db
+    .select({
+      orgId: orgMetadata.orgId,
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
     })
+    .from(orgMetadata)
     .where(
       and(
         inArray(orgMetadata.tier, ["pro", "team"]),
@@ -650,12 +657,127 @@ export async function downgradeStalePaymentFailedSubscriptions(options?: {
           lte(orgMetadata.currentPeriodEnd, staleBefore),
         ),
       ),
-    )
-    .returning({
-      orgId: orgMetadata.orgId,
-      subscriptionId: orgMetadata.stripeSubscriptionId,
-      status: orgMetadata.subscriptionStatus,
-    });
+    );
+
+  const downgraded: Array<{
+    orgId: string;
+    subscriptionId: string | null;
+    status: string | null;
+  }> = [];
+
+  for (const candidate of candidates) {
+    if (!candidate.stripeSubscriptionId) continue;
+
+    const subscription = await stripe.subscriptions.retrieve(
+      candidate.stripeSubscriptionId,
+    );
+    const stripePeriodEnd = subscriptionPeriodEnd(subscription);
+    const canRefreshPaidThrough =
+      subscriptionCanRefreshPaidThrough(subscription);
+    const isPaymentFailed = subscriptionIsPaymentFailed(subscription);
+    const syncedFields = {
+      subscriptionStatus: subscription.status,
+      cancelAtPeriodEnd: subscription.cancel_at_period_end,
+      updatedAt: now,
+      ...(stripePeriodEnd ? { currentPeriodEnd: stripePeriodEnd } : {}),
+    };
+
+    const currentCandidate = and(
+      eq(orgMetadata.orgId, candidate.orgId),
+      eq(orgMetadata.stripeSubscriptionId, candidate.stripeSubscriptionId),
+      inArray(orgMetadata.tier, ["pro", "team"]),
+      inArray(orgMetadata.subscriptionStatus, [
+        ...PAYMENT_FAILED_SUBSCRIPTION_STATUSES,
+      ]),
+    );
+
+    // Scheduled cancellations stay active with cancel_at_period_end=true until
+    // the period ends. If Stripe now says canceled, this is a missed
+    // subscription.deleted-equivalent terminal state.
+    if (subscription.status === "canceled") {
+      const rows = await db
+        .update(orgMetadata)
+        .set({
+          tier: "free",
+          subscriptionStatus: "canceled",
+          stripeSubscriptionId: null,
+          cancelAtPeriodEnd: false,
+          updatedAt: now,
+        })
+        .where(currentCandidate)
+        .returning({
+          orgId: orgMetadata.orgId,
+          status: orgMetadata.subscriptionStatus,
+        });
+      downgraded.push(
+        ...rows.map((row) => {
+          return {
+            ...row,
+            subscriptionId: candidate.stripeSubscriptionId,
+          };
+        }),
+      );
+      continue;
+    }
+
+    if (!isPaymentFailed) {
+      if (!canRefreshPaidThrough) {
+        log.warn(
+          "payment-failed local subscription has unexpected Stripe status; skipping downgrade",
+          {
+            orgId: candidate.orgId,
+            subscriptionId: candidate.stripeSubscriptionId,
+            status: subscription.status,
+          },
+        );
+        continue;
+      }
+
+      const priceId = subscription.items.data[0]?.price?.id;
+      const tier = priceId ? tierFromPriceId(priceId) : undefined;
+
+      await db
+        .update(orgMetadata)
+        .set({
+          ...syncedFields,
+          ...(tier ? { tier } : {}),
+        })
+        .where(currentCandidate);
+      continue;
+    }
+
+    if (!stripePeriodEnd) {
+      await db.update(orgMetadata).set(syncedFields).where(currentCandidate);
+      log.warn(
+        "payment-failed subscription missing paid-through in Stripe; skipping downgrade",
+        {
+          orgId: candidate.orgId,
+          subscriptionId: candidate.stripeSubscriptionId,
+          status: subscription.status,
+        },
+      );
+      continue;
+    }
+
+    if (stripePeriodEnd > staleBefore) {
+      await db.update(orgMetadata).set(syncedFields).where(currentCandidate);
+      continue;
+    }
+
+    const rows = await db
+      .update(orgMetadata)
+      .set({
+        tier: "free",
+        ...syncedFields,
+      })
+      .where(currentCandidate)
+      .returning({
+        orgId: orgMetadata.orgId,
+        subscriptionId: orgMetadata.stripeSubscriptionId,
+        status: orgMetadata.subscriptionStatus,
+      });
+    downgraded.push(...rows);
+  }
 
   if (downgraded.length > 0) {
     log.warn("stale payment-failed subscriptions downgraded", {

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -747,19 +747,15 @@ export async function downgradeStalePaymentFailedSubscriptions(options?: {
     }
 
     if (!stripePeriodEnd) {
-      await db.update(orgMetadata).set(syncedFields).where(currentCandidate);
       log.warn(
-        "payment-failed subscription missing paid-through in Stripe; skipping downgrade",
+        "payment-failed subscription missing paid-through in Stripe; downgrading",
         {
           orgId: candidate.orgId,
           subscriptionId: candidate.stripeSubscriptionId,
           status: subscription.status,
         },
       );
-      continue;
-    }
-
-    if (stripePeriodEnd > staleBefore) {
+    } else if (stripePeriodEnd > staleBefore) {
       await db.update(orgMetadata).set(syncedFields).where(currentCandidate);
       continue;
     }

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, lte, or, sql } from "drizzle-orm";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
 import { getStripe } from "../stripe";
 import { env } from "../../../env";
@@ -57,7 +57,12 @@ interface SubscriptionInput {
   id: string;
   status: string;
   cancel_at_period_end: boolean;
-  items: { data: Array<{ price: { id: string } }> };
+  items: {
+    data: Array<{
+      price: { id: string };
+      current_period_end?: number | null;
+    }>;
+  };
 }
 
 /** Fields read by {@link handleSubscriptionDeleted}. */
@@ -70,6 +75,23 @@ const TIER_MONTHLY_CREDITS: Record<OrgTier, number> = {
   pro: 20_000,
   team: 120_000,
 };
+
+const ENTITLEMENT_PERIOD_REFRESH_STATUSES = new Set(["active", "trialing"]);
+const PAYMENT_FAILED_SUBSCRIPTION_STATUSES = ["past_due", "unpaid"] as const;
+const PAYMENT_FAILURE_DOWNGRADE_GRACE_MS = 24 * 60 * 60 * 1000;
+
+function subscriptionPeriodEnd(subscription: SubscriptionInput): Date | null {
+  const periodEndUnix = subscription.items.data[0]?.current_period_end;
+  return typeof periodEndUnix === "number"
+    ? new Date(periodEndUnix * 1000)
+    : null;
+}
+
+function subscriptionCanRefreshPaidThrough(
+  subscription: SubscriptionInput,
+): boolean {
+  return ENTITLEMENT_PERIOD_REFRESH_STATUSES.has(subscription.status);
+}
 
 function tierFromPriceId(priceId: string): OrgTier {
   const priceMap = env().ZERO_PRICE;
@@ -543,9 +565,13 @@ export async function handleSubscriptionUpdated(
   // Determine tier from price ID if price changed (upgrade/downgrade via Billing Portal).
   // Unknown price IDs propagate as errors so Stripe retries the webhook,
   // alerting operators to a configuration mismatch.
-  const tier: OrgTier | undefined = priceId
-    ? tierFromPriceId(priceId)
-    : undefined;
+  const canSyncPaidEntitlement =
+    subscriptionCanRefreshPaidThrough(subscription);
+  const tier: OrgTier | undefined =
+    canSyncPaidEntitlement && priceId ? tierFromPriceId(priceId) : undefined;
+  const periodEnd = canSyncPaidEntitlement
+    ? subscriptionPeriodEnd(subscription)
+    : null;
 
   await db
     .update(orgMetadata)
@@ -554,6 +580,7 @@ export async function handleSubscriptionUpdated(
       cancelAtPeriodEnd: subscription.cancel_at_period_end,
       updatedAt: new Date(),
       ...(tier ? { tier } : {}),
+      ...(periodEnd ? { currentPeriodEnd: periodEnd } : {}),
     })
     .where(eq(orgMetadata.stripeSubscriptionId, subscription.id));
 
@@ -585,6 +612,61 @@ export async function handleSubscriptionDeleted(
   log.info("subscription deleted — downgraded to free", {
     subscriptionId: subscription.id,
   });
+}
+
+/**
+ * Local billing entitlement reconciliation for the known webhook gap where an
+ * org can stay on a paid tier after Stripe moves the subscription to a failed
+ * payment state. This intentionally avoids Stripe API calls and only touches
+ * rows that no longer have a future paid-through timestamp locally.
+ */
+export async function downgradeStalePaymentFailedSubscriptions(options?: {
+  now?: Date;
+}): Promise<{ downgraded: number }> {
+  const db = globalThis.services.db;
+  const now = options?.now ?? new Date();
+  const staleBefore = new Date(
+    now.getTime() - PAYMENT_FAILURE_DOWNGRADE_GRACE_MS,
+  );
+
+  const downgraded = await db
+    .update(orgMetadata)
+    .set({
+      tier: "free",
+      updatedAt: now,
+    })
+    .where(
+      and(
+        inArray(orgMetadata.tier, ["pro", "team"]),
+        isNotNull(orgMetadata.stripeSubscriptionId),
+        inArray(orgMetadata.subscriptionStatus, [
+          ...PAYMENT_FAILED_SUBSCRIPTION_STATUSES,
+        ]),
+        or(
+          and(
+            isNull(orgMetadata.currentPeriodEnd),
+            lte(orgMetadata.updatedAt, staleBefore),
+          ),
+          lte(orgMetadata.currentPeriodEnd, staleBefore),
+        ),
+      ),
+    )
+    .returning({
+      orgId: orgMetadata.orgId,
+      subscriptionId: orgMetadata.stripeSubscriptionId,
+      status: orgMetadata.subscriptionStatus,
+    });
+
+  if (downgraded.length > 0) {
+    log.warn("stale payment-failed subscriptions downgraded", {
+      count: downgraded.length,
+      subscriptionIds: downgraded.slice(0, 10).map((row) => {
+        return row.subscriptionId;
+      }),
+    });
+  }
+
+  return { downgraded: downgraded.length };
 }
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/web/vercel.json
+++ b/turbo/apps/web/vercel.json
@@ -36,6 +36,10 @@
       "schedule": "* * * * *"
     },
     {
+      "path": "/api/cron/reconcile-billing-entitlements",
+      "schedule": "0 0,12 * * *"
+    },
+    {
       "path": "/api/cron/voice-chat-cleanup",
       "schedule": "* * * * *"
     },


### PR DESCRIPTION
## Summary
- add a twice-daily billing entitlement reconciliation cron that downgrades stale `past_due`/`unpaid` paid orgs only after paid-through has expired, or after the null-period old-data case is stale
- prevent `customer.subscription.updated` in failed-payment states from restoring paid tier from Stripe price data
- keep active/trialing subscription updates refreshing `currentPeriodEnd` from subscription item period end

## Test plan
- `pnpm prettier --check apps/web/src/lib/zero/billing/billing-service.ts apps/web/app/api/cron/reconcile-billing-entitlements/__tests__/route.test.ts apps/web/app/api/webhooks/stripe/__tests__/route.test.ts`
- `pnpm vitest run apps/web/app/api/webhooks/stripe/__tests__/route.test.ts apps/web/app/api/cron/reconcile-billing-entitlements/__tests__/route.test.ts`
- `pnpm --filter web lint`
- `pnpm --filter web check-types` (fails on existing unrelated web type errors)
- pre-commit `pnpm check-types` (fails on existing unrelated apps/platform type errors)

Fixes #12160