### PR TITLE
fix(api): align connector configured types

### DIFF
--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -48,12 +48,28 @@ const {
   return {};
 });
 
+const {
+  get: getOptionalOverrideEnv,
+  set: setOptionalOverrideEnv,
+  clear: clearOptionalOverrideEnv,
+} = testOverride<Readonly<Record<string, string | undefined>>>(() => {
+  return {};
+});
+
 export function env<K extends EnvKey>(name: K): EnvShape[K] {
   const overrideEnv = getOverrideEnv();
   if (Object.prototype.hasOwnProperty.call(overrideEnv, name)) {
     return overrideEnv[name] as EnvShape[K];
   }
   return baseEnv[name];
+}
+
+export function optionalEnv(name: string): string | undefined {
+  const overrideEnv = getOptionalOverrideEnv();
+  if (Object.prototype.hasOwnProperty.call(overrideEnv, name)) {
+    return overrideEnv[name];
+  }
+  return process.env[name] || undefined;
 }
 
 export function mockEnv<K extends EnvKey>(name: K, value: EnvShape[K]): void {
@@ -64,6 +80,14 @@ export function mockEnv<K extends EnvKey>(name: K, value: EnvShape[K]): void {
   });
 }
 
+export function mockOptionalEnv(name: string, value: string | undefined): void {
+  setOptionalOverrideEnv({
+    ...getOptionalOverrideEnv(),
+    [name]: value,
+  });
+}
+
 export function clearMockedEnv(): void {
   clearOverrideEnv();
+  clearOptionalOverrideEnv();
 }

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -4,6 +4,7 @@ import { createStore } from "ccstate";
 import { secrets } from "@vm0/db/schema/secret";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { mockOptionalEnv } from "../../../lib/env";
 import { writeDb$ } from "../../external/db";
 import {
   zeroConnectorList,
@@ -47,6 +48,22 @@ describe("zeroConnectorList", () => {
 
     const sorted = [...list.configuredTypes].sort();
     expect(list.configuredTypes).toStrictEqual(sorted);
+  });
+
+  it("returns configuredTypes from OAuth and computer runtime env", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+
+    mockOptionalEnv("AIRTABLE_OAUTH_CLIENT_ID", "airtable-client-id");
+    mockOptionalEnv("AIRTABLE_OAUTH_CLIENT_SECRET", "airtable-client-secret");
+    mockOptionalEnv("NGROK_API_KEY", "ngrok-api-key");
+    mockOptionalEnv("NGROK_COMPUTER_CONNECTOR_DOMAIN", "computer.example.com");
+
+    const list = await store.get(zeroConnectorList({ orgId, userId }));
+
+    expect(list.configuredTypes).toContain("airtable");
+    expect(list.configuredTypes).toContain("computer");
+    expect(list.configuredTypes).toContain("amplitude");
   });
 });
 

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -8,7 +8,7 @@ import type { ConnectorSearchAuthMethod } from "@vm0/api-contracts/contracts/zer
 import {
   deriveApiTokenConnectedTypes,
   getApiTokenFieldsByType,
-  getConnectorDefaultAuthMethod,
+  getConfiguredConnectorTypes,
   getConnectorProvidedSecretNames,
   getScopeDiff,
 } from "@vm0/connectors/connector-utils";
@@ -24,6 +24,7 @@ import { variables } from "@vm0/db/schema/variable";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
+import { optionalEnv } from "../../lib/env";
 import { db$ } from "../external/db";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
@@ -61,12 +62,6 @@ function storedConnectorRowToResponse(
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
   };
