### PR TITLE
perf(vsock-host): cap bounded exec stream forwarding

### DIFF
--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -134,9 +134,46 @@ struct BoundedOutputEventPlan {
     truncated: bool,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct BoundedOutputEventPlans {
+    first: Option<BoundedOutputEventPlan>,
+    second: Option<BoundedOutputEventPlan>,
+}
+
+impl BoundedOutputEventPlans {
+    fn empty() -> Self {
+        Self {
+            first: None,
+            second: None,
+        }
+    }
+
+    fn one(first: BoundedOutputEventPlan) -> Self {
+        Self {
+            first: Some(first),
+            second: None,
+        }
+    }
+
+    fn two(first: BoundedOutputEventPlan, second: BoundedOutputEventPlan) -> Self {
+        Self {
+            first: Some(first),
+            second: Some(second),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.first.is_none() && self.second.is_none()
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &BoundedOutputEventPlan> {
+        self.first.iter().chain(self.second.iter())
+    }
+}
+
 struct BoundedOutputForwardPlan {
     event_tx: mpsc::UnboundedSender<BoundedExecOutputEvent>,
-    events: Vec<BoundedOutputEventPlan>,
+    events: BoundedOutputEventPlans,
 }
 
 impl BoundedOutputRegistration {
@@ -206,9 +243,9 @@ impl BoundedOutputStreamState {
         chunk_len: usize,
         incoming_truncated: bool,
         chunk_limit_bytes: usize,
-    ) -> Vec<BoundedOutputEventPlan> {
+    ) -> BoundedOutputEventPlans {
         if self.is_closed_or_disabled() {
-            return Vec::new();
+            return BoundedOutputEventPlans::empty();
         }
 
         let remaining = self.limit_bytes.saturating_sub(self.forwarded_bytes);
@@ -217,47 +254,55 @@ impl BoundedOutputStreamState {
             let allowed_len = chunk_len.min(chunk_limit_bytes).min(remaining);
             self.forwarded_bytes = self.forwarded_bytes.saturating_add(allowed_len);
             self.closed = true;
-            return vec![BoundedOutputEventPlan {
+            return BoundedOutputEventPlans::one(BoundedOutputEventPlan {
                 stream,
                 sequence,
                 chunk_len: allowed_len,
                 truncated: true,
-            }];
+            });
         }
 
         if remaining == 0 || chunk_limit_bytes == 0 {
             self.closed = true;
-            return vec![BoundedOutputEventPlan {
+            return BoundedOutputEventPlans::one(BoundedOutputEventPlan {
                 stream,
                 sequence,
                 chunk_len: 0,
                 truncated: true,
-            }];
+            });
         }
 
         let allowed_len = chunk_len.min(chunk_limit_bytes).min(remaining);
-        let mut events = Vec::with_capacity(2);
-        if allowed_len > 0 {
-            events.push(BoundedOutputEventPlan {
+        let prefix = if allowed_len > 0 {
+            self.forwarded_bytes = self.forwarded_bytes.saturating_add(allowed_len);
+            Some(BoundedOutputEventPlan {
                 stream,
                 sequence,
                 chunk_len: allowed_len,
                 truncated: false,
-            });
-            self.forwarded_bytes = self.forwarded_bytes.saturating_add(allowed_len);
-        }
+            })
+        } else {
+            None
+        };
 
         if allowed_len < chunk_len {
             self.closed = true;
-            events.push(BoundedOutputEventPlan {
+            let marker = BoundedOutputEventPlan {
                 stream,
                 sequence: sequence.wrapping_add(1),
                 chunk_len: 0,
                 truncated: true,
-            });
+            };
+            return match prefix {
+                Some(prefix) => BoundedOutputEventPlans::two(prefix, marker),
+                None => BoundedOutputEventPlans::one(marker),
+            };
         }
 
-        events
+        match prefix {
+            Some(prefix) => BoundedOutputEventPlans::one(prefix),
+            None => BoundedOutputEventPlans::empty(),
+        }
     }
 }
 
@@ -739,7 +784,7 @@ async fn reader_loop(
                         }
                     };
                     if let Some(forward_plan) = forward_plan {
-                        for event_plan in forward_plan.events {
+                        for event_plan in forward_plan.events.iter() {
                             let event = BoundedExecOutputEvent {
                                 stream: event_plan.stream,
                                 sequence: event_plan.sequence,

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -566,14 +566,19 @@ impl Shared {
     }
 
     fn remove_bounded_output_sender(&self, seq: u32) {
-        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
-        if let ConnectionState::Connected {
-            bounded_output_senders,
-            ..
-        } = &mut *guard
-        {
-            bounded_output_senders.remove(&seq);
-        }
+        let removed = {
+            let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            if let ConnectionState::Connected {
+                bounded_output_senders,
+                ..
+            } = &mut *guard
+            {
+                bounded_output_senders.remove(&seq)
+            } else {
+                None
+            }
+        };
+        drop(removed);
     }
 }
 
@@ -754,7 +759,7 @@ async fn reader_loop(
             } else if msg.msg_type == MSG_BOUNDED_EXEC_OUTPUT_CHUNK && msg.seq != 0 {
                 if let Ok(decoded) = vsock_proto::decode_bounded_exec_output_chunk(&msg.payload) {
                     let stream = proto_stream_to_host(decoded.stream);
-                    let forward_plan = {
+                    let (forward_plan, closed_registration) = {
                         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
                         match &mut *guard {
                             ConnectionState::Connected {
@@ -775,14 +780,15 @@ async fn reader_loop(
                                 } else {
                                     (None, false)
                                 };
-                                if remove_registration {
-                                    bounded_output_senders.remove(&msg.seq);
-                                }
-                                plan
+                                let closed_registration = remove_registration
+                                    .then(|| bounded_output_senders.remove(&msg.seq))
+                                    .flatten();
+                                (plan, closed_registration)
                             }
-                            ConnectionState::Closed { .. } => None,
+                            ConnectionState::Closed { .. } => (None, None),
                         }
                     };
+                    drop(closed_registration);
                     if let Some(forward_plan) = forward_plan {
                         for event_plan in forward_plan.events.iter() {
                             let event = BoundedExecOutputEvent {
@@ -807,7 +813,7 @@ async fn reader_loop(
                 // from pending_stdout to stdout_senders BEFORE dispatching the
                 // response — under one lock so the channel is keyed by pid in
                 // stdout_senders before any subsequent MSG_STDOUT_CHUNK arrives.
-                let response_sender = {
+                let (response_sender, bounded_output_sender) = {
                     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
                     match &mut *guard {
                         ConnectionState::Connected {
@@ -824,12 +830,15 @@ async fn reader_loop(
                             {
                                 stdout_senders.insert(pid, tx);
                             }
-                            bounded_output_senders.remove(&msg.seq);
-                            pending.remove(&msg.seq)
+                            (
+                                pending.remove(&msg.seq),
+                                bounded_output_senders.remove(&msg.seq),
+                            )
                         }
-                        ConnectionState::Closed { .. } => None,
+                        ConnectionState::Closed { .. } => (None, None),
                     }
                 };
+                drop(bounded_output_sender);
                 if let Some(tx) = response_sender {
                     let _ = tx.send(msg);
                 }

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -2207,6 +2207,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_bounded_exec_truncation_marker_sequence_wraps() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+
+            write_bounded_stream_chunk(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecStream::Stdout,
+                u32::MAX,
+                b"abcdef",
+                false,
+            )
+            .await;
+            write_bounded_exec_result(&mut guest, msgs[0].seq, b"done").await;
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let request = simple_bounded_request(
+            "sequence-wrap",
+            Some(bounded_stream_request_with_limits(
+                event_tx,
+                true,
+                false,
+                vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES,
+                4,
+                0,
+            )),
+        );
+
+        let result = host.bounded_exec(&request).await.unwrap();
+        drop(request);
+        assert_eq!(result.stdout, b"done");
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: u32::MAX,
+                chunk: b"abcd".to_vec(),
+                truncated: false,
+            }
+        );
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 0,
+                chunk: Vec::new(),
+                truncated: true,
+            }
+        );
+        assert_bounded_event_stream_closed(&mut event_rx);
+    }
+
+    #[tokio::test]
     async fn test_bounded_exec_stdout_cap_does_not_close_stderr() {
         let (host_stream, mut guest) = make_pair();
 
@@ -2344,6 +2407,74 @@ mod tests {
                 stream: BoundedExecStream::Stdout,
                 sequence: 30,
                 chunk: b"abcd".to_vec(),
+                truncated: true,
+            }
+        );
+        assert_bounded_event_stream_closed(&mut event_rx);
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_incoming_truncation_caps_at_chunk_limit() {
+        let (host_stream, mut guest) = make_pair();
+        let chunk_limit = vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES;
+        let oversized_chunk = vec![b'z'; chunk_limit + 9];
+
+        tokio::spawn({
+            let oversized_chunk = oversized_chunk.clone();
+            async move {
+                let mut decoder = Decoder::new();
+                mock_handshake(&mut guest, &mut decoder).await;
+
+                let mut buf = [0u8; 4096];
+                let n = guest.read(&mut buf).await.unwrap();
+                let msgs = decoder.decode(&buf[..n]).unwrap();
+                assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+
+                write_bounded_stream_chunk(
+                    &mut guest,
+                    msgs[0].seq,
+                    vsock_proto::BoundedExecStream::Stdout,
+                    90,
+                    &oversized_chunk,
+                    true,
+                )
+                .await;
+                write_bounded_stream_chunk(
+                    &mut guest,
+                    msgs[0].seq,
+                    vsock_proto::BoundedExecStream::Stdout,
+                    91,
+                    b"ignored",
+                    false,
+                )
+                .await;
+                write_bounded_exec_result(&mut guest, msgs[0].seq, b"done").await;
+            }
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let request = simple_bounded_request(
+            "incoming-truncated-chunk-cap",
+            Some(bounded_stream_request_with_limits(
+                event_tx,
+                true,
+                false,
+                chunk_limit,
+                (chunk_limit * 2) as u32,
+                0,
+            )),
+        );
+
+        let result = host.bounded_exec(&request).await.unwrap();
+        drop(request);
+        assert_eq!(result.stdout, b"done");
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 90,
+                chunk: vec![b'z'; chunk_limit],
                 truncated: true,
             }
         );

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -2131,6 +2131,78 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_bounded_exec_exact_stream_limit_truncates_on_next_chunk() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+
+            write_bounded_stream_chunk(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecStream::Stdout,
+                40,
+                b"abcd",
+                false,
+            )
+            .await;
+            write_bounded_stream_chunk(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecStream::Stdout,
+                41,
+                b"e",
+                false,
+            )
+            .await;
+            write_bounded_exec_result(&mut guest, msgs[0].seq, b"done").await;
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let request = simple_bounded_request(
+            "exact-stream-limit",
+            Some(bounded_stream_request_with_limits(
+                event_tx,
+                true,
+                false,
+                vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES,
+                4,
+                0,
+            )),
+        );
+
+        let result = host.bounded_exec(&request).await.unwrap();
+        drop(request);
+        assert_eq!(result.stdout, b"done");
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 40,
+                chunk: b"abcd".to_vec(),
+                truncated: false,
+            }
+        );
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 41,
+                chunk: Vec::new(),
+                truncated: true,
+            }
+        );
+        assert_bounded_event_stream_closed(&mut event_rx);
+    }
+
+    #[tokio::test]
     async fn test_bounded_exec_stdout_cap_does_not_close_stderr() {
         let (host_stream, mut guest) = make_pair();
 
@@ -2208,6 +2280,7 @@ mod tests {
                 truncated: false,
             }
         );
+        assert_bounded_event_stream_closed(&mut event_rx);
     }
 
     #[tokio::test]
@@ -2267,6 +2340,69 @@ mod tests {
                 stream: BoundedExecStream::Stdout,
                 sequence: 30,
                 chunk: b"abcd".to_vec(),
+                truncated: true,
+            }
+        );
+        assert_bounded_event_stream_closed(&mut event_rx);
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_empty_incoming_truncation_closes_stream_once() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+
+            write_bounded_stream_chunk(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecStream::Stdout,
+                70,
+                b"",
+                true,
+            )
+            .await;
+            write_bounded_stream_chunk(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecStream::Stdout,
+                71,
+                b"ignored",
+                false,
+            )
+            .await;
+            write_bounded_exec_result(&mut guest, msgs[0].seq, b"done").await;
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let request = simple_bounded_request(
+            "empty-incoming-truncated",
+            Some(bounded_stream_request_with_limits(
+                event_tx,
+                true,
+                false,
+                vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES,
+                4,
+                0,
+            )),
+        );
+
+        let result = host.bounded_exec(&request).await.unwrap();
+        drop(request);
+        assert_eq!(result.stdout, b"done");
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 70,
+                chunk: Vec::new(),
                 truncated: true,
             }
         );
@@ -2419,6 +2555,7 @@ mod tests {
                 truncated: false,
             }
         );
