### PR TITLE
chore(voice-chat): clean up stale realtime relay token references

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat-candidate/voice-chat-candidate-session.ts
@@ -98,6 +98,9 @@ const internalWakeLock$ = state<WakeLockSentinel | null>(null);
 // `transcription.completed` usage to /api/zero/voice-chat-candidate/:id/usage.
 // Mirror of the main path; see voice-chat-session.ts for design rationale.
 const internalUsageReporter$ = state<UsageReporter | null>(null);
+// `relaySessionId` is the audit-row id from /session-started; the field
+// name is a wire-format artifact from the original relay design (Epic
+// #12128 pre-pivot). Plan D keeps the name for contract stability.
 const internalRelaySessionId$ = state<string | null>(null);
 
 const resetSessionSignal$ = resetSignal();

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -93,6 +93,9 @@ const internalWakeLock$ = state<WakeLockSentinel | null>(null);
 // audit row created by /session-started; null means the
 // VoiceChatRealtimeBilling switch is OFF (server returns `id: null` no-op).
 const internalUsageReporter$ = state<UsageReporter | null>(null);
+// `relaySessionId` is the audit-row id from /session-started; the field
+// name is a wire-format artifact from the original relay design (Epic
+// #12128 pre-pivot). Plan D keeps the name for contract stability.
 const internalRelaySessionId$ = state<string | null>(null);
 
 const resetSessionSignal$ = resetSignal();

--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -33,13 +33,6 @@ GIT_COMMIT_SHA=local-dev
 
 SECRETS_ENCRYPTION_KEY=op://Development/vm0/SECRETS_ENCRYPTION_KEY
 
-# Required: HMAC secret for the voice-chat realtime relay token. Verified by
-# apps/api at the WS upgrade endpoint; minted by apps/web bootstrap (added by
-# sub-issue #12140). Mirrored from web/.env.local into api/.env.local by
-# scripts/sync-env.sh. Production deploys MUST set this; the relay route
-# fails closed (WS close 1011) when unset.
-VOICE_CHAT_RELAY_TOKEN_SECRET=op://Development/vm0/VOICE_CHAT_RELAY_TOKEN_SECRET
-
 # Optional: Slack Integration
 SLACK_CLIENT_ID=op://Development/slack/SLACK_CLIENT_ID
 SLACK_CLIENT_SECRET=op://Development/slack/SLACK_CLIENT_SECRET

--- a/turbo/apps/web/app/api/zero/voice-chat-candidate/_support.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat-candidate/_support.ts
@@ -109,8 +109,10 @@ interface VoiceChatGates {
   voiceChatEnabled: boolean;
   /**
    * FeatureSwitchKey.VoiceChatRealtimeBilling — when ON, the token route
-   * mints a VM0 relay-bootstrap instead of an OpenAI client_secret
-   * (Epic #12128). Default OFF; staff-org rollout.
+   * runs credit + pricing admission and the /session-started, /usage,
+   * /session-ended endpoints record + accept browser-reported usage
+   * (Plan D, Epic #12128). When OFF, those endpoints are 200 no-ops.
+   * Default OFF; staff-org rollout.
    */
   realtimeBillingEnabled: boolean;
 }

--- a/turbo/apps/web/app/api/zero/voice-chat-candidate/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat-candidate/token/__tests__/route.test.ts
@@ -168,7 +168,6 @@ describe("POST /api/zero/voice-chat-candidate/token", () => {
       const body = await response.json();
       expect(response.status).toBe(200);
       expect(body.client_secret.value).toBe("ek_test_value");
-      expect(body).not.toHaveProperty("relayToken");
       expect(received?.model).toBe("gpt-realtime-2");
       expect(received?.modalities).toEqual(["text", "audio"]);
       expect(typeof received?.instructions).toBe("string");
@@ -266,7 +265,6 @@ describe("POST /api/zero/voice-chat-candidate/token", () => {
       const body = await response.json();
       expect(response.status).toBe(200);
       expect(body.client_secret.value).toBe("ek_admitted");
-      expect(body).not.toHaveProperty("relayToken");
     });
   });
 });

