### PR TITLE
chore(web): elevate no-new-api-routes to error severity

### DIFF
--- a/turbo/apps/web/eslint.config.js
+++ b/turbo/apps/web/eslint.config.js
@@ -117,7 +117,7 @@ export default [
       web: webPlugin,
     },
     rules: {
-      "web/no-new-api-routes": "warn",
+      "web/no-new-api-routes": "error",
       "web/no-request-json-as": "error",
     },
   },


### PR DESCRIPTION
## Summary

Promote `web/no-new-api-routes` from `"warn"` to `"error"` in `turbo/apps/web/eslint.config.js`. Part of epic #12290 — make the freeze on new `apps/web/app/api` routes a first-class enforcement signal.

## Why

The rule was registered as `"warn"`. Web's lint script already runs `eslint . --max-warnings 0`, so warnings fail CI today, but the soft severity:

- leaves the intent ambiguous at the rule definition site
- makes enforcement implicitly dependent on the `--max-warnings` flag (any future change to that flag would silently un-gate the rule)
- treats the migration freeze as cosmetic rather than mandatory

`"error"` makes the freeze explicit, independent of any external flag, and consistent with the strict gating the API migration applies elsewhere.

## Safety

The current baseline (`turbo/apps/web/custom-eslint/baselines/web-api-routes.ts`) matches on-disk routes exactly:

- 254 `app/api/**/route.ts` files on disk
- 254 baseline entries
- 0 routes outside the baseline (would trigger `noNewApiRoute`)
- 0 stale baseline entries (would trigger `staleApiRouteBaseline`)

Flipping to `error` introduces no new lint failures.

## Test plan

- [x] `pnpm -F web lint` passes locally
- [x] `pnpm -F web exec prettier --check eslint.config.js` passes
- [ ] CI lint job stays green