### PR TITLE
feat(platform): keep Send visible while typing during a run, recall queue on Stop

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-stop-button-recall.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-stop-button-recall.test.tsx
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import type { PendingMessage } from "@vm0/api-contracts/contracts/chat-threads";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import {
+  click,
+  detachedSetupPage,
+  fill,
+} from "../../../__tests__/page-helper.ts";
+import {
+  mockChatLifecycle,
+  sendMessageInUI,
+  PLACEHOLDER,
+} from "./chat-test-helpers.ts";
+
+const context = testContext();
+
+const THREAD_ID = "thread-test-1";
+const CHAT_PATH = `/chats/${THREAD_ID}`;
+
+function getActiveRunTextarea(): Promise<HTMLTextAreaElement> {
+  return waitFor(() => {
+    return screen.getByPlaceholderText(
+      /Type your next message/,
+    ) as HTMLTextAreaElement;
+  });
+}
+
+async function startActiveRun(
+  user: ReturnType<typeof userEvent.setup>,
+): Promise<HTMLTextAreaElement> {
+  const textarea = await waitFor(() => {
+    return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+  });
+
+  await sendMessageInUI(user, textarea, "start the active run");
+
+  await waitFor(() => {
+    expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+  });
+
+  return await getActiveRunTextarea();
+}
+
+describe("composer Stop button + draft recall on cancel", () => {
+  it("shows Send (not Stop) when draft has content during an active run", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockChatLifecycle();
+
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.QueueMessage]: true },
+    });
+
+    const textarea = await startActiveRun(user);
+
+    // Empty composer during the active run → Stop button.
+    expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Send")).toBeNull();
+
+    await fill(textarea, "draft while running");
+
+    // Typing draft content swaps Stop → Send (still during the active run).
+    await waitFor(() => {
+      expect(screen.getByLabelText("Send")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Stop")).toBeNull();
+    });
+  });
+
+  it("queues the message when Send is clicked during an active run", async () => {
+    const user = userEvent.setup({ delay: null });
+    const appendedContents: (string | undefined)[] = [];
+    mockChatLifecycle({
+      onPendingMessageAppend: (body) => {
+        appendedContents.push(body.content);
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.QueueMessage]: true },
+    });
+
+    const textarea = await startActiveRun(user);
+    await fill(textarea, "queued via send click");
+
+    // Click — not Enter — to make sure the button click path also queues.
+    const sendButton = await waitFor(() => {
+      return screen.getByLabelText("Send");
+    });
+    click(sendButton);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Queued message")).toBeInTheDocument();
+      expect(screen.getByText("queued via send click")).toBeInTheDocument();
+    });
+    expect(appendedContents).toStrictEqual(["queued via send click"]);
+    expect(textarea.value).toBe("");
+
+    // Composer empty again → Stop button comes back.
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    });
+  });
+
+  it("Stop click recalls the queued message back into the draft and cancels the run", async () => {
+    const user = userEvent.setup({ delay: null });
+    let recallRequestSeen = false;
+    const ctrl = mockChatLifecycle({
+      onPendingMessageRecall: () => {
+        recallRequestSeen = true;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.QueueMessage]: true },
+    });
+
+    let textarea = await startActiveRun(user);
+    await fill(textarea, "queued before stop");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+        "queued before stop",
+      );
+    });
+
+    // Composer is empty after the queue — Stop button is visible.
+    const stopButton = await waitFor(() => {
+      return screen.getByLabelText("Stop");
+    });
+    click(stopButton);
+
+    // Server-confirmed cancel — the run flips to cancelled, sending ends.
+    ctrl.cancelRun();
+
+    // Queued bubble disappears and the draft is repopulated with the
+    // recalled content. The cancel completes and Send button is back.
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Send")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Stop")).toBeNull();
+    });
+
+    textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+    expect(textarea.value).toBe("queued before stop");
+
+    await waitFor(() => {
+      expect(recallRequestSeen).toBeTruthy();
+    });
+  });
+
+  it("Stop click recalls a server-side queued message even when nothing was just queued client-side", async () => {
+    // Resume scenario: thread already has a pending message from a previous
+    // session. The user clicks Stop while the run is active — recall should
+    // still pull the persisted queue back into the draft.
+    const user = userEvent.setup({ delay: null });
+    const pendingMessage: PendingMessage = {
+      content: "queued from earlier session",
+      attachments: null,
+      createdAt: "2026-03-10T00:01:00Z",
+      updatedAt: "2026-03-10T00:01:00Z",
+      clientMessageId: null,
+    };
+    let recallRequestSeen = false;
+    const ctrl = mockChatLifecycle({
+      pendingMessage,
+      onPendingMessageRecall: () => {
+        recallRequestSeen = true;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.QueueMessage]: true },
+    });
+
+    await startActiveRun(user);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+        "queued from earlier session",
+      );
+    });
+
+    const stopButton = await waitFor(() => {
+      return screen.getByLabelText("Stop");
+    });
+    click(stopButton);
+    ctrl.cancelRun();
+
+    await waitFor(() => {
+      expect(recallRequestSeen).toBeTruthy();
+      expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+    });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+    expect(textarea.value).toBe("queued from earlier session");
+  });
+
+  it("Stop click without a queued message just cancels the run", async () => {
+    const user = userEvent.setup({ delay: null });
+    let recallRequestSeen = false;
+    const ctrl = mockChatLifecycle({
+      onPendingMessageRecall: () => {
+        recallRequestSeen = true;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.QueueMessage]: true },
+    });
+
+    await startActiveRun(user);
+
+    const stopButton = await waitFor(() => {
+      return screen.getByLabelText("Stop");
+    });
+    click(stopButton);
+    ctrl.cancelRun();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Send")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Stop")).toBeNull();
+    });
+
+    // Recall route never fires when there is nothing to recall — the
+    // platform command short-circuits before hitting the network.
+    expect(recallRequestSeen).toBeFalsy();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-stop-button-recall.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-stop-button-recall.test.tsx
@@ -107,7 +107,7 @@ describe("composer Stop button + draft recall on cancel", () => {
     });
   });
 
