### PR TITLE
test: remove fixed sleeps from runner main loop tests

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -462,6 +462,8 @@ pub async fn run_start(
         orphan_reap_process_discovery: None,
         #[cfg(test)]
         outer_job_panic: None,
+        #[cfg(test)]
+        test_probes: StartLoopTestProbes::default(),
     };
 
     run(config).await
@@ -502,6 +504,8 @@ struct RunConfig {
     signal_source: SignalSource,
     #[cfg(test)]
     outer_job_panic: Option<OuterJobPanicPoint>,
+    #[cfg(test)]
+    test_probes: StartLoopTestProbes,
 }
 
 enum SignalSource {
@@ -513,6 +517,25 @@ enum SignalSource {
     /// below; non-test code matches on it but never builds it.
     #[cfg_attr(not(test), allow(dead_code))]
     Override(SignalController),
+}
+
+#[cfg(test)]
+#[derive(Clone, Default)]
+struct StartLoopTestProbes {
+    budget_exhausted_reactor: Arc<tokio::sync::Notify>,
+}
+
+#[cfg(test)]
+impl StartLoopTestProbes {
+    fn notify_budget_exhausted_reactor(&self) {
+        self.budget_exhausted_reactor.notify_one();
+    }
+
+    async fn wait_budget_exhausted_reactor(&self, timeout: Duration) {
+        tokio::time::timeout(timeout, self.budget_exhausted_reactor.notified())
+            .await
+            .expect("runner did not enter budget-exhausted reactor within timeout");
+    }
 }
 
 #[cfg(test)]
@@ -562,6 +585,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         signal_source,
         #[cfg(test)]
         outer_job_panic,
+        #[cfg(test)]
+        test_probes,
     } = config;
 
     let mut factories =
@@ -753,6 +778,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         } else {
             false
         };
