### PR TITLE
refactor: introduce resolved model route

### DIFF
--- a/turbo/apps/web/src/lib/zero/context/__tests__/resolve-model-provider.test.ts
+++ b/turbo/apps/web/src/lib/zero/context/__tests__/resolve-model-provider.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { resolveModelProviderSecrets } from "../resolve-model-provider";
+import {
+  resolveModelProviderSecrets,
+  resolveModelRoute,
+} from "../resolve-model-provider";
 import {
   isBadRequest,
   isModelProviderConnectRequired,
@@ -246,6 +249,33 @@ describe("resolveModelProviderSecrets — framework gate removed (#11526)", () =
 
     expect(result.resolvedModelProvider).toBe("openai-api-key");
     expect(result.framework).toBe("codex");
+  });
+
+  it("resolves a route whose provider framework overrides the compose framework", async () => {
+    const userId = uniqueId("route-cross-framework");
+    const orgId = await setupOrg(userId);
+    await insertOrgDefaultModelProvider(orgId, "openai-api-key");
+    const modelProviderId = await getTestModelProviderIdByType(
+      orgId,
+      "openai-api-key",
+    );
+
+    const route = await resolveModelRoute({
+      orgId,
+      userId,
+      framework: "claude-code",
+      modelProviderId,
+    });
+
+    expect(route.provider.type).toBe("openai-api-key");
+    expect(route.framework).toBe("codex");
+    expect(route.model.canonical).toBe("gpt-5.5");
+    expect(route.model.runtime).toBe("gpt-5.5");
+    expect(route.credential).toEqual({
+      scope: "org",
+      modelProviderId,
+      ownerUserId: ORG_SENTINEL_USER_ID,
+    });
   });
 });
 
@@ -506,6 +536,39 @@ describe("resolveModelProviderSecrets — personal tier (#11899)", () => {
     expect(result.resolvedModelProvider).toBe("openai-api-key");
     expect(result.framework).toBe("codex");
     expect(result.secrets?.OPENAI_API_KEY).toBe("personal-pin-key");
+  });
+
+  it("resolves a personal default route with member-owned credentials", async () => {
+    const userId = uniqueId("personal-route");
+    const orgId = await setupOrg(userId);
+    await enablePersonalModelProviderForUser(orgId, userId);
+    const modelProviderId = await insertUserDefaultModelProvider(
+      orgId,
+      userId,
+      "openai-api-key",
+      "gpt-5.4",
+    );
+    await insertOrgDefaultModelProvider(
+      orgId,
+      "anthropic-api-key",
+      "claude-sonnet-4-6",
+    );
+
+    const route = await resolveModelRoute({
+      orgId,
+      userId,
+      framework: "claude-code",
+      preferPersonalProvider: true,
+    });
+
+    expect(route.provider.type).toBe("openai-api-key");
+    expect(route.framework).toBe("codex");
+    expect(route.model.canonical).toBe("gpt-5.4");
+    expect(route.credential).toEqual({
+      scope: "member",
+      modelProviderId,
+      ownerUserId: userId,
+    });
   });
 });
 
@@ -781,6 +844,45 @@ describe("resolveModelProviderSecrets — model-first policy (#12130)", () => {
     expect(result.injectedEnvironment?.ANTHROPIC_MODEL).toBe("z-ai/glm-5.1");
   });
 
+  it("resolves model-first org API-key routes into route framework/model/credential", async () => {
+    const userId = uniqueId("mf-route-org");
+    const orgId = await setupOrg(userId);
+    await enableModelFirstModelProviderForUser(orgId, userId);
+    await insertOrgNonDefaultModelProvider(orgId, "openrouter-api-key");
+    const providerId = await getTestModelProviderIdByType(
+      orgId,
+      "openrouter-api-key",
+    );
+    await insertOrgModelPolicy({
+      orgId,
+      model: "glm-5.1",
+      sortOrder: 0,
+      defaultProviderType: "openrouter-api-key",
+      credentialScope: "org",
+      modelProviderId: providerId,
+    });
+
+    const route = await resolveModelRoute({
+      orgId,
+      userId,
+      framework: "codex",
+      selectedModelOverride: "glm-5.1",
+    });
+
+    expect(route.provider.type).toBe("openrouter-api-key");
+    expect(route.framework).toBe("claude-code");
+    expect(route.model).toEqual({
+      selected: "glm-5.1",
+      canonical: "glm-5.1",
+      runtime: "z-ai/glm-5.1",
+    });
+    expect(route.credential).toEqual({
+      scope: "org",
+      modelProviderId: providerId,
+      ownerUserId: ORG_SENTINEL_USER_ID,
+    });
+  });
+
   it("uses the current member's OAuth credential for member-scoped routes", async () => {
     const userId = uniqueId("mf-member-oauth");
     const orgId = await setupOrg(userId);
@@ -825,6 +927,41 @@ describe("resolveModelProviderSecrets — model-first policy (#12130)", () => {
       CHATGPT_ACCOUNT_ID: "member-account",
     });
     expect(result.injectedEnvironment?.OPENAI_MODEL).toBe("gpt-5.5");
+  });
+
+  it("resolves model-first member OAuth routes into member-owned Codex routes", async () => {
+    const userId = uniqueId("mf-route-member");
+    const orgId = await setupOrg(userId);
+    await enableModelFirstModelProviderForUser(orgId, userId);
+    await insertUserMultiAuthModelProvider(
+      orgId,
+      userId,
+      "codex-oauth-token",
+      "auth_json",
+    );
+    await insertOrgModelPolicy({
+      orgId,
+      model: "gpt-5.5",
+      sortOrder: 0,
+      defaultProviderType: "codex-oauth-token",
+      credentialScope: "member",
+    });
+
+    const route = await resolveModelRoute({
+      orgId,
+      userId,
+      framework: "claude-code",
+      selectedModelOverride: "gpt-5.5",
+    });
+
+    expect(route.provider.type).toBe("codex-oauth-token");
+    expect(route.framework).toBe("codex");
+    expect(route.model.runtime).toBe("gpt-5.5");
+    expect(route.credential).toEqual({
+      scope: "member",
+      modelProviderId: null,
+      ownerUserId: userId,
+    });
   });
 
   it("throws connect-required for missing member OAuth and does not fallback", async () => {
@@ -951,6 +1088,30 @@ describe("resolveModelProviderSecrets — model-first policy (#12130)", () => {
       ),
     ).rejects.toSatisfy((err: unknown) => {
       return isProviderDeleted(err);
+    });
+  });
+
+  it("rejects vm0 model routes before materialization when no concrete mapping exists", async () => {
+    const userId = uniqueId("mf-vm0-missing-map");
+    const orgId = await setupOrg(userId);
+    await enableModelFirstModelProviderForUser(orgId, userId);
+    await insertOrgModelPolicy({
+      orgId,
+      model: "gpt-5.5",
+      sortOrder: 0,
+      defaultProviderType: "vm0",
+      credentialScope: "org",
+    });
+
+    await expect(
+      resolveModelRoute({
+        orgId,
+        userId,
+        framework: "codex",
+        selectedModelOverride: "gpt-5.5",
+      }),
+    ).rejects.toSatisfy((err: unknown) => {
+      return isBadRequest(err);
     });
   });
 