-  it("Stop click recalls the queued message back into the draft and cancels the run", async () => {
+  it("stop click recalls the queued message back into the draft and cancels the run", async () => {
     const user = userEvent.setup({ delay: null });
     let recallRequestSeen = false;
     const ctrl = mockChatLifecycle({
@@ -159,7 +159,7 @@ describe("composer Stop button + draft recall on cancel", () => {
     });
   });
 
-  it("Stop click recalls a server-side queued message even when nothing was just queued client-side", async () => {
+  it("stop click recalls a server-side queued message even when nothing was just queued client-side", async () => {
     // Resume scenario: thread already has a pending message from a previous
     // session. The user clicks Stop while the run is active — recall should
     // still pull the persisted queue back into the draft.
@@ -210,7 +210,7 @@ describe("composer Stop button + draft recall on cancel", () => {
     expect(textarea.value).toBe("queued from earlier session");
   });
 
-  it("Stop click without a queued message just cancels the run", async () => {
+  it("stop click without a queued message just cancels the run", async () => {
     const user = userEvent.setup({ delay: null });
     let recallRequestSeen = false;
     const ctrl = mockChatLifecycle({

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -153,7 +153,11 @@ interface ZeroChatComposerProps {
   onQueue?: (message: string) => void;
   sending?: boolean;
   queueWhileSending?: boolean;
-  /** Cancel the active run. When provided, a stop button replaces the send button while sending. */
+  /**
+   * Cancel the active run. When provided, the Send button switches to a Stop
+   * button while sending and the composer is empty; with content present the
+   * Send button stays visible and clicks queue the message instead.
+   */
   onCancel?: () => void;
   displayName: string;
   className?: string;
@@ -1079,32 +1083,29 @@ export function ZeroChatComposer({
     setSavingType(null);
   };
 
+  const sendAction = resolveKeyboardSendAction({
+    canSend,
+    sending,
+    queueWhileSending,
+    hasQueueHandler: onQueue !== undefined,
+  });
+
   const handleSend = () => {
-    if (!canSend || sending) {
+    if (sendAction === "send") {
+      // Fire-and-forget: request push permission on first send, never blocks
+      detach(ensurePushSubscription(rootSignal), Reason.DomCallback);
+      onSend(input.trim());
       return;
     }
-    // Fire-and-forget: request push permission on first send, never blocks
-    detach(ensurePushSubscription(rootSignal), Reason.DomCallback);
-    onSend(input.trim());
+    if (sendAction === "queue") {
+      onQueue?.(input.trim());
+    }
   };
 
-  const handleKeyboardSend = () => {
-    const handlers: Record<KeyboardSendAction, (() => void) | undefined> = {
-      none: undefined,
-      send: handleSend,
-      queue: () => {
-        onQueue?.(input.trim());
-      },
-    };
-    handlers[
-      resolveKeyboardSendAction({
-        canSend,
-        sending,
-        queueWhileSending,
-        hasQueueHandler: onQueue !== undefined,
-      })
-    ]?.();
-  };
+  // Stop button replaces Send only when there is nothing to dispatch — i.e.
+  // the composer is empty during an active run. With draft content present
+  // the Send button stays visible so the click can queue the message.
+  const showStopButton = Boolean(sending && onCancel) && !canSend;
 
   const sendModeLoadable = useLastLoadable(sendMode$);
   const sendMode =
@@ -1116,7 +1117,7 @@ export function ZeroChatComposer({
       return;
     }
     const send = () => {
-      handleKeyboardSend();
+      handleSend();
     };
     processShortcut(
       {
@@ -1309,7 +1310,7 @@ export function ZeroChatComposer({
                         onDraftChange?.();
                       }}
                     />
-                    {sending && onCancel ? (
+                    {showStopButton ? (
                       <Button
                         size="sm"
                         variant="destructive"
@@ -1324,7 +1325,7 @@ export function ZeroChatComposer({
                         size="sm"
                         className="rounded-lg h-9 w-9 p-0 shrink-0"
                         onClick={handleSend}
-                        disabled={!canSend || !!sending}
+                        disabled={sendAction === "none"}
                         aria-label="Send"
                       >
                         <IconArrowUp size={18} stroke={2} />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1885,6 +1885,7 @@ function ChatThreadComposer({
   const input = useGet(thread.draft.input$);
   const setInput = useSet(thread.draft.setInput$);
   const cancelRun = useSet(thread.cancelRun$);
+  const recallPendingMessage = useSet(thread.recallPendingMessage$);
   const setInputRef = useSet(thread.setInputRef$);
   const scheduleDraftSync = useSet(thread.scheduleDraftSync$);
   const pageSignal = useGet(pageSignal$);
@@ -1957,7 +1958,18 @@ function ChatThreadComposer({
             onCancel={
               allFinishedResolved
                 ? () => {
-                    detach(cancelRun(pageSignal), Reason.DomCallback);
+                    // Recall any queued pending message back into the draft
+                    // before cancelling so the auto-send hook on the cancel
+                    // callback finds an empty pending and is a no-op. The
+                    // recall is optimistic — the draft repopulates
+                    // synchronously while the server clear races the cancel.
+                    detach(
+                      (async () => {
+                        await recallPendingMessage(rootSignal);
+                        await cancelRun(pageSignal);
+                      })(),
+                      Reason.DomCallback,
+                    );
                   }
                 : undefined
             }

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
@@ -13,6 +13,12 @@ import {
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
 import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/runs";
+import {
+  addTestRunToThread,
+  insertTestChatThread,
+  setTestChatThreadPendingMessage,
+} from "../../../../../../../src/__tests__/db-test-seeders/agents";
+import { getTestChatThreadPendingMessage } from "../../../../../../../src/__tests__/db-test-assertions/agents";
 
 const context = testContext();
 
@@ -113,6 +119,46 @@ describe("POST /api/zero/runs/:id/cancel", () => {
       ),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("should cancel a running run while the thread has a queued pending message", async () => {
+    // The Stop button on the composer recalls the queued message into the
+    // draft and then calls this cancel endpoint. The recall and cancel
+    // round-trips race in practice, so the cancel route must succeed even
+    // when the thread row still carries pending_message_* columns at the
+    // moment the request lands.
+    const userId = uniqueId("zcanc-pend");
+    await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("zcanc")}`);
+    const threadId = await insertTestChatThread(
+      userId,
+      compose.composeId,
+      "Cancel with pending",
+    );
+    const { runId } = await seedTestRun(userId, compose.composeId, {
+      status: "running",
+      chatThreadId: threadId,
+    });
+    await addTestRunToThread(threadId, runId, userId);
+    await setTestChatThreadPendingMessage(threadId, {
+      content: "draft to recall",
+      attachments: null,
+    });
+
+    const response = await POST(
+      createTestRequest(cancelUrl(runId), { method: "POST" }),
+    );
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.id).toBe(runId);
+    expect(data.status).toBe("cancelled");
+
+    // Cancel does not touch pending_message_* columns — that responsibility
+    // belongs to the recall endpoint the client invokes alongside this one.
+    const pending = await getTestChatThreadPendingMessage(threadId);
+    expect(pending?.pendingMessageContent).toBe("draft to recall");
+    expect(pending?.pendingMessageCreatedAt).not.toBeNull();
   });
 
   it("should return 403 for sandbox token without agent-run:write capability", async () => {


### PR DESCRIPTION
## Summary
- Composer **Send** button stays visible (not Stop) while a run is active and the draft has content; clicking it now **queues** the message instead of opening a new send. The keyboard path already queued — the click path now matches.
- The **Stop** button only appears when the composer is empty during an active run.
- Clicking **Stop** when a queued message exists now **recalls** the queued content back into the draft before cancelling the run. Recall lands first so the chat callback's auto-send hook finds an empty pending and is a no-op.

## Why
Today the composer flips entirely to a destructive Stop button the moment a run starts, even mid-typing — surprising for users who want to follow up on the in-flight run. The team already shipped queue-on-Enter; this aligns the click path and the visual affordance with that intent. And when the user does want to bail out (Stop), losing the queued draft to auto-send was the wrong default.

## Tests
- **Platform view tests** (\`apps/platform/src/views/zero-page/__tests__/chat-stop-button-recall.test.tsx\`):
  - Send (not Stop) shown while typing during an active run
  - Send click during run queues the message
  - Stop click with queued message recalls into draft + cancels run
  - Stop click recalls a server-side persisted queue (resume scenario)
  - Stop click without a queue just cancels (no recall network call)
- **Web API test** (\`apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts\`):
  - Cancel still succeeds when the thread row carries pending_message_* columns; cancel does not touch the pending columns (recall is the dedicated route).

## Test plan
- [ ] CI: \`pnpm -F @vm0/platform exec vitest run src/views/zero-page/__tests__/chat-stop-button-recall.test.tsx src/views/zero-page/__tests__/chat-queue-message.test.tsx src/views/zero-page/__tests__/chat-failure-cancel.test.tsx\`
- [ ] CI: \`pnpm -F @vm0/web exec vitest run app/api/zero/runs/\\[id\\]/cancel/__tests__/route.test.ts\`
- [ ] Manual: open a chat, send a message, while running type a draft → Send button stays visible; click Send → queued bubble appears, draft clears, Stop returns
- [ ] Manual: queue a message during a run, click Stop → run cancels and the queued text returns to the draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)