### PR TITLE
fix: route api axiom session queries to sessions token

### DIFF
--- a/turbo/apps/api/src/signals/external/__tests__/axiom-datasets.test.ts
+++ b/turbo/apps/api/src/signals/external/__tests__/axiom-datasets.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { getAxiomTokenEnvNameForApl } from "../axiom-datasets";
+
+describe("getAxiomTokenEnvNameForApl", () => {
+  it("uses the sessions token for agent run events", () => {
+    expect(
+      getAxiomTokenEnvNameForApl(
+        "['vm0-agent-run-events-dev'] | where runId == \"run_123\"",
+      ),
+    ).toBe("AXIOM_TOKEN_SESSIONS");
+  });
+
+  it("uses the telemetry token for telemetry datasets", () => {
+    expect(
+      getAxiomTokenEnvNameForApl(
+        "['vm0-sandbox-telemetry-network-dev'] | limit 1",
+      ),
+    ).toBe("AXIOM_TOKEN_TELEMETRY");
+  });
+
+  it("defaults unknown APL to the telemetry token", () => {
+    expect(getAxiomTokenEnvNameForApl("limit 1")).toBe("AXIOM_TOKEN_TELEMETRY");
+  });
+});

--- a/turbo/apps/api/src/signals/external/axiom-datasets.ts
+++ b/turbo/apps/api/src/signals/external/axiom-datasets.ts
@@ -1,0 +1,16 @@
+type AxiomTokenEnvName = "AXIOM_TOKEN_SESSIONS" | "AXIOM_TOKEN_TELEMETRY";
+
+function extractDatasetFromApl(apl: string): string | null {
+  const match = apl.match(/\['([^']+)'\]/);
+  return match?.[1] ?? null;
+}
+
+function isSessionsDataset(datasetName: string | null): boolean {
+  return datasetName?.includes("agent-run-events") ?? false;
+}
+
+export function getAxiomTokenEnvNameForApl(apl: string): AxiomTokenEnvName {
+  return isSessionsDataset(extractDatasetFromApl(apl))
+    ? "AXIOM_TOKEN_SESSIONS"
+    : "AXIOM_TOKEN_TELEMETRY";
+}

--- a/turbo/apps/api/src/signals/external/axiom.ts
+++ b/turbo/apps/api/src/signals/external/axiom.ts
@@ -2,23 +2,33 @@ import { computed, type Computed } from "ccstate";
 import { Axiom } from "@axiomhq/js";
 import { env } from "../../lib/env";
 import { singleton } from "../../lib/singleton";
+import { getAxiomTokenEnvNameForApl } from "./axiom-datasets";
 
-const axiomClient = singleton(() => {
-  return new Axiom({ token: env("AXIOM_TOKEN_TELEMETRY") });
+const sessionsAxiomClient = singleton(() => {
+  return new Axiom({ token: env("AXIOM_TOKEN_SESSIONS") });
 });
-const axiomClient$ = computed(() => {
-  return axiomClient();
+
+const telemetryAxiomClient = singleton(() => {
+  return new Axiom({ token: env("AXIOM_TOKEN_TELEMETRY") });
 });
 
 export function getDatasetName(base: string): string {
   return `vm0-${base}-${env("AXIOM_DATASET_SUFFIX")}`;
 }
 
+function axiomClientForApl(apl: string): Axiom {
+  const tokenEnvName = getAxiomTokenEnvNameForApl(apl);
+  if (tokenEnvName === "AXIOM_TOKEN_SESSIONS") {
+    return sessionsAxiomClient();
+  }
+  return telemetryAxiomClient();
+}
+
 export function queryAxiom(
   apl: string,
 ): Computed<Promise<readonly Record<string, unknown>[]>> {
-  return computed(async (get): Promise<readonly Record<string, unknown>[]> => {
-    const client = await get(axiomClient$);
+  return computed(async (): Promise<readonly Record<string, unknown>[]> => {
+    const client = axiomClientForApl(apl);
     if (!client) {
       return [];
     }


### PR DESCRIPTION
## Summary

Fixes #12264.

When `apiBackend` is enabled, activity log detail requests hit `api.vm0.ai` and the api backend queries Axiom directly. The api backend Axiom helper was using `AXIOM_TOKEN_TELEMETRY` for every dataset, including `agent-run-events`, which is sessions-scoped. This changes the api backend helper to select the Axiom token from the APL dataset name:

- `agent-run-events` -> `AXIOM_TOKEN_SESSIONS`
- other datasets -> `AXIOM_TOKEN_TELEMETRY`

Axiom requests remain server-side; the platform browser only calls vm0 API endpoints.

## Testing

- `pnpm -F api exec vitest src/signals/external/__tests__/axiom-datasets.test.ts`
- `pnpm -F api exec eslint src/signals/external/axiom.ts src/signals/external/axiom-datasets.ts src/signals/external/__tests__/axiom-datasets.test.ts --max-warnings 0`
- `pnpm -F api exec oxlint src/signals/external/axiom.ts src/signals/external/axiom-datasets.ts src/signals/external/__tests__/axiom-datasets.test.ts`

## Local check note

`pnpm -F api check-types` and the pre-commit `pnpm check-types` are currently blocked locally by existing type errors outside this change, primarily in route/client typing (`Property 'body' does not exist on type 'never'`, `Expected 1 arguments, but got 0`). The targeted changed files pass ESLint, Oxlint, and Vitest.
