### PR TITLE
refactor: require execution context framework

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -391,6 +391,7 @@ const router = tsr.router(runsMainContract, {
           orgId: org.orgId,
           agentComposeVersionId: composeMeta.agentComposeVersionId,
           agentCompose: composeContent,
+          framework: resolved.framework,
           prompt: body.prompt,
           sandboxToken,
           appendSystemPrompt: body.appendSystemPrompt,

--- a/turbo/apps/web/src/lib/infra/run/context/build-context.ts
+++ b/turbo/apps/web/src/lib/infra/run/context/build-context.ts
@@ -6,6 +6,7 @@ import type {
   ResumeSession,
 } from "../types";
 import type { AdditionalVolume } from "../../storage/types";
+import type { SupportedFramework } from "@vm0/core/frameworks";
 import type {
   Firewalls,
   NetworkPolicies,
@@ -18,6 +19,7 @@ interface BuildInfraContextParams {
   orgId: string;
   agentComposeVersionId: string;
   agentCompose: unknown;
+  framework: SupportedFramework;
   prompt: string;
   sandboxToken: string;
   appendSystemPrompt?: string;
@@ -77,6 +79,7 @@ export function buildInfraExecutionContext(
     orgId: params.orgId,
     agentComposeVersionId: params.agentComposeVersionId,
     agentCompose: params.agentCompose,
+    framework: params.framework,
     prompt: params.prompt,
     appendSystemPrompt: params.appendSystemPrompt,
     vars: params.vars,

--- a/turbo/apps/web/src/lib/infra/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/infra/run/context/execution-preparer.ts
@@ -16,7 +16,6 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
-import { resolveRuntimeFramework } from "../utils";
 
 const log = logger("context:preparer");
 
@@ -81,13 +80,10 @@ export async function prepareForExecution(
   const orgId = context.orgId;
   log.debug(`Preparing execution context for run ${context.runId}...`);
 
-  // Resolve runtime framework once; runner payloads still call this
-  // `cliAgentType` at the protocol boundary.
+  // ExecutionContext builders already resolved the final runtime framework.
+  // Runner payloads still call this value `cliAgentType` at the protocol boundary.
   const workingDir = extractWorkingDir(context.agentCompose);
-  const runtimeFramework = resolveRuntimeFramework({
-    resolvedFramework: context.resolvedFramework,
-    agentCompose: context.agentCompose,
-  });
+  const runtimeFramework = context.framework;
   const cliAgentType = runtimeFramework;
   const runnerGroup = resolveRunnerGroup(context.agentCompose);
   const profile = resolveRunnerProfile(context.agentCompose);

--- a/turbo/apps/web/src/lib/infra/run/resolvers/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/resolvers/types.ts
@@ -30,7 +30,7 @@ export interface ConversationResolution {
   /**
    * Framework recorded on the conversation being continued
    * (`conversations.cliAgentType`). Source of truth for the previous run's
-   * framework — compared against `resolvedFramework` in build-zero-context to
+   * framework — compared against the resolved execution context framework to
    * detect mid-thread framework switches. Undefined for direct-conversation
    * resumes from data that predates cliAgentType persistence.
    */

--- a/turbo/apps/web/src/lib/infra/run/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/types.ts
@@ -1,4 +1,5 @@
 import type { AdditionalVolume } from "../storage/types";
+import type { SupportedFramework } from "@vm0/core/frameworks";
 import type { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type {
   Firewalls,
@@ -137,11 +138,10 @@ export interface ExecutionContext {
   // vm0-managed model provider runs; BYOK/custom providers leave it unset.
   modelUsageProvider?: string;
 
-  // Provider-derived framework when zero-layer resolution ran. Source of
-  // truth for downstream framework-aware logic (dispatch + validation).
-  // Falls back to compose framework via resolveRuntimeFramework when undefined
-  // (CLI path, no provider context).
-  resolvedFramework?: string;
+  // Final runtime framework for this execution. Builders must resolve this
+  // before creating the context; downstream infra only maps it to the runner
+  // protocol field (`cliAgentType`).
+  framework: SupportedFramework;
 
   // API start time for E2E timing metrics — epoch millis captured at the route
   // handler's first line by the caller (see issue #9936).

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -16,6 +16,7 @@ import {
   getModelProviderFirewall,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
+import type { SupportedFramework } from "@vm0/core/frameworks";
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { badRequest, notFound } from "@vm0/api-services/errors";
@@ -260,7 +261,7 @@ async function resolveSecretsAndEnvironment(
     | Record<string, SecretConnectorMetadata>
     | undefined;
   resolvedModelProvider: ModelProviderType | undefined;
-  resolvedFramework: string;
+  resolvedFramework: SupportedFramework;
   modelProviderConfig: ExpandedFirewallConfig | undefined;
   modelProviderId: string | null | undefined;
   modelProviderCredentialScope: string | undefined;
@@ -475,6 +476,9 @@ async function resolveSecretsAndEnvironment(
     }
   }
   timings.billableFirewalls = Date.now() - billableFirewallsStart;
+  const resolvedFramework = resolveRuntimeFramework({
+    resolvedFramework: resolvedModelProviderResult.framework ?? framework,
+  });
 
   return {
     secrets,
@@ -484,7 +488,7 @@ async function resolveSecretsAndEnvironment(
     resolvedModelProvider: resolvedModelProviderResult.resolvedModelProvider,
     // Provider-derived framework when resolution ran; otherwise the compose
     // framework. Source-of-truth for downstream framework-aware logic.
-    resolvedFramework: resolvedModelProviderResult.framework ?? framework,
+    resolvedFramework,
     modelProviderConfig,
     modelProviderId: resolvedModelProviderResult.modelProviderId,
     modelProviderCredentialScope: resolvedModelProviderResult.credentialScope,
@@ -517,8 +521,8 @@ interface BuildZeroContextResult {
   modelProviderId: string | null | undefined;
   /** Model-first credential scope, if provider resolution used model policy. */
   modelProviderCredentialScope: string | undefined;
-  /** Provider-derived framework, source-of-truth for downstream. */
-  resolvedFramework: string;
+  /** Final framework for this execution context. */
+  framework: SupportedFramework;
   /** The logical model name selected by the user, for model usage billing. */
   selectedModel: string | undefined;
 }
@@ -678,6 +682,7 @@ interface ResolvedCliContext {
   modelProviderId?: string | null;
   modelProviderCredentialScope?: string;
   selectedModel?: string;
+  framework: SupportedFramework;
 
   billableFirewalls: string[];
   modelUsageProvider?: string;
@@ -767,6 +772,7 @@ export async function resolveCliRunContext(
     return {
       artifacts,
       vars,
+      framework: resolveRuntimeFramework({ agentCompose }),
       billableFirewalls: [],
       timings: {
         resolveSource: resolveEnd - resolveStart,
@@ -875,6 +881,7 @@ export async function resolveCliRunContext(
     modelProviderId,
     modelProviderCredentialScope,
     selectedModel,
+    framework: resolvedFramework,
     billableFirewalls,
     modelUsageProvider,
     timings: {
@@ -1043,8 +1050,8 @@ export async function buildZeroExecutionContext(
   // - Provider: avoid mid-conversation base URL mismatches.
   // - Framework: persisted cliAgentSessionHistory is in the previous
   //   framework's format; switching binaries mid-thread can't replay it.
-  //   resolvedFramework is the source of truth (provider-derived since
-  //   #11649); the compose's `framework` field is no longer authoritative.
+  //   ExecutionContext.framework is the source of truth (provider-derived
+  //   since #11649); the compose's `framework` field is no longer authoritative.
   const compatibilityChecksStart = Date.now();
   checkProviderCompatibility(originalModelProvider, resolvedModelProvider);
   checkFrameworkCompatibility(resolution?.sessionFramework, resolvedFramework);
@@ -1109,11 +1116,7 @@ export async function buildZeroExecutionContext(
       modelUsageProvider,
       // API start time for E2E timing metrics
       apiStartTime: params.apiStartTime,
-      // Provider-derived framework — source of truth for downstream
-      // dispatch (execution-preparer) and admission validation. Undefined
-      // on the CLI path (no provider context); dispatch falls back to
-      // compose framework via resolveRuntimeFramework.
-      resolvedFramework,
+      framework: resolvedFramework,
     },
     timings: {
       ...timingDetails,
@@ -1122,7 +1125,7 @@ export async function buildZeroExecutionContext(
     resolvedModelProvider,
     modelProviderId,
     modelProviderCredentialScope,
-    resolvedFramework,
+    framework: resolvedFramework,
     selectedModel,
   };
 }

--- a/turbo/apps/web/src/lib/zero/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/zero/model-provider/model-provider-service.ts
@@ -1252,7 +1252,7 @@ export function getOrgDefaultModelProvider(
  * Used as the cross-framework fallback by admission (Stage B) when
  * `getOrgDefaultModelProvider(orgId, composeFramework)` returns null. Per
  * Epic #11520, the provider's framework wins; admission accepts any default
- * and downstream stages route via `resolvedFramework`.
+ * and downstream stages route via the execution context framework.
  *
  * Returns null only when the org has no `isDefault: true` provider for any
  * framework. Telegram / Slack / chat-title callers keep using the strict


### PR DESCRIPTION
## Summary
- make `ExecutionContext.framework` required and typed as `SupportedFramework`
- thread the resolved framework through Zero and CLI context builders
- stop `execution-preparer` from falling back to compose framework; it now only maps context framework to runner `cliAgentType`

## Tests
- `pnpm -F web check-types`
- `pnpm -F web lint`
- `pnpm -F web exec vitest run app/api/zero/chat/messages/__tests__/route.test.ts -t "dispatch framework derivation"`
- `pnpm -F web exec vitest run app/api/agent/runs/__tests__/route.test.ts -t "should skip injection when compose has explicit ANTHROPIC_API_KEY"`
- `pnpm -F web exec vitest run src/lib/zero/__tests__/build-zero-context.test.ts`
- `pnpm format`
- `git diff --check`