### PR TITLE
fix: stop chat file links before annotation punctuation

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { parseBodyRenderBlocks } from "../parse-body-blocks.ts";
+
+describe("parseBodyRenderBlocks", () => {
+  it.each([
+    "（公开 URL，可以分享给设计/PM）。",
+    "，公开 URL，可以分享给设计/PM。",
+  ])(
+    "does not include annotation text after a platform file URL: %s",
+    (suffix) => {
+      const imageUrl =
+        "https://www.vm0.ai/f/36PnTFtD4dBQ9zg5jj6E5r918aV/24b42fb4-4b7b-4521-800f-defc356ae7b4/image-24b42fb4.png";
+
+      const { blocks } = parseBodyRenderBlocks(
+        `图也存好了：${imageUrl}${suffix}`,
+      );
+
+      expect(blocks).toStrictEqual([
+        {
+          type: "preview",
+          id: "preview-1",
+          preview: {
+            filename: "image-24b42fb4.png",
+            url: imageUrl,
+            kind: "image",
+          },
+        },
+      ]);
+    },
+  );
+});

--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -53,6 +53,7 @@ type ExtractedPreviewUrl = {
 const TEXT_PREVIEW_MAX_BYTES = 65_536;
 const PLATFORM_FILE_PATH_PATTERN = /^\/f\/[^/]+\/[^/]+\/[^/]+$/;
 const PLATFORM_FILE_HOST_SUFFIXES = ["vm0.ai", "vm6.ai", "vm7.ai"] as const;
+const URL_TOKEN_PATTERN = String.raw`(?:https?:\/\/|\/f\/)[^\s<>"'()（）【】《》「」『』“”‘’，。；：！？、]+`;
 
 // ---------------------------------------------------------------------------
 // classifyChatAttachment helpers
@@ -333,9 +334,9 @@ function trimPreviewUrl(value: string): string {
 function extractPreviewUrlFromLine(line: string): ExtractedPreviewUrl | null {
   const candidate = stripMarkdownLineDecorations(line);
   const markdownLinkMatch = candidate.match(
-    /^\[([^\]]+)\]\((https?:\/\/[^)\s]+|\/f\/[^)\s]+)\)$/,
+    new RegExp(String.raw`^\[([^\]]+)\]\((${URL_TOKEN_PATTERN})\)$`),
   );
-  const bareUrlMatch = candidate.match(/^(https?:\/\/\S+|\/f\/\S+)$/);
+  const bareUrlMatch = candidate.match(new RegExp(`^(${URL_TOKEN_PATTERN})$`));
   if (markdownLinkMatch?.[2]) {
     return {
       url: trimPreviewUrl(markdownLinkMatch[2]),
@@ -350,7 +351,7 @@ function extractPreviewUrlFromLine(line: string): ExtractedPreviewUrl | null {
   }
 
   const urls = Array.from(
-    candidate.matchAll(/(?:https?:\/\/|\/f\/)[^\s<>"']+/g),
+    candidate.matchAll(new RegExp(URL_TOKEN_PATTERN, "g")),
     (match) => {
       return trimPreviewUrl(match[0]);
     },


### PR DESCRIPTION
## Summary
- stop chat body file URL extraction before Chinese/paired annotation punctuation
- add regression coverage for vm0 file links followed by Chinese explanatory text

## Tests
- pnpm --filter @vm0/app test src/signals/chat-page/__tests__/parse-body-blocks.test.ts
- pnpm --filter @vm0/app test src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
- pnpm --filter @vm0/app lint
- pnpm --filter @vm0/app check-types
- pre-commit: turbo check-types