### PR TITLE
feat(api): add attachDatabasePool and env-configurable pool params

### DIFF
--- a/turbo/apps/api/src/lib/db.ts
+++ b/turbo/apps/api/src/lib/db.ts
@@ -8,6 +8,8 @@ import { schema } from "@vm0/db";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import { Pool, type PoolClient, type QueryConfig } from "pg";
 
+import { attachDatabasePool } from "@vercel/functions";
+
 import { env } from "./env";
 import { singleton } from "./singleton";
 import { deriveSqlSpanName } from "./sql-span-name";
@@ -135,14 +137,20 @@ const pool = singleton((): Pool => {
     return target;
   }
 
-  return instrumentPool(
+  const pgPool = instrumentPool(
     new Pool({
       allowExitOnIdle: true,
       connectionString: env("DATABASE_URL"),
       min: 1,
-      max: 5,
+      max: env("DB_POOL_MAX"),
+      idleTimeoutMillis: env("DB_POOL_IDLE_TIMEOUT_MS"),
+      connectionTimeoutMillis: env("DB_POOL_CONNECT_TIMEOUT_MS"),
     }),
   );
+
+  attachDatabasePool(pgPool);
+
+  return pgPool;
 });
 
 export const db = singleton((): NodePgDatabase<typeof schema> => {

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -26,6 +26,9 @@ const SCHEMA = {
   AXIOM_TOKEN_TELEMETRY: z.string().min(1),
   AXIOM_DATASET_SUFFIX: z.enum(["dev", "prod"]),
   STRIPE_SECRET_KEY: z.string().min(1),
+  DB_POOL_MAX: z.coerce.number().int().min(1).default(10),
+  DB_POOL_IDLE_TIMEOUT_MS: z.coerce.number().int().min(0).default(5000),
+  DB_POOL_CONNECT_TIMEOUT_MS: z.coerce.number().int().min(0).optional(),
 } as const;
 
 const baseEnv = createEnv<undefined, typeof SCHEMA>({


### PR DESCRIPTION
## Summary

Align the API package's PostgreSQL pool configuration with the web package's best practices for Vercel Fluid Compute:

- **Add `attachDatabasePool()`** — Calls `attachDatabasePool(pgPool)` from `@vercel/functions` (v3.4.4, already a dependency) to gracefully close idle connections before Fluid suspends the function instance. Without this, connections can leak when the instance is paused.
- **Make pool max env-configurable** — `DB_POOL_MAX` (default `10`, was hardcoded `5`). Matches web's default of 10.
- **Add idle timeout** — `DB_POOL_IDLE_TIMEOUT_MS` (default `5000`). Matches web's `pg-pool` idle timeout pattern. The `pg.Pool` default is 30s which is too long for serverless.
- **Add connect timeout (optional)** — `DB_POOL_CONNECT_TIMEOUT_MS` (no default, optional). The `pg.Pool` default is 0 (no timeout), which can hang indefinitely in serverless.

## Changes

| File | Change |
|------|--------|
| `turbo/apps/api/src/lib/env.ts` | Add `DB_POOL_MAX`, `DB_POOL_IDLE_TIMEOUT_MS`, `DB_POOL_CONNECT_TIMEOUT_MS` env vars |
| `turbo/apps/api/src/lib/db.ts` | Import `attachDatabasePool`, use env vars for pool config, call `attachDatabasePool(pgPool)` |

## Test plan

- [ ] Verify pool config respects env vars in preview deploy
- [ ] Verify no connection leaks after Fluid suspend/resume cycles
- [ ] Existing tests pass (`pnpm -F @vm0/api exec vitest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)