### PR TITLE
fix: wait for terminal axiom events on read paths

### DIFF
--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -120,7 +120,6 @@ describe("run command", () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
@@ -1090,7 +1089,6 @@ describe("run command", () => {
     });
 
     it("should drain terminal events that become visible after completion", async () => {
-      vi.useFakeTimers();
       let pollCount = 0;
       server.use(
         http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
@@ -1148,14 +1146,7 @@ describe("run command", () => {
         }),
       );
 
-      const commandPromise = runCommand.parseAsync([
-        "node",
-        "cli",
-        testUuid,
-        "test prompt",
-      ]);
-      await vi.advanceTimersByTimeAsync(500);
-      await commandPromise;
+      await runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]);
 
       expect(pollCount).toBe(2);
       expect(mockConsoleLog).toHaveBeenCalledWith(
@@ -1173,7 +1164,7 @@ describe("run command", () => {
       });
       expect(resultIndex).toBeGreaterThan(-1);
       expect(completionIndex).toBeGreaterThan(resultIndex);
-    });
+    }, 5_000);
 
     it("should not idle drain after result is visible before completion", async () => {
       let pollCount = 0;
@@ -1445,7 +1436,6 @@ describe("run command", () => {
     });
 
     it("should wait for terminal watermark instead of exiting on idle", async () => {
-      vi.useFakeTimers();
       let pollCount = 0;
       server.use(
         http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
@@ -1505,14 +1495,7 @@ describe("run command", () => {
         }),
       );
 
-      const commandPromise = runCommand.parseAsync([
-        "node",
-        "cli",
-        testUuid,
-        "test prompt",
-      ]);
-      await vi.advanceTimersByTimeAsync(1500);
-      await commandPromise;
+      await runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]);
 
       expect(pollCount).toBe(4);
       expect(mockConsoleLog).toHaveBeenCalledWith(
@@ -1521,7 +1504,7 @@ describe("run command", () => {
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("Run completed successfully"),
       );
-    });
+    }, 6_000);
 
     it("should return when terminal watermark was already reached before completion", async () => {
       let pollCount = 0;
@@ -1678,7 +1661,6 @@ describe("run command", () => {
     });
 
     it("should bound terminal drain when a sequence gap never fills", async () => {
-      vi.useFakeTimers();
       let pollCount = 0;
       server.use(
         http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
@@ -1732,14 +1714,7 @@ describe("run command", () => {
         }),
       );
 
-      const commandPromise = runCommand.parseAsync([
-        "node",
-        "cli",
-        testUuid,
-        "test prompt",
-      ]);
-      await vi.advanceTimersByTimeAsync(4000);
-      await commandPromise;
+      await runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]);
 
       expect(pollCount).toBeGreaterThan(2);
       expect(mockConsoleLog).toHaveBeenCalledWith(
@@ -1748,10 +1723,9 @@ describe("run command", () => {
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("Run completed successfully"),
       );
-    });
+    }, 7_000);
 
     it("should bound terminal drain when terminal watermark never becomes visible", async () => {
-      vi.useFakeTimers();
       let pollCount = 0;
       server.use(
         http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
@@ -1775,20 +1749,13 @@ describe("run command", () => {
         }),
       );
 
-      const commandPromise = runCommand.parseAsync([
-        "node",
-        "cli",
-        testUuid,
-        "test prompt",
-      ]);
-      await vi.advanceTimersByTimeAsync(4000);
-      await commandPromise;
+      await runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]);
 
       expect(pollCount).toBeGreaterThan(2);
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("Run completed successfully"),
       );
