### PR TITLE
Render Codex events on activity pages

### DIFF
--- a/turbo/apps/platform/src/views/activity/__tests__/log-detail-utils.test.ts
+++ b/turbo/apps/platform/src/views/activity/__tests__/log-detail-utils.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "vitest";
+import type { AgentEvent } from "../../../signals/zero-page/log-types.ts";
+import { groupEventsIntoMessages } from "../../zero-page/components/log-views/log-detail-utils.ts";
+
+const createdAt = "2026-05-08T08:00:00.000Z";
+
+function codexEvent(sequenceNumber: number, eventData: unknown): AgentEvent {
+  const eventType =
+    typeof eventData === "object" &&
+    eventData !== null &&
+    "type" in eventData &&
+    typeof eventData.type === "string"
+      ? eventData.type
+      : "unknown";
+
+  return {
+    sequenceNumber,
+    eventType,
+    eventData,
+    createdAt,
+  };
+}
+
+describe("log detail event grouping", () => {
+  it("groups Codex JSONL events into visible timeline messages", () => {
+    const messages = groupEventsIntoMessages([
+      codexEvent(1, {
+        type: "thread.started",
+        thread_id: "00000000-0000-0000-0000-000000000001",
+      }),
+      codexEvent(2, {
+        type: "item.started",
+        item: {
+          id: "item-cmd-1",
+          type: "command_execution",
+          status: "in_progress",
+          command: "echo hello",
+        },
+      }),
+      codexEvent(3, {
+        type: "item.completed",
+        item: {
+          id: "item-cmd-1",
+          type: "command_execution",
+          status: "completed",
+          command: "echo hello",
+          exit_code: 0,
+          aggregated_output: "hello\n",
+        },
+      }),
+      codexEvent(4, {
+        type: "item.started",
+        item: {
+          id: "item-edit-1",
+          type: "file_edit",
+          status: "in_progress",
+          path: "/tmp/edit-target.txt",
+        },
+      }),
+      codexEvent(5, {
+        type: "item.completed",
+        item: {
+          id: "item-edit-1",
+          type: "file_edit",
+          status: "completed",
+          path: "/tmp/edit-target.txt",
+          diff: "@@ -1 +1 @@\n-old\n+new\n",
+        },
+      }),
+      codexEvent(6, {
+        type: "item.started",
+        item: {
+          id: "item-read-1",
+          type: "file_read",
+          status: "in_progress",
+          path: "/tmp/read-target.txt",
+        },
+      }),
+      codexEvent(7, {
+        type: "item.completed",
+        item: {
+          id: "item-read-1",
+          type: "file_read",
+          status: "completed",
+          path: "/tmp/read-target.txt",
+        },
+      }),
+      codexEvent(8, {
+        type: "item.completed",
+        item: {
+          id: "item-change-1",
+          type: "file_change",
+          changes: [
+            { kind: "add", path: "/tmp/created.txt" },
+            { kind: "modify", path: "/tmp/modified.txt" },
+            { kind: "delete", path: "/tmp/removed.txt" },
+          ],
+        },
+      }),
+      codexEvent(9, {
+        type: "item.completed",
+        item: {
+          id: "item-think-1",
+          type: "reasoning",
+          text: "Considering the request before acting",
+        },
+      }),
+      codexEvent(10, {
+        type: "item.completed",
+        item: {
+          id: "item-msg-1",
+          type: "agent_message",
+          text: "Fixture event walkthrough complete",
+        },
+      }),
+      codexEvent(11, {
+        type: "turn.completed",
+        usage: {
+          input_tokens: 50,
+          cached_input_tokens: 25,
+          output_tokens: 100,
+          reasoning_output_tokens: 10,
+        },
+      }),
+    ]);
+
+    expect(
+      messages.map((message) => {
+        return message.type;
+      }),
+    ).toStrictEqual([
+      "system",
+      "assistant",
+      "assistant",
+      "assistant",
+      "assistant",
+      "result",
+    ]);
+
+    const toolMessage = messages[1];
+    expect(
+      toolMessage.toolOperations?.map((operation) => {
+        return operation.toolName;
+      }),
+    ).toStrictEqual(["Bash", "Edit", "Read"]);
+    expect(toolMessage.toolOperations?.[0]?.result).toMatchObject({
+      content: "hello\n",
+      isError: false,
+    });
+    expect(toolMessage.toolOperations?.[1]?.result?.content).toContain("+new");
+    expect(toolMessage.toolOperations?.[2]?.result?.content).toBe(
+      "File read completed",
+    );
+
+    expect(messages[2].textBefore).toContain("Files changed");
+    expect(messages[2].textBefore).toContain("modify /tmp/modified.txt");
+    expect(messages[3].textBefore).toBe(
+      "[thinking] Considering the request before acting",
+    );
+    expect(messages[4].textBefore).toBe("Fixture event walkthrough complete");
+
+    const resultData = messages[5].eventData as {
+      result?: string;
+      modelUsage?: { codex?: { inputTokens?: number; outputTokens?: number } };
+      codex_usage?: {
+        cached_input_tokens?: number;
+        reasoning_output_tokens?: number;
+      };
+    };
+    expect(resultData.result).toBe("");
+    expect(resultData.modelUsage?.codex).toMatchObject({
+      inputTokens: 50,
+      outputTokens: 100,
+    });
+    expect(resultData.codex_usage).toMatchObject({
+      cached_input_tokens: 25,
+      reasoning_output_tokens: 10,
+    });
+  });
+
+  it("renders Codex turn failure and top-level error events as failed results", () => {
+    const messages = groupEventsIntoMessages([
+      codexEvent(1, {
+        type: "thread.started",
+        thread_id: "00000000-0000-0000-0000-000000000002",
+      }),
+      codexEvent(2, {
+        type: "item.completed",
+        item: {
+          id: "item-msg-2",
+          type: "agent_message",
+          text: "Attempting the turn",
+        },
+      }),
+      codexEvent(3, {
+        type: "turn.failed",
+        error: "Mock turn failure for fixture testing",
+      }),
+      codexEvent(4, {
+        type: "error",
+        message: "Mock error event for fixture testing",
+      }),
+    ]);
+
+    expect(
+      messages.map((message) => {
+        return message.type;
+      }),
+    ).toStrictEqual(["system", "assistant", "result", "result"]);
+    expect(messages[1].textBefore).toBe("Attempting the turn");
+    expect(messages[2].eventData).toMatchObject({
+      is_error: true,
+      result: "Mock turn failure for fixture testing",
+    });
+    expect(messages[3].eventData).toMatchObject({
+      is_error: true,
+      result: "Mock error event for fixture testing",
+    });
+  });
+
+  it("renders unknown Codex item types with a visible fallback", () => {
+    const messages = groupEventsIntoMessages([
+      codexEvent(1, {
+        type: "item.completed",
+        item: {
+          id: "item-web-1",
+          type: "web_search",
+          status: "completed",
+          query: "codex event schema",
+        },
+      }),
+    ]);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      type: "assistant",
+      textBefore:
+        "Codex web_search (item.completed, status: completed, id: item-web-1)\ncodex event schema",
+    });
+  });
+
+  it("renders unhandled Codex item lifecycle events with a visible fallback", () => {
+    const messages = groupEventsIntoMessages([
+      codexEvent(1, {
+        type: "item.updated",
+        item: {
+          id: "item-cmd-2",
+          type: "command_execution",
+          status: "in_progress",
+          output: "partial output",
+        },
+      }),
+    ]);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      type: "assistant",
+      textBefore:
+        "Codex command_execution (item.updated, status: in_progress, id: item-cmd-2)\npartial output",
+    });
+  });
+
+  it("keeps Claude-shaped events on the existing grouping path", () => {
+    const messages = groupEventsIntoMessages([
+      {
+        sequenceNumber: 1,
+        eventType: "assistant",
+        eventData: {
+          message: {
+            content: [{ type: "text", text: "Claude response text" }],
+          },
+        },
+        createdAt,
+      },
+      {
+        sequenceNumber: 2,
+        eventType: "result",
+        eventData: {
+          result: "Claude result text",
+          is_error: false,
+          num_turns: 1,
+        },
+        createdAt,
+      },
+    ]);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({
+      type: "assistant",
+      textBefore: "Claude response text",
+    });
+    expect(messages[1]).toMatchObject({
+      type: "result",
+      eventData: { result: "Claude result text" },
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -91,6 +91,514 @@ interface GroupingEventData {
   is_error?: boolean;
 }
 
+interface CodexUsage {
+  input_tokens?: number;
+  cached_input_tokens?: number;
+  output_tokens?: number;
+  reasoning_output_tokens?: number;
+}
+
+interface CodexFileChange {
+  kind?: string;
+  path?: string;
+}
+
+interface CodexItem {
+  id?: string;
+  type?: string;
+  status?: string;
+  command?: string;
+  exit_code?: number;
+  output?: string;
+  aggregated_output?: string;
+  text?: string;
+  title?: string;
+  name?: string;
+  query?: string;
+  url?: string;
+  path?: string;
+  diff?: string;
+  changes?: CodexFileChange[];
+}
+
+interface CodexEventData {
+  type?: string;
+  thread_id?: string;
+  usage?: CodexUsage;
+  item?: CodexItem;
+  error?: string;
+  message?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getStringField(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function getNumberField(
+  record: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = record[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+function parseCodexUsage(value: unknown): CodexUsage | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return {
+    input_tokens: getNumberField(value, "input_tokens"),
+    cached_input_tokens: getNumberField(value, "cached_input_tokens"),
+    output_tokens: getNumberField(value, "output_tokens"),
+    reasoning_output_tokens: getNumberField(value, "reasoning_output_tokens"),
+  };
+}
+
+function parseCodexChanges(value: unknown): CodexFileChange[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value.filter(isRecord).map((change) => {
+    return {
+      kind: getStringField(change, "kind"),
+      path: getStringField(change, "path"),
+    };
+  });
+}
+
+function parseCodexItem(value: unknown): CodexItem | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return {
+    id: getStringField(value, "id"),
+    type: getStringField(value, "type"),
+    status: getStringField(value, "status"),
+    command: getStringField(value, "command"),
+    exit_code: getNumberField(value, "exit_code"),
+    output: getStringField(value, "output"),
+    aggregated_output: getStringField(value, "aggregated_output"),
+    text: getStringField(value, "text"),
+    title: getStringField(value, "title"),
+    name: getStringField(value, "name"),
+    query: getStringField(value, "query"),
+    url: getStringField(value, "url"),
+    path: getStringField(value, "path"),
+    diff: getStringField(value, "diff"),
+    changes: parseCodexChanges(value.changes),
+  };
+}
+
+function parseCodexEventData(value: unknown): CodexEventData | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return {
+    type: getStringField(value, "type"),
+    thread_id: getStringField(value, "thread_id"),
+    usage: parseCodexUsage(value.usage),
+    item: parseCodexItem(value.item),
+    error: getStringField(value, "error"),
+    message: getStringField(value, "message"),
+  };
+}
+
+function isCodexEventType(eventType: string): boolean {
+  return (
+    eventType === "thread.started" ||
+    eventType === "turn.started" ||
+    eventType === "turn.completed" ||
+    eventType === "turn.failed" ||
+    eventType === "error" ||
+    eventType.startsWith("item.")
+  );
+}
+
+function makeCodexSystemEvent(
+  event: AgentEvent,
+  codexEvent: CodexEventData,
+): AgentEvent {
+  return {
+    ...event,
+    eventType: "system",
+    eventData: {
+      subtype: "init",
+      framework: "codex",
+      session_id: codexEvent.thread_id ?? null,
+      tools: [],
+      agents: [],
+      slash_commands: [],
+      codex_event_type: codexEvent.type,
+    },
+  };
+}
+
+function makeCodexResultEvent(params: {
+  event: AgentEvent;
+  success: boolean;
+  result: string;
+  usage?: CodexUsage;
+}): AgentEvent {
+  const { event, success, result, usage } = params;
+  return {
+    ...event,
+    eventType: "result",
+    eventData: {
+      type: "result",
+      is_error: !success,
+      result,
+      num_turns: 1,
+      modelUsage: usage
+        ? {
+            codex: {
+              inputTokens: usage.input_tokens ?? null,
+              outputTokens: usage.output_tokens ?? null,
+            },
+          }
+        : undefined,
+      codex_usage: usage,
+    },
+  };
+}
+
+function makeCodexAssistantTextEvent(
+  event: AgentEvent,
+  text: string,
+): AgentEvent {
+  return {
+    ...event,
+    eventType: "assistant",
+    eventData: {
+      message: {
+        content: [{ type: "text", text }],
+      },
+    },
+  };
+}
+
+function makeCodexToolUseEvent(params: {
+  event: AgentEvent;
+  item: CodexItem;
+  toolName: string;
+  input: Record<string, unknown>;
+}): AgentEvent {
+  const { event, item, toolName, input } = params;
+  return {
+    ...event,
+    eventType: "assistant",
+    eventData: {
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: item.id,
+            name: toolName,
+            input,
+          },
+        ],
+      },
+    },
+  };
+}
+
+function makeCodexToolResultEvent(params: {
+  event: AgentEvent;
+  item: CodexItem;
+  content: string;
+  isError?: boolean;
+}): AgentEvent {
+  const { event, item, content, isError = false } = params;
+  return {
+    ...event,
+    eventType: "user",
+    eventData: {
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: item.id,
+            content,
+            is_error: isError,
+          },
+        ],
+      },
+    },
+  };
+}
+
+function formatCodexFileChanges(changes: CodexFileChange[]): string {
+  if (changes.length === 0) {
+    return "[files] Files changed";
+  }
+
+  const lines = changes.map((change) => {
+    const kind = change.kind ?? "change";
+    const path = change.path ?? "unknown path";
+    return `- ${kind} ${path}`;
+  });
+
+  return ["[files] Files changed:", ...lines].join("\n");
+}
+
+function formatGenericCodexItem(
+  eventType: string,
+  item: CodexItem | undefined,
+): string {
+  if (!item) {
+    return `Codex ${eventType}`;
+  }
+
+  const label = item.type ?? "item";
+  const details: string[] = [];
+
+  if (item.status) {
+    details.push(`status: ${item.status}`);
+  }
+  if (item.id) {
+    details.push(`id: ${item.id}`);
+  }
+
+  const readable =
+    item.text ??
+    item.title ??
+    item.name ??
+    item.command ??
+    item.query ??
+    item.url ??
+    item.path ??
+    item.diff ??
+    item.output;
+  const suffix = readable ? `\n${readable}` : "";
+
+  return `Codex ${label} (${eventType}${details.length > 0 ? `, ${details.join(", ")}` : ""})${suffix}`;
+}
+
+function normalizeCodexRunEvent(
+  event: AgentEvent,
+  codexType: string,
+  codexEvent: CodexEventData | undefined,
+): AgentEvent | null {
+  switch (codexType) {
+    case "thread.started": {
+      return makeCodexSystemEvent(event, codexEvent ?? { type: codexType });
+    }
+    case "turn.started": {
+      return null;
+    }
+    case "turn.completed": {
+      return makeCodexResultEvent({
+        event,
+        success: true,
+        result: "",
+        usage: codexEvent?.usage,
+      });
+    }
+    case "turn.failed": {
+      return makeCodexResultEvent({
+        event,
+        success: false,
+        result: codexEvent?.error ?? "Turn failed",
+        usage: codexEvent?.usage,
+      });
+    }
+    case "error": {
+      return makeCodexResultEvent({
+        event,
+        success: false,
+        result: codexEvent?.message ?? codexEvent?.error ?? "Codex error",
+        usage: codexEvent?.usage,
+      });
+    }
+    default: {
+      return event;
+    }
+  }
+}
+
+function normalizeCodexCommandEvent(
+  event: AgentEvent,
+  codexType: string,
+  item: CodexItem,
+): AgentEvent | null {
+  if (codexType === "item.started" && item.command) {
+    return makeCodexToolUseEvent({
+      event,
+      item,
+      toolName: "Bash",
+      input: { command: item.command },
+    });
+  }
+
+  if (codexType === "item.completed") {
+    return makeCodexToolResultEvent({
+      event,
+      item,
+      content: item.aggregated_output ?? item.output ?? "",
+      isError:
+        typeof item.exit_code === "number" ? item.exit_code !== 0 : false,
+    });
+  }
+
+  return null;
+}
+
+function normalizeCodexFileMutationEvent(
+  event: AgentEvent,
+  codexType: string,
+  item: CodexItem,
+): AgentEvent | null {
+  const toolName = item.type === "file_edit" ? "Edit" : "Write";
+  if (codexType === "item.started" && item.path) {
+    return makeCodexToolUseEvent({
+      event,
+      item,
+      toolName,
+      input: { file_path: item.path },
+    });
+  }
+
+  if (codexType === "item.completed") {
+    return makeCodexToolResultEvent({
+      event,
+      item,
+      content: item.diff ?? "File operation completed",
+    });
+  }
+
+  return null;
+}
+
+function normalizeCodexFileReadEvent(
+  event: AgentEvent,
+  codexType: string,
+  item: CodexItem,
+): AgentEvent | null {
+  if (codexType === "item.started" && item.path) {
+    return makeCodexToolUseEvent({
+      event,
+      item,
+      toolName: "Read",
+      input: { file_path: item.path },
+    });
+  }
+
+  if (codexType === "item.completed") {
+    return makeCodexToolResultEvent({
+      event,
+      item,
+      content: item.output ?? "File read completed",
+    });
+  }
+
+  return null;
+}
+
+function normalizeCodexItemEvent(
+  event: AgentEvent,
+  codexType: string,
+  item: CodexItem | undefined,
+): AgentEvent | null {
+  if (!item) {
+    return makeCodexAssistantTextEvent(
+      event,
+      formatGenericCodexItem(codexType, undefined),
+    );
+  }
+
+  switch (item.type) {
+    case "agent_message": {
+      return item.text
+        ? makeCodexAssistantTextEvent(event, item.text)
+        : makeCodexAssistantTextEvent(
+            event,
+            formatGenericCodexItem(codexType, item),
+          );
+    }
+    case "reasoning": {
+      return item.text
+        ? makeCodexAssistantTextEvent(event, `[thinking] ${item.text}`)
+        : makeCodexAssistantTextEvent(
+            event,
+            formatGenericCodexItem(codexType, item),
+          );
+    }
+    case "command_execution": {
+      return (
+        normalizeCodexCommandEvent(event, codexType, item) ??
+        makeCodexAssistantTextEvent(
+          event,
+          formatGenericCodexItem(codexType, item),
+        )
+      );
+    }
+    case "file_edit":
+    case "file_write": {
+      return (
+        normalizeCodexFileMutationEvent(event, codexType, item) ??
+        makeCodexAssistantTextEvent(
+          event,
+          formatGenericCodexItem(codexType, item),
+        )
+      );
+    }
+    case "file_read": {
+      return (
+        normalizeCodexFileReadEvent(event, codexType, item) ??
+        makeCodexAssistantTextEvent(
+          event,
+          formatGenericCodexItem(codexType, item),
+        )
+      );
+    }
+    case "file_change": {
+      return codexType === "item.completed"
+        ? makeCodexAssistantTextEvent(
+            event,
+            formatCodexFileChanges(item.changes ?? []),
+          )
+        : makeCodexAssistantTextEvent(
+            event,
+            formatGenericCodexItem(codexType, item),
+          );
+    }
+    default: {
+      return makeCodexAssistantTextEvent(
+        event,
+        formatGenericCodexItem(codexType, item),
+      );
+    }
+  }
+}
+
+function normalizeCodexEventForGrouping(event: AgentEvent): AgentEvent | null {
+  const codexEvent = parseCodexEventData(event.eventData);
+  const codexType = isCodexEventType(event.eventType)
+    ? event.eventType
+    : codexEvent?.type;
+
+  if (!codexType || !isCodexEventType(codexType)) {
+    return event;
+  }
+
+  if (codexType.startsWith("item.")) {
+    return normalizeCodexItemEvent(event, codexType, codexEvent?.item);
+  }
+
+  return normalizeCodexRunEvent(event, codexType, codexEvent);
+}
+
 /**
  * Shape of task-related system event data (task_started, task_notification, task_progress).
  */
@@ -627,7 +1135,11 @@ export function groupEventsIntoMessages(
     taskByToolUseId: new Map(),
   };
 
-  for (const event of deduped) {
+  for (const rawEvent of deduped) {
+    const event = normalizeCodexEventForGrouping(rawEvent);
+    if (!event) {
+      continue;
+    }
     const eventData = event.eventData as GroupingEventData;
 
     if (event.eventType === "system") {


### PR DESCRIPTION
## Summary

- Add a Codex JSONL display adapter for activity/log detail grouping while preserving raw telemetry.
- Render Codex thread, turn, item, tool, file, reasoning, assistant message, failure, and unknown item events into the existing timeline model.
- Add regression coverage for Codex happy path, failure/error events, unknown item fallback, and existing Claude grouping behavior.

Fixes #12178

## Validation

- `pnpm -F @vm0/app exec vitest src/views/activity/__tests__/log-detail-utils.test.ts`
- `pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-activity-detail-page-display.test.tsx src/views/activity/__tests__/activity-inspect-page.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm check-types` currently fails on pre-existing `@vm0/app` type errors outside this PR; the changed files are not present in the typecheck error output.