--- a/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
@@ -10,6 +10,7 @@ import {
   getVm0ConcreteProviderType,
   getVm0Vendor,
   type ModelProviderCredentialScope,
+  type ModelProviderFramework,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import {
@@ -164,6 +165,63 @@ export interface ResolveModelProviderSecretTimings {
   environmentMapping?: number;
 }
 
+interface ResolvedModelRouteModel {
+  /** Model explicitly chosen by the caller, provider row, or model-first policy. */
+  selected: string | undefined;
+  /** Effective canonical model after default fallback, when the provider has one. */
+  canonical: string | undefined;
+  /** Provider-specific runtime model id after alias translation. */
+  runtime: string | undefined;
+}
+
+interface ResolvedModelRouteProvider {
+  type: ModelProviderType;
+  /** Concrete upstream provider for meta-providers like vm0. */
+  concreteType?: ModelProviderType;
+}
+
+type ResolvedModelRouteCredential =
+  | {
+      scope: "org";
+      modelProviderId: string | null;
+      ownerUserId: typeof ORG_SENTINEL_USER_ID;
+    }
+  | {
+      scope: "member";
+      modelProviderId: string | null;
+      ownerUserId: string;
+    };
+
+interface ResolvedModelRouteSourceProvider {
+  id: string;
+  userId: string;
+  type: ModelProviderType;
+  authMethod?: string | null;
+  selectedModel: string | null;
+  needsReconnect: boolean;
+  lastRefreshErrorCode: string | null;
+}
+
+interface ResolvedModelRoute {
+  source: "legacy" | "model-first";
+  framework: ModelProviderFramework;
+  model: ResolvedModelRouteModel;
+  provider: ResolvedModelRouteProvider;
+  credential: ResolvedModelRouteCredential;
+  sourceProvider?: ResolvedModelRouteSourceProvider;
+}
+
+interface ResolveModelRouteParams {
+  orgId: string;
+  userId: string;
+  framework: string;
+  explicitModelProvider?: string;
+  modelProviderId?: string;
+  selectedModelOverride?: string;
+  preferPersonalProvider?: boolean;
+  modelProviderCredentialScope?: string;
+}
+
 /**
  * Result of model provider secret resolution
  */
@@ -262,6 +320,160 @@ function buildModelProviderRefreshMaps(
   };
 }
 
+function toRouteSourceProvider(
+  provider: ModelProviderInfo | null | undefined,
+): ResolvedModelRouteSourceProvider | undefined {
+  if (!provider) return undefined;
+  return {
+    id: provider.id,
+    userId: provider.userId,
+    type: provider.type,
+    authMethod: provider.authMethod,
+    selectedModel: provider.selectedModel,
+    needsReconnect: provider.needsReconnect,
+    lastRefreshErrorCode: provider.lastRefreshErrorCode,
+  };
+}
+
+function assertProviderFresh(provider: ModelProviderInfo | null): void {
+  if (!provider?.needsReconnect) return;
+  throw staleProvider(provider.type, provider.lastRefreshErrorCode);
+}
+
+function getVm0ConcreteProviderTypeForRoute(
+  selectedModel: string,
+): ModelProviderType {
+  try {
+    return getVm0ConcreteProviderType(selectedModel);
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : `Unknown VM0 model "${selectedModel}"`;
+    throw badRequest(message);
+  }
+}
+
+function resolveRouteModel(
+  providerType: ModelProviderType,
+  selectedModel: string | undefined,
+): ResolvedModelRouteModel {
+  const defaultModel = getDefaultModel(providerType) || undefined;
+  const canonical = selectedModel ?? defaultModel;
+  return {
+    selected: selectedModel,
+    canonical,
+    runtime: canonical
+      ? getProviderRuntimeModel(providerType, canonical)
+      : undefined,
+  };
+}
+
+function resolveRouteProvider(
+  providerType: ModelProviderType,
+  canonicalModel: string | undefined,
+): ResolvedModelRouteProvider {
+  if (providerType !== "vm0") {
+    return { type: providerType };
+  }
+  if (!canonicalModel) {
+    throw badRequest("VM0 provider requires a selected model");
+  }
+  return {
+    type: providerType,
+    concreteType: getVm0ConcreteProviderTypeForRoute(canonicalModel),
+  };
+}
+
+function buildRouteCredential(params: {
+  scope: ModelProviderCredentialScope;
+  modelProviderId: string | null;
+  ownerUserId: string;
+}): ResolvedModelRouteCredential {
+  if (params.scope === "org") {
+    return {
+      scope: "org",
+      modelProviderId: params.modelProviderId,
+      ownerUserId: ORG_SENTINEL_USER_ID,
+    };
+  }
+  return {
+    scope: "member",
+    modelProviderId: params.modelProviderId,
+    ownerUserId: params.ownerUserId,
+  };
+}
+
+function buildResolvedModelRoute(params: {
+  source: ResolvedModelRoute["source"];
+  providerType: ModelProviderType;
+  selectedModel: string | undefined;
+  credentialScope: ModelProviderCredentialScope;
+  modelProviderId: string | null;
+  ownerUserId: string;
+  sourceProvider?: ModelProviderInfo | null;
+}): ResolvedModelRoute {
+  const model = resolveRouteModel(params.providerType, params.selectedModel);
+  const provider = resolveRouteProvider(params.providerType, model.canonical);
+  return {
+    source: params.source,
+    framework: getFrameworkForType(provider.concreteType ?? provider.type),
+    model,
+    provider,
+    credential: buildRouteCredential({
+      scope: params.credentialScope,
+      modelProviderId: params.modelProviderId,
+      ownerUserId: params.ownerUserId,
+    }),
+    sourceProvider: toRouteSourceProvider(params.sourceProvider),
+  };
+}
+
+function shouldExposeRouteCredentialMetadata(
+  route: ResolvedModelRoute,
+): boolean {
+  return route.source === "model-first" || route.provider.type === "vm0";
+}
+
+function withRouteMetadata(
+  route: ResolvedModelRoute,
+  result: ModelProviderSecretResult,
+): ModelProviderSecretResult {
+  const includeCredentialMetadata = shouldExposeRouteCredentialMetadata(route);
+  const selectedModel =
+    route.provider.type === "vm0"
+      ? route.model.canonical
+      : route.model.selected;
+  return {
+    ...result,
+    resolvedModelProvider: route.provider.type,
+    framework: route.framework,
+    concreteProviderType: route.provider.concreteType,
+    selectedModel,
+    credentialScope: includeCredentialMetadata
+      ? route.credential.scope
+      : undefined,
+    modelProviderId: includeCredentialMetadata
+      ? route.credential.modelProviderId
+      : undefined,
+  };
+}
+
+function finalizeMaterializedRoute(
+  route: ResolvedModelRoute,
+  result: ModelProviderSecretResult,
+): ModelProviderSecretResult {
+  const decorated = withRouteMetadata(route, result);
+  if (
+    route.source === "model-first" &&
+    route.credential.scope === "member" &&
+    !decorated.secrets
+  ) {
+    throw modelProviderConnectRequired(route.provider.type);
+  }
+  return decorated;
+}
+
 /**
  * Resolve VM0 managed provider: map selected model to concrete provider,
  * fetch API key from pool, and resolve environment mapping.
@@ -269,7 +481,7 @@ function buildModelProviderRefreshMaps(
 async function resolveVm0Provider(
   selectedModel: string,
 ): Promise<ModelProviderSecretResult> {
-  const concreteType = getVm0ConcreteProviderType(selectedModel);
+  const concreteType = getVm0ConcreteProviderTypeForRoute(selectedModel);
   const vendor = getVm0Vendor(selectedModel);
   const apiModel = getProviderRuntimeModel("vm0", selectedModel);
   const poolKey = await getVm0ApiKey(vendor);
@@ -385,178 +597,105 @@ async function resolveMultiAuthProviderSecrets(
   };
 }
 
-async function resolveProviderSecretsForRoute(params: {
+async function materializeModelRoute(params: {
   orgId: string;
-  secretUserId: string;
-  providerType: ModelProviderType;
-  authMethod?: string | null;
-  canonicalModel: string;
-  credentialScope?: ModelProviderCredentialScope;
-  modelProviderId?: string | null;
+  route: ResolvedModelRoute;
+  timings?: ResolveModelProviderSecretTimings;
 }): Promise<ModelProviderSecretResult> {
-  const {
-    orgId,
-    secretUserId,
-    providerType,
-    authMethod,
-    canonicalModel,
-    credentialScope,
-    modelProviderId,
-  } = params;
+  const { orgId, route, timings } = params;
+  const providerType = route.provider.type;
+  const secretUserId = route.credential.ownerUserId;
 
   if (providerType === "vm0") {
-    return resolveVm0Provider(canonicalModel);
+    if (!route.model.canonical) {
+      throw badRequest("VM0 provider requires a selected model");
+    }
+    const vm0ProviderStart = Date.now();
+    const resolved = await resolveVm0Provider(route.model.canonical);
+    if (timings) {
+      timings.vm0ProviderResolution = Date.now() - vm0ProviderStart;
+    }
+    return finalizeMaterializedRoute(route, resolved);
   }
 
-  const runtimeModel = getProviderRuntimeModel(providerType, canonicalModel);
-  const resolvedFramework = getFrameworkForType(providerType);
-
   if (hasAuthMethods(providerType)) {
+    const multiAuthStart = Date.now();
     const resolved = await resolveMultiAuthProviderSecrets(
       orgId,
       secretUserId,
       providerType,
-      authMethod,
-      runtimeModel,
-      canonicalModel,
+      route.sourceProvider?.authMethod,
+      route.model.runtime,
+      route.model.selected,
     );
-    return (
-      resolved ?? {
+    if (timings) {
+      timings.multiAuthSecretResolution = Date.now() - multiAuthStart;
+    }
+    const result =
+      resolved ??
+      ({
         secrets: undefined,
         injectedEnvironment: undefined,
         resolvedModelProvider: providerType,
-        framework: resolvedFramework,
-        selectedModel: canonicalModel,
-        credentialScope,
-        modelProviderId,
-      }
-    );
+        framework: route.framework,
+        selectedModel: route.model.selected,
+      } satisfies ModelProviderSecretResult);
+    return finalizeMaterializedRoute(route, result);
   }
 
   const secretName = getSecretNameForType(providerType);
   if (!secretName) {
-    return {
+    return finalizeMaterializedRoute(route, {
       secrets: undefined,
       injectedEnvironment: undefined,
       resolvedModelProvider: providerType,
-      framework: resolvedFramework,
-      selectedModel: canonicalModel,
-      credentialScope,
-      modelProviderId,
-    };
+      framework: route.framework,
+      selectedModel: route.model.selected,
+    });
   }
 
+  const secretFetchStart = Date.now();
   const secretValue = await getSecretValue(
     orgId,
     secretUserId,
     secretName,
     "model-provider",
   );
+  if (timings) {
+    timings.singleSecretFetch = Date.now() - secretFetchStart;
+  }
 
   if (!secretValue) {
-    return {
+    return finalizeMaterializedRoute(route, {
       secrets: undefined,
       injectedEnvironment: undefined,
       resolvedModelProvider: providerType,
-      framework: resolvedFramework,
-      selectedModel: canonicalModel,
-      credentialScope,
-      modelProviderId,
-    };
+      framework: route.framework,
+      selectedModel: route.model.selected,
+    });
   }
 
+  const environmentMappingStart = Date.now();
   const injectedEnvironment = resolveEnvironmentMapping(
     providerType,
     secretName,
-    runtimeModel,
+    route.model.runtime,
   );
+  if (timings) {
+    timings.environmentMapping = Date.now() - environmentMappingStart;
+  }
 
   log.debug(
-    `Resolved model-first model provider env: ${Object.keys(injectedEnvironment).join(", ")}`,
+    `Resolved model provider env: ${Object.keys(injectedEnvironment).join(", ")}`,
   );
 
-  return {
+  return finalizeMaterializedRoute(route, {
     secrets: { [secretName]: secretValue },
     injectedEnvironment,
     resolvedModelProvider: providerType,
-    framework: resolvedFramework,
-    selectedModel: canonicalModel,
-    credentialScope,
-    modelProviderId,
-  };
-}
-
-async function resolveModelFirstProviderSecrets(params: {
-  orgId: string;
-  userId: string;
-  selectedModelOverride?: string;
-  explicitModelProvider?: string;
-  modelProviderId?: string;
-  modelProviderCredentialScope?: string;
-}): Promise<ModelProviderSecretResult> {
-  const route = await resolveModelFirstRouteDescriptor({
-    orgId: params.orgId,
-    userId: params.userId,
-    selectedModel: params.selectedModelOverride,
-    providerType: params.explicitModelProvider,
-    credentialScope: params.modelProviderCredentialScope,
-    modelProviderId: params.modelProviderId,
+    framework: route.framework,
+    selectedModel: route.model.selected,
   });
-
-  let providerRow: ModelProviderInfo | null = null;
-  let secretUserId = ORG_SENTINEL_USER_ID;
-
-  if (route.credentialScope === "member") {
-    providerRow = await getUserModelProviderByType(
-      params.orgId,
-      params.userId,
-      route.providerType,
-    );
-    if (!providerRow) {
-      throw modelProviderConnectRequired(route.providerType);
-    }
-    secretUserId = params.userId;
-  } else if (route.providerType !== "vm0") {
-    if (!route.modelProviderId) {
-      throw badRequest("Org-scoped model route is missing modelProviderId");
-    }
-    providerRow = await getModelProviderById(
-      params.orgId,
-      params.userId,
-      route.modelProviderId,
-    );
-    if (
-      !providerRow ||
-      providerRow.userId !== ORG_SENTINEL_USER_ID ||
-      providerRow.type !== route.providerType
-    ) {
-      throw providerDeleted();
-    }
-  }
-
-  if (providerRow?.needsReconnect) {
-    throw staleProvider(providerRow.type, providerRow.lastRefreshErrorCode);
-  }
-
-  const resolved = await resolveProviderSecretsForRoute({
-    orgId: params.orgId,
-    secretUserId,
-    providerType: route.providerType,
-    authMethod: providerRow?.authMethod,
-    canonicalModel: route.selectedModel,
-    credentialScope: route.credentialScope,
-    modelProviderId: route.modelProviderId,
-  });
-
-  if (route.credentialScope === "member" && !resolved.secrets) {
-    throw modelProviderConnectRequired(route.providerType);
-  }
-
-  return {
-    ...resolved,
-    credentialScope: route.credentialScope,
-    modelProviderId: route.modelProviderId,
-  };
 }
 
 /**
@@ -630,6 +769,139 @@ async function resolveMatchingProviderForType(params: {
   return getOrgModelProviderByType(orgId, providerType);
 }
 
+async function resolveModelFirstModelRoute(
+  params: ResolveModelRouteParams,
+): Promise<ResolvedModelRoute> {
+  const descriptor = await resolveModelFirstRouteDescriptor({
+    orgId: params.orgId,
+    userId: params.userId,
+    selectedModel: params.selectedModelOverride,
+    providerType: params.explicitModelProvider,
+    credentialScope: params.modelProviderCredentialScope,
+    modelProviderId: params.modelProviderId,
+  });
+
+  let providerRow: ModelProviderInfo | null = null;
+  let ownerUserId = ORG_SENTINEL_USER_ID;
+
+  if (descriptor.credentialScope === "member") {
+    providerRow = await getUserModelProviderByType(
+      params.orgId,
+      params.userId,
+      descriptor.providerType,
+    );
+    if (!providerRow) {
+      throw modelProviderConnectRequired(descriptor.providerType);
+    }
+    ownerUserId = params.userId;
+  } else if (descriptor.providerType !== "vm0") {
+    if (!descriptor.modelProviderId) {
+      throw badRequest("Org-scoped model route is missing modelProviderId");
+    }
+    providerRow = await getModelProviderById(
+      params.orgId,
+      params.userId,
+      descriptor.modelProviderId,
+    );
+    if (
+      !providerRow ||
+      providerRow.userId !== ORG_SENTINEL_USER_ID ||
+      providerRow.type !== descriptor.providerType
+    ) {
+      throw providerDeleted();
+    }
+  }
+
+  assertProviderFresh(providerRow);
+
+  return buildResolvedModelRoute({
+    source: "model-first",
+    providerType: descriptor.providerType,
+    selectedModel: descriptor.selectedModel,
+    credentialScope: descriptor.credentialScope,
+    modelProviderId: descriptor.modelProviderId,
+    ownerUserId,
+    sourceProvider: providerRow,
+  });
+}
+
+async function resolveLegacyModelRoute(
+  params: ResolveModelRouteParams,
+  timings?: ResolveModelProviderSecretTimings,
+): Promise<ResolvedModelRoute> {
+  const personalEligibilityStart = Date.now();
+  const personalEligible = await isPersonalTierEligible(
+    params.orgId,
+    params.userId,
+    params.preferPersonalProvider,
+  );
+  if (timings) {
+    timings.personalEligibility = Date.now() - personalEligibilityStart;
+  }
+
+  const defaultProviderStart = Date.now();
+  const defaultProvider = await resolveDefaultProviderRow({
+    orgId: params.orgId,
+    userId: params.userId,
+    framework: params.framework,
+    modelProviderId: params.modelProviderId,
+    personalEligible,
+  });
+  if (timings) {
+    timings.defaultProviderLookup = Date.now() - defaultProviderStart;
+  }
+
+  const providerType = resolveProviderType(
+    defaultProvider,
+    params.explicitModelProvider,
+  );
+
+  const matchingProviderStart = Date.now();
+  const matchingProvider = await resolveMatchingProviderForType({
+    orgId: params.orgId,
+    userId: params.userId,
+    providerType,
+    defaultProvider,
+    explicitModelProvider: params.explicitModelProvider,
+    modelProviderId: params.modelProviderId,
+    personalEligible,
+  });
+  if (timings) {
+    timings.matchingProviderLookup = Date.now() - matchingProviderStart;
+  }
+
+  assertProviderFresh(matchingProvider);
+
+  const selectedModel =
+    params.selectedModelOverride ??
+    matchingProvider?.selectedModel ??
+    undefined;
+  const credentialScope: ModelProviderCredentialScope =
+    matchingProvider?.userId && matchingProvider.userId !== ORG_SENTINEL_USER_ID
+      ? "member"
+      : "org";
+
+  return buildResolvedModelRoute({
+    source: "legacy",
+    providerType,
+    selectedModel,
+    credentialScope,
+    modelProviderId: matchingProvider?.id ?? null,
+    ownerUserId: matchingProvider?.userId ?? ORG_SENTINEL_USER_ID,
+    sourceProvider: matchingProvider,
+  });
+}
+
+export async function resolveModelRoute(
+  params: ResolveModelRouteParams,
+  timings?: ResolveModelProviderSecretTimings,
+): Promise<ResolvedModelRoute> {
+  if (await isModelFirstModelProviderEnabled(params.orgId, params.userId)) {
+    return resolveModelFirstModelRoute(params);
+  }
+  return resolveLegacyModelRoute(params, timings);
+}
+
 /**
  * Resolve and inject model provider secret if needed
  * Only injects if no explicit model provider config in compose environment
@@ -675,189 +947,19 @@ export async function resolveModelProviderSecrets(
     };
   }
 
-  if (await isModelFirstModelProviderEnabled(orgId, userId)) {
-    return resolveModelFirstProviderSecrets({
+  const route = await resolveModelRoute(
+    {
       orgId,
       userId,
-      selectedModelOverride,
+      framework,
       explicitModelProvider,
       modelProviderId,
+      selectedModelOverride,
+      preferPersonalProvider,
       modelProviderCredentialScope,
-    });
-  }
-
-  // Resolve provider: specific ID override → personal-tier branch (gated) →
-  // framework-scoped org default → cross-framework fallback. The personal
-  // branch is consulted first only when (Epic #11868):
-  //   1. caller opted in via agent/schedule `prefer_personal_provider` AND
-  //   2. the `personalModelProvider` feature switch is on for the caller.
-  // The cross-framework fallback (org chain, identical user chain) mirrors
-  // admission (zero-run-policy.ts) and implements Epic #11520's "provider's
-  // framework wins" rule at the dispatch boundary: an org with only a codex
-  // provider still resolves secrets for a claude-code compose; the
-  // provider's framework propagates downstream via `resolvedFramework`.
-  const personalEligibilityStart = Date.now();
-  const personalEligible = await isPersonalTierEligible(
-    orgId,
-    userId,
-    preferPersonalProvider,
-  );
-  timings.personalEligibility = Date.now() - personalEligibilityStart;
-
-  const defaultProviderStart = Date.now();
-  const defaultProvider = await resolveDefaultProviderRow({
-    orgId,
-    userId,
-    framework,
-    modelProviderId,
-    personalEligible,
-  });
-  timings.defaultProviderLookup = Date.now() - defaultProviderStart;
-
-  const providerType = resolveProviderType(
-    defaultProvider,
-    explicitModelProvider,
-  );
-  // Only borrow `selectedModel` / `authMethod` from a provider row that
-  // actually matches the resolved `providerType`. When an explicit
-  // `modelProvider` request differs from the workspace default's type (e.g.
-  // workspace default is `claude-code-oauth-token` with selectedModel
-  // `claude-sonnet-4-5`, request asks for `openai-api-key`), passing the
-  // foreign selectedModel through would inject `OPENAI_MODEL=claude-sonnet-4-5`
-  // and the codex CLI would refuse to run.
-  //
-  // When defaultProvider is for the wrong type AND we have an explicit type
-  // override (no modelProviderId pin), look up the explicit provider's row
-  // by type so vm0/multi-auth flows still see their stored selectedModel/
-  // authMethod. The user-tier lookup is consulted first when
-  // `personalEligible` so a user with a personal `openai-api-key` row gets
-  // their own secret + selectedModel even when their default is org-tier
-  // (Epic #11868). Falls back to undefined when no row exists, in which case
-  // `resolveEnvironmentMapping` uses `getDefaultModel(providerType)`.
-  const matchingProviderStart = Date.now();
-  const matchingProvider = await resolveMatchingProviderForType({
-    orgId,
-    userId,
-    providerType,
-    defaultProvider,
-    explicitModelProvider,
-    modelProviderId,
-    personalEligible,
-  });
-  timings.matchingProviderLookup = Date.now() - matchingProviderStart;
-  // Derive `secretUserId` from the row whose secret we're about to fetch
-  // (`matchingProvider`), not blindly from `defaultProvider`. They diverge
-  // in the explicit-type-override path: an explicit `openai-api-key`
-  // request can land on the org's `openai-api-key` even when the user has
-  // a personal default of a different type. The secret lives under the
-  // matching row's owner — using `defaultProvider.userId` would miss the
-  // org's OPENAI_API_KEY in that case (Epic #11868 — replaces the prior
-  // hardcoded sentinel).
-  const secretUserId = matchingProvider?.userId ?? ORG_SENTINEL_USER_ID;
-  // selectedModelOverride (from agent/schedule config) takes precedence over provider's stored model
-  const selectedModel =
-    selectedModelOverride ?? matchingProvider?.selectedModel ?? undefined;
-
-  // Stale-provider gate: an OAuth-typed provider whose refresh failed
-  // (needsReconnect flipped by the firewall webhook in #11921) MUST NOT
-  // dispatch a sandbox — the user would see a confusing 401 mid-run.
-  // Failing fast here covers chat dispatch + CLI runs + scheduled runs from
-  // the single resolver choke point.
-  if (matchingProvider?.needsReconnect) {
-    throw staleProvider(
-      matchingProvider.type,
-      matchingProvider.lastRefreshErrorCode,
-    );
-  }
-
-  // Handle VM0 managed provider (meta-provider resolution)
-  if (providerType === "vm0") {
-    if (!selectedModel) {
-      throw badRequest("VM0 provider requires a selected model");
-    }
-    const vm0ProviderStart = Date.now();
-    const resolved = await resolveVm0Provider(selectedModel);
-    timings.vm0ProviderResolution = Date.now() - vm0ProviderStart;
-    return { ...resolved, timings };
-  }
-
-  const resolvedFramework = getFrameworkForType(providerType);
-
-  // Handle multi-auth providers (like aws-bedrock)
-  if (hasAuthMethods(providerType)) {
-    const multiAuthStart = Date.now();
-    const resolved = await resolveMultiAuthProviderSecrets(
-      orgId,
-      secretUserId,
-      providerType,
-      matchingProvider?.authMethod,
-      selectedModel,
-    );
-    timings.multiAuthSecretResolution = Date.now() - multiAuthStart;
-    return resolved
-      ? { ...resolved, timings }
-      : {
-          secrets,
-          injectedEnvironment: undefined,
-          resolvedModelProvider: providerType,
-          framework: resolvedFramework,
-          selectedModel,
-          timings,
-        };
-  }
-
-  // Handle single-secret providers
-  const secretName = getSecretNameForType(providerType);
-  if (!secretName) {
-    return {
-      secrets,
-      injectedEnvironment: undefined,
-      resolvedModelProvider: providerType,
-      framework: resolvedFramework,
-      selectedModel,
-      timings,
-    };
-  }
-
-  const secretFetchStart = Date.now();
-  const secretValue = await getSecretValue(
-    orgId,
-    secretUserId,
-    secretName,
-    "model-provider",
-  );
-  timings.singleSecretFetch = Date.now() - secretFetchStart;
-
-  if (!secretValue) {
-    return {
-      secrets,
-      injectedEnvironment: undefined,
-      resolvedModelProvider: providerType,
-      framework: resolvedFramework,
-      selectedModel,
-      timings,
-    };
-  }
-
-  // Resolve environment mapping as template references
-  const environmentMappingStart = Date.now();
-  const injectedEnvironment = resolveEnvironmentMapping(
-    providerType,
-    secretName,
-    selectedModel,
-  );
-  timings.environmentMapping = Date.now() - environmentMappingStart;
-
-  log.debug(
-    `Resolved model provider env: ${Object.keys(injectedEnvironment).join(", ")}`,
-  );
-
-  return {
-    secrets: { [secretName]: secretValue },
-    injectedEnvironment,
-    resolvedModelProvider: providerType,
-    framework: resolvedFramework,
-    selectedModel,
+    },
     timings,
-  };
+  );
+  const result = await materializeModelRoute({ orgId, route, timings });
+  return { ...result, timings };
 }

--- a/turbo/apps/web/src/lib/zero/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/zero/model-provider/model-provider-service.ts
@@ -16,7 +16,6 @@ import { encryptSecretValue } from "../../shared/crypto";
 import { badRequest, notFound } from "@vm0/api-services/errors";
 import { logger } from "../../shared/logger";
 import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
-import type { Database } from "../../../types/global";
 
 const log = logger("service:model-provider");
 
@@ -154,19 +153,6 @@ function toModelProviderInfo(params: {
     createdAt: params.createdAt,
     updatedAt: params.updatedAt,
   };
-}
-
-/**
- * Get all provider types that belong to a given framework.
- *
- * Accepts `string` rather than `ModelProviderFramework` so callers that derive
- * the framework from a compose document (codex, claude-code, …) can filter
- * without first widening the registry's enum.
- */
-function getTypesForFramework(framework: string): string[] {
-  return Object.keys(MODEL_PROVIDER_TYPES).filter((t) => {
-    return getFrameworkForType(t as ModelProviderType) === framework;
-  });
 }
 
 /**
@@ -1261,43 +1247,6 @@ export function getOrgDefaultModelProvider(
 }
 
 /**
- * Get the org-level default model provider type for run-policy checks.
- *
- * Filters by framework so a claude-code default does not satisfy a codex run
- * (and vice versa) — without this filter, admission checks would pass for
- * cross-framework configurations and fail later at provider-resolution time
- * with a worse error.
- *
- * Accepts a db handle so callers inside queue-drain transactions can keep
- * the read in the same boundary.
- */
-export async function getOrgDefaultModelProviderType(
-  orgId: string,
-  framework: string,
-  db: Database = globalThis.services.db,
-): Promise<string | null> {
-  const frameworkTypes = getTypesForFramework(framework);
-  if (frameworkTypes.length === 0) {
-    return null;
-  }
-
-  const [row] = await db
-    .select({ type: modelProviders.type })
-    .from(modelProviders)
-    .where(
-      and(
-        eq(modelProviders.orgId, orgId),
-        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
-        eq(modelProviders.isDefault, true),
-        inArray(modelProviders.type, frameworkTypes),
-      ),
-    )
-    .limit(1);
-
-  return row?.type ?? null;
-}
-
-/**
  * Get the org-level default model provider regardless of framework.
  *
  * Used as the cross-framework fallback by admission (Stage B) when
@@ -1313,30 +1262,6 @@ export function getOrgAnyDefaultModelProvider(
   orgId: string,
 ): Promise<ModelProviderInfo | null> {
   return getAnyDefaultModelProvider(orgId, ORG_SENTINEL_USER_ID);
-}
-
-/**
- * Type-only variant of `getOrgAnyDefaultModelProvider`, mirroring the shape
- * of `getOrgDefaultModelProviderType`. Accepts a db handle so callers inside
- * queue-drain transactions can keep the read in the same boundary.
- */
-export async function getOrgAnyDefaultModelProviderType(
-  orgId: string,
-  db: Database = globalThis.services.db,
-): Promise<string | null> {
-  const [row] = await db
-    .select({ type: modelProviders.type })
-    .from(modelProviders)
-    .where(
-      and(
-        eq(modelProviders.orgId, orgId),
-        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
-        eq(modelProviders.isDefault, true),
-      ),
-    )
-    .limit(1);
-
-  return row?.type ?? null;
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -4,9 +4,7 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import {
   concurrentRunLimit,
   forbidden,
-  modelProviderConnectRequired,
-  noModelProvider,
-  staleProvider,
+  isNoModelProvider,
 } from "@vm0/api-services/errors";
 import {
   MODEL_PROVIDER_TYPES,
@@ -15,26 +13,14 @@ import {
 import { canAccessCompose } from "../infra/agent/compose-access";
 import { validateFrameworkApiKey } from "../infra/run/utils";
 import { logger } from "../shared/logger";
-import { MODEL_PROVIDER_ENV_VARS } from "./context/resolve-model-provider";
+import {
+  MODEL_PROVIDER_ENV_VARS,
+  resolveModelRoute,
+} from "./context/resolve-model-provider";
 import {
   checkOrgCredits,
   type CheckOrgCreditsOptions,
 } from "./credit/check-org-credits";
-import {
-  getOrgDefaultModelProvider,
-  getOrgDefaultModelProviderType,
-  getOrgAnyDefaultModelProvider,
-  getOrgAnyDefaultModelProviderType,
-  getModelProviderById,
-  getUserDefaultModelProvider,
-  getUserAnyDefaultModelProvider,
-  getUserModelProviderByType,
-} from "./model-provider/model-provider-service";
-import { isPersonalTierEligible } from "./personal-tier-gate";
-import {
-  isModelFirstModelProviderEnabled,
-  resolveModelFirstRouteDescriptor,
-} from "./model-policy/model-first-route-service";
 import type { Database } from "../../types/global";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
 import type { AgentComposeYaml } from "../infra/agent-compose/types";
@@ -153,22 +139,12 @@ export async function validateComposeRequirements(
 
 /**
  * Resolve the provider type that admission checks should treat as the
- * effective key source for this run. Precedence:
- *   explicit override → explicit modelProviderId → personal-tier (gated) →
- *   org default for compose framework → any org default (cross-framework
- *   fallback).
+ * effective key source for this run.
  *
- * The cross-framework fallback implements Epic #11520's "provider's framework
- * wins" rule at the admission boundary: an org with only a codex provider
- * still admits a claude-code compose; the provider's framework propagates
- * downstream via `resolvedFramework` so dispatch launches the right binary.
- *
- * The personal-tier branch (Epic #11868) admits a user with only personal
- * providers — without it admission would throw `noModelProvider()` even
- * though the resolver downstream would have served them.
- *
- * Returns null only when the user has no personal tier (or it's gated off)
- * AND the org has no `isDefault: true` provider at all.
+ * This intentionally reuses the dispatch route resolver so credit admission
+ * and sandbox dispatch cannot drift on provider/default precedence. It returns
+ * null only when no provider route exists; explicit compose env validation
+ * happens separately in `checkModelProviderConfigured`.
  */
 async function resolveProviderTypeForAdmission(params: {
   orgId: string;
@@ -180,47 +156,26 @@ async function resolveProviderTypeForAdmission(params: {
   composeFramework: string;
   preferPersonalProvider?: boolean;
 }): Promise<ModelProviderType | null> {
-  if (await isModelFirstModelProviderEnabled(params.orgId, params.userId)) {
-    const route = await resolveModelFirstRouteDescriptor({
+  if (params.modelProvider && !(params.modelProvider in MODEL_PROVIDER_TYPES)) {
+    return null;
+  }
+  try {
+    const route = await resolveModelRoute({
       orgId: params.orgId,
       userId: params.userId,
-      selectedModel: params.selectedModelOverride,
-      providerType: params.modelProvider,
-      credentialScope: params.modelProviderCredentialScope,
-      modelProviderId: params.modelProviderId,
+      framework: params.composeFramework,
+      explicitModelProvider: params.modelProvider ?? undefined,
+      modelProviderId: params.modelProviderId ?? undefined,
+      modelProviderCredentialScope:
+        params.modelProviderCredentialScope ?? undefined,
+      selectedModelOverride: params.selectedModelOverride ?? undefined,
+      preferPersonalProvider: params.preferPersonalProvider,
     });
-    return route.providerType;
+    return route.provider.type;
+  } catch (error) {
+    if (isNoModelProvider(error)) return null;
+    throw error;
   }
-
-  if (params.modelProvider && params.modelProvider in MODEL_PROVIDER_TYPES) {
-    return params.modelProvider as ModelProviderType;
-  }
-  if (params.modelProviderId) {
-    const row = await getModelProviderById(
-      params.orgId,
-      params.userId,
-      params.modelProviderId,
-    );
-    return row?.type ?? null;
-  }
-  const personalEligible = await isPersonalTierEligible(
-    params.orgId,
-    params.userId,
-    params.preferPersonalProvider,
-  );
-  if (personalEligible) {
-    const userDef =
-      (await getUserDefaultModelProvider(
-        params.orgId,
-        params.userId,
-        params.composeFramework,
-      )) ?? (await getUserAnyDefaultModelProvider(params.orgId, params.userId));
-    if (userDef) return userDef.type;
-  }
-  const def =
-    (await getOrgDefaultModelProvider(params.orgId, params.composeFramework)) ??
-    (await getOrgAnyDefaultModelProvider(params.orgId));
-  return def?.type ?? null;
 }
 
 interface RunAdmissionContext {
@@ -268,14 +223,9 @@ export async function checkOrgCreditsForRunAdmission(
 /**
  * Pre-flight check: ensure a model provider is configured.
  *
- * Skips when compose has explicit env vars, an explicit modelProvider param
- * is provided, or the framework doesn't use model providers.
- *
- * When `preferPersonalProvider` is on AND the personal feature switch is
- * enabled for the caller (Epic #11868), accepts a personal-tier provider
- * before falling through to the org chain — without this the admission
- * boundary would throw `noModelProvider()` for users who only have personal
- * providers, even though the resolver downstream would have served them.
+ * Skips when compose has explicit env vars. Otherwise this uses the same
+ * central route resolver as dispatch so pre-flight configuration checks and
+ * runtime materialization agree on provider/default semantics.
  */
 export async function checkModelProviderConfigured(
   orgId: string,
@@ -296,53 +246,16 @@ export async function checkModelProviderConfigured(
     return firstAgent?.environment?.[v] !== undefined;
   });
   if (hasExplicitConfig) return;
+  if (modelProvider && !(modelProvider in MODEL_PROVIDER_TYPES)) return;
 
-  if (await isModelFirstModelProviderEnabled(orgId, userId)) {
-    const route = await resolveModelFirstRouteDescriptor({
-      orgId,
-      userId,
-      selectedModel: selectedModelOverride,
-      providerType: modelProvider,
-      credentialScope: modelProviderCredentialScope,
-      modelProviderId,
-    });
-    if (route.credentialScope === "member") {
-      const memberProvider = await getUserModelProviderByType(
-        orgId,
-        userId,
-        route.providerType,
-      );
-      if (!memberProvider) {
-        throw modelProviderConnectRequired(route.providerType);
-      }
-      if (memberProvider.needsReconnect) {
-        throw staleProvider(
-          memberProvider.type,
-          memberProvider.lastRefreshErrorCode,
-        );
-      }
-    }
-    return;
-  }
-
-  if (modelProvider) return;
-
-  if (await isPersonalTierEligible(orgId, userId, preferPersonalProvider)) {
-    const userType =
-      (await getUserDefaultModelProvider(orgId, userId, framework))?.type ??
-      (await getUserAnyDefaultModelProvider(orgId, userId))?.type;
-    if (userType) return;
-  }
-
-  // Framework-scoped default first; fall back to any org default so a
-  // codex-only org still admits a claude-code compose. Mirrors the
-  // cross-framework fallback in resolveProviderTypeForAdmission — see
-  // Epic #11520 for the provider-framework-wins design intent.
-  const defaultProviderType =
-    (await getOrgDefaultModelProviderType(orgId, framework)) ??
-    (await getOrgAnyDefaultModelProviderType(orgId));
-
-  if (!defaultProviderType) {
-    throw noModelProvider();
-  }
+  await resolveModelRoute({
+    orgId,
+    userId,
+    framework,
+    explicitModelProvider: modelProvider ?? undefined,
+    modelProviderId: modelProviderId ?? undefined,
+    modelProviderCredentialScope: modelProviderCredentialScope ?? undefined,
+    selectedModelOverride: selectedModelOverride ?? undefined,
+    preferPersonalProvider,
+  });
 }


### PR DESCRIPTION
## Summary
- Introduce a central `resolveModelRoute` step that resolves the effective framework, model, provider, and credential owner before secret materialization.
- Make model routing provider-derived so cross-framework combinations resolve to the concrete provider framework, e.g. a Claude Code compose with a Codex/OpenAI provider routes to Codex.
- Reuse the route resolver in zero run admission checks and remove now-unused provider-default helper exports.
- Preserve org credential ownership through `ORG_SENTINEL_USER_ID` and keep legacy compatibility behavior in `resolveModelProviderSecrets`.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm -F web db:migrate`
- `pnpm -F web exec vitest src/lib/zero/context/__tests__/resolve-model-provider.test.ts src/lib/zero/__tests__/credit-check.test.ts`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `pnpm format`
- `pnpm knip`
- `pnpm check-types`

Fixes #12187