### PR TITLE
feat(guest-agent): record last event to cli exit metric

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -541,6 +541,8 @@ pub async fn execute_cli(
     });
 
     let mut heartbeat_done = false;
+    let mut last_read_event_at: Option<Instant> = None;
+    let mut cli_exit_at: Option<Instant> = None;
     let event_result: Result<(), AgentError> = loop {
         tokio::select! {
             line_result = reader.next_line(), if !stdout_eof => {
@@ -556,6 +558,7 @@ pub async fn execute_cli(
                         }
 
                         if let Ok(mut event) = serde_json::from_str::<serde_json::Value>(stripped) {
+                            last_read_event_at = Some(Instant::now());
                             // First event is the CLI init (system/init or thread.started)
                             if seq == 0 {
                                 timing::record_e2e_from_api("api_to_cli_init");
@@ -618,6 +621,7 @@ pub async fn execute_cli(
             status = child.wait(), if cli_status.is_none() => {
                 match status {
                     Ok(s) => {
+                        cli_exit_at = Some(Instant::now());
                         log_info!(LOG_TAG, "CLI process exited (status: {s}), draining stdout");
                         cli_status = Some(s);
                         // CLI exited on its own (possibly in response to our
@@ -818,8 +822,22 @@ pub async fn execute_cli(
 
     let status = match cli_status {
         Some(s) => s,
-        None => child.wait().await?,
+        None => {
+            let status = child.wait().await?;
+            cli_exit_at = Some(Instant::now());
+            status
+        }
     };
+    if let (Some(last_read_event_at), Some(cli_exit_at)) = (last_read_event_at, cli_exit_at) {
+        record_sandbox_op(
+            "last_read_event_to_cli_exit",
+            cli_exit_at
+                .checked_duration_since(last_read_event_at)
+                .unwrap_or(Duration::ZERO),
+            true,
+            None,
+        );
+    }
     let exit_code = match status.code() {
         Some(code) => code,
         None => {

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -41,6 +41,8 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
     let _ = std::fs::remove_file(guest_agent::paths::event_error_flag());
     let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
     let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
+    let ops_file = guest_common::telemetry::sandbox_ops_log();
+    let _ = std::fs::remove_file(ops_file);
 
     let disabled = http
         .post_json("http://127.0.0.1:1/should-not-send", &json!({}), 1)
@@ -104,6 +106,20 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
     assert!(
         !std::path::Path::new(guest_agent::paths::event_error_flag()).exists(),
         "no-API execute_cli must not write event error flag"
+    );
+    let ops = std::fs::read_to_string(ops_file)?;
+    let cli_exit_metric_count = ops
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter(|entry| {
+            entry["action_type"] == "last_read_event_to_cli_exit"
+                && entry["success"] == true
+                && entry["duration_ms"].as_u64().is_some()
+        })
+        .count();
+    assert_eq!(
+        cli_exit_metric_count, 1,
+        "execute_cli should record exactly one last-read-event to CLI-exit sandbox op: {ops}"
     );
 
     let _ = std::fs::remove_file(guest_agent::paths::event_error_flag());


### PR DESCRIPTION
## Summary
- record a sandbox op when the CLI process exits after at least one JSON event was read
- emit `last_read_event_to_cli_exit` using the currently last-read event timestamp
- cover the op in the no-API execute_cli regression test

## Tests
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test no_api_mode -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p guest-agent
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings
- pre-commit: cargo-fmt, cargo-doc, cargo-clippy