### PR TITLE
fix(platform): swap pinned thread trigger to kebab on desktop hover

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -383,8 +383,7 @@ function ChatThreadSideDecorator({
   renameEnabled: boolean;
   indicatorState: IndicatorState | null;
 }) {
-  const showPin = pinEnabled && isPinned;
-  if (indicatorState === "draft" && !showPin) {
+  if (indicatorState === "draft") {
     return (
       <div className="pointer-events-none absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
         <span className="flex items-center justify-center">
@@ -395,7 +394,11 @@ function ChatThreadSideDecorator({
   }
   return (
     <div className="pointer-events-none absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
-      {showPin ? (
+      {indicatorState !== null ? (
+        <span className="flex items-center justify-center group-hover:invisible">
+          <SessionStateIndicator state={indicatorState} />
+        </span>
+      ) : pinEnabled && isPinned ? (
         <TooltipProvider delayDuration={200}>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -412,13 +415,7 @@ function ChatThreadSideDecorator({
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
-      ) : (
-        indicatorState !== null && (
-          <span className="flex items-center justify-center group-hover:invisible">
-            <SessionStateIndicator state={indicatorState} />
-          </span>
-        )
-      )}
+      ) : null}
       {pinEnabled || renameEnabled ? (
         <ChatThreadMenu
           threadId={threadId}

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -262,27 +262,6 @@ function ChatThreadDeleteButton({
   );
 }
 
-function MenuTriggerIcon({
-  label,
-  className,
-  children,
-}: {
-  label: string;
-  className?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className={className}>{children}</span>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">
-        <p className="text-xs">{label}</p>
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
 function ChatThreadMenu({
   threadId,
   isPinned,
@@ -330,11 +309,7 @@ function ChatThreadMenu({
           <button
             type="button"
             onClick={handleMenuTriggerClick}
-            className={`pointer-events-auto absolute top-1 left-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-md transition-opacity duration-150 ${
-              isPinned
-                ? "visible"
-                : "visible md:invisible md:group-hover:visible md:data-[state=open]:visible"
-            } ${
+            className={`pointer-events-auto absolute top-1 left-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-md visible md:invisible md:group-hover:visible md:data-[state=open]:visible transition-opacity duration-150 ${
               isHighlighted
                 ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-300))]"
                 : "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-200))]"
@@ -343,26 +318,16 @@ function ChatThreadMenu({
             data-testid="chat-thread-menu-trigger"
             data-pinned={isPinned ? "true" : "false"}
           >
-            {isPinned ? (
-              <>
-                <MenuTriggerIcon
-                  label="Pinned"
-                  className="block md:group-hover:hidden"
-                >
-                  <IconPin size={16} stroke={2} />
-                </MenuTriggerIcon>
-                <MenuTriggerIcon
-                  label="More"
-                  className="hidden md:group-hover:block"
-                >
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
                   <IconDots size={16} stroke={2} />
-                </MenuTriggerIcon>
-              </>
-            ) : (
-              <MenuTriggerIcon label="More">
-                <IconDots size={16} stroke={2} />
-              </MenuTriggerIcon>
-            )}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p className="text-xs">More</p>
+              </TooltipContent>
+            </Tooltip>
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-40">
@@ -418,7 +383,8 @@ function ChatThreadSideDecorator({
   renameEnabled: boolean;
   indicatorState: IndicatorState | null;
 }) {
-  if (indicatorState === "draft") {
+  const showPin = pinEnabled && isPinned;
+  if (indicatorState === "draft" && !showPin) {
     return (
       <div className="pointer-events-none absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
         <span className="flex items-center justify-center">
@@ -429,10 +395,29 @@ function ChatThreadSideDecorator({
   }
   return (
     <div className="pointer-events-none absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
-      {indicatorState !== null && (
-        <span className="flex items-center justify-center group-hover:invisible">
-          <SessionStateIndicator state={indicatorState} />
-        </span>
+      {showPin ? (
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                aria-label="Pinned"
+                data-testid="chat-thread-pinned-indicator"
+                className="flex items-center justify-center text-sidebar-foreground/70 group-hover:invisible"
+              >
+                <IconPin size={16} stroke={2} />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p className="text-xs">Pinned</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        indicatorState !== null && (
+          <span className="flex items-center justify-center group-hover:invisible">
+            <SessionStateIndicator state={indicatorState} />
+          </span>
+        )
       )}
       {pinEnabled || renameEnabled ? (
         <ChatThreadMenu

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -308,7 +308,11 @@ function ChatThreadMenu({
         <button
           type="button"
           onClick={handleMenuTriggerClick}
-          className={`pointer-events-auto absolute top-1 left-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-md visible md:invisible md:group-hover:visible md:data-[state=open]:visible transition-opacity duration-150 ${
+          className={`pointer-events-auto absolute top-1 left-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-md transition-opacity duration-150 ${
+            isPinned
+              ? "visible"
+              : "visible md:invisible md:group-hover:visible md:data-[state=open]:visible"
+          } ${
             isHighlighted
               ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-300))]"
               : "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-200))]"
@@ -318,7 +322,18 @@ function ChatThreadMenu({
           data-pinned={isPinned ? "true" : "false"}
         >
           {isPinned ? (
-            <IconPin size={16} stroke={2} />
+            <>
+              <IconPin
+                size={16}
+                stroke={2}
+                className="block md:group-hover:hidden"
+              />
+              <IconDots
+                size={16}
+                stroke={2}
+                className="hidden md:group-hover:block"
+              />
+            </>
           ) : (
             <IconDots size={16} stroke={2} />
           )}

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -303,76 +303,97 @@ function ChatThreadMenu({
   }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          onClick={handleMenuTriggerClick}
-          className={`pointer-events-auto absolute top-1 left-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-md transition-opacity duration-150 ${
-            isPinned
-              ? "visible"
-              : "visible md:invisible md:group-hover:visible md:data-[state=open]:visible"
-          } ${
-            isHighlighted
-              ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-300))]"
-              : "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-200))]"
-          }`}
-          aria-label="Open chat menu"
-          data-testid="chat-thread-menu-trigger"
-          data-pinned={isPinned ? "true" : "false"}
-        >
-          {isPinned ? (
-            <>
-              <IconPin
-                size={16}
-                stroke={2}
-                className="block md:group-hover:hidden"
-              />
-              <IconDots
-                size={16}
-                stroke={2}
-                className="hidden md:group-hover:block"
-              />
-            </>
-          ) : (
-            <IconDots size={16} stroke={2} />
-          )}
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-40">
-        {pinEnabled && (
-          <DropdownMenuItem onSelect={handleTogglePin}>
+    <TooltipProvider delayDuration={200}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            onClick={handleMenuTriggerClick}
+            className={`pointer-events-auto absolute top-1 left-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-md transition-opacity duration-150 ${
+              isPinned
+                ? "visible"
+                : "visible md:invisible md:group-hover:visible md:data-[state=open]:visible"
+            } ${
+              isHighlighted
+                ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-300))]"
+                : "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-200))]"
+            }`}
+            aria-label="Open chat menu"
+            data-testid="chat-thread-menu-trigger"
+            data-pinned={isPinned ? "true" : "false"}
+          >
             {isPinned ? (
               <>
-                <IconPinnedOff size={16} stroke={2} className="mr-2" />
-                Unpin chat
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="block md:group-hover:hidden">
+                      <IconPin size={16} stroke={2} />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <p className="text-xs">Pinned</p>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="hidden md:group-hover:block">
+                      <IconDots size={16} stroke={2} />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <p className="text-xs">More</p>
+                  </TooltipContent>
+                </Tooltip>
               </>
             ) : (
-              <>
-                <IconPin size={16} stroke={2} className="mr-2" />
-                Pin chat
-              </>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <IconDots size={16} stroke={2} />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p className="text-xs">More</p>
+                </TooltipContent>
+              </Tooltip>
             )}
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-40">
+          {pinEnabled && (
+            <DropdownMenuItem onSelect={handleTogglePin}>
+              {isPinned ? (
+                <>
+                  <IconPinnedOff size={16} stroke={2} className="mr-2" />
+                  Unpin chat
+                </>
+              ) : (
+                <>
+                  <IconPin size={16} stroke={2} className="mr-2" />
+                  Pin chat
+                </>
+              )}
+            </DropdownMenuItem>
+          )}
+          {renameEnabled && (
+            <DropdownMenuItem onSelect={openRenameDialog}>
+              <IconPencil size={16} stroke={2} className="mr-2" />
+              Rename chat
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault();
+              setPendingDeleteThreadId(threadId);
+            }}
+            className="text-destructive focus:text-destructive"
+          >
+            <IconTrash size={16} stroke={2} className="mr-2" />
+            Delete chat
           </DropdownMenuItem>
-        )}
-        {renameEnabled && (
-          <DropdownMenuItem onSelect={openRenameDialog}>
-            <IconPencil size={16} stroke={2} className="mr-2" />
-            Rename chat
-          </DropdownMenuItem>
-        )}
-        <DropdownMenuItem
-          onSelect={(e) => {
-            e.preventDefault();
-            setPendingDeleteThreadId(threadId);
-          }}
-          className="text-destructive focus:text-destructive"
-        >
-          <IconTrash size={16} stroke={2} className="mr-2" />
-          Delete chat
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </TooltipProvider>
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -262,6 +262,27 @@ function ChatThreadDeleteButton({
   );
 }
 
+function MenuTriggerIcon({
+  label,
+  className,
+  children,
+}: {
+  label: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={className}>{children}</span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        <p className="text-xs">{label}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function ChatThreadMenu({
   threadId,
   isPinned,
@@ -324,38 +345,23 @@ function ChatThreadMenu({
           >
             {isPinned ? (
               <>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="block md:group-hover:hidden">
-                      <IconPin size={16} stroke={2} />
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    <p className="text-xs">Pinned</p>
-                  </TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="hidden md:group-hover:block">
-                      <IconDots size={16} stroke={2} />
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    <p className="text-xs">More</p>
-                  </TooltipContent>
-                </Tooltip>
+                <MenuTriggerIcon
+                  label="Pinned"
+                  className="block md:group-hover:hidden"
+                >
+                  <IconPin size={16} stroke={2} />
+                </MenuTriggerIcon>
+                <MenuTriggerIcon
+                  label="More"
+                  className="hidden md:group-hover:block"
+                >
+                  <IconDots size={16} stroke={2} />
+                </MenuTriggerIcon>
               </>
             ) : (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span>
-                    <IconDots size={16} stroke={2} />
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  <p className="text-xs">More</p>
-                </TooltipContent>
-              </Tooltip>
+              <MenuTriggerIcon label="More">
+                <IconDots size={16} stroke={2} />
+              </MenuTriggerIcon>
             )}
           </button>
         </DropdownMenuTrigger>

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -282,8 +282,7 @@ function ChatThreadMenu({
   const setRenameDialogInput = useSet(setRenameDialogInput$);
   const pageSignal = useGet(pageSignal$);
 
-  function handleTogglePin(e: Event) {
-    e.preventDefault();
+  function handleTogglePin() {
     if (isPinned) {
       detach(unpinChatThread(threadId, pageSignal), Reason.DomCallback);
     } else {
@@ -296,8 +295,7 @@ function ChatThreadMenu({
     e.stopPropagation();
   }
 
-  function openRenameDialog(e: Event) {
-    e.preventDefault();
+  function openRenameDialog() {
     setRenameDialogInput("");
     setRenameDialogThreadId(threadId);
   }
@@ -353,8 +351,7 @@ function ChatThreadMenu({
             </DropdownMenuItem>
           )}
           <DropdownMenuItem
-            onSelect={(e) => {
-              e.preventDefault();
+            onSelect={() => {
               setPendingDeleteThreadId(threadId);
             }}
             className="text-destructive focus:text-destructive"

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -309,7 +309,7 @@ function ChatThreadMenu({
           <button
             type="button"
             onClick={handleMenuTriggerClick}
-            className={`pointer-events-auto absolute top-1 left-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-md visible md:invisible md:group-hover:visible md:data-[state=open]:visible transition-opacity duration-150 ${
+            className={`peer pointer-events-auto absolute top-1 left-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-md visible md:invisible md:group-hover:visible md:data-[state=open]:visible transition-opacity duration-150 ${
               isHighlighted
                 ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-300))]"
                 : "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-200))]"
@@ -394,28 +394,6 @@ function ChatThreadSideDecorator({
   }
   return (
     <div className="pointer-events-none absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
-      {indicatorState !== null ? (
-        <span className="flex items-center justify-center group-hover:invisible">
-          <SessionStateIndicator state={indicatorState} />
-        </span>
-      ) : pinEnabled && isPinned ? (
-        <TooltipProvider delayDuration={200}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span
-                aria-label="Pinned"
-                data-testid="chat-thread-pinned-indicator"
-                className="flex items-center justify-center text-sidebar-foreground/70 group-hover:invisible"
-              >
-                <IconPin size={16} stroke={2} />
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <p className="text-xs">Pinned</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      ) : null}
       {pinEnabled || renameEnabled ? (
         <ChatThreadMenu
           threadId={threadId}
@@ -430,6 +408,28 @@ function ChatThreadSideDecorator({
           isHighlighted={isHighlighted}
         />
       )}
+      {indicatorState !== null ? (
+        <span className="flex items-center justify-center group-hover:hidden peer-data-[state=open]:hidden">
+          <SessionStateIndicator state={indicatorState} />
+        </span>
+      ) : pinEnabled && isPinned ? (
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                aria-label="Pinned"
+                data-testid="chat-thread-pinned-indicator"
+                className="flex items-center justify-center text-sidebar-foreground/70 group-hover:hidden peer-data-[state=open]:hidden"
+              >
+                <IconPin size={16} stroke={2} />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p className="text-xs">Pinned</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- On desktop, a pinned chat row at rest now shows a static pin icon as the state indicator; hovering the row swaps the icon to the kebab (`...`) so the menu is the only action affordance.
- Mobile behavior is unchanged — the trigger has always been visible there, and there's no hover state to confuse the user.

**Why:** previously, on desktop the trigger was hidden at rest, so a pinned thread looked identical to a regular one. On hover the trigger appeared with a pin icon, which read as "pin again" rather than "this is pinned." This swap separates state (pin at rest) from action (kebab on hover).

## Test plan

- [ ] Desktop: pinned thread shows a pin icon when not hovering
- [ ] Desktop: hovering a pinned thread swaps the pin to the kebab
- [ ] Desktop: clicking the kebab on a pinned thread opens the menu with Unpin / Rename / Delete
- [ ] Desktop: non-pinned threads behave exactly as before (kebab shown only on hover)
- [ ] Mobile: pinned and non-pinned rows look unchanged
- [ ] Existing pin tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)