+        #[cfg(test)]
+        if matches!(mode, RunnerMode::Running) && !can_discover {
+            test_probes.notify_budget_exhausted_reactor();
+        }
         tokio::select! {
             // Job discovery via provider (Ably wakeups + HTTP poll).
             // The future is pinned outside the loop so heartbeat/cleanup

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -184,21 +184,32 @@ async fn discover_survives_heartbeat_ticks() {
         Duration::from_secs(20), // poll delay: 20s
     );
     let run_handle = tokio::spawn(run(config));
+    assert!(
+        env.handle
+            .wait_discover_poll_started(Duration::from_secs(5))
+            .await,
+        "discover poll delay should start before virtual time advances"
+    );
 
     // Push job immediately — it's in the channel, waiting for
     // discover to finish its poll delay and read it.
     let run_id = RunId::new_v4();
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
 
-    // Advance past the 20s poll delay. Heartbeat fires at 10s but
-    // must NOT restart the delay (because discover_fut is pinned).
-    tokio::time::sleep(Duration::from_secs(25)).await;
-
-    // Heartbeat should have fired during the wait.
+    // Advance to the first heartbeat while the 20s discover delay is still
+    // pending, then let the runner task observe the ready timer.
+    tokio::time::advance(HEARTBEAT_PERIOD).await;
+    tokio::task::yield_now().await;
     assert!(
-        env.handle.heartbeat_count() > 0,
+        env.handle
+            .wait_heartbeat_past(0, Duration::from_secs(1))
+            .await,
         "heartbeat should fire while discover poll delay is running"
     );
+
+    // Advance past the rest of the 20s poll delay. If discover was cancelled
+    // and recreated at t=10s, the delay restarts and this is still too early.
+    tokio::time::advance(Duration::from_secs(15)).await;
 
     // Job should have been discovered and completed.
     // If discover was cancelled and recreated at t=10s, the 20s delay
@@ -234,8 +245,8 @@ async fn shutdown_completes_without_deadlock() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let run_handle = tokio::spawn(run(config));
 
-    // Let the main loop start and enter select!.
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    // Let the main loop start and enter the discover select arm.
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     // Only send Draining — do NOT cancel. The Draining path sees
     // `jobs.is_empty()` immediately (no active jobs), breaks to
@@ -266,6 +277,7 @@ async fn drain_then_resume_keeps_jobs_running() {
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+    let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 
     // Claim a job and let it reach the gated wait.
@@ -275,11 +287,11 @@ async fn drain_then_resume_keeps_jobs_running() {
 
     // Enter Draining. The job keeps running; no cancellation is fired.
     env.drain();
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    wait_status_mode(&status_path, "draining", Duration::from_secs(5)).await;
 
     // Resume. Job is still alive in the executor.
     env.resume();
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    wait_status_mode(&status_path, "running", Duration::from_secs(5)).await;
 
     // Release the gated job so it completes normally.
     gate.notify_one();
@@ -400,6 +412,7 @@ async fn heartbeat_fires_while_draining() {
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+    let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 
     // Claim a gated job so Draining mode has an active job to wait
@@ -409,13 +422,10 @@ async fn heartbeat_fires_while_draining() {
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
     let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
 
-    // Enter Draining before the first heartbeat tick fires. The sleep
-    // lets the runner observe `mode_rx.changed()` and re-enter the
-    // reactor with Draining-mode guards. There is no production-side
-    // notifier for "Draining mode entered", so this
-    // synchronization has to be time-based.
+    // Enter Draining before the first heartbeat tick fires. `status.json`
+    // is updated only after the main loop observes the mode transition.
     env.drain();
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    wait_status_mode(&status_path, "draining", Duration::from_secs(5)).await;
     assert_eq!(*env.mode_tx.borrow(), RunnerMode::Draining);
     let before = env.handle.heartbeat_count();
 
@@ -458,10 +468,8 @@ async fn heartbeat_fires_while_budget_exhausted() {
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
     // Wait for the reservation — after this, the next loop iteration
     // enters the budget-exhausted wait state at the can_afford check.
-    // The sleep yields to the runner so it reaches the reactor `select!`
-    // before the time advance below.
     wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    wait_budget_exhausted_reactor(&env, Duration::from_secs(5)).await;
     let before = env.handle.heartbeat_count();
 
     // Advance past the first tick while the runner is budget-exhausted.
@@ -494,7 +502,7 @@ async fn drain_without_active_jobs_exits_promptly() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let run_handle = tokio::spawn(run(config));
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
     env.drain();
 
     match tokio::time::timeout(Duration::from_secs(2), run_handle).await {
@@ -515,7 +523,6 @@ async fn resume_on_running_is_noop() {
     // SIGUSR2 while already Running — state guard blocks the send,
     // leaving mode unchanged and discovery uninterrupted.
     env.resume();
-    tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Runner is still claiming jobs.
     let run_id = RunId::new_v4();
@@ -578,6 +585,7 @@ async fn drain_then_hard_shutdown_upgrades() {
         gate,
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+    let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -586,7 +594,7 @@ async fn drain_then_hard_shutdown_upgrades() {
 
     // Draining. Without hard shutdown, this would wait up to JOB_TIMEOUT = 2h.
     env.drain();
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    wait_status_mode(&status_path, "draining", Duration::from_secs(5)).await;
 
     // Upgrade to hard shutdown.
     env.trigger_stopping().await;
@@ -768,8 +776,8 @@ async fn drain_with_jobs_transitions_to_stopping_when_empty() {
         .wait_completion(run_id, Duration::from_secs(5))
         .await;
 
-    // Give the main loop a moment to clean up the jobset, then drain.
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    // Wait for the main loop to reap the completed job, then drain.
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
     env.drain();
 
     // Draining mode should observe jobs.is_empty() and self-send
@@ -830,6 +838,7 @@ async fn draining_auto_stop_preserves_concurrent_resume() {
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+    let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 
     // Claim a job and hold it at the gate so Draining mode has
@@ -840,7 +849,7 @@ async fn draining_auto_stop_preserves_concurrent_resume() {
     let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
 
     env.drain();
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    wait_status_mode(&status_path, "draining", Duration::from_secs(5)).await;
     assert_eq!(*env.mode_tx.borrow(), RunnerMode::Draining);
 
     // Silently flip to Running — the `false` return suppresses
@@ -860,7 +869,8 @@ async fn draining_auto_stop_preserves_concurrent_resume() {
         .handle
         .wait_completion(run_id, Duration::from_secs(5))
         .await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_status_mode(&status_path, "running", Duration::from_secs(5)).await;
 
     assert_eq!(
         *env.mode_tx.borrow(),
@@ -943,6 +953,8 @@ async fn unknown_profile_skipped() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let run_handle = tokio::spawn(run(config));
 
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
     // Push a job with a profile that doesn't exist in the profiles map.
     // The main loop should log a warning and continue without claiming.
     let bad_id = RunId::new_v4();
@@ -953,8 +965,8 @@ async fn unknown_profile_skipped() {
         Some(minimal_context(bad_id)),
     );
 
-    // Give main loop time to skip the bad job.
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // The next discover wait proves the bad job was consumed and skipped.
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
 
     // Push a valid job — it should succeed despite the earlier bad one.
     let good_id = RunId::new_v4();
@@ -989,15 +1001,22 @@ async fn unknown_profile_skipped() {
 async fn duplicate_discovery_deduplicated() {
     // Budget for 2 jobs — enough for the duplicate to pass the budget
     // check and reach the cancel_tokens dedup logic.
-    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+        Arc::clone(&gate),
+    ));
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
     let budget = Arc::clone(&config.budget);
     let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     let run_id = RunId::new_v4();
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
 
-    // Wait for job to be claimed and executing (cancel_tokens now has run_id).
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Wait for the original job to be claimed and blocked at the sandbox gate.
+    let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
 
     // Push the same run_id again (simulates duplicate discovery).
     // Budget has room, but cancel_tokens already contains this run_id →
@@ -1006,8 +1025,10 @@ async fn duplicate_discovery_deduplicated() {
         .discover_tx
         .send((run_id, "vm0/default".into()))
         .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
 
     // Wait for the original job to complete.
+    gate.notify_one();
     let completion = env
         .handle
         .wait_completion(run_id, Duration::from_secs(5))

--- a/crates/runner/src/cmd/start/tests/support.rs
+++ b/crates/runner/src/cmd/start/tests/support.rs
@@ -33,6 +33,7 @@ pub(super) struct MockRunEnv {
     pub(super) idle_pool: SharedIdlePool,
     pub(super) lifecycle: LifecycleController,
     pub(super) parking_gate: ParkingGate,
+    pub(super) start_probes: StartLoopTestProbes,
     pub(super) mode_tx: tokio::sync::watch::Sender<RunnerMode>,
     pub(super) cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
     pub(super) cancel: CancellationToken,
@@ -148,6 +149,7 @@ pub(super) fn build_mock_run_config_with_runtime(
     let (mode_tx, mode_rx) = tokio::sync::watch::channel(RunnerMode::Running);
     let parking_gate = ParkingGate::new_open();
     let lifecycle = LifecycleController::new(mode_tx, parking_gate.clone());
+    let start_probes = StartLoopTestProbes::default();
     let cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
         Arc::new(tokio::sync::Mutex::new(HashMap::new()));
 
@@ -224,6 +226,7 @@ pub(super) fn build_mock_run_config_with_runtime(
             handler_abort: None,
         }),
         outer_job_panic: None,
+        test_probes: start_probes.clone(),
     };
 
     let env = MockRunEnv {
@@ -232,6 +235,7 @@ pub(super) fn build_mock_run_config_with_runtime(
         idle_pool,
         lifecycle: lifecycle.clone(),
         parking_gate,
+        start_probes,
         mode_tx: lifecycle.mode_tx().clone(),
         cancel_tokens,
         cancel,
@@ -567,6 +571,11 @@ struct StatusSnapshot {
 }
 
 #[derive(serde::Deserialize)]
+struct StatusModeSnapshot {
+    mode: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
 struct ActiveRunSnapshot {
     run_id: String,
 }
@@ -598,6 +607,45 @@ pub(super) async fn status_idle_sessions_and_active_runs(
 
 pub(super) async fn status_idle_sessions(status_path: &std::path::Path) -> Vec<String> {
     status_idle_sessions_and_active_runs(status_path).await.0
+}
+
+pub(super) async fn status_mode_if_exists(status_path: &std::path::Path) -> Option<Option<String>> {
+    match tokio::fs::try_exists(status_path).await {
+        Ok(true) => {
+            let raw = tokio::fs::read_to_string(status_path).await.unwrap();
+            let status: StatusModeSnapshot = serde_json::from_str(&raw).unwrap();
+            Some(status.mode)
+        }
+        Ok(false) => None,
+        Err(err) => panic!(
+            "failed to check status file {}: {err}",
+            status_path.display()
+        ),
+    }
+}
+
+pub(super) async fn wait_status_mode(
+    status_path: &std::path::Path,
+    expected: &str,
+    timeout: Duration,
+) {
+    wait_for_probe(timeout, || async {
+        match status_mode_if_exists(status_path).await {
+            Some(Some(mode)) if mode == expected => WaitProbe::Ready(()),
+            Some(Some(mode)) => WaitProbe::Pending(format!(
+                "status mode did not reach {expected:?} within {timeout:?} (actual: {mode:?})",
+            )),
+            Some(None) => WaitProbe::Pending(format!(
+                "status file {} did not contain mode within {timeout:?}",
+                status_path.display(),
+            )),
+            None => WaitProbe::Pending(format!(
+                "status file {} was not written within {timeout:?}",
+                status_path.display(),
+            )),
+        }
+    })
+    .await;
 }
 
 #[tokio::test]
@@ -754,4 +802,16 @@ pub(super) async fn wait_cancel_token_removed(
         }
     })
     .await;
+}
+
+pub(super) async fn wait_discover_entered(env: &MockRunEnv, timeout: Duration) {
+    tokio::time::timeout(timeout, env.handle.discover_entered.notified())
+        .await
+        .expect("run() did not enter discover_fut select! within timeout");
+}
+
+pub(super) async fn wait_budget_exhausted_reactor(env: &MockRunEnv, timeout: Duration) {
+    env.start_probes
+        .wait_budget_exhausted_reactor(timeout)
+        .await;
 }

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -70,6 +70,10 @@ pub struct MockJobProvider {
     /// Event-driven waiting eliminates the polling loop whose wall-clock
     /// deadline was racing coverage-CI slowdown (see #10146).
     completion_notify: Arc<Notify>,
+    /// Fired after `discover()` has been polled and its optional poll delay is
+    /// about to start. Paused-time tests use this to avoid advancing virtual
+    /// time before the discover timer exists.
+    discover_poll_started: Arc<Notify>,
     /// Fired by `heartbeat()` after a state is appended to `heartbeats`.
     /// `wait_heartbeat_past` uses the same subscribe-then-check pattern as
     /// `wait_completion` so a heartbeat that lands mid-check is still observed.
@@ -85,6 +89,8 @@ pub struct MockProviderHandle {
     pub discover_entered: Arc<Notify>,
     /// See [`MockJobProvider::completion_notify`].
     completion_notify: Arc<Notify>,
+    /// See [`MockJobProvider::discover_poll_started`].
+    discover_poll_started: Arc<Notify>,
     /// See [`MockJobProvider::heartbeat_notify`].
     heartbeat_notify: Arc<Notify>,
 }
@@ -113,6 +119,7 @@ impl MockJobProvider {
         let heartbeats = Arc::new(StdMutex::new(Vec::new()));
         let discover_entered = Arc::new(Notify::new());
         let completion_notify = Arc::new(Notify::new());
+        let discover_poll_started = Arc::new(Notify::new());
         let heartbeat_notify = Arc::new(Notify::new());
         let provider = Arc::new(Self {
             discovery: Mutex::new(rx),
@@ -123,6 +130,7 @@ impl MockJobProvider {
             cancel,
             discover_entered: Arc::clone(&discover_entered),
             completion_notify: Arc::clone(&completion_notify),
+            discover_poll_started: Arc::clone(&discover_poll_started),
             heartbeat_notify: Arc::clone(&heartbeat_notify),
         });
         let handle = MockProviderHandle {
@@ -131,6 +139,7 @@ impl MockJobProvider {
             heartbeats,
             discover_entered,
             completion_notify,
+            discover_poll_started,
             heartbeat_notify,
         };
         (provider, handle)
@@ -176,6 +185,14 @@ impl MockProviderHandle {
                 return None;
             }
         }
+    }
+
+    /// Wait until `discover()` has been polled at least once and its optional
+    /// poll-delay timer has been created.
+    pub async fn wait_discover_poll_started(&self, timeout: Duration) -> bool {
+        tokio::time::timeout(timeout, self.discover_poll_started.notified())
+            .await
+            .is_ok()
     }
 
     /// Return the number of heartbeats recorded so far.
@@ -228,6 +245,7 @@ impl JobProvider for MockJobProvider {
     ///   the Mutex deadlocks — exactly reproducing the production bug.
     async fn discover(&self) -> Option<(RunId, String)> {
         let mut rx = self.discovery.lock().await;
+        self.discover_poll_started.notify_one();
         if let Some(delay) = self.poll_delay {
             tokio::time::sleep(delay).await;
         }


### PR DESCRIPTION
## Summary
- replace fixed runner main-loop test sleeps with event/status probes
- add test-only probes for budget-exhausted reactor entry and mock discover poll start
- gate duplicate-discovery test on sandbox completion instead of timing

Fixes #12194

## Verification
- cargo test --manifest-path crates/Cargo.toml -p runner --bin runner cmd::start::tests::main_loop -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p runner --bin runner
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings
- pre-commit: cargo fmt, cargo doc, cargo clippy