### PR TITLE
test(runner): add start-loop test observer

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -463,7 +463,7 @@ pub async fn run_start(
         #[cfg(test)]
         outer_job_panic: None,
         #[cfg(test)]
-        test_probes: StartLoopTestProbes::default(),
+        test_observer: StartLoopTestObserver::default(),
     };
 
     run(config).await
@@ -505,7 +505,7 @@ struct RunConfig {
     #[cfg(test)]
     outer_job_panic: Option<OuterJobPanicPoint>,
     #[cfg(test)]
-    test_probes: StartLoopTestProbes,
+    test_observer: StartLoopTestObserver,
 }
 
 enum SignalSource {
@@ -520,21 +520,95 @@ enum SignalSource {
 }
 
 #[cfg(test)]
-#[derive(Clone, Default)]
-struct StartLoopTestProbes {
-    budget_exhausted_reactor: Arc<tokio::sync::Notify>,
+#[derive(Debug, PartialEq, Eq)]
+enum StartLoopEvent {
+    BudgetExhaustedReactorEntered,
+    IdleCleanupProcessed { expired_count: usize },
 }
 
 #[cfg(test)]
-impl StartLoopTestProbes {
+#[derive(Clone, Default)]
+struct StartLoopTestObserver {
+    inner: Arc<StartLoopTestObserverInner>,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct StartLoopTestObserverInner {
+    events: std::sync::Mutex<Vec<StartLoopEvent>>,
+    notify: tokio::sync::Notify,
+}
+
+#[cfg(test)]
+impl StartLoopTestObserver {
+    fn record(&self, event: StartLoopEvent) {
+        self.inner
+            .events
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(event);
+        self.inner.notify.notify_waiters();
+    }
+
+    async fn wait_for<T>(
+        &self,
+        timeout: Duration,
+        context: &'static str,
+        mut predicate: impl FnMut(&StartLoopEvent) -> Option<T>,
+    ) -> T {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let notified = self.inner.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            {
+                let events = self
+                    .inner
+                    .events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                if let Some(value) = events.iter().find_map(&mut predicate) {
+                    return value;
+                }
+            }
+
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "runner did not observe {context} within {timeout:?}"
+            );
+            let observed = tokio::time::timeout(remaining, notified).await;
+            assert!(
+                observed.is_ok(),
+                "runner did not observe {context} within {timeout:?}"
+            );
+        }
+    }
+
     fn notify_budget_exhausted_reactor(&self) {
-        self.budget_exhausted_reactor.notify_one();
+        self.record(StartLoopEvent::BudgetExhaustedReactorEntered);
     }
 
     async fn wait_budget_exhausted_reactor(&self, timeout: Duration) {
-        tokio::time::timeout(timeout, self.budget_exhausted_reactor.notified())
-            .await
-            .expect("runner did not enter budget-exhausted reactor within timeout");
+        self.wait_for(timeout, "budget-exhausted reactor entry", |event| {
+            matches!(event, StartLoopEvent::BudgetExhaustedReactorEntered).then_some(())
+        })
+        .await;
+    }
+
+    async fn wait_idle_cleanup_processed_with_expired_entries(&self, timeout: Duration) -> usize {
+        self.wait_for(
+            timeout,
+            "idle cleanup processing expired entries",
+            |event| match event {
+                StartLoopEvent::IdleCleanupProcessed { expired_count } if *expired_count > 0 => {
+                    Some(*expired_count)
+                }
+                _ => None,
+            },
+        )
+        .await
     }
 }
 
@@ -586,7 +660,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         #[cfg(test)]
         outer_job_panic,
         #[cfg(test)]
-        test_probes,
+        test_observer,
     } = config;
 
     let mut factories =
@@ -780,7 +854,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         };
         #[cfg(test)]
         if matches!(mode, RunnerMode::Running) && !can_discover {
-            test_probes.notify_budget_exhausted_reactor();
+            test_observer.notify_budget_exhausted_reactor();
         }
         tokio::select! {
             // Job discovery via provider (Ably wakeups + HTTP poll).
@@ -853,9 +927,13 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             // Idle pool cleanup: evict expired VMs and update status
             _ = idle_cleanup.tick(), if can_discover => {
                 let expired = cleanup_expired_idle_entries(&idle_pool, &status).await;
+                #[cfg(test)]
+                let expired_count = expired.len();
                 for entry in expired {
                     spawn_idle_destroy_job(&mut destroy_tasks, entry, "idle_expired");
                 }
+                #[cfg(test)]
+                test_observer.record(StartLoopEvent::IdleCleanupProcessed { expired_count });
             }
             // Heartbeat: report runner state to the server
             _ = heartbeat_tick.tick() => {

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -140,12 +140,14 @@ async fn cleanup_tick_evicts_expired_entries() {
     assert_eq!(budget.allocated().2, 1, "seeded entry holds budget");
 
     let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
 
-    // Advance past the first cleanup tick (every 10s).
-    // The tick interval fires once immediately (at t=0), but the entry
-    // was just inserted so it may not be expired yet from Instant::now()'s
-    // perspective. Advance 11s to ensure at least one full tick fires.
-    tokio::time::sleep(Duration::from_secs(11)).await;
+    // Advance to the first cleanup tick, then synchronize on the loop's
+    // cleanup event instead of using the fixed sleep as the assertion gate.
+    tokio::time::advance(Duration::from_secs(11)).await;
+    let expired_count =
+        wait_idle_cleanup_processed_with_expired_entries(&env, Duration::from_secs(5)).await;
+    assert_eq!(expired_count, 1, "cleanup should process the expired entry");
 
     // Eviction spawns a destroy_task that releases the idle entry lease.
     // Poll until it completes.

--- a/crates/runner/src/cmd/start/tests/support.rs
+++ b/crates/runner/src/cmd/start/tests/support.rs
@@ -33,7 +33,7 @@ pub(super) struct MockRunEnv {
     pub(super) idle_pool: SharedIdlePool,
     pub(super) lifecycle: LifecycleController,
     pub(super) parking_gate: ParkingGate,
-    pub(super) start_probes: StartLoopTestProbes,
+    pub(super) start_observer: StartLoopTestObserver,
     pub(super) mode_tx: tokio::sync::watch::Sender<RunnerMode>,
     pub(super) cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>>,
     pub(super) cancel: CancellationToken,
@@ -149,7 +149,7 @@ pub(super) fn build_mock_run_config_with_runtime(
     let (mode_tx, mode_rx) = tokio::sync::watch::channel(RunnerMode::Running);
     let parking_gate = ParkingGate::new_open();
     let lifecycle = LifecycleController::new(mode_tx, parking_gate.clone());
-    let start_probes = StartLoopTestProbes::default();
+    let start_observer = StartLoopTestObserver::default();
     let cancel_tokens: Arc<tokio::sync::Mutex<HashMap<RunId, CancellationToken>>> =
         Arc::new(tokio::sync::Mutex::new(HashMap::new()));
 
@@ -226,7 +226,7 @@ pub(super) fn build_mock_run_config_with_runtime(
             handler_abort: None,
         }),
         outer_job_panic: None,
-        test_probes: start_probes.clone(),
+        test_observer: start_observer.clone(),
     };
 
     let env = MockRunEnv {
@@ -235,7 +235,7 @@ pub(super) fn build_mock_run_config_with_runtime(
         idle_pool,
         lifecycle: lifecycle.clone(),
         parking_gate,
-        start_probes,
+        start_observer,
         mode_tx: lifecycle.mode_tx().clone(),
         cancel_tokens,
         cancel,
@@ -854,7 +854,16 @@ pub(super) async fn wait_discover_entered(env: &MockRunEnv, timeout: Duration) {
 }
 
 pub(super) async fn wait_budget_exhausted_reactor(env: &MockRunEnv, timeout: Duration) {
-    env.start_probes
+    env.start_observer
         .wait_budget_exhausted_reactor(timeout)
         .await;
+}
+
+pub(super) async fn wait_idle_cleanup_processed_with_expired_entries(
+    env: &MockRunEnv,
+    timeout: Duration,
+) -> usize {
+    env.start_observer
+        .wait_idle_cleanup_processed_with_expired_entries(timeout)
+        .await
 }


### PR DESCRIPTION
## Summary
- replace the single-purpose runner start-loop test probe with a typed test-only observer that stores event history
- record budget-exhausted and idle-cleanup lifecycle events through the observer
- migrate cleanup_tick_evicts_expired_entries away from fixed sleep gating to observer-based synchronization

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner start::tests::budget::cleanup_tick_evicts_expired_entries
- cargo test --manifest-path crates/Cargo.toml -p runner start::tests::budget
- cargo test --manifest-path crates/Cargo.toml -p runner start::tests::main_loop
- cargo test --manifest-path crates/Cargo.toml -p runner
- cd crates && cargo fmt --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings
- lefthook pre-commit: cargo-fmt, cargo-clippy, cargo-doc

Closes #12206