### PR TITLE
fix: clear optimistic pending on recall so queued card disappears synchronously

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1535,6 +1535,7 @@ function createPendingMessageView(
 
   const markPendingRecalled$ = command(({ set }, updatedAt: string) => {
     set(internalRecalledUpdatedAt$, updatedAt);
+    set(internalOptimisticPending$, null);
   });
 
   return {


### PR DESCRIPTION
## Summary

When the user clicks recall on a queued message, the optimistic pending bubble was not being cleared — only the server-confirmed row was masked. The fallback in `pendingMessageWithSource$` (`serverPendingActive ?? optimistic`) then picked up the stale optimistic slot, leaving the queued card visible with the Recall button stuck in a disabled state.

## Fix

One line in `markPendingRecalled$`: also null out `internalOptimisticPending$` so both sources are masked synchronously.

## Test plan
- [ ] Queue a message during an active run, then click recall — the queued card disappears immediately and the draft is repopulated
- [ ] Recall button never shows a disabled state on the queued card
- [ ] Existing recall tests pass (chat-queue-message.test.tsx, chat-stop-button-recall.test.tsx, create-chat-thread.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)