--- a/turbo/apps/web/app/api/zero/voice-chat/_support.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/_support.ts
@@ -109,8 +109,10 @@ interface VoiceChatGates {
   voiceChatEnabled: boolean;
   /**
    * FeatureSwitchKey.VoiceChatRealtimeBilling — when ON, the token route
-   * mints a VM0 relay-bootstrap instead of an OpenAI client_secret
-   * (Epic #12128). Default OFF; staff-org rollout.
+   * runs credit + pricing admission and the /session-started, /usage,
+   * /session-ended endpoints record + accept browser-reported usage
+   * (Plan D, Epic #12128). When OFF, those endpoints are 200 no-ops.
+   * Default OFF; staff-org rollout.
    */
   realtimeBillingEnabled: boolean;
 }

--- a/turbo/apps/web/app/api/zero/voice-chat/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/token/__tests__/route.test.ts
@@ -166,7 +166,6 @@ describe("POST /api/zero/voice-chat/token", () => {
       const body = await response.json();
       expect(response.status).toBe(200);
       expect(body.client_secret.value).toBe("ek_test_value");
-      expect(body).not.toHaveProperty("relayToken");
       expect(received?.model).toBe("gpt-realtime-2");
       expect(received?.modalities).toEqual(["text", "audio"]);
       expect(typeof received?.instructions).toBe("string");
@@ -264,7 +263,6 @@ describe("POST /api/zero/voice-chat/token", () => {
       const body = await response.json();
       expect(response.status).toBe(200);
       expect(body.client_secret.value).toBe("ek_admitted");
-      expect(body).not.toHaveProperty("relayToken");
     });
   });
 });

