### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1068,13 +1068,12 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1936,18 +1935,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.5",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,7 +2191,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2241,12 +2228,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "potential_utf"
@@ -2418,15 +2399,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -3316,9 +3288,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",


### PR DESCRIPTION
## Summary

Weekly Rust dependency refresh for the `crates/` workspace. Three lockfile entries advanced to their latest semver-compatible releases; three transitive deps remain stuck on older versions because they are pinned upstream.

## What was updated

| Crate | From | To |
|-------|------|-----|
| `cc` | 1.2.61 | 1.2.62 |
| `filetime` | 0.2.27 | 0.2.28 |
| `tokio` | 1.52.2 | 1.52.3 |

`filetime` 0.2.28 dropped its `libredox` path, so the lockfile also removed the no-longer-needed transitive crates `libredox`, `plain`, and `redox_syscall` 0.7.5.

## Dependencies that could NOT be updated

| Crate | Current | Available | Reason |
|-------|---------|-----------|--------|
| `crc` | 3.3.0 | 3.4.0 | Pinned by `crc-fast` 1.9.0 (transitive via `aws-smithy-checksums` 0.64.7) |
| `crc-fast` | 1.9.0 | 1.10.0 | Pinned by `aws-smithy-checksums` 0.64.7 (latest release of that crate) |
| `generic-array` | 0.14.7 | 0.14.9 | Pinned by `block-buffer` 0.10.4 / `crypto-common` 0.1.7 (transitive via `digest` 0.10.7) |

All three are transitive and gated by upstream releases of `aws-smithy-checksums` and the `digest` 0.10 family. They will unblock once those upstream crates publish updates.

## Manual `Cargo.toml` version bumps

None. Every direct workspace dependency in `crates/Cargo.toml` is already at the latest semver-compatible major; no manual specifier bumps were needed.

## Test status

`cargo test --workspace -j 1 --no-fail-fast` (with `CARGO_PROFILE_TEST_DEBUG=0` to keep the sandbox linker under its 4GB ceiling): **2307 passed, 3 failed, 14 ignored**.

The three failures are all in `vsock-guest`:

- `exec::tests::create_env_script_cleans_dir_on_script_build_failure`
- `exec::tests::env_script_invocation_keeps_secret_out_of_argv`
- `exec::tests::env_script_removes_file_and_directory_when_started`

Each fails with `env script directory is writable by group/other`. These are **pre-existing environmental failures**, not caused by this update — the sandbox runs with `umask 0002`, so `temp_dir()` in `crates/vsock-guest/src/exec.rs:677` creates `0o775` directories, which the security check at `crates/vsock-guest/src/exec.rs:299` correctly rejects. Reproduced on `main` at `9a8063a` with the lockfile reverted; CI does not see this because its umask is `0022`.

## Test plan

- [ ] CI green on linux runners
- [ ] No regressions in `runner` integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)