### PR TITLE
chore: add guest mock codex lib target

### DIFF
--- a/crates/guest-mock-codex/src/lib.rs
+++ b/crates/guest-mock-codex/src/lib.rs
@@ -1,0 +1,2 @@
+// This file exists so that guest-mock-codex can be used as a dev-dependency
+// by other crates in the workspace for release-please version tracking.


### PR DESCRIPTION
## Summary
- add a placeholder lib target for guest-mock-codex
- allow runner dev-dependency version tracking to include guest-mock-codex without Cargo warnings

## Testing
- cargo tree --manifest-path crates/Cargo.toml -p runner --edges dev --depth 1
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- pre-commit hook: cargo-fmt, cargo-doc, cargo-clippy