### PR TITLE
fix: read codex output in callbacks

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/schedule/cron/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/cron/route.ts
@@ -114,7 +114,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Generate run summary (best-effort — errors handled internally)
   if (status === "completed" && schedule.prompt) {
-    const resultText = await getRunOutputText(result.data.runId).catch(() => {
+    const resultText = await getRunOutputText(result.data.runId, {
+      waitForOutput: false,
+    }).catch(() => {
       return undefined;
     });
     await saveRunSummary(

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/loop/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/loop/route.ts
@@ -109,7 +109,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Generate run summary (best-effort — errors handled internally)
   if (status === "completed" && schedule.prompt) {
-    const resultText = await getRunOutputText(result.data.runId).catch(() => {
+    const resultText = await getRunOutputText(result.data.runId, {
+      waitForOutput: false,
+    }).catch(() => {
       return undefined;
     });
     await saveRunSummary(

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
@@ -250,6 +250,61 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     expect(call.thread_ts).toBe(threadTs);
   });
 
+  it("posts Codex agent_message output instead of the completion fallback", async () => {
+    const { workspaceId, connectionId } = await setupOrgSlack();
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await seedTestRun(user.userId, composeId, {
+      prompt: "Test prompt",
+    });
+    await setTestRunSelectedModel(runId, "gpt-5.5");
+    await completeTestRun(user.userId, runId);
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      {
+        eventType: "item.completed",
+        eventData: {
+          item: {
+            type: "agent_message",
+            text: "I am okay.",
+          },
+        },
+      },
+    ]);
+
+    const channelId = uniqueId("C-ch");
+    const threadTs = uniqueId("ts");
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId,
+      threadTs,
+      messageTs: threadTs,
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createSignedCallbackRequest(
+      "http://localhost/api/internal/callbacks/slack/org",
+      { runId, status: "completed", payload },
+      secret,
+    );
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    const call = (mockClient.chat.postMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as { text: string; blocks: unknown[] };
+    const blocksStr = JSON.stringify(call.blocks);
+    expect(call.text).toBe("I am okay.");
+    expect(call.text).not.toBe("Task completed successfully.");
+    expect(blocksStr).toContain("gpt-5.5");
+  });
+
   it("posts error message for failed status", async () => {
     const { workspaceId, connectionId } = await setupOrgSlack();
     const { composeId } = await createTestCompose(uniqueId("agent"));

--- a/turbo/apps/web/src/lib/infra/run/__tests__/extract-run-output.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/extract-run-output.test.ts
@@ -59,7 +59,7 @@ describe("extractRunOutput", () => {
   });
 
   it("returns the result from the single event returned by the limit-1 query", async () => {
-    // queryResultEvent uses `limit 1 + order by desc` so Axiom returns only the latest event
+    // queryOutputEventsDesc orders newest-first, so the first output event wins.
     mockQuery.mockResolvedValue(
       axiomResponse([{ eventData: { result: "latest" } }]),
     );
@@ -67,6 +67,91 @@ describe("extractRunOutput", () => {
     const output = await extractRunOutput("run-1");
 
     expect(output.result).toBe("latest");
+  });
+
+  it("limits the single-output query after filtering to publishable events", async () => {
+    mockQuery.mockResolvedValue(axiomResponse([]));
+
+    await extractRunOutput("run-1");
+
+    const apl = mockQuery.mock.calls[0]![0] as string;
+    expect(apl).toContain('eventType == "result"');
+    expect(apl).toContain("['eventData.item.type'] == \"agent_message\"");
+    expect(apl).not.toContain("eventData.item.type ==");
+    expect(apl).toContain("| limit 1");
+  });
+
+  it("returns Codex agent_message text from item.completed events", async () => {
+    mockQuery.mockResolvedValue(
+      axiomResponse([
+        {
+          eventType: "item.completed",
+          eventData: {
+            item: {
+              type: "agent_message",
+              text: "Codex completed text",
+            },
+          },
+        },
+      ]),
+    );
+
+    const output = await extractRunOutput("run-1");
+
+    expect(output.result).toBe("Codex completed text");
+  });
+
+  it("retries briefly when the latest output event is not searchable yet", async () => {
+    mockQuery
+      .mockResolvedValueOnce(axiomResponse([]))
+      .mockResolvedValueOnce(
+        axiomResponse([{ eventData: { result: "eventually indexed" } }]),
+      );
+
+    const output = await extractRunOutput("run-1");
+
+    expect(output.result).toBe("eventually indexed");
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("can skip waiting for output visibility", async () => {
+    mockQuery.mockResolvedValue(axiomResponse([]));
+
+    const output = await extractRunOutput("run-1", null, {
+      waitForOutput: false,
+    });
+
+    expect(output.result).toBeNull();
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips newer Codex non-message items when finding the latest output", async () => {
+    mockQuery.mockResolvedValue(
+      axiomResponse([
+        {
+          eventType: "item.completed",
+          eventData: {
+            item: {
+              type: "command_execution",
+              output: "README.md",
+            },
+          },
+        },
+        {
+          eventType: "item.completed",
+          eventData: {
+            item: {
+              type: "agent_message",
+              text: "Latest agent text",
+            },
+          },
+        },
+      ]),
+    );
+
+    const output = await extractRunOutput("run-1");
+
+    expect(output.result).toBe("Latest agent text");
   });
 
   it("passes error through", async () => {
@@ -122,6 +207,48 @@ describe("extractAllRunOutputs", () => {
     ).toEqual(["step 1 done", "step 2 done", "final summary"]);
   });
 
+  it("returns one output per Codex agent_message in order", async () => {
+    mockQuery.mockResolvedValue(
+      axiomResponse([
+        {
+          eventType: "item.completed",
+          eventData: {
+            item: {
+              type: "agent_message",
+              text: "first codex answer",
+            },
+          },
+        },
+        {
+          eventType: "item.completed",
+          eventData: {
+            item: {
+              type: "command_execution",
+              output: "ignored command output",
+            },
+          },
+        },
+        {
+          eventType: "item.completed",
+          eventData: {
+            item: {
+              type: "agent_message",
+              text: "second codex answer",
+            },
+          },
+        },
+      ]),
+    );
+
+    const outputs = await extractAllRunOutputs("run-1");
+
+    expect(
+      outputs.map((o) => {
+        return o.result;
+      }),
+    ).toEqual(["first codex answer", "second codex answer"]);
+  });
+
   it("handles events with missing result gracefully", async () => {
     mockQuery.mockResolvedValue(
       axiomResponse([
@@ -162,5 +289,25 @@ describe("getAllRunOutputTexts", () => {
     const texts = await getAllRunOutputTexts("run-1");
 
     expect(texts).toEqual(["first result", "second result"]);
+  });
+
+  it("returns Codex agent_message text", async () => {
+    mockQuery.mockResolvedValue(
+      axiomResponse([
+        {
+          eventType: "item.completed",
+          eventData: {
+            item: {
+              type: "agent_message",
+              text: "codex text",
+            },
+          },
+        },
+      ]),
+    );
+
+    const texts = await getAllRunOutputTexts("run-1");
+
+    expect(texts).toEqual(["codex text"]);
   });
 });

--- a/turbo/apps/web/src/lib/infra/run/extract-run-output.ts
+++ b/turbo/apps/web/src/lib/infra/run/extract-run-output.ts
@@ -5,44 +5,82 @@ import { queryAxiom, getDatasetName, DATASETS } from "../../shared/axiom";
 // ---------------------------------------------------------------------------
 
 export interface RunOutput {
-  /** Raw result text from the agent */
+  /** Raw output text from the agent */
   result: string | null;
   /** Run error message (if failed) */
   error: string | null;
+}
+
+interface RunOutputQueryOptions {
+  /**
+   * Wait briefly for Axiom search visibility when a terminal output event has
+   * not been indexed yet. User-facing callbacks should wait; best-effort
+   * background summaries can opt out.
+   */
+  waitForOutput?: boolean;
 }
 
 // ---------------------------------------------------------------------------
 // Axiom query
 // ---------------------------------------------------------------------------
 
-interface ResultEvent {
+interface CodexItem {
+  type?: string;
+  text?: string;
+}
+
+interface RunOutputEvent {
+  eventType?: string;
   eventData: {
     result?: string;
+    item?: CodexItem;
   };
 }
 
-async function queryResultEvent(
-  runId: string,
-): Promise<ResultEvent | undefined> {
+const OUTPUT_EVENT_FILTER = `eventType == "result" or (eventType == "item.completed" and ['eventData.item.type'] == "agent_message")`;
+const OUTPUT_QUERY_ATTEMPTS = 4;
+const OUTPUT_QUERY_RETRY_MS = 500;
+
+function waitForOutputRetry(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, OUTPUT_QUERY_RETRY_MS);
+  });
+}
+
+async function queryOutputEventsDesc(runId: string): Promise<RunOutputEvent[]> {
   const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
   const apl = `['${dataset}']
 | where runId == "${runId}"
-| where eventType == "result"
+| where ${OUTPUT_EVENT_FILTER}
 | order by sequenceNumber desc
 | limit 1`;
 
-  const events = await queryAxiom<ResultEvent>(apl);
-  return events[0];
+  return queryAxiom<RunOutputEvent>(apl);
 }
 
-async function queryAllResultEvents(runId: string): Promise<ResultEvent[]> {
+async function queryLatestOutputEvent(
+  runId: string,
+  options: RunOutputQueryOptions = {},
+): Promise<RunOutputEvent | undefined> {
+  const attempts = options.waitForOutput === false ? 1 : OUTPUT_QUERY_ATTEMPTS;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const event = (await queryOutputEventsDesc(runId)).find(isOutputEvent);
+    if (event || attempt === attempts) {
+      return event;
+    }
+    await waitForOutputRetry();
+  }
+  return undefined;
+}
+
+async function queryAllOutputEvents(runId: string): Promise<RunOutputEvent[]> {
   const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
   const apl = `['${dataset}']
 | where runId == "${runId}"
-| where eventType == "result"
+| where ${OUTPUT_EVENT_FILTER}
 | order by sequenceNumber asc`;
 
-  return queryAxiom<ResultEvent>(apl);
+  return queryAxiom<RunOutputEvent>(apl);
 }
 
 // ---------------------------------------------------------------------------
@@ -56,13 +94,14 @@ async function queryAllResultEvents(runId: string): Promise<ResultEvent[]> {
  * - `extractResultFromAxiom` (webhook complete handler)
  * - `getRunResultData` / `getRunOutput` (Slack handler)
  *
- * Single Axiom query for the result event.
+ * Single Axiom query for terminal output events.
  */
 export async function extractRunOutput(
   runId: string,
   error?: string | null,
+  options?: RunOutputQueryOptions,
 ): Promise<RunOutput> {
-  const event = await queryResultEvent(runId);
+  const event = await queryLatestOutputEvent(runId, options);
 
   if (!event) {
     return {
@@ -77,15 +116,15 @@ export async function extractRunOutput(
 /**
  * Extract ALL structured run outputs from Axiom (ordered by sequence number).
  *
- * A run may produce multiple result events (e.g. intermediate task
+ * A run may produce multiple output events (e.g. intermediate task
  * notifications followed by a final summary). This returns one RunOutput
- * per result event so callers can post each one individually.
+ * per output event so callers can post each one individually.
  */
 export async function extractAllRunOutputs(
   runId: string,
   error?: string | null,
 ): Promise<RunOutput[]> {
-  const events = await queryAllResultEvents(runId);
+  const events = (await queryAllOutputEvents(runId)).filter(isOutputEvent);
 
   if (events.length === 0) {
     return [
@@ -101,9 +140,43 @@ export async function extractAllRunOutputs(
   });
 }
 
-function buildRunOutput(event: ResultEvent, error?: string | null): RunOutput {
-  const result =
-    typeof event.eventData?.result === "string" ? event.eventData.result : null;
+function extractCodexAgentMessageText(
+  item: CodexItem | undefined,
+): string | null {
+  if (
+    item?.type !== "agent_message" ||
+    typeof item.text !== "string" ||
+    item.text.length === 0
+  ) {
+    return null;
+  }
+  return item.text;
+}
+
+function isOutputEvent(event: RunOutputEvent): boolean {
+  if (event.eventType === "item.completed") {
+    return extractCodexAgentMessageText(event.eventData?.item) !== null;
+  }
+
+  return event.eventType === "result" || event.eventType === undefined;
+}
+
+function extractOutputText(event: RunOutputEvent): string | null {
+  const result = event.eventData?.result;
+  if (typeof result === "string") return result;
+
+  const item = event.eventData?.item;
+  const codexText = extractCodexAgentMessageText(item);
+  if (codexText !== null) return codexText;
+
+  return null;
+}
+
+function buildRunOutput(
+  event: RunOutputEvent,
+  error?: string | null,
+): RunOutput {
+  const result = extractOutputText(event);
 
   return {
     result,
@@ -112,9 +185,9 @@ function buildRunOutput(event: ResultEvent, error?: string | null): RunOutput {
 }
 
 /**
- * Get ALL formatted run output texts (one per result event).
+ * Get ALL formatted run output texts (one per output event).
  *
- * Convenience wrapper for channels that post each result as a separate message.
+ * Convenience wrapper for channels that post each output as a separate message.
  */
 export async function getAllRunOutputTexts(runId: string): Promise<string[]> {
   const outputs = await extractAllRunOutputs(runId);
@@ -136,7 +209,8 @@ export async function getAllRunOutputTexts(runId: string): Promise<string[]> {
  */
 export async function getRunOutputText(
   runId: string,
+  options?: RunOutputQueryOptions,
 ): Promise<string | undefined> {
-  const output = await extractRunOutput(runId);
+  const output = await extractRunOutput(runId, undefined, options);
   return output.result ?? undefined;
 }


### PR DESCRIPTION
## Summary
- read Codex `item.completed` agent messages from shared run output extraction
- skip non-message Codex items so callbacks do not post completion fallback text
- add Slack org callback regression coverage for `gpt-5.5` selected-model runs

## Testing
- `pnpm -C turbo -F web exec vitest src/lib/infra/run/__tests__/extract-run-output.test.ts app/api/internal/callbacks/slack/org/__tests__/route.test.ts --run`
- `pnpm -C turbo -F web lint`
- `pnpm -C turbo -F web check-types`
- pre-commit: prettier, knip, full `pnpm check-types`, commitlint