### PR TITLE
refactor: migrate voice IO quota GET to api

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-quota.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-quota.test.ts
@@ -2,7 +2,6 @@ import { zeroVoiceIoQuotaContract } from "@vm0/api-contracts/contracts/zero-voic
 import { createStore } from "ccstate";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import {
   deleteVoiceIoQuotaOrg$,
   seedVoiceIoQuotaOrg$,
@@ -17,9 +16,19 @@ const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
+const AUDIO_INPUT_FREE_QUOTA = 10;
+
 describe("GET /api/zero/voice-io/quota", () => {
   const track = createFixtureTracker<VoiceIoQuotaFixture>((fixture) => {
     return store.set(deleteVoiceIoQuotaOrg$, fixture, context.signal);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(zeroVoiceIoQuotaContract);
+
+    const response = await accept(client.get({ headers: {} }), [401]);
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
   });
 
   it("defaults a missing org metadata row to the free quota", async () => {
@@ -27,7 +36,6 @@ describe("GET /api/zero/voice-io/quota", () => {
       store.set(seedVoiceIoQuotaOrg$, {}, context.signal),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
-    mockApiShadowCompareRoutes([zeroVoiceIoQuotaContract.get]);
 
     const client = setupApp({ context })(zeroVoiceIoQuotaContract);
 
@@ -41,16 +49,67 @@ describe("GET /api/zero/voice-io/quota", () => {
     expect(response.body).toStrictEqual({
       allowed: true,
       count: 0,
-      limit: 10,
+      limit: AUDIO_INPUT_FREE_QUOTA,
+    });
+  });
+
+  it("allows free tier users with partial lifetime audio input usage", async () => {
+    const fixture = await track(
+      store.set(seedVoiceIoQuotaOrg$, { count: 2 }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroVoiceIoQuotaContract);
+
+    const response = await accept(
+      client.get({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      allowed: true,
+      count: 2,
+      limit: AUDIO_INPUT_FREE_QUOTA,
+    });
+  });
+
+  it("allows free tier users one below the lifetime audio input quota", async () => {
+    const fixture = await track(
+      store.set(
+        seedVoiceIoQuotaOrg$,
+        { count: AUDIO_INPUT_FREE_QUOTA - 1 },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroVoiceIoQuotaContract);
+
+    const response = await accept(
+      client.get({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      allowed: true,
+      count: AUDIO_INPUT_FREE_QUOTA - 1,
+      limit: AUDIO_INPUT_FREE_QUOTA,
     });
   });
 
   it("blocks free tier users at the lifetime audio input quota", async () => {
     const fixture = await track(
-      store.set(seedVoiceIoQuotaOrg$, { count: 10 }, context.signal),
+      store.set(
+        seedVoiceIoQuotaOrg$,
+        { count: AUDIO_INPUT_FREE_QUOTA },
+        context.signal,
+      ),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
-    mockApiShadowCompareRoutes([zeroVoiceIoQuotaContract.get]);
 
     const client = setupApp({ context })(zeroVoiceIoQuotaContract);
 
@@ -63,8 +122,34 @@ describe("GET /api/zero/voice-io/quota", () => {
 
     expect(response.body).toStrictEqual({
       allowed: false,
-      count: 10,
-      limit: 10,
+      count: AUDIO_INPUT_FREE_QUOTA,
+      limit: AUDIO_INPUT_FREE_QUOTA,
+    });
+  });
+
+  it("blocks free tier users above the lifetime audio input quota", async () => {
+    const fixture = await track(
+      store.set(
+        seedVoiceIoQuotaOrg$,
+        { count: AUDIO_INPUT_FREE_QUOTA + 1 },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroVoiceIoQuotaContract);
+
+    const response = await accept(
+      client.get({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      allowed: false,
+      count: AUDIO_INPUT_FREE_QUOTA + 1,
+      limit: AUDIO_INPUT_FREE_QUOTA,
     });
   });
 
@@ -80,7 +165,35 @@ describe("GET /api/zero/voice-io/quota", () => {
       ),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
-    mockApiShadowCompareRoutes([zeroVoiceIoQuotaContract.get]);
+
+    const client = setupApp({ context })(zeroVoiceIoQuotaContract);
+
+    const response = await accept(
+      client.get({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      allowed: true,
+      count: 0,
+      limit: null,
+    });
+  });
+
+  it("does not apply the free quota to team tier orgs", async () => {
+    const fixture = await track(
+      store.set(
+        seedVoiceIoQuotaOrg$,
+        {
+          tier: "team",
+          count: AUDIO_INPUT_FREE_QUOTA,
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(zeroVoiceIoQuotaContract);
 

--- a/turbo/apps/api/src/signals/routes/zero-voice-io-quota.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-io-quota.ts
@@ -3,7 +3,6 @@ import { zeroVoiceIoQuotaContract } from "@vm0/api-contracts/contracts/zero-voic
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import type { RouteEntry } from "../route";
 import { audioInputQuota } from "../services/voice-io.service";
 
@@ -19,12 +18,9 @@ const getVoiceIoQuotaInner$ = computed(async (get): Promise<unknown> => {
 export const zeroVoiceIoQuotaRoutes: readonly RouteEntry[] = [
   {
     route: zeroVoiceIoQuotaContract.get,
-    handler: shadowCompareRoute({
-      route: zeroVoiceIoQuotaContract.get,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        getVoiceIoQuotaInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      getVoiceIoQuotaInner$,
+    ),
   },
 ];


### PR DESCRIPTION
## Summary

- make `GET /api/zero/voice-io/quota` API-authoritative when traffic reaches `apps/api`
- remove the route's default `shadowCompareRoute(...)` wrapper
- port the remaining web quota behavior coverage into API route tests

Closes #12313

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-voice-io-quota.test.ts`
- `pnpm -F api lint`
- `pnpm exec prettier --check apps/api/src/signals/routes/zero-voice-io-quota.ts apps/api/src/signals/routes/__tests__/zero-voice-io-quota.test.ts`
- `git diff --check`

## Notes

`pnpm check-types` currently fails locally on latest `origin/main` before reaching this API slice, with `@vm0/app` ts-rest type errors such as `Property 'body' does not exist on type 'never'` and missing `headers` arguments. This PR does not touch platform code.
