### PR TITLE
refactor(api): migrate user preferences get

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-preferences.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-preferences.test.ts
@@ -4,7 +4,6 @@ import { zeroUserPreferencesContract } from "@vm0/api-contracts/contracts/zero-u
 import { createStore } from "ccstate";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -24,6 +23,42 @@ describe("GET /api/zero/user-preferences", () => {
     return store.set(deleteUserData$, fixture, context.signal);
   });
 
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroUserPreferencesContract);
+
+    const response = await accept(client.get({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    const fixture = await track(
+      store.set(seedUserPreferences$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+
+    const client = setupApp({ context })(zeroUserPreferencesContract);
+
+    const response = await accept(
+      client.get({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
   it("returns the persisted preferences for the current org member", async () => {
     const fixture = await track(
       store.set(
@@ -38,7 +73,6 @@ describe("GET /api/zero/user-preferences", () => {
       ),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
-    mockApiShadowCompareRoutes([zeroUserPreferencesContract.get]);
 
     const client = setupApp({ context })(zeroUserPreferencesContract);
 
@@ -61,7 +95,6 @@ describe("GET /api/zero/user-preferences", () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
-    mockApiShadowCompareRoutes([zeroUserPreferencesContract.get]);
 
     const client = setupApp({ context })(zeroUserPreferencesContract);
 

--- a/turbo/apps/api/src/signals/routes/zero-user-preferences.ts
+++ b/turbo/apps/api/src/signals/routes/zero-user-preferences.ts
@@ -3,7 +3,6 @@ import { zeroUserPreferencesContract } from "@vm0/api-contracts/contracts/zero-u
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import type { RouteEntry } from "../route";
 import { userPreferences } from "../services/zero-user-data.service";
 
@@ -21,12 +20,9 @@ const getUserPreferencesInner$ = computed(async (get): Promise<unknown> => {
 export const zeroUserPreferencesRoutes: readonly RouteEntry[] = [
   {
     route: zeroUserPreferencesContract.get,
-    handler: shadowCompareRoute({
-      route: zeroUserPreferencesContract.get,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        getUserPreferencesInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      getUserPreferencesInner$,
+    ),
   },
 ];


### PR DESCRIPTION
Closes #12310

## Summary
- make `GET /api/zero/user-preferences` authoritative in `apps/api` by removing the shadow-compare wrapper
- keep `POST /api/zero/user-preferences` untouched for the follow-up migration
- add API route coverage for unauthenticated, missing organization, default, and persisted preference reads

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-user-preferences.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- pre-commit: prettier, knip, `turbo run check-types`
