### PR TITLE
feat: add bounded exec output policies

### DIFF
--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1179,6 +1179,35 @@ fn sandbox_output_to_host(
     }
 }
 
+fn spawn_bounded_stream_bridge(
+    expected_stream: HostBoundedExecStream,
+    stream: Option<&sandbox::BoundedExecStreamPolicy>,
+    bridge_tasks: &mut Vec<tokio::task::JoinHandle<()>>,
+) -> Option<HostBoundedExecStreamPolicy> {
+    let stream = stream?;
+    let (host_tx, mut host_rx) = mpsc::unbounded_channel::<HostBoundedExecOutputEvent>();
+    let sandbox_tx = stream.event_tx.clone();
+    bridge_tasks.push(tokio::spawn(async move {
+        while let Some(event) = host_rx.recv().await {
+            debug_assert_eq!(event.stream, expected_stream);
+            if event.stream != expected_stream {
+                continue;
+            }
+            if sandbox_tx
+                .send(host_bounded_event_to_sandbox(event))
+                .is_err()
+            {
+                break;
+            }
+        }
+    }));
+    Some(HostBoundedExecStreamPolicy {
+        event_tx: host_tx,
+        limit_bytes: stream.limit_bytes,
+        chunk_limit_bytes: stream.chunk_limit_bytes,
+    })
+}
+
 #[async_trait]
 impl Sandbox for FirecrackerSandbox {
     // -- identity --
@@ -1442,59 +1471,17 @@ impl Sandbox for FirecrackerSandbox {
         let operation = SandboxOperation::BoundedExec;
         let guest = self.operation_guest(operation).await?;
 
-        let has_stream = request.stdout.stream.is_some() || request.stderr.stream.is_some();
-        let (bridge_task, stdout_stream, stderr_stream) = if has_stream {
-            let (host_tx, mut host_rx) = mpsc::unbounded_channel::<HostBoundedExecOutputEvent>();
-            let mut stdout_tx = request
-                .stdout
-                .stream
-                .as_ref()
-                .map(|stream| stream.event_tx.clone());
-            let mut stderr_tx = request
-                .stderr
-                .stream
-                .as_ref()
-                .map(|stream| stream.event_tx.clone());
-            let task = tokio::spawn(async move {
-                while let Some(event) = host_rx.recv().await {
-                    let target = match event.stream {
-                        HostBoundedExecStream::Stdout => &mut stdout_tx,
-                        HostBoundedExecStream::Stderr => &mut stderr_tx,
-                    };
-                    if let Some(tx) = target
-                        && tx.send(host_bounded_event_to_sandbox(event)).is_err()
-                    {
-                        *target = None;
-                    }
-                    if stdout_tx.is_none() && stderr_tx.is_none() {
-                        break;
-                    }
-                }
-            });
-            let stdout_stream =
-                request
-                    .stdout
-                    .stream
-                    .as_ref()
-                    .map(|stream| HostBoundedExecStreamPolicy {
-                        event_tx: host_tx.clone(),
-                        limit_bytes: stream.limit_bytes,
-                        chunk_limit_bytes: stream.chunk_limit_bytes,
-                    });
-            let stderr_stream =
-                request
-                    .stderr
-                    .stream
-                    .as_ref()
-                    .map(|stream| HostBoundedExecStreamPolicy {
-                        event_tx: host_tx,
-                        limit_bytes: stream.limit_bytes,
-                        chunk_limit_bytes: stream.chunk_limit_bytes,
-                    });
-            (Some(task), stdout_stream, stderr_stream)
-        } else {
-            (None, None, None)
-        };
+        let mut bridge_tasks = Vec::new();
+        let stdout_stream = spawn_bounded_stream_bridge(
+            HostBoundedExecStream::Stdout,
+            request.stdout.stream.as_ref(),
+            &mut bridge_tasks,
+        );
+        let stderr_stream = spawn_bounded_stream_bridge(
+            HostBoundedExecStream::Stderr,
+            request.stderr.stream.as_ref(),
+            &mut bridge_tasks,
+        );
 
         let host_request = HostBoundedExecRequest {
             command: request.cmd,
@@ -1518,7 +1505,7 @@ impl Sandbox for FirecrackerSandbox {
         };
 
         drop(host_request);
-        if let Some(task) = bridge_task {
+        for task in bridge_tasks {
             let _ = task.await;
         }
 
@@ -2110,6 +2097,80 @@ mod tests {
 
             assert_operation_reason(err, SandboxOperationReason::BackendCrashed);
         }
+    }
+
+    #[tokio::test]
+    async fn bounded_stream_bridges_close_independently() {
+        let (stdout_tx, stdout_rx) = mpsc::unbounded_channel();
+        drop(stdout_rx);
+        let (stderr_tx, mut stderr_rx) = mpsc::unbounded_channel();
+        let stdout_policy = sandbox::BoundedExecStreamPolicy {
+            event_tx: stdout_tx,
+            limit_bytes: 128,
+            chunk_limit_bytes: 64,
+        };
+        let stderr_policy = sandbox::BoundedExecStreamPolicy {
+            event_tx: stderr_tx,
+            limit_bytes: 256,
+            chunk_limit_bytes: 64,
+        };
+
+        let mut bridge_tasks = Vec::new();
+        let stdout_host = spawn_bounded_stream_bridge(
+            HostBoundedExecStream::Stdout,
+            Some(&stdout_policy),
+            &mut bridge_tasks,
+        )
+        .expect("stdout stream should create a host bridge");
+        let stderr_host = spawn_bounded_stream_bridge(
+            HostBoundedExecStream::Stderr,
+            Some(&stderr_policy),
+            &mut bridge_tasks,
+        )
+        .expect("stderr stream should create a host bridge");
+        assert_eq!(bridge_tasks.len(), 2);
+
+        let stdout_task = bridge_tasks.remove(0);
+        let stderr_task = bridge_tasks.remove(0);
+        stdout_host
+            .event_tx
+            .send(HostBoundedExecOutputEvent {
+                stream: HostBoundedExecStream::Stdout,
+                sequence: 1,
+                chunk: b"lost".to_vec(),
+                truncated: false,
+            })
+            .expect("stdout host bridge should be open for first event");
+        tokio::time::timeout(Duration::from_secs(1), stdout_task)
+            .await
+            .expect("stdout bridge should exit after receiver is dropped")
+            .expect("stdout bridge task should not panic");
+        assert!(stdout_host.event_tx.is_closed());
+
+        stderr_host
+            .event_tx
+            .send(HostBoundedExecOutputEvent {
+                stream: HostBoundedExecStream::Stderr,
+                sequence: 2,
+                chunk: b"kept".to_vec(),
+                truncated: true,
+            })
+            .expect("stderr host bridge should remain open");
+        assert_eq!(
+            stderr_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stderr,
+                sequence: 2,
+                chunk: b"kept".to_vec(),
+                truncated: true,
+            }
+        );
+
+        drop(stderr_host);
+        tokio::time::timeout(Duration::from_secs(1), stderr_task)
+            .await
+            .expect("stderr bridge should exit after host sender is dropped")
+            .expect("stderr bridge task should not panic");
     }
 
     /// Exercise the `monitor_process` crash detection flow through real child

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -8,10 +8,10 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use sandbox::{
-    BoundedExecOutputEvent, BoundedExecRequest, BoundedExecResult, BoundedExecStream,
-    BoundedExecTermination, ExecRequest, ExecResult, ProcessExit, Sandbox, SandboxConfig,
-    SandboxError, SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation,
-    SandboxOperationReason, SpawnHandle,
+    BoundedExecCapturePolicy, BoundedExecOutput, BoundedExecOutputEvent, BoundedExecOutputRequest,
+    BoundedExecRequest, BoundedExecResult, BoundedExecStream, BoundedExecTermination, ExecRequest,
+    ExecResult, ProcessExit, Sandbox, SandboxConfig, SandboxError, SandboxIdleTransition,
+    SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason, SpawnHandle,
 };
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::sync::{mpsc, watch};
@@ -19,9 +19,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, trace, warn};
 use vsock_host::{
     BoundedExecOutputEvent as HostBoundedExecOutputEvent,
+    BoundedExecOutputRequest as HostBoundedExecOutputRequest,
     BoundedExecRequest as HostBoundedExecRequest, BoundedExecResult as HostBoundedExecResult,
     BoundedExecStream as HostBoundedExecStream,
-    BoundedExecStreamRequest as HostBoundedExecStreamRequest,
+    BoundedExecStreamPolicy as HostBoundedExecStreamPolicy,
     BoundedExecTermination as HostBoundedExecTermination, VsockHost,
 };
 
@@ -1138,14 +1139,43 @@ fn host_bounded_termination_to_sandbox(
     }
 }
 
+fn host_bounded_output_to_sandbox(output: vsock_host::BoundedExecOutput) -> BoundedExecOutput {
+    match output {
+        vsock_host::BoundedExecOutput::Discarded => BoundedExecOutput::Discarded,
+        vsock_host::BoundedExecOutput::Captured { bytes, truncated } => {
+            BoundedExecOutput::Captured { bytes, truncated }
+        }
+    }
+}
+
 fn host_bounded_result_to_sandbox(result: HostBoundedExecResult) -> BoundedExecResult {
     BoundedExecResult {
         termination: host_bounded_termination_to_sandbox(result.termination),
         duration: Duration::from_millis(result.duration_ms),
-        stdout: result.stdout,
-        stderr: result.stderr,
-        stdout_truncated: result.stdout_truncated,
-        stderr_truncated: result.stderr_truncated,
+        stdout: host_bounded_output_to_sandbox(result.stdout),
+        stderr: host_bounded_output_to_sandbox(result.stderr),
+        diagnostic: result.diagnostic,
+    }
+}
+
+fn sandbox_capture_to_host(
+    capture: BoundedExecCapturePolicy,
+) -> vsock_host::BoundedExecCapturePolicy {
+    match capture {
+        BoundedExecCapturePolicy::Discard => vsock_host::BoundedExecCapturePolicy::Discard,
+        BoundedExecCapturePolicy::Capture { limit_bytes } => {
+            vsock_host::BoundedExecCapturePolicy::Capture { limit_bytes }
+        }
+    }
+}
+
+fn sandbox_output_to_host(
+    output: &BoundedExecOutputRequest,
+    stream: Option<HostBoundedExecStreamPolicy>,
+) -> HostBoundedExecOutputRequest {
+    HostBoundedExecOutputRequest {
+        capture: sandbox_capture_to_host(output.capture),
+        stream,
     }
 }
 
