### PR TITLE
fix: remove redundant web chat system prompt line

### DIFF
--- a/turbo/apps/web/src/lib/zero/__tests__/integration-prompt.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/integration-prompt.test.ts
@@ -158,6 +158,6 @@ describe("buildWebChatPrompt", () => {
     const result = buildWebChatPrompt();
 
     expect(result).toContain("web chat UI");
-    expect(result).toContain("displayed to the user directly");
+    expect(result).toContain("You are communicating with the user");
   });
 });

--- a/turbo/apps/web/src/lib/zero/integration-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/integration-prompt.ts
@@ -176,15 +176,11 @@ export function buildSchedulePrompt(opts: { triggerType: string }): string {
 
 /**
  * Build the full appendSystemPrompt for Web Chat integration.
- *
- * The user is interacting through the web chat UI, so the final result of the
- * run will be rendered directly to them. Keep this in mind when producing
- * output — there is no separate delivery step.
  */
 export function buildWebChatPrompt(): string {
   const header = buildIntegrationPrompt("Web");
   const description =
-    "You are communicating with the user through the web chat UI. The final result you return will be displayed to the user directly in the chat.";
+    "You are communicating with the user through the web chat UI.";
   return [header, description].join("\n\n");
 }
 


### PR DESCRIPTION
## Summary
- Remove the redundant sentence "The final result you return will be displayed to the user directly in the chat." from the web chat system prompt
- The remaining text "You are communicating with the user through the web chat UI." already conveys sufficient context

## Test plan
- [x] Updated test assertion to match new output
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)