### PR TITLE
fix: mirror legacy zero resources for codex

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -11,6 +11,8 @@ use crate::timing;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
 use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 use tokio::io::AsyncBufReadExt;
@@ -291,6 +293,12 @@ pub fn setup_codex() -> Result<(), AgentError> {
     let codex_home = format!("{}/.codex", env::home_dir());
     std::fs::create_dir_all(&codex_home)?;
     log_info!(LOG_TAG, "Codex home directory: {codex_home}");
+    if let Err(error) = ensure_codex_resource_fallbacks(Path::new(&env::home_dir())) {
+        log_warn!(
+            LOG_TAG,
+            "failed to mirror legacy Claude resources into Codex home (non-fatal): {error}"
+        );
+    }
 
     let api_key = env::openai_api_key();
     if api_key.is_empty() {
@@ -336,6 +344,12 @@ pub fn setup_codex() -> Result<(), AgentError> {
 fn setup_codex_chatgpt() -> Result<(), AgentError> {
     let setup_start = Instant::now();
     let home = std::path::PathBuf::from(env::home_dir());
+    if let Err(error) = ensure_codex_resource_fallbacks(&home) {
+        log_warn!(
+            LOG_TAG,
+            "failed to mirror legacy Claude resources into Codex home (non-fatal): {error}"
+        );
+    }
     let result = crate::codex_auth::setup_codex_chatgpt_inner(&home, chrono::Utc::now());
 
     let success = result.is_ok();
@@ -351,6 +365,66 @@ fn setup_codex_chatgpt() -> Result<(), AgentError> {
         log_info!(LOG_TAG, "Codex ChatGPT-OAuth auth.json written");
     }
     result
+}
+
+fn ensure_codex_resource_fallbacks(home: &Path) -> std::io::Result<()> {
+    let claude_home = home.join(".claude");
+    let codex_home = home.join(".codex");
+
+    let claude_instructions = claude_home.join("CLAUDE.md");
+    let codex_instructions = codex_home.join("AGENTS.md");
+    if claude_instructions.is_file() && !codex_instructions.exists() {
+        fs::create_dir_all(&codex_home)?;
+        fs::copy(&claude_instructions, &codex_instructions)?;
+        log_info!(
+            LOG_TAG,
+            "Mirrored legacy ~/.claude/CLAUDE.md to ~/.codex/AGENTS.md"
+        );
+    }
+
+    let claude_skills = claude_home.join("skills");
+    let codex_skills = codex_home.join("skills");
+    if claude_skills.is_dir() {
+        copy_missing_dir_entries(&claude_skills, &codex_skills)?;
+    }
+
+    Ok(())
+}
+
+fn copy_missing_dir_entries(source: &Path, destination: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if destination_path.exists() {
+            continue;
+        }
+
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            copy_dir_recursive(&source_path, &destination_path)?;
+        } else if file_type.is_file() {
+            fs::copy(&source_path, &destination_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn copy_dir_recursive(source: &Path, destination: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            copy_dir_recursive(&source_path, &destination_path)?;
+        } else if file_type.is_file() {
+            fs::copy(&source_path, &destination_path)?;
+        }
+    }
+    Ok(())
 }
 
 struct PreparedEvent {
@@ -902,6 +976,65 @@ mod tests {
     fn build_claude_command_for_test(use_mock: bool) -> Vec<String> {
         disable_system_log();
         build_claude_command(use_mock)
+    }
+
+    #[test]
+    fn ensure_codex_resource_fallbacks_mirrors_legacy_instructions_and_skills() {
+        disable_system_log();
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path();
+
+        let claude_home = home.join(".claude");
+        std::fs::create_dir_all(claude_home.join("skills/github")).unwrap();
+        std::fs::write(claude_home.join("CLAUDE.md"), "legacy instructions").unwrap();
+        std::fs::write(claude_home.join("skills/github/SKILL.md"), "github skill").unwrap();
+
+        let codex_home = home.join(".codex");
+        std::fs::create_dir_all(codex_home.join("skills/.system")).unwrap();
+        std::fs::write(codex_home.join("skills/.system/SKILL.md"), "system").unwrap();
+
+        ensure_codex_resource_fallbacks(home).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(codex_home.join("AGENTS.md")).unwrap(),
+            "legacy instructions"
+        );
+        assert_eq!(
+            std::fs::read_to_string(codex_home.join("skills/github/SKILL.md")).unwrap(),
+            "github skill"
+        );
+        assert_eq!(
+            std::fs::read_to_string(codex_home.join("skills/.system/SKILL.md")).unwrap(),
+            "system"
+        );
+    }
+
+    #[test]
+    fn ensure_codex_resource_fallbacks_preserves_existing_codex_resources() {
+        disable_system_log();
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path();
+
+        let claude_home = home.join(".claude");
+        std::fs::create_dir_all(claude_home.join("skills/github")).unwrap();
+        std::fs::write(claude_home.join("CLAUDE.md"), "legacy instructions").unwrap();
+        std::fs::write(claude_home.join("skills/github/SKILL.md"), "legacy github").unwrap();
+
+        let codex_home = home.join(".codex");
+        std::fs::create_dir_all(codex_home.join("skills/github")).unwrap();
+        std::fs::write(codex_home.join("AGENTS.md"), "codex instructions").unwrap();
+        std::fs::write(codex_home.join("skills/github/SKILL.md"), "codex github").unwrap();
+
+        ensure_codex_resource_fallbacks(home).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(codex_home.join("AGENTS.md")).unwrap(),
+            "codex instructions"
+        );
+        assert_eq!(
+            std::fs::read_to_string(codex_home.join("skills/github/SKILL.md")).unwrap(),
+            "codex github"
+        );
     }
 
     /// Assert prompt is last and preceded by "--" separator.

--- a/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import {
   createTestCompose,
+  createTestVolume,
   enablePersonalModelProviderForUser,
   findMostRecentRunForUser,
   findTestRunnerJobEntry,
@@ -32,9 +33,11 @@ import {
   clearComposeHeadVersion,
   setTestZeroAgentPreferPersonalProvider,
 } from "../../../../../../src/__tests__/db-test-seeders/agents";
+import { bindCustomSkillToAgent } from "../../../../../../src/__tests__/db-test-seeders/skills";
 import { insertTestUserModelProviderSecret } from "../../../../../../src/__tests__/db-test-seeders/secrets";
 import { reloadEnv } from "../../../../../../src/env";
 import { nextAfterArgForms } from "../../../../../../src/__tests__/next-after-hooks";
+import { getCustomSkillStorageName } from "@vm0/core/storage-names";
 
 vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
   const actual =
@@ -414,6 +417,9 @@ describe("POST /api/zero/slack/events", () => {
         "claude-opus-4-7",
       );
       await setTestZeroAgentPreferPersonalProvider(agentId, true);
+      const skillName = uniqueId("personal-codex-skill");
+      await bindCustomSkillToAgent(agentId, skillName);
+      await createTestVolume(getCustomSkillStorageName(skillName));
 
       await enablePersonalModelProviderForUser(user.orgId, user.userId);
       await insertUserMultiAuthModelProvider(
@@ -479,6 +485,18 @@ describe("POST /api/zero/slack/events", () => {
       expect(job!.executionContext.environment).toMatchObject({
         OPENAI_MODEL: "gpt-5.5",
       });
+      expect(job!.executionContext.storageManifest!.storages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            mountPath: `/home/user/.codex/skills/${skillName}`,
+          }),
+        ]),
+      );
+      expect(
+        job!.executionContext.storageManifest!.storages.some((storage) => {
+          return storage.mountPath === `/home/user/.claude/skills/${skillName}`;
+        }),
+      ).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- Mirror legacy ~/.claude/CLAUDE.md into ~/.codex/AGENTS.md before Codex startup when Codex instructions are missing.
- Copy missing legacy Claude skill directories into ~/.codex/skills without overwriting existing Codex resources.
- Extend the Slack personal Codex provider regression to assert custom skill storage mounts under ~/.codex, not ~/.claude.

## Why
Personal codex-oauth runs can have Codex auth/runtime active while legacy Zero resources are still present under ~/.claude. Codex then starts without AGENTS.md or Zero skills in its own home. The guest fallback makes Codex startup resilient to that legacy resource layout while preserving native Codex resources when they already exist.

## Validation
- cargo fmt --manifest-path crates/Cargo.toml --package guest-agent --check
- cargo test --manifest-path crates/Cargo.toml -p guest-agent ensure_codex_resource_fallbacks -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p guest-agent setup_codex -- --nocapture
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings
- pnpm -C turbo exec prettier --check apps/web/app/api/zero/slack/events/__tests__/route.test.ts
- pnpm -C turbo -F web exec eslint app/api/zero/slack/events/__tests__/route.test.ts --max-warnings 0
- pnpm -C turbo -F web exec oxlint app/api/zero/slack/events/__tests__/route.test.ts

## Not run
- Targeted Vitest for the Slack route is blocked locally because Postgres is not available on localhost:5432 during global setup.