--- a/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/credits.ts
@@ -224,9 +224,9 @@ export async function deleteTestUsagePricing(params: {
 
 /**
  * Seed the full Realtime + transcription pricing matrix used by the
- * voice-chat relay billing path. Idempotent (each row upserts on
+ * voice-chat realtime billing path (Plan D). Idempotent (each row upserts on
  * `(kind, provider, category)`), so it is safe to call from any test that
- * needs the relay billable categories priced. Tests that exercise the
+ * needs the realtime billable categories priced. Tests that exercise the
  * missing-pricing-503 path can call `deleteTestUsagePricing(...)` for one
  * specific (provider, category) pair after this helper has seeded the matrix.
  *

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -351,13 +351,16 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.VoiceChatRealtimeBilling]: {
     maintainer: "lancy@vm0.ai",
     description:
-      "Switch the voice-chat token endpoint to mint a VM0 relay-bootstrap " +
-      "instead of an OpenAI client_secret. When OFF, browsers receive the " +
-      "legacy ephemeral OpenAI token. When ON, the route runs credit + " +
-      "pricing admission and mints a short-lived HMAC relay token; the " +
-      "browser opens a WebSocket to /api/zero/voice-chat/relay (sub-issue " +
-      "#12139). Staff-only during rollout; operator flips per org via the " +
-      "feature-switch overrides API.",
+      "Gate voice-chat realtime billing (Plan D, Epic #12128). When OFF, " +
+      "the token route mints an OpenAI ephemeral token without admission " +
+      "checks and the /session-started, /usage, and /session-ended " +
+      "endpoints are 200 no-ops — the org gets unmetered voice-chat. " +
+      "When ON, the token route runs credit + pricing admission, " +
+      "/session-started inserts an audit row in voice_chat_realtime_" +
+      "sessions, and the browser self-reports response.done + " +
+      "transcription.completed usage events for billing. Staff-only " +
+      "during rollout; operator flips per org via the feature-switch " +
+      "overrides API.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },

--- a/turbo/packages/core/src/voice-chat/session-config.ts
+++ b/turbo/packages/core/src/voice-chat/session-config.ts
@@ -1,13 +1,10 @@
 // Static session configuration pushed to OpenAI when configuring the Realtime
-// Talker session. Lives in @vm0/core because two server runtimes consume it:
-//
-//   1. apps/web's createEphemeralToken() — legacy browser-direct path.
-//   2. apps/api's voice-chat-relay openai-realtime-client — server-relayed path.
-//
-// Bytewise equality of the resulting `session.update` (and the legacy REST body)
-// is load-bearing for the realtime-billing rollout: both paths must configure
-// the Talker identically so OpenAI usage events line up across the cutover.
-// Do not duplicate this file — both consumers must import from here.
+// Talker session. Lives in @vm0/core because two consumers in apps/web import
+// it: the production /token route's createEphemeralToken and the candidate-
+// route mirror. Keeping the config in one place makes sure the production and
+// candidate paths configure the Talker identically so OpenAI usage events line
+// up across the A/B comparison. Do not duplicate this file — both consumers
+// must import from here.
 
 const TOOL_PROMPT_PARAM = {
   type: "object",

--- a/turbo/packages/db/src/schema/voice-chat.ts
+++ b/turbo/packages/db/src/schema/voice-chat.ts
@@ -168,13 +168,15 @@ export const voiceChatTasks = pgTable(
 );
 
 /**
- * Server-side OpenAI Realtime relay attempts for a voice-chat session.
- *
- * One row per relay connection. Reconnects (browser drops, network blips,
+ * Audit rows for browser-direct OpenAI Realtime sessions (Plan D, Epic
+ * #12128). One row per browser session; reconnects (network blips,
  * deliberate end-and-resume) create new rows so the `usage_event` audit
- * trail can be correlated by relay session, not by voice-chat session.
+ * trail can be correlated by realtime session, not by voice-chat session.
  *
- * Status flow: starting → active → ended | error.
+ * Lifecycle: /session-started inserts with `status: "active"`;
+ * /session-ended flips to `"ended"`. The `"starting"` and `"error"`
+ * status values are reserved for any future server-side relay path but
+ * are unreachable from the current Plan D code.
  */
 export const voiceChatRealtimeSessions = pgTable(
   "voice_chat_realtime_sessions",


### PR DESCRIPTION
## Summary

Closes #12256.

The relay code itself was retired by #12190 (Plan D pivot — Vercel can't host long-lived WebSocket servers, so the architecture moved to browser-direct WebRTC + browser-reported usage events for billing). What remained on `main` was **stale prose** in comments, JSDoc, env templates, and tests that still described the deleted relay design. This PR aligns the leftover text with what the code actually does today.

- Remove dead `VOICE_CHAT_RELAY_TOKEN_SECRET` line from `.env.local.tpl` (already gone from runtime env / `turbo.json` / api env).
- Rewrite `VoiceChatRealtimeBilling` description to describe what it actually gates today: token-route admission + audit-row insert + browser-reported usage acceptance.
- Rewrite the matching `VoiceChatGates` JSDoc in both `voice-chat` and `voice-chat-candidate` `_support.ts`.
- Rewrite `session-config.ts` header to list only the two live consumers in `apps/web` (`apps/api` consumer was deleted in #12190).
- Rewrite `voice_chat_realtime_sessions` table doc-comment to describe Plan D's actual lifecycle (`active` → `ended`), noting that the `starting` / `error` status values are reserved but unreachable.
- Add a clarifying comment at the platform's `internalRelaySessionId$` declarations explaining the name is a wire-format artifact from the original relay design, kept for contract stability.
- Delete four `relayToken` `not.toHaveProperty` tautology asserts whose only purpose was guarding against a property the contract no longer permits.
- Polish the `seedRealtimeBillingPricing` JSDoc to drop the "relay" wording.

**No behavior change, no contract change, no DB migration.** Both `voice-chat` and `voice-chat-candidate` trees are kept in lockstep.

## Test plan

- [x] `pnpm format` — clean.
- [x] `pnpm turbo run lint` — 0 warnings, 0 errors across all 10 lint tasks.
- [x] `pnpm check-types` — green for all 11 packages.
- [x] `pnpm vitest` — full suite, 861 files / 9179 tests passed.
- [x] `pnpm knip` — exit 0, no orphans introduced.
- [x] `grep -RIn "VOICE_CHAT_RELAY_TOKEN_SECRET" turbo/` — empty.
- [x] `grep -RIn "VM0 relay-bootstrap" turbo/` — empty.
- [x] `grep -RIn "HMAC relay token" turbo/` — empty.
- [x] `grep -RIn "relayToken" turbo/apps/web/app/api/zero/` — empty.
- [x] No remaining "voice-chat-relay openai-realtime-client" cross-reference in `session-config.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)