### PR TITLE
fix(ci): stop preview runner before cleanup

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1542,6 +1542,25 @@ jobs:
             local REMOTE="${METAL_USER}@${HOST}"
             echo "=== Preparing ${HOST} (runner: ${RUNNER_NAME}) ==="
 
+            # Stop the old service before deleting its runner directory. A live
+            # runner can keep claiming jobs after its base_dir disappears.
+            if ! ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${RUNNER_NAME}" <<'REMOTE_SCRIPT'
+          set -euo pipefail
+          BIN_DIR=$1
+          RUNNER_NAME=$2
+          UNIT="vm0-runner-${RUNNER_NAME}.service"
+
+          if [ -x "${BIN_DIR}/runner" ]; then
+            sudo "${BIN_DIR}/runner" service stop --name "${RUNNER_NAME}" --force
+          else
+            sudo systemctl stop "${UNIT}" 2>/dev/null || true
+            sudo systemctl reset-failed "${UNIT}" 2>/dev/null || true
+          fi
+          REMOTE_SCRIPT
+            then
+              return 1
+            fi
+
             # Clean previous run artifacts and upload runner (guests are embedded)
             # shellcheck disable=SC2029
             if ! ssh "$REMOTE" "sudo rm -rf ${BIN_DIR} ${RUNNER_DIR} && sudo mkdir -p ${BIN_DIR}"; then

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1554,8 +1554,14 @@ jobs:
             sudo "${BIN_DIR}/runner" service stop --name "${RUNNER_NAME}" --force
           else
             sudo systemctl stop "${UNIT}" 2>/dev/null || true
-            sudo systemctl reset-failed "${UNIT}" 2>/dev/null || true
           fi
+
+          if sudo systemctl is-active --quiet "${UNIT}" 2>/dev/null; then
+            echo "runner service ${UNIT} is still active after stop" >&2
+            exit 1
+          fi
+
+          sudo systemctl reset-failed "${UNIT}" 2>/dev/null || true
           REMOTE_SCRIPT
             then
               return 1


### PR DESCRIPTION
## Summary

- stop the existing per-host preview runner service during `deploy-runner-prepare` before deleting `${BIN_DIR}` or `${RUNNER_DIR}`
- use the old runner CLI when available, and fall back to direct `systemctl stop` / `reset-failed` when the old binary is absent
- keep the later start-stage stop as an idempotent guard

Fixes #12183.

## Testing

- `./actionlint .github/workflows/turbo.yml`
- `git diff --check`
