### PR TITLE
fix: allow full codex backend subtree in codex-oauth-token firewall

### DIFF
--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -544,6 +544,26 @@ describe("codex-oauth-token codex provider", () => {
     ]);
   });
 
+  it.each([
+    ["GET", "/"],
+    ["POST", "/oauth/token"],
+    ["DELETE", "/sessions/abc"],
+  ] as const)(
+    "auth.openai.com matches no allow permission for %s %s",
+    (method, path) => {
+      // The `ANY /*` rule on apis[1] is a literal-segment match on "*" and
+      // never matches real traffic — that's intentional. The deny is
+      // delivered by defaultPolicies.unknownPolicy: "deny" (asserted just
+      // above), so traffic to auth.openai.com must NOT resolve to any
+      // permission name on apis[1]. This pins behavior so a future edit
+      // to `apis[1].permissions` (e.g. adding an allow rule) breaks the
+      // test rather than silently widening auth.openai.com.
+      const config = MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"];
+      const fwConfig = { name: config.name, apis: [config.apis[1]!] };
+      expect(findMatchingPermissions(method, path, fwConfig)).toEqual([]);
+    },
+  );
+
   it("CHATGPT_ACCESS_TOKEN placeholder is an opaque marker (not a JWT)", () => {
     // Codex doesn't read this env var in ChatGPT mode — it reads the real
     // JWT from ~/.codex/auth.json (written by guest-agent #11877). The

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -31,6 +31,7 @@ import {
   modelProviderFrameworkSchema,
   type ModelProviderType,
 } from "../model-providers";
+import { findMatchingPermissions } from "@vm0/connectors/firewall-rule-matcher";
 
 describe("model-first canonical catalog", () => {
   it("exposes the curated flat model list only", () => {
@@ -494,20 +495,43 @@ describe("codex-oauth-token codex provider", () => {
     });
   });
 
-  it("firewall allows the known ChatGPT Codex backend routes", () => {
+  it("firewall allows the entire ChatGPT Codex backend subtree under GET/POST", () => {
     const config = MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"];
     expect(config.apis[0]!.permissions).toEqual([
       {
         name: "codex:api",
-        rules: [
-          "GET /models",
-          "GET /responses",
-          "POST /responses",
-          "POST /analytics-events/events",
-        ],
+        rules: ["GET /{path*}", "POST /{path*}"],
       },
     ]);
   });
+
+  it.each([
+    ["GET", "/models"],
+    ["GET", "/responses"],
+    ["POST", "/responses"],
+    ["POST", "/responses/compact"],
+    ["GET", "/responses/abc123"],
+    ["POST", "/analytics-events/events"],
+  ] as const)("codex:api permission matches %s %s", (method, path) => {
+    const config = MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"];
+    const fwConfig = { name: config.name, apis: [config.apis[0]!] };
+    expect(findMatchingPermissions(method, path, fwConfig)).toEqual([
+      "codex:api",
+    ]);
+  });
+
+  it.each([
+    ["DELETE", "/responses/abc123"],
+    ["PUT", "/responses/abc123"],
+    ["PATCH", "/settings"],
+  ] as const)(
+    "codex:api permission rejects %s %s (method narrowing)",
+    (method, path) => {
+      const config = MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"];
+      const fwConfig = { name: config.name, apis: [config.apis[0]!] };
+      expect(findMatchingPermissions(method, path, fwConfig)).toEqual([]);
+    },
+  );
 
   it("firewall denies auth.openai.com via defaultPolicies + permission rule", () => {
     const config = MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"];

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -1008,12 +1008,14 @@ export const MODEL_PROVIDER_FIREWALL_CONFIGS: Record<
         permissions: [
           {
             name: "codex:api",
-            rules: [
-              "GET /models",
-              "GET /responses",
-              "POST /responses",
-              "POST /analytics-events/events",
-            ],
+            // Subtree-wildcard the codex backend: codex's path surface keeps
+            // growing (#12099 added /responses, then /responses/compact 403'd
+            // again). Method narrowing to GET/POST is the actual safety net —
+            // it blocks accidental DELETE/PUT/PATCH on the user's ChatGPT
+            // account if codex is ever prompt-injected. Base is already
+            // locked to /backend-api/codex, so the blast radius is just
+            // codex's own surface area.
+            rules: ["GET /{path*}", "POST /{path*}"],
           },
         ],
       },


### PR DESCRIPTION
## Summary

- Codex's remote compact task `POST /responses/compact` was 403'd by the firewall — the `codex-oauth-token` allowlist only had exact `POST /responses`, and our path matcher is exact-match (not prefix). Visible in activity log as `Error running remote compact task: unexpected status 403 Forbidden ... permission_denied: no matching permission rule`.
- This is the second hit of the same shape (after #12099 added `/responses` and `/analytics-events/events`). Replacing the 4 exact-path rules with subtree wildcards on GET/POST means future codex endpoints under `/backend-api/codex` won't 403 again.
- Method narrowing is preserved — DELETE/PUT/PATCH still rejected, blocking accidental destructive calls under the user's ChatGPT account if codex is ever prompt-injected.

## Risk analysis

| Concern | Mitigation |
|---|---|
| Method discrimination | Preserved (GET/POST only; DELETE/PUT/PATCH still denied) |
| Token blast radius | Unchanged — base still pinned to `https://chatgpt.com/backend-api/codex`, sandbox sees placeholder, proxy substitutes at egress |
| `auth.openai.com` refresh path | Untouched — separate deny entry + `CODEX_REFRESH_TOKEN_URL_OVERRIDE` defense-in-depth |
| Future endpoints under same base | Auto-allowed under GET/POST — acceptable since base is narrow (codex's own surface area), and failing closed has cost real outages twice |

## Test plan

- [x] `pnpm -F @vm0/api-contracts exec vitest` — added `findMatchingPermissions` cases for `/responses/compact`, `/responses/{id}`, `/models`, `/analytics-events/events`, plus negative cases for DELETE/PUT/PATCH
- [x] `pnpm -F web exec vitest run src/lib/zero/context/__tests__/resolve-permissions.test.ts` — existing codex policy shape test still passes
- [x] `pnpm check-types`
- [x] `pnpm turbo run lint`
- [x] `pnpm knip`
- [ ] Verify in sandbox: trigger remote compact via codex-oauth-token connector and confirm no 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)