@@ -1412,34 +1442,58 @@ impl Sandbox for FirecrackerSandbox {
         let operation = SandboxOperation::BoundedExec;
         let guest = self.operation_guest(operation).await?;
 
-        let (bridge_task, host_stream) = if let Some(stream) = &request.stream
-            && (stream.stdout || stream.stderr)
-        {
-            let (host_tx, mut host_rx) = mpsc::unbounded_channel();
-            let sandbox_tx = stream.event_tx.clone();
+        let has_stream = request.stdout.stream.is_some() || request.stderr.stream.is_some();
+        let (bridge_task, stdout_stream, stderr_stream) = if has_stream {
+            let (host_tx, mut host_rx) = mpsc::unbounded_channel::<HostBoundedExecOutputEvent>();
+            let mut stdout_tx = request
+                .stdout
+                .stream
+                .as_ref()
+                .map(|stream| stream.event_tx.clone());
+            let mut stderr_tx = request
+                .stderr
+                .stream
+                .as_ref()
+                .map(|stream| stream.event_tx.clone());
             let task = tokio::spawn(async move {
                 while let Some(event) = host_rx.recv().await {
-                    if sandbox_tx
-                        .send(host_bounded_event_to_sandbox(event))
-                        .is_err()
+                    let target = match event.stream {
+                        HostBoundedExecStream::Stdout => &mut stdout_tx,
+                        HostBoundedExecStream::Stderr => &mut stderr_tx,
+                    };
+                    if let Some(tx) = target
+                        && tx.send(host_bounded_event_to_sandbox(event)).is_err()
                     {
+                        *target = None;
+                    }
+                    if stdout_tx.is_none() && stderr_tx.is_none() {
                         break;
                     }
                 }
             });
-            (
-                Some(task),
-                Some(HostBoundedExecStreamRequest {
-                    event_tx: host_tx,
-                    stdout: stream.stdout,
-                    stderr: stream.stderr,
-                    chunk_limit_bytes: stream.chunk_limit_bytes,
-                    stdout_limit_bytes: stream.stdout_limit_bytes,
-                    stderr_limit_bytes: stream.stderr_limit_bytes,
-                }),
-            )
+            let stdout_stream =
+                request
+                    .stdout
+                    .stream
+                    .as_ref()
+                    .map(|stream| HostBoundedExecStreamPolicy {
+                        event_tx: host_tx.clone(),
+                        limit_bytes: stream.limit_bytes,
+                        chunk_limit_bytes: stream.chunk_limit_bytes,
+                    });
+            let stderr_stream =
+                request
+                    .stderr
+                    .stream
+                    .as_ref()
+                    .map(|stream| HostBoundedExecStreamPolicy {
+                        event_tx: host_tx,
+                        limit_bytes: stream.limit_bytes,
+                        chunk_limit_bytes: stream.chunk_limit_bytes,
+                    });
+            (Some(task), stdout_stream, stderr_stream)
         } else {
-            (None, None)
+            (None, None, None)
         };
 
         let host_request = HostBoundedExecRequest {
@@ -1448,9 +1502,8 @@ impl Sandbox for FirecrackerSandbox {
             env: request.env,
             sudo: request.sudo,
             stdin: request.stdin,
-            stdout_limit_bytes: request.stdout_limit_bytes,
-            stderr_limit_bytes: request.stderr_limit_bytes,
-            stream: host_stream,
+            stdout: sandbox_output_to_host(&request.stdout, stdout_stream),
+            stderr: sandbox_output_to_host(&request.stderr, stderr_stream),
         };
 
         let result = tokio::select! {

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -57,13 +57,20 @@ pub struct BoundedExecCall {
     pub env: Vec<(String, String)>,
     pub sudo: bool,
     pub stdin: Option<Vec<u8>>,
-    pub stdout_limit_bytes: u32,
-    pub stderr_limit_bytes: u32,
-    pub stream_stdout: bool,
-    pub stream_stderr: bool,
-    pub stream_chunk_limit_bytes: u32,
-    pub stdout_stream_limit_bytes: u32,
-    pub stderr_stream_limit_bytes: u32,
+    pub stdout: BoundedExecOutputCall,
+    pub stderr: BoundedExecOutputCall,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BoundedExecOutputCall {
+    pub capture: BoundedExecCapturePolicy,
+    pub stream: Option<BoundedExecStreamCall>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BoundedExecStreamCall {
+    pub limit_bytes: u32,
+    pub chunk_limit_bytes: u32,
 }
 
 pub struct BoundedExecResponse {
@@ -424,10 +431,25 @@ fn default_bounded_exec_result() -> BoundedExecResult {
     BoundedExecResult {
         termination: BoundedExecTermination::Exited { exit_code: 0 },
         duration: Duration::ZERO,
-        stdout: Vec::new(),
-        stderr: Vec::new(),
-        stdout_truncated: false,
-        stderr_truncated: false,
+        stdout: BoundedExecOutput::Captured {
+            bytes: Vec::new(),
+            truncated: false,
+        },
+        stderr: BoundedExecOutput::Captured {
+            bytes: Vec::new(),
+            truncated: false,
+        },
+        diagnostic: None,
+    }
+}
+
+fn output_call_from_request(output: &BoundedExecOutputRequest) -> BoundedExecOutputCall {
+    BoundedExecOutputCall {
+        capture: output.capture,
+        stream: output.stream.as_ref().map(|stream| BoundedExecStreamCall {
+            limit_bytes: stream.limit_bytes,
+            chunk_limit_bytes: stream.chunk_limit_bytes,
+        }),
     }
 }
 
@@ -441,37 +463,18 @@ fn bounded_exec_call_from_request(request: &BoundedExecRequest<'_>) -> BoundedEx
             .collect(),
         sudo: request.sudo,
         stdin: request.stdin.map(<[u8]>::to_vec),
-        stdout_limit_bytes: request.stdout_limit_bytes,
-        stderr_limit_bytes: request.stderr_limit_bytes,
-        stream_stdout: request.stream.as_ref().is_some_and(|stream| stream.stdout),
-        stream_stderr: request.stream.as_ref().is_some_and(|stream| stream.stderr),
-        stream_chunk_limit_bytes: request
-            .stream
-            .as_ref()
-            .map_or(0, |stream| stream.chunk_limit_bytes),
-        stdout_stream_limit_bytes: request
-            .stream
-            .as_ref()
-            .map_or(0, |stream| stream.stdout_limit_bytes),
-        stderr_stream_limit_bytes: request
-            .stream
-            .as_ref()
-            .map_or(0, |stream| stream.stderr_limit_bytes),
+        stdout: output_call_from_request(&request.stdout),
+        stderr: output_call_from_request(&request.stderr),
     }
 }
 
 fn emit_bounded_exec_events(request: &BoundedExecRequest<'_>, events: Vec<BoundedExecOutputEvent>) {
-    let Some(stream) = &request.stream else {
-        return;
-    };
     for event in events {
-        let requested = match event.stream {
-            BoundedExecStream::Stdout => stream.stdout,
-            BoundedExecStream::Stderr => stream.stderr,
+        let target = match event.stream {
+            BoundedExecStream::Stdout => request.stdout.stream.as_ref(),
+            BoundedExecStream::Stderr => request.stderr.stream.as_ref(),
         };
-        if !requested {
-            continue;
-        }
+        let Some(stream) = target else { continue };
         let _ = stream.event_tx.send(event);
     }
 }
@@ -953,6 +956,34 @@ mod tests {
         }
     }
 
+    fn capture_output(limit_bytes: u32) -> BoundedExecOutputRequest {
+        BoundedExecOutputRequest {
+            capture: BoundedExecCapturePolicy::Capture { limit_bytes },
+            stream: None,
+        }
+    }
+
+    fn captured_output(bytes: &[u8], truncated: bool) -> BoundedExecOutput {
+        BoundedExecOutput::Captured {
+            bytes: bytes.to_vec(),
+            truncated,
+        }
+    }
+
+    fn assert_captured_output(
+        output: &BoundedExecOutput,
+        expected_bytes: &[u8],
+        expected_truncated: bool,
+    ) {
+        match output {
+            BoundedExecOutput::Captured { bytes, truncated } => {
+                assert_eq!(bytes, expected_bytes);
+                assert_eq!(*truncated, expected_truncated);
+            }
+            BoundedExecOutput::Discarded => panic!("expected captured output"),
+        }
+    }
+
     #[tokio::test]
     async fn snapshot_provider_can_discard_uncommitted_snapshot() {
         let provider = MockSnapshotProvider;
@@ -995,9 +1026,8 @@ mod tests {
             env: &env,
             sudo: true,
             stdin: Some(b"input"),
-            stdout_limit_bytes: 100,
-            stderr_limit_bytes: 101,
-            stream: None,
+            stdout: capture_output(100),
+            stderr: capture_output(101),
         };
 
         let result = sandbox.bounded_exec(&request).await.unwrap();
@@ -1006,7 +1036,7 @@ mod tests {
             result.termination,
             BoundedExecTermination::Exited { exit_code: 0 }
         );
-        assert!(result.stdout.is_empty());
+        assert_captured_output(&result.stdout, b"", false);
         assert_eq!(
             sandbox.bounded_exec_calls(),
             vec![BoundedExecCall {
@@ -1014,13 +1044,14 @@ mod tests {
                 env: vec![("K".to_string(), "V".to_string())],
                 sudo: true,
                 stdin: Some(b"input".to_vec()),
-                stdout_limit_bytes: 100,
-                stderr_limit_bytes: 101,
-                stream_stdout: false,
-                stream_stderr: false,
-                stream_chunk_limit_bytes: 0,
-                stdout_stream_limit_bytes: 0,
-                stderr_stream_limit_bytes: 0,
+                stdout: BoundedExecOutputCall {
+                    capture: BoundedExecCapturePolicy::Capture { limit_bytes: 100 },
+                    stream: None,
+                },
+                stderr: BoundedExecOutputCall {
+                    capture: BoundedExecCapturePolicy::Capture { limit_bytes: 101 },
+                    stream: None,
+                },
             }]
         );
     }
@@ -1046,10 +1077,9 @@ mod tests {
             result: Ok(BoundedExecResult {
                 termination: BoundedExecTermination::TimedOut,
                 duration: Duration::from_millis(25),
-                stdout: b"final-out".to_vec(),
-                stderr: b"final-err".to_vec(),
-                stdout_truncated: false,
-                stderr_truncated: true,
+                stdout: captured_output(b"final-out", false),
+                stderr: captured_output(b"final-err", true),
+                diagnostic: None,
             }),
         });
 
@@ -1060,26 +1090,26 @@ mod tests {
             env: &[],
             sudo: false,
             stdin: None,
-            stdout_limit_bytes: 100,
-            stderr_limit_bytes: 100,
-            stream: Some(BoundedExecStreamRequest {
-                event_tx,
-                stdout: true,
-                stderr: false,
-                chunk_limit_bytes: 1024,
-                stdout_limit_bytes: 2048,
-                stderr_limit_bytes: 0,
-            }),
+            stdout: BoundedExecOutputRequest {
+                capture: BoundedExecCapturePolicy::Capture { limit_bytes: 100 },
+                stream: Some(BoundedExecStreamPolicy {
+                    event_tx,
+                    limit_bytes: 2048,
+                    chunk_limit_bytes: 1024,
+                }),
+            },
+            stderr: BoundedExecOutputRequest {
+                capture: BoundedExecCapturePolicy::Capture { limit_bytes: 100 },
+                stream: None,
+            },
         };
 
         let result = sandbox.bounded_exec(&request).await.unwrap();
 
         assert_eq!(result.termination, BoundedExecTermination::TimedOut);
         assert_eq!(result.duration, Duration::from_millis(25));
-        assert_eq!(result.stdout, b"final-out");
-        assert_eq!(result.stderr, b"final-err");
-        assert!(!result.stdout_truncated);
-        assert!(result.stderr_truncated);
+        assert_captured_output(&result.stdout, b"final-out", false);
+        assert_captured_output(&result.stderr, b"final-err", true);
         assert_eq!(
             event_rx.recv().await.unwrap(),
             BoundedExecOutputEvent {
@@ -1100,13 +1130,17 @@ mod tests {
                 env: vec![],
                 sudo: false,
                 stdin: None,
-                stdout_limit_bytes: 100,
-                stderr_limit_bytes: 100,
-                stream_stdout: true,
-                stream_stderr: false,
-                stream_chunk_limit_bytes: 1024,
-                stdout_stream_limit_bytes: 2048,
-                stderr_stream_limit_bytes: 0,
+                stdout: BoundedExecOutputCall {
+                    capture: BoundedExecCapturePolicy::Capture { limit_bytes: 100 },
+                    stream: Some(BoundedExecStreamCall {
+                        limit_bytes: 2048,
+                        chunk_limit_bytes: 1024,
+                    }),
+                },
+                stderr: BoundedExecOutputCall {
+                    capture: BoundedExecCapturePolicy::Capture { limit_bytes: 100 },
+                    stream: None,
+                },
             }]
         );
     }
@@ -1119,10 +1153,9 @@ mod tests {
             result: Ok(BoundedExecResult {
                 termination: BoundedExecTermination::Exited { exit_code: 42 },
                 duration: Duration::from_millis(10),
-                stdout: b"shared".to_vec(),
-                stderr: Vec::new(),
-                stdout_truncated: false,
-                stderr_truncated: false,
+                stdout: captured_output(b"shared", false),
+                stderr: captured_output(b"", false),
+                diagnostic: None,
             }),
         });
         let mut factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
@@ -1136,9 +1169,8 @@ mod tests {
             env: &[],
             sudo: false,
             stdin: None,
-            stdout_limit_bytes: 100,
-            stderr_limit_bytes: 100,
-            stream: None,
+            stdout: capture_output(100),
+            stderr: capture_output(100),
         };
 
         let queued = first.bounded_exec(&request).await.unwrap();
@@ -1148,7 +1180,7 @@ mod tests {
             queued.termination,
             BoundedExecTermination::Exited { exit_code: 42 }
         );
-        assert_eq!(queued.stdout, b"shared");
+        assert_captured_output(&queued.stdout, b"shared", false);
         assert_eq!(
             fallback.termination,
             BoundedExecTermination::Exited { exit_code: 0 }

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -41,7 +41,7 @@ pub use snapshot::{
     PendingSnapshotPublish, SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider,
 };
 pub use types::{
-    BoundedExecOutputEvent, BoundedExecRequest, BoundedExecResult, BoundedExecStream,
-    BoundedExecStreamRequest, BoundedExecTermination, ExecRequest, ExecResult, ProcessExit,
-    SpawnHandle, SpawnOutputMode,
+    BoundedExecCapturePolicy, BoundedExecOutput, BoundedExecOutputEvent, BoundedExecOutputRequest,
+    BoundedExecRequest, BoundedExecResult, BoundedExecStream, BoundedExecStreamPolicy,
+    BoundedExecTermination, ExecRequest, ExecResult, ProcessExit, SpawnHandle, SpawnOutputMode,
 };

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -186,9 +186,14 @@ pub trait Sandbox: Send + Sync + Any {
     /// Returns an error if the sandbox is not running or if the backing
     /// process crashes during execution.
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult>;
-    /// Run `request.cmd` in the guest with structured termination status,
-    /// bounded final stdout/stderr buffers, and optional request-scoped
-    /// stdout/stderr stream events.
+    /// Run `request.cmd` in the guest with structured termination status and
+    /// independently configured stdout/stderr output policies.
+    ///
+    /// Each stream can discard final output, capture bounded final bytes, emit
+    /// request-scoped stream events, or stream and capture at the same time.
+    /// `Discard` is distinct from `Capture { limit_bytes: 0 }`: capture-zero
+    /// still drains and reports truncation when output exists, while discarded
+    /// non-streamed output may be connected to `/dev/null`.
     ///
     /// Returns an error if the sandbox is not running, if the backing
     /// process crashes during execution, or if the host/guest transport fails.

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -23,13 +23,21 @@ pub struct BoundedExecOutputEvent {
     pub truncated: bool,
 }
 
-pub struct BoundedExecStreamRequest {
+pub struct BoundedExecStreamPolicy {
     pub event_tx: tokio::sync::mpsc::UnboundedSender<BoundedExecOutputEvent>,
-    pub stdout: bool,
-    pub stderr: bool,
+    pub limit_bytes: u32,
     pub chunk_limit_bytes: u32,
-    pub stdout_limit_bytes: u32,
-    pub stderr_limit_bytes: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BoundedExecCapturePolicy {
+    Discard,
+    Capture { limit_bytes: u32 },
+}
+
+pub struct BoundedExecOutputRequest {
+    pub capture: BoundedExecCapturePolicy,
+    pub stream: Option<BoundedExecStreamPolicy>,
 }
 
 pub struct BoundedExecRequest<'a> {
@@ -38,9 +46,8 @@ pub struct BoundedExecRequest<'a> {
     pub env: &'a [(&'a str, &'a str)],
     pub sudo: bool,
     pub stdin: Option<&'a [u8]>,
-    pub stdout_limit_bytes: u32,
-    pub stderr_limit_bytes: u32,
-    pub stream: Option<BoundedExecStreamRequest>,
+    pub stdout: BoundedExecOutputRequest,
+    pub stderr: BoundedExecOutputRequest,
 }
 
 impl BoundedExecRequest<'_> {
@@ -53,10 +60,15 @@ impl BoundedExecRequest<'_> {
 pub struct BoundedExecResult {
     pub termination: BoundedExecTermination,
     pub duration: Duration,
-    pub stdout: Vec<u8>,
-    pub stderr: Vec<u8>,
-    pub stdout_truncated: bool,
-    pub stderr_truncated: bool,
+    pub stdout: BoundedExecOutput,
+    pub stderr: BoundedExecOutput,
+    pub diagnostic: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BoundedExecOutput {
+    Discarded,
+    Captured { bytes: Vec<u8>, truncated: bool },
 }
 
 pub struct ExecRequest<'a> {
@@ -168,9 +180,14 @@ mod tests {
             env: &[],
             sudo: false,
             stdin: None,
-            stdout_limit_bytes: 0,
-            stderr_limit_bytes: 0,
-            stream: None,
+            stdout: BoundedExecOutputRequest {
+                capture: BoundedExecCapturePolicy::Capture { limit_bytes: 0 },
+                stream: None,
+            },
+            stderr: BoundedExecOutputRequest {
+                capture: BoundedExecCapturePolicy::Capture { limit_bytes: 0 },
+                stream: None,
+            },
         };
         assert_eq!(req.timeout_ms(), u32::MAX);
     }

--- a/crates/vsock-guest/src/bounded_exec.rs
+++ b/crates/vsock-guest/src/bounded_exec.rs
@@ -1,4 +1,5 @@
-use std::io::{self, Write};
+use std::io;
+use std::os::fd::{AsRawFd, RawFd};
 use std::process::{Child, ChildStdin};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -28,6 +29,7 @@ const THREAD_BOUNDED_STDOUT: &str = "vsock-bounded-stdout";
 const THREAD_BOUNDED_STDERR: &str = "vsock-bounded-stderr";
 const THREAD_BOUNDED_STDIN: &str = "vsock-bounded-stdin";
 const STREAM_CHUNK_WRITE_DEADLINE: Duration = Duration::from_secs(2);
+const STDIN_WRITE_POLL_TIMEOUT_MS: libc::c_int = 100;
 
 pub(crate) struct BoundedExecWorkerRequest {
     pub(crate) seq: u32,
@@ -111,6 +113,23 @@ struct BoundedExecResultFrame<'a> {
     stdout: vsock_proto::BoundedExecOutput<'a>,
     stderr: vsock_proto::BoundedExecOutput<'a>,
     diagnostic: Option<&'a str>,
+}
+
+struct BoundedStdinWorker {
+    handle: JoinHandle<()>,
+    error_rx: mpsc::Receiver<String>,
+    done_rx: mpsc::Receiver<()>,
+}
+
+impl BoundedStdinWorker {
+    fn is_pending(&self) -> bool {
+        matches!(self.done_rx.try_recv(), Err(mpsc::TryRecvError::Empty))
+    }
+
+    fn finish(self) -> mpsc::Receiver<String> {
+        let _ = self.handle.join();
+        self.error_rx
+    }
 }
 
 #[derive(Debug)]
@@ -277,6 +296,7 @@ fn run_bounded_exec<S>(
         mut child,
         env_script,
     } = spawned;
+    let child_pid = child.id();
     let _env_script = env_script;
 
     let stdout = if request.stdout.requires_pipe() {
@@ -339,6 +359,7 @@ fn run_bounded_exec<S>(
 
     let drain_cancel = Arc::new(AtomicBool::new(false));
     let command_cancel = Arc::new(AtomicBool::new(false));
+    let stdin_cancel = Arc::new(AtomicBool::new(false));
     let (drain_done_tx, drain_done_rx) = mpsc::channel::<()>();
 
     let stdout_worker = match stdout {
@@ -423,11 +444,18 @@ fn run_bounded_exec<S>(
 
     let stdin_worker = match (stdin, request.stdin) {
         (Some(stdin), Some(stdin_bytes)) => {
-            match spawn_stdin_writer(stdin, stdin_bytes, command_cancel.clone(), spawner.clone()) {
+            match spawn_stdin_writer(
+                stdin,
+                stdin_bytes,
+                command_cancel.clone(),
+                stdin_cancel.clone(),
+                spawner.clone(),
+            ) {
                 Ok(worker) => Some(worker),
                 Err(e) => {
                     drain_cancel.store(true, Ordering::Release);
                     command_cancel.store(true, Ordering::Release);
+                    stdin_cancel.store(true, Ordering::Release);
                     kill_and_reap_child(child);
                     if let Some((stdout_handle, _)) = stdout_worker {
                         let _ = stdout_handle.join();
@@ -469,6 +497,23 @@ fn run_bounded_exec<S>(
     {
         drain_cancel.store(true, Ordering::Release);
     }
+    if matches!(outcome, WaitOutcome::Exited(_) | WaitOutcome::WaitFailed(_))
+        && stdin_worker
+            .as_ref()
+            .is_some_and(BoundedStdinWorker::is_pending)
+    {
+        // The direct child is gone, but a descendant may still hold stdin open
+        // without reading it. Signal the process group before waiting for
+        // stdout/stderr drain so inherited output fds do not burn the whole
+        // drain deadline.
+        kill_process_group_best_effort(child_pid);
+    }
+    if matches!(
+        outcome,
+        WaitOutcome::TimedOut | WaitOutcome::Cancelled | WaitOutcome::WaitFailed(_)
+    ) {
+        stdin_cancel.store(true, Ordering::Release);
+    }
 
     let expected_drains =
         usize::from(stdout_worker.is_some()) + usize::from(stderr_worker.is_some());
@@ -482,10 +527,8 @@ fn run_bounded_exec<S>(
 
     let stdout_output = finish_drain_worker(request.stdout, stdout_worker);
     let stderr_output = finish_drain_worker(request.stderr, stderr_worker);
-    let stdin_error_rx = stdin_worker.map(|(stdin_handle, stdin_error_rx)| {
-        let _ = stdin_handle.join();
-        stdin_error_rx
-    });
+    stdin_cancel.store(true, Ordering::Release);
+    let stdin_error_rx = stdin_worker.map(BoundedStdinWorker::finish);
 
     let mut diagnostic = None;
     let mut termination = match outcome {
@@ -597,7 +640,7 @@ fn spawn_bounded_drain<R, S>(
     spawner: S,
 ) -> io::Result<(JoinHandle<()>, mpsc::Receiver<BoundedDrainResult>)>
 where
-    R: std::os::unix::io::AsRawFd + Send + 'static,
+    R: AsRawFd + Send + 'static,
     S: ThreadSpawner,
 {
     let BoundedDrainWorker {
@@ -665,20 +708,28 @@ fn finish_drain_worker(
 }
 
 fn spawn_stdin_writer<S>(
-    mut stdin: ChildStdin,
+    stdin: ChildStdin,
     stdin_bytes: Vec<u8>,
     command_cancel: Arc<AtomicBool>,
+    stdin_cancel: Arc<AtomicBool>,
     spawner: S,
-) -> io::Result<(JoinHandle<()>, mpsc::Receiver<String>)>
+) -> io::Result<BoundedStdinWorker>
 where
     S: ThreadSpawner,
 {
     let (error_tx, error_rx) = mpsc::channel();
+    let (done_tx, done_rx) = mpsc::channel();
     let handle = spawner.spawn_unit(
         THREAD_BOUNDED_STDIN,
         Box::new(move || {
-            let write_result = stdin.write_all(&stdin_bytes);
+            let write_result = write_stdin_cancellable(
+                &stdin,
+                &stdin_bytes,
+                command_cancel.as_ref(),
+                stdin_cancel.as_ref(),
+            );
             drop(stdin);
+            let _ = done_tx.send(());
             if let Err(e) = write_result {
                 if e.kind() == io::ErrorKind::BrokenPipe {
                     return;
@@ -688,7 +739,130 @@ where
             }
         }),
     )?;
-    Ok((handle, error_rx))
+    Ok(BoundedStdinWorker {
+        handle,
+        error_rx,
+        done_rx,
+    })
+}
+
+fn kill_process_group_best_effort(child_pid: u32) {
+    // SAFETY: child_pid came from Command::spawn; ESRCH is fine because the
+    // process group may already be gone by the time the stdin writer lags.
+    let _ = unsafe { libc::kill(-(child_pid as i32), libc::SIGKILL) };
+}
+
+fn write_stdin_cancellable(
+    stdin: &ChildStdin,
+    bytes: &[u8],
+    command_cancel: &AtomicBool,
+    stdin_cancel: &AtomicBool,
+) -> io::Result<()> {
+    let fd = stdin.as_raw_fd();
+    set_fd_nonblocking(fd)?;
+    let mut written = 0usize;
+    while written < bytes.len() {
+        if command_cancel.load(Ordering::Acquire) || stdin_cancel.load(Ordering::Acquire) {
+            return Ok(());
+        }
+
+        let Some(remaining) = bytes.get(written..) else {
+            return Err(io::Error::other("stdin write offset exceeded input length"));
+        };
+        match write_nonblocking(fd, remaining) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "stdin write returned zero bytes",
+                ));
+            }
+            Ok(n) => {
+                written = written
+                    .checked_add(n)
+                    .filter(|next| *next <= bytes.len())
+                    .ok_or_else(|| io::Error::other("stdin write exceeded input length"))?;
+            }
+            Err(e) if e.kind() == io::ErrorKind::BrokenPipe => return Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                wait_stdin_writable(fd, command_cancel, stdin_cancel)?
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+fn set_fd_nonblocking(fd: RawFd) -> io::Result<()> {
+    // SAFETY: fcntl is called with a valid fd owned by ChildStdin.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if flags & libc::O_NONBLOCK != 0 {
+        return Ok(());
+    }
+
+    // SAFETY: fcntl only updates descriptor flags for this owned fd.
+    let ret = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn write_nonblocking(fd: RawFd, bytes: &[u8]) -> io::Result<usize> {
+    // SAFETY: bytes is a valid readable buffer and write does not retain it.
+    let ret = unsafe { libc::write(fd, bytes.as_ptr().cast::<libc::c_void>(), bytes.len()) };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(ret as usize)
+}
+
+fn wait_stdin_writable(
+    fd: RawFd,
+    command_cancel: &AtomicBool,
+    stdin_cancel: &AtomicBool,
+) -> io::Result<()> {
+    loop {
+        if command_cancel.load(Ordering::Acquire) || stdin_cancel.load(Ordering::Acquire) {
+            return Ok(());
+        }
+
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLOUT,
+            revents: 0,
+        };
+        // SAFETY: pfd points to one initialized descriptor entry.
+        let ret = unsafe { libc::poll(&mut pfd, 1, STDIN_WRITE_POLL_TIMEOUT_MS) };
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err);
+        }
+        if ret == 0 {
+            continue;
+        }
+        if pfd.revents & libc::POLLNVAL != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "stdin fd is invalid",
+            ));
+        }
+        if pfd.revents & (libc::POLLERR | libc::POLLHUP) != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "stdin pipe is no longer writable",
+            ));
+        }
+        if pfd.revents & libc::POLLOUT != 0 {
+            return Ok(());
+        }
+    }
 }
 
 fn kill_and_send_wait_failed(

--- a/crates/vsock-guest/src/bounded_exec.rs
+++ b/crates/vsock-guest/src/bounded_exec.rs
@@ -499,15 +499,14 @@ fn run_bounded_exec<S>(
     {
         drain_cancel.store(true, Ordering::Release);
     }
-    if matches!(outcome, WaitOutcome::Exited(_) | WaitOutcome::WaitFailed(_))
-        && stdin_worker
-            .as_ref()
-            .is_some_and(BoundedStdinWorker::is_pending)
+    if stdin_worker
+        .as_ref()
+        .is_some_and(BoundedStdinWorker::is_pending)
     {
-        // The direct child is gone, but a descendant may still hold stdin open
-        // without reading it. Signal the process group before waiting for
-        // stdout/stderr drain so inherited output fds do not burn the whole
-        // drain deadline.
+        // The direct child may have exited or been killed, but a descendant can
+        // still hold stdin open without reading it. Signal the process group
+        // before waiting for stdout/stderr drain, then clean up any process
+        // still holding this exact stdin pipe.
         kill_process_group_best_effort(child_pid);
         if let Some(pipe_link) = stdin_worker
             .as_ref()

--- a/crates/vsock-guest/src/bounded_exec.rs
+++ b/crates/vsock-guest/src/bounded_exec.rs
@@ -1032,3 +1032,150 @@ fn send_bounded_exec_output_chunk(
 fn duration_ms(started: Instant) -> u64 {
     u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+    use std::os::unix::net::UnixStream;
+
+    use crate::threading::test_support::FailingThreadSpawner;
+
+    fn capture_output(limit_bytes: u32) -> BoundedOutputRequest {
+        BoundedOutputRequest {
+            capture: vsock_proto::BoundedExecCapturePolicy::Capture { limit_bytes },
+            stream: None,
+        }
+    }
+
+    fn bounded_request(seq: u32, command: &str) -> BoundedExecWorkerRequest {
+        BoundedExecWorkerRequest {
+            seq,
+            timeout_ms: 5_000,
+            command: command.to_string(),
+            env: Vec::new(),
+            sudo: false,
+            stdin: None,
+            stdout: capture_output(1024),
+            stderr: capture_output(1024),
+        }
+    }
+
+    fn read_message(stream: &mut UnixStream) -> vsock_proto::RawMessage {
+        let mut hdr = [0u8; 4];
+        stream.read_exact(&mut hdr).unwrap();
+        let body_len = u32::from_be_bytes(hdr) as usize;
+        let mut body = vec![0u8; body_len];
+        stream.read_exact(&mut body).unwrap();
+
+        let mut full = Vec::with_capacity(4 + body_len);
+        full.extend_from_slice(&hdr);
+        full.extend_from_slice(&body);
+        let mut decoder = vsock_proto::Decoder::new();
+        let mut messages = decoder.decode(&full).unwrap();
+        assert_eq!(messages.len(), 1);
+        messages.remove(0)
+    }
+
+    fn assert_bounded_exec_result(
+        stream: &mut UnixStream,
+        seq: u32,
+        expected_termination: BoundedExecTermination,
+        expected_diagnostic: &str,
+    ) {
+        let msg = read_message(stream);
+        assert_eq!(msg.msg_type, MSG_BOUNDED_EXEC_RESULT);
+        assert_eq!(msg.seq, seq);
+        let decoded = vsock_proto::decode_bounded_exec_result(&msg.payload).unwrap();
+        assert_eq!(decoded.termination, expected_termination);
+        let diagnostic = decoded.diagnostic.unwrap_or_default();
+        assert!(
+            diagnostic.contains(expected_diagnostic),
+            "expected diagnostic to contain {expected_diagnostic:?}, got {diagnostic:?}",
+        );
+    }
+
+    #[test]
+    fn bounded_exec_worker_spawn_failure_returns_start_failed_result() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let writer = GuestWriter::new(guest);
+
+        spawn_bounded_exec_worker_with_spawner(
+            bounded_request(41, "echo should-not-run"),
+            writer,
+            Arc::new(AtomicBool::new(false)),
+            FailingThreadSpawner::fail_once(THREAD_BOUNDED_EXEC_WORKER),
+        )
+        .unwrap();
+
+        assert_bounded_exec_result(
+            &mut host,
+            41,
+            BoundedExecTermination::StartFailed,
+            "bounded exec worker thread",
+        );
+    }
+
+    #[test]
+    fn stdout_drain_spawn_failure_returns_wait_failed_result() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+
+        run_bounded_exec(
+            bounded_request(42, "sleep 60"),
+            GuestWriter::new(guest),
+            Arc::new(AtomicBool::new(false)),
+            FailingThreadSpawner::fail_once(THREAD_BOUNDED_STDOUT),
+        );
+
+        assert_bounded_exec_result(
+            &mut host,
+            42,
+            BoundedExecTermination::WaitFailed,
+            "stdout drain thread",
+        );
+    }
+
+    #[test]
+    fn stderr_drain_spawn_failure_returns_wait_failed_result() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+
+        run_bounded_exec(
+            bounded_request(43, "sleep 60"),
+            GuestWriter::new(guest),
+            Arc::new(AtomicBool::new(false)),
+            FailingThreadSpawner::fail_once(THREAD_BOUNDED_STDERR),
+        );
+
+        assert_bounded_exec_result(
+            &mut host,
+            43,
+            BoundedExecTermination::WaitFailed,
+            "stderr drain thread",
+        );
+    }
+
+    #[test]
+    fn stdin_writer_spawn_failure_returns_wait_failed_result() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let mut request = bounded_request(44, "sleep 60");
+        request.stdin = Some(vec![b'x'; 1024]);
+
+        run_bounded_exec(
+            request,
+            GuestWriter::new(guest),
+            Arc::new(AtomicBool::new(false)),
+            FailingThreadSpawner::fail_once(THREAD_BOUNDED_STDIN),
+        );
+
+        assert_bounded_exec_result(
+            &mut host,
+            44,
+            BoundedExecTermination::WaitFailed,
+            "stdin writer thread",
+        );
+    }
+}

--- a/crates/vsock-guest/src/bounded_exec.rs
+++ b/crates/vsock-guest/src/bounded_exec.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::io;
 use std::os::fd::{AsRawFd, RawFd};
 use std::process::{Child, ChildStdin};
@@ -119,6 +120,7 @@ struct BoundedStdinWorker {
     handle: JoinHandle<()>,
     error_rx: mpsc::Receiver<String>,
     done_rx: mpsc::Receiver<()>,
+    pipe_link: Option<String>,
 }
 
 impl BoundedStdinWorker {
@@ -507,6 +509,12 @@ fn run_bounded_exec<S>(
         // stdout/stderr drain so inherited output fds do not burn the whole
         // drain deadline.
         kill_process_group_best_effort(child_pid);
+        if let Some(pipe_link) = stdin_worker
+            .as_ref()
+            .and_then(|worker| worker.pipe_link.as_deref())
+        {
+            kill_processes_holding_pipe(pipe_link);
+        }
     }
     if matches!(
         outcome,
@@ -719,6 +727,7 @@ where
 {
     let (error_tx, error_rx) = mpsc::channel();
     let (done_tx, done_rx) = mpsc::channel();
+    let pipe_link = stdin_pipe_link(&stdin);
     let handle = spawner.spawn_unit(
         THREAD_BOUNDED_STDIN,
         Box::new(move || {
@@ -743,6 +752,7 @@ where
         handle,
         error_rx,
         done_rx,
+        pipe_link,
     })
 }
 
@@ -750,6 +760,64 @@ fn kill_process_group_best_effort(child_pid: u32) {
     // SAFETY: child_pid came from Command::spawn; ESRCH is fine because the
     // process group may already be gone by the time the stdin writer lags.
     let _ = unsafe { libc::kill(-(child_pid as i32), libc::SIGKILL) };
+}
+
+fn stdin_pipe_link(stdin: &ChildStdin) -> Option<String> {
+    let path = format!("/proc/self/fd/{}", stdin.as_raw_fd());
+    std::fs::read_link(path)
+        .ok()
+        .map(|target| target.to_string_lossy().into_owned())
+}
+
+fn kill_processes_holding_pipe(pipe_link: &str) {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return;
+    };
+
+    let self_pid = std::process::id();
+    // SAFETY: getpgrp has no preconditions.
+    let self_pgid = unsafe { libc::getpgrp() };
+    let mut killed_pgroups = HashSet::new();
+
+    for entry in entries.flatten() {
+        let Ok(pid) = entry.file_name().to_string_lossy().parse::<u32>() else {
+            continue;
+        };
+        if pid == self_pid {
+            continue;
+        }
+
+        let fd_dir = entry.path().join("fd");
+        let Ok(fds) = std::fs::read_dir(fd_dir) else {
+            continue;
+        };
+        let mut holds_pipe = false;
+        for fd in fds.flatten() {
+            let Ok(target) = std::fs::read_link(fd.path()) else {
+                continue;
+            };
+            if target.to_string_lossy() == pipe_link {
+                holds_pipe = true;
+                break;
+            }
+        }
+        if !holds_pipe {
+            continue;
+        }
+
+        // SAFETY: pid came from /proc. getpgid may fail if the process exits.
+        let pgid = unsafe { libc::getpgid(pid as libc::pid_t) };
+        if pgid > 0 && pgid != self_pgid && killed_pgroups.insert(pgid) {
+            // SAFETY: pgid is positive and not our own process group.
+            let ret = unsafe { libc::kill(-pgid, libc::SIGKILL) };
+            if ret == 0 {
+                continue;
+            }
+        }
+
+        // SAFETY: pid came from /proc and may already be gone; errors ignored.
+        let _ = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+    }
 }
 
 fn write_stdin_cancellable(

--- a/crates/vsock-guest/src/bounded_exec.rs
+++ b/crates/vsock-guest/src/bounded_exec.rs
@@ -498,19 +498,23 @@ fn run_bounded_exec<S>(
     {
         drain_cancel.store(true, Ordering::Release);
     }
+    // The direct child may have exited or been killed, but a descendant can
+    // still hold stdin open without reading it. Clean up any process still
+    // holding this exact stdin pipe before waiting for stdout/stderr drain.
+    //
+    // Do this even if the stdin writer already finished: pipe capacity is
+    // platform-dependent, so a small-enough stdin payload can be fully buffered
+    // while a daemonized descendant still leaks the read end.
+    if let Some(pipe_link) = stdin_worker
+        .as_ref()
+        .and_then(|worker| worker.pipe_link.as_deref())
+    {
+        kill_processes_holding_pipe(pipe_link);
+    }
     if stdin_worker
         .as_ref()
         .is_some_and(BoundedStdinWorker::is_pending)
     {
-        // The direct child may have exited or been killed, but a descendant can
-        // still hold stdin open without reading it. Clean up any process still
-        // holding this exact stdin pipe before waiting for stdout/stderr drain.
-        if let Some(pipe_link) = stdin_worker
-            .as_ref()
-            .and_then(|worker| worker.pipe_link.as_deref())
-        {
-            kill_processes_holding_pipe(pipe_link);
-        }
         stdin_cancel.store(true, Ordering::Release);
     }
     if matches!(

--- a/crates/vsock-guest/src/bounded_exec.rs
+++ b/crates/vsock-guest/src/bounded_exec.rs
@@ -298,7 +298,6 @@ fn run_bounded_exec<S>(
         mut child,
         env_script,
     } = spawned;
-    let child_pid = child.id();
     let _env_script = env_script;
 
     let stdout = if request.stdout.requires_pipe() {
@@ -504,16 +503,15 @@ fn run_bounded_exec<S>(
         .is_some_and(BoundedStdinWorker::is_pending)
     {
         // The direct child may have exited or been killed, but a descendant can
-        // still hold stdin open without reading it. Signal the process group
-        // before waiting for stdout/stderr drain, then clean up any process
-        // still holding this exact stdin pipe.
-        kill_process_group_best_effort(child_pid);
+        // still hold stdin open without reading it. Clean up any process still
+        // holding this exact stdin pipe before waiting for stdout/stderr drain.
         if let Some(pipe_link) = stdin_worker
             .as_ref()
             .and_then(|worker| worker.pipe_link.as_deref())
         {
             kill_processes_holding_pipe(pipe_link);
         }
+        stdin_cancel.store(true, Ordering::Release);
     }
     if matches!(
         outcome,
@@ -755,17 +753,11 @@ where
     })
 }
 
-fn kill_process_group_best_effort(child_pid: u32) {
-    // SAFETY: child_pid came from Command::spawn; ESRCH is fine because the
-    // process group may already be gone by the time the stdin writer lags.
-    let _ = unsafe { libc::kill(-(child_pid as i32), libc::SIGKILL) };
-}
-
 fn stdin_pipe_link(stdin: &ChildStdin) -> Option<String> {
     let path = format!("/proc/self/fd/{}", stdin.as_raw_fd());
-    std::fs::read_link(path)
-        .ok()
-        .map(|target| target.to_string_lossy().into_owned())
+    let target = std::fs::read_link(path).ok()?;
+    let link = target.to_string_lossy().into_owned();
+    link.starts_with("pipe:[").then_some(link)
 }
 
 fn kill_processes_holding_pipe(pipe_link: &str) {

--- a/crates/vsock-guest/src/bounded_exec.rs
+++ b/crates/vsock-guest/src/bounded_exec.rs
@@ -36,13 +36,42 @@ pub(crate) struct BoundedExecWorkerRequest {
     pub(crate) env: Vec<(String, String)>,
     pub(crate) sudo: bool,
     pub(crate) stdin: Option<Vec<u8>>,
-    pub(crate) stdout_limit_bytes: u32,
-    pub(crate) stderr_limit_bytes: u32,
-    pub(crate) stream_stdout: bool,
-    pub(crate) stream_stderr: bool,
-    pub(crate) stream_chunk_limit_bytes: u32,
-    pub(crate) stdout_stream_limit_bytes: u32,
-    pub(crate) stderr_stream_limit_bytes: u32,
+    pub(crate) stdout: BoundedOutputRequest,
+    pub(crate) stderr: BoundedOutputRequest,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct BoundedOutputRequest {
+    pub(crate) capture: vsock_proto::BoundedExecCapturePolicy,
+    pub(crate) stream: Option<BoundedStreamConfig>,
+}
+
+impl BoundedOutputRequest {
+    fn from_proto(policy: vsock_proto::BoundedExecOutputPolicy) -> Self {
+        Self {
+            capture: policy.capture,
+            stream: policy.stream.map(|stream| BoundedStreamConfig {
+                chunk_limit_bytes: stream.chunk_limit_bytes as usize,
+                stream_limit_bytes: stream.limit_bytes as usize,
+            }),
+        }
+    }
+
+    fn requires_pipe(self) -> bool {
+        matches!(
+            self.capture,
+            vsock_proto::BoundedExecCapturePolicy::Capture { .. }
+        ) || self.stream.is_some()
+    }
+
+    fn final_limit_bytes(self) -> Option<usize> {
+        match self.capture {
+            vsock_proto::BoundedExecCapturePolicy::Discard => None,
+            vsock_proto::BoundedExecCapturePolicy::Capture { limit_bytes } => {
+                Some(limit_bytes as usize)
+            }
+        }
+    }
 }
 
 impl BoundedExecWorkerRequest {
@@ -58,13 +87,8 @@ impl BoundedExecWorkerRequest {
                 .collect(),
             sudo: decoded.sudo,
             stdin: decoded.stdin.map(<[u8]>::to_vec),
-            stdout_limit_bytes: decoded.stdout_limit_bytes,
-            stderr_limit_bytes: decoded.stderr_limit_bytes,
-            stream_stdout: decoded.stream_stdout,
-            stream_stderr: decoded.stream_stderr,
-            stream_chunk_limit_bytes: decoded.stream_chunk_limit_bytes,
-            stdout_stream_limit_bytes: decoded.stdout_stream_limit_bytes,
-            stderr_stream_limit_bytes: decoded.stderr_stream_limit_bytes,
+            stdout: BoundedOutputRequest::from_proto(decoded.stdout),
+            stderr: BoundedOutputRequest::from_proto(decoded.stderr),
         }
     }
 }
@@ -72,7 +96,7 @@ impl BoundedExecWorkerRequest {
 struct BoundedDrainWorker {
     seq: u32,
     stream: BoundedExecStream,
-    final_limit_bytes: usize,
+    final_limit_bytes: Option<usize>,
     stream_config: Option<BoundedStreamConfig>,
     writer: GuestWriter,
     drain_cancel: Arc<AtomicBool>,
@@ -84,10 +108,49 @@ struct BoundedExecResultFrame<'a> {
     seq: u32,
     termination: BoundedExecTermination,
     duration_ms: u64,
-    stdout: &'a [u8],
-    stderr: &'a [u8],
-    stdout_truncated: bool,
-    stderr_truncated: bool,
+    stdout: vsock_proto::BoundedExecOutput<'a>,
+    stderr: vsock_proto::BoundedExecOutput<'a>,
+    diagnostic: Option<&'a str>,
+}
+
+#[derive(Debug)]
+enum GuestBoundedOutput {
+    Discarded,
+    Captured(BoundedDrainResult),
+}
+
+impl GuestBoundedOutput {
+    fn empty_for_policy(policy: BoundedOutputRequest) -> Self {
+        if policy.final_limit_bytes().is_some() {
+            Self::Captured(BoundedDrainResult::default())
+        } else {
+            Self::Discarded
+        }
+    }
+
+    fn as_proto(&self) -> vsock_proto::BoundedExecOutput<'_> {
+        match self {
+            Self::Discarded => vsock_proto::BoundedExecOutput::Discarded,
+            Self::Captured(result) => vsock_proto::BoundedExecOutput::Captured {
+                bytes: &result.output,
+                truncated: result.truncated,
+            },
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Discarded => 0,
+            Self::Captured(result) => result.output.len(),
+        }
+    }
+
+    fn truncated(&self) -> bool {
+        match self {
+            Self::Discarded => false,
+            Self::Captured(result) => result.truncated,
+        }
+    }
 }
 
 pub(crate) fn spawn_bounded_exec_worker(
@@ -108,6 +171,8 @@ where
     S: ThreadSpawner,
 {
     let seq = request.seq;
+    let stdout_policy = request.stdout;
+    let stderr_policy = request.stderr;
     let worker_writer = writer.clone();
     let worker_spawner = spawner.clone();
     let result = spawner.spawn_unit(
@@ -120,16 +185,17 @@ where
     match result {
         Ok(_) => Ok(()),
         Err(e) => {
-            let stderr = format!("Failed to spawn bounded exec worker thread: {e}");
+            let diagnostic = format!("Failed to spawn bounded exec worker thread: {e}");
+            let stdout = GuestBoundedOutput::empty_for_policy(stdout_policy);
+            let stderr = GuestBoundedOutput::empty_for_policy(stderr_policy);
             send_bounded_exec_result(
                 BoundedExecResultFrame {
                     seq,
                     termination: BoundedExecTermination::StartFailed,
                     duration_ms: 0,
-                    stdout: &[],
-                    stderr: stderr.as_bytes(),
-                    stdout_truncated: false,
-                    stderr_truncated: false,
+                    stdout: stdout.as_proto(),
+                    stderr: stderr.as_proto(),
+                    diagnostic: Some(&diagnostic),
                 },
                 &writer,
             )
@@ -148,30 +214,28 @@ fn run_bounded_exec<S>(
     log(
         "INFO",
         &format!(
-            "bounded_exec: {} (timeout={}ms, sudo={}, stdin={}, stdout_limit={}, stderr_limit={}, stream_stdout={}, stream_stderr={}, {})",
+            "bounded_exec: {} (timeout={}ms, sudo={}, stdin={}, stdout={}, stderr={}, {})",
             truncate_preview(&request.command),
             request.timeout_ms,
             request.sudo,
             request.stdin.as_ref().map_or(0, Vec::len),
-            request.stdout_limit_bytes,
-            request.stderr_limit_bytes,
-            request.stream_stdout,
-            request.stream_stderr,
+            format_output_policy(request.stdout),
+            format_output_policy(request.stderr),
             format_env_diagnostics(&request.command, &env_refs(&request.env)),
         ),
     );
 
     let started = Instant::now();
     if let Err(error) = validate_request(&request) {
+        let stdout = GuestBoundedOutput::empty_for_policy(request.stdout);
+        let stderr = GuestBoundedOutput::empty_for_policy(request.stderr);
         send_final_best_effort(
             request.seq,
             BoundedExecTermination::StartFailed,
             duration_ms(started),
-            &BoundedDrainResult::default(),
-            &BoundedDrainResult {
-                output: error.into_bytes(),
-                truncated: false,
-            },
+            &stdout,
+            &stderr,
+            Some(&error),
             &writer,
         );
         return;
@@ -183,22 +247,25 @@ fn run_bounded_exec<S>(
         &env_refs,
         request.sudo,
         request.stdin.is_some(),
+        request.stdout.requires_pipe(),
+        request.stderr.requires_pipe(),
     ) {
         Ok(spawned) => spawned,
         Err(e) => {
-            let stderr = format!(
+            let diagnostic = format!(
                 "Failed to execute: {e} ({})",
                 format_env_diagnostics(&request.command, &env_refs)
             );
+            let stdout = GuestBoundedOutput::empty_for_policy(request.stdout);
+            let stderr = GuestBoundedOutput::empty_for_policy(request.stderr);
             let _ = send_bounded_exec_result(
                 BoundedExecResultFrame {
                     seq: request.seq,
                     termination: BoundedExecTermination::StartFailed,
                     duration_ms: duration_ms(started),
-                    stdout: &[],
-                    stderr: stderr.as_bytes(),
-                    stdout_truncated: false,
-                    stderr_truncated: false,
+                    stdout: stdout.as_proto(),
+                    stderr: stderr.as_proto(),
+                    diagnostic: Some(&diagnostic),
                 },
                 &writer,
             );
@@ -212,19 +279,43 @@ fn run_bounded_exec<S>(
     } = spawned;
     let _env_script = env_script;
 
-    let stdout = match child.stdout.take() {
-        Some(stdout) => stdout,
-        None => {
-            kill_and_send_wait_failed(request.seq, started, child, "missing stdout pipe", &writer);
-            return;
+    let stdout = if request.stdout.requires_pipe() {
+        match child.stdout.take() {
+            Some(stdout) => Some(stdout),
+            None => {
+                kill_and_send_wait_failed(
+                    request.seq,
+                    started,
+                    child,
+                    request.stdout,
+                    request.stderr,
+                    "missing stdout pipe",
+                    &writer,
+                );
+                return;
+            }
         }
+    } else {
+        None
     };
-    let stderr = match child.stderr.take() {
-        Some(stderr) => stderr,
-        None => {
-            kill_and_send_wait_failed(request.seq, started, child, "missing stderr pipe", &writer);
-            return;
+    let stderr = if request.stderr.requires_pipe() {
+        match child.stderr.take() {
+            Some(stderr) => Some(stderr),
+            None => {
+                kill_and_send_wait_failed(
+                    request.seq,
+                    started,
+                    child,
+                    request.stdout,
+                    request.stderr,
+                    "missing stderr pipe",
+                    &writer,
+                );
+                return;
+            }
         }
+    } else {
+        None
     };
     let stdin = if request.stdin.is_some() {
         match child.stdin.take() {
@@ -234,6 +325,8 @@ fn run_bounded_exec<S>(
                     request.seq,
                     started,
                     child,
+                    request.stdout,
+                    request.stderr,
                     "missing stdin pipe",
                     &writer,
                 );
@@ -248,77 +341,84 @@ fn run_bounded_exec<S>(
     let command_cancel = Arc::new(AtomicBool::new(false));
     let (drain_done_tx, drain_done_rx) = mpsc::channel::<()>();
 
-    let stdout_rx = spawn_bounded_drain(
-        stdout,
-        BoundedDrainWorker {
-            seq: request.seq,
-            stream: BoundedExecStream::Stdout,
-            final_limit_bytes: request.stdout_limit_bytes as usize,
-            stream_config: stream_config(
-                request.stream_stdout,
-                request.stream_chunk_limit_bytes,
-                request.stdout_stream_limit_bytes,
-            ),
-            writer: writer.clone(),
-            drain_cancel: drain_cancel.clone(),
-            command_cancel: command_cancel.clone(),
-            drain_done_tx: drain_done_tx.clone(),
-        },
-        spawner.clone(),
-    );
-    let (stdout_handle, stdout_result_rx) = match stdout_rx {
-        Ok(parts) => parts,
-        Err(e) => {
-            drain_cancel.store(true, Ordering::Release);
-            kill_and_send_wait_failed(
-                request.seq,
-                started,
-                child,
-                &format!("failed to spawn stdout drain thread: {e}"),
-                &writer,
-            );
-            return;
+    let stdout_worker = match stdout {
+        Some(stdout) => {
+            match spawn_bounded_drain(
+                stdout,
+                BoundedDrainWorker {
+                    seq: request.seq,
+                    stream: BoundedExecStream::Stdout,
+                    final_limit_bytes: request.stdout.final_limit_bytes(),
+                    stream_config: request.stdout.stream,
+                    writer: writer.clone(),
+                    drain_cancel: drain_cancel.clone(),
+                    command_cancel: command_cancel.clone(),
+                    drain_done_tx: drain_done_tx.clone(),
+                },
+                spawner.clone(),
+            ) {
+                Ok(parts) => Some(parts),
+                Err(e) => {
+                    drain_cancel.store(true, Ordering::Release);
+                    kill_and_send_wait_failed(
+                        request.seq,
+                        started,
+                        child,
+                        request.stdout,
+                        request.stderr,
+                        &format!("failed to spawn stdout drain thread: {e}"),
+                        &writer,
+                    );
+                    return;
+                }
+            }
         }
+        None => None,
     };
 
-    let stderr_rx = spawn_bounded_drain(
-        stderr,
-        BoundedDrainWorker {
-            seq: request.seq,
-            stream: BoundedExecStream::Stderr,
-            final_limit_bytes: request.stderr_limit_bytes as usize,
-            stream_config: stream_config(
-                request.stream_stderr,
-                request.stream_chunk_limit_bytes,
-                request.stderr_stream_limit_bytes,
-            ),
-            writer: writer.clone(),
-            drain_cancel: drain_cancel.clone(),
-            command_cancel: command_cancel.clone(),
-            drain_done_tx: drain_done_tx.clone(),
-        },
-        spawner.clone(),
-    );
-    let (stderr_handle, stderr_result_rx) = match stderr_rx {
-        Ok(parts) => parts,
-        Err(e) => {
-            drain_cancel.store(true, Ordering::Release);
-            kill_and_reap_child(child);
-            let _ = stdout_handle.join();
-            let _ = send_bounded_exec_result(
-                BoundedExecResultFrame {
+    let stderr_worker = match stderr {
+        Some(stderr) => {
+            match spawn_bounded_drain(
+                stderr,
+                BoundedDrainWorker {
                     seq: request.seq,
-                    termination: BoundedExecTermination::WaitFailed,
-                    duration_ms: duration_ms(started),
-                    stdout: &[],
-                    stderr: format!("failed to spawn stderr drain thread: {e}").as_bytes(),
-                    stdout_truncated: false,
-                    stderr_truncated: false,
+                    stream: BoundedExecStream::Stderr,
+                    final_limit_bytes: request.stderr.final_limit_bytes(),
+                    stream_config: request.stderr.stream,
+                    writer: writer.clone(),
+                    drain_cancel: drain_cancel.clone(),
+                    command_cancel: command_cancel.clone(),
+                    drain_done_tx: drain_done_tx.clone(),
                 },
-                &writer,
-            );
-            return;
+                spawner.clone(),
+            ) {
+                Ok(parts) => Some(parts),
+                Err(e) => {
+                    drain_cancel.store(true, Ordering::Release);
+                    command_cancel.store(true, Ordering::Release);
+                    kill_and_reap_child(child);
+                    if let Some((stdout_handle, _)) = stdout_worker {
+                        let _ = stdout_handle.join();
+                    }
+                    let stdout_output = GuestBoundedOutput::empty_for_policy(request.stdout);
+                    let stderr_output = GuestBoundedOutput::empty_for_policy(request.stderr);
+                    let diagnostic = format!("failed to spawn stderr drain thread: {e}");
+                    let _ = send_bounded_exec_result(
+                        BoundedExecResultFrame {
+                            seq: request.seq,
+                            termination: BoundedExecTermination::WaitFailed,
+                            duration_ms: duration_ms(started),
+                            stdout: stdout_output.as_proto(),
+                            stderr: stderr_output.as_proto(),
+                            diagnostic: Some(&diagnostic),
+                        },
+                        &writer,
+                    );
+                    return;
+                }
+            }
         }
+        None => None,
     };
 
     let stdin_worker = match (stdin, request.stdin) {
@@ -329,17 +429,23 @@ fn run_bounded_exec<S>(
                     drain_cancel.store(true, Ordering::Release);
                     command_cancel.store(true, Ordering::Release);
                     kill_and_reap_child(child);
-                    let _ = stdout_handle.join();
-                    let _ = stderr_handle.join();
+                    if let Some((stdout_handle, _)) = stdout_worker {
+                        let _ = stdout_handle.join();
+                    }
+                    if let Some((stderr_handle, _)) = stderr_worker {
+                        let _ = stderr_handle.join();
+                    }
+                    let stdout_output = GuestBoundedOutput::empty_for_policy(request.stdout);
+                    let stderr_output = GuestBoundedOutput::empty_for_policy(request.stderr);
+                    let diagnostic = format!("failed to spawn stdin writer thread: {e}");
                     let _ = send_bounded_exec_result(
                         BoundedExecResultFrame {
                             seq: request.seq,
                             termination: BoundedExecTermination::WaitFailed,
                             duration_ms: duration_ms(started),
-                            stdout: &[],
-                            stderr: format!("failed to spawn stdin writer thread: {e}").as_bytes(),
-                            stdout_truncated: false,
-                            stderr_truncated: false,
+                            stdout: stdout_output.as_proto(),
+                            stderr: stderr_output.as_proto(),
+                            diagnostic: Some(&diagnostic),
                         },
                         &writer,
                     );
@@ -364,23 +470,24 @@ fn run_bounded_exec<S>(
         drain_cancel.store(true, Ordering::Release);
     }
 
-    let completed = await_drain_deadline(&drain_done_rx, 2, &drain_cancel);
-    if completed < 2 {
+    let expected_drains =
+        usize::from(stdout_worker.is_some()) + usize::from(stderr_worker.is_some());
+    let completed = await_drain_deadline(&drain_done_rx, expected_drains, &drain_cancel);
+    if completed < expected_drains {
         log(
             "WARN",
             &format!("bounded_exec: drain deadline reached after {DRAIN_DEADLINE_SECS}s",),
         );
     }
 
-    let _ = stdout_handle.join();
-    let _ = stderr_handle.join();
+    let stdout_output = finish_drain_worker(request.stdout, stdout_worker);
+    let stderr_output = finish_drain_worker(request.stderr, stderr_worker);
     let stdin_error_rx = stdin_worker.map(|(stdin_handle, stdin_error_rx)| {
         let _ = stdin_handle.join();
         stdin_error_rx
     });
-    let stdout_result = stdout_result_rx.recv().unwrap_or_default();
-    let mut stderr_result = stderr_result_rx.recv().unwrap_or_default();
 
+    let mut diagnostic = None;
     let mut termination = match outcome {
         WaitOutcome::Exited(status) => BoundedExecTermination::Exited {
             exit_code: crate::process::extract_exit_code(status),
@@ -388,10 +495,7 @@ fn run_bounded_exec<S>(
         WaitOutcome::TimedOut => BoundedExecTermination::TimedOut,
         WaitOutcome::Cancelled => BoundedExecTermination::Cancelled,
         WaitOutcome::WaitFailed(msg) => {
-            if stderr_result.output.is_empty() {
-                stderr_result.output = format!("Failed to wait: {msg}").into_bytes();
-                stderr_result.truncated = false;
-            }
+            diagnostic = Some(format!("Failed to wait: {msg}"));
             BoundedExecTermination::WaitFailed
         }
     };
@@ -400,18 +504,18 @@ fn run_bounded_exec<S>(
         && let Ok(stdin_error) = stdin_error_rx.try_recv()
     {
         termination = BoundedExecTermination::WaitFailed;
-        stderr_result.output = format!("Failed to write stdin: {stdin_error}").into_bytes();
-        stderr_result.truncated = false;
+        diagnostic = Some(format!("Failed to write stdin: {stdin_error}"));
     }
 
     log(
         "INFO",
         &format!(
-            "bounded_exec result: termination={termination:?}, stdout_len={}, stderr_len={}, stdout_truncated={}, stderr_truncated={}",
-            stdout_result.output.len(),
-            stderr_result.output.len(),
-            stdout_result.truncated,
-            stderr_result.truncated,
+            "bounded_exec result: termination={termination:?}, stdout_len={}, stderr_len={}, stdout_truncated={}, stderr_truncated={}, diagnostic={}",
+            stdout_output.len(),
+            stderr_output.len(),
+            stdout_output.truncated(),
+            stderr_output.truncated(),
+            diagnostic.is_some(),
         ),
     );
 
@@ -419,15 +523,16 @@ fn run_bounded_exec<S>(
         request.seq,
         termination,
         duration_ms(started),
-        &stdout_result,
-        &stderr_result,
+        &stdout_output,
+        &stderr_output,
+        diagnostic.as_deref(),
         &writer,
     );
 }
 
 fn validate_request(request: &BoundedExecWorkerRequest) -> Result<(), String> {
-    let stdout_limit = request.stdout_limit_bytes as usize;
-    let stderr_limit = request.stderr_limit_bytes as usize;
+    let stdout_limit = request.stdout.final_limit_bytes().unwrap_or(0);
+    let stderr_limit = request.stderr.final_limit_bytes().unwrap_or(0);
     let total_limit = stdout_limit
         .checked_add(stderr_limit)
         .ok_or_else(|| "bounded exec final output limits overflow".to_string())?;
@@ -439,19 +544,22 @@ fn validate_request(request: &BoundedExecWorkerRequest) -> Result<(), String> {
         ));
     }
 
-    if request.stream_stdout || request.stream_stderr {
-        let stream_chunk_limit = request.stream_chunk_limit_bytes as usize;
+    for stream in [request.stdout.stream, request.stderr.stream]
+        .into_iter()
+        .flatten()
+    {
+        let stream_chunk_limit = stream.chunk_limit_bytes;
         if stream_chunk_limit < vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES {
             return Err(format!(
                 "bounded exec stream chunk limit below minimum: {} < {}",
-                request.stream_chunk_limit_bytes,
+                stream.chunk_limit_bytes,
                 vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES
             ));
         }
         if stream_chunk_limit > vsock_proto::MAX_BOUNDED_EXEC_OUTPUT_CHUNK_BYTES {
             return Err(format!(
                 "bounded exec stream chunk limit exceeds protocol frame: {} > {}",
-                request.stream_chunk_limit_bytes,
+                stream.chunk_limit_bytes,
                 vsock_proto::MAX_BOUNDED_EXEC_OUTPUT_CHUNK_BYTES
             ));
         }
@@ -460,21 +568,27 @@ fn validate_request(request: &BoundedExecWorkerRequest) -> Result<(), String> {
     Ok(())
 }
 
+fn format_output_policy(policy: BoundedOutputRequest) -> String {
+    let capture = match policy.capture {
+        vsock_proto::BoundedExecCapturePolicy::Discard => "discard".to_string(),
+        vsock_proto::BoundedExecCapturePolicy::Capture { limit_bytes } => {
+            format!("capture({limit_bytes})")
+        }
+    };
+    let stream = match policy.stream {
+        Some(stream) => format!(
+            "stream(limit={}, chunk={})",
+            stream.stream_limit_bytes, stream.chunk_limit_bytes
+        ),
+        None => "no-stream".to_string(),
+    };
+    format!("{capture}+{stream}")
+}
+
 fn env_refs(env: &[(String, String)]) -> Vec<(&str, &str)> {
     env.iter()
         .map(|(key, value)| (key.as_str(), value.as_str()))
         .collect()
-}
-
-fn stream_config(
-    enabled: bool,
-    chunk_limit_bytes: u32,
-    stream_limit_bytes: u32,
-) -> Option<BoundedStreamConfig> {
-    enabled.then_some(BoundedStreamConfig {
-        chunk_limit_bytes: chunk_limit_bytes as usize,
-        stream_limit_bytes: stream_limit_bytes as usize,
-    })
 }
 
 fn spawn_bounded_drain<R, S>(
@@ -534,6 +648,22 @@ where
     Ok((handle, result_rx))
 }
 
+fn finish_drain_worker(
+    policy: BoundedOutputRequest,
+    worker: Option<(JoinHandle<()>, mpsc::Receiver<BoundedDrainResult>)>,
+) -> GuestBoundedOutput {
+    let Some((handle, result_rx)) = worker else {
+        return GuestBoundedOutput::empty_for_policy(policy);
+    };
+    let _ = handle.join();
+    let result = result_rx.recv().unwrap_or_default();
+    if policy.final_limit_bytes().is_some() {
+        GuestBoundedOutput::Captured(result)
+    } else {
+        GuestBoundedOutput::Discarded
+    }
+}
+
 fn spawn_stdin_writer<S>(
     mut stdin: ChildStdin,
     stdin_bytes: Vec<u8>,
@@ -565,19 +695,22 @@ fn kill_and_send_wait_failed(
     seq: u32,
     started: Instant,
     child: Child,
+    stdout_policy: BoundedOutputRequest,
+    stderr_policy: BoundedOutputRequest,
     error: &str,
     writer: &GuestWriter,
 ) {
     kill_and_reap_child(child);
+    let stdout = GuestBoundedOutput::empty_for_policy(stdout_policy);
+    let stderr = GuestBoundedOutput::empty_for_policy(stderr_policy);
     let _ = send_bounded_exec_result(
         BoundedExecResultFrame {
             seq,
             termination: BoundedExecTermination::WaitFailed,
             duration_ms: duration_ms(started),
-            stdout: &[],
-            stderr: error.as_bytes(),
-            stdout_truncated: false,
-            stderr_truncated: false,
+            stdout: stdout.as_proto(),
+            stderr: stderr.as_proto(),
+            diagnostic: Some(error),
         },
         writer,
     );
@@ -587,8 +720,9 @@ fn send_final_best_effort(
     seq: u32,
     termination: BoundedExecTermination,
     duration_ms: u64,
-    stdout: &BoundedDrainResult,
-    stderr: &BoundedDrainResult,
+    stdout: &GuestBoundedOutput,
+    stderr: &GuestBoundedOutput,
+    diagnostic: Option<&str>,
     writer: &GuestWriter,
 ) {
     if let Err(e) = send_bounded_exec_result(
@@ -596,10 +730,9 @@ fn send_final_best_effort(
             seq,
             termination,
             duration_ms,
-            stdout: &stdout.output,
-            stderr: &stderr.output,
-            stdout_truncated: stdout.truncated,
-            stderr_truncated: stderr.truncated,
+            stdout: stdout.as_proto(),
+            stderr: stderr.as_proto(),
+            diagnostic,
         },
         writer,
     ) {
@@ -617,16 +750,14 @@ fn send_bounded_exec_result(
         duration_ms,
         stdout,
         stderr,
-        stdout_truncated,
-        stderr_truncated,
+        diagnostic,
     } = frame;
     let payload = match vsock_proto::encode_bounded_exec_result(
         termination,
         duration_ms,
         stdout,
         stderr,
-        stdout_truncated,
-        stderr_truncated,
+        diagnostic,
     ) {
         Ok(payload) => payload,
         Err(e) => {
@@ -638,10 +769,9 @@ fn send_bounded_exec_result(
             vsock_proto::encode_bounded_exec_result(
                 BoundedExecTermination::WaitFailed,
                 duration_ms,
-                &[],
-                diagnostic.as_bytes(),
-                false,
-                false,
+                vsock_proto::BoundedExecOutput::Discarded,
+                vsock_proto::BoundedExecOutput::Discarded,
+                Some(&diagnostic),
             )
             .map_err(to_io_error)?
         }

--- a/crates/vsock-guest/src/bounded_exec.rs
+++ b/crates/vsock-guest/src/bounded_exec.rs
@@ -802,16 +802,12 @@ fn kill_processes_holding_pipe(pipe_link: &str) {
 
         // SAFETY: pid came from /proc. getpgid may fail if the process exits.
         let pgid = unsafe { libc::getpgid(pid as libc::pid_t) };
-        if pgid > 0 && pgid != self_pgid && killed_pgroups.insert(pgid) {
-            // SAFETY: pgid is positive and not our own process group.
-            let ret = unsafe { libc::kill(-pgid, libc::SIGKILL) };
-            if ret == 0 {
-                continue;
-            }
+        if pgid <= 0 || pgid == self_pgid || !killed_pgroups.insert(pgid) {
+            continue;
         }
 
-        // SAFETY: pid came from /proc and may already be gone; errors ignored.
-        let _ = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+        // SAFETY: pgid is positive and not our own process group.
+        let _ = unsafe { libc::kill(-pgid, libc::SIGKILL) };
     }
 }
 

--- a/crates/vsock-guest/src/drain.rs
+++ b/crates/vsock-guest/src/drain.rs
@@ -101,38 +101,44 @@ where
 
 /// Bounded variant of [`drain_until_eof_or_cancelled`].
 ///
-/// The returned final buffer retains only the first `final_limit_bytes` bytes,
-/// but the helper continues reading after truncation so the child cannot block
-/// on a full pipe. When `stream` is set, early bytes are additionally forwarded
-/// through `on_stream_chunk` up to the configured stream budget. Returning
-/// `false` from the callback disables further stream forwarding, but draining
-/// still continues until EOF or cancellation.
+/// When `final_limit_bytes` is set, the returned final buffer retains only the
+/// first N bytes, but the helper continues reading after truncation so the child
+/// cannot block on a full pipe. `Some(0)` intentionally means capture zero bytes
+/// and report truncation when output exists. `None` means do not retain final
+/// bytes; this is used for stream-only drains.
+///
+/// When `stream` is set, early bytes are additionally forwarded through
+/// `on_stream_chunk` up to the configured stream budget. Returning `false` from
+/// the callback disables further stream forwarding, but draining still
+/// continues until EOF or cancellation.
 pub(crate) fn drain_bounded_cancellable<R>(
     pipe: R,
     cancel: &AtomicBool,
-    final_limit_bytes: usize,
+    final_limit_bytes: Option<usize>,
     stream: Option<BoundedStreamConfig>,
     mut on_stream_chunk: impl FnMut(&[u8], bool) -> bool,
 ) -> BoundedDrainResult
 where
     R: std::os::unix::io::AsRawFd,
 {
-    let mut output = Vec::with_capacity(final_limit_bytes.min(STDOUT_CHUNK_SIZE));
+    let mut output = Vec::with_capacity(final_limit_bytes.unwrap_or(0).min(STDOUT_CHUNK_SIZE));
     let mut truncated = false;
     let mut stream_emitted = 0usize;
     let mut stream_truncated = false;
     let mut stream_enabled = stream.is_some();
 
     drain_until_eof_or_cancelled(pipe, cancel, |chunk| {
-        if output.len() < final_limit_bytes {
-            let remaining = final_limit_bytes - output.len();
-            let keep = remaining.min(chunk.len());
-            output.extend_from_slice(chunk.get(..keep).unwrap_or_default());
-            if keep < chunk.len() {
+        if let Some(final_limit_bytes) = final_limit_bytes {
+            if output.len() < final_limit_bytes {
+                let remaining = final_limit_bytes - output.len();
+                let keep = remaining.min(chunk.len());
+                output.extend_from_slice(chunk.get(..keep).unwrap_or_default());
+                if keep < chunk.len() {
+                    truncated = true;
+                }
+            } else if !chunk.is_empty() {
                 truncated = true;
             }
-        } else if !chunk.is_empty() {
-            truncated = true;
         }
 
         let Some(config) = stream else {
@@ -248,7 +254,7 @@ mod tests {
         drop(writer);
 
         let cancel = AtomicBool::new(false);
-        let result = drain_bounded_cancellable(reader, &cancel, 3, None, |_, _| true);
+        let result = drain_bounded_cancellable(reader, &cancel, Some(3), None, |_, _| true);
 
         assert_eq!(result.output, b"abc".to_vec());
         assert!(result.truncated);
@@ -261,10 +267,37 @@ mod tests {
         drop(writer);
 
         let cancel = AtomicBool::new(false);
-        let result = drain_bounded_cancellable(reader, &cancel, 0, None, |_, _| true);
+        let result = drain_bounded_cancellable(reader, &cancel, Some(0), None, |_, _| true);
 
         assert!(result.output.is_empty());
         assert!(result.truncated);
+    }
+
+    #[test]
+    fn bounded_drain_stream_only_does_not_retain_final_bytes() {
+        let (reader, mut writer) = pipe_pair();
+        writer.write_all(b"abcdef").unwrap();
+        drop(writer);
+
+        let cancel = AtomicBool::new(false);
+        let mut chunks = Vec::new();
+        let result = drain_bounded_cancellable(
+            reader,
+            &cancel,
+            None,
+            Some(BoundedStreamConfig {
+                chunk_limit_bytes: 10,
+                stream_limit_bytes: 10,
+            }),
+            |chunk, truncated| {
+                chunks.push((chunk.to_vec(), truncated));
+                true
+            },
+        );
+
+        assert!(result.output.is_empty());
+        assert!(!result.truncated);
+        assert_eq!(chunks, vec![(b"abcdef".to_vec(), false)]);
     }
 
     #[test]
@@ -278,7 +311,7 @@ mod tests {
         let result = drain_bounded_cancellable(
             reader,
             &cancel,
-            10,
+            Some(10),
             Some(BoundedStreamConfig {
                 chunk_limit_bytes: 2,
                 stream_limit_bytes: 5,
@@ -311,7 +344,7 @@ mod tests {
         let result = drain_bounded_cancellable(
             reader,
             &cancel,
-            10,
+            Some(10),
             Some(BoundedStreamConfig {
                 chunk_limit_bytes: 10,
                 stream_limit_bytes: 10,

--- a/crates/vsock-guest/src/drain.rs
+++ b/crates/vsock-guest/src/drain.rs
@@ -336,6 +336,63 @@ mod tests {
     }
 
     #[test]
+    fn bounded_drain_exact_stream_limit_at_eof_does_not_mark_truncation() {
+        let (reader, mut writer) = pipe_pair();
+        writer.write_all(b"abcd").unwrap();
+        drop(writer);
+
+        let cancel = AtomicBool::new(false);
+        let mut chunks = Vec::new();
+        let result = drain_bounded_cancellable(
+            reader,
+            &cancel,
+            Some(10),
+            Some(BoundedStreamConfig {
+                chunk_limit_bytes: 2,
+                stream_limit_bytes: 4,
+            }),
+            |chunk, truncated| {
+                chunks.push((chunk.to_vec(), truncated));
+                true
+            },
+        );
+
+        assert_eq!(result.output, b"abcd".to_vec());
+        assert!(!result.truncated);
+        assert_eq!(
+            chunks,
+            vec![(b"ab".to_vec(), false), (b"cd".to_vec(), false)]
+        );
+    }
+
+    #[test]
+    fn bounded_drain_stream_callback_false_keeps_final_capture_draining() {
+        let (reader, mut writer) = pipe_pair();
+        writer.write_all(b"abcdef").unwrap();
+        drop(writer);
+
+        let cancel = AtomicBool::new(false);
+        let mut chunks = Vec::new();
+        let result = drain_bounded_cancellable(
+            reader,
+            &cancel,
+            Some(10),
+            Some(BoundedStreamConfig {
+                chunk_limit_bytes: 2,
+                stream_limit_bytes: 10,
+            }),
+            |chunk, truncated| {
+                chunks.push((chunk.to_vec(), truncated));
+                false
+            },
+        );
+
+        assert_eq!(result.output, b"abcdef".to_vec());
+        assert!(!result.truncated);
+        assert_eq!(chunks, vec![(b"ab".to_vec(), false)]);
+    }
+
+    #[test]
     fn bounded_drain_cancel_exits_while_writer_fd_remains_open() {
         let (reader, mut writer) = pipe_pair();
         let cancel = AtomicBool::new(false);

--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -623,14 +623,16 @@ pub(crate) fn spawn_with_pipes(
     Ok(SpawnedCommand { child, env_script })
 }
 
-/// Spawn `command` for bounded exec with stdout/stderr piped and caller-selected
-/// stdin behavior. Existing legacy exec/spawn_watch keep using
+/// Spawn `command` for bounded exec with caller-selected stdin/stdout/stderr
+/// behavior. Existing legacy exec/spawn_watch keep using
 /// [`spawn_with_pipes`] so their stdin semantics stay unchanged.
 pub(crate) fn spawn_bounded_exec_command(
     command: &str,
     env: &[(&str, &str)],
     sudo: bool,
     pipe_stdin: bool,
+    pipe_stdout: bool,
+    pipe_stderr: bool,
 ) -> io::Result<SpawnedCommand> {
     let PreparedExecCommand {
         mut command,
@@ -641,7 +643,16 @@ pub(crate) fn spawn_bounded_exec_command(
     } else {
         command.stdin(Stdio::null());
     }
-    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    if pipe_stdout {
+        command.stdout(Stdio::piped());
+    } else {
+        command.stdout(Stdio::null());
+    }
+    if pipe_stderr {
+        command.stderr(Stdio::piped());
+    } else {
+        command.stderr(Stdio::null());
+    }
     let child = spawn_in_own_process_group(&mut command)?;
     Ok(SpawnedCommand { child, env_script })
 }

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -435,6 +435,30 @@ fn bounded_exec_stdin_writer_exits_when_grandchild_holds_stdin() {
 }
 
 #[test]
+fn bounded_exec_cleans_stdin_holder_after_small_stdin_finishes() {
+    let orphan = OrphanProcessGuard::new("bounded-exec-small-stdin-orphan");
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let stdin = b"x";
+    let command = format!(
+        "python3 -c \"import os,signal; p=os.fork(); (os.write(os.open('{}', os.O_WRONLY|os.O_CREAT|os.O_TRUNC, 0o600), str(p).encode()), os._exit(0)) if p else (os.setsid(), os.dup2(os.open('/dev/null', os.O_WRONLY), 1), os.dup2(os.open('/dev/null', os.O_WRONLY), 2), signal.pause())\"",
+        orphan.pid_path()
+    );
+    let request = bounded_request(&command, &[], Some(stdin.as_slice()));
+    send_bounded_exec(&mut host_stream, 39, &request);
+    let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 39);
+
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    let orphan_pid = read_pid_file(orphan.pid_path());
+    wait_for_pid_exit(orphan_pid, "bounded exec small stdin cleanup");
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn bounded_exec_disconnect_kills_setsid_grandchild_holding_stdin() {
     let orphan = OrphanProcessGuard::new("bounded-exec-cancel-stdin-orphan");
     let (handle, mut host_stream) = start_guest_connection();

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -435,6 +435,30 @@ fn bounded_exec_stdin_writer_exits_when_grandchild_holds_stdin() {
 }
 
 #[test]
+fn bounded_exec_disconnect_kills_setsid_grandchild_holding_stdin() {
+    let orphan = OrphanProcessGuard::new("bounded-exec-cancel-stdin-orphan");
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let stdin = vec![b'x'; 8 * 1024 * 1024];
+    let command = format!(
+        "python3 -c \"import os,signal; p=os.fork(); (lambda fd: (os.write(fd, str(p).encode()), os.close(fd), signal.pause()))(os.open('{}', os.O_WRONLY|os.O_CREAT|os.O_TRUNC, 0o600)) if p else (os.setsid(), os.dup2(os.open('/dev/null', os.O_WRONLY), 1), os.dup2(os.open('/dev/null', os.O_WRONLY), 2), signal.pause())\"",
+        orphan.pid_path()
+    );
+    let request = bounded_request(&command, &[], Some(stdin.as_slice()));
+    send_bounded_exec(&mut host_stream, 38, &request);
+
+    let orphan_pid = read_pid_file(orphan.pid_path());
+    assert!(
+        pid_alive(orphan_pid),
+        "setsid grandchild should be running before disconnect"
+    );
+
+    drop(host_stream);
+    let _ = handle.join();
+    wait_for_pid_exit(orphan_pid, "bounded exec disconnect stdin cleanup");
+}
+
+#[test]
 fn bounded_exec_streams_stdout_before_final_result() {
     let (handle, mut host_stream) = start_guest_connection();
 

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -417,7 +417,7 @@ fn bounded_exec_stdin_writer_exits_when_grandchild_holds_stdin() {
 
     let stdin = vec![b'x'; 8 * 1024 * 1024];
     let command = format!(
-        "python3 -c \"import os,time; p=os.fork(); (os.write(os.open('{}', os.O_WRONLY|os.O_CREAT|os.O_TRUNC, 0o600), str(p).encode()), os._exit(0)) if p else (os.setsid(), os.dup2(os.open('/dev/null', os.O_WRONLY), 1), os.dup2(os.open('/dev/null', os.O_WRONLY), 2), time.sleep(30))\"",
+        "python3 -c \"import os,signal; p=os.fork(); (os.write(os.open('{}', os.O_WRONLY|os.O_CREAT|os.O_TRUNC, 0o600), str(p).encode()), os._exit(0)) if p else (os.setsid(), os.dup2(os.open('/dev/null', os.O_WRONLY), 1), os.dup2(os.open('/dev/null', os.O_WRONLY), 2), signal.pause())\"",
         orphan.pid_path()
     );
     let request = bounded_request(&command, &[], Some(stdin.as_slice()));

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -1953,12 +1953,19 @@ fn exec_captures_grandchild_output_before_drain_deadline() {
     let _ = handle.join();
 }
 
-/// Returns true iff `pid` is still a live (or zombie-but-unreaped) process
-/// the test owner has permission to signal. Implemented via `kill(pid, 0)`,
-/// the canonical existence check. After bash dies via SIGPIPE the kernel
-/// reaps it (we're not its parent — it was reparented to PID 1 when its
-/// process group died), so this transitions to false.
+/// Returns true iff `pid` is still running. Zombies have already terminated
+/// and may remain visible until PID 1 reaps them, so they are treated as not
+/// alive for cleanup assertions.
 fn pid_alive(pid: u32) -> bool {
+    if let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+        let state = stat
+            .rfind(')')
+            .and_then(|close| stat.get(close + 2..))
+            .and_then(|fields| fields.split_whitespace().next());
+        if state == Some("Z") {
+            return false;
+        }
+    }
     // SAFETY: `kill` with sig=0 is a no-op existence check.
     unsafe { libc::kill(pid as i32, 0) == 0 }
 }

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -417,7 +417,7 @@ fn bounded_exec_stdin_writer_exits_when_grandchild_holds_stdin() {
 
     let stdin = vec![b'x'; 8 * 1024 * 1024];
     let command = format!(
-        "python3 -c \"import os,time; p=os.fork(); (os.write(os.open('{}', os.O_WRONLY|os.O_CREAT|os.O_TRUNC, 0o600), str(p).encode()), os._exit(0)) if p else (os.dup2(os.open('/dev/null', os.O_WRONLY), 1), os.dup2(os.open('/dev/null', os.O_WRONLY), 2), time.sleep(30))\"",
+        "python3 -c \"import os,time; p=os.fork(); (os.write(os.open('{}', os.O_WRONLY|os.O_CREAT|os.O_TRUNC, 0o600), str(p).encode()), os._exit(0)) if p else (os.setsid(), os.dup2(os.open('/dev/null', os.O_WRONLY), 1), os.dup2(os.open('/dev/null', os.O_WRONLY), 2), time.sleep(30))\"",
         orphan.pid_path()
     );
     let request = bounded_request(&command, &[], Some(stdin.as_slice()));

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -11,7 +11,8 @@ use std::time::Duration;
 
 use vsock_guest::{handle_connection, run};
 use vsock_proto::{
-    self, BoundedExecRequest, BoundedExecStream, BoundedExecTermination, MSG_BOUNDED_EXEC,
+    self, BoundedExecCapturePolicy, BoundedExecOutput, BoundedExecOutputPolicy, BoundedExecRequest,
+    BoundedExecStream, BoundedExecStreamPolicy, BoundedExecTermination, MSG_BOUNDED_EXEC,
     MSG_BOUNDED_EXEC_OUTPUT_CHUNK, MSG_BOUNDED_EXEC_RESULT, MSG_ERROR, MSG_EXEC, MSG_EXEC_RESULT,
     MSG_PROCESS_EXIT, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT,
     MSG_STDOUT_CHUNK,
@@ -178,10 +179,50 @@ struct BoundedChunk {
 
 struct BoundedResult {
     termination: BoundedExecTermination,
-    stdout: Vec<u8>,
-    stderr: Vec<u8>,
-    stdout_truncated: bool,
-    stderr_truncated: bool,
+    stdout: OwnedBoundedOutput,
+    stderr: OwnedBoundedOutput,
+    diagnostic: Option<String>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum OwnedBoundedOutput {
+    Discarded,
+    Captured { bytes: Vec<u8>, truncated: bool },
+}
+
+fn owned_output(output: BoundedExecOutput<'_>) -> OwnedBoundedOutput {
+    match output {
+        BoundedExecOutput::Discarded => OwnedBoundedOutput::Discarded,
+        BoundedExecOutput::Captured { bytes, truncated } => OwnedBoundedOutput::Captured {
+            bytes: bytes.to_vec(),
+            truncated,
+        },
+    }
+}
+
+fn assert_captured_output(
+    output: &OwnedBoundedOutput,
+    expected_bytes: &[u8],
+    expected_truncated: bool,
+) {
+    match output {
+        OwnedBoundedOutput::Captured { bytes, truncated } => {
+            assert_eq!(bytes, expected_bytes);
+            assert_eq!(*truncated, expected_truncated);
+        }
+        OwnedBoundedOutput::Discarded => panic!("expected captured output"),
+    }
+}
+
+fn assert_discarded_output(output: &OwnedBoundedOutput) {
+    assert_eq!(*output, OwnedBoundedOutput::Discarded);
+}
+
+fn captured_bytes(output: &OwnedBoundedOutput) -> &[u8] {
+    match output {
+        OwnedBoundedOutput::Captured { bytes, .. } => bytes,
+        OwnedBoundedOutput::Discarded => panic!("expected captured output"),
+    }
 }
 
 fn bounded_request<'a>(
@@ -195,13 +236,29 @@ fn bounded_request<'a>(
         env,
         sudo: false,
         stdin,
-        stdout_limit_bytes: 1024 * 1024,
-        stderr_limit_bytes: 1024 * 1024,
-        stream_stdout: false,
-        stream_stderr: false,
-        stream_chunk_limit_bytes: 8192,
-        stdout_stream_limit_bytes: 1024 * 1024,
-        stderr_stream_limit_bytes: 1024 * 1024,
+        stdout: capture_policy(1024 * 1024),
+        stderr: capture_policy(1024 * 1024),
+    }
+}
+
+fn capture_policy(limit_bytes: u32) -> BoundedExecOutputPolicy {
+    BoundedExecOutputPolicy {
+        capture: BoundedExecCapturePolicy::Capture { limit_bytes },
+        stream: None,
+    }
+}
+
+fn discard_policy() -> BoundedExecOutputPolicy {
+    BoundedExecOutputPolicy {
+        capture: BoundedExecCapturePolicy::Discard,
+        stream: None,
+    }
+}
+
+fn stream_policy(limit_bytes: u32, chunk_limit_bytes: u32) -> BoundedExecStreamPolicy {
+    BoundedExecStreamPolicy {
+        limit_bytes,
+        chunk_limit_bytes,
     }
 }
 
@@ -242,10 +299,9 @@ fn read_bounded_exec_result(
                         chunks,
                         BoundedResult {
                             termination: decoded.termination,
-                            stdout: decoded.stdout.to_vec(),
-                            stderr: decoded.stderr.to_vec(),
-                            stdout_truncated: decoded.stdout_truncated,
-                            stderr_truncated: decoded.stderr_truncated,
+                            stdout: owned_output(decoded.stdout),
+                            stderr: owned_output(decoded.stderr),
+                            diagnostic: decoded.diagnostic.map(ToOwned::to_owned),
                         },
                     );
                 }
@@ -290,10 +346,8 @@ fn bounded_exec_stdout_stderr_success() {
         result.termination,
         BoundedExecTermination::Exited { exit_code: 0 }
     );
-    assert_eq!(result.stdout, b"stdout");
-    assert_eq!(result.stderr, b"stderr");
-    assert!(!result.stdout_truncated);
-    assert!(!result.stderr_truncated);
+    assert_captured_output(&result.stdout, b"stdout", false);
+    assert_captured_output(&result.stderr, b"stderr", false);
 
     finish_guest_connection(handle, host_stream);
 }
@@ -310,8 +364,8 @@ fn bounded_exec_nonzero_exit_is_exited() {
         result.termination,
         BoundedExecTermination::Exited { exit_code: 42 }
     );
-    assert_eq!(result.stdout, b"");
-    assert_eq!(result.stderr, b"failed");
+    assert_captured_output(&result.stdout, b"", false);
+    assert_captured_output(&result.stderr, b"failed", false);
 
     finish_guest_connection(handle, host_stream);
 }
@@ -333,8 +387,8 @@ fn bounded_exec_stdin_is_written_and_closed() {
         result.termination,
         BoundedExecTermination::Exited { exit_code: 0 }
     );
-    assert_eq!(result.stdout, b"hello from stdin:eof");
-    assert_eq!(result.stderr, b"");
+    assert_captured_output(&result.stdout, b"hello from stdin:eof", false);
+    assert_captured_output(&result.stderr, b"", false);
 
     finish_guest_connection(handle, host_stream);
 }
@@ -361,9 +415,10 @@ fn bounded_exec_streams_stdout_before_final_result() {
     let (handle, mut host_stream) = start_guest_connection();
 
     let mut request = bounded_request("printf login-url; printf done", &[], None);
-    request.stream_stdout = true;
-    request.stream_chunk_limit_bytes = vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32;
-    request.stdout_stream_limit_bytes = 64;
+    request.stdout.stream = Some(stream_policy(
+        64,
+        vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32,
+    ));
     send_bounded_exec(&mut host_stream, 15, &request);
     let (chunks, result) = read_bounded_exec_result(&mut host_stream, 15);
 
@@ -371,7 +426,7 @@ fn bounded_exec_streams_stdout_before_final_result() {
         result.termination,
         BoundedExecTermination::Exited { exit_code: 0 }
     );
-    assert_eq!(result.stdout, b"login-urldone");
+    assert_captured_output(&result.stdout, b"login-urldone", false);
     assert!(
         !chunks.is_empty(),
         "expected stream chunks before final result"
@@ -393,9 +448,14 @@ fn bounded_exec_streams_stdout_and_stderr_independently() {
     let (handle, mut host_stream) = start_guest_connection();
 
     let mut request = bounded_request("printf out; printf err >&2", &[], None);
-    request.stream_stdout = true;
-    request.stream_stderr = true;
-    request.stream_chunk_limit_bytes = vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32;
+    request.stdout.stream = Some(stream_policy(
+        1024 * 1024,
+        vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32,
+    ));
+    request.stderr.stream = Some(stream_policy(
+        1024 * 1024,
+        vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32,
+    ));
     send_bounded_exec(&mut host_stream, 16, &request);
     let (chunks, result) = read_bounded_exec_result(&mut host_stream, 16);
 
@@ -431,7 +491,7 @@ fn bounded_exec_timeout_returns_timed_out_with_partial_output() {
     let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 17);
 
     assert_eq!(result.termination, BoundedExecTermination::TimedOut);
-    assert_eq!(result.stdout, b"before");
+    assert_captured_output(&result.stdout, b"before", false);
 
     finish_guest_connection(handle, host_stream);
 }
@@ -441,8 +501,8 @@ fn bounded_exec_tracks_stdout_stderr_truncation_independently() {
     let (handle, mut host_stream) = start_guest_connection();
 
     let mut request = bounded_request("printf abcdefghij; printf err >&2", &[], None);
-    request.stdout_limit_bytes = 4;
-    request.stderr_limit_bytes = 10;
+    request.stdout.capture = BoundedExecCapturePolicy::Capture { limit_bytes: 4 };
+    request.stderr.capture = BoundedExecCapturePolicy::Capture { limit_bytes: 10 };
     send_bounded_exec(&mut host_stream, 18, &request);
     let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 18);
 
@@ -450,10 +510,8 @@ fn bounded_exec_tracks_stdout_stderr_truncation_independently() {
         result.termination,
         BoundedExecTermination::Exited { exit_code: 0 }
     );
-    assert_eq!(result.stdout, b"abcd");
-    assert_eq!(result.stderr, b"err");
-    assert!(result.stdout_truncated);
-    assert!(!result.stderr_truncated);
+    assert_captured_output(&result.stdout, b"abcd", true);
+    assert_captured_output(&result.stderr, b"err", false);
 
     finish_guest_connection(handle, host_stream);
 }
@@ -467,8 +525,8 @@ fn bounded_exec_over_cap_output_continues_draining() {
         &[],
         None,
     );
-    request.stdout_limit_bytes = 32;
-    request.stderr_limit_bytes = 32;
+    request.stdout.capture = BoundedExecCapturePolicy::Capture { limit_bytes: 32 };
+    request.stderr.capture = BoundedExecCapturePolicy::Capture { limit_bytes: 32 };
     send_bounded_exec(&mut host_stream, 19, &request);
     let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 19);
 
@@ -476,10 +534,8 @@ fn bounded_exec_over_cap_output_continues_draining() {
         result.termination,
         BoundedExecTermination::Exited { exit_code: 0 }
     );
-    assert_eq!(result.stdout, vec![b'A'; 32]);
-    assert_eq!(result.stderr, vec![b'B'; 32]);
-    assert!(result.stdout_truncated);
-    assert!(result.stderr_truncated);
+    assert_captured_output(&result.stdout, &[b'A'; 32], true);
+    assert_captured_output(&result.stderr, &[b'B'; 32], true);
 
     finish_guest_connection(handle, host_stream);
 }
@@ -519,9 +575,9 @@ fn bounded_exec_large_env_payload_succeeds() {
         result.termination,
         BoundedExecTermination::Exited { exit_code: 0 },
         "stderr: {}",
-        String::from_utf8_lossy(&result.stderr),
+        String::from_utf8_lossy(captured_bytes(&result.stderr)),
     );
-    assert_large_env_stdout(&result.stdout);
+    assert_large_env_stdout(captured_bytes(&result.stdout));
 
     finish_guest_connection(handle, host_stream);
 }
@@ -535,11 +591,11 @@ fn bounded_exec_invalid_env_payload_returns_start_failed_without_leaking_value()
     let request = bounded_request("echo should-not-run", &env, None);
     send_bounded_exec(&mut host_stream, 22, &request);
     let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 22);
-    let stderr = String::from_utf8_lossy(&result.stderr);
+    let diagnostic = result.diagnostic.as_deref().unwrap_or_default();
 
     assert_eq!(result.termination, BoundedExecTermination::StartFailed);
-    assert!(stderr.contains("invalid environment variable name"));
-    assert!(!stderr.contains(secret));
+    assert!(diagnostic.contains("invalid environment variable name"));
+    assert!(!diagnostic.contains(secret));
 
     finish_guest_connection(handle, host_stream);
 }
@@ -549,15 +605,14 @@ fn bounded_exec_rejects_tiny_stream_chunk_limit() {
     let (handle, mut host_stream) = start_guest_connection();
 
     let mut request = bounded_request("echo should-not-run", &[], None);
-    request.stream_stdout = true;
-    request.stream_chunk_limit_bytes = 1;
+    request.stdout.stream = Some(stream_policy(1024, 1));
     send_bounded_exec(&mut host_stream, 23, &request);
     let (chunks, result) = read_bounded_exec_result(&mut host_stream, 23);
-    let stderr = String::from_utf8_lossy(&result.stderr);
+    let diagnostic = result.diagnostic.as_deref().unwrap_or_default();
 
     assert!(chunks.is_empty());
     assert_eq!(result.termination, BoundedExecTermination::StartFailed);
-    assert!(stderr.contains("stream chunk limit below minimum"));
+    assert!(diagnostic.contains("stream chunk limit below minimum"));
 
     finish_guest_connection(handle, host_stream);
 }
@@ -567,15 +622,17 @@ fn bounded_exec_rejects_final_output_limits_that_cannot_fit_result_frame() {
     let (handle, mut host_stream) = start_guest_connection();
 
     let mut request = bounded_request("echo should-not-run", &[], None);
-    request.stdout_limit_bytes = vsock_proto::MAX_BOUNDED_EXEC_RESULT_OUTPUT_BYTES as u32;
-    request.stderr_limit_bytes = 1;
+    request.stdout.capture = BoundedExecCapturePolicy::Capture {
+        limit_bytes: vsock_proto::MAX_BOUNDED_EXEC_RESULT_OUTPUT_BYTES as u32,
+    };
+    request.stderr.capture = BoundedExecCapturePolicy::Capture { limit_bytes: 1 };
     send_bounded_exec(&mut host_stream, 24, &request);
     let (chunks, result) = read_bounded_exec_result(&mut host_stream, 24);
-    let stderr = String::from_utf8_lossy(&result.stderr);
+    let diagnostic = result.diagnostic.as_deref().unwrap_or_default();
 
     assert!(chunks.is_empty());
     assert_eq!(result.termination, BoundedExecTermination::StartFailed);
-    assert!(stderr.contains("final output limits exceed protocol result frame"));
+    assert!(diagnostic.contains("final output limits exceed protocol result frame"));
 
     finish_guest_connection(handle, host_stream);
 }
@@ -585,8 +642,8 @@ fn bounded_exec_zero_final_limits_return_empty_truncated_output() {
     let (handle, mut host_stream) = start_guest_connection();
 
     let mut request = bounded_request("printf stdout; printf stderr >&2", &[], None);
-    request.stdout_limit_bytes = 0;
-    request.stderr_limit_bytes = 0;
+    request.stdout.capture = BoundedExecCapturePolicy::Capture { limit_bytes: 0 };
+    request.stderr.capture = BoundedExecCapturePolicy::Capture { limit_bytes: 0 };
     send_bounded_exec(&mut host_stream, 25, &request);
     let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 25);
 
@@ -594,10 +651,129 @@ fn bounded_exec_zero_final_limits_return_empty_truncated_output() {
         result.termination,
         BoundedExecTermination::Exited { exit_code: 0 }
     );
-    assert!(result.stdout.is_empty());
-    assert!(result.stderr.is_empty());
-    assert!(result.stdout_truncated);
-    assert!(result.stderr_truncated);
+    assert_captured_output(&result.stdout, b"", true);
+    assert_captured_output(&result.stderr, b"", true);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_discarded_outputs_do_not_block_large_writes() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request(
+        "head -c 200000 /dev/zero | tr '\\0' A; head -c 200000 /dev/zero | tr '\\0' B >&2",
+        &[],
+        None,
+    );
+    request.stdout = discard_policy();
+    request.stderr = discard_policy();
+    send_bounded_exec(&mut host_stream, 32, &request);
+    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 32);
+
+    assert!(chunks.is_empty());
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    assert_discarded_output(&result.stdout);
+    assert_discarded_output(&result.stderr);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_can_discard_stdout_while_capturing_stderr() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request("printf out; printf err >&2", &[], None);
+    request.stdout = discard_policy();
+    request.stderr = capture_policy(16);
+    send_bounded_exec(&mut host_stream, 33, &request);
+    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 33);
+
+    assert!(chunks.is_empty());
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    assert_discarded_output(&result.stdout);
+    assert_captured_output(&result.stderr, b"err", false);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_can_discard_stderr_while_capturing_stdout() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request("printf out; printf err >&2", &[], None);
+    request.stdout = capture_policy(16);
+    request.stderr = discard_policy();
+    send_bounded_exec(&mut host_stream, 34, &request);
+    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 34);
+
+    assert!(chunks.is_empty());
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    assert_captured_output(&result.stdout, b"out", false);
+    assert_discarded_output(&result.stderr);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_stream_only_returns_discarded_final_output() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let mut request = bounded_request("printf stream-only", &[], None);
+    request.stdout = BoundedExecOutputPolicy {
+        capture: BoundedExecCapturePolicy::Discard,
+        stream: Some(stream_policy(
+            1024,
+            vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32,
+        )),
+    };
+    request.stderr = discard_policy();
+    send_bounded_exec(&mut host_stream, 35, &request);
+    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 35);
+
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks[0].stream, BoundedExecStream::Stdout);
+    assert_eq!(chunks[0].sequence, 0);
+    assert_eq!(chunks[0].chunk, b"stream-only");
+    assert!(!chunks[0].truncated);
+    assert_discarded_output(&result.stdout);
+    assert_discarded_output(&result.stderr);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn bounded_exec_diagnostic_survives_discarded_outputs() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let secret = "discarded-diagnostic-secret";
+    let env = [("BAD;KEY", secret)];
+    let mut request = bounded_request("echo should-not-run", &env, None);
+    request.stdout = discard_policy();
+    request.stderr = discard_policy();
+    send_bounded_exec(&mut host_stream, 36, &request);
+    let (chunks, result) = read_bounded_exec_result(&mut host_stream, 36);
+    let diagnostic = result.diagnostic.as_deref().unwrap_or_default();
+
+    assert!(chunks.is_empty());
+    assert_eq!(result.termination, BoundedExecTermination::StartFailed);
+    assert_discarded_output(&result.stdout);
+    assert_discarded_output(&result.stderr);
+    assert!(diagnostic.contains("invalid environment variable name"));
+    assert!(!diagnostic.contains(secret));
 
     finish_guest_connection(handle, host_stream);
 }
@@ -607,11 +783,8 @@ fn bounded_exec_ignores_stream_limits_when_streaming_is_disabled() {
     let (handle, mut host_stream) = start_guest_connection();
 
     let mut request = bounded_request("printf no-stream", &[], None);
-    request.stream_stdout = false;
-    request.stream_stderr = false;
-    request.stream_chunk_limit_bytes = 0;
-    request.stdout_stream_limit_bytes = 0;
-    request.stderr_stream_limit_bytes = 0;
+    request.stdout.stream = None;
+    request.stderr.stream = None;
     send_bounded_exec(&mut host_stream, 26, &request);
     let (chunks, result) = read_bounded_exec_result(&mut host_stream, 26);
 
@@ -620,10 +793,8 @@ fn bounded_exec_ignores_stream_limits_when_streaming_is_disabled() {
         result.termination,
         BoundedExecTermination::Exited { exit_code: 0 }
     );
-    assert_eq!(result.stdout, b"no-stream");
-    assert_eq!(result.stderr, b"");
-    assert!(!result.stdout_truncated);
-    assert!(!result.stderr_truncated);
+    assert_captured_output(&result.stdout, b"no-stream", false);
+    assert_captured_output(&result.stderr, b"", false);
 
     finish_guest_connection(handle, host_stream);
 }
@@ -633,9 +804,10 @@ fn bounded_exec_zero_stream_budget_emits_truncation_marker_only() {
     let (handle, mut host_stream) = start_guest_connection();
 
     let mut request = bounded_request("printf streamed", &[], None);
-    request.stream_stdout = true;
-    request.stream_chunk_limit_bytes = vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32;
-    request.stdout_stream_limit_bytes = 0;
+    request.stdout.stream = Some(stream_policy(
+        0,
+        vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32,
+    ));
     send_bounded_exec(&mut host_stream, 27, &request);
     let (chunks, result) = read_bounded_exec_result(&mut host_stream, 27);
 
@@ -643,7 +815,7 @@ fn bounded_exec_zero_stream_budget_emits_truncation_marker_only() {
         result.termination,
         BoundedExecTermination::Exited { exit_code: 0 }
     );
-    assert_eq!(result.stdout, b"streamed");
+    assert_captured_output(&result.stdout, b"streamed", false);
     assert_eq!(chunks.len(), 1);
     assert_eq!(chunks[0].stream, BoundedExecStream::Stdout);
     assert_eq!(chunks[0].sequence, 0);
@@ -658,9 +830,10 @@ fn bounded_exec_stream_limit_emits_data_then_truncation_marker() {
     let (handle, mut host_stream) = start_guest_connection();
 
     let mut request = bounded_request("head -c 2500 /dev/zero | tr '\\0' S", &[], None);
-    request.stream_stdout = true;
-    request.stream_chunk_limit_bytes = vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32;
-    request.stdout_stream_limit_bytes = 1500;
+    request.stdout.stream = Some(stream_policy(
+        1500,
+        vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32,
+    ));
     send_bounded_exec(&mut host_stream, 28, &request);
     let (chunks, result) = read_bounded_exec_result(&mut host_stream, 28);
 
@@ -668,9 +841,8 @@ fn bounded_exec_stream_limit_emits_data_then_truncation_marker() {
         result.termination,
         BoundedExecTermination::Exited { exit_code: 0 }
     );
-    assert_eq!(result.stdout, vec![b'S'; 2500]);
-    assert!(!result.stdout_truncated);
-    assert!(!result.stderr_truncated);
+    assert_captured_output(&result.stdout, &vec![b'S'; 2500], false);
+    assert_captured_output(&result.stderr, b"", false);
 
     assert!(
         chunks.len() >= 2,
@@ -706,16 +878,17 @@ fn bounded_exec_rejects_stream_chunk_limit_that_cannot_fit_frame() {
     let (handle, mut host_stream) = start_guest_connection();
 
     let mut request = bounded_request("echo should-not-run", &[], None);
-    request.stream_stdout = true;
-    request.stream_chunk_limit_bytes =
-        (vsock_proto::MAX_BOUNDED_EXEC_OUTPUT_CHUNK_BYTES + 1) as u32;
+    request.stdout.stream = Some(stream_policy(
+        1024,
+        (vsock_proto::MAX_BOUNDED_EXEC_OUTPUT_CHUNK_BYTES + 1) as u32,
+    ));
     send_bounded_exec(&mut host_stream, 29, &request);
     let (chunks, result) = read_bounded_exec_result(&mut host_stream, 29);
-    let stderr = String::from_utf8_lossy(&result.stderr);
+    let diagnostic = result.diagnostic.as_deref().unwrap_or_default();
 
     assert!(chunks.is_empty());
     assert_eq!(result.termination, BoundedExecTermination::StartFailed);
-    assert!(stderr.contains("stream chunk limit exceeds protocol frame"));
+    assert!(diagnostic.contains("stream chunk limit exceeds protocol frame"));
 
     finish_guest_connection(handle, host_stream);
 }
@@ -736,8 +909,8 @@ fn bounded_exec_slow_request_does_not_block_fast_request() {
         result.termination,
         BoundedExecTermination::Exited { exit_code: 0 }
     );
-    assert_eq!(result.stdout, b"fast");
-    assert_eq!(result.stderr, b"");
+    assert_captured_output(&result.stdout, b"fast", false);
+    assert_captured_output(&result.stderr, b"", false);
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -1821,21 +1821,103 @@ fn read_spawn_watch_pid(stream: &mut impl std::io::Read, seq: u32) -> u32 {
 fn read_pid_file(path: &str) -> u32 {
     let deadline = std::time::Instant::now() + Duration::from_secs(3);
     loop {
-        match std::fs::read_to_string(path) {
-            Ok(contents) => {
-                if let Ok(pid) = contents.trim().parse() {
-                    return pid;
-                }
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => panic!("failed to read pid file {path}: {e}"),
+        if let Some(pid) = try_read_pid_file(path) {
+            return pid;
         }
         assert!(
             std::time::Instant::now() < deadline,
             "pid file {path} was not created",
         );
+        if wait_for_pid_file_change(path, deadline).unwrap_or(false) {
+            continue;
+        }
         thread::sleep(Duration::from_millis(50));
     }
+}
+
+fn try_read_pid_file(path: &str) -> Option<u32> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => contents.trim().parse().ok(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => panic!("failed to read pid file {path}: {e}"),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn wait_for_pid_file_change(path: &str, deadline: std::time::Instant) -> std::io::Result<bool> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::Path;
+
+    let path = Path::new(path);
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let parent_c = CString::new(parent.as_os_str().as_bytes())?;
+
+    // SAFETY: inotify_init1 has no preconditions; the returned fd is checked.
+    let fd = unsafe { libc::inotify_init1(libc::IN_CLOEXEC) };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    struct FdGuard(libc::c_int);
+    impl Drop for FdGuard {
+        fn drop(&mut self) {
+            // SAFETY: the fd is owned by this guard.
+            unsafe {
+                libc::close(self.0);
+            }
+        }
+    }
+    let fd = FdGuard(fd);
+
+    let mask = libc::IN_CREATE | libc::IN_CLOSE_WRITE | libc::IN_MODIFY | libc::IN_MOVED_TO;
+    // SAFETY: parent_c is a valid nul-terminated path and fd is an inotify fd.
+    let wd = unsafe { libc::inotify_add_watch(fd.0, parent_c.as_ptr(), mask) };
+    if wd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    if try_read_pid_file(path.to_string_lossy().as_ref()).is_some() {
+        return Ok(true);
+    }
+
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return Ok(false);
+        }
+        let timeout_ms = remaining.as_millis().clamp(1, libc::c_int::MAX as u128) as libc::c_int;
+        let mut pfd = libc::pollfd {
+            fd: fd.0,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: pfd points to one initialized pollfd and timeout_ms is bounded.
+        let ret = unsafe { libc::poll(&mut pfd, 1, timeout_ms) };
+        if ret < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err);
+        }
+        if ret == 0 {
+            return Ok(false);
+        }
+
+        let mut buf = [0u8; 4096];
+        // SAFETY: buf is valid writable memory and fd is readable after poll.
+        let _ = unsafe { libc::read(fd.0, buf.as_mut_ptr().cast(), buf.len()) };
+        return Ok(true);
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn wait_for_pid_file_change(_path: &str, _deadline: std::time::Instant) -> std::io::Result<bool> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "inotify is linux-only",
+    ))
 }
 
 fn kill_pid_group(pid: u32) {
@@ -1846,6 +1928,18 @@ fn kill_pid_group(pid: u32) {
 }
 
 fn wait_for_pid_exit(pid: u32, context: &str) {
+    if !pid_alive(pid) {
+        return;
+    }
+
+    if let Ok(exited) = wait_for_pid_exit_with_pidfd(pid, Duration::from_secs(5)) {
+        if exited {
+            return;
+        }
+        kill_pid_group(pid);
+        panic!("pid {pid} did not terminate within 5s after {context}");
+    }
+
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
     while pid_alive(pid) {
         if std::time::Instant::now() >= deadline {
@@ -1854,6 +1948,71 @@ fn wait_for_pid_exit(pid: u32, context: &str) {
         }
         thread::sleep(Duration::from_millis(50));
     }
+}
+
+#[cfg(target_os = "linux")]
+fn wait_for_pid_exit_with_pidfd(pid: u32, timeout: Duration) -> std::io::Result<bool> {
+    // SAFETY: pidfd_open is called with a pid produced by this test and flags=0.
+    let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid as libc::pid_t, 0) };
+    if fd < 0 {
+        let err = std::io::Error::last_os_error();
+        if !pid_alive(pid) {
+            return Ok(true);
+        }
+        return Err(err);
+    }
+
+    struct FdGuard(libc::c_int);
+    impl Drop for FdGuard {
+        fn drop(&mut self) {
+            // SAFETY: the fd is owned by this guard.
+            unsafe {
+                libc::close(self.0);
+            }
+        }
+    }
+
+    let pidfd = FdGuard(fd as libc::c_int);
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if !pid_alive(pid) {
+            return Ok(true);
+        }
+
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return Ok(false);
+        }
+        let timeout_ms = remaining.as_millis().clamp(1, libc::c_int::MAX as u128) as libc::c_int;
+        let mut pfd = libc::pollfd {
+            fd: pidfd.0,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: pfd points to one initialized pollfd and timeout_ms is bounded.
+        let ret = unsafe { libc::poll(&mut pfd, 1, timeout_ms) };
+        if ret < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err);
+        }
+        if ret == 0 {
+            return Ok(!pid_alive(pid));
+        }
+        if pfd.revents & (libc::POLLIN | libc::POLLHUP | libc::POLLERR) != 0 {
+            return Ok(true);
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn wait_for_pid_exit_with_pidfd(_pid: u32, _timeout: Duration) -> std::io::Result<bool> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "pidfd is linux-only",
+    ))
 }
 
 /// Regression for #11077 (`MSG_EXEC` side): with `timeout_ms = 0`, a
@@ -2149,20 +2308,7 @@ fn streaming_terminates_child_on_vsock_disconnect() {
     drop(host_stream);
     let _ = handle.join();
 
-    // Wait for the child to terminate. Timing budget: ≤100 ms drain
-    // poll + 50 ms next echo + tear-down. 5 s deadline is generous.
-    let kill_deadline = Instant::now() + Duration::from_secs(5);
-    while pid_alive(pid) {
-        if Instant::now() >= kill_deadline {
-            // Best-effort cleanup before failing
-            // SAFETY: pid was obtained from MSG_SPAWN_WATCH_RESULT.
-            unsafe {
-                libc::kill(pid as i32, libc::SIGKILL);
-            }
-            panic!("pid {pid} did not terminate within 5s after vsock disconnect");
-        }
-        thread::sleep(Duration::from_millis(50));
-    }
+    wait_for_pid_exit(pid, "vsock disconnect");
 }
 
 /// Regression: a child producing > 64 KB on **both** stdout and stderr

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -411,6 +411,30 @@ fn bounded_exec_broken_pipe_stdin_keeps_child_exit_status() {
 }
 
 #[test]
+fn bounded_exec_stdin_writer_exits_when_grandchild_holds_stdin() {
+    let orphan = OrphanProcessGuard::new("bounded-exec-stdin-orphan");
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let stdin = vec![b'x'; 8 * 1024 * 1024];
+    let command = format!(
+        "python3 -c \"import os,time; p=os.fork(); (os.write(os.open('{}', os.O_WRONLY|os.O_CREAT|os.O_TRUNC, 0o600), str(p).encode()), os._exit(0)) if p else (os.dup2(os.open('/dev/null', os.O_WRONLY), 1), os.dup2(os.open('/dev/null', os.O_WRONLY), 2), time.sleep(30))\"",
+        orphan.pid_path()
+    );
+    let request = bounded_request(&command, &[], Some(stdin.as_slice()));
+    send_bounded_exec(&mut host_stream, 37, &request);
+    let (_chunks, result) = read_bounded_exec_result(&mut host_stream, 37);
+
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    let orphan_pid = read_pid_file(orphan.pid_path());
+    wait_for_pid_exit(orphan_pid, "bounded exec stdin cleanup");
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn bounded_exec_streams_stdout_before_final_result() {
     let (handle, mut host_stream) = start_guest_connection();
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -186,6 +186,7 @@ impl BoundedOutputEventPlans {
 struct BoundedOutputForwardPlan {
     event_tx: mpsc::UnboundedSender<BoundedExecOutputEvent>,
     events: BoundedOutputEventPlans,
+    closed_stream_sender: Option<mpsc::UnboundedSender<BoundedExecOutputEvent>>,
 }
 
 impl BoundedOutputRegistration {
@@ -209,7 +210,12 @@ impl BoundedOutputRegistration {
         if events.is_empty() {
             return None;
         }
-        Some(BoundedOutputForwardPlan { event_tx, events })
+        let closed_stream_sender = state.closed.then(|| state.event_tx.take()).flatten();
+        Some(BoundedOutputForwardPlan {
+            event_tx,
+            events,
+            closed_stream_sender,
+        })
     }
 
     fn all_streams_closed(&self) -> bool {
@@ -907,7 +913,13 @@ async fn reader_loop(
                     };
                     drop(closed_registration);
                     if let Some(forward_plan) = forward_plan {
-                        for event_plan in forward_plan.events.iter() {
+                        let BoundedOutputForwardPlan {
+                            event_tx,
+                            events,
+                            closed_stream_sender,
+                        } = forward_plan;
+                        drop(closed_stream_sender);
+                        for event_plan in events.iter() {
                             debug_assert!(
                                 event_plan.chunk_len <= decoded.chunk.len(),
                                 "bounded output plan length must fit decoded chunk length"
@@ -922,7 +934,7 @@ async fn reader_loop(
                                 chunk: chunk.to_vec(),
                                 truncated: event_plan.truncated,
                             };
-                            if forward_plan.event_tx.send(event).is_err() {
+                            if event_tx.send(event).is_err() {
                                 shared.close_bounded_output_stream(msg.seq, event_plan.stream);
                                 break;
                             }
@@ -1785,6 +1797,23 @@ mod tests {
                 bounded_output_senders.len(),
             ),
             ConnectionState::Closed { .. } => (0, 0, 0, 0),
+        }
+    }
+
+    fn bounded_stream_sender_presence(host: &VsockHost) -> Option<(bool, bool)> {
+        let guard = host.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        match &*guard {
+            ConnectionState::Connected {
+                bounded_output_senders,
+                ..
+            } => {
+                let registration = bounded_output_senders.values().next()?;
+                Some((
+                    registration.stdout.event_tx.is_some(),
+                    registration.stderr.event_tx.is_some(),
+                ))
+            }
+            ConnectionState::Closed { .. } => None,
         }
     }
 
@@ -2754,6 +2783,93 @@ mod tests {
             }
         );
         assert_bounded_event_stream_closed(&mut event_rx);
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_closed_stream_drops_sender_before_result() {
+        let (host_stream, mut guest) = make_pair();
+        let stdout_capped = std::sync::Arc::new(Notify::new());
+        let release_result = std::sync::Arc::new(Notify::new());
+
+        {
+            let stdout_capped = std::sync::Arc::clone(&stdout_capped);
+            let release_result = std::sync::Arc::clone(&release_result);
+            tokio::spawn(async move {
+                let mut decoder = Decoder::new();
+                mock_handshake(&mut guest, &mut decoder).await;
+
+                let mut buf = [0u8; 4096];
+                let n = guest.read(&mut buf).await.unwrap();
+                let msgs = decoder.decode(&buf[..n]).unwrap();
+                assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+
+                write_bounded_stream_chunk(
+                    &mut guest,
+                    msgs[0].seq,
+                    vsock_proto::BoundedExecStream::Stdout,
+                    1,
+                    b"abcd",
+                    false,
+                )
+                .await;
+                stdout_capped.notify_one();
+
+                release_result.notified().await;
+                write_bounded_exec_result(&mut guest, msgs[0].seq, b"done").await;
+            });
+        }
+
+        let host = std::sync::Arc::new(host_from_stream(host_stream).await.unwrap());
+        let task_host = std::sync::Arc::clone(&host);
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let task = tokio::spawn(async move {
+            let request = simple_bounded_request(
+                "cap-stdout-release-sender",
+                Some(bounded_stream_request_with_limits(
+                    event_tx,
+                    true,
+                    true,
+                    vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES,
+                    3,
+                    8,
+                )),
+            );
+            task_host.bounded_exec(&request).await
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), stdout_capped.notified())
+            .await
+            .expect("guest should send stdout chunk");
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 1,
+                chunk: b"abc".to_vec(),
+                truncated: false,
+            }
+        );
+        assert_eq!(
+            event_rx.recv().await.unwrap(),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stdout,
+                sequence: 2,
+                chunk: Vec::new(),
+                truncated: true,
+            }
+        );
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while bounded_stream_sender_presence(&host) != Some((false, true)) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("closed stdout stream should release its sender before final result");
+
+        release_result.notify_one();
+        let result = task.await.unwrap().unwrap();
+        assert_host_captured_output(&result.stdout, b"done", false);
+        assert_eq!(registration_counts(&host), (0, 0, 0, 0));
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -2861,13 +2861,11 @@ mod tests {
                 truncated: true,
             }
         );
-        tokio::time::timeout(Duration::from_secs(5), async {
-            while bounded_stream_sender_presence(&host) != Some((false, true)) {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("closed stdout stream should release its sender before final result");
+        assert_eq!(
+            bounded_stream_sender_presence(&host),
+            Some((false, true)),
+            "closed stdout stream should release its sender before final result"
+        );
 
         release_result.notify_one();
         let result = task.await.unwrap().unwrap();

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1326,6 +1326,9 @@ impl VsockHost {
     /// This is request/response scoped like [`exec`](Self::exec), but it
     /// returns structured termination, bounded final buffers, and optional
     /// request-scoped stdout/stderr stream events.
+    /// [`BoundedExecOutput::Discarded`] means final capture was disabled for
+    /// that stream; `diagnostic` carries bounded-exec setup/wait details and is
+    /// independent of stdout/stderr capture.
     pub async fn bounded_exec(
         &self,
         request: &BoundedExecRequest<'_>,

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -82,13 +82,21 @@ pub struct BoundedExecOutputEvent {
     pub truncated: bool,
 }
 
-pub struct BoundedExecStreamRequest {
+pub struct BoundedExecStreamPolicy {
     pub event_tx: mpsc::UnboundedSender<BoundedExecOutputEvent>,
-    pub stdout: bool,
-    pub stderr: bool,
+    pub limit_bytes: u32,
     pub chunk_limit_bytes: u32,
-    pub stdout_limit_bytes: u32,
-    pub stderr_limit_bytes: u32,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum BoundedExecCapturePolicy {
+    Discard,
+    Capture { limit_bytes: u32 },
+}
+
+pub struct BoundedExecOutputRequest {
+    pub capture: BoundedExecCapturePolicy,
+    pub stream: Option<BoundedExecStreamPolicy>,
 }
 
 pub struct BoundedExecRequest<'a> {
@@ -97,32 +105,35 @@ pub struct BoundedExecRequest<'a> {
     pub env: &'a [(&'a str, &'a str)],
     pub sudo: bool,
     pub stdin: Option<&'a [u8]>,
-    pub stdout_limit_bytes: u32,
-    pub stderr_limit_bytes: u32,
-    pub stream: Option<BoundedExecStreamRequest>,
+    pub stdout: BoundedExecOutputRequest,
+    pub stderr: BoundedExecOutputRequest,
 }
 
 #[derive(Debug, Clone)]
 pub struct BoundedExecResult {
     pub termination: BoundedExecTermination,
     pub duration_ms: u64,
-    pub stdout: Vec<u8>,
-    pub stderr: Vec<u8>,
-    pub stdout_truncated: bool,
-    pub stderr_truncated: bool,
+    pub stdout: BoundedExecOutput,
+    pub stderr: BoundedExecOutput,
+    pub diagnostic: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum BoundedExecOutput {
+    Discarded,
+    Captured { bytes: Vec<u8>, truncated: bool },
 }
 
 struct BoundedOutputRegistration {
-    event_tx: mpsc::UnboundedSender<BoundedExecOutputEvent>,
-    chunk_limit_bytes: usize,
     stdout: BoundedOutputStreamState,
     stderr: BoundedOutputStreamState,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct BoundedOutputStreamState {
-    enabled: bool,
+    event_tx: Option<mpsc::UnboundedSender<BoundedExecOutputEvent>>,
     limit_bytes: usize,
+    chunk_limit_bytes: usize,
     forwarded_bytes: usize,
     closed: bool,
 }
@@ -178,12 +189,10 @@ struct BoundedOutputForwardPlan {
 }
 
 impl BoundedOutputRegistration {
-    fn new(request: &BoundedExecStreamRequest) -> Self {
+    fn new(stdout: &BoundedExecOutputRequest, stderr: &BoundedExecOutputRequest) -> Self {
         Self {
-            event_tx: request.event_tx.clone(),
-            chunk_limit_bytes: request.chunk_limit_bytes as usize,
-            stdout: BoundedOutputStreamState::new(request.stdout, request.stdout_limit_bytes),
-            stderr: BoundedOutputStreamState::new(request.stderr, request.stderr_limit_bytes),
+            stdout: BoundedOutputStreamState::new(stdout.stream.as_ref()),
+            stderr: BoundedOutputStreamState::new(stderr.stream.as_ref()),
         }
     }
 
@@ -194,25 +203,24 @@ impl BoundedOutputRegistration {
         chunk_len: usize,
         truncated: bool,
     ) -> Option<BoundedOutputForwardPlan> {
-        let chunk_limit_bytes = self.chunk_limit_bytes;
-        let events = self.stream_mut(stream).forward_plan(
-            stream,
-            sequence,
-            chunk_len,
-            truncated,
-            chunk_limit_bytes,
-        );
+        let state = self.stream_mut(stream);
+        let event_tx = state.event_tx.clone()?;
+        let events = state.forward_plan(stream, sequence, chunk_len, truncated);
         if events.is_empty() {
             return None;
         }
-        Some(BoundedOutputForwardPlan {
-            event_tx: self.event_tx.clone(),
-            events,
-        })
+        Some(BoundedOutputForwardPlan { event_tx, events })
     }
 
     fn all_streams_closed(&self) -> bool {
         self.stdout.is_closed_or_disabled() && self.stderr.is_closed_or_disabled()
+    }
+
+    fn close_stream(
+        &mut self,
+        stream: BoundedExecStream,
+    ) -> Option<mpsc::UnboundedSender<BoundedExecOutputEvent>> {
+        self.stream_mut(stream).close()
     }
 
     fn stream_mut(&mut self, stream: BoundedExecStream) -> &mut BoundedOutputStreamState {
@@ -224,17 +232,23 @@ impl BoundedOutputRegistration {
 }
 
 impl BoundedOutputStreamState {
-    fn new(enabled: bool, limit_bytes: u32) -> Self {
+    fn new(stream: Option<&BoundedExecStreamPolicy>) -> Self {
         Self {
-            enabled,
-            limit_bytes: limit_bytes as usize,
+            event_tx: stream.map(|stream| stream.event_tx.clone()),
+            limit_bytes: stream.map_or(0, |stream| stream.limit_bytes as usize),
+            chunk_limit_bytes: stream.map_or(0, |stream| stream.chunk_limit_bytes as usize),
             forwarded_bytes: 0,
             closed: false,
         }
     }
 
     fn is_closed_or_disabled(&self) -> bool {
-        !self.enabled || self.closed
+        self.event_tx.is_none() || self.closed
+    }
+
+    fn close(&mut self) -> Option<mpsc::UnboundedSender<BoundedExecOutputEvent>> {
+        self.closed = true;
+        self.event_tx.take()
     }
 
     fn forward_plan(
@@ -243,13 +257,13 @@ impl BoundedOutputStreamState {
         sequence: u32,
         chunk_len: usize,
         incoming_truncated: bool,
-        chunk_limit_bytes: usize,
     ) -> BoundedOutputEventPlans {
         if self.is_closed_or_disabled() {
             return BoundedOutputEventPlans::empty();
         }
 
         let remaining = self.limit_bytes.saturating_sub(self.forwarded_bytes);
+        let chunk_limit_bytes = self.chunk_limit_bytes;
 
         if incoming_truncated {
             let allowed_len = chunk_len.min(chunk_limit_bytes).min(remaining);
@@ -613,6 +627,32 @@ impl Shared {
         };
         drop(removed);
     }
+
+    fn close_bounded_output_stream(&self, seq: u32, stream: BoundedExecStream) {
+        let (removed_stream_sender, removed_registration) = {
+            let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            if let ConnectionState::Connected {
+                bounded_output_senders,
+                ..
+            } = &mut *guard
+            {
+                if let Some(registration) = bounded_output_senders.get_mut(&seq) {
+                    let removed_stream_sender = registration.close_stream(stream);
+                    let removed_registration = registration
+                        .all_streams_closed()
+                        .then(|| bounded_output_senders.remove(&seq))
+                        .flatten();
+                    (removed_stream_sender, removed_registration)
+                } else {
+                    (None, None)
+                }
+            } else {
+                (None, None)
+            }
+        };
+        drop(removed_stream_sender);
+        drop(removed_registration);
+    }
 }
 
 /// Host-side vsock endpoint.
@@ -666,6 +706,48 @@ fn proto_termination_to_host(termination: ProtoBoundedExecTermination) -> Bounde
     }
 }
 
+fn host_output_request_to_proto(
+    request: &BoundedExecOutputRequest,
+) -> vsock_proto::BoundedExecOutputPolicy {
+    let capture = match request.capture {
+        BoundedExecCapturePolicy::Discard => vsock_proto::BoundedExecCapturePolicy::Discard,
+        BoundedExecCapturePolicy::Capture { limit_bytes } => {
+            vsock_proto::BoundedExecCapturePolicy::Capture { limit_bytes }
+        }
+    };
+    let stream = request
+        .stream
+        .as_ref()
+        .map(|stream| vsock_proto::BoundedExecStreamPolicy {
+            limit_bytes: stream.limit_bytes,
+            chunk_limit_bytes: stream.chunk_limit_bytes,
+        });
+    vsock_proto::BoundedExecOutputPolicy { capture, stream }
+}
+
+fn proto_output_to_host(output: vsock_proto::BoundedExecOutput<'_>) -> BoundedExecOutput {
+    match output {
+        vsock_proto::BoundedExecOutput::Discarded => BoundedExecOutput::Discarded,
+        vsock_proto::BoundedExecOutput::Captured { bytes, truncated } => {
+            BoundedExecOutput::Captured {
+                bytes: bytes.to_vec(),
+                truncated,
+            }
+        }
+    }
+}
+
+fn captured_limit_bytes(request: &BoundedExecOutputRequest) -> Option<usize> {
+    match request.capture {
+        BoundedExecCapturePolicy::Discard => None,
+        BoundedExecCapturePolicy::Capture { limit_bytes } => Some(limit_bytes as usize),
+    }
+}
+
+fn has_bounded_stream(request: &BoundedExecRequest<'_>) -> bool {
+    request.stdout.stream.is_some() || request.stderr.stream.is_some()
+}
+
 fn validate_bounded_exec_request(request: &BoundedExecRequest<'_>) -> io::Result<()> {
     if request.timeout_ms == 0 {
         return Err(io::Error::new(
@@ -674,8 +756,9 @@ fn validate_bounded_exec_request(request: &BoundedExecRequest<'_>) -> io::Result
         ));
     }
 
-    let total_output_limit = (request.stdout_limit_bytes as usize)
-        .checked_add(request.stderr_limit_bytes as usize)
+    let total_output_limit = captured_limit_bytes(&request.stdout)
+        .unwrap_or(0)
+        .checked_add(captured_limit_bytes(&request.stderr).unwrap_or(0))
         .ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -693,8 +776,9 @@ fn validate_bounded_exec_request(request: &BoundedExecRequest<'_>) -> io::Result
         ));
     }
 
-    if let Some(stream) = &request.stream
-        && (stream.stdout || stream.stderr)
+    for stream in [&request.stdout.stream, &request.stderr.stream]
+        .into_iter()
+        .flatten()
     {
         let chunk_limit = stream.chunk_limit_bytes as usize;
         if chunk_limit < vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES {
@@ -839,7 +923,7 @@ async fn reader_loop(
                                 truncated: event_plan.truncated,
                             };
                             if forward_plan.event_tx.send(event).is_err() {
-                                shared.remove_bounded_output_sender(msg.seq);
+                                shared.close_bounded_output_stream(msg.seq, event_plan.stream);
                                 break;
                             }
                         }
@@ -1236,25 +1320,14 @@ impl VsockHost {
     ) -> io::Result<BoundedExecResult> {
         validate_bounded_exec_request(request)?;
 
-        let stream_stdout = request.stream.as_ref().is_some_and(|s| s.stdout);
-        let stream_stderr = request.stream.as_ref().is_some_and(|s| s.stderr);
-        let stream_chunk_limit_bytes = request.stream.as_ref().map_or(0, |s| s.chunk_limit_bytes);
-        let stdout_stream_limit_bytes = request.stream.as_ref().map_or(0, |s| s.stdout_limit_bytes);
-        let stderr_stream_limit_bytes = request.stream.as_ref().map_or(0, |s| s.stderr_limit_bytes);
-
         let proto_request = vsock_proto::BoundedExecRequest {
             timeout_ms: request.timeout_ms,
             command: request.command,
             env: request.env,
             sudo: request.sudo,
             stdin: request.stdin,
-            stdout_limit_bytes: request.stdout_limit_bytes,
-            stderr_limit_bytes: request.stderr_limit_bytes,
-            stream_stdout,
-            stream_stderr,
-            stream_chunk_limit_bytes,
-            stdout_stream_limit_bytes,
-            stderr_stream_limit_bytes,
+            stdout: host_output_request_to_proto(&request.stdout),
+            stderr: host_output_request_to_proto(&request.stderr),
         };
         let payload = vsock_proto::encode_bounded_exec(&proto_request)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
@@ -1278,19 +1351,18 @@ impl VsockHost {
                     ..
                 } => {
                     pending.insert(seq, tx);
-                    if let Some(stream) = &request.stream
-                        && (stream.stdout || stream.stderr)
-                    {
-                        bounded_output_senders.insert(seq, BoundedOutputRegistration::new(stream));
+                    if has_bounded_stream(request) {
+                        bounded_output_senders.insert(
+                            seq,
+                            BoundedOutputRegistration::new(&request.stdout, &request.stderr),
+                        );
                     }
                 }
             }
         }
         let _pending_guard = PendingRequestGuard::new(Arc::clone(&self.shared), seq);
-        let _bounded_output_guard = request.stream.as_ref().and_then(|stream| {
-            (stream.stdout || stream.stderr)
-                .then(|| PendingBoundedOutputGuard::new(Arc::clone(&self.shared), seq))
-        });
+        let _bounded_output_guard = has_bounded_stream(request)
+            .then(|| PendingBoundedOutputGuard::new(Arc::clone(&self.shared), seq));
 
         write_frame_on_shared(&self.shared, &data).await?;
 
@@ -1327,10 +1399,9 @@ impl VsockHost {
         Ok(BoundedExecResult {
             termination: proto_termination_to_host(decoded.termination),
             duration_ms: decoded.duration_ms,
-            stdout: decoded.stdout.to_vec(),
-            stderr: decoded.stderr.to_vec(),
-            stdout_truncated: decoded.stdout_truncated,
-            stderr_truncated: decoded.stderr_truncated,
+            stdout: proto_output_to_host(decoded.stdout),
+            stderr: proto_output_to_host(decoded.stderr),
+            diagnostic: decoded.diagnostic.map(ToOwned::to_owned),
         })
     }
 
@@ -1717,25 +1788,87 @@ mod tests {
         }
     }
 
+    struct TestBoundedExecStreams {
+        event_tx: mpsc::UnboundedSender<BoundedExecOutputEvent>,
+        stdout: bool,
+        stderr: bool,
+        chunk_limit_bytes: u32,
+        stdout_budget_bytes: u32,
+        stderr_budget_bytes: u32,
+    }
+
+    fn capture_output(limit_bytes: u32) -> BoundedExecOutputRequest {
+        BoundedExecOutputRequest {
+            capture: BoundedExecCapturePolicy::Capture { limit_bytes },
+            stream: None,
+        }
+    }
+
+    fn discard_output() -> BoundedExecOutputRequest {
+        BoundedExecOutputRequest {
+            capture: BoundedExecCapturePolicy::Discard,
+            stream: None,
+        }
+    }
+
+    fn proto_captured_output(bytes: &[u8], truncated: bool) -> vsock_proto::BoundedExecOutput<'_> {
+        vsock_proto::BoundedExecOutput::Captured { bytes, truncated }
+    }
+
+    fn assert_host_captured_output(
+        output: &BoundedExecOutput,
+        expected_bytes: &[u8],
+        expected_truncated: bool,
+    ) {
+        match output {
+            BoundedExecOutput::Captured { bytes, truncated } => {
+                assert_eq!(bytes, expected_bytes);
+                assert_eq!(*truncated, expected_truncated);
+            }
+            BoundedExecOutput::Discarded => panic!("expected captured output"),
+        }
+    }
+
+    fn assert_host_discarded_output(output: &BoundedExecOutput) {
+        assert_eq!(*output, BoundedExecOutput::Discarded);
+    }
+
     fn simple_bounded_request<'a>(
         command: &'a str,
-        stream: Option<BoundedExecStreamRequest>,
+        stream: Option<TestBoundedExecStreams>,
     ) -> BoundedExecRequest<'a> {
+        let mut stdout = capture_output(1024);
+        let mut stderr = capture_output(1024);
+        if let Some(stream) = stream {
+            if stream.stdout {
+                stdout.stream = Some(BoundedExecStreamPolicy {
+                    event_tx: stream.event_tx.clone(),
+                    limit_bytes: stream.stdout_budget_bytes,
+                    chunk_limit_bytes: stream.chunk_limit_bytes,
+                });
+            }
+            if stream.stderr {
+                stderr.stream = Some(BoundedExecStreamPolicy {
+                    event_tx: stream.event_tx,
+                    limit_bytes: stream.stderr_budget_bytes,
+                    chunk_limit_bytes: stream.chunk_limit_bytes,
+                });
+            }
+        }
         BoundedExecRequest {
             command,
             timeout_ms: 5000,
             env: &[],
             sudo: false,
             stdin: None,
-            stdout_limit_bytes: 1024,
-            stderr_limit_bytes: 1024,
-            stream,
+            stdout,
+            stderr,
         }
     }
 
     fn bounded_stream_request(
         event_tx: mpsc::UnboundedSender<BoundedExecOutputEvent>,
-    ) -> BoundedExecStreamRequest {
+    ) -> TestBoundedExecStreams {
         bounded_stream_request_with_limits(
             event_tx,
             true,
@@ -1751,16 +1884,16 @@ mod tests {
         stdout: bool,
         stderr: bool,
         chunk_limit_bytes: usize,
-        stdout_limit_bytes: u32,
-        stderr_limit_bytes: u32,
-    ) -> BoundedExecStreamRequest {
-        BoundedExecStreamRequest {
+        stdout_budget_bytes: u32,
+        stderr_budget_bytes: u32,
+    ) -> TestBoundedExecStreams {
+        TestBoundedExecStreams {
             event_tx,
             stdout,
             stderr,
             chunk_limit_bytes: chunk_limit_bytes as u32,
-            stdout_limit_bytes,
-            stderr_limit_bytes,
+            stdout_budget_bytes,
+            stderr_budget_bytes,
         }
     }
 
@@ -1783,10 +1916,15 @@ mod tests {
         let payload = vsock_proto::encode_bounded_exec_result(
             vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
             1,
-            stdout,
-            b"",
-            false,
-            false,
+            vsock_proto::BoundedExecOutput::Captured {
+                bytes: stdout,
+                truncated: false,
+            },
+            vsock_proto::BoundedExecOutput::Captured {
+                bytes: b"",
+                truncated: false,
+            },
+            None,
         )
         .unwrap();
         let frame = vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, seq, &payload).unwrap();
@@ -1925,18 +2063,23 @@ mod tests {
             assert_eq!(d.env, vec![("K", "V")]);
             assert!(d.sudo);
             assert_eq!(d.stdin, Some(b"input".as_slice()));
-            assert_eq!(d.stdout_limit_bytes, 10);
-            assert_eq!(d.stderr_limit_bytes, 11);
-            assert!(!d.stream_stdout);
-            assert!(!d.stream_stderr);
+            assert_eq!(
+                d.stdout.capture,
+                vsock_proto::BoundedExecCapturePolicy::Capture { limit_bytes: 10 }
+            );
+            assert_eq!(
+                d.stderr.capture,
+                vsock_proto::BoundedExecCapturePolicy::Capture { limit_bytes: 11 }
+            );
+            assert!(d.stdout.stream.is_none());
+            assert!(d.stderr.stream.is_none());
 
             let payload = vsock_proto::encode_bounded_exec_result(
                 vsock_proto::BoundedExecTermination::Exited { exit_code: 7 },
                 123,
-                b"out",
-                b"err",
-                true,
-                false,
+                proto_captured_output(b"out", true),
+                proto_captured_output(b"err", false),
+                Some("diag"),
             )
             .unwrap();
             let resp = vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
@@ -1951,9 +2094,8 @@ mod tests {
             env: &env,
             sudo: true,
             stdin: Some(b"input"),
-            stdout_limit_bytes: 10,
-            stderr_limit_bytes: 11,
-            stream: None,
+            stdout: capture_output(10),
+            stderr: capture_output(11),
         };
         let result = host.bounded_exec(&request).await.unwrap();
         assert_eq!(
@@ -1961,10 +2103,59 @@ mod tests {
             BoundedExecTermination::Exited { exit_code: 7 }
         );
         assert_eq!(result.duration_ms, 123);
-        assert_eq!(result.stdout, b"out");
-        assert_eq!(result.stderr, b"err");
-        assert!(result.stdout_truncated);
-        assert!(!result.stderr_truncated);
+        assert_host_captured_output(&result.stdout, b"out", true);
+        assert_host_captured_output(&result.stderr, b"err", false);
+        assert_eq!(result.diagnostic.as_deref(), Some("diag"));
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_distinguishes_discarded_and_captured_empty_outputs() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+
+            let d = vsock_proto::decode_bounded_exec(&msgs[0].payload).unwrap();
+            assert_eq!(
+                d.stdout.capture,
+                vsock_proto::BoundedExecCapturePolicy::Discard
+            );
+            assert_eq!(
+                d.stderr.capture,
+                vsock_proto::BoundedExecCapturePolicy::Capture { limit_bytes: 0 }
+            );
+
+            let payload = vsock_proto::encode_bounded_exec_result(
+                vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
+                1,
+                vsock_proto::BoundedExecOutput::Discarded,
+                proto_captured_output(b"", false),
+                None,
+            )
+            .unwrap();
+            let resp = vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
+            guest.write_all(&resp).await.unwrap();
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let request = BoundedExecRequest {
+            command: "printf bounded",
+            timeout_ms: 7500,
+            env: &[],
+            sudo: false,
+            stdin: None,
+            stdout: discard_output(),
+            stderr: capture_output(0),
+        };
+        let result = host.bounded_exec(&request).await.unwrap();
+        assert_host_discarded_output(&result.stdout);
+        assert_host_captured_output(&result.stderr, b"", false);
     }
 
     #[tokio::test]
@@ -2014,10 +2205,9 @@ mod tests {
                 let payload = vsock_proto::encode_bounded_exec_result(
                     vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
                     1,
-                    stdout.as_bytes(),
-                    b"",
-                    false,
-                    false,
+                    proto_captured_output(stdout.as_bytes(), false),
+                    proto_captured_output(b"", false),
+                    None,
                 )
                 .unwrap();
                 let resp = vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, *seq, &payload).unwrap();
@@ -2043,8 +2233,8 @@ mod tests {
 
         let result_a = task_a.await.unwrap().unwrap();
         let result_b = task_b.await.unwrap().unwrap();
-        assert_eq!(result_a.stdout, b"final-cmd-a");
-        assert_eq!(result_b.stdout, b"final-cmd-b");
+        assert_host_captured_output(&result_a.stdout, b"final-cmd-a", false);
+        assert_host_captured_output(&result_b.stdout, b"final-cmd-b", false);
 
         assert_eq!(
             rx_a.recv().await.unwrap(),
@@ -2079,8 +2269,8 @@ mod tests {
             let msgs = decoder.decode(&buf[..n]).unwrap();
             assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
             let decoded = vsock_proto::decode_bounded_exec(&msgs[0].payload).unwrap();
-            assert!(decoded.stream_stdout);
-            assert!(!decoded.stream_stderr);
+            assert!(decoded.stdout.stream.is_some());
+            assert!(decoded.stderr.stream.is_none());
 
             let ignored_payload = vsock_proto::encode_bounded_exec_output_chunk(
                 vsock_proto::BoundedExecStream::Stderr,
@@ -2109,10 +2299,9 @@ mod tests {
             let payload = vsock_proto::encode_bounded_exec_result(
                 vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
                 1,
-                b"done",
-                b"",
-                false,
-                false,
+                proto_captured_output(b"done", false),
+                proto_captured_output(b"", false),
+                None,
             )
             .unwrap();
             let resp = vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
@@ -2123,19 +2312,19 @@ mod tests {
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
         let request = simple_bounded_request(
             "stdout-only",
-            Some(BoundedExecStreamRequest {
+            Some(TestBoundedExecStreams {
                 event_tx,
                 stdout: true,
                 stderr: false,
                 chunk_limit_bytes: vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32,
-                stdout_limit_bytes: 2048,
-                stderr_limit_bytes: 0,
+                stdout_budget_bytes: 2048,
+                stderr_budget_bytes: 0,
             }),
         );
 
         let result = host.bounded_exec(&request).await.unwrap();
         drop(request);
-        assert_eq!(result.stdout, b"done");
+        assert_host_captured_output(&result.stdout, b"done", false);
         assert_eq!(
             event_rx.recv().await.unwrap(),
             BoundedExecOutputEvent {
@@ -2198,7 +2387,7 @@ mod tests {
 
         let result = host.bounded_exec(&request).await.unwrap();
         drop(request);
-        assert_eq!(result.stdout, b"done");
+        assert_host_captured_output(&result.stdout, b"done", false);
         assert_eq!(
             event_rx.recv().await.unwrap(),
             BoundedExecOutputEvent {
@@ -2270,7 +2459,7 @@ mod tests {
 
         let result = host.bounded_exec(&request).await.unwrap();
         drop(request);
-        assert_eq!(result.stdout, b"done");
+        assert_host_captured_output(&result.stdout, b"done", false);
         assert_eq!(
             event_rx.recv().await.unwrap(),
             BoundedExecOutputEvent {
@@ -2333,7 +2522,7 @@ mod tests {
 
         let result = host.bounded_exec(&request).await.unwrap();
         drop(request);
-        assert_eq!(result.stdout, b"done");
+        assert_host_captured_output(&result.stdout, b"done", false);
         assert_eq!(
             event_rx.recv().await.unwrap(),
             BoundedExecOutputEvent {
@@ -2405,7 +2594,7 @@ mod tests {
 
         let result = host.bounded_exec(&request).await.unwrap();
         drop(request);
-        assert_eq!(result.stdout, b"done");
+        assert_host_captured_output(&result.stdout, b"done", false);
         assert_eq!(
             event_rx.recv().await.unwrap(),
             BoundedExecOutputEvent {
@@ -2486,7 +2675,7 @@ mod tests {
 
         let result = host.bounded_exec(&request).await.unwrap();
         drop(request);
-        assert_eq!(result.stdout, b"done");
+        assert_host_captured_output(&result.stdout, b"done", false);
         assert_eq!(
             event_rx.recv().await.unwrap(),
             BoundedExecOutputEvent {
@@ -2554,7 +2743,7 @@ mod tests {
 
         let result = host.bounded_exec(&request).await.unwrap();
         drop(request);
-        assert_eq!(result.stdout, b"done");
+        assert_host_captured_output(&result.stdout, b"done", false);
         assert_eq!(
             event_rx.recv().await.unwrap(),
             BoundedExecOutputEvent {
@@ -2617,7 +2806,7 @@ mod tests {
 
         let result = host.bounded_exec(&request).await.unwrap();
         drop(request);
-        assert_eq!(result.stdout, b"done");
+        assert_host_captured_output(&result.stdout, b"done", false);
         assert_eq!(
             event_rx.recv().await.unwrap(),
             BoundedExecOutputEvent {
@@ -2685,7 +2874,7 @@ mod tests {
 
         let result = host.bounded_exec(&request).await.unwrap();
         drop(request);
-        assert_eq!(result.stdout, b"done");
+        assert_host_captured_output(&result.stdout, b"done", false);
         assert_eq!(
             event_rx.recv().await.unwrap(),
             BoundedExecOutputEvent {
@@ -2757,7 +2946,7 @@ mod tests {
 
         let result = host.bounded_exec(&request).await.unwrap();
         drop(request);
-        assert_eq!(result.stdout, b"done");
+        assert_host_captured_output(&result.stdout, b"done", false);
         assert_eq!(
             event_rx.recv().await.unwrap(),
             BoundedExecOutputEvent {
@@ -2815,10 +3004,9 @@ mod tests {
             let payload = vsock_proto::encode_bounded_exec_result(
                 vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
                 1,
-                b"done",
-                b"",
-                false,
-                false,
+                proto_captured_output(b"done", false),
+                proto_captured_output(b"", false),
+                None,
             )
             .unwrap();
             let resp = vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
@@ -2833,7 +3021,7 @@ mod tests {
         let result = host.bounded_exec(&request).await.unwrap();
         drop(request);
 
-        assert_eq!(result.stdout, b"done");
+        assert_host_captured_output(&result.stdout, b"done", false);
         assert_bounded_event_stream_closed(&mut event_rx);
         assert_eq!(registration_counts(&host), (0, 0, 0, 0));
     }
@@ -2854,10 +3042,9 @@ mod tests {
             let result_payload = vsock_proto::encode_bounded_exec_result(
                 vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
                 1,
-                b"done",
-                b"",
-                false,
-                false,
+                proto_captured_output(b"done", false),
+                proto_captured_output(b"", false),
+                None,
             )
             .unwrap();
             let result =
@@ -2889,7 +3076,7 @@ mod tests {
         let result = host.bounded_exec(&request).await.unwrap();
         drop(request);
 
-        assert_eq!(result.stdout, b"done");
+        assert_host_captured_output(&result.stdout, b"done", false);
         assert_bounded_event_stream_closed(&mut event_rx);
         assert_eq!(registration_counts(&host), (0, 0, 0, 0));
     }
@@ -2916,10 +3103,9 @@ mod tests {
             let payload = vsock_proto::encode_bounded_exec_result(
                 vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
                 1,
-                b"ok",
-                b"",
-                false,
-                false,
+                proto_captured_output(b"ok", false),
+                proto_captured_output(b"", false),
+                None,
             )
             .unwrap();
             let ok_resp =
@@ -2940,7 +3126,7 @@ mod tests {
 
         let request = simple_bounded_request("good-result", None);
         let result = host.bounded_exec(&request).await.unwrap();
-        assert_eq!(result.stdout, b"ok");
+        assert_host_captured_output(&result.stdout, b"ok", false);
     }
 
     #[tokio::test]
@@ -3147,9 +3333,22 @@ mod tests {
                 env: &[],
                 sudo: false,
                 stdin: Some(&stdin),
-                stdout_limit_bytes: 1024,
-                stderr_limit_bytes: 1024,
-                stream: Some(bounded_stream_request(tx)),
+                stdout: BoundedExecOutputRequest {
+                    capture: BoundedExecCapturePolicy::Capture { limit_bytes: 1024 },
+                    stream: Some(BoundedExecStreamPolicy {
+                        event_tx: tx.clone(),
+                        limit_bytes: 2048,
+                        chunk_limit_bytes: vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32,
+                    }),
+                },
+                stderr: BoundedExecOutputRequest {
+                    capture: BoundedExecCapturePolicy::Capture { limit_bytes: 1024 },
+                    stream: Some(BoundedExecStreamPolicy {
+                        event_tx: tx,
+                        limit_bytes: 2048,
+                        chunk_limit_bytes: vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32,
+                    }),
+                },
             };
             task_host.bounded_exec(&request).await
         });
@@ -3254,10 +3453,9 @@ mod tests {
                 let payload = vsock_proto::encode_bounded_exec_result(
                     vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
                     1,
-                    b"done",
-                    b"",
-                    false,
-                    false,
+                    proto_captured_output(b"done", false),
+                    proto_captured_output(b"", false),
+                    None,
                 )
                 .unwrap();
                 let resp =
@@ -3271,8 +3469,17 @@ mod tests {
         let task = tokio::spawn(async move {
             let (tx, rx) = mpsc::unbounded_channel();
             drop(rx);
-            let request =
-                simple_bounded_request("dropped-receiver", Some(bounded_stream_request(tx)));
+            let request = simple_bounded_request(
+                "dropped-receiver",
+                Some(TestBoundedExecStreams {
+                    event_tx: tx,
+                    stdout: true,
+                    stderr: false,
+                    chunk_limit_bytes: vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32,
+                    stdout_budget_bytes: 2048,
+                    stderr_budget_bytes: 0,
+                }),
+            );
             task_host.bounded_exec(&request).await
         });
 
@@ -3289,8 +3496,91 @@ mod tests {
 
         release_result.notify_one();
         let result = task.await.unwrap().unwrap();
-        assert_eq!(result.stdout, b"done");
+        assert_host_captured_output(&result.stdout, b"done", false);
         assert_eq!(registration_counts(&host), (0, 0, 0, 0));
+    }
+
+    #[tokio::test]
+    async fn test_bounded_exec_dropped_stdout_receiver_does_not_close_stderr() {
+        let (host_stream, mut guest) = make_pair();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
+            let decoded = vsock_proto::decode_bounded_exec(&msgs[0].payload).unwrap();
+            assert!(decoded.stdout.stream.is_some());
+            assert!(decoded.stderr.stream.is_some());
+
+            write_bounded_stream_chunk(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecStream::Stdout,
+                1,
+                b"lost",
+                false,
+            )
+            .await;
+            write_bounded_stream_chunk(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecStream::Stderr,
+                2,
+                b"kept",
+                false,
+            )
+            .await;
+            write_bounded_exec_result(&mut guest, msgs[0].seq, b"done").await;
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (stdout_tx, stdout_rx) = mpsc::unbounded_channel();
+        drop(stdout_rx);
+        let (stderr_tx, mut stderr_rx) = mpsc::unbounded_channel();
+        let request = BoundedExecRequest {
+            command: "dropped-stdout-receiver",
+            timeout_ms: 5000,
+            env: &[],
+            sudo: false,
+            stdin: None,
+            stdout: BoundedExecOutputRequest {
+                capture: BoundedExecCapturePolicy::Capture { limit_bytes: 1024 },
+                stream: Some(BoundedExecStreamPolicy {
+                    event_tx: stdout_tx,
+                    limit_bytes: 1024,
+                    chunk_limit_bytes: vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32,
+                }),
+            },
+            stderr: BoundedExecOutputRequest {
+                capture: BoundedExecCapturePolicy::Capture { limit_bytes: 1024 },
+                stream: Some(BoundedExecStreamPolicy {
+                    event_tx: stderr_tx,
+                    limit_bytes: 1024,
+                    chunk_limit_bytes: vsock_proto::MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES as u32,
+                }),
+            },
+        };
+
+        let result = host.bounded_exec(&request).await.unwrap();
+        drop(request);
+        assert_host_captured_output(&result.stdout, b"done", false);
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(5), stderr_rx.recv())
+                .await
+                .expect("stderr stream should stay active after stdout receiver is dropped")
+                .expect("stderr stream should receive event"),
+            BoundedExecOutputEvent {
+                stream: BoundedExecStream::Stderr,
+                sequence: 2,
+                chunk: b"kept".to_vec(),
+                truncated: false,
+            }
+        );
+        assert_bounded_event_stream_closed(&mut stderr_rx);
     }
 
     #[tokio::test]
@@ -3315,10 +3605,9 @@ mod tests {
             let payload = vsock_proto::encode_bounded_exec_result(
                 vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
                 1,
-                b"ok",
-                b"",
-                false,
-                false,
+                proto_captured_output(b"ok", false),
+                proto_captured_output(b"", false),
+                None,
             )
             .unwrap();
             let ok_resp =
@@ -3340,7 +3629,7 @@ mod tests {
 
         let request = simple_bounded_request("good-result", None);
         let result = host.bounded_exec(&request).await.unwrap();
-        assert_eq!(result.stdout, b"ok");
+        assert_host_captured_output(&result.stdout, b"ok", false);
     }
 
     #[tokio::test]
@@ -3361,19 +3650,17 @@ mod tests {
                 let msgs = decoder.decode(&buf[..n]).unwrap();
                 assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
                 let decoded = vsock_proto::decode_bounded_exec(&msgs[0].payload).unwrap();
-                assert!(!decoded.stream_stdout);
-                assert!(!decoded.stream_stderr);
-                assert_eq!(decoded.stream_chunk_limit_bytes, 0);
+                assert!(decoded.stdout.stream.is_none());
+                assert!(decoded.stderr.stream.is_none());
                 request_seen.notify_one();
 
                 release_result.notified().await;
                 let payload = vsock_proto::encode_bounded_exec_result(
                     vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
                     1,
-                    b"done",
-                    b"",
-                    false,
-                    false,
+                    proto_captured_output(b"done", false),
+                    proto_captured_output(b"", false),
+                    None,
                 )
                 .unwrap();
                 let resp =
@@ -3388,13 +3675,13 @@ mod tests {
             let (event_tx, _event_rx) = mpsc::unbounded_channel();
             let request = simple_bounded_request(
                 "no-streams",
-                Some(BoundedExecStreamRequest {
+                Some(TestBoundedExecStreams {
                     event_tx,
                     stdout: false,
                     stderr: false,
                     chunk_limit_bytes: 0,
-                    stdout_limit_bytes: 0,
-                    stderr_limit_bytes: 0,
+                    stdout_budget_bytes: 0,
+                    stderr_budget_bytes: 0,
                 }),
             );
             task_host.bounded_exec(&request).await
@@ -3411,7 +3698,7 @@ mod tests {
 
         release_result.notify_one();
         let result = task.await.unwrap().unwrap();
-        assert_eq!(result.stdout, b"done");
+        assert_host_captured_output(&result.stdout, b"done", false);
         assert_eq!(registration_counts(&host), (0, 0, 0, 0));
     }
 
@@ -3433,32 +3720,30 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
 
         let oversized_final = BoundedExecRequest {
-            stdout_limit_bytes: u32::MAX,
-            stderr_limit_bytes: u32::MAX,
+            stdout: capture_output(u32::MAX),
+            stderr: capture_output(u32::MAX),
             ..simple_bounded_request("oversized-final", None)
         };
         let err = host.bounded_exec(&oversized_final).await.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
 
         let (tx, _rx) = mpsc::unbounded_channel();
-        let invalid_stream = BoundedExecRequest {
-            stream: Some(BoundedExecStreamRequest {
-                chunk_limit_bytes: 0,
-                ..bounded_stream_request(tx)
-            }),
-            ..simple_bounded_request("invalid-stream", None)
-        };
+        let mut invalid_stream = simple_bounded_request("invalid-stream", None);
+        invalid_stream.stdout.stream = Some(BoundedExecStreamPolicy {
+            event_tx: tx,
+            limit_bytes: 1,
+            chunk_limit_bytes: 0,
+        });
         let err = host.bounded_exec(&invalid_stream).await.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
 
         let (tx, _rx) = mpsc::unbounded_channel();
-        let oversized_stream = BoundedExecRequest {
-            stream: Some(BoundedExecStreamRequest {
-                chunk_limit_bytes: u32::MAX,
-                ..bounded_stream_request(tx)
-            }),
-            ..simple_bounded_request("oversized-stream", None)
-        };
+        let mut oversized_stream = simple_bounded_request("oversized-stream", None);
+        oversized_stream.stderr.stream = Some(BoundedExecStreamPolicy {
+            event_tx: tx,
+            limit_bytes: 1,
+            chunk_limit_bytes: u32::MAX,
+        });
         let err = host.bounded_exec(&oversized_stream).await.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -1881,6 +1881,45 @@ mod tests {
     }
 
     #[test]
+    fn decode_bounded_exec_rejects_truncated_output_policy_lengths() {
+        let mut capture_limit_truncated = Vec::new();
+        capture_limit_truncated.extend_from_slice(&1_u32.to_be_bytes());
+        capture_limit_truncated.push(0);
+        capture_limit_truncated.push(BOUNDED_EXEC_CAPTURE_CAPTURE);
+        capture_limit_truncated.extend_from_slice(&1_u32.to_be_bytes()[..3]);
+        let err = decode_bounded_exec(&capture_limit_truncated).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec output capture limit truncated")
+        ));
+
+        let mut stream_limit_truncated = Vec::new();
+        stream_limit_truncated.extend_from_slice(&1_u32.to_be_bytes());
+        stream_limit_truncated.push(0);
+        stream_limit_truncated.push(BOUNDED_EXEC_CAPTURE_DISCARD);
+        stream_limit_truncated.push(BOUNDED_EXEC_STREAM_MODE_STREAM);
+        stream_limit_truncated.extend_from_slice(&1_u32.to_be_bytes()[..3]);
+        let err = decode_bounded_exec(&stream_limit_truncated).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec output stream limit truncated")
+        ));
+
+        let mut stream_chunk_limit_truncated = Vec::new();
+        stream_chunk_limit_truncated.extend_from_slice(&1_u32.to_be_bytes());
+        stream_chunk_limit_truncated.push(0);
+        stream_chunk_limit_truncated.push(BOUNDED_EXEC_CAPTURE_DISCARD);
+        stream_chunk_limit_truncated.push(BOUNDED_EXEC_STREAM_MODE_STREAM);
+        stream_chunk_limit_truncated.extend_from_slice(&1_u32.to_be_bytes());
+        stream_chunk_limit_truncated.extend_from_slice(&1_u32.to_be_bytes()[..3]);
+        let err = decode_bounded_exec(&stream_chunk_limit_truncated).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec output stream chunk limit truncated")
+        ));
+    }
+
+    #[test]
     fn decode_bounded_exec_rejects_truncated_command() {
         let mut payload = Vec::new();
         payload.extend_from_slice(&1_u32.to_be_bytes());
@@ -2232,6 +2271,63 @@ mod tests {
     }
 
     #[test]
+    fn decode_bounded_exec_result_rejects_truncated_output_len() {
+        let mut payload = Vec::new();
+        payload.push(BOUNDED_EXEC_TERMINATION_EXITED);
+        payload.extend_from_slice(&0_i32.to_be_bytes());
+        payload.extend_from_slice(&0_u64.to_be_bytes());
+        payload.push(BOUNDED_EXEC_OUTPUT_CAPTURED);
+        payload.push(0);
+        payload.extend_from_slice(&3_u32.to_be_bytes()[..3]);
+
+        let err = decode_bounded_exec_result(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_result output_len truncated")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_result_rejects_invalid_output_truncated_flag() {
+        let mut payload = encode_bounded_exec_result(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            0,
+            captured_output(b"", false),
+            captured_output(b"", false),
+            None,
+        )
+        .unwrap();
+        payload[14] = 2;
+
+        let err = decode_bounded_exec_result(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_result invalid output truncated flag")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_result_rejects_invalid_utf8_diagnostic() {
+        let mut payload = encode_bounded_exec_result(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            0,
+            captured_output(b"", false),
+            captured_output(b"", false),
+            None,
+        )
+        .unwrap();
+        let diagnostic_len_offset = payload.len() - 4;
+        payload[diagnostic_len_offset..].copy_from_slice(&1_u32.to_be_bytes());
+        payload.push(0xFF);
+
+        let err = decode_bounded_exec_result(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("invalid UTF-8 in bounded_exec_result diagnostic")
+        ));
+    }
+
+    #[test]
     fn decode_bounded_exec_result_rejects_truncated_diagnostic() {
         let mut payload = encode_bounded_exec_result(
             BoundedExecTermination::Exited { exit_code: 0 },
@@ -2353,6 +2449,21 @@ mod tests {
         assert!(matches!(
             err,
             ProtocolError::InvalidPayload("bounded_exec_output_chunk chunk truncated")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_output_chunk_rejects_truncated_chunk_len() {
+        let mut payload = Vec::new();
+        payload.push(BOUNDED_EXEC_STREAM_STDOUT);
+        payload.push(0);
+        payload.extend_from_slice(&0_u32.to_be_bytes());
+        payload.extend_from_slice(&3_u32.to_be_bytes()[..3]);
+
+        let err = decode_bounded_exec_output_chunk(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec_output_chunk chunk_len truncated")
         ));
     }
 

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -28,8 +28,8 @@
 //! | 0x0A | H→G       | shutdown          | (empty) |
 //! | 0x0B | G→H       | shutdown_ack      | (empty) |
 //! | 0x0C | G→H       | stdout_chunk      | `[4B pid][data]` |
-//! | 0x0D | H→G       | bounded_exec      | `[4B timeout_ms][1B flags][4B stdout_limit][4B stderr_limit][4B stream_chunk_limit][4B stdout_stream_limit][4B stderr_stream_limit][4B cmd_len][command][4B env_count]([4B key_len][key][4B val_len][value])*[4B stdin_len][stdin]` |
-//! | 0x0E | G→H       | bounded_exec_result | `[1B termination][1B flags][4B exit_code][8B duration_ms][4B stdout_len][stdout][4B stderr_len][stderr]` |
+//! | 0x0D | H→G       | bounded_exec      | `[4B timeout_ms][1B flags][stdout_policy][stderr_policy][4B cmd_len][command][4B env_count]([4B key_len][key][4B val_len][value])*[4B stdin_len][stdin]` |
+//! | 0x0E | G→H       | bounded_exec_result | `[1B termination][4B exit_code][8B duration_ms][stdout_output][stderr_output][4B diagnostic_len][diagnostic]` |
 //! | 0x0F | G→H       | bounded_exec_output_chunk | `[1B stream][1B flags][4B sequence][4B chunk_len][chunk]` |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
@@ -37,9 +37,12 @@
 //! `seq` as the bounded exec request. They are separate from pid-scoped
 //! `MSG_STDOUT_CHUNK` messages used by `spawn_watch`.
 //!
-//! Bounded exec stream tags are `0 = stdout` and `1 = stderr`. Termination
-//! tags are `0 = exited`, `1 = timed_out`, `2 = cancelled`,
-//! `3 = start_failed`, and `4 = wait_failed`.
+//! Bounded exec stream tags are `0 = stdout` and `1 = stderr`. Bounded exec
+//! output policies use capture tags `0 = discard`, `1 = capture` and stream
+//! tags `0 = none`, `1 = stream`. Bounded exec result outputs use tags
+//! `0 = discarded`, `1 = captured`. Termination tags are `0 = exited`,
+//! `1 = timed_out`, `2 = cancelled`, `3 = start_failed`, and
+//! `4 = wait_failed`.
 
 /// Header size (4-byte length prefix).
 pub const HEADER_SIZE: usize = 4;
@@ -50,8 +53,9 @@ pub const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
 /// Minimum body size: type (1) + seq (4).
 pub const MIN_BODY_SIZE: usize = 5;
 
-/// Fixed bytes in a bounded_exec_result payload before stdout/stderr contents.
-pub const BOUNDED_EXEC_RESULT_FIXED_PAYLOAD_BYTES: usize = 1 + 1 + 4 + 8 + 4 + 4;
+/// Fixed bytes in a bounded_exec_result payload before captured output and diagnostic contents.
+pub const BOUNDED_EXEC_RESULT_FIXED_PAYLOAD_BYTES: usize =
+    1 + 4 + 8 + (1 + 1 + 4) + (1 + 1 + 4) + 4;
 /// Fixed bytes in a bounded_exec_output_chunk payload before chunk contents.
 pub const BOUNDED_EXEC_OUTPUT_CHUNK_FIXED_PAYLOAD_BYTES: usize = 1 + 1 + 4 + 4;
 /// Maximum combined stdout+stderr bytes that fit in one bounded_exec_result frame.
@@ -98,27 +102,22 @@ pub const WRITE_FILE_FLAG_APPEND: u8 = 0x02;
 
 // Bounded-exec payload flags.
 pub const BOUNDED_EXEC_FLAG_SUDO: u8 = 0x01;
-pub const BOUNDED_EXEC_FLAG_STREAM_STDOUT: u8 = 0x02;
-pub const BOUNDED_EXEC_FLAG_STREAM_STDERR: u8 = 0x04;
-pub const BOUNDED_EXEC_FLAG_STDIN_PRESENT: u8 = 0x08;
-
-// Bounded-exec-result payload flags.
-pub const BOUNDED_EXEC_RESULT_FLAG_STDOUT_TRUNCATED: u8 = 0x01;
-pub const BOUNDED_EXEC_RESULT_FLAG_STDERR_TRUNCATED: u8 = 0x02;
+pub const BOUNDED_EXEC_FLAG_STDIN_PRESENT: u8 = 0x02;
 
 // Bounded-exec-output-chunk payload flags.
 pub const BOUNDED_EXEC_OUTPUT_CHUNK_FLAG_TRUNCATED: u8 = 0x01;
 
-const BOUNDED_EXEC_KNOWN_FLAGS: u8 = BOUNDED_EXEC_FLAG_SUDO
-    | BOUNDED_EXEC_FLAG_STREAM_STDOUT
-    | BOUNDED_EXEC_FLAG_STREAM_STDERR
-    | BOUNDED_EXEC_FLAG_STDIN_PRESENT;
-const BOUNDED_EXEC_RESULT_KNOWN_FLAGS: u8 =
-    BOUNDED_EXEC_RESULT_FLAG_STDOUT_TRUNCATED | BOUNDED_EXEC_RESULT_FLAG_STDERR_TRUNCATED;
+const BOUNDED_EXEC_KNOWN_FLAGS: u8 = BOUNDED_EXEC_FLAG_SUDO | BOUNDED_EXEC_FLAG_STDIN_PRESENT;
 const BOUNDED_EXEC_OUTPUT_CHUNK_KNOWN_FLAGS: u8 = BOUNDED_EXEC_OUTPUT_CHUNK_FLAG_TRUNCATED;
 
 const BOUNDED_EXEC_STREAM_STDOUT: u8 = 0;
 const BOUNDED_EXEC_STREAM_STDERR: u8 = 1;
+const BOUNDED_EXEC_CAPTURE_DISCARD: u8 = 0;
+const BOUNDED_EXEC_CAPTURE_CAPTURE: u8 = 1;
+const BOUNDED_EXEC_STREAM_MODE_NONE: u8 = 0;
+const BOUNDED_EXEC_STREAM_MODE_STREAM: u8 = 1;
+const BOUNDED_EXEC_OUTPUT_DISCARDED: u8 = 0;
+const BOUNDED_EXEC_OUTPUT_CAPTURED: u8 = 1;
 
 const BOUNDED_EXEC_TERMINATION_EXITED: u8 = 0;
 const BOUNDED_EXEC_TERMINATION_TIMED_OUT: u8 = 1;
@@ -139,6 +138,30 @@ pub enum BoundedExecTermination {
     Cancelled,
     StartFailed,
     WaitFailed,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum BoundedExecCapturePolicy {
+    Discard,
+    Capture { limit_bytes: u32 },
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct BoundedExecStreamPolicy {
+    pub limit_bytes: u32,
+    pub chunk_limit_bytes: u32,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct BoundedExecOutputPolicy {
+    pub capture: BoundedExecCapturePolicy,
+    pub stream: Option<BoundedExecStreamPolicy>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum BoundedExecOutput<'a> {
+    Discarded,
+    Captured { bytes: &'a [u8], truncated: bool },
 }
 
 /// Protocol error.
@@ -373,38 +396,25 @@ pub struct BoundedExecRequest<'a> {
     pub env: &'a [(&'a str, &'a str)],
     pub sudo: bool,
     pub stdin: Option<&'a [u8]>,
-    pub stdout_limit_bytes: u32,
-    pub stderr_limit_bytes: u32,
-    /// Whether stdout should be emitted through request-scoped
-    /// `MSG_BOUNDED_EXEC_OUTPUT_CHUNK` messages.
-    pub stream_stdout: bool,
-    /// Whether stderr should be emitted through request-scoped
-    /// `MSG_BOUNDED_EXEC_OUTPUT_CHUNK` messages.
-    pub stream_stderr: bool,
-    pub stream_chunk_limit_bytes: u32,
-    /// Maximum emitted stdout bytes when `stream_stdout` is enabled.
-    /// Execution layers should ignore this field when stdout streaming is off.
-    pub stdout_stream_limit_bytes: u32,
-    /// Maximum emitted stderr bytes when `stream_stderr` is enabled.
-    /// Execution layers should ignore this field when stderr streaming is off.
-    pub stderr_stream_limit_bytes: u32,
+    pub stdout: BoundedExecOutputPolicy,
+    pub stderr: BoundedExecOutputPolicy,
 }
 
 /// Encode bounded_exec payload.
 ///
 /// Wire format:
-/// `[4B timeout_ms][1B flags][4B stdout_limit][4B stderr_limit]`
-/// `[4B stream_chunk_limit][4B stdout_stream_limit][4B stderr_stream_limit]`
+/// `[4B timeout_ms][1B flags][stdout_policy][stderr_policy]`
 /// `[4B cmd_len][command][4B env_count]([4B key_len][key][4B val_len][value])*`
 /// `[4B stdin_len][stdin]`.
 ///
-/// This encoder preserves protocol fields as provided. Execution policy, such
-/// as whether non-zero stream limits are valid when a stream flag is disabled,
-/// belongs in the host/guest execution layers.
+/// Each output policy is encoded as `[1B capture_tag]([4B capture_limit])`
+/// `[1B stream_tag]([4B stream_limit][4B stream_chunk_limit])`.
 pub fn encode_bounded_exec(request: &BoundedExecRequest<'_>) -> Result<Vec<u8>, ProtocolError> {
     let command = request.command.as_bytes();
     let stdin = request.stdin.unwrap_or_default();
-    let mut capacity = 25;
+    let mut capacity = 5;
+    add_bounded_exec_output_policy_capacity(&mut capacity, "stdout policy", request.stdout)?;
+    add_bounded_exec_output_policy_capacity(&mut capacity, "stderr policy", request.stderr)?;
     add_len_prefixed_capacity(&mut capacity, "command", command)?;
     add_payload_capacity(&mut capacity, "env", 4)?;
     for (key, val) in request.env {
@@ -419,21 +429,12 @@ pub fn encode_bounded_exec(request: &BoundedExecRequest<'_>) -> Result<Vec<u8>, 
     if request.sudo {
         flags |= BOUNDED_EXEC_FLAG_SUDO;
     }
-    if request.stream_stdout {
-        flags |= BOUNDED_EXEC_FLAG_STREAM_STDOUT;
-    }
-    if request.stream_stderr {
-        flags |= BOUNDED_EXEC_FLAG_STREAM_STDERR;
-    }
     if request.stdin.is_some() {
         flags |= BOUNDED_EXEC_FLAG_STDIN_PRESENT;
     }
     p.push(flags);
-    p.extend_from_slice(&request.stdout_limit_bytes.to_be_bytes());
-    p.extend_from_slice(&request.stderr_limit_bytes.to_be_bytes());
-    p.extend_from_slice(&request.stream_chunk_limit_bytes.to_be_bytes());
-    p.extend_from_slice(&request.stdout_stream_limit_bytes.to_be_bytes());
-    p.extend_from_slice(&request.stderr_stream_limit_bytes.to_be_bytes());
+    append_bounded_exec_output_policy(&mut p, request.stdout);
+    append_bounded_exec_output_policy(&mut p, request.stderr);
     append_len_prefixed_bytes(&mut p, "command", command)?;
     p.extend_from_slice(&checked_u32_len("env", request.env.len())?.to_be_bytes());
     for (key, val) in request.env {
@@ -442,6 +443,44 @@ pub fn encode_bounded_exec(request: &BoundedExecRequest<'_>) -> Result<Vec<u8>, 
     }
     append_len_prefixed_bytes(&mut p, "stdin", stdin)?;
     Ok(p)
+}
+
+fn add_bounded_exec_output_policy_capacity(
+    capacity: &mut usize,
+    field: &'static str,
+    policy: BoundedExecOutputPolicy,
+) -> Result<(), ProtocolError> {
+    add_payload_capacity(capacity, field, 1)?;
+    if matches!(policy.capture, BoundedExecCapturePolicy::Capture { .. }) {
+        add_payload_capacity(capacity, field, 4)?;
+    }
+    add_payload_capacity(capacity, field, 1)?;
+    if policy.stream.is_some() {
+        add_payload_capacity(capacity, field, 8)?;
+    }
+    Ok(())
+}
+
+fn append_bounded_exec_output_policy(p: &mut Vec<u8>, policy: BoundedExecOutputPolicy) {
+    match policy.capture {
+        BoundedExecCapturePolicy::Discard => {
+            p.push(BOUNDED_EXEC_CAPTURE_DISCARD);
+        }
+        BoundedExecCapturePolicy::Capture { limit_bytes } => {
+            p.push(BOUNDED_EXEC_CAPTURE_CAPTURE);
+            p.extend_from_slice(&limit_bytes.to_be_bytes());
+        }
+    }
+    match policy.stream {
+        None => {
+            p.push(BOUNDED_EXEC_STREAM_MODE_NONE);
+        }
+        Some(stream) => {
+            p.push(BOUNDED_EXEC_STREAM_MODE_STREAM);
+            p.extend_from_slice(&stream.limit_bytes.to_be_bytes());
+            p.extend_from_slice(&stream.chunk_limit_bytes.to_be_bytes());
+        }
+    }
 }
 
 fn bounded_exec_stream_tag(stream: BoundedExecStream) -> u8 {
@@ -467,32 +506,57 @@ fn bounded_exec_termination_tag(termination: BoundedExecTermination) -> (u8, i32
 pub fn encode_bounded_exec_result(
     termination: BoundedExecTermination,
     duration_ms: u64,
-    stdout: &[u8],
-    stderr: &[u8],
-    stdout_truncated: bool,
-    stderr_truncated: bool,
+    stdout: BoundedExecOutput<'_>,
+    stderr: BoundedExecOutput<'_>,
+    diagnostic: Option<&str>,
 ) -> Result<Vec<u8>, ProtocolError> {
     let (termination_tag, exit_code) = bounded_exec_termination_tag(termination);
-    let mut flags = 0u8;
-    if stdout_truncated {
-        flags |= BOUNDED_EXEC_RESULT_FLAG_STDOUT_TRUNCATED;
-    }
-    if stderr_truncated {
-        flags |= BOUNDED_EXEC_RESULT_FLAG_STDERR_TRUNCATED;
-    }
 
-    let mut capacity = 14;
-    add_len_prefixed_capacity(&mut capacity, "stdout", stdout)?;
-    add_len_prefixed_capacity(&mut capacity, "stderr", stderr)?;
+    let diagnostic = diagnostic.unwrap_or_default().as_bytes();
+    let mut capacity = 13;
+    add_bounded_exec_output_capacity(&mut capacity, "stdout", stdout)?;
+    add_bounded_exec_output_capacity(&mut capacity, "stderr", stderr)?;
+    add_len_prefixed_capacity(&mut capacity, "diagnostic", diagnostic)?;
 
     let mut p = Vec::with_capacity(capacity);
     p.push(termination_tag);
-    p.push(flags);
     p.extend_from_slice(&exit_code.to_be_bytes());
     p.extend_from_slice(&duration_ms.to_be_bytes());
-    append_len_prefixed_bytes(&mut p, "stdout", stdout)?;
-    append_len_prefixed_bytes(&mut p, "stderr", stderr)?;
+    append_bounded_exec_output(&mut p, "stdout", stdout)?;
+    append_bounded_exec_output(&mut p, "stderr", stderr)?;
+    append_len_prefixed_bytes(&mut p, "diagnostic", diagnostic)?;
     Ok(p)
+}
+
+fn add_bounded_exec_output_capacity(
+    capacity: &mut usize,
+    field: &'static str,
+    output: BoundedExecOutput<'_>,
+) -> Result<(), ProtocolError> {
+    add_payload_capacity(capacity, field, 1)?;
+    if let BoundedExecOutput::Captured { bytes, .. } = output {
+        add_payload_capacity(capacity, field, 1)?;
+        add_len_prefixed_capacity(capacity, field, bytes)?;
+    }
+    Ok(())
+}
+
+fn append_bounded_exec_output(
+    p: &mut Vec<u8>,
+    field: &'static str,
+    output: BoundedExecOutput<'_>,
+) -> Result<(), ProtocolError> {
+    match output {
+        BoundedExecOutput::Discarded => {
+            p.push(BOUNDED_EXEC_OUTPUT_DISCARDED);
+        }
+        BoundedExecOutput::Captured { bytes, truncated } => {
+            p.push(BOUNDED_EXEC_OUTPUT_CAPTURED);
+            p.push(u8::from(truncated));
+            append_len_prefixed_bytes(p, field, bytes)?;
+        }
+    }
+    Ok(())
 }
 
 /// Encode bounded_exec_output_chunk payload.
@@ -887,23 +951,17 @@ pub struct DecodedBoundedExec<'a> {
     pub env: Vec<(&'a str, &'a str)>,
     pub sudo: bool,
     pub stdin: Option<&'a [u8]>,
-    pub stdout_limit_bytes: u32,
-    pub stderr_limit_bytes: u32,
-    pub stream_stdout: bool,
-    pub stream_stderr: bool,
-    pub stream_chunk_limit_bytes: u32,
-    pub stdout_stream_limit_bytes: u32,
-    pub stderr_stream_limit_bytes: u32,
+    pub stdout: BoundedExecOutputPolicy,
+    pub stderr: BoundedExecOutputPolicy,
 }
 
 #[derive(Debug)]
 pub struct DecodedBoundedExecResult<'a> {
     pub termination: BoundedExecTermination,
     pub duration_ms: u64,
-    pub stdout: &'a [u8],
-    pub stderr: &'a [u8],
-    pub stdout_truncated: bool,
-    pub stderr_truncated: bool,
+    pub stdout: BoundedExecOutput<'a>,
+    pub stderr: BoundedExecOutput<'a>,
+    pub diagnostic: Option<&'a str>,
 }
 
 #[derive(Debug)]
@@ -1063,6 +1121,89 @@ fn decode_bounded_exec_stream(tag: u8) -> Result<BoundedExecStream, ProtocolErro
     }
 }
 
+fn decode_bounded_exec_output_policy(
+    payload: &[u8],
+    offset: &mut usize,
+) -> Result<BoundedExecOutputPolicy, ProtocolError> {
+    let capture_tag = read_u8_cursor(payload, offset, "bounded_exec output capture tag truncated")?;
+    let capture = match capture_tag {
+        BOUNDED_EXEC_CAPTURE_DISCARD => BoundedExecCapturePolicy::Discard,
+        BOUNDED_EXEC_CAPTURE_CAPTURE => {
+            let limit_bytes = read_u32_cursor(
+                payload,
+                offset,
+                "bounded_exec output capture limit truncated",
+            )?;
+            BoundedExecCapturePolicy::Capture { limit_bytes }
+        }
+        _ => {
+            return Err(ProtocolError::InvalidPayload(
+                "bounded_exec output invalid capture tag",
+            ));
+        }
+    };
+
+    let stream_tag = read_u8_cursor(payload, offset, "bounded_exec output stream tag truncated")?;
+    let stream = match stream_tag {
+        BOUNDED_EXEC_STREAM_MODE_NONE => None,
+        BOUNDED_EXEC_STREAM_MODE_STREAM => {
+            let limit_bytes = read_u32_cursor(
+                payload,
+                offset,
+                "bounded_exec output stream limit truncated",
+            )?;
+            let chunk_limit_bytes = read_u32_cursor(
+                payload,
+                offset,
+                "bounded_exec output stream chunk limit truncated",
+            )?;
+            Some(BoundedExecStreamPolicy {
+                limit_bytes,
+                chunk_limit_bytes,
+            })
+        }
+        _ => {
+            return Err(ProtocolError::InvalidPayload(
+                "bounded_exec output invalid stream tag",
+            ));
+        }
+    };
+
+    Ok(BoundedExecOutputPolicy { capture, stream })
+}
+
+fn decode_bounded_exec_output<'a>(
+    payload: &'a [u8],
+    offset: &mut usize,
+) -> Result<BoundedExecOutput<'a>, ProtocolError> {
+    let output_tag = read_u8_cursor(payload, offset, "bounded_exec_result output tag truncated")?;
+    match output_tag {
+        BOUNDED_EXEC_OUTPUT_DISCARDED => Ok(BoundedExecOutput::Discarded),
+        BOUNDED_EXEC_OUTPUT_CAPTURED => {
+            let truncated =
+                read_u8_cursor(payload, offset, "bounded_exec_result output truncated flag")?;
+            if truncated > 1 {
+                return Err(ProtocolError::InvalidPayload(
+                    "bounded_exec_result invalid output truncated flag",
+                ));
+            }
+            let bytes = read_len_prefixed_bytes_cursor(
+                payload,
+                offset,
+                "bounded_exec_result output_len truncated",
+                "bounded_exec_result output truncated",
+            )?;
+            Ok(BoundedExecOutput::Captured {
+                bytes,
+                truncated: truncated == 1,
+            })
+        }
+        _ => Err(ProtocolError::InvalidPayload(
+            "bounded_exec_result invalid output tag",
+        )),
+    }
+}
+
 /// Decode bounded_exec payload into a [`DecodedBoundedExec`] struct.
 pub fn decode_bounded_exec(payload: &[u8]) -> Result<DecodedBoundedExec<'_>, ProtocolError> {
     let mut offset = 0usize;
@@ -1073,25 +1214,8 @@ pub fn decode_bounded_exec(payload: &[u8]) -> Result<DecodedBoundedExec<'_>, Pro
         BOUNDED_EXEC_KNOWN_FLAGS,
         "bounded_exec unknown flags",
     )?;
-    let stdout_limit_bytes =
-        read_u32_cursor(payload, &mut offset, "bounded_exec stdout_limit truncated")?;
-    let stderr_limit_bytes =
-        read_u32_cursor(payload, &mut offset, "bounded_exec stderr_limit truncated")?;
-    let stream_chunk_limit_bytes = read_u32_cursor(
-        payload,
-        &mut offset,
-        "bounded_exec stream_chunk_limit truncated",
-    )?;
-    let stdout_stream_limit_bytes = read_u32_cursor(
-        payload,
-        &mut offset,
-        "bounded_exec stdout_stream_limit truncated",
-    )?;
-    let stderr_stream_limit_bytes = read_u32_cursor(
-        payload,
-        &mut offset,
-        "bounded_exec stderr_stream_limit truncated",
-    )?;
+    let stdout = decode_bounded_exec_output_policy(payload, &mut offset)?;
+    let stderr = decode_bounded_exec_output_policy(payload, &mut offset)?;
     let command = read_len_prefixed_str_cursor(
         payload,
         &mut offset,
@@ -1139,13 +1263,8 @@ pub fn decode_bounded_exec(payload: &[u8]) -> Result<DecodedBoundedExec<'_>, Pro
         env,
         sudo: flags & BOUNDED_EXEC_FLAG_SUDO != 0,
         stdin: stdin_present.then_some(stdin_bytes),
-        stdout_limit_bytes,
-        stderr_limit_bytes,
-        stream_stdout: flags & BOUNDED_EXEC_FLAG_STREAM_STDOUT != 0,
-        stream_stderr: flags & BOUNDED_EXEC_FLAG_STREAM_STDERR != 0,
-        stream_chunk_limit_bytes,
-        stdout_stream_limit_bytes,
-        stderr_stream_limit_bytes,
+        stdout,
+        stderr,
     })
 }
 
@@ -1159,16 +1278,6 @@ pub fn decode_bounded_exec_result(
         &mut offset,
         "bounded_exec_result payload too short",
     )?;
-    let flags = read_u8_cursor(
-        payload,
-        &mut offset,
-        "bounded_exec_result payload too short",
-    )?;
-    reject_unknown_flags(
-        flags,
-        BOUNDED_EXEC_RESULT_KNOWN_FLAGS,
-        "bounded_exec_result unknown flags",
-    )?;
     validate_bounded_exec_termination_tag(termination_tag)?;
     let exit_code = read_i32_cursor(
         payload,
@@ -1180,18 +1289,21 @@ pub fn decode_bounded_exec_result(
         &mut offset,
         "bounded_exec_result duration_ms truncated",
     )?;
-    let stdout = read_len_prefixed_bytes_cursor(
+    let stdout = decode_bounded_exec_output(payload, &mut offset)?;
+    let stderr = decode_bounded_exec_output(payload, &mut offset)?;
+    let diagnostic_bytes = read_len_prefixed_bytes_cursor(
         payload,
         &mut offset,
-        "bounded_exec_result stdout_len truncated",
-        "bounded_exec_result stdout truncated",
+        "bounded_exec_result diagnostic_len truncated",
+        "bounded_exec_result diagnostic truncated",
     )?;
-    let stderr = read_len_prefixed_bytes_cursor(
-        payload,
-        &mut offset,
-        "bounded_exec_result stderr_len truncated",
-        "bounded_exec_result stderr truncated",
-    )?;
+    let diagnostic = if diagnostic_bytes.is_empty() {
+        None
+    } else {
+        Some(std::str::from_utf8(diagnostic_bytes).map_err(|_| {
+            ProtocolError::InvalidPayload("invalid UTF-8 in bounded_exec_result diagnostic")
+        })?)
+    };
     ensure_no_trailing_bytes(payload, offset, "bounded_exec_result trailing bytes")?;
 
     Ok(DecodedBoundedExecResult {
@@ -1199,8 +1311,7 @@ pub fn decode_bounded_exec_result(
         duration_ms,
         stdout,
         stderr,
-        stdout_truncated: flags & BOUNDED_EXEC_RESULT_FLAG_STDOUT_TRUNCATED != 0,
-        stderr_truncated: flags & BOUNDED_EXEC_RESULT_FLAG_STDERR_TRUNCATED != 0,
+        diagnostic,
     })
 }
 
@@ -1489,14 +1600,62 @@ mod tests {
             env: &[("TOKEN", "secret"), ("HOME", "/home/user")],
             sudo: true,
             stdin: Some(b"input"),
-            stdout_limit_bytes: 1024,
-            stderr_limit_bytes: 2048,
-            stream_stdout: true,
-            stream_stderr: true,
-            stream_chunk_limit_bytes: 256,
-            stdout_stream_limit_bytes: 4096,
-            stderr_stream_limit_bytes: 8192,
+            stdout: BoundedExecOutputPolicy {
+                capture: BoundedExecCapturePolicy::Capture { limit_bytes: 1024 },
+                stream: Some(BoundedExecStreamPolicy {
+                    limit_bytes: 4096,
+                    chunk_limit_bytes: 256,
+                }),
+            },
+            stderr: BoundedExecOutputPolicy {
+                capture: BoundedExecCapturePolicy::Capture { limit_bytes: 2048 },
+                stream: Some(BoundedExecStreamPolicy {
+                    limit_bytes: 8192,
+                    chunk_limit_bytes: 256,
+                }),
+            },
         }
+    }
+
+    fn capture_policy(limit_bytes: u32) -> BoundedExecOutputPolicy {
+        BoundedExecOutputPolicy {
+            capture: BoundedExecCapturePolicy::Capture { limit_bytes },
+            stream: None,
+        }
+    }
+
+    fn discard_policy() -> BoundedExecOutputPolicy {
+        BoundedExecOutputPolicy {
+            capture: BoundedExecCapturePolicy::Discard,
+            stream: None,
+        }
+    }
+
+    fn captured_output(bytes: &[u8], truncated: bool) -> BoundedExecOutput<'_> {
+        BoundedExecOutput::Captured { bytes, truncated }
+    }
+
+    fn assert_captured_output(
+        output: BoundedExecOutput<'_>,
+        expected_bytes: &[u8],
+        expected_truncated: bool,
+    ) {
+        match output {
+            BoundedExecOutput::Captured { bytes, truncated } => {
+                assert_eq!(bytes, expected_bytes);
+                assert_eq!(truncated, expected_truncated);
+            }
+            BoundedExecOutput::Discarded => panic!("expected captured output"),
+        }
+    }
+
+    fn append_discard_output_policies(payload: &mut Vec<u8>) {
+        payload.extend_from_slice(&[
+            BOUNDED_EXEC_CAPTURE_DISCARD,
+            BOUNDED_EXEC_STREAM_MODE_NONE,
+            BOUNDED_EXEC_CAPTURE_DISCARD,
+            BOUNDED_EXEC_STREAM_MODE_NONE,
+        ]);
     }
 
     #[test]
@@ -1510,13 +1669,28 @@ mod tests {
         assert_eq!(d.env, request.env);
         assert!(d.sudo);
         assert_eq!(d.stdin, Some(b"input".as_slice()));
-        assert_eq!(d.stdout_limit_bytes, 1024);
-        assert_eq!(d.stderr_limit_bytes, 2048);
-        assert!(d.stream_stdout);
-        assert!(d.stream_stderr);
-        assert_eq!(d.stream_chunk_limit_bytes, 256);
-        assert_eq!(d.stdout_stream_limit_bytes, 4096);
-        assert_eq!(d.stderr_stream_limit_bytes, 8192);
+        assert_eq!(
+            d.stdout.capture,
+            BoundedExecCapturePolicy::Capture { limit_bytes: 1024 }
+        );
+        assert_eq!(
+            d.stdout.stream,
+            Some(BoundedExecStreamPolicy {
+                limit_bytes: 4096,
+                chunk_limit_bytes: 256,
+            })
+        );
+        assert_eq!(
+            d.stderr.capture,
+            BoundedExecCapturePolicy::Capture { limit_bytes: 2048 }
+        );
+        assert_eq!(
+            d.stderr.stream,
+            Some(BoundedExecStreamPolicy {
+                limit_bytes: 8192,
+                chunk_limit_bytes: 256,
+            })
+        );
     }
 
     #[test]
@@ -1527,13 +1701,8 @@ mod tests {
             env: &[],
             sudo: false,
             stdin: None,
-            stdout_limit_bytes: 0,
-            stderr_limit_bytes: 0,
-            stream_stdout: false,
-            stream_stderr: false,
-            stream_chunk_limit_bytes: 0,
-            stdout_stream_limit_bytes: 0,
-            stderr_stream_limit_bytes: 0,
+            stdout: discard_policy(),
+            stderr: capture_policy(0),
         };
         let payload = encode_bounded_exec(&request).unwrap();
         let d = decode_bounded_exec(&payload).unwrap();
@@ -1543,8 +1712,45 @@ mod tests {
         assert!(d.env.is_empty());
         assert!(!d.sudo);
         assert_eq!(d.stdin, None);
-        assert!(!d.stream_stdout);
-        assert!(!d.stream_stderr);
+        assert_eq!(d.stdout.capture, BoundedExecCapturePolicy::Discard);
+        assert!(d.stdout.stream.is_none());
+        assert_eq!(
+            d.stderr.capture,
+            BoundedExecCapturePolicy::Capture { limit_bytes: 0 }
+        );
+        assert!(d.stderr.stream.is_none());
+    }
+
+    #[test]
+    fn bounded_exec_payload_roundtrip_stream_only() {
+        let request = BoundedExecRequest {
+            timeout_ms: 1,
+            command: "true",
+            env: &[],
+            sudo: false,
+            stdin: None,
+            stdout: BoundedExecOutputPolicy {
+                capture: BoundedExecCapturePolicy::Discard,
+                stream: Some(BoundedExecStreamPolicy {
+                    limit_bytes: 4096,
+                    chunk_limit_bytes: 512,
+                }),
+            },
+            stderr: discard_policy(),
+        };
+        let payload = encode_bounded_exec(&request).unwrap();
+        let d = decode_bounded_exec(&payload).unwrap();
+
+        assert_eq!(d.stdout.capture, BoundedExecCapturePolicy::Discard);
+        assert_eq!(
+            d.stdout.stream,
+            Some(BoundedExecStreamPolicy {
+                limit_bytes: 4096,
+                chunk_limit_bytes: 512,
+            })
+        );
+        assert_eq!(d.stderr.capture, BoundedExecCapturePolicy::Discard);
+        assert!(d.stderr.stream.is_none());
     }
 
     #[test]
@@ -1600,9 +1806,7 @@ mod tests {
         let mut payload = Vec::new();
         payload.extend_from_slice(&1_u32.to_be_bytes());
         payload.push(0);
-        for _ in 0..5 {
-            payload.extend_from_slice(&0_u32.to_be_bytes());
-        }
+        append_discard_output_policies(&mut payload);
         payload.extend_from_slice(&0_u32.to_be_bytes()); // empty command
         payload.extend_from_slice(&0_u32.to_be_bytes()); // empty env
 
@@ -1626,13 +1830,53 @@ mod tests {
     }
 
     #[test]
+    fn decode_bounded_exec_rejects_invalid_output_capture_tag() {
+        let request = BoundedExecRequest {
+            timeout_ms: 1,
+            command: "true",
+            env: &[],
+            sudo: false,
+            stdin: None,
+            stdout: discard_policy(),
+            stderr: discard_policy(),
+        };
+        let mut payload = encode_bounded_exec(&request).unwrap();
+        payload[5] = 0x80;
+
+        let err = decode_bounded_exec(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec output invalid capture tag")
+        ));
+    }
+
+    #[test]
+    fn decode_bounded_exec_rejects_invalid_output_stream_tag() {
+        let request = BoundedExecRequest {
+            timeout_ms: 1,
+            command: "true",
+            env: &[],
+            sudo: false,
+            stdin: None,
+            stdout: discard_policy(),
+            stderr: discard_policy(),
+        };
+        let mut payload = encode_bounded_exec(&request).unwrap();
+        payload[6] = 0x80;
+
+        let err = decode_bounded_exec(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("bounded_exec output invalid stream tag")
+        ));
+    }
+
+    #[test]
     fn decode_bounded_exec_rejects_truncated_command() {
         let mut payload = Vec::new();
         payload.extend_from_slice(&1_u32.to_be_bytes());
         payload.push(0);
-        for _ in 0..5 {
-            payload.extend_from_slice(&0_u32.to_be_bytes());
-        }
+        append_discard_output_policies(&mut payload);
         payload.extend_from_slice(&3_u32.to_be_bytes());
         payload.extend_from_slice(b"ab");
 
@@ -1648,9 +1892,7 @@ mod tests {
         let mut payload = Vec::new();
         payload.extend_from_slice(&1_u32.to_be_bytes());
         payload.push(0);
-        for _ in 0..5 {
-            payload.extend_from_slice(&0_u32.to_be_bytes());
-        }
+        append_discard_output_policies(&mut payload);
         payload.extend_from_slice(&0_u32.to_be_bytes()); // empty command
         payload.extend_from_slice(&1_u32.to_be_bytes()); // one env pair
         payload.extend_from_slice(&1_u32.to_be_bytes()); // key len
@@ -1670,9 +1912,7 @@ mod tests {
         let mut payload = Vec::new();
         payload.extend_from_slice(&1_u32.to_be_bytes());
         payload.push(0);
-        for _ in 0..5 {
-            payload.extend_from_slice(&0_u32.to_be_bytes());
-        }
+        append_discard_output_policies(&mut payload);
         payload.extend_from_slice(&1_u32.to_be_bytes());
         payload.push(0xFF);
         payload.extend_from_slice(&0_u32.to_be_bytes());
@@ -1690,9 +1930,7 @@ mod tests {
         let mut payload = Vec::new();
         payload.extend_from_slice(&1_u32.to_be_bytes());
         payload.push(0);
-        for _ in 0..5 {
-            payload.extend_from_slice(&0_u32.to_be_bytes());
-        }
+        append_discard_output_policies(&mut payload);
         payload.extend_from_slice(&0_u32.to_be_bytes()); // empty command
         payload.extend_from_slice(&1_u32.to_be_bytes()); // one env pair
         payload.extend_from_slice(&1_u32.to_be_bytes()); // key len
@@ -1712,9 +1950,7 @@ mod tests {
         let mut payload = Vec::new();
         payload.extend_from_slice(&1_u32.to_be_bytes());
         payload.push(0);
-        for _ in 0..5 {
-            payload.extend_from_slice(&0_u32.to_be_bytes());
-        }
+        append_discard_output_policies(&mut payload);
         payload.extend_from_slice(&0_u32.to_be_bytes()); // empty command
         payload.extend_from_slice(&1_u32.to_be_bytes()); // one env pair
         payload.extend_from_slice(&1_u32.to_be_bytes()); // key len
@@ -1735,9 +1971,7 @@ mod tests {
         let mut payload = Vec::new();
         payload.extend_from_slice(&1_u32.to_be_bytes());
         payload.push(0);
-        for _ in 0..5 {
-            payload.extend_from_slice(&0_u32.to_be_bytes());
-        }
+        append_discard_output_policies(&mut payload);
         payload.extend_from_slice(&0_u32.to_be_bytes()); // empty command
         payload.extend_from_slice(&u32::MAX.to_be_bytes());
 
@@ -1765,10 +1999,9 @@ mod tests {
         let payload = encode_bounded_exec_result(
             BoundedExecTermination::Exited { exit_code: 42 },
             123,
-            b"out",
-            b"err",
-            false,
-            true,
+            captured_output(b"out", false),
+            captured_output(b"err", true),
+            Some("diagnostic"),
         )
         .unwrap();
         let d = decode_bounded_exec_result(&payload).unwrap();
@@ -1778,21 +2011,19 @@ mod tests {
             BoundedExecTermination::Exited { exit_code: 42 }
         );
         assert_eq!(d.duration_ms, 123);
-        assert_eq!(d.stdout, b"out");
-        assert_eq!(d.stderr, b"err");
-        assert!(!d.stdout_truncated);
-        assert!(d.stderr_truncated);
+        assert_captured_output(d.stdout, b"out", false);
+        assert_captured_output(d.stderr, b"err", true);
+        assert_eq!(d.diagnostic, Some("diagnostic"));
     }
 
     #[test]
-    fn bounded_exec_result_empty_output_roundtrip() {
+    fn bounded_exec_result_captured_empty_output_roundtrip() {
         let payload = encode_bounded_exec_result(
             BoundedExecTermination::Exited { exit_code: 0 },
             0,
-            b"",
-            b"",
-            false,
-            false,
+            captured_output(b"", false),
+            captured_output(b"", false),
+            None,
         )
         .unwrap();
         let d = decode_bounded_exec_result(&payload).unwrap();
@@ -1802,31 +2033,61 @@ mod tests {
             BoundedExecTermination::Exited { exit_code: 0 }
         );
         assert_eq!(d.duration_ms, 0);
-        assert!(d.stdout.is_empty());
-        assert!(d.stderr.is_empty());
-        assert!(!d.stdout_truncated);
-        assert!(!d.stderr_truncated);
+        assert_captured_output(d.stdout, b"", false);
+        assert_captured_output(d.stderr, b"", false);
+        assert_eq!(d.diagnostic, None);
     }
 
     #[test]
-    fn bounded_exec_result_truncation_flags_roundtrip_independently() {
-        for (stdout_truncated, stderr_truncated) in
-            [(false, false), (true, false), (false, true), (true, true)]
-        {
-            let payload = encode_bounded_exec_result(
-                BoundedExecTermination::Exited { exit_code: 0 },
-                1,
-                b"out",
-                b"err",
-                stdout_truncated,
-                stderr_truncated,
-            )
-            .unwrap();
-            let d = decode_bounded_exec_result(&payload).unwrap();
+    fn bounded_exec_result_fixed_payload_constant_matches_captured_empty_frame() {
+        let payload = encode_bounded_exec_result(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            0,
+            captured_output(b"", false),
+            captured_output(b"", false),
+            None,
+        )
+        .unwrap();
 
-            assert_eq!(d.stdout_truncated, stdout_truncated);
-            assert_eq!(d.stderr_truncated, stderr_truncated);
-        }
+        assert_eq!(payload.len(), BOUNDED_EXEC_RESULT_FIXED_PAYLOAD_BYTES);
+        assert_eq!(
+            MIN_BODY_SIZE
+                + BOUNDED_EXEC_RESULT_FIXED_PAYLOAD_BYTES
+                + MAX_BOUNDED_EXEC_RESULT_OUTPUT_BYTES,
+            MAX_MESSAGE_SIZE
+        );
+    }
+
+    #[test]
+    fn bounded_exec_result_discarded_output_roundtrip() {
+        let payload = encode_bounded_exec_result(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            1,
+            BoundedExecOutput::Discarded,
+            captured_output(b"err", false),
+            None,
+        )
+        .unwrap();
+        let d = decode_bounded_exec_result(&payload).unwrap();
+
+        assert_eq!(d.stdout, BoundedExecOutput::Discarded);
+        assert_captured_output(d.stderr, b"err", false);
+    }
+
+    #[test]
+    fn bounded_exec_result_truncation_roundtrips_per_captured_output() {
+        let payload = encode_bounded_exec_result(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            1,
+            captured_output(b"out", true),
+            captured_output(b"err", false),
+            None,
+        )
+        .unwrap();
+        let d = decode_bounded_exec_result(&payload).unwrap();
+
+        assert_captured_output(d.stdout, b"out", true);
+        assert_captured_output(d.stderr, b"err", false);
     }
 
     #[test]
@@ -1837,25 +2098,34 @@ mod tests {
             BoundedExecTermination::StartFailed,
             BoundedExecTermination::WaitFailed,
         ] {
-            let payload =
-                encode_bounded_exec_result(termination, 999, b"partial", b"diagnostic", true, true)
-                    .unwrap();
+            let payload = encode_bounded_exec_result(
+                termination,
+                999,
+                captured_output(b"partial", true),
+                BoundedExecOutput::Discarded,
+                Some("diagnostic"),
+            )
+            .unwrap();
             let d = decode_bounded_exec_result(&payload).unwrap();
 
             assert_eq!(d.termination, termination);
             assert_eq!(d.duration_ms, 999);
-            assert_eq!(d.stdout, b"partial");
-            assert_eq!(d.stderr, b"diagnostic");
-            assert!(d.stdout_truncated);
-            assert!(d.stderr_truncated);
+            assert_captured_output(d.stdout, b"partial", true);
+            assert_eq!(d.stderr, BoundedExecOutput::Discarded);
+            assert_eq!(d.diagnostic, Some("diagnostic"));
         }
     }
 
     #[test]
     fn decode_bounded_exec_result_rejects_invalid_termination_tag() {
-        let mut payload =
-            encode_bounded_exec_result(BoundedExecTermination::TimedOut, 0, b"", b"", false, false)
-                .unwrap();
+        let mut payload = encode_bounded_exec_result(
+            BoundedExecTermination::TimedOut,
+            0,
+            captured_output(b"", false),
+            captured_output(b"", false),
+            None,
+        )
+        .unwrap();
         payload[0] = 0xFF;
 
         let err = decode_bounded_exec_result(&payload).unwrap_err();
@@ -1875,22 +2145,27 @@ mod tests {
     }
 
     #[test]
-    fn decode_bounded_exec_result_rejects_unknown_flags() {
-        let mut payload =
-            encode_bounded_exec_result(BoundedExecTermination::TimedOut, 0, b"", b"", false, false)
-                .unwrap();
-        payload[1] = 0x80;
+    fn decode_bounded_exec_result_rejects_invalid_output_tag() {
+        let mut payload = encode_bounded_exec_result(
+            BoundedExecTermination::TimedOut,
+            0,
+            captured_output(b"", false),
+            captured_output(b"", false),
+            None,
+        )
+        .unwrap();
+        payload[13] = 0x80;
 
         let err = decode_bounded_exec_result(&payload).unwrap_err();
         assert!(matches!(
             err,
-            ProtocolError::InvalidPayload("bounded_exec_result unknown flags")
+            ProtocolError::InvalidPayload("bounded_exec_result invalid output tag")
         ));
     }
 
     #[test]
     fn decode_bounded_exec_result_rejects_truncated_exit_code() {
-        let payload = [BOUNDED_EXEC_TERMINATION_EXITED, 0, 0, 0, 0];
+        let payload = [BOUNDED_EXEC_TERMINATION_EXITED, 0, 0, 0];
 
         let err = decode_bounded_exec_result(&payload).unwrap_err();
         assert!(matches!(
@@ -1903,7 +2178,6 @@ mod tests {
     fn decode_bounded_exec_result_rejects_truncated_duration() {
         let mut payload = Vec::new();
         payload.push(BOUNDED_EXEC_TERMINATION_EXITED);
-        payload.push(0);
         payload.extend_from_slice(&0_i32.to_be_bytes());
         payload.extend_from_slice(&0_u64.to_be_bytes()[..7]);
 
@@ -1915,31 +2189,31 @@ mod tests {
     }
 
     #[test]
-    fn decode_bounded_exec_result_rejects_truncated_stdout() {
+    fn decode_bounded_exec_result_rejects_truncated_output() {
         let mut payload = Vec::new();
         payload.push(BOUNDED_EXEC_TERMINATION_EXITED);
-        payload.push(0);
         payload.extend_from_slice(&0_i32.to_be_bytes());
         payload.extend_from_slice(&0_u64.to_be_bytes());
+        payload.push(BOUNDED_EXEC_OUTPUT_CAPTURED);
+        payload.push(0);
         payload.extend_from_slice(&3_u32.to_be_bytes());
         payload.extend_from_slice(b"ab");
 
         let err = decode_bounded_exec_result(&payload).unwrap_err();
         assert!(matches!(
             err,
-            ProtocolError::InvalidPayload("bounded_exec_result stdout truncated")
+            ProtocolError::InvalidPayload("bounded_exec_result output truncated")
         ));
     }
 
     #[test]
-    fn decode_bounded_exec_result_rejects_truncated_stderr() {
+    fn decode_bounded_exec_result_rejects_truncated_diagnostic() {
         let mut payload = encode_bounded_exec_result(
             BoundedExecTermination::Exited { exit_code: 0 },
             0,
-            b"out",
-            b"err",
-            false,
-            false,
+            captured_output(b"out", false),
+            captured_output(b"err", false),
+            Some("diagnostic"),
         )
         .unwrap();
         payload.pop();
@@ -1947,7 +2221,7 @@ mod tests {
         let err = decode_bounded_exec_result(&payload).unwrap_err();
         assert!(matches!(
             err,
-            ProtocolError::InvalidPayload("bounded_exec_result stderr truncated")
+            ProtocolError::InvalidPayload("bounded_exec_result diagnostic truncated")
         ));
     }
 
@@ -1956,10 +2230,9 @@ mod tests {
         let mut payload = encode_bounded_exec_result(
             BoundedExecTermination::Exited { exit_code: 0 },
             0,
-            b"out",
-            b"err",
-            false,
-            false,
+            captured_output(b"out", false),
+            captured_output(b"err", false),
+            None,
         )
         .unwrap();
         payload.push(0);
@@ -2077,10 +2350,9 @@ mod tests {
         let result_payload = encode_bounded_exec_result(
             BoundedExecTermination::Exited { exit_code: 0 },
             15,
-            b"out",
-            b"err",
-            false,
-            false,
+            captured_output(b"out", false),
+            captured_output(b"err", false),
+            None,
         )
         .unwrap();
         let chunk_payload =

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -517,6 +517,15 @@ pub fn encode_bounded_exec_result(
     add_bounded_exec_output_capacity(&mut capacity, "stdout", stdout)?;
     add_bounded_exec_output_capacity(&mut capacity, "stderr", stderr)?;
     add_len_prefixed_capacity(&mut capacity, "diagnostic", diagnostic)?;
+    let body_len = MIN_BODY_SIZE
+        .checked_add(capacity)
+        .ok_or(ProtocolError::PayloadTooLarge(
+            "bounded_exec_result",
+            usize::MAX,
+        ))?;
+    if body_len > MAX_MESSAGE_SIZE {
+        return Err(ProtocolError::MessageTooLarge(body_len));
+    }
 
     let mut p = Vec::with_capacity(capacity);
     p.push(termination_tag);
@@ -2056,6 +2065,22 @@ mod tests {
                 + MAX_BOUNDED_EXEC_RESULT_OUTPUT_BYTES,
             MAX_MESSAGE_SIZE
         );
+    }
+
+    #[test]
+    fn bounded_exec_result_rejects_diagnostic_past_message_budget() {
+        let stdout = vec![0u8; MAX_BOUNDED_EXEC_RESULT_OUTPUT_BYTES];
+
+        let err = encode_bounded_exec_result(
+            BoundedExecTermination::WaitFailed,
+            0,
+            captured_output(&stdout, true),
+            captured_output(b"", false),
+            Some("diagnostic"),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, ProtocolError::MessageTooLarge(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add explicit per-stream bounded exec output policies: discard, capture, stream-only, and stream+capture
- return discarded vs captured outputs distinctly and carry infrastructure diagnostics separately from user stderr
- avoid guest stdout/stderr pipes for non-streamed discarded output and keep host stream cleanup per stream

## Tests
- cargo fmt --all --manifest-path crates/Cargo.toml --check
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-host -p vsock-guest -p sandbox -p sandbox-fc -p sandbox-mock --all-targets --all-features
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-host -p vsock-guest -p sandbox -p sandbox-fc -p sandbox-mock --all-targets --all-features

Closes #12284