-}
-
-function configuredConnectorTypes(): readonly ConnectorType[] {
-  return (Object.keys(CONNECTOR_TYPES) as ConnectorType[]).filter((type) => {
-    return getConnectorDefaultAuthMethod(type) === "api-token";
-  });
 }
 
 function apiTokenConnectorTypes(args: {
@@ -180,7 +175,9 @@ export function zeroConnectorList(args: {
     const connectorList = [...dbConnectors, ...derivedConnectors];
     return {
       connectors: connectorList,
-      configuredTypes: [...configuredConnectorTypes()].sort(),
+      configuredTypes: getConfiguredConnectorTypes((name) => {
+        return optionalEnv(name);
+      }),
       connectorProvidedSecretNames: [
         ...getConnectorProvidedSecretNames(
           connectorList.map((connector) => {

--- a/turbo/apps/web/src/lib/zero/connector/provider-registry.ts
+++ b/turbo/apps/web/src/lib/zero/connector/provider-registry.ts
@@ -1,5 +1,5 @@
 import type { ConnectorType } from "@vm0/connectors/connectors";
-import { getConnectorDefaultAuthMethod } from "@vm0/connectors/connector-utils";
+import { getConfiguredConnectorTypes as getConfiguredConnectorTypesFromEnv } from "@vm0/connectors/connector-utils";
 import { type Env } from "../../../env";
 import {
   type AuthUrlResult,
@@ -376,24 +376,8 @@ export const PROVIDER_HANDLERS: Record<
  * configured in the current environment.
  */
 export function getConfiguredConnectorTypes(currentEnv: Env): ConnectorType[] {
-  const configured: ConnectorType[] = [];
-
-  for (const [type, handler] of Object.entries(PROVIDER_HANDLERS)) {
-    const connectorType = type as ConnectorType;
-    if (
-      handler.getClientId(currentEnv) &&
-      handler.getClientSecret(currentEnv)
-    ) {
-      configured.push(connectorType);
-    } else if (getConnectorDefaultAuthMethod(connectorType) === "api-token") {
-      configured.push(connectorType);
-    }
-  }
-
-  // computer connector: no OAuth — uses ngrok credentials instead
-  if (currentEnv.NGROK_API_KEY && currentEnv.NGROK_COMPUTER_CONNECTOR_DOMAIN) {
-    configured.push("computer");
-  }
-
-  return configured.sort();
+  return getConfiguredConnectorTypesFromEnv((name) => {
+    const value = currentEnv[name as keyof Env];
+    return typeof value === "string" ? value : undefined;
+  });
 }

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -8,6 +8,7 @@ import {
   getConnectorProvidedSecretNames,
   getConnectorAuthMethods,
   getConnectorOAuthConfig,
+  getConfiguredConnectorTypes,
   isGoogleOAuthConnector,
 } from "../connector-utils";
 
@@ -221,6 +222,100 @@ describe("getConnectorEnvironmentMapping", () => {
         ).toBe(true);
       }
     }
+  });
+});
+
+describe("getConfiguredConnectorTypes", () => {
+  const emptyEnv = () => {
+    return undefined;
+  };
+
+  it("includes api-token connectors without environment credentials", () => {
+    const configuredTypes = getConfiguredConnectorTypes(emptyEnv);
+
+    expect(configuredTypes).toContain("amplitude");
+    expect(configuredTypes).toContain("openai");
+  });
+
+  it("includes OAuth connectors only when client id and secret are configured", () => {
+    const env = new Map([
+      ["AIRTABLE_OAUTH_CLIENT_ID", "airtable-client-id"],
+      ["AIRTABLE_OAUTH_CLIENT_SECRET", "airtable-client-secret"],
+      ["SENTRY_OAUTH_CLIENT_ID", "sentry-client-id"],
+    ]);
+
+    const configuredTypes = getConfiguredConnectorTypes((name) => {
+      return env.get(name);
+    });
+
+    expect(configuredTypes).toContain("airtable");
+    expect(configuredTypes).not.toContain("sentry");
+  });
+
+  it("includes all connectors that share a configured OAuth app", () => {
+    const env = new Map([
+      ["GOOGLE_OAUTH_CLIENT_ID", "google-client-id"],
+      ["GOOGLE_OAUTH_CLIENT_SECRET", "google-client-secret"],
+    ]);
+
+    const configuredTypes = getConfiguredConnectorTypes((name) => {
+      return env.get(name);
+    });
+
+    expect(configuredTypes).toEqual(
+      expect.arrayContaining([
+        "gmail",
+        "google-calendar",
+        "google-docs",
+        "google-drive",
+        "google-meet",
+        "google-sheets",
+      ]),
+    );
+  });
+
+  it("includes active OAuth connectors when their runtime env is configured", () => {
+    const oauthTypesWithoutRuntimeClientCredentials = new Set([
+      "codex-oauth",
+      "mailchimp",
+    ]);
+    const activeOAuthTypes = connectorTypeSchema.options.filter((type) => {
+      return (
+        getConnectorOAuthConfig(type) &&
+        !oauthTypesWithoutRuntimeClientCredentials.has(type)
+      );
+    });
+
+    const configuredTypes = getConfiguredConnectorTypes(() => {
+      return "configured";
+    });
+
+    expect(configuredTypes).toEqual(expect.arrayContaining(activeOAuthTypes));
+  });
+
+  it("includes computer only when both ngrok env vars are configured", () => {
+    const partialComputerEnv = new Map([["NGROK_API_KEY", "ngrok-api-key"]]);
+    const fullComputerEnv = new Map([
+      ["NGROK_API_KEY", "ngrok-api-key"],
+      ["NGROK_COMPUTER_CONNECTOR_DOMAIN", "computer.example.com"],
+    ]);
+
+    expect(
+      getConfiguredConnectorTypes((name) => {
+        return partialComputerEnv.get(name);
+      }),
+    ).not.toContain("computer");
+    expect(
+      getConfiguredConnectorTypes((name) => {
+        return fullComputerEnv.get(name);
+      }),
+    ).toContain("computer");
+  });
+
+  it("returns connector types in sorted order", () => {
+    const configuredTypes = getConfiguredConnectorTypes(emptyEnv);
+
+    expect(configuredTypes).toStrictEqual([...configuredTypes].sort());
   });
 });
 

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -27,6 +27,243 @@ export function getConnectorDefaultAuthMethod(
   return CONNECTOR_TYPES[type].defaultAuthMethod;
 }
 
+export type ConnectorEnvReader = (name: string) => string | undefined;
+
+interface ConnectorOAuthEnvKeys {
+  readonly clientId: string;
+  readonly clientSecret: string;
+}
+
+const OAUTH_ENV_KEYS_BY_CONNECTOR: Partial<
+  Record<ConnectorType, ConnectorOAuthEnvKeys>
+> = {
+  ahrefs: {
+    clientId: "AHREFS_OAUTH_CLIENT_ID",
+    clientSecret: "AHREFS_OAUTH_CLIENT_SECRET",
+  },
+  airtable: {
+    clientId: "AIRTABLE_OAUTH_CLIENT_ID",
+    clientSecret: "AIRTABLE_OAUTH_CLIENT_SECRET",
+  },
+  asana: {
+    clientId: "ASANA_OAUTH_CLIENT_ID",
+    clientSecret: "ASANA_OAUTH_CLIENT_SECRET",
+  },
+  canva: {
+    clientId: "CANVA_OAUTH_CLIENT_ID",
+    clientSecret: "CANVA_OAUTH_CLIENT_SECRET",
+  },
+  close: {
+    clientId: "CLOSE_OAUTH_CLIENT_ID",
+    clientSecret: "CLOSE_OAUTH_CLIENT_SECRET",
+  },
+  deel: {
+    clientId: "DEEL_OAUTH_CLIENT_ID",
+    clientSecret: "DEEL_OAUTH_CLIENT_SECRET",
+  },
+  docusign: {
+    clientId: "DOCUSIGN_OAUTH_CLIENT_ID",
+    clientSecret: "DOCUSIGN_OAUTH_CLIENT_SECRET",
+  },
+  dropbox: {
+    clientId: "DROPBOX_OAUTH_CLIENT_ID",
+    clientSecret: "DROPBOX_OAUTH_CLIENT_SECRET",
+  },
+  figma: {
+    clientId: "FIGMA_OAUTH_CLIENT_ID",
+    clientSecret: "FIGMA_OAUTH_CLIENT_SECRET",
+  },
+  "garmin-connect": {
+    clientId: "GARMIN_CONNECT_OAUTH_CLIENT_ID",
+    clientSecret: "GARMIN_CONNECT_OAUTH_CLIENT_SECRET",
+  },
+  github: {
+    clientId: "GH_OAUTH_CLIENT_ID",
+    clientSecret: "GH_OAUTH_CLIENT_SECRET",
+  },
+  gmail: {
+    clientId: "GOOGLE_OAUTH_CLIENT_ID",
+    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
+  },
+  "google-ads": {
+    clientId: "GOOGLE_OAUTH_CLIENT_ID",
+    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
+  },
+  "google-calendar": {
+    clientId: "GOOGLE_OAUTH_CLIENT_ID",
+    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
+  },
+  "google-docs": {
+    clientId: "GOOGLE_OAUTH_CLIENT_ID",
+    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
+  },
+  "google-drive": {
+    clientId: "GOOGLE_OAUTH_CLIENT_ID",
+    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
+  },
+  "google-meet": {
+    clientId: "GOOGLE_OAUTH_CLIENT_ID",
+    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
+  },
+  "google-sheets": {
+    clientId: "GOOGLE_OAUTH_CLIENT_ID",
+    clientSecret: "GOOGLE_OAUTH_CLIENT_SECRET",
+  },
+  gumroad: {
+    clientId: "GUMROAD_OAUTH_CLIENT_ID",
+    clientSecret: "GUMROAD_OAUTH_CLIENT_SECRET",
+  },
+  hubspot: {
+    clientId: "HUBSPOT_OAUTH_CLIENT_ID",
+    clientSecret: "HUBSPOT_OAUTH_CLIENT_SECRET",
+  },
+  "intervals-icu": {
+    clientId: "INTERVALS_ICU_OAUTH_CLIENT_ID",
+    clientSecret: "INTERVALS_ICU_OAUTH_CLIENT_SECRET",
+  },
+  linear: {
+    clientId: "LINEAR_OAUTH_CLIENT_ID",
+    clientSecret: "LINEAR_OAUTH_CLIENT_SECRET",
+  },
+  mercury: {
+    clientId: "MERCURY_OAUTH_CLIENT_ID",
+    clientSecret: "MERCURY_OAUTH_CLIENT_SECRET",
+  },
+  "meta-ads": {
+    clientId: "META_ADS_OAUTH_CLIENT_ID",
+    clientSecret: "META_ADS_OAUTH_CLIENT_SECRET",
+  },
+  monday: {
+    clientId: "MONDAY_OAUTH_CLIENT_ID",
+    clientSecret: "MONDAY_OAUTH_CLIENT_SECRET",
+  },
+  neon: {
+    clientId: "NEON_OAUTH_CLIENT_ID",
+    clientSecret: "NEON_OAUTH_CLIENT_SECRET",
+  },
+  notion: {
+    clientId: "NOTION_OAUTH_CLIENT_ID",
+    clientSecret: "NOTION_OAUTH_CLIENT_SECRET",
+  },
+  "outlook-calendar": {
+    clientId: "MICROSOFT_OAUTH_CLIENT_ID",
+    clientSecret: "MICROSOFT_OAUTH_CLIENT_SECRET",
+  },
+  "outlook-mail": {
+    clientId: "MICROSOFT_OAUTH_CLIENT_ID",
+    clientSecret: "MICROSOFT_OAUTH_CLIENT_SECRET",
+  },
+  posthog: {
+    clientId: "POSTHOG_OAUTH_CLIENT_ID",
+    clientSecret: "POSTHOG_OAUTH_CLIENT_SECRET",
+  },
+  reddit: {
+    clientId: "REDDIT_OAUTH_CLIENT_ID",
+    clientSecret: "REDDIT_OAUTH_CLIENT_SECRET",
+  },
+  sentry: {
+    clientId: "SENTRY_OAUTH_CLIENT_ID",
+    clientSecret: "SENTRY_OAUTH_CLIENT_SECRET",
+  },
+  slack: {
+    clientId: "SLACK_CLIENT_ID",
+    clientSecret: "SLACK_CLIENT_SECRET",
+  },
+  spotify: {
+    clientId: "SPOTIFY_OAUTH_CLIENT_ID",
+    clientSecret: "SPOTIFY_OAUTH_CLIENT_SECRET",
+  },
+  strava: {
+    clientId: "STRAVA_OAUTH_CLIENT_ID",
+    clientSecret: "STRAVA_OAUTH_CLIENT_SECRET",
+  },
+  stripe: {
+    clientId: "STRIPE_OAUTH_CLIENT_ID",
+    clientSecret: "STRIPE_OAUTH_CLIENT_SECRET",
+  },
+  supabase: {
+    clientId: "SUPABASE_OAUTH_CLIENT_ID",
+    clientSecret: "SUPABASE_OAUTH_CLIENT_SECRET",
+  },
+  todoist: {
+    clientId: "TODOIST_OAUTH_CLIENT_ID",
+    clientSecret: "TODOIST_OAUTH_CLIENT_SECRET",
+  },
+  vercel: {
+    clientId: "VERCEL_OAUTH_CLIENT_ID",
+    clientSecret: "VERCEL_OAUTH_CLIENT_SECRET",
+  },
+  webflow: {
+    clientId: "WEBFLOW_OAUTH_CLIENT_ID",
+    clientSecret: "WEBFLOW_OAUTH_CLIENT_SECRET",
+  },
+  x: {
+    clientId: "X_OAUTH_CLIENT_ID",
+    clientSecret: "X_OAUTH_CLIENT_SECRET",
+  },
+  xero: {
+    clientId: "XERO_OAUTH_CLIENT_ID",
+    clientSecret: "XERO_OAUTH_CLIENT_SECRET",
+  },
+  zoom: {
+    clientId: "ZOOM_OAUTH_CLIENT_ID",
+    clientSecret: "ZOOM_OAUTH_CLIENT_SECRET",
+  },
+};
+
+const STATIC_OAUTH_CONFIGURED_CONNECTOR_TYPES = new Set<ConnectorType>([
+  "test-oauth",
+]);
+
+function hasEnvValue(readEnv: ConnectorEnvReader, name: string): boolean {
+  return Boolean(readEnv(name));
+}
+
+function hasConfiguredOAuth(
+  readEnv: ConnectorEnvReader,
+  type: ConnectorType,
+): boolean {
+  if (STATIC_OAUTH_CONFIGURED_CONNECTOR_TYPES.has(type)) {
+    return true;
+  }
+  const keys = OAUTH_ENV_KEYS_BY_CONNECTOR[type];
+  return keys
+    ? hasEnvValue(readEnv, keys.clientId) &&
+        hasEnvValue(readEnv, keys.clientSecret)
+    : false;
+}
+
+/**
+ * Return connector types configured by platform/runtime environment.
+ *
+ * This is intentionally the shared source of truth for the Web and API
+ * implementations of GET /api/zero/connectors.
+ */
+export function getConfiguredConnectorTypes(
+  readEnv: ConnectorEnvReader,
+): ConnectorType[] {
+  const configured = new Set<ConnectorType>();
+
+  for (const type of Object.keys(CONNECTOR_TYPES) as ConnectorType[]) {
+    const defaultAuthMethod = getConnectorDefaultAuthMethod(type);
+    if (
+      hasConfiguredOAuth(readEnv, type) ||
+      defaultAuthMethod === "api-token"
+    ) {
+      configured.add(type);
+    }
+  }
+
+  if (
+    hasEnvValue(readEnv, "NGROK_API_KEY") &&
+    hasEnvValue(readEnv, "NGROK_COMPUTER_CONNECTOR_DOMAIN")
+  ) {
+    configured.add("computer");
+  }
+
+  return [...configured].sort();
+}
+
 /**
  * Get secrets config for a specific auth method
  */


### PR DESCRIPTION
## Summary

- Move connector configured type calculation into a shared connector utility used by both Web and API.
- Make the API read runtime OAuth and computer connector env values when building `configuredTypes`.
- Add regression coverage for OAuth-configured, api-token, shared OAuth app, computer env-gated, and API service configured type behavior.

Fixes #12299

## Tests

- `pnpm --dir turbo -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts`
- `pnpm --dir turbo -F @vm0/connectors check-types`
- `pnpm --dir turbo -F @vm0/connectors lint`
- `pnpm --dir turbo -F api exec vitest run src/signals/services/__tests__/zero-connector-data.service.test.ts`
- `pnpm --dir turbo -F api check-types`
- `pnpm --dir turbo -F api lint`
- `pnpm --dir turbo -F web check-types`
- `pnpm --dir turbo -F web lint`
- `pnpm --dir turbo format`
- pre-commit: `pnpm knip`, `pnpm check-types`