+        assert_bounded_event_stream_closed(&mut event_rx);
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -791,14 +791,18 @@ async fn reader_loop(
                     drop(closed_registration);
                     if let Some(forward_plan) = forward_plan {
                         for event_plan in forward_plan.events.iter() {
+                            debug_assert!(
+                                event_plan.chunk_len <= decoded.chunk.len(),
+                                "bounded output plan length must fit decoded chunk length"
+                            );
+                            let Some(chunk) = decoded.chunk.get(..event_plan.chunk_len) else {
+                                shared.remove_bounded_output_sender(msg.seq);
+                                break;
+                            };
                             let event = BoundedExecOutputEvent {
                                 stream: event_plan.stream,
                                 sequence: event_plan.sequence,
-                                chunk: decoded
-                                    .chunk
-                                    .get(..event_plan.chunk_len)
-                                    .unwrap_or_default()
-                                    .to_vec(),
+                                chunk: chunk.to_vec(),
                                 truncated: event_plan.truncated,
                             };
                             if forward_plan.event_tx.send(event).is_err() {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1703,6 +1703,15 @@ mod tests {
         guest.write_all(&frame).await.unwrap();
     }
 
+    fn assert_bounded_event_stream_closed(
+        event_rx: &mut mpsc::UnboundedReceiver<BoundedExecOutputEvent>,
+    ) {
+        assert!(matches!(
+            event_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Disconnected)
+        ));
+    }
+
     #[tokio::test]
     async fn wait_for_connection_removes_listener_socket_on_abort() {
         let unique = std::time::SystemTime::now()
@@ -2035,6 +2044,7 @@ mod tests {
         );
 
         let result = host.bounded_exec(&request).await.unwrap();
+        drop(request);
         assert_eq!(result.stdout, b"done");
         assert_eq!(
             event_rx.recv().await.unwrap(),
@@ -2045,10 +2055,7 @@ mod tests {
                 truncated: false,
             }
         );
-        assert!(matches!(
-            event_rx.try_recv(),
-            Err(mpsc::error::TryRecvError::Empty)
-        ));
+        assert_bounded_event_stream_closed(&mut event_rx);
     }
 
     #[tokio::test]
@@ -2100,6 +2107,7 @@ mod tests {
         );
 
         let result = host.bounded_exec(&request).await.unwrap();
+        drop(request);
         assert_eq!(result.stdout, b"done");
         assert_eq!(
             event_rx.recv().await.unwrap(),
@@ -2119,10 +2127,7 @@ mod tests {
                 truncated: true,
             }
         );
-        assert!(matches!(
-            event_rx.try_recv(),
-            Err(mpsc::error::TryRecvError::Empty)
-        ));
+        assert_bounded_event_stream_closed(&mut event_rx);
     }
 
     #[tokio::test]
@@ -2174,6 +2179,7 @@ mod tests {
         );
 
         let result = host.bounded_exec(&request).await.unwrap();
+        drop(request);
         assert_eq!(result.stdout, b"done");
         assert_eq!(
             event_rx.recv().await.unwrap(),
@@ -2253,6 +2259,7 @@ mod tests {
         );
 
         let result = host.bounded_exec(&request).await.unwrap();
+        drop(request);
         assert_eq!(result.stdout, b"done");
         assert_eq!(
             event_rx.recv().await.unwrap(),
@@ -2263,10 +2270,7 @@ mod tests {
                 truncated: true,
             }
         );
-        assert!(matches!(
-            event_rx.try_recv(),
-            Err(mpsc::error::TryRecvError::Empty)
-        ));
+        assert_bounded_event_stream_closed(&mut event_rx);
     }
 
     #[tokio::test]
@@ -2323,6 +2327,7 @@ mod tests {
         );
 
         let result = host.bounded_exec(&request).await.unwrap();
+        drop(request);
         assert_eq!(result.stdout, b"done");
         assert_eq!(
             event_rx.recv().await.unwrap(),
@@ -2342,10 +2347,7 @@ mod tests {
                 truncated: true,
             }
         );
-        assert!(matches!(
-            event_rx.try_recv(),
-            Err(mpsc::error::TryRecvError::Empty)
-        ));
+        assert_bounded_event_stream_closed(&mut event_rx);
     }
 
     #[tokio::test]
@@ -2397,6 +2399,7 @@ mod tests {
         );
 
         let result = host.bounded_exec(&request).await.unwrap();
+        drop(request);
         assert_eq!(result.stdout, b"done");
         assert_eq!(
             event_rx.recv().await.unwrap(),
@@ -2470,12 +2473,10 @@ mod tests {
             simple_bounded_request("ignore-bad-chunks", Some(bounded_stream_request(event_tx)));
 
         let result = host.bounded_exec(&request).await.unwrap();
+        drop(request);
 
         assert_eq!(result.stdout, b"done");
-        assert!(matches!(
-            event_rx.try_recv(),
-            Err(mpsc::error::TryRecvError::Empty)
-        ));
+        assert_bounded_event_stream_closed(&mut event_rx);
         assert_eq!(registration_counts(&host), (0, 0, 0, 0));
     }
 
@@ -2528,12 +2529,10 @@ mod tests {
         let request = simple_bounded_request("late-chunk", Some(bounded_stream_request(event_tx)));
 
         let result = host.bounded_exec(&request).await.unwrap();
+        drop(request);
 
         assert_eq!(result.stdout, b"done");
-        assert!(matches!(
-            event_rx.try_recv(),
-            Err(mpsc::error::TryRecvError::Empty)
-        ));
+        assert_bounded_event_stream_closed(&mut event_rx);
         assert_eq!(registration_counts(&host), (0, 0, 0, 0));
     }
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -111,19 +111,153 @@ pub struct BoundedExecResult {
     pub stderr_truncated: bool,
 }
 
-#[derive(Clone)]
 struct BoundedOutputRegistration {
     event_tx: mpsc::UnboundedSender<BoundedExecOutputEvent>,
-    stdout: bool,
-    stderr: bool,
+    chunk_limit_bytes: usize,
+    stdout: BoundedOutputStreamState,
+    stderr: BoundedOutputStreamState,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BoundedOutputStreamState {
+    enabled: bool,
+    limit_bytes: usize,
+    forwarded_bytes: usize,
+    closed: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct BoundedOutputEventPlan {
+    stream: BoundedExecStream,
+    sequence: u32,
+    chunk_len: usize,
+    truncated: bool,
+}
+
+struct BoundedOutputForwardPlan {
+    event_tx: mpsc::UnboundedSender<BoundedExecOutputEvent>,
+    events: Vec<BoundedOutputEventPlan>,
 }
 
 impl BoundedOutputRegistration {
-    fn allows(&self, stream: BoundedExecStream) -> bool {
-        match stream {
-            BoundedExecStream::Stdout => self.stdout,
-            BoundedExecStream::Stderr => self.stderr,
+    fn new(request: &BoundedExecStreamRequest) -> Self {
+        Self {
+            event_tx: request.event_tx.clone(),
+            chunk_limit_bytes: request.chunk_limit_bytes as usize,
+            stdout: BoundedOutputStreamState::new(request.stdout, request.stdout_limit_bytes),
+            stderr: BoundedOutputStreamState::new(request.stderr, request.stderr_limit_bytes),
         }
+    }
+
+    fn forward_plan(
+        &mut self,
+        stream: BoundedExecStream,
+        sequence: u32,
+        chunk_len: usize,
+        truncated: bool,
+    ) -> Option<BoundedOutputForwardPlan> {
+        let chunk_limit_bytes = self.chunk_limit_bytes;
+        let events = self.stream_mut(stream).forward_plan(
+            stream,
+            sequence,
+            chunk_len,
+            truncated,
+            chunk_limit_bytes,
+        );
+        if events.is_empty() {
+            return None;
+        }
+        Some(BoundedOutputForwardPlan {
+            event_tx: self.event_tx.clone(),
+            events,
+        })
+    }
+
+    fn all_streams_closed(&self) -> bool {
+        self.stdout.is_closed_or_disabled() && self.stderr.is_closed_or_disabled()
+    }
+
+    fn stream_mut(&mut self, stream: BoundedExecStream) -> &mut BoundedOutputStreamState {
+        match stream {
+            BoundedExecStream::Stdout => &mut self.stdout,
+            BoundedExecStream::Stderr => &mut self.stderr,
+        }
+    }
+}
+
+impl BoundedOutputStreamState {
+    fn new(enabled: bool, limit_bytes: u32) -> Self {
+        Self {
+            enabled,
+            limit_bytes: limit_bytes as usize,
+            forwarded_bytes: 0,
+            closed: false,
+        }
+    }
+
+    fn is_closed_or_disabled(&self) -> bool {
+        !self.enabled || self.closed
+    }
+
+    fn forward_plan(
+        &mut self,
+        stream: BoundedExecStream,
+        sequence: u32,
+        chunk_len: usize,
+        incoming_truncated: bool,
+        chunk_limit_bytes: usize,
+    ) -> Vec<BoundedOutputEventPlan> {
+        if self.is_closed_or_disabled() {
+            return Vec::new();
+        }
+
+        let remaining = self.limit_bytes.saturating_sub(self.forwarded_bytes);
+
+        if incoming_truncated {
+            let allowed_len = chunk_len.min(chunk_limit_bytes).min(remaining);
+            self.forwarded_bytes = self.forwarded_bytes.saturating_add(allowed_len);
+            self.closed = true;
+            return vec![BoundedOutputEventPlan {
+                stream,
+                sequence,
+                chunk_len: allowed_len,
+                truncated: true,
+            }];
+        }
+
+        if remaining == 0 || chunk_limit_bytes == 0 {
+            self.closed = true;
+            return vec![BoundedOutputEventPlan {
+                stream,
+                sequence,
+                chunk_len: 0,
+                truncated: true,
+            }];
+        }
+
+        let allowed_len = chunk_len.min(chunk_limit_bytes).min(remaining);
+        let mut events = Vec::with_capacity(2);
+        if allowed_len > 0 {
+            events.push(BoundedOutputEventPlan {
+                stream,
+                sequence,
+                chunk_len: allowed_len,
+                truncated: false,
+            });
+            self.forwarded_bytes = self.forwarded_bytes.saturating_add(allowed_len);
+        }
+
+        if allowed_len < chunk_len {
+            self.closed = true;
+            events.push(BoundedOutputEventPlan {
+                stream,
+                sequence: sequence.wrapping_add(1),
+                chunk_len: 0,
+                truncated: true,
+            });
+        }
+
+        events
     }
 }
 
@@ -575,28 +709,51 @@ async fn reader_loop(
             } else if msg.msg_type == MSG_BOUNDED_EXEC_OUTPUT_CHUNK && msg.seq != 0 {
                 if let Ok(decoded) = vsock_proto::decode_bounded_exec_output_chunk(&msg.payload) {
                     let stream = proto_stream_to_host(decoded.stream);
-                    let registration = {
-                        let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-                        match &*guard {
+                    let forward_plan = {
+                        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+                        match &mut *guard {
                             ConnectionState::Connected {
                                 bounded_output_senders,
                                 ..
-                            } => bounded_output_senders.get(&msg.seq).cloned(),
+                            } => {
+                                let (plan, remove_registration) = if let Some(registration) =
+                                    bounded_output_senders.get_mut(&msg.seq)
+                                {
+                                    let plan = registration.forward_plan(
+                                        stream,
+                                        decoded.sequence,
+                                        decoded.chunk.len(),
+                                        decoded.truncated,
+                                    );
+                                    let remove_registration = registration.all_streams_closed();
+                                    (plan, remove_registration)
+                                } else {
+                                    (None, false)
+                                };
+                                if remove_registration {
+                                    bounded_output_senders.remove(&msg.seq);
+                                }
+                                plan
+                            }
                             ConnectionState::Closed { .. } => None,
                         }
                     };
-                    if let Some(registration) = registration {
-                        if !registration.allows(stream) {
-                            continue;
-                        }
-                        let event = BoundedExecOutputEvent {
-                            stream,
-                            sequence: decoded.sequence,
-                            chunk: decoded.chunk.to_vec(),
-                            truncated: decoded.truncated,
-                        };
-                        if registration.event_tx.send(event).is_err() {
-                            shared.remove_bounded_output_sender(msg.seq);
+                    if let Some(forward_plan) = forward_plan {
+                        for event_plan in forward_plan.events {
+                            let event = BoundedExecOutputEvent {
+                                stream: event_plan.stream,
+                                sequence: event_plan.sequence,
+                                chunk: decoded
+                                    .chunk
+                                    .get(..event_plan.chunk_len)
+                                    .unwrap_or_default()
+                                    .to_vec(),
+                                truncated: event_plan.truncated,
+                            };
+                            if forward_plan.event_tx.send(event).is_err() {
+                                shared.remove_bounded_output_sender(msg.seq);
+                                break;
+                            }
                         }
                     }
                 }
@@ -1012,14 +1169,7 @@ impl VsockHost {
                     if let Some(stream) = &request.stream
                         && (stream.stdout || stream.stderr)
                     {
-                        bounded_output_senders.insert(
-                            seq,
-                            BoundedOutputRegistration {
-                                event_tx: stream.event_tx.clone(),
-                                stdout: stream.stdout,
-                                stderr: stream.stderr,
-                            },
-                        );
+                        bounded_output_senders.insert(seq, BoundedOutputRegistration::new(stream));
                     }
                 }
             }
@@ -1442,14 +1592,61 @@ mod tests {
     fn bounded_stream_request(
         event_tx: mpsc::UnboundedSender<BoundedExecOutputEvent>,
     ) -> BoundedExecStreamRequest {
+        bounded_stream_request_with_limits(
+            event_tx,
+            true,
+            true,
+            vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES,
+            2048,
+            2048,
+        )
+    }
+
+    fn bounded_stream_request_with_limits(
+        event_tx: mpsc::UnboundedSender<BoundedExecOutputEvent>,
+        stdout: bool,
+        stderr: bool,
+        chunk_limit_bytes: usize,
+        stdout_limit_bytes: u32,
+        stderr_limit_bytes: u32,
+    ) -> BoundedExecStreamRequest {
         BoundedExecStreamRequest {
             event_tx,
-            stdout: true,
-            stderr: true,
-            chunk_limit_bytes: vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32,
-            stdout_limit_bytes: 2048,
-            stderr_limit_bytes: 2048,
+            stdout,
+            stderr,
+            chunk_limit_bytes: chunk_limit_bytes as u32,
+            stdout_limit_bytes,
+            stderr_limit_bytes,
         }
+    }
+
+    async fn write_bounded_stream_chunk(
+        guest: &mut UnixStream,
+        seq: u32,
+        stream: vsock_proto::BoundedExecStream,
+        sequence: u32,
+        chunk: &[u8],
+        truncated: bool,
+    ) {
+        let payload =
+            vsock_proto::encode_bounded_exec_output_chunk(stream, sequence, chunk, truncated)
+                .unwrap();
+        let frame = vsock_proto::encode(MSG_BOUNDED_EXEC_OUTPUT_CHUNK, seq, &payload).unwrap();
+        guest.write_all(&frame).await.unwrap();
+    }
+
+    async fn write_bounded_exec_result(guest: &mut UnixStream, seq: u32, stdout: &[u8]) {
+        let payload = vsock_proto::encode_bounded_exec_result(
+            vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
+            1,
+            stdout,
+            b"",
+            false,
+            false,
+        )
+        .unwrap();
+        let frame = vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, seq, &payload).unwrap();
+        guest.write_all(&frame).await.unwrap();
     }
 
     #[tokio::test]
@@ -1798,6 +1995,373 @@ mod tests {
             event_rx.try_recv(),
             Err(mpsc::error::TryRecvError::Empty)
         ));
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_caps_stream_output_at_requested_limit() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+
+            write_bounded_stream_chunk(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecStream::Stdout,
+                7,
+                b"abcdef",
+                false,
+            )
+            .await;
+            write_bounded_stream_chunk(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecStream::Stdout,
+                9,
+                b"ignored",
+                false,
+            )
+            .await;
+            write_bounded_exec_result(&mut guest, msgs[0].seq, b"done").await;
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let request = simple_bounded_request(
+            "cap-stdout",
+            Some(bounded_stream_request_with_limits(
+                event_tx,
+                true,
+                false,
+                vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES,
+                4,
+                0,
+            )),
+        );
+
+        let result = host.bounded_exec(&request).await.unwrap();
+        assert_eq!(result.stdout, b"done");
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 7,
+                chunk: b"abcd".to_vec(),
+                truncated: false,
+            }
+        );
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 8,
+                chunk: Vec::new(),
+                truncated: true,
+            }
+        );
+        assert!(matches!(
+            event_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_stdout_cap_does_not_close_stderr() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+
+            write_bounded_stream_chunk(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecStream::Stdout,
+                1,
+                b"abcd",
+                false,
+            )
+            .await;
+            write_bounded_stream_chunk(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecStream::Stderr,
+                5,
+                b"err",
+                false,
+            )
+            .await;
+            write_bounded_exec_result(&mut guest, msgs[0].seq, b"done").await;
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let request = simple_bounded_request(
+            "cap-stdout-keep-stderr",
+            Some(bounded_stream_request_with_limits(
+                event_tx,
+                true,
+                true,
+                vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES,
+                3,
+                8,
+            )),
+        );
+
+        let result = host.bounded_exec(&request).await.unwrap();
+        assert_eq!(result.stdout, b"done");
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 1,
+                chunk: b"abc".to_vec(),
+                truncated: false,
+            }
+        );
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 2,
+                chunk: Vec::new(),
+                truncated: true,
+            }
+        );
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stderr,
+                sequence: 5,
+                chunk: b"err".to_vec(),
+                truncated: false,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_incoming_truncation_closes_stream_once() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+
+            write_bounded_stream_chunk(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecStream::Stdout,
+                30,
+                b"abcdef",
+                true,
+            )
+            .await;
+            write_bounded_stream_chunk(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecStream::Stdout,
+                31,
+                b"ignored",
+                false,
+            )
+            .await;
+            write_bounded_exec_result(&mut guest, msgs[0].seq, b"done").await;
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let request = simple_bounded_request(
+            "incoming-truncated",
+            Some(bounded_stream_request_with_limits(
+                event_tx,
+                true,
+                false,
+                vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES,
+                4,
+                0,
+            )),
+        );
+
+        let result = host.bounded_exec(&request).await.unwrap();
+        assert_eq!(result.stdout, b"done");
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 30,
+                chunk: b"abcd".to_vec(),
+                truncated: true,
+            }
+        );
+        assert!(matches!(
+            event_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_caps_oversized_stream_chunk() {
+        let (host_stream, mut guest) = make_pair();
+        let chunk_limit = vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES;
+        let oversized_chunk = vec![b'a'; chunk_limit + 7];
+
+        tokio::spawn({
+            let oversized_chunk = oversized_chunk.clone();
+            async move {
+                let mut decoder = Decoder::new();
+                mock_handshake(&mut guest, &mut decoder).await;
+
+                let mut buf = [0u8; 4096];
+                let n = guest.read(&mut buf).await.unwrap();
+                let msgs = decoder.decode(&buf[..n]).unwrap();
+                assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+
+                write_bounded_stream_chunk(
+                    &mut guest,
+                    msgs[0].seq,
+                    vsock_proto::BoundedExecStream::Stdout,
+                    11,
+                    &oversized_chunk,
+                    false,
+                )
+                .await;
+                write_bounded_stream_chunk(
+                    &mut guest,
+                    msgs[0].seq,
+                    vsock_proto::BoundedExecStream::Stdout,
+                    13,
+                    b"ignored",
+                    false,
+                )
+                .await;
+                write_bounded_exec_result(&mut guest, msgs[0].seq, b"done").await;
+            }
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let request = simple_bounded_request(
+            "cap-chunk",
+            Some(bounded_stream_request_with_limits(
+                event_tx,
+                true,
+                false,
+                chunk_limit,
+                (chunk_limit * 2) as u32,
+                0,
+            )),
+        );
+
+        let result = host.bounded_exec(&request).await.unwrap();
+        assert_eq!(result.stdout, b"done");
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 11,
+                chunk: vec![b'a'; chunk_limit],
+                truncated: false,
+            }
+        );
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 12,
+                chunk: Vec::new(),
+                truncated: true,
+            }
+        );
+        assert!(matches!(
+            event_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_zero_stream_limit_emits_truncation_marker() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+
+            write_bounded_stream_chunk(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecStream::Stdout,
+                21,
+                b"ignored",
+                false,
+            )
+            .await;
+            write_bounded_stream_chunk(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecStream::Stderr,
+                22,
+                b"err",
+                false,
+            )
+            .await;
+            write_bounded_exec_result(&mut guest, msgs[0].seq, b"done").await;
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let request = simple_bounded_request(
+            "zero-stdout-limit",
+            Some(bounded_stream_request_with_limits(
+                event_tx,
+                true,
+                true,
+                vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES,
+                0,
+                8,
+            )),
+        );
+
+        let result = host.bounded_exec(&request).await.unwrap();
+        assert_eq!(result.stdout, b"done");
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 21,
+                chunk: Vec::new(),
+                truncated: true,
+            }
+        );
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stderr,
+                sequence: 22,
+                chunk: b"err".to_vec(),
+                truncated: false,
+            }
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add host-side per-stream bounded exec forwarding state for stdout/stderr
- enforce stream byte limits and chunk limits before copying forwarded event bytes
- preserve truncation semantics while keeping stdout and stderr independent
- add abnormal guest regression coverage for over-limit, oversized chunk, incoming truncation, and zero-limit streams

Fixes #12211

## Verification
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host bounded_exec`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets`
- pre-commit: `cargo-doc`, workspace `cargo-clippy`
