### PR TITLE
docs(runner): document http client constructor

### DIFF
--- a/crates/runner/src/http.rs
+++ b/crates/runner/src/http.rs
@@ -24,6 +24,14 @@ struct Inner {
 }
 
 impl HttpClient {
+    /// Create a shared API HTTP client using `api_url` as the base URL for generated routes.
+    ///
+    /// The client uses the runner's default request timeout and captures
+    /// `VERCEL_AUTOMATION_BYPASS_SECRET` at construction time. When present,
+    /// that value is attached as `x-vercel-protection-bypass` on authenticated
+    /// requests.
+    ///
+    /// Returns an error if the underlying HTTP client cannot be built.
     pub fn new(api_url: String) -> RunnerResult<Self> {
         let client = Client::builder()
             .timeout(DEFAULT_TIMEOUT)


### PR DESCRIPTION
## Summary
- Add rustdoc for `HttpClient::new`
- Document API base URL semantics, default timeout behavior, and implicit Vercel bypass header capture
- Keep implementation unchanged

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- pre-commit: cargo-fmt, cargo-clippy, cargo-doc

Fixes #12145