### PR TITLE
fix(api,web): sort configuredTypes to eliminate connector shadow divergence

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -33,4 +33,14 @@ describe("zeroConnectorList", () => {
       expect(openai.updatedAt).toBe("1970-01-01T00:00:00.000Z");
     }
   });
+
+  it("returns configuredTypes in sorted order", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+
+    const list = await store.get(zeroConnectorList({ orgId, userId }));
+
+    const sorted = [...list.configuredTypes].sort();
+    expect(list.configuredTypes).toStrictEqual(sorted);
+  });
 });

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -224,7 +224,7 @@ export function zeroConnectorList(args: {
     const connectorList = [...dbConnectors, ...derivedConnectors];
     return {
       connectors: connectorList,
-      configuredTypes: [...configuredConnectorTypes()],
+      configuredTypes: [...configuredConnectorTypes()].sort(),
       connectorProvidedSecretNames: [
         ...getConnectorProvidedSecretNames(
           connectorList.map((connector) => {

--- a/turbo/apps/web/src/lib/zero/connector/provider-registry.ts
+++ b/turbo/apps/web/src/lib/zero/connector/provider-registry.ts
@@ -397,5 +397,5 @@ export function getConfiguredConnectorTypes(currentEnv: Env): ConnectorType[] {
     configured.push("computer");
   }
 
-  return configured;
+  return configured.sort();
 }


### PR DESCRIPTION
## Summary

- API's `configuredConnectorTypes()` iterates `Object.keys(CONNECTOR_TYPES)` while web's `getConfiguredConnectorTypes()` iterates `Object.entries(PROVIDER_HANDLERS)` — different object insertion order produces the same set of connector types but a different array order
- `diffJson` compares arrays element-by-element by index, so position shifts cause all entries to mismatch
- Fix: sort both arrays before returning

## Changes

- **API** (`zero-connector-data.service.ts`): `[...configuredConnectorTypes()].sort()`
- **Web** (`provider-registry.ts`): `return configured.sort()`
- **Test** (`zero-connector-data.service.test.ts`): reproduction test that verifies `configuredTypes` is returned in sorted order

## Test plan

- [x] Reproduction test verifies sort invariant
- [x] All 253 API tests pass
- [x] TypeScript compiles on both api and web packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)