### PR TITLE
fix: pin vercel CLI to 53.2.0 to avoid broken @vercel/cli-config dependency

### DIFF
--- a/.github/actions/vercel-setup/action.yml
+++ b/.github/actions/vercel-setup/action.yml
@@ -21,7 +21,7 @@ runs:
         # Check if Vercel CLI is installed, install if not
         if ! command -v vercel &> /dev/null; then
           echo "Vercel CLI not found, installing..."
-          npm install -g vercel@latest
+          npm install -g vercel@53.2.0
         else
           echo "Vercel CLI already installed"
         fi


### PR DESCRIPTION
## Summary
- `vercel@53.3.0` was published at 09:11:43 UTC with a dependency on `@vercel/cli-config@0.1.0`, which was never published to npm
- This broke all `promote-app-production` jobs (the failing job happened to run right after 53.3.0 landed; earlier promote jobs got 53.2.0 and succeeded)
- Pin to `vercel@53.2.0` (the last known-good version) instead of `@latest`

## Test plan
- [x] Verified `vercel@53.2.0` does NOT depend on `@vercel/cli-config`
- [x] Verified `@vercel/cli-config` returns 404 from npm registry
- [ ] CI passes on this PR
- [ ] Next release pipeline runs promote-app-production successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)