### PR TITLE
feat: switch zero model pickers to model-first

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
@@ -193,23 +193,41 @@ describe("GET/PUT /api/zero/model-policies", () => {
     ).toBe(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL);
   });
 
-  it("requires admins for policy reads and writes", async () => {
+  it("allows members to read policy controls", async () => {
     const fixture = await seedFixture({
       [FeatureSwitchKey.ModelFirstModelProvider]: true,
     });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
-    const client = apiClient();
-    const listResponse = await client.list({
-      headers: { authorization: "Bearer clerk-session" },
+    const response = await accept(
+      apiClient().list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(
+      response.body.policies.map((policy) => {
+        return policy.model;
+      }),
+    ).toStrictEqual(DEFAULT_ORG_MODEL_POLICY_MODELS);
+    expect(response.body.workspaceDefaultModel).toBe(
+      DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+    );
+  });
+
+  it("requires admins for policy writes", async () => {
+    const fixture = await seedFixture({
+      [FeatureSwitchKey.ModelFirstModelProvider]: true,
     });
-    const updateResponse = await client.update({
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const response = await apiClient().update({
       headers: { authorization: "Bearer clerk-session" },
       body: { policies: [] },
     });
 
-    expect(listResponse.status).toBe(403);
-    expect(updateResponse.status).toBe(403);
+    expect(response.status).toBe(403);
   });
 
   it("updates the explicit workspace default", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-model-policies.ts
+++ b/turbo/apps/api/src/signals/routes/zero-model-policies.ts
@@ -58,9 +58,6 @@ const listModelPoliciesInner$ = command(
     if (!(await isModelPolicyEnabled(get, auth.orgId, auth.userId))) {
       return modelPoliciesDisabled;
     }
-    if (auth.orgRole !== "admin") {
-      return adminRequired;
-    }
 
     const body = await set(
       listOrgModelPolicies$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -36,11 +36,19 @@ import type { ModelProviderSelection } from "../../views/zero-page/components/mo
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { agentById } from "../agent.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
+import {
+  featureSwitch$,
+  modelFirstModelProviderEnabled$,
+} from "../external/feature-switch.ts";
+import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { pinnedAgentIds$ } from "../zero-page/zero-pinned-agents.ts";
 import { composerModelProviders$ } from "../zero-page/composer-model-providers.ts";
-import { resolveEffectiveAgentDefaultSelection } from "../zero-page/model-provider-default.ts";
+import {
+  createModelFirstSelection,
+  resolveEffectiveAgentDefaultSelection,
+  resolveModelFirstAgentDefaultSelection,
+} from "../zero-page/model-provider-default.ts";
 import {
   writeChatMessageToClipboard,
   type ChatClipboardPayload,
@@ -274,6 +282,10 @@ function createModelSelection(
         return user.value;
       }
       const thread = await get(threadData$);
+      const modelFirstEnabled = get(modelFirstModelProviderEnabled$);
+      if (modelFirstEnabled && thread?.selectedModel) {
+        return createModelFirstSelection(thread.selectedModel);
+      }
       if (thread?.modelProviderId && thread.selectedModel) {
         return {
           modelProviderId: thread.modelProviderId,
@@ -290,6 +302,10 @@ function createModelSelection(
       const agent = thread?.agentId
         ? await get(agentById(thread.agentId))
         : null;
+      if (modelFirstEnabled) {
+        const policies = await get(orgModelPolicies$);
+        return resolveModelFirstAgentDefaultSelection({ agent, policies });
+      }
       const composerProviders = await get(composerModelProviders$);
       return resolveEffectiveAgentDefaultSelection({
         agent,
@@ -376,6 +392,10 @@ function createAgentInfoSignals(
         return null;
       }
       const agent = await get(agentById(agentId));
+      if (get(modelFirstModelProviderEnabled$)) {
+        const policies = await get(orgModelPolicies$);
+        return resolveModelFirstAgentDefaultSelection({ agent, policies });
+      }
       const composerProviders = await get(composerModelProviders$);
       return resolveEffectiveAgentDefaultSelection({
         agent,
@@ -1172,14 +1192,24 @@ function createSendMessage(deps: SendMessageDeps) {
       if (!effectiveSelectedModel) {
         const agent = await get(agentById(agentId));
         signal.throwIfAborted();
-        const composerProviders = await get(composerModelProviders$);
-        signal.throwIfAborted();
-        effectiveSelectedModel =
-          resolveEffectiveAgentDefaultSelection({
-            agent,
-            providers: composerProviders.providers,
-            tiers: composerProviders.tiers,
-          })?.selectedModel ?? undefined;
+        if (get(modelFirstModelProviderEnabled$)) {
+          const policies = await get(orgModelPolicies$);
+          signal.throwIfAborted();
+          effectiveSelectedModel =
+            resolveModelFirstAgentDefaultSelection({
+              agent,
+              policies,
+            })?.selectedModel ?? undefined;
+        } else {
+          const composerProviders = await get(composerModelProviders$);
+          signal.throwIfAborted();
+          effectiveSelectedModel =
+            resolveEffectiveAgentDefaultSelection({
+              agent,
+              providers: composerProviders.providers,
+              tiers: composerProviders.tiers,
+            })?.selectedModel ?? undefined;
+        }
       }
 
       const result = await set(

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -39,7 +39,12 @@ import {
 import { toVoid } from "../utils.ts";
 import { agentById } from "../agent.ts";
 import { composerModelProviders$ } from "../zero-page/composer-model-providers.ts";
-import { resolveEffectiveAgentDefaultSelection } from "../zero-page/model-provider-default.ts";
+import {
+  resolveEffectiveAgentDefaultSelection,
+  resolveModelFirstAgentDefaultSelection,
+} from "../zero-page/model-provider-default.ts";
+import { modelFirstModelProviderEnabled$ } from "../external/feature-switch.ts";
+import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { logger } from "../log.ts";
 
 export type { OptimisticChatPane };
@@ -357,14 +362,24 @@ const sendNewThreadMessage$ = command(
     if (!effectiveSelectedModel) {
       const agent = await get(agentById(agentId));
       signal.throwIfAborted();
-      const composerProviders = await get(composerModelProviders$);
-      signal.throwIfAborted();
-      effectiveSelectedModel =
-        resolveEffectiveAgentDefaultSelection({
-          agent,
-          providers: composerProviders.providers,
-          tiers: composerProviders.tiers,
-        })?.selectedModel ?? undefined;
+      if (get(modelFirstModelProviderEnabled$)) {
+        const policies = await get(orgModelPolicies$);
+        signal.throwIfAborted();
+        effectiveSelectedModel =
+          resolveModelFirstAgentDefaultSelection({
+            agent,
+            policies,
+          })?.selectedModel ?? undefined;
+      } else {
+        const composerProviders = await get(composerModelProviders$);
+        signal.throwIfAborted();
+        effectiveSelectedModel =
+          resolveEffectiveAgentDefaultSelection({
+            agent,
+            providers: composerProviders.providers,
+            tiers: composerProviders.tiers,
+          })?.selectedModel ?? undefined;
+      }
     }
     const prepared = await set(
       prepareUserMessageFromDraft$,

--- a/turbo/apps/platform/src/signals/schedule-page/schedule-form.ts
+++ b/turbo/apps/platform/src/signals/schedule-page/schedule-form.ts
@@ -1,6 +1,9 @@
 import { command, computed, state, type Computed } from "ccstate";
 import { agentById } from "../agent.ts";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
+import { modelFirstModelProviderEnabled$ } from "../external/feature-switch.ts";
+import { orgModelPolicies$ } from "../external/org-model-policies.ts";
+import { resolveModelFirstAgentDefaultSelection } from "../zero-page/model-provider-default.ts";
 
 // ---------------------------------------------------------------------------
 // Schedule form data — single state object for all form fields
@@ -213,6 +216,10 @@ function createAgentModelDefault$(
       return null;
     }
     const agent = await get(agentById(agentId));
+    if (get(modelFirstModelProviderEnabled$)) {
+      const policies = await get(orgModelPolicies$);
+      return resolveModelFirstAgentDefaultSelection({ agent, policies });
+    }
     if (!agent?.modelProviderId || !agent.selectedModel) {
       return null;
     }

--- a/turbo/apps/platform/src/signals/zero-page/model-provider-default.ts
+++ b/turbo/apps/platform/src/signals/zero-page/model-provider-default.ts
@@ -3,6 +3,7 @@ import {
   getDefaultModel,
   getModels,
   type ModelProviderResponse,
+  type OrgModelPoliciesResponse,
 } from "@vm0/api-contracts/contracts/model-providers";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 
@@ -12,6 +13,21 @@ interface AgentModelDefaultSource {
   modelProviderId: string | null;
   selectedModel: string | null;
   preferPersonalProvider?: boolean;
+}
+
+const MODEL_FIRST_SELECTION_PROVIDER_ID =
+  "00000000-0000-4000-8000-000000000000";
+
+export function createModelFirstSelection(
+  selectedModel: string | null | undefined,
+): ModelProviderSelection | null {
+  if (!selectedModel) {
+    return null;
+  }
+  return {
+    modelProviderId: MODEL_FIRST_SELECTION_PROVIDER_ID,
+    selectedModel,
+  };
 }
 
 function canProviderUseModel(
@@ -99,4 +115,25 @@ export function resolveEffectiveAgentDefaultSelection(params: {
   }
 
   return resolveWorkspaceDefaultSelection(params.providers, params.tiers);
+}
+
+function resolveModelFirstWorkspaceDefaultSelection(
+  policies: OrgModelPoliciesResponse | null | undefined,
+): ModelProviderSelection | null {
+  const defaultPolicy = policies?.policies.find((policy) => {
+    return policy.isDefault && policy.routeStatus === "valid";
+  });
+  return createModelFirstSelection(
+    defaultPolicy?.model ?? policies?.workspaceDefaultModel,
+  );
+}
+
+export function resolveModelFirstAgentDefaultSelection(params: {
+  agent: AgentModelDefaultSource | null | undefined;
+  policies: OrgModelPoliciesResponse | null | undefined;
+}): ModelProviderSelection | null {
+  return (
+    createModelFirstSelection(params.agent?.selectedModel) ??
+    resolveModelFirstWorkspaceDefaultSelection(params.policies)
+  );
 }

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -1,11 +1,18 @@
 import { command, computed, state } from "ccstate";
 import { talkDraft$ } from "./chat-draft.ts";
 import { getRandomPrompts } from "../../views/zero-page/zero-ideation-data.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
+import {
+  featureSwitch$,
+  modelFirstModelProviderEnabled$,
+} from "../external/feature-switch.ts";
+import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import { currentChatAgent$ } from "../agent-chat.ts";
 import { composerModelProviders$ } from "./composer-model-providers.ts";
-import { resolveEffectiveAgentDefaultSelection } from "./model-provider-default.ts";
+import {
+  resolveEffectiveAgentDefaultSelection,
+  resolveModelFirstAgentDefaultSelection,
+} from "./model-provider-default.ts";
 
 // ---------------------------------------------------------------------------
 // Landing page local UI state for ZeroChatPage
@@ -60,6 +67,26 @@ export const chatPageModelSelection$ = computed(
     // `createModelSelection` (create-chat-thread.ts) for the full
     // display/run mismatch reasoning.
     const agent = await get(currentChatAgent$);
+    if (get(modelFirstModelProviderEnabled$)) {
+      const policies = await get(orgModelPolicies$);
+      return resolveModelFirstAgentDefaultSelection({ agent, policies });
+    }
+    const composerProviders = await get(composerModelProviders$);
+    return resolveEffectiveAgentDefaultSelection({
+      agent,
+      providers: composerProviders.providers,
+      tiers: composerProviders.tiers,
+    });
+  },
+);
+
+export const chatPageAgentModelDefault$ = computed(
+  async (get): Promise<ModelProviderSelection | null> => {
+    const agent = await get(currentChatAgent$);
+    if (get(modelFirstModelProviderEnabled$)) {
+      const policies = await get(orgModelPolicies$);
+      return resolveModelFirstAgentDefaultSelection({ agent, policies });
+    }
     const composerProviders = await get(composerModelProviders$);
     return resolveEffectiveAgentDefaultSelection({
       agent,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-picker-shortcut.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-picker-shortcut.test.tsx
@@ -29,9 +29,11 @@ import {
   setMockOrgModelProviders,
   resetMockOrgModelProviders,
 } from "../../../mocks/handlers/api-org-model-providers.ts";
+import { resetMockOrgModelPolicies } from "../../../mocks/handlers/api-org-model-policies.ts";
 import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.helpers.ts";
 import { setChatShortcutHelpOpen$ } from "../../../signals/chat-page/chat-shortcut-help.ts";
 import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const context = testContext();
 const THREAD_ID = "thread-test-shortcut";
@@ -80,6 +82,7 @@ async function openThreadWithPicker(): Promise<HTMLTextAreaElement> {
 describe("chat composer — mod+alt+. opens the model picker", () => {
   beforeEach(() => {
     resetMockOrgModelProviders();
+    resetMockOrgModelPolicies();
   });
 
   // CHAT-SHORT-MP-001
@@ -103,6 +106,31 @@ describe("chat composer — mod+alt+. opens the model picker", () => {
     // Default model option is present inside the open listbox, confirming the
     // picker wired its provider data into the dropdown body.
     expect(screen.getAllByRole("option").length).toBeGreaterThan(0);
+  });
+
+  it("does not show the agent default option in the model-first chat picker", async () => {
+    const user = userEvent.setup();
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.ModelFirstModelProvider]: true,
+    });
+    setMockOrgModelProviders([]);
+
+    await openThreadWithPicker();
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Use agent default")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Use agent default model"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: /Claude Opus 4\.7/ }),
+    ).toBeInTheDocument();
   });
 
   // CHAT-SHORT-MP-002

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-picker-shortcut.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-picker-shortcut.test.tsx
@@ -125,6 +125,7 @@ describe("chat composer — mod+alt+. opens the model picker", () => {
       expect(screen.getByRole("listbox")).toBeInTheDocument();
     });
     expect(screen.queryByText("Use agent default")).not.toBeInTheDocument();
+    expect(screen.getByText("Models")).toBeInTheDocument();
     expect(
       screen.queryByLabelText("Use agent default model"),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/model-provider-picker-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/model-provider-picker-display.test.tsx
@@ -26,7 +26,9 @@ import {
   setMockOrgModelProviders,
   resetMockOrgModelProviders,
 } from "../../../mocks/handlers/api-org-model-providers.ts";
+import { resetMockOrgModelPolicies } from "../../../mocks/handlers/api-org-model-policies.ts";
 import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.helpers.ts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -87,6 +89,7 @@ async function openProfileTab() {
 describe("model-provider-picker - display with null value", () => {
   beforeEach(() => {
     resetMockOrgModelProviders();
+    resetMockOrgModelPolicies();
   });
 
   // MPKR-D-001: When value is null and default provider has a selectedModel,
@@ -180,6 +183,22 @@ describe("model-provider-picker - display with null value", () => {
     await waitFor(() => {
       expect(
         screen.getByRole("combobox", { name: "Inherit from org default" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows the model-policy workspace default when model-first is enabled with no providers", async () => {
+    setupMockAgent();
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.ModelFirstModelProvider]: true,
+    });
+    setMockOrgModelProviders([]);
+
+    await openProfileTab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
       ).toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/model-provider-picker-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/model-provider-picker-display.test.tsx
@@ -13,6 +13,7 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
   zeroAgentsByIdContract,
   zeroAgentInstructionsContract,
@@ -201,5 +202,34 @@ describe("model-provider-picker - display with null value", () => {
         screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
       ).toBeInTheDocument();
     });
+  });
+
+  it("hides model-policy rows while inheriting and shows all rows after opting out", async () => {
+    const user = userEvent.setup();
+    setupMockAgent();
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.ModelFirstModelProvider]: true,
+    });
+    setMockOrgModelProviders([]);
+
+    await openProfileTab();
+
+    const trigger = await waitFor(() => {
+      return screen.getByRole("combobox", { name: "Claude Sonnet 4.6" });
+    });
+    await user.click(trigger);
+
+    expect(screen.getByLabelText("Use workspace default model")).toBeChecked();
+    expect(screen.queryByText("Models")).not.toBeInTheDocument();
+    expect(screen.queryByText("DeepSeek V4 Pro")).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Use workspace default model"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Models")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Claude Opus 4.7")).toBeInTheDocument();
+    expect(screen.getAllByText("Claude Sonnet 4.6").length).toBeGreaterThan(1);
+    expect(screen.getByText("DeepSeek V4 Pro")).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -27,11 +27,11 @@ import {
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   featureSwitch$,
+  modelFirstModelProviderEnabled$,
   trinityEnabled$,
 } from "../../signals/external/feature-switch.ts";
 import {
   currentChatAgentId$,
-  currentChatAgent$,
   currentChatAgentDisplayName$,
 } from "../../signals/agent-chat.ts";
 import {
@@ -50,8 +50,8 @@ import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-ma
 import { ZeroChatComposer } from "./zero-chat-composer.tsx";
 import { AttachmentLightbox } from "./zero-attachment-chips.tsx";
 import { composerModelProviders$ } from "../../signals/zero-page/composer-model-providers.ts";
-import { resolveEffectiveAgentDefaultSelection } from "../../signals/zero-page/model-provider-default.ts";
 import {
+  chatPageAgentModelDefault$,
   chatPageInput$,
   chatPageModelSelection$,
   setChatPageInput$,
@@ -476,14 +476,8 @@ export function AgentChatPage() {
   const modelSelection = useLastResolved(chatPageModelSelection$) ?? null;
   const setModelSelection = useSet(setChatPageModelSelection$);
   const resetModelSelection = useSet(resetChatPageModelSelection$);
-  const currentAgent = useLastResolved(currentChatAgent$);
-  const agentModelDefault = composerProviders
-    ? resolveEffectiveAgentDefaultSelection({
-        agent: currentAgent,
-        providers: composerProviders.providers,
-        tiers: composerProviders.tiers,
-      })
-    : null;
+  const modelFirstEnabled = useGet(modelFirstModelProviderEnabled$);
+  const agentModelDefault = useLastResolved(chatPageAgentModelDefault$) ?? null;
 
   const handleSendMessage = (message: string) => {
     if (!currentChatAgentId) {
@@ -559,7 +553,8 @@ export function AgentChatPage() {
             displayName={currentChatAgentDisplayName ?? ""}
             autoFocus
             modelPicker={
-              composerProviders && composerProviders.providers.length > 0
+              composerProviders &&
+              (modelFirstEnabled || composerProviders.providers.length > 0)
                 ? {
                     providers: composerProviders.providers,
                     tiers: composerProviders.tiers,

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -563,6 +563,7 @@ export function AgentChatPage() {
                     // No prior session exists on the landing page.
                     sessionProviderType: null,
                     agentDefault: agentModelDefault,
+                    showUseDefault: !modelFirstEnabled,
                   }
                 : undefined
             }

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -523,13 +523,19 @@ function ModelFirstTriggerLabel({
     );
   }
   const iconType = getModelFirstIconType(selectedModel);
+  const multiplier = getVm0ModelMultiplier(selectedModel);
   return (
     <ResponsiveTriggerContent
       mobileIcon={mobileIcon}
       iconType={iconType}
       label={
-        <span className="truncate">
-          {getCanonicalModelDisplayName(selectedModel)}
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span className="truncate">
+            {getCanonicalModelDisplayName(selectedModel)}
+          </span>
+          {multiplier !== undefined && (
+            <MultiplierBadge multiplier={multiplier} />
+          )}
         </span>
       }
     />
@@ -642,10 +648,7 @@ function modelFirstSelectionFromRaw(
 
 function ModelFirstPolicyRow({ policy }: { policy: OrgModelPolicy }) {
   const iconType = getModelFirstIconType(policy.model);
-  const multiplier =
-    policy.defaultProviderType === "vm0"
-      ? getVm0ModelMultiplier(policy.model)
-      : undefined;
+  const multiplier = getVm0ModelMultiplier(policy.model);
   return (
     <SelectItem
       key={policy.id}
@@ -659,11 +662,6 @@ function ModelFirstPolicyRow({ policy }: { policy: OrgModelPolicy }) {
         </span>
         {multiplier !== undefined && (
           <MultiplierBadge multiplier={multiplier} />
-        )}
-        {policy.isDefault && (
-          <span className="ml-0.5 shrink-0 rounded bg-accent px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-            Workspace default
-          </span>
         )}
       </span>
     </SelectItem>

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -797,10 +797,12 @@ function ModelFirstModelPicker({
             onChange(effectiveDefault);
           }}
         />
-        <ModelFirstPolicyItems
-          policies={policies}
-          explicitSelectedModel={explicitSelectedModel}
-        />
+        {value !== null && (
+          <ModelFirstPolicyItems
+            policies={policies}
+            explicitSelectedModel={explicitSelectedModel}
+          />
+        )}
       </SelectContent>
     </Select>
   );

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -789,12 +789,10 @@ function ModelFirstModelPicker({
             onChange(effectiveDefault);
           }}
         />
-        {value !== null && (
-          <ModelFirstPolicyItems
-            policies={policies}
-            explicitSelectedModel={explicitSelectedModel}
-          />
-        )}
+        <ModelFirstPolicyItems
+          policies={policies}
+          explicitSelectedModel={explicitSelectedModel}
+        />
       </SelectContent>
     </Select>
   );

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -736,6 +736,7 @@ function ModelFirstModelPicker({
   const defaultSource = inheritLabel ?? autoDefaultSource;
   const selectedModel = resolved?.selectedModel ?? null;
   const explicitSelectedModel = value?.selectedModel ?? null;
+  const showModelPolicies = value !== null;
   const triggerAriaLabel = selectedModel
     ? getCanonicalModelDisplayName(selectedModel)
     : placeholder;
@@ -789,10 +790,12 @@ function ModelFirstModelPicker({
             onChange(effectiveDefault);
           }}
         />
-        <ModelFirstPolicyItems
-          policies={policies}
-          explicitSelectedModel={explicitSelectedModel}
-        />
+        {showModelPolicies && (
+          <ModelFirstPolicyItems
+            policies={policies}
+            explicitSelectedModel={explicitSelectedModel}
+          />
+        )}
       </SelectContent>
     </Select>
   );

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -523,19 +523,13 @@ function ModelFirstTriggerLabel({
     );
   }
   const iconType = getModelFirstIconType(selectedModel);
-  const multiplier = getVm0ModelMultiplier(selectedModel);
   return (
     <ResponsiveTriggerContent
       mobileIcon={mobileIcon}
       iconType={iconType}
       label={
-        <span className="flex min-w-0 items-center gap-1.5">
-          <span className="truncate">
-            {getCanonicalModelDisplayName(selectedModel)}
-          </span>
-          {multiplier !== undefined && (
-            <MultiplierBadge multiplier={multiplier} />
-          )}
+        <span className="truncate">
+          {getCanonicalModelDisplayName(selectedModel)}
         </span>
       }
     />

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -103,6 +103,8 @@ interface ModelProviderPickerProps {
    * the agent itself falls back to workspace.
    */
   inheritLabel?: "agent" | "workspace";
+  /** When false, hide the "Use default" row from the dropdown. */
+  showUseDefault?: boolean;
   /**
    * Per-provider tier annotation (Wave 3 of Epic #11868). When provided,
    * the picker groups items into "Personal" and "Org" sections with
@@ -714,6 +716,7 @@ function ModelFirstModelPicker({
   disabled,
   agentDefault,
   inheritLabel,
+  showUseDefault = true,
 }: ModelProviderPickerProps & {
   placeholder: string;
   compactTrigger: boolean;
@@ -736,7 +739,7 @@ function ModelFirstModelPicker({
   const defaultSource = inheritLabel ?? autoDefaultSource;
   const selectedModel = resolved?.selectedModel ?? null;
   const explicitSelectedModel = value?.selectedModel ?? null;
-  const showModelPolicies = value !== null;
+  const showModelPolicies = !showUseDefault || value !== null;
   const triggerAriaLabel = selectedModel
     ? getCanonicalModelDisplayName(selectedModel)
     : placeholder;
@@ -776,20 +779,32 @@ function ModelFirstModelPicker({
           />
         </SelectValue>
       </SelectTrigger>
-      <SelectContent className="max-h-[280px] min-w-[260px]">
-        <ModelFirstInheritToggleRow
-          effectiveDefault={effectiveDefault}
-          defaultSource={defaultSource}
-          isInheriting={value === null}
-          onToggle={(inherit) => {
-            if (inherit) {
-              onChange(null);
-              onOpenChange?.(false);
-              return;
-            }
-            onChange(effectiveDefault);
-          }}
-        />
+      <SelectContent
+        className="max-h-none min-w-[260px]"
+        hideScrollButtons
+        viewportClassName="h-auto max-h-none"
+      >
+        {showUseDefault ? (
+          <ModelFirstInheritToggleRow
+            effectiveDefault={effectiveDefault}
+            defaultSource={defaultSource}
+            isInheriting={value === null}
+            onToggle={(inherit) => {
+              if (inherit) {
+                onChange(null);
+                onOpenChange?.(false);
+                return;
+              }
+              onChange(effectiveDefault);
+            }}
+          />
+        ) : (
+          value === null && (
+            <SelectItem value={INHERIT_SENTINEL} className="hidden absolute">
+              {placeholder}
+            </SelectItem>
+          )
+        )}
         {showModelPolicies && (
           <ModelFirstPolicyItems
             policies={policies}
@@ -1101,6 +1116,11 @@ function ModelSelectDropdown({
         </SelectValue>
       </SelectTrigger>
       <SelectContent className="max-h-[280px] min-w-[260px]">
+        {!showUseDefault && value === null && (
+          <SelectItem value={INHERIT_SENTINEL} className="hidden absolute">
+            {placeholder}
+          </SelectItem>
+        )}
         {showUseDefault && (
           <InheritToggleRow
             effectiveDefault={effectiveDefault}
@@ -1159,6 +1179,7 @@ export function ModelProviderPicker({
   disabled = false,
   agentDefault,
   inheritLabel,
+  showUseDefault = true,
   tiers,
 }: ModelProviderPickerProps) {
   const features = useLastResolved(featureSwitch$);
@@ -1180,6 +1201,7 @@ export function ModelProviderPicker({
         disabled={disabled}
         agentDefault={agentDefault}
         inheritLabel={inheritLabel}
+        showUseDefault={showUseDefault}
         tiers={tiers}
       />
     );
@@ -1227,7 +1249,7 @@ export function ModelProviderPicker({
       onChange={onChange}
       open={open}
       onOpenChange={onOpenChange}
-      showUseDefault
+      showUseDefault={showUseDefault}
       tiers={tiers}
     />
   );

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -1,6 +1,7 @@
 import type { MouseEvent, ReactNode } from "react";
-import { useGet, useLastResolved, useSet } from "ccstate-react";
+import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import { IconCpu } from "@tabler/icons-react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   Select,
   SelectContent,
@@ -20,25 +21,35 @@ import {
 import {
   areProvidersCompatible,
   getDefaultModel,
+  getCanonicalModelDisplayName,
   getModels,
+  getProvidersForModel,
   getVm0VisibleModels,
   MODEL_PROVIDER_TYPES,
   VM0_MODEL_TO_PROVIDER,
   type ModelProviderResponse,
   type ModelProviderType,
+  type OrgModelPolicy,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { getModelDisplayName } from "@vm0/core/model-display-name";
 import {
   showAllVm0Models$,
   toggleShowAllVm0Models$,
 } from "../../../signals/zero-page/model-picker-ui";
-import { featureSwitch$ } from "../../../signals/external/feature-switch";
+import {
+  featureSwitch$,
+  modelFirstModelProviderEnabled$,
+} from "../../../signals/external/feature-switch";
+import { orgModelPolicies$ } from "../../../signals/external/org-model-policies";
 import {
   getUILabel,
   getVm0ModelMultiplier,
   isVm0PrimaryModel,
 } from "./settings/provider-ui-config";
 import { ProviderIcon } from "./settings/provider-icons";
+
+export const MODEL_FIRST_SELECTION_PROVIDER_ID =
+  "00000000-0000-4000-8000-000000000000";
 
 export interface ModelProviderSelection {
   modelProviderId: string;
@@ -446,6 +457,355 @@ function DisabledPickerLabel({
   );
 }
 
+function isModelFirstPolicyVisible(
+  policy: OrgModelPolicy,
+  features: Parameters<typeof getVm0VisibleModels>[0] | undefined,
+): boolean {
+  if (policy.model.startsWith("gpt-")) {
+    return features?.[FeatureSwitchKey.CodexBeta] ?? false;
+  }
+  return true;
+}
+
+function getModelFirstIconType(model: string): ModelProviderType | undefined {
+  const vm0Entry = VM0_MODEL_TO_PROVIDER[model];
+  if (vm0Entry) {
+    return vm0Entry.concreteType as ModelProviderType;
+  }
+  return getProvidersForModel(model).find((type) => {
+    return type !== "vm0";
+  });
+}
+
+function resolveModelFirstDefault(
+  value: ModelProviderSelection | null,
+  agentDefault: ModelProviderSelection | null | undefined,
+  policies: OrgModelPolicy[],
+): {
+  resolved: ModelProviderSelection | null;
+  effectiveDefault: ModelProviderSelection | null;
+  defaultSource: DefaultSource;
+} {
+  const validWorkspaceDefault = policies.find((policy) => {
+    return policy.isDefault && policy.routeStatus === "valid";
+  });
+  const effectiveDefault =
+    agentDefault ??
+    (validWorkspaceDefault
+      ? {
+          modelProviderId: MODEL_FIRST_SELECTION_PROVIDER_ID,
+          selectedModel: validWorkspaceDefault.model,
+        }
+      : null);
+  return {
+    resolved: value ?? effectiveDefault,
+    effectiveDefault,
+    defaultSource: agentDefault ? "agent" : "workspace",
+  };
+}
+
+function ModelFirstTriggerLabel({
+  selectedModel,
+  placeholder,
+  mobileIcon,
+}: {
+  selectedModel: string | null;
+  placeholder: string;
+  mobileIcon: boolean;
+}) {
+  if (!selectedModel) {
+    return (
+      <ResponsiveTriggerContent
+        mobileIcon={mobileIcon}
+        iconType={undefined}
+        label={<span>{placeholder}</span>}
+      />
+    );
+  }
+  const iconType = getModelFirstIconType(selectedModel);
+  return (
+    <ResponsiveTriggerContent
+      mobileIcon={mobileIcon}
+      iconType={iconType}
+      label={
+        <span className="truncate">
+          {getCanonicalModelDisplayName(selectedModel)}
+        </span>
+      }
+    />
+  );
+}
+
+function ModelFirstDisabledPickerLabel({
+  value,
+  placeholder,
+  mobileIconTrigger,
+  triggerClassName,
+  agentDefault,
+  policies,
+}: Pick<
+  ModelProviderPickerProps,
+  | "value"
+  | "placeholder"
+  | "compactTrigger"
+  | "mobileIconTrigger"
+  | "triggerClassName"
+  | "agentDefault"
+> & {
+  placeholder: string;
+  compactTrigger: boolean;
+  mobileIconTrigger: boolean;
+  policies: OrgModelPolicy[];
+}) {
+  const { resolved } = resolveModelFirstDefault(value, agentDefault, policies);
+  const selectedModel = resolved?.selectedModel ?? null;
+  return (
+    <span
+      aria-label={
+        selectedModel
+          ? getCanonicalModelDisplayName(selectedModel)
+          : placeholder
+      }
+      className={cn(
+        "inline-flex items-center px-2 text-sm text-muted-foreground cursor-default",
+        stripInteractiveClasses(triggerClassName),
+      )}
+    >
+      <ModelFirstTriggerLabel
+        selectedModel={selectedModel}
+        placeholder={placeholder}
+        mobileIcon={mobileIconTrigger}
+      />
+    </span>
+  );
+}
+
+function ModelFirstInheritToggleRow({
+  effectiveDefault,
+  defaultSource,
+  isInheriting,
+  onToggle,
+}: {
+  effectiveDefault: ModelProviderSelection | null;
+  defaultSource: DefaultSource;
+  isInheriting: boolean;
+  onToggle: (inherit: boolean) => void;
+}) {
+  const sourceLabel = defaultSource === "agent" ? "agent" : "workspace";
+  return (
+    <>
+      <SelectItem value={INHERIT_SENTINEL} className="hidden absolute">
+        Use {sourceLabel} default
+      </SelectItem>
+      <div
+        className="flex items-center justify-between gap-3 rounded-md px-2 py-1.5 text-sm cursor-pointer hover:bg-accent transition-colors"
+        onClick={(e) => {
+          e.preventDefault();
+          onToggle(!isInheriting);
+        }}
+      >
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <span className="font-medium text-foreground">
+            Use {sourceLabel} default
+          </span>
+          {effectiveDefault && (
+            <span className="truncate text-xs text-muted-foreground">
+              {getCanonicalModelDisplayName(effectiveDefault.selectedModel)}
+            </span>
+          )}
+        </div>
+        <Switch
+          size="sm"
+          checked={isInheriting}
+          onCheckedChange={onToggle}
+          onClick={(e: MouseEvent) => {
+            e.stopPropagation();
+          }}
+          aria-label={`Use ${sourceLabel} default model`}
+        />
+      </div>
+    </>
+  );
+}
+
+function modelFirstSelectionFromRaw(
+  raw: string,
+): ModelProviderSelection | null {
+  if (raw === INHERIT_SENTINEL) {
+    return null;
+  }
+  return {
+    modelProviderId: MODEL_FIRST_SELECTION_PROVIDER_ID,
+    selectedModel: raw,
+  };
+}
+
+function ModelFirstPolicyRow({ policy }: { policy: OrgModelPolicy }) {
+  const iconType = getModelFirstIconType(policy.model);
+  const multiplier =
+    policy.defaultProviderType === "vm0"
+      ? getVm0ModelMultiplier(policy.model)
+      : undefined;
+  return (
+    <SelectItem
+      key={policy.id}
+      value={policy.model}
+      disabled={policy.routeStatus !== "valid"}
+    >
+      <span className="flex min-w-0 items-center gap-2">
+        {iconType && <ProviderIcon type={iconType} size={16} />}
+        <span className="truncate">
+          {policy.modelLabel || getCanonicalModelDisplayName(policy.model)}
+        </span>
+        {multiplier !== undefined && (
+          <MultiplierBadge multiplier={multiplier} />
+        )}
+        {policy.isDefault && (
+          <span className="ml-0.5 shrink-0 rounded bg-accent px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Workspace default
+          </span>
+        )}
+      </span>
+    </SelectItem>
+  );
+}
+
+function ModelFirstPolicyItems({
+  policies,
+  explicitSelectedModel,
+}: {
+  policies: OrgModelPolicy[];
+  explicitSelectedModel: string | null;
+}) {
+  const hasExplicitSelectedPolicy =
+    explicitSelectedModel === null ||
+    policies.some((policy) => {
+      return policy.model === explicitSelectedModel;
+    });
+  return (
+    <>
+      {(!hasExplicitSelectedPolicy || policies.length > 0) && (
+        <SelectSeparator className="my-0" />
+      )}
+      {!hasExplicitSelectedPolicy && explicitSelectedModel && (
+        <SelectItem value={explicitSelectedModel} className="hidden absolute">
+          {getCanonicalModelDisplayName(explicitSelectedModel)}
+        </SelectItem>
+      )}
+      {policies.length === 0 ? (
+        <div className="px-2 py-2 text-sm text-muted-foreground">
+          No configured models
+        </div>
+      ) : (
+        <SelectGroup>
+          <SelectLabel className="pl-2 pr-8 py-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/60">
+            Models
+          </SelectLabel>
+          {policies.map((policy) => {
+            return <ModelFirstPolicyRow key={policy.id} policy={policy} />;
+          })}
+        </SelectGroup>
+      )}
+    </>
+  );
+}
+
+function ModelFirstModelPicker({
+  value,
+  onChange,
+  placeholder,
+  triggerClassName,
+  compactTrigger,
+  mobileIconTrigger,
+  open,
+  onOpenChange,
+  disabled,
+  agentDefault,
+  inheritLabel,
+}: ModelProviderPickerProps & {
+  placeholder: string;
+  compactTrigger: boolean;
+  mobileIconTrigger: boolean;
+}) {
+  const policiesLoadable = useLoadable(orgModelPolicies$);
+  const lastPolicies = useLastResolved(orgModelPolicies$);
+  const features = useLastResolved(featureSwitch$);
+  const policyResponse =
+    policiesLoadable.state === "hasData" ? policiesLoadable.data : lastPolicies;
+  const policies =
+    policyResponse?.policies.filter((policy) => {
+      return isModelFirstPolicyVisible(policy, features);
+    }) ?? [];
+  const {
+    resolved,
+    effectiveDefault,
+    defaultSource: autoDefaultSource,
+  } = resolveModelFirstDefault(value, agentDefault, policies);
+  const defaultSource = inheritLabel ?? autoDefaultSource;
+  const selectedModel = resolved?.selectedModel ?? null;
+  const explicitSelectedModel = value?.selectedModel ?? null;
+  const triggerAriaLabel = selectedModel
+    ? getCanonicalModelDisplayName(selectedModel)
+    : placeholder;
+
+  if (disabled) {
+    return (
+      <ModelFirstDisabledPickerLabel
+        value={value}
+        placeholder={placeholder}
+        compactTrigger={compactTrigger}
+        mobileIconTrigger={mobileIconTrigger}
+        triggerClassName={triggerClassName}
+        agentDefault={agentDefault}
+        policies={policies}
+      />
+    );
+  }
+
+  return (
+    <Select
+      value={value ? value.selectedModel : INHERIT_SENTINEL}
+      onValueChange={(raw) => {
+        onChange(modelFirstSelectionFromRaw(raw));
+      }}
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <SelectTrigger
+        aria-label={triggerAriaLabel}
+        className={cn("h-9 w-full", triggerClassName)}
+      >
+        <SelectValue placeholder={placeholder}>
+          <ModelFirstTriggerLabel
+            selectedModel={selectedModel}
+            placeholder={placeholder}
+            mobileIcon={mobileIconTrigger}
+          />
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent className="max-h-[280px] min-w-[260px]">
+        <ModelFirstInheritToggleRow
+          effectiveDefault={effectiveDefault}
+          defaultSource={defaultSource}
+          isInheriting={value === null}
+          onToggle={(inherit) => {
+            if (inherit) {
+              onChange(null);
+              onOpenChange?.(false);
+              return;
+            }
+            onChange(effectiveDefault);
+          }}
+        />
+        <ModelFirstPolicyItems
+          policies={policies}
+          explicitSelectedModel={explicitSelectedModel}
+        />
+      </SelectContent>
+    </Select>
+  );
+}
+
 interface ProviderGroup {
   provider: ModelProviderResponse;
   label: string;
@@ -807,6 +1167,28 @@ export function ModelProviderPicker({
   tiers,
 }: ModelProviderPickerProps) {
   const features = useLastResolved(featureSwitch$);
+  const modelFirstEnabled = useGet(modelFirstModelProviderEnabled$);
+
+  if (modelFirstEnabled) {
+    return (
+      <ModelFirstModelPicker
+        providers={providers}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        triggerClassName={triggerClassName}
+        sessionProviderType={sessionProviderType}
+        compactTrigger={compactTrigger}
+        mobileIconTrigger={mobileIconTrigger}
+        open={open}
+        onOpenChange={onOpenChange}
+        disabled={disabled}
+        agentDefault={agentDefault}
+        inheritLabel={inheritLabel}
+        tiers={tiers}
+      />
+    );
+  }
 
   if (disabled) {
     return (

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -667,9 +667,11 @@ function ModelFirstPolicyRow({ policy }: { policy: OrgModelPolicy }) {
 function ModelFirstPolicyItems({
   policies,
   explicitSelectedModel,
+  showSeparator = true,
 }: {
   policies: OrgModelPolicy[];
   explicitSelectedModel: string | null;
+  showSeparator?: boolean;
 }) {
   const hasExplicitSelectedPolicy =
     explicitSelectedModel === null ||
@@ -678,7 +680,7 @@ function ModelFirstPolicyItems({
     });
   return (
     <>
-      {(!hasExplicitSelectedPolicy || policies.length > 0) && (
+      {showSeparator && (!hasExplicitSelectedPolicy || policies.length > 0) && (
         <SelectSeparator className="my-0" />
       )}
       {!hasExplicitSelectedPolicy && explicitSelectedModel && (
@@ -809,6 +811,7 @@ function ModelFirstModelPicker({
           <ModelFirstPolicyItems
             policies={policies}
             explicitSelectedModel={explicitSelectedModel}
+            showSeparator={showUseDefault}
           />
         )}
       </SelectContent>

--- a/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
@@ -3,6 +3,7 @@
 import { useGet, useSet, useLastResolved } from "ccstate-react";
 import { createPortal } from "react-dom";
 import { IconX } from "@tabler/icons-react";
+import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
 import {
   Button,
   Input,
@@ -33,10 +34,15 @@ import {
   showConfirm$,
   setShowConfirm$,
   dialogAgentModelDefault$,
+  type ScheduleFormData,
 } from "../../signals/schedule-page/schedule-form.ts";
 import { orgModelProviders$ } from "../../signals/external/org-model-providers.ts";
-import { personalModelProviderEnabled$ } from "../../signals/external/feature-switch.ts";
 import {
+  modelFirstModelProviderEnabled$,
+  personalModelProviderEnabled$,
+} from "../../signals/external/feature-switch.ts";
+import {
+  MODEL_FIRST_SELECTION_PROVIDER_ID,
   ModelProviderPicker,
   type ModelProviderSelection,
 } from "./components/model-provider-picker.tsx";
@@ -544,6 +550,88 @@ function getSaveLabel(mode: "create" | "edit", saving: boolean): string {
   return saving ? "Creating\u2026" : "Create";
 }
 
+function getScheduleModelPickerValue(
+  form: ScheduleFormData,
+  modelFirstEnabled: boolean,
+): ModelProviderSelection | null {
+  if (!form.selectedModel || (!modelFirstEnabled && !form.modelProviderId)) {
+    return null;
+  }
+  return {
+    modelProviderId: form.modelProviderId ?? MODEL_FIRST_SELECTION_PROVIDER_ID,
+    selectedModel: form.selectedModel,
+  };
+}
+
+function ScheduleDialogModelControls({
+  form,
+  updateForm,
+  orgProviders,
+  agentModelDefault,
+  modelFirstEnabled,
+  personalProviderEnabled,
+}: {
+  form: ScheduleFormData;
+  updateForm: (patch: Partial<ScheduleFormData>) => void;
+  orgProviders: { modelProviders: ModelProviderResponse[] } | undefined;
+  agentModelDefault: ModelProviderSelection | null;
+  modelFirstEnabled: boolean;
+  personalProviderEnabled: boolean;
+}) {
+  const showModelPicker =
+    orgProviders &&
+    (modelFirstEnabled || orgProviders.modelProviders.length > 0);
+  return (
+    <>
+      {showModelPicker && (
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-foreground">
+            Model
+            <span className="text-muted-foreground font-normal ml-1">
+              (optional)
+            </span>
+          </label>
+          <ModelProviderPicker
+            providers={orgProviders.modelProviders}
+            value={getScheduleModelPickerValue(form, modelFirstEnabled)}
+            onChange={(sel: ModelProviderSelection | null) => {
+              updateForm({
+                modelProviderId: modelFirstEnabled
+                  ? null
+                  : (sel?.modelProviderId ?? null),
+                selectedModel: sel?.selectedModel ?? null,
+              });
+            }}
+            agentDefault={agentModelDefault}
+            inheritLabel="agent"
+          />
+        </div>
+      )}
+
+      {personalProviderEnabled && !modelFirstEnabled && (
+        <div className="flex items-start gap-2">
+          <Switch
+            id="schedule-prefer-personal"
+            checked={form.preferPersonalProvider}
+            onCheckedChange={(v) => {
+              updateForm({ preferPersonalProvider: v });
+            }}
+            aria-label="Use personal provider"
+            className="mt-0.5"
+          />
+          <label
+            htmlFor="schedule-prefer-personal"
+            className="text-sm text-muted-foreground leading-snug"
+          >
+            Use the caller&apos;s personal provider when available, fall back to
+            the selected one above.
+          </label>
+        </div>
+      )}
+    </>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Inner dialog (manages form state, mounted only when open)
 // ---------------------------------------------------------------------------
@@ -559,7 +647,7 @@ function ScheduleFormDialogInner({
 }: Omit<ScheduleFormDialogProps, "open"> & {
   preferredTimezone: string | null | undefined;
 }) {
-  const init = buildDefaults(agents, initialValues, preferredTimezone);
+  const baseInit = buildDefaults(agents, initialValues, preferredTimezone);
 
   const updateForm = useSet(updateDialogForm$);
   const form = useGet(dialogForm$);
@@ -570,7 +658,11 @@ function ScheduleFormDialogInner({
 
   const agentModelDefault = useLastResolved(dialogAgentModelDefault$) ?? null;
 
+  const modelFirstEnabled = useGet(modelFirstModelProviderEnabled$);
   const personalProviderEnabled = useGet(personalModelProviderEnabled$);
+  const init = modelFirstEnabled
+    ? { ...baseInit, modelProviderId: null }
+    : baseInit;
 
   const current: ScheduleFormValues = {
     prompt: form.prompt,
@@ -584,7 +676,7 @@ function ScheduleFormDialogInner({
     loopMinutes: form.loopMinutes,
     dayOfWeek: form.dayOfWeek,
     dayOfMonth: form.dayOfMonth,
-    modelProviderId: form.modelProviderId,
+    modelProviderId: modelFirstEnabled ? null : form.modelProviderId,
     selectedModel: form.selectedModel,
     preferPersonalProvider: form.preferPersonalProvider,
   };
@@ -756,56 +848,14 @@ function ScheduleFormDialogInner({
             }}
           />
 
-          {orgProviders && orgProviders.modelProviders.length > 0 && (
-            <div className="flex flex-col gap-2">
-              <label className="text-sm font-medium text-foreground">
-                Model
-                <span className="text-muted-foreground font-normal ml-1">
-                  (optional)
-                </span>
-              </label>
-              <ModelProviderPicker
-                providers={orgProviders.modelProviders}
-                value={
-                  form.modelProviderId && form.selectedModel
-                    ? {
-                        modelProviderId: form.modelProviderId,
-                        selectedModel: form.selectedModel,
-                      }
-                    : null
-                }
-                onChange={(sel: ModelProviderSelection | null) => {
-                  updateForm({
-                    modelProviderId: sel?.modelProviderId ?? null,
-                    selectedModel: sel?.selectedModel ?? null,
-                  });
-                }}
-                agentDefault={agentModelDefault}
-                inheritLabel="agent"
-              />
-            </div>
-          )}
-
-          {personalProviderEnabled && (
-            <div className="flex items-start gap-2">
-              <Switch
-                id="schedule-prefer-personal"
-                checked={form.preferPersonalProvider}
-                onCheckedChange={(v) => {
-                  updateForm({ preferPersonalProvider: v });
-                }}
-                aria-label="Use personal provider"
-                className="mt-0.5"
-              />
-              <label
-                htmlFor="schedule-prefer-personal"
-                className="text-sm text-muted-foreground leading-snug"
-              >
-                Use the caller&apos;s personal provider when available, fall
-                back to the selected one above.
-              </label>
-            </div>
-          )}
+          <ScheduleDialogModelControls
+            form={form}
+            updateForm={updateForm}
+            orgProviders={orgProviders}
+            agentModelDefault={agentModelDefault}
+            modelFirstEnabled={modelFirstEnabled}
+            personalProviderEnabled={personalProviderEnabled}
+          />
         </div>
 
         <DialogFooter>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -213,6 +213,8 @@ interface ZeroChatComposerProps {
     disabled?: boolean;
     /** The agent-level default model, shown as a "Default" tag in the dropdown. */
     agentDefault?: ModelProviderSelection | null;
+    /** Hide the "Use default" row in compact chat pickers. */
+    showUseDefault?: boolean;
   };
 }
 
@@ -1309,6 +1311,7 @@ export function ZeroChatComposer({
                         disabled={modelPicker.disabled}
                         agentDefault={modelPicker.agentDefault}
                         inheritLabel="agent"
+                        showUseDefault={modelPicker.showUseDefault}
                       />
                     )}
                     <div className="mx-0 h-5 w-px bg-border/60 sm:mx-0.5" />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -59,7 +59,10 @@ import type {
 import emptyChatImg from "./assets/empty-chat.webp";
 import emptyArtifactImg from "./assets/empty-artifact.webp";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import {
+  featureSwitch$,
+  modelFirstModelProviderEnabled$,
+} from "../../signals/external/feature-switch.ts";
 import { playTts$, stopTts$ } from "../../signals/voice-io/voice-io-tts.ts";
 import {
   autoReadEnabled$,
@@ -1901,6 +1904,7 @@ function ChatThreadComposer({
   const modelSelection = useLastResolved(thread.modelSelection$) ?? null;
   const setModelSelection = useSet(thread.setModelSelection$);
   const agentModelDefault = useLastResolved(thread.agentModelDefault$) ?? null;
+  const modelFirstEnabled = useGet(modelFirstModelProviderEnabled$);
   // During thread switch the thread-level skeleton is visible and
   // `threadData` / `allFinished$` may still reflect the previous thread;
   // render the whole action cluster as a skeleton so we don't flash stale
@@ -1985,7 +1989,8 @@ function ChatThreadComposer({
             setInputRef={setInputRef}
             actionsLoading={skeletonVisible}
             modelPicker={
-              composerProviders && composerProviders.providers.length > 0
+              composerProviders &&
+              (modelFirstEnabled || composerProviders.providers.length > 0)
                 ? {
                     providers: composerProviders.providers,
                     tiers: composerProviders.tiers,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2003,6 +2003,7 @@ function ChatThreadComposer({
                     // continuity.
                     disabled: hasUserMessages,
                     agentDefault: agentModelDefault,
+                    showUseDefault: !modelFirstEnabled,
                   }
                 : undefined
             }

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
@@ -103,8 +103,12 @@ import {
   type ScheduleSettingsSnapshot,
 } from "../../signals/schedule-page/schedule-form.ts";
 import { orgModelProviders$ } from "../../signals/external/org-model-providers.ts";
-import { personalModelProviderEnabled$ } from "../../signals/external/feature-switch.ts";
 import {
+  modelFirstModelProviderEnabled$,
+  personalModelProviderEnabled$,
+} from "../../signals/external/feature-switch.ts";
+import {
+  MODEL_FIRST_SELECTION_PROVIDER_ID,
   ModelProviderPicker,
   type ModelProviderSelection,
 } from "./components/model-provider-picker.tsx";
@@ -325,10 +329,14 @@ function ScheduleSettingsForm({
 
   const agentModelDefault = useLastResolved(scheduleAgentModelDefault$) ?? null;
 
+  const modelFirstEnabled = useGet(modelFirstModelProviderEnabled$);
   const personalProviderEnabled = useGet(personalModelProviderEnabled$);
+  const normalizedInitial = modelFirstEnabled
+    ? { ...initial, modelProviderId: null }
+    : initial;
 
   // Reset form when entry changes (component is keyed by entry.id)
-  useSet(syncSettingsFormEntry$)(entry.id, entry.prompt, initial);
+  useSet(syncSettingsFormEntry$)(entry.id, entry.prompt, normalizedInitial);
 
   const current: ScheduleSettingsSnapshot = {
     freq: form.freq,
@@ -341,7 +349,7 @@ function ScheduleSettingsForm({
     description: form.description,
     dayOfWeek: form.dayOfWeek,
     dayOfMonth: form.dayOfMonth,
-    modelProviderId: form.modelProviderId,
+    modelProviderId: modelFirstEnabled ? null : form.modelProviderId,
     selectedModel: form.selectedModel,
     preferPersonalProvider: form.preferPersonalProvider,
   };
@@ -381,7 +389,7 @@ function ScheduleSettingsForm({
       intervalSeconds: form.loopMinutes * 60,
       editName: entry.name,
       agentId: form.agentId,
-      modelProviderId: form.modelProviderId,
+      modelProviderId: modelFirstEnabled ? null : form.modelProviderId,
       selectedModel: form.selectedModel,
       preferPersonalProvider: form.preferPersonalProvider,
       ...(form.freq === "every_week" ? { dayOfWeek: form.dayOfWeek } : {}),
@@ -490,35 +498,41 @@ function ScheduleSettingsForm({
             />
           </InlineSettingsRow>
 
-          {orgProviders && orgProviders.modelProviders.length > 0 && (
-            <InlineSettingsRow
-              label="Model"
-              description="Override the agent's default model for this schedule."
-            >
-              <div className={SCHEDULE_DETAIL_CONTROL_WIDTH}>
-                <ModelProviderPicker
-                  providers={orgProviders.modelProviders}
-                  value={
-                    form.modelProviderId && form.selectedModel
-                      ? {
-                          modelProviderId: form.modelProviderId,
-                          selectedModel: form.selectedModel,
-                        }
-                      : null
-                  }
-                  onChange={(sel: ModelProviderSelection | null) => {
-                    updateForm({
-                      modelProviderId: sel?.modelProviderId ?? null,
-                      selectedModel: sel?.selectedModel ?? null,
-                    });
-                  }}
-                  agentDefault={agentModelDefault}
-                  inheritLabel="agent"
-                />
-              </div>
-            </InlineSettingsRow>
-          )}
-          {personalProviderEnabled && (
+          {orgProviders &&
+            (modelFirstEnabled || orgProviders.modelProviders.length > 0) && (
+              <InlineSettingsRow
+                label="Model"
+                description="Override the agent's default model for this schedule."
+              >
+                <div className={SCHEDULE_DETAIL_CONTROL_WIDTH}>
+                  <ModelProviderPicker
+                    providers={orgProviders.modelProviders}
+                    value={
+                      form.selectedModel &&
+                      (modelFirstEnabled || form.modelProviderId)
+                        ? {
+                            modelProviderId:
+                              form.modelProviderId ??
+                              MODEL_FIRST_SELECTION_PROVIDER_ID,
+                            selectedModel: form.selectedModel,
+                          }
+                        : null
+                    }
+                    onChange={(sel: ModelProviderSelection | null) => {
+                      updateForm({
+                        modelProviderId: modelFirstEnabled
+                          ? null
+                          : (sel?.modelProviderId ?? null),
+                        selectedModel: sel?.selectedModel ?? null,
+                      });
+                    }}
+                    agentDefault={agentModelDefault}
+                    inheritLabel="agent"
+                  />
+                </div>
+              </InlineSettingsRow>
+            )}
+          {personalProviderEnabled && !modelFirstEnabled && (
             <InlineSettingsRow
               label="Personal provider"
               description="Use the caller's personal provider when available, fall back to the selected one above."

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -56,8 +56,12 @@ import {
   setSettingsPreferPersonalProvider$,
 } from "../../signals/zero-page/settings/settings-tab.ts";
 import { orgModelProviders$ } from "../../signals/external/org-model-providers.ts";
-import { personalModelProviderEnabled$ } from "../../signals/external/feature-switch.ts";
 import {
+  modelFirstModelProviderEnabled$,
+  personalModelProviderEnabled$,
+} from "../../signals/external/feature-switch.ts";
+import {
+  MODEL_FIRST_SELECTION_PROVIDER_ID,
   ModelProviderPicker,
   type ModelProviderSelection,
 } from "./components/model-provider-picker.tsx";
@@ -105,10 +109,13 @@ export function ZeroSettingsTab({
   isDefaultAgent = false,
   onDelete,
 }: ZeroSettingsTabProps) {
+  const modelFirstEnabled = useGet(modelFirstModelProviderEnabled$);
   const initialModelSelection: ModelProviderSelection | null =
-    initialModelProviderId && initialSelectedModel
+    initialSelectedModel && (modelFirstEnabled || initialModelProviderId)
       ? {
-          modelProviderId: initialModelProviderId,
+          modelProviderId: modelFirstEnabled
+            ? MODEL_FIRST_SELECTION_PROVIDER_ID
+            : (initialModelProviderId ?? MODEL_FIRST_SELECTION_PROVIDER_ID),
           selectedModel: initialSelectedModel,
         }
       : null;
@@ -163,7 +170,9 @@ export function ZeroSettingsTab({
             description: desc,
             sound: tone,
             avatarUrl,
-            modelProviderId: modelSelection?.modelProviderId ?? null,
+            modelProviderId: modelFirstEnabled
+              ? null
+              : (modelSelection?.modelProviderId ?? null),
             selectedModel: modelSelection?.selectedModel ?? null,
             preferPersonalProvider,
           },
@@ -219,8 +228,9 @@ export function ZeroSettingsTab({
                           description: desc,
                           sound: tone,
                           avatarUrl: newAvatarUrl,
-                          modelProviderId:
-                            modelSelection?.modelProviderId ?? null,
+                          modelProviderId: modelFirstEnabled
+                            ? null
+                            : (modelSelection?.modelProviderId ?? null),
                           selectedModel: modelSelection?.selectedModel ?? null,
                           preferPersonalProvider,
                         },
@@ -332,19 +342,20 @@ export function ZeroSettingsTab({
                 </div>
               </div>
             </InlineSettingsRow>
-            {orgProviders && orgProviders.modelProviders.length > 0 && (
-              <InlineSettingsRow
-                label="Model"
-                description="The model used by this agent. Defaults to the workspace setting."
-              >
-                <ModelProviderPicker
-                  providers={orgProviders.modelProviders}
-                  value={modelSelection}
-                  onChange={setModelSelection}
-                />
-              </InlineSettingsRow>
-            )}
-            {personalProviderEnabled && (
+            {orgProviders &&
+              (modelFirstEnabled || orgProviders.modelProviders.length > 0) && (
+                <InlineSettingsRow
+                  label="Model"
+                  description="The model used by this agent. Defaults to the workspace setting."
+                >
+                  <ModelProviderPicker
+                    providers={orgProviders.modelProviders}
+                    value={modelSelection}
+                    onChange={setModelSelection}
+                  />
+                </InlineSettingsRow>
+              )}
+            {personalProviderEnabled && !modelFirstEnabled && (
               <InlineSettingsRow
                 label="Personal provider"
                 description="Use the caller's personal provider when available, fall back to the selected one above."

--- a/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/index.ts
@@ -227,6 +227,7 @@ export {
   seedUserCacheEntry,
   insertUserCacheEntry,
   insertVm0ApiKeys,
+  deleteInsertedVm0ApiKeys,
   insertTestVoiceChatSession,
   countUserRows,
   getPushSubscriptionsByEndpoint,

--- a/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
@@ -16,6 +16,7 @@ export {
   seedUserCacheEntry,
   insertUserCacheEntry,
   insertVm0ApiKeys,
+  deleteInsertedVm0ApiKeys,
 } from "../db-test-seeders/users";
 export { insertTestVoiceChatSession } from "../db-test-seeders/voice-chat";
 

--- a/turbo/apps/web/src/__tests__/db-test-seeders/users.ts
+++ b/turbo/apps/web/src/__tests__/db-test-seeders/users.ts
@@ -1,4 +1,5 @@
 import { initServices } from "../../lib/init-services";
+import { and, eq, or } from "drizzle-orm";
 import { users } from "@vm0/db/schema/user";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
@@ -65,4 +66,38 @@ export async function insertVm0ApiKeys(
 ) {
   initServices();
   await globalThis.services.db.insert(vm0ApiKeys).values(keys);
+  insertedVm0ApiKeys.push(...keys);
+}
+
+type InsertedVm0ApiKey = {
+  vendor: string;
+  model: string;
+  apiKey: string;
+};
+
+const insertedVm0ApiKeys: InsertedVm0ApiKey[] = [];
+
+/**
+ * Delete VM0 API keys inserted through insertVm0ApiKeys in the current test worker.
+ * @why-db-direct Cleans up direct VM0 key-pool fixtures so local dev-seed keys are not polluted
+ */
+export async function deleteInsertedVm0ApiKeys(): Promise<void> {
+  initServices();
+  const keys = insertedVm0ApiKeys.splice(0);
+
+  if (keys.length > 0) {
+    const predicate = or(
+      ...keys.map((key) => {
+        return and(
+          eq(vm0ApiKeys.vendor, key.vendor),
+          eq(vm0ApiKeys.model, key.model),
+          eq(vm0ApiKeys.apiKey, key.apiKey),
+        );
+      }),
+    );
+
+    if (predicate) {
+      await globalThis.services.db.delete(vm0ApiKeys).where(predicate);
+    }
+  }
 }

--- a/turbo/apps/web/src/__tests__/vm0-provider.test.ts
+++ b/turbo/apps/web/src/__tests__/vm0-provider.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { POST } from "../../app/api/zero/model-providers/route";
 import {
   createTestRequest,
   createTestOrg,
   insertVm0ApiKeys,
+  deleteInsertedVm0ApiKeys,
   getTestVm0ApiKey,
   insertOrgDefaultModelProvider,
 } from "./api-test-helpers";
@@ -46,6 +47,10 @@ function orgUrl(): string {
 describe("VM0 managed model provider", () => {
   beforeEach(() => {
     context.setupMocks();
+  });
+
+  afterEach(async () => {
+    await deleteInsertedVm0ApiKeys();
   });
 
   describe("API route: org slug check", () => {

--- a/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   testContext,
   uniqueId,
@@ -13,6 +13,7 @@ import {
   completeTestRun,
   findTestRunnerJobEntry,
   insertVm0ApiKeys,
+  deleteInsertedVm0ApiKeys,
   insertTestConnectorSecret,
   insertUserDefaultModelProvider,
   enablePersonalModelProviderForUser,
@@ -44,6 +45,10 @@ import { AUTO_MEMORY_ARTIFACT_NAME, AUTO_MEMORY_MOUNT_PATH } from "../memory";
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 
 const context = testContext();
+
+afterEach(async () => {
+  await deleteInsertedVm0ApiKeys();
+});
 
 describe("Org-Level Runtime Resolution (Zero Layer)", () => {
   let user: UserContext;

--- a/turbo/apps/web/src/lib/zero/context/__tests__/resolve-model-provider.test.ts
+++ b/turbo/apps/web/src/lib/zero/context/__tests__/resolve-model-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   resolveModelProviderSecrets,
   resolveModelRoute,
@@ -23,6 +23,7 @@ import {
   enableModelFirstModelProviderForUser,
   insertOrgModelPolicy,
   insertVm0ApiKeys,
+  deleteInsertedVm0ApiKeys,
   setTestModelProviderNeedsReconnect,
   ORG_SENTINEL_USER_ID,
 } from "../../../../__tests__/api-test-helpers";
@@ -34,6 +35,10 @@ import {
 } from "../../../../__tests__/db-test-seeders/secrets";
 
 const context = testContext();
+
+afterEach(async () => {
+  await deleteInsertedVm0ApiKeys();
+});
 
 async function setupOrg(userId: string): Promise<string> {
   const orgSlug = uniqueId("resolver");
@@ -1085,7 +1090,7 @@ describe("resolveModelProviderSecrets — model-first policy (#12130)", () => {
     await enableModelFirstModelProviderForUser(orgId, userId);
     await insertOrgModelPolicy({
       orgId,
-      model: "gpt-5.5",
+      model: "deepseek-v4-pro",
       isDefault: true,
       defaultProviderType: "vm0",
       credentialScope: "org",
@@ -1099,7 +1104,7 @@ describe("resolveModelProviderSecrets — model-first policy (#12130)", () => {
         false,
         undefined,
         undefined,
-        "gpt-5.5",
+        "deepseek-v4-pro",
       ),
     ).rejects.toSatisfy((err: unknown) => {
       return isBadRequest(err);

--- a/turbo/packages/ui/src/components/ui/select.tsx
+++ b/turbo/packages/ui/src/components/ui/select.tsx
@@ -75,41 +75,58 @@ SelectScrollDownButton.displayName =
 
 const SelectContent = React.forwardRef<
   React.ComponentRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", style, ...props }, ref) => {
-  return (
-    <SelectPrimitive.Portal>
-      <SelectPrimitive.Content
-        ref={ref}
-        className={cn(
-          "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-card text-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-          position === "popper" &&
-            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-          className,
-        )}
-        style={{
-          boxShadow:
-            "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)",
-          ...style,
-        }}
-        position={position}
-        {...props}
-      >
-        <SelectScrollUpButton />
-        <SelectPrimitive.Viewport
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
+    hideScrollButtons?: boolean;
+    viewportClassName?: string;
+  }
+>(
+  (
+    {
+      className,
+      children,
+      position = "popper",
+      style,
+      hideScrollButtons = false,
+      viewportClassName,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <SelectPrimitive.Portal>
+        <SelectPrimitive.Content
+          ref={ref}
           className={cn(
-            "flex flex-col gap-1 p-1",
+            "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-card text-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
             position === "popper" &&
-              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+              "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+            className,
           )}
+          style={{
+            boxShadow:
+              "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)",
+            ...style,
+          }}
+          position={position}
+          {...props}
         >
-          {children}
-        </SelectPrimitive.Viewport>
-        <SelectScrollDownButton />
-      </SelectPrimitive.Content>
-    </SelectPrimitive.Portal>
-  );
-});
+          {!hideScrollButtons && <SelectScrollUpButton />}
+          <SelectPrimitive.Viewport
+            className={cn(
+              "flex flex-col gap-1 p-1",
+              position === "popper" &&
+                "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+              viewportClassName,
+            )}
+          >
+            {children}
+          </SelectPrimitive.Viewport>
+          {!hideScrollButtons && <SelectScrollDownButton />}
+        </SelectPrimitive.Content>
+      </SelectPrimitive.Portal>
+    );
+  },
+);
 SelectContent.displayName = SelectPrimitive.Content.displayName;
 
 const SelectLabel = React.forwardRef<


### PR DESCRIPTION
## Summary
- Gate chat, agent settings, and schedule model pickers behind ModelFirstModelProvider and render configured org model policies instead of provider/model groups
- Persist selectedModel-only for agent and schedule overrides under the switch while keeping provider-first payloads unchanged when off
- Resolve composer/default display and visual attachment model checks from model policies under the switch

## Tests
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/model-provider-picker-display.test.tsx

Note: the repo-wide pre-commit check-types hook currently fails in web on src/lib/zero/voice-chat/usage-namespaces.ts missing the uuid module/types; platform check-types passes.

Closes #12132