### PR TITLE
refactor(api): migrate user preferences post

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-preferences.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-preferences.test.ts
@@ -17,14 +17,30 @@ import {
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
+const track = createFixtureTracker<UserDataFixture>((fixture) => {
+  return store.set(deleteUserData$, fixture, context.signal);
+});
+
+function apiClient() {
+  return setupApp({ context })(zeroUserPreferencesContract);
+}
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function createTrackedFixture(): Promise<UserDataFixture> {
+  return track(
+    Promise.resolve({
+      orgId: `org_${randomUUID()}`,
+      userId: `user_${randomUUID()}`,
+    }),
+  );
+}
 
 describe("GET /api/zero/user-preferences", () => {
-  const track = createFixtureTracker<UserDataFixture>((fixture) => {
-    return store.set(deleteUserData$, fixture, context.signal);
-  });
-
   it("returns 401 when the request is unauthenticated", async () => {
-    const client = setupApp({ context })(zeroUserPreferencesContract);
+    const client = apiClient();
 
     const response = await accept(client.get({ headers: {} }), [401]);
 
@@ -42,11 +58,11 @@ describe("GET /api/zero/user-preferences", () => {
     );
     mocks.clerk.session(fixture.userId, null);
 
-    const client = setupApp({ context })(zeroUserPreferencesContract);
+    const client = apiClient();
 
     const response = await accept(
       client.get({
-        headers: { authorization: "Bearer clerk-session" },
+        headers: authHeaders(),
       }),
       [401],
     );
@@ -74,11 +90,11 @@ describe("GET /api/zero/user-preferences", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context })(zeroUserPreferencesContract);
+    const client = apiClient();
 
     const response = await accept(
       client.get({
-        headers: { authorization: "Bearer clerk-session" },
+        headers: authHeaders(),
       }),
       [200],
     );
@@ -96,11 +112,11 @@ describe("GET /api/zero/user-preferences", () => {
     const userId = `user_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
 
-    const client = setupApp({ context })(zeroUserPreferencesContract);
+    const client = apiClient();
 
     const response = await accept(
       client.get({
-        headers: { authorization: "Bearer clerk-session" },
+        headers: authHeaders(),
       }),
       [200],
     );
@@ -110,6 +126,262 @@ describe("GET /api/zero/user-preferences", () => {
       pinnedAgentIds: [],
       sendMode: "enter",
       captureNetworkBodiesRemaining: 0,
+    });
+  });
+});
+
+describe("POST /api/zero/user-preferences", () => {
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = apiClient();
+
+    const response = await accept(
+      client.update({
+        headers: {},
+        body: { timezone: "America/New_York" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    const fixture = await track(
+      store.set(seedUserPreferences$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+
+    const client = apiClient();
+
+    const response = await accept(
+      client.update({
+        headers: authHeaders(),
+        body: { timezone: "America/New_York" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 400 when timezone is invalid", async () => {
+    const fixture = await track(
+      store.set(seedUserPreferences$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = apiClient();
+
+    const response = await accept(
+      client.update({
+        headers: authHeaders(),
+        body: { timezone: "Invalid/Timezone" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Invalid request",
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+
+  it("returns 400 when no preference update is provided", async () => {
+    const fixture = await track(
+      store.set(seedUserPreferences$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = apiClient();
+
+    const response = await accept(
+      client.update({
+        headers: authHeaders(),
+        body: {},
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("creates preferences with all supported fields", async () => {
+    const fixture = await createTrackedFixture();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = apiClient();
+
+    const updateResponse = await accept(
+      client.update({
+        headers: authHeaders(),
+        body: {
+          timezone: "Europe/London",
+          pinnedAgentIds: ["agent-a", "agent-b"],
+          sendMode: "cmd-enter",
+          captureNetworkBodiesRemaining: 4,
+        },
+      }),
+      [200],
+    );
+
+    const expected = {
+      timezone: "Europe/London",
+      pinnedAgentIds: ["agent-a", "agent-b"],
+      sendMode: "cmd-enter",
+      captureNetworkBodiesRemaining: 4,
+    };
+    expect(updateResponse.body).toStrictEqual(expected);
+
+    const getResponse = await accept(
+      client.get({
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    expect(getResponse.body).toStrictEqual(expected);
+  });
+
+  it("updates timezone without changing existing preference fields", async () => {
+    const fixture = await track(
+      store.set(
+        seedUserPreferences$,
+        {
+          timezone: "Asia/Tokyo",
+          pinnedAgentIds: ["agent-old"],
+          sendMode: "cmd-enter",
+          captureNetworkBodiesRemaining: 2,
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = apiClient();
+
+    const response = await accept(
+      client.update({
+        headers: authHeaders(),
+        body: { timezone: "America/Los_Angeles" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      timezone: "America/Los_Angeles",
+      pinnedAgentIds: ["agent-old"],
+      sendMode: "cmd-enter",
+      captureNetworkBodiesRemaining: 2,
+    });
+  });
+
+  it("updates pinnedAgentIds without changing existing preference fields", async () => {
+    const fixture = await track(
+      store.set(
+        seedUserPreferences$,
+        {
+          timezone: "Asia/Tokyo",
+          pinnedAgentIds: ["agent-old"],
+          sendMode: "cmd-enter",
+          captureNetworkBodiesRemaining: 2,
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = apiClient();
+
+    const response = await accept(
+      client.update({
+        headers: authHeaders(),
+        body: { pinnedAgentIds: ["agent-new", "agent-extra"] },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      timezone: "Asia/Tokyo",
+      pinnedAgentIds: ["agent-new", "agent-extra"],
+      sendMode: "cmd-enter",
+      captureNetworkBodiesRemaining: 2,
+    });
+  });
+
+  it("updates sendMode without changing existing preference fields", async () => {
+    const fixture = await track(
+      store.set(
+        seedUserPreferences$,
+        {
+          timezone: "Asia/Tokyo",
+          pinnedAgentIds: ["agent-old"],
+          sendMode: "enter",
+          captureNetworkBodiesRemaining: 2,
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = apiClient();
+
+    const response = await accept(
+      client.update({
+        headers: authHeaders(),
+        body: { sendMode: "cmd-enter" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      timezone: "Asia/Tokyo",
+      pinnedAgentIds: ["agent-old"],
+      sendMode: "cmd-enter",
+      captureNetworkBodiesRemaining: 2,
+    });
+  });
+
+  it("updates captureNetworkBodiesRemaining without changing existing preference fields", async () => {
+    const fixture = await track(
+      store.set(
+        seedUserPreferences$,
+        {
+          timezone: "Asia/Tokyo",
+          pinnedAgentIds: ["agent-old"],
+          sendMode: "cmd-enter",
+          captureNetworkBodiesRemaining: 2,
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = apiClient();
+
+    const response = await accept(
+      client.update({
+        headers: authHeaders(),
+        body: { captureNetworkBodiesRemaining: 7 },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      timezone: "Asia/Tokyo",
+      pinnedAgentIds: ["agent-old"],
+      sendMode: "cmd-enter",
+      captureNetworkBodiesRemaining: 7,
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-user-preferences.ts
+++ b/turbo/apps/api/src/signals/routes/zero-user-preferences.ts
@@ -1,10 +1,19 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import { zeroUserPreferencesContract } from "@vm0/api-contracts/contracts/zero-user-preferences";
 
+import { badRequestMessage } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route";
-import { userPreferences } from "../services/zero-user-data.service";
+import {
+  updateUserPreferences$,
+  userPreferences,
+} from "../services/zero-user-data.service";
+
+const updateUserPreferencesBody$ = bodyResultOf(
+  zeroUserPreferencesContract.update,
+);
 
 const getUserPreferencesInner$ = computed(async (get): Promise<unknown> => {
   const auth = get(organizationAuthContext$);
@@ -17,12 +26,48 @@ const getUserPreferencesInner$ = computed(async (get): Promise<unknown> => {
   };
 });
 
+const updateUserPreferencesInner$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<unknown> => {
+    const auth = get(organizationAuthContext$);
+    const body = await get(updateUserPreferencesBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const result = await set(
+      updateUserPreferences$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        preferences: body.data,
+      },
+      signal,
+    );
+    if (!result.ok) {
+      return badRequestMessage(result.message);
+    }
+
+    return {
+      status: 200 as const,
+      body: result.data,
+    };
+  },
+);
+
 export const zeroUserPreferencesRoutes: readonly RouteEntry[] = [
   {
     route: zeroUserPreferencesContract.get,
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       getUserPreferencesInner$,
+    ),
+  },
+  {
+    route: zeroUserPreferencesContract.update,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      updateUserPreferencesInner$,
     ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-user-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-data.service.ts
@@ -1,10 +1,11 @@
-import { computed, type Computed } from "ccstate";
+import { command, computed, type Computed } from "ccstate";
 import type {
   ApiKeyListResponse,
   ApiKeyItem,
 } from "@vm0/api-contracts/contracts/api-keys";
 import type {
   SendMode,
+  UpdateUserPreferencesRequest,
   UserPreferencesResponse,
 } from "@vm0/api-contracts/contracts/zero-user-preferences";
 import type {
@@ -18,7 +19,9 @@ import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
 import { and, desc, eq } from "drizzle-orm";
 
-import { db$ } from "../external/db";
+import { nowDate } from "../../lib/time";
+import { db$, writeDb$ } from "../external/db";
+import { isValidTimeZone } from "../utils";
 
 const API_KEY_PREFIX_LENGTH = 12;
 
@@ -127,6 +130,94 @@ export function userPreferences({
     };
   });
 }
+
+interface UpdateUserPreferencesArgs extends UserScopedQuery {
+  readonly preferences: UpdateUserPreferencesRequest;
+}
+
+type UpdateUserPreferencesResult =
+  | { readonly ok: true; readonly data: UserPreferencesResponse }
+  | { readonly ok: false; readonly message: string };
+
+export const updateUserPreferences$ = command(
+  async (
+    { get, set },
+    args: UpdateUserPreferencesArgs,
+    signal: AbortSignal,
+  ): Promise<UpdateUserPreferencesResult> => {
+    const preferences = args.preferences;
+    if (
+      preferences.timezone !== undefined &&
+      !isValidTimeZone(preferences.timezone)
+    ) {
+      return {
+        ok: false,
+        message: "Invalid request",
+      };
+    }
+
+    const existing = await get(
+      userPreferences({ orgId: args.orgId, userId: args.userId }),
+    );
+    signal.throwIfAborted();
+
+    const merged: UserPreferencesResponse = {
+      timezone:
+        preferences.timezone !== undefined
+          ? preferences.timezone
+          : existing.timezone,
+      pinnedAgentIds:
+        preferences.pinnedAgentIds !== undefined
+          ? [...preferences.pinnedAgentIds]
+          : existing.pinnedAgentIds,
+      sendMode:
+        preferences.sendMode !== undefined
+          ? preferences.sendMode
+          : existing.sendMode,
+      captureNetworkBodiesRemaining:
+        preferences.captureNetworkBodiesRemaining !== undefined
+          ? preferences.captureNetworkBodiesRemaining
+          : existing.captureNetworkBodiesRemaining,
+    };
+
+    const updatedAt = nowDate();
+    const writeDb = set(writeDb$);
+    await writeDb
+      .insert(orgMembersMetadata)
+      .values({
+        orgId: args.orgId,
+        userId: args.userId,
+        timezone: merged.timezone,
+        pinnedAgentIds: merged.pinnedAgentIds,
+        sendMode: merged.sendMode,
+        captureNetworkBodiesRemaining: merged.captureNetworkBodiesRemaining,
+        createdAt: updatedAt,
+        updatedAt,
+      })
+      .onConflictDoUpdate({
+        target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
+        set: {
+          ...(preferences.timezone !== undefined && {
+            timezone: preferences.timezone,
+          }),
+          ...(preferences.pinnedAgentIds !== undefined && {
+            pinnedAgentIds: [...preferences.pinnedAgentIds],
+          }),
+          ...(preferences.sendMode !== undefined && {
+            sendMode: preferences.sendMode,
+          }),
+          ...(preferences.captureNetworkBodiesRemaining !== undefined && {
+            captureNetworkBodiesRemaining:
+              preferences.captureNetworkBodiesRemaining,
+          }),
+          updatedAt,
+        },
+      });
+    signal.throwIfAborted();
+
+    return { ok: true, data: merged };
+  },
+);
 
 export function userVariables({
   orgId,

--- a/turbo/apps/api/src/signals/utils.ts
+++ b/turbo/apps/api/src/signals/utils.ts
@@ -52,6 +52,17 @@ export function safeUrlParse(input: string): URL | undefined {
   }
 }
 
+export function isValidTimeZone(input: string): boolean {
+  // eslint-disable-next-line no-restricted-syntax -- centralized guarded Intl timezone validation
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone: input });
+    return true;
+  } catch (error) {
+    throwIfAbort(error);
+    return false;
+  }
+}
+
 export function detach(
   promise: Promise<unknown>,
   mechanism: Mechanism,


### PR DESCRIPTION
Closes #12311

## Summary
- add `POST /api/zero/user-preferences` to `apps/api` as the authoritative side-effecting route
- add a ccstate command service that validates timezone and upserts org member preferences with `writeDb$`
- keep the existing GET route authoritative and add POST route coverage for auth, validation, full updates, partial updates, and persistence

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-user-preferences.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- pre-commit: prettier, knip, `turbo run check-types`
