### PR TITLE
fix: add missing model display names for GPT and MiniMax OpenRouter models

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-send.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-send.test.tsx
@@ -225,7 +225,7 @@ describe("chat composer — model picker display vs. send body", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("combobox", { name: "gpt-5.4" }),
+        screen.getByRole("combobox", { name: "GPT-5.4" }),
       ).toBeInTheDocument();
     });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
@@ -354,7 +354,7 @@ describe("chat composer — default model resolution", () => {
     detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
     await expectAgentChatLoaded();
 
-    await expectComposerShowsModel("gpt-5.4");
+    await expectComposerShowsModel("GPT-5.4");
   });
 
   it("uses the personal provider default when the agent model is incompatible", async () => {
@@ -391,7 +391,7 @@ describe("chat composer — default model resolution", () => {
     detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
     await expectAgentChatLoaded();
 
-    await expectComposerShowsModel("gpt-5.5");
+    await expectComposerShowsModel("GPT-5.5");
     expect(
       screen.queryByRole("combobox", { name: "DeepSeek V4 Pro" }),
     ).not.toBeInTheDocument();

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
@@ -302,7 +302,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     const blocksStr = JSON.stringify(call.blocks);
     expect(call.text).toBe("I am okay.");
     expect(call.text).not.toBe("Task completed successfully.");
-    expect(blocksStr).toContain("gpt-5.5");
+    expect(blocksStr).toContain("GPT-5.5");
   });
 
   it("posts error message for failed status", async () => {

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -94,7 +94,7 @@ const SUPPORTED_RUN_MODEL_LABELS: Record<SupportedRunModel, string> = {
   "deepseek-v4-pro": "DeepSeek V4 Pro",
   "kimi-k2.6": "Kimi K2.6",
   "kimi-k2.5": "Kimi K2.5",
-  "glm-5.1": "GLM 5.1",
+  "glm-5.1": "GLM-5.1",
 };
 
 const SUPPORTED_RUN_MODEL_SET: ReadonlySet<string> = new Set(

--- a/turbo/packages/core/src/model-display-name.ts
+++ b/turbo/packages/core/src/model-display-name.ts
@@ -39,6 +39,14 @@ const MODEL_DISPLAY_NAMES = Object.freeze<Record<string, string>>({
   "glm-4.5-air": "GLM-4.5 Air",
   "zai/glm-5-turbo": "GLM-5 Turbo",
   "z-ai/glm-5.1": "GLM-5.1",
+  // Minimax via OpenRouter
+  "minimax/minimax-m2.7": "MiniMax M2.7",
+  // OpenAI / Codex
+  "gpt-5.5": "GPT-5.5",
+  "gpt-5.4": "GPT-5.4",
+  "gpt-5.4-mini": "GPT-5.4 Mini",
+  "gpt-5.3-codex": "GPT-5.3 Codex",
+  "gpt-5.2": "GPT-5.2",
 });
 
 /**


### PR DESCRIPTION
## Summary

- Added 6 missing model display names to `MODEL_DISPLAY_NAMES` so `getModelDisplayName()` returns friendly labels instead of raw IDs
- Fixed `SUPPORTED_RUN_MODEL_LABELS` inconsistency: `"GLM 5.1"` → `"GLM-5.1"` to match the models page and `MODEL_DISPLAY_NAMES`

## Details

`getModelDisplayName()` is used by Slack footer, Telegram footer, model picker UI, and chat composer. GPT models were entirely missing from the lookup, causing raw IDs like `gpt-5.5` to appear in user-facing UI.

New entries in `MODEL_DISPLAY_NAMES`:
- `gpt-5.5` → GPT-5.5
- `gpt-5.4` → GPT-5.4  
- `gpt-5.4-mini` → GPT-5.4 Mini
- `gpt-5.3-codex` → GPT-5.3 Codex
- `gpt-5.2` → GPT-5.2
- `minimax/minimax-m2.7` → MiniMax M2.7

## Context

Reported by Ethan — Zero's Slack message footer showed `gpt-5.5` instead of a friendly label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)