### PR TITLE
fix(chat): unblock thinking indicator when initial page is empty

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/create-chat-thread.test.ts
@@ -319,6 +319,129 @@ describe("fetchNextPage$ cursor", () => {
     expect(capturedSinceId).toBe("server-msg-2");
   });
 
+  it("issues a no-cursor fetch when initialPage is empty", async () => {
+    // Brand-new thread scenario: the swap-time `initialPage$` fetch returns
+    // empty because the send POST has not yet persisted the user row. With
+    // no anchor, `fetchNextPage$` must still query the server (sinceId is
+    // optional in the contract — passing it as undefined returns the latest
+    // page) and ingest whatever lands. Without this, every Ably-triggered
+    // refetch exits early and the rendered list stays stuck on the thinking
+    // indicator until the user manually refreshes.
+    const threadId = "thread-cursor-no-anchor";
+    const userMessageId = "11111111-1111-4111-8111-111111111111";
+    const assistantMessageId = "22222222-2222-4222-8222-222222222222";
+    const serverMessages: PagedChatMessage[] = [
+      {
+        id: userMessageId,
+        role: "user",
+        content: "hi",
+        createdAt: "2026-05-01T00:00:00Z",
+      },
+      {
+        id: assistantMessageId,
+        role: "assistant",
+        content: "hello back",
+        createdAt: "2026-05-01T00:00:01Z",
+      },
+    ];
+
+    const capturedSinceIds: (string | undefined)[] = [];
+
+    const mockDataSource: ChatThreadDataSource = {
+      getThread$: computed(() => {
+        return Promise.resolve({
+          id: threadId,
+          title: null,
+          agentId: "agent-1",
+          latestSessionId: null,
+          lastReadMessageId: null,
+          latestSessionProviderType: null,
+          activeRunIds: [],
+          activeRuns: [],
+          isLegacySession: false,
+          draftContent: null,
+          draftAttachments: null,
+          pendingMessage: null,
+          modelProviderId: null,
+          selectedModel: null,
+        });
+      }),
+      reloadThread$: command(() => {}),
+      initialPage$: computed(() => {
+        return Promise.resolve({
+          messages: [],
+          hasHistoryBefore: false,
+        });
+      }),
+      patchDraft$: command(
+        (_ctx, _args: PatchDraftArgs, _signal: AbortSignal) => {
+          return Promise.resolve();
+        },
+      ),
+      appendPendingMessage$: command(
+        (_ctx, _args: AppendPendingMessageArgs, _signal: AbortSignal) => {
+          return Promise.resolve(createEmptyPendingMessage());
+        },
+      ),
+      recallPendingMessage$: command(() => {
+        return Promise.resolve({
+          draftContent: null,
+          draftAttachments: null,
+        });
+      }),
+      listMessagesAfter$: command((_ctx, args) => {
+        capturedSinceIds.push(args.sinceId);
+        // First call (no anchor): return the full page the server has now.
+        // Second call (cursor advanced to assistant id): nothing new.
+        if (args.sinceId === undefined) {
+          return Promise.resolve({
+            messages: serverMessages,
+            reachedEnd: true,
+          });
+        }
+        return Promise.resolve({ messages: [], reachedEnd: true });
+      }),
+      listMessagesBefore$: command(() => {
+        return Promise.resolve({ messages: [], hasMore: false });
+      }),
+      cancelRuns$: command(
+        (_ctx, _args: CancelRunsArgs, _signal: AbortSignal) => {
+          return Promise.resolve();
+        },
+      ),
+      markRead$: command(() => {
+        return Promise.resolve(null);
+      }),
+      subscribeRealtime$: command(
+        (_ctx, _args: SubscribeRealtimeArgs, _signal: AbortSignal) => {
+          return Promise.resolve();
+        },
+      ),
+    };
+
+    const { draft } = context.store.set(ensureDraft$, threadId);
+    const thread = createChatThreadSignals(threadId, draft, mockDataSource);
+
+    await context.store.set(thread.fetchNextPage$, context.signal);
+
+    expect(capturedSinceIds[0]).toBeUndefined();
+
+    const groups = await context.store.get(thread.groupedChatMessages$);
+    const ids = groups.flatMap((g) => {
+      return g.messages.map((m) => {
+        return m.id;
+      });
+    });
+    expect(ids).toContain(userMessageId);
+    expect(ids).toContain(assistantMessageId);
+
+    // Subsequent calls advance the cursor to the last server-validated id.
+    await context.store.set(thread.fetchNextPage$, context.signal);
+    expect(capturedSinceIds[capturedSinceIds.length - 1]).toBe(
+      assistantMessageId,
+    );
+  });
+
   it("loops until reachedEnd when a single page is not enough", async () => {
     const threadId = "thread-drain-loop";
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -1,5 +1,6 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import { currentChatThreadId$ } from "../agent-chat.ts";
+import { logger } from "../log.ts";
 import {
   pushPathSilently$,
   searchParams$,
@@ -23,6 +24,8 @@ import { setupChatThreadInitScroll$ } from "./setup-chat-thread-signals.ts";
 import { syncPrimaryThread$ } from "./sync-primary-thread.ts";
 
 export const SIDEBAR_PARAM = "sidebar";
+
+const L = logger("ChatPanes");
 
 const internalLeftThread$ = state<ChatThreadSignals | null>(null);
 const internalRightThread$ = state<ChatThreadSignals | null>(null);
@@ -120,6 +123,7 @@ const resolvePaneThread$ = command(
     const { spec, thread, isNew, matchingOptimistic } = args;
 
     if (matchingOptimistic) {
+      L.debug("resolvePaneThread$ swap start", { threadId: thread.threadId });
       // Transfer optimistic messages from the local pending thread to the
       // remote-backed thread's delta so messages sent during the optimistic
       // window survive the handoff. On a new thread the remote initial page
@@ -129,6 +133,9 @@ const resolvePaneThread$ = command(
         matchingOptimistic.pendingThread.groupedChatMessages$,
       );
       signal.throwIfAborted();
+      const transferred = optimisticGroups.reduce((n, g) => {
+        return n + g.messages.length;
+      }, 0);
       for (const group of optimisticGroups) {
         for (const msg of group.messages) {
           set(thread.insertOptimisticMessage$, msg);
@@ -140,14 +147,25 @@ const resolvePaneThread$ = command(
       set(thread.hideSkeleton$);
       set(spec.setPaneThread$, thread);
       set(clearMatchingOptimisticChatThread$, matchingOptimistic);
+      L.debug("resolvePaneThread$ swap done", {
+        threadId: thread.threadId,
+        transferred,
+      });
     }
 
+    L.debug("resolvePaneThread$ Promise.all start", {
+      threadId: thread.threadId,
+    });
     await Promise.all([
       set(loadDraft$, thread, isNew, signal),
       set(setupChatThreadInitScroll$, thread, signal),
       set(thread.runPhraseLoop$, signal),
       set(thread.subscribeChatThread$, signal),
     ]);
+    signal.throwIfAborted();
+    L.debug("resolvePaneThread$ Promise.all done", {
+      threadId: thread.threadId,
+    });
   },
 );
 
@@ -168,6 +186,10 @@ const setupPaneThread$ = command(
     const optimisticThread = get(spec.optimisticSource$);
     const matchingOptimistic =
       optimisticThread?.threadId === threadId ? optimisticThread : null;
+    L.debug("setupPaneThread$ start", {
+      threadId,
+      hasOptimistic: Boolean(matchingOptimistic),
+    });
 
     if (matchingOptimistic) {
       set(spec.setPaneThread$, matchingOptimistic.pendingThread);
@@ -196,7 +218,9 @@ const setupPaneThread$ = command(
     }
 
     if (matchingOptimistic) {
+      L.debug("setupPaneThread$ awaiting settleResult", { threadId });
       await matchingOptimistic.settleResult;
+      L.debug("setupPaneThread$ settleResult resolved", { threadId });
       signal.throwIfAborted();
     }
 

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -689,28 +689,42 @@ function createPagedMessages(
   });
 
   const fetchNextPage$ = command(async ({ get, set }, signal: AbortSignal) => {
-    let sinceId = get(nextCursorId$);
+    let sinceId: string | undefined = get(nextCursorId$);
     if (!sinceId) {
       const initial = await get(initialPage$);
       signal.throwIfAborted();
       sinceId = initial.messages[initial.messages.length - 1]?.id;
+      L.debug("fetchNextPage$ initialPage seeded sinceId", {
+        threadId,
+        sinceId: sinceId ?? null,
+        initialCount: initial.messages.length,
+      });
       if (sinceId) {
         set(nextCursorId$, sinceId);
       }
     }
     signal.throwIfAborted();
-    if (!sinceId) {
-      return true;
-    }
-    // Drain all pending pages so a single trigger fully catches the client
-    // up.  Without this loop, one Ably event or visibilitychange fetches at
-    // most 50 messages then stops; a burst larger than one page leaves the
-    // client permanently behind if the thread goes quiet afterward.
+    // No sinceId is *not* the same as "nothing to fetch": the server side
+    // accepts an absent cursor and returns the latest page in that case.
+    // Brand-new threads hit this path when the swap-time `initialPage$`
+    // fetch raced ahead of the server-side persist and got cached as
+    // empty — without a full fetch here, every Ably-triggered call would
+    // exit early and the rendered list would stay stuck on the thinking
+    // indicator. Drain all pending pages so a single trigger fully catches
+    // the client up; without this loop a burst larger than one page leaves
+    // the client permanently behind if the thread goes quiet afterwards.
     const MAX_PAGES = 10;
     for (let i = 0; i < MAX_PAGES; i++) {
       const result: { messages: PagedChatMessage[]; reachedEnd: boolean } =
         await set(dataSource.listMessagesAfter$, { threadId, sinceId }, signal);
       signal.throwIfAborted();
+      L.debug("fetchNextPage$ listMessagesAfter result", {
+        threadId,
+        sinceId: sinceId ?? null,
+        gotCount: result.messages.length,
+        reachedEnd: result.reachedEnd,
+        page: i,
+      });
       if (result.messages.length > 0) {
         set(appendDeltaMessages$, result.messages);
         sinceId = result.messages[result.messages.length - 1].id;
@@ -1019,8 +1033,18 @@ function createRunTracking({
 
       // Catch up any messages that arrived since the initial page was loaded.
       // On IDB cache hit this fetches messages that arrived after the cache
-      // was written; on cache miss fetchNextPage$ hits reachedEnd (no-op).
+      // was written; on cache miss `fetchNextPage$` issues a no-cursor fetch
+      // (since the contract treats `sinceId` as optional) and ingests the
+      // server's latest page. This must run before the subscribe loop below
+      // because that loop never resolves — `setAblyLoop$` blocks on the
+      // realtime channel for the lifetime of the thread.
+      L.debug("subscribeChatThread$ pre-subscribe fetchNextPage$ start", {
+        threadId,
+      });
       await set(fetchNextPage$, signal);
+      L.debug("subscribeChatThread$ pre-subscribe fetchNextPage$ done", {
+        threadId,
+      });
 
       // Track pending-message presence across reloads so we can re-scroll once
       // the server consumes a queued message: `onRunChanged$` reloads the
@@ -1037,7 +1061,9 @@ function createRunTracking({
       let previouslyHadPending = Boolean(initialThread?.pendingMessage);
 
       const onMessageCreated$ = command(async ({ set }, sig: AbortSignal) => {
+        L.debug("onMessageCreated$ fired", { threadId });
         await set(fetchNextPage$, sig);
+        L.debug("onMessageCreated$ fetchNextPage$ done", { threadId });
         await set(markThreadReadIfNeeded$, sig);
         animationFrame(
           () => {
@@ -1049,6 +1075,7 @@ function createRunTracking({
       });
 
       const onRunChanged$ = command(async ({ get, set }, sig: AbortSignal) => {
+        L.debug("onRunChanged$ fired", { threadId });
         set(reloadThread$);
         if (!queueEnabled) {
           return false;
@@ -1068,6 +1095,7 @@ function createRunTracking({
         return false;
       });
 
+      L.debug("subscribeChatThread$ subscribeRealtime$ start", { threadId });
       await Promise.all([
         set(markThreadReadIfNeeded$, signal),
         set(

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -40,11 +40,14 @@ import { toVoid } from "../utils.ts";
 import { agentById } from "../agent.ts";
 import { composerModelProviders$ } from "../zero-page/composer-model-providers.ts";
 import { resolveEffectiveAgentDefaultSelection } from "../zero-page/model-provider-default.ts";
+import { logger } from "../log.ts";
 
 export type { OptimisticChatPane };
 export { optimisticChatThread$ };
 
 const SIDEBAR_PARAM = "sidebar";
+
+const L = logger("OptimisticChat");
 
 /**
  * Persist the (threadId, agentId) pairing into the IDB cache the moment the
@@ -198,6 +201,10 @@ const createNewChatThread$ = command(
     }
 
     const threadId = crypto.randomUUID();
+    L.debug("createNewChatThread$ optimistic thread minted", {
+      threadId,
+      agentId: resolvedComposeId,
+    });
     await set(writeThreadAgentToCache$, threadId, resolvedComposeId, signal);
     const createdAt = new Date().toISOString();
     const dataSource = createLocalChatThreadDataSource({
@@ -213,6 +220,7 @@ const createNewChatThread$ = command(
     set(localThread.hideSkeleton$);
 
     const createClient = get(zeroClient$);
+    L.debug("createNewChatThread$ POST chat-threads start", { threadId });
     const settleResult = (async (): Promise<void> => {
       await createChatThread(
         createClient,
@@ -221,6 +229,7 @@ const createNewChatThread$ = command(
         undefined,
         threadId,
       );
+      L.debug("createNewChatThread$ POST chat-threads 201", { threadId });
       signal.throwIfAborted();
     })();
 
@@ -374,6 +383,10 @@ const sendNewThreadMessage$ = command(
     }
 
     const threadId = crypto.randomUUID();
+    L.debug("sendNewThreadMessage$ optimistic thread minted", {
+      threadId,
+      agentId,
+    });
     await set(writeThreadAgentToCache$, threadId, agentId, signal);
     const clientMessageId = crypto.randomUUID();
     const createdAt = new Date().toISOString();
@@ -403,6 +416,10 @@ const sendNewThreadMessage$ = command(
     set(draft.clear$);
 
     const client = get(zeroClient$)(chatMessagesContract);
+    L.debug("sendNewThreadMessage$ POST chat/messages start", {
+      threadId,
+      clientMessageId,
+    });
     const sendResult = (async (): Promise<SendNewThreadMessageResult> => {
       const result = await accept(
         client.send({
@@ -420,6 +437,10 @@ const sendNewThreadMessage$ = command(
         [201],
       );
       signal.throwIfAborted();
+      L.debug("sendNewThreadMessage$ POST chat/messages 201", {
+        threadId: result.body.threadId,
+        runId: result.body.runId,
+      });
       set(reloadChatThreads$);
 
       return { threadId: result.body.threadId, runId: result.body.runId };


### PR DESCRIPTION
## Summary
- `fetchNextPage$` exits early when both `nextCursorId$` and the initial-page's last id are missing. For brand-new chat threads the swap-time `initialPage$` fetch can race ahead of the server-side persist of the user message and cache an empty page, leaving the cursor permanently null. Every subsequent Ably-triggered refetch then takes the exit-early branch — the rendered list stays stuck on the thinking indicator until the user manually refreshes.
- The `chatThreadMessagesContract.list` contract treats `sinceId` as optional (server returns the latest page when it is absent) and `appendDeltaMessages$` already dedupes by id, so dropping the early-exit and letting `listMessagesAfter$` run with `sinceId === undefined` is safe and resyncs the client with the server's latest state. The cursor advances to the last server-validated id on the first non-empty result, so subsequent calls fall back into the existing incremental path naturally.
- Existing constraint preserved: when `initialPage$` does have messages, the cursor is still seeded from its last (server-validated) id — optimistic ids in the delta never leak into `sinceId`. The pre-existing `fetchNextPage$ cursor` test still passes unchanged.

## Repro
1. Click "New chat with Zero" (or any new-thread entry point) and immediately type + send a message during the optimistic-thread window.
2. The chat header settles into the thinking indicator (`Brewing... → Wiring up... → Sketching out...` rotating phrases) while the sidebar correctly updates with the auto-titled thread — i.e. the user-channel Ably events are flowing, but the per-thread `chatThreadMessageCreated` events route to `onMessageCreated$ → fetchNextPage$ → exit early on no sinceId`.
3. With this fix, the first `fetchNextPage$` call issues a no-cursor request and the assistant reply lands. Subsequent `chatThreadMessageCreated` events advance the cursor incrementally as before.

## Diagnostic logs
Adds debug logs across the swap and subscribe path so this class of race is easy to read off the browser console. Enable with:

```js
window._vm0.loggers["OptimisticChat"].debug = true
window._vm0.loggers["ChatPanes"].debug = true
window._vm0.loggers["ChatThread"].debug = true
window._vm0.loggers["Realtime"].debug = true
```

## Test plan
- [ ] CI: `@vm0/app` vitest (264 files / 2368 tests pass locally).
- [ ] CI: lint, type-check, knip.
- [ ] Manual: send the first message in a brand-new thread, verify the assistant reply renders without manual refresh.
- [ ] Manual: existing-thread send + receive still works (incremental cursor path unchanged).
- [ ] Manual: reload an existing thread that was previously stuck (IDB cache may be stale empty); the post-reload `fetchNextPage$` should now resync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)