### PR TITLE
fix: standardize mobile chat composer icon spacing and touch targets

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -516,7 +516,7 @@ function ConnectorsPopoverButton({
             <TooltipTrigger asChild>
               <button
                 type="button"
-                className="inline-flex h-8 min-w-8 shrink-0 items-center justify-center rounded-lg px-1 transition-colors hover:bg-accent sm:h-9 sm:min-w-9 sm:px-1.5"
+                className="inline-flex h-11 min-w-11 shrink-0 items-center justify-center rounded-lg px-0 transition-colors hover:bg-accent sm:h-9 sm:min-w-9 sm:px-1.5"
                 aria-label="Connectors"
               >
                 <ConnectorTriggerIcons connectors={agentConnectors} />
@@ -674,8 +674,8 @@ function MicButton({
             className={cn(
               "inline-flex shrink-0 items-center justify-center rounded-lg transition-colors",
               recording || transcribing
-                ? "gap-[3px] h-9 w-[52px] bg-[#2E9E9F] text-white hover:bg-[#279394]"
-                : "h-9 w-9 text-muted-foreground hover:bg-accent hover:text-foreground",
+                ? "gap-[3px] h-11 w-[52px] bg-[#2E9E9F] text-white hover:bg-[#279394] sm:h-9"
+                : "h-11 w-11 text-muted-foreground hover:bg-accent hover:text-foreground sm:h-9 sm:w-9",
             )}
             onClick={handleClick}
             disabled={transcribing}
@@ -1245,7 +1245,7 @@ export function ZeroChatComposer({
                     <TooltipTrigger asChild>
                       <button
                         type="button"
-                        className="rounded-lg p-2 transition-colors duration-200 hover:bg-accent hover:text-foreground sm:p-[9px]"
+                        className="inline-flex h-11 w-11 items-center justify-center rounded-lg p-0 transition-colors duration-200 hover:bg-accent hover:text-foreground sm:h-9 sm:w-9"
                         aria-label="Attach"
                         onClick={handleFileSelect}
                       >
@@ -1285,7 +1285,7 @@ export function ZeroChatComposer({
                         onChange={handleModelPickerChange}
                         placeholder="Default"
                         triggerClassName={cn(
-                          "h-9 w-9 max-w-none gap-0 border-transparent bg-transparent px-0 text-sm text-muted-foreground transition-colors sm:w-auto sm:max-w-[14rem] sm:gap-1 sm:px-2",
+                          "h-11 w-11 max-w-none gap-0 border-transparent bg-transparent px-0 text-sm text-muted-foreground transition-colors sm:h-9 sm:w-auto sm:max-w-[14rem] sm:gap-1 sm:px-2",
                           "[&>span]:flex [&>span]:items-center [&>span]:justify-center sm:[&>span]:justify-start [&>svg]:hidden sm:[&>svg]:block",
                           "hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground",
                         )}
@@ -1299,7 +1299,7 @@ export function ZeroChatComposer({
                         inheritLabel="agent"
                       />
                     )}
-                    <div className="mx-0 h-5 w-px bg-border/60 sm:mx-0.5" />
+                    <div className="mx-1 h-5 w-px bg-border/60 sm:mx-0.5" />
                     <MicButton
                       onTranscribed={(text) => {
                         const base = input;
@@ -1313,7 +1313,7 @@ export function ZeroChatComposer({
                       <Button
                         size="sm"
                         variant="destructive"
-                        className="rounded-lg h-9 w-9 p-0 shrink-0"
+                        className="rounded-lg h-11 w-11 p-0 shrink-0 sm:h-9 sm:w-9"
                         onClick={onCancel}
                         aria-label="Stop"
                       >
@@ -1322,7 +1322,7 @@ export function ZeroChatComposer({
                     ) : (
                       <Button
                         size="sm"
-                        className="rounded-lg h-9 w-9 p-0 shrink-0"
+                        className="rounded-lg h-11 w-11 p-0 shrink-0 sm:h-9 sm:w-9"
                         onClick={handleSend}
                         disabled={!canSend || !!sending}
                         aria-label="Send"


### PR DESCRIPTION
## Summary
- All icon buttons in the mobile chat composer now use `h-11 w-11` (44px) for consistent visual spacing and proper iOS touch targets
- Desktop sizing preserved at `h-9` (36px) via `sm:` breakpoints
- Divider gets `mx-1` on mobile for consistent horizontal spacing

## Before
Icon buttons had three different sizes (32px, 34px, 36px) with inconsistent internal padding, causing visual gaps between icons to vary from 13px to 22px. All touch targets were below the 44px mobile standard.

## After
- Attach: `h-11 w-11 p-0` (was ~34px with p-2)
- Connectors: `h-11 min-w-11 px-0` (was 32px h-8)
- Model picker: `h-11 w-11` (was 36px h-9)
- Mic: `h-11 w-11` (was 36px h-9)
- Send/Stop: `h-11 w-11` (was 36px h-9)
- Divider: `mx-1` (was mx-0)

All touch targets now meet the 44px minimum; visual gaps between all adjacent icons are now uniform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)