### PR TITLE
feat(sandbox): wire bounded exec through host and firecracker sandbox

### DIFF
--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -8,15 +8,22 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use sandbox::{
-    ExecRequest, ExecResult, ProcessExit, Sandbox, SandboxConfig, SandboxError,
-    SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
-    SpawnHandle,
+    BoundedExecOutputEvent, BoundedExecRequest, BoundedExecResult, BoundedExecStream,
+    BoundedExecTermination, ExecRequest, ExecResult, ProcessExit, Sandbox, SandboxConfig,
+    SandboxError, SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation,
+    SandboxOperationReason, SpawnHandle,
 };
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, trace, warn};
-use vsock_host::VsockHost;
+use vsock_host::{
+    BoundedExecOutputEvent as HostBoundedExecOutputEvent,
+    BoundedExecRequest as HostBoundedExecRequest, BoundedExecResult as HostBoundedExecResult,
+    BoundedExecStream as HostBoundedExecStream,
+    BoundedExecStreamRequest as HostBoundedExecStreamRequest,
+    BoundedExecTermination as HostBoundedExecTermination, VsockHost,
+};
 
 use crate::api::ApiError;
 use nbd_cow::PooledNbdCowDevice;
@@ -1101,6 +1108,47 @@ fn monitor_process_with_log_readers(
     ProcessMonitorHandle { kill_tx, task }
 }
 
+fn host_bounded_stream_to_sandbox(stream: HostBoundedExecStream) -> BoundedExecStream {
+    match stream {
+        HostBoundedExecStream::Stdout => BoundedExecStream::Stdout,
+        HostBoundedExecStream::Stderr => BoundedExecStream::Stderr,
+    }
+}
+
+fn host_bounded_event_to_sandbox(event: HostBoundedExecOutputEvent) -> BoundedExecOutputEvent {
+    BoundedExecOutputEvent {
+        stream: host_bounded_stream_to_sandbox(event.stream),
+        sequence: event.sequence,
+        chunk: event.chunk,
+        truncated: event.truncated,
+    }
+}
+
+fn host_bounded_termination_to_sandbox(
+    termination: HostBoundedExecTermination,
+) -> BoundedExecTermination {
+    match termination {
+        HostBoundedExecTermination::Exited { exit_code } => {
+            BoundedExecTermination::Exited { exit_code }
+        }
+        HostBoundedExecTermination::TimedOut => BoundedExecTermination::TimedOut,
+        HostBoundedExecTermination::Cancelled => BoundedExecTermination::Cancelled,
+        HostBoundedExecTermination::StartFailed => BoundedExecTermination::StartFailed,
+        HostBoundedExecTermination::WaitFailed => BoundedExecTermination::WaitFailed,
+    }
+}
+
+fn host_bounded_result_to_sandbox(result: HostBoundedExecResult) -> BoundedExecResult {
+    BoundedExecResult {
+        termination: host_bounded_termination_to_sandbox(result.termination),
+        duration: Duration::from_millis(result.duration_ms),
+        stdout: result.stdout,
+        stderr: result.stderr,
+        stdout_truncated: result.stdout_truncated,
+        stderr_truncated: result.stderr_truncated,
+    }
+}
+
 #[async_trait]
 impl Sandbox for FirecrackerSandbox {
     // -- identity --
@@ -1355,6 +1403,73 @@ impl Sandbox for FirecrackerSandbox {
                 Err(Self::backend_crashed_error(operation))
             }
         }
+    }
+
+    async fn bounded_exec(
+        &self,
+        request: &BoundedExecRequest<'_>,
+    ) -> sandbox::Result<BoundedExecResult> {
+        let operation = SandboxOperation::BoundedExec;
+        let guest = self.operation_guest(operation).await?;
+
+        let (bridge_task, host_stream) = if let Some(stream) = &request.stream
+            && (stream.stdout || stream.stderr)
+        {
+            let (host_tx, mut host_rx) = mpsc::unbounded_channel();
+            let sandbox_tx = stream.event_tx.clone();
+            let task = tokio::spawn(async move {
+                while let Some(event) = host_rx.recv().await {
+                    if sandbox_tx
+                        .send(host_bounded_event_to_sandbox(event))
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            });
+            (
+                Some(task),
+                Some(HostBoundedExecStreamRequest {
+                    event_tx: host_tx,
+                    stdout: stream.stdout,
+                    stderr: stream.stderr,
+                    chunk_limit_bytes: stream.chunk_limit_bytes,
+                    stdout_limit_bytes: stream.stdout_limit_bytes,
+                    stderr_limit_bytes: stream.stderr_limit_bytes,
+                }),
+            )
+        } else {
+            (None, None)
+        };
+
+        let host_request = HostBoundedExecRequest {
+            command: request.cmd,
+            timeout_ms: request.timeout_ms(),
+            env: request.env,
+            sudo: request.sudo,
+            stdin: request.stdin,
+            stdout_limit_bytes: request.stdout_limit_bytes,
+            stderr_limit_bytes: request.stderr_limit_bytes,
+            stream: host_stream,
+        };
+
+        let result = tokio::select! {
+            result = guest.bounded_exec(&host_request) => {
+                result
+                    .map(host_bounded_result_to_sandbox)
+                    .map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))
+            }
+            () = wait_for_backend_crash(self.state_tx.subscribe()) => {
+                Err(Self::backend_crashed_error(operation))
+            }
+        };
+
+        drop(host_request);
+        if let Some(task) = bridge_task {
+            let _ = task.await;
+        }
+
+        result
     }
 
     async fn write_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
