### PR TITLE
feat: enable QueueMessage feature switch at org level for staff

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -232,6 +232,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Allow keyboard sends during an active chat thread run to append the draft to that thread's pending message queue.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ChatThreadPin]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

- Adds `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` to the `QueueMessage` feature switch
- This enables the queue message feature (keyboard sends during active run to queue pending messages) for the staff org, matching the pattern of other staff-gated features like `ApiBackend`, `ConnectorCategories`, `PlatformConnectors`, etc.

## Test plan

- [ ] Queue message feature is available to staff org members
- [ ] Queue message feature remains disabled for non-staff orgs

🤖 Generated with [Claude Code](https://claude.com/claude-code)