### PR TITLE
fix: mount Zero skills under Codex home

### DIFF
--- a/turbo/apps/web/src/lib/infra/framework/__tests__/framework-config.test.ts
+++ b/turbo/apps/web/src/lib/infra/framework/__tests__/framework-config.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   resolveFrameworkWorkingDir,
   resolveFrameworkInstructionsMountPath,
+  resolveFrameworkSkillsMountPath,
   resolveFrameworkApiKeyEnvVar,
 } from "../framework-config";
 
@@ -15,6 +16,19 @@ describe("framework-config", () => {
     it("returns /home/user/.codex for codex", () => {
       expect(resolveFrameworkInstructionsMountPath("codex")).toBe(
         "/home/user/.codex",
+      );
+    });
+  });
+
+  describe("resolveFrameworkSkillsMountPath", () => {
+    it("returns /home/user/.claude/skills for claude-code", () => {
+      expect(resolveFrameworkSkillsMountPath("claude-code")).toBe(
+        "/home/user/.claude/skills",
+      );
+    });
+    it("returns /home/user/.codex/skills for codex", () => {
+      expect(resolveFrameworkSkillsMountPath("codex")).toBe(
+        "/home/user/.codex/skills",
       );
     });
   });

--- a/turbo/apps/web/src/lib/infra/framework/framework-config.ts
+++ b/turbo/apps/web/src/lib/infra/framework/framework-config.ts
@@ -15,6 +15,7 @@ import type { SupportedFramework } from "@vm0/core/frameworks";
 interface FrameworkDefaults {
   workingDir: string;
   instructionsMountPath: string;
+  skillsMountPath: string;
   apiKeyEnvVar: string;
 }
 
@@ -25,11 +26,13 @@ const FRAMEWORK_DEFAULTS: Record<SupportedFramework, FrameworkDefaults> = {
   "claude-code": {
     workingDir: "/home/user/workspace",
     instructionsMountPath: "/home/user/.claude",
+    skillsMountPath: "/home/user/.claude/skills",
     apiKeyEnvVar: "ANTHROPIC_API_KEY",
   },
   codex: {
     workingDir: "/home/user/workspace",
     instructionsMountPath: "/home/user/.codex",
+    skillsMountPath: "/home/user/.codex/skills",
     apiKeyEnvVar: "OPENAI_API_KEY",
   },
 };
@@ -56,6 +59,18 @@ export function resolveFrameworkInstructionsMountPath(
   framework: SupportedFramework,
 ): string {
   return FRAMEWORK_DEFAULTS[framework].instructionsMountPath;
+}
+
+/**
+ * Resolve the skills mount path for a framework
+ *
+ * @param framework - The supported framework
+ * @returns The mount path where skill volumes are attached
+ */
+export function resolveFrameworkSkillsMountPath(
+  framework: SupportedFramework,
+): string {
+  return FRAMEWORK_DEFAULTS[framework].skillsMountPath;
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -270,6 +270,31 @@ describe("createZeroRun() — service-only parameters", () => {
       );
     });
 
