### PR TITLE
fix(slack): post only latest agent output

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
@@ -322,6 +322,70 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     expect(blocksStr).toContain("GPT-5.5");
   });
 
+  it("posts only the latest publishable output to Slack", async () => {
+    vi.stubEnv("AXIOM_TOKEN_SESSIONS", "test-sessions-token");
+    reloadEnv();
+
+    const { workspaceId, connectionId } = await setupOrgSlack();
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await seedTestRun(user.userId, composeId, {
+      prompt: "Test prompt",
+    });
+    await completeTestRun(user.userId, runId, undefined, {
+      lastEventSequence: 10,
+    });
+    context.mocks.axiom.queryAxiom
+      .mockResolvedValueOnce([{ sequenceNumber: 10 }])
+      .mockResolvedValueOnce([
+        {
+          eventType: "item.completed",
+          eventData: {
+            item: {
+              type: "agent_message",
+              text: "latest codex answer",
+            },
+          },
+        },
+      ]);
+
+    const channelId = uniqueId("C-ch");
+    const threadTs = uniqueId("ts");
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId,
+      threadTs,
+      messageTs: threadTs,
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createSignedCallbackRequest(
+      "http://localhost/api/internal/callbacks/slack/org",
+      { runId, status: "completed", payload },
+      secret,
+    );
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    expect(mockClient.chat.postMessage).toHaveBeenCalledOnce();
+    const call = (mockClient.chat.postMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as { text: string };
+    expect(call.text).toBe("latest codex answer");
+
+    const outputQuery = context.mocks.axiom.queryAxiom.mock
+      .calls[1]![0] as string;
+    expect(outputQuery).toContain("| order by sequenceNumber desc");
+    expect(outputQuery).toContain("| limit 1");
+  });
+
   it("posts error message for failed status", async () => {
     const { workspaceId, connectionId } = await setupOrgSlack();
     const { composeId } = await createTestCompose(uniqueId("agent"));

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
@@ -19,7 +19,7 @@ import {
   setThreadStatus,
 } from "../../../../../../src/lib/zero/slack/client";
 import { buildAgentResponseMessage } from "../../../../../../src/lib/zero/slack/blocks";
-import { extractAllRunOutputs } from "../../../../../../src/lib/infra/run/extract-run-output";
+import { extractRunOutput } from "../../../../../../src/lib/infra/run/extract-run-output";
 import {
   saveThreadSession,
   buildLogsUrl,
@@ -317,7 +317,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     .where(eq(agentRuns.id, runId))
     .limit(1);
 
-  const allOutputs = await extractAllRunOutputs(
+  const runOutput = await extractRunOutput(
     runId,
     error,
     runContext?.lastEventSequence,
@@ -343,16 +343,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     ? await resolveFooterText(runContext.orgId, payload, selectedModel)
     : undefined;
 
-  // Post each result as a separate Slack reply (in order)
-  for (let i = 0; i < allOutputs.length; i++) {
-    const output = allOutputs[i]!;
-    const responseText = buildResponseText(status, error, output);
-    if (!responseText) continue;
-
-    const isLast = i === allOutputs.length - 1;
-    const logsUrl =
-      isLast && auditLinkEnabled ? buildLogsUrl(runId) : undefined;
-
+  const responseText = buildResponseText(status, error, runOutput);
+  if (responseText) {
+    const logsUrl = auditLinkEnabled ? buildLogsUrl(runId) : undefined;
     await postMessage(client, payload.channelId, responseText, {
       threadTs: payload.threadTs,
       blocks: buildAgentResponseMessage(responseText, logsUrl, footerText),
@@ -361,13 +354,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Generate run summary (best-effort — errors handled internally)
   if (runContext?.prompt) {
-    const combinedOutput = allOutputs
-      .map((o) => {
-        return o.result;
-      })
-      .filter(Boolean)
-      .join("\n");
-    await saveRunSummary(runId, "slack", runContext.prompt, combinedOutput);
+    await saveRunSummary(
+      runId,
+      "slack",
+      runContext.prompt,
+      runOutput.result ?? "",
+    );
   }
 
   // Fire-and-forget: clearing the status is a UI hint; failure must not affect


### PR DESCRIPTION
## Summary
- Change Slack org completion callback to extract only the latest publishable run output
- Keep Slack summary generation aligned with the single posted output
- Add regression coverage that the Slack callback posts only one latest output

## Testing
- [ERR_PNPM_NO_PKG_MANIFEST] No package.json found in /home/user/workspace/vm0
[ERROR] Command failed with exit code 1: /usr/bin/node /home/user/.cache/node/corepack/v1/pnpm/11.0.8/bin/pnpm.mjs install

pnpm: Command failed with exit code 1: /usr/bin/node /home/user/.cache/node/corepack/v1/pnpm/11.0.8/bin/pnpm.mjs install
    at getFinalError (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:28550:14)
    at makeError (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:30857:21)
    at getSyncResult (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:32701:10)
    at spawnSubprocessSync (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:32661:14)
    at execaCoreSync (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:32591:23)
    at callBoundExeca (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:35119:23)
    at boundExeca (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:35096:49)
    at sync (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:35255:10)
    at runPnpmCli (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:208877:5)
    at runDepsStatusCheck (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:210581:7)
- [ERR_PNPM_NO_PKG_MANIFEST] No package.json found in /home/user/workspace/vm0
[ERROR] Command failed with exit code 1: /usr/bin/node /home/user/.cache/node/corepack/v1/pnpm/11.0.8/bin/pnpm.mjs install

pnpm: Command failed with exit code 1: /usr/bin/node /home/user/.cache/node/corepack/v1/pnpm/11.0.8/bin/pnpm.mjs install
    at getFinalError (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:28550:14)
    at makeError (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:30857:21)
    at getSyncResult (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:32701:10)
    at spawnSubprocessSync (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:32661:14)
    at execaCoreSync (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:32591:23)
    at callBoundExeca (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:35119:23)
    at boundExeca (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:35096:49)
    at sync (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:35255:10)
    at runPnpmCli (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:208877:5)
    at runDepsStatusCheck (file:///home/user/.cache/node/corepack/v1/pnpm/11.0.8/dist/pnpm.mjs:210581:7) *(blocked: local PostgreSQL is not running; global setup fails with ECONNREFUSED 127.0.0.1:5432)*