### PR TITLE
fix: patch hono audit advisories

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -32,7 +32,7 @@
     "@vm0/db": "workspace:*",
     "ccstate": "^5.3.0",
     "drizzle-orm": "^0.45.2",
-    "hono": "^4.12.16",
+    "hono": "^4.12.18",
     "pg": "^8.20.0",
     "stripe": "^20.4.1",
     "undici": "^6.24.1",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -114,10 +114,10 @@ importers:
         version: 3.4.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hono/node-server':
         specifier: ^1.19.14
-        version: 1.19.14(hono@4.12.16)
+        version: 1.19.14(hono@4.12.18)
       '@hono/otel':
         specifier: ^1.1.1
-        version: 1.1.1(hono@4.12.16)
+        version: 1.1.1(hono@4.12.18)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -158,8 +158,8 @@ importers:
         specifier: ^0.45.2
         version: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0)(postgres@3.4.9)
       hono:
-        specifier: ^4.12.16
-        version: 4.12.16
+        specifier: ^4.12.18
+        version: 4.12.18
       pg:
         specifier: ^8.20.0
         version: 8.20.0
@@ -175,7 +175,7 @@ importers:
     devDependencies:
       '@hono/vite-build':
         specifier: ^1.11.1
-        version: 1.11.1(hono@4.12.16)
+        version: 1.11.1(hono@4.12.18)
       '@ts-rest/core':
         specifier: 3.53.0-rc.1
         version: 3.53.0-rc.1(@types/node@24.3.0)
@@ -6840,8 +6840,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.16:
-    resolution: {integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==}
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -10555,19 +10555,19 @@ snapshots:
     dependencies:
       graphql: 16.13.2
 
-  '@hono/node-server@1.19.14(hono@4.12.16)':
+  '@hono/node-server@1.19.14(hono@4.12.18)':
     dependencies:
-      hono: 4.12.16
+      hono: 4.12.18
 
-  '@hono/otel@1.1.1(hono@4.12.16)':
+  '@hono/otel@1.1.1(hono@4.12.18)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
-      hono: 4.12.16
+      hono: 4.12.18
 
-  '@hono/vite-build@1.11.1(hono@4.12.16)':
+  '@hono/vite-build@1.11.1(hono@4.12.18)':
     dependencies:
-      hono: 4.12.16
+      hono: 4.12.18
 
   '@humanfs/core@0.19.1': {}
 
@@ -15641,7 +15641,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.16: {}
+  hono@4.12.18: {}
 
   html-escaper@2.0.2: {}
 


### PR DESCRIPTION
## Summary
- bump `apps/api` direct `hono` dependency to `^4.12.18`
- refresh `turbo/pnpm-lock.yaml` so Hono and its peer snapshots resolve to `4.12.18`

## Why
`pnpm audit` reports Hono advisories for versions `<4.12.18` via `apps__api>hono`.

## Tests
- `cd turbo && pnpm audit`
- `cd turbo && pnpm install --frozen-lockfile --ignore-scripts`
- `cd turbo && pnpm --filter api lint`
- `cd turbo && pnpm -F @vm0/firewalls-generator generate && pnpm --filter api check-types`
- `git diff --check`

## Note
Local pre-commit `knip` currently reports an unrelated existing `apps/platform` dependency issue; this PR leaves that unrelated area untouched.