### PR TITLE
fix: keep codex activity final text

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-display.test.tsx
@@ -320,6 +320,110 @@ describe("zeroActivityDetailPageDisplay", () => {
     });
   });
 
+  it("should keep final Codex text before an empty turn result", async () => {
+    const finalText = "Codex final answer stays visible.";
+    const eventsResponse: AgentEventsResponse = {
+      events: [
+        {
+          sequenceNumber: 1,
+          eventType: "item.completed",
+          eventData: {
+            type: "item.completed",
+            item: {
+              id: "item-final-message",
+              type: "agent_message",
+              text: finalText,
+            },
+          },
+          createdAt: "2026-03-10T14:56:08Z",
+        },
+        {
+          sequenceNumber: 2,
+          eventType: "turn.completed",
+          eventData: {
+            type: "turn.completed",
+            usage: {
+              input_tokens: 10,
+              output_tokens: 20,
+            },
+          },
+          createdAt: "2026-03-10T14:56:10Z",
+        },
+      ],
+      hasMore: false,
+      framework: "codex",
+    };
+
+    mockDetailAPI(
+      {
+        framework: "codex",
+        modelProvider: "openai-api-key",
+        selectedModel: "gpt-5.5",
+      },
+      eventsResponse,
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/activities/${BASE_LOG_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Display Test Agent" }),
+      ).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("2 total")).toBeInTheDocument();
+    });
+    expect(screen.getByText(finalText)).toBeInTheDocument();
+    expect(screen.getByText("Summary")).toBeInTheDocument();
+  });
+
+  it("should hide text-only Claude messages before a non-empty result", async () => {
+    const events: AgentEvent[] = [
+      {
+        sequenceNumber: 1,
+        eventType: "assistant",
+        eventData: {
+          message: {
+            content: [{ type: "text", text: "Draft final answer" }],
+          },
+        },
+        createdAt: "2026-03-10T14:56:08Z",
+      },
+      {
+        sequenceNumber: 2,
+        eventType: "result",
+        eventData: {
+          result: "Claude result answer",
+          is_error: false,
+        },
+        createdAt: "2026-03-10T14:56:10Z",
+      },
+    ];
+
+    mockDetailAPI({}, events);
+
+    detachedSetupPage({
+      context,
+      path: `/activities/${BASE_LOG_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Display Test Agent" }),
+      ).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("1 total")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Draft final answer")).toBeNull();
+    expect(screen.getByText("Claude result answer")).toBeInTheDocument();
+  });
+
   it("should render prompt content in a collapsible block (ACT-D-025)", async () => {
     mockDetailAPI({ prompt: "Build a web app" });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -113,17 +113,28 @@ function RunErrorBanner({ error }: { error: string }) {
 // ---------------------------------------------------------------------------
 
 /**
- * Returns true if a grouped message should be shown (filters out text-only
- * assistant messages immediately before a result message).
+ * Returns true if a grouped message should be shown.
+ *
+ * Claude Code emits a result event that repeats the final assistant text, so
+ * text-only assistant messages immediately before a non-empty result are
+ * hidden. Other frameworks keep the assistant message as-is.
  */
 export function isVisibleMessage(
   message: GroupedMessage,
   nextMessage: GroupedMessage | undefined,
+  framework?: string | null,
 ): boolean {
   if (message.type !== "assistant") {
     return true;
   }
   if (!nextMessage || nextMessage.type !== "result") {
+    return true;
+  }
+  if (framework !== "claude-code") {
+    return true;
+  }
+  const result = (nextMessage.eventData as { result?: unknown }).result;
+  if (typeof result !== "string" || result.trim().length === 0) {
     return true;
   }
   return (message.toolOperations?.length ?? 0) > 0;
@@ -339,7 +350,11 @@ export function ActivityHeaderCard({
 }
 
 function prepareRenderData(
-  detail: { prompt: string | null; appendSystemPrompt: string | null },
+  detail: {
+    prompt: string | null;
+    appendSystemPrompt: string | null;
+    framework: string | null;
+  },
   rawEvents: AgentEvent[] | null,
   stepSearch: string,
   features: Record<FeatureSwitchKey, boolean> | undefined,
@@ -347,7 +362,7 @@ function prepareRenderData(
   const events: AgentEvent[] = rawEvents ?? [];
   const allMessages = groupEventsIntoMessages(events);
   const visibleMessages = allMessages.filter((message, index) => {
-    return isVisibleMessage(message, allMessages[index + 1]);
+    return isVisibleMessage(message, allMessages[index + 1], detail.framework);
   });
   const messages = visibleMessages.filter((m) => {
     return groupedMessageMatchesSearch(m, stepSearch.trim());


### PR DESCRIPTION
## Summary
- Scope the assistant text deduplication before result events to Claude Code activities only
- Keep Codex final text visible when the following turn result has no repeated result text
- Add display tests for Codex and Claude Code behavior

## Validation
- git diff --check
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-activity-detail-page-display.test.tsx src/views/activity/__tests__/log-detail-utils.test.ts