### PR TITLE
feat(runner): batch stage storage cache archives

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1290,6 +1290,7 @@ dependencies = [
  "flate2",
  "guest-common",
  "httpmock",
+ "libc",
  "serde",
  "serde_json",
  "tar",

--- a/crates/README.md
+++ b/crates/README.md
@@ -21,7 +21,7 @@ This workspace contains Rust crates for the vm0 sandbox runtime — VM orchestra
 | **guest-mock-claude** | Mock Claude CLI for testing — executes bash commands and outputs Claude-compatible JSONL |
 | **guest-mock-codex** | Mock Codex CLI for testing — emits Codex JSONL protocol on stdout and persists zstd-compressed session files |
 | **guest-reseed** | Entropy reseed after snapshot restore — injects host entropy via RNDADDENTROPY and forces CRNG reseed via RNDRESEEDCRNG |
-| **guest-write-file** | Direct file writer for vsock `write_file` — writes stdin to guest files without shell startup overhead |
+| **guest-write-file** | Direct file writer for vsock `write_file`/`write_files` — writes stdin and batch streams to guest files without shell startup overhead |
 | **ably-subscriber** | Ably Pub/Sub subscribe-only realtime client — WebSocket/MessagePack protocol with token auth and automatic reconnection |
 
 ## Architecture

--- a/crates/guest-download/Cargo.toml
+++ b/crates/guest-download/Cargo.toml
@@ -10,6 +10,7 @@ serde_json.workspace = true
 tar.workspace = true
 ureq = { workspace = true, features = ["platform-verifier"] }
 guest-common.workspace = true
+libc.workspace = true
 
 [dev-dependencies]
 httpmock.workspace = true

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -888,9 +888,18 @@ fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadErro
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    static STAGE_DIR_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     fn disable_system_log() {
         guest_common::log::clear_system_log_file();
+    }
+
+    fn stage_dir_test_guard() -> MutexGuard<'static, ()> {
+        STAGE_DIR_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
     }
 
     fn write_test_archive(path: &Path, entries: &[(&str, &[u8])]) {
@@ -1101,6 +1110,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn download_and_extract_rejects_stage_archive_symlink() {
+        let _stage_guard = stage_dir_test_guard();
         disable_system_log();
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -1134,6 +1144,7 @@ mod tests {
 
     #[test]
     fn run_removes_local_stage_archive_after_duplicate_success() {
+        let _stage_guard = stage_dir_test_guard();
         disable_system_log();
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -310,7 +310,7 @@ fn append_download_tasks(
 fn local_stage_archive_path(url: &str) -> Option<PathBuf> {
     let path = Path::new(url.strip_prefix("file://")?);
     let normalized = normalize_path(path);
-    if normalized.starts_with(Path::new(GUEST_STAGE_DIR)) {
+    if normalized.parent() == Some(Path::new(GUEST_STAGE_DIR)) {
         Some(normalized)
     } else {
         None
@@ -354,6 +354,39 @@ fn cleanup_local_stage_archives(paths: &BTreeSet<PathBuf>) {
             "Failed to remove local stage dir {GUEST_STAGE_DIR}: {e}"
         ),
     }
+}
+
+fn open_local_stage_archive(path: &Path) -> Result<fs::File, DownloadError> {
+    let stage_metadata = fs::symlink_metadata(GUEST_STAGE_DIR).map_err(|e| {
+        DownloadError::fatal(format!(
+            "Failed to inspect local stage dir {GUEST_STAGE_DIR}: {e}"
+        ))
+    })?;
+    if !stage_metadata.is_dir() {
+        return Err(DownloadError::fatal(format!(
+            "Refusing local archive because {GUEST_STAGE_DIR} is not a directory"
+        )));
+    }
+
+    let archive_metadata = fs::symlink_metadata(path).map_err(|e| {
+        DownloadError::fatal(format!(
+            "Failed to inspect local archive {}: {e}",
+            path.display()
+        ))
+    })?;
+    if !archive_metadata.is_file() {
+        return Err(DownloadError::fatal(format!(
+            "Refusing local archive that is not a regular file: {}",
+            path.display()
+        )));
+    }
+
+    fs::File::open(path).map_err(|e| {
+        DownloadError::fatal(format!(
+            "Failed to open local archive {}: {e}",
+            path.display()
+        ))
+    })
 }
 
 fn valid_instruction_filename(filename: &str) -> bool {
@@ -592,11 +625,14 @@ fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadErro
     // Obtain a reader for the archive bytes. HTTP is the production path today;
     // file:// is used by the runner-side storage cache (epic #10800) to feed
     // host-staged tarballs that were pushed into the guest over vsock.
-    let reader: Box<dyn Read> = if let Some(path) = url.strip_prefix("file://") {
-        log_info!(LOG_TAG, "Reading local archive from {path}");
-        let file = fs::File::open(path).map_err(|e| {
-            DownloadError::fatal(format!("Failed to open local archive {path}: {e}"))
+    let reader: Box<dyn Read> = if url.starts_with("file://") {
+        let path = local_stage_archive_path(url).ok_or_else(|| {
+            DownloadError::fatal(format!(
+                "Refusing local archive outside {GUEST_STAGE_DIR}: {url}"
+            ))
         })?;
+        log_info!(LOG_TAG, "Reading local archive from {}", path.display());
+        let file = open_local_stage_archive(&path)?;
         Box::new(file)
     } else {
         let response = HTTP_AGENT.get(url).call().map_err(|e| {
@@ -910,9 +946,71 @@ mod tests {
             None
         );
         assert_eq!(
+            local_stage_archive_path("file:///tmp/vm0-storage-cache/nested/abc.tar.gz"),
+            None
+        );
+        assert_eq!(
+            local_stage_archive_path("file:///tmp/vm0-storage-cache-evil/abc.tar.gz"),
+            None
+        );
+        assert_eq!(
             local_stage_archive_path("https://example.com/a.tar.gz"),
             None
         );
+    }
+
+    #[test]
+    fn download_and_extract_rejects_file_url_outside_stage_dir() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let archive_path = dir.path().join("outside.tar.gz");
+        write_test_archive(&archive_path, &[("data.txt", b"nope")]);
+        let target = dir.path().join("target");
+        let url = format!("file://{}", archive_path.display());
+
+        let err = download_and_extract(&url, target.to_str().unwrap()).unwrap_err();
+
+        assert!(!err.retriable);
+        assert!(
+            err.message.contains(GUEST_STAGE_DIR),
+            "got: {}",
+            err.message
+        );
+        assert!(!target.join("data.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn download_and_extract_rejects_stage_archive_symlink() {
+        disable_system_log();
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let stage_dir = Path::new(GUEST_STAGE_DIR);
+        fs::create_dir_all(stage_dir).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let outside_archive = dir.path().join("outside.tar.gz");
+        write_test_archive(&outside_archive, &[("data.txt", b"nope")]);
+
+        let archive_path = stage_dir.join(format!("guest-download-symlink-test-{unique}.tar.gz"));
+        let _ = fs::remove_file(&archive_path);
+        std::os::unix::fs::symlink(&outside_archive, &archive_path).unwrap();
+
+        let target = dir.path().join("target");
+        let url = format!("file://{}", archive_path.display());
+        let err = download_and_extract(&url, target.to_str().unwrap()).unwrap_err();
+
+        assert!(!err.retriable);
+        assert!(
+            err.message.contains("not a regular file"),
+            "got: {}",
+            err.message
+        );
+        assert!(!target.join("data.txt").exists());
+
+        fs::remove_file(&archive_path).unwrap();
     }
 
     #[test]

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -7,6 +7,7 @@
 
 use guest_common::{log_error, log_info, log_warn, telemetry::record_sandbox_op};
 use serde::Deserialize;
+use std::collections::BTreeSet;
 use std::fs;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
@@ -102,6 +103,7 @@ const MAX_RETRIES: u32 = 3;
 const RETRY_DELAY: Duration = Duration::from_secs(1);
 const TIMEOUT: Duration = Duration::from_secs(60);
 const MAX_CONCURRENT: usize = 4;
+const GUEST_STAGE_DIR: &str = "/tmp/vm0-storage-cache";
 
 /// Global HTTP agent with timeout and system certificate verification.
 /// Uses platform verifier to trust system CA certificates (including proxy CA).
@@ -194,8 +196,10 @@ pub fn run(manifest_path: &str) -> bool {
         }
     }
 
+    let local_stage_archives = local_stage_archives(&tasks);
     let success = download_all_parallel(tasks);
     if success {
+        cleanup_local_stage_archives(&local_stage_archives);
         normalize_instruction_files(&manifest.storages);
     }
     success
@@ -300,6 +304,55 @@ fn append_download_tasks(
                 allow_404,
             });
         }
+    }
+}
+
+fn local_stage_archive_path(url: &str) -> Option<PathBuf> {
+    let path = Path::new(url.strip_prefix("file://")?);
+    let normalized = normalize_path(path);
+    if normalized.starts_with(Path::new(GUEST_STAGE_DIR)) {
+        Some(normalized)
+    } else {
+        None
+    }
+}
+
+fn local_stage_archives(tasks: &[DownloadTask]) -> BTreeSet<PathBuf> {
+    tasks
+        .iter()
+        .filter_map(|task| local_stage_archive_path(&task.url))
+        .collect()
+}
+
+fn cleanup_local_stage_archives(paths: &BTreeSet<PathBuf>) {
+    if paths.is_empty() {
+        return;
+    }
+
+    for path in paths {
+        match fs::remove_file(path) {
+            Ok(()) => log_info!(LOG_TAG, "Removed local stage archive {}", path.display()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => log_warn!(
+                LOG_TAG,
+                "Failed to remove local stage archive {}: {}",
+                path.display(),
+                e
+            ),
+        }
+    }
+
+    match fs::remove_dir(GUEST_STAGE_DIR) {
+        Ok(()) => log_info!(LOG_TAG, "Removed empty local stage dir {GUEST_STAGE_DIR}"),
+        Err(e)
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::DirectoryNotEmpty
+            ) => {}
+        Err(e) => log_warn!(
+            LOG_TAG,
+            "Failed to remove local stage dir {GUEST_STAGE_DIR}: {e}"
+        ),
     }
 }
 
@@ -685,6 +738,26 @@ mod tests {
         guest_common::log::clear_system_log_file();
     }
 
+    fn write_test_archive(path: &Path, entries: &[(&str, &[u8])]) {
+        let file = fs::File::create(path).unwrap();
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+
+        for (entry_path, contents) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_path(entry_path).unwrap();
+            header.set_size(contents.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append(&header, std::io::Cursor::new(*contents))
+                .unwrap();
+        }
+
+        let encoder = builder.into_inner().unwrap();
+        encoder.finish().unwrap();
+    }
+
     // -- normalize_path tests --
 
     #[test]
@@ -824,6 +897,59 @@ mod tests {
         assert!(is_valid_url(&Some(
             "file:///tmp/vm0-storage-cache/abc.tar.gz".to_string()
         )));
+    }
+
+    #[test]
+    fn local_stage_archive_path_accepts_only_stage_dir() {
+        assert_eq!(
+            local_stage_archive_path("file:///tmp/vm0-storage-cache/abc.tar.gz").unwrap(),
+            PathBuf::from("/tmp/vm0-storage-cache/abc.tar.gz")
+        );
+        assert_eq!(
+            local_stage_archive_path("file:///tmp/vm0-storage-cache/../outside.tar.gz"),
+            None
+        );
+        assert_eq!(
+            local_stage_archive_path("https://example.com/a.tar.gz"),
+            None
+        );
+    }
+
+    #[test]
+    fn run_removes_local_stage_archive_after_duplicate_success() {
+        disable_system_log();
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let stage_dir = Path::new(GUEST_STAGE_DIR);
+        fs::create_dir_all(stage_dir).unwrap();
+        let archive_path = stage_dir.join(format!("guest-download-test-{unique}.tar.gz"));
+        write_test_archive(&archive_path, &[("data.txt", b"hello")]);
+
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.json");
+        let mount_a = dir.path().join("mount-a");
+        let mount_b = dir.path().join("mount-b");
+        let archive_url = format!("file://{}", archive_path.display());
+        let manifest = serde_json::json!({
+            "storages": [
+                {"mountPath": mount_a.to_string_lossy(), "archiveUrl": archive_url.clone()},
+                {"mountPath": mount_b.to_string_lossy(), "archiveUrl": archive_url}
+            ]
+        });
+        fs::write(&manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+
+        assert!(run(manifest_path.to_str().unwrap()));
+        assert_eq!(
+            fs::read_to_string(mount_a.join("data.txt")).unwrap(),
+            "hello"
+        );
+        assert_eq!(
+            fs::read_to_string(mount_b.join("data.txt")).unwrap(),
+            "hello"
+        );
+        assert!(!archive_path.exists());
     }
 
     #[test]

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -9,7 +9,7 @@ use guest_common::{log_error, log_info, log_warn, telemetry::record_sandbox_op};
 use serde::Deserialize;
 use std::collections::BTreeSet;
 use std::fs;
-use std::io::Read;
+use std::io::{self, Read};
 use std::path::{Component, Path, PathBuf};
 use std::sync::LazyLock;
 use std::thread;
@@ -356,18 +356,85 @@ fn cleanup_local_stage_archives(paths: &BTreeSet<PathBuf>) {
     }
 }
 
+#[cfg(unix)]
 fn open_local_stage_archive(path: &Path) -> Result<fs::File, DownloadError> {
-    let stage_metadata = fs::symlink_metadata(GUEST_STAGE_DIR).map_err(|e| {
-        DownloadError::fatal(format!(
-            "Failed to inspect local stage dir {GUEST_STAGE_DIR}: {e}"
-        ))
-    })?;
-    if !stage_metadata.is_dir() {
-        return Err(DownloadError::fatal(format!(
-            "Refusing local archive because {GUEST_STAGE_DIR} is not a directory"
-        )));
+    use std::ffi::CString;
+    use std::os::fd::{FromRawFd, RawFd};
+    use std::os::unix::ffi::OsStrExt;
+
+    struct FdGuard(RawFd);
+
+    impl Drop for FdGuard {
+        fn drop(&mut self) {
+            // SAFETY: `FdGuard` owns a valid fd returned by `open`; close is
+            // best-effort during cleanup and has no Rust-side aliasing impact.
+            let _ = unsafe { libc::close(self.0) };
+        }
     }
 
+    let stage_dir = CString::new(GUEST_STAGE_DIR)
+        .map_err(|_| DownloadError::fatal("local stage dir contains NUL"))?;
+    // Open the trusted parent first and use openat for the child. This removes
+    // the symlink/rename race between validating the stage directory and
+    // opening the archive path.
+    // SAFETY: `stage_dir` is a NUL-terminated C string and flags request a
+    // read-only directory fd. On success, `FdGuard` owns and closes it.
+    let stage_fd = unsafe {
+        libc::open(
+            stage_dir.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if stage_fd < 0 {
+        return Err(DownloadError::fatal(format!(
+            "Failed to open local stage dir {GUEST_STAGE_DIR}: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    let stage_fd = FdGuard(stage_fd);
+
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| DownloadError::fatal("local archive path has no file name"))?;
+    let file_name = CString::new(file_name.as_bytes()).map_err(|_| {
+        DownloadError::fatal(format!(
+            "Refusing local archive with invalid file name: {}",
+            path.display()
+        ))
+    })?;
+    // `O_NOFOLLOW` rejects symlink archives. `O_NONBLOCK` prevents opening a
+    // malicious FIFO from blocking if the staged path changes before openat.
+    // SAFETY: `stage_fd` is a live directory fd and `file_name` is a
+    // NUL-terminated basename. On success, `File::from_raw_fd` takes ownership.
+    let archive_fd = unsafe {
+        libc::openat(
+            stage_fd.0,
+            file_name.as_ptr(),
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
+        )
+    };
+    if archive_fd < 0 {
+        return Err(DownloadError::fatal(format!(
+            "Failed to open local archive {}: {}",
+            path.display(),
+            std::io::Error::last_os_error()
+        )));
+    }
+    // SAFETY: `archive_fd` was returned by openat and is now exclusively owned
+    // by the File.
+    let file = unsafe { fs::File::from_raw_fd(archive_fd) };
+    validate_local_stage_file(&file, path)?;
+    clear_nonblocking(&file).map_err(|e| {
+        DownloadError::fatal(format!(
+            "Failed to configure local archive {}: {e}",
+            path.display()
+        ))
+    })?;
+    Ok(file)
+}
+
+#[cfg(not(unix))]
+fn open_local_stage_archive(path: &Path) -> Result<fs::File, DownloadError> {
     let archive_metadata = fs::symlink_metadata(path).map_err(|e| {
         DownloadError::fatal(format!(
             "Failed to inspect local archive {}: {e}",
@@ -381,12 +448,53 @@ fn open_local_stage_archive(path: &Path) -> Result<fs::File, DownloadError> {
         )));
     }
 
-    fs::File::open(path).map_err(|e| {
+    let file = fs::File::open(path).map_err(|e| {
         DownloadError::fatal(format!(
             "Failed to open local archive {}: {e}",
             path.display()
         ))
-    })
+    })?;
+    validate_local_stage_file(&file, path)?;
+    Ok(file)
+}
+
+fn validate_local_stage_file(file: &fs::File, path: &Path) -> Result<(), DownloadError> {
+    let metadata = file.metadata().map_err(|e| {
+        DownloadError::fatal(format!(
+            "Failed to inspect local archive {}: {e}",
+            path.display()
+        ))
+    })?;
+    if !metadata.is_file() {
+        return Err(DownloadError::fatal(format!(
+            "Refusing local archive that is not a regular file: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn clear_nonblocking(file: &fs::File) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+
+    let fd = file.as_raw_fd();
+    // SAFETY: `fd` comes from a live File and F_GETFL only reads descriptor
+    // status flags.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if flags & libc::O_NONBLOCK == 0 {
+        return Ok(());
+    }
+    // SAFETY: `fd` comes from a live File. F_SETFL updates descriptor status
+    // flags and leaves the open file description otherwise intact.
+    let result = unsafe { libc::fcntl(fd, libc::F_SETFL, flags & !libc::O_NONBLOCK) };
+    if result < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 fn valid_instruction_filename(filename: &str) -> bool {
@@ -1004,7 +1112,7 @@ mod tests {
 
         assert!(!err.retriable);
         assert!(
-            err.message.contains("not a regular file"),
+            err.message.contains("Failed to open local archive"),
             "got: {}",
             err.message
         );

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -124,6 +124,11 @@ static HTTP_AGENT: LazyLock<ureq::Agent> = LazyLock::new(|| {
 /// Run the download process for the given manifest file.
 /// Returns `true` if all downloads succeeded, `false` otherwise.
 pub fn run(manifest_path: &str) -> bool {
+    run_with_retry_delay(manifest_path, RETRY_DELAY)
+}
+
+#[doc(hidden)]
+pub fn run_with_retry_delay(manifest_path: &str, retry_delay: Duration) -> bool {
     // Read and parse manifest
     let manifest_json = match fs::read_to_string(manifest_path) {
         Ok(json) => json,
@@ -199,7 +204,7 @@ pub fn run(manifest_path: &str) -> bool {
         }
     }
 
-    let success = download_all_parallel(tasks);
+    let success = download_all_parallel(tasks, retry_delay);
     cleanup_local_stage_archives(&local_stage_archives);
     if success {
         normalize_instruction_files(&manifest.storages);
@@ -594,7 +599,7 @@ fn remove_alternate_instruction_files(mount_path: &Path, target_filename: &str) 
 /// Download all tasks in parallel using std::thread.
 /// Limits concurrency to MAX_CONCURRENT to avoid spawning too many threads.
 /// Returns true if all downloads succeeded, false if any failed.
-fn download_all_parallel(tasks: Vec<DownloadTask>) -> bool {
+fn download_all_parallel(tasks: Vec<DownloadTask>, retry_delay: Duration) -> bool {
     if tasks.is_empty() {
         return true;
     }
@@ -626,7 +631,7 @@ fn download_all_parallel(tasks: Vec<DownloadTask>) -> bool {
                         task.mount_path
                     );
 
-                    match download_with_retry(&task.url, &task.mount_path) {
+                    match download_with_retry(&task.url, &task.mount_path, retry_delay) {
                         Ok(()) => {
                             let elapsed = start.elapsed();
                             record_sandbox_op(task.op_name, elapsed, true, None);
@@ -704,7 +709,11 @@ impl std::fmt::Display for DownloadError {
     }
 }
 
-fn download_with_retry(url: &str, target_path: &str) -> Result<(), DownloadError> {
+fn download_with_retry(
+    url: &str,
+    target_path: &str,
+    retry_delay: Duration,
+) -> Result<(), DownloadError> {
     let mut last_error = None;
 
     for attempt in 1..=MAX_RETRIES {
@@ -718,7 +727,7 @@ fn download_with_retry(url: &str, target_path: &str) -> Result<(), DownloadError
                     break;
                 }
                 if attempt < MAX_RETRIES {
-                    thread::sleep(RETRY_DELAY);
+                    thread::sleep(retry_delay);
                 }
             }
         }

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -182,6 +182,8 @@ pub fn run(manifest_path: &str) -> bool {
         true,
     );
 
+    let local_stage_archives = local_stage_archives(&tasks);
+
     // Pre-create all target directories before parallel downloads.
     // This avoids races between parent-child mount paths (e.g. /home/user/.claude
     // and /home/user/.claude/skills/foo) when they land in the same concurrent chunk.
@@ -192,14 +194,14 @@ pub fn run(manifest_path: &str) -> bool {
                 "Failed to create directory {}: {e}",
                 task.mount_path
             );
+            cleanup_local_stage_archives(&local_stage_archives);
             return false;
         }
     }
 
-    let local_stage_archives = local_stage_archives(&tasks);
     let success = download_all_parallel(tasks);
+    cleanup_local_stage_archives(&local_stage_archives);
     if success {
-        cleanup_local_stage_archives(&local_stage_archives);
         normalize_instruction_files(&manifest.storages);
     }
     success

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -4,9 +4,11 @@ use httpmock::prelude::*;
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard};
 use tempfile::TempDir;
 
 static RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+static STAGE_DIR_TEST_LOCK: Mutex<()> = Mutex::new(());
 const GUEST_STAGE_DIR: &str = "/tmp/vm0-storage-cache";
 
 enum TarEntry<'a> {
@@ -204,6 +206,12 @@ fn write_stage_archive(test_name: &str, bytes: &[u8]) -> std::io::Result<PathBuf
             path.display()
         ),
     ))
+}
+
+fn stage_dir_test_guard() -> MutexGuard<'static, ()> {
+    STAGE_DIR_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
 }
 
 struct RunFileCleanup {
@@ -1272,6 +1280,7 @@ fn symlink_missing_link_target_skipped() {
 // tarball is removed after the run succeeds.
 #[test]
 fn file_scheme_extraction_success() {
+    let _stage_guard = stage_dir_test_guard();
     let tar_gz = create_tar_gz(&[("hello.txt", b"hello from file")]).unwrap();
 
     let dir = tempfile::tempdir().unwrap();
@@ -1293,6 +1302,7 @@ fn file_scheme_extraction_success() {
 
 #[test]
 fn file_scheme_staged_archive_removed_after_failed_run() {
+    let _stage_guard = stage_dir_test_guard();
     let dir = tempfile::tempdir().unwrap();
     let staged = write_stage_archive(
         "file-scheme-staged-archive-failed-run",
@@ -1312,6 +1322,7 @@ fn file_scheme_staged_archive_removed_after_failed_run() {
 
 #[test]
 fn file_scheme_all_staged_archives_removed_after_partial_failure() {
+    let _stage_guard = stage_dir_test_guard();
     let tar_gz = create_tar_gz(&[("ok.txt", b"ok")]).unwrap();
 
     let dir = tempfile::tempdir().unwrap();
@@ -1345,6 +1356,7 @@ fn file_scheme_all_staged_archives_removed_after_partial_failure() {
 
 #[test]
 fn file_scheme_staged_archive_removed_after_mount_create_failure() {
+    let _stage_guard = stage_dir_test_guard();
     let tar_gz = create_tar_gz(&[("hello.txt", b"hello")]).unwrap();
 
     let dir = tempfile::tempdir().unwrap();
@@ -1366,6 +1378,7 @@ fn file_scheme_staged_archive_removed_after_mount_create_failure() {
 // but this is the production path for runner-staged storage cache tarballs.
 #[test]
 fn file_scheme_malicious_entries_are_skipped_while_safe_entries_extract() {
+    let _stage_guard = stage_dir_test_guard();
     let tar_gz = create_tar_gz_entries(&[
         TarEntry::File("safe.txt", b"safe"),
         TarEntry::Symlink("evil_symlink", "../outside.txt"),
@@ -1406,6 +1419,7 @@ fn file_scheme_malicious_entries_are_skipped_while_safe_entries_extract() {
 // archive does not create the symlink; it is already present in the target.
 #[test]
 fn file_scheme_preexisting_symlink_ancestor_blocks_nested_entry() {
+    let _stage_guard = stage_dir_test_guard();
     let tar_gz = create_tar_gz_entries(&[
         TarEntry::File("safe.txt", b"safe"),
         TarEntry::File("escape/payload.txt", b"malicious"),
@@ -1447,6 +1461,7 @@ fn file_scheme_preexisting_symlink_ancestor_blocks_nested_entry() {
 // broken runner contract — fatal, no retry (status_code is None, retriable false).
 #[test]
 fn file_scheme_missing_storage_fatal() {
+    let _stage_guard = stage_dir_test_guard();
     let dir = tempfile::tempdir().unwrap();
     let missing = unique_stage_archive_path("file-scheme-missing-storage");
     assert!(!missing.exists());
@@ -1465,6 +1480,7 @@ fn file_scheme_missing_storage_fatal() {
 // file lands, so a missing file signals a broken contract, not an absent artifact.
 #[test]
 fn file_scheme_missing_artifact_fatal() {
+    let _stage_guard = stage_dir_test_guard();
     let dir = tempfile::tempdir().unwrap();
     let missing = unique_stage_archive_path("file-scheme-missing-artifact");
     assert!(!missing.exists());

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -1291,6 +1291,44 @@ fn file_scheme_extraction_success() {
     assert!(!staged.exists());
 }
 
+#[test]
+fn file_scheme_staged_archive_removed_after_failed_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let staged = write_stage_archive(
+        "file-scheme-staged-archive-failed-run",
+        b"not a gzip archive",
+    )
+    .unwrap();
+
+    let mount = dir.path().join("mount");
+    let url = format!("file://{}", staged.display());
+    let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let result = run_guest_download(manifest.to_str().unwrap());
+
+    assert!(!result);
+    assert!(!staged.exists());
+}
+
+#[test]
+fn file_scheme_staged_archive_removed_after_mount_create_failure() {
+    let tar_gz = create_tar_gz(&[("hello.txt", b"hello")]).unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let staged = write_stage_archive("file-scheme-staged-archive-mount-failure", &tar_gz).unwrap();
+    let blocked_parent = dir.path().join("not-a-dir");
+    std::fs::write(&blocked_parent, "file").unwrap();
+
+    let mount = blocked_parent.join("mount");
+    let url = format!("file://{}", staged.display());
+    let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let result = run_guest_download(manifest.to_str().unwrap());
+
+    assert!(!result);
+    assert!(!staged.exists());
+}
+
 // Security regression: file:// archives use the same extraction path as HTTP,
 // but this is the production path for runner-staged storage cache tarballs.
 #[test]

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tempfile::TempDir;
 
 static RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+const GUEST_STAGE_DIR: &str = "/tmp/vm0-storage-cache";
 
 enum TarEntry<'a> {
     File(&'a str, &'a [u8]),
@@ -171,6 +172,38 @@ fn unique_run_id(test_name: &str) -> String {
         std::process::id(),
         RUN_ID_COUNTER.fetch_add(1, Ordering::Relaxed)
     )
+}
+
+fn unique_stage_archive_path(test_name: &str) -> PathBuf {
+    PathBuf::from(GUEST_STAGE_DIR).join(format!(
+        "{test_name}-{}-{}.tar.gz",
+        std::process::id(),
+        RUN_ID_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ))
+}
+
+fn write_stage_archive(test_name: &str, bytes: &[u8]) -> std::io::Result<PathBuf> {
+    let path = unique_stage_archive_path(test_name);
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("stage archive path has no parent"))?;
+
+    for _ in 0..3 {
+        std::fs::create_dir_all(parent)?;
+        match std::fs::write(&path, bytes) {
+            Ok(()) => return Ok(path),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
+        }
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        format!(
+            "failed to write staged archive {} after retries",
+            path.display()
+        ),
+    ))
 }
 
 struct RunFileCleanup {
@@ -1234,17 +1267,15 @@ fn symlink_missing_link_target_skipped() {
 // file:// scheme — host-staged tarballs (epic #10800)
 // ---------------------------------------------------------------------------
 
-// Successful file:// extraction: the local tarball is read and its contents are
-// extracted into the mount path. The staged tarball is intentionally left in
-// place — /tmp is wiped on VM teardown, and deleting it early breaks runs where
-// two manifest entries share the same staged path.
+// Successful file:// extraction: the local tarball is read from the guest stage
+// directory, its contents are extracted into the mount path, and the staged
+// tarball is removed after the run succeeds.
 #[test]
 fn file_scheme_extraction_success() {
     let tar_gz = create_tar_gz(&[("hello.txt", b"hello from file")]).unwrap();
 
     let dir = tempfile::tempdir().unwrap();
-    let staged = dir.path().join("staged.tar.gz");
-    std::fs::write(&staged, &tar_gz).unwrap();
+    let staged = write_stage_archive("file-scheme-extraction-success", &tar_gz).unwrap();
 
     let mount = dir.path().join("mount");
     let url = format!("file://{}", staged.display());
@@ -1257,8 +1288,7 @@ fn file_scheme_extraction_success() {
         std::fs::read_to_string(mount.join("hello.txt")).unwrap(),
         "hello from file"
     );
-    // Staged tarball is preserved — runner cleans /tmp on VM teardown.
-    assert!(staged.exists());
+    assert!(!staged.exists());
 }
 
 // Security regression: file:// archives use the same extraction path as HTTP,
@@ -1282,8 +1312,7 @@ fn file_scheme_malicious_entries_are_skipped_while_safe_entries_extract() {
     let outside_file = dir.path().join("outside.txt");
     std::fs::write(&outside_file, "outside").unwrap();
 
-    let staged = dir.path().join("staged.tar.gz");
-    std::fs::write(&staged, &tar_gz).unwrap();
+    let staged = write_stage_archive("file-scheme-malicious-entries", &tar_gz).unwrap();
 
     let mount = dir.path().join("mount");
     let url = format!("file://{}", staged.display());
@@ -1313,8 +1342,7 @@ fn file_scheme_preexisting_symlink_ancestor_blocks_nested_entry() {
     .unwrap();
 
     let dir = tempfile::tempdir().unwrap();
-    let staged = dir.path().join("staged.tar.gz");
-    std::fs::write(&staged, &tar_gz).unwrap();
+    let staged = write_stage_archive("file-scheme-preexisting-symlink", &tar_gz).unwrap();
 
     let mount = dir.path().join("mount");
     let outside = dir.path().join("outside");
@@ -1349,7 +1377,7 @@ fn file_scheme_preexisting_symlink_ancestor_blocks_nested_entry() {
 #[test]
 fn file_scheme_missing_storage_fatal() {
     let dir = tempfile::tempdir().unwrap();
-    let missing = dir.path().join("never-existed.tar.gz");
+    let missing = unique_stage_archive_path("file-scheme-missing-storage");
     assert!(!missing.exists());
 
     let mount = dir.path().join("mount");
@@ -1367,7 +1395,7 @@ fn file_scheme_missing_storage_fatal() {
 #[test]
 fn file_scheme_missing_artifact_fatal() {
     let dir = tempfile::tempdir().unwrap();
-    let missing = dir.path().join("never-existed.tar.gz");
+    let missing = unique_stage_archive_path("file-scheme-missing-artifact");
     assert!(!missing.exists());
 
     let mount = dir.path().join("artifact_mount");

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -1,10 +1,12 @@
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use httpmock::prelude::*;
-use std::io::Write;
+use std::io::{self, Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, MutexGuard};
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 static RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -165,7 +167,71 @@ fn write_manifest(
 
 fn run_guest_download(manifest_path: &str) -> bool {
     guest_common::log::clear_system_log_file();
-    guest_download::run(manifest_path)
+    guest_download::run_with_retry_delay(manifest_path, Duration::ZERO)
+}
+
+fn start_retry_then_success_server(
+    body: Vec<u8>,
+) -> io::Result<(String, std::thread::JoinHandle<io::Result<()>>)> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    listener.set_nonblocking(true)?;
+    let addr = listener.local_addr()?;
+    let url = format!("http://{addr}/storage.tar.gz");
+
+    let handle = std::thread::spawn(move || -> io::Result<()> {
+        let mut first = accept_http_request(&listener)?;
+        write_http_response(&mut first, "500 Internal Server Error", &[])?;
+
+        let mut second = accept_http_request(&listener)?;
+        write_http_response(&mut second, "200 OK", &body)
+    });
+
+    Ok((url, handle))
+}
+
+fn accept_http_request(listener: &TcpListener) -> io::Result<TcpStream> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut stream = loop {
+        match listener.accept() {
+            Ok((stream, _)) => break stream,
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock && Instant::now() < deadline => {
+                std::thread::yield_now();
+            }
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "timed out waiting for retry test request",
+                ));
+            }
+            Err(e) => return Err(e),
+        }
+    };
+
+    let mut request = Vec::new();
+    let mut buf = [0u8; 1024];
+    loop {
+        let n = stream.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        let Some(chunk) = buf.get(..n) else {
+            return Err(io::Error::other("read length exceeded buffer"));
+        };
+        request.extend_from_slice(chunk);
+        if request.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+    }
+    Ok(stream)
+}
+
+fn write_http_response(stream: &mut TcpStream, status: &str, body: &[u8]) -> io::Result<()> {
+    write!(
+        stream,
+        "HTTP/1.1 {status}\r\nContent-Length: {}\r\nContent-Type: application/gzip\r\nConnection: close\r\n\r\n",
+        body.len()
+    )?;
+    stream.write_all(body)
 }
 
 fn unique_run_id(test_name: &str) -> String {
@@ -756,43 +822,19 @@ fn artifact_500_fatal() {
 // ---------------------------------------------------------------------------
 #[test]
 fn retry_then_succeed() {
-    let server = MockServer::start();
     let tar_gz = create_tar_gz(&[("recovered.txt", b"recovered")]).unwrap();
-
-    // Start with a 500 mock
-    let mut fail_mock = server.mock(|when, then| {
-        when.method(GET).path("/storage.tar.gz");
-        then.status(500);
-    });
+    let (url, server) =
+        start_retry_then_success_server(tar_gz).expect("failed to start retry test server");
 
     let dir = tempfile::tempdir().unwrap();
     let mount = dir.path().join("mount");
-    let url = server.url("/storage.tar.gz");
     let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
-    let manifest_str = manifest.to_str().unwrap().to_string();
 
-    // Run in background thread so we can swap the mock during RETRY_DELAY
-    let handle = std::thread::spawn(move || run_guest_download(&manifest_str));
-
-    // Poll until the first request has been made, then swap mock before retry fires (RETRY_DELAY = 1s).
-    // Timeout after 5s to avoid infinite loop if the spawned thread panics before making a request.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    while fail_mock.calls() < 1 {
-        assert!(
-            std::time::Instant::now() < deadline,
-            "timed out waiting for first mock hit"
-        );
-        std::thread::sleep(std::time::Duration::from_millis(10));
-    }
-    fail_mock.delete();
-    server.mock(|when, then| {
-        when.method(GET).path("/storage.tar.gz");
-        then.status(200)
-            .header("content-type", "application/gzip")
-            .body(&tar_gz);
-    });
-
-    let result = handle.join().unwrap();
+    let result = run_guest_download(manifest.to_str().unwrap());
+    server
+        .join()
+        .expect("retry test server panicked")
+        .expect("retry test server failed");
     assert!(result);
     assert_eq!(
         std::fs::read_to_string(mount.join("recovered.txt")).unwrap(),

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -1311,6 +1311,39 @@ fn file_scheme_staged_archive_removed_after_failed_run() {
 }
 
 #[test]
+fn file_scheme_all_staged_archives_removed_after_partial_failure() {
+    let tar_gz = create_tar_gz(&[("ok.txt", b"ok")]).unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let good_staged = write_stage_archive("file-scheme-partial-good", &tar_gz).unwrap();
+    let bad_staged = write_stage_archive("file-scheme-partial-bad", b"not a gzip archive").unwrap();
+
+    let good_mount = dir.path().join("good");
+    let bad_mount = dir.path().join("bad");
+    let good_url = format!("file://{}", good_staged.display());
+    let bad_url = format!("file://{}", bad_staged.display());
+    let manifest = write_manifest(
+        &dir,
+        &[
+            (good_mount.to_str().unwrap(), Some(&good_url)),
+            (bad_mount.to_str().unwrap(), Some(&bad_url)),
+        ],
+        None,
+    )
+    .unwrap();
+
+    let result = run_guest_download(manifest.to_str().unwrap());
+
+    assert!(!result);
+    assert_eq!(
+        std::fs::read_to_string(good_mount.join("ok.txt")).unwrap(),
+        "ok"
+    );
+    assert!(!good_staged.exists());
+    assert!(!bad_staged.exists());
+}
+
+#[test]
 fn file_scheme_staged_archive_removed_after_mount_create_failure() {
     let tar_gz = create_tar_gz(&[("hello.txt", b"hello")]).unwrap();
 

--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -336,6 +336,25 @@ mod tests {
     }
 
     #[test]
+    fn batch_writes_empty_file_with_parents() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("nested").join("empty.txt");
+        let payload = batch_payload(&[(&target, b"")]);
+
+        run(
+            Args {
+                batch: true,
+                create_parents: true,
+                path: None,
+            },
+            payload.as_slice(),
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read(&target).unwrap(), b"");
+    }
+
+    #[test]
     fn batch_truncated_content_preserves_write_file_truncate_semantics() {
         let temp = tempfile::tempdir().unwrap();
         let target = temp.path().join("out.txt");

--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -1,4 +1,7 @@
 //! Direct guest file writer used by vsock-guest.
+//!
+//! Writes use shell-like create/truncate/write semantics. A failed write may
+//! leave an empty or partial target.
 
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};

--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -168,7 +168,7 @@ fn output_options() -> OpenOptions {
     {
         use std::os::unix::fs::OpenOptionsExt;
 
-        options.custom_flags(libc::O_NONBLOCK);
+        options.custom_flags(libc::O_NONBLOCK | libc::O_NOFOLLOW);
     }
 
     options

--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -8,7 +8,6 @@ const BATCH_MAGIC: &[u8; 8] = b"VM0WFB1\n";
 
 #[derive(Debug, Eq, PartialEq)]
 struct Args {
-    append: bool,
     batch: bool,
     create_parents: bool,
     path: Option<PathBuf>,
@@ -18,7 +17,6 @@ fn parse_args<I>(args: I) -> Result<Args, String>
 where
     I: IntoIterator<Item = String>,
 {
-    let mut append = false;
     let mut batch = false;
     let mut create_parents = false;
     let mut path = None;
@@ -27,10 +25,6 @@ where
     for arg in args {
         if !positional_only {
             match arg.as_str() {
-                "--append" => {
-                    append = true;
-                    continue;
-                }
                 "--batch" => {
                     batch = true;
                     continue;
@@ -55,12 +49,6 @@ where
         }
     }
 
-    if append && create_parents {
-        return Err("--append and --create-parents cannot be used together".to_string());
-    }
-    if append && batch {
-        return Err("--append and --batch cannot be used together".to_string());
-    }
     if batch && path.is_some() {
         return Err("--batch does not accept a path argument".to_string());
     }
@@ -69,7 +57,6 @@ where
     }
 
     Ok(Args {
-        append,
         batch,
         create_parents,
         path,
@@ -84,7 +71,7 @@ fn run(args: Args, mut stdin: impl Read) -> io::Result<()> {
         .path
         .as_ref()
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "missing path"))?;
-    write_file_from_reader(path, args.append, args.create_parents, &mut stdin, None)
+    write_file_from_reader(path, args.create_parents, &mut stdin, None)
 }
 
 fn run_batch(create_parents: bool, mut stdin: impl Read) -> io::Result<()> {
@@ -106,7 +93,7 @@ fn run_batch(create_parents: bool, mut stdin: impl Read) -> io::Result<()> {
             io::Error::new(io::ErrorKind::InvalidData, "invalid UTF-8 in batch path")
         })?);
         let content_len = read_u64(&mut stdin)?;
-        write_file_from_reader(&path, false, create_parents, &mut stdin, Some(content_len))?;
+        write_file_from_reader(&path, create_parents, &mut stdin, Some(content_len))?;
     }
     Ok(())
 }
@@ -131,7 +118,6 @@ fn read_u64(reader: &mut impl Read) -> io::Result<u64> {
 
 fn write_file_from_reader(
     path: &Path,
-    append: bool,
     create_parents: bool,
     input: &mut impl Read,
     exact_len: Option<u64>,
@@ -143,7 +129,7 @@ fn write_file_from_reader(
         fs::create_dir_all(parent)?;
     }
 
-    let mut file = open_output_file(path, append)?;
+    let mut file = open_output_file(path)?;
     match exact_len {
         Some(len) => copy_exact_len(input, &mut file, len)?,
         None => {
@@ -168,19 +154,15 @@ fn copy_exact_len(input: &mut impl Read, output: &mut impl Write, len: u64) -> i
     Ok(())
 }
 
-fn open_output_file(path: &Path, append: bool) -> io::Result<File> {
-    let file = output_options(append).open(path)?;
+fn open_output_file(path: &Path) -> io::Result<File> {
+    let file = output_options().open(path)?;
     prepare_output_file(&file)?;
     Ok(file)
 }
 
-fn output_options(append: bool) -> OpenOptions {
+fn output_options() -> OpenOptions {
     let mut options = OpenOptions::new();
-    options
-        .create(true)
-        .write(true)
-        .append(append)
-        .truncate(!append);
+    options.create(true).write(true).truncate(true);
 
     #[cfg(unix)]
     {
@@ -248,7 +230,7 @@ where
             let _ = writeln!(stderr, "guest-write-file: {e}");
             let _ = writeln!(
                 stderr,
-                "usage: guest-write-file [--append | --create-parents] <path> | --batch [--create-parents]"
+                "usage: guest-write-file [--create-parents] <path> | --batch [--create-parents]"
             );
             return 2;
         }
@@ -290,30 +272,9 @@ mod tests {
         assert_eq!(
             args,
             Args {
-                append: false,
                 batch: false,
                 create_parents: true,
                 path: Some(PathBuf::from("/tmp/out.txt")),
-            }
-        );
-    }
-
-    #[test]
-    fn parse_append_after_separator_path_starting_with_dash() {
-        let args = parse_args([
-            "--append".to_string(),
-            "--".to_string(),
-            "-literal".to_string(),
-        ])
-        .unwrap();
-
-        assert_eq!(
-            args,
-            Args {
-                append: true,
-                batch: false,
-                create_parents: false,
-                path: Some(PathBuf::from("-literal")),
             }
         );
     }
@@ -333,25 +294,12 @@ mod tests {
     }
 
     #[test]
-    fn rejects_append_with_create_parents() {
-        let err = parse_args([
-            "--append".to_string(),
-            "--create-parents".to_string(),
-            "/tmp/a".to_string(),
-        ])
-        .unwrap_err();
-
-        assert!(err.contains("cannot be used together"));
-    }
-
-    #[test]
     fn parse_batch_without_path() {
         let args = parse_args(["--batch".to_string(), "--create-parents".to_string()]).unwrap();
 
         assert_eq!(
             args,
             Args {
-                append: false,
                 batch: true,
                 create_parents: true,
                 path: None,
@@ -375,7 +323,6 @@ mod tests {
 
         run(
             Args {
-                append: false,
                 batch: true,
                 create_parents: true,
                 path: None,
@@ -404,7 +351,6 @@ mod tests {
 
         let err = run(
             Args {
-                append: false,
                 batch: true,
                 create_parents: true,
                 path: None,

--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -4,11 +4,14 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
+const BATCH_MAGIC: &[u8; 8] = b"VM0WFB1\n";
+
 #[derive(Debug, Eq, PartialEq)]
 struct Args {
     append: bool,
+    batch: bool,
     create_parents: bool,
-    path: PathBuf,
+    path: Option<PathBuf>,
 }
 
 fn parse_args<I>(args: I) -> Result<Args, String>
@@ -16,6 +19,7 @@ where
     I: IntoIterator<Item = String>,
 {
     let mut append = false;
+    let mut batch = false;
     let mut create_parents = false;
     let mut path = None;
     let mut positional_only = false;
@@ -25,6 +29,10 @@ where
             match arg.as_str() {
                 "--append" => {
                     append = true;
+                    continue;
+                }
+                "--batch" => {
+                    batch = true;
                     continue;
                 }
                 "--create-parents" => {
@@ -47,30 +55,117 @@ where
         }
     }
 
-    let path = path.ok_or_else(|| "missing path".to_string())?;
     if append && create_parents {
         return Err("--append and --create-parents cannot be used together".to_string());
+    }
+    if append && batch {
+        return Err("--append and --batch cannot be used together".to_string());
+    }
+    if batch && path.is_some() {
+        return Err("--batch does not accept a path argument".to_string());
+    }
+    if !batch && path.is_none() {
+        return Err("missing path".to_string());
     }
 
     Ok(Args {
         append,
+        batch,
         create_parents,
         path,
     })
 }
 
 fn run(args: Args, mut stdin: impl Read) -> io::Result<()> {
-    if args.create_parents
-        && let Some(parent) = args.path.parent()
+    if args.batch {
+        return run_batch(args.create_parents, stdin);
+    }
+    let path = args
+        .path
+        .as_ref()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "missing path"))?;
+    write_file_from_reader(path, args.append, args.create_parents, &mut stdin, None)
+}
+
+fn run_batch(create_parents: bool, mut stdin: impl Read) -> io::Result<()> {
+    let mut magic = [0u8; BATCH_MAGIC.len()];
+    stdin.read_exact(&mut magic)?;
+    if &magic != BATCH_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid batch magic",
+        ));
+    }
+    let count = read_u32(&mut stdin)?;
+    for _ in 0..count {
+        let _file_index = read_u32(&mut stdin)?;
+        let path_len = read_u16(&mut stdin)? as usize;
+        let mut path = vec![0u8; path_len];
+        stdin.read_exact(&mut path)?;
+        let path = PathBuf::from(String::from_utf8(path).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidData, "invalid UTF-8 in batch path")
+        })?);
+        let content_len = read_u64(&mut stdin)?;
+        write_file_from_reader(&path, false, create_parents, &mut stdin, Some(content_len))?;
+    }
+    Ok(())
+}
+
+fn read_u16(reader: &mut impl Read) -> io::Result<u16> {
+    let mut buf = [0u8; 2];
+    reader.read_exact(&mut buf)?;
+    Ok(u16::from_be_bytes(buf))
+}
+
+fn read_u32(reader: &mut impl Read) -> io::Result<u32> {
+    let mut buf = [0u8; 4];
+    reader.read_exact(&mut buf)?;
+    Ok(u32::from_be_bytes(buf))
+}
+
+fn read_u64(reader: &mut impl Read) -> io::Result<u64> {
+    let mut buf = [0u8; 8];
+    reader.read_exact(&mut buf)?;
+    Ok(u64::from_be_bytes(buf))
+}
+
+fn write_file_from_reader(
+    path: &Path,
+    append: bool,
+    create_parents: bool,
+    input: &mut impl Read,
+    exact_len: Option<u64>,
+) -> io::Result<()> {
+    if create_parents
+        && let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
     {
         fs::create_dir_all(parent)?;
     }
 
-    let mut file = open_output_file(&args.path, args.append)?;
-
-    io::copy(&mut stdin, &mut file)?;
+    let mut file = open_output_file(path, append)?;
+    match exact_len {
+        Some(len) => copy_exact_len(input, &mut file, len)?,
+        None => {
+            io::copy(input, &mut file)?;
+        }
+    }
     file.flush()
+}
+
+fn copy_exact_len(input: &mut impl Read, output: &mut impl Write, len: u64) -> io::Result<()> {
+    let mut remaining = len;
+    let mut buf = [0u8; 64 * 1024];
+    while remaining > 0 {
+        let n = remaining.min(buf.len() as u64) as usize;
+        let chunk = buf
+            .get_mut(..n)
+            .ok_or_else(|| io::Error::other("copy chunk length exceeds buffer"))?;
+        input.read_exact(chunk)?;
+        output.write_all(chunk)?;
+        remaining -= n as u64;
+    }
+    Ok(())
 }
 
 fn open_output_file(path: &Path, append: bool) -> io::Result<File> {
@@ -153,7 +248,7 @@ where
             let _ = writeln!(stderr, "guest-write-file: {e}");
             let _ = writeln!(
                 stderr,
-                "usage: guest-write-file [--append | --create-parents] <path>"
+                "usage: guest-write-file [--append | --create-parents] <path> | --batch [--create-parents]"
             );
             return 2;
         }
@@ -171,6 +266,22 @@ where
 mod tests {
     use super::*;
 
+    fn batch_payload(files: &[(&Path, &[u8])]) -> Vec<u8> {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(BATCH_MAGIC);
+        payload.extend_from_slice(&(files.len() as u32).to_be_bytes());
+        for (index, (path, content)) in files.iter().enumerate() {
+            let path = path.to_string_lossy();
+            let path_bytes = path.as_bytes();
+            payload.extend_from_slice(&(index as u32).to_be_bytes());
+            payload.extend_from_slice(&(path_bytes.len() as u16).to_be_bytes());
+            payload.extend_from_slice(path_bytes);
+            payload.extend_from_slice(&(content.len() as u64).to_be_bytes());
+            payload.extend_from_slice(content);
+        }
+        payload
+    }
+
     #[test]
     fn parse_create_parents() {
         let args =
@@ -180,8 +291,9 @@ mod tests {
             args,
             Args {
                 append: false,
+                batch: false,
                 create_parents: true,
-                path: PathBuf::from("/tmp/out.txt"),
+                path: Some(PathBuf::from("/tmp/out.txt")),
             }
         );
     }
@@ -199,8 +311,9 @@ mod tests {
             args,
             Args {
                 append: true,
+                batch: false,
                 create_parents: false,
-                path: PathBuf::from("-literal"),
+                path: Some(PathBuf::from("-literal")),
             }
         );
     }
@@ -229,5 +342,82 @@ mod tests {
         .unwrap_err();
 
         assert!(err.contains("cannot be used together"));
+    }
+
+    #[test]
+    fn parse_batch_without_path() {
+        let args = parse_args(["--batch".to_string(), "--create-parents".to_string()]).unwrap();
+
+        assert_eq!(
+            args,
+            Args {
+                append: false,
+                batch: true,
+                create_parents: true,
+                path: None,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_batch_with_path() {
+        let err = parse_args(["--batch".to_string(), "/tmp/out".to_string()]).unwrap_err();
+
+        assert!(err.contains("does not accept a path"));
+    }
+
+    #[test]
+    fn batch_writes_multiple_files_with_parents() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = temp.path().join("a.txt");
+        let second = temp.path().join("nested").join("b.txt");
+        let payload = batch_payload(&[(&first, b"one"), (&second, b"two")]);
+
+        run(
+            Args {
+                append: false,
+                batch: true,
+                create_parents: true,
+                path: None,
+            },
+            payload.as_slice(),
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read(&first).unwrap(), b"one");
+        assert_eq!(std::fs::read(&second).unwrap(), b"two");
+    }
+
+    #[test]
+    fn batch_truncated_content_preserves_write_file_truncate_semantics() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("out.txt");
+        let mut payload = Vec::new();
+        payload.extend_from_slice(BATCH_MAGIC);
+        payload.extend_from_slice(&1u32.to_be_bytes());
+        let path = target.to_string_lossy();
+        payload.extend_from_slice(&0u32.to_be_bytes());
+        payload.extend_from_slice(&(path.len() as u16).to_be_bytes());
+        payload.extend_from_slice(path.as_bytes());
+        payload.extend_from_slice(&10u64.to_be_bytes());
+        payload.extend_from_slice(b"short");
+
+        let err = run(
+            Args {
+                append: false,
+                batch: true,
+                create_parents: true,
+                path: None,
+            },
+            payload.as_slice(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert_eq!(
+            std::fs::read(&target).unwrap(),
+            b"",
+            "batch mode should match existing write_file truncate-before-write behavior"
+        );
     }
 }

--- a/crates/guest-write-file/src/main.rs
+++ b/crates/guest-write-file/src/main.rs
@@ -1,10 +1,9 @@
 //! Direct guest file writer used by vsock-guest.
 //!
-//! Usage: `guest-write-file [--append | --create-parents] <path>`.
+//! Usage: `guest-write-file [--create-parents] <path> | --batch [--create-parents]`.
 //!
-//! Content is read from stdin. Create mode truncates or creates the target.
-//! Append mode creates the target file when its parent already exists, matching
-//! shell `>>`, but does not create missing parents.
+//! Content is read from stdin. Single-file mode truncates or creates the target.
+//! Batch mode reads the vm0 write-files batch stream from stdin.
 
 use std::io;
 

--- a/crates/guest-write-file/src/main.rs
+++ b/crates/guest-write-file/src/main.rs
@@ -3,7 +3,8 @@
 //! Usage: `guest-write-file [--create-parents] <path> | --batch [--create-parents]`.
 //!
 //! Content is read from stdin. Single-file mode truncates or creates the target.
-//! Batch mode reads the vm0 write-files batch stream from stdin.
+//! Batch mode reads the vm0 write-files batch stream from stdin and applies the
+//! same create/truncate/write semantics to each file.
 
 use std::io;
 

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -7,6 +7,23 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 const BIN: &str = env!("CARGO_BIN_EXE_guest-write-file");
+const BATCH_MAGIC: &[u8; 8] = b"VM0WFB1\n";
+
+fn batch_payload(files: &[(&Path, &[u8])]) -> Vec<u8> {
+    let mut payload = Vec::new();
+    payload.extend_from_slice(BATCH_MAGIC);
+    payload.extend_from_slice(&(files.len() as u32).to_be_bytes());
+    for (index, (path, content)) in files.iter().enumerate() {
+        let path = path.to_string_lossy();
+        let path_bytes = path.as_bytes();
+        payload.extend_from_slice(&(index as u32).to_be_bytes());
+        payload.extend_from_slice(&(path_bytes.len() as u16).to_be_bytes());
+        payload.extend_from_slice(path_bytes);
+        payload.extend_from_slice(&(content.len() as u64).to_be_bytes());
+        payload.extend_from_slice(content);
+    }
+    payload
+}
 
 fn run_helper(args: &[&str], stdin: &[u8]) -> std::process::Output {
     run_helper_with_current_dir(args, stdin, None)
@@ -129,6 +146,49 @@ fn path_starting_with_dash_is_treated_as_path_after_separator() {
     assert_eq!(
         std::fs::read(dir.path().join("-literal.txt")).unwrap(),
         b"hello"
+    );
+}
+
+#[test]
+fn batch_mode_writes_multiple_files_with_parents() {
+    let dir = tempfile::tempdir().unwrap();
+    let first = dir.path().join("one.txt");
+    let second = dir.path().join("nested/two.txt");
+    let empty = dir.path().join("nested/empty.txt");
+    let payload = batch_payload(&[(&first, b"one"), (&second, b"two"), (&empty, b"")]);
+
+    let output = run_helper(&["--batch", "--create-parents"], &payload);
+
+    assert!(output.status.success(), "stderr={:?}", output.stderr);
+    assert_eq!(std::fs::read(first).unwrap(), b"one");
+    assert_eq!(std::fs::read(second).unwrap(), b"two");
+    assert_eq!(std::fs::read(empty).unwrap(), b"");
+}
+
+#[test]
+fn batch_mode_truncated_content_returns_error_after_truncating_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("out.txt");
+    std::fs::write(&target, b"original").unwrap();
+    let path = target.to_string_lossy();
+    let path_bytes = path.as_bytes();
+    let mut payload = Vec::new();
+    payload.extend_from_slice(BATCH_MAGIC);
+    payload.extend_from_slice(&1u32.to_be_bytes());
+    payload.extend_from_slice(&0u32.to_be_bytes());
+    payload.extend_from_slice(&(path_bytes.len() as u16).to_be_bytes());
+    payload.extend_from_slice(path_bytes);
+    payload.extend_from_slice(&10u64.to_be_bytes());
+    payload.extend_from_slice(b"short");
+
+    let output = run_helper(&["--batch"], &payload);
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("guest-write-file"));
+    assert_eq!(
+        std::fs::read(&target).unwrap(),
+        b"",
+        "batch mode uses shell-like truncate-before-write semantics"
     );
 }
 

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -184,6 +184,22 @@ fn create_mode_rejects_character_device_target() {
 
 #[cfg(unix)]
 #[test]
+fn create_mode_rejects_symlink_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("target.txt");
+    let link = dir.path().join("link.txt");
+    std::fs::write(&target, b"original").unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    let link_str = link.to_str().unwrap();
+
+    let output = run_helper(&[link_str], b"replacement");
+
+    assert!(!output.status.success());
+    assert_eq!(std::fs::read(&target).unwrap(), b"original");
+}
+
+#[cfg(unix)]
+#[test]
 fn create_mode_fails_fast_for_fifo_without_reader() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("fifo");

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -91,19 +91,6 @@ fn create_mode_creates_missing_parents_and_writes_content() {
 }
 
 #[test]
-fn append_mode_appends_existing_file() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("out.txt");
-    std::fs::write(&path, b"first").unwrap();
-    let path_str = path.to_str().unwrap();
-
-    let output = run_helper(&["--append", path_str], b"second");
-
-    assert!(output.status.success(), "stderr={:?}", output.stderr);
-    assert_eq!(std::fs::read(path).unwrap(), b"firstsecond");
-}
-
-#[test]
 fn create_mode_truncates_existing_file() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("out.txt");
@@ -126,44 +113,6 @@ fn create_mode_writes_empty_file() {
 
     assert!(output.status.success(), "stderr={:?}", output.stderr);
     assert_eq!(std::fs::read(path).unwrap(), b"");
-}
-
-#[test]
-fn append_mode_creates_missing_file_when_parent_exists() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("out.txt");
-    let path_str = path.to_str().unwrap();
-
-    let output = run_helper(&["--append", path_str], b"hello");
-
-    assert!(output.status.success(), "stderr={:?}", output.stderr);
-    assert_eq!(std::fs::read(path).unwrap(), b"hello");
-}
-
-#[test]
-fn append_mode_does_not_create_missing_parents() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("missing/out.txt");
-    let path_str = path.to_str().unwrap();
-
-    let output = run_helper(&["--append", path_str], b"hello");
-
-    assert!(!output.status.success());
-    assert!(String::from_utf8_lossy(&output.stderr).contains("No such file"));
-    assert!(!path.exists());
-}
-
-#[test]
-fn append_mode_rejects_create_parents() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("missing/out.txt");
-    let path_str = path.to_str().unwrap();
-
-    let output = run_helper(&["--append", "--create-parents", path_str], b"hello");
-
-    assert_eq!(output.status.code(), Some(2));
-    assert!(String::from_utf8_lossy(&output.stderr).contains("cannot be used together"));
-    assert!(!path.exists());
 }
 
 #[test]

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -1657,7 +1657,7 @@ async fn gc_storage_staging_dir(
     dry_run: bool,
 ) -> u64 {
     let lock_path = home.storage_lock_for_cache_key(name_hash, version_hash);
-    let _lock = match probe_lock(&lock_path) {
+    let lock = match probe_lock(&lock_path) {
         LockProbe::Free(l) => l,
         LockProbe::Held => {
             info!("storages/{name_hash}/{version_hash}.tmp: in use, skipping");
@@ -1694,9 +1694,40 @@ async fn gc_storage_staging_dir(
             "removed stale storage staging storages/{name_hash}/{version_hash}.tmp ({})",
             human_bytes(size)
         );
+        remove_storage_lock_after_stale_staging_eviction(
+            &lock_path,
+            &lock,
+            path,
+            name_hash,
+            version_hash,
+        )
+        .await;
     }
 
     size
+}
+
+async fn remove_storage_lock_after_stale_staging_eviction(
+    lock_path: &Path,
+    lock: &Flock<std::fs::File>,
+    staging_path: &Path,
+    name_hash: &str,
+    version_hash: &str,
+) {
+    let final_path = staging_path.with_file_name(version_hash);
+    match tokio::fs::metadata(&final_path).await {
+        Ok(_) => return,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            warn!(
+                "storages/{name_hash}/{version_hash}.tmp: failed to stat final cache dir {} before lock cleanup: {e}",
+                final_path.display()
+            );
+            return;
+        }
+    }
+
+    remove_storage_lock_after_eviction(lock_path, lock, name_hash, version_hash).await;
 }
 
 fn human_bytes(bytes: u64) -> String {
@@ -3940,6 +3971,56 @@ mod tests {
         assert_eq!(freed, tmp_size, "stale .tmp bytes must be reported");
         assert!(real.exists(), "real entry must survive");
         assert!(!tmp.exists(), "stale .tmp staging dir must be removed");
+    }
+
+    #[tokio::test]
+    async fn gc_storage_cache_removes_orphan_lock_after_stale_tmp_without_final_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+        let t_old = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let tmp = make_storage_staging_entry(&home, "foo", "v1", &[0u8; 128], t_old);
+        let lock_path = home.storage_lock("foo", "v1");
+        drop(lock::open_lock_file(&lock_path).unwrap());
+        assert!(lock_path.exists(), "test setup must create the lock file");
+
+        let freed = gc_storage_cache_with_cap(&home, 1 << 20, false)
+            .await
+            .unwrap();
+
+        assert!(freed > 0, "stale .tmp bytes must be reported");
+        assert!(!tmp.exists(), "stale .tmp staging dir must be removed");
+        assert!(
+            !lock_path.exists(),
+            "orphan lock should be removed when no final cache entry exists"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_storage_cache_keeps_lock_after_stale_tmp_when_final_entry_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+        let t_old = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let real = make_storage_entry(&home, "foo", "v1", &[0u8; 128], t_old);
+        let tmp = make_storage_staging_entry(&home, "foo", "v1", &[0u8; 128], t_old);
+        let lock_path = home.storage_lock("foo", "v1");
+        drop(lock::open_lock_file(&lock_path).unwrap());
+        assert!(lock_path.exists(), "test setup must create the lock file");
+
+        let freed = gc_storage_cache_with_cap(&home, 1 << 20, false)
+            .await
+            .unwrap();
+
+        assert!(freed > 0, "stale .tmp bytes must be reported");
+        assert!(real.exists(), "real entry must survive");
+        assert!(!tmp.exists(), "stale .tmp staging dir must be removed");
+        assert!(
+            lock_path.exists(),
+            "lock should stay while the final cache entry still exists"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -96,7 +96,7 @@ struct StageArchive {
 
 struct ProcessedTarget {
     outcome: TargetOutcome,
-    _guard: nix::fcntl::Flock<std::fs::File>,
+    _guard: Option<nix::fcntl::Flock<std::fs::File>>,
 }
 
 enum TargetOutcome {
@@ -322,7 +322,7 @@ async fn process_one(
                         len: metadata.len(),
                     },
                 },
-                _guard: guard,
+                _guard: Some(guard),
             });
         }
         Ok(metadata) => {
@@ -354,7 +354,7 @@ async fn process_one(
                 outcome: TargetOutcome::SkippedHeadFailed {
                     reason: "missing-size-header".to_string(),
                 },
-                _guard: guard,
+                _guard: None,
             });
         }
         Err(e) => {
@@ -367,7 +367,7 @@ async fn process_one(
             );
             return Ok(ProcessedTarget {
                 outcome: TargetOutcome::SkippedHeadFailed { reason },
-                _guard: guard,
+                _guard: None,
             });
         }
     };
@@ -380,7 +380,7 @@ async fn process_one(
         );
         return Ok(ProcessedTarget {
             outcome: TargetOutcome::SkippedOverSize,
-            _guard: guard,
+            _guard: None,
         });
     }
 
@@ -417,7 +417,7 @@ async fn process_one(
                 len,
             },
         },
-        _guard: guard,
+        _guard: Some(guard),
     })
 }
 
@@ -972,6 +972,40 @@ mod tests {
             ops.iter()
                 .any(|(k, _, _)| k == "storage_cache_skipped_over_size")
         );
+    }
+
+    #[tokio::test]
+    async fn skipped_outcome_does_not_keep_cache_lock() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let http = Client::builder().build().unwrap();
+        let server = MockServer::start_async().await;
+
+        let too_big = CACHE_MAX_SIZE + 1;
+        let probe = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/big.tar.gz")
+                    .header("range", "bytes=0-0");
+                then.status(206)
+                    .header("content-range", format!("bytes 0-0/{too_big}"))
+                    .body(b"x");
+            })
+            .await;
+
+        let target = CacheTarget {
+            kind: TargetKind::Storage,
+            index: 0,
+            name: "user-volume".to_string(),
+            version: "v9".to_string(),
+            archive_url: server.url("/big.tar.gz"),
+        };
+
+        let processed = process_one(&target, &http, &home).await.unwrap();
+
+        probe.assert_async().await;
+        assert!(matches!(processed.outcome, TargetOutcome::SkippedOverSize));
+        assert!(processed._guard.is_none());
     }
 
     #[tokio::test]

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -23,6 +23,7 @@
 //! `guest-download` understands after #10805. The PR adding this module
 //! must not merge before #10805 is on `main`.
 
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -30,9 +31,8 @@ use std::time::{Duration, Instant};
 use bytes::Bytes;
 use futures_util::stream::{self, StreamExt};
 use reqwest::Client;
-use sandbox::Sandbox;
+use sandbox::{Sandbox, WriteFileRequest, WriteFileSource};
 use tokio::fs;
-use tokio::io::AsyncReadExt as _;
 use tracing::{debug, warn};
 
 use crate::error::{RunnerError, RunnerResult};
@@ -44,7 +44,7 @@ use crate::types::GuestDownloadManifest;
 /// Archive sizes strictly larger than this are passthrough.
 const CACHE_MAX_SIZE: u64 = 8 * 1024 * 1024;
 
-/// Parallel (probe GET / full GET / flock / vsock) operations per `populate_cache` call.
+/// Parallel (probe GET / full GET / flock) operations per `populate_cache` call.
 const CONCURRENCY: usize = 4;
 
 /// Guest stage directory for `file://` archives.
@@ -76,16 +76,36 @@ struct CacheTarget {
     archive_url: String,
 }
 
+struct TargetGroup {
+    representative: CacheTarget,
+    members: Vec<CacheTarget>,
+}
+
 #[derive(Clone, Copy)]
 enum TargetKind {
     Storage,
     Artifact,
 }
 
+#[derive(Clone)]
+struct StageArchive {
+    guest_path: String,
+    archive_path: PathBuf,
+    len: u64,
+}
+
+struct ProcessedTarget {
+    outcome: TargetOutcome,
+    _guard: nix::fcntl::Flock<std::fs::File>,
+}
+
 enum TargetOutcome {
-    Hit,
+    Hit {
+        stage: StageArchive,
+    },
     Miss {
         download_duration: Duration,
+        stage: StageArchive,
     },
     SkippedOverSize,
     /// Size probe (`GET` + `Range: bytes=0-0`) could not determine the
@@ -97,6 +117,15 @@ enum TargetOutcome {
     SkippedHeadFailed {
         reason: String,
     },
+}
+
+impl TargetOutcome {
+    fn stage(&self) -> Option<&StageArchive> {
+        match self {
+            Self::Hit { stage } | Self::Miss { stage, .. } => Some(stage),
+            Self::SkippedOverSize | Self::SkippedHeadFailed { .. } => None,
+        }
+    }
 }
 
 enum DownloadBody {
@@ -120,8 +149,8 @@ pub async fn populate_cache(
     home: &HomePaths,
     telemetry: &mut JobTelemetry,
 ) -> RunnerResult<()> {
-    let targets = collect_targets(manifest);
-    if targets.is_empty() {
+    let groups = group_targets(collect_targets(manifest));
+    if groups.is_empty() {
         return Ok(());
     }
 
@@ -133,11 +162,15 @@ pub async fn populate_cache(
     // keeping their borrows alive on the caller's stack. Unlike
     // `tokio::task::JoinSet`, it does not require `'static` futures — which
     // matters because our `sandbox: &dyn Sandbox` is a borrow, not an Arc.
-    let outcomes: Vec<(CacheTarget, RunnerResult<TargetOutcome>)> = stream::iter(targets)
+    let representatives = groups
+        .iter()
+        .map(|group| group.representative.clone())
+        .collect::<Vec<_>>();
+    let outcomes: Vec<(CacheTarget, RunnerResult<ProcessedTarget>)> = stream::iter(representatives)
         .map(|target| {
             let http = http.clone();
             async move {
-                let res = process_one(&target, &http, home, sandbox).await;
+                let res = process_one(&target, &http, home).await;
                 (target, res)
             }
         })
@@ -145,9 +178,46 @@ pub async fn populate_cache(
         .collect()
         .await;
 
-    for (target, outcome) in outcomes {
-        let outcome = outcome?;
-        apply_outcome(manifest, &target, &outcome, telemetry);
+    let mut resolved = HashMap::new();
+    let mut staged = Vec::new();
+    let mut staged_by_guest_path = HashSet::new();
+    for (target, processed) in outcomes {
+        let processed = processed?;
+        if let Some(stage) = processed.outcome.stage()
+            && staged_by_guest_path.insert(stage.guest_path.clone())
+        {
+            staged.push(stage.clone());
+        }
+        resolved.insert(cache_key(&target.name, &target.version), processed);
+    }
+
+    if !staged.is_empty() {
+        let requests = staged
+            .iter()
+            .map(|stage| WriteFileRequest {
+                path: stage.guest_path.as_str(),
+                source: WriteFileSource::File {
+                    path: &stage.archive_path,
+                    len: stage.len,
+                },
+            })
+            .collect::<Vec<_>>();
+        let started = Instant::now();
+        sandbox.write_files(&requests).await?;
+        telemetry.record("storage_cache_guest_stage", started.elapsed(), true, None);
+    }
+
+    for group in groups {
+        let key = cache_key(&group.representative.name, &group.representative.version);
+        let processed = resolved.get(&key).ok_or_else(|| {
+            RunnerError::Internal(format!(
+                "storage cache missing outcome for {}@{}",
+                group.representative.name, group.representative.version
+            ))
+        })?;
+        for target in &group.members {
+            apply_outcome(manifest, target, &processed.outcome, telemetry);
+        }
     }
     Ok(())
 }
@@ -201,35 +271,59 @@ fn collect_targets(manifest: &GuestDownloadManifest) -> Vec<CacheTarget> {
     out
 }
 
+fn cache_key(name: &str, version: &str) -> (String, String) {
+    (name.to_string(), version.to_string())
+}
+
+fn group_targets(targets: Vec<CacheTarget>) -> Vec<TargetGroup> {
+    let mut groups = Vec::<TargetGroup>::new();
+    let mut by_key = HashMap::<(String, String), usize>::new();
+
+    for target in targets {
+        let key = cache_key(&target.name, &target.version);
+        if let Some(group) = by_key.get(&key).and_then(|index| groups.get_mut(*index)) {
+            group.members.push(target);
+            continue;
+        }
+        let index = groups.len();
+        by_key.insert(key, index);
+        groups.push(TargetGroup {
+            representative: target.clone(),
+            members: vec![target],
+        });
+    }
+
+    groups
+}
+
 async fn process_one(
     target: &CacheTarget,
     http: &Client,
     home: &HomePaths,
-    sandbox: &dyn Sandbox,
-) -> RunnerResult<TargetOutcome> {
+) -> RunnerResult<ProcessedTarget> {
     // Acquire the per-version flock (blocking, cross-process dedup).
     // Disk-check happens under the lock so we never race with a writer.
     let lock_path = home.storage_lock(&target.name, &target.version);
-    let _guard = lock::acquire(lock_path).await?;
+    let guard = lock::acquire(lock_path).await?;
 
     let cache_dir = home.storage_cache_dir(&target.name, &target.version);
     let archive_path = cache_dir.join("archive.tar.gz");
 
-    // 1. Fast path: disk hit. Read the bytes directly and skip the network.
-    //    This also makes the hit path resilient to transient probe failures.
+    // 1. Fast path: disk hit. Stage the local archive path and skip the
+    //    network, so hits stay resilient to transient probe failures.
     match fs::metadata(&archive_path).await {
         Ok(metadata) if metadata.len() <= CACHE_MAX_SIZE => {
-            match read_cached_archive(&archive_path, CACHE_MAX_SIZE).await? {
-                DownloadBody::Complete(bytes) => {
-                    touch_mtime(&cache_dir);
-                    let guest_path = guest_archive_path(&target.name, &target.version);
-                    sandbox.write_file(&guest_path, &bytes).await?;
-                    return Ok(TargetOutcome::Hit);
-                }
-                DownloadBody::OverSize { observed_size } => {
-                    evict_oversized_cache(target, &cache_dir, observed_size).await?;
-                }
-            }
+            touch_mtime(&cache_dir);
+            return Ok(ProcessedTarget {
+                outcome: TargetOutcome::Hit {
+                    stage: StageArchive {
+                        guest_path: guest_archive_path(&target.name, &target.version),
+                        archive_path,
+                        len: metadata.len(),
+                    },
+                },
+                _guard: guard,
+            });
         }
         Ok(metadata) => {
             evict_oversized_cache(target, &cache_dir, metadata.len()).await?;
@@ -256,8 +350,11 @@ async fn process_one(
                 version = %target.version,
                 "storage_cache: probe returned no size header, passthrough"
             );
-            return Ok(TargetOutcome::SkippedHeadFailed {
-                reason: "missing-size-header".to_string(),
+            return Ok(ProcessedTarget {
+                outcome: TargetOutcome::SkippedHeadFailed {
+                    reason: "missing-size-header".to_string(),
+                },
+                _guard: guard,
             });
         }
         Err(e) => {
@@ -268,7 +365,10 @@ async fn process_one(
                 error = %reason,
                 "storage_cache: probe failed, passthrough"
             );
-            return Ok(TargetOutcome::SkippedHeadFailed { reason });
+            return Ok(ProcessedTarget {
+                outcome: TargetOutcome::SkippedHeadFailed { reason },
+                _guard: guard,
+            });
         }
     };
     if size > CACHE_MAX_SIZE {
@@ -278,13 +378,15 @@ async fn process_one(
             size,
             "storage_cache: entry over size limit, passthrough"
         );
-        return Ok(TargetOutcome::SkippedOverSize);
+        return Ok(ProcessedTarget {
+            outcome: TargetOutcome::SkippedOverSize,
+            _guard: guard,
+        });
     }
 
-    // 3. Download, stage, fsync, atomic rename, then push to guest.
-    //    `Bytes` is Arc-backed, so passing `&bytes[..]` to both the disk
-    //    writer and the sandbox `write_file` costs zero extra allocation
-    //    over the single response body.
+    // 3. Download, stage, fsync, and atomic rename. Guest staging happens
+    //    later in one write_files batch, after every cacheable target has a
+    //    durable local archive.
     let t = Instant::now();
     let bytes = match download_tarball(http, &target.archive_url, CACHE_MAX_SIZE).await? {
         DownloadBody::Complete(bytes) => bytes,
@@ -303,12 +405,19 @@ async fn process_one(
             )));
         }
     };
+    let len = bytes.len() as u64;
     write_to_cache(&cache_dir, &bytes).await?;
-    let guest_path = guest_archive_path(&target.name, &target.version);
-    sandbox.write_file(&guest_path, &bytes).await?;
 
-    Ok(TargetOutcome::Miss {
-        download_duration: t.elapsed(),
+    Ok(ProcessedTarget {
+        outcome: TargetOutcome::Miss {
+            download_duration: t.elapsed(),
+            stage: StageArchive {
+                guest_path: guest_archive_path(&target.name, &target.version),
+                archive_path,
+                len,
+            },
+        },
+        _guard: guard,
     })
 }
 
@@ -398,38 +507,6 @@ async fn download_tarball(http: &Client, url: &str, max_size: u64) -> RunnerResu
     {
         if let Some(observed_size) =
             append_limited_chunk(&mut bytes, &mut downloaded, &chunk, max_size)?
-        {
-            return Ok(DownloadBody::OverSize { observed_size });
-        }
-    }
-
-    Ok(DownloadBody::Complete(Bytes::from(bytes)))
-}
-
-async fn read_cached_archive(path: &Path, max_size: u64) -> RunnerResult<DownloadBody> {
-    let mut file = fs::File::open(path)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("open cached {}: {e}", path.display())))?;
-    let mut bytes = Vec::with_capacity(max_size.min(64 * 1024) as usize);
-    let mut downloaded = 0u64;
-    let mut buf = [0u8; 64 * 1024];
-
-    loop {
-        let n = file
-            .read(&mut buf)
-            .await
-            .map_err(|e| RunnerError::Internal(format!("read cached {}: {e}", path.display())))?;
-        if n == 0 {
-            break;
-        }
-        let chunk = buf.get(..n).ok_or_else(|| {
-            RunnerError::Internal(format!(
-                "read cached {} produced invalid chunk length {n}",
-                path.display()
-            ))
-        })?;
-        if let Some(observed_size) =
-            append_limited_chunk(&mut bytes, &mut downloaded, chunk, max_size)?
         {
             return Ok(DownloadBody::OverSize { observed_size });
         }
@@ -582,11 +659,13 @@ fn apply_outcome(
     telemetry: &mut JobTelemetry,
 ) {
     match outcome {
-        TargetOutcome::Hit => {
+        TargetOutcome::Hit { .. } => {
             rewrite_url(manifest, target);
             telemetry.record("storage_cache_hit", Duration::ZERO, true, None);
         }
-        TargetOutcome::Miss { download_duration } => {
+        TargetOutcome::Miss {
+            download_duration, ..
+        } => {
             rewrite_url(manifest, target);
             telemetry.record("storage_cache_miss", Duration::ZERO, true, None);
             telemetry.record("storage_cache_download", *download_duration, true, None);
@@ -660,7 +739,7 @@ mod tests {
     use httpmock::Method::{GET, HEAD};
     use httpmock::prelude::*;
     use sandbox::{SandboxError, SandboxOperation, SandboxOperationReason};
-    use sandbox_mock::MockSandbox;
+    use sandbox_mock::{MockSandbox, WriteFilesCallSource};
     use tokio::io::AsyncWriteExt as _;
     use tokio::net::TcpListener;
 
@@ -699,12 +778,31 @@ mod tests {
         b"pretend-tar-gz-bytes".to_vec()
     }
 
-    fn sandbox_write_file_error(message: impl Into<String>) -> SandboxError {
+    fn sandbox_write_files_error(message: impl Into<String>) -> SandboxError {
         SandboxError::Operation {
-            operation: SandboxOperation::WriteFile,
+            operation: SandboxOperation::WriteFiles,
             reason: SandboxOperationReason::Guest,
             message: message.into(),
         }
+    }
+
+    fn assert_single_stage_file(
+        sandbox: &MockSandbox,
+        guest_path: &str,
+        archive_path: &Path,
+        len: u64,
+    ) {
+        let calls = sandbox.write_files_calls();
+        assert_eq!(calls.len(), 1, "expected one write_files call: {calls:?}");
+        assert_eq!(calls[0].files.len(), 1, "expected one staged file");
+        assert_eq!(calls[0].files[0].path, guest_path);
+        assert_eq!(
+            calls[0].files[0].source,
+            WriteFilesCallSource::File {
+                path: archive_path.to_path_buf(),
+                len,
+            }
+        );
     }
 
     async fn raw_http_url(
@@ -755,6 +853,16 @@ mod tests {
         assert!(
             ops.iter().any(|(k, _, _)| k == "storage_cache_hit"),
             "expected storage_cache_hit in {ops:?}"
+        );
+        assert!(
+            ops.iter().any(|(k, _, _)| k == "storage_cache_guest_stage"),
+            "expected storage_cache_guest_stage in {ops:?}"
+        );
+        assert_single_stage_file(
+            &sandbox,
+            &guest_archive_path(name, version),
+            &cache_dir.join("archive.tar.gz"),
+            tarball_bytes().len() as u64,
         );
     }
 
@@ -810,6 +918,13 @@ mod tests {
         let ops = telemetry.pending_ops_snapshot();
         assert!(ops.iter().any(|(k, _, _)| k == "storage_cache_miss"));
         assert!(ops.iter().any(|(k, _, _)| k == "storage_cache_download"));
+        assert!(ops.iter().any(|(k, _, _)| k == "storage_cache_guest_stage"));
+        assert_single_stage_file(
+            &sandbox,
+            &guest_archive_path(name, version),
+            &final_path,
+            body.len() as u64,
+        );
     }
 
     #[tokio::test]
@@ -864,7 +979,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);
         let sandbox = MockSandbox::new("test");
-        sandbox.push_write_file_result(Err(sandbox_write_file_error("unexpected archive write")));
+        sandbox.push_write_files_result(Err(sandbox_write_files_error("unexpected archive write")));
         let mut telemetry = new_telemetry();
         let server = MockServer::start_async().await;
 
@@ -919,9 +1034,13 @@ mod tests {
                 .iter()
                 .any(|(k, _, _)| k == "storage_cache_miss")
         );
+        let sentinel = [WriteFileRequest {
+            path: "/tmp/sentinel",
+            source: WriteFileSource::Bytes(b"x"),
+        }];
         assert!(
-            sandbox.write_file("/tmp/sentinel", b"x").await.is_err(),
-            "queued write_file error should remain if archive write was not attempted"
+            sandbox.write_files(&sentinel).await.is_err(),
+            "queued write_files error should remain if archive write was not attempted"
         );
     }
 
@@ -1123,6 +1242,61 @@ mod tests {
         assert_eq!(
             manifest.artifacts[0].archive_url.as_deref(),
             Some(format!("file://{}", guest_archive_path(name, version)).as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_cache_key_is_staged_once_for_storage_and_artifact() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+
+        let name = "shared-cache-key";
+        let version = "same-version";
+        let body = tarball_bytes();
+        let cache_dir = home.storage_cache_dir(name, version);
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::write(cache_dir.join("archive.tar.gz"), &body).unwrap();
+
+        let mut manifest = GuestDownloadManifest {
+            storages: vec![GuestDownloadStorageEntry {
+                mount_path: "/mnt/storage".into(),
+                archive_url: Some("https://r2.example.com/storage.tar.gz".into()),
+                cached: false,
+                instructions_target_filename: None,
+                vas_storage_name: name.to_string(),
+                vas_version_id: version.to_string(),
+            }],
+            artifacts: vec![GuestDownloadArtifactEntry {
+                mount_path: "/mnt/artifact".into(),
+                archive_url: Some("https://r2.example.com/artifact.tar.gz".into()),
+                cached: false,
+                vas_storage_name: name.to_string(),
+                vas_storage_id: String::new(),
+                vas_version_id: version.to_string(),
+            }],
+            cleanup_paths: Vec::new(),
+        };
+
+        populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap();
+
+        let expected = format!("file://{}", guest_archive_path(name, version));
+        assert_eq!(
+            manifest.storages[0].archive_url.as_deref(),
+            Some(expected.as_str())
+        );
+        assert_eq!(
+            manifest.artifacts[0].archive_url.as_deref(),
+            Some(expected.as_str())
+        );
+        assert_single_stage_file(
+            &sandbox,
+            &guest_archive_path(name, version),
+            &cache_dir.join("archive.tar.gz"),
+            body.len() as u64,
         );
     }
 
@@ -1357,25 +1531,6 @@ mod tests {
             DownloadBody::Complete(bytes) => {
                 panic!(
                     "stream over limit should be rejected, read {} bytes",
-                    bytes.len()
-                )
-            }
-            DownloadBody::OverSize { observed_size } => assert_eq!(observed_size, 7),
-        }
-    }
-
-    #[tokio::test]
-    async fn cached_archive_read_rejects_one_byte_over_limit() {
-        let temp = tempfile::tempdir().unwrap();
-        let archive_path = temp.path().join("archive.tar.gz");
-        fs::write(&archive_path, b"abcdefg").await.unwrap();
-
-        let result = read_cached_archive(&archive_path, 6).await.unwrap();
-
-        match result {
-            DownloadBody::Complete(bytes) => {
-                panic!(
-                    "cached file over limit should be rejected, read {} bytes",
                     bytes.len()
                 )
             }

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -242,8 +242,15 @@ pub async fn populate_cache(
             })
             .collect::<Vec<_>>();
         let started = Instant::now();
-        sandbox.write_files(&requests).await?;
-        telemetry.record("storage_cache_guest_stage", started.elapsed(), true, None);
+        let result = sandbox.write_files(&requests).await;
+        let error = result.as_ref().err().map(ToString::to_string);
+        telemetry.record(
+            "storage_cache_guest_stage",
+            started.elapsed(),
+            result.is_ok(),
+            error.as_deref(),
+        );
+        result?;
     }
     drop(stage_guards);
 
@@ -975,6 +982,46 @@ mod tests {
             &guest_archive_path(name, version),
             &cache_dir.join("archive.tar.gz"),
             tarball_bytes().len() as u64,
+        );
+    }
+
+    #[tokio::test]
+    async fn guest_stage_failure_records_failed_telemetry() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_write_files_result(Err(sandbox_write_files_error("stage failed")));
+        let mut telemetry = new_telemetry();
+
+        let name = "stage-failure";
+        let version = "v1";
+        let cache_dir = home.storage_cache_dir(name, version);
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::write(cache_dir.join("archive.tar.gz"), tarball_bytes()).unwrap();
+
+        let original = "https://r2.example.com/stage-failure.tar.gz".to_string();
+        let mut manifest = manifest_single_storage(original.clone(), name, version);
+
+        let err = populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("stage failed"), "got: {err}");
+        assert_eq!(
+            manifest.storages[0].archive_url.as_deref(),
+            Some(original.as_str())
+        );
+        let ops = telemetry.pending_ops_snapshot();
+        let (_, success, error) = ops
+            .iter()
+            .find(|(k, _, _)| k == "storage_cache_guest_stage")
+            .expect("expected failed guest stage telemetry");
+        assert!(!success);
+        assert!(
+            error
+                .as_deref()
+                .is_some_and(|error| error.contains("stage failed")),
+            "expected stage failure reason in {ops:?}"
         );
     }
 

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -89,6 +89,8 @@ enum TargetKind {
 
 #[derive(Clone)]
 struct StageArchive {
+    name: String,
+    version: String,
     guest_path: String,
     archive_path: PathBuf,
     len: u64,
@@ -96,7 +98,6 @@ struct StageArchive {
 
 struct ProcessedTarget {
     outcome: TargetOutcome,
-    _guard: Option<nix::fcntl::Flock<std::fs::File>>,
 }
 
 enum TargetOutcome {
@@ -117,15 +118,35 @@ enum TargetOutcome {
     SkippedHeadFailed {
         reason: String,
     },
+    /// The local archive was ready after cache processing, but became
+    /// unavailable before guest staging. Cache is an optimization, so keep the
+    /// manifest pointed at the original URL instead of failing the run.
+    SkippedStageUnavailable {
+        reason: String,
+    },
 }
 
 impl TargetOutcome {
     fn stage(&self) -> Option<&StageArchive> {
         match self {
             Self::Hit { stage } | Self::Miss { stage, .. } => Some(stage),
-            Self::SkippedOverSize | Self::SkippedHeadFailed { .. } => None,
+            Self::SkippedOverSize
+            | Self::SkippedHeadFailed { .. }
+            | Self::SkippedStageUnavailable { .. } => None,
         }
     }
+}
+
+struct LockedStageArchives {
+    stages: Vec<StageArchive>,
+    skipped: Vec<SkippedStageArchive>,
+    guards: Vec<nix::fcntl::Flock<std::fs::File>>,
+}
+
+struct SkippedStageArchive {
+    name: String,
+    version: String,
+    reason: String,
 }
 
 enum DownloadBody {
@@ -191,8 +212,26 @@ pub async fn populate_cache(
         resolved.insert(cache_key(&target.name, &target.version), processed);
     }
 
-    if !staged.is_empty() {
-        let requests = staged
+    let LockedStageArchives {
+        stages: locked_stages,
+        skipped: skipped_stages,
+        guards: stage_guards,
+    } = lock_stage_archives(staged, home).await?;
+    for skipped in skipped_stages {
+        let key = cache_key(&skipped.name, &skipped.version);
+        let processed = resolved.get_mut(&key).ok_or_else(|| {
+            RunnerError::Internal(format!(
+                "storage cache missing skipped stage outcome for {}@{}",
+                skipped.name, skipped.version
+            ))
+        })?;
+        processed.outcome = TargetOutcome::SkippedStageUnavailable {
+            reason: skipped.reason,
+        };
+    }
+
+    if !locked_stages.is_empty() {
+        let requests = locked_stages
             .iter()
             .map(|stage| WriteFileRequest {
                 path: stage.guest_path.as_str(),
@@ -206,6 +245,7 @@ pub async fn populate_cache(
         sandbox.write_files(&requests).await?;
         telemetry.record("storage_cache_guest_stage", started.elapsed(), true, None);
     }
+    drop(stage_guards);
 
     for group in groups {
         let key = cache_key(&group.representative.name, &group.representative.version);
@@ -304,7 +344,7 @@ async fn process_one(
     // Acquire the per-version flock (blocking, cross-process dedup).
     // Disk-check happens under the lock so we never race with a writer.
     let lock_path = home.storage_lock(&target.name, &target.version);
-    let guard = lock::acquire(lock_path).await?;
+    let _guard = lock::acquire(lock_path).await?;
 
     let cache_dir = home.storage_cache_dir(&target.name, &target.version);
     let archive_path = cache_dir.join("archive.tar.gz");
@@ -317,12 +357,13 @@ async fn process_one(
             return Ok(ProcessedTarget {
                 outcome: TargetOutcome::Hit {
                     stage: StageArchive {
+                        name: target.name.clone(),
+                        version: target.version.clone(),
                         guest_path: guest_archive_path(&target.name, &target.version),
                         archive_path,
                         len: metadata.len(),
                     },
                 },
-                _guard: Some(guard),
             });
         }
         Ok(metadata) => {
@@ -354,7 +395,6 @@ async fn process_one(
                 outcome: TargetOutcome::SkippedHeadFailed {
                     reason: "missing-size-header".to_string(),
                 },
-                _guard: None,
             });
         }
         Err(e) => {
@@ -367,7 +407,6 @@ async fn process_one(
             );
             return Ok(ProcessedTarget {
                 outcome: TargetOutcome::SkippedHeadFailed { reason },
-                _guard: None,
             });
         }
     };
@@ -380,7 +419,6 @@ async fn process_one(
         );
         return Ok(ProcessedTarget {
             outcome: TargetOutcome::SkippedOverSize,
-            _guard: None,
         });
     }
 
@@ -412,13 +450,79 @@ async fn process_one(
         outcome: TargetOutcome::Miss {
             download_duration: t.elapsed(),
             stage: StageArchive {
+                name: target.name.clone(),
+                version: target.version.clone(),
                 guest_path: guest_archive_path(&target.name, &target.version),
                 archive_path,
                 len,
             },
         },
-        _guard: Some(guard),
     })
+}
+
+async fn lock_stage_archives(
+    mut stages: Vec<StageArchive>,
+    home: &HomePaths,
+) -> RunnerResult<LockedStageArchives> {
+    sort_stage_archives(&mut stages);
+
+    let mut locked_stages = Vec::with_capacity(stages.len());
+    let mut skipped = Vec::new();
+    let mut guards = Vec::with_capacity(stages.len());
+    for stage in stages {
+        let guard = lock::acquire_shared(home.storage_lock(&stage.name, &stage.version)).await?;
+        match validate_stage_archive(&stage).await {
+            Ok(()) => {
+                guards.push(guard);
+                locked_stages.push(stage);
+            }
+            Err(reason) => {
+                warn!(
+                    name = %stage.name,
+                    version = %stage.version,
+                    reason = %reason,
+                    "storage_cache: staged archive unavailable, passthrough"
+                );
+                skipped.push(SkippedStageArchive {
+                    name: stage.name,
+                    version: stage.version,
+                    reason,
+                });
+            }
+        }
+    }
+
+    Ok(LockedStageArchives {
+        stages: locked_stages,
+        skipped,
+        guards,
+    })
+}
+
+fn sort_stage_archives(stages: &mut [StageArchive]) {
+    stages.sort_by(|a, b| {
+        a.name
+            .cmp(&b.name)
+            .then_with(|| a.version.cmp(&b.version))
+            .then_with(|| a.guest_path.cmp(&b.guest_path))
+    });
+}
+
+async fn validate_stage_archive(stage: &StageArchive) -> Result<(), String> {
+    let metadata = fs::metadata(&stage.archive_path)
+        .await
+        .map_err(|e| format!("stat {}: {e}", stage.archive_path.display()))?;
+    if !metadata.is_file() {
+        return Err(format!("{} is not a file", stage.archive_path.display()));
+    }
+    if metadata.len() != stage.len {
+        return Err(format!(
+            "size changed from {} to {} bytes",
+            stage.len,
+            metadata.len()
+        ));
+    }
+    Ok(())
 }
 
 async fn probe_size(http: &Client, url: &str) -> RunnerResult<Option<u64>> {
@@ -681,6 +785,14 @@ fn apply_outcome(
         TargetOutcome::SkippedHeadFailed { reason } => {
             telemetry.record(
                 "storage_cache_skipped_head_failed",
+                Duration::ZERO,
+                true,
+                Some(reason.as_str()),
+            );
+        }
+        TargetOutcome::SkippedStageUnavailable { reason } => {
+            telemetry.record(
+                "storage_cache_skipped_stage_unavailable",
                 Duration::ZERO,
                 true,
                 Some(reason.as_str()),
@@ -1005,7 +1117,37 @@ mod tests {
 
         probe.assert_async().await;
         assert!(matches!(processed.outcome, TargetOutcome::SkippedOverSize));
-        assert!(processed._guard.is_none());
+        let _lock = lock::try_acquire(home.storage_lock("user-volume", "v9"))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn hit_outcome_does_not_keep_cache_lock() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let http = Client::builder().build().unwrap();
+
+        let name = "cached-hit";
+        let version = "v1";
+        let cache_dir = home.storage_cache_dir(name, version);
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::write(cache_dir.join("archive.tar.gz"), tarball_bytes()).unwrap();
+
+        let target = CacheTarget {
+            kind: TargetKind::Storage,
+            index: 0,
+            name: name.to_string(),
+            version: version.to_string(),
+            archive_url: "https://r2.example.com/ignored.tar.gz".to_string(),
+        };
+
+        let processed = process_one(&target, &http, &home).await.unwrap();
+
+        assert!(matches!(processed.outcome, TargetOutcome::Hit { .. }));
+        let _lock = lock::try_acquire(home.storage_lock(name, version))
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -1572,6 +1714,53 @@ mod tests {
         }
     }
 
+    #[test]
+    fn stage_archives_sort_by_cache_key() {
+        let mut stages = vec![
+            StageArchive {
+                name: "z-storage".to_string(),
+                version: "v1".to_string(),
+                guest_path: "/tmp/z.tar.gz".to_string(),
+                archive_path: PathBuf::from("/cache/z/archive.tar.gz"),
+                len: 1,
+            },
+            StageArchive {
+                name: "a-storage".to_string(),
+                version: "v1".to_string(),
+                guest_path: "/tmp/a.tar.gz".to_string(),
+                archive_path: PathBuf::from("/cache/a/archive.tar.gz"),
+                len: 1,
+            },
+        ];
+
+        sort_stage_archives(&mut stages);
+
+        let names = stages
+            .iter()
+            .map(|stage| stage.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["a-storage", "z-storage"]);
+    }
+
+    #[tokio::test]
+    async fn unavailable_stage_archive_is_skipped_before_guest_write() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let stage = StageArchive {
+            name: "missing-stage".to_string(),
+            version: "v1".to_string(),
+            guest_path: guest_archive_path("missing-stage", "v1"),
+            archive_path: temp.path().join("missing.tar.gz"),
+            len: 1,
+        };
+
+        let locked = lock_stage_archives(vec![stage], &home).await.unwrap();
+
+        assert!(locked.stages.is_empty());
+        assert_eq!(locked.skipped.len(), 1);
+        assert!(locked.skipped[0].reason.contains("stat"));
+    }
+
     #[tokio::test]
     async fn shared_version_distinct_names_get_distinct_guest_paths() {
         // Regression guard: two manifest entries that share `vasVersionId`
@@ -1633,6 +1822,63 @@ mod tests {
         assert_eq!(
             url_b,
             format!("file://{}", guest_archive_path(name_b, version))
+        );
+    }
+
+    #[tokio::test]
+    async fn staged_archives_are_written_in_stable_lock_order() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+
+        let version = "v1";
+        for name in ["z-storage", "a-storage"] {
+            let cache_dir = home.storage_cache_dir(name, version);
+            std::fs::create_dir_all(&cache_dir).unwrap();
+            std::fs::write(cache_dir.join("archive.tar.gz"), tarball_bytes()).unwrap();
+        }
+
+        let mut manifest = GuestDownloadManifest {
+            storages: vec![
+                GuestDownloadStorageEntry {
+                    mount_path: "/mnt/z".into(),
+                    archive_url: Some("https://r2.example.com/z.tar.gz".into()),
+                    cached: false,
+                    instructions_target_filename: None,
+                    vas_storage_name: "z-storage".into(),
+                    vas_version_id: version.into(),
+                },
+                GuestDownloadStorageEntry {
+                    mount_path: "/mnt/a".into(),
+                    archive_url: Some("https://r2.example.com/a.tar.gz".into()),
+                    cached: false,
+                    instructions_target_filename: None,
+                    vas_storage_name: "a-storage".into(),
+                    vas_version_id: version.into(),
+                },
+            ],
+            artifacts: Vec::new(),
+            cleanup_paths: Vec::new(),
+        };
+
+        populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap();
+
+        let calls = sandbox.write_files_calls();
+        assert_eq!(calls.len(), 1, "expected one batched write_files call");
+        let paths = calls[0]
+            .files
+            .iter()
+            .map(|file| file.path.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            paths,
+            vec![
+                guest_archive_path("a-storage", version),
+                guest_archive_path("z-storage", version),
+            ]
         );
     }
 

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -27,7 +27,7 @@ use std::time::{Duration, Instant};
 use bytes::Bytes;
 use futures_util::stream::{self, StreamExt};
 use reqwest::Client;
-use sandbox::{Sandbox, WriteFileRequest, WriteFileSource};
+use sandbox::{ExecRequest, Sandbox, WriteFileRequest, WriteFileSource};
 use tokio::fs;
 use tracing::{debug, warn};
 
@@ -238,7 +238,12 @@ pub async fn populate_cache(
             })
             .collect::<Vec<_>>();
         let started = Instant::now();
-        let result = sandbox.write_files(&requests).await;
+        let result = async {
+            prepare_guest_stage_dir(sandbox).await?;
+            sandbox.write_files(&requests).await?;
+            Ok::<(), RunnerError>(())
+        }
+        .await;
         let error = result.as_ref().err().map(ToString::to_string);
         telemetry.record(
             "storage_cache_guest_stage",
@@ -261,6 +266,26 @@ pub async fn populate_cache(
         for target in &group.members {
             apply_outcome(manifest, target, &processed.outcome, telemetry);
         }
+    }
+    Ok(())
+}
+
+async fn prepare_guest_stage_dir(sandbox: &dyn Sandbox) -> RunnerResult<()> {
+    let cmd = format!("rm -rf -- {GUEST_STAGE_DIR} && mkdir -p -- {GUEST_STAGE_DIR}");
+    let result = sandbox
+        .exec(&ExecRequest {
+            cmd: &cmd,
+            timeout: Duration::from_secs(10),
+            env: &[],
+            sudo: false,
+        })
+        .await?;
+    if result.exit_code != 0 {
+        return Err(RunnerError::Internal(format!(
+            "prepare guest storage cache stage dir failed: exit_code={} stderr={}",
+            result.exit_code,
+            String::from_utf8_lossy(&result.stderr).trim()
+        )));
     }
     Ok(())
 }
@@ -1018,6 +1043,56 @@ mod tests {
                 .as_deref()
                 .is_some_and(|error| error.contains("stage failed")),
             "expected stage failure reason in {ops:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn guest_stage_prepare_failure_records_failed_telemetry_and_skips_write_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_exec_result(Ok(sandbox::ExecResult {
+            exit_code: 1,
+            stdout: Vec::new(),
+            stderr: b"rm failed".to_vec(),
+        }));
+        let mut telemetry = new_telemetry();
+
+        let name = "stage-prepare-failure";
+        let version = "v1";
+        let cache_dir = home.storage_cache_dir(name, version);
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::write(cache_dir.join("archive.tar.gz"), tarball_bytes()).unwrap();
+
+        let original = "https://r2.example.com/stage-prepare-failure.tar.gz".to_string();
+        let mut manifest = manifest_single_storage(original.clone(), name, version);
+
+        let err = populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("prepare guest storage cache stage dir failed"),
+            "got: {err}"
+        );
+        assert!(err.to_string().contains("rm failed"), "got: {err}");
+        assert!(sandbox.write_files_calls().is_empty());
+        assert_eq!(
+            manifest.storages[0].archive_url.as_deref(),
+            Some(original.as_str())
+        );
+        let ops = telemetry.pending_ops_snapshot();
+        let (_, success, error) = ops
+            .iter()
+            .find(|(k, _, _)| k == "storage_cache_guest_stage")
+            .expect("expected failed guest stage telemetry");
+        assert!(!success);
+        assert!(
+            error
+                .as_deref()
+                .is_some_and(|error| error.contains("rm failed")),
+            "expected stage prepare failure reason in {ops:?}"
         );
     }
 

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -27,7 +27,10 @@ use std::time::{Duration, Instant};
 use bytes::Bytes;
 use futures_util::stream::{self, StreamExt};
 use reqwest::Client;
-use sandbox::{ExecRequest, Sandbox, WriteFileRequest, WriteFileSource};
+use sandbox::{
+    BoundedExecCapturePolicy, BoundedExecOutput, BoundedExecOutputRequest, BoundedExecRequest,
+    BoundedExecTermination, Sandbox, WriteFileRequest, WriteFileSource,
+};
 use tokio::fs;
 use tracing::{debug, warn};
 
@@ -273,21 +276,51 @@ pub async fn populate_cache(
 async fn prepare_guest_stage_dir(sandbox: &dyn Sandbox) -> RunnerResult<()> {
     let cmd = format!("rm -rf -- {GUEST_STAGE_DIR} && mkdir -p -- {GUEST_STAGE_DIR}");
     let result = sandbox
-        .exec(&ExecRequest {
+        .bounded_exec(&BoundedExecRequest {
             cmd: &cmd,
             timeout: Duration::from_secs(10),
             env: &[],
             sudo: false,
+            stdin: None,
+            stdout: capture_bounded_output(4 * 1024),
+            stderr: capture_bounded_output(16 * 1024),
         })
         .await?;
-    if result.exit_code != 0 {
-        return Err(RunnerError::Internal(format!(
-            "prepare guest storage cache stage dir failed: exit_code={} stderr={}",
-            result.exit_code,
-            String::from_utf8_lossy(&result.stderr).trim()
-        )));
+
+    match result.termination {
+        BoundedExecTermination::Exited { exit_code: 0 } => Ok(()),
+        BoundedExecTermination::Exited { exit_code } => Err(RunnerError::Internal(format!(
+            "prepare guest storage cache stage dir failed: exit_code={exit_code} stderr={}",
+            bounded_output_preview(&result.stderr)
+        ))),
+        termination => Err(RunnerError::Internal(format!(
+            "prepare guest storage cache stage dir failed: termination={termination:?} stderr={}",
+            bounded_output_preview(&result.stderr)
+        ))),
     }
-    Ok(())
+}
+
+fn capture_bounded_output(limit_bytes: u32) -> BoundedExecOutputRequest {
+    BoundedExecOutputRequest {
+        capture: BoundedExecCapturePolicy::Capture { limit_bytes },
+        stream: None,
+    }
+}
+
+fn bounded_output_preview(output: &BoundedExecOutput) -> String {
+    match output {
+        BoundedExecOutput::Discarded => String::new(),
+        BoundedExecOutput::Captured { bytes, truncated } => {
+            let text = String::from_utf8_lossy(bytes).trim().to_string();
+            if *truncated && text.is_empty() {
+                "[truncated]".to_string()
+            } else if *truncated {
+                format!("{text} [truncated]")
+            } else {
+                text
+            }
+        }
+    }
 }
 
 fn collect_targets(manifest: &GuestDownloadManifest) -> Vec<CacheTarget> {
@@ -879,7 +912,7 @@ mod tests {
     use httpmock::Method::{GET, HEAD};
     use httpmock::prelude::*;
     use sandbox::{SandboxError, SandboxOperation, SandboxOperationReason};
-    use sandbox_mock::{MockSandbox, WriteFilesCallSource};
+    use sandbox_mock::{BoundedExecResponse, MockSandbox, WriteFilesCallSource};
     use tokio::io::AsyncWriteExt as _;
     use tokio::net::TcpListener;
 
@@ -1051,11 +1084,22 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);
         let sandbox = MockSandbox::new("test");
-        sandbox.push_exec_result(Ok(sandbox::ExecResult {
-            exit_code: 1,
-            stdout: Vec::new(),
-            stderr: b"rm failed".to_vec(),
-        }));
+        sandbox.push_bounded_exec_response(BoundedExecResponse {
+            events: Vec::new(),
+            result: Ok(sandbox::BoundedExecResult {
+                termination: sandbox::BoundedExecTermination::Exited { exit_code: 1 },
+                duration: Duration::ZERO,
+                stdout: sandbox::BoundedExecOutput::Captured {
+                    bytes: Vec::new(),
+                    truncated: false,
+                },
+                stderr: sandbox::BoundedExecOutput::Captured {
+                    bytes: b"rm failed".to_vec(),
+                    truncated: false,
+                },
+                diagnostic: None,
+            }),
+        });
         let mut telemetry = new_telemetry();
 
         let name = "stage-prepare-failure";

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -2,10 +2,10 @@
 //!
 //! Sits between `filter_unchanged_storages` and `download_storages` in
 //! `run_in_sandbox`. For each eligible manifest entry, checks a host-local
-//! cache keyed by `(vasStorageName, vasVersionId)`. On hit, reads the cached
-//! tarball from disk and pushes it into the guest via vsock; on miss,
-//! downloads the archive from R2 into the cache first. Either way, the
-//! entry's `archive_url` is rewritten to
+//! cache keyed by `(vasStorageName, vasVersionId)`. On hit, stages the cached
+//! tarball into the guest with a batched `write_files` vsock stream; on miss,
+//! downloads the archive from R2 into the cache first and then stages it with
+//! the same path. Either way, the entry's `archive_url` is rewritten to
 //! `file:///tmp/vm0-storage-cache/<hash(name)>-<hash(version)>.tar.gz`
 //! so `guest-download` reads from the local stage instead of re-fetching.
 //! Keying on both name and version keeps the guest file injective in the
@@ -18,10 +18,6 @@
 //! If the probe says an entry is cache-eligible but the full response exceeds
 //! [`CACHE_MAX_SIZE`], the cache fails closed instead of handing the same
 //! inconsistent URL to the guest.
-//!
-//! Merge-order contract: this module produces `file://` URLs, which only
-//! `guest-download` understands after #10805. The PR adding this module
-//! must not merge before #10805 is on `main`.
 
 use std::collections::{HashMap, HashSet};
 use std::io;

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -57,8 +57,8 @@ const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(120);
 ///
 /// Must be injective in `(name, version)`: two manifest entries that differ
 /// only in `vas_storage_name` but share `vas_version_id` end up at distinct
-/// `file://` URLs so the second `sandbox.write_file` does not clobber the
-/// first. Uses the same `short_digest` helper that `HomePaths` uses for
+/// `file://` URLs so one staged archive cannot clobber another. Uses the
+/// same `short_digest` helper that `HomePaths` uses for
 /// the host cache dir, so the two keys always map 1:1.
 fn guest_archive_path(name: &str, version: &str) -> String {
     let name_hash = short_digest(name);
@@ -1543,8 +1543,8 @@ mod tests {
         // Regression guard: two manifest entries that share `vasVersionId`
         // but differ in `vasStorageName` must resolve to distinct guest
         // `file://` URLs. Before the host/guest key symmetrization, both
-        // entries collided on `{GUEST_STAGE_DIR}/{version}.tar.gz` and the
-        // second `sandbox.write_file` clobbered the first.
+        // entries collided on `{GUEST_STAGE_DIR}/{version}.tar.gz` and one
+        // staged archive clobbered the other.
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);
         let sandbox = MockSandbox::new("test");

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -1762,6 +1762,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn changed_stage_archive_size_is_skipped_before_guest_write() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let archive_path = temp.path().join("changed.tar.gz");
+        std::fs::write(&archive_path, b"longer-than-expected").unwrap();
+        let stage = StageArchive {
+            name: "changed-stage".to_string(),
+            version: "v1".to_string(),
+            guest_path: guest_archive_path("changed-stage", "v1"),
+            archive_path,
+            len: 1,
+        };
+
+        let locked = lock_stage_archives(vec![stage], &home).await.unwrap();
+
+        assert!(locked.stages.is_empty());
+        assert_eq!(locked.skipped.len(), 1);
+        assert!(locked.skipped[0].reason.contains("size changed"));
+    }
+
+    #[tokio::test]
     async fn shared_version_distinct_names_get_distinct_guest_paths() {
         // Regression guard: two manifest entries that share `vasVersionId`
         // but differ in `vasStorageName` must resolve to distinct guest

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -12,6 +12,7 @@ use sandbox::{
     BoundedExecRequest, BoundedExecResult, BoundedExecStream, BoundedExecTermination, ExecRequest,
     ExecResult, ProcessExit, Sandbox, SandboxConfig, SandboxError, SandboxIdleTransition,
     SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason, SpawnHandle,
+    WriteFileRequest, WriteFileSource,
 };
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::sync::{mpsc, watch};
@@ -24,6 +25,7 @@ use vsock_host::{
     BoundedExecStream as HostBoundedExecStream,
     BoundedExecStreamPolicy as HostBoundedExecStreamPolicy,
     BoundedExecTermination as HostBoundedExecTermination, VsockHost,
+    WriteFileRequest as HostWriteFileRequest, WriteFileSource as HostWriteFileSource,
 };
 
 use crate::api::ApiError;
@@ -1529,6 +1531,32 @@ impl Sandbox for FirecrackerSandbox {
         }
     }
 
+    async fn write_files(&self, files: &[WriteFileRequest<'_>]) -> sandbox::Result<()> {
+        let operation = SandboxOperation::WriteFiles;
+        let guest = self.operation_guest(operation).await?;
+        let host_files: Vec<HostWriteFileRequest<'_>> = files
+            .iter()
+            .map(|file| HostWriteFileRequest {
+                path: file.path,
+                source: match &file.source {
+                    WriteFileSource::Bytes(bytes) => HostWriteFileSource::Bytes(bytes),
+                    WriteFileSource::File { path, len } => {
+                        HostWriteFileSource::File { path, len: *len }
+                    }
+                },
+            })
+            .collect();
+
+        tokio::select! {
+            result = guest.write_files(&host_files, false) => {
+                result.map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))
+            }
+            () = wait_for_backend_crash(self.state_tx.subscribe()) => {
+                Err(Self::backend_crashed_error(operation))
+            }
+        }
+    }
+
     async fn spawn_watch(
         &self,
         request: &ExecRequest<'_>,
@@ -2073,6 +2101,7 @@ mod tests {
             SandboxOperation::Exec,
             SandboxOperation::BoundedExec,
             SandboxOperation::WriteFile,
+            SandboxOperation::WriteFiles,
             SandboxOperation::SpawnWatch,
             SandboxOperation::WaitExit,
         ] {
@@ -2092,6 +2121,7 @@ mod tests {
             SandboxOperation::Exec,
             SandboxOperation::BoundedExec,
             SandboxOperation::WriteFile,
+            SandboxOperation::WriteFiles,
             SandboxOperation::SpawnWatch,
             SandboxOperation::WaitExit,
         ] {

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! All mocks succeed by default with exit code 0 and empty output.
 //! Use [`MockSandbox::push_exec_result`], [`MockSandbox::push_write_file_result`],
+//! [`MockSandbox::push_write_files_result`],
 //! [`MockSandbox::push_bounded_exec_response`],
 //! or [`MockSandboxControl::push_exec_remote_response`] to queue custom responses
 //! consumed in FIFO order.
@@ -375,7 +376,8 @@ impl Default for MockSandboxOverrides {
 ///
 /// Queue custom results with [`push_exec_result`](Self::push_exec_result)
 /// [`push_bounded_exec_response`](Self::push_bounded_exec_response), and
-/// [`push_write_file_result`](Self::push_write_file_result).
+/// [`push_write_file_result`](Self::push_write_file_result), and
+/// [`push_write_files_result`](Self::push_write_files_result).
 /// When a queue is empty, the operation returns its default success value.
 pub struct MockSandbox {
     id: String,

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -97,6 +97,23 @@ pub struct WriteFileCall {
     pub content: Vec<u8>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum WriteFilesCallSource {
+    Bytes(Vec<u8>),
+    File { path: PathBuf, len: u64 },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WriteFilesCallEntry {
+    pub path: String,
+    pub source: WriteFilesCallSource,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WriteFilesCall {
+    pub files: Vec<WriteFilesCallEntry>,
+}
+
 enum LifecycleBehavior {
     Result(Result<()>),
     Panic(String),
@@ -368,6 +385,8 @@ pub struct MockSandbox {
     bounded_exec_calls: Mutex<Vec<BoundedExecCall>>,
     write_file_results: Mutex<VecDeque<Result<()>>>,
     write_file_calls: Mutex<Vec<WriteFileCall>>,
+    write_files_results: Mutex<VecDeque<Result<()>>>,
+    write_files_calls: Mutex<Vec<WriteFilesCall>>,
     overrides: Option<Arc<MockSandboxOverrides>>,
     /// Holds the stdout channel sender alive when simulating a non-closing
     /// channel (e.g. wait_exit_error override). Without this, the sender is
@@ -385,6 +404,8 @@ impl MockSandbox {
             bounded_exec_calls: Mutex::new(Vec::new()),
             write_file_results: Mutex::new(VecDeque::new()),
             write_file_calls: Mutex::new(Vec::new()),
+            write_files_results: Mutex::new(VecDeque::new()),
+            write_files_calls: Mutex::new(Vec::new()),
             overrides: None,
             stdout_tx: Mutex::new(None),
         }
@@ -399,6 +420,8 @@ impl MockSandbox {
             bounded_exec_calls: Mutex::new(Vec::new()),
             write_file_results: Mutex::new(VecDeque::new()),
             write_file_calls: Mutex::new(Vec::new()),
+            write_files_results: Mutex::new(VecDeque::new()),
+            write_files_calls: Mutex::new(Vec::new()),
             overrides: Some(overrides),
             stdout_tx: Mutex::new(None),
         }
@@ -435,6 +458,18 @@ impl MockSandbox {
 
     pub fn write_file_calls(&self) -> Vec<WriteFileCall> {
         self.write_file_calls.lock_ignoring_poison().clone()
+    }
+
+    /// Queue a write_files result. Results are consumed in FIFO order.
+    /// When the queue is empty, write_files returns `Ok(())`.
+    pub fn push_write_files_result(&self, result: Result<()>) {
+        self.write_files_results
+            .lock_ignoring_poison()
+            .push_back(result);
+    }
+
+    pub fn write_files_calls(&self) -> Vec<WriteFilesCall> {
+        self.write_files_calls.lock_ignoring_poison().clone()
     }
 }
 
@@ -484,6 +519,24 @@ fn bounded_exec_call_from_request(request: &BoundedExecRequest<'_>) -> BoundedEx
         stdin: request.stdin.map(<[u8]>::to_vec),
         stdout: output_call_from_request(&request.stdout),
         stderr: output_call_from_request(&request.stderr),
+    }
+}
+
+fn write_files_call_from_request(files: &[WriteFileRequest<'_>]) -> WriteFilesCall {
+    WriteFilesCall {
+        files: files
+            .iter()
+            .map(|file| WriteFilesCallEntry {
+                path: file.path.to_string(),
+                source: match &file.source {
+                    WriteFileSource::Bytes(bytes) => WriteFilesCallSource::Bytes(bytes.to_vec()),
+                    WriteFileSource::File { path, len } => WriteFilesCallSource::File {
+                        path: path.to_path_buf(),
+                        len: *len,
+                    },
+                },
+            })
+            .collect(),
     }
 }
 
@@ -642,6 +695,16 @@ impl Sandbox for MockSandbox {
                 content: content.to_vec(),
             });
         self.write_file_results
+            .lock_ignoring_poison()
+            .pop_front()
+            .unwrap_or(Ok(()))
+    }
+
+    async fn write_files(&self, files: &[WriteFileRequest<'_>]) -> Result<()> {
+        self.write_files_calls
+            .lock_ignoring_poison()
+            .push(write_files_call_from_request(files));
+        self.write_files_results
             .lock_ignoring_poison()
             .pop_front()
             .unwrap_or(Ok(()))

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -88,6 +88,8 @@ pub enum SandboxOperation {
     BoundedExec,
     /// [`Sandbox::write_file`](crate::Sandbox::write_file).
     WriteFile,
+    /// [`Sandbox::write_files`](crate::Sandbox::write_files).
+    WriteFiles,
     /// [`Sandbox::spawn_watch`](crate::Sandbox::spawn_watch).
     SpawnWatch,
     /// [`Sandbox::wait_exit`](crate::Sandbox::wait_exit).
@@ -100,6 +102,7 @@ impl fmt::Display for SandboxOperation {
             Self::Exec => f.write_str("exec"),
             Self::BoundedExec => f.write_str("bounded exec"),
             Self::WriteFile => f.write_str("write file"),
+            Self::WriteFiles => f.write_str("write files"),
             Self::SpawnWatch => f.write_str("spawn watch"),
             Self::WaitExit => f.write_str("wait exit"),
         }

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -47,4 +47,5 @@ pub use types::{
     BoundedExecCapturePolicy, BoundedExecOutput, BoundedExecOutputEvent, BoundedExecOutputRequest,
     BoundedExecRequest, BoundedExecResult, BoundedExecStream, BoundedExecStreamPolicy,
     BoundedExecTermination, ExecRequest, ExecResult, ProcessExit, SpawnHandle, SpawnOutputMode,
+    WriteFileRequest, WriteFileSource,
 };

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -24,7 +24,8 @@
 //! # Operations
 //! Once running, callers invoke [`exec`](Sandbox::exec) /
 //! [`bounded_exec`](Sandbox::bounded_exec) /
-//! [`write_file`](Sandbox::write_file) / [`spawn_watch`](Sandbox::spawn_watch) /
+//! [`write_file`](Sandbox::write_file) / [`write_files`](Sandbox::write_files) /
+//! [`spawn_watch`](Sandbox::spawn_watch) /
 //! [`wait_exit`](Sandbox::wait_exit) via the host-to-guest IPC channel
 //! (vsock, in the Firecracker backend). Operations race against a crash
 //! notifier so that a dying backend process surfaces as a specific
@@ -38,6 +39,7 @@ use async_trait::async_trait;
 use crate::error::Result;
 use crate::types::{
     BoundedExecRequest, BoundedExecResult, ExecRequest, ExecResult, ProcessExit, SpawnHandle,
+    WriteFileRequest,
 };
 
 /// A process-isolation environment that runs guest workloads for the runner.
@@ -63,8 +65,9 @@ use crate::types::{
 /// # Operations
 /// Once running, callers invoke [`exec`](Self::exec) /
 /// [`bounded_exec`](Self::bounded_exec) / [`write_file`](Self::write_file) /
-/// [`spawn_watch`](Self::spawn_watch) / [`wait_exit`](Self::wait_exit) via
-/// the host-to-guest IPC channel (vsock, in the Firecracker backend).
+/// [`write_files`](Self::write_files) / [`spawn_watch`](Self::spawn_watch) /
+/// [`wait_exit`](Self::wait_exit) via the host-to-guest IPC channel (vsock,
+/// in the Firecracker backend).
 /// Operations race against a crash notifier so that a dying backend process
 /// surfaces as a specific error rather than an opaque IPC timeout.
 ///
@@ -209,6 +212,10 @@ pub trait Sandbox: Send + Sync + Any {
     /// directories and truncating the file as needed. Returns an error if
     /// the sandbox is not running or if the backing process crashes.
     async fn write_file(&self, path: &str, content: &[u8]) -> Result<()>;
+    /// Write a batch of files inside the guest, creating parent directories
+    /// and truncating files as needed. Returns an error if the sandbox is not
+    /// running or if the backing process crashes.
+    async fn write_files(&self, files: &[WriteFileRequest<'_>]) -> Result<()>;
     /// Spawn `request.cmd` in the guest and return a handle for later
     /// supervision via [`wait_exit`](Self::wait_exit).
     ///

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -209,12 +209,15 @@ pub trait Sandbox: Send + Sync + Any {
     /// process crashes during execution, or if the host/guest transport fails.
     async fn bounded_exec(&self, request: &BoundedExecRequest<'_>) -> Result<BoundedExecResult>;
     /// Write `content` to `path` inside the guest, creating parent
-    /// directories and truncating the file as needed. Returns an error if
-    /// the sandbox is not running or if the backing process crashes.
+    /// directories and truncating the file as needed. This has shell-like
+    /// create/truncate/write semantics: a failed write may leave an empty or
+    /// partial target. Returns an error if the sandbox is not running or if
+    /// the backing process crashes.
     async fn write_file(&self, path: &str, content: &[u8]) -> Result<()>;
     /// Write a batch of files inside the guest, creating parent directories
-    /// and truncating files as needed. Returns an error if the sandbox is not
-    /// running or if the backing process crashes.
+    /// and truncating files as needed. This is not a cross-file transaction:
+    /// already-written files are not rolled back on later failure. Returns an
+    /// error if the sandbox is not running or if the backing process crashes.
     async fn write_files(&self, files: &[WriteFileRequest<'_>]) -> Result<()>;
     /// Spawn `request.cmd` in the guest and return a handle for later
     /// supervision via [`wait_exit`](Self::wait_exit).

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -93,6 +94,16 @@ pub struct ExecResult {
     pub exit_code: i32,
     pub stdout: Vec<u8>,
     pub stderr: Vec<u8>,
+}
+
+pub enum WriteFileSource<'a> {
+    Bytes(&'a [u8]),
+    File { path: &'a Path, len: u64 },
+}
+
+pub struct WriteFileRequest<'a> {
+    pub path: &'a str,
+    pub source: WriteFileSource<'a>,
 }
 
 pub struct SpawnHandle {

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -98,7 +98,15 @@ pub struct ExecResult {
 
 pub enum WriteFileSource<'a> {
     Bytes(&'a [u8]),
-    File { path: &'a Path, len: u64 },
+    /// Stream bytes from a regular host-side file.
+    ///
+    /// `len` must match the file's metadata length. Implementations may check
+    /// this before and during streaming, so callers must keep the source file
+    /// unchanged until the write finishes.
+    File {
+        path: &'a Path,
+        len: u64,
+    },
 }
 
 pub struct WriteFileRequest<'a> {

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::io::{self, Read};
 use std::os::unix::net::UnixStream;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -8,14 +8,14 @@ use std::time::Duration;
 
 use vsock_proto::{
     self, MSG_BOUNDED_EXEC, MSG_BOUNDED_EXEC_CANCEL, MSG_EXEC, MSG_EXEC_RESULT, MSG_READY,
-    MSG_SPAWN_WATCH,
+    MSG_SPAWN_WATCH, MSG_WRITE_FILES_START, RawMessage,
 };
 
 use crate::bounded_exec::{
     BoundedExecCleanup, BoundedExecWorkerRequest, spawn_bounded_exec_worker,
 };
 use crate::error::to_io_error;
-use crate::handlers::{MessageOutcome, handle_exec, handle_message};
+use crate::handlers::{MessageOutcome, handle_exec, handle_message, handle_write_files_stream};
 use crate::log::log;
 use crate::monitor::{SpawnWatchRequest, handle_spawn_watch};
 use crate::threading::{SystemThreadSpawner, ThreadSpawner};
@@ -40,6 +40,46 @@ struct ExecWorkerRequest {
     env: Vec<(String, String)>,
     sudo: bool,
     seq: u32,
+}
+
+struct MessageReader {
+    reader: UnixStream,
+    decoder: vsock_proto::Decoder,
+    queue: VecDeque<RawMessage>,
+    buf: [u8; READ_BUFFER_SIZE],
+}
+
+impl MessageReader {
+    fn new(reader: UnixStream, decoder: vsock_proto::Decoder) -> Self {
+        Self {
+            reader,
+            decoder,
+            queue: VecDeque::new(),
+            buf: [0u8; READ_BUFFER_SIZE],
+        }
+    }
+
+    fn next_message(&mut self) -> io::Result<Option<RawMessage>> {
+        if let Some(msg) = self.queue.pop_front() {
+            return Ok(Some(msg));
+        }
+        loop {
+            let n = self.reader.read(&mut self.buf)?;
+            if n == 0 {
+                return Ok(None);
+            }
+            for msg in self
+                .decoder
+                .decode(self.buf.get(..n).unwrap_or_default())
+                .map_err(to_io_error)?
+            {
+                self.queue.push_back(msg);
+            }
+            if let Some(msg) = self.queue.pop_front() {
+                return Ok(Some(msg));
+            }
+        }
+    }
 }
 
 /// Signals all command work spawned for this host connection when the
@@ -116,13 +156,13 @@ pub fn handle_connection(stream: UnixStream) -> io::Result<()> {
 fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEnd> {
     // Clone the stream to get separate reader and writer
     // This avoids deadlock: reader can block while writer sends process_exit
-    let mut reader = stream.try_clone()?;
+    let reader = stream.try_clone()?;
     let writer = GuestWriter::new(stream);
     let connection_cancel = Arc::new(AtomicBool::new(false));
     let _cancel_on_drop = ConnectionCancelGuard(connection_cancel.clone());
     let bounded_exec_cancels = Arc::new(Mutex::new(HashMap::<u32, Arc<AtomicBool>>::new()));
 
-    let mut decoder = vsock_proto::Decoder::new();
+    let decoder = vsock_proto::Decoder::new();
 
     // Send ready signal
     {
@@ -131,124 +171,113 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
     }
     log("INFO", "Sent ready signal");
 
-    let mut buf = [0u8; READ_BUFFER_SIZE];
-    loop {
-        // Read from stream (reader is separate, no lock needed)
-        let n = reader.read(&mut buf)?;
-
-        if n == 0 {
-            break;
-        }
-
-        // n <= buf.len() is guaranteed by read()
-        for msg in decoder
-            .decode(buf.get(..n).unwrap_or_default())
-            .map_err(to_io_error)?
-        {
-            // Command-style messages run in background threads to avoid
-            // blocking the event loop. A blocking child process (e.g. reading a
-            // pipe fd) would otherwise stall all subsequent messages.
-            if msg.msg_type == MSG_SPAWN_WATCH {
-                let d = vsock_proto::decode_spawn_watch(&msg.payload).map_err(to_io_error)?;
-                // handle_spawn_watch writes the response itself (before
-                // spawning the streaming thread) to prevent a race where
-                // stdout chunks could arrive at the host before the result.
-                handle_spawn_watch(
-                    SpawnWatchRequest {
-                        timeout_ms: d.exec.timeout_ms,
-                        command: d.exec.command,
-                        env: &d.exec.env,
-                        sudo: d.exec.sudo,
-                        stream_stdout: d.stream_stdout,
-                        stdout_log_path: d.stdout_log_path,
-                    },
-                    msg.seq,
-                    writer.clone(),
-                    connection_cancel.clone(),
-                )?;
-            } else if msg.msg_type == MSG_BOUNDED_EXEC {
-                log(
-                    "INFO",
-                    &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),
-                );
-                let decoded =
-                    vsock_proto::decode_bounded_exec(&msg.payload).map_err(to_io_error)?;
-                let request_cancel = Arc::new(AtomicBool::new(false));
-                {
-                    let mut cancels = bounded_exec_cancels
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner());
-                    if let Some(previous) = cancels.insert(msg.seq, request_cancel.clone()) {
-                        previous.store(true, Ordering::Release);
-                    }
-                }
-                let cleanup_cancels = Arc::clone(&bounded_exec_cancels);
-                let cleanup_cancel = Arc::clone(&request_cancel);
-                let cleanup_seq = msg.seq;
-                let cleanup: BoundedExecCleanup = Box::new(move || {
-                    let mut cancels = cleanup_cancels.lock().unwrap_or_else(|e| e.into_inner());
-                    if cancels
-                        .get(&cleanup_seq)
-                        .is_some_and(|current| Arc::ptr_eq(current, &cleanup_cancel))
-                    {
-                        cancels.remove(&cleanup_seq);
-                    }
-                });
-                spawn_bounded_exec_worker(
-                    BoundedExecWorkerRequest::from_decoded(msg.seq, decoded),
-                    writer.clone(),
-                    connection_cancel.clone(),
-                    request_cancel,
-                    cleanup,
-                )?;
-            } else if msg.msg_type == MSG_BOUNDED_EXEC_CANCEL {
-                if let Some(cancel) = bounded_exec_cancels
+    let mut message_reader = MessageReader::new(reader, decoder);
+    while let Some(msg) = message_reader.next_message()? {
+        // Command-style messages run in background threads to avoid
+        // blocking the event loop. A blocking child process (e.g. reading a
+        // pipe fd) would otherwise stall all subsequent messages.
+        if msg.msg_type == MSG_SPAWN_WATCH {
+            let d = vsock_proto::decode_spawn_watch(&msg.payload).map_err(to_io_error)?;
+            // handle_spawn_watch writes the response itself (before
+            // spawning the streaming thread) to prevent a race where
+            // stdout chunks could arrive at the host before the result.
+            handle_spawn_watch(
+                SpawnWatchRequest {
+                    timeout_ms: d.exec.timeout_ms,
+                    command: d.exec.command,
+                    env: &d.exec.env,
+                    sudo: d.exec.sudo,
+                    stream_stdout: d.stream_stdout,
+                    stdout_log_path: d.stdout_log_path,
+                },
+                msg.seq,
+                writer.clone(),
+                connection_cancel.clone(),
+            )?;
+        } else if msg.msg_type == MSG_WRITE_FILES_START {
+            let response = handle_write_files_stream(&msg, || message_reader.next_message())?;
+            writer.write_frame(&response)?;
+        } else if msg.msg_type == MSG_BOUNDED_EXEC {
+            log(
+                "INFO",
+                &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),
+            );
+            let decoded = vsock_proto::decode_bounded_exec(&msg.payload).map_err(to_io_error)?;
+            let request_cancel = Arc::new(AtomicBool::new(false));
+            {
+                let mut cancels = bounded_exec_cancels
                     .lock()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .get(&msg.seq)
-                {
-                    cancel.store(true, Ordering::Release);
+                    .unwrap_or_else(|e| e.into_inner());
+                if let Some(previous) = cancels.insert(msg.seq, request_cancel.clone()) {
+                    previous.store(true, Ordering::Release);
                 }
-            } else if msg.msg_type == MSG_EXEC {
-                // Legacy buffered exec path. New request/response command
-                // execution should use MSG_BOUNDED_EXEC.
-                log(
-                    "INFO",
-                    &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),
-                );
-                let d = vsock_proto::decode_exec(&msg.payload).map_err(to_io_error)?;
-                let timeout_ms = d.timeout_ms;
-                let command = d.command.to_owned();
-                let env: Vec<(String, String)> = d
-                    .env
-                    .iter()
-                    .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
-                    .collect();
-                let sudo = d.sudo;
-                let seq = msg.seq;
-                spawn_exec_worker(
-                    ExecWorkerRequest {
-                        timeout_ms,
-                        command,
-                        env,
-                        sudo,
-                        seq,
-                    },
-                    writer.clone(),
-                    connection_cancel.clone(),
-                )?;
-            } else {
-                match handle_message(&msg)? {
-                    MessageOutcome::Response(response) => {
-                        writer.write_frame(&response)?;
+            }
+            let cleanup_cancels = Arc::clone(&bounded_exec_cancels);
+            let cleanup_cancel = Arc::clone(&request_cancel);
+            let cleanup_seq = msg.seq;
+            let cleanup: BoundedExecCleanup = Box::new(move || {
+                let mut cancels = cleanup_cancels.lock().unwrap_or_else(|e| e.into_inner());
+                if cancels
+                    .get(&cleanup_seq)
+                    .is_some_and(|current| Arc::ptr_eq(current, &cleanup_cancel))
+                {
+                    cancels.remove(&cleanup_seq);
+                }
+            });
+            spawn_bounded_exec_worker(
+                BoundedExecWorkerRequest::from_decoded(msg.seq, decoded),
+                writer.clone(),
+                connection_cancel.clone(),
+                request_cancel,
+                cleanup,
+            )?;
+        } else if msg.msg_type == MSG_BOUNDED_EXEC_CANCEL {
+            if let Some(cancel) = bounded_exec_cancels
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .get(&msg.seq)
+            {
+                cancel.store(true, Ordering::Release);
+            }
+        } else if msg.msg_type == MSG_EXEC {
+            // Legacy buffered exec path. New request/response command
+            // execution should use MSG_BOUNDED_EXEC.
+            log(
+                "INFO",
+                &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),
+            );
+            let d = vsock_proto::decode_exec(&msg.payload).map_err(to_io_error)?;
+            let timeout_ms = d.timeout_ms;
+            let command = d.command.to_owned();
+            let env: Vec<(String, String)> = d
+                .env
+                .iter()
+                .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+                .collect();
+            let sudo = d.sudo;
+            let seq = msg.seq;
+            spawn_exec_worker(
+                ExecWorkerRequest {
+                    timeout_ms,
+                    command,
+                    env,
+                    sudo,
+                    seq,
+                },
+                writer.clone(),
+                connection_cancel.clone(),
+            )?;
+        } else {
+            match handle_message(&msg)? {
+                MessageOutcome::Response(response) => {
+                    writer.write_frame(&response)?;
+                }
+                MessageOutcome::Shutdown(response) => {
+                    if let Err(e) = writer.write_frame(&response) {
+                        log("WARN", &format!("Failed to send shutdown_ack: {e}"));
                     }
-                    MessageOutcome::Shutdown(response) => {
-                        if let Err(e) = writer.write_frame(&response) {
-                            log("WARN", &format!("Failed to send shutdown_ack: {e}"));
-                        }
-                        log("INFO", "Shutdown complete, exiting");
-                        return Ok(ConnectionEnd::Shutdown);
-                    }
+                    log("INFO", "Shutdown complete, exiting");
+                    return Ok(ConnectionEnd::Shutdown);
                 }
             }
         }

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -619,21 +619,12 @@ impl BatchChild {
     }
 }
 
-fn write_files_result_response(
-    seq: u32,
-    file_count: u32,
-    success: bool,
-    error: &str,
-) -> io::Result<Vec<u8>> {
+fn write_files_success_response(seq: u32, file_count: u32) -> io::Result<Vec<u8>> {
     let entries: Vec<WriteFilesResultEntry> = (0..file_count)
         .map(|file_index| WriteFilesResultEntry {
             file_index,
-            success,
-            error: if success {
-                String::new()
-            } else {
-                error.to_string()
-            },
+            success: true,
+            error: String::new(),
         })
         .collect();
     let payload = vsock_proto::encode_write_files_result(&entries).map_err(to_io_error)?;
@@ -656,7 +647,7 @@ where
     let child = match BatchChild::spawn(start.sudo) {
         Ok(child) => child,
         Err(error) => {
-            return write_files_result_response(start_msg.seq, start.file_count, false, &error);
+            return error_response(start_msg.seq, error);
         }
     };
     let mut batch_header = Vec::with_capacity(BATCH_MAGIC.len() + 4);
@@ -665,7 +656,7 @@ where
     {
         let error = e.to_string();
         child.kill();
-        return write_files_result_response(start_msg.seq, start.file_count, false, &error);
+        return error_response(start_msg.seq, error);
     }
 
     let mut seen = HashSet::new();
@@ -736,12 +727,7 @@ where
                 {
                     let error = e.to_string();
                     child.kill();
-                    return write_files_result_response(
-                        start_msg.seq,
-                        start.file_count,
-                        false,
-                        &error,
-                    );
+                    return error_response(start_msg.seq, error);
                 }
                 if file.content_len > 0 {
                     current = Some((file.file_index, file.content_len));
@@ -772,12 +758,7 @@ where
                 if let Err(e) = child.write_chunk_payload(msg.payload) {
                     let error = e.to_string();
                     child.kill();
-                    return write_files_result_response(
-                        start_msg.seq,
-                        start.file_count,
-                        false,
-                        &error,
-                    );
+                    return error_response(start_msg.seq, error);
                 }
                 let next_remaining = remaining - chunk_len;
                 current = (next_remaining > 0).then_some((file_index, next_remaining));
@@ -798,22 +779,15 @@ where
                     );
                 }
                 let (success, error) = child.finish();
-                return write_files_result_response(
-                    start_msg.seq,
-                    start.file_count,
-                    success,
-                    &error,
-                );
+                if success {
+                    return write_files_success_response(start_msg.seq, start.file_count);
+                }
+                return error_response(start_msg.seq, error);
             }
             MSG_WRITE_FILES_ABORT => {
                 let _ = vsock_proto::decode_write_files_abort(&msg.payload);
                 child.kill();
-                return write_files_result_response(
-                    start_msg.seq,
-                    start.file_count,
-                    false,
-                    "write_files aborted",
-                );
+                return error_response(start_msg.seq, "write_files aborted");
             }
             _ => {
                 child.kill();
@@ -1120,6 +1094,42 @@ mod tests {
             error.contains("write_files_chunk too short"),
             "got: {error}"
         );
+    }
+
+    #[test]
+    fn write_files_stream_batch_failure_returns_single_error_response() {
+        let _guard = WRITE_FILE_CHILD_TESTS.lock().unwrap();
+        let _path_guard = install_test_guest_write_file(
+            "cat >/dev/null; printf '%*s' 20000 '' | tr ' ' x >&2; exit 1",
+        );
+        let file_count = vsock_proto::MAX_WRITE_FILES_COUNT as u32;
+        let start_payload = vsock_proto::encode_write_files_start(false, file_count, 0).unwrap();
+        let start = RawMessage {
+            msg_type: vsock_proto::MSG_WRITE_FILES_START,
+            seq: 9,
+            payload: start_payload,
+        };
+        let mut messages = VecDeque::new();
+        for file_index in 0..file_count {
+            let path = format!("/tmp/file-{file_index}");
+            messages.push_back(RawMessage {
+                msg_type: MSG_WRITE_FILES_FILE,
+                seq: 9,
+                payload: vsock_proto::encode_write_files_file(file_index, &path, 0).unwrap(),
+            });
+        }
+        messages.push_back(RawMessage {
+            msg_type: MSG_WRITE_FILES_FINISH,
+            seq: 9,
+            payload: Vec::new(),
+        });
+
+        let response = handle_write_files_stream(&start, || Ok(messages.pop_front())).unwrap();
+        let response = decode_single_response(&response);
+
+        assert_eq!(response.msg_type, MSG_ERROR);
+        let error = vsock_proto::decode_error(&response.payload).unwrap();
+        assert!(error.contains("write failed:"), "got: {error}");
     }
 
     #[test]

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -673,12 +673,19 @@ where
     let mut received_total = 0u64;
 
     loop {
-        let Some(msg) = next_msg()? else {
-            child.kill();
-            return Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "connection closed during write_files stream",
-            ));
+        let msg = match next_msg() {
+            Ok(Some(msg)) => msg,
+            Ok(None) => {
+                child.kill();
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "connection closed during write_files stream",
+                ));
+            }
+            Err(e) => {
+                child.kill();
+                return Err(e);
+            }
         };
         if msg.seq != start_msg.seq {
             child.kill();
@@ -693,8 +700,13 @@ where
                         "write_files file started before prior file completed",
                     );
                 }
-                let file =
-                    vsock_proto::decode_write_files_file(&msg.payload).map_err(to_io_error)?;
+                let file = match vsock_proto::decode_write_files_file(&msg.payload) {
+                    Ok(file) => file,
+                    Err(e) => {
+                        child.kill();
+                        return error_response(start_msg.seq, e.to_string());
+                    }
+                };
                 if file.file_index >= start.file_count {
                     child.kill();
                     return error_response(start_msg.seq, "write_files file index out of range");
@@ -737,8 +749,13 @@ where
                 received_total += file.content_len;
             }
             MSG_WRITE_FILES_CHUNK => {
-                let chunk =
-                    vsock_proto::decode_write_files_chunk(&msg.payload).map_err(to_io_error)?;
+                let chunk = match vsock_proto::decode_write_files_chunk(&msg.payload) {
+                    Ok(chunk) => chunk,
+                    Err(e) => {
+                        child.kill();
+                        return error_response(start_msg.seq, e.to_string());
+                    }
+                };
                 let Some((file_index, remaining)) = current else {
                     child.kill();
                     return error_response(start_msg.seq, "write_files chunk without active file");
@@ -845,9 +862,59 @@ pub(crate) fn handle_message(msg: &RawMessage) -> io::Result<MessageOutcome> {
 mod tests {
     use super::*;
     use crate::threading::test_support::FailingThreadSpawner;
+    use std::os::unix::fs::PermissionsExt;
     use std::sync::Mutex;
 
     static WRITE_FILE_CHILD_TESTS: Mutex<()> = Mutex::new(());
+
+    struct DebugGuestWriteFilePathGuard {
+        previous: Option<PathBuf>,
+        dir: PathBuf,
+    }
+
+    impl Drop for DebugGuestWriteFilePathGuard {
+        fn drop(&mut self) {
+            *DEBUG_GUEST_WRITE_FILE_PATH
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()) = self.previous.take();
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    fn install_test_guest_write_file(script: &str) -> DebugGuestWriteFilePathGuard {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "vm0-vsock-guest-write-file-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("guest-write-file");
+        std::fs::write(&path, format!("#!/bin/sh\n{script}\n")).unwrap();
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&path, permissions).unwrap();
+
+        let previous = {
+            let mut guard = DEBUG_GUEST_WRITE_FILE_PATH
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let previous = guard.clone();
+            *guard = Some(path);
+            previous
+        };
+
+        DebugGuestWriteFilePathGuard { previous, dir }
+    }
+
+    fn decode_single_response(response: &[u8]) -> RawMessage {
+        let mut decoder = vsock_proto::Decoder::new();
+        let mut messages = decoder.decode(response).unwrap();
+        assert_eq!(messages.len(), 1);
+        messages.remove(0)
+    }
 
     fn spawn_write_file_test_child(script: &str) -> Child {
         // Use a stable shell binary instead of a freshly written temp
@@ -994,6 +1061,65 @@ mod tests {
             _ => panic!("expected queue to remain usable after oversized item rejection"),
         }
         assert!(queue.recv().is_none());
+    }
+
+    #[test]
+    fn write_files_stream_malformed_file_payload_returns_error_response() {
+        let _guard = WRITE_FILE_CHILD_TESTS.lock().unwrap();
+        let _path_guard = install_test_guest_write_file("cat >/dev/null");
+        let start_payload = vsock_proto::encode_write_files_start(false, 1, 1).unwrap();
+        let start = RawMessage {
+            msg_type: vsock_proto::MSG_WRITE_FILES_START,
+            seq: 7,
+            payload: start_payload,
+        };
+        let mut messages = VecDeque::from([RawMessage {
+            msg_type: MSG_WRITE_FILES_FILE,
+            seq: 7,
+            payload: vec![0],
+        }]);
+
+        let response = handle_write_files_stream(&start, || Ok(messages.pop_front())).unwrap();
+        let response = decode_single_response(&response);
+
+        assert_eq!(response.msg_type, MSG_ERROR);
+        let error = vsock_proto::decode_error(&response.payload).unwrap();
+        assert!(error.contains("write_files_file too short"), "got: {error}");
+    }
+
+    #[test]
+    fn write_files_stream_malformed_chunk_payload_returns_error_response() {
+        let _guard = WRITE_FILE_CHILD_TESTS.lock().unwrap();
+        let _path_guard = install_test_guest_write_file("cat >/dev/null");
+        let start_payload = vsock_proto::encode_write_files_start(false, 1, 1).unwrap();
+        let start = RawMessage {
+            msg_type: vsock_proto::MSG_WRITE_FILES_START,
+            seq: 8,
+            payload: start_payload,
+        };
+        let file_payload = vsock_proto::encode_write_files_file(0, "/tmp/file", 1).unwrap();
+        let mut messages = VecDeque::from([
+            RawMessage {
+                msg_type: MSG_WRITE_FILES_FILE,
+                seq: 8,
+                payload: file_payload,
+            },
+            RawMessage {
+                msg_type: MSG_WRITE_FILES_CHUNK,
+                seq: 8,
+                payload: vec![0],
+            },
+        ]);
+
+        let response = handle_write_files_stream(&start, || Ok(messages.pop_front())).unwrap();
+        let response = decode_single_response(&response);
+
+        assert_eq!(response.msg_type, MSG_ERROR);
+        let error = vsock_proto::decode_error(&response.payload).unwrap();
+        assert!(
+            error.contains("write_files_chunk too short"),
+            "got: {error}"
+        );
     }
 
     #[test]

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -97,24 +97,16 @@ pub(crate) fn handle_exec(
 }
 
 /// Handle write_file message
-fn handle_write_file(path: &str, content: &[u8], use_sudo: bool, append: bool) -> (bool, String) {
+fn handle_write_file(path: &str, content: &[u8], use_sudo: bool) -> (bool, String) {
     log(
         "INFO",
         &format!(
-            "write_file: path={} size={} sudo={} append={}",
+            "write_file: path={} size={} sudo={}",
             path,
             content.len(),
             use_sudo,
-            append,
         ),
     );
-
-    if append {
-        return (
-            false,
-            "append write_file is no longer supported".to_string(),
-        );
-    }
 
     let child = match spawn_write_files_command(use_sudo) {
         Ok(c) => c,
@@ -603,9 +595,9 @@ pub(crate) fn handle_message(msg: &RawMessage) -> io::Result<MessageOutcome> {
             vsock_proto::encode(MSG_PONG, msg.seq, &[]).map_err(to_io_error)?,
         )),
         MSG_WRITE_FILE => {
-            let (path, content, use_sudo, append) =
+            let (path, content, use_sudo) =
                 vsock_proto::decode_write_file(&msg.payload).map_err(to_io_error)?;
-            let (success, error) = handle_write_file(path, content, use_sudo, append);
+            let (success, error) = handle_write_file(path, content, use_sudo);
             let payload = vsock_proto::encode_write_file_result(success, &error);
             Ok(MessageOutcome::Response(
                 vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload)

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -1163,6 +1163,97 @@ mod tests {
     }
 
     #[test]
+    fn write_files_stream_rejects_wrong_seq() {
+        assert_write_files_stream_error(
+            write_files_start(15, 1, 0),
+            vec![write_files_message(
+                MSG_WRITE_FILES_FILE,
+                16,
+                vsock_proto::encode_write_files_file(0, "/tmp/file", 0).unwrap(),
+            )],
+            "write_files stream received wrong seq",
+        );
+    }
+
+    #[test]
+    fn write_files_stream_rejects_file_content_len_over_total() {
+        assert_write_files_stream_error(
+            write_files_start(16, 1, 1),
+            vec![write_files_message(
+                MSG_WRITE_FILES_FILE,
+                16,
+                vsock_proto::encode_write_files_file(0, "/tmp/file", 2).unwrap(),
+            )],
+            "write_files content length exceeds total",
+        );
+    }
+
+    #[test]
+    fn write_files_stream_rejects_chunk_index_mismatch() {
+        assert_write_files_stream_error(
+            write_files_start(17, 1, 1),
+            vec![
+                write_files_message(
+                    MSG_WRITE_FILES_FILE,
+                    17,
+                    vsock_proto::encode_write_files_file(0, "/tmp/file", 1).unwrap(),
+                ),
+                write_files_message(
+                    MSG_WRITE_FILES_CHUNK,
+                    17,
+                    vsock_proto::encode_write_files_chunk(1, b"x").unwrap(),
+                ),
+            ],
+            "write_files chunk index mismatch",
+        );
+    }
+
+    #[test]
+    fn write_files_stream_rejects_chunk_exceeding_file_len() {
+        assert_write_files_stream_error(
+            write_files_start(18, 1, 1),
+            vec![
+                write_files_message(
+                    MSG_WRITE_FILES_FILE,
+                    18,
+                    vsock_proto::encode_write_files_file(0, "/tmp/file", 1).unwrap(),
+                ),
+                write_files_message(
+                    MSG_WRITE_FILES_CHUNK,
+                    18,
+                    vsock_proto::encode_write_files_chunk(0, b"xy").unwrap(),
+                ),
+            ],
+            "write_files chunk exceeds file length",
+        );
+    }
+
+    #[test]
+    fn write_files_stream_rejects_finish_before_all_files_received() {
+        assert_write_files_stream_error(
+            write_files_start(19, 2, 0),
+            vec![
+                write_files_message(
+                    MSG_WRITE_FILES_FILE,
+                    19,
+                    vsock_proto::encode_write_files_file(0, "/tmp/a", 0).unwrap(),
+                ),
+                write_files_message(MSG_WRITE_FILES_FINISH, 19, Vec::new()),
+            ],
+            "write_files finish before all files received",
+        );
+    }
+
+    #[test]
+    fn write_files_stream_rejects_unexpected_message_type() {
+        assert_write_files_stream_error(
+            write_files_start(20, 1, 0),
+            vec![write_files_message(MSG_PING, 20, Vec::new())],
+            "unexpected message in write_files stream",
+        );
+    }
+
+    #[test]
     fn write_files_stream_batch_failure_returns_single_error_response() {
         let _guard = WRITE_FILE_CHILD_TESTS.lock().unwrap();
         let _path_guard = install_test_guest_write_file(

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -2,10 +2,10 @@ use std::collections::HashSet;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process::{Child, ChildStdin, Command, Stdio};
-use std::sync::Arc;
 #[cfg(any(debug_assertions, feature = "test-support"))]
 use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, mpsc};
 use std::thread::JoinHandle;
 
 use vsock_proto::{
@@ -34,6 +34,7 @@ const THREAD_WRITE_STDIN: &str = "vsock-write-stdin";
 const WRITE_TIMEOUT_MS: u32 = 30_000;
 const GUEST_WRITE_FILE_PATH: &str = "/sbin/guest-write-file";
 const BATCH_MAGIC: &[u8; 8] = b"VM0WFB1\n";
+const WRITE_FILES_CHUNK_DATA_OFFSET: usize = 8;
 #[cfg(any(debug_assertions, feature = "test-support"))]
 static DEBUG_GUEST_WRITE_FILE_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
 
@@ -306,18 +307,43 @@ pub(crate) fn set_debug_guest_write_file_path(path: PathBuf) -> Result<(), PathB
     Ok(())
 }
 
+enum BatchWrite {
+    Bytes(Vec<u8>),
+    WriteFilesChunkPayload(Vec<u8>),
+}
+
+impl BatchWrite {
+    fn write_to(self, stdin: &mut ChildStdin) -> io::Result<()> {
+        match self {
+            Self::Bytes(bytes) => stdin.write_all(&bytes),
+            Self::WriteFilesChunkPayload(payload) => {
+                let chunk = payload
+                    .get(WRITE_FILES_CHUNK_DATA_OFFSET..)
+                    .ok_or_else(|| io::Error::other("write_files chunk payload too short"))?;
+                stdin.write_all(chunk)
+            }
+        }
+    }
+}
+
 struct BatchChild {
     child: Child,
-    stdin: ChildStdin,
+    stdin_tx: Option<mpsc::Sender<BatchWrite>>,
+    stdin_handle: JoinHandle<io::Result<()>>,
+    stdin_done_rx: mpsc::Receiver<()>,
     stderr_handle: JoinHandle<Vec<u8>>,
-    done_rx: std::sync::mpsc::Receiver<()>,
+    stderr_done_rx: mpsc::Receiver<()>,
     cancel: Arc<AtomicBool>,
 }
 
 impl BatchChild {
     fn spawn(use_sudo: bool) -> Result<Self, String> {
-        let mut child = spawn_write_files_command(use_sudo)
+        let child = spawn_write_files_command(use_sudo)
             .map_err(|e| format!("Failed to spawn write command: {e}"))?;
+        Self::from_child(child)
+    }
+
+    fn from_child(mut child: Child) -> Result<Self, String> {
         let stdin = match child.stdin.take() {
             Some(stdin) => stdin,
             None => {
@@ -332,53 +358,112 @@ impl BatchChild {
                 return Err("missing stderr pipe".to_string());
             }
         };
+
+        // Keep helper stdin writes off the connection loop. The protocol total
+        // byte cap bounds this queue if the helper stops reading.
+        let (stdin_tx, stdin_rx) = mpsc::channel::<BatchWrite>();
+        let (stdin_done_tx, stdin_done_rx) = mpsc::channel::<()>();
+        let stdin_handle = match std::thread::Builder::new()
+            .name(THREAD_WRITE_STDIN.to_string())
+            .spawn(move || {
+                let mut stdin = stdin;
+                let result = (|| {
+                    for write in stdin_rx {
+                        write.write_to(&mut stdin)?;
+                    }
+                    stdin.flush()
+                })();
+                let _ = stdin_done_tx.send(());
+                result
+            }) {
+            Ok(handle) => handle,
+            Err(e) => {
+                kill_and_reap_child(child);
+                return Err(format!("Failed to spawn stdin writer thread: {e}"));
+            }
+        };
+
         let cancel = Arc::new(AtomicBool::new(false));
-        let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
+        let (stderr_done_tx, stderr_done_rx) = mpsc::channel::<()>();
         let drain_cancel = cancel.clone();
         let stderr_handle = match SystemThreadSpawner.spawn_vec(
             THREAD_WRITE_STDERR,
             Box::new(move || {
                 let buf = drain_into_vec_cancellable(stderr, &drain_cancel);
-                let _ = done_tx.send(());
+                let _ = stderr_done_tx.send(());
                 buf
             }),
         ) {
             Ok(handle) => handle,
             Err(e) => {
                 cancel.store(true, std::sync::atomic::Ordering::Release);
+                drop(stdin_tx);
                 kill_and_reap_child(child);
+                let _ = stdin_handle.join();
                 return Err(format!("Failed to spawn stderr drain thread: {e}"));
             }
         };
 
         Ok(Self {
             child,
-            stdin,
+            stdin_tx: Some(stdin_tx),
+            stdin_handle,
+            stdin_done_rx,
             stderr_handle,
-            done_rx,
+            stderr_done_rx,
             cancel,
         })
+    }
+
+    fn write_bytes(&self, bytes: Vec<u8>) -> io::Result<()> {
+        let tx = self
+            .stdin_tx
+            .as_ref()
+            .ok_or_else(|| io::Error::other("write command stdin already closed"))?;
+        tx.send(BatchWrite::Bytes(bytes))
+            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "write command stdin closed"))
+    }
+
+    fn write_chunk_payload(&self, payload: Vec<u8>) -> io::Result<()> {
+        let tx = self
+            .stdin_tx
+            .as_ref()
+            .ok_or_else(|| io::Error::other("write command stdin already closed"))?;
+        tx.send(BatchWrite::WriteFilesChunkPayload(payload))
+            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "write command stdin closed"))
     }
 
     fn kill(mut self) {
         self.cancel
             .store(true, std::sync::atomic::Ordering::Release);
-        let _ = self.stdin.flush();
-        drop(self.stdin);
+        drop(self.stdin_tx.take());
         kill_and_reap_child(self.child);
-        let _ = await_drain_deadline(&self.done_rx, 1, &self.cancel);
+        let _ = self.stdin_handle.join();
+        let _ = await_drain_deadline(&self.stderr_done_rx, 1, &self.cancel);
         let _ = self.stderr_handle.join();
     }
 
-    fn finish(mut self) -> (bool, String) {
+    fn finish(self) -> (bool, String) {
+        self.finish_with_timeout(WRITE_TIMEOUT_MS)
+    }
+
+    fn finish_with_timeout(mut self, timeout_ms: u32) -> (bool, String) {
         let child_pid = self.child.id();
-        let _ = self.stdin.flush();
-        drop(self.stdin);
-        let outcome = wait_with_kill_timeout(self.child, WRITE_TIMEOUT_MS);
-        if matches!(outcome, WaitOutcome::Exited(_) | WaitOutcome::WaitFailed(_)) {
+        drop(self.stdin_tx.take());
+        let outcome = wait_with_kill_timeout(self.child, timeout_ms);
+        if matches!(outcome, WaitOutcome::Exited(_) | WaitOutcome::WaitFailed(_))
+            && matches!(
+                self.stdin_done_rx.try_recv(),
+                Err(mpsc::TryRecvError::Empty)
+            )
+        {
             let _ = unsafe { kill_process_tree(child_pid) };
         }
-        let _ = await_drain_deadline(&self.done_rx, 1, &self.cancel);
+        let stdin_result = match self.stdin_handle.join() {
+            Ok(result) => result,
+            Err(panic) => std::panic::resume_unwind(panic),
+        };
+        let _ = await_drain_deadline(&self.stderr_done_rx, 1, &self.cancel);
         let stderr = self.stderr_handle.join().unwrap_or_default();
         match outcome {
             WaitOutcome::TimedOut => (false, "write timed out".to_string()),
@@ -387,7 +472,10 @@ impl BatchChild {
             WaitOutcome::Exited(status) => {
                 let exit_code = extract_exit_code(status);
                 if exit_code == 0 {
-                    (true, String::new())
+                    match stdin_result {
+                        Ok(()) => (true, String::new()),
+                        Err(e) => (false, format!("Failed to write to stdin: {e}")),
+                    }
                 } else {
                     (
                         false,
@@ -433,13 +521,16 @@ where
     F: FnMut() -> io::Result<Option<RawMessage>>,
 {
     let start = vsock_proto::decode_write_files_start(&start_msg.payload).map_err(to_io_error)?;
-    let mut child = match BatchChild::spawn(start.sudo) {
+    let child = match BatchChild::spawn(start.sudo) {
         Ok(child) => child,
         Err(error) => {
             return write_files_result_response(start_msg.seq, start.file_count, false, &error);
         }
     };
-    if let Err(e) = write_batch_header(&mut child.stdin, start.file_count) {
+    let mut batch_header = Vec::with_capacity(BATCH_MAGIC.len() + 4);
+    if let Err(e) = write_batch_header(&mut batch_header, start.file_count)
+        .and_then(|_| child.write_bytes(batch_header))
+    {
         let error = e.to_string();
         child.kill();
         return write_files_result_response(start_msg.seq, start.file_count, false, &error);
@@ -490,12 +581,15 @@ where
                         "write_files content length exceeds total",
                     );
                 }
+                let mut file_header = Vec::with_capacity(14 + file.path.len());
                 if let Err(e) = write_batch_file_header(
-                    &mut child.stdin,
+                    &mut file_header,
                     file.file_index,
                     file.path,
                     file.content_len,
-                ) {
+                )
+                .and_then(|_| child.write_bytes(file_header))
+                {
                     let error = e.to_string();
                     child.kill();
                     return write_files_result_response(
@@ -526,7 +620,7 @@ where
                     child.kill();
                     return error_response(start_msg.seq, "write_files chunk exceeds file length");
                 }
-                if let Err(e) = child.stdin.write_all(chunk.chunk) {
+                if let Err(e) = child.write_chunk_payload(msg.payload) {
                     let error = e.to_string();
                     child.kill();
                     return write_files_result_response(
@@ -685,6 +779,36 @@ mod tests {
 
         assert!(!success);
         assert_eq!(error, "write timed out");
+        assert!(!pid_alive(pid), "child pid {pid} should have been reaped");
+    }
+
+    #[test]
+    fn write_files_batch_timeout_kills_child_while_stdin_writer_is_blocked() {
+        let _guard = WRITE_FILE_CHILD_TESTS.lock().unwrap();
+        let child = spawn_write_file_test_child("sleep 60; cat >/dev/null");
+        let pid = child.id();
+        let batch = BatchChild::from_child(child).unwrap();
+
+        batch.write_bytes(vec![b'x'; 1024 * 1024]).unwrap();
+        let (success, error) = batch.finish_with_timeout(10);
+
+        assert!(!success);
+        assert_eq!(error, "write timed out");
+        assert!(!pid_alive(pid), "child pid {pid} should have been reaped");
+    }
+
+    #[test]
+    fn write_files_batch_kills_lingering_process_group_after_parent_exit() {
+        let _guard = WRITE_FILE_CHILD_TESTS.lock().unwrap();
+        let child = spawn_write_file_test_child("sleep 60 <&0 >/dev/null 2>/dev/null & exit 0");
+        let pid = child.id();
+        let batch = BatchChild::from_child(child).unwrap();
+
+        batch.write_bytes(vec![b'x'; 1024 * 1024]).unwrap();
+        let (success, error) = batch.finish_with_timeout(1_000);
+
+        assert!(!success);
+        assert!(error.contains("Failed to write to stdin"), "got: {error}");
         assert!(!pid_alive(pid), "child pid {pid} should have been reaped");
     }
 

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -109,11 +109,6 @@ fn handle_write_file(path: &str, content: &[u8], use_sudo: bool) -> (bool, Strin
         ),
     );
 
-    let child = match spawn_write_files_command(use_sudo) {
-        Ok(c) => c,
-        Err(e) => return (false, format!("Failed to spawn write command: {e}")),
-    };
-
     let mut batch = Vec::with_capacity(BATCH_MAGIC.len() + 4 + 14 + path.len() + content.len());
     if let Err(e) = write_batch_header(&mut batch, 1)
         .and_then(|_| write_batch_file_header(&mut batch, 0, path, content.len() as u64))
@@ -121,6 +116,11 @@ fn handle_write_file(path: &str, content: &[u8], use_sudo: bool) -> (bool, Strin
     {
         return (false, format!("Failed to encode write batch: {e}"));
     }
+
+    let child = match spawn_write_files_command(use_sudo) {
+        Ok(c) => c,
+        Err(e) => return (false, format!("Failed to spawn write command: {e}")),
+    };
 
     wait_write_file_child(child, &batch, SystemThreadSpawner)
 }

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -1,14 +1,17 @@
+use std::collections::HashSet;
 use std::io::{self, Write};
 use std::path::PathBuf;
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::Arc;
 #[cfg(any(debug_assertions, feature = "test-support"))]
 use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
+use std::thread::JoinHandle;
 
 use vsock_proto::{
     self, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
-    RawMessage,
+    MSG_WRITE_FILES_ABORT, MSG_WRITE_FILES_CHUNK, MSG_WRITE_FILES_FILE, MSG_WRITE_FILES_FINISH,
+    MSG_WRITE_FILES_RESULT, RawMessage, WriteFilesResultEntry,
 };
 
 use crate::drain::drain_into_vec_cancellable;
@@ -30,6 +33,7 @@ const THREAD_WRITE_STDERR: &str = "vsock-write-stderr";
 const THREAD_WRITE_STDIN: &str = "vsock-write-stdin";
 const WRITE_TIMEOUT_MS: u32 = 30_000;
 const GUEST_WRITE_FILE_PATH: &str = "/sbin/guest-write-file";
+const BATCH_MAGIC: &[u8; 8] = b"VM0WFB1\n";
 #[cfg(any(debug_assertions, feature = "test-support"))]
 static DEBUG_GUEST_WRITE_FILE_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
 
@@ -105,12 +109,27 @@ fn handle_write_file(path: &str, content: &[u8], use_sudo: bool, append: bool) -
         ),
     );
 
-    let child = match spawn_write_file_command(path, use_sudo, append) {
+    if append {
+        return (
+            false,
+            "append write_file is no longer supported".to_string(),
+        );
+    }
+
+    let child = match spawn_write_files_command(use_sudo) {
         Ok(c) => c,
         Err(e) => return (false, format!("Failed to spawn write command: {e}")),
     };
 
-    wait_write_file_child(child, content, SystemThreadSpawner)
+    let mut batch = Vec::with_capacity(BATCH_MAGIC.len() + 4 + 14 + path.len() + content.len());
+    if let Err(e) = write_batch_header(&mut batch, 1)
+        .and_then(|_| write_batch_file_header(&mut batch, 0, path, content.len() as u64))
+        .and_then(|_| batch.write_all(content))
+    {
+        return (false, format!("Failed to encode write batch: {e}"));
+    }
+
+    wait_write_file_child(child, &batch, SystemThreadSpawner)
 }
 
 fn wait_write_file_child<S>(child: Child, content: &[u8], spawner: S) -> (bool, String)
@@ -233,21 +252,42 @@ where
     })
 }
 
-fn spawn_write_file_command(path: &str, use_sudo: bool, append: bool) -> io::Result<Child> {
+fn spawn_write_files_command(use_sudo: bool) -> io::Result<Child> {
     let mut command = Command::new(guest_write_file_path());
-    if append {
-        command.arg("--append");
-    } else if !use_sudo {
+    command.arg("--batch");
+    if !use_sudo {
         command.arg("--create-parents");
     }
     command
-        .arg("--")
-        .arg(path)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
     apply_write_file_identity(&mut command, use_sudo)?;
     spawn_in_own_process_group(&mut command)
+}
+
+fn write_batch_header(writer: &mut impl Write, file_count: u32) -> io::Result<()> {
+    writer.write_all(BATCH_MAGIC)?;
+    writer.write_all(&file_count.to_be_bytes())
+}
+
+fn write_batch_file_header(
+    writer: &mut impl Write,
+    file_index: u32,
+    path: &str,
+    content_len: u64,
+) -> io::Result<()> {
+    let path_bytes = path.as_bytes();
+    let path_len = u16::try_from(path_bytes.len()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "write_files path too long for helper protocol",
+        )
+    })?;
+    writer.write_all(&file_index.to_be_bytes())?;
+    writer.write_all(&path_len.to_be_bytes())?;
+    writer.write_all(path_bytes)?;
+    writer.write_all(&content_len.to_be_bytes())
 }
 
 fn guest_write_file_path() -> PathBuf {
@@ -272,6 +312,280 @@ pub(crate) fn set_debug_guest_write_file_path(path: PathBuf) -> Result<(), PathB
         .lock()
         .unwrap_or_else(|e| e.into_inner()) = Some(path);
     Ok(())
+}
+
+struct BatchChild {
+    child: Child,
+    stdin: ChildStdin,
+    stderr_handle: JoinHandle<Vec<u8>>,
+    done_rx: std::sync::mpsc::Receiver<()>,
+    cancel: Arc<AtomicBool>,
+}
+
+impl BatchChild {
+    fn spawn(use_sudo: bool) -> Result<Self, String> {
+        let mut child = spawn_write_files_command(use_sudo)
+            .map_err(|e| format!("Failed to spawn write command: {e}"))?;
+        let stdin = match child.stdin.take() {
+            Some(stdin) => stdin,
+            None => {
+                kill_and_reap_child(child);
+                return Err("missing stdin pipe".to_string());
+            }
+        };
+        let stderr = match child.stderr.take() {
+            Some(stderr) => stderr,
+            None => {
+                kill_and_reap_child(child);
+                return Err("missing stderr pipe".to_string());
+            }
+        };
+        let cancel = Arc::new(AtomicBool::new(false));
+        let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
+        let drain_cancel = cancel.clone();
+        let stderr_handle = match SystemThreadSpawner.spawn_vec(
+            THREAD_WRITE_STDERR,
+            Box::new(move || {
+                let buf = drain_into_vec_cancellable(stderr, &drain_cancel);
+                let _ = done_tx.send(());
+                buf
+            }),
+        ) {
+            Ok(handle) => handle,
+            Err(e) => {
+                cancel.store(true, std::sync::atomic::Ordering::Release);
+                kill_and_reap_child(child);
+                return Err(format!("Failed to spawn stderr drain thread: {e}"));
+            }
+        };
+
+        Ok(Self {
+            child,
+            stdin,
+            stderr_handle,
+            done_rx,
+            cancel,
+        })
+    }
+
+    fn kill(mut self) {
+        self.cancel
+            .store(true, std::sync::atomic::Ordering::Release);
+        let _ = self.stdin.flush();
+        drop(self.stdin);
+        kill_and_reap_child(self.child);
+        let _ = await_drain_deadline(&self.done_rx, 1, &self.cancel);
+        let _ = self.stderr_handle.join();
+    }
+
+    fn finish(mut self) -> (bool, String) {
+        let child_pid = self.child.id();
+        let _ = self.stdin.flush();
+        drop(self.stdin);
+        let outcome = wait_with_kill_timeout(self.child, WRITE_TIMEOUT_MS);
+        if matches!(outcome, WaitOutcome::Exited(_) | WaitOutcome::WaitFailed(_)) {
+            let _ = unsafe { kill_process_tree(child_pid) };
+        }
+        let _ = await_drain_deadline(&self.done_rx, 1, &self.cancel);
+        let stderr = self.stderr_handle.join().unwrap_or_default();
+        match outcome {
+            WaitOutcome::TimedOut => (false, "write timed out".to_string()),
+            WaitOutcome::Cancelled => (false, "write cancelled".to_string()),
+            WaitOutcome::WaitFailed(msg) => (false, format!("write wait failed: {msg}")),
+            WaitOutcome::Exited(status) => {
+                let exit_code = extract_exit_code(status);
+                if exit_code == 0 {
+                    (true, String::new())
+                } else {
+                    (
+                        false,
+                        format!("write failed: {}", String::from_utf8_lossy(&stderr)),
+                    )
+                }
+            }
+        }
+    }
+}
+
+fn write_files_result_response(
+    seq: u32,
+    file_count: u32,
+    success: bool,
+    error: &str,
+) -> io::Result<Vec<u8>> {
+    let entries: Vec<WriteFilesResultEntry> = (0..file_count)
+        .map(|file_index| WriteFilesResultEntry {
+            file_index,
+            success,
+            error: if success {
+                String::new()
+            } else {
+                error.to_string()
+            },
+        })
+        .collect();
+    let payload = vsock_proto::encode_write_files_result(&entries).map_err(to_io_error)?;
+    vsock_proto::encode(MSG_WRITE_FILES_RESULT, seq, &payload).map_err(to_io_error)
+}
+
+fn error_response(seq: u32, message: impl AsRef<str>) -> io::Result<Vec<u8>> {
+    let payload = vsock_proto::encode_error(message.as_ref());
+    vsock_proto::encode(MSG_ERROR, seq, &payload).map_err(to_io_error)
+}
+
+pub(crate) fn handle_write_files_stream<F>(
+    start_msg: &RawMessage,
+    mut next_msg: F,
+) -> io::Result<Vec<u8>>
+where
+    F: FnMut() -> io::Result<Option<RawMessage>>,
+{
+    let start = vsock_proto::decode_write_files_start(&start_msg.payload).map_err(to_io_error)?;
+    let mut child = match BatchChild::spawn(start.sudo) {
+        Ok(child) => child,
+        Err(error) => {
+            return write_files_result_response(start_msg.seq, start.file_count, false, &error);
+        }
+    };
+    if let Err(e) = write_batch_header(&mut child.stdin, start.file_count) {
+        let error = e.to_string();
+        child.kill();
+        return write_files_result_response(start_msg.seq, start.file_count, false, &error);
+    }
+
+    let mut seen = HashSet::new();
+    let mut current: Option<(u32, u64)> = None;
+    let mut received_total = 0u64;
+
+    loop {
+        let Some(msg) = next_msg()? else {
+            child.kill();
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "connection closed during write_files stream",
+            ));
+        };
+        if msg.seq != start_msg.seq {
+            child.kill();
+            return error_response(start_msg.seq, "write_files stream received wrong seq");
+        }
+        match msg.msg_type {
+            MSG_WRITE_FILES_FILE => {
+                if current.is_some() {
+                    child.kill();
+                    return error_response(
+                        start_msg.seq,
+                        "write_files file started before prior file completed",
+                    );
+                }
+                let file =
+                    vsock_proto::decode_write_files_file(&msg.payload).map_err(to_io_error)?;
+                if file.file_index >= start.file_count {
+                    child.kill();
+                    return error_response(start_msg.seq, "write_files file index out of range");
+                }
+                if !seen.insert(file.file_index) {
+                    child.kill();
+                    return error_response(start_msg.seq, "write_files duplicate file index");
+                }
+                if received_total
+                    .checked_add(file.content_len)
+                    .is_none_or(|n| n > start.total_bytes)
+                {
+                    child.kill();
+                    return error_response(
+                        start_msg.seq,
+                        "write_files content length exceeds total",
+                    );
+                }
+                if let Err(e) = write_batch_file_header(
+                    &mut child.stdin,
+                    file.file_index,
+                    file.path,
+                    file.content_len,
+                ) {
+                    let error = e.to_string();
+                    child.kill();
+                    return write_files_result_response(
+                        start_msg.seq,
+                        start.file_count,
+                        false,
+                        &error,
+                    );
+                }
+                if file.content_len > 0 {
+                    current = Some((file.file_index, file.content_len));
+                }
+                received_total += file.content_len;
+            }
+            MSG_WRITE_FILES_CHUNK => {
+                let chunk =
+                    vsock_proto::decode_write_files_chunk(&msg.payload).map_err(to_io_error)?;
+                let Some((file_index, remaining)) = current else {
+                    child.kill();
+                    return error_response(start_msg.seq, "write_files chunk without active file");
+                };
+                if chunk.file_index != file_index {
+                    child.kill();
+                    return error_response(start_msg.seq, "write_files chunk index mismatch");
+                }
+                let chunk_len = chunk.chunk.len() as u64;
+                if chunk_len > remaining {
+                    child.kill();
+                    return error_response(start_msg.seq, "write_files chunk exceeds file length");
+                }
+                if let Err(e) = child.stdin.write_all(chunk.chunk) {
+                    let error = e.to_string();
+                    child.kill();
+                    return write_files_result_response(
+                        start_msg.seq,
+                        start.file_count,
+                        false,
+                        &error,
+                    );
+                }
+                let next_remaining = remaining - chunk_len;
+                current = (next_remaining > 0).then_some((file_index, next_remaining));
+            }
+            MSG_WRITE_FILES_FINISH => {
+                if current.is_some() {
+                    child.kill();
+                    return error_response(
+                        start_msg.seq,
+                        "write_files finish before file content complete",
+                    );
+                }
+                if seen.len() != start.file_count as usize || received_total != start.total_bytes {
+                    child.kill();
+                    return error_response(
+                        start_msg.seq,
+                        "write_files finish before all files received",
+                    );
+                }
+                let (success, error) = child.finish();
+                return write_files_result_response(
+                    start_msg.seq,
+                    start.file_count,
+                    success,
+                    &error,
+                );
+            }
+            MSG_WRITE_FILES_ABORT => {
+                let _ = vsock_proto::decode_write_files_abort(&msg.payload);
+                child.kill();
+                return write_files_result_response(
+                    start_msg.seq,
+                    start.file_count,
+                    false,
+                    "write_files aborted",
+                );
+            }
+            _ => {
+                child.kill();
+                return error_response(start_msg.seq, "unexpected message in write_files stream");
+            }
+        }
+    }
 }
 
 /// Handle incoming message and return the connection-loop outcome.

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -1163,6 +1163,31 @@ mod tests {
     }
 
     #[test]
+    fn write_files_stream_rejects_next_file_before_prior_content_complete() {
+        assert_write_files_stream_error(
+            write_files_start(21, 2, 2),
+            vec![
+                write_files_message(
+                    MSG_WRITE_FILES_FILE,
+                    21,
+                    vsock_proto::encode_write_files_file(0, "/tmp/a", 2).unwrap(),
+                ),
+                write_files_message(
+                    MSG_WRITE_FILES_CHUNK,
+                    21,
+                    vsock_proto::encode_write_files_chunk(0, b"x").unwrap(),
+                ),
+                write_files_message(
+                    MSG_WRITE_FILES_FILE,
+                    21,
+                    vsock_proto::encode_write_files_file(1, "/tmp/b", 0).unwrap(),
+                ),
+            ],
+            "write_files file started before prior file completed",
+        );
+    }
+
+    #[test]
     fn write_files_stream_rejects_wrong_seq() {
         assert_write_files_stream_error(
             write_files_start(15, 1, 0),
@@ -1185,6 +1210,27 @@ mod tests {
                 vsock_proto::encode_write_files_file(0, "/tmp/file", 2).unwrap(),
             )],
             "write_files content length exceeds total",
+        );
+    }
+
+    #[test]
+    fn write_files_stream_rejects_finish_before_declared_total_bytes() {
+        assert_write_files_stream_error(
+            write_files_start(22, 1, 2),
+            vec![
+                write_files_message(
+                    MSG_WRITE_FILES_FILE,
+                    22,
+                    vsock_proto::encode_write_files_file(0, "/tmp/file", 1).unwrap(),
+                ),
+                write_files_message(
+                    MSG_WRITE_FILES_CHUNK,
+                    22,
+                    vsock_proto::encode_write_files_chunk(0, b"x").unwrap(),
+                ),
+                write_files_message(MSG_WRITE_FILES_FINISH, 22, Vec::new()),
+            ],
+            "write_files finish before all files received",
         );
     }
 

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -1,12 +1,11 @@
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process::{Child, ChildStdin, Command, Stdio};
-#[cfg(any(debug_assertions, feature = "test-support"))]
-use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, mpsc};
+use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 use vsock_proto::{
     self, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
@@ -35,6 +34,7 @@ const WRITE_TIMEOUT_MS: u32 = 30_000;
 const GUEST_WRITE_FILE_PATH: &str = "/sbin/guest-write-file";
 const BATCH_MAGIC: &[u8; 8] = b"VM0WFB1\n";
 const WRITE_FILES_CHUNK_DATA_OFFSET: usize = 8;
+const WRITE_FILES_STDIN_QUEUE_BYTES: usize = 32 * 1024 * 1024;
 #[cfg(any(debug_assertions, feature = "test-support"))]
 static DEBUG_GUEST_WRITE_FILE_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
 
@@ -313,6 +313,12 @@ enum BatchWrite {
 }
 
 impl BatchWrite {
+    fn queued_len(&self) -> usize {
+        match self {
+            Self::Bytes(bytes) | Self::WriteFilesChunkPayload(bytes) => bytes.len(),
+        }
+    }
+
     fn write_to(self, stdin: &mut ChildStdin) -> io::Result<()> {
         match self {
             Self::Bytes(bytes) => stdin.write_all(&bytes),
@@ -326,9 +332,135 @@ impl BatchWrite {
     }
 }
 
+struct BatchWriteQueueState {
+    queue: VecDeque<BatchWrite>,
+    queued_bytes: usize,
+    closed: bool,
+}
+
+struct BatchWriteQueue {
+    state: Mutex<BatchWriteQueueState>,
+    available: Condvar,
+    space: Condvar,
+}
+
+impl BatchWriteQueue {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(BatchWriteQueueState {
+                queue: VecDeque::new(),
+                queued_bytes: 0,
+                closed: false,
+            }),
+            available: Condvar::new(),
+            space: Condvar::new(),
+        }
+    }
+
+    fn send(&self, write: BatchWrite, timeout: Duration) -> io::Result<()> {
+        self.send_with_limit(write, timeout, WRITE_FILES_STDIN_QUEUE_BYTES)
+    }
+
+    fn send_with_limit(
+        &self,
+        write: BatchWrite,
+        timeout: Duration,
+        max_queued_bytes: usize,
+    ) -> io::Result<()> {
+        let len = write.queued_len();
+        if len > max_queued_bytes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "write command stdin queue item exceeds limit",
+            ));
+        }
+
+        let deadline = Instant::now()
+            .checked_add(timeout)
+            .unwrap_or_else(Instant::now);
+        let mut write = Some(write);
+        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        loop {
+            if guard.closed {
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "write command stdin closed",
+                ));
+            }
+
+            if guard.queued_bytes.saturating_add(len) <= max_queued_bytes {
+                guard.queued_bytes += len;
+                let Some(write) = write.take() else {
+                    return Err(io::Error::other("write command queued more than once"));
+                };
+                guard.queue.push_back(write);
+                self.available.notify_one();
+                return Ok(());
+            }
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "write command stdin queue full",
+                ));
+            }
+
+            let (next_guard, wait_result) = self
+                .space
+                .wait_timeout(guard, remaining)
+                .unwrap_or_else(|e| e.into_inner());
+            guard = next_guard;
+            if wait_result.timed_out() && guard.queued_bytes.saturating_add(len) > max_queued_bytes
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "write command stdin queue full",
+                ));
+            }
+        }
+    }
+
+    fn recv(&self) -> Option<BatchWrite> {
+        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        loop {
+            if let Some(write) = guard.queue.pop_front() {
+                guard.queued_bytes = guard.queued_bytes.saturating_sub(write.queued_len());
+                self.space.notify_all();
+                return Some(write);
+            }
+
+            if guard.closed {
+                return None;
+            }
+
+            guard = self
+                .available
+                .wait(guard)
+                .unwrap_or_else(|e| e.into_inner());
+        }
+    }
+
+    fn close_input(&self) {
+        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        guard.closed = true;
+        self.available.notify_all();
+        self.space.notify_all();
+    }
+
+    fn abort(&self) {
+        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        guard.closed = true;
+        guard.queue.clear();
+        guard.queued_bytes = 0;
+        self.available.notify_all();
+        self.space.notify_all();
+    }
+}
+
 struct BatchChild {
     child: Child,
-    stdin_tx: Option<mpsc::Sender<BatchWrite>>,
+    stdin_queue: Arc<BatchWriteQueue>,
     stdin_handle: JoinHandle<io::Result<()>>,
     stdin_done_rx: mpsc::Receiver<()>,
     stderr_handle: JoinHandle<Vec<u8>>,
@@ -359,17 +491,21 @@ impl BatchChild {
             }
         };
 
-        // Keep helper stdin writes off the connection loop. The protocol total
-        // byte cap bounds this queue if the helper stops reading.
-        let (stdin_tx, stdin_rx) = mpsc::channel::<BatchWrite>();
+        // Keep helper stdin writes off the connection loop, but bound queued
+        // bytes so a stuck helper cannot accumulate the whole stream in memory.
+        let stdin_queue = Arc::new(BatchWriteQueue::new());
+        let writer_queue = Arc::clone(&stdin_queue);
         let (stdin_done_tx, stdin_done_rx) = mpsc::channel::<()>();
         let stdin_handle = match std::thread::Builder::new()
             .name(THREAD_WRITE_STDIN.to_string())
             .spawn(move || {
                 let mut stdin = stdin;
                 let result = (|| {
-                    for write in stdin_rx {
-                        write.write_to(&mut stdin)?;
+                    while let Some(write) = writer_queue.recv() {
+                        if let Err(e) = write.write_to(&mut stdin) {
+                            writer_queue.abort();
+                            return Err(e);
+                        }
                     }
                     stdin.flush()
                 })();
@@ -397,7 +533,7 @@ impl BatchChild {
             Ok(handle) => handle,
             Err(e) => {
                 cancel.store(true, std::sync::atomic::Ordering::Release);
-                drop(stdin_tx);
+                stdin_queue.abort();
                 kill_and_reap_child(child);
                 let _ = stdin_handle.join();
                 return Err(format!("Failed to spawn stderr drain thread: {e}"));
@@ -406,7 +542,7 @@ impl BatchChild {
 
         Ok(Self {
             child,
-            stdin_tx: Some(stdin_tx),
+            stdin_queue,
             stdin_handle,
             stdin_done_rx,
             stderr_handle,
@@ -416,27 +552,23 @@ impl BatchChild {
     }
 
     fn write_bytes(&self, bytes: Vec<u8>) -> io::Result<()> {
-        let tx = self
-            .stdin_tx
-            .as_ref()
-            .ok_or_else(|| io::Error::other("write command stdin already closed"))?;
-        tx.send(BatchWrite::Bytes(bytes))
-            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "write command stdin closed"))
+        self.stdin_queue.send(
+            BatchWrite::Bytes(bytes),
+            Duration::from_millis(u64::from(WRITE_TIMEOUT_MS)),
+        )
     }
 
     fn write_chunk_payload(&self, payload: Vec<u8>) -> io::Result<()> {
-        let tx = self
-            .stdin_tx
-            .as_ref()
-            .ok_or_else(|| io::Error::other("write command stdin already closed"))?;
-        tx.send(BatchWrite::WriteFilesChunkPayload(payload))
-            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "write command stdin closed"))
+        self.stdin_queue.send(
+            BatchWrite::WriteFilesChunkPayload(payload),
+            Duration::from_millis(u64::from(WRITE_TIMEOUT_MS)),
+        )
     }
 
-    fn kill(mut self) {
+    fn kill(self) {
         self.cancel
             .store(true, std::sync::atomic::Ordering::Release);
-        drop(self.stdin_tx.take());
+        self.stdin_queue.abort();
         kill_and_reap_child(self.child);
         let _ = self.stdin_handle.join();
         let _ = await_drain_deadline(&self.stderr_done_rx, 1, &self.cancel);
@@ -447,9 +579,9 @@ impl BatchChild {
         self.finish_with_timeout(WRITE_TIMEOUT_MS)
     }
 
-    fn finish_with_timeout(mut self, timeout_ms: u32) -> (bool, String) {
+    fn finish_with_timeout(self, timeout_ms: u32) -> (bool, String) {
         let child_pid = self.child.id();
-        drop(self.stdin_tx.take());
+        self.stdin_queue.close_input();
         let outcome = wait_with_kill_timeout(self.child, timeout_ms);
         if matches!(outcome, WaitOutcome::Exited(_) | WaitOutcome::WaitFailed(_))
             && matches!(
@@ -810,6 +942,22 @@ mod tests {
         assert!(!success);
         assert!(error.contains("Failed to write to stdin"), "got: {error}");
         assert!(!pid_alive(pid), "child pid {pid} should have been reaped");
+    }
+
+    #[test]
+    fn write_files_batch_queue_is_bounded_and_abort_drops_backlog() {
+        let queue = BatchWriteQueue::new();
+
+        queue
+            .send_with_limit(BatchWrite::Bytes(vec![0; 8]), Duration::ZERO, 8)
+            .unwrap();
+        let err = queue
+            .send_with_limit(BatchWrite::Bytes(vec![1]), Duration::ZERO, 8)
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+
+        queue.abort();
+        assert!(queue.recv().is_none());
     }
 
     #[test]

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -961,6 +961,42 @@ mod tests {
     }
 
     #[test]
+    fn write_files_batch_queue_close_preserves_backlog() {
+        let queue = BatchWriteQueue::new();
+
+        queue
+            .send_with_limit(BatchWrite::Bytes(vec![1, 2, 3]), Duration::ZERO, 8)
+            .unwrap();
+        queue.close_input();
+
+        match queue.recv() {
+            Some(BatchWrite::Bytes(bytes)) => assert_eq!(bytes, vec![1, 2, 3]),
+            _ => panic!("expected queued bytes after close_input"),
+        }
+        assert!(queue.recv().is_none());
+    }
+
+    #[test]
+    fn write_files_batch_queue_rejects_oversized_item_without_closing() {
+        let queue = BatchWriteQueue::new();
+
+        let err = queue
+            .send_with_limit(BatchWrite::Bytes(vec![0; 9]), Duration::ZERO, 8)
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+
+        queue
+            .send_with_limit(BatchWrite::Bytes(vec![1]), Duration::ZERO, 8)
+            .unwrap();
+        queue.close_input();
+        match queue.recv() {
+            Some(BatchWrite::Bytes(bytes)) => assert_eq!(bytes, vec![1]),
+            _ => panic!("expected queue to remain usable after oversized item rejection"),
+        }
+        assert!(queue.recv().is_none());
+    }
+
+    #[test]
     fn write_file_kills_lingering_process_group_after_parent_exit() {
         let _guard = WRITE_FILE_CHILD_TESTS.lock().unwrap();
         let child = spawn_write_file_test_child("sleep 60 <&0 >/dev/null 2>/dev/null & exit 0");

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -890,6 +890,39 @@ mod tests {
         messages.remove(0)
     }
 
+    fn write_files_start(seq: u32, file_count: u32, total_bytes: u64) -> RawMessage {
+        RawMessage {
+            msg_type: vsock_proto::MSG_WRITE_FILES_START,
+            seq,
+            payload: vsock_proto::encode_write_files_start(false, file_count, total_bytes).unwrap(),
+        }
+    }
+
+    fn write_files_message(msg_type: u8, seq: u32, payload: Vec<u8>) -> RawMessage {
+        RawMessage {
+            msg_type,
+            seq,
+            payload,
+        }
+    }
+
+    fn assert_write_files_stream_error(
+        start: RawMessage,
+        messages: Vec<RawMessage>,
+        expected: &str,
+    ) {
+        let _guard = WRITE_FILE_CHILD_TESTS.lock().unwrap();
+        let _path_guard = install_test_guest_write_file("cat >/dev/null");
+        let mut messages = VecDeque::from(messages);
+
+        let response = handle_write_files_stream(&start, || Ok(messages.pop_front())).unwrap();
+        let response = decode_single_response(&response);
+
+        assert_eq!(response.msg_type, MSG_ERROR);
+        let error = vsock_proto::decode_error(&response.payload).unwrap();
+        assert!(error.contains(expected), "got: {error}");
+    }
+
     fn spawn_write_file_test_child(script: &str) -> Child {
         // Use a stable shell binary instead of a freshly written temp
         // executable; some CI filesystems can transiently reject immediate exec
@@ -1039,60 +1072,93 @@ mod tests {
 
     #[test]
     fn write_files_stream_malformed_file_payload_returns_error_response() {
-        let _guard = WRITE_FILE_CHILD_TESTS.lock().unwrap();
-        let _path_guard = install_test_guest_write_file("cat >/dev/null");
-        let start_payload = vsock_proto::encode_write_files_start(false, 1, 1).unwrap();
-        let start = RawMessage {
-            msg_type: vsock_proto::MSG_WRITE_FILES_START,
-            seq: 7,
-            payload: start_payload,
-        };
-        let mut messages = VecDeque::from([RawMessage {
-            msg_type: MSG_WRITE_FILES_FILE,
-            seq: 7,
-            payload: vec![0],
-        }]);
-
-        let response = handle_write_files_stream(&start, || Ok(messages.pop_front())).unwrap();
-        let response = decode_single_response(&response);
-
-        assert_eq!(response.msg_type, MSG_ERROR);
-        let error = vsock_proto::decode_error(&response.payload).unwrap();
-        assert!(error.contains("write_files_file too short"), "got: {error}");
+        assert_write_files_stream_error(
+            write_files_start(7, 1, 1),
+            vec![write_files_message(MSG_WRITE_FILES_FILE, 7, vec![0])],
+            "write_files_file too short",
+        );
     }
 
     #[test]
     fn write_files_stream_malformed_chunk_payload_returns_error_response() {
-        let _guard = WRITE_FILE_CHILD_TESTS.lock().unwrap();
-        let _path_guard = install_test_guest_write_file("cat >/dev/null");
-        let start_payload = vsock_proto::encode_write_files_start(false, 1, 1).unwrap();
-        let start = RawMessage {
-            msg_type: vsock_proto::MSG_WRITE_FILES_START,
-            seq: 8,
-            payload: start_payload,
-        };
-        let file_payload = vsock_proto::encode_write_files_file(0, "/tmp/file", 1).unwrap();
-        let mut messages = VecDeque::from([
-            RawMessage {
-                msg_type: MSG_WRITE_FILES_FILE,
-                seq: 8,
-                payload: file_payload,
-            },
-            RawMessage {
-                msg_type: MSG_WRITE_FILES_CHUNK,
-                seq: 8,
-                payload: vec![0],
-            },
-        ]);
+        assert_write_files_stream_error(
+            write_files_start(8, 1, 1),
+            vec![
+                write_files_message(
+                    MSG_WRITE_FILES_FILE,
+                    8,
+                    vsock_proto::encode_write_files_file(0, "/tmp/file", 1).unwrap(),
+                ),
+                write_files_message(MSG_WRITE_FILES_CHUNK, 8, vec![0]),
+            ],
+            "write_files_chunk too short",
+        );
+    }
 
-        let response = handle_write_files_stream(&start, || Ok(messages.pop_front())).unwrap();
-        let response = decode_single_response(&response);
+    #[test]
+    fn write_files_stream_rejects_file_index_out_of_range() {
+        assert_write_files_stream_error(
+            write_files_start(11, 1, 0),
+            vec![write_files_message(
+                MSG_WRITE_FILES_FILE,
+                11,
+                vsock_proto::encode_write_files_file(1, "/tmp/file", 0).unwrap(),
+            )],
+            "write_files file index out of range",
+        );
+    }
 
-        assert_eq!(response.msg_type, MSG_ERROR);
-        let error = vsock_proto::decode_error(&response.payload).unwrap();
-        assert!(
-            error.contains("write_files_chunk too short"),
-            "got: {error}"
+    #[test]
+    fn write_files_stream_rejects_duplicate_file_index() {
+        assert_write_files_stream_error(
+            write_files_start(12, 2, 0),
+            vec![
+                write_files_message(
+                    MSG_WRITE_FILES_FILE,
+                    12,
+                    vsock_proto::encode_write_files_file(0, "/tmp/a", 0).unwrap(),
+                ),
+                write_files_message(
+                    MSG_WRITE_FILES_FILE,
+                    12,
+                    vsock_proto::encode_write_files_file(0, "/tmp/b", 0).unwrap(),
+                ),
+            ],
+            "write_files duplicate file index",
+        );
+    }
+
+    #[test]
+    fn write_files_stream_rejects_chunk_without_active_file() {
+        assert_write_files_stream_error(
+            write_files_start(13, 1, 1),
+            vec![write_files_message(
+                MSG_WRITE_FILES_CHUNK,
+                13,
+                vsock_proto::encode_write_files_chunk(0, b"x").unwrap(),
+            )],
+            "write_files chunk without active file",
+        );
+    }
+
+    #[test]
+    fn write_files_stream_rejects_finish_before_file_content_complete() {
+        assert_write_files_stream_error(
+            write_files_start(14, 1, 2),
+            vec![
+                write_files_message(
+                    MSG_WRITE_FILES_FILE,
+                    14,
+                    vsock_proto::encode_write_files_file(0, "/tmp/file", 2).unwrap(),
+                ),
+                write_files_message(
+                    MSG_WRITE_FILES_CHUNK,
+                    14,
+                    vsock_proto::encode_write_files_chunk(0, b"x").unwrap(),
+                ),
+                write_files_message(MSG_WRITE_FILES_FINISH, 14, Vec::new()),
+            ],
+            "write_files finish before file content complete",
         );
     }
 

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -1133,6 +1133,30 @@ mod tests {
     }
 
     #[test]
+    fn write_files_stream_abort_returns_error_response() {
+        let _guard = WRITE_FILE_CHILD_TESTS.lock().unwrap();
+        let _path_guard = install_test_guest_write_file("cat >/dev/null");
+        let start_payload = vsock_proto::encode_write_files_start(false, 1, 1).unwrap();
+        let start = RawMessage {
+            msg_type: vsock_proto::MSG_WRITE_FILES_START,
+            seq: 10,
+            payload: start_payload,
+        };
+        let mut messages = VecDeque::from([RawMessage {
+            msg_type: MSG_WRITE_FILES_ABORT,
+            seq: 10,
+            payload: vsock_proto::encode_write_files_abort("host cancelled"),
+        }]);
+
+        let response = handle_write_files_stream(&start, || Ok(messages.pop_front())).unwrap();
+        let response = decode_single_response(&response);
+
+        assert_eq!(response.msg_type, MSG_ERROR);
+        let error = vsock_proto::decode_error(&response.payload).unwrap();
+        assert_eq!(error, "write_files aborted");
+    }
+
+    #[test]
     fn write_file_kills_lingering_process_group_after_parent_exit() {
         let _guard = WRITE_FILE_CHILD_TESTS.lock().unwrap();
         let child = spawn_write_file_test_child("sleep 60 <&0 >/dev/null 2>/dev/null & exit 0");

--- a/crates/vsock-host/Cargo.toml
+++ b/crates/vsock-host/Cargo.toml
@@ -6,7 +6,7 @@ description = "Vsock host client for Firecracker VM communication"
 
 [dependencies]
 nix = { workspace = true, features = ["net"] }
-tokio = { workspace = true, features = ["net", "io-util", "time", "rt", "macros", "sync"] }
+tokio = { workspace = true, features = ["fs", "net", "io-util", "time", "rt", "macros", "sync"] }
 vsock-proto.workspace = true
 
 [dev-dependencies]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1245,6 +1245,7 @@ async fn send_write_files_stream(
     seq: u32,
     mut files: Vec<PreparedWriteFile<'_>>,
     sudo: bool,
+    timeout: Duration,
 ) -> io::Result<()> {
     let file_count = u32::try_from(files.len()).map_err(|_| {
         io::Error::new(
@@ -1264,63 +1265,84 @@ async fn send_write_files_stream(
         }
     }
 
-    // Active after START; any cancellation or write/read failure before
-    // FINISH poisons the connection so the guest stream cannot hang.
-    let mut write_guard = FrameWriteGuard::new(Arc::clone(shared));
-    let start = vsock_proto::encode_write_files_start(sudo, file_count, total_bytes)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
-    write_proto_frame(&mut writer, MSG_WRITE_FILES_START, seq, &start).await?;
-
-    let mut read_buf = vec![0u8; vsock_proto::MAX_WRITE_FILES_CHUNK_BYTES];
-    for (index, file) in files.iter_mut().enumerate() {
-        let file_index = u32::try_from(index).map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "write_files file index exceeds u32",
-            )
-        })?;
-        let len = file.source.len();
-        let payload = vsock_proto::encode_write_files_file(file_index, &file.path, len)
+    let stream_result = tokio::time::timeout(timeout, async {
+        // Active after START; any cancellation or write/read failure before
+        // FINISH poisons the connection so the guest stream cannot hang.
+        let mut write_guard = FrameWriteGuard::new(Arc::clone(shared));
+        let start = vsock_proto::encode_write_files_start(sudo, file_count, total_bytes)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
-        write_proto_frame(&mut writer, MSG_WRITE_FILES_FILE, seq, &payload).await?;
+        write_proto_frame(&mut writer, MSG_WRITE_FILES_START, seq, &start).await?;
 
-        match &mut file.source {
-            PreparedWriteFileSource::Bytes(bytes) => {
-                for chunk in bytes.chunks(vsock_proto::MAX_WRITE_FILES_CHUNK_BYTES) {
-                    let payload = vsock_proto::encode_write_files_chunk(file_index, chunk)
-                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
-                    write_proto_frame(&mut writer, MSG_WRITE_FILES_CHUNK, seq, &payload).await?;
-                }
-            }
-            PreparedWriteFileSource::File { file, len } => {
-                let mut remaining = *len;
-                while remaining > 0 {
-                    let max = remaining.min(read_buf.len() as u64) as usize;
-                    let read_chunk = read_buf.get_mut(..max).ok_or_else(|| {
-                        io::Error::other("write_files read length exceeds buffer")
-                    })?;
-                    let n = file.read(read_chunk).await?;
-                    if n == 0 {
-                        return Err(io::Error::new(
-                            io::ErrorKind::UnexpectedEof,
-                            "write_files source ended before expected length",
-                        ));
+        let mut read_buf = vec![0u8; vsock_proto::MAX_WRITE_FILES_CHUNK_BYTES];
+        for (index, file) in files.iter_mut().enumerate() {
+            let file_index = u32::try_from(index).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "write_files file index exceeds u32",
+                )
+            })?;
+            let len = file.source.len();
+            let payload = vsock_proto::encode_write_files_file(file_index, &file.path, len)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+            write_proto_frame(&mut writer, MSG_WRITE_FILES_FILE, seq, &payload).await?;
+
+            match &mut file.source {
+                PreparedWriteFileSource::Bytes(bytes) => {
+                    for chunk in bytes.chunks(vsock_proto::MAX_WRITE_FILES_CHUNK_BYTES) {
+                        let payload = vsock_proto::encode_write_files_chunk(file_index, chunk)
+                            .map_err(|e| {
+                                io::Error::new(io::ErrorKind::InvalidInput, e.to_string())
+                            })?;
+                        write_proto_frame(&mut writer, MSG_WRITE_FILES_CHUNK, seq, &payload)
+                            .await?;
                     }
-                    remaining -= n as u64;
-                    let payload_chunk = read_chunk
-                        .get(..n)
-                        .ok_or_else(|| io::Error::other("write_files read length exceeds chunk"))?;
-                    let payload = vsock_proto::encode_write_files_chunk(file_index, payload_chunk)
-                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
-                    write_proto_frame(&mut writer, MSG_WRITE_FILES_CHUNK, seq, &payload).await?;
+                }
+                PreparedWriteFileSource::File { file, len } => {
+                    let mut remaining = *len;
+                    while remaining > 0 {
+                        let max = remaining.min(read_buf.len() as u64) as usize;
+                        let read_chunk = read_buf.get_mut(..max).ok_or_else(|| {
+                            io::Error::other("write_files read length exceeds buffer")
+                        })?;
+                        let n = file.read(read_chunk).await?;
+                        if n == 0 {
+                            return Err(io::Error::new(
+                                io::ErrorKind::UnexpectedEof,
+                                "write_files source ended before expected length",
+                            ));
+                        }
+                        remaining -= n as u64;
+                        let payload_chunk = read_chunk.get(..n).ok_or_else(|| {
+                            io::Error::other("write_files read length exceeds chunk")
+                        })?;
+                        let payload =
+                            vsock_proto::encode_write_files_chunk(file_index, payload_chunk)
+                                .map_err(|e| {
+                                    io::Error::new(io::ErrorKind::InvalidInput, e.to_string())
+                                })?;
+                        write_proto_frame(&mut writer, MSG_WRITE_FILES_CHUNK, seq, &payload)
+                            .await?;
+                    }
                 }
             }
         }
-    }
 
-    write_proto_frame(&mut writer, MSG_WRITE_FILES_FINISH, seq, &[]).await?;
-    write_guard.disarm();
-    Ok(())
+        write_proto_frame(&mut writer, MSG_WRITE_FILES_FINISH, seq, &[]).await?;
+        write_guard.disarm();
+        Ok(())
+    })
+    .await;
+
+    match stream_result {
+        Ok(result) => result,
+        Err(_) => {
+            shared.poison_connection();
+            Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "write_files stream timeout",
+            ))
+        }
+    }
 }
 
 async fn write_proto_frame(
@@ -1985,7 +2007,8 @@ impl VsockHost {
         }
         let _pending_guard = PendingRequestGuard::new(Arc::clone(&self.shared), seq);
 
-        send_write_files_stream(&self.shared, seq, prepared, sudo).await?;
+        send_write_files_stream(&self.shared, seq, prepared, sudo, Self::WRITE_FILES_TIMEOUT)
+            .await?;
 
         let resp = tokio::select! {
             biased;
@@ -5063,6 +5086,72 @@ mod tests {
         host.write_file("/tmp/big.bin", &content, false)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_files_stream_timeout_closes_connection() {
+        let (host_stream, mut guest) = make_pair();
+        set_send_buffer(&host_stream, 4096).unwrap();
+
+        let frame_started = std::sync::Arc::new(Notify::new());
+        let release_guest = std::sync::Arc::new(Notify::new());
+
+        let guest_task = {
+            let frame_started = std::sync::Arc::clone(&frame_started);
+            let release_guest = std::sync::Arc::clone(&release_guest);
+            tokio::spawn(async move {
+                let mut decoder = Decoder::new();
+                mock_handshake(&mut guest, &mut decoder).await;
+
+                for expected_type in [MSG_WRITE_FILES_START, MSG_WRITE_FILES_FILE] {
+                    let mut len = [0u8; vsock_proto::HEADER_SIZE];
+                    guest.read_exact(&mut len).await.unwrap();
+                    let body_len = u32::from_be_bytes(len) as usize;
+                    let mut body = vec![0u8; body_len];
+                    guest.read_exact(&mut body).await.unwrap();
+                    assert_eq!(body.first().copied(), Some(expected_type));
+                }
+
+                let mut len = [0u8; vsock_proto::HEADER_SIZE];
+                guest.read_exact(&mut len).await.unwrap();
+                let chunk_body_len = u32::from_be_bytes(len) as usize;
+                let mut msg_type = [0u8; 1];
+                guest.read_exact(&mut msg_type).await.unwrap();
+                assert_eq!(msg_type[0], MSG_WRITE_FILES_CHUNK);
+                assert!(
+                    chunk_body_len > 1024 * 1024,
+                    "test needs a large chunk body so the host blocks while guest stops reading",
+                );
+                frame_started.notify_one();
+
+                release_guest.notified().await;
+            })
+        };
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let content = vec![b'x'; 8 * 1024 * 1024];
+        let files = vec![PreparedWriteFile {
+            path: "/tmp/large.bin".to_string(),
+            source: PreparedWriteFileSource::Bytes(&content),
+        }];
+        let seq = host.shared.next_seq();
+
+        let send =
+            send_write_files_stream(&host.shared, seq, files, false, Duration::from_millis(50));
+        tokio::pin!(send);
+        tokio::select! {
+            _ = frame_started.notified() => {}
+            result = &mut send => panic!("write_files stream completed before blocking: {result:?}"),
+        }
+
+        let err = send.await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        release_guest.notify_one();
+        guest_task.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -5219,6 +5219,110 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_write_files_empty_batch_does_not_send_request() {
+        let (host_stream, mut guest) = make_pair();
+
+        let guest_task = tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            assert_ne!(n, 0, "connection closed before follow-up exec");
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs.len(), 1);
+            assert_eq!(msgs[0].msg_type, MSG_EXEC);
+
+            let decoded = vsock_proto::decode_exec(&msgs[0].payload).unwrap();
+            assert_eq!(decoded.command, "after-empty-write-files");
+
+            let payload = vsock_proto::encode_exec_result(0, b"ok", b"");
+            let resp = vsock_proto::encode(MSG_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
+            guest.write_all(&resp).await.unwrap();
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let empty: &[WriteFileRequest<'_>] = &[];
+        host.write_files(empty, false).await.unwrap();
+        let result = host
+            .exec("after-empty-write-files", 5000, &[], false)
+            .await
+            .unwrap();
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, b"ok");
+        guest_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_files_zero_length_file_sends_no_chunk() {
+        let (host_stream, mut guest) = make_pair();
+
+        let guest_task = tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut seq = None;
+            let mut saw_file = false;
+            let mut buf = [0u8; 4096];
+            loop {
+                let n = guest.read(&mut buf).await.unwrap();
+                assert_ne!(n, 0, "connection closed before write_files finish");
+                for msg in decoder.decode(&buf[..n]).unwrap() {
+                    seq.get_or_insert(msg.seq);
+                    assert_eq!(Some(msg.seq), seq);
+                    match msg.msg_type {
+                        MSG_WRITE_FILES_START => {
+                            let start =
+                                vsock_proto::decode_write_files_start(&msg.payload).unwrap();
+                            assert_eq!(start.file_count, 1);
+                            assert_eq!(start.total_bytes, 0);
+                        }
+                        MSG_WRITE_FILES_FILE => {
+                            let file = vsock_proto::decode_write_files_file(&msg.payload).unwrap();
+                            assert_eq!(file.file_index, 0);
+                            assert_eq!(file.path, "/tmp/empty");
+                            assert_eq!(file.content_len, 0);
+                            saw_file = true;
+                        }
+                        MSG_WRITE_FILES_CHUNK => {
+                            panic!("zero-length file must not send an empty chunk");
+                        }
+                        MSG_WRITE_FILES_FINISH => {
+                            assert!(saw_file);
+                            let payload = vsock_proto::encode_write_files_result(&[
+                                vsock_proto::WriteFilesResultEntry {
+                                    file_index: 0,
+                                    success: true,
+                                    error: String::new(),
+                                },
+                            ])
+                            .unwrap();
+                            let resp =
+                                vsock_proto::encode(MSG_WRITE_FILES_RESULT, msg.seq, &payload)
+                                    .unwrap();
+                            guest.write_all(&resp).await.unwrap();
+                            return;
+                        }
+                        other => panic!("unexpected message type: {other:#x}"),
+                    }
+                }
+            }
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        host.write_files(
+            &[WriteFileRequest {
+                path: "/tmp/empty",
+                source: WriteFileSource::Bytes(b""),
+            }],
+            false,
+        )
+        .await
+        .unwrap();
+        guest_task.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_write_files_surfaces_per_file_failure() {
         let (host_stream, mut guest) = make_pair();
 
@@ -5272,6 +5376,64 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("disk full"));
+    }
+
+    #[tokio::test]
+    async fn test_write_files_rejects_duplicate_result_index() {
+        let (host_stream, mut guest) = make_pair();
+
+        let guest_task = tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            loop {
+                let n = guest.read(&mut buf).await.unwrap();
+                assert_ne!(n, 0);
+                for msg in decoder.decode(&buf[..n]).unwrap() {
+                    if msg.msg_type == MSG_WRITE_FILES_FINISH {
+                        let payload = vsock_proto::encode_write_files_result(&[
+                            vsock_proto::WriteFilesResultEntry {
+                                file_index: 0,
+                                success: true,
+                                error: String::new(),
+                            },
+                            vsock_proto::WriteFilesResultEntry {
+                                file_index: 0,
+                                success: true,
+                                error: String::new(),
+                            },
+                        ])
+                        .unwrap();
+                        let resp =
+                            vsock_proto::encode(MSG_WRITE_FILES_RESULT, msg.seq, &payload).unwrap();
+                        guest.write_all(&resp).await.unwrap();
+                        return;
+                    }
+                }
+            }
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let err = host
+            .write_files(
+                &[
+                    WriteFileRequest {
+                        path: "/tmp/a",
+                        source: WriteFileSource::Bytes(b"a"),
+                    },
+                    WriteFileRequest {
+                        path: "/tmp/b",
+                        source: WriteFileSource::Bytes(b"b"),
+                    },
+                ],
+                false,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("duplicate result index"));
+        guest_task.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1478,6 +1478,39 @@ fn validate_write_files_result(
     Ok(())
 }
 
+fn handle_write_files_response(
+    resp: RawMessage,
+    expected_count: usize,
+    early_response: bool,
+) -> io::Result<()> {
+    if resp.msg_type == MSG_ERROR {
+        let msg = vsock_proto::decode_error(&resp.payload)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        return Err(io::Error::other(msg));
+    }
+
+    if early_response {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "write_files response before stream finished: 0x{:02X}",
+                resp.msg_type
+            ),
+        ));
+    }
+
+    if resp.msg_type != MSG_WRITE_FILES_RESULT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unexpected response type: 0x{:02X}", resp.msg_type),
+        ));
+    }
+
+    let entries = vsock_proto::decode_write_files_result(&resp.payload)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    validate_write_files_result(&entries, expected_count)
+}
+
 async fn exec_on_shared(
     shared: &Arc<Shared>,
     command: &str,
@@ -2113,40 +2146,49 @@ impl VsockHost {
             }
         }
         let _pending_guard = PendingRequestGuard::new(Arc::clone(&self.shared), seq);
+        let mut rx = rx;
 
-        send_write_files_stream(&self.shared, seq, prepared, sudo, Self::WRITE_FILES_TIMEOUT)
-            .await?;
-
-        let resp = tokio::select! {
+        let early_resp = tokio::select! {
             biased;
-            result = rx => {
-                result.map_err(|_| io::Error::new(
+            result = send_write_files_stream(
+                &self.shared,
+                seq,
+                prepared,
+                sudo,
+                Self::WRITE_FILES_TIMEOUT,
+            ) => {
+                result?;
+                None
+            }
+            result = &mut rx => {
+                self.shared.poison_connection();
+                Some(result.map_err(|_| io::Error::new(
                     io::ErrorKind::ConnectionReset,
                     "connection closed",
-                ))?
-            }
-            _ = tokio::time::sleep(Self::WRITE_FILES_TIMEOUT) => {
-                self.shared.poison_connection();
-                return Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"));
+                ))?)
             }
         };
 
-        if resp.msg_type == MSG_ERROR {
-            let msg = vsock_proto::decode_error(&resp.payload)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-            return Err(io::Error::other(msg));
-        }
+        let resp = match early_resp {
+            Some(resp) => return handle_write_files_response(resp, expected_count, true),
+            None => {
+                tokio::select! {
+                    biased;
+                    result = &mut rx => {
+                        result.map_err(|_| io::Error::new(
+                            io::ErrorKind::ConnectionReset,
+                            "connection closed",
+                        ))?
+                    }
+                    _ = tokio::time::sleep(Self::WRITE_FILES_TIMEOUT) => {
+                        self.shared.poison_connection();
+                        return Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"));
+                    }
+                }
+            }
+        };
 
-        if resp.msg_type != MSG_WRITE_FILES_RESULT {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("unexpected response type: 0x{:02X}", resp.msg_type),
-            ));
-        }
-
-        let entries = vsock_proto::decode_write_files_result(&resp.payload)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-        validate_write_files_result(&entries, expected_count)
+        handle_write_files_response(resp, expected_count, false)
     }
 
     /// Spawn a process on the guest and monitor for exit.
@@ -5256,6 +5298,62 @@ mod tests {
         let _ = timeout_tx.send(());
         let err = send.await.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        release_guest.notify_one();
+        guest_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_files_early_guest_error_stops_stream() {
+        let (host_stream, mut guest) = make_pair();
+        set_send_buffer(&host_stream, 4096).unwrap();
+
+        let release_guest = std::sync::Arc::new(Notify::new());
+        let guest_task = {
+            let release_guest = std::sync::Arc::clone(&release_guest);
+            tokio::spawn(async move {
+                let mut decoder = Decoder::new();
+                mock_handshake(&mut guest, &mut decoder).await;
+
+                let mut buf = [0u8; 4096];
+                loop {
+                    let n = guest.read(&mut buf).await.unwrap();
+                    assert_ne!(n, 0, "connection closed before write_files start");
+                    for msg in decoder.decode(&buf[..n]).unwrap() {
+                        if msg.msg_type == MSG_WRITE_FILES_START {
+                            let payload = vsock_proto::encode_error("early write failure");
+                            let resp = vsock_proto::encode(MSG_ERROR, msg.seq, &payload).unwrap();
+                            guest.write_all(&resp).await.unwrap();
+                            release_guest.notified().await;
+
+                            let mut drain = [0u8; 4096];
+                            loop {
+                                let n = guest.read(&mut drain).await.unwrap();
+                                if n == 0 {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+        };
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let content = vec![b'x'; 8 * 1024 * 1024];
+        let files = [WriteFileRequest {
+            path: "/tmp/large.bin",
+            source: WriteFileSource::Bytes(&content),
+        }];
+
+        let err = tokio::time::timeout(Duration::from_secs(5), host.write_files(&files, false))
+            .await
+            .expect("early guest error must stop streaming promptly")
+            .unwrap_err();
+        assert!(err.to_string().contains("early write failure"));
         host.wait_until_closed(Duration::from_secs(5))
             .await
             .unwrap();

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -168,7 +168,7 @@ pub struct WriteFileRequest<'a> {
 
 enum PreparedWriteFileSource<'a> {
     Bytes(&'a [u8]),
-    File { file: tokio::fs::File, len: u64 },
+    File { path: &'a Path, len: u64 },
 }
 
 impl PreparedWriteFileSource<'_> {
@@ -1216,20 +1216,8 @@ async fn prepare_write_files<'a>(
         let source = match &file.source {
             WriteFileSource::Bytes(bytes) => PreparedWriteFileSource::Bytes(bytes),
             WriteFileSource::File { path, len } => {
-                let file = tokio::fs::File::open(path).await?;
-                let actual_len = file.metadata().await?.len();
-                if actual_len != *len {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        format!(
-                            "write_files source length changed for {}: expected {}, got {}",
-                            path.display(),
-                            len,
-                            actual_len
-                        ),
-                    ));
-                }
-                PreparedWriteFileSource::File { file, len: *len }
+                validate_file_source_len(path, *len).await?;
+                PreparedWriteFileSource::File { path, len: *len }
             }
         };
         prepared.push(PreparedWriteFile {
@@ -1239,6 +1227,35 @@ async fn prepare_write_files<'a>(
     }
 
     Ok(prepared)
+}
+
+async fn validate_file_source_len(path: &Path, expected_len: u64) -> io::Result<()> {
+    let actual_len = tokio::fs::metadata(path).await?.len();
+    if actual_len != expected_len {
+        return Err(file_source_len_error(path, expected_len, actual_len));
+    }
+    Ok(())
+}
+
+async fn open_prepared_file_source(path: &Path, expected_len: u64) -> io::Result<tokio::fs::File> {
+    let file = tokio::fs::File::open(path).await?;
+    let actual_len = file.metadata().await?.len();
+    if actual_len != expected_len {
+        return Err(file_source_len_error(path, expected_len, actual_len));
+    }
+    Ok(file)
+}
+
+fn file_source_len_error(path: &Path, expected_len: u64, actual_len: u64) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!(
+            "write_files source length changed for {}: expected {}, got {}",
+            path.display(),
+            expected_len,
+            actual_len
+        ),
+    )
 }
 
 async fn send_write_files_stream(
@@ -1257,7 +1274,7 @@ async fn send_write_files_stream(
 async fn send_write_files_stream_until(
     shared: &Arc<Shared>,
     seq: u32,
-    mut files: Vec<PreparedWriteFile<'_>>,
+    files: Vec<PreparedWriteFile<'_>>,
     sudo: bool,
     timeout: impl Future<Output = ()>,
 ) -> io::Result<()> {
@@ -1293,7 +1310,7 @@ async fn send_write_files_stream_until(
         write_proto_frame(&mut writer, MSG_WRITE_FILES_START, seq, &start).await?;
 
         let mut read_buf = vec![0u8; vsock_proto::MAX_WRITE_FILES_CHUNK_BYTES];
-        for (index, file) in files.iter_mut().enumerate() {
+        for (index, file) in files.iter().enumerate() {
             let file_index = u32::try_from(index).map_err(|_| {
                 io::Error::new(
                     io::ErrorKind::InvalidInput,
@@ -1301,11 +1318,17 @@ async fn send_write_files_stream_until(
                 )
             })?;
             let len = file.source.len();
+            let mut source_file = match &file.source {
+                PreparedWriteFileSource::Bytes(_) => None,
+                PreparedWriteFileSource::File { path, len } => {
+                    Some(open_prepared_file_source(path, *len).await?)
+                }
+            };
             let payload = vsock_proto::encode_write_files_file(file_index, &file.path, len)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
             write_proto_frame(&mut writer, MSG_WRITE_FILES_FILE, seq, &payload).await?;
 
-            match &mut file.source {
+            match &file.source {
                 PreparedWriteFileSource::Bytes(bytes) => {
                     for chunk in bytes.chunks(vsock_proto::MAX_WRITE_FILES_CHUNK_BYTES) {
                         let payload = vsock_proto::encode_write_files_chunk(file_index, chunk)
@@ -1316,14 +1339,17 @@ async fn send_write_files_stream_until(
                             .await?;
                     }
                 }
-                PreparedWriteFileSource::File { file, len } => {
+                PreparedWriteFileSource::File { len, .. } => {
+                    let source_file = source_file
+                        .as_mut()
+                        .ok_or_else(|| io::Error::other("write_files source file not open"))?;
                     let mut remaining = *len;
                     while remaining > 0 {
                         let max = remaining.min(read_buf.len() as u64) as usize;
                         let read_chunk = read_buf.get_mut(..max).ok_or_else(|| {
                             io::Error::other("write_files read length exceeds buffer")
                         })?;
-                        let n = file.read(read_chunk).await?;
+                        let n = source_file.read(read_chunk).await?;
                         if n == 0 {
                             return Err(io::Error::new(
                                 io::ErrorKind::UnexpectedEof,
@@ -5531,6 +5557,38 @@ mod tests {
             .unwrap_err();
         let _ = tokio::fs::remove_file(&source).await;
         assert!(err.to_string().contains("source length changed"));
+    }
+
+    #[tokio::test]
+    async fn test_prepare_write_files_keeps_file_sources_lazy() {
+        let source = std::env::temp_dir().join(format!(
+            "vm0-vsock-host-lazy-source-{}-{}.tar.gz",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        tokio::fs::write(&source, b"archive").await.unwrap();
+        let requests = [WriteFileRequest {
+            path: "/tmp/archive.tar.gz",
+            source: WriteFileSource::File {
+                path: &source,
+                len: 7,
+            },
+        }];
+
+        let prepared = prepare_write_files(&requests).await.unwrap();
+
+        let _ = tokio::fs::remove_file(&source).await;
+        assert_eq!(prepared.len(), 1);
+        match &prepared[0].source {
+            PreparedWriteFileSource::File { path, len } => {
+                assert_eq!(*path, source.as_path());
+                assert_eq!(*len, 7);
+            }
+            PreparedWriteFileSource::Bytes(_) => panic!("expected lazy file source"),
+        }
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -165,12 +165,12 @@ pub struct WriteFileRequest<'a> {
     pub source: WriteFileSource<'a>,
 }
 
-enum PreparedWriteFileSource {
-    Bytes(Vec<u8>),
+enum PreparedWriteFileSource<'a> {
+    Bytes(&'a [u8]),
     File { file: tokio::fs::File, len: u64 },
 }
 
-impl PreparedWriteFileSource {
+impl PreparedWriteFileSource<'_> {
     fn len(&self) -> u64 {
         match self {
             Self::Bytes(bytes) => bytes.len() as u64,
@@ -179,9 +179,9 @@ impl PreparedWriteFileSource {
     }
 }
 
-struct PreparedWriteFile {
+struct PreparedWriteFile<'a> {
     path: String,
-    source: PreparedWriteFileSource,
+    source: PreparedWriteFileSource<'a>,
 }
 
 #[derive(Clone)]
@@ -1163,7 +1163,9 @@ async fn send_bounded_exec_cancel_on_shared_with_timeout(
         })
 }
 
-async fn prepare_write_files(files: &[WriteFileRequest<'_>]) -> io::Result<Vec<PreparedWriteFile>> {
+async fn prepare_write_files<'a>(
+    files: &'a [WriteFileRequest<'a>],
+) -> io::Result<Vec<PreparedWriteFile<'a>>> {
     if files.len() > vsock_proto::MAX_WRITE_FILES_COUNT {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -1211,7 +1213,7 @@ async fn prepare_write_files(files: &[WriteFileRequest<'_>]) -> io::Result<Vec<P
         }
 
         let source = match &file.source {
-            WriteFileSource::Bytes(bytes) => PreparedWriteFileSource::Bytes(bytes.to_vec()),
+            WriteFileSource::Bytes(bytes) => PreparedWriteFileSource::Bytes(bytes),
             WriteFileSource::File { path, len } => {
                 let file = tokio::fs::File::open(path).await?;
                 let actual_len = file.metadata().await?.len();
@@ -1241,7 +1243,7 @@ async fn prepare_write_files(files: &[WriteFileRequest<'_>]) -> io::Result<Vec<P
 async fn send_write_files_stream(
     shared: &Arc<Shared>,
     seq: u32,
-    mut files: Vec<PreparedWriteFile>,
+    mut files: Vec<PreparedWriteFile<'_>>,
     sudo: bool,
 ) -> io::Result<()> {
     let file_count = u32::try_from(files.len()).map_err(|_| {
@@ -1954,7 +1956,11 @@ impl VsockHost {
         Ok(())
     }
 
-    pub async fn write_files(&self, files: &[WriteFileRequest<'_>], sudo: bool) -> io::Result<()> {
+    pub async fn write_files<'a>(
+        &self,
+        files: &'a [WriteFileRequest<'a>],
+        sudo: bool,
+    ) -> io::Result<()> {
         let expected_count = files.len();
         let prepared = prepare_write_files(files).await?;
         if prepared.is_empty() {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -31,6 +31,7 @@
 use std::collections::HashMap;
 use std::io;
 use std::os::fd::RawFd;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
@@ -47,7 +48,9 @@ use vsock_proto::{
     MSG_BOUNDED_EXEC_CANCEL, MSG_BOUNDED_EXEC_OUTPUT_CHUNK, MSG_BOUNDED_EXEC_RESULT,
     MSG_CONTROL_HELLO, MSG_CONTROL_HELLO_ACK, MSG_ERROR, MSG_EXEC, MSG_EXEC_RESULT, MSG_PING,
     MSG_PONG, MSG_PROCESS_EXIT, MSG_READY, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH,
-    MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, RawMessage,
+    MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
+    MSG_WRITE_FILES_CHUNK, MSG_WRITE_FILES_FILE, MSG_WRITE_FILES_FINISH, MSG_WRITE_FILES_RESULT,
+    MSG_WRITE_FILES_START, RawMessage,
 };
 
 const READ_BUF_SIZE: usize = 64 * 1024;
@@ -143,6 +146,45 @@ pub enum BoundedExecOutput {
     Captured { bytes: Vec<u8>, truncated: bool },
 }
 
+pub enum WriteFileSource<'a> {
+    Bytes(&'a [u8]),
+    File { path: &'a Path, len: u64 },
+}
+
+impl WriteFileSource<'_> {
+    fn len(&self) -> u64 {
+        match self {
+            Self::Bytes(bytes) => bytes.len() as u64,
+            Self::File { len, .. } => *len,
+        }
+    }
+}
+
+pub struct WriteFileRequest<'a> {
+    pub path: &'a str,
+    pub source: WriteFileSource<'a>,
+}
+
+enum PreparedWriteFileSource {
+    Bytes(Vec<u8>),
+    File { file: tokio::fs::File, len: u64 },
+}
+
+impl PreparedWriteFileSource {
+    fn len(&self) -> u64 {
+        match self {
+            Self::Bytes(bytes) => bytes.len() as u64,
+            Self::File { len, .. } => *len,
+        }
+    }
+}
+
+struct PreparedWriteFile {
+    path: String,
+    source: PreparedWriteFileSource,
+}
+
+#[derive(Clone)]
 struct BoundedOutputRegistration {
     stdout: BoundedOutputStreamState,
     stderr: BoundedOutputStreamState,
@@ -455,63 +497,6 @@ impl PendingStdoutGuard {
 impl Drop for PendingStdoutGuard {
     fn drop(&mut self) {
         self.shared.remove_pending_stdout(self.seq);
-    }
-}
-
-struct ChunkedWriteCleanupGuard {
-    shared: Option<Arc<Shared>>,
-    command: String,
-    sudo: bool,
-}
-
-impl ChunkedWriteCleanupGuard {
-    fn new(shared: Arc<Shared>, command: String, sudo: bool) -> Self {
-        Self {
-            shared: Some(shared),
-            command,
-            sudo,
-        }
-    }
-
-    fn disarm(&mut self) {
-        self.shared = None;
-    }
-
-    async fn cleanup_now(&mut self) {
-        if let Some(shared) = self.shared.as_ref() {
-            let _ = bounded_exec_cleanup_on_shared(
-                shared,
-                &self.command,
-                VsockHost::CLEANUP_EXEC_TIMEOUT_MS,
-                &[],
-                self.sudo,
-            )
-            .await;
-        }
-        self.disarm();
-    }
-}
-
-impl Drop for ChunkedWriteCleanupGuard {
-    fn drop(&mut self) {
-        let Some(shared) = self.shared.take() else {
-            return;
-        };
-
-        let command = std::mem::take(&mut self.command);
-        let sudo = self.sudo;
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            handle.spawn(async move {
-                let _ = bounded_exec_cleanup_on_shared(
-                    &shared,
-                    &command,
-                    VsockHost::CLEANUP_EXEC_TIMEOUT_MS,
-                    &[],
-                    sudo,
-                )
-                .await;
-            });
-        }
     }
 }
 
@@ -1178,6 +1163,240 @@ async fn send_bounded_exec_cancel_on_shared_with_timeout(
         })
 }
 
+async fn prepare_write_files(files: &[WriteFileRequest<'_>]) -> io::Result<Vec<PreparedWriteFile>> {
+    if files.len() > vsock_proto::MAX_WRITE_FILES_COUNT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "write_files file count exceeds limit: {} > {}",
+                files.len(),
+                vsock_proto::MAX_WRITE_FILES_COUNT
+            ),
+        ));
+    }
+
+    let mut total = 0u64;
+    let mut prepared = Vec::with_capacity(files.len());
+    for file in files {
+        if file.path.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "write_files path must not be empty",
+            ));
+        }
+        if file.path.len() > vsock_proto::MAX_WRITE_FILES_PATH_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("write_files path too long: {}", file.path.len()),
+            ));
+        }
+        let len = file.source.len();
+        if len > vsock_proto::MAX_WRITE_FILES_FILE_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("write_files file too large: {len}"),
+            ));
+        }
+        total = total.checked_add(len).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "write_files total size overflow",
+            )
+        })?;
+        if total > vsock_proto::MAX_WRITE_FILES_TOTAL_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("write_files total bytes exceed limit: {total}"),
+            ));
+        }
+
+        let source = match &file.source {
+            WriteFileSource::Bytes(bytes) => PreparedWriteFileSource::Bytes(bytes.to_vec()),
+            WriteFileSource::File { path, len } => {
+                let file = tokio::fs::File::open(path).await?;
+                let actual_len = file.metadata().await?.len();
+                if actual_len != *len {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "write_files source length changed for {}: expected {}, got {}",
+                            path.display(),
+                            len,
+                            actual_len
+                        ),
+                    ));
+                }
+                PreparedWriteFileSource::File { file, len: *len }
+            }
+        };
+        prepared.push(PreparedWriteFile {
+            path: file.path.to_string(),
+            source,
+        });
+    }
+
+    Ok(prepared)
+}
+
+async fn send_write_files_stream(
+    shared: &Arc<Shared>,
+    seq: u32,
+    mut files: Vec<PreparedWriteFile>,
+    sudo: bool,
+) -> io::Result<()> {
+    let file_count = u32::try_from(files.len()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "write_files file count exceeds u32",
+        )
+    })?;
+    let total_bytes = files.iter().map(|file| file.source.len()).sum::<u64>();
+    let mut writer = shared.writer.lock().await;
+    {
+        let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        if matches!(&*guard, ConnectionState::Closed { .. }) {
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "connection closed",
+            ));
+        }
+    }
+
+    // Active after START; any cancellation or write/read failure before
+    // FINISH poisons the connection so the guest stream cannot hang.
+    let mut write_guard = FrameWriteGuard::new(Arc::clone(shared));
+    let start = vsock_proto::encode_write_files_start(sudo, file_count, total_bytes)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    write_proto_frame(&mut writer, MSG_WRITE_FILES_START, seq, &start).await?;
+
+    let mut read_buf = vec![0u8; vsock_proto::MAX_WRITE_FILES_CHUNK_BYTES];
+    for (index, file) in files.iter_mut().enumerate() {
+        let file_index = u32::try_from(index).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "write_files file index exceeds u32",
+            )
+        })?;
+        let len = file.source.len();
+        let payload = vsock_proto::encode_write_files_file(file_index, &file.path, len)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+        write_proto_frame(&mut writer, MSG_WRITE_FILES_FILE, seq, &payload).await?;
+
+        match &mut file.source {
+            PreparedWriteFileSource::Bytes(bytes) => {
+                for chunk in bytes.chunks(vsock_proto::MAX_WRITE_FILES_CHUNK_BYTES) {
+                    let payload = vsock_proto::encode_write_files_chunk(file_index, chunk)
+                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+                    write_proto_frame(&mut writer, MSG_WRITE_FILES_CHUNK, seq, &payload).await?;
+                }
+            }
+            PreparedWriteFileSource::File { file, len } => {
+                let mut remaining = *len;
+                while remaining > 0 {
+                    let max = remaining.min(read_buf.len() as u64) as usize;
+                    let read_chunk = read_buf.get_mut(..max).ok_or_else(|| {
+                        io::Error::other("write_files read length exceeds buffer")
+                    })?;
+                    let n = file.read(read_chunk).await?;
+                    if n == 0 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "write_files source ended before expected length",
+                        ));
+                    }
+                    remaining -= n as u64;
+                    let payload_chunk = read_chunk
+                        .get(..n)
+                        .ok_or_else(|| io::Error::other("write_files read length exceeds chunk"))?;
+                    let payload = vsock_proto::encode_write_files_chunk(file_index, payload_chunk)
+                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+                    write_proto_frame(&mut writer, MSG_WRITE_FILES_CHUNK, seq, &payload).await?;
+                }
+            }
+        }
+    }
+
+    write_proto_frame(&mut writer, MSG_WRITE_FILES_FINISH, seq, &[]).await?;
+    write_guard.disarm();
+    Ok(())
+}
+
+async fn write_proto_frame(
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    msg_type: u8,
+    seq: u32,
+    payload: &[u8],
+) -> io::Result<()> {
+    let data = vsock_proto::encode(msg_type, seq, payload)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    writer.write_all(&data).await
+}
+
+fn validate_write_files_result(
+    entries: &[vsock_proto::WriteFilesResultEntry],
+    expected_count: usize,
+) -> io::Result<()> {
+    if entries.len() != expected_count {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "write_files result count mismatch: expected {}, got {}",
+                expected_count,
+                entries.len()
+            ),
+        ));
+    }
+
+    let mut seen = vec![false; expected_count];
+    for entry in entries {
+        let index = usize::try_from(entry.file_index).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("write_files result index too large: {}", entry.file_index),
+            )
+        })?;
+        if index >= expected_count {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "write_files result index out of range: {}",
+                    entry.file_index
+                ),
+            ));
+        }
+        let seen_slot = seen.get_mut(index).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "write_files result index out of range: {}",
+                    entry.file_index
+                ),
+            )
+        })?;
+        if std::mem::replace(seen_slot, true) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("write_files duplicate result index: {}", entry.file_index),
+            ));
+        }
+        if !entry.success {
+            return Err(io::Error::other(format!(
+                "write_files failed for index {}: {}",
+                entry.file_index, entry.error
+            )));
+        }
+    }
+
+    if let Some(index) = seen.iter().position(|seen| !seen) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("write_files missing result index: {index}"),
+        ));
+    }
+
+    Ok(())
+}
+
 async fn exec_on_shared(
     shared: &Arc<Shared>,
     command: &str,
@@ -1188,40 +1407,6 @@ async fn exec_on_shared(
     let request_timeout = Duration::from_millis(timeout_ms as u64 + 5000);
     exec_on_shared_with_request_timeout(shared, command, timeout_ms, env, sudo, request_timeout)
         .await
-}
-
-async fn bounded_exec_cleanup_on_shared(
-    shared: &Arc<Shared>,
-    command: &str,
-    timeout_ms: u32,
-    env: &[(&str, &str)],
-    sudo: bool,
-) -> io::Result<BoundedExecResult> {
-    let request = BoundedExecRequest {
-        command,
-        timeout_ms,
-        env,
-        sudo,
-        stdin: None,
-        stdout: BoundedExecOutputRequest {
-            capture: BoundedExecCapturePolicy::Capture {
-                limit_bytes: VsockHost::HELPER_EXEC_STDOUT_LIMIT_BYTES,
-            },
-            stream: None,
-        },
-        stderr: BoundedExecOutputRequest {
-            capture: BoundedExecCapturePolicy::Capture {
-                limit_bytes: VsockHost::HELPER_EXEC_STDERR_LIMIT_BYTES,
-            },
-            stream: None,
-        },
-    };
-    bounded_exec_on_shared_with_request_timeout(
-        shared,
-        &request,
-        Duration::from_millis(timeout_ms as u64),
-    )
-    .await
 }
 
 async fn exec_on_shared_with_request_timeout(
@@ -1712,117 +1897,36 @@ impl VsockHost {
         bounded_exec_on_shared(&self.shared, request).await
     }
 
-    /// Maximum content per write_file message.  Leaves headroom below
+    /// Maximum content per inline write_file message.  Leaves headroom below
     /// [`vsock_proto::MAX_MESSAGE_SIZE`] for the path and frame overhead.
-    const WRITE_FILE_CHUNK_LIMIT: usize = 15 * 1024 * 1024;
-
-    /// Timeout (ms) for short helper commands (mv, rm) used during chunked writes.
-    const HELPER_EXEC_TIMEOUT_MS: u32 = 5000;
-    const HELPER_EXEC_STDOUT_LIMIT_BYTES: u32 = 4 * 1024;
-    const HELPER_EXEC_STDERR_LIMIT_BYTES: u32 = 16 * 1024;
-
-    /// Shorter timeout (ms) for best-effort cleanup when the connection may
-    /// already be broken.  Avoids blocking for a full 5 s on a dead socket.
-    const CLEANUP_EXEC_TIMEOUT_MS: u32 = 1000;
+    const WRITE_FILE_INLINE_LIMIT: usize = 15 * 1024 * 1024;
+    const WRITE_FILES_TIMEOUT: Duration = Duration::from_secs(300);
 
     /// Write a file on the guest.
     ///
-    /// Content larger than 15 MB is automatically split into multiple
-    /// messages using the `WRITE_FILE_FLAG_APPEND` protocol flag. Chunks are written
-    /// to a temporary file and atomically renamed to the target path after
-    /// the last chunk succeeds, so a partial transfer never leaves a
-    /// truncated file at the destination.
+    /// Small content is sent with the compact inline write_file message.
+    /// Larger content uses the streamed write_files protocol as a one-file
+    /// batch so large and multi-file writes share one guest write engine.
     ///
     /// Non-sudo writes create missing parent directories on the guest.
     pub async fn write_file(&self, path: &str, content: &[u8], sudo: bool) -> io::Result<()> {
-        if content.len() <= Self::WRITE_FILE_CHUNK_LIMIT {
-            return self.write_file_chunk(path, content, sudo, false).await;
+        if content.len() <= Self::WRITE_FILE_INLINE_LIMIT {
+            return self.write_file_inline(path, content, sudo).await;
         }
 
-        // Write chunks to a per-call temp file, then atomic rename. The
-        // suffix prevents concurrent large writes to the same destination
-        // from appending to or cleaning up each other's staging file.
-        let tmp = format!("{path}.vm0tmp-{}", self.shared.next_seq());
-        let escaped_tmp = tmp.replace('\'', "'\\''");
-        let rm_tmp = format!("rm -f -- '{escaped_tmp}'");
-        let mut cleanup_guard =
-            ChunkedWriteCleanupGuard::new(Arc::clone(&self.shared), rm_tmp, sudo);
-
-        let result = async {
-            for (i, chunk) in content.chunks(Self::WRITE_FILE_CHUNK_LIMIT).enumerate() {
-                self.write_file_chunk(&tmp, chunk, sudo, i > 0).await?;
-            }
-            io::Result::Ok(())
-        }
-        .await;
-
-        if result.is_err() {
-            // Best-effort cleanup of the temp file.
-            cleanup_guard.cleanup_now().await;
-            return result;
-        }
-
-        // Atomic rename temp → target.
-        let escaped_path = path.replace('\'', "'\\''");
-        let mv_cmd = format!("mv -f -- '{escaped_tmp}' '{escaped_path}'");
-        let mv_request = BoundedExecRequest {
-            command: &mv_cmd,
-            timeout_ms: Self::HELPER_EXEC_TIMEOUT_MS,
-            env: &[],
+        self.write_files(
+            &[WriteFileRequest {
+                path,
+                source: WriteFileSource::Bytes(content),
+            }],
             sudo,
-            stdin: None,
-            stdout: BoundedExecOutputRequest {
-                capture: BoundedExecCapturePolicy::Capture {
-                    limit_bytes: Self::HELPER_EXEC_STDOUT_LIMIT_BYTES,
-                },
-                stream: None,
-            },
-            stderr: BoundedExecOutputRequest {
-                capture: BoundedExecCapturePolicy::Capture {
-                    limit_bytes: Self::HELPER_EXEC_STDERR_LIMIT_BYTES,
-                },
-                stream: None,
-            },
-        };
-        match self.bounded_exec(&mv_request).await {
-            Ok(r)
-                if matches!(
-                    r.termination,
-                    BoundedExecTermination::Exited { exit_code: 0 }
-                ) =>
-            {
-                cleanup_guard.disarm();
-                Ok(())
-            }
-            Ok(r) => {
-                cleanup_guard.cleanup_now().await;
-                let stderr = match &r.stderr {
-                    BoundedExecOutput::Captured { bytes, .. } => bytes.as_slice(),
-                    BoundedExecOutput::Discarded => &[],
-                };
-                Err(io::Error::other(format!(
-                    "failed to rename temp file to {path}: termination={:?}, stderr={}",
-                    r.termination,
-                    String::from_utf8_lossy(stderr),
-                )))
-            }
-            Err(e) => {
-                // Connection likely broken — short timeout to avoid blocking.
-                cleanup_guard.cleanup_now().await;
-                Err(e)
-            }
-        }
+        )
+        .await
     }
 
     /// Send a single write_file message and validate the response.
-    async fn write_file_chunk(
-        &self,
-        path: &str,
-        content: &[u8],
-        sudo: bool,
-        append: bool,
-    ) -> io::Result<()> {
-        let payload = vsock_proto::encode_write_file(path, content, sudo, append)
+    async fn write_file_inline(&self, path: &str, content: &[u8], sudo: bool) -> io::Result<()> {
+        let payload = vsock_proto::encode_write_file(path, content, sudo, false)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
         let timeout = Duration::from_secs(300);
         let resp = self.request(MSG_WRITE_FILE, &payload, timeout).await?;
@@ -1848,6 +1952,65 @@ impl VsockHost {
         }
 
         Ok(())
+    }
+
+    pub async fn write_files(&self, files: &[WriteFileRequest<'_>], sudo: bool) -> io::Result<()> {
+        let expected_count = files.len();
+        let prepared = prepare_write_files(files).await?;
+        if prepared.is_empty() {
+            return Ok(());
+        }
+
+        let seq = self.shared.next_seq();
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut guard = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+            match &mut *guard {
+                ConnectionState::Closed { .. } => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::ConnectionReset,
+                        "connection closed",
+                    ));
+                }
+                ConnectionState::Connected { pending, .. } => {
+                    pending.insert(seq, tx);
+                }
+            }
+        }
+        let _pending_guard = PendingRequestGuard::new(Arc::clone(&self.shared), seq);
+
+        send_write_files_stream(&self.shared, seq, prepared, sudo).await?;
+
+        let resp = tokio::select! {
+            biased;
+            result = rx => {
+                result.map_err(|_| io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "connection closed",
+                ))?
+            }
+            _ = tokio::time::sleep(Self::WRITE_FILES_TIMEOUT) => {
+                self.shared.poison_connection();
+                return Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"));
+            }
+        };
+
+        if resp.msg_type == MSG_ERROR {
+            let msg = vsock_proto::decode_error(&resp.payload)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+            return Err(io::Error::other(msg));
+        }
+
+        if resp.msg_type != MSG_WRITE_FILES_RESULT {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unexpected response type: 0x{:02X}", resp.msg_type),
+            ));
+        }
+
+        let entries = vsock_proto::decode_write_files_result(&resp.payload)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        validate_write_files_result(&entries, expected_count)
     }
 
     /// Spawn a process on the guest and monitor for exit.
@@ -4828,83 +4991,68 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_write_file_chunked() {
+    async fn test_write_file_large_uses_streamed_batch() {
         let (host_stream, mut guest) = make_pair();
 
-        // Content just over the chunk limit → 2 write messages + 1 exec (mv)
-        let chunk_limit = VsockHost::WRITE_FILE_CHUNK_LIMIT;
-        let content = vec![0xABu8; chunk_limit + 100];
+        let content = vec![0xABu8; VsockHost::WRITE_FILE_INLINE_LIMIT + 100];
         let content_clone = content.clone();
 
         tokio::spawn(async move {
             let mut decoder = Decoder::new();
             mock_handshake(&mut guest, &mut decoder).await;
 
-            let mut chunks_received = Vec::new();
-            let mut temp_path = None::<String>;
-            let mut buf = vec![0u8; chunk_limit + 4096];
-
-            // Read write_file chunks + final bounded_exec (mv) message
+            let mut seq = None;
+            let mut chunks = Vec::new();
+            let mut saw_file = false;
+            let mut buf = vec![0u8; vsock_proto::MAX_WRITE_FILES_CHUNK_BYTES + 4096];
             loop {
                 let n = guest.read(&mut buf).await.unwrap();
-                if n == 0 {
-                    break;
-                }
-                let msgs = decoder.decode(&buf[..n]).unwrap();
-                for msg in msgs {
-                    if msg.msg_type == MSG_WRITE_FILE {
-                        let (path, chunk, _sudo, append) =
-                            vsock_proto::decode_write_file(&msg.payload).unwrap();
-                        // Chunks go to temp file
-                        if let Some(temp_path) = &temp_path {
-                            assert_eq!(path, temp_path);
-                        } else {
-                            assert!(path.starts_with("/tmp/big.bin.vm0tmp-"));
-                            temp_path = Some(path.to_string());
+                assert_ne!(n, 0, "connection closed before write_file message");
+                for msg in decoder.decode(&buf[..n]).unwrap() {
+                    seq.get_or_insert(msg.seq);
+                    assert_eq!(Some(msg.seq), seq);
+                    match msg.msg_type {
+                        MSG_WRITE_FILES_START => {
+                            let start =
+                                vsock_proto::decode_write_files_start(&msg.payload).unwrap();
+                            assert!(!start.sudo);
+                            assert_eq!(start.file_count, 1);
+                            assert_eq!(start.total_bytes, content_clone.len() as u64);
                         }
-                        chunks_received.push((append, chunk.to_vec()));
-
-                        let payload = vsock_proto::encode_write_file_result(true, "");
-                        let resp =
-                            vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
-                        guest.write_all(&resp).await.unwrap();
-                    } else if msg.msg_type == MSG_BOUNDED_EXEC {
-                        // Atomic rename: mv temp → target
-                        let decoded = vsock_proto::decode_bounded_exec(&msg.payload).unwrap();
-                        let temp_path = temp_path.as_ref().expect("temp path");
-                        assert!(decoded.command.contains("mv -f --"));
-                        assert!(decoded.command.contains(temp_path));
-                        assert!(decoded.command.contains("/tmp/big.bin"));
-                        assert_eq!(
-                            decoded.stdout.capture,
-                            vsock_proto::BoundedExecCapturePolicy::Capture {
-                                limit_bytes: 4 * 1024
-                            }
-                        );
-                        assert_eq!(
-                            decoded.stderr.capture,
-                            vsock_proto::BoundedExecCapturePolicy::Capture {
-                                limit_bytes: 16 * 1024
-                            }
-                        );
-                        assert_eq!(decoded.stdout.stream, None);
-                        assert_eq!(decoded.stderr.stream, None);
-
-                        write_bounded_exec_result(&mut guest, msg.seq, &[]).await;
-                        // Done — verify chunks and return
-                        assert_eq!(chunks_received.len(), 2);
-                        assert!(!chunks_received[0].0); // first: create
-                        assert_eq!(chunks_received[0].1.len(), chunk_limit);
-                        assert!(chunks_received[1].0); // second: append
-                        assert_eq!(chunks_received[1].1.len(), 100);
-                        let mut reassembled = chunks_received[0].1.clone();
-                        reassembled.extend_from_slice(&chunks_received[1].1);
-                        assert_eq!(reassembled, content_clone);
-                        return;
+                        MSG_WRITE_FILES_FILE => {
+                            let file = vsock_proto::decode_write_files_file(&msg.payload).unwrap();
+                            assert_eq!(file.file_index, 0);
+                            assert_eq!(file.path, "/tmp/big.bin");
+                            assert_eq!(file.content_len, content_clone.len() as u64);
+                            saw_file = true;
+                        }
+                        MSG_WRITE_FILES_CHUNK => {
+                            let chunk =
+                                vsock_proto::decode_write_files_chunk(&msg.payload).unwrap();
+                            assert_eq!(chunk.file_index, 0);
+                            chunks.extend_from_slice(chunk.chunk);
+                        }
+                        MSG_WRITE_FILES_FINISH => {
+                            assert!(saw_file);
+                            assert_eq!(chunks, content_clone);
+                            let payload = vsock_proto::encode_write_files_result(&[
+                                vsock_proto::WriteFilesResultEntry {
+                                    file_index: 0,
+                                    success: true,
+                                    error: String::new(),
+                                },
+                            ])
+                            .unwrap();
+                            let resp =
+                                vsock_proto::encode(MSG_WRITE_FILES_RESULT, msg.seq, &payload)
+                                    .unwrap();
+                            guest.write_all(&resp).await.unwrap();
+                            return;
+                        }
+                        other => panic!("unexpected message type: {other:#x}"),
                     }
                 }
             }
-            panic!("guest loop ended without receiving bounded_exec (mv)");
         });
 
         let host = host_from_stream(host_stream).await.unwrap();
@@ -4914,18 +5062,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_write_file_at_chunk_limit_uses_single_message() {
+    async fn test_write_file_at_inline_limit_uses_single_message() {
         let (host_stream, mut guest) = make_pair();
 
-        let chunk_limit = VsockHost::WRITE_FILE_CHUNK_LIMIT;
-        let content = vec![0xABu8; chunk_limit];
+        let inline_limit = VsockHost::WRITE_FILE_INLINE_LIMIT;
+        let content = vec![0xABu8; inline_limit];
         let content_clone = content.clone();
 
         tokio::spawn(async move {
             let mut decoder = Decoder::new();
             mock_handshake(&mut guest, &mut decoder).await;
 
-            let mut buf = vec![0u8; chunk_limit + 4096];
+            let mut buf = vec![0u8; inline_limit + 4096];
             let mut msgs = Vec::new();
             while msgs.is_empty() {
                 let n = guest.read(&mut buf).await.unwrap();
@@ -4953,64 +5101,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_write_file_chunked_cleans_up_on_chunk_failure() {
+    async fn test_write_files_surfaces_per_file_failure() {
         let (host_stream, mut guest) = make_pair();
-
-        let chunk_limit = VsockHost::WRITE_FILE_CHUNK_LIMIT;
-        let content = vec![0xABu8; chunk_limit + 100];
 
         tokio::spawn(async move {
             let mut decoder = Decoder::new();
             mock_handshake(&mut guest, &mut decoder).await;
 
-            let mut buf = vec![0u8; chunk_limit + 4096];
-            let mut chunk_count = 0u32;
-            let mut temp_path = None::<String>;
+            let mut buf = vec![0u8; 4096];
             loop {
                 let n = guest.read(&mut buf).await.unwrap();
-                if n == 0 {
-                    break;
-                }
-                let msgs = decoder.decode(&buf[..n]).unwrap();
-                for msg in msgs {
-                    if msg.msg_type == MSG_WRITE_FILE {
-                        chunk_count += 1;
-                        let (path, _chunk, _sudo, _append) =
-                            vsock_proto::decode_write_file(&msg.payload).unwrap();
-                        if let Some(temp_path) = &temp_path {
-                            assert_eq!(path, temp_path);
-                        } else {
-                            assert!(path.starts_with("/tmp/big.bin.vm0tmp-"));
-                            temp_path = Some(path.to_string());
-                        }
-                        let (success, err) = if chunk_count == 2 {
-                            (false, "disk full")
-                        } else {
-                            (true, "")
-                        };
-                        let payload = vsock_proto::encode_write_file_result(success, err);
+                assert_ne!(n, 0);
+                for msg in decoder.decode(&buf[..n]).unwrap() {
+                    if msg.msg_type == MSG_WRITE_FILES_FINISH {
+                        let payload = vsock_proto::encode_write_files_result(&[
+                            vsock_proto::WriteFilesResultEntry {
+                                file_index: 0,
+                                success: true,
+                                error: String::new(),
+                            },
+                            vsock_proto::WriteFilesResultEntry {
+                                file_index: 1,
+                                success: false,
+                                error: "disk full".to_string(),
+                            },
+                        ])
+                        .unwrap();
                         let resp =
-                            vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
+                            vsock_proto::encode(MSG_WRITE_FILES_RESULT, msg.seq, &payload).unwrap();
                         guest.write_all(&resp).await.unwrap();
-                    } else if msg.msg_type == MSG_BOUNDED_EXEC {
-                        // Cleanup: rm -f temp file
-                        let decoded = vsock_proto::decode_bounded_exec(&msg.payload).unwrap();
-                        let temp_path = temp_path.as_ref().expect("temp path");
-                        assert!(decoded.command.contains("rm -f --"));
-                        assert!(decoded.command.contains(temp_path));
-                        assert_eq!(
-                            decoded.stdout.capture,
-                            vsock_proto::BoundedExecCapturePolicy::Capture {
-                                limit_bytes: 4 * 1024
-                            }
-                        );
-                        assert_eq!(
-                            decoded.stderr.capture,
-                            vsock_proto::BoundedExecCapturePolicy::Capture {
-                                limit_bytes: 16 * 1024
-                            }
-                        );
-                        write_bounded_exec_result(&mut guest, msg.seq, &[]).await;
                         return;
                     }
                 }
@@ -5019,205 +5138,49 @@ mod tests {
 
         let host = host_from_stream(host_stream).await.unwrap();
         let err = host
-            .write_file("/tmp/big.bin", &content, false)
+            .write_files(
+                &[
+                    WriteFileRequest {
+                        path: "/tmp/a",
+                        source: WriteFileSource::Bytes(b"a"),
+                    },
+                    WriteFileRequest {
+                        path: "/tmp/b",
+                        source: WriteFileSource::Bytes(b"b"),
+                    },
+                ],
+                false,
+            )
             .await
             .unwrap_err();
         assert!(err.to_string().contains("disk full"));
     }
 
     #[tokio::test]
-    async fn test_write_file_chunked_cleans_up_on_mv_failure() {
+    async fn test_write_files_rejects_incomplete_success_result() {
         let (host_stream, mut guest) = make_pair();
-
-        let chunk_limit = VsockHost::WRITE_FILE_CHUNK_LIMIT;
-        let content = vec![0xABu8; chunk_limit + 100];
 
         tokio::spawn(async move {
             let mut decoder = Decoder::new();
             mock_handshake(&mut guest, &mut decoder).await;
 
-            let mut buf = vec![0u8; chunk_limit + 4096];
-            let mut exec_count = 0u32;
-            let mut temp_path = None::<String>;
+            let mut buf = vec![0u8; 4096];
             loop {
                 let n = guest.read(&mut buf).await.unwrap();
-                if n == 0 {
-                    break;
-                }
-                let msgs = decoder.decode(&buf[..n]).unwrap();
-                for msg in msgs {
-                    if msg.msg_type == MSG_WRITE_FILE {
-                        let (path, _chunk, _sudo, _append) =
-                            vsock_proto::decode_write_file(&msg.payload).unwrap();
-                        if let Some(temp_path) = &temp_path {
-                            assert_eq!(path, temp_path);
-                        } else {
-                            assert!(path.starts_with("/tmp/big.bin.vm0tmp-"));
-                            temp_path = Some(path.to_string());
-                        }
-                        let payload = vsock_proto::encode_write_file_result(true, "");
+                assert_ne!(n, 0);
+                for msg in decoder.decode(&buf[..n]).unwrap() {
+                    if msg.msg_type == MSG_WRITE_FILES_FINISH {
+                        let payload = vsock_proto::encode_write_files_result(&[
+                            vsock_proto::WriteFilesResultEntry {
+                                file_index: 0,
+                                success: true,
+                                error: String::new(),
+                            },
+                        ])
+                        .unwrap();
                         let resp =
-                            vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
+                            vsock_proto::encode(MSG_WRITE_FILES_RESULT, msg.seq, &payload).unwrap();
                         guest.write_all(&resp).await.unwrap();
-                    } else if msg.msg_type == MSG_BOUNDED_EXEC {
-                        exec_count += 1;
-                        let decoded = vsock_proto::decode_bounded_exec(&msg.payload).unwrap();
-                        let temp_path = temp_path.as_ref().expect("temp path");
-                        if decoded.command.contains("mv -f --") {
-                            // mv fails
-                            assert!(decoded.command.contains(temp_path));
-                            write_bounded_exec_result_full(
-                                &mut guest,
-                                msg.seq,
-                                vsock_proto::BoundedExecTermination::Exited { exit_code: 1 },
-                                &[],
-                                b"permission denied",
-                                false,
-                                false,
-                            )
-                            .await;
-                        } else {
-                            // cleanup rm
-                            assert!(decoded.command.contains("rm -f --"));
-                            assert!(decoded.command.contains(temp_path));
-                            write_bounded_exec_result(&mut guest, msg.seq, &[]).await;
-                            assert_eq!(exec_count, 2); // mv then rm
-                            return;
-                        }
-                    }
-                }
-            }
-        });
-
-        let host = host_from_stream(host_stream).await.unwrap();
-        let err = host
-            .write_file("/tmp/big.bin", &content, false)
-            .await
-            .unwrap_err();
-        assert!(err.to_string().contains("permission denied"));
-    }
-
-    #[tokio::test]
-    async fn test_write_file_chunked_cleans_up_on_mv_timeout() {
-        let (host_stream, mut guest) = make_pair();
-
-        let chunk_limit = VsockHost::WRITE_FILE_CHUNK_LIMIT;
-        let content = vec![0xABu8; chunk_limit + 100];
-
-        tokio::spawn(async move {
-            let mut decoder = Decoder::new();
-            mock_handshake(&mut guest, &mut decoder).await;
-
-            let mut buf = vec![0u8; chunk_limit + 4096];
-            let mut exec_count = 0u32;
-            let mut temp_path = None::<String>;
-            loop {
-                let n = guest.read(&mut buf).await.unwrap();
-                if n == 0 {
-                    break;
-                }
-                let msgs = decoder.decode(&buf[..n]).unwrap();
-                for msg in msgs {
-                    if msg.msg_type == MSG_WRITE_FILE {
-                        let (path, _chunk, _sudo, _append) =
-                            vsock_proto::decode_write_file(&msg.payload).unwrap();
-                        if let Some(temp_path) = &temp_path {
-                            assert_eq!(path, temp_path);
-                        } else {
-                            assert!(path.starts_with("/tmp/big.bin.vm0tmp-"));
-                            temp_path = Some(path.to_string());
-                        }
-                        let payload = vsock_proto::encode_write_file_result(true, "");
-                        let resp =
-                            vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
-                        guest.write_all(&resp).await.unwrap();
-                    } else if msg.msg_type == MSG_BOUNDED_EXEC {
-                        exec_count += 1;
-                        let decoded = vsock_proto::decode_bounded_exec(&msg.payload).unwrap();
-                        let temp_path = temp_path.as_ref().expect("temp path");
-                        if decoded.command.contains("mv -f --") {
-                            assert!(decoded.command.contains(temp_path));
-                            write_bounded_exec_result_full(
-                                &mut guest,
-                                msg.seq,
-                                vsock_proto::BoundedExecTermination::TimedOut,
-                                &[],
-                                b"",
-                                false,
-                                false,
-                            )
-                            .await;
-                        } else {
-                            assert!(decoded.command.contains("rm -f --"));
-                            assert!(decoded.command.contains(temp_path));
-                            write_bounded_exec_result(&mut guest, msg.seq, &[]).await;
-                            assert_eq!(exec_count, 2); // mv then rm
-                            return;
-                        }
-                    }
-                }
-            }
-        });
-
-        let host = host_from_stream(host_stream).await.unwrap();
-        let err = host
-            .write_file("/tmp/big.bin", &content, false)
-            .await
-            .unwrap_err();
-        assert!(err.to_string().contains("TimedOut"), "got: {err}");
-    }
-
-    #[tokio::test]
-    async fn test_write_file_chunked_cleans_up_when_cancelled() {
-        let (host_stream, mut guest) = make_pair();
-
-        let chunk_limit = VsockHost::WRITE_FILE_CHUNK_LIMIT;
-        let content = vec![0xABu8; chunk_limit + 100];
-        let (first_chunk_tx, first_chunk_rx) = oneshot::channel::<()>();
-        let (cleanup_tx, cleanup_rx) = oneshot::channel::<String>();
-
-        tokio::spawn(async move {
-            let mut decoder = Decoder::new();
-            mock_handshake(&mut guest, &mut decoder).await;
-
-            let mut buf = vec![0u8; chunk_limit + 4096];
-            let mut temp_path = None::<String>;
-            let mut first_chunk_tx = Some(first_chunk_tx);
-            let mut cleanup_tx = Some(cleanup_tx);
-
-            loop {
-                let n = guest.read(&mut buf).await.unwrap();
-                if n == 0 {
-                    break;
-                }
-                let msgs = decoder.decode(&buf[..n]).unwrap();
-                for msg in msgs {
-                    if msg.msg_type == MSG_WRITE_FILE {
-                        let (path, _chunk, _sudo, _append) =
-                            vsock_proto::decode_write_file(&msg.payload).unwrap();
-                        if let Some(temp_path) = &temp_path {
-                            assert_eq!(path, temp_path);
-                            continue;
-                        }
-
-                        assert!(path.starts_with("/tmp/big.bin.vm0tmp-"));
-                        temp_path = Some(path.to_string());
-                        let payload = vsock_proto::encode_write_file_result(true, "");
-                        let resp =
-                            vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
-                        guest.write_all(&resp).await.unwrap();
-                        if let Some(tx) = first_chunk_tx.take() {
-                            let _ = tx.send(());
-                        }
-                    } else if msg.msg_type == MSG_BOUNDED_EXEC {
-                        let decoded = vsock_proto::decode_bounded_exec(&msg.payload).unwrap();
-                        let temp_path = temp_path.as_ref().expect("temp path");
-                        assert!(decoded.command.contains("rm -f --"));
-                        assert!(decoded.command.contains(temp_path));
-                        if let Some(tx) = cleanup_tx.take() {
-                            let _ = tx.send(decoded.command.to_string());
-                        }
-                        write_bounded_exec_result(&mut guest, msg.seq, &[]).await;
                         return;
                     }
                 }
@@ -5225,18 +5188,61 @@ mod tests {
         });
 
         let host = host_from_stream(host_stream).await.unwrap();
-        let mut write = Box::pin(host.write_file("/tmp/big.bin", &content, false));
-        tokio::select! {
-            _ = &mut write => panic!("chunked write completed before cancellation"),
-            result = first_chunk_rx => result.unwrap(),
-        }
-        drop(write);
-
-        let cleanup_command = tokio::time::timeout(Duration::from_secs(2), cleanup_rx)
+        let err = host
+            .write_files(
+                &[
+                    WriteFileRequest {
+                        path: "/tmp/a",
+                        source: WriteFileSource::Bytes(b"a"),
+                    },
+                    WriteFileRequest {
+                        path: "/tmp/b",
+                        source: WriteFileSource::Bytes(b"b"),
+                    },
+                ],
+                false,
+            )
             .await
-            .expect("cleanup command was not sent after cancellation")
-            .expect("cleanup sender dropped");
-        assert!(cleanup_command.contains("rm -f --"));
+            .unwrap_err();
+        assert!(err.to_string().contains("result count mismatch"));
+    }
+
+    #[tokio::test]
+    async fn test_write_files_rejects_changed_file_source_length_before_sending() {
+        let (host_stream, mut guest) = make_pair();
+        let source = std::env::temp_dir().join(format!(
+            "vm0-vsock-host-source-len-{}-{}.tar.gz",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        tokio::fs::write(&source, b"actual").await.unwrap();
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+            let mut buf = [0u8; 1];
+            let _ = guest.read(&mut buf).await;
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let err = host
+            .write_files(
+                &[WriteFileRequest {
+                    path: "/tmp/archive.tar.gz",
+                    source: WriteFileSource::File {
+                        path: &source,
+                        len: 1,
+                    },
+                }],
+                false,
+            )
+            .await
+            .unwrap_err();
+        let _ = tokio::fs::remove_file(&source).await;
+        assert!(err.to_string().contains("source length changed"));
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -5363,6 +5363,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_write_files_early_non_error_response_is_rejected() {
+        let (host_stream, mut guest) = make_pair();
+        set_send_buffer(&host_stream, 4096).unwrap();
+
+        let release_guest = std::sync::Arc::new(Notify::new());
+        let guest_task = {
+            let release_guest = std::sync::Arc::clone(&release_guest);
+            tokio::spawn(async move {
+                let mut decoder = Decoder::new();
+                mock_handshake(&mut guest, &mut decoder).await;
+
+                let mut buf = [0u8; 4096];
+                loop {
+                    let n = guest.read(&mut buf).await.unwrap();
+                    assert_ne!(n, 0, "connection closed before write_files start");
+                    for msg in decoder.decode(&buf[..n]).unwrap() {
+                        if msg.msg_type == MSG_WRITE_FILES_START {
+                            let payload = vsock_proto::encode_write_files_result(&[
+                                vsock_proto::WriteFilesResultEntry {
+                                    file_index: 0,
+                                    success: true,
+                                    error: String::new(),
+                                },
+                            ])
+                            .unwrap();
+                            let resp =
+                                vsock_proto::encode(MSG_WRITE_FILES_RESULT, msg.seq, &payload)
+                                    .unwrap();
+                            guest.write_all(&resp).await.unwrap();
+                            release_guest.notified().await;
+
+                            let mut drain = [0u8; 4096];
+                            loop {
+                                let n = guest.read(&mut drain).await.unwrap();
+                                if n == 0 {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+        };
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let content = vec![b'x'; 8 * 1024 * 1024];
+        let files = [WriteFileRequest {
+            path: "/tmp/large.bin",
+            source: WriteFileSource::Bytes(&content),
+        }];
+
+        let err = tokio::time::timeout(Duration::from_secs(5), host.write_files(&files, false))
+            .await
+            .expect("early guest response must stop streaming promptly")
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string()
+                .contains("write_files response before stream finished")
+        );
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        release_guest.notify_one();
+        guest_task.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_write_file_at_inline_limit_uses_single_message() {
         let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -5480,21 +5480,28 @@ mod tests {
 
             let mut buf = [0u8; 4096];
             let n = guest.read(&mut buf).await.unwrap();
-            assert_ne!(n, 0, "connection closed before follow-up exec");
+            assert_ne!(n, 0, "connection closed before follow-up bounded_exec");
             let msgs = decoder.decode(&buf[..n]).unwrap();
             assert_eq!(msgs.len(), 1);
             let _ = first_msg_tx.send(msgs[0].msg_type);
             assert_eq!(
-                msgs[0].msg_type, MSG_EXEC,
+                msgs[0].msg_type, MSG_BOUNDED_EXEC,
                 "empty write_file path must not send a write_file frame"
             );
 
-            let decoded = vsock_proto::decode_exec(&msgs[0].payload).unwrap();
+            let decoded = vsock_proto::decode_bounded_exec(&msgs[0].payload).unwrap();
             assert_eq!(decoded.command, "after-empty-write-file-path");
 
-            let payload = vsock_proto::encode_exec_result(0, b"ok", b"");
-            let resp = vsock_proto::encode(MSG_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
-            guest.write_all(&resp).await.unwrap();
+            write_bounded_exec_result_full(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
+                b"ok",
+                b"",
+                false,
+                false,
+            )
+            .await;
         });
 
         let host = host_from_stream(host_stream).await.unwrap();
@@ -5509,12 +5516,13 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
         assert!(err.to_string().contains("path must not be empty"));
 
-        let result = host
-            .exec("after-empty-write-file-path", 5000, &[], false)
-            .await
-            .unwrap();
-        assert_eq!(result.exit_code, 0);
-        assert_eq!(result.stdout, b"ok");
+        let request = simple_bounded_request("after-empty-write-file-path", None);
+        let result = host.bounded_exec(&request).await.unwrap();
+        assert_eq!(
+            result.termination,
+            BoundedExecTermination::Exited { exit_code: 0 }
+        );
+        assert_host_captured_output(&result.stdout, b"ok", false);
         guest_task.await.unwrap();
     }
 
@@ -5528,28 +5536,36 @@ mod tests {
 
             let mut buf = [0u8; 4096];
             let n = guest.read(&mut buf).await.unwrap();
-            assert_ne!(n, 0, "connection closed before follow-up exec");
+            assert_ne!(n, 0, "connection closed before follow-up bounded_exec");
             let msgs = decoder.decode(&buf[..n]).unwrap();
             assert_eq!(msgs.len(), 1);
-            assert_eq!(msgs[0].msg_type, MSG_EXEC);
+            assert_eq!(msgs[0].msg_type, MSG_BOUNDED_EXEC);
 
-            let decoded = vsock_proto::decode_exec(&msgs[0].payload).unwrap();
+            let decoded = vsock_proto::decode_bounded_exec(&msgs[0].payload).unwrap();
             assert_eq!(decoded.command, "after-empty-write-files");
 
-            let payload = vsock_proto::encode_exec_result(0, b"ok", b"");
-            let resp = vsock_proto::encode(MSG_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
-            guest.write_all(&resp).await.unwrap();
+            write_bounded_exec_result_full(
+                &mut guest,
+                msgs[0].seq,
+                vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
+                b"ok",
+                b"",
+                false,
+                false,
+            )
+            .await;
         });
 
         let host = host_from_stream(host_stream).await.unwrap();
         let empty: &[WriteFileRequest<'_>] = &[];
         host.write_files(empty, false).await.unwrap();
-        let result = host
-            .exec("after-empty-write-files", 5000, &[], false)
-            .await
-            .unwrap();
-        assert_eq!(result.exit_code, 0);
-        assert_eq!(result.stdout, b"ok");
+        let request = simple_bounded_request("after-empty-write-files", None);
+        let result = host.bounded_exec(&request).await.unwrap();
+        assert_eq!(
+            result.termination,
+            BoundedExecTermination::Exited { exit_code: 0 }
+        );
+        assert_host_captured_output(&result.stdout, b"ok", false);
         guest_task.await.unwrap();
     }
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1160,18 +1160,7 @@ async fn prepare_write_files<'a>(
 ) -> io::Result<Vec<PreparedWriteFile<'a>>> {
     let mut prepared = Vec::with_capacity(files.len());
     for file in files {
-        if file.path.is_empty() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "write_files path must not be empty",
-            ));
-        }
-        if file.path.len() > vsock_proto::MAX_WRITE_FILES_PATH_BYTES {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("write_files path too long: {}", file.path.len()),
-            ));
-        }
+        validate_guest_write_path("write_files", file.path)?;
         let source = match &file.source {
             WriteFileSource::Bytes(bytes) => PreparedWriteFileSource::Bytes(bytes),
             WriteFileSource::File { path, len } => {
@@ -1186,6 +1175,22 @@ async fn prepare_write_files<'a>(
     }
 
     Ok(prepared)
+}
+
+fn validate_guest_write_path(operation: &str, path: &str) -> io::Result<()> {
+    if path.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{operation} path must not be empty"),
+        ));
+    }
+    if path.len() > vsock_proto::MAX_WRITE_FILES_PATH_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{operation} path too long: {}", path.len()),
+        ));
+    }
+    Ok(())
 }
 
 fn write_files_total_bytes(files: &[PreparedWriteFile<'_>]) -> io::Result<u64> {
@@ -1989,6 +1994,7 @@ impl VsockHost {
     ///
     /// Non-sudo writes create missing parent directories on the guest.
     pub async fn write_file(&self, path: &str, content: &[u8], sudo: bool) -> io::Result<()> {
+        validate_guest_write_path("write_file", path)?;
         if content.len() <= Self::WRITE_FILE_INLINE_LIMIT {
             return self.write_file_inline(path, content, sudo).await;
         }
@@ -5293,6 +5299,55 @@ mod tests {
         host.write_file("/tmp/exact-limit.bin", &content, false)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_file_rejects_empty_path_before_sending() {
+        let (host_stream, mut guest) = make_pair();
+        let (first_msg_tx, mut first_msg_rx) = oneshot::channel();
+
+        let guest_task = tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            assert_ne!(n, 0, "connection closed before follow-up exec");
+            let msgs = decoder.decode(&buf[..n]).unwrap();
+            assert_eq!(msgs.len(), 1);
+            let _ = first_msg_tx.send(msgs[0].msg_type);
+            assert_eq!(
+                msgs[0].msg_type, MSG_EXEC,
+                "empty write_file path must not send a write_file frame"
+            );
+
+            let decoded = vsock_proto::decode_exec(&msgs[0].payload).unwrap();
+            assert_eq!(decoded.command, "after-empty-write-file-path");
+
+            let payload = vsock_proto::encode_exec_result(0, b"ok", b"");
+            let resp = vsock_proto::encode(MSG_EXEC_RESULT, msgs[0].seq, &payload).unwrap();
+            guest.write_all(&resp).await.unwrap();
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let write_file = host.write_file("", b"data", false);
+        tokio::pin!(write_file);
+        let err = tokio::select! {
+            result = &mut write_file => result.unwrap_err(),
+            Ok(msg_type) = &mut first_msg_rx => panic!(
+                "empty write_file path sent frame type 0x{msg_type:02X}"
+            ),
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("path must not be empty"));
+
+        let result = host
+            .exec("after-empty-write-file-path", 5000, &[], false)
+            .await
+            .unwrap();
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, b"ok");
+        guest_task.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1926,7 +1926,7 @@ impl VsockHost {
 
     /// Send a single write_file message and validate the response.
     async fn write_file_inline(&self, path: &str, content: &[u8], sudo: bool) -> io::Result<()> {
-        let payload = vsock_proto::encode_write_file(path, content, sudo, false)
+        let payload = vsock_proto::encode_write_file(path, content, sudo)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
         let timeout = Duration::from_secs(300);
         let resp = self.request(MSG_WRITE_FILE, &payload, timeout).await?;
@@ -4972,12 +4972,10 @@ mod tests {
             let msgs = decoder.decode(&buf[..n]).unwrap();
             assert_eq!(msgs[0].msg_type, MSG_WRITE_FILE);
 
-            let (path, content, sudo, append) =
-                vsock_proto::decode_write_file(&msgs[0].payload).unwrap();
+            let (path, content, sudo) = vsock_proto::decode_write_file(&msgs[0].payload).unwrap();
             assert_eq!(path, "/tmp/test.txt");
             assert_eq!(content, b"hello");
             assert!(!sudo);
-            assert!(!append);
 
             let payload = vsock_proto::encode_write_file_result(true, "");
             let resp = vsock_proto::encode(MSG_WRITE_FILE_RESULT, msgs[0].seq, &payload).unwrap();
@@ -5083,11 +5081,9 @@ mod tests {
             assert_eq!(msgs.len(), 1);
             assert_eq!(msgs[0].msg_type, MSG_WRITE_FILE);
 
-            let (path, chunk, _sudo, append) =
-                vsock_proto::decode_write_file(&msgs[0].payload).unwrap();
+            let (path, chunk, _sudo) = vsock_proto::decode_write_file(&msgs[0].payload).unwrap();
             assert_eq!(path, "/tmp/exact-limit.bin");
             assert_eq!(chunk, content_clone);
-            assert!(!append);
 
             let payload = vsock_proto::encode_write_file_result(true, "");
             let resp = vsock_proto::encode(MSG_WRITE_FILE_RESULT, msgs[0].seq, &payload).unwrap();

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -5592,6 +5592,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_write_files_missing_lazy_file_source_closes_connection() {
+        let (host_stream, mut guest) = make_pair();
+        let guest_task = tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            let n = guest.read(&mut buf).await.unwrap();
+            assert_ne!(n, 0, "connection closed before write_files start");
+            let messages = decoder.decode(&buf[..n]).unwrap();
+            assert!(
+                messages
+                    .iter()
+                    .any(|msg| msg.msg_type == MSG_WRITE_FILES_START),
+                "expected start frame before lazy source open failure"
+            );
+
+            let n = guest.read(&mut buf).await.unwrap();
+            assert_eq!(
+                n, 0,
+                "connection should close after lazy source open failure"
+            );
+        });
+
+        let missing = std::env::temp_dir().join(format!(
+            "vm0-vsock-host-missing-lazy-source-{}-{}.tar.gz",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let host = host_from_stream(host_stream).await.unwrap();
+        let seq = host.shared.next_seq();
+        let files = vec![PreparedWriteFile {
+            path: "/tmp/missing.tar.gz".to_string(),
+            source: PreparedWriteFileSource::File {
+                path: &missing,
+                len: 1,
+            },
+        }];
+
+        let err =
+            send_write_files_stream_until(&host.shared, seq, files, false, std::future::pending())
+                .await
+                .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        host.wait_until_closed(Duration::from_secs(5))
+            .await
+            .unwrap();
+        guest_task.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_write_file_failure() {
         let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1956,6 +1956,9 @@ impl VsockHost {
     /// Larger content uses the streamed write_files protocol as a one-file
     /// batch so large and multi-file writes share one guest write engine.
     ///
+    /// Semantics match shell redirection: create/truncate the target, then
+    /// write bytes. A failed write may leave an empty or partial target.
+    ///
     /// Non-sudo writes create missing parent directories on the guest.
     pub async fn write_file(&self, path: &str, content: &[u8], sudo: bool) -> io::Result<()> {
         if content.len() <= Self::WRITE_FILE_INLINE_LIMIT {
@@ -2002,6 +2005,11 @@ impl VsockHost {
         Ok(())
     }
 
+    /// Write multiple files on the guest with the same shell-like
+    /// create/truncate/write semantics as [`Self::write_file`].
+    ///
+    /// This is not a cross-file transaction: failures may leave files that
+    /// were already written, and the currently active file may be partial.
     pub async fn write_files<'a>(
         &self,
         files: &'a [WriteFileRequest<'a>],

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -29,6 +29,7 @@
 //! keyed by sequence number.
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::io;
 use std::os::fd::RawFd;
 use std::path::Path;
@@ -1243,9 +1244,22 @@ async fn prepare_write_files<'a>(
 async fn send_write_files_stream(
     shared: &Arc<Shared>,
     seq: u32,
-    mut files: Vec<PreparedWriteFile<'_>>,
+    files: Vec<PreparedWriteFile<'_>>,
     sudo: bool,
     timeout: Duration,
+) -> io::Result<()> {
+    send_write_files_stream_until(shared, seq, files, sudo, async move {
+        tokio::time::sleep(timeout).await;
+    })
+    .await
+}
+
+async fn send_write_files_stream_until(
+    shared: &Arc<Shared>,
+    seq: u32,
+    mut files: Vec<PreparedWriteFile<'_>>,
+    sudo: bool,
+    timeout: impl Future<Output = ()>,
 ) -> io::Result<()> {
     let file_count = u32::try_from(files.len()).map_err(|_| {
         io::Error::new(
@@ -1265,7 +1279,12 @@ async fn send_write_files_stream(
         }
     }
 
-    let stream_result = tokio::time::timeout(timeout, async {
+    enum StreamResult {
+        Completed(io::Result<()>),
+        TimedOut,
+    }
+
+    let stream = async {
         // Active after START; any cancellation or write/read failure before
         // FINISH poisons the connection so the guest stream cannot hang.
         let mut write_guard = FrameWriteGuard::new(Arc::clone(shared));
@@ -1330,12 +1349,17 @@ async fn send_write_files_stream(
         write_proto_frame(&mut writer, MSG_WRITE_FILES_FINISH, seq, &[]).await?;
         write_guard.disarm();
         Ok(())
-    })
-    .await;
+    };
+
+    tokio::pin!(timeout);
+    let stream_result = tokio::select! {
+        result = stream => StreamResult::Completed(result),
+        _ = &mut timeout => StreamResult::TimedOut,
+    };
 
     match stream_result {
-        Ok(result) => result,
-        Err(_) => {
+        StreamResult::Completed(result) => result,
+        StreamResult::TimedOut => {
             shared.poison_connection();
             Err(io::Error::new(
                 io::ErrorKind::TimedOut,
@@ -5135,15 +5159,18 @@ mod tests {
             source: PreparedWriteFileSource::Bytes(&content),
         }];
         let seq = host.shared.next_seq();
+        let (timeout_tx, timeout_rx) = oneshot::channel::<()>();
 
-        let send =
-            send_write_files_stream(&host.shared, seq, files, false, Duration::from_millis(50));
+        let send = send_write_files_stream_until(&host.shared, seq, files, false, async {
+            let _ = timeout_rx.await;
+        });
         tokio::pin!(send);
         tokio::select! {
             _ = frame_started.notified() => {}
             result = &mut send => panic!("write_files stream completed before blocking: {result:?}"),
         }
 
+        let _ = timeout_tx.send(());
         let err = send.await.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::TimedOut);
         host.wait_until_closed(Duration::from_secs(5))

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1309,11 +1309,12 @@ async fn send_write_files_stream_until(
     }
 
     let stream = async {
+        let start = vsock_proto::encode_write_files_start(sudo, file_count, total_bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+
         // Active after START; any cancellation or write/read failure before
         // FINISH poisons the connection so the guest stream cannot hang.
         let mut write_guard = FrameWriteGuard::new(Arc::clone(shared));
-        let start = vsock_proto::encode_write_files_start(sudo, file_count, total_bytes)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
         write_proto_frame(&mut writer, MSG_WRITE_FILES_START, seq, &start).await?;
 
         let mut read_buf = vec![0u8; vsock_proto::MAX_WRITE_FILES_CHUNK_BYTES];

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1216,7 +1216,25 @@ fn prepared_batch<'files, 'data>(
 }
 
 async fn validate_file_source_len(path: &Path, expected_len: u64) -> io::Result<()> {
-    let actual_len = tokio::fs::metadata(path).await?.len();
+    let metadata = tokio::fs::metadata(path).await?;
+    validate_file_source_metadata(path, expected_len, &metadata)
+}
+
+fn validate_file_source_metadata(
+    path: &Path,
+    expected_len: u64,
+    metadata: &std::fs::Metadata,
+) -> io::Result<()> {
+    if !metadata.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "write_files source is not a regular file: {}",
+                path.display()
+            ),
+        ));
+    }
+    let actual_len = metadata.len();
     if actual_len != expected_len {
         return Err(file_source_len_error(path, expected_len, actual_len));
     }
@@ -1225,10 +1243,8 @@ async fn validate_file_source_len(path: &Path, expected_len: u64) -> io::Result<
 
 async fn open_prepared_file_source(path: &Path, expected_len: u64) -> io::Result<tokio::fs::File> {
     let file = tokio::fs::File::open(path).await?;
-    let actual_len = file.metadata().await?.len();
-    if actual_len != expected_len {
-        return Err(file_source_len_error(path, expected_len, actual_len));
-    }
+    let metadata = file.metadata().await?;
+    validate_file_source_metadata(path, expected_len, &metadata)?;
     Ok(file)
 }
 
@@ -5672,6 +5688,48 @@ mod tests {
             .unwrap_err();
         let _ = tokio::fs::remove_file(&source).await;
         assert!(err.to_string().contains("source length changed"));
+    }
+
+    #[tokio::test]
+    async fn test_write_files_rejects_non_file_source_before_sending() {
+        let (host_stream, mut guest) = make_pair();
+        let source = std::env::temp_dir().join(format!(
+            "vm0-vsock-host-source-dir-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        tokio::fs::create_dir(&source).await.unwrap();
+
+        let guest_task = tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+            let mut buf = [0u8; 1];
+            let _ = guest.read(&mut buf).await;
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let err = host
+            .write_files(
+                &[WriteFileRequest {
+                    path: "/tmp/archive.tar.gz",
+                    source: WriteFileSource::File {
+                        path: &source,
+                        len: 0,
+                    },
+                }],
+                false,
+            )
+            .await
+            .unwrap_err();
+        let _ = tokio::fs::remove_dir(&source).await;
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("not a regular file"));
+
+        drop(host);
+        guest_task.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -5602,6 +5602,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_write_files_rejects_out_of_range_result_index() {
+        let (host_stream, mut guest) = make_pair();
+
+        let guest_task = tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = [0u8; 4096];
+            loop {
+                let n = guest.read(&mut buf).await.unwrap();
+                assert_ne!(n, 0);
+                for msg in decoder.decode(&buf[..n]).unwrap() {
+                    if msg.msg_type == MSG_WRITE_FILES_FINISH {
+                        let payload = vsock_proto::encode_write_files_result(&[
+                            vsock_proto::WriteFilesResultEntry {
+                                file_index: 0,
+                                success: true,
+                                error: String::new(),
+                            },
+                            vsock_proto::WriteFilesResultEntry {
+                                file_index: 2,
+                                success: true,
+                                error: String::new(),
+                            },
+                        ])
+                        .unwrap();
+                        let resp =
+                            vsock_proto::encode(MSG_WRITE_FILES_RESULT, msg.seq, &payload).unwrap();
+                        guest.write_all(&resp).await.unwrap();
+                        return;
+                    }
+                }
+            }
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let err = host
+            .write_files(
+                &[
+                    WriteFileRequest {
+                        path: "/tmp/a",
+                        source: WriteFileSource::Bytes(b"a"),
+                    },
+                    WriteFileRequest {
+                        path: "/tmp/b",
+                        source: WriteFileSource::Bytes(b"b"),
+                    },
+                ],
+                false,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("result index out of range"));
+        guest_task.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_write_files_rejects_incomplete_success_result() {
         let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -6553,7 +6553,7 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_exec_and_wait_exit() {
         let (host_stream, mut guest) = make_pair();
-        let (send_exit_tx, send_exit_rx) = oneshot::channel::<()>();
+        let (release_exit_tx, release_exit_rx) = oneshot::channel::<()>();
 
         tokio::spawn(async move {
             let mut decoder = Decoder::new();
@@ -6582,7 +6582,9 @@ mod tests {
             let exec_resp = vsock_proto::encode(MSG_EXEC_RESULT, exec_seq, &exec_payload).unwrap();
             guest.write_all(&exec_resp).await.unwrap();
 
-            let _ = send_exit_rx.await;
+            // Keep wait_for_exit pending until the host has observed the exec
+            // response; this is deterministic and avoids fixed timing delays.
+            release_exit_rx.await.unwrap();
             let exit_payload = vsock_proto::encode_process_exit(50, 42, b"exited", b"");
             let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, 0, &exit_payload).unwrap();
             guest.write_all(&exit_msg).await.unwrap();
@@ -6611,8 +6613,7 @@ mod tests {
             .unwrap();
         assert_eq!(exec_result.exit_code, 0);
         assert_eq!(exec_result.stdout, b"concurrent");
-
-        send_exit_tx.send(()).unwrap();
+        release_exit_tx.send(()).unwrap();
 
         // wait_for_exit should also resolve
         let exit_event = wait_task.await.unwrap().unwrap();

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -152,15 +152,6 @@ pub enum WriteFileSource<'a> {
     File { path: &'a Path, len: u64 },
 }
 
-impl WriteFileSource<'_> {
-    fn len(&self) -> u64 {
-        match self {
-            Self::Bytes(bytes) => bytes.len() as u64,
-            Self::File { len, .. } => *len,
-        }
-    }
-}
-
 pub struct WriteFileRequest<'a> {
     pub path: &'a str,
     pub source: WriteFileSource<'a>,
@@ -1167,18 +1158,6 @@ async fn send_bounded_exec_cancel_on_shared_with_timeout(
 async fn prepare_write_files<'a>(
     files: &'a [WriteFileRequest<'a>],
 ) -> io::Result<Vec<PreparedWriteFile<'a>>> {
-    if files.len() > vsock_proto::MAX_WRITE_FILES_COUNT {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!(
-                "write_files file count exceeds limit: {} > {}",
-                files.len(),
-                vsock_proto::MAX_WRITE_FILES_COUNT
-            ),
-        ));
-    }
-
-    let mut total = 0u64;
     let mut prepared = Vec::with_capacity(files.len());
     for file in files {
         if file.path.is_empty() {
@@ -1193,26 +1172,6 @@ async fn prepare_write_files<'a>(
                 format!("write_files path too long: {}", file.path.len()),
             ));
         }
-        let len = file.source.len();
-        if len > vsock_proto::MAX_WRITE_FILES_FILE_BYTES {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("write_files file too large: {len}"),
-            ));
-        }
-        total = total.checked_add(len).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "write_files total size overflow",
-            )
-        })?;
-        if total > vsock_proto::MAX_WRITE_FILES_TOTAL_BYTES {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("write_files total bytes exceed limit: {total}"),
-            ));
-        }
-
         let source = match &file.source {
             WriteFileSource::Bytes(bytes) => PreparedWriteFileSource::Bytes(bytes),
             WriteFileSource::File { path, len } => {
@@ -1227,6 +1186,33 @@ async fn prepare_write_files<'a>(
     }
 
     Ok(prepared)
+}
+
+fn write_files_total_bytes(files: &[PreparedWriteFile<'_>]) -> io::Result<u64> {
+    files.iter().try_fold(0u64, |total, file| {
+        total.checked_add(file.source.len()).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "write_files total size overflow",
+            )
+        })
+    })
+}
+
+fn prepared_batch<'files, 'data>(
+    files: &'files [PreparedWriteFile<'data>],
+    start: usize,
+    end: usize,
+) -> io::Result<&'files [PreparedWriteFile<'data>]> {
+    files.get(start..end).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "write_files batch range out of bounds: {start}..{end} of {}",
+                files.len()
+            ),
+        )
+    })
 }
 
 async fn validate_file_source_len(path: &Path, expected_len: u64) -> io::Result<()> {
@@ -1261,7 +1247,7 @@ fn file_source_len_error(path: &Path, expected_len: u64, actual_len: u64) -> io:
 async fn send_write_files_stream(
     shared: &Arc<Shared>,
     seq: u32,
-    files: Vec<PreparedWriteFile<'_>>,
+    files: &[PreparedWriteFile<'_>],
     sudo: bool,
     timeout: Duration,
 ) -> io::Result<()> {
@@ -1274,7 +1260,7 @@ async fn send_write_files_stream(
 async fn send_write_files_stream_until(
     shared: &Arc<Shared>,
     seq: u32,
-    files: Vec<PreparedWriteFile<'_>>,
+    files: &[PreparedWriteFile<'_>],
     sudo: bool,
     timeout: impl Future<Output = ()>,
 ) -> io::Result<()> {
@@ -1284,7 +1270,7 @@ async fn send_write_files_stream_until(
             "write_files file count exceeds u32",
         )
     })?;
-    let total_bytes = files.iter().map(|file| file.source.len()).sum::<u64>();
+    let total_bytes = write_files_total_bytes(files)?;
     let mut writer = shared.writer.lock().await;
     {
         let guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
@@ -2034,6 +2020,10 @@ impl VsockHost {
     /// Write multiple files on the guest with the same shell-like
     /// create/truncate/write semantics as [`Self::write_file`].
     ///
+    /// Large calls may be split across multiple bounded protocol streams; this
+    /// is transparent to callers and each target file is still sent exactly
+    /// once.
+    ///
     /// This is not a cross-file transaction: failures may leave files that
     /// were already written, and the currently active file may be partial.
     pub async fn write_files<'a>(
@@ -2041,12 +2031,49 @@ impl VsockHost {
         files: &'a [WriteFileRequest<'a>],
         sudo: bool,
     ) -> io::Result<()> {
-        let expected_count = files.len();
         let prepared = prepare_write_files(files).await?;
         if prepared.is_empty() {
             return Ok(());
         }
 
+        let mut batch_start = 0usize;
+        let mut batch_bytes = 0u64;
+        for (index, file) in prepared.iter().enumerate() {
+            let batch_count = index - batch_start;
+            let would_exceed_count = batch_count >= vsock_proto::MAX_WRITE_FILES_COUNT;
+            let would_overflow_total = batch_bytes.checked_add(file.source.len()).is_none();
+            if batch_count > 0 && (would_exceed_count || would_overflow_total) {
+                self.write_files_batch(prepared_batch(&prepared, batch_start, index)?, sudo)
+                    .await?;
+                batch_start = index;
+                batch_bytes = 0;
+            }
+
+            batch_bytes = batch_bytes.checked_add(file.source.len()).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "write_files total size overflow",
+                )
+            })?;
+        }
+
+        if batch_start < prepared.len() {
+            self.write_files_batch(
+                prepared_batch(&prepared, batch_start, prepared.len())?,
+                sudo,
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn write_files_batch(
+        &self,
+        prepared: &[PreparedWriteFile<'_>],
+        sudo: bool,
+    ) -> io::Result<()> {
+        let expected_count = prepared.len();
         let seq = self.shared.next_seq();
         let (tx, rx) = oneshot::channel();
         {
@@ -5195,7 +5222,7 @@ mod tests {
         let seq = host.shared.next_seq();
         let (timeout_tx, timeout_rx) = oneshot::channel::<()>();
 
-        let send = send_write_files_stream_until(&host.shared, seq, files, false, async {
+        let send = send_write_files_stream_until(&host.shared, seq, &files, false, async {
             let _ = timeout_rx.await;
         });
         tokio::pin!(send);
@@ -5354,6 +5381,94 @@ mod tests {
         .await
         .unwrap();
         guest_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_files_batches_by_protocol_file_count() {
+        let (host_stream, mut guest) = make_pair();
+
+        let guest_task = tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut batches = Vec::new();
+            let mut current: Option<(u32, u32, u32)> = None;
+            let mut buf = [0u8; 64 * 1024];
+            loop {
+                let n = guest.read(&mut buf).await.unwrap();
+                assert_ne!(
+                    n, 0,
+                    "connection closed before write_files batches completed"
+                );
+                for msg in decoder.decode(&buf[..n]).unwrap() {
+                    match msg.msg_type {
+                        MSG_WRITE_FILES_START => {
+                            assert!(current.is_none(), "nested write_files stream");
+                            let start =
+                                vsock_proto::decode_write_files_start(&msg.payload).unwrap();
+                            assert_eq!(start.total_bytes, 0);
+                            current = Some((msg.seq, start.file_count, 0));
+                        }
+                        MSG_WRITE_FILES_FILE => {
+                            let Some((seq, file_count, seen)) = current.as_mut() else {
+                                panic!("file before start");
+                            };
+                            assert_eq!(msg.seq, *seq);
+                            let file = vsock_proto::decode_write_files_file(&msg.payload).unwrap();
+                            assert!(file.file_index < *file_count);
+                            assert_eq!(file.content_len, 0);
+                            *seen += 1;
+                        }
+                        MSG_WRITE_FILES_FINISH => {
+                            let Some((seq, file_count, seen)) = current.take() else {
+                                panic!("finish before start");
+                            };
+                            assert_eq!(msg.seq, seq);
+                            assert_eq!(seen, file_count);
+                            let entries = (0..file_count)
+                                .map(|file_index| vsock_proto::WriteFilesResultEntry {
+                                    file_index,
+                                    success: true,
+                                    error: String::new(),
+                                })
+                                .collect::<Vec<_>>();
+                            let payload = vsock_proto::encode_write_files_result(&entries).unwrap();
+                            let resp =
+                                vsock_proto::encode(MSG_WRITE_FILES_RESULT, seq, &payload).unwrap();
+                            guest.write_all(&resp).await.unwrap();
+                            batches.push(file_count);
+                            if batches.len() == 2 {
+                                return batches;
+                            }
+                        }
+                        other => panic!("unexpected message type: {other:#x}"),
+                    }
+                }
+            }
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let paths = (0..=vsock_proto::MAX_WRITE_FILES_COUNT)
+            .map(|index| format!("/tmp/empty-{index}"))
+            .collect::<Vec<_>>();
+        let files = paths
+            .iter()
+            .map(|path| WriteFileRequest {
+                path: path.as_str(),
+                source: WriteFileSource::Bytes(b""),
+            })
+            .collect::<Vec<_>>();
+
+        host.write_files(&files, false).await.unwrap();
+
+        let batches = guest_task.await.unwrap();
+        assert_eq!(
+            batches,
+            vec![
+                u32::try_from(vsock_proto::MAX_WRITE_FILES_COUNT).unwrap(),
+                1
+            ]
+        );
     }
 
     #[tokio::test]
@@ -5592,6 +5707,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_prepare_write_files_allows_large_sparse_file_source() {
+        let source = std::env::temp_dir().join(format!(
+            "vm0-vsock-host-large-source-{}-{}.bin",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let large_len = 8 * 1024 * 1024 * 1024u64;
+        let file = std::fs::File::create(&source).unwrap();
+        file.set_len(large_len).unwrap();
+        drop(file);
+        let requests = [WriteFileRequest {
+            path: "/tmp/large.bin",
+            source: WriteFileSource::File {
+                path: &source,
+                len: large_len,
+            },
+        }];
+
+        let prepared = prepare_write_files(&requests).await.unwrap();
+
+        let _ = tokio::fs::remove_file(&source).await;
+        assert_eq!(prepared.len(), 1);
+        assert_eq!(prepared.first().unwrap().source.len(), large_len);
+    }
+
+    #[tokio::test]
     async fn test_write_files_missing_lazy_file_source_closes_connection() {
         let (host_stream, mut guest) = make_pair();
         let guest_task = tokio::spawn(async move {
@@ -5635,7 +5779,7 @@ mod tests {
         }];
 
         let err =
-            send_write_files_stream_until(&host.shared, seq, files, false, std::future::pending())
+            send_write_files_stream_until(&host.shared, seq, &files, false, std::future::pending())
                 .await
                 .unwrap_err();
 

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -140,7 +140,6 @@ pub const SPAWN_WATCH_FLAG_STREAM_STDOUT: u8 = 0x02;
 
 // Write-file payload flags.
 pub const WRITE_FILE_FLAG_SUDO: u8 = 0x01;
-pub const WRITE_FILE_FLAG_APPEND: u8 = 0x02;
 
 // Write-files payload flags.
 pub const WRITE_FILES_FLAG_SUDO: u8 = 0x01;
@@ -733,12 +732,7 @@ pub fn encode_bounded_exec_output_chunk(
 ///
 /// Returns `Err` if path exceeds 65535 bytes (u16 field limit).
 /// Total message size is validated by [`encode`].
-pub fn encode_write_file(
-    path: &str,
-    content: &[u8],
-    sudo: bool,
-    append: bool,
-) -> Result<Vec<u8>, ProtocolError> {
+pub fn encode_write_file(path: &str, content: &[u8], sudo: bool) -> Result<Vec<u8>, ProtocolError> {
     let path_bytes = path.as_bytes();
     if path_bytes.len() > u16::MAX as usize {
         return Err(ProtocolError::PayloadTooLarge("path", path_bytes.len()));
@@ -747,9 +741,6 @@ pub fn encode_write_file(
     let mut flags = 0u8;
     if sudo {
         flags |= WRITE_FILE_FLAG_SUDO;
-    }
-    if append {
-        flags |= WRITE_FILE_FLAG_APPEND;
     }
     let mut p = Vec::with_capacity(7 + path_len as usize + content.len());
     p.extend_from_slice(&path_len.to_be_bytes());
@@ -1212,8 +1203,8 @@ fn decode_output_pair_at(
     Ok((stdout, stderr))
 }
 
-/// Decode write_file payload. Returns `(path, content, sudo, append)`.
-pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool, bool), ProtocolError> {
+/// Decode write_file payload. Returns `(path, content, sudo)`.
+pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool), ProtocolError> {
     let path_len = read_u16_at(payload, 0)
         .ok_or(ProtocolError::InvalidPayload("write_file too short"))? as usize;
     let path = std::str::from_utf8(
@@ -1224,11 +1215,7 @@ pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool, bool), Pr
     .map_err(|_| ProtocolError::InvalidPayload("invalid UTF-8 in path"))?;
     let flags = read_u8_at(payload, 2 + path_len)
         .ok_or(ProtocolError::InvalidPayload("write_file too short"))?;
-    reject_unknown_flags(
-        flags,
-        WRITE_FILE_FLAG_SUDO | WRITE_FILE_FLAG_APPEND,
-        "write_file unknown flags",
-    )?;
+    reject_unknown_flags(flags, WRITE_FILE_FLAG_SUDO, "write_file unknown flags")?;
     let content_len = read_u32_at(payload, 3 + path_len)
         .ok_or(ProtocolError::InvalidPayload("write_file too short"))?
         as usize;
@@ -1242,12 +1229,7 @@ pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool, bool), Pr
         7 + path_len + content_len,
         "write_file trailing bytes",
     )?;
-    Ok((
-        path,
-        content,
-        (flags & WRITE_FILE_FLAG_SUDO) != 0,
-        (flags & WRITE_FILE_FLAG_APPEND) != 0,
-    ))
+    Ok((path, content, (flags & WRITE_FILE_FLAG_SUDO) != 0))
 }
 
 /// Decode write_file_result payload. Returns `(success, error)`.
@@ -3137,53 +3119,33 @@ mod tests {
 
     #[test]
     fn write_file_payload_roundtrip() {
-        let payload = encode_write_file("/tmp/test.txt", b"content", false, false).unwrap();
-        let (path, content, sudo, append) = decode_write_file(&payload).unwrap();
+        let payload = encode_write_file("/tmp/test.txt", b"content", false).unwrap();
+        let (path, content, sudo) = decode_write_file(&payload).unwrap();
         assert_eq!(path, "/tmp/test.txt");
         assert_eq!(content, b"content");
         assert!(!sudo);
-        assert!(!append);
     }
 
     #[test]
     fn write_file_with_sudo() {
-        let payload = encode_write_file("/etc/hosts", b"127.0.0.1", true, false).unwrap();
-        let (path, content, sudo, append) = decode_write_file(&payload).unwrap();
+        let payload = encode_write_file("/etc/hosts", b"127.0.0.1", true).unwrap();
+        let (path, content, sudo) = decode_write_file(&payload).unwrap();
         assert_eq!(path, "/etc/hosts");
         assert_eq!(content, b"127.0.0.1");
         assert!(sudo);
-        assert!(!append);
-    }
-
-    #[test]
-    fn write_file_with_append() {
-        let payload = encode_write_file("/tmp/out.log", b"more data", false, true).unwrap();
-        let (path, content, sudo, append) = decode_write_file(&payload).unwrap();
-        assert_eq!(path, "/tmp/out.log");
-        assert_eq!(content, b"more data");
-        assert!(!sudo);
-        assert!(append);
-    }
-
-    #[test]
-    fn write_file_with_sudo_and_append() {
-        let payload = encode_write_file("/etc/conf", b"line", true, true).unwrap();
-        let (_, _, sudo, append) = decode_write_file(&payload).unwrap();
-        assert!(sudo);
-        assert!(append);
     }
 
     #[test]
     fn write_file_path_too_long() {
         let long_path = "a".repeat(65536);
-        let err = encode_write_file(&long_path, b"", false, false).unwrap_err();
+        let err = encode_write_file(&long_path, b"", false).unwrap_err();
         assert!(matches!(err, ProtocolError::PayloadTooLarge("path", 65536)));
     }
 
     #[test]
     fn write_file_content_too_large() {
         let big = vec![0u8; MAX_MESSAGE_SIZE];
-        let payload = encode_write_file("/tmp/f", &big, false, false).unwrap();
+        let payload = encode_write_file("/tmp/f", &big, false).unwrap();
         let err = encode(MSG_WRITE_FILE, 1, &payload).unwrap_err();
         assert!(matches!(err, ProtocolError::MessageTooLarge(_)));
     }

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -20,7 +20,7 @@
 //! | 0x02 | G→H       | pong              | (empty) |
 //! | 0x03 | H→G       | exec              | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)` |
 //! | 0x04 | G→H       | exec_result       | `[4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]` |
-//! | 0x05 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` (flags: `SUDO=0x01`, `APPEND=0x02`) |
+//! | 0x05 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` (flags: `SUDO=0x01`) |
 //! | 0x06 | G→H       | write_file_result | `[1B success][2B error_len][error]` |
 //! | 0x07 | H→G       | spawn_watch       | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)([2B log_path_len][log_path])` (flags: `SUDO=0x01`, `STREAM_STDOUT=0x02`) |
 //! | 0x08 | G→H       | spawn_watch_result| `[4B pid]` |

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -1219,8 +1219,12 @@ pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool), Protocol
 /// Decode write_file_result payload. Returns `(success, error)`.
 pub fn decode_write_file_result(payload: &[u8]) -> Result<(bool, &str), ProtocolError> {
     let success = read_u8_at(payload, 0)
-        .ok_or(ProtocolError::InvalidPayload("write_file_result too short"))?
-        == 1;
+        .ok_or(ProtocolError::InvalidPayload("write_file_result too short"))?;
+    if success > 1 {
+        return Err(ProtocolError::InvalidPayload(
+            "write_file_result invalid success flag",
+        ));
+    }
     let err_len = read_u16_at(payload, 1)
         .ok_or(ProtocolError::InvalidPayload("write_file_result too short"))?
         as usize;
@@ -1229,7 +1233,7 @@ pub fn decode_write_file_result(payload: &[u8]) -> Result<(bool, &str), Protocol
     )?)
     .map_err(|_| ProtocolError::InvalidPayload("invalid UTF-8 in error"))?;
     ensure_no_trailing_bytes(payload, 3 + err_len, "write_file_result trailing bytes")?;
-    Ok((success, error))
+    Ok((success == 1, error))
 }
 
 pub fn decode_write_files_start(payload: &[u8]) -> Result<DecodedWriteFilesStart, ProtocolError> {
@@ -1330,7 +1334,12 @@ pub fn decode_write_files_result(
     let mut entries = Vec::with_capacity(count);
     for _ in 0..count {
         let file_index = read_u32_cursor(payload, &mut offset, "write_files_result too short")?;
-        let success = read_u8_cursor(payload, &mut offset, "write_files_result too short")? == 1;
+        let success = read_u8_cursor(payload, &mut offset, "write_files_result too short")?;
+        if success > 1 {
+            return Err(ProtocolError::InvalidPayload(
+                "write_files_result invalid success flag",
+            ));
+        }
         let err_len =
             read_u16_cursor(payload, &mut offset, "write_files_result too short")? as usize;
         let error = std::str::from_utf8(read_bytes_cursor(
@@ -1342,7 +1351,7 @@ pub fn decode_write_files_result(
         .map_err(|_| ProtocolError::InvalidPayload("invalid UTF-8 in write_files result"))?;
         entries.push(WriteFilesResultEntry {
             file_index,
-            success,
+            success: success == 1,
             error: error.to_string(),
         });
     }
@@ -3108,6 +3117,20 @@ mod tests {
     }
 
     #[test]
+    fn write_file_rejects_unknown_flags() {
+        let path = "/tmp/test.txt";
+        let mut payload = encode_write_file(path, b"content", false).unwrap();
+        payload[2 + path.len()] = 0x02;
+
+        let err = decode_write_file(&payload).unwrap_err();
+
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("write_file unknown flags")
+        ));
+    }
+
+    #[test]
     fn write_file_path_too_long() {
         let long_path = "a".repeat(65536);
         let err = encode_write_file(&long_path, b"", false).unwrap_err();
@@ -3133,6 +3156,16 @@ mod tests {
         let (success, error) = decode_write_file_result(&payload).unwrap();
         assert!(!success);
         assert_eq!(error, "permission denied");
+    }
+
+    #[test]
+    fn write_file_result_rejects_invalid_success_flag() {
+        let err = decode_write_file_result(&[2, 0, 0]).unwrap_err();
+
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("write_file_result invalid success flag")
+        ));
     }
 
     #[test]
@@ -3273,6 +3306,18 @@ mod tests {
         assert!(matches!(
             err,
             ProtocolError::InvalidPayload("invalid UTF-8 in write_files result")
+        ));
+
+        let err = decode_write_files_result(&[
+            0, 0, 0, 1, // result_count
+            0, 0, 0, 0, // file_index
+            2, // invalid success
+            0, 0, // err_len
+        ])
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("write_files_result invalid success flag")
         ));
 
         let mut payload = encode_write_files_result(&[]).unwrap();

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -85,10 +85,6 @@ pub const MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES: usize = 1024;
 pub const MAX_WRITE_FILES_COUNT: usize = 1024;
 /// Maximum guest path length accepted by write_files.
 pub const MAX_WRITE_FILES_PATH_BYTES: usize = u16::MAX as usize;
-/// Maximum per-file content length accepted by write_files.
-pub const MAX_WRITE_FILES_FILE_BYTES: u64 = 512 * 1024 * 1024;
-/// Maximum aggregate content length accepted by one write_files stream.
-pub const MAX_WRITE_FILES_TOTAL_BYTES: u64 = 512 * 1024 * 1024;
 /// Maximum payload chunk bytes emitted by host implementations.
 pub const MAX_WRITE_FILES_CHUNK_BYTES: usize = 4 * 1024 * 1024;
 
@@ -776,12 +772,6 @@ pub fn encode_write_files_start(
             file_count as usize,
         ));
     }
-    if total_bytes > MAX_WRITE_FILES_TOTAL_BYTES {
-        return Err(ProtocolError::PayloadTooLarge(
-            "write_files total_bytes",
-            total_bytes as usize,
-        ));
-    }
     let mut p = Vec::with_capacity(13);
     p.push(if sudo { WRITE_FILES_FLAG_SUDO } else { 0 });
     p.extend_from_slice(&file_count.to_be_bytes());
@@ -799,12 +789,6 @@ pub fn encode_write_files_file(
         return Err(ProtocolError::PayloadTooLarge(
             "write_files path",
             path_bytes.len(),
-        ));
-    }
-    if content_len > MAX_WRITE_FILES_FILE_BYTES {
-        return Err(ProtocolError::PayloadTooLarge(
-            "write_files content_len",
-            content_len as usize,
         ));
     }
     let path_len = path_bytes.len() as u16;
@@ -1265,12 +1249,6 @@ pub fn decode_write_files_start(payload: &[u8]) -> Result<DecodedWriteFilesStart
             file_count as usize,
         ));
     }
-    if total_bytes > MAX_WRITE_FILES_TOTAL_BYTES {
-        return Err(ProtocolError::PayloadTooLarge(
-            "write_files total_bytes",
-            total_bytes as usize,
-        ));
-    }
     Ok(DecodedWriteFilesStart {
         sudo: (flags & WRITE_FILES_FLAG_SUDO) != 0,
         file_count,
@@ -1293,12 +1271,6 @@ pub fn decode_write_files_file(payload: &[u8]) -> Result<DecodedWriteFilesFile<'
     ensure_no_trailing_bytes(payload, offset, "write_files_file trailing bytes")?;
     if path_len > MAX_WRITE_FILES_PATH_BYTES {
         return Err(ProtocolError::PayloadTooLarge("write_files path", path_len));
-    }
-    if content_len > MAX_WRITE_FILES_FILE_BYTES {
-        return Err(ProtocolError::PayloadTooLarge(
-            "write_files content_len",
-            content_len as usize,
-        ));
     }
     Ok(DecodedWriteFilesFile {
         file_index,
@@ -3179,6 +3151,19 @@ mod tests {
         assert_eq!(decoded.file_index, 7);
         assert_eq!(decoded.path, "/tmp/a.txt");
         assert_eq!(decoded.content_len, 42);
+    }
+
+    #[test]
+    fn write_files_allows_large_declared_lengths() {
+        let large = 8 * 1024 * 1024 * 1024u64;
+
+        let start_payload = encode_write_files_start(false, 1, large).unwrap();
+        let start = decode_write_files_start(&start_payload).unwrap();
+        assert_eq!(start.total_bytes, large);
+
+        let file_payload = encode_write_files_file(0, "/tmp/large.bin", large).unwrap();
+        let file = decode_write_files_file(&file_payload).unwrap();
+        assert_eq!(file.content_len, large);
     }
 
     #[test]

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -36,6 +36,12 @@
 //! | 0x12 | H→G       | control_quiesce   | (empty) |
 //! | 0x13 | G→H       | control_quiesce_ack | `[1B status]` |
 //! | 0x14 | H→G       | bounded_exec_cancel | (empty) |
+//! | 0x15 | H→G       | write_files_start | `[1B flags][4B file_count][8B total_bytes]` (flags: `SUDO=0x01`) |
+//! | 0x16 | H→G       | write_files_file  | `[4B file_index][2B path_len][path][8B content_len]` |
+//! | 0x17 | H→G       | write_files_chunk | `[4B file_index][4B chunk_len][chunk]` |
+//! | 0x18 | H→G       | write_files_finish | (empty) |
+//! | 0x19 | H→G       | write_files_abort | `[2B error_len][error]` |
+//! | 0x1A | G→H       | write_files_result | `[4B result_count]([4B file_index][1B success][2B error_len][error])*` |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
 //! Bounded exec output chunks are request-scoped: they use the same non-zero
@@ -75,6 +81,16 @@ pub const MAX_BOUNDED_EXEC_OUTPUT_CHUNK_BYTES: usize =
     MAX_MESSAGE_SIZE - MIN_BODY_SIZE - BOUNDED_EXEC_OUTPUT_CHUNK_FIXED_PAYLOAD_BYTES;
 /// Minimum stream chunk limit accepted by bounded exec implementations.
 pub const MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES: usize = 1024;
+/// Maximum file count accepted by a single write_files stream.
+pub const MAX_WRITE_FILES_COUNT: usize = 1024;
+/// Maximum guest path length accepted by write_files.
+pub const MAX_WRITE_FILES_PATH_BYTES: usize = u16::MAX as usize;
+/// Maximum per-file content length accepted by write_files.
+pub const MAX_WRITE_FILES_FILE_BYTES: u64 = 512 * 1024 * 1024;
+/// Maximum aggregate content length accepted by one write_files stream.
+pub const MAX_WRITE_FILES_TOTAL_BYTES: u64 = 512 * 1024 * 1024;
+/// Maximum payload chunk bytes emitted by host implementations.
+pub const MAX_WRITE_FILES_CHUNK_BYTES: usize = 4 * 1024 * 1024;
 
 // Message type constants.
 pub const MSG_READY: u8 = 0x00;
@@ -98,6 +114,12 @@ pub const MSG_CONTROL_HELLO_ACK: u8 = 0x11;
 pub const MSG_CONTROL_QUIESCE: u8 = 0x12;
 pub const MSG_CONTROL_QUIESCE_ACK: u8 = 0x13;
 pub const MSG_BOUNDED_EXEC_CANCEL: u8 = 0x14;
+pub const MSG_WRITE_FILES_START: u8 = 0x15;
+pub const MSG_WRITE_FILES_FILE: u8 = 0x16;
+pub const MSG_WRITE_FILES_CHUNK: u8 = 0x17;
+pub const MSG_WRITE_FILES_FINISH: u8 = 0x18;
+pub const MSG_WRITE_FILES_ABORT: u8 = 0x19;
+pub const MSG_WRITE_FILES_RESULT: u8 = 0x1A;
 pub const MSG_ERROR: u8 = 0xFF;
 
 /// Default vsock port for host-guest communication.
@@ -120,6 +142,9 @@ pub const SPAWN_WATCH_FLAG_STREAM_STDOUT: u8 = 0x02;
 pub const WRITE_FILE_FLAG_SUDO: u8 = 0x01;
 pub const WRITE_FILE_FLAG_APPEND: u8 = 0x02;
 
+// Write-files payload flags.
+pub const WRITE_FILES_FLAG_SUDO: u8 = 0x01;
+
 // Bounded-exec payload flags.
 pub const BOUNDED_EXEC_FLAG_SUDO: u8 = 0x01;
 pub const BOUNDED_EXEC_FLAG_STDIN_PRESENT: u8 = 0x02;
@@ -129,6 +154,7 @@ pub const BOUNDED_EXEC_OUTPUT_CHUNK_FLAG_TRUNCATED: u8 = 0x01;
 
 const BOUNDED_EXEC_KNOWN_FLAGS: u8 = BOUNDED_EXEC_FLAG_SUDO | BOUNDED_EXEC_FLAG_STDIN_PRESENT;
 const BOUNDED_EXEC_OUTPUT_CHUNK_KNOWN_FLAGS: u8 = BOUNDED_EXEC_OUTPUT_CHUNK_FLAG_TRUNCATED;
+const WRITE_FILES_KNOWN_FLAGS: u8 = WRITE_FILES_FLAG_SUDO;
 
 const BOUNDED_EXEC_STREAM_STDOUT: u8 = 0;
 const BOUNDED_EXEC_STREAM_STDERR: u8 = 1;
@@ -195,6 +221,33 @@ pub struct DecodedControlHello<'a> {
 pub enum ControlQuiesceStatus {
     Ready,
     Busy,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct DecodedWriteFilesStart {
+    pub sudo: bool,
+    pub file_count: u32,
+    pub total_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct DecodedWriteFilesFile<'a> {
+    pub file_index: u32,
+    pub path: &'a str,
+    pub content_len: u64,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct DecodedWriteFilesChunk<'a> {
+    pub file_index: u32,
+    pub chunk: &'a [u8],
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct WriteFilesResultEntry {
+    pub file_index: u32,
+    pub success: bool,
+    pub error: String,
 }
 
 /// Protocol error.
@@ -721,6 +774,114 @@ pub fn encode_write_file_result(success: bool, error: &str) -> Vec<u8> {
     p
 }
 
+pub fn encode_write_files_start(
+    sudo: bool,
+    file_count: u32,
+    total_bytes: u64,
+) -> Result<Vec<u8>, ProtocolError> {
+    if file_count as usize > MAX_WRITE_FILES_COUNT {
+        return Err(ProtocolError::PayloadTooLarge(
+            "write_files file_count",
+            file_count as usize,
+        ));
+    }
+    if total_bytes > MAX_WRITE_FILES_TOTAL_BYTES {
+        return Err(ProtocolError::PayloadTooLarge(
+            "write_files total_bytes",
+            total_bytes as usize,
+        ));
+    }
+    let mut p = Vec::with_capacity(13);
+    p.push(if sudo { WRITE_FILES_FLAG_SUDO } else { 0 });
+    p.extend_from_slice(&file_count.to_be_bytes());
+    p.extend_from_slice(&total_bytes.to_be_bytes());
+    Ok(p)
+}
+
+pub fn encode_write_files_file(
+    file_index: u32,
+    path: &str,
+    content_len: u64,
+) -> Result<Vec<u8>, ProtocolError> {
+    let path_bytes = path.as_bytes();
+    if path_bytes.len() > MAX_WRITE_FILES_PATH_BYTES {
+        return Err(ProtocolError::PayloadTooLarge(
+            "write_files path",
+            path_bytes.len(),
+        ));
+    }
+    if content_len > MAX_WRITE_FILES_FILE_BYTES {
+        return Err(ProtocolError::PayloadTooLarge(
+            "write_files content_len",
+            content_len as usize,
+        ));
+    }
+    let path_len = path_bytes.len() as u16;
+    let mut p = Vec::with_capacity(14 + path_bytes.len());
+    p.extend_from_slice(&file_index.to_be_bytes());
+    p.extend_from_slice(&path_len.to_be_bytes());
+    p.extend_from_slice(path_bytes);
+    p.extend_from_slice(&content_len.to_be_bytes());
+    Ok(p)
+}
+
+pub fn encode_write_files_chunk(file_index: u32, chunk: &[u8]) -> Result<Vec<u8>, ProtocolError> {
+    if chunk.is_empty() {
+        return Err(ProtocolError::InvalidPayload("write_files chunk empty"));
+    }
+    if chunk.len() > MAX_WRITE_FILES_CHUNK_BYTES {
+        return Err(ProtocolError::PayloadTooLarge(
+            "write_files chunk",
+            chunk.len(),
+        ));
+    }
+    let mut p = Vec::with_capacity(8 + chunk.len());
+    p.extend_from_slice(&file_index.to_be_bytes());
+    p.extend_from_slice(&checked_u32_len("write_files chunk", chunk.len())?.to_be_bytes());
+    p.extend_from_slice(chunk);
+    Ok(p)
+}
+
+pub fn encode_write_files_abort(error: &str) -> Vec<u8> {
+    let err = error.as_bytes();
+    let err_len = err.len().min(u16::MAX as usize) as u16;
+    let mut p = Vec::with_capacity(2 + err_len as usize);
+    p.extend_from_slice(&err_len.to_be_bytes());
+    p.extend_from_slice(err.get(..err_len as usize).unwrap_or(err));
+    p
+}
+
+pub fn encode_write_files_result(
+    entries: &[WriteFilesResultEntry],
+) -> Result<Vec<u8>, ProtocolError> {
+    if entries.len() > MAX_WRITE_FILES_COUNT {
+        return Err(ProtocolError::PayloadTooLarge(
+            "write_files result_count",
+            entries.len(),
+        ));
+    }
+    let mut capacity = 4usize;
+    for entry in entries {
+        add_payload_capacity(&mut capacity, "write_files result", 7)?;
+        add_payload_capacity(
+            &mut capacity,
+            "write_files result error",
+            entry.error.len().min(u16::MAX as usize),
+        )?;
+    }
+    let mut p = Vec::with_capacity(capacity);
+    p.extend_from_slice(&checked_u32_len("write_files result_count", entries.len())?.to_be_bytes());
+    for entry in entries {
+        let err = entry.error.as_bytes();
+        let err_len = err.len().min(u16::MAX as usize) as u16;
+        p.extend_from_slice(&entry.file_index.to_be_bytes());
+        p.push(u8::from(entry.success));
+        p.extend_from_slice(&err_len.to_be_bytes());
+        p.extend_from_slice(err.get(..err_len as usize).unwrap_or(err));
+    }
+    Ok(p)
+}
+
 /// Encode spawn_watch_result payload: `[4B pid]`.
 pub fn encode_spawn_watch_result(pid: u32) -> Vec<u8> {
     pid.to_be_bytes().to_vec()
@@ -1063,6 +1224,11 @@ pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool, bool), Pr
     .map_err(|_| ProtocolError::InvalidPayload("invalid UTF-8 in path"))?;
     let flags = read_u8_at(payload, 2 + path_len)
         .ok_or(ProtocolError::InvalidPayload("write_file too short"))?;
+    reject_unknown_flags(
+        flags,
+        WRITE_FILE_FLAG_SUDO | WRITE_FILE_FLAG_APPEND,
+        "write_file unknown flags",
+    )?;
     let content_len = read_u32_at(payload, 3 + path_len)
         .ok_or(ProtocolError::InvalidPayload("write_file too short"))?
         as usize;
@@ -1071,6 +1237,11 @@ pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool, bool), Pr
         .ok_or(ProtocolError::InvalidPayload(
             "write_file content truncated",
         ))?;
+    ensure_no_trailing_bytes(
+        payload,
+        7 + path_len + content_len,
+        "write_file trailing bytes",
+    )?;
     Ok((
         path,
         content,
@@ -1091,7 +1262,138 @@ pub fn decode_write_file_result(payload: &[u8]) -> Result<(bool, &str), Protocol
         ProtocolError::InvalidPayload("write_file_result error truncated"),
     )?)
     .map_err(|_| ProtocolError::InvalidPayload("invalid UTF-8 in error"))?;
+    ensure_no_trailing_bytes(payload, 3 + err_len, "write_file_result trailing bytes")?;
     Ok((success, error))
+}
+
+pub fn decode_write_files_start(payload: &[u8]) -> Result<DecodedWriteFilesStart, ProtocolError> {
+    let mut offset = 0usize;
+    let flags = read_u8_cursor(payload, &mut offset, "write_files_start too short")?;
+    reject_unknown_flags(
+        flags,
+        WRITE_FILES_KNOWN_FLAGS,
+        "write_files_start unknown flags",
+    )?;
+    let file_count = read_u32_cursor(payload, &mut offset, "write_files_start too short")?;
+    let total_bytes = read_u64_cursor(payload, &mut offset, "write_files_start too short")?;
+    ensure_no_trailing_bytes(payload, offset, "write_files_start trailing bytes")?;
+    if file_count as usize > MAX_WRITE_FILES_COUNT {
+        return Err(ProtocolError::PayloadTooLarge(
+            "write_files file_count",
+            file_count as usize,
+        ));
+    }
+    if total_bytes > MAX_WRITE_FILES_TOTAL_BYTES {
+        return Err(ProtocolError::PayloadTooLarge(
+            "write_files total_bytes",
+            total_bytes as usize,
+        ));
+    }
+    Ok(DecodedWriteFilesStart {
+        sudo: (flags & WRITE_FILES_FLAG_SUDO) != 0,
+        file_count,
+        total_bytes,
+    })
+}
+
+pub fn decode_write_files_file(payload: &[u8]) -> Result<DecodedWriteFilesFile<'_>, ProtocolError> {
+    let mut offset = 0usize;
+    let file_index = read_u32_cursor(payload, &mut offset, "write_files_file too short")?;
+    let path_len = read_u16_cursor(payload, &mut offset, "write_files_file too short")? as usize;
+    let path = std::str::from_utf8(read_bytes_cursor(
+        payload,
+        &mut offset,
+        path_len,
+        "write_files_file path truncated",
+    )?)
+    .map_err(|_| ProtocolError::InvalidPayload("invalid UTF-8 in write_files path"))?;
+    let content_len = read_u64_cursor(payload, &mut offset, "write_files_file too short")?;
+    ensure_no_trailing_bytes(payload, offset, "write_files_file trailing bytes")?;
+    if path_len > MAX_WRITE_FILES_PATH_BYTES {
+        return Err(ProtocolError::PayloadTooLarge("write_files path", path_len));
+    }
+    if content_len > MAX_WRITE_FILES_FILE_BYTES {
+        return Err(ProtocolError::PayloadTooLarge(
+            "write_files content_len",
+            content_len as usize,
+        ));
+    }
+    Ok(DecodedWriteFilesFile {
+        file_index,
+        path,
+        content_len,
+    })
+}
+
+pub fn decode_write_files_chunk(
+    payload: &[u8],
+) -> Result<DecodedWriteFilesChunk<'_>, ProtocolError> {
+    let mut offset = 0usize;
+    let file_index = read_u32_cursor(payload, &mut offset, "write_files_chunk too short")?;
+    let chunk_len = read_u32_cursor(payload, &mut offset, "write_files_chunk too short")? as usize;
+    if chunk_len == 0 {
+        return Err(ProtocolError::InvalidPayload("write_files chunk empty"));
+    }
+    if chunk_len > MAX_WRITE_FILES_CHUNK_BYTES {
+        return Err(ProtocolError::PayloadTooLarge(
+            "write_files chunk",
+            chunk_len,
+        ));
+    }
+    let chunk = read_bytes_cursor(
+        payload,
+        &mut offset,
+        chunk_len,
+        "write_files_chunk data truncated",
+    )?;
+    ensure_no_trailing_bytes(payload, offset, "write_files_chunk trailing bytes")?;
+    Ok(DecodedWriteFilesChunk { file_index, chunk })
+}
+
+pub fn decode_write_files_abort(payload: &[u8]) -> Result<&str, ProtocolError> {
+    let err_len = read_u16_at(payload, 0)
+        .ok_or(ProtocolError::InvalidPayload("write_files_abort too short"))?
+        as usize;
+    let error = std::str::from_utf8(payload.get(2..2 + err_len).ok_or(
+        ProtocolError::InvalidPayload("write_files_abort error truncated"),
+    )?)
+    .map_err(|_| ProtocolError::InvalidPayload("invalid UTF-8 in write_files abort"))?;
+    ensure_no_trailing_bytes(payload, 2 + err_len, "write_files_abort trailing bytes")?;
+    Ok(error)
+}
+
+pub fn decode_write_files_result(
+    payload: &[u8],
+) -> Result<Vec<WriteFilesResultEntry>, ProtocolError> {
+    let mut offset = 0usize;
+    let count = read_u32_cursor(payload, &mut offset, "write_files_result too short")? as usize;
+    if count > MAX_WRITE_FILES_COUNT {
+        return Err(ProtocolError::PayloadTooLarge(
+            "write_files result_count",
+            count,
+        ));
+    }
+    let mut entries = Vec::with_capacity(count);
+    for _ in 0..count {
+        let file_index = read_u32_cursor(payload, &mut offset, "write_files_result too short")?;
+        let success = read_u8_cursor(payload, &mut offset, "write_files_result too short")? == 1;
+        let err_len =
+            read_u16_cursor(payload, &mut offset, "write_files_result too short")? as usize;
+        let error = std::str::from_utf8(read_bytes_cursor(
+            payload,
+            &mut offset,
+            err_len,
+            "write_files_result error truncated",
+        )?)
+        .map_err(|_| ProtocolError::InvalidPayload("invalid UTF-8 in write_files result"))?;
+        entries.push(WriteFilesResultEntry {
+            file_index,
+            success,
+            error: error.to_string(),
+        });
+    }
+    ensure_no_trailing_bytes(payload, offset, "write_files_result trailing bytes")?;
+    Ok(entries)
 }
 
 /// Decode spawn_watch_result payload. Returns `pid`.
@@ -1165,6 +1467,15 @@ fn read_u8_cursor(
 ) -> Result<u8, ProtocolError> {
     let start = advance_offset(offset, 1, msg)?;
     read_u8_at(payload, start).ok_or(ProtocolError::InvalidPayload(msg))
+}
+
+fn read_u16_cursor(
+    payload: &[u8],
+    offset: &mut usize,
+    msg: &'static str,
+) -> Result<u16, ProtocolError> {
+    let start = advance_offset(offset, 2, msg)?;
+    read_u16_at(payload, start).ok_or(ProtocolError::InvalidPayload(msg))
 }
 
 fn read_u32_cursor(
@@ -2888,6 +3199,89 @@ mod tests {
         let (success, error) = decode_write_file_result(&payload).unwrap();
         assert!(!success);
         assert_eq!(error, "permission denied");
+    }
+
+    #[test]
+    fn write_files_start_roundtrip() {
+        let payload = encode_write_files_start(true, 2, 123).unwrap();
+        let decoded = decode_write_files_start(&payload).unwrap();
+        assert!(decoded.sudo);
+        assert_eq!(decoded.file_count, 2);
+        assert_eq!(decoded.total_bytes, 123);
+    }
+
+    #[test]
+    fn write_files_file_roundtrip() {
+        let payload = encode_write_files_file(7, "/tmp/a.txt", 42).unwrap();
+        let decoded = decode_write_files_file(&payload).unwrap();
+        assert_eq!(decoded.file_index, 7);
+        assert_eq!(decoded.path, "/tmp/a.txt");
+        assert_eq!(decoded.content_len, 42);
+    }
+
+    #[test]
+    fn write_files_chunk_roundtrip() {
+        let payload = encode_write_files_chunk(3, b"abc").unwrap();
+        let decoded = decode_write_files_chunk(&payload).unwrap();
+        assert_eq!(decoded.file_index, 3);
+        assert_eq!(decoded.chunk, b"abc");
+    }
+
+    #[test]
+    fn write_files_result_roundtrip() {
+        let entries = vec![
+            WriteFilesResultEntry {
+                file_index: 0,
+                success: true,
+                error: String::new(),
+            },
+            WriteFilesResultEntry {
+                file_index: 1,
+                success: false,
+                error: "disk full".to_string(),
+            },
+        ];
+        let payload = encode_write_files_result(&entries).unwrap();
+        assert_eq!(decode_write_files_result(&payload).unwrap(), entries);
+    }
+
+    #[test]
+    fn write_files_rejects_trailing_bytes() {
+        let mut payload = encode_write_files_file(0, "/tmp/a", 0).unwrap();
+        payload.push(0);
+        let err = decode_write_files_file(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("write_files_file trailing bytes")
+        ));
+    }
+
+    #[test]
+    fn write_files_rejects_oversized_chunk() {
+        let chunk = vec![0; MAX_WRITE_FILES_CHUNK_BYTES + 1];
+        let err = encode_write_files_chunk(0, &chunk).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::PayloadTooLarge("write_files chunk", _)
+        ));
+    }
+
+    #[test]
+    fn write_files_rejects_empty_chunk() {
+        let err = encode_write_files_chunk(0, b"").unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("write_files chunk empty")
+        ));
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&0u32.to_be_bytes());
+        payload.extend_from_slice(&0u32.to_be_bytes());
+        let err = decode_write_files_chunk(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("write_files chunk empty")
+        ));
     }
 
     #[test]

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -3204,6 +3204,95 @@ mod tests {
     }
 
     #[test]
+    fn write_files_start_rejects_malformed_payloads() {
+        let err =
+            decode_write_files_start(&[0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("write_files_start unknown flags")
+        ));
+
+        let mut payload = encode_write_files_start(false, 1, 0).unwrap();
+        payload.push(0);
+        let err = decode_write_files_start(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("write_files_start trailing bytes")
+        ));
+
+        let mut payload = Vec::new();
+        payload.push(0);
+        payload.extend_from_slice(&((MAX_WRITE_FILES_COUNT as u32) + 1).to_be_bytes());
+        payload.extend_from_slice(&0u64.to_be_bytes());
+        let err = decode_write_files_start(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::PayloadTooLarge("write_files file_count", _)
+        ));
+    }
+
+    #[test]
+    fn write_files_abort_rejects_malformed_payloads() {
+        let err = decode_write_files_abort(&[0, 4, b'o']).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("write_files_abort error truncated")
+        ));
+
+        let err = decode_write_files_abort(&[0, 1, 0xFF]).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("invalid UTF-8 in write_files abort")
+        ));
+
+        let mut payload = encode_write_files_abort("cancelled");
+        payload.push(0);
+        let err = decode_write_files_abort(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("write_files_abort trailing bytes")
+        ));
+    }
+
+    #[test]
+    fn write_files_result_rejects_malformed_payloads() {
+        let err = decode_write_files_result(&[0, 0, 0, 1, 0]).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("write_files_result too short")
+        ));
+
+        let err = decode_write_files_result(&[
+            0, 0, 0, 1, // result_count
+            0, 0, 0, 0, // file_index
+            0, // success
+            0, 1, // err_len
+            0xFF,
+        ])
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("invalid UTF-8 in write_files result")
+        ));
+
+        let mut payload = encode_write_files_result(&[]).unwrap();
+        payload.push(0);
+        let err = decode_write_files_result(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidPayload("write_files_result trailing bytes")
+        ));
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&((MAX_WRITE_FILES_COUNT as u32) + 1).to_be_bytes());
+        let err = decode_write_files_result(&payload).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::PayloadTooLarge("write_files result_count", _)
+        ));
+    }
+
+    #[test]
     fn write_files_rejects_oversized_chunk() {
         let chunk = vec![0; MAX_WRITE_FILES_CHUNK_BYTES + 1];
         let err = encode_write_files_chunk(0, &chunk).unwrap_err();

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -81,7 +81,7 @@ pub const MAX_BOUNDED_EXEC_OUTPUT_CHUNK_BYTES: usize =
     MAX_MESSAGE_SIZE - MIN_BODY_SIZE - BOUNDED_EXEC_OUTPUT_CHUNK_FIXED_PAYLOAD_BYTES;
 /// Minimum stream chunk limit accepted by bounded exec implementations.
 pub const MIN_BOUNDED_EXEC_STREAM_CHUNK_BYTES: usize = 1024;
-/// Maximum file count accepted by a single write_files stream.
+/// Maximum file_count/result_count accepted by one write_files protocol exchange.
 pub const MAX_WRITE_FILES_COUNT: usize = 1024;
 /// Maximum guest path length accepted by write_files.
 pub const MAX_WRITE_FILES_PATH_BYTES: usize = u16::MAX as usize;

--- a/crates/vsock-test/tests/integration.rs
+++ b/crates/vsock-test/tests/integration.rs
@@ -13,7 +13,10 @@ use std::sync::Once;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use vsock_host::{VsockHost, WriteFileRequest, WriteFileSource};
+use vsock_host::{
+    BoundedExecCapturePolicy, BoundedExecOutput, BoundedExecOutputRequest, BoundedExecRequest,
+    BoundedExecTermination, VsockHost, WriteFileRequest, WriteFileSource,
+};
 
 static WRITE_FILE_HELPER: Once = Once::new();
 const WRITE_FILE_HELPER_BIN: &str = env!("CARGO_BIN_EXE_guest-write-file-test-helper");
@@ -57,6 +60,35 @@ fn shell_quote(value: &str) -> String {
 
 fn shell_quote_path(path: &Path) -> String {
     shell_quote(path.to_str().expect("test path must be valid UTF-8"))
+}
+
+fn bounded_exec_capture(limit_bytes: u32) -> BoundedExecOutputRequest {
+    BoundedExecOutputRequest {
+        capture: BoundedExecCapturePolicy::Capture { limit_bytes },
+        stream: None,
+    }
+}
+
+fn simple_bounded_exec_request(command: &str) -> BoundedExecRequest<'_> {
+    BoundedExecRequest {
+        command,
+        timeout_ms: 5000,
+        env: &[],
+        sudo: false,
+        stdin: None,
+        stdout: bounded_exec_capture(1024),
+        stderr: bounded_exec_capture(1024),
+    }
+}
+
+fn assert_bounded_stdout(output: &BoundedExecOutput, expected: &[u8]) {
+    match output {
+        BoundedExecOutput::Captured { bytes, truncated } => {
+            assert_eq!(bytes, expected);
+            assert!(!truncated);
+        }
+        BoundedExecOutput::Discarded => panic!("expected captured stdout"),
+    }
 }
 
 async fn wait_for_path(path: &Path, timeout: Duration) {
@@ -437,12 +469,16 @@ async fn test_write_files_invalid_path_fails_before_partial_write() {
         "write_files must validate the whole batch before sending any file"
     );
 
+    let request = simple_bounded_exec_request("echo after-invalid-write-files");
     let result = h
-        .exec("echo after-invalid-write-files", 5000, &[], false)
+        .bounded_exec(&request)
         .await
         .expect("connection should remain usable after local validation failure");
-    assert_eq!(result.exit_code, 0);
-    assert_eq!(result.stdout, b"after-invalid-write-files\n");
+    assert_eq!(
+        result.termination,
+        BoundedExecTermination::Exited { exit_code: 0 }
+    );
+    assert_bounded_stdout(&result.stdout, b"after-invalid-write-files\n");
     h.finish();
 }
 

--- a/crates/vsock-test/tests/integration.rs
+++ b/crates/vsock-test/tests/integration.rs
@@ -13,7 +13,7 @@ use std::sync::Once;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use vsock_host::VsockHost;
+use vsock_host::{VsockHost, WriteFileRequest, WriteFileSource};
 
 static WRITE_FILE_HELPER: Once = Once::new();
 const WRITE_FILE_HELPER_BIN: &str = env!("CARGO_BIN_EXE_guest-write-file-test-helper");
@@ -367,6 +367,85 @@ async fn test_write_file_unwritable_path_fails() {
 
     h.finish();
 }
+
+#[tokio::test]
+async fn test_write_files_writes_bytes_file_source_and_empty_file() {
+    let h = Harness::new().await;
+
+    let source_path = h.dir.join("source.bin");
+    let source_content = b"from file source";
+    std::fs::write(&source_path, source_content).expect("failed to write source file");
+
+    let bytes_path = h.dir.join("batch/bytes.txt");
+    let file_source_path = h.dir.join("batch/from-file.bin");
+    let empty_path = h.dir.join("batch/empty quote '.txt");
+    let bytes_path_str = bytes_path.to_string_lossy().to_string();
+    let file_source_path_str = file_source_path.to_string_lossy().to_string();
+    let empty_path_str = empty_path.to_string_lossy().to_string();
+    let files = [
+        WriteFileRequest {
+            path: &bytes_path_str,
+            source: WriteFileSource::Bytes(b"from bytes"),
+        },
+        WriteFileRequest {
+            path: &file_source_path_str,
+            source: WriteFileSource::File {
+                path: &source_path,
+                len: source_content.len() as u64,
+            },
+        },
+        WriteFileRequest {
+            path: &empty_path_str,
+            source: WriteFileSource::Bytes(b""),
+        },
+    ];
+
+    h.write_files(&files, false)
+        .await
+        .expect("write_files failed");
+
+    assert_eq!(std::fs::read(&bytes_path).unwrap(), b"from bytes");
+    assert_eq!(std::fs::read(&file_source_path).unwrap(), source_content);
+    assert_eq!(std::fs::read(&empty_path).unwrap(), b"");
+    h.finish();
+}
+
+#[tokio::test]
+async fn test_write_files_invalid_path_fails_before_partial_write() {
+    let h = Harness::new().await;
+
+    let should_not_write = h.dir.join("batch/should-not-write.txt");
+    let should_not_write_str = should_not_write.to_string_lossy().to_string();
+    let files = [
+        WriteFileRequest {
+            path: &should_not_write_str,
+            source: WriteFileSource::Bytes(b"must not be written"),
+        },
+        WriteFileRequest {
+            path: "",
+            source: WriteFileSource::Bytes(b"invalid"),
+        },
+    ];
+
+    let err = h
+        .write_files(&files, false)
+        .await
+        .expect_err("invalid write_files path should fail");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert!(
+        !should_not_write.exists(),
+        "write_files must validate the whole batch before sending any file"
+    );
+
+    let result = h
+        .exec("echo after-invalid-write-files", 5000, &[], false)
+        .await
+        .expect("connection should remain usable after local validation failure");
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.stdout, b"after-invalid-write-files\n");
+    h.finish();
+}
+
 // ── spawn_watch ──────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/vsock-test/tests/integration.rs
+++ b/crates/vsock-test/tests/integration.rs
@@ -917,8 +917,8 @@ async fn test_write_file_chunked() {
 
     let file_path = h.dir.join("chunked'quote.bin");
     let file_path_str = file_path.to_string_lossy().to_string();
-    // 16 MB content exceeds the 15 MB chunk limit, triggering the staging +
-    // shell rename path. The quote in the file name covers shell escaping.
+    // 16 MB content exceeds the 15 MB inline limit and exercises the streamed
+    // write_files path. The quote in the file name covers path framing.
     let content = vec![0xABu8; 16 * 1024 * 1024];
 
     h.write_file(&file_path_str, &content, false)
@@ -929,13 +929,6 @@ async fn test_write_file_chunked() {
     assert_eq!(written.len(), content.len());
     assert_eq!(written, content);
 
-    // Temp file should not remain
-    let temp_prefix = format!("{file_path_str}.vm0tmp-");
-    let temp_remains = std::fs::read_dir(file_path.parent().unwrap())
-        .expect("failed to read temp dir")
-        .flatten()
-        .any(|entry| entry.path().to_string_lossy().starts_with(&temp_prefix));
-    assert!(!temp_remains, "temp file was not cleaned up");
     h.finish();
 }
 

--- a/crates/vsock-test/tests/integration.rs
+++ b/crates/vsock-test/tests/integration.rs
@@ -862,25 +862,22 @@ async fn test_concurrent_exec_not_blocked() {
 
     // Launch a slow exec and wait until its guest-side shell has started
     // before submitting the fast exec.
-    let slow = h.exec(&slow_command, 10000, &[], false);
-    let fast = async {
-        wait_for_path(&ready_marker, Duration::from_secs(3)).await;
-        tokio::time::timeout(Duration::from_secs(3), h.exec("echo ok", 5000, &[], false))
-            .await
-            .expect("fast exec timed out — slow exec is blocking the event loop")
-            .expect("fast exec failed")
-    };
+    let fast_result = {
+        let slow = h.exec(&slow_command, 10000, &[], false);
+        tokio::pin!(slow);
+        let fast = async {
+            wait_for_path(&ready_marker, Duration::from_secs(3)).await;
+            tokio::time::timeout(Duration::from_secs(3), h.exec("echo ok", 5000, &[], false))
+                .await
+                .expect("fast exec timed out — slow exec is blocking the event loop")
+                .expect("fast exec failed")
+        };
 
-    let (_, fast_result) = tokio::join!(
-        // We don't care about slow's result — just cancel it after fast completes
-        async {
-            tokio::select! {
-                r = slow => Some(r),
-                _ = tokio::time::sleep(Duration::from_secs(5)) => None,
-            }
-        },
-        fast
-    );
+        tokio::select! {
+            result = fast => result,
+            _ = &mut slow => panic!("slow exec completed before fast exec"),
+        }
+    };
 
     assert_eq!(fast_result.exit_code, 0);
     assert_eq!(fast_result.stdout, b"ok\n");


### PR DESCRIPTION
Closes #12274

## Summary
- add streamed write_files vsock protocol with inline write_file kept for small payloads
- add guest-write-file --batch and route guest write_file/write_files through the same helper semantics
- batch stage runner storage cache archives via sandbox.write_files while holding cache locks through guest staging

## Tests
- cargo test -p vsock-proto -p vsock-host -p guest-write-file -p vsock-guest
- cargo test -p sandbox --tests
- cargo test -p sandbox-mock --tests
- cargo test -p sandbox-fc --lib
- cargo test -p runner storage_cache
- cargo clippy/fmt/doc via pre-commit