@@ -1881,6 +1996,7 @@ mod tests {
     fn operation_error_classifies_observed_backend_crash_for_all_operations() {
         for operation in [
             SandboxOperation::Exec,
+            SandboxOperation::BoundedExec,
             SandboxOperation::WriteFile,
             SandboxOperation::SpawnWatch,
             SandboxOperation::WaitExit,
@@ -1899,6 +2015,7 @@ mod tests {
     fn unavailable_guest_classifies_observed_backend_crash_for_all_operations() {
         for operation in [
             SandboxOperation::Exec,
+            SandboxOperation::BoundedExec,
             SandboxOperation::WriteFile,
             SandboxOperation::SpawnWatch,
             SandboxOperation::WaitExit,

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! All mocks succeed by default with exit code 0 and empty output.
 //! Use [`MockSandbox::push_exec_result`], [`MockSandbox::push_write_file_result`],
+//! [`MockSandbox::push_bounded_exec_response`],
 //! or [`MockSandboxControl::push_exec_remote_result`] to queue custom responses
 //! consumed in FIFO order.
 //!
@@ -51,6 +52,26 @@ pub struct ExecMatcher {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BoundedExecCall {
+    pub cmd: String,
+    pub env: Vec<(String, String)>,
+    pub sudo: bool,
+    pub stdin: Option<Vec<u8>>,
+    pub stdout_limit_bytes: u32,
+    pub stderr_limit_bytes: u32,
+    pub stream_stdout: bool,
+    pub stream_stderr: bool,
+    pub stream_chunk_limit_bytes: u32,
+    pub stdout_stream_limit_bytes: u32,
+    pub stderr_stream_limit_bytes: u32,
+}
+
+pub struct BoundedExecResponse {
+    pub events: Vec<BoundedExecOutputEvent>,
+    pub result: Result<BoundedExecResult>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SpawnWatchCall {
     pub streams_stdout: bool,
     pub guest_log_path: Option<String>,
@@ -82,6 +103,9 @@ pub struct MockSandboxOverrides {
     /// Pattern-matched exec results. First matching pattern wins and is
     /// consumed (one-shot).
     exec_matchers: Mutex<Vec<ExecMatcher>>,
+    /// FIFO bounded_exec responses consumed across all sandboxes built from
+    /// these overrides. Empty queue → default success.
+    bounded_exec_responses: Mutex<VecDeque<BoundedExecResponse>>,
     /// When `Some`, `wait_exit` returns this exit code instead of 0.
     wait_exit_code: Option<i32>,
     /// When set, `wait_exit` awaits this [`tokio::sync::Notify`] before
@@ -111,6 +135,9 @@ pub struct MockSandboxOverrides {
     /// Recorded spawn_watch output modes across all sandboxes built from
     /// this override set.
     spawn_watch_calls: Mutex<Vec<SpawnWatchCall>>,
+    /// Recorded bounded_exec calls across all sandboxes built from this
+    /// override set.
+    bounded_exec_calls: Mutex<Vec<BoundedExecCall>>,
     /// Total `park()` calls across all sandboxes built from this override set.
     park_calls: Mutex<u32>,
     /// Total `unpark()` calls across all sandboxes built from this override set.
@@ -124,6 +151,7 @@ impl MockSandboxOverrides {
     pub fn new() -> Self {
         Self {
             exec_matchers: Mutex::new(Vec::new()),
+            bounded_exec_responses: Mutex::new(VecDeque::new()),
             wait_exit_code: None,
             wait_exit_gate: None,
             wait_exit_error: None,
@@ -134,6 +162,7 @@ impl MockSandboxOverrides {
             unpark_behaviors: Mutex::new(VecDeque::new()),
             destroy_gate: Mutex::new(None),
             spawn_watch_calls: Mutex::new(Vec::new()),
+            bounded_exec_calls: Mutex::new(Vec::new()),
             park_calls: Mutex::new(0),
             unpark_calls: Mutex::new(0),
             destroy_calls: Mutex::new(0),
@@ -169,6 +198,14 @@ impl MockSandboxOverrides {
     /// Register a pattern matcher consumed on first match.
     pub fn add_exec_matcher(&self, matcher: ExecMatcher) {
         self.exec_matchers.lock_ignoring_poison().push(matcher);
+    }
+
+    /// Queue a bounded_exec response consumed FIFO across all sandboxes built
+    /// with these overrides. Empty queue → default success.
+    pub fn push_bounded_exec_response(&self, response: BoundedExecResponse) {
+        self.bounded_exec_responses
+            .lock_ignoring_poison()
+            .push_back(response);
     }
 
     /// Queue a `start()` result applied to the next factory-created sandbox.
@@ -266,6 +303,12 @@ impl MockSandboxOverrides {
     pub fn spawn_watch_calls(&self) -> Vec<SpawnWatchCall> {
         self.spawn_watch_calls.lock_ignoring_poison().clone()
     }
+
+    /// Recorded bounded_exec calls across all sandboxes built from this
+    /// override set, in call order.
+    pub fn bounded_exec_calls(&self) -> Vec<BoundedExecCall> {
+        self.bounded_exec_calls.lock_ignoring_poison().clone()
+    }
 }
 
 async fn wait_blocking_gate(gate: &Mutex<Option<BlockingGate>>) {
@@ -295,6 +338,8 @@ pub struct MockSandbox {
     id: String,
     source_ip: String,
     exec_results: Mutex<VecDeque<Result<ExecResult>>>,
+    bounded_exec_responses: Mutex<VecDeque<BoundedExecResponse>>,
+    bounded_exec_calls: Mutex<Vec<BoundedExecCall>>,
     write_file_results: Mutex<VecDeque<Result<()>>>,
     write_file_calls: Mutex<Vec<WriteFileCall>>,
     overrides: Option<Arc<MockSandboxOverrides>>,
@@ -310,6 +355,8 @@ impl MockSandbox {
             id: id.into(),
             source_ip: "10.0.0.1".into(),
             exec_results: Mutex::new(VecDeque::new()),
+            bounded_exec_responses: Mutex::new(VecDeque::new()),
+            bounded_exec_calls: Mutex::new(Vec::new()),
             write_file_results: Mutex::new(VecDeque::new()),
             write_file_calls: Mutex::new(Vec::new()),
             overrides: None,
@@ -322,6 +369,8 @@ impl MockSandbox {
             id: id.into(),
             source_ip: "10.0.0.1".into(),
             exec_results: Mutex::new(VecDeque::new()),
+            bounded_exec_responses: Mutex::new(VecDeque::new()),
+            bounded_exec_calls: Mutex::new(Vec::new()),
             write_file_results: Mutex::new(VecDeque::new()),
             write_file_calls: Mutex::new(Vec::new()),
             overrides: Some(overrides),
@@ -337,6 +386,17 @@ impl MockSandbox {
     /// Queue an exec result. Results are consumed in FIFO order.
     pub fn push_exec_result(&self, result: Result<ExecResult>) {
         self.exec_results.lock_ignoring_poison().push_back(result);
+    }
+
+    /// Queue a bounded_exec response. Responses are consumed in FIFO order.
+    pub fn push_bounded_exec_response(&self, response: BoundedExecResponse) {
+        self.bounded_exec_responses
+            .lock_ignoring_poison()
+            .push_back(response);
+    }
+
+    pub fn bounded_exec_calls(&self) -> Vec<BoundedExecCall> {
+        self.bounded_exec_calls.lock_ignoring_poison().clone()
     }
 
     /// Queue a write_file result. Results are consumed in FIFO order.
@@ -357,6 +417,55 @@ fn default_exec_result() -> ExecResult {
         exit_code: 0,
         stdout: Vec::new(),
         stderr: Vec::new(),
+    }
+}
+
+fn default_bounded_exec_result() -> BoundedExecResult {
+    BoundedExecResult {
+        termination: BoundedExecTermination::Exited { exit_code: 0 },
+        duration: Duration::ZERO,
+        stdout: Vec::new(),
+        stderr: Vec::new(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+    }
+}
+
+fn bounded_exec_call_from_request(request: &BoundedExecRequest<'_>) -> BoundedExecCall {
+    BoundedExecCall {
+        cmd: request.cmd.to_string(),
+        env: request
+            .env
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect(),
+        sudo: request.sudo,
+        stdin: request.stdin.map(<[u8]>::to_vec),
+        stdout_limit_bytes: request.stdout_limit_bytes,
+        stderr_limit_bytes: request.stderr_limit_bytes,
+        stream_stdout: request.stream.as_ref().is_some_and(|stream| stream.stdout),
+        stream_stderr: request.stream.as_ref().is_some_and(|stream| stream.stderr),
+        stream_chunk_limit_bytes: request
+            .stream
+            .as_ref()
+            .map_or(0, |stream| stream.chunk_limit_bytes),
+        stdout_stream_limit_bytes: request
+            .stream
+            .as_ref()
+            .map_or(0, |stream| stream.stdout_limit_bytes),
+        stderr_stream_limit_bytes: request
+            .stream
+            .as_ref()
+            .map_or(0, |stream| stream.stderr_limit_bytes),
+    }
+}
+
+fn emit_bounded_exec_events(request: &BoundedExecRequest<'_>, events: Vec<BoundedExecOutputEvent>) {
+    let Some(stream) = &request.stream else {
+        return;
+    };
+    for event in events {
+        let _ = stream.event_tx.send(event);
     }
 }
 
@@ -453,6 +562,36 @@ impl Sandbox for MockSandbox {
             .lock_ignoring_poison()
             .pop_front()
             .unwrap_or_else(|| Ok(default_exec_result()))
+    }
+
+    async fn bounded_exec(&self, request: &BoundedExecRequest<'_>) -> Result<BoundedExecResult> {
+        let call = bounded_exec_call_from_request(request);
+        self.bounded_exec_calls
+            .lock_ignoring_poison()
+            .push(call.clone());
+        if let Some(overrides) = &self.overrides {
+            overrides
+                .bounded_exec_calls
+                .lock_ignoring_poison()
+                .push(call);
+            if let Some(response) = overrides
+                .bounded_exec_responses
+                .lock_ignoring_poison()
+                .pop_front()
+            {
+                emit_bounded_exec_events(request, response.events);
+                return response.result;
+            }
+        }
+        if let Some(response) = self
+            .bounded_exec_responses
+            .lock_ignoring_poison()
+            .pop_front()
+        {
+            emit_bounded_exec_events(request, response.events);
+            return response.result;
+        }
+        Ok(default_bounded_exec_result())
     }
 
     async fn write_file(&self, path: &str, content: &[u8]) -> Result<()> {
@@ -837,6 +976,165 @@ mod tests {
         let exec = result.unwrap();
         assert_eq!(exec.exit_code, 0);
         assert!(exec.stdout.is_empty());
+    }
+
+    #[tokio::test]
+    async fn sandbox_default_bounded_exec_succeeds_and_records_call() {
+        let sandbox = MockSandbox::new("test-1");
+        let env = [("K", "V")];
+        let request = BoundedExecRequest {
+            cmd: "echo bounded",
+            timeout: Duration::from_secs(5),
+            env: &env,
+            sudo: true,
+            stdin: Some(b"input"),
+            stdout_limit_bytes: 100,
+            stderr_limit_bytes: 101,
+            stream: None,
+        };
+
+        let result = sandbox.bounded_exec(&request).await.unwrap();
+
+        assert_eq!(
+            result.termination,
+            BoundedExecTermination::Exited { exit_code: 0 }
+        );
+        assert!(result.stdout.is_empty());
+        assert_eq!(
+            sandbox.bounded_exec_calls(),
+            vec![BoundedExecCall {
+                cmd: "echo bounded".to_string(),
+                env: vec![("K".to_string(), "V".to_string())],
+                sudo: true,
+                stdin: Some(b"input".to_vec()),
+                stdout_limit_bytes: 100,
+                stderr_limit_bytes: 101,
+                stream_stdout: false,
+                stream_stderr: false,
+                stream_chunk_limit_bytes: 0,
+                stdout_stream_limit_bytes: 0,
+                stderr_stream_limit_bytes: 0,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn sandbox_queued_bounded_exec_response_emits_stream_events() {
+        let sandbox = MockSandbox::new("test-1");
+        sandbox.push_bounded_exec_response(BoundedExecResponse {
+            events: vec![BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 7,
+                chunk: b"chunk".to_vec(),
+                truncated: true,
+            }],
+            result: Ok(BoundedExecResult {
+                termination: BoundedExecTermination::TimedOut,
+                duration: Duration::from_millis(25),
+                stdout: b"final-out".to_vec(),
+                stderr: b"final-err".to_vec(),
+                stdout_truncated: false,
+                stderr_truncated: true,
+            }),
+        });
+
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
+        let request = BoundedExecRequest {
+            cmd: "timeout",
+            timeout: Duration::from_secs(5),
+            env: &[],
+            sudo: false,
+            stdin: None,
+            stdout_limit_bytes: 100,
+            stderr_limit_bytes: 100,
+            stream: Some(BoundedExecStreamRequest {
+                event_tx,
+                stdout: true,
+                stderr: false,
+                chunk_limit_bytes: 1024,
+                stdout_limit_bytes: 2048,
+                stderr_limit_bytes: 0,
+            }),
+        };
+
+        let result = sandbox.bounded_exec(&request).await.unwrap();
+
+        assert_eq!(result.termination, BoundedExecTermination::TimedOut);
+        assert_eq!(result.duration, Duration::from_millis(25));
+        assert_eq!(result.stdout, b"final-out");
+        assert_eq!(result.stderr, b"final-err");
+        assert!(!result.stdout_truncated);
+        assert!(result.stderr_truncated);
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 7,
+                chunk: b"chunk".to_vec(),
+                truncated: true,
+            }
+        );
+        assert_eq!(
+            sandbox.bounded_exec_calls(),
+            vec![BoundedExecCall {
+                cmd: "timeout".to_string(),
+                env: vec![],
+                sudo: false,
+                stdin: None,
+                stdout_limit_bytes: 100,
+                stderr_limit_bytes: 100,
+                stream_stdout: true,
+                stream_stderr: false,
+                stream_chunk_limit_bytes: 1024,
+                stdout_stream_limit_bytes: 2048,
+                stderr_stream_limit_bytes: 0,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn overrides_queue_bounded_exec_responses_across_factory_sandboxes() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.push_bounded_exec_response(BoundedExecResponse {
+            events: vec![],
+            result: Ok(BoundedExecResult {
+                termination: BoundedExecTermination::Exited { exit_code: 42 },
+                duration: Duration::from_millis(10),
+                stdout: b"shared".to_vec(),
+                stderr: Vec::new(),
+                stdout_truncated: false,
+                stderr_truncated: false,
+            }),
+        });
+        let mut factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        factory.startup().await.unwrap();
+
+        let first = factory.create(test_sandbox_config()).await.unwrap();
+        let second = factory.create(test_sandbox_config()).await.unwrap();
+        let request = BoundedExecRequest {
+            cmd: "shared",
+            timeout: Duration::from_secs(5),
+            env: &[],
+            sudo: false,
+            stdin: None,
+            stdout_limit_bytes: 100,
+            stderr_limit_bytes: 100,
+            stream: None,
+        };
+
+        let queued = first.bounded_exec(&request).await.unwrap();
+        let fallback = second.bounded_exec(&request).await.unwrap();
+
+        assert_eq!(
+            queued.termination,
+            BoundedExecTermination::Exited { exit_code: 42 }
+        );
+        assert_eq!(queued.stdout, b"shared");
+        assert_eq!(
+            fallback.termination,
+            BoundedExecTermination::Exited { exit_code: 0 }
+        );
+        assert_eq!(overrides.bounded_exec_calls().len(), 2);
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -465,6 +465,13 @@ fn emit_bounded_exec_events(request: &BoundedExecRequest<'_>, events: Vec<Bounde
         return;
     };
     for event in events {
+        let requested = match event.stream {
+            BoundedExecStream::Stdout => stream.stdout,
+            BoundedExecStream::Stderr => stream.stderr,
+        };
+        if !requested {
+            continue;
+        }
         let _ = stream.event_tx.send(event);
     }
 }
@@ -1022,12 +1029,20 @@ mod tests {
     async fn sandbox_queued_bounded_exec_response_emits_stream_events() {
         let sandbox = MockSandbox::new("test-1");
         sandbox.push_bounded_exec_response(BoundedExecResponse {
-            events: vec![BoundedExecOutputEvent {
-                stream: BoundedExecStream::Stdout,
-                sequence: 7,
-                chunk: b"chunk".to_vec(),
-                truncated: true,
-            }],
+            events: vec![
+                BoundedExecOutputEvent {
+                    stream: BoundedExecStream::Stdout,
+                    sequence: 7,
+                    chunk: b"chunk".to_vec(),
+                    truncated: true,
+                },
+                BoundedExecOutputEvent {
+                    stream: BoundedExecStream::Stderr,
+                    sequence: 8,
+                    chunk: b"ignored".to_vec(),
+                    truncated: false,
+                },
+            ],
             result: Ok(BoundedExecResult {
                 termination: BoundedExecTermination::TimedOut,
                 duration: Duration::from_millis(25),
@@ -1074,6 +1089,10 @@ mod tests {
                 truncated: true,
             }
         );
+        assert!(matches!(
+            event_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
         assert_eq!(
             sandbox.bounded_exec_calls(),
             vec![BoundedExecCall {

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -84,6 +84,8 @@ impl fmt::Display for SandboxInitializationPhase {
 pub enum SandboxOperation {
     /// [`Sandbox::exec`](crate::Sandbox::exec).
     Exec,
+    /// [`Sandbox::bounded_exec`](crate::Sandbox::bounded_exec).
+    BoundedExec,
     /// [`Sandbox::write_file`](crate::Sandbox::write_file).
     WriteFile,
     /// [`Sandbox::spawn_watch`](crate::Sandbox::spawn_watch).
@@ -96,6 +98,7 @@ impl fmt::Display for SandboxOperation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Exec => f.write_str("exec"),
+            Self::BoundedExec => f.write_str("bounded exec"),
             Self::WriteFile => f.write_str("write file"),
             Self::SpawnWatch => f.write_str("spawn watch"),
             Self::WaitExit => f.write_str("wait exit"),

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -40,4 +40,8 @@ pub use sandbox::Sandbox;
 pub use snapshot::{
     PendingSnapshotPublish, SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider,
 };
-pub use types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle, SpawnOutputMode};
+pub use types::{
+    BoundedExecOutputEvent, BoundedExecRequest, BoundedExecResult, BoundedExecStream,
+    BoundedExecStreamRequest, BoundedExecTermination, ExecRequest, ExecResult, ProcessExit,
+    SpawnHandle, SpawnOutputMode,
+};

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -23,6 +23,7 @@
 //!
 //! # Operations
 //! Once running, callers invoke [`exec`](Sandbox::exec) /
+//! [`bounded_exec`](Sandbox::bounded_exec) /
 //! [`write_file`](Sandbox::write_file) / [`spawn_watch`](Sandbox::spawn_watch) /
 //! [`wait_exit`](Sandbox::wait_exit) via the host-to-guest IPC channel
 //! (vsock, in the Firecracker backend). Operations race against a crash
@@ -35,7 +36,9 @@ use std::time::Duration;
 use async_trait::async_trait;
 
 use crate::error::Result;
-use crate::types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle};
+use crate::types::{
+    BoundedExecRequest, BoundedExecResult, ExecRequest, ExecResult, ProcessExit, SpawnHandle,
+};
 
 /// A process-isolation environment that runs guest workloads for the runner.
 ///
@@ -59,11 +62,11 @@ use crate::types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle};
 ///
 /// # Operations
 /// Once running, callers invoke [`exec`](Self::exec) /
-/// [`write_file`](Self::write_file) / [`spawn_watch`](Self::spawn_watch) /
-/// [`wait_exit`](Self::wait_exit) via the host-to-guest IPC channel
-/// (vsock, in the Firecracker backend). Operations race against a crash
-/// notifier so that a dying backend process surfaces as a specific
-/// error rather than an opaque IPC timeout.
+/// [`bounded_exec`](Self::bounded_exec) / [`write_file`](Self::write_file) /
+/// [`spawn_watch`](Self::spawn_watch) / [`wait_exit`](Self::wait_exit) via
+/// the host-to-guest IPC channel (vsock, in the Firecracker backend).
+/// Operations race against a crash notifier so that a dying backend process
+/// surfaces as a specific error rather than an opaque IPC timeout.
 ///
 /// # Thread-safety and trait objects
 /// Implementations are consumed as `Box<dyn Sandbox>` and shared across
@@ -154,7 +157,7 @@ pub trait Sandbox: Send + Sync + Any {
     /// Transition the sandbox back to the active state.
     ///
     /// Must be called before any further work is dispatched via `exec` /
-    /// `spawn_watch` on a previously parked sandbox. Implementations
+    /// `bounded_exec` / `spawn_watch` on a previously parked sandbox. Implementations
     /// should restore whatever state `park()` altered (resume vCPUs,
     /// balloon deflate, respawn background tickers, etc).
     ///
@@ -183,6 +186,13 @@ pub trait Sandbox: Send + Sync + Any {
     /// Returns an error if the sandbox is not running or if the backing
     /// process crashes during execution.
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult>;
+    /// Run `request.cmd` in the guest with structured termination status,
+    /// bounded final stdout/stderr buffers, and optional request-scoped
+    /// stdout/stderr stream events.
+    ///
+    /// Returns an error if the sandbox is not running, if the backing
+    /// process crashes during execution, or if the host/guest transport fails.
+    async fn bounded_exec(&self, request: &BoundedExecRequest<'_>) -> Result<BoundedExecResult>;
     /// Write `content` to `path` inside the guest, creating parent
     /// directories and truncating the file as needed. Returns an error if
     /// the sandbox is not running or if the backing process crashes.

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -1,5 +1,64 @@
 use std::time::Duration;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BoundedExecStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BoundedExecTermination {
+    Exited { exit_code: i32 },
+    TimedOut,
+    Cancelled,
+    StartFailed,
+    WaitFailed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BoundedExecOutputEvent {
+    pub stream: BoundedExecStream,
+    pub sequence: u32,
+    pub chunk: Vec<u8>,
+    pub truncated: bool,
+}
+
+pub struct BoundedExecStreamRequest {
+    pub event_tx: tokio::sync::mpsc::UnboundedSender<BoundedExecOutputEvent>,
+    pub stdout: bool,
+    pub stderr: bool,
+    pub chunk_limit_bytes: u32,
+    pub stdout_limit_bytes: u32,
+    pub stderr_limit_bytes: u32,
+}
+
+pub struct BoundedExecRequest<'a> {
+    pub cmd: &'a str,
+    pub timeout: Duration,
+    pub env: &'a [(&'a str, &'a str)],
+    pub sudo: bool,
+    pub stdin: Option<&'a [u8]>,
+    pub stdout_limit_bytes: u32,
+    pub stderr_limit_bytes: u32,
+    pub stream: Option<BoundedExecStreamRequest>,
+}
+
+impl BoundedExecRequest<'_> {
+    /// Return the timeout as whole milliseconds, saturating at `u32::MAX`.
+    pub fn timeout_ms(&self) -> u32 {
+        u32::try_from(self.timeout.as_millis()).unwrap_or(u32::MAX)
+    }
+}
+
+pub struct BoundedExecResult {
+    pub termination: BoundedExecTermination,
+    pub duration: Duration,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub stdout_truncated: bool,
+    pub stderr_truncated: bool,
+}
+
 pub struct ExecRequest<'a> {
     pub cmd: &'a str,
     pub timeout: Duration,
@@ -97,6 +156,21 @@ mod tests {
             timeout: Duration::from_millis(u32::MAX as u64),
             env: &[],
             sudo: false,
+        };
+        assert_eq!(req.timeout_ms(), u32::MAX);
+    }
+
+    #[test]
+    fn bounded_timeout_ms_saturates_at_u32_max() {
+        let req = BoundedExecRequest {
+            cmd: "sleep infinity",
+            timeout: Duration::from_secs(u64::MAX / 1000),
+            env: &[],
+            sudo: false,
+            stdin: None,
+            stdout_limit_bytes: 0,
+            stderr_limit_bytes: 0,
+            stream: None,
         };
         assert_eq!(req.timeout_ms(), u32::MAX);
     }

--- a/crates/sandbox/tests/error.rs
+++ b/crates/sandbox/tests/error.rs
@@ -98,3 +98,15 @@ fn display_includes_category_and_message() {
     assert!(text.contains("backend crashed"), "got: {text}");
     assert!(text.contains("firecracker process crashed"), "got: {text}");
 }
+
+#[test]
+fn bounded_exec_operation_display_name_is_stable() {
+    let err = SandboxError::Operation {
+        operation: SandboxOperation::BoundedExec,
+        reason: SandboxOperationReason::Guest,
+        message: "guest error".into(),
+    };
+
+    let text = err.to_string();
+    assert!(text.contains("bounded exec"), "got: {text}");
+}

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1012,7 +1012,14 @@ impl VsockHost {
                     if let Some(stream) = &request.stream
                         && (stream.stdout || stream.stderr)
                     {
-                        bounded_output_senders.insert(seq, stream.event_tx.clone());
+                        bounded_output_senders.insert(
+                            seq,
+                            BoundedOutputRegistration {
+                                event_tx: stream.event_tx.clone(),
+                                stdout: stream.stdout,
+                                stderr: stream.stderr,
+                            },
+                        );
                     }
                 }
             }
@@ -1707,6 +1714,90 @@ mod tests {
                 truncated: false,
             }
         );
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_stream_events_filter_unrequested_streams() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+            let decoded = vsock_proto::decode_bounded_exec(&msgs[0].payload).unwrap();
+            assert!(decoded.stream_stdout);
+            assert!(!decoded.stream_stderr);
+
+            let ignored_payload = vsock_proto::encode_bounded_exec_output_chunk(
+                vsock_proto::BoundedExecStream::Stderr,
+                1,
+                b"ignored",
+                false,
+            )
+            .unwrap();
+            let ignored =
+                vsock_proto::encode(MSG_BOUNDED_EXEC_OUTPUT_CHUNK, msgs[0].seq, &ignored_payload)
+                    .unwrap();
+            guest.write_all(&ignored).await.unwrap();
+
+            let kept_payload = vsock_proto::encode_bounded_exec_output_chunk(
+                vsock_proto::BoundedExecStream::Stdout,
+                2,
+                b"kept",
+                false,
+            )
+            .unwrap();
+            let kept =
+                vsock_proto::encode(MSG_BOUNDED_EXEC_OUTPUT_CHUNK, msgs[0].seq, &kept_payload)
+                    .unwrap();
+            guest.write_all(&kept).await.unwrap();
+
+            let payload = vsock_proto::encode_bounded_exec_result(
+                vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
+                1,
+                b"done",
+                b"",
+                false,
+                false,
+            )
+            .unwrap();
+            let resp = vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
+            guest.write_all(&resp).await.unwrap();
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let request = simple_bounded_request(
+            "stdout-only",
+            Some(BoundedExecStreamRequest {
+                event_tx,
+                stdout: true,
+                stderr: false,
+                chunk_limit_bytes: vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32,
+                stdout_limit_bytes: 2048,
+                stderr_limit_bytes: 0,
+            }),
+        );
+
+        let result = host.bounded_exec(&request).await.unwrap();
+        assert_eq!(result.stdout, b"done");
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 2,
+                chunk: b"kept".to_vec(),
+                truncated: false,
+            }
+        );
+        assert!(matches!(
+            event_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -129,11 +129,11 @@ impl BoundedOutputRegistration {
 
 /// Connection lifecycle, expressed as data rather than a separate atomic flag.
 ///
-/// The three registration tables (`pending`, `pending_stdout`, `stdout_senders`)
-/// live inside the `Connected` variant so they are structurally unreachable
-/// once the reader task has exited. `exits` lives in BOTH variants because it
-/// is an observation log — a cached exit event remains a valid answer to
-/// `wait_for_exit` after the connection closes.
+/// The request and stream registration maps live inside the `Connected`
+/// variant so they are structurally unreachable once the reader task has
+/// exited. `exits` lives in BOTH variants because it is an observation log —
+/// a cached exit event remains a valid answer to `wait_for_exit` after the
+/// connection closes.
 ///
 /// The invariant "connection is closed ⇔ registrations are impossible" is
 /// enforced by the type: every code path that cares about liveness must

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1801,6 +1801,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_bounded_exec_ignores_unroutable_or_malformed_stream_chunks() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+
+            let valid_chunk = vsock_proto::encode_bounded_exec_output_chunk(
+                vsock_proto::BoundedExecStream::Stdout,
+                1,
+                b"ignored",
+                false,
+            )
+            .unwrap();
+            let seq_zero =
+                vsock_proto::encode(MSG_BOUNDED_EXEC_OUTPUT_CHUNK, 0, &valid_chunk).unwrap();
+            guest.write_all(&seq_zero).await.unwrap();
+
+            let unknown_seq =
+                vsock_proto::encode(MSG_BOUNDED_EXEC_OUTPUT_CHUNK, msgs[0].seq + 1, &valid_chunk)
+                    .unwrap();
+            guest.write_all(&unknown_seq).await.unwrap();
+
+            let malformed =
+                vsock_proto::encode(MSG_BOUNDED_EXEC_OUTPUT_CHUNK, msgs[0].seq, b"\x00").unwrap();
+            guest.write_all(&malformed).await.unwrap();
+
+            let payload = vsock_proto::encode_bounded_exec_result(
+                vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
+                1,
+                b"done",
+                b"",
+                false,
+                false,
+            )
+            .unwrap();
+            let resp = vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
+            guest.write_all(&resp).await.unwrap();
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let request =
+            simple_bounded_request("ignore-bad-chunks", Some(bounded_stream_request(event_tx)));
+
+        let result = host.bounded_exec(&request).await.unwrap();
+
+        assert_eq!(result.stdout, b"done");
+        assert!(matches!(
+            event_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+        assert_eq!(registration_counts(&host), (0, 0, 0, 0));
+    }
+
+    #[tokio::test]
     async fn test_bounded_exec_malformed_result_cleans_up() {
         let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1897,6 +1897,250 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_bounded_exec_connection_close_cleans_up_registrations() {
+        let (host_stream, mut guest) = make_pair();
+        let request_seen = std::sync::Arc::new(Notify::new());
+        let release_guest = std::sync::Arc::new(Notify::new());
+
+        {
+            let request_seen = std::sync::Arc::clone(&request_seen);
+            let release_guest = std::sync::Arc::clone(&release_guest);
+            tokio::spawn(async move {
+                let mut decoder = Decoder::new();
+                mock_handshake(&mut guest, &mut decoder).await;
+
+                let mut buf = [0u8; 4096];
+                let n = guest.read(&mut buf).await.unwrap();
+                let msgs = decoder.decode(&buf[..n]).unwrap();
+                assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+                request_seen.notify_one();
+
+                release_guest.notified().await;
+                drop(guest);
+            });
+        }
+
+        let host = std::sync::Arc::new(host_from_stream(host_stream).await.unwrap());
+        let task_host = std::sync::Arc::clone(&host);
+        let task = tokio::spawn(async move {
+            let (tx, _rx) = mpsc::unbounded_channel();
+            let request =
+                simple_bounded_request("connection-close", Some(bounded_stream_request(tx)));
+            task_host.bounded_exec(&request).await
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), request_seen.notified())
+            .await
+            .expect("guest should receive bounded_exec request");
+        assert_eq!(registration_counts(&host), (1, 0, 0, 1));
+
+        release_guest.notify_one();
+        let err = task.await.unwrap().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+        assert_eq!(
+            registration_counts(&host),
+            (0, 0, 0, 0),
+            "closed connection must clean pending bounded_exec registrations",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_dropped_event_receiver_removes_stream_registration() {
+        let (host_stream, mut guest) = make_pair();
+        let chunk_written = std::sync::Arc::new(Notify::new());
+        let release_result = std::sync::Arc::new(Notify::new());
+
+        {
+            let chunk_written = std::sync::Arc::clone(&chunk_written);
+            let release_result = std::sync::Arc::clone(&release_result);
+            tokio::spawn(async move {
+                let mut decoder = Decoder::new();
+                mock_handshake(&mut guest, &mut decoder).await;
+
+                let mut buf = [0u8; 4096];
+                let n = guest.read(&mut buf).await.unwrap();
+                let msgs = decoder.decode(&buf[..n]).unwrap();
+                assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+
+                let payload = vsock_proto::encode_bounded_exec_output_chunk(
+                    vsock_proto::BoundedExecStream::Stdout,
+                    1,
+                    b"orphaned",
+                    false,
+                )
+                .unwrap();
+                let chunk =
+                    vsock_proto::encode(MSG_BOUNDED_EXEC_OUTPUT_CHUNK, msgs[0].seq, &payload)
+                        .unwrap();
+                guest.write_all(&chunk).await.unwrap();
+                chunk_written.notify_one();
+
+                release_result.notified().await;
+                let payload = vsock_proto::encode_bounded_exec_result(
+                    vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
+                    1,
+                    b"done",
+                    b"",
+                    false,
+                    false,
+                )
+                .unwrap();
+                let resp =
+                    vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
+                guest.write_all(&resp).await.unwrap();
+            });
+        }
+
+        let host = std::sync::Arc::new(host_from_stream(host_stream).await.unwrap());
+        let task_host = std::sync::Arc::clone(&host);
+        let task = tokio::spawn(async move {
+            let (tx, rx) = mpsc::unbounded_channel();
+            drop(rx);
+            let request =
+                simple_bounded_request("dropped-receiver", Some(bounded_stream_request(tx)));
+            task_host.bounded_exec(&request).await
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), chunk_written.notified())
+            .await
+            .expect("guest should write bounded_exec stream chunk");
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while registration_counts(&host) != (1, 0, 0, 0) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropped receiver should remove bounded stream registration");
+
+        release_result.notify_one();
+        let result = task.await.unwrap().unwrap();
+        assert_eq!(result.stdout, b"done");
+        assert_eq!(registration_counts(&host), (0, 0, 0, 0));
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_error_response_cleans_up_registrations() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+            let payload = vsock_proto::encode_error("bounded failed");
+            let resp = vsock_proto::encode(MSG_ERROR, msgs[0].seq, &payload).unwrap();
+            guest.write_all(&resp).await.unwrap();
+
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+            let payload = vsock_proto::encode_bounded_exec_result(
+                vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
+                1,
+                b"ok",
+                b"",
+                false,
+                false,
+            )
+            .unwrap();
+            let ok_resp =
+                vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
+            guest.write_all(&ok_resp).await.unwrap();
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let request = simple_bounded_request("error-result", Some(bounded_stream_request(tx)));
+        let err = host.bounded_exec(&request).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(err.to_string(), "bounded failed");
+        assert_eq!(
+            registration_counts(&host),
+            (0, 0, 0, 0),
+            "bounded_exec MSG_ERROR response must clean pending registrations",
+        );
+
+        let request = simple_bounded_request("good-result", None);
+        let result = host.bounded_exec(&request).await.unwrap();
+        assert_eq!(result.stdout, b"ok");
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_stream_request_with_no_streams_does_not_register_sender() {
+        let (host_stream, mut guest) = make_pair();
+        let request_seen = std::sync::Arc::new(Notify::new());
+        let release_result = std::sync::Arc::new(Notify::new());
+
+        {
+            let request_seen = std::sync::Arc::clone(&request_seen);
+            let release_result = std::sync::Arc::clone(&release_result);
+            tokio::spawn(async move {
+                let mut decoder = Decoder::new();
+                mock_handshake(&mut guest, &mut decoder).await;
+
+                let mut buf = [0u8; 4096];
+                let n = guest.read(&mut buf).await.unwrap();
+                let msgs = decoder.decode(&buf[..n]).unwrap();
+                assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+                let decoded = vsock_proto::decode_bounded_exec(&msgs[0].payload).unwrap();
+                assert!(!decoded.stream_stdout);
+                assert!(!decoded.stream_stderr);
+                assert_eq!(decoded.stream_chunk_limit_bytes, 0);
+                request_seen.notify_one();
+
+                release_result.notified().await;
+                let payload = vsock_proto::encode_bounded_exec_result(
+                    vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
+                    1,
+                    b"done",
+                    b"",
+                    false,
+                    false,
+                )
+                .unwrap();
+                let resp =
+                    vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
+                guest.write_all(&resp).await.unwrap();
+            });
+        }
+
+        let host = std::sync::Arc::new(host_from_stream(host_stream).await.unwrap());
+        let task_host = std::sync::Arc::clone(&host);
+        let task = tokio::spawn(async move {
+            let (event_tx, _event_rx) = mpsc::unbounded_channel();
+            let request = simple_bounded_request(
+                "no-streams",
+                Some(BoundedExecStreamRequest {
+                    event_tx,
+                    stdout: false,
+                    stderr: false,
+                    chunk_limit_bytes: 0,
+                    stdout_limit_bytes: 0,
+                    stderr_limit_bytes: 0,
+                }),
+            );
+            task_host.bounded_exec(&request).await
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), request_seen.notified())
+            .await
+            .expect("guest should receive bounded_exec request");
+        assert_eq!(
+            registration_counts(&host),
+            (1, 0, 0, 0),
+            "disabled streams should not create a stream registration",
+        );
+
+        release_result.notify_one();
+        let result = task.await.unwrap().unwrap();
+        assert_eq!(result.stdout, b"done");
+        assert_eq!(registration_counts(&host), (0, 0, 0, 0));
+    }
+
+    #[tokio::test]
     async fn test_bounded_exec_rejects_invalid_boundaries() {
         let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1862,6 +1862,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_bounded_exec_ignores_stream_chunks_after_final_result() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+
+            let result_payload = vsock_proto::encode_bounded_exec_result(
+                vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
+                1,
+                b"done",
+                b"",
+                false,
+                false,
+            )
+            .unwrap();
+            let result =
+                vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, msgs[0].seq, &result_payload).unwrap();
+
+            let late_chunk_payload = vsock_proto::encode_bounded_exec_output_chunk(
+                vsock_proto::BoundedExecStream::Stdout,
+                99,
+                b"late",
+                false,
+            )
+            .unwrap();
+            let late_chunk = vsock_proto::encode(
+                MSG_BOUNDED_EXEC_OUTPUT_CHUNK,
+                msgs[0].seq,
+                &late_chunk_payload,
+            )
+            .unwrap();
+
+            let mut combined = result;
+            combined.extend_from_slice(&late_chunk);
+            guest.write_all(&combined).await.unwrap();
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let request = simple_bounded_request("late-chunk", Some(bounded_stream_request(event_tx)));
+
+        let result = host.bounded_exec(&request).await.unwrap();
+
+        assert_eq!(result.stdout, b"done");
+        assert!(matches!(
+            event_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+        assert_eq!(registration_counts(&host), (0, 0, 0, 0));
+    }
+
+    #[tokio::test]
     async fn test_bounded_exec_malformed_result_cleans_up() {
         let (host_stream, mut guest) = make_pair();
 
@@ -2235,6 +2293,17 @@ mod tests {
             ..simple_bounded_request("invalid-stream", None)
         };
         let err = host.bounded_exec(&invalid_stream).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let oversized_stream = BoundedExecRequest {
+            stream: Some(BoundedExecStreamRequest {
+                chunk_limit_bytes: u32::MAX,
+                ..bounded_stream_request(tx)
+            }),
+            ..simple_bounded_request("oversized-stream", None)
+        };
+        let err = host.bounded_exec(&oversized_stream).await.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -31,9 +31,12 @@ use tokio::task::JoinHandle;
 use tokio::time::{self, Instant};
 
 use vsock_proto::{
-    Decoder, MSG_ERROR, MSG_EXEC, MSG_EXEC_RESULT, MSG_PING, MSG_PONG, MSG_PROCESS_EXIT, MSG_READY,
-    MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK,
-    MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, RawMessage,
+    BoundedExecStream as ProtoBoundedExecStream,
+    BoundedExecTermination as ProtoBoundedExecTermination, Decoder, MSG_BOUNDED_EXEC,
+    MSG_BOUNDED_EXEC_OUTPUT_CHUNK, MSG_BOUNDED_EXEC_RESULT, MSG_ERROR, MSG_EXEC, MSG_EXEC_RESULT,
+    MSG_PING, MSG_PONG, MSG_PROCESS_EXIT, MSG_READY, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
+    MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK, MSG_WRITE_FILE,
+    MSG_WRITE_FILE_RESULT, RawMessage,
 };
 
 const READ_BUF_SIZE: usize = 64 * 1024;
@@ -53,6 +56,75 @@ pub struct ProcessExitEvent {
     pub exit_code: i32,
     pub stdout: Vec<u8>,
     pub stderr: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum BoundedExecStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum BoundedExecTermination {
+    Exited { exit_code: i32 },
+    TimedOut,
+    Cancelled,
+    StartFailed,
+    WaitFailed,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct BoundedExecOutputEvent {
+    pub stream: BoundedExecStream,
+    pub sequence: u32,
+    pub chunk: Vec<u8>,
+    pub truncated: bool,
+}
+
+pub struct BoundedExecStreamRequest {
+    pub event_tx: mpsc::UnboundedSender<BoundedExecOutputEvent>,
+    pub stdout: bool,
+    pub stderr: bool,
+    pub chunk_limit_bytes: u32,
+    pub stdout_limit_bytes: u32,
+    pub stderr_limit_bytes: u32,
+}
+
+pub struct BoundedExecRequest<'a> {
+    pub command: &'a str,
+    pub timeout_ms: u32,
+    pub env: &'a [(&'a str, &'a str)],
+    pub sudo: bool,
+    pub stdin: Option<&'a [u8]>,
+    pub stdout_limit_bytes: u32,
+    pub stderr_limit_bytes: u32,
+    pub stream: Option<BoundedExecStreamRequest>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BoundedExecResult {
+    pub termination: BoundedExecTermination,
+    pub duration_ms: u64,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub stdout_truncated: bool,
+    pub stderr_truncated: bool,
+}
+
+#[derive(Clone)]
+struct BoundedOutputRegistration {
+    event_tx: mpsc::UnboundedSender<BoundedExecOutputEvent>,
+    stdout: bool,
+    stderr: bool,
+}
+
+impl BoundedOutputRegistration {
+    fn allows(&self, stream: BoundedExecStream) -> bool {
+        match stream {
+            BoundedExecStream::Stdout => self.stdout,
+            BoundedExecStream::Stderr => self.stderr,
+        }
+    }
 }
 
 /// Connection lifecycle, expressed as data rather than a separate atomic flag.
@@ -81,6 +153,11 @@ enum ConnectionState {
         /// Populated by `reader_loop` when it processes `spawn_watch_result`,
         /// fed by `reader_loop` when it processes `stdout_chunk`.
         stdout_senders: HashMap<u32, mpsc::UnboundedSender<Vec<u8>>>,
+        /// Bounded exec output registrations: request seq → event sender and
+        /// requested stream allow-list.
+        /// Populated before sending a bounded exec request and fed directly
+        /// by request-scoped bounded output chunk events.
+        bounded_output_senders: HashMap<u32, BoundedOutputRegistration>,
         /// Cached process exit events (unsolicited, seq=0).
         exits: HashMap<u32, ProcessExitEvent>,
     },
@@ -216,6 +293,23 @@ impl Drop for ChunkedWriteCleanupGuard {
     }
 }
 
+struct PendingBoundedOutputGuard {
+    shared: Arc<Shared>,
+    seq: u32,
+}
+
+impl PendingBoundedOutputGuard {
+    fn new(shared: Arc<Shared>, seq: u32) -> Self {
+        Self { shared, seq }
+    }
+}
+
+impl Drop for PendingBoundedOutputGuard {
+    fn drop(&mut self) {
+        self.shared.remove_bounded_output_sender(self.seq);
+    }
+}
+
 impl Shared {
     /// Get next sequence number, skipping 0 (reserved for unsolicited messages).
     fn next_seq(&self) -> u32 {
@@ -229,7 +323,7 @@ impl Shared {
     }
 
     /// Transition `Connected → Closed`, preserving the cached `exits` map and
-    /// dropping the three registration tables outside the state lock so that
+    /// dropping the registration tables outside the state lock so that
     /// oneshot/mpsc sender drops (which wake their receivers) run without the
     /// lock held. Idempotent: a second call preserves whatever `exits` the
     /// first call cached and performs no further work.
@@ -253,10 +347,16 @@ impl Shared {
                     pending,
                     pending_stdout,
                     stdout_senders,
+                    bounded_output_senders,
                     exits,
                 } => {
                     *guard = ConnectionState::Closed { exits };
-                    Some((pending, pending_stdout, stdout_senders))
+                    Some((
+                        pending,
+                        pending_stdout,
+                        stdout_senders,
+                        bounded_output_senders,
+                    ))
                 }
                 closed @ ConnectionState::Closed { .. } => {
                     // Reassign the whole variant; cached `exits` preserved
@@ -283,6 +383,17 @@ impl Shared {
         let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
         if let ConnectionState::Connected { pending_stdout, .. } = &mut *guard {
             pending_stdout.remove(&seq);
+        }
+    }
+
+    fn remove_bounded_output_sender(&self, seq: u32) {
+        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if let ConnectionState::Connected {
+            bounded_output_senders,
+            ..
+        } = &mut *guard
+        {
+            bounded_output_senders.remove(&seq);
         }
     }
 }
@@ -317,6 +428,81 @@ impl Drop for VsockHost {
         let _ = nix::sys::socket::shutdown(self.fd, nix::sys::socket::Shutdown::Both);
         self._reader.abort();
     }
+}
+
+fn proto_stream_to_host(stream: ProtoBoundedExecStream) -> BoundedExecStream {
+    match stream {
+        ProtoBoundedExecStream::Stdout => BoundedExecStream::Stdout,
+        ProtoBoundedExecStream::Stderr => BoundedExecStream::Stderr,
+    }
+}
+
+fn proto_termination_to_host(termination: ProtoBoundedExecTermination) -> BoundedExecTermination {
+    match termination {
+        ProtoBoundedExecTermination::Exited { exit_code } => {
+            BoundedExecTermination::Exited { exit_code }
+        }
+        ProtoBoundedExecTermination::TimedOut => BoundedExecTermination::TimedOut,
+        ProtoBoundedExecTermination::Cancelled => BoundedExecTermination::Cancelled,
+        ProtoBoundedExecTermination::StartFailed => BoundedExecTermination::StartFailed,
+        ProtoBoundedExecTermination::WaitFailed => BoundedExecTermination::WaitFailed,
+    }
+}
+
+fn validate_bounded_exec_request(request: &BoundedExecRequest<'_>) -> io::Result<()> {
+    if request.timeout_ms == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "bounded_exec requires a positive timeout",
+        ));
+    }
+
+    let total_output_limit = (request.stdout_limit_bytes as usize)
+        .checked_add(request.stderr_limit_bytes as usize)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "bounded_exec final output limits overflow",
+            )
+        })?;
+    if total_output_limit > vsock_proto::MAX_BOUNDED_EXEC_RESULT_OUTPUT_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "bounded_exec final output limits exceed protocol result frame: {} > {}",
+                total_output_limit,
+                vsock_proto::MAX_BOUNDED_EXEC_RESULT_OUTPUT_BYTES
+            ),
+        ));
+    }
+
+    if let Some(stream) = &request.stream
+        && (stream.stdout || stream.stderr)
+    {
+        let chunk_limit = stream.chunk_limit_bytes as usize;
+        if chunk_limit < vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "bounded_exec stream chunk limit below minimum: {} < {}",
+                    stream.chunk_limit_bytes,
+                    vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES
+                ),
+            ));
+        }
+        if chunk_limit > vsock_proto::MAX_BOUNDED_EXEC_OUTPUT_CHUNK_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "bounded_exec stream chunk limit exceeds protocol frame: {} > {}",
+                    stream.chunk_limit_bytes,
+                    vsock_proto::MAX_BOUNDED_EXEC_OUTPUT_CHUNK_BYTES
+                ),
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 /// Background reader task: owns the read half and decoder exclusively.
@@ -386,6 +572,34 @@ async fn reader_loop(
                     }
                     shared.exit_notify.notify_waiters();
                 }
+            } else if msg.msg_type == MSG_BOUNDED_EXEC_OUTPUT_CHUNK && msg.seq != 0 {
+                if let Ok(decoded) = vsock_proto::decode_bounded_exec_output_chunk(&msg.payload) {
+                    let stream = proto_stream_to_host(decoded.stream);
+                    let registration = {
+                        let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+                        match &*guard {
+                            ConnectionState::Connected {
+                                bounded_output_senders,
+                                ..
+                            } => bounded_output_senders.get(&msg.seq).cloned(),
+                            ConnectionState::Closed { .. } => None,
+                        }
+                    };
+                    if let Some(registration) = registration {
+                        if !registration.allows(stream) {
+                            continue;
+                        }
+                        let event = BoundedExecOutputEvent {
+                            stream,
+                            sequence: decoded.sequence,
+                            chunk: decoded.chunk.to_vec(),
+                            truncated: decoded.truncated,
+                        };
+                        if registration.event_tx.send(event).is_err() {
+                            shared.remove_bounded_output_sender(msg.seq);
+                        }
+                    }
+                }
             } else {
                 // For spawn_watch_result: move the pre-registered stdout sender
                 // from pending_stdout to stdout_senders BEFORE dispatching the
@@ -398,6 +612,7 @@ async fn reader_loop(
                             pending,
                             pending_stdout,
                             stdout_senders,
+                            bounded_output_senders,
                             ..
                         } => {
                             if msg.msg_type == MSG_SPAWN_WATCH_RESULT
@@ -407,6 +622,7 @@ async fn reader_loop(
                             {
                                 stdout_senders.insert(pid, tx);
                             }
+                            bounded_output_senders.remove(&msg.seq);
                             pending.remove(&msg.seq)
                         }
                         ConnectionState::Closed { .. } => None,
@@ -624,6 +840,7 @@ impl VsockHost {
                 pending: HashMap::new(),
                 pending_stdout: HashMap::new(),
                 stdout_senders: HashMap::new(),
+                bounded_output_senders: HashMap::new(),
                 exits: HashMap::new(),
             }),
             exit_notify: Notify::new(),
@@ -737,6 +954,115 @@ impl VsockHost {
         sudo: bool,
     ) -> io::Result<ExecResult> {
         exec_on_shared(&self.shared, command, timeout_ms, env, sudo).await
+    }
+
+    /// Execute a command on the guest using the bounded exec protocol.
+    ///
+    /// This is request/response scoped like [`exec`](Self::exec), but it
+    /// returns structured termination, bounded final buffers, and optional
+    /// request-scoped stdout/stderr stream events.
+    pub async fn bounded_exec(
+        &self,
+        request: &BoundedExecRequest<'_>,
+    ) -> io::Result<BoundedExecResult> {
+        validate_bounded_exec_request(request)?;
+
+        let stream_stdout = request.stream.as_ref().is_some_and(|s| s.stdout);
+        let stream_stderr = request.stream.as_ref().is_some_and(|s| s.stderr);
+        let stream_chunk_limit_bytes = request.stream.as_ref().map_or(0, |s| s.chunk_limit_bytes);
+        let stdout_stream_limit_bytes = request.stream.as_ref().map_or(0, |s| s.stdout_limit_bytes);
+        let stderr_stream_limit_bytes = request.stream.as_ref().map_or(0, |s| s.stderr_limit_bytes);
+
+        let proto_request = vsock_proto::BoundedExecRequest {
+            timeout_ms: request.timeout_ms,
+            command: request.command,
+            env: request.env,
+            sudo: request.sudo,
+            stdin: request.stdin,
+            stdout_limit_bytes: request.stdout_limit_bytes,
+            stderr_limit_bytes: request.stderr_limit_bytes,
+            stream_stdout,
+            stream_stderr,
+            stream_chunk_limit_bytes,
+            stdout_stream_limit_bytes,
+            stderr_stream_limit_bytes,
+        };
+        let payload = vsock_proto::encode_bounded_exec(&proto_request)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+
+        let seq = self.shared.next_seq();
+        let data = vsock_proto::encode(MSG_BOUNDED_EXEC, seq, &payload)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut guard = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+            match &mut *guard {
+                ConnectionState::Closed { .. } => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::ConnectionReset,
+                        "connection closed",
+                    ));
+                }
+                ConnectionState::Connected {
+                    pending,
+                    bounded_output_senders,
+                    ..
+                } => {
+                    pending.insert(seq, tx);
+                    if let Some(stream) = &request.stream
+                        && (stream.stdout || stream.stderr)
+                    {
+                        bounded_output_senders.insert(seq, stream.event_tx.clone());
+                    }
+                }
+            }
+        }
+        let _pending_guard = PendingRequestGuard::new(Arc::clone(&self.shared), seq);
+        let _bounded_output_guard = request.stream.as_ref().and_then(|stream| {
+            (stream.stdout || stream.stderr)
+                .then(|| PendingBoundedOutputGuard::new(Arc::clone(&self.shared), seq))
+        });
+
+        self.shared.writer.lock().await.write_all(&data).await?;
+
+        let timeout = Duration::from_millis(request.timeout_ms as u64 + 5000);
+        let resp = tokio::select! {
+            biased;
+            result = rx => {
+                result.map_err(|_| io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "connection closed",
+                ))?
+            }
+            _ = tokio::time::sleep(timeout) => {
+                return Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"));
+            }
+        };
+
+        if resp.msg_type == MSG_ERROR {
+            let msg = vsock_proto::decode_error(&resp.payload)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+            return Err(io::Error::other(msg));
+        }
+
+        if resp.msg_type != MSG_BOUNDED_EXEC_RESULT {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unexpected response type: 0x{:02X}", resp.msg_type),
+            ));
+        }
+
+        let decoded = vsock_proto::decode_bounded_exec_result(&resp.payload)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+        Ok(BoundedExecResult {
+            termination: proto_termination_to_host(decoded.termination),
+            duration_ms: decoded.duration_ms,
+            stdout: decoded.stdout.to_vec(),
+            stderr: decoded.stderr.to_vec(),
+            stdout_truncated: decoded.stdout_truncated,
+            stderr_truncated: decoded.stderr_truncated,
+        })
     }
 
     /// Maximum content per write_file message.  Leaves headroom below
@@ -1071,16 +1397,51 @@ mod tests {
         VsockHost::from_stream(stream, deadline).await
     }
 
-    fn registration_counts(host: &VsockHost) -> (usize, usize, usize) {
+    fn registration_counts(host: &VsockHost) -> (usize, usize, usize, usize) {
         let guard = host.shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &*guard {
             ConnectionState::Connected {
                 pending,
                 pending_stdout,
                 stdout_senders,
+                bounded_output_senders,
                 ..
-            } => (pending.len(), pending_stdout.len(), stdout_senders.len()),
-            ConnectionState::Closed { .. } => (0, 0, 0),
+            } => (
+                pending.len(),
+                pending_stdout.len(),
+                stdout_senders.len(),
+                bounded_output_senders.len(),
+            ),
+            ConnectionState::Closed { .. } => (0, 0, 0, 0),
+        }
+    }
+
+    fn simple_bounded_request<'a>(
+        command: &'a str,
+        stream: Option<BoundedExecStreamRequest>,
+    ) -> BoundedExecRequest<'a> {
+        BoundedExecRequest {
+            command,
+            timeout_ms: 5000,
+            env: &[],
+            sudo: false,
+            stdin: None,
+            stdout_limit_bytes: 1024,
+            stderr_limit_bytes: 1024,
+            stream,
+        }
+    }
+
+    fn bounded_stream_request(
+        event_tx: mpsc::UnboundedSender<BoundedExecOutputEvent>,
+    ) -> BoundedExecStreamRequest {
+        BoundedExecStreamRequest {
+            event_tx,
+            stdout: true,
+            stderr: true,
+            chunk_limit_bytes: vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32,
+            stdout_limit_bytes: 2048,
+            stderr_limit_bytes: 2048,
         }
     }
 
@@ -1186,6 +1547,299 @@ mod tests {
         let result = host.exec("badcmd", 5000, &[], false).await.unwrap();
         assert_eq!(result.exit_code, 1);
         assert_eq!(result.stderr, b"command not found");
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+
+            let d = vsock_proto::decode_bounded_exec(&msgs[0].payload).unwrap();
+            assert_eq!(d.command, "printf bounded");
+            assert_eq!(d.timeout_ms, 7500);
+            assert_eq!(d.env, vec![("K", "V")]);
+            assert!(d.sudo);
+            assert_eq!(d.stdin, Some(b"input".as_slice()));
+            assert_eq!(d.stdout_limit_bytes, 10);
+            assert_eq!(d.stderr_limit_bytes, 11);
+            assert!(!d.stream_stdout);
+            assert!(!d.stream_stderr);
+
+            let payload = vsock_proto::encode_bounded_exec_result(
+                vsock_proto::BoundedExecTermination::Exited { exit_code: 7 },
+                123,
+                b"out",
+                b"err",
+                true,
+                false,
+            )
+            .unwrap();
+            let resp = vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
+            guest.write_all(&resp).await.unwrap();
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let env = [("K", "V")];
+        let request = BoundedExecRequest {
+            command: "printf bounded",
+            timeout_ms: 7500,
+            env: &env,
+            sudo: true,
+            stdin: Some(b"input"),
+            stdout_limit_bytes: 10,
+            stderr_limit_bytes: 11,
+            stream: None,
+        };
+        let result = host.bounded_exec(&request).await.unwrap();
+        assert_eq!(
+            result.termination,
+            BoundedExecTermination::Exited { exit_code: 7 }
+        );
+        assert_eq!(result.duration_ms, 123);
+        assert_eq!(result.stdout, b"out");
+        assert_eq!(result.stderr, b"err");
+        assert!(result.stdout_truncated);
+        assert!(!result.stderr_truncated);
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_stream_events_route_by_request_seq() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut requests = Vec::new();
+            let mut buf = [0u8; 4096];
+            while requests.len() < 2 {
+                let n = guest.read(&mut buf).await.unwrap();
+                let msgs = decoder.decode(&buf[..n]).unwrap();
+                for msg in msgs {
+                    assert_eq!(msg.msg_type, MSG_BOUNDED_EXEC);
+                    let decoded = vsock_proto::decode_bounded_exec(&msg.payload).unwrap();
+                    requests.push((msg.seq, decoded.command.to_string()));
+                }
+            }
+
+            for (seq, command) in &requests {
+                let (stream, sequence, chunk) = if command == "cmd-a" {
+                    (
+                        vsock_proto::BoundedExecStream::Stdout,
+                        11,
+                        b"a-out".as_slice(),
+                    )
+                } else {
+                    (
+                        vsock_proto::BoundedExecStream::Stderr,
+                        22,
+                        b"b-err".as_slice(),
+                    )
+                };
+                let payload =
+                    vsock_proto::encode_bounded_exec_output_chunk(stream, sequence, chunk, false)
+                        .unwrap();
+                let msg =
+                    vsock_proto::encode(MSG_BOUNDED_EXEC_OUTPUT_CHUNK, *seq, &payload).unwrap();
+                guest.write_all(&msg).await.unwrap();
+            }
+
+            for (seq, command) in requests.iter().rev() {
+                let stdout = format!("final-{command}");
+                let payload = vsock_proto::encode_bounded_exec_result(
+                    vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
+                    1,
+                    stdout.as_bytes(),
+                    b"",
+                    false,
+                    false,
+                )
+                .unwrap();
+                let resp = vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, *seq, &payload).unwrap();
+                guest.write_all(&resp).await.unwrap();
+            }
+        });
+
+        let host = std::sync::Arc::new(host_from_stream(host_stream).await.unwrap());
+        let (tx_a, mut rx_a) = mpsc::unbounded_channel();
+        let (tx_b, mut rx_b) = mpsc::unbounded_channel();
+
+        let host_a = std::sync::Arc::clone(&host);
+        let task_a = tokio::spawn(async move {
+            let request = simple_bounded_request("cmd-a", Some(bounded_stream_request(tx_a)));
+            host_a.bounded_exec(&request).await
+        });
+
+        let host_b = std::sync::Arc::clone(&host);
+        let task_b = tokio::spawn(async move {
+            let request = simple_bounded_request("cmd-b", Some(bounded_stream_request(tx_b)));
+            host_b.bounded_exec(&request).await
+        });
+
+        let result_a = task_a.await.unwrap().unwrap();
+        let result_b = task_b.await.unwrap().unwrap();
+        assert_eq!(result_a.stdout, b"final-cmd-a");
+        assert_eq!(result_b.stdout, b"final-cmd-b");
+
+        assert_eq!(
+            rx_a.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 11,
+                chunk: b"a-out".to_vec(),
+                truncated: false,
+            }
+        );
+        assert_eq!(
+            rx_b.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stderr,
+                sequence: 22,
+                chunk: b"b-err".to_vec(),
+                truncated: false,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_malformed_result_cleans_up() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+            let bad_resp =
+                vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, msgs[0].seq, b"\x00").unwrap();
+            guest.write_all(&bad_resp).await.unwrap();
+
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+            let payload = vsock_proto::encode_bounded_exec_result(
+                vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
+                1,
+                b"ok",
+                b"",
+                false,
+                false,
+            )
+            .unwrap();
+            let ok_resp =
+                vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
+            guest.write_all(&ok_resp).await.unwrap();
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let request = simple_bounded_request("bad-result", Some(bounded_stream_request(tx)));
+        let err = host.bounded_exec(&request).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(
+            registration_counts(&host),
+            (0, 0, 0, 0),
+            "malformed bounded_exec result must clean pending registrations",
+        );
+
+        let request = simple_bounded_request("good-result", None);
+        let result = host.bounded_exec(&request).await.unwrap();
+        assert_eq!(result.stdout, b"ok");
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_cancel_cleans_up_registrations() {
+        let (host_stream, mut guest) = make_pair();
+        let request_seen = std::sync::Arc::new(Notify::new());
+        let release_guest = std::sync::Arc::new(Notify::new());
+
+        {
+            let request_seen = std::sync::Arc::clone(&request_seen);
+            let release_guest = std::sync::Arc::clone(&release_guest);
+            tokio::spawn(async move {
+                let mut decoder = Decoder::new();
+                mock_handshake(&mut guest, &mut decoder).await;
+
+                let mut buf = [0u8; 4096];
+                let n = guest.read(&mut buf).await.unwrap();
+                let msgs = decoder.decode(&buf[..n]).unwrap();
+                assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+                request_seen.notify_one();
+
+                release_guest.notified().await;
+            });
+        }
+
+        let host = std::sync::Arc::new(host_from_stream(host_stream).await.unwrap());
+        let task_host = std::sync::Arc::clone(&host);
+        let task = tokio::spawn(async move {
+            let (tx, _rx) = mpsc::unbounded_channel();
+            let request = simple_bounded_request("long-running", Some(bounded_stream_request(tx)));
+            task_host.bounded_exec(&request).await
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), request_seen.notified())
+            .await
+            .expect("guest should receive bounded_exec request");
+        assert_eq!(registration_counts(&host), (1, 0, 0, 1));
+
+        task.abort();
+        let _ = task.await;
+        assert_eq!(
+            registration_counts(&host),
+            (0, 0, 0, 0),
+            "aborted bounded_exec future must clean pending registrations",
+        );
+
+        release_guest.notify_one();
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_rejects_invalid_boundaries() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let zero_timeout = BoundedExecRequest {
+            timeout_ms: 0,
+            ..simple_bounded_request("zero-timeout", None)
+        };
+        let err = host.bounded_exec(&zero_timeout).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+
+        let oversized_final = BoundedExecRequest {
+            stdout_limit_bytes: u32::MAX,
+            stderr_limit_bytes: u32::MAX,
+            ..simple_bounded_request("oversized-final", None)
+        };
+        let err = host.bounded_exec(&oversized_final).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let invalid_stream = BoundedExecRequest {
+            stream: Some(BoundedExecStreamRequest {
+                chunk_limit_bytes: 0,
+                ..bounded_stream_request(tx)
+            }),
+            ..simple_bounded_request("invalid-stream", None)
+        };
+        let err = host.bounded_exec(&invalid_stream).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 
     #[tokio::test]
@@ -1793,13 +2447,13 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(5), request_seen.notified())
             .await
             .expect("guest should receive spawn_watch request");
-        assert_eq!(registration_counts(&host), (1, 1, 0));
+        assert_eq!(registration_counts(&host), (1, 1, 0, 0));
 
         task.abort();
         let _ = task.await;
         assert_eq!(
             registration_counts(&host),
-            (0, 0, 0),
+            (0, 0, 0, 0),
             "aborted spawn_watch future must clean pending registrations",
         );
 


### PR DESCRIPTION
## Summary
- add sandbox-level bounded exec request/result/event types and trait method
- wire bounded exec through vsock-host with request-scoped stdout/stderr stream routing
- implement Firecracker and mock sandbox support with cleanup/race regression coverage

## Tests
- cargo test --manifest-path crates/Cargo.toml -p vsock-host -p sandbox-mock -p sandbox-fc -p sandbox
- cargo clippy --manifest-path crates/Cargo.toml -p sandbox -p vsock-host -p sandbox-mock -p sandbox-fc --all-targets -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest

Closes #12111