+    it("should mount codex custom skills under .codex/skills", async () => {
+      const agentName = uniqueId("codex-skill-agent");
+      await createTestCompose(agentName, {
+        overrides: {
+          framework: "codex",
+          environment: { OPENAI_API_KEY: "test-api-key" },
+        },
+      });
+      const skillAgentId = await getTestZeroAgentId(user.orgId, agentName);
+      await bindCustomSkillToAgent(skillAgentId, "my-skill");
+
+      const result = await createZeroRun(baseParams({ agentId: skillAgentId }));
+
+      const run = await findTestRunRecord(result.runId);
+      expect(run).toBeDefined();
+      expect(run!.additionalVolumes).toEqual(
+        expect.arrayContaining([
+          {
+            name: "custom-skill@my-skill",
+            mountPath: "/home/user/.codex/skills/my-skill",
+          },
+        ]),
+      );
+    });
+
     it("should inject only system skill volumes when agent has no custom skills", async () => {
       const result = await createZeroRun(baseParams());
 
@@ -280,6 +305,36 @@ describe("createZeroRun() — service-only parameters", () => {
       expect(
         run!.additionalVolumes!.every((v) => {
           return v.system === true;
+        }),
+      ).toBe(true);
+    });
+
+    it("should mount codex system skills under .codex/skills", async () => {
+      const agentName = uniqueId("codex-system-skill-agent");
+      await createTestCompose(agentName, {
+        overrides: {
+          framework: "codex",
+          environment: { OPENAI_API_KEY: "test-api-key" },
+        },
+      });
+      const codexAgentId = await getTestZeroAgentId(user.orgId, agentName);
+
+      const result = await createZeroRun(baseParams({ agentId: codexAgentId }));
+
+      const run = await findTestRunRecord(result.runId);
+      expect(run).toBeDefined();
+      const systemVolumes = run!.additionalVolumes!.filter((v) => {
+        return v.system === true;
+      });
+      expect(systemVolumes.length).toBeGreaterThan(0);
+      expect(
+        systemVolumes.every((v) => {
+          return v.mountPath.startsWith("/home/user/.codex/skills/");
+        }),
+      ).toBe(true);
+      expect(
+        systemVolumes.some((v) => {
+          return v.mountPath === "/home/user/.codex/skills/deep-dive";
         }),
       ).toBe(true);
     });

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -64,6 +64,8 @@ import { SEED_SKILLS } from "./seed-skills";
 import { logger } from "../shared/logger";
 import { recordChatSpan, type ChatSpanDimensions } from "../infra/metrics";
 import { CHAT_REQUEST_OPS, timed } from "./chat-thread/request-span-ops";
+import { getValidatedFramework } from "@vm0/core/frameworks";
+import { resolveFrameworkSkillsMountPath } from "../infra/framework/framework-config";
 
 const log = logger("service:zero-run");
 
@@ -266,7 +268,10 @@ function loadOrgAdmissionMetadata(
  * skills are injected only for connectors the user has authorized for the
  * agent (via the user_connectors table).
  */
-function buildSystemSkillVolumes(connectorTypes: readonly string[]): Array<{
+function buildSystemSkillVolumes(
+  connectorTypes: readonly string[],
+  skillsMountPath: string,
+): Array<{
   name: string;
   mountPath: string;
   system: boolean;
@@ -279,7 +284,7 @@ function buildSystemSkillVolumes(connectorTypes: readonly string[]): Array<{
     return [
       {
         name: getSkillStorageName(parsed.fullPath),
-        mountPath: `/home/user/.claude/skills/${parsed.skillName}`,
+        mountPath: `${skillsMountPath}/${parsed.skillName}`,
         system: true,
       },
     ];
@@ -660,15 +665,22 @@ async function createZeroRunRecord(
     params.appendSystemPrompt,
   );
 
+  const composeAgents = resolved.composeContent?.agents
+    ? Object.values(resolved.composeContent.agents)
+    : [];
+  const composeFramework = getValidatedFramework(composeAgents[0]?.framework);
+  const skillsMountPath = resolveFrameworkSkillsMountPath(composeFramework);
+
   // Construct CreateRunParams (infra knows nothing about ZERO_TOKEN)
   // Inject system + custom skill volumes (needed on every run).
   const systemSkillVolumes = buildSystemSkillVolumes(
     allowedConnectorTypes ?? [],
+    skillsMountPath,
   );
   const customSkillVolumes = (row?.customSkills ?? []).map((name) => {
     return {
       name: getCustomSkillStorageName(name),
-      mountPath: `/home/user/.claude/skills/${name}`,
+      mountPath: `${skillsMountPath}/${name}`,
     };
   });
   // System skills first, custom skills after (custom overrides system at same mount path)
@@ -706,10 +718,6 @@ async function createZeroRunRecord(
   });
   const authorizeTime = Date.now();
 
-  const composeAgents = resolved.composeContent?.agents
-    ? Object.values(resolved.composeContent.agents)
-    : [];
-  const composeFramework = composeAgents[0]?.framework ?? "claude-code";
   const admissionContext = await resolveRunAdmissionContext({
     orgId: resolved.orgId,
     userId: params.userId,


### PR DESCRIPTION
## Summary
- add a framework-aware skills mount path alongside existing instructions mount config
- mount Zero system and custom skills under /home/user/.codex/skills for codex agents
- add coverage for codex system/custom skill mount paths

## Verification
- corepack pnpm exec prettier --check apps/web/src/lib/infra/framework/framework-config.ts apps/web/src/lib/infra/framework/__tests__/framework-config.test.ts apps/web/src/lib/zero/zero-run-service.ts apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
- corepack pnpm exec oxlint src/lib/infra/framework/framework-config.ts src/lib/infra/framework/__tests__/framework-config.test.ts src/lib/zero/zero-run-service.ts src/lib/zero/__tests__/zero-run-service.test.ts (from turbo/apps/web)
- corepack pnpm exec eslint src/lib/infra/framework/framework-config.ts src/lib/infra/framework/__tests__/framework-config.test.ts src/lib/zero/zero-run-service.ts src/lib/zero/__tests__/zero-run-service.test.ts --max-warnings 0 (from turbo/apps/web)
- corepack pnpm --dir turbo --filter web check-types

## Notes
- Vitest service tests could not run in this sandbox because local Postgres on localhost:5432 is unavailable; web global setup fails while seeding skills before tests execute.