-    });
+    }, 7_000);
 
     it("should render the latest terminal status after drain", async () => {
       let pollCount = 0;
@@ -2028,7 +1995,6 @@ describe("run command", () => {
     });
 
     it("should wait for terminal watermark before rendering failed run", async () => {
-      vi.useFakeTimers();
       let pollCount = 0;
       server.use(
         http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
@@ -2077,7 +2043,6 @@ describe("run command", () => {
       const commandPromise = expect(
         runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]),
       ).rejects.toThrow("process.exit called");
-      await vi.advanceTimersByTimeAsync(500);
       await commandPromise;
 
       expect(pollCount).toBe(2);
@@ -2087,7 +2052,7 @@ describe("run command", () => {
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Run failed"),
       );
-    });
+    }, 5_000);
 
     it("should exit immediately when run is cancelled without terminal watermark", async () => {
       let pollCount = 0;
@@ -2141,7 +2106,6 @@ describe("run command", () => {
     });
 
     it("should bound terminal drain when completed has no result event or watermark", async () => {
-      vi.useFakeTimers();
       let pollCount = 0;
       server.use(
         http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
@@ -2164,14 +2128,7 @@ describe("run command", () => {
         }),
       );
 
-      const commandPromise = runCommand.parseAsync([
-        "node",
-        "cli",
-        testUuid,
-        "test prompt",
-      ]);
-      await vi.advanceTimersByTimeAsync(1000);
-      await commandPromise;
+      await runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]);
 
       expect(pollCount).toBeGreaterThan(1);
       expect(mockConsoleLog).toHaveBeenCalledWith(
@@ -2180,7 +2137,7 @@ describe("run command", () => {
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("Checkpoint:"),
       );
-    });
+    }, 5_000);
   });
 
   describe("org error handling", () => {

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { GET } from "../route";
 import {
   createTestRequest,
@@ -14,6 +14,7 @@ import {
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
+import { reloadEnv } from "../../../../../../../src/env";
 
 // Only mock external services
 
@@ -284,6 +285,39 @@ describe("GET /api/agent/runs/:id/events", () => {
       const apl = context.mocks.axiom.queryAxiom.mock.calls[0]![0];
       expect(apl).toContain("sequenceNumber > 2");
       expect(apl).not.toContain("project sequenceNumber");
+    });
+
+    it("should wait only for the current page terminal watermark target", async () => {
+      vi.stubEnv("AXIOM_TOKEN_SESSIONS", "test-sessions-token");
+      reloadEnv();
+      context.mocks.axiom.queryAxiom
+        .mockResolvedValueOnce([{ sequenceNumber: 0 }])
+        .mockResolvedValueOnce([
+          createAxiomAgentEvent({
+            runId: testRunId,
+            sequenceNumber: 0,
+            eventType: "assistant",
+            eventData: { type: "assistant" },
+          }),
+        ]);
+
+      await completeTestRun(user.userId, testRunId, undefined, {
+        lastEventSequence: 50,
+      });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${testRunId}/events?since=-1&limit=1`,
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledTimes(2);
+      const visibilityApl = context.mocks.axiom.queryAxiom.mock.calls[0]![0];
+      expect(visibilityApl).toContain("project sequenceNumber");
+      expect(visibilityApl).toContain("sequenceNumber > -1");
+      const eventsApl = context.mocks.axiom.queryAxiom.mock.calls[1]![0];
+      expect(eventsApl).toContain("limit 1");
     });
   });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
@@ -317,6 +317,9 @@ describe("GET /api/agent/runs/:id/events", () => {
       expect(visibilityApl).toContain("project sequenceNumber");
       expect(visibilityApl).toContain("sequenceNumber > -1");
       const eventsApl = context.mocks.axiom.queryAxiom.mock.calls[1]![0];
+      expect(context.mocks.axiom.queryAxiom.mock.calls[1]![1]).toMatchObject({
+        noCache: true,
+      });
       expect(eventsApl).toContain("limit 1");
     });
   });

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
@@ -265,6 +265,26 @@ describe("GET /api/agent/runs/:id/events", () => {
       expect(data.run.status).toBe("completed");
       expect(data.run.lastEventSequence).toBe(0);
     });
+
+    it("should not wait for terminal watermark when since already reached it", async () => {
+      context.mocks.axiom.queryAxiom.mockResolvedValue([]);
+
+      await completeTestRun(user.userId, testRunId, undefined, {
+        lastEventSequence: 2,
+      });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${testRunId}/events?since=2`,
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledTimes(1);
+      const apl = context.mocks.axiom.queryAxiom.mock.calls[0]![0];
+      expect(apl).toContain("sequenceNumber > 2");
+      expect(apl).not.toContain("project sequenceNumber");
+    });
   });
 
   // ============================================

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
@@ -23,7 +23,10 @@ import type {
 } from "../../../../../../src/lib/infra/run/types";
 import { extractFrameworkFromCompose } from "../../../../../../src/lib/infra/framework/framework-config";
 import { filterConsecutiveEvents, type AxiomAgentEvent } from "./filter-events";
-import { waitForRunEventWatermarkVisible } from "../../../../../../src/lib/infra/run/agent-event-visibility";
+import {
+  getAgentEventPageWatermarkTarget,
+  waitForRunEventWatermarkVisible,
+} from "../../../../../../src/lib/infra/run/agent-event-visibility";
 
 const router = tsr.router(runEventsContract, {
   getEvents: async ({ params, query, headers }) => {
@@ -91,14 +94,13 @@ const router = tsr.router(runEventsContract, {
         >[0],
       ) ?? "claude-code";
 
-    if (
-      runWithCompose.lastEventSequence !== null &&
-      since < runWithCompose.lastEventSequence
-    ) {
-      await waitForRunEventWatermarkVisible(
-        params.id,
-        runWithCompose.lastEventSequence,
-      );
+    const watermarkTarget = getAgentEventPageWatermarkTarget(
+      runWithCompose.lastEventSequence,
+      since,
+      limit,
+    );
+    if (watermarkTarget !== null) {
+      await waitForRunEventWatermarkVisible(params.id, watermarkTarget);
     }
 
     // Build APL query for Axiom

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
@@ -14,6 +14,7 @@ import {
   queryAxiom,
   getDatasetName,
   DATASETS,
+  escapeAplString,
 } from "../../../../../../src/lib/shared/axiom";
 import type {
   RunStatus,
@@ -22,6 +23,7 @@ import type {
 } from "../../../../../../src/lib/infra/run/types";
 import { extractFrameworkFromCompose } from "../../../../../../src/lib/infra/framework/framework-config";
 import { filterConsecutiveEvents, type AxiomAgentEvent } from "./filter-events";
+import { waitForRunEventWatermarkVisible } from "../../../../../../src/lib/infra/run/agent-event-visibility";
 
 const router = tsr.router(runEventsContract, {
   getEvents: async ({ params, query, headers }) => {
@@ -89,10 +91,20 @@ const router = tsr.router(runEventsContract, {
         >[0],
       ) ?? "claude-code";
 
+    if (
+      runWithCompose.lastEventSequence !== null &&
+      since < runWithCompose.lastEventSequence
+    ) {
+      await waitForRunEventWatermarkVisible(
+        params.id,
+        runWithCompose.lastEventSequence,
+      );
+    }
+
     // Build APL query for Axiom
     const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
     const apl = `['${dataset}']
-| where runId == "${params.id}"
+| where runId == "${escapeAplString(params.id)}"
 | where sequenceNumber > ${since}
 | order by sequenceNumber asc
 | limit ${limit}`;

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
@@ -102,6 +102,8 @@ const router = tsr.router(runEventsContract, {
     if (watermarkTarget !== null) {
       await waitForRunEventWatermarkVisible(params.id, watermarkTarget);
     }
+    const axiomQueryOptions =
+      watermarkTarget !== null ? ({ noCache: true } as const) : undefined;
 
     // Build APL query for Axiom
     const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
@@ -112,7 +114,9 @@ const router = tsr.router(runEventsContract, {
 | limit ${limit}`;
 
     // Query Axiom for agent events
-    const rawEvents = await queryAxiom<AxiomAgentEvent>(apl);
+    const rawEvents = axiomQueryOptions
+      ? await queryAxiom<AxiomAgentEvent>(apl, axiomQueryOptions)
+      : await queryAxiom<AxiomAgentEvent>(apl);
 
     // Filter to only consecutive events to handle Axiom's eventual consistency.
     const events = filterConsecutiveEvents(rawEvents, since);

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
+  completeTestRun,
 } from "../../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -11,6 +12,7 @@ import {
 } from "../../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
+import { reloadEnv } from "../../../../../../../../src/env";
 
 // Only mock external services
 vi.mock("@clerk/nextjs/server");
@@ -318,6 +320,41 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
       expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledWith(
         expect.stringContaining(`where sequenceNumber > ${sinceSequence}`),
       );
+    });
+
+    it("should wait only for the current asc page terminal watermark target", async () => {
+      vi.stubEnv("AXIOM_TOKEN_SESSIONS", "test-sessions-token");
+      reloadEnv();
+      context.mocks.axiom.queryAxiom
+        .mockResolvedValueOnce([{ sequenceNumber: 0 }])
+        .mockResolvedValueOnce([
+          createAxiomAgentEvent(
+            "2024-01-01T00:00:00Z",
+            0,
+            "event0",
+            { type: "event0" },
+            testRunId,
+          ),
+        ]);
+
+      await completeTestRun(user.userId, testRunId, undefined, {
+        lastEventSequence: 50,
+      });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/agent?order=asc&limit=1`,
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledTimes(2);
+      const visibilityApl = context.mocks.axiom.queryAxiom.mock.calls[0]![0];
+      expect(visibilityApl).toContain("project sequenceNumber");
+      expect(visibilityApl).toContain("sequenceNumber > -1");
+      const eventsApl = context.mocks.axiom.queryAxiom.mock.calls[1]![0];
+      expect(eventsApl).toContain("order by sequenceNumber asc");
+      expect(eventsApl).toContain("limit 2");
     });
   });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/__tests__/route.test.ts
@@ -363,6 +363,9 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
       expect(visibilityApl).toContain("project sequenceNumber");
       expect(visibilityApl).toContain("sequenceNumber > -1");
       const eventsApl = context.mocks.axiom.queryAxiom.mock.calls[1]![0];
+      expect(context.mocks.axiom.queryAxiom.mock.calls[1]![1]).toMatchObject({
+        noCache: true,
+      });
       expect(eventsApl).toContain("order by sequenceNumber asc");
       expect(eventsApl).toContain("limit 2");
     });
@@ -412,6 +415,9 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
       const visibilityApl = context.mocks.axiom.queryAxiom.mock.calls[0]![0];
       expect(visibilityApl).toContain("project sequenceNumber");
       const eventsApl = context.mocks.axiom.queryAxiom.mock.calls[1]![0];
+      expect(context.mocks.axiom.queryAxiom.mock.calls[1]![1]).toMatchObject({
+        noCache: true,
+      });
       expect(eventsApl).toContain("order by sequenceNumber desc");
       expect(eventsApl).toContain("limit 2");
     });

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/__tests__/route.test.ts
@@ -326,13 +326,20 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
       vi.stubEnv("AXIOM_TOKEN_SESSIONS", "test-sessions-token");
       reloadEnv();
       context.mocks.axiom.queryAxiom
-        .mockResolvedValueOnce([{ sequenceNumber: 0 }])
+        .mockResolvedValueOnce([{ sequenceNumber: 0 }, { sequenceNumber: 1 }])
         .mockResolvedValueOnce([
           createAxiomAgentEvent(
             "2024-01-01T00:00:00Z",
             0,
             "event0",
             { type: "event0" },
+            testRunId,
+          ),
+          createAxiomAgentEvent(
+            "2024-01-01T00:00:01Z",
+            1,
+            "event1",
+            { type: "event1" },
             testRunId,
           ),
         ]);
@@ -348,6 +355,9 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
       const response = await GET(request);
 
       expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.events).toHaveLength(1);
+      expect(data.hasMore).toBe(true);
       expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledTimes(2);
       const visibilityApl = context.mocks.axiom.queryAxiom.mock.calls[0]![0];
       expect(visibilityApl).toContain("project sequenceNumber");

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/__tests__/route.test.ts
@@ -366,6 +366,55 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
       expect(eventsApl).toContain("order by sequenceNumber asc");
       expect(eventsApl).toContain("limit 2");
     });
+
+    it("should wait for terminal watermark before default desc pagination", async () => {
+      vi.stubEnv("AXIOM_TOKEN_SESSIONS", "test-sessions-token");
+      reloadEnv();
+      context.mocks.axiom.queryAxiom
+        .mockResolvedValueOnce(
+          Array.from({ length: 51 }, (_, sequenceNumber) => {
+            return { sequenceNumber };
+          }),
+        )
+        .mockResolvedValueOnce([
+          createAxiomAgentEvent(
+            "2024-01-01T00:00:50Z",
+            50,
+            "result",
+            { type: "result" },
+            testRunId,
+          ),
+          createAxiomAgentEvent(
+            "2024-01-01T00:00:49Z",
+            49,
+            "assistant",
+            { type: "assistant" },
+            testRunId,
+          ),
+        ]);
+
+      await completeTestRun(user.userId, testRunId, undefined, {
+        lastEventSequence: 50,
+      });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/agent?limit=1`,
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.events).toHaveLength(1);
+      expect(data.events[0].sequenceNumber).toBe(50);
+      expect(data.hasMore).toBe(true);
+      expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledTimes(2);
+      const visibilityApl = context.mocks.axiom.queryAxiom.mock.calls[0]![0];
+      expect(visibilityApl).toContain("project sequenceNumber");
+      const eventsApl = context.mocks.axiom.queryAxiom.mock.calls[1]![0];
+      expect(eventsApl).toContain("order by sequenceNumber desc");
+      expect(eventsApl).toContain("limit 2");
+    });
   });
 
   describe("Event Data", () => {

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/route.ts
@@ -13,6 +13,7 @@ import {
   queryAxiom,
   getDatasetName,
   DATASETS,
+  escapeAplString,
 } from "../../../../../../../src/lib/shared/axiom";
 interface AxiomMetricEvent {
   _time: string;
@@ -74,7 +75,7 @@ const router = tsr.router(runMetricsContract, {
       ? `| where _time > datetime("${new Date(since).toISOString()}")`
       : "";
     const apl = `['${dataset}']
-| where runId == "${params.id}"
+| where runId == "${escapeAplString(params.id)}"
 ${sinceFilter}
 | order by _time ${order}
 | limit ${limit + 1}`;

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
@@ -14,6 +14,7 @@ import {
   queryAxiom,
   getDatasetName,
   DATASETS,
+  escapeAplString,
 } from "../../../../../../../src/lib/shared/axiom";
 
 const router = tsr.router(runNetworkLogsContract, {
@@ -65,7 +66,7 @@ const router = tsr.router(runNetworkLogsContract, {
       ? `| where _time > datetime("${new Date(since).toISOString()}")`
       : "";
     const apl = `['${dataset}']
-| where runId == "${params.id}"
+| where runId == "${escapeAplString(params.id)}"
 ${sinceFilter}
 | order by _time ${order}
 | limit ${limit + 1}`;

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/route.ts
@@ -13,6 +13,7 @@ import {
   queryAxiom,
   getDatasetName,
   DATASETS,
+  escapeAplString,
 } from "../../../../../../../src/lib/shared/axiom";
 interface AxiomSystemLogEvent {
   _time: string;
@@ -70,7 +71,7 @@ const router = tsr.router(runSystemLogContract, {
       ? `| where _time > datetime("${new Date(since).toISOString()}")`
       : "";
     const apl = `['${dataset}']
-| where runId == "${params.id}"
+| where runId == "${escapeAplString(params.id)}"
 ${sinceFilter}
 | order by _time ${order}
 | limit ${limit + 1}`;

--- a/turbo/apps/web/app/api/internal/callbacks/agent/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/agent/route.ts
@@ -31,13 +31,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // Only generate summary on successful completion
   if (status === "completed") {
     const [run] = await globalThis.services.db
-      .select({ prompt: agentRuns.prompt })
+      .select({
+        prompt: agentRuns.prompt,
+        lastEventSequence: agentRuns.lastEventSequence,
+      })
       .from(agentRuns)
       .where(eq(agentRuns.id, runId))
       .limit(1);
 
     if (run) {
-      const resultText = await getRunOutputText(runId);
+      const resultText = await getRunOutputText(runId, run.lastEventSequence);
       await saveRunSummary(runId, "agent", run.prompt, resultText ?? "");
     }
   }

--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -97,7 +97,9 @@ async function queryChatOutputEvents(
 | order by sequenceNumber asc
 | limit 200`;
 
-  const events = await queryAxiom<AxiomChatOutputEvent>(apl);
+  const events = await queryAxiom<AxiomChatOutputEvent>(apl, {
+    noCache: true,
+  });
 
   const assistantItems: AssistantEventItem[] = [];
   let resultFallback: ResultEventItem | null = null;

--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -28,7 +28,9 @@ import {
   flushAxiom,
   getDatasetName,
   DATASETS,
+  escapeAplString,
 } from "../../../../../src/lib/shared/axiom";
+import { waitForRunEventWatermarkVisible } from "../../../../../src/lib/infra/run/agent-event-visibility";
 import type { ChatCallbackPayload } from "../../../../../src/lib/infra/callback/callback-payloads";
 import { logger } from "../../../../../src/lib/shared/logger";
 
@@ -83,9 +85,11 @@ async function queryChatOutputEvents(runId: string): Promise<{
   assistantItems: AssistantEventItem[];
   resultFallback: ResultEventItem | null;
 }> {
+  await waitForRunEventWatermarkVisible(runId);
+
   const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
   const apl = `['${dataset}']
-| where runId == "${runId}"
+| where runId == "${escapeAplString(runId)}"
 | where eventType == "assistant" or eventType == "result" or eventType == "item.completed"
 | order by sequenceNumber asc
 | limit 200`;

--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -81,11 +81,14 @@ interface ResultEventItem {
  * source; a result event is kept only as a fallback for result-only CLI
  * outputs such as Claude Code slash-command messages.
  */
-async function queryChatOutputEvents(runId: string): Promise<{
+async function queryChatOutputEvents(
+  runId: string,
+  lastEventSequence: number | null,
+): Promise<{
   assistantItems: AssistantEventItem[];
   resultFallback: ResultEventItem | null;
 }> {
-  await waitForRunEventWatermarkVisible(runId);
+  await waitForRunEventWatermarkVisible(runId, lastEventSequence);
 
   const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
   const apl = `['${dataset}']
@@ -260,13 +263,17 @@ async function handleCompleted(
   prompt: string,
   threadId: string,
   userId: string,
+  lastEventSequence: number | null,
 ): Promise<void> {
   // Final sweep: re-query Axiom and insert any assistant output the live
   // consumer missed. Result-only CLI output is inserted only when no assistant
   // output exists for the run. Inserts are idempotent via the
   // `(run_id, sequence_number)` unique index, so concurrent writes from the
   // consumer and this sweep cannot produce duplicates.
-  const { assistantItems, resultFallback } = await queryChatOutputEvents(runId);
+  const { assistantItems, resultFallback } = await queryChatOutputEvents(
+    runId,
+    lastEventSequence,
+  );
   if (assistantItems.length > 0) {
     await insertAssistantEventMessages(runId, threadId, userId, assistantItems);
   }
@@ -398,6 +405,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     .select({
       prompt: agentRuns.prompt,
       error: agentRuns.error,
+      lastEventSequence: agentRuns.lastEventSequence,
     })
     .from(agentRuns)
     .where(eq(agentRuns.id, runId))
@@ -431,6 +439,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       run.prompt,
       chatThread.chatThreadId,
       chatThread.userId,
+      run.lastEventSequence,
     );
   } else if (status === "failed") {
     const errorMessage = error ?? run.error ?? "Run failed";

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
@@ -89,6 +89,7 @@ async function givenGitHubCallbackSetup(overrides?: {
 
   const { runId } = await seedTestRun(userId, composeId, {
     prompt: "Test GitHub prompt",
+    lastEventSequence: 0,
   });
   const installation = await insertTestGitHubInstallation(composeId);
 
@@ -260,6 +261,7 @@ describe("POST /api/internal/callbacks/github/issues", () => {
       expect(capturedComments[0]!.issueNumber).toBe("42");
       expect(capturedComments[0]!.body).not.toContain("Audit");
       expect(capturedComments[0]!.body).not.toContain(`/activities/${runId}`);
+      expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledTimes(1);
     });
 
     it("should include audit link when AuditLink switch is on", async () => {

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
@@ -22,6 +22,7 @@ import { POST } from "../route";
 import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
 import { seedUserFeatureSwitches } from "../../../../../../../src/__tests__/db-test-seeders/feature-switches";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { reloadEnv } from "../../../../../../../src/env";
 
 const context = testContext();
 
@@ -203,12 +204,22 @@ describe("POST /api/internal/callbacks/slack/org", () => {
   });
 
   it("posts completion message to Slack thread", async () => {
+    vi.stubEnv("AXIOM_TOKEN_SESSIONS", "test-sessions-token");
+    reloadEnv();
+
     const { workspaceId, connectionId } = await setupOrgSlack();
     const { composeId } = await createTestCompose(uniqueId("agent"));
     const { runId } = await seedTestRun(user.userId, composeId, {
       prompt: "Test prompt",
     });
-    await completeTestRun(user.userId, runId);
+    context.mocks.axiom.queryAxiom
+      .mockResolvedValueOnce([{ sequenceNumber: 0 }])
+      .mockResolvedValueOnce([
+        { eventData: { result: "HELLO_FROM_CALLBACK" } },
+      ]);
+    await completeTestRun(user.userId, runId, undefined, {
+      lastEventSequence: 0,
+    });
 
     const channelId = uniqueId("C-ch");
     const threadTs = uniqueId("ts");
@@ -245,9 +256,15 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     expect(mockClient.chat.postMessage).toHaveBeenCalled();
     const call = (
       mockClient.chat.postMessage as ReturnType<typeof import("vitest").vi.fn>
-    ).mock.calls[0]![0] as { channel: string; thread_ts: string };
+    ).mock.calls[0]![0] as {
+      channel: string;
+      thread_ts: string;
+      text: string;
+    };
     expect(call.channel).toBe(channelId);
     expect(call.thread_ts).toBe(threadTs);
+    expect(call.text).toContain("HELLO_FROM_CALLBACK");
+    expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledTimes(2);
   });
 
   it("posts Codex agent_message output instead of the completion fallback", async () => {

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
@@ -306,17 +306,22 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   );
   const client = createSlackClient(botToken);
 
-  const allOutputs = await extractAllRunOutputs(runId, error);
-
   const [runContext] = await globalThis.services.db
     .select({
       userId: agentRuns.userId,
       orgId: agentRuns.orgId,
       prompt: agentRuns.prompt,
+      lastEventSequence: agentRuns.lastEventSequence,
     })
     .from(agentRuns)
     .where(eq(agentRuns.id, runId))
     .limit(1);
+
+  const allOutputs = await extractAllRunOutputs(
+    runId,
+    error,
+    runContext?.lastEventSequence,
+  );
 
   const selectedModel = await resolveSelectedModel(runId);
 

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
@@ -200,6 +200,17 @@ async function handleCompletion(ctx: CompletionContext): Promise<void> {
   // Send typing indicator while building response
   await sendChatAction(client, chatId, "typing");
 
+  const [run] = await globalThis.services.db
+    .select({
+      userId: agentRuns.userId,
+      orgId: agentRuns.orgId,
+      createdAt: agentRuns.createdAt,
+      lastEventSequence: agentRuns.lastEventSequence,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+
   // Query Axiom for the agent's output
   if (status === "failed") {
     log.error("Agent run failed", {
@@ -209,17 +220,11 @@ async function handleCompletion(ctx: CompletionContext): Promise<void> {
       error,
     });
   }
-  const runOutput = await extractRunOutput(runId, error);
-
-  const [run] = await globalThis.services.db
-    .select({
-      userId: agentRuns.userId,
-      orgId: agentRuns.orgId,
-      createdAt: agentRuns.createdAt,
-    })
-    .from(agentRuns)
-    .where(eq(agentRuns.id, runId))
-    .limit(1);
+  const runOutput = await extractRunOutput(
+    runId,
+    error,
+    run?.lastEventSequence,
+  );
 
   // Build response text
   const logsUrl = run

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat-candidate/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat-candidate/route.ts
@@ -29,26 +29,31 @@ function parsePayload(payload: unknown): VoiceChatCallbackPayload | null {
   return { taskId: p.taskId };
 }
 
-async function readRunAgentId(runId: string): Promise<string> {
+async function readRunInfo(
+  runId: string,
+): Promise<{ agentId: string; lastEventSequence: number | null }> {
   const [run] = await globalThis.services.db
-    .select({ vars: agentRuns.vars })
+    .select({
+      vars: agentRuns.vars,
+      lastEventSequence: agentRuns.lastEventSequence,
+    })
     .from(agentRuns)
     .where(eq(agentRuns.id, runId))
     .limit(1);
 
   if (!run) {
     log.warn("run not found while resolving ZERO_AGENT_ID", { runId });
-    return "";
+    return { agentId: "", lastEventSequence: null };
   }
 
   const vars = run.vars as { ZERO_AGENT_ID?: unknown } | null;
   const zeroAgentId = vars?.ZERO_AGENT_ID;
   if (typeof zeroAgentId !== "string" || zeroAgentId.length === 0) {
     log.warn("vars.ZERO_AGENT_ID absent on run", { runId });
-    return "";
+    return { agentId: "", lastEventSequence: run.lastEventSequence };
   }
 
-  return zeroAgentId;
+  return { agentId: zeroAgentId, lastEventSequence: run.lastEventSequence };
 }
 
 /**
@@ -78,14 +83,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ success: true });
   }
 
-  const agentId = await readRunAgentId(runId);
+  const run = await readRunInfo(runId);
 
   const resultText =
     status === "completed"
-      ? await getRunOutputText(runId).catch((err: unknown) => {
-          log.warn("Failed to extract run output text", { runId, err });
-          return undefined;
-        })
+      ? await getRunOutputText(runId, run.lastEventSequence).catch(
+          (err: unknown) => {
+            log.warn("Failed to extract run output text", { runId, err });
+            return undefined;
+          },
+        )
       : undefined;
   const errorText = status === "failed" ? (error ?? "Run failed") : null;
 
@@ -97,7 +104,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       taskId: payload.taskId,
       result: resultText ?? null,
       error: errorText,
-      agentId,
+      agentId: run.agentId,
     });
     sessionId = outcome.session.id;
     userId = outcome.session.userId;

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat/route.ts
@@ -22,26 +22,31 @@ function parsePayload(payload: unknown): VoiceChatCallbackPayload | null {
   return { taskId: p.taskId };
 }
 
-async function readRunAgentId(runId: string): Promise<string> {
+async function readRunInfo(
+  runId: string,
+): Promise<{ agentId: string; lastEventSequence: number | null }> {
   const [run] = await globalThis.services.db
-    .select({ vars: agentRuns.vars })
+    .select({
+      vars: agentRuns.vars,
+      lastEventSequence: agentRuns.lastEventSequence,
+    })
     .from(agentRuns)
     .where(eq(agentRuns.id, runId))
     .limit(1);
 
   if (!run) {
     log.warn("run not found while resolving ZERO_AGENT_ID", { runId });
-    return "";
+    return { agentId: "", lastEventSequence: null };
   }
 
   const vars = run.vars as { ZERO_AGENT_ID?: unknown } | null;
   const zeroAgentId = vars?.ZERO_AGENT_ID;
   if (typeof zeroAgentId !== "string" || zeroAgentId.length === 0) {
     log.warn("vars.ZERO_AGENT_ID absent on run", { runId });
-    return "";
+    return { agentId: "", lastEventSequence: run.lastEventSequence };
   }
 
-  return zeroAgentId;
+  return { agentId: zeroAgentId, lastEventSequence: run.lastEventSequence };
 }
 
 /**
@@ -71,14 +76,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ success: true });
   }
 
-  const agentId = await readRunAgentId(runId);
+  const run = await readRunInfo(runId);
 
   const resultText =
     status === "completed"
-      ? await getRunOutputText(runId).catch((err: unknown) => {
-          log.warn("Failed to extract run output text", { runId, err });
-          return undefined;
-        })
+      ? await getRunOutputText(runId, run.lastEventSequence).catch(
+          (err: unknown) => {
+            log.warn("Failed to extract run output text", { runId, err });
+            return undefined;
+          },
+        )
       : undefined;
   const errorText = status === "failed" ? (error ?? "Run failed") : null;
 
@@ -89,7 +96,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       taskId: payload.taskId,
       result: resultText ?? null,
       error: errorText,
-      agentId,
+      agentId: run.agentId,
     });
     sessionId = outcome.session.id;
     userId = outcome.session.userId;

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -323,7 +323,7 @@ describe("POST /api/webhooks/agent/complete", () => {
       expect(data.status).toBe("completed");
     });
 
-    it("should persist lastEventSequence without waiting for Axiom visibility", async () => {
+    it("should persist lastEventSequence without waiting in the response path", async () => {
       await createCheckpoint();
 
       const request = createTestRequest(
@@ -348,6 +348,9 @@ describe("POST /api/webhooks/agent/complete", () => {
       const run = await findTestRunRecord(testRunId);
       expect(run!.status).toBe("completed");
       expect(run!.lastEventSequence).toBe(2);
+
+      await context.mocks.flushAfter();
+
       expect(context.mocks.axiom.queryAxiom).not.toHaveBeenCalled();
     });
 

--- a/turbo/apps/web/app/api/zero/developer-support/route.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/route.ts
@@ -72,6 +72,7 @@ const router = tsr.router(zeroDeveloperSupportContract, {
         createdAt: agentRuns.createdAt,
         startedAt: agentRuns.startedAt,
         completedAt: agentRuns.completedAt,
+        lastEventSequence: agentRuns.lastEventSequence,
         agentComposeVersionId: agentRuns.agentComposeVersionId,
         runnerGroup: agentRuns.runnerGroup,
         continuedFromSessionId: agentRuns.continuedFromSessionId,

--- a/turbo/apps/web/app/api/zero/email/callbacks/reply/route.ts
+++ b/turbo/apps/web/app/api/zero/email/callbacks/reply/route.ts
@@ -146,22 +146,26 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ success: true, skipped: true });
   }
 
-  // Get run output
+  // Get run output and agentSessionId from run result for session continuity
   const logsUrl = await resolveEmailAuditLogsUrl({
     orgId,
     userId: session.userId,
     runId,
   });
-  const rawOutput =
-    status === "completed" ? ((await getRunOutputText(runId)) ?? null) : null;
-  const output = formatOutput(status, rawOutput, error);
-
-  // Get agentSessionId from run result for session continuity
   const [run] = await globalThis.services.db
-    .select({ result: agentRuns.result, prompt: agentRuns.prompt })
+    .select({
+      result: agentRuns.result,
+      prompt: agentRuns.prompt,
+      lastEventSequence: agentRuns.lastEventSequence,
+    })
     .from(agentRuns)
     .where(eq(agentRuns.id, runId))
     .limit(1);
+  const rawOutput =
+    status === "completed"
+      ? ((await getRunOutputText(runId, run?.lastEventSequence)) ?? null)
+      : null;
+  const output = formatOutput(status, rawOutput, error);
 
   const newAgentSessionId = extractAgentSessionId(run?.result);
 

--- a/turbo/apps/web/app/api/zero/email/callbacks/trigger/route.ts
+++ b/turbo/apps/web/app/api/zero/email/callbacks/trigger/route.ts
@@ -147,15 +147,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Get run output and session ID
   const logsUrl = await resolveEmailAuditLogsUrl({ orgId, userId, runId });
-  const rawOutput =
-    status === "completed" ? await getRunOutputText(runId) : null;
-  const output = formatOutput(status, rawOutput, error);
-
   const [run] = await globalThis.services.db
-    .select({ result: agentRuns.result, prompt: agentRuns.prompt })
+    .select({
+      result: agentRuns.result,
+      prompt: agentRuns.prompt,
+      lastEventSequence: agentRuns.lastEventSequence,
+    })
     .from(agentRuns)
     .where(eq(agentRuns.id, runId))
     .limit(1);
+  const rawOutput =
+    status === "completed"
+      ? await getRunOutputText(runId, run?.lastEventSequence)
+      : null;
+  const output = formatOutput(status, rawOutput, error);
 
   const agentSessionId = extractAgentSessionId(run?.result);
 

--- a/turbo/apps/web/app/api/zero/report-error/route.ts
+++ b/turbo/apps/web/app/api/zero/report-error/route.ts
@@ -41,6 +41,7 @@ const router = tsr.router(zeroReportErrorContract, {
         createdAt: agentRuns.createdAt,
         startedAt: agentRuns.startedAt,
         completedAt: agentRuns.completedAt,
+        lastEventSequence: agentRuns.lastEventSequence,
         agentComposeVersionId: agentRuns.agentComposeVersionId,
         runnerGroup: agentRuns.runnerGroup,
         continuedFromSessionId: agentRuns.continuedFromSessionId,

--- a/turbo/apps/web/app/api/zero/runs/[id]/network/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/network/route.ts
@@ -12,6 +12,7 @@ import {
   queryAxiom,
   getDatasetName,
   DATASETS,
+  escapeAplString,
 } from "../../../../../../src/lib/shared/axiom";
 
 const router = tsr.router(zeroRunNetworkLogsContract, {
@@ -43,7 +44,7 @@ const router = tsr.router(zeroRunNetworkLogsContract, {
       ? `| where _time > datetime("${new Date(since).toISOString()}")`
       : "";
     const apl = `['${dataset}']
-| where runId == "${params.id}"
+| where runId == "${escapeAplString(params.id)}"
 ${sinceFilter}
 | order by _time ${order}
 | limit ${limit + 1}`;

--- a/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/runs.ts
@@ -95,6 +95,7 @@ type CreateRunDirectOptions = {
   startedAt?: Date;
   completedAt?: Date;
   result?: Record<string, unknown>;
+  lastEventSequence?: number;
   additionalVolumes?: Array<{
     name: string;
     version?: string;
@@ -120,6 +121,7 @@ async function createRunDirect(
     startedAt,
     completedAt,
     result,
+    lastEventSequence,
     additionalVolumes = null,
   } = options;
   const sessionId = await ensureTestAgentSession({
@@ -142,6 +144,7 @@ async function createRunDirect(
       ...(startedAt ? { startedAt } : {}),
       ...(completedAt ? { completedAt } : {}),
       ...(result ? { result } : {}),
+      ...(lastEventSequence !== undefined ? { lastEventSequence } : {}),
     })
     .returning({ id: agentRuns.id });
 
@@ -180,6 +183,7 @@ export async function seedTestRun(
     startedAt?: Date;
     completedAt?: Date;
     result?: Record<string, unknown>;
+    lastEventSequence?: number;
     additionalVolumes?: Array<{
       name: string;
       version?: string;
@@ -235,6 +239,7 @@ export async function seedTestRun(
       startedAt: options?.startedAt,
       completedAt: options?.completedAt,
       result: options?.result,
+      lastEventSequence: options?.lastEventSequence,
       additionalVolumes: options?.additionalVolumes,
     },
   );

--- a/turbo/apps/web/src/lib/infra/run/__tests__/agent-event-visibility.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/agent-event-visibility.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import { waitForAgentEventPrefixVisible } from "../agent-event-visibility";
+
+describe("waitForAgentEventPrefixVisible", () => {
+  it("waits until Axiom exposes the contiguous prefix", async () => {
+    let now = 0;
+    const queryAxiomFn = vi
+      .fn()
+      .mockResolvedValueOnce([{ sequenceNumber: 0 }, { sequenceNumber: 2 }])
+      .mockResolvedValueOnce([{ sequenceNumber: 1 }, { sequenceNumber: 2 }]);
+
+    const result = await waitForAgentEventPrefixVisible("run-1", 2, {
+      timeoutMs: 1_000,
+      intervalMs: 10,
+      queryAxiomFn,
+      now: () => {
+        return now;
+      },
+      sleep: async (ms) => {
+        now += ms;
+      },
+    });
+
+    expect(result).toMatchObject({
+      visible: true,
+      visibleThrough: 2,
+      reason: "visible",
+    });
+    expect(queryAxiomFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses only sequenceNumber and does not require result events", async () => {
+    const queryAxiomFn = vi.fn().mockResolvedValue([
+      { sequenceNumber: 0, eventType: "tool_use" },
+      { sequenceNumber: 1, eventType: "user" },
+    ]);
+
+    const result = await waitForAgentEventPrefixVisible("run-1", 1, {
+      queryAxiomFn,
+    });
+
+    expect(result.visible).toBe(true);
+    expect(result.visibleThrough).toBe(1);
+  });
+
+  it("continues querying when the visible prefix spans multiple batches", async () => {
+    const queryAxiomFn = vi
+      .fn()
+      .mockResolvedValueOnce([{ sequenceNumber: 0 }, { sequenceNumber: 1 }])
+      .mockResolvedValueOnce([{ sequenceNumber: 2 }, { sequenceNumber: 3 }]);
+    const sleep = vi.fn(async () => {});
+
+    const result = await waitForAgentEventPrefixVisible("run-1", 3, {
+      timeoutMs: 1_000,
+      batchSize: 2,
+      queryAxiomFn,
+      sleep,
+    });
+
+    expect(result).toMatchObject({
+      visible: true,
+      visibleThrough: 3,
+      reason: "visible",
+    });
+    expect(queryAxiomFn).toHaveBeenCalledTimes(2);
+    expect(queryAxiomFn.mock.calls[1]?.[0]).toContain(
+      "| where sequenceNumber > 1",
+    );
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("returns timeout when the prefix remains incomplete", async () => {
+    let now = 0;
+    const queryAxiomFn = vi.fn().mockResolvedValue([{ sequenceNumber: 1 }]);
+
+    const result = await waitForAgentEventPrefixVisible("run-1", 0, {
+      timeoutMs: 25,
+      intervalMs: 10,
+      queryAxiomFn,
+      now: () => {
+        return now;
+      },
+      sleep: async (ms) => {
+        now += ms;
+      },
+    });
+
+    expect(result).toMatchObject({
+      visible: false,
+      visibleThrough: -1,
+      targetSequence: 0,
+      reason: "timeout",
+    });
+    expect(queryAxiomFn).toHaveBeenCalled();
+  });
+
+  it("recovers from transient Axiom query errors", async () => {
+    let now = 0;
+    const queryAxiomFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("axiom down"))
+      .mockResolvedValueOnce([{ sequenceNumber: 0 }]);
+
+    const result = await waitForAgentEventPrefixVisible("run-1", 0, {
+      timeoutMs: 1_000,
+      intervalMs: 10,
+      queryAxiomFn,
+      now: () => {
+        return now;
+      },
+      sleep: async (ms) => {
+        now += ms;
+      },
+    });
+
+    expect(result).toMatchObject({
+      visible: true,
+      visibleThrough: 0,
+      targetSequence: 0,
+      reason: "visible",
+    });
+    expect(queryAxiomFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails open after repeated Axiom query errors", async () => {
+    let now = 0;
+    const queryAxiomFn = vi.fn().mockRejectedValue(new Error("axiom down"));
+
+    const result = await waitForAgentEventPrefixVisible("run-1", 0, {
+      timeoutMs: 25,
+      intervalMs: 10,
+      queryAxiomFn,
+      now: () => {
+        return now;
+      },
+      sleep: async (ms) => {
+        now += ms;
+      },
+    });
+
+    expect(result).toMatchObject({
+      visible: false,
+      visibleThrough: -1,
+      targetSequence: 0,
+      reason: "query_error",
+    });
+    expect(result.error).toBeInstanceOf(Error);
+    expect(queryAxiomFn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/turbo/apps/web/src/lib/infra/run/__tests__/agent-event-visibility.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/agent-event-visibility.test.ts
@@ -46,6 +46,11 @@ describe("waitForAgentEventPrefixVisible", () => {
       reason: "visible",
     });
     expect(queryAxiomFn).toHaveBeenCalledTimes(2);
+    expect(queryAxiomFn).toHaveBeenCalledWith(expect.any(String), {
+      maxRetries: 0,
+      noCache: true,
+      streamingDuration: "1s",
+    });
   });
 
   it("uses only sequenceNumber and does not require result events", async () => {

--- a/turbo/apps/web/src/lib/infra/run/__tests__/agent-event-visibility.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/agent-event-visibility.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
 import { reloadEnv } from "../../../../env";
 import {
   getAgentEventPageWatermarkTarget,
@@ -231,5 +233,49 @@ describe("waitForRunEventWatermarkVisible", () => {
     await expect(
       waitForRunEventWatermarkVisible("run-1", null),
     ).resolves.toBeUndefined();
+  });
+
+  it("returns the known watermark after Axiom exposes it", async () => {
+    vi.stubEnv("AXIOM_TOKEN_SESSIONS", "test-axiom-token");
+    reloadEnv();
+
+    let visibilityRequests = 0;
+    server.use(
+      http.post("https://api.axiom.co/v1/datasets/_apl", () => {
+        visibilityRequests++;
+        return HttpResponse.json({
+          matches: [
+            {
+              _time: new Date().toISOString(),
+              data: { sequenceNumber: 0 },
+            },
+            {
+              _time: new Date().toISOString(),
+              data: { sequenceNumber: 1 },
+            },
+          ],
+        });
+      }),
+    );
+
+    await expect(
+      waitForRunEventWatermarkVisible(
+        "550e8400-e29b-41d4-a716-446655440000",
+        1,
+      ),
+    ).resolves.toBe(1);
+    expect(visibilityRequests).toBe(1);
+  });
+
+  it("returns the known watermark when Axiom is not configured", async () => {
+    vi.stubEnv("AXIOM_TOKEN_SESSIONS", "");
+    reloadEnv();
+
+    await expect(
+      waitForRunEventWatermarkVisible(
+        "550e8400-e29b-41d4-a716-446655440000",
+        0,
+      ),
+    ).resolves.toBe(0);
   });
 });

--- a/turbo/apps/web/src/lib/infra/run/__tests__/agent-event-visibility.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/agent-event-visibility.test.ts
@@ -102,6 +102,7 @@ describe("waitForAgentEventPrefixVisible", () => {
       maxRetries: 0,
       noCache: true,
       streamingDuration: "1s",
+      timeoutMs: 1_000,
     });
   });
 

--- a/turbo/apps/web/src/lib/infra/run/__tests__/agent-event-visibility.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/agent-event-visibility.test.ts
@@ -1,9 +1,61 @@
 import { describe, expect, it, vi } from "vitest";
 import { reloadEnv } from "../../../../env";
 import {
+  getAgentEventPageWatermarkTarget,
   waitForAgentEventPrefixVisible,
   waitForRunEventWatermarkVisible,
 } from "../agent-event-visibility";
+
+describe("getAgentEventPageWatermarkTarget", () => {
+  it.each([
+    {
+      name: "skips when no terminal watermark exists",
+      lastEventSequence: null,
+      since: -1,
+      limit: 100,
+      expected: null,
+    },
+    {
+      name: "waits for sequence zero when zero is terminal",
+      lastEventSequence: 0,
+      since: -1,
+      limit: 100,
+      expected: 0,
+    },
+    {
+      name: "skips when cursor already reached terminal",
+      lastEventSequence: 5,
+      since: 5,
+      limit: 100,
+      expected: null,
+    },
+    {
+      name: "caps target to current page",
+      lastEventSequence: 50,
+      since: -1,
+      limit: 1,
+      expected: 0,
+    },
+    {
+      name: "caps target to terminal within current page",
+      lastEventSequence: 2,
+      since: -1,
+      limit: 100,
+      expected: 2,
+    },
+    {
+      name: "skips invalid page sizes defensively",
+      lastEventSequence: 2,
+      since: -1,
+      limit: 0,
+      expected: null,
+    },
+  ])("$name", ({ lastEventSequence, since, limit, expected }) => {
+    expect(
+      getAgentEventPageWatermarkTarget(lastEventSequence, since, limit),
+    ).toBe(expected);
+  });
+});
 
 describe("waitForAgentEventPrefixVisible", () => {
   it("skips when the sessions Axiom dataset is not configured", async () => {

--- a/turbo/apps/web/src/lib/infra/run/__tests__/agent-event-visibility.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/agent-event-visibility.test.ts
@@ -1,7 +1,26 @@
 import { describe, expect, it, vi } from "vitest";
-import { waitForAgentEventPrefixVisible } from "../agent-event-visibility";
+import { reloadEnv } from "../../../../env";
+import {
+  waitForAgentEventPrefixVisible,
+  waitForRunEventWatermarkVisible,
+} from "../agent-event-visibility";
 
 describe("waitForAgentEventPrefixVisible", () => {
+  it("skips when the sessions Axiom dataset is not configured", async () => {
+    vi.stubEnv("AXIOM_TOKEN_SESSIONS", "");
+    reloadEnv();
+
+    const result = await waitForAgentEventPrefixVisible("run-1", 0);
+
+    expect(result).toMatchObject({
+      visible: false,
+      visibleThrough: -1,
+      targetSequence: 0,
+      attempts: 0,
+      reason: "not_configured",
+    });
+  });
+
   it("waits until Axiom exposes the contiguous prefix", async () => {
     let now = 0;
     const queryAxiomFn = vi
@@ -146,5 +165,13 @@ describe("waitForAgentEventPrefixVisible", () => {
     });
     expect(result.error).toBeInstanceOf(Error);
     expect(queryAxiomFn).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("waitForRunEventWatermarkVisible", () => {
+  it("returns immediately when no terminal watermark exists", async () => {
+    await expect(
+      waitForRunEventWatermarkVisible("run-1", null),
+    ).resolves.toBeUndefined();
   });
 });

--- a/turbo/apps/web/src/lib/infra/run/__tests__/extract-run-output.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/extract-run-output.test.ts
@@ -110,25 +110,18 @@ describe("extractRunOutput", () => {
   });
 
   it("retries briefly when the latest output event is not searchable yet", async () => {
-    vi.useFakeTimers();
     mockQuery
       .mockResolvedValueOnce(axiomResponse([]))
       .mockResolvedValueOnce(
         axiomResponse([{ eventData: { result: "eventually indexed" } }]),
       );
 
-    try {
-      const outputPromise = extractRunOutput("run-1");
-      await vi.advanceTimersByTimeAsync(0);
-      expect(mockQuery).toHaveBeenCalledTimes(1);
-      await vi.advanceTimersByTimeAsync(500);
-      const output = await outputPromise;
+    const output = await extractRunOutput("run-1", undefined, {
+      outputRetryDelayMs: 0,
+    });
 
-      expect(output.result).toBe("eventually indexed");
-      expect(mockQuery).toHaveBeenCalledTimes(2);
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(output.result).toBe("eventually indexed");
+    expect(mockQuery).toHaveBeenCalledTimes(2);
   });
 
   it("does not retry output query after terminal watermark is visible", async () => {

--- a/turbo/apps/web/src/lib/infra/run/__tests__/extract-run-output.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/extract-run-output.test.ts
@@ -52,7 +52,9 @@ describe("extractRunOutput", () => {
   it("returns empty output when no events found", async () => {
     mockQuery.mockResolvedValue(axiomResponse([]));
 
-    const output = await extractRunOutput("run-1");
+    const output = await extractRunOutput("run-1", undefined, {
+      waitForOutput: false,
+    });
 
     expect(output).toEqual({
       result: null,
@@ -66,7 +68,9 @@ describe("extractRunOutput", () => {
       axiomResponse([{ eventData: { result: "latest" } }]),
     );
 
-    const output = await extractRunOutput("run-1");
+    const output = await extractRunOutput("run-1", undefined, {
+      waitForOutput: false,
+    });
 
     expect(output.result).toBe("latest");
   });
@@ -74,7 +78,7 @@ describe("extractRunOutput", () => {
   it("limits the single-output query after filtering to publishable events", async () => {
     mockQuery.mockResolvedValue(axiomResponse([]));
 
-    await extractRunOutput("run-1");
+    await extractRunOutput("run-1", undefined, { waitForOutput: false });
 
     const apl = mockQuery.mock.calls[0]![0] as string;
     expect(apl).toContain('eventType == "result"');
@@ -98,22 +102,33 @@ describe("extractRunOutput", () => {
       ]),
     );
 
-    const output = await extractRunOutput("run-1");
+    const output = await extractRunOutput("run-1", undefined, {
+      waitForOutput: false,
+    });
 
     expect(output.result).toBe("Codex completed text");
   });
 
   it("retries briefly when the latest output event is not searchable yet", async () => {
+    vi.useFakeTimers();
     mockQuery
       .mockResolvedValueOnce(axiomResponse([]))
       .mockResolvedValueOnce(
         axiomResponse([{ eventData: { result: "eventually indexed" } }]),
       );
 
-    const output = await extractRunOutput("run-1");
+    try {
+      const outputPromise = extractRunOutput("run-1");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(500);
+      const output = await outputPromise;
 
-    expect(output.result).toBe("eventually indexed");
-    expect(mockQuery).toHaveBeenCalledTimes(2);
+      expect(output.result).toBe("eventually indexed");
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not retry output query after terminal watermark is visible", async () => {
@@ -180,7 +195,9 @@ describe("extractRunOutput", () => {
       ]),
     );
 
-    const output = await extractRunOutput("run-1");
+    const output = await extractRunOutput("run-1", undefined, {
+      waitForOutput: false,
+    });
 
     expect(output.result).toBe("Latest agent text");
   });
@@ -188,7 +205,9 @@ describe("extractRunOutput", () => {
   it("passes error through", async () => {
     mockQuery.mockResolvedValue(axiomResponse([]));
 
-    const output = await extractRunOutput("run-1", "sandbox crashed");
+    const output = await extractRunOutput("run-1", "sandbox crashed", {
+      waitForOutput: false,
+    });
 
     expect(output.error).toBe("sandbox crashed");
     expect(output.result).toBeNull();
@@ -203,7 +222,9 @@ describe("extractAllRunOutputs", () => {
   it("returns one empty output when no events found", async () => {
     mockQuery.mockResolvedValue(axiomResponse([]));
 
-    const outputs = await extractAllRunOutputs("run-1");
+    const outputs = await extractAllRunOutputs("run-1", undefined, {
+      waitForOutput: false,
+    });
 
     expect(outputs).toHaveLength(1);
     expect(outputs[0]!.result).toBeNull();
@@ -213,7 +234,9 @@ describe("extractAllRunOutputs", () => {
   it("returns one empty output with error when no events found", async () => {
     mockQuery.mockResolvedValue(axiomResponse([]));
 
-    const outputs = await extractAllRunOutputs("run-1", "timeout");
+    const outputs = await extractAllRunOutputs("run-1", "timeout", {
+      waitForOutput: false,
+    });
 
     expect(outputs).toHaveLength(1);
     expect(outputs[0]!.error).toBe("timeout");
@@ -228,7 +251,9 @@ describe("extractAllRunOutputs", () => {
       ]),
     );
 
-    const outputs = await extractAllRunOutputs("run-1");
+    const outputs = await extractAllRunOutputs("run-1", undefined, {
+      waitForOutput: false,
+    });
 
     expect(outputs).toHaveLength(3);
     expect(
@@ -271,7 +296,9 @@ describe("extractAllRunOutputs", () => {
       ]),
     );
 
-    const outputs = await extractAllRunOutputs("run-1");
+    const outputs = await extractAllRunOutputs("run-1", undefined, {
+      waitForOutput: false,
+    });
 
     expect(
       outputs.map((o) => {
@@ -288,7 +315,9 @@ describe("extractAllRunOutputs", () => {
       ]),
     );
 
-    const outputs = await extractAllRunOutputs("run-1");
+    const outputs = await extractAllRunOutputs("run-1", undefined, {
+      waitForOutput: false,
+    });
 
     expect(outputs).toHaveLength(2);
     expect(outputs[0]!.result).toBeNull();
@@ -304,7 +333,9 @@ describe("getAllRunOutputTexts", () => {
   it("returns empty array when all events have no result", async () => {
     mockQuery.mockResolvedValue(axiomResponse([{ eventData: {} }]));
 
-    const texts = await getAllRunOutputTexts("run-1");
+    const texts = await getAllRunOutputTexts("run-1", {
+      waitForOutput: false,
+    });
 
     expect(texts).toEqual([]);
   });
@@ -317,7 +348,9 @@ describe("getAllRunOutputTexts", () => {
       ]),
     );
 
-    const texts = await getAllRunOutputTexts("run-1");
+    const texts = await getAllRunOutputTexts("run-1", {
+      waitForOutput: false,
+    });
 
     expect(texts).toEqual(["first result", "second result"]);
   });
@@ -337,7 +370,9 @@ describe("getAllRunOutputTexts", () => {
       ]),
     );
 
-    const texts = await getAllRunOutputTexts("run-1");
+    const texts = await getAllRunOutputTexts("run-1", {
+      waitForOutput: false,
+    });
 
     expect(texts).toEqual(["codex text"]);
   });

--- a/turbo/apps/web/src/lib/infra/run/__tests__/extract-run-output.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/extract-run-output.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
 
 // Mock @axiomhq/js at the package boundary (not internal modules).
 // We provide a controllable `query` method that returns Axiom-shaped responses.
@@ -115,9 +117,17 @@ describe("extractRunOutput", () => {
   });
 
   it("does not retry output query after terminal watermark is visible", async () => {
-    mockQuery
-      .mockResolvedValueOnce(axiomResponse([{ sequenceNumber: 0 }]))
-      .mockResolvedValueOnce(axiomResponse([]));
+    let visibilityRequests = 0;
+    server.use(
+      http.post("https://api.axiom.co/v1/datasets/_apl", ({ request }) => {
+        visibilityRequests++;
+        const url = new URL(request.url);
+        expect(url.searchParams.get("nocache")).toBe("true");
+        expect(url.searchParams.get("streaming-duration")).toBe("1s");
+        return HttpResponse.json(axiomResponse([{ sequenceNumber: 0 }]));
+      }),
+    );
+    mockQuery.mockResolvedValueOnce(axiomResponse([]));
 
     const output = await extractRunOutput(
       "550e8400-e29b-41d4-a716-446655440000",
@@ -126,13 +136,13 @@ describe("extractRunOutput", () => {
     );
 
     expect(output.result).toBeNull();
-    expect(mockQuery).toHaveBeenCalledTimes(2);
-    expect(mockQuery.mock.calls[0]![0]).toContain("project sequenceNumber");
-    expect(mockQuery.mock.calls[1]![0]).toContain('eventType == "result"');
-    expect(mockQuery.mock.calls[1]![0]).toContain(
+    expect(visibilityRequests).toBe(1);
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockQuery.mock.calls[0]![0]).toContain('eventType == "result"');
+    expect(mockQuery.mock.calls[0]![0]).toContain(
       "['eventData.item.type'] == \"agent_message\"",
     );
-    expect(mockQuery.mock.calls[1]![1]).toMatchObject({ noCache: true });
+    expect(mockQuery.mock.calls[0]![1]).toMatchObject({ noCache: true });
   });
 
   it("can skip waiting for output visibility", async () => {

--- a/turbo/apps/web/src/lib/infra/run/__tests__/extract-run-output.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/extract-run-output.test.ts
@@ -114,6 +114,26 @@ describe("extractRunOutput", () => {
     expect(mockQuery).toHaveBeenCalledTimes(2);
   });
 
+  it("does not retry output query after terminal watermark is visible", async () => {
+    mockQuery
+      .mockResolvedValueOnce(axiomResponse([{ sequenceNumber: 0 }]))
+      .mockResolvedValueOnce(axiomResponse([]));
+
+    const output = await extractRunOutput(
+      "550e8400-e29b-41d4-a716-446655440000",
+      null,
+      0,
+    );
+
+    expect(output.result).toBeNull();
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    expect(mockQuery.mock.calls[0]![0]).toContain("project sequenceNumber");
+    expect(mockQuery.mock.calls[1]![0]).toContain('eventType == "result"');
+    expect(mockQuery.mock.calls[1]![0]).toContain(
+      "['eventData.item.type'] == \"agent_message\"",
+    );
+  });
+
   it("can skip waiting for output visibility", async () => {
     mockQuery.mockResolvedValue(axiomResponse([]));
 

--- a/turbo/apps/web/src/lib/infra/run/__tests__/extract-run-output.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/extract-run-output.test.ts
@@ -132,6 +132,7 @@ describe("extractRunOutput", () => {
     expect(mockQuery.mock.calls[1]![0]).toContain(
       "['eventData.item.type'] == \"agent_message\"",
     );
+    expect(mockQuery.mock.calls[1]![1]).toMatchObject({ noCache: true });
   });
 
   it("can skip waiting for output visibility", async () => {

--- a/turbo/apps/web/src/lib/infra/run/activity-log-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/activity-log-service.ts
@@ -39,6 +39,10 @@ interface AgentMeta {
   composeContent?: unknown;
 }
 
+interface AssembleActivityLogOptions {
+  waitForAgentEventWatermark?: boolean;
+}
+
 /**
  * Assemble an activity log JSON matching the format downloaded from the
  * activity detail page (meta + events + context + networkLogs).
@@ -50,9 +54,11 @@ export async function assembleActivityLog(
   runId: string,
   run: RunMeta,
   agent: AgentMeta,
+  options: AssembleActivityLogOptions = {},
 ): Promise<Record<string, unknown>> {
+  const waitForAgentEventWatermark = options.waitForAgentEventWatermark ?? true;
   const [events, networkLogs, runContext] = await Promise.all([
-    queryAgentEvents(runId, run.lastEventSequence),
+    queryAgentEvents(runId, run.lastEventSequence, waitForAgentEventWatermark),
     queryNetworkLogs(runId),
     queryRunContext(runId).catch((err) => {
       log.warn("Failed to collect run context", { error: String(err) });
@@ -162,8 +168,9 @@ function mapNetworkLogs(logs: AxiomNetworkEvent[]): Record<string, unknown>[] {
 async function queryAgentEvents(
   runId: string,
   lastEventSequence: number | null,
+  waitForAgentEventWatermark: boolean,
 ): Promise<AxiomAgentEvent[]> {
-  if (lastEventSequence !== null) {
+  if (waitForAgentEventWatermark && lastEventSequence !== null) {
     await waitForRunEventWatermarkVisible(runId, lastEventSequence);
   }
 

--- a/turbo/apps/web/src/lib/infra/run/activity-log-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/activity-log-service.ts
@@ -1,7 +1,13 @@
 import type { AxiomNetworkEvent } from "@vm0/api-contracts/contracts/runs";
-import { queryAxiom, getDatasetName, DATASETS } from "../../shared/axiom";
+import {
+  queryAxiom,
+  getDatasetName,
+  DATASETS,
+  escapeAplString,
+} from "../../shared/axiom";
 import { queryRunContext } from "./run-context-service";
 import { logger } from "../../shared/logger";
+import { waitForRunEventWatermarkVisible } from "./agent-event-visibility";
 
 const log = logger("service:activity-log");
 
@@ -22,6 +28,7 @@ export interface RunMeta {
   createdAt: Date;
   startedAt: Date | null;
   completedAt: Date | null;
+  lastEventSequence: number | null;
   runnerGroup: string | null;
   continuedFromSessionId: string | null;
   result: unknown;
@@ -45,7 +52,7 @@ export async function assembleActivityLog(
   agent: AgentMeta,
 ): Promise<Record<string, unknown>> {
   const [events, networkLogs, runContext] = await Promise.all([
-    queryAgentEvents(runId),
+    queryAgentEvents(runId, run.lastEventSequence),
     queryNetworkLogs(runId),
     queryRunContext(runId).catch((err) => {
       log.warn("Failed to collect run context", { error: String(err) });
@@ -152,10 +159,17 @@ function mapNetworkLogs(logs: AxiomNetworkEvent[]): Record<string, unknown>[] {
   });
 }
 
-async function queryAgentEvents(runId: string): Promise<AxiomAgentEvent[]> {
+async function queryAgentEvents(
+  runId: string,
+  lastEventSequence: number | null,
+): Promise<AxiomAgentEvent[]> {
+  if (lastEventSequence !== null) {
+    await waitForRunEventWatermarkVisible(runId, lastEventSequence);
+  }
+
   const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
   const apl = `['${dataset}']
-| where runId == "${runId}"
+| where runId == "${escapeAplString(runId)}"
 | order by _time asc, sequenceNumber asc
 | limit 5000`;
   return queryAxiom<AxiomAgentEvent>(apl).catch((err) => {
@@ -167,7 +181,7 @@ async function queryAgentEvents(runId: string): Promise<AxiomAgentEvent[]> {
 async function queryNetworkLogs(runId: string): Promise<AxiomNetworkEvent[]> {
   const dataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_NETWORK);
   const apl = `['${dataset}']
-| where runId == "${runId}"
+| where runId == "${escapeAplString(runId)}"
 | order by _time asc
 | limit 5000`;
   return queryAxiom<AxiomNetworkEvent>(apl).catch((err) => {

--- a/turbo/apps/web/src/lib/infra/run/activity-log-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/activity-log-service.ts
@@ -179,7 +179,7 @@ async function queryAgentEvents(
 | where runId == "${escapeAplString(runId)}"
 | order by _time asc, sequenceNumber asc
 | limit 5000`;
-  return queryAxiom<AxiomAgentEvent>(apl).catch((err) => {
+  return queryAxiom<AxiomAgentEvent>(apl, { noCache: true }).catch((err) => {
     log.warn("Failed to collect agent telemetry", { error: String(err) });
     return [];
   });

--- a/turbo/apps/web/src/lib/infra/run/agent-event-visibility.ts
+++ b/turbo/apps/web/src/lib/infra/run/agent-event-visibility.ts
@@ -217,7 +217,11 @@ export async function waitForAgentEventPrefixVisible(
       let events: AxiomAgentEventSequence[];
       try {
         events = await withTimeout(
-          queryAxiomFn<AxiomAgentEventSequence>(apl, { maxRetries: 0 }),
+          queryAxiomFn<AxiomAgentEventSequence>(apl, {
+            maxRetries: 0,
+            noCache: true,
+            streamingDuration: "1s",
+          }),
           remainingMs,
         );
         lastQueryError = undefined;

--- a/turbo/apps/web/src/lib/infra/run/agent-event-visibility.ts
+++ b/turbo/apps/web/src/lib/infra/run/agent-event-visibility.ts
@@ -1,0 +1,316 @@
+import "server-only";
+
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { eq } from "drizzle-orm";
+import {
+  DATASETS,
+  escapeAplString,
+  getDatasetName,
+  isAxiomDatasetConfigured,
+  queryAxiom,
+  type QueryAxiomOptions,
+} from "../../shared/axiom";
+import { logger } from "../../shared/logger";
+
+const DEFAULT_TIMEOUT_MS = 2_000;
+const DEFAULT_INTERVAL_MS = 100;
+const DEFAULT_BATCH_SIZE = 500;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const log = logger("run-event-visibility");
+
+interface AxiomAgentEventSequence {
+  sequenceNumber: number;
+}
+
+type QueryAxiomFn = <T>(
+  apl: string,
+  options?: QueryAxiomOptions,
+) => Promise<T[]>;
+
+interface WaitOptions {
+  timeoutMs?: number;
+  intervalMs?: number;
+  batchSize?: number;
+  queryAxiomFn?: QueryAxiomFn;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}
+
+interface AgentEventVisibilityResult {
+  visible: boolean;
+  visibleThrough: number;
+  targetSequence: number;
+  attempts: number;
+  elapsedMs: number;
+  reason: "visible" | "not_configured" | "timeout" | "query_error";
+  error?: unknown;
+}
+
+function getInitializedDb(): typeof globalThis.services.db | undefined {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "services");
+  if (!descriptor) {
+    return undefined;
+  }
+
+  try {
+    return globalThis.services.db;
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveLastEventSequence(
+  runId: string,
+): Promise<number | undefined> {
+  if (!UUID_RE.test(runId)) {
+    return undefined;
+  }
+
+  const db = getInitializedDb();
+  if (!db) {
+    return undefined;
+  }
+
+  const [run] = await db
+    .select({ lastEventSequence: agentRuns.lastEventSequence })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+
+  return run?.lastEventSequence ?? undefined;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  if (timeoutMs <= 0) {
+    throw new Error("Axiom visibility query timed out");
+  }
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error("Axiom visibility query timed out"));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function advanceVisiblePrefix(
+  events: AxiomAgentEventSequence[],
+  visibleThrough: number,
+): number {
+  let nextVisibleThrough = visibleThrough;
+  let expected = nextVisibleThrough + 1;
+
+  for (const event of events) {
+    if (event.sequenceNumber < expected) {
+      continue;
+    }
+    if (event.sequenceNumber !== expected) {
+      break;
+    }
+    nextVisibleThrough = event.sequenceNumber;
+    expected++;
+  }
+
+  return nextVisibleThrough;
+}
+
+function buildAgentEventVisibilityQuery(
+  dataset: string,
+  runId: string,
+  visibleThrough: number,
+  batchSize: number,
+): string {
+  return `['${dataset}']
+| where runId == "${escapeAplString(runId)}"
+| where sequenceNumber > ${visibleThrough}
+| project sequenceNumber
+| order by sequenceNumber asc
+| limit ${batchSize}`;
+}
+
+/**
+ * Best-effort Axiom visibility barrier for terminal callbacks.
+ *
+ * The guest reports the highest event sequence whose events webhook POST
+ * completed. Terminal callbacks read agent output back from Axiom, so wait
+ * briefly until Axiom can query the contiguous sequence prefix through that
+ * watermark before callbacks try to extract result events.
+ */
+export async function waitForAgentEventPrefixVisible(
+  runId: string,
+  targetSequence: number,
+  options: WaitOptions = {},
+): Promise<AgentEventVisibilityResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  const queryAxiomFn = options.queryAxiomFn ?? queryAxiom;
+  const sleepFn = options.sleep ?? sleep;
+  const now = options.now ?? Date.now;
+  const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
+
+  const startedAt = now();
+  if (!options.queryAxiomFn && !isAxiomDatasetConfigured(dataset)) {
+    return {
+      visible: false,
+      visibleThrough: -1,
+      targetSequence,
+      attempts: 0,
+      elapsedMs: 0,
+      reason: "not_configured",
+    };
+  }
+
+  const deadline = startedAt + timeoutMs;
+  let visibleThrough = -1;
+  let attempts = 0;
+  let lastQueryError: unknown;
+
+  outer: while (now() < deadline) {
+    do {
+      attempts++;
+      const remainingMs = deadline - now();
+      const apl = buildAgentEventVisibilityQuery(
+        dataset,
+        runId,
+        visibleThrough,
+        batchSize,
+      );
+
+      let events: AxiomAgentEventSequence[];
+      try {
+        events = await withTimeout(
+          queryAxiomFn<AxiomAgentEventSequence>(apl, { maxRetries: 0 }),
+          remainingMs,
+        );
+        lastQueryError = undefined;
+      } catch (error) {
+        lastQueryError = error;
+        const remainingAfterErrorMs = deadline - now();
+        if (remainingAfterErrorMs <= 0) {
+          break outer;
+        }
+        await sleepFn(Math.min(intervalMs, remainingAfterErrorMs));
+        continue outer;
+      }
+
+      const previousVisibleThrough = visibleThrough;
+      visibleThrough = advanceVisiblePrefix(events, visibleThrough);
+
+      if (visibleThrough >= targetSequence) {
+        return {
+          visible: true,
+          visibleThrough,
+          targetSequence,
+          attempts,
+          elapsedMs: now() - startedAt,
+          reason: "visible",
+        };
+      }
+
+      if (
+        visibleThrough <= previousVisibleThrough ||
+        events.length < batchSize
+      ) {
+        break;
+      }
+    } while (now() < deadline);
+
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0) {
+      break;
+    }
+    await sleepFn(Math.min(intervalMs, remainingMs));
+  }
+
+  if (lastQueryError) {
+    return {
+      visible: false,
+      visibleThrough,
+      targetSequence,
+      attempts,
+      elapsedMs: now() - startedAt,
+      reason: "query_error",
+      error: lastQueryError,
+    };
+  }
+
+  return {
+    visible: false,
+    visibleThrough,
+    targetSequence,
+    attempts,
+    elapsedMs: now() - startedAt,
+    reason: "timeout",
+  };
+}
+
+/**
+ * Best-effort barrier for code that reads run events back from Axiom after the
+ * terminal webhook. The complete route records the terminal watermark without
+ * blocking; readers that need final output call this before querying Axiom.
+ */
+export async function waitForRunEventWatermarkVisible(
+  runId: string,
+  knownTargetSequence?: number | null,
+): Promise<void> {
+  if (knownTargetSequence === null) {
+    return;
+  }
+
+  let targetSequence: number | undefined;
+  try {
+    targetSequence =
+      knownTargetSequence === undefined
+        ? await resolveLastEventSequence(runId)
+        : knownTargetSequence;
+  } catch (error) {
+    log.warn("Unable to resolve run event watermark before reading Axiom", {
+      runId,
+      error,
+    });
+    return;
+  }
+
+  if (targetSequence === undefined) {
+    return;
+  }
+
+  const visibility = await waitForAgentEventPrefixVisible(
+    runId,
+    targetSequence,
+  );
+  if (visibility.visible || visibility.reason === "not_configured") {
+    return;
+  }
+
+  log.warn("Reading run Axiom events before terminal watermark is visible", {
+    runId,
+    targetSequence: visibility.targetSequence,
+    visibleThrough: visibility.visibleThrough,
+    attempts: visibility.attempts,
+    elapsedMs: visibility.elapsedMs,
+    reason: visibility.reason,
+    error: visibility.error,
+  });
+}

--- a/turbo/apps/web/src/lib/infra/run/agent-event-visibility.ts
+++ b/turbo/apps/web/src/lib/infra/run/agent-event-visibility.ts
@@ -221,6 +221,7 @@ export async function waitForAgentEventPrefixVisible(
             maxRetries: 0,
             noCache: true,
             streamingDuration: "1s",
+            timeoutMs: remainingMs,
           }),
           remainingMs,
         );

--- a/turbo/apps/web/src/lib/infra/run/agent-event-visibility.ts
+++ b/turbo/apps/web/src/lib/infra/run/agent-event-visibility.ts
@@ -48,6 +48,23 @@ interface AgentEventVisibilityResult {
   error?: unknown;
 }
 
+export function getAgentEventPageWatermarkTarget(
+  lastEventSequence: number | null,
+  since: number | undefined,
+  limit: number,
+): number | null {
+  if (lastEventSequence === null || limit <= 0) {
+    return null;
+  }
+
+  const cursor = Math.max(-1, Math.floor(since ?? -1));
+  if (cursor >= lastEventSequence) {
+    return null;
+  }
+
+  return Math.min(lastEventSequence, cursor + limit);
+}
+
 function getInitializedDb(): typeof globalThis.services.db | undefined {
   const descriptor = Object.getOwnPropertyDescriptor(globalThis, "services");
   if (!descriptor) {

--- a/turbo/apps/web/src/lib/infra/run/agent-event-visibility.ts
+++ b/turbo/apps/web/src/lib/infra/run/agent-event-visibility.ts
@@ -216,15 +216,15 @@ export async function waitForAgentEventPrefixVisible(
 
       let events: AxiomAgentEventSequence[];
       try {
-        events = await withTimeout(
-          queryAxiomFn<AxiomAgentEventSequence>(apl, {
-            maxRetries: 0,
-            noCache: true,
-            streamingDuration: "1s",
-            timeoutMs: remainingMs,
-          }),
-          remainingMs,
-        );
+        const queryPromise = queryAxiomFn<AxiomAgentEventSequence>(apl, {
+          maxRetries: 0,
+          noCache: true,
+          streamingDuration: "1s",
+          timeoutMs: remainingMs,
+        });
+        events = options.queryAxiomFn
+          ? await withTimeout(queryPromise, remainingMs)
+          : await queryPromise;
         lastQueryError = undefined;
       } catch (error) {
         lastQueryError = error;
@@ -295,9 +295,9 @@ export async function waitForAgentEventPrefixVisible(
 export async function waitForRunEventWatermarkVisible(
   runId: string,
   knownTargetSequence?: number | null,
-): Promise<void> {
+): Promise<number | undefined> {
   if (knownTargetSequence === null) {
-    return;
+    return undefined;
   }
 
   let targetSequence: number | undefined;
@@ -311,11 +311,11 @@ export async function waitForRunEventWatermarkVisible(
       runId,
       error,
     });
-    return;
+    return undefined;
   }
 
   if (targetSequence === undefined) {
-    return;
+    return undefined;
   }
 
   const visibility = await waitForAgentEventPrefixVisible(
@@ -323,7 +323,7 @@ export async function waitForRunEventWatermarkVisible(
     targetSequence,
   );
   if (visibility.visible || visibility.reason === "not_configured") {
-    return;
+    return targetSequence;
   }
 
   log.warn("Reading run Axiom events before terminal watermark is visible", {
@@ -335,4 +335,5 @@ export async function waitForRunEventWatermarkVisible(
     reason: visibility.reason,
     error: visibility.error,
   });
+  return targetSequence;
 }

--- a/turbo/apps/web/src/lib/infra/run/extract-run-output.ts
+++ b/turbo/apps/web/src/lib/infra/run/extract-run-output.ts
@@ -86,7 +86,11 @@ async function queryLatestOutputEvent(
   runId: string,
   options: RunOutputQueryOptions = {},
 ): Promise<RunOutputEvent | undefined> {
-  const attempts = options.waitForOutput === false ? 1 : OUTPUT_QUERY_ATTEMPTS;
+  const attempts =
+    options.waitForOutput === false ||
+    typeof options.knownLastEventSequence === "number"
+      ? 1
+      : OUTPUT_QUERY_ATTEMPTS;
   for (let attempt = 1; attempt <= attempts; attempt++) {
     const event = (await queryOutputEventsDesc(runId)).find(isOutputEvent);
     if (event || attempt === attempts) {

--- a/turbo/apps/web/src/lib/infra/run/extract-run-output.ts
+++ b/turbo/apps/web/src/lib/infra/run/extract-run-output.ts
@@ -1,4 +1,12 @@
-import { queryAxiom, getDatasetName, DATASETS } from "../../shared/axiom";
+import "server-only";
+
+import {
+  queryAxiom,
+  getDatasetName,
+  DATASETS,
+  escapeAplString,
+} from "../../shared/axiom";
+import { waitForRunEventWatermarkVisible } from "./agent-event-visibility";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -18,7 +26,18 @@ interface RunOutputQueryOptions {
    * background summaries can opt out.
    */
   waitForOutput?: boolean;
+  /**
+   * Terminal event sequence already read with the run row. Passing it avoids
+   * an extra DB lookup before waiting for Axiom visibility.
+   */
+  knownLastEventSequence?: number | null;
 }
+
+type RunOutputOptionsInput =
+  | RunOutputQueryOptions
+  | number
+  | null
+  | undefined;
 
 // ---------------------------------------------------------------------------
 // Axiom query
@@ -41,6 +60,13 @@ const OUTPUT_EVENT_FILTER = `eventType == "result" or (eventType == "item.comple
 const OUTPUT_QUERY_ATTEMPTS = 4;
 const OUTPUT_QUERY_RETRY_MS = 500;
 
+function normalizeOptions(input?: RunOutputOptionsInput): RunOutputQueryOptions {
+  if (typeof input === "number" || input === null) {
+    return { knownLastEventSequence: input };
+  }
+  return input ?? {};
+}
+
 function waitForOutputRetry(): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, OUTPUT_QUERY_RETRY_MS);
@@ -50,7 +76,7 @@ function waitForOutputRetry(): Promise<void> {
 async function queryOutputEventsDesc(runId: string): Promise<RunOutputEvent[]> {
   const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
   const apl = `['${dataset}']
-| where runId == "${runId}"
+| where runId == "${escapeAplString(runId)}"
 | where ${OUTPUT_EVENT_FILTER}
 | order by sequenceNumber desc
 | limit 1`;
@@ -76,11 +102,21 @@ async function queryLatestOutputEvent(
 async function queryAllOutputEvents(runId: string): Promise<RunOutputEvent[]> {
   const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
   const apl = `['${dataset}']
-| where runId == "${runId}"
+| where runId == "${escapeAplString(runId)}"
 | where ${OUTPUT_EVENT_FILTER}
 | order by sequenceNumber asc`;
 
   return queryAxiom<RunOutputEvent>(apl);
+}
+
+async function waitForVisibleOutput(
+  runId: string,
+  options: RunOutputQueryOptions,
+): Promise<void> {
+  if (options.waitForOutput === false) {
+    return;
+  }
+  await waitForRunEventWatermarkVisible(runId, options.knownLastEventSequence);
 }
 
 // ---------------------------------------------------------------------------
@@ -99,8 +135,11 @@ async function queryAllOutputEvents(runId: string): Promise<RunOutputEvent[]> {
 export async function extractRunOutput(
   runId: string,
   error?: string | null,
-  options?: RunOutputQueryOptions,
+  optionsInput?: RunOutputOptionsInput,
 ): Promise<RunOutput> {
+  const options = normalizeOptions(optionsInput);
+  await waitForVisibleOutput(runId, options);
+
   const event = await queryLatestOutputEvent(runId, options);
 
   if (!event) {
@@ -123,7 +162,11 @@ export async function extractRunOutput(
 export async function extractAllRunOutputs(
   runId: string,
   error?: string | null,
+  optionsInput?: RunOutputOptionsInput,
 ): Promise<RunOutput[]> {
+  const options = normalizeOptions(optionsInput);
+  await waitForVisibleOutput(runId, options);
+
   const events = (await queryAllOutputEvents(runId)).filter(isOutputEvent);
 
   if (events.length === 0) {
@@ -189,8 +232,11 @@ function buildRunOutput(
  *
  * Convenience wrapper for channels that post each output as a separate message.
  */
-export async function getAllRunOutputTexts(runId: string): Promise<string[]> {
-  const outputs = await extractAllRunOutputs(runId);
+export async function getAllRunOutputTexts(
+  runId: string,
+  optionsInput?: RunOutputOptionsInput,
+): Promise<string[]> {
+  const outputs = await extractAllRunOutputs(runId, undefined, optionsInput);
   const texts: string[] = [];
 
   for (const output of outputs) {
@@ -209,8 +255,8 @@ export async function getAllRunOutputTexts(runId: string): Promise<string[]> {
  */
 export async function getRunOutputText(
   runId: string,
-  options?: RunOutputQueryOptions,
+  optionsInput?: RunOutputOptionsInput,
 ): Promise<string | undefined> {
-  const output = await extractRunOutput(runId, undefined, options);
+  const output = await extractRunOutput(runId, undefined, optionsInput);
   return output.result ?? undefined;
 }

--- a/turbo/apps/web/src/lib/infra/run/extract-run-output.ts
+++ b/turbo/apps/web/src/lib/infra/run/extract-run-output.ts
@@ -55,6 +55,7 @@ interface RunOutputEvent {
 const OUTPUT_EVENT_FILTER = `eventType == "result" or (eventType == "item.completed" and ['eventData.item.type'] == "agent_message")`;
 const OUTPUT_QUERY_ATTEMPTS = 4;
 const OUTPUT_QUERY_RETRY_MS = 500;
+const FRESH_AXIOM_QUERY_OPTIONS = { noCache: true } as const;
 
 function normalizeOptions(
   input?: RunOutputOptionsInput,
@@ -79,7 +80,7 @@ async function queryOutputEventsDesc(runId: string): Promise<RunOutputEvent[]> {
 | order by sequenceNumber desc
 | limit 1`;
 
-  return queryAxiom<RunOutputEvent>(apl);
+  return queryAxiom<RunOutputEvent>(apl, FRESH_AXIOM_QUERY_OPTIONS);
 }
 
 async function queryLatestOutputEvent(
@@ -108,7 +109,7 @@ async function queryAllOutputEvents(runId: string): Promise<RunOutputEvent[]> {
 | where ${OUTPUT_EVENT_FILTER}
 | order by sequenceNumber asc`;
 
-  return queryAxiom<RunOutputEvent>(apl);
+  return queryAxiom<RunOutputEvent>(apl, FRESH_AXIOM_QUERY_OPTIONS);
 }
 
 async function waitForVisibleOutput(

--- a/turbo/apps/web/src/lib/infra/run/extract-run-output.ts
+++ b/turbo/apps/web/src/lib/infra/run/extract-run-output.ts
@@ -31,6 +31,12 @@ interface RunOutputQueryOptions {
    * an extra DB lookup before waiting for Axiom visibility.
    */
   knownLastEventSequence?: number | null;
+  /**
+   * Override only the legacy output-query retry delay. Production callers use
+   * the default; tests set this to zero to exercise retry behavior without
+   * fake timers or slow sleeps.
+   */
+  outputRetryDelayMs?: number;
 }
 
 type RunOutputOptionsInput = RunOutputQueryOptions | number | null | undefined;
@@ -66,9 +72,9 @@ function normalizeOptions(
   return input ?? {};
 }
 
-function waitForOutputRetry(): Promise<void> {
+function waitForOutputRetry(delayMs: number): Promise<void> {
   return new Promise((resolve) => {
-    setTimeout(resolve, OUTPUT_QUERY_RETRY_MS);
+    setTimeout(resolve, delayMs);
   });
 }
 
@@ -97,7 +103,9 @@ async function queryLatestOutputEvent(
     if (event || attempt === attempts) {
       return event;
     }
-    await waitForOutputRetry();
+    await waitForOutputRetry(
+      options.outputRetryDelayMs ?? OUTPUT_QUERY_RETRY_MS,
+    );
   }
   return undefined;
 }

--- a/turbo/apps/web/src/lib/infra/run/extract-run-output.ts
+++ b/turbo/apps/web/src/lib/infra/run/extract-run-output.ts
@@ -115,11 +115,11 @@ async function queryAllOutputEvents(runId: string): Promise<RunOutputEvent[]> {
 async function waitForVisibleOutput(
   runId: string,
   options: RunOutputQueryOptions,
-): Promise<void> {
+): Promise<number | undefined> {
   if (options.waitForOutput === false) {
-    return;
+    return undefined;
   }
-  await waitForRunEventWatermarkVisible(runId, options.knownLastEventSequence);
+  return waitForRunEventWatermarkVisible(runId, options.knownLastEventSequence);
 }
 
 // ---------------------------------------------------------------------------
@@ -141,9 +141,14 @@ export async function extractRunOutput(
   optionsInput?: RunOutputOptionsInput,
 ): Promise<RunOutput> {
   const options = normalizeOptions(optionsInput);
-  await waitForVisibleOutput(runId, options);
+  const resolvedLastEventSequence = await waitForVisibleOutput(runId, options);
+  const queryOptions =
+    options.knownLastEventSequence === undefined &&
+    typeof resolvedLastEventSequence === "number"
+      ? { ...options, knownLastEventSequence: resolvedLastEventSequence }
+      : options;
 
-  const event = await queryLatestOutputEvent(runId, options);
+  const event = await queryLatestOutputEvent(runId, queryOptions);
 
   if (!event) {
     return {

--- a/turbo/apps/web/src/lib/infra/run/extract-run-output.ts
+++ b/turbo/apps/web/src/lib/infra/run/extract-run-output.ts
@@ -33,11 +33,7 @@ interface RunOutputQueryOptions {
   knownLastEventSequence?: number | null;
 }
 
-type RunOutputOptionsInput =
-  | RunOutputQueryOptions
-  | number
-  | null
-  | undefined;
+type RunOutputOptionsInput = RunOutputQueryOptions | number | null | undefined;
 
 // ---------------------------------------------------------------------------
 // Axiom query
@@ -60,7 +56,9 @@ const OUTPUT_EVENT_FILTER = `eventType == "result" or (eventType == "item.comple
 const OUTPUT_QUERY_ATTEMPTS = 4;
 const OUTPUT_QUERY_RETRY_MS = 500;
 
-function normalizeOptions(input?: RunOutputOptionsInput): RunOutputQueryOptions {
+function normalizeOptions(
+  input?: RunOutputOptionsInput,
+): RunOutputQueryOptions {
   if (typeof input === "number" || input === null) {
     return { knownLastEventSequence: input };
   }

--- a/turbo/apps/web/src/lib/infra/run/log-search-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/log-search-service.ts
@@ -6,7 +6,12 @@ import {
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { and, eq, inArray, gte } from "drizzle-orm";
-import { queryAxiom, getDatasetName, DATASETS } from "../../shared/axiom";
+import {
+  queryAxiom,
+  getDatasetName,
+  DATASETS,
+  escapeAplString,
+} from "../../shared/axiom";
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -17,10 +22,6 @@ interface AxiomAgentEvent {
   sequenceNumber: number;
   eventType: string;
   eventData: unknown;
-}
-
-function escapeApl(value: string): string {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
 async function getAgentNames(
@@ -106,10 +107,10 @@ async function getUserRunIds(
 
 function buildRunIdFilter(runIds: string[]): string {
   return runIds.length === 1
-    ? `| where runId == "${escapeApl(runIds[0]!)}"`
+    ? `| where runId == "${escapeAplString(runIds[0]!)}"`
     : `| where runId in (${runIds
         .map((id) => {
-          return `"${escapeApl(id)}"`;
+          return `"${escapeAplString(id)}"`;
         })
         .join(", ")})`;
 }
@@ -128,7 +129,7 @@ async function searchEventsInAxiom(
   const apl = `['${dataset}']
 | where _time > datetime("${sinceISO}")
 ${runIdFilter}
-| search "*${escapeApl(keyword)}*"
+| search "*${escapeAplString(keyword)}*"
 | order by _time desc
 | limit ${limit + 1}`;
 
@@ -150,7 +151,7 @@ async function fetchContextEvents(
   const contextConditions = matches.map((match) => {
     const seqMin = Math.max(0, match.sequenceNumber - before);
     const seqMax = match.sequenceNumber + after;
-    return `(runId == "${escapeApl(match.runId)}" and sequenceNumber >= ${seqMin} and sequenceNumber <= ${seqMax})`;
+    return `(runId == "${escapeAplString(match.runId)}" and sequenceNumber >= ${seqMin} and sequenceNumber <= ${seqMax})`;
   });
 
   const apl = `['${dataset}']

--- a/turbo/apps/web/src/lib/infra/run/run-context-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-context-service.ts
@@ -1,5 +1,6 @@
 import { queryAxiom, type RunContextSnapshot } from "../../shared/axiom/client";
 import { getDatasetName, DATASETS } from "../../shared/axiom/datasets";
+import { escapeAplString } from "../../shared/axiom/apl";
 
 /**
  * Query a run's execution context snapshot from Axiom.
@@ -8,15 +9,9 @@ import { getDatasetName, DATASETS } from "../../shared/axiom/datasets";
 export async function queryRunContext(
   runId: string,
 ): Promise<RunContextSnapshot | null> {
-  // Sanitize runId to prevent APL injection — only allow alphanumeric, hyphens, and underscores
-  const sanitizedRunId = runId.replace(/[^a-zA-Z0-9_-]/g, "");
-  if (sanitizedRunId !== runId) {
-    return null;
-  }
-
   const dataset = getDatasetName(DATASETS.RUN_CONTEXT);
   const apl = `['${dataset}']
-| where runId == "${sanitizedRunId}"
+| where runId == "${escapeAplString(runId)}"
 | limit 1`;
 
   const results = await queryAxiom<RunContextSnapshot>(apl);

--- a/turbo/apps/web/src/lib/infra/run/run-telemetry-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-telemetry-service.ts
@@ -1,9 +1,15 @@
 import { eq, and } from "drizzle-orm";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
-import { queryAxiom, getDatasetName, DATASETS } from "../../shared/axiom";
+import {
+  queryAxiom,
+  getDatasetName,
+  DATASETS,
+  escapeAplString,
+} from "../../shared/axiom";
 import { notFound } from "@vm0/api-services/errors";
 import { extractFrameworkFromCompose } from "../framework/framework-config";
+import { waitForRunEventWatermarkVisible } from "./agent-event-visibility";
 
 interface AxiomAgentEvent {
   _time: string;
@@ -46,6 +52,7 @@ export async function getRunAgentEvents(
   const [runWithCompose] = await db
     .select({
       id: agentRuns.id,
+      lastEventSequence: agentRuns.lastEventSequence,
       composeContent: agentComposeVersions.content,
     })
     .from(agentRuns)
@@ -85,8 +92,19 @@ export async function getRunAgentEvents(
   // integer `sequenceNumber` avoids any precision loss.
   const sinceFilter =
     since !== undefined ? `| where sequenceNumber > ${since}` : "";
+
+  if (
+    runWithCompose.lastEventSequence !== null &&
+    (since === undefined || since < runWithCompose.lastEventSequence)
+  ) {
+    await waitForRunEventWatermarkVisible(
+      runId,
+      runWithCompose.lastEventSequence,
+    );
+  }
+
   const apl = `['${dataset}']
-| where runId == "${runId}"
+| where runId == "${escapeAplString(runId)}"
 ${sinceFilter}
 | order by sequenceNumber ${order}
 | limit ${limit + 1}`;

--- a/turbo/apps/web/src/lib/infra/run/run-telemetry-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-telemetry-service.ts
@@ -130,6 +130,8 @@ export async function getRunAgentEvents(
   if (watermarkTarget !== null) {
     await waitForRunEventWatermarkVisible(runId, watermarkTarget);
   }
+  const axiomQueryOptions =
+    watermarkTarget !== null ? ({ noCache: true } as const) : undefined;
 
   const apl = `['${dataset}']
 | where runId == "${escapeAplString(runId)}"
@@ -137,7 +139,9 @@ ${sinceFilter}
 | order by sequenceNumber ${order}
 | limit ${limit + 1}`;
 
-  const events = await queryAxiom<AxiomAgentEvent>(apl);
+  const events = axiomQueryOptions
+    ? await queryAxiom<AxiomAgentEvent>(apl, axiomQueryOptions)
+    : await queryAxiom<AxiomAgentEvent>(apl);
 
   const hasMore = events.length > limit;
   const resultEvents = hasMore ? events.slice(0, limit) : events;

--- a/turbo/apps/web/src/lib/infra/run/run-telemetry-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-telemetry-service.ts
@@ -51,7 +51,11 @@ function getAgentEventsVisibilityTarget(
   }
 
   if (order === "asc") {
-    return getAgentEventPageWatermarkTarget(lastEventSequence, since, limit);
+    return getAgentEventPageWatermarkTarget(
+      lastEventSequence,
+      since,
+      limit + 1,
+    );
   }
 
   if (since !== undefined && since >= lastEventSequence) {

--- a/turbo/apps/web/src/lib/infra/run/run-telemetry-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-telemetry-service.ts
@@ -9,7 +9,10 @@ import {
 } from "../../shared/axiom";
 import { notFound } from "@vm0/api-services/errors";
 import { extractFrameworkFromCompose } from "../framework/framework-config";
-import { waitForRunEventWatermarkVisible } from "./agent-event-visibility";
+import {
+  getAgentEventPageWatermarkTarget,
+  waitForRunEventWatermarkVisible,
+} from "./agent-event-visibility";
 
 interface AxiomAgentEvent {
   _time: string;
@@ -35,6 +38,27 @@ interface AgentEventsResult {
   }>;
   hasMore: boolean;
   framework: string;
+}
+
+function getAgentEventsVisibilityTarget(
+  lastEventSequence: number | null,
+  since: number | undefined,
+  limit: number,
+  order: "asc" | "desc",
+): number | null {
+  if (lastEventSequence === null) {
+    return null;
+  }
+
+  if (order === "asc") {
+    return getAgentEventPageWatermarkTarget(lastEventSequence, since, limit);
+  }
+
+  if (since !== undefined && since >= lastEventSequence) {
+    return null;
+  }
+
+  return lastEventSequence;
 }
 
 /**
@@ -93,14 +117,14 @@ export async function getRunAgentEvents(
   const sinceFilter =
     since !== undefined ? `| where sequenceNumber > ${since}` : "";
 
-  if (
-    runWithCompose.lastEventSequence !== null &&
-    (since === undefined || since < runWithCompose.lastEventSequence)
-  ) {
-    await waitForRunEventWatermarkVisible(
-      runId,
-      runWithCompose.lastEventSequence,
-    );
+  const watermarkTarget = getAgentEventsVisibilityTarget(
+    runWithCompose.lastEventSequence,
+    since,
+    limit,
+    order,
+  );
+  if (watermarkTarget !== null) {
+    await waitForRunEventWatermarkVisible(runId, watermarkTarget);
   }
 
   const apl = `['${dataset}']

--- a/turbo/apps/web/src/lib/shared/axiom/__tests__/client.test.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/__tests__/client.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
 
 // Mock @axiomhq/js at the package boundary.
 const mockQuery = vi.fn();
@@ -229,35 +231,31 @@ describe("queryAxiom", () => {
   });
 
   it("uses an abortable direct query when timeoutMs is provided", async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(
-        new Response(JSON.stringify(axiomResponse([{ eventType: "result" }])), {
-          status: 200,
-        }),
-      );
+    let capturedRequest: Request | undefined;
+    server.use(
+      http.post("https://api.axiom.co/v1/datasets/_apl", ({ request }) => {
+        capturedRequest = request;
+        return HttpResponse.json(axiomResponse([{ eventType: "result" }]));
+      }),
+    );
 
-    try {
-      const results = await queryAxiom(apl, {
-        maxRetries: 0,
-        noCache: true,
-        streamingDuration: "1s",
-        timeoutMs: 2_000,
-      });
+    const results = await queryAxiom(apl, {
+      maxRetries: 0,
+      noCache: true,
+      streamingDuration: "1s",
+      timeoutMs: 2_000,
+    });
 
-      expect(results).toHaveLength(1);
-      expect(mockQuery).not.toHaveBeenCalled();
-      const [url, init] = fetchSpy.mock.calls[0]!;
-      expect(String(url)).toContain("https://api.axiom.co/v1/datasets/_apl?");
-      expect(String(url)).toContain("nocache=true");
-      expect(String(url)).toContain("streaming-duration=1s");
-      expect(init).toMatchObject({
-        method: "POST",
-        cache: "no-store",
-      });
-      expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
-    } finally {
-      fetchSpy.mockRestore();
-    }
+    expect(results).toHaveLength(1);
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(capturedRequest).toBeDefined();
+    expect(capturedRequest!.url).toContain(
+      "https://api.axiom.co/v1/datasets/_apl?",
+    );
+    expect(capturedRequest!.url).toContain("nocache=true");
+    expect(capturedRequest!.url).toContain("streaming-duration=1s");
+    expect(capturedRequest!.method).toBe("POST");
+    expect(capturedRequest!.cache).toBe("no-store");
+    expect(capturedRequest!.signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/turbo/apps/web/src/lib/shared/axiom/__tests__/client.test.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/__tests__/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server";
 
@@ -46,11 +46,6 @@ beforeEach(() => {
   mockQuery.mockReset();
   mockIngest.mockReset();
   mockFlush.mockReset();
-  vi.useFakeTimers();
-});
-
-afterEach(() => {
-  vi.useRealTimers();
 });
 
 function axiomResponse(events: Array<Record<string, unknown>>) {
@@ -171,30 +166,24 @@ describe("queryAxiom", () => {
 
   it("retries on rate limit error and succeeds", async () => {
     mockQuery
-      .mockRejectedValueOnce(new Error("429 rate limit"))
+      .mockRejectedValueOnce(new Error("429 rate limit, try again in 0m0s"))
       .mockResolvedValueOnce(axiomResponse([{ eventType: "result" }]));
 
-    const promise = queryAxiom(apl);
-    await vi.advanceTimersByTimeAsync(2000);
-    const results = await promise;
+    const results = await queryAxiom(apl);
 
     expect(results).toHaveLength(1);
     expect(mockQuery).toHaveBeenCalledTimes(2);
   });
 
   it("throws after exhausting retries on persistent rate limit", async () => {
-    mockQuery.mockRejectedValue(new Error("429 rate limit"));
+    mockQuery.mockRejectedValue(new Error("429 rate limit, try again in 0m0s"));
 
-    // Attach catch immediately to prevent unhandled rejection
-    const promise = queryAxiom(apl).catch((e: unknown) => {
+    const error = await queryAxiom(apl).catch((e: unknown) => {
       return e;
     });
-    // Advance through all 3 retry backoffs: 2s + 4s + 8s = 14s
-    await vi.advanceTimersByTimeAsync(20_000);
 
-    const error = await promise;
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toBe("429 rate limit");
+    expect((error as Error).message).toBe("429 rate limit, try again in 0m0s");
     // 1 initial + 3 retries = 4 total attempts
     expect(mockQuery).toHaveBeenCalledTimes(4);
   });

--- a/turbo/apps/web/src/lib/shared/axiom/__tests__/client.test.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/__tests__/client.test.ts
@@ -212,4 +212,19 @@ describe("queryAxiom", () => {
     );
     expect(mockQuery).toHaveBeenCalledTimes(1);
   });
+
+  it("passes Axiom query options through to the SDK", async () => {
+    mockQuery.mockResolvedValue(axiomResponse([{ eventType: "result" }]));
+
+    await queryAxiom(apl, {
+      maxRetries: 0,
+      noCache: true,
+      streamingDuration: "1s",
+    });
+
+    expect(mockQuery).toHaveBeenCalledWith(apl, {
+      noCache: true,
+      streamingDuration: "1s",
+    });
+  });
 });

--- a/turbo/apps/web/src/lib/shared/axiom/__tests__/client.test.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/__tests__/client.test.ts
@@ -227,4 +227,37 @@ describe("queryAxiom", () => {
       streamingDuration: "1s",
     });
   });
+
+  it("uses an abortable direct query when timeoutMs is provided", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify(axiomResponse([{ eventType: "result" }])), {
+          status: 200,
+        }),
+      );
+
+    try {
+      const results = await queryAxiom(apl, {
+        maxRetries: 0,
+        noCache: true,
+        streamingDuration: "1s",
+        timeoutMs: 2_000,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(mockQuery).not.toHaveBeenCalled();
+      const [url, init] = fetchSpy.mock.calls[0]!;
+      expect(String(url)).toContain("https://api.axiom.co/v1/datasets/_apl?");
+      expect(String(url)).toContain("nocache=true");
+      expect(String(url)).toContain("streaming-duration=1s");
+      expect(init).toMatchObject({
+        method: "POST",
+        cache: "no-store",
+      });
+      expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
 });

--- a/turbo/apps/web/src/lib/shared/axiom/apl.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/apl.ts
@@ -1,0 +1,11 @@
+export function escapeAplString(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r");
+}
+
+export function quoteAplString(value: string): string {
+  return `"${escapeAplString(value)}"`;
+}

--- a/turbo/apps/web/src/lib/shared/axiom/apl.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/apl.ts
@@ -5,7 +5,3 @@ export function escapeAplString(value: string): string {
     .replace(/\n/g, "\\n")
     .replace(/\r/g, "\\r");
 }
-
-export function quoteAplString(value: string): string {
-  return `"${escapeAplString(value)}"`;
-}

--- a/turbo/apps/web/src/lib/shared/axiom/client.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/client.ts
@@ -1,5 +1,9 @@
 import "server-only";
-import type { Axiom } from "@axiomhq/js";
+import type {
+  Axiom,
+  QueryOptions as AxiomQueryOptions,
+  QueryResult,
+} from "@axiomhq/js";
 import { Entry } from "@axiomhq/js";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
 import { env } from "../../../env";
@@ -117,6 +121,8 @@ const QUERY_BACKOFF_BASE_MS = 2000;
 
 export interface QueryAxiomOptions {
   maxRetries?: number;
+  noCache?: AxiomQueryOptions["noCache"];
+  streamingDuration?: AxiomQueryOptions["streamingDuration"];
 }
 
 function isRateLimitError(error: unknown): boolean {
@@ -162,10 +168,20 @@ export async function queryAxiom<T = Record<string, unknown>>(
   }
 
   const maxRetries = options.maxRetries ?? MAX_QUERY_RETRIES;
+  const axiomQueryOptions: AxiomQueryOptions = {};
+  if (options.noCache !== undefined) {
+    axiomQueryOptions.noCache = options.noCache;
+  }
+  if (options.streamingDuration !== undefined) {
+    axiomQueryOptions.streamingDuration = options.streamingDuration;
+  }
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
-      const result = await client.query(apl);
+      const result = (await client.query(
+        apl,
+        axiomQueryOptions,
+      )) as QueryResult;
       // Axiom stores _time separately from data, merge them for the response
       return (
         result.matches?.map((m: Entry) => {

--- a/turbo/apps/web/src/lib/shared/axiom/client.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/client.ts
@@ -123,6 +123,7 @@ export interface QueryAxiomOptions {
   maxRetries?: number;
   noCache?: AxiomQueryOptions["noCache"];
   streamingDuration?: AxiomQueryOptions["streamingDuration"];
+  timeoutMs?: number;
 }
 
 function isRateLimitError(error: unknown): boolean {
@@ -159,10 +160,13 @@ export async function queryAxiom<T = Record<string, unknown>>(
 ): Promise<T[]> {
   const dataset = extractDatasetFromApl(apl);
   // If we can't determine the dataset, default to telemetry client (broader scope)
-  const client = dataset
-    ? getClientForDataset(dataset)
-    : getTelemetryInstance(env().AXIOM_TOKEN_TELEMETRY);
-  if (!client) {
+  const client =
+    options.timeoutMs === undefined
+      ? dataset
+        ? getClientForDataset(dataset)
+        : getTelemetryInstance(env().AXIOM_TOKEN_TELEMETRY)
+      : null;
+  if (options.timeoutMs === undefined && !client) {
     log.debug("Axiom not configured, skipping query");
     return [];
   }
@@ -178,10 +182,16 @@ export async function queryAxiom<T = Record<string, unknown>>(
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
-      const result = (await client.query(
-        apl,
-        axiomQueryOptions,
-      )) as QueryResult;
+      let result: QueryResult;
+      if (options.timeoutMs === undefined) {
+        if (!client) {
+          log.debug("Axiom not configured, skipping query");
+          return [];
+        }
+        result = (await client.query(apl, axiomQueryOptions)) as QueryResult;
+      } else {
+        result = await queryAxiomWithTimeout(apl, dataset, options);
+      }
       // Axiom stores _time separately from data, merge them for the response
       return (
         result.matches?.map((m: Entry) => {
@@ -208,6 +218,103 @@ export async function queryAxiom<T = Record<string, unknown>>(
   throw new Error(
     "queryAxiom: unreachable — retry loop exited without return or throw",
   );
+}
+
+async function queryAxiomWithTimeout(
+  apl: string,
+  dataset: string | null,
+  options: QueryAxiomOptions,
+): Promise<QueryResult> {
+  const token = dataset
+    ? isSessionsDataset(dataset)
+      ? env().AXIOM_TOKEN_SESSIONS
+      : env().AXIOM_TOKEN_TELEMETRY
+    : env().AXIOM_TOKEN_TELEMETRY;
+  if (!token) {
+    log.debug("Axiom not configured, skipping query");
+    return emptyQueryResult(dataset);
+  }
+
+  const timeoutMs = Math.max(1, options.timeoutMs ?? 1);
+  const params = new URLSearchParams({ format: "legacy" });
+  if (options.noCache !== undefined) {
+    params.set("nocache", String(options.noCache));
+  }
+  if (options.streamingDuration !== undefined) {
+    params.set("streaming-duration", options.streamingDuration);
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+
+  try {
+    const response = await fetch(
+      `https://api.axiom.co/v1/datasets/_apl?${params.toString()}`,
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ apl }),
+        signal: controller.signal,
+        cache: "no-store",
+      },
+    );
+
+    if (response.status === 429) {
+      throw new Error("429 rate limit");
+    }
+    if (response.status === 401) {
+      throw new Error("forbidden");
+    }
+    if (response.status >= 400) {
+      const payload = (await response.json().catch(() => {
+        return {};
+      })) as { message?: string };
+      throw new Error(
+        payload.message ?? `Axiom query failed: ${response.status}`,
+      );
+    }
+
+    return (await response.json()) as QueryResult;
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`Axiom query timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function emptyQueryResult(dataset: string | null): QueryResult {
+  const epoch = "1970-01-01T00:00:00.000Z";
+  return {
+    request: {
+      startTime: epoch,
+      endTime: epoch,
+      resolution: "auto",
+    },
+    buckets: {},
+    datasetNames: dataset ? [dataset] : [],
+    matches: [],
+    status: {
+      blocksExamined: 0,
+      elapsedTime: 0,
+      isPartial: false,
+      maxBlockTime: epoch,
+      minBlockTime: epoch,
+      numGroups: 0,
+      rowsExamined: 0,
+      rowsMatched: 0,
+      maxCursor: "",
+      minCursor: "",
+    },
+  };
 }
 
 interface RequestLogEntry {

--- a/turbo/apps/web/src/lib/shared/axiom/index.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/index.ts
@@ -7,4 +7,5 @@ export {
   ingestRequestLog,
   ingestSandboxOpLog,
 } from "./client";
+export { escapeAplString, quoteAplString } from "./apl";
 export { getDatasetName, DATASETS } from "./datasets";

--- a/turbo/apps/web/src/lib/shared/axiom/index.ts
+++ b/turbo/apps/web/src/lib/shared/axiom/index.ts
@@ -7,5 +7,5 @@ export {
   ingestRequestLog,
   ingestSandboxOpLog,
 } from "./client";
-export { escapeAplString, quoteAplString } from "./apl";
+export { escapeAplString } from "./apl";
 export { getDatasetName, DATASETS } from "./datasets";

--- a/turbo/apps/web/src/lib/zero/support/diagnostic-bundle-service.ts
+++ b/turbo/apps/web/src/lib/zero/support/diagnostic-bundle-service.ts
@@ -28,6 +28,7 @@ import { logger } from "../../shared/logger";
 const log = logger("service:diagnostic-bundle");
 
 const DOWNLOAD_EXPIRY_SECONDS = 72 * 60 * 60;
+const AGENT_EVENT_WATERMARK_WAIT_CONCURRENCY = 4;
 
 interface ZipEntry {
   path: string;
@@ -448,11 +449,7 @@ async function collectAgentEvents(
     return run.lastEventSequence !== null;
   });
   if (terminalRuns.length > 0) {
-    await Promise.all(
-      terminalRuns.map((run) => {
-        return waitForRunEventWatermarkVisible(run.id, run.lastEventSequence);
-      }),
-    );
+    await waitForAgentEventWatermarks(terminalRuns);
   }
 
   const runIdList = sessionRunIds
@@ -471,4 +468,24 @@ async function collectAgentEvents(
     });
     return [] as ChatHistoryEvent[];
   });
+}
+
+async function waitForAgentEventWatermarks(
+  terminalRuns: RunMeta[],
+): Promise<void> {
+  for (
+    let offset = 0;
+    offset < terminalRuns.length;
+    offset += AGENT_EVENT_WATERMARK_WAIT_CONCURRENCY
+  ) {
+    const batch = terminalRuns.slice(
+      offset,
+      offset + AGENT_EVENT_WATERMARK_WAIT_CONCURRENCY,
+    );
+    await Promise.all(
+      batch.map((run) => {
+        return waitForRunEventWatermarkVisible(run.id, run.lastEventSequence);
+      }),
+    );
+  }
 }

--- a/turbo/apps/web/src/lib/zero/support/diagnostic-bundle-service.ts
+++ b/turbo/apps/web/src/lib/zero/support/diagnostic-bundle-service.ts
@@ -462,7 +462,7 @@ async function collectAgentEvents(
 | where runId in (${runIdList})
 | order by _time asc, sequenceNumber asc
 | limit 2000`;
-  return queryAxiom<ChatHistoryEvent>(apl).catch((err) => {
+  return queryAxiom<ChatHistoryEvent>(apl, { noCache: true }).catch((err) => {
     log.warn("Failed to collect agent events from Axiom", {
       error: String(err),
     });

--- a/turbo/apps/web/src/lib/zero/support/diagnostic-bundle-service.ts
+++ b/turbo/apps/web/src/lib/zero/support/diagnostic-bundle-service.ts
@@ -6,11 +6,17 @@ import {
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { queryAxiom, getDatasetName, DATASETS } from "../../shared/axiom";
+import {
+  queryAxiom,
+  getDatasetName,
+  DATASETS,
+  escapeAplString,
+} from "../../shared/axiom";
 import {
   assembleActivityLog,
   type RunMeta,
 } from "../../infra/run/activity-log-service";
+import { waitForRunEventWatermarkVisible } from "../../infra/run/agent-event-visibility";
 import { listConnectors } from "../connector/connector-service";
 import { uploadS3Buffer, generatePresignedUrl } from "../../infra/s3/s3-client";
 import { createPlainSupportThread } from "./plain-service";
@@ -110,7 +116,7 @@ export async function submitDiagnosticBundle(
     return r.id;
   });
   const [agentEvents, systemLogText, networkLogEntries] = await Promise.all([
-    collectAgentEvents(sessionRunIds),
+    collectAgentEvents(sessionRuns),
     collectSystemLog(sessionRunIds),
     collectNetworkLog(sessionRunIds),
   ]);
@@ -350,6 +356,7 @@ const sessionRunSelect = {
   createdAt: agentRuns.createdAt,
   startedAt: agentRuns.startedAt,
   completedAt: agentRuns.completedAt,
+  lastEventSequence: agentRuns.lastEventSequence,
   runnerGroup: agentRuns.runnerGroup,
   continuedFromSessionId: agentRuns.continuedFromSessionId,
   result: agentRuns.result,
@@ -384,7 +391,7 @@ async function collectSystemLog(sessionRunIds: string[]): Promise<string> {
   if (sessionRunIds.length === 0) return "";
   const runIdList = sessionRunIds
     .map((id) => {
-      return `"${id}"`;
+      return `"${escapeAplString(id)}"`;
     })
     .join(", ");
   const dataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_SYSTEM);
@@ -410,7 +417,7 @@ async function collectNetworkLog(
   if (sessionRunIds.length === 0) return [];
   const runIdList = sessionRunIds
     .map((id) => {
-      return `"${id}"`;
+      return `"${escapeAplString(id)}"`;
     })
     .join(", ");
   const dataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_NETWORK);
@@ -428,12 +435,27 @@ async function collectNetworkLog(
 }
 
 async function collectAgentEvents(
-  sessionRunIds: string[],
+  sessionRuns: RunMeta[],
 ): Promise<ChatHistoryEvent[]> {
+  const sessionRunIds = sessionRuns.map((run) => {
+    return run.id;
+  });
   if (sessionRunIds.length === 0) return [];
+
+  const terminalRuns = sessionRuns.filter((run) => {
+    return run.lastEventSequence !== null;
+  });
+  if (terminalRuns.length > 0) {
+    await Promise.all(
+      terminalRuns.map((run) => {
+        return waitForRunEventWatermarkVisible(run.id, run.lastEventSequence);
+      }),
+    );
+  }
+
   const runIdList = sessionRunIds
     .map((id) => {
-      return `"${id}"`;
+      return `"${escapeAplString(id)}"`;
     })
     .join(", ");
   const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);

--- a/turbo/apps/web/src/lib/zero/support/diagnostic-bundle-service.ts
+++ b/turbo/apps/web/src/lib/zero/support/diagnostic-bundle-service.ts
@@ -154,7 +154,9 @@ export async function submitDiagnosticBundle(
   // entire diagnostic bundle submit.
   const activityLogs = await Promise.all(
     sessionRuns.map((r) => {
-      return assembleActivityLog(r.id, r, agentConfig).catch((err) => {
+      return assembleActivityLog(r.id, r, agentConfig, {
+        waitForAgentEventWatermark: false,
+      }).catch((err) => {
         log.warn("Failed to assemble activity log for run", {
           runId: r.id,
           error: String(err),


### PR DESCRIPTION
## Summary
- keep the complete webhook non-blocking and move Axiom terminal visibility waits to read paths
- add a reusable terminal event-prefix visibility barrier using `lastEventSequence`
- apply the barrier to callback output extraction, run event polling, zero logs, and diagnostic/activity reads; also centralize APL string escaping

## Tests
- `pnpm -C turbo/apps/web exec vitest run src/lib/infra/run/__tests__/agent-event-visibility.test.ts src/lib/infra/run/__tests__/extract-run-output.test.ts app/api/internal/callbacks/slack/org/__tests__/route.test.ts app/api/internal/callbacks/chat/__tests__/route.test.ts app/api/webhooks/agent/complete/__tests__/route.test.ts app/api/agent/runs/[id]/events/__tests__/route.test.ts app/api/agent/runs/[id]/telemetry/agent/__tests__/route.test.ts app/api/zero/runs/[id]/telemetry/agent/__tests__/route.test.ts app/api/logs/search/__tests__/route.test.ts app/api/zero/logs/search/__tests__/route.test.ts app/api/zero/report-error/__tests__/route.test.ts app/api/zero/developer-support/__tests__/route.test.ts app/api/zero/email/callbacks/reply/__tests__/route.test.ts app/api/zero/email/callbacks/trigger/__tests__/route.test.ts`
- `pnpm -C turbo/apps/web lint`
- `pnpm -C turbo/apps/web check-types`

Refs #12152