### PR TITLE
fix: honor feature switch overrides in sandbox flags

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -49,6 +49,9 @@ import {
   seedStalePendingRun,
 } from "../../../../../src/__tests__/db-test-seeders/runs";
 import { reloadEnv } from "../../../../../src/env";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Route-level setup for feature-switch override state
+import { updateUserFeatureSwitches } from "../../../../../src/lib/zero/user/feature-switches-service";
 
 const context = testContext();
 
@@ -169,6 +172,22 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
       const job = await findTestRunnerJobEntry(data.runId);
       expect(job).toBeDefined();
+    });
+
+    it("should propagate user feature switch overrides through runner job dispatch", async () => {
+      vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/production");
+      reloadEnv();
+      await updateUserFeatureSwitches(user.orgId, user.userId, {
+        [FeatureSwitchKey.ComputerUse]: true,
+      });
+
+      const data = await createTestRun(testComposeId, "Hello");
+
+      const job = await findTestRunnerJobEntry(data.runId);
+      expect(job).toBeDefined();
+      expect(
+        job!.executionContext.featureFlags?.[FeatureSwitchKey.ComputerUse],
+      ).toBe(true);
     });
 
     it("should always set lastHeartbeatAt", async () => {

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -403,6 +403,7 @@ const router = tsr.router(runsMainContract, {
           additionalVolumes: finalAdditionalVolumes,
           environment: resolved.environment,
           userTimezone: resolved.userTimezone,
+          featureSwitchOverrides: resolved.featureSwitchOverrides,
           firewalls: resolved.firewalls,
           networkPolicies: resolved.networkPolicies,
           disallowedTools: body.disallowedTools,

--- a/turbo/apps/web/src/lib/infra/run/context/build-context.ts
+++ b/turbo/apps/web/src/lib/infra/run/context/build-context.ts
@@ -1,4 +1,5 @@
 import { expandEnvironmentFromCompose } from "../environment/expand-environment";
+import type { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type {
   ContextArtifact,
   ExecutionContext,
@@ -29,6 +30,7 @@ interface BuildInfraContextParams {
   additionalVolumes?: AdditionalVolume[];
   environment?: Record<string, string>;
   userTimezone?: string;
+  featureSwitchOverrides?: Partial<Record<FeatureSwitchKey, boolean>>;
   firewalls?: Firewalls;
   networkPolicies?: NetworkPolicies;
   disallowedTools?: string[];
@@ -87,6 +89,7 @@ export function buildInfraExecutionContext(
     additionalVolumes: params.additionalVolumes,
     environment,
     userTimezone: params.userTimezone,
+    featureSwitchOverrides: params.featureSwitchOverrides,
     firewalls: params.firewalls,
     networkPolicies: params.networkPolicies,
     disallowedTools: params.disallowedTools,

--- a/turbo/apps/web/src/lib/infra/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/infra/run/context/execution-preparer.ts
@@ -254,6 +254,7 @@ function buildPreparedContext(
     featureFlags: getAllFeatureStates({
       userId: context.userId,
       orgId: context.orgId,
+      overrides: context.featureSwitchOverrides,
     }),
 
     // Metadata

--- a/turbo/apps/web/src/lib/infra/run/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/types.ts
@@ -1,4 +1,5 @@
 import type { AdditionalVolume } from "../storage/types";
+import type { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type {
   Firewalls,
   NetworkPolicies,
@@ -94,6 +95,9 @@ export interface ExecutionContext {
   // User's timezone preference (IANA format, e.g., "Asia/Shanghai")
   // Injected as TZ environment variable in sandbox if not already set in environment
   userTimezone?: string;
+
+  // Per-user Lab feature switch overrides loaded by the caller.
+  featureSwitchOverrides?: Partial<Record<FeatureSwitchKey, boolean>>;
 
   // Firewall for proxy-side token replacement
   firewalls?: Firewalls;

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -33,6 +33,9 @@ import { createZeroRun } from "../zero-run-service";
 import { AUTO_MEMORY_ARTIFACT_NAME, AUTO_MEMORY_MOUNT_PATH } from "../memory";
 import { reloadEnv } from "../../../env";
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+// eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
+import { updateUserFeatureSwitches } from "../user/feature-switches-service";
 
 // ---------------------------------------------------------------------------
 // Tests for createZeroRun parameters NOT exposed by the POST /api/zero/runs
@@ -126,6 +129,21 @@ describe("createZeroRun() — service-only parameters", () => {
   });
 
   describe("parameter forwarding", () => {
+    it("should propagate user feature switch overrides into runner feature flags", async () => {
+      await updateUserFeatureSwitches(user.orgId, user.userId, {
+        [FeatureSwitchKey.ComputerUse]: true,
+      });
+
+      const result = await createZeroRun(baseParams());
+      await context.mocks.flushAfter();
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      expect(
+        job!.executionContext.featureFlags?.[FeatureSwitchKey.ComputerUse],
+      ).toBe(true);
+    });
+
     it("should propagate scheduleId to run record", async () => {
       const agentName = uniqueId("sched-agent");
       const compose = await createTestCompose(agentName);

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -11,6 +11,7 @@ import type {
   Firewalls,
   NetworkPolicies,
 } from "@vm0/connectors/firewall-types";
+import type { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   getModelProviderFirewall,
   type ModelProviderType,
@@ -57,6 +58,7 @@ import {
   checkFrameworkCompatibility,
   applyResolutionDefaults,
 } from "./context/resolve-source";
+import { loadFeatureSwitchOverrides } from "./user/feature-switches-service";
 
 // Re-exports for API compatibility
 export {
@@ -224,6 +226,8 @@ interface BuildZeroContextParams {
   allowedCustomConnectorIds?: string[];
   // Pre-fetched user timezone from Phase 1 — skips getUserPreferences() when provided
   preloadedUserTimezone?: string;
+  // Pre-fetched Lab feature switch overrides from Phase 1.
+  featureSwitchOverrides?: Partial<Record<FeatureSwitchKey, boolean>>;
   // Origin of the run request, injected into the sandbox as VM0_RUN_SOURCE.
   triggerSource?: string;
 }
@@ -666,6 +670,7 @@ interface ResolvedCliContext {
   firewalls?: Firewalls;
   networkPolicies?: NetworkPolicies;
   userTimezone?: string;
+  featureSwitchOverrides?: Partial<Record<FeatureSwitchKey, boolean>>;
 
   // Model provider metadata (for zero_runs upsert)
   resolvedModelProvider?: ModelProviderType;
@@ -782,7 +787,12 @@ export async function resolveCliRunContext(
 
   // Step 4: Resolve secrets, user preferences in parallel.
   const resolveSecretsStart = Date.now();
-  const [secretsResult, userPrefs, originalModelProvider] = await Promise.all([
+  const [
+    secretsResult,
+    userPrefs,
+    featureSwitchOverrides,
+    originalModelProvider,
+  ] = await Promise.all([
     resolveSecretsAndEnvironment(
       params.orgId,
       agentCompose,
@@ -799,6 +809,7 @@ export async function resolveCliRunContext(
       params.preferPersonalProvider,
     ),
     getUserPreferences(params.orgId, params.userId),
+    loadFeatureSwitchOverrides(params.orgId, params.userId),
     // Fetch previous run's model provider for compatibility check
     resolution?.previousRunId
       ? globalThis.services.db
@@ -858,6 +869,7 @@ export async function resolveCliRunContext(
     firewalls: permissionResult?.firewalls,
     networkPolicies: permissionResult?.networkPolicies,
     userTimezone,
+    featureSwitchOverrides,
     resolvedModelProvider,
     modelProviderId,
     modelProviderCredentialScope,
@@ -1077,6 +1089,7 @@ export async function buildZeroExecutionContext(
       additionalVolumes,
       environment: runtimeEnvironment,
       userTimezone,
+      featureSwitchOverrides: params.featureSwitchOverrides,
       firewalls: permissionResult?.firewalls,
       networkPolicies: permissionResult?.networkPolicies,
       disallowedTools: params.disallowedTools,

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -637,6 +637,7 @@ export async function dispatchQueuedZeroRun(
     sandboxToken,
     agentCompose: composeContent,
     runId,
+    featureSwitchOverrides: overrides,
     apiStartTime,
   });
   // Tag the context so the downstream api_to_executor span records

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -859,6 +859,7 @@ async function dispatchZeroRun(
       agentCompose: record.composeContent,
       agentName: runParams.agentName,
       preloadedUserTimezone: result.userTimezone,
+      featureSwitchOverrides: overrides,
       apiStartTime: record.apiStartTime,
     });
 


### PR DESCRIPTION
## Summary

- Thread per-user Lab feature switch overrides into execution contexts for direct Zero runs, queued Zero dispatch, and internal/CLI runs.
- Evaluate runner `featureFlags` with those overrides so sandbox `VM0_FEATURE_FLAGS` reflects switches users enabled.
- Add coverage for Zero service and internal runs route dispatch paths.

## Validation

Passed:
- `pnpm exec prettier --check apps/web/src/lib/infra/run/types.ts apps/web/src/lib/infra/run/context/execution-preparer.ts apps/web/src/lib/infra/run/context/build-context.ts apps/web/src/lib/zero/build-zero-context.ts apps/web/src/lib/zero/zero-run-service.ts apps/web/src/lib/zero/zero-run-queue-service.ts apps/web/app/api/agent/runs/route.ts apps/web/src/lib/zero/__tests__/zero-run-service.test.ts apps/web/app/api/agent/runs/__tests__/route.test.ts`
- `pnpm --filter web lint`
- `pnpm exec vitest run packages/core/src/__tests__/feature-switch.test.ts`

Blocked locally:
- `pnpm exec vitest run apps/web/src/lib/zero/__tests__/zero-run-service.test.ts apps/web/app/api/agent/runs/__tests__/route.test.ts` fails during setup because the local test DB is missing existing column `zero_agents.prefer_personal_provider`.
- `pnpm --filter web check-types` fails on unrelated pre-existing route type errors outside this change.
- `pnpm --filter web db:migrate` fails because the local migration table is inconsistent with existing table `redemption_codes`.
