### PR TITLE
refactor(runner): migrate internal execs to bounded exec

### DIFF
--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -771,12 +771,21 @@ async fn sequential_same_session_reuse_cycle() {
 #[tokio::test(start_paused = true)]
 async fn park_evicts_via_guest_session_id() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
-        pattern: "cat /tmp/vm0-session-".into(),
-        exit_code: 0,
-        stdout: b"sess-evict".to_vec(),
-        stderr: Vec::new(),
-    });
+    // Snapshot-backed profiles run clock fix + entropy reseed before the agent;
+    // the third bounded exec is the post-job guest session-id read.
+    for stdout in [Vec::new(), Vec::new(), b"sess-evict".to_vec()] {
+        overrides.push_bounded_exec_response(sandbox_mock::BoundedExecResponse {
+            events: Vec::new(),
+            result: Ok(sandbox::BoundedExecResult {
+                termination: sandbox::BoundedExecTermination::Exited { exit_code: 0 },
+                duration: Duration::ZERO,
+                stdout,
+                stderr: Vec::new(),
+                stdout_truncated: false,
+                stderr_truncated: false,
+            }),
+        });
+    }
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
     let budget = Arc::clone(&config.budget);
     let idle_pool = Arc::clone(&config.idle_pool);

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -778,10 +778,15 @@ async fn park_evicts_via_guest_session_id() {
             result: Ok(sandbox::BoundedExecResult {
                 termination: sandbox::BoundedExecTermination::Exited { exit_code: 0 },
                 duration: Duration::ZERO,
-                stdout: b"sess-evict".to_vec(),
-                stderr: Vec::new(),
-                stdout_truncated: false,
-                stderr_truncated: false,
+                stdout: sandbox::BoundedExecOutput::Captured {
+                    bytes: b"sess-evict".to_vec(),
+                    truncated: false,
+                },
+                stderr: sandbox::BoundedExecOutput::Captured {
+                    bytes: Vec::new(),
+                    truncated: false,
+                },
+                diagnostic: None,
             }),
         },
     });

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -771,21 +771,20 @@ async fn sequential_same_session_reuse_cycle() {
 #[tokio::test(start_paused = true)]
 async fn park_evicts_via_guest_session_id() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    // Snapshot-backed profiles run clock fix + entropy reseed before the agent;
-    // the third bounded exec is the post-job guest session-id read.
-    for stdout in [Vec::new(), Vec::new(), b"sess-evict".to_vec()] {
-        overrides.push_bounded_exec_response(sandbox_mock::BoundedExecResponse {
+    overrides.add_bounded_exec_matcher(sandbox_mock::BoundedExecMatcher {
+        pattern: "cat /tmp/vm0-session-".into(),
+        response: sandbox_mock::BoundedExecResponse {
             events: Vec::new(),
             result: Ok(sandbox::BoundedExecResult {
                 termination: sandbox::BoundedExecTermination::Exited { exit_code: 0 },
                 duration: Duration::ZERO,
-                stdout,
+                stdout: b"sess-evict".to_vec(),
                 stderr: Vec::new(),
                 stdout_truncated: false,
                 stderr_truncated: false,
             }),
-        });
-    }
+        },
+    });
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
     let budget = Arc::clone(&config.budget);
     let idle_pool = Arc::clone(&config.idle_pool);
@@ -798,7 +797,7 @@ async fn park_evicts_via_guest_session_id() {
 
     // Push job WITHOUT resume_session — first run, no session context.
     // read_guest_session_id() will be called and return "sess-evict"
-    // via the exec matcher.
+    // via the bounded_exec matcher.
     let run_id = RunId::new_v4();
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2752,6 +2752,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn download_storages_failure_marks_truncated_output() {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_bounded_exec_response(BoundedExecResponse {
+            events: Vec::new(),
+            result: Ok(BoundedExecResult {
+                termination: BoundedExecTermination::Exited { exit_code: 1 },
+                duration: Duration::ZERO,
+                stdout: b"partial stdout".to_vec(),
+                stderr: b"partial stderr".to_vec(),
+                stdout_truncated: true,
+                stderr_truncated: false,
+            }),
+        });
+        let ctx = minimal_context();
+        let manifest = GuestDownloadManifest {
+            storages: vec![],
+            artifacts: vec![],
+            cleanup_paths: vec![],
+        };
+
+        let err = download_storages(&sandbox, &ctx, &manifest)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("(output truncated)"), "got: {err}");
+        assert!(err.to_string().contains("partial stderr"), "got: {err}");
+    }
+
+    #[tokio::test]
     async fn download_storages_allows_truncated_output_on_success() {
         let sandbox = MockSandbox::new("test");
         sandbox.push_bounded_exec_response(BoundedExecResponse {

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2738,6 +2738,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn download_storages_fails_on_truncated_output() {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_bounded_exec_response(BoundedExecResponse {
+            events: Vec::new(),
+            result: Ok(BoundedExecResult {
+                termination: BoundedExecTermination::Exited { exit_code: 0 },
+                duration: Duration::ZERO,
+                stdout: b"partial stdout".to_vec(),
+                stderr: b"partial stderr".to_vec(),
+                stdout_truncated: false,
+                stderr_truncated: true,
+            }),
+        });
+        let ctx = minimal_context();
+        let manifest = GuestDownloadManifest {
+            storages: vec![],
+            artifacts: vec![],
+            cleanup_paths: vec![],
+        };
+
+        let err = download_storages(&sandbox, &ctx, &manifest)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("storage download output truncated"),
+            "got: {err}"
+        );
+        assert!(err.to_string().contains("partial stderr"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn download_storages_fails_on_timeout_termination() {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_bounded_exec_response(bounded_exec_response(
+            BoundedExecTermination::TimedOut,
+            b"partial stdout".to_vec(),
+            b"partial stderr".to_vec(),
+        ));
+        let ctx = minimal_context();
+        let manifest = GuestDownloadManifest {
+            storages: vec![],
+            artifacts: vec![],
+            cleanup_paths: vec![],
+        };
+
+        let err = download_storages(&sandbox, &ctx, &manifest)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("storage download failed (timed out)"),
+            "got: {err}"
+        );
+        assert!(err.to_string().contains("partial stderr"), "got: {err}");
+    }
+
+    #[tokio::test]
     async fn restore_session_writes_history() {
         let sandbox = MockSandbox::new("test");
         let mut ctx = minimal_context();

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1300,24 +1300,38 @@ async fn download_storages(
         })
         .await?;
 
-    if result.stdout_truncated || result.stderr_truncated {
-        return Err(RunnerError::Internal(format!(
-            "storage download output truncated{}",
-            bounded_exec_output_summary(&result.stdout, &result.stderr)
-        )));
-    }
-
     match result.termination {
-        BoundedExecTermination::Exited { exit_code: 0 } => {}
+        BoundedExecTermination::Exited { exit_code: 0 } => {
+            // Truncated output only means diagnostics were clipped; the
+            // command exit status remains the success source of truth.
+            if result.stdout_truncated || result.stderr_truncated {
+                warn!(
+                    run_id = %context.run_id,
+                    stdout_truncated = result.stdout_truncated,
+                    stderr_truncated = result.stderr_truncated,
+                    "storage download output was truncated"
+                );
+            }
+        }
         BoundedExecTermination::Exited { exit_code } => {
+            let truncated = if result.stdout_truncated || result.stderr_truncated {
+                " (output truncated)"
+            } else {
+                ""
+            };
             return Err(RunnerError::Internal(format!(
-                "storage download failed (exit code {exit_code}){}",
+                "storage download failed (exit code {exit_code}){truncated}{}",
                 bounded_exec_output_summary(&result.stdout, &result.stderr)
             )));
         }
         termination => {
+            let truncated = if result.stdout_truncated || result.stderr_truncated {
+                " (output truncated)"
+            } else {
+                ""
+            };
             return Err(RunnerError::Internal(format!(
-                "storage download failed ({}){}",
+                "storage download failed ({}){truncated}{}",
                 describe_bounded_exec_termination(termination),
                 bounded_exec_output_summary(&result.stdout, &result.stderr)
             )));
@@ -2738,7 +2752,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn download_storages_fails_on_truncated_output() {
+    async fn download_storages_allows_truncated_output_on_success() {
         let sandbox = MockSandbox::new("test");
         sandbox.push_bounded_exec_response(BoundedExecResponse {
             events: Vec::new(),
@@ -2758,16 +2772,7 @@ mod tests {
             cleanup_paths: vec![],
         };
 
-        let err = download_storages(&sandbox, &ctx, &manifest)
-            .await
-            .unwrap_err();
-
-        assert!(
-            err.to_string()
-                .contains("storage download output truncated"),
-            "got: {err}"
-        );
-        assert!(err.to_string().contains("partial stderr"), "got: {err}");
+        download_storages(&sandbox, &ctx, &manifest).await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -19,7 +19,10 @@ use std::panic::AssertUnwindSafe;
 use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
-use sandbox::{ExecRequest, Sandbox, SandboxConfig, SandboxFactory, SandboxId, SpawnOutputMode};
+use sandbox::{
+    BoundedExecRequest, BoundedExecTermination, ExecRequest, Sandbox, SandboxConfig,
+    SandboxFactory, SandboxId, SpawnOutputMode,
+};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -33,6 +36,7 @@ const EXIT_SIGKILL: i32 = 137;
 const EXIT_SIGNAL_KILL: i32 = 9;
 /// Default timeout for guest commands (5 minutes).
 const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
+const EXEC_ERROR_OUTPUT_PREVIEW_BYTES: usize = 8 * 1024;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
@@ -646,23 +650,43 @@ async fn run_in_sandbox(
     if !cancel.is_cancelled()
         && (exit.exit_code == EXIT_SIGKILL || exit.exit_code == EXIT_SIGNAL_KILL)
     {
-        let dmesg_req = ExecRequest {
+        let dmesg_req = BoundedExecRequest {
             cmd: "dmesg | tail -20 2>/dev/null",
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: true,
+            stdin: None,
+            stdout_limit_bytes: 64 * 1024,
+            stderr_limit_bytes: 8 * 1024,
+            stream: None,
         };
-        match sandbox.exec(&dmesg_req).await {
-            Ok(dmesg) if dmesg_indicates_oom(&String::from_utf8_lossy(&dmesg.stdout)) => {
-                warn!(run_id = %context.run_id, "OOM kill detected via dmesg");
-                // Return exit code 1 with descriptive message instead of raw 137,
-                // so callers see a clear error rather than an opaque signal code.
-                return Ok((1, Some("Agent process killed by OOM killer".into())));
+        match sandbox.bounded_exec(&dmesg_req).await {
+            Ok(dmesg)
+                if matches!(
+                    dmesg.termination,
+                    BoundedExecTermination::Exited { exit_code: 0 }
+                ) =>
+            {
+                if dmesg.stdout_truncated {
+                    warn!(run_id = %context.run_id, "dmesg OOM check output was truncated");
+                }
+                if dmesg_indicates_oom(&String::from_utf8_lossy(&dmesg.stdout)) {
+                    warn!(run_id = %context.run_id, "OOM kill detected via dmesg");
+                    // Return exit code 1 with descriptive message instead of raw 137,
+                    // so callers see a clear error rather than an opaque signal code.
+                    return Ok((1, Some("Agent process killed by OOM killer".into())));
+                }
+            }
+            Ok(dmesg) => {
+                warn!(
+                    run_id = %context.run_id,
+                    termination = ?dmesg.termination,
+                    "dmesg OOM check did not complete successfully"
+                );
             }
             Err(e) => {
-                warn!(run_id = %context.run_id, error = %e, "failed to exec dmesg for OOM check");
+                warn!(run_id = %context.run_id, error = %e, "failed to run dmesg for OOM check");
             }
-            _ => {}
         }
     }
 
@@ -700,17 +724,31 @@ async fn read_guest_error_file(sandbox: &dyn Sandbox, run_id: RunId) -> Option<S
     let error_path = format!("/tmp/vm0-checkpoint-error-{run_id}");
     let cat_cmd = format!("cat {error_path} 2>/dev/null");
     match sandbox
-        .exec(&ExecRequest {
+        .bounded_exec(&BoundedExecRequest {
             cmd: &cat_cmd,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
+            stdin: None,
+            stdout_limit_bytes: 16 * 1024,
+            stderr_limit_bytes: 4 * 1024,
+            stream: None,
         })
         .await
     {
-        Ok(result) if result.exit_code == 0 && !result.stdout.is_empty() => {
+        Ok(result)
+            if matches!(
+                result.termination,
+                BoundedExecTermination::Exited { exit_code: 0 }
+            ) && !result.stdout.is_empty()
+                && !result.stdout_truncated =>
+        {
             let msg = String::from_utf8_lossy(&result.stdout).trim().to_string();
             Some(msg).filter(|s| !s.is_empty())
+        }
+        Ok(result) if result.stdout_truncated => {
+            warn!(run_id = %run_id, path = %error_path, "guest checkpoint error file was truncated");
+            None
         }
         _ => None,
     }
@@ -728,17 +766,31 @@ async fn read_guest_session_id(sandbox: &dyn Sandbox, run_id: RunId) -> Option<S
     let path = format!("/tmp/vm0-session-{run_id}.txt");
     let cmd = format!("cat {path} 2>/dev/null");
     match sandbox
-        .exec(&ExecRequest {
+        .bounded_exec(&BoundedExecRequest {
             cmd: &cmd,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
+            stdin: None,
+            stdout_limit_bytes: 4 * 1024,
+            stderr_limit_bytes: 4 * 1024,
+            stream: None,
         })
         .await
     {
-        Ok(result) if result.exit_code == 0 && !result.stdout.is_empty() => {
+        Ok(result)
+            if matches!(
+                result.termination,
+                BoundedExecTermination::Exited { exit_code: 0 }
+            ) && !result.stdout.is_empty()
+                && !result.stdout_truncated =>
+        {
             let id = String::from_utf8_lossy(&result.stdout).trim().to_string();
             Some(id).filter(|s| !s.is_empty())
+        }
+        Ok(result) if result.stdout_truncated => {
+            warn!(run_id = %run_id, path = %path, "guest session id file was truncated");
+            None
         }
         _ => None,
     }
@@ -748,6 +800,57 @@ async fn read_guest_session_id(sandbox: &dyn Sandbox, run_id: RunId) -> Option<S
 fn dmesg_indicates_oom(stdout: &str) -> bool {
     let lower = stdout.to_lowercase();
     lower.contains("out of memory") || lower.contains("oom-kill") || lower.contains("oom_reaper")
+}
+
+fn describe_bounded_exec_termination(termination: BoundedExecTermination) -> &'static str {
+    match termination {
+        BoundedExecTermination::Exited { .. } => "exited",
+        BoundedExecTermination::TimedOut => "timed out",
+        BoundedExecTermination::Cancelled => "cancelled",
+        BoundedExecTermination::StartFailed => "start failed",
+        BoundedExecTermination::WaitFailed => "wait failed",
+    }
+}
+
+fn bounded_exec_output_summary(stdout: &[u8], stderr: &[u8]) -> String {
+    let stderr = bounded_exec_output_preview(stderr);
+    let stdout = bounded_exec_output_preview(stdout);
+    match (stdout.is_empty(), stderr.is_empty()) {
+        (true, true) => String::new(),
+        (false, false) => format!(": stderr: {stderr}; stdout: {stdout}"),
+        (true, false) => format!(": {stderr}"),
+        (false, true) => format!(": {}", stdout),
+    }
+}
+
+fn bounded_exec_output_preview(output: &[u8]) -> String {
+    let output = redact_http_url_queries(String::from_utf8_lossy(output).trim());
+    if output.len() <= EXEC_ERROR_OUTPUT_PREVIEW_BYTES {
+        return output;
+    }
+
+    let mut end = EXEC_ERROR_OUTPUT_PREVIEW_BYTES;
+    while !output.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &output[..end])
+}
+
+fn redact_http_url_queries(input: &str) -> String {
+    input
+        .split_whitespace()
+        .map(|token| {
+            let Some(scheme_pos) = token.find("https://").or_else(|| token.find("http://")) else {
+                return token.to_string();
+            };
+            let Some(query_rel) = token[scheme_pos..].find('?') else {
+                return token.to_string();
+            };
+            let query_pos = scheme_pos + query_rel;
+            format!("{}?[redacted]", &token[..query_pos])
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Check host dmesg for a cgroup OOM kill of a specific firecracker process.
@@ -897,14 +1000,34 @@ pub(crate) async fn fix_guest_clock(sandbox: &dyn Sandbox) -> RunnerResult<()> {
             .as_secs_f64()
     );
     let date_cmd = format!("date -s \"@{timestamp}\"");
-    sandbox
-        .exec(&ExecRequest {
+    let result = sandbox
+        .bounded_exec(&BoundedExecRequest {
             cmd: &date_cmd,
             timeout: DEFAULT_EXEC_TIMEOUT,
             env: &[],
             sudo: true,
+            stdin: None,
+            stdout_limit_bytes: 4 * 1024,
+            stderr_limit_bytes: 16 * 1024,
+            stream: None,
         })
         .await?;
+    match result.termination {
+        BoundedExecTermination::Exited { exit_code: 0 } => {}
+        BoundedExecTermination::Exited { exit_code } => {
+            return Err(RunnerError::Internal(format!(
+                "guest clock sync failed (exit code {exit_code}){}",
+                bounded_exec_output_summary(&result.stdout, &result.stderr)
+            )));
+        }
+        termination => {
+            return Err(RunnerError::Internal(format!(
+                "guest clock sync failed ({}){}",
+                describe_bounded_exec_termination(termination),
+                bounded_exec_output_summary(&result.stdout, &result.stderr)
+            )));
+        }
+    }
     Ok(())
 }
 
@@ -928,20 +1051,33 @@ pub(crate) async fn reseed_guest_entropy(sandbox: &dyn Sandbox) -> RunnerResult<
 
     let hex = hex::encode(&entropy);
     let result = sandbox
-        .exec(&ExecRequest {
+        .bounded_exec(&BoundedExecRequest {
             cmd: &format!("guest-reseed {hex}"),
             timeout: DEFAULT_EXEC_TIMEOUT,
             env: &[],
             sudo: true,
+            stdin: None,
+            stdout_limit_bytes: 4 * 1024,
+            stderr_limit_bytes: 16 * 1024,
+            stream: None,
         })
         .await?;
 
-    if result.exit_code != 0 {
-        let stderr = String::from_utf8_lossy(&result.stderr);
-        return Err(RunnerError::Internal(format!(
-            "guest-reseed failed (exit code {}): {stderr}",
-            result.exit_code
-        )));
+    match result.termination {
+        BoundedExecTermination::Exited { exit_code: 0 } => {}
+        BoundedExecTermination::Exited { exit_code } => {
+            return Err(RunnerError::Internal(format!(
+                "guest-reseed failed (exit code {exit_code}){}",
+                bounded_exec_output_summary(&result.stdout, &result.stderr)
+            )));
+        }
+        termination => {
+            return Err(RunnerError::Internal(format!(
+                "guest-reseed failed ({}){}",
+                describe_bounded_exec_termination(termination),
+                bounded_exec_output_summary(&result.stdout, &result.stderr)
+            )));
+        }
     }
 
     Ok(())
@@ -979,16 +1115,46 @@ async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &ExecutionContext) 
          echo 'TZ={tz}' >> /etc/environment"
     );
     // Best-effort: don't fail the run if timezone setup fails.
-    if let Err(e) = sandbox
-        .exec(&ExecRequest {
+    match sandbox
+        .bounded_exec(&BoundedExecRequest {
             cmd: &cmd,
             timeout: DEFAULT_EXEC_TIMEOUT,
             env: &[],
             sudo: true,
+            stdin: None,
+            stdout_limit_bytes: 4 * 1024,
+            stderr_limit_bytes: 16 * 1024,
+            stream: None,
         })
         .await
     {
-        tracing::warn!(tz = %tz, error = %e, "failed to set guest timezone");
+        Ok(result)
+            if matches!(
+                result.termination,
+                BoundedExecTermination::Exited { exit_code: 0 }
+            ) =>
+        {
+            if result.stdout_truncated || result.stderr_truncated {
+                tracing::warn!(
+                    tz = %tz,
+                    stdout_truncated = result.stdout_truncated,
+                    stderr_truncated = result.stderr_truncated,
+                    "guest timezone setup output was truncated"
+                );
+            }
+        }
+        Ok(result) => {
+            tracing::warn!(
+                tz = %tz,
+                termination = ?result.termination,
+                stdout_truncated = result.stdout_truncated,
+                stderr_truncated = result.stderr_truncated,
+                "failed to set guest timezone"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(tz = %tz, error = %e, "failed to set guest timezone");
+        }
     }
 }
 
@@ -1122,19 +1288,40 @@ async fn download_storages(
     let download_env = guest_download_env(&run_id);
     info!(run_id = %context.run_id, "downloading storages");
     let result = sandbox
-        .exec(&ExecRequest {
+        .bounded_exec(&BoundedExecRequest {
             cmd: &download_cmd,
             timeout: DEFAULT_EXEC_TIMEOUT,
             env: &download_env,
             sudo: false,
+            stdin: None,
+            stdout_limit_bytes: 1024 * 1024,
+            stderr_limit_bytes: 1024 * 1024,
+            stream: None,
         })
         .await?;
 
-    if result.exit_code != 0 {
+    if result.stdout_truncated || result.stderr_truncated {
         return Err(RunnerError::Internal(format!(
-            "storage download failed (exit code {})",
-            result.exit_code
+            "storage download output truncated{}",
+            bounded_exec_output_summary(&result.stdout, &result.stderr)
         )));
+    }
+
+    match result.termination {
+        BoundedExecTermination::Exited { exit_code: 0 } => {}
+        BoundedExecTermination::Exited { exit_code } => {
+            return Err(RunnerError::Internal(format!(
+                "storage download failed (exit code {exit_code}){}",
+                bounded_exec_output_summary(&result.stdout, &result.stderr)
+            )));
+        }
+        termination => {
+            return Err(RunnerError::Internal(format!(
+                "storage download failed ({}){}",
+                describe_bounded_exec_termination(termination),
+                bounded_exec_output_summary(&result.stdout, &result.stderr)
+            )));
+        }
     }
     Ok(())
 }
@@ -1994,6 +2181,19 @@ mod tests {
         assert!(dmesg_indicates_oom("OOM-kill: constraint=MEMCG"));
     }
 
+    #[test]
+    fn bounded_exec_output_summary_redacts_url_queries() {
+        let summary = bounded_exec_output_summary(
+            b"",
+            b"HTTP 403 url=https://r2.example.com/archive.tar.gz?X-Amz-Signature=secret&X-Amz-Credential=credential",
+        );
+
+        assert!(summary.contains("https://r2.example.com/archive.tar.gz?[redacted]"));
+        assert!(!summary.contains("X-Amz-Signature"));
+        assert!(!summary.contains("secret"));
+        assert!(!summary.contains("credential"));
+    }
+
     /// Real `sudo dmesg | grep 'oom-kill'` output captured from prod-3.
     const PROD3_OOM_GREP: &str = "\
         [1718300.650867] fc_vcpu 0 invoked oom-killer: gfp_mask=0xcc0(GFP_KERNEL), order=0, oom_score_adj=0\n\
@@ -2179,16 +2379,42 @@ mod tests {
     // -----------------------------------------------------------------------
 
     use sandbox::{
-        ExecResult, SandboxError, SandboxInitializationPhase, SandboxOperation,
-        SandboxOperationReason,
+        BoundedExecResult, BoundedExecTermination, ExecResult, SandboxError,
+        SandboxInitializationPhase, SandboxOperation, SandboxOperationReason,
     };
-    use sandbox_mock::MockSandbox;
+    use sandbox_mock::{BoundedExecResponse, MockSandbox};
 
     fn sandbox_exec_error(message: impl Into<String>) -> SandboxError {
         SandboxError::Operation {
             operation: SandboxOperation::Exec,
             reason: SandboxOperationReason::Guest,
             message: message.into(),
+        }
+    }
+
+    fn sandbox_bounded_exec_error(message: impl Into<String>) -> SandboxError {
+        SandboxError::Operation {
+            operation: SandboxOperation::BoundedExec,
+            reason: SandboxOperationReason::Guest,
+            message: message.into(),
+        }
+    }
+
+    fn bounded_exec_response(
+        termination: BoundedExecTermination,
+        stdout: impl Into<Vec<u8>>,
+        stderr: impl Into<Vec<u8>>,
+    ) -> BoundedExecResponse {
+        BoundedExecResponse {
+            events: Vec::new(),
+            result: Ok(BoundedExecResult {
+                termination,
+                duration: Duration::ZERO,
+                stdout: stdout.into(),
+                stderr: stderr.into(),
+                stdout_truncated: false,
+                stderr_truncated: false,
+            }),
         }
     }
 
@@ -2212,14 +2438,37 @@ mod tests {
         let sandbox = MockSandbox::new("test");
         // Default mock returns exit 0 — clock fix should succeed.
         fix_guest_clock(&sandbox).await.unwrap();
+        let calls = sandbox.bounded_exec_calls();
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].cmd.starts_with("date -s "));
+        assert!(calls[0].sudo);
+        assert_eq!(calls[0].stdout_limit_bytes, 4 * 1024);
+        assert_eq!(calls[0].stderr_limit_bytes, 16 * 1024);
+        assert!(!calls[0].stream_stdout);
+        assert!(!calls[0].stream_stderr);
     }
 
     #[tokio::test]
-    async fn fix_guest_clock_propagates_exec_error() {
+    async fn fix_guest_clock_propagates_bounded_exec_error() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_exec_result(Err(sandbox_exec_error("timeout")));
+        sandbox.push_bounded_exec_response(BoundedExecResponse {
+            events: Vec::new(),
+            result: Err(sandbox_bounded_exec_error("timeout")),
+        });
         let result = fix_guest_clock(&sandbox).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn fix_guest_clock_fails_on_timeout_termination() {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_bounded_exec_response(bounded_exec_response(
+            BoundedExecTermination::TimedOut,
+            Vec::new(),
+            Vec::new(),
+        ));
+        let err = fix_guest_clock(&sandbox).await.unwrap_err();
+        assert!(err.to_string().contains("timed out"), "got: {err}");
     }
 
     #[tokio::test]
@@ -2227,13 +2476,22 @@ mod tests {
         let sandbox = MockSandbox::new("test");
         // write_file returns Ok by default, exec returns exit 0 by default.
         reseed_guest_entropy(&sandbox).await.unwrap();
+        let calls = sandbox.bounded_exec_calls();
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].cmd.starts_with("guest-reseed "));
+        assert!(calls[0].sudo);
+        assert_eq!(calls[0].stdout_limit_bytes, 4 * 1024);
+        assert_eq!(calls[0].stderr_limit_bytes, 16 * 1024);
     }
 
     #[tokio::test]
-    async fn reseed_guest_entropy_propagates_exec_error() {
+    async fn reseed_guest_entropy_propagates_bounded_exec_error() {
         let sandbox = MockSandbox::new("test");
         // Sandbox-level failure (vsock connection issue).
-        sandbox.push_exec_result(Err(sandbox_exec_error("reseed failed")));
+        sandbox.push_bounded_exec_response(BoundedExecResponse {
+            events: Vec::new(),
+            result: Err(sandbox_bounded_exec_error("reseed failed")),
+        });
         let result = reseed_guest_entropy(&sandbox).await;
         assert!(result.is_err());
     }
@@ -2242,11 +2500,11 @@ mod tests {
     async fn reseed_guest_entropy_fails_on_nonzero_exit() {
         let sandbox = MockSandbox::new("test");
         // guest-reseed exits with code 1 (e.g., ioctl failed).
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 1,
-            stdout: Vec::new(),
-            stderr: b"RNDADDENTROPY failed: Operation not permitted".to_vec(),
-        }));
+        sandbox.push_bounded_exec_response(bounded_exec_response(
+            BoundedExecTermination::Exited { exit_code: 1 },
+            Vec::new(),
+            b"RNDADDENTROPY failed: Operation not permitted".to_vec(),
+        ));
         let result = reseed_guest_entropy(&sandbox).await;
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
@@ -2260,16 +2518,21 @@ mod tests {
         ctx.user_timezone = Some("America/New_York".into());
         // Should exec one command and not panic.
         sync_guest_timezone(&sandbox, &ctx).await;
+        let calls = sandbox.bounded_exec_calls();
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].cmd.contains("America/New_York"));
+        assert!(calls[0].sudo);
+        assert_eq!(calls[0].stdout_limit_bytes, 4 * 1024);
+        assert_eq!(calls[0].stderr_limit_bytes, 16 * 1024);
     }
 
     #[tokio::test]
     async fn sync_guest_timezone_skips_when_none() {
         let sandbox = MockSandbox::new("test");
         let ctx = minimal_context();
-        // No timezone — should skip without calling exec.
-        // Push an error to detect if exec is called unexpectedly.
-        sandbox.push_exec_result(Err(sandbox_exec_error("should not be called")));
+        // No timezone — should skip without calling bounded exec.
         sync_guest_timezone(&sandbox, &ctx).await;
+        assert!(sandbox.bounded_exec_calls().is_empty());
     }
 
     #[tokio::test]
@@ -2277,9 +2540,8 @@ mod tests {
         let sandbox = MockSandbox::new("test");
         let mut ctx = minimal_context();
         ctx.user_timezone = Some("$(rm -rf /)".into());
-        // Push an error to detect if exec is called — it should NOT be.
-        sandbox.push_exec_result(Err(sandbox_exec_error("should not be called")));
         sync_guest_timezone(&sandbox, &ctx).await;
+        assert!(sandbox.bounded_exec_calls().is_empty());
     }
 
     #[tokio::test]
@@ -2287,30 +2549,34 @@ mod tests {
         let sandbox = MockSandbox::new("test");
         let mut ctx = minimal_context();
         ctx.user_timezone = Some(String::new());
-        sandbox.push_exec_result(Err(sandbox_exec_error("should not be called")));
         sync_guest_timezone(&sandbox, &ctx).await;
+        assert!(sandbox.bounded_exec_calls().is_empty());
     }
 
     #[tokio::test]
     async fn read_guest_error_file_returns_content() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 0,
-            stdout: b"checkpoint error: disk full".to_vec(),
-            stderr: Vec::new(),
-        }));
+        sandbox.push_bounded_exec_response(bounded_exec_response(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            b"checkpoint error: disk full".to_vec(),
+            Vec::new(),
+        ));
         let msg = read_guest_error_file(&sandbox, RunId::nil()).await;
         assert_eq!(msg.as_deref(), Some("checkpoint error: disk full"));
+        let calls = sandbox.bounded_exec_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].stdout_limit_bytes, 16 * 1024);
+        assert_eq!(calls[0].stderr_limit_bytes, 4 * 1024);
     }
 
     #[tokio::test]
     async fn read_guest_error_file_returns_none_on_missing_file() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 1, // cat fails — file not found
-            stdout: Vec::new(),
-            stderr: b"No such file".to_vec(),
-        }));
+        sandbox.push_bounded_exec_response(bounded_exec_response(
+            BoundedExecTermination::Exited { exit_code: 1 }, // cat fails — file not found
+            Vec::new(),
+            b"No such file".to_vec(),
+        ));
         let msg = read_guest_error_file(&sandbox, RunId::nil()).await;
         assert!(msg.is_none());
     }
@@ -2318,27 +2584,82 @@ mod tests {
     #[tokio::test]
     async fn read_guest_error_file_returns_none_on_empty_content() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 0,
-            stdout: b"   \n  ".to_vec(), // whitespace-only
-            stderr: Vec::new(),
-        }));
+        sandbox.push_bounded_exec_response(bounded_exec_response(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            b"   \n  ".to_vec(), // whitespace-only
+            Vec::new(),
+        ));
         let msg = read_guest_error_file(&sandbox, RunId::nil()).await;
         assert!(msg.is_none());
     }
 
     #[tokio::test]
-    async fn read_guest_error_file_returns_none_on_exec_error() {
+    async fn read_guest_error_file_returns_none_on_bounded_exec_error() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_exec_result(Err(sandbox_exec_error("vsock timeout")));
+        sandbox.push_bounded_exec_response(BoundedExecResponse {
+            events: Vec::new(),
+            result: Err(sandbox_bounded_exec_error("vsock timeout")),
+        });
         let msg = read_guest_error_file(&sandbox, RunId::nil()).await;
         assert!(msg.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_guest_error_file_returns_none_on_truncated_stdout() {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_bounded_exec_response(BoundedExecResponse {
+            events: Vec::new(),
+            result: Ok(BoundedExecResult {
+                termination: BoundedExecTermination::Exited { exit_code: 0 },
+                duration: Duration::ZERO,
+                stdout: b"partial checkpoint error".to_vec(),
+                stderr: Vec::new(),
+                stdout_truncated: true,
+                stderr_truncated: false,
+            }),
+        });
+        let msg = read_guest_error_file(&sandbox, RunId::nil()).await;
+        assert!(msg.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_guest_session_id_returns_content() {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_bounded_exec_response(bounded_exec_response(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            b"sess-123\n".to_vec(),
+            Vec::new(),
+        ));
+        let id = read_guest_session_id(&sandbox, RunId::nil()).await;
+        assert_eq!(id.as_deref(), Some("sess-123"));
+        let calls = sandbox.bounded_exec_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].stdout_limit_bytes, 4 * 1024);
+        assert_eq!(calls[0].stderr_limit_bytes, 4 * 1024);
+    }
+
+    #[tokio::test]
+    async fn read_guest_session_id_ignores_truncated_stdout() {
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_bounded_exec_response(BoundedExecResponse {
+            events: Vec::new(),
+            result: Ok(BoundedExecResult {
+                termination: BoundedExecTermination::Exited { exit_code: 0 },
+                duration: Duration::ZERO,
+                stdout: b"sess-partial".to_vec(),
+                stderr: Vec::new(),
+                stdout_truncated: true,
+                stderr_truncated: false,
+            }),
+        });
+        let id = read_guest_session_id(&sandbox, RunId::nil()).await;
+        assert!(id.is_none());
     }
 
     #[tokio::test]
     async fn download_storages_success() {
         let sandbox = MockSandbox::new("test");
-        // write_file succeeds by default, exec returns exit 0 by default.
+        // write_file succeeds by default, bounded exec returns exit 0 by default.
         let ctx = minimal_context();
         let manifest = GuestDownloadManifest {
             storages: vec![guest_storage(
@@ -2351,6 +2672,16 @@ mod tests {
             cleanup_paths: vec![],
         };
         download_storages(&sandbox, &ctx, &manifest).await.unwrap();
+        let calls = sandbox.bounded_exec_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].cmd, guest_download_command());
+        assert_eq!(
+            calls[0].env,
+            vec![("VM0_RUN_ID".into(), ctx.run_id.to_string())]
+        );
+        assert!(!calls[0].sudo);
+        assert!(!calls[0].stream_stdout);
+        assert!(!calls[0].stream_stderr);
     }
 
     #[test]
@@ -2380,11 +2711,11 @@ mod tests {
     async fn download_storages_nonzero_exit_code() {
         let sandbox = MockSandbox::new("test");
         // write_file succeeds, but exec returns non-zero.
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 1,
-            stdout: Vec::new(),
-            stderr: b"download failed".to_vec(),
-        }));
+        sandbox.push_bounded_exec_response(bounded_exec_response(
+            BoundedExecTermination::Exited { exit_code: 1 },
+            Vec::new(),
+            b"download failed".to_vec(),
+        ));
         let ctx = minimal_context();
         let manifest = GuestDownloadManifest {
             storages: vec![],
@@ -2395,6 +2726,15 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("storage download failed"));
+        assert!(err.to_string().contains("download failed"));
+        let calls = sandbox.bounded_exec_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].env,
+            vec![("VM0_RUN_ID".into(), ctx.run_id.to_string())]
+        );
+        assert_eq!(calls[0].stdout_limit_bytes, 1024 * 1024);
+        assert_eq!(calls[0].stderr_limit_bytes, 1024 * 1024);
     }
 
     #[tokio::test]
@@ -2431,10 +2771,10 @@ mod tests {
             session_history: "data".into(),
         };
         // Unknown frameworks must no-op silently (warn-and-skip) so a typo in
-        // CLI_AGENT_TYPE does not block the run. Pushing an exec error detects
-        // any accidental fallthrough into either framework's restore path.
-        sandbox.push_exec_result(Err(sandbox_exec_error("should not be called")));
+        // CLI_AGENT_TYPE does not block the run.
         restore_session(&sandbox, &ctx, &session).await.unwrap();
+        assert!(sandbox.write_file_calls().is_empty());
+        assert!(sandbox.bounded_exec_calls().is_empty());
     }
 
     #[tokio::test]
@@ -3197,9 +3537,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
 
-        // Build a MockSandbox that fails on the first exec (fix_guest_clock)
+        // Build a MockSandbox that fails on the first bounded_exec (fix_guest_clock).
         let sandbox = MockSandbox::new("reuse-clock-fail");
-        sandbox.push_exec_result(Err(sandbox_exec_error("vsock broken")));
+        sandbox.push_bounded_exec_response(BoundedExecResponse {
+            events: Vec::new(),
+            result: Err(sandbox_bounded_exec_error("vsock broken")),
+        });
 
         let cancel = tokio_util::sync::CancellationToken::new();
         let (idle_sandbox, _lease) =
@@ -3221,14 +3564,17 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
 
-        // First exec (fix_guest_clock) succeeds, second (reseed_guest_entropy) fails
+        // First bounded_exec (fix_guest_clock) succeeds, second (reseed_guest_entropy) fails.
         let sandbox = MockSandbox::new("reuse-reseed-fail");
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 0,
-            stdout: Vec::new(),
-            stderr: Vec::new(),
-        }));
-        sandbox.push_exec_result(Err(sandbox_exec_error("reseed timeout")));
+        sandbox.push_bounded_exec_response(bounded_exec_response(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            Vec::new(),
+            Vec::new(),
+        ));
+        sandbox.push_bounded_exec_response(BoundedExecResponse {
+            events: Vec::new(),
+            result: Err(sandbox_bounded_exec_error("reseed timeout")),
+        });
 
         let cancel = tokio_util::sync::CancellationToken::new();
         let (idle_sandbox, _lease) =

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -20,8 +20,9 @@ use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
 use sandbox::{
-    BoundedExecRequest, BoundedExecTermination, ExecRequest, Sandbox, SandboxConfig,
-    SandboxFactory, SandboxId, SpawnOutputMode,
+    BoundedExecCapturePolicy, BoundedExecOutput, BoundedExecOutputRequest, BoundedExecRequest,
+    BoundedExecTermination, ExecRequest, Sandbox, SandboxConfig, SandboxFactory, SandboxId,
+    SpawnOutputMode,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -37,6 +38,13 @@ const EXIT_SIGNAL_KILL: i32 = 9;
 /// Default timeout for guest commands (5 minutes).
 const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
 const EXEC_ERROR_OUTPUT_PREVIEW_BYTES: usize = 8 * 1024;
+
+fn capture_bounded_output(limit_bytes: u32) -> BoundedExecOutputRequest {
+    BoundedExecOutputRequest {
+        capture: BoundedExecCapturePolicy::Capture { limit_bytes },
+        stream: None,
+    }
+}
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
@@ -656,9 +664,8 @@ async fn run_in_sandbox(
             env: &[],
             sudo: true,
             stdin: None,
-            stdout_limit_bytes: 64 * 1024,
-            stderr_limit_bytes: 8 * 1024,
-            stream: None,
+            stdout: capture_bounded_output(64 * 1024),
+            stderr: capture_bounded_output(8 * 1024),
         };
         match sandbox.bounded_exec(&dmesg_req).await {
             Ok(dmesg)
@@ -667,10 +674,11 @@ async fn run_in_sandbox(
                     BoundedExecTermination::Exited { exit_code: 0 }
                 ) =>
             {
-                if dmesg.stdout_truncated {
+                let (stdout, stdout_truncated) = bounded_exec_captured_output(&dmesg.stdout);
+                if stdout_truncated {
                     warn!(run_id = %context.run_id, "dmesg OOM check output was truncated");
                 }
-                if dmesg_indicates_oom(&String::from_utf8_lossy(&dmesg.stdout)) {
+                if dmesg_indicates_oom(&String::from_utf8_lossy(stdout)) {
                     warn!(run_id = %context.run_id, "OOM kill detected via dmesg");
                     // Return exit code 1 with descriptive message instead of raw 137,
                     // so callers see a clear error rather than an opaque signal code.
@@ -730,9 +738,8 @@ async fn read_guest_error_file(sandbox: &dyn Sandbox, run_id: RunId) -> Option<S
             env: &[],
             sudo: false,
             stdin: None,
-            stdout_limit_bytes: 16 * 1024,
-            stderr_limit_bytes: 4 * 1024,
-            stream: None,
+            stdout: capture_bounded_output(16 * 1024),
+            stderr: capture_bounded_output(4 * 1024),
         })
         .await
     {
@@ -740,13 +747,16 @@ async fn read_guest_error_file(sandbox: &dyn Sandbox, run_id: RunId) -> Option<S
             if matches!(
                 result.termination,
                 BoundedExecTermination::Exited { exit_code: 0 }
-            ) && !result.stdout.is_empty()
-                && !result.stdout_truncated =>
+            ) && {
+                let (stdout, stdout_truncated) = bounded_exec_captured_output(&result.stdout);
+                !stdout.is_empty() && !stdout_truncated
+            } =>
         {
-            let msg = String::from_utf8_lossy(&result.stdout).trim().to_string();
+            let (stdout, _) = bounded_exec_captured_output(&result.stdout);
+            let msg = String::from_utf8_lossy(stdout).trim().to_string();
             Some(msg).filter(|s| !s.is_empty())
         }
-        Ok(result) if result.stdout_truncated => {
+        Ok(result) if bounded_exec_output_truncated(&result.stdout) => {
             warn!(run_id = %run_id, path = %error_path, "guest checkpoint error file was truncated");
             None
         }
@@ -772,9 +782,8 @@ async fn read_guest_session_id(sandbox: &dyn Sandbox, run_id: RunId) -> Option<S
             env: &[],
             sudo: false,
             stdin: None,
-            stdout_limit_bytes: 4 * 1024,
-            stderr_limit_bytes: 4 * 1024,
-            stream: None,
+            stdout: capture_bounded_output(4 * 1024),
+            stderr: capture_bounded_output(4 * 1024),
         })
         .await
     {
@@ -782,13 +791,16 @@ async fn read_guest_session_id(sandbox: &dyn Sandbox, run_id: RunId) -> Option<S
             if matches!(
                 result.termination,
                 BoundedExecTermination::Exited { exit_code: 0 }
-            ) && !result.stdout.is_empty()
-                && !result.stdout_truncated =>
+            ) && {
+                let (stdout, stdout_truncated) = bounded_exec_captured_output(&result.stdout);
+                !stdout.is_empty() && !stdout_truncated
+            } =>
         {
-            let id = String::from_utf8_lossy(&result.stdout).trim().to_string();
+            let (stdout, _) = bounded_exec_captured_output(&result.stdout);
+            let id = String::from_utf8_lossy(stdout).trim().to_string();
             Some(id).filter(|s| !s.is_empty())
         }
-        Ok(result) if result.stdout_truncated => {
+        Ok(result) if bounded_exec_output_truncated(&result.stdout) => {
             warn!(run_id = %run_id, path = %path, "guest session id file was truncated");
             None
         }
@@ -812,7 +824,31 @@ fn describe_bounded_exec_termination(termination: BoundedExecTermination) -> &'s
     }
 }
 
-fn bounded_exec_output_summary(stdout: &[u8], stderr: &[u8]) -> String {
+fn bounded_exec_captured_output(output: &BoundedExecOutput) -> (&[u8], bool) {
+    match output {
+        BoundedExecOutput::Captured { bytes, truncated } => (bytes.as_slice(), *truncated),
+        BoundedExecOutput::Discarded => (&[], false),
+    }
+}
+
+fn bounded_exec_output_truncated(output: &BoundedExecOutput) -> bool {
+    match output {
+        BoundedExecOutput::Captured { truncated, .. } => *truncated,
+        BoundedExecOutput::Discarded => false,
+    }
+}
+
+fn bounded_exec_outputs_truncated(stdout: &BoundedExecOutput, stderr: &BoundedExecOutput) -> bool {
+    bounded_exec_output_truncated(stdout) || bounded_exec_output_truncated(stderr)
+}
+
+fn bounded_exec_output_summary(stdout: &BoundedExecOutput, stderr: &BoundedExecOutput) -> String {
+    let (stdout, _) = bounded_exec_captured_output(stdout);
+    let (stderr, _) = bounded_exec_captured_output(stderr);
+    bounded_exec_bytes_summary(stdout, stderr)
+}
+
+fn bounded_exec_bytes_summary(stdout: &[u8], stderr: &[u8]) -> String {
     let stderr = bounded_exec_output_preview(stderr);
     let stdout = bounded_exec_output_preview(stdout);
     match (stdout.is_empty(), stderr.is_empty()) {
@@ -1007,9 +1043,8 @@ pub(crate) async fn fix_guest_clock(sandbox: &dyn Sandbox) -> RunnerResult<()> {
             env: &[],
             sudo: true,
             stdin: None,
-            stdout_limit_bytes: 4 * 1024,
-            stderr_limit_bytes: 16 * 1024,
-            stream: None,
+            stdout: capture_bounded_output(4 * 1024),
+            stderr: capture_bounded_output(16 * 1024),
         })
         .await?;
     match result.termination {
@@ -1057,9 +1092,8 @@ pub(crate) async fn reseed_guest_entropy(sandbox: &dyn Sandbox) -> RunnerResult<
             env: &[],
             sudo: true,
             stdin: None,
-            stdout_limit_bytes: 4 * 1024,
-            stderr_limit_bytes: 16 * 1024,
-            stream: None,
+            stdout: capture_bounded_output(4 * 1024),
+            stderr: capture_bounded_output(16 * 1024),
         })
         .await?;
 
@@ -1122,9 +1156,8 @@ async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &ExecutionContext) 
             env: &[],
             sudo: true,
             stdin: None,
-            stdout_limit_bytes: 4 * 1024,
-            stderr_limit_bytes: 16 * 1024,
-            stream: None,
+            stdout: capture_bounded_output(4 * 1024),
+            stderr: capture_bounded_output(16 * 1024),
         })
         .await
     {
@@ -1134,21 +1167,25 @@ async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &ExecutionContext) 
                 BoundedExecTermination::Exited { exit_code: 0 }
             ) =>
         {
-            if result.stdout_truncated || result.stderr_truncated {
+            let stdout_truncated = bounded_exec_output_truncated(&result.stdout);
+            let stderr_truncated = bounded_exec_output_truncated(&result.stderr);
+            if stdout_truncated || stderr_truncated {
                 tracing::warn!(
                     tz = %tz,
-                    stdout_truncated = result.stdout_truncated,
-                    stderr_truncated = result.stderr_truncated,
+                    stdout_truncated,
+                    stderr_truncated,
                     "guest timezone setup output was truncated"
                 );
             }
         }
         Ok(result) => {
+            let stdout_truncated = bounded_exec_output_truncated(&result.stdout);
+            let stderr_truncated = bounded_exec_output_truncated(&result.stderr);
             tracing::warn!(
                 tz = %tz,
                 termination = ?result.termination,
-                stdout_truncated = result.stdout_truncated,
-                stderr_truncated = result.stderr_truncated,
+                stdout_truncated,
+                stderr_truncated,
                 "failed to set guest timezone"
             );
         }
@@ -1294,9 +1331,8 @@ async fn download_storages(
             env: &download_env,
             sudo: false,
             stdin: None,
-            stdout_limit_bytes: 1024 * 1024,
-            stderr_limit_bytes: 1024 * 1024,
-            stream: None,
+            stdout: capture_bounded_output(1024 * 1024),
+            stderr: capture_bounded_output(1024 * 1024),
         })
         .await?;
 
@@ -1304,17 +1340,19 @@ async fn download_storages(
         BoundedExecTermination::Exited { exit_code: 0 } => {
             // Truncated output only means diagnostics were clipped; the
             // command exit status remains the success source of truth.
-            if result.stdout_truncated || result.stderr_truncated {
+            let stdout_truncated = bounded_exec_output_truncated(&result.stdout);
+            let stderr_truncated = bounded_exec_output_truncated(&result.stderr);
+            if stdout_truncated || stderr_truncated {
                 warn!(
                     run_id = %context.run_id,
-                    stdout_truncated = result.stdout_truncated,
-                    stderr_truncated = result.stderr_truncated,
+                    stdout_truncated,
+                    stderr_truncated,
                     "storage download output was truncated"
                 );
             }
         }
         BoundedExecTermination::Exited { exit_code } => {
-            let truncated = if result.stdout_truncated || result.stderr_truncated {
+            let truncated = if bounded_exec_outputs_truncated(&result.stdout, &result.stderr) {
                 " (output truncated)"
             } else {
                 ""
@@ -1325,7 +1363,7 @@ async fn download_storages(
             )));
         }
         termination => {
-            let truncated = if result.stdout_truncated || result.stderr_truncated {
+            let truncated = if bounded_exec_outputs_truncated(&result.stdout, &result.stderr) {
                 " (output truncated)"
             } else {
                 ""
@@ -2197,7 +2235,7 @@ mod tests {
 
     #[test]
     fn bounded_exec_output_summary_redacts_url_queries() {
-        let summary = bounded_exec_output_summary(
+        let summary = bounded_exec_bytes_summary(
             b"",
             b"HTTP 403 url=https://r2.example.com/archive.tar.gz?X-Amz-Signature=secret&X-Amz-Credential=credential",
         );
@@ -2424,12 +2462,55 @@ mod tests {
             result: Ok(BoundedExecResult {
                 termination,
                 duration: Duration::ZERO,
-                stdout: stdout.into(),
-                stderr: stderr.into(),
-                stdout_truncated: false,
-                stderr_truncated: false,
+                stdout: BoundedExecOutput::Captured {
+                    bytes: stdout.into(),
+                    truncated: false,
+                },
+                stderr: BoundedExecOutput::Captured {
+                    bytes: stderr.into(),
+                    truncated: false,
+                },
+                diagnostic: None,
             }),
         }
+    }
+
+    fn truncated_bounded_exec_response(
+        termination: BoundedExecTermination,
+        stdout: impl Into<Vec<u8>>,
+        stdout_truncated: bool,
+        stderr: impl Into<Vec<u8>>,
+        stderr_truncated: bool,
+    ) -> BoundedExecResponse {
+        BoundedExecResponse {
+            events: Vec::new(),
+            result: Ok(BoundedExecResult {
+                termination,
+                duration: Duration::ZERO,
+                stdout: BoundedExecOutput::Captured {
+                    bytes: stdout.into(),
+                    truncated: stdout_truncated,
+                },
+                stderr: BoundedExecOutput::Captured {
+                    bytes: stderr.into(),
+                    truncated: stderr_truncated,
+                },
+                diagnostic: None,
+            }),
+        }
+    }
+
+    fn assert_capture_call(
+        output: &sandbox_mock::BoundedExecOutputCall,
+        expected_limit_bytes: u32,
+    ) {
+        assert_eq!(
+            output.capture,
+            BoundedExecCapturePolicy::Capture {
+                limit_bytes: expected_limit_bytes
+            }
+        );
+        assert_eq!(output.stream, None);
     }
 
     fn sandbox_write_file_error(message: impl Into<String>) -> SandboxError {
@@ -2456,10 +2537,8 @@ mod tests {
         assert_eq!(calls.len(), 1);
         assert!(calls[0].cmd.starts_with("date -s "));
         assert!(calls[0].sudo);
-        assert_eq!(calls[0].stdout_limit_bytes, 4 * 1024);
-        assert_eq!(calls[0].stderr_limit_bytes, 16 * 1024);
-        assert!(!calls[0].stream_stdout);
-        assert!(!calls[0].stream_stderr);
+        assert_capture_call(&calls[0].stdout, 4 * 1024);
+        assert_capture_call(&calls[0].stderr, 16 * 1024);
     }
 
     #[tokio::test]
@@ -2494,8 +2573,8 @@ mod tests {
         assert_eq!(calls.len(), 1);
         assert!(calls[0].cmd.starts_with("guest-reseed "));
         assert!(calls[0].sudo);
-        assert_eq!(calls[0].stdout_limit_bytes, 4 * 1024);
-        assert_eq!(calls[0].stderr_limit_bytes, 16 * 1024);
+        assert_capture_call(&calls[0].stdout, 4 * 1024);
+        assert_capture_call(&calls[0].stderr, 16 * 1024);
     }
 
     #[tokio::test]
@@ -2536,8 +2615,8 @@ mod tests {
         assert_eq!(calls.len(), 1);
         assert!(calls[0].cmd.contains("America/New_York"));
         assert!(calls[0].sudo);
-        assert_eq!(calls[0].stdout_limit_bytes, 4 * 1024);
-        assert_eq!(calls[0].stderr_limit_bytes, 16 * 1024);
+        assert_capture_call(&calls[0].stdout, 4 * 1024);
+        assert_capture_call(&calls[0].stderr, 16 * 1024);
     }
 
     #[tokio::test]
@@ -2579,8 +2658,8 @@ mod tests {
         assert_eq!(msg.as_deref(), Some("checkpoint error: disk full"));
         let calls = sandbox.bounded_exec_calls();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].stdout_limit_bytes, 16 * 1024);
-        assert_eq!(calls[0].stderr_limit_bytes, 4 * 1024);
+        assert_capture_call(&calls[0].stdout, 16 * 1024);
+        assert_capture_call(&calls[0].stderr, 4 * 1024);
     }
 
     #[tokio::test]
@@ -2621,17 +2700,13 @@ mod tests {
     #[tokio::test]
     async fn read_guest_error_file_returns_none_on_truncated_stdout() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_bounded_exec_response(BoundedExecResponse {
-            events: Vec::new(),
-            result: Ok(BoundedExecResult {
-                termination: BoundedExecTermination::Exited { exit_code: 0 },
-                duration: Duration::ZERO,
-                stdout: b"partial checkpoint error".to_vec(),
-                stderr: Vec::new(),
-                stdout_truncated: true,
-                stderr_truncated: false,
-            }),
-        });
+        sandbox.push_bounded_exec_response(truncated_bounded_exec_response(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            b"partial checkpoint error".to_vec(),
+            true,
+            Vec::new(),
+            false,
+        ));
         let msg = read_guest_error_file(&sandbox, RunId::nil()).await;
         assert!(msg.is_none());
     }
@@ -2648,24 +2723,20 @@ mod tests {
         assert_eq!(id.as_deref(), Some("sess-123"));
         let calls = sandbox.bounded_exec_calls();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].stdout_limit_bytes, 4 * 1024);
-        assert_eq!(calls[0].stderr_limit_bytes, 4 * 1024);
+        assert_capture_call(&calls[0].stdout, 4 * 1024);
+        assert_capture_call(&calls[0].stderr, 4 * 1024);
     }
 
     #[tokio::test]
     async fn read_guest_session_id_ignores_truncated_stdout() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_bounded_exec_response(BoundedExecResponse {
-            events: Vec::new(),
-            result: Ok(BoundedExecResult {
-                termination: BoundedExecTermination::Exited { exit_code: 0 },
-                duration: Duration::ZERO,
-                stdout: b"sess-partial".to_vec(),
-                stderr: Vec::new(),
-                stdout_truncated: true,
-                stderr_truncated: false,
-            }),
-        });
+        sandbox.push_bounded_exec_response(truncated_bounded_exec_response(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            b"sess-partial".to_vec(),
+            true,
+            Vec::new(),
+            false,
+        ));
         let id = read_guest_session_id(&sandbox, RunId::nil()).await;
         assert!(id.is_none());
     }
@@ -2694,8 +2765,8 @@ mod tests {
             vec![("VM0_RUN_ID".into(), ctx.run_id.to_string())]
         );
         assert!(!calls[0].sudo);
-        assert!(!calls[0].stream_stdout);
-        assert!(!calls[0].stream_stderr);
+        assert_eq!(calls[0].stdout.stream, None);
+        assert_eq!(calls[0].stderr.stream, None);
     }
 
     #[test]
@@ -2747,24 +2818,20 @@ mod tests {
             calls[0].env,
             vec![("VM0_RUN_ID".into(), ctx.run_id.to_string())]
         );
-        assert_eq!(calls[0].stdout_limit_bytes, 1024 * 1024);
-        assert_eq!(calls[0].stderr_limit_bytes, 1024 * 1024);
+        assert_capture_call(&calls[0].stdout, 1024 * 1024);
+        assert_capture_call(&calls[0].stderr, 1024 * 1024);
     }
 
     #[tokio::test]
     async fn download_storages_failure_marks_truncated_output() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_bounded_exec_response(BoundedExecResponse {
-            events: Vec::new(),
-            result: Ok(BoundedExecResult {
-                termination: BoundedExecTermination::Exited { exit_code: 1 },
-                duration: Duration::ZERO,
-                stdout: b"partial stdout".to_vec(),
-                stderr: b"partial stderr".to_vec(),
-                stdout_truncated: true,
-                stderr_truncated: false,
-            }),
-        });
+        sandbox.push_bounded_exec_response(truncated_bounded_exec_response(
+            BoundedExecTermination::Exited { exit_code: 1 },
+            b"partial stdout".to_vec(),
+            true,
+            b"partial stderr".to_vec(),
+            false,
+        ));
         let ctx = minimal_context();
         let manifest = GuestDownloadManifest {
             storages: vec![],
@@ -2783,17 +2850,13 @@ mod tests {
     #[tokio::test]
     async fn download_storages_allows_truncated_output_on_success() {
         let sandbox = MockSandbox::new("test");
-        sandbox.push_bounded_exec_response(BoundedExecResponse {
-            events: Vec::new(),
-            result: Ok(BoundedExecResult {
-                termination: BoundedExecTermination::Exited { exit_code: 0 },
-                duration: Duration::ZERO,
-                stdout: b"partial stdout".to_vec(),
-                stderr: b"partial stderr".to_vec(),
-                stdout_truncated: false,
-                stderr_truncated: true,
-            }),
-        });
+        sandbox.push_bounded_exec_response(truncated_bounded_exec_response(
+            BoundedExecTermination::Exited { exit_code: 0 },
+            b"partial stdout".to_vec(),
+            false,
+            b"partial stderr".to_vec(),
+            true,
+        ));
         let ctx = minimal_context();
         let manifest = GuestDownloadManifest {
             storages: vec![],

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -34,6 +34,22 @@ pub const SNAPSHOT_COMPLETE_MARKER_CONTENT: &[u8] = b"snapshot-complete-v1\n";
 
 use crate::factory::{DESTROY_RETRIES, DESTROY_RETRY_DELAY};
 
+fn capture_bounded_output(limit_bytes: u32) -> vsock_host::BoundedExecOutputRequest {
+    vsock_host::BoundedExecOutputRequest {
+        capture: vsock_host::BoundedExecCapturePolicy::Capture { limit_bytes },
+        stream: None,
+    }
+}
+
+fn bounded_exec_captured_output(output: &vsock_host::BoundedExecOutput) -> (&[u8], bool) {
+    match output {
+        vsock_host::BoundedExecOutput::Captured { bytes, truncated } => {
+            (bytes.as_slice(), *truncated)
+        }
+        vsock_host::BoundedExecOutput::Discarded => (&[], false),
+    }
+}
+
 fn cow_destroy_retry_policy() -> DestroyRetryPolicy {
     DestroyRetryPolicy {
         attempts: DESTROY_RETRIES,
@@ -2008,9 +2024,8 @@ async fn run_with_firecracker(
             env: &[],
             sudo: false,
             stdin: None,
-            stdout_limit_bytes: 64 * 1024,
-            stderr_limit_bytes: 256 * 1024,
-            stream: None,
+            stdout: capture_bounded_output(64 * 1024),
+            stderr: capture_bounded_output(256 * 1024),
         })
         .await
         .map_err(|e| SnapshotError::Setup(format!("pre-warm bounded exec: {e}")))?;
@@ -2018,21 +2033,24 @@ async fn run_with_firecracker(
         vsock_host::BoundedExecTermination::Exited { exit_code: 0 } => {
             // Truncated output only means diagnostics were clipped; a zero
             // exit status still means pre-warm succeeded.
-            if prewarm_result.stdout_truncated || prewarm_result.stderr_truncated {
+            let (_, stdout_truncated) = bounded_exec_captured_output(&prewarm_result.stdout);
+            let (_, stderr_truncated) = bounded_exec_captured_output(&prewarm_result.stderr);
+            if stdout_truncated || stderr_truncated {
                 tracing::warn!(
-                    stdout_truncated = prewarm_result.stdout_truncated,
-                    stderr_truncated = prewarm_result.stderr_truncated,
+                    stdout_truncated,
+                    stderr_truncated,
                     "pre-warm output was truncated"
                 );
             }
         }
         vsock_host::BoundedExecTermination::Exited { exit_code } => {
-            if prewarm_result.stderr_truncated {
+            let (stderr, stderr_truncated) = bounded_exec_captured_output(&prewarm_result.stderr);
+            if stderr_truncated {
                 return Err(SnapshotError::Setup(
                     "pre-warm failed: stderr output was truncated".into(),
                 ));
             }
-            let stderr = String::from_utf8_lossy(&prewarm_result.stderr);
+            let stderr = String::from_utf8_lossy(stderr);
             return Err(SnapshotError::Setup(format!(
                 "pre-warm failed (exit code {exit_code}): {}",
                 stderr.trim(),

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -2014,14 +2014,24 @@ async fn run_with_firecracker(
         })
         .await
         .map_err(|e| SnapshotError::Setup(format!("pre-warm bounded exec: {e}")))?;
-    if prewarm_result.stderr_truncated {
-        return Err(SnapshotError::Setup(
-            "pre-warm failed: stderr output was truncated".into(),
-        ));
-    }
     match prewarm_result.termination {
-        vsock_host::BoundedExecTermination::Exited { exit_code: 0 } => {}
+        vsock_host::BoundedExecTermination::Exited { exit_code: 0 } => {
+            // Truncated output only means diagnostics were clipped; a zero
+            // exit status still means pre-warm succeeded.
+            if prewarm_result.stdout_truncated || prewarm_result.stderr_truncated {
+                tracing::warn!(
+                    stdout_truncated = prewarm_result.stdout_truncated,
+                    stderr_truncated = prewarm_result.stderr_truncated,
+                    "pre-warm output was truncated"
+                );
+            }
+        }
         vsock_host::BoundedExecTermination::Exited { exit_code } => {
+            if prewarm_result.stderr_truncated {
+                return Err(SnapshotError::Setup(
+                    "pre-warm failed: stderr output was truncated".into(),
+                ));
+            }
             let stderr = String::from_utf8_lossy(&prewarm_result.stderr);
             return Err(SnapshotError::Setup(format!(
                 "pre-warm failed (exit code {exit_code}): {}",

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -2002,16 +2002,37 @@ async fn run_with_firecracker(
     //      are fast. The snapshot captures memory + disk state, so caches
     //      populated here persist across restores.
     let prewarm_result = guest
-        .exec(inv.prewarm_script, 30_000, &[], false)
+        .bounded_exec(&vsock_host::BoundedExecRequest {
+            command: inv.prewarm_script,
+            timeout_ms: 30_000,
+            env: &[],
+            sudo: false,
+            stdin: None,
+            stdout_limit_bytes: 64 * 1024,
+            stderr_limit_bytes: 256 * 1024,
+            stream: None,
+        })
         .await
-        .map_err(|e| SnapshotError::Setup(format!("pre-warm exec: {e}")))?;
-    if prewarm_result.exit_code != 0 {
-        let stderr = String::from_utf8_lossy(&prewarm_result.stderr);
-        return Err(SnapshotError::Setup(format!(
-            "pre-warm failed (exit code {}): {}",
-            prewarm_result.exit_code,
-            stderr.trim(),
-        )));
+        .map_err(|e| SnapshotError::Setup(format!("pre-warm bounded exec: {e}")))?;
+    if prewarm_result.stderr_truncated {
+        return Err(SnapshotError::Setup(
+            "pre-warm failed: stderr output was truncated".into(),
+        ));
+    }
+    match prewarm_result.termination {
+        vsock_host::BoundedExecTermination::Exited { exit_code: 0 } => {}
+        vsock_host::BoundedExecTermination::Exited { exit_code } => {
+            let stderr = String::from_utf8_lossy(&prewarm_result.stderr);
+            return Err(SnapshotError::Setup(format!(
+                "pre-warm failed (exit code {exit_code}): {}",
+                stderr.trim(),
+            )));
+        }
+        termination => {
+            return Err(SnapshotError::Setup(format!(
+                "pre-warm failed ({termination:?})"
+            )));
+        }
     }
     info!("pre-warm complete");
 

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -603,16 +603,16 @@ impl Sandbox for MockSandbox {
                 .bounded_exec_calls
                 .lock_ignoring_poison()
                 .push(call);
-            {
+            let matched_response = {
                 let mut matchers = overrides.bounded_exec_matchers.lock_ignoring_poison();
-                if let Some(idx) = matchers
+                matchers
                     .iter()
                     .position(|m| request.cmd.contains(&m.pattern))
-                {
-                    let matcher = matchers.remove(idx);
-                    emit_bounded_exec_events(request, matcher.response.events);
-                    return matcher.response.result;
-                }
+                    .map(|idx| matchers.remove(idx).response)
+            };
+            if let Some(response) = matched_response {
+                emit_bounded_exec_events(request, response.events);
+                return response.result;
             }
             if let Some(response) = overrides
                 .bounded_exec_responses

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -1228,10 +1228,9 @@ mod tests {
                 result: Ok(BoundedExecResult {
                     termination: BoundedExecTermination::Exited { exit_code: 0 },
                     duration: Duration::from_millis(10),
-                    stdout: b"sess-1".to_vec(),
-                    stderr: Vec::new(),
-                    stdout_truncated: false,
-                    stderr_truncated: false,
+                    stdout: captured_output(b"sess-1", false),
+                    stderr: captured_output(b"", false),
+                    diagnostic: None,
                 }),
             },
         });
@@ -1245,9 +1244,8 @@ mod tests {
             env: &[],
             sudo: true,
             stdin: None,
-            stdout_limit_bytes: 100,
-            stderr_limit_bytes: 100,
-            stream: None,
+            stdout: capture_output(100),
+            stderr: capture_output(100),
         };
         let session_request = BoundedExecRequest {
             cmd: "cat /tmp/vm0-session-run.txt 2>/dev/null",
@@ -1255,9 +1253,8 @@ mod tests {
             env: &[],
             sudo: false,
             stdin: None,
-            stdout_limit_bytes: 100,
-            stderr_limit_bytes: 100,
-            stream: None,
+            stdout: capture_output(100),
+            stderr: capture_output(100),
         };
 
         let setup = sandbox.bounded_exec(&setup_request).await.unwrap();
@@ -1268,9 +1265,9 @@ mod tests {
             setup.termination,
             BoundedExecTermination::Exited { exit_code: 0 }
         );
-        assert!(setup.stdout.is_empty());
-        assert_eq!(matched.stdout, b"sess-1");
-        assert!(fallback.stdout.is_empty());
+        assert_captured_output(&setup.stdout, b"", false);
+        assert_captured_output(&matched.stdout, b"sess-1", false);
+        assert_captured_output(&fallback.stdout, b"", false);
         assert_eq!(overrides.bounded_exec_calls().len(), 3);
     }
 

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -8,8 +8,8 @@
 //!
 //! For advanced control, create [`MockSandboxOverrides`] and pass it via
 //! [`MockSandboxRuntime::with_overrides`]. This enables pattern-matched exec
-//! results, custom `wait_exit` exit codes, and blocking gates for lifecycle
-//! and cancellation testing.
+//! and bounded_exec results, custom `wait_exit` exit codes, and blocking gates
+//! for lifecycle and cancellation testing.
 //!
 //! ```toml
 //! [dev-dependencies]
@@ -49,6 +49,13 @@ pub struct ExecMatcher {
     pub exit_code: i32,
     pub stdout: Vec<u8>,
     pub stderr: Vec<u8>,
+}
+
+/// Behavior override applied to bounded_exec calls whose command contains the pattern.
+pub struct BoundedExecMatcher {
+    /// Substring to match against `BoundedExecRequest.cmd`.
+    pub pattern: String,
+    pub response: BoundedExecResponse,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -110,6 +117,9 @@ pub struct MockSandboxOverrides {
     /// Pattern-matched exec results. First matching pattern wins and is
     /// consumed (one-shot).
     exec_matchers: Mutex<Vec<ExecMatcher>>,
+    /// Pattern-matched bounded_exec responses. First matching pattern wins and
+    /// is consumed (one-shot).
+    bounded_exec_matchers: Mutex<Vec<BoundedExecMatcher>>,
     /// FIFO bounded_exec responses consumed across all sandboxes built from
     /// these overrides. Empty queue → default success.
     bounded_exec_responses: Mutex<VecDeque<BoundedExecResponse>>,
@@ -158,6 +168,7 @@ impl MockSandboxOverrides {
     pub fn new() -> Self {
         Self {
             exec_matchers: Mutex::new(Vec::new()),
+            bounded_exec_matchers: Mutex::new(Vec::new()),
             bounded_exec_responses: Mutex::new(VecDeque::new()),
             wait_exit_code: None,
             wait_exit_gate: None,
@@ -205,6 +216,13 @@ impl MockSandboxOverrides {
     /// Register a pattern matcher consumed on first match.
     pub fn add_exec_matcher(&self, matcher: ExecMatcher) {
         self.exec_matchers.lock_ignoring_poison().push(matcher);
+    }
+
+    /// Register a bounded_exec pattern matcher consumed on first match.
+    pub fn add_bounded_exec_matcher(&self, matcher: BoundedExecMatcher) {
+        self.bounded_exec_matchers
+            .lock_ignoring_poison()
+            .push(matcher);
     }
 
     /// Queue a bounded_exec response consumed FIFO across all sandboxes built
@@ -339,7 +357,8 @@ impl Default for MockSandboxOverrides {
 /// A mock [`Sandbox`] that succeeds on all operations by default.
 ///
 /// Queue custom results with [`push_exec_result`](Self::push_exec_result)
-/// and [`push_write_file_result`](Self::push_write_file_result).
+/// [`push_bounded_exec_response`](Self::push_bounded_exec_response), and
+/// [`push_write_file_result`](Self::push_write_file_result).
 /// When a queue is empty, the operation returns its default success value.
 pub struct MockSandbox {
     id: String,
@@ -584,6 +603,17 @@ impl Sandbox for MockSandbox {
                 .bounded_exec_calls
                 .lock_ignoring_poison()
                 .push(call);
+            {
+                let mut matchers = overrides.bounded_exec_matchers.lock_ignoring_poison();
+                if let Some(idx) = matchers
+                    .iter()
+                    .position(|m| request.cmd.contains(&m.pattern))
+                {
+                    let matcher = matchers.remove(idx);
+                    emit_bounded_exec_events(request, matcher.response.events);
+                    return matcher.response.result;
+                }
+            }
             if let Some(response) = overrides
                 .bounded_exec_responses
                 .lock_ignoring_poison()
@@ -1186,6 +1216,62 @@ mod tests {
             BoundedExecTermination::Exited { exit_code: 0 }
         );
         assert_eq!(overrides.bounded_exec_calls().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn overrides_match_bounded_exec_response_by_command() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.add_bounded_exec_matcher(BoundedExecMatcher {
+            pattern: "cat /tmp/vm0-session-".into(),
+            response: BoundedExecResponse {
+                events: vec![],
+                result: Ok(BoundedExecResult {
+                    termination: BoundedExecTermination::Exited { exit_code: 0 },
+                    duration: Duration::from_millis(10),
+                    stdout: b"sess-1".to_vec(),
+                    stderr: Vec::new(),
+                    stdout_truncated: false,
+                    stderr_truncated: false,
+                }),
+            },
+        });
+        let mut factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        factory.startup().await.unwrap();
+
+        let sandbox = factory.create(test_sandbox_config()).await.unwrap();
+        let setup_request = BoundedExecRequest {
+            cmd: "date -s @0",
+            timeout: Duration::from_secs(5),
+            env: &[],
+            sudo: true,
+            stdin: None,
+            stdout_limit_bytes: 100,
+            stderr_limit_bytes: 100,
+            stream: None,
+        };
+        let session_request = BoundedExecRequest {
+            cmd: "cat /tmp/vm0-session-run.txt 2>/dev/null",
+            timeout: Duration::from_secs(5),
+            env: &[],
+            sudo: false,
+            stdin: None,
+            stdout_limit_bytes: 100,
+            stderr_limit_bytes: 100,
+            stream: None,
+        };
+
+        let setup = sandbox.bounded_exec(&setup_request).await.unwrap();
+        let matched = sandbox.bounded_exec(&session_request).await.unwrap();
+        let fallback = sandbox.bounded_exec(&session_request).await.unwrap();
+
+        assert_eq!(
+            setup.termination,
+            BoundedExecTermination::Exited { exit_code: 0 }
+        );
+        assert!(setup.stdout.is_empty());
+        assert_eq!(matched.stdout, b"sess-1");
+        assert!(fallback.stdout.is_empty());
+        assert_eq!(overrides.bounded_exec_calls().len(), 3);
     }
 
     #[tokio::test]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -4838,6 +4838,7 @@ mod tests {
     #[tokio::test]
     async fn test_wait_for_exit_connection_closed() {
         let (host_stream, mut guest) = make_pair();
+        let (close_tx, close_rx) = oneshot::channel::<()>();
 
         tokio::spawn(async move {
             let mut decoder = Decoder::new();
@@ -4854,22 +4855,22 @@ mod tests {
             let resp = vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, msgs[0].seq, &payload).unwrap();
             guest.write_all(&resp).await.unwrap();
 
-            // Small delay then close the connection WITHOUT sending process_exit.
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            let _ = close_rx.await;
             drop(guest);
         });
 
-        let host = host_from_stream(host_stream).await.unwrap();
+        let host = Arc::new(host_from_stream(host_stream).await.unwrap());
         let (pid, _stdout_rx) = host
             .spawn_watch("long-running", 0, &[], false, false, None)
             .await
             .unwrap();
         assert_eq!(pid, 77);
 
-        let err = host
-            .wait_for_exit(77, Duration::from_secs(5))
-            .await
-            .unwrap_err();
+        let wait_host = Arc::clone(&host);
+        let wait_task =
+            tokio::spawn(async move { wait_host.wait_for_exit(77, Duration::from_secs(5)).await });
+        close_tx.send(()).unwrap();
+        let err = wait_task.await.unwrap().unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
     }
 
@@ -5018,6 +5019,7 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_exec_and_wait_exit() {
         let (host_stream, mut guest) = make_pair();
+        let (send_exit_tx, send_exit_rx) = oneshot::channel::<()>();
 
         tokio::spawn(async move {
             let mut decoder = Decoder::new();
@@ -5046,8 +5048,7 @@ mod tests {
             let exec_resp = vsock_proto::encode(MSG_EXEC_RESULT, exec_seq, &exec_payload).unwrap();
             guest.write_all(&exec_resp).await.unwrap();
 
-            // Small delay then send process_exit
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            let _ = send_exit_rx.await;
             let exit_payload = vsock_proto::encode_process_exit(50, 42, b"exited", b"");
             let exit_msg = vsock_proto::encode(MSG_PROCESS_EXIT, 0, &exit_payload).unwrap();
             guest.write_all(&exit_msg).await.unwrap();
@@ -5076,6 +5077,8 @@ mod tests {
             .unwrap();
         assert_eq!(exec_result.exit_code, 0);
         assert_eq!(exec_result.stdout, b"concurrent");
+
+        send_exit_tx.send(()).unwrap();
 
         // wait_for_exit should also resolve
         let exit_event = wait_task.await.unwrap().unwrap();

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -3860,13 +3860,10 @@ mod tests {
         let request =
             simple_bounded_request("request-timeout", Some(bounded_stream_request(event_tx)));
 
-        let err = bounded_exec_on_shared_with_request_timeout(
-            &host.shared,
-            &request,
-            Duration::from_millis(1),
-        )
-        .await
-        .unwrap_err();
+        let err =
+            bounded_exec_on_shared_with_request_timeout(&host.shared, &request, Duration::ZERO)
+                .await
+                .unwrap_err();
 
         assert_eq!(err.kind(), io::ErrorKind::TimedOut);
         assert_eq!(

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -460,7 +460,7 @@ impl ChunkedWriteCleanupGuard {
 
     async fn cleanup_now(&mut self) {
         if let Some(shared) = self.shared.as_ref() {
-            let _ = exec_cleanup_on_shared(
+            let _ = bounded_exec_cleanup_on_shared(
                 shared,
                 &self.command,
                 VsockHost::CLEANUP_EXEC_TIMEOUT_MS,
@@ -483,7 +483,7 @@ impl Drop for ChunkedWriteCleanupGuard {
         let sudo = self.sudo;
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
-                let _ = exec_cleanup_on_shared(
+                let _ = bounded_exec_cleanup_on_shared(
                     &shared,
                     &command,
                     VsockHost::CLEANUP_EXEC_TIMEOUT_MS,
@@ -1081,19 +1081,35 @@ async fn exec_on_shared(
         .await
 }
 
-async fn exec_cleanup_on_shared(
+async fn bounded_exec_cleanup_on_shared(
     shared: &Arc<Shared>,
     command: &str,
     timeout_ms: u32,
     env: &[(&str, &str)],
     sudo: bool,
-) -> io::Result<ExecResult> {
-    exec_on_shared_with_request_timeout(
-        shared,
+) -> io::Result<BoundedExecResult> {
+    let request = BoundedExecRequest {
         command,
         timeout_ms,
         env,
         sudo,
+        stdin: None,
+        stdout: BoundedExecOutputRequest {
+            capture: BoundedExecCapturePolicy::Capture {
+                limit_bytes: VsockHost::HELPER_EXEC_STDOUT_LIMIT_BYTES,
+            },
+            stream: None,
+        },
+        stderr: BoundedExecOutputRequest {
+            capture: BoundedExecCapturePolicy::Capture {
+                limit_bytes: VsockHost::HELPER_EXEC_STDERR_LIMIT_BYTES,
+            },
+            stream: None,
+        },
+    };
+    bounded_exec_on_shared_with_request_timeout(
+        shared,
+        &request,
         Duration::from_millis(timeout_ms as u64),
     )
     .await
@@ -1140,6 +1156,105 @@ async fn exec_on_shared_with_request_timeout(
         exit_code,
         stdout: stdout.to_vec(),
         stderr: stderr.to_vec(),
+    })
+}
+
+async fn bounded_exec_on_shared(
+    shared: &Arc<Shared>,
+    request: &BoundedExecRequest<'_>,
+) -> io::Result<BoundedExecResult> {
+    let timeout = Duration::from_millis(request.timeout_ms as u64 + 5000);
+    bounded_exec_on_shared_with_request_timeout(shared, request, timeout).await
+}
+
+async fn bounded_exec_on_shared_with_request_timeout(
+    shared: &Arc<Shared>,
+    request: &BoundedExecRequest<'_>,
+    request_timeout: Duration,
+) -> io::Result<BoundedExecResult> {
+    validate_bounded_exec_request(request)?;
+
+    let proto_request = vsock_proto::BoundedExecRequest {
+        timeout_ms: request.timeout_ms,
+        command: request.command,
+        env: request.env,
+        sudo: request.sudo,
+        stdin: request.stdin,
+        stdout: host_output_request_to_proto(&request.stdout),
+        stderr: host_output_request_to_proto(&request.stderr),
+    };
+    let payload = vsock_proto::encode_bounded_exec(&proto_request)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+
+    let seq = shared.next_seq();
+    let data = vsock_proto::encode(MSG_BOUNDED_EXEC, seq, &payload)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    let (tx, rx) = oneshot::channel();
+    {
+        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        match &mut *guard {
+            ConnectionState::Closed { .. } => {
+                return Err(io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "connection closed",
+                ));
+            }
+            ConnectionState::Connected {
+                pending,
+                bounded_output_senders,
+                ..
+            } => {
+                pending.insert(seq, tx);
+                if has_bounded_stream(request) {
+                    bounded_output_senders.insert(
+                        seq,
+                        BoundedOutputRegistration::new(&request.stdout, &request.stderr),
+                    );
+                }
+            }
+        }
+    }
+    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
+    let _bounded_output_guard =
+        has_bounded_stream(request).then(|| PendingBoundedOutputGuard::new(Arc::clone(shared), seq));
+
+    write_frame_on_shared(shared, &data).await?;
+
+    let resp = tokio::select! {
+        biased;
+        result = rx => {
+            result.map_err(|_| io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "connection closed",
+            ))?
+        }
+        _ = tokio::time::sleep(request_timeout) => {
+            return Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"));
+        }
+    };
+
+    if resp.msg_type == MSG_ERROR {
+        let msg = vsock_proto::decode_error(&resp.payload)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        return Err(io::Error::other(msg));
+    }
+
+    if resp.msg_type != MSG_BOUNDED_EXEC_RESULT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unexpected response type: 0x{:02X}", resp.msg_type),
+        ));
+    }
+
+    let decoded = vsock_proto::decode_bounded_exec_result(&resp.payload)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+    Ok(BoundedExecResult {
+        termination: proto_termination_to_host(decoded.termination),
+        duration_ms: decoded.duration_ms,
+        stdout: proto_output_to_host(decoded.stdout),
+        stderr: proto_output_to_host(decoded.stderr),
+        diagnostic: decoded.diagnostic.map(ToOwned::to_owned),
     })
 }
 
@@ -1333,91 +1448,7 @@ impl VsockHost {
         &self,
         request: &BoundedExecRequest<'_>,
     ) -> io::Result<BoundedExecResult> {
-        validate_bounded_exec_request(request)?;
-
-        let proto_request = vsock_proto::BoundedExecRequest {
-            timeout_ms: request.timeout_ms,
-            command: request.command,
-            env: request.env,
-            sudo: request.sudo,
-            stdin: request.stdin,
-            stdout: host_output_request_to_proto(&request.stdout),
-            stderr: host_output_request_to_proto(&request.stderr),
-        };
-        let payload = vsock_proto::encode_bounded_exec(&proto_request)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
-
-        let seq = self.shared.next_seq();
-        let data = vsock_proto::encode(MSG_BOUNDED_EXEC, seq, &payload)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
-        let (tx, rx) = oneshot::channel();
-        {
-            let mut guard = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
-            match &mut *guard {
-                ConnectionState::Closed { .. } => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::ConnectionReset,
-                        "connection closed",
-                    ));
-                }
-                ConnectionState::Connected {
-                    pending,
-                    bounded_output_senders,
-                    ..
-                } => {
-                    pending.insert(seq, tx);
-                    if has_bounded_stream(request) {
-                        bounded_output_senders.insert(
-                            seq,
-                            BoundedOutputRegistration::new(&request.stdout, &request.stderr),
-                        );
-                    }
-                }
-            }
-        }
-        let _pending_guard = PendingRequestGuard::new(Arc::clone(&self.shared), seq);
-        let _bounded_output_guard = has_bounded_stream(request)
-            .then(|| PendingBoundedOutputGuard::new(Arc::clone(&self.shared), seq));
-
-        write_frame_on_shared(&self.shared, &data).await?;
-
-        let timeout = Duration::from_millis(request.timeout_ms as u64 + 5000);
-        let resp = tokio::select! {
-            biased;
-            result = rx => {
-                result.map_err(|_| io::Error::new(
-                    io::ErrorKind::ConnectionReset,
-                    "connection closed",
-                ))?
-            }
-            _ = tokio::time::sleep(timeout) => {
-                return Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"));
-            }
-        };
-
-        if resp.msg_type == MSG_ERROR {
-            let msg = vsock_proto::decode_error(&resp.payload)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-            return Err(io::Error::other(msg));
-        }
-
-        if resp.msg_type != MSG_BOUNDED_EXEC_RESULT {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("unexpected response type: 0x{:02X}", resp.msg_type),
-            ));
-        }
-
-        let decoded = vsock_proto::decode_bounded_exec_result(&resp.payload)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-
-        Ok(BoundedExecResult {
-            termination: proto_termination_to_host(decoded.termination),
-            duration_ms: decoded.duration_ms,
-            stdout: proto_output_to_host(decoded.stdout),
-            stderr: proto_output_to_host(decoded.stderr),
-            diagnostic: decoded.diagnostic.map(ToOwned::to_owned),
-        })
+        bounded_exec_on_shared(&self.shared, request).await
     }
 
     /// Maximum content per write_file message.  Leaves headroom below
@@ -1426,6 +1457,8 @@ impl VsockHost {
 
     /// Timeout (ms) for short helper commands (mv, rm) used during chunked writes.
     const HELPER_EXEC_TIMEOUT_MS: u32 = 5000;
+    const HELPER_EXEC_STDOUT_LIMIT_BYTES: u32 = 4 * 1024;
+    const HELPER_EXEC_STDERR_LIMIT_BYTES: u32 = 16 * 1024;
 
     /// Shorter timeout (ms) for best-effort cleanup when the connection may
     /// already be broken.  Avoids blocking for a full 5 s on a dead socket.
@@ -1471,18 +1504,40 @@ impl VsockHost {
         // Atomic rename temp → target.
         let escaped_path = path.replace('\'', "'\\''");
         let mv_cmd = format!("mv -f -- '{escaped_tmp}' '{escaped_path}'");
-        match self
-            .exec(&mv_cmd, Self::HELPER_EXEC_TIMEOUT_MS, &[], sudo)
-            .await
-        {
-            Ok(r) if r.exit_code == 0 => {
+        let mv_request = BoundedExecRequest {
+            command: &mv_cmd,
+            timeout_ms: Self::HELPER_EXEC_TIMEOUT_MS,
+            env: &[],
+            sudo,
+            stdin: None,
+            stdout: BoundedExecOutputRequest {
+                capture: BoundedExecCapturePolicy::Capture {
+                    limit_bytes: Self::HELPER_EXEC_STDOUT_LIMIT_BYTES,
+                },
+                stream: None,
+            },
+            stderr: BoundedExecOutputRequest {
+                capture: BoundedExecCapturePolicy::Capture {
+                    limit_bytes: Self::HELPER_EXEC_STDERR_LIMIT_BYTES,
+                },
+                stream: None,
+            },
+        };
+        match self.bounded_exec(&mv_request).await {
+            Ok(r)
+                if matches!(
+                    r.termination,
+                    BoundedExecTermination::Exited { exit_code: 0 }
+                ) =>
+            {
                 cleanup_guard.disarm();
                 Ok(())
             }
             Ok(r) => {
                 cleanup_guard.cleanup_now().await;
                 Err(io::Error::other(format!(
-                    "failed to rename temp file to {path}: {}",
+                    "failed to rename temp file to {path}: termination={:?}, stderr={}",
+                    r.termination,
                     String::from_utf8_lossy(&r.stderr),
                 )))
             }
@@ -1945,16 +2000,37 @@ mod tests {
     }
 
     async fn write_bounded_exec_result(guest: &mut UnixStream, seq: u32, stdout: &[u8]) {
-        let payload = vsock_proto::encode_bounded_exec_result(
+        write_bounded_exec_result_full(
+            guest,
+            seq,
             vsock_proto::BoundedExecTermination::Exited { exit_code: 0 },
+            stdout,
+            b"",
+            false,
+            false,
+        )
+        .await;
+    }
+
+    async fn write_bounded_exec_result_full(
+        guest: &mut UnixStream,
+        seq: u32,
+        termination: vsock_proto::BoundedExecTermination,
+        stdout: &[u8],
+        stderr: &[u8],
+        stdout_truncated: bool,
+        stderr_truncated: bool,
+    ) {
+        let payload = vsock_proto::encode_bounded_exec_result(
+            termination,
             1,
             vsock_proto::BoundedExecOutput::Captured {
                 bytes: stdout,
-                truncated: false,
+                truncated: stdout_truncated,
             },
             vsock_proto::BoundedExecOutput::Captured {
-                bytes: b"",
-                truncated: false,
+                bytes: stderr,
+                truncated: stderr_truncated,
             },
             None,
         )
@@ -3913,7 +3989,7 @@ mod tests {
             let mut temp_path = None::<String>;
             let mut buf = vec![0u8; chunk_limit + 4096];
 
-            // Read write_file chunks + final exec (mv) message
+            // Read write_file chunks + final bounded_exec (mv) message
             loop {
                 let n = guest.read(&mut buf).await.unwrap();
                 if n == 0 {
@@ -3937,17 +4013,29 @@ mod tests {
                         let resp =
                             vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
                         guest.write_all(&resp).await.unwrap();
-                    } else if msg.msg_type == MSG_EXEC {
+                    } else if msg.msg_type == MSG_BOUNDED_EXEC {
                         // Atomic rename: mv temp → target
-                        let decoded = vsock_proto::decode_exec(&msg.payload).unwrap();
+                        let decoded = vsock_proto::decode_bounded_exec(&msg.payload).unwrap();
                         let temp_path = temp_path.as_ref().expect("temp path");
                         assert!(decoded.command.contains("mv -f --"));
                         assert!(decoded.command.contains(temp_path));
                         assert!(decoded.command.contains("/tmp/big.bin"));
+                        assert_eq!(
+                            decoded.stdout.capture,
+                            vsock_proto::BoundedExecCapturePolicy::Capture {
+                                limit_bytes: 4 * 1024
+                            }
+                        );
+                        assert_eq!(
+                            decoded.stderr.capture,
+                            vsock_proto::BoundedExecCapturePolicy::Capture {
+                                limit_bytes: 16 * 1024
+                            }
+                        );
+                        assert_eq!(decoded.stdout.stream, None);
+                        assert_eq!(decoded.stderr.stream, None);
 
-                        let payload = vsock_proto::encode_exec_result(0, &[], &[]);
-                        let resp = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
-                        guest.write_all(&resp).await.unwrap();
+                        write_bounded_exec_result(&mut guest, msg.seq, &[]).await;
                         // Done — verify chunks and return
                         assert_eq!(chunks_received.len(), 2);
                         assert!(!chunks_received[0].0); // first: create
@@ -3961,7 +4049,7 @@ mod tests {
                     }
                 }
             }
-            panic!("guest loop ended without receiving exec (mv)");
+            panic!("guest loop ended without receiving bounded_exec (mv)");
         });
 
         let host = host_from_stream(host_stream).await.unwrap();
@@ -4049,15 +4137,25 @@ mod tests {
                         let resp =
                             vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
                         guest.write_all(&resp).await.unwrap();
-                    } else if msg.msg_type == MSG_EXEC {
+                    } else if msg.msg_type == MSG_BOUNDED_EXEC {
                         // Cleanup: rm -f temp file
-                        let decoded = vsock_proto::decode_exec(&msg.payload).unwrap();
+                        let decoded = vsock_proto::decode_bounded_exec(&msg.payload).unwrap();
                         let temp_path = temp_path.as_ref().expect("temp path");
                         assert!(decoded.command.contains("rm -f --"));
                         assert!(decoded.command.contains(temp_path));
-                        let payload = vsock_proto::encode_exec_result(0, &[], &[]);
-                        let resp = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
-                        guest.write_all(&resp).await.unwrap();
+                        assert_eq!(
+                            decoded.stdout.capture,
+                            vsock_proto::BoundedExecCapturePolicy::Capture {
+                                limit_bytes: 4 * 1024
+                            }
+                        );
+                        assert_eq!(
+                            decoded.stderr.capture,
+                            vsock_proto::BoundedExecCapturePolicy::Capture {
+                                limit_bytes: 16 * 1024
+                            }
+                        );
+                        write_bounded_exec_result(&mut guest, msg.seq, &[]).await;
                         return;
                     }
                 }
@@ -4106,26 +4204,28 @@ mod tests {
                         let resp =
                             vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
                         guest.write_all(&resp).await.unwrap();
-                    } else if msg.msg_type == MSG_EXEC {
+                    } else if msg.msg_type == MSG_BOUNDED_EXEC {
                         exec_count += 1;
-                        let decoded = vsock_proto::decode_exec(&msg.payload).unwrap();
+                        let decoded = vsock_proto::decode_bounded_exec(&msg.payload).unwrap();
                         let temp_path = temp_path.as_ref().expect("temp path");
                         if decoded.command.contains("mv -f --") {
                             // mv fails
                             assert!(decoded.command.contains(temp_path));
-                            let payload =
-                                vsock_proto::encode_exec_result(1, &[], b"permission denied");
-                            let resp =
-                                vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
-                            guest.write_all(&resp).await.unwrap();
+                            write_bounded_exec_result_full(
+                                &mut guest,
+                                msg.seq,
+                                vsock_proto::BoundedExecTermination::Exited { exit_code: 1 },
+                                &[],
+                                b"permission denied",
+                                false,
+                                false,
+                            )
+                            .await;
                         } else {
                             // cleanup rm
                             assert!(decoded.command.contains("rm -f --"));
                             assert!(decoded.command.contains(temp_path));
-                            let payload = vsock_proto::encode_exec_result(0, &[], &[]);
-                            let resp =
-                                vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
-                            guest.write_all(&resp).await.unwrap();
+                            write_bounded_exec_result(&mut guest, msg.seq, &[]).await;
                             assert_eq!(exec_count, 2); // mv then rm
                             return;
                         }
@@ -4184,17 +4284,15 @@ mod tests {
                         if let Some(tx) = first_chunk_tx.take() {
                             let _ = tx.send(());
                         }
-                    } else if msg.msg_type == MSG_EXEC {
-                        let decoded = vsock_proto::decode_exec(&msg.payload).unwrap();
+                    } else if msg.msg_type == MSG_BOUNDED_EXEC {
+                        let decoded = vsock_proto::decode_bounded_exec(&msg.payload).unwrap();
                         let temp_path = temp_path.as_ref().expect("temp path");
                         assert!(decoded.command.contains("rm -f --"));
                         assert!(decoded.command.contains(temp_path));
                         if let Some(tx) = cleanup_tx.take() {
                             let _ = tx.send(decoded.command.to_string());
                         }
-                        let payload = vsock_proto::encode_exec_result(0, &[], &[]);
-                        let resp = vsock_proto::encode(MSG_EXEC_RESULT, msg.seq, &payload).unwrap();
-                        guest.write_all(&resp).await.unwrap();
+                        write_bounded_exec_result(&mut guest, msg.seq, &[]).await;
                         return;
                     }
                 }

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -4301,6 +4301,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_write_file_chunked_cleans_up_on_mv_timeout() {
+        let (host_stream, mut guest) = make_pair();
+
+        let chunk_limit = VsockHost::WRITE_FILE_CHUNK_LIMIT;
+        let content = vec![0xABu8; chunk_limit + 100];
+
+        tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut buf = vec![0u8; chunk_limit + 4096];
+            let mut exec_count = 0u32;
+            let mut temp_path = None::<String>;
+            loop {
+                let n = guest.read(&mut buf).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                let msgs = decoder.decode(&buf[..n]).unwrap();
+                for msg in msgs {
+                    if msg.msg_type == MSG_WRITE_FILE {
+                        let (path, _chunk, _sudo, _append) =
+                            vsock_proto::decode_write_file(&msg.payload).unwrap();
+                        if let Some(temp_path) = &temp_path {
+                            assert_eq!(path, temp_path);
+                        } else {
+                            assert!(path.starts_with("/tmp/big.bin.vm0tmp-"));
+                            temp_path = Some(path.to_string());
+                        }
+                        let payload = vsock_proto::encode_write_file_result(true, "");
+                        let resp =
+                            vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload).unwrap();
+                        guest.write_all(&resp).await.unwrap();
+                    } else if msg.msg_type == MSG_BOUNDED_EXEC {
+                        exec_count += 1;
+                        let decoded = vsock_proto::decode_bounded_exec(&msg.payload).unwrap();
+                        let temp_path = temp_path.as_ref().expect("temp path");
+                        if decoded.command.contains("mv -f --") {
+                            assert!(decoded.command.contains(temp_path));
+                            write_bounded_exec_result_full(
+                                &mut guest,
+                                msg.seq,
+                                vsock_proto::BoundedExecTermination::TimedOut,
+                                &[],
+                                b"",
+                                false,
+                                false,
+                            )
+                            .await;
+                        } else {
+                            assert!(decoded.command.contains("rm -f --"));
+                            assert!(decoded.command.contains(temp_path));
+                            write_bounded_exec_result(&mut guest, msg.seq, &[]).await;
+                            assert_eq!(exec_count, 2); // mv then rm
+                            return;
+                        }
+                    }
+                }
+            }
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let err = host
+            .write_file("/tmp/big.bin", &content, false)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("TimedOut"), "got: {err}");
+    }
+
+    #[tokio::test]
     async fn test_write_file_chunked_cleans_up_when_cancelled() {
         let (host_stream, mut guest) = make_pair();
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1215,8 +1215,8 @@ async fn bounded_exec_on_shared_with_request_timeout(
         }
     }
     let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
-    let _bounded_output_guard =
-        has_bounded_stream(request).then(|| PendingBoundedOutputGuard::new(Arc::clone(shared), seq));
+    let _bounded_output_guard = has_bounded_stream(request)
+        .then(|| PendingBoundedOutputGuard::new(Arc::clone(shared), seq));
 
     write_frame_on_shared(shared, &data).await?;
 
@@ -1535,10 +1535,14 @@ impl VsockHost {
             }
             Ok(r) => {
                 cleanup_guard.cleanup_now().await;
+                let stderr = match &r.stderr {
+                    BoundedExecOutput::Captured { bytes, .. } => bytes.as_slice(),
+                    BoundedExecOutput::Discarded => &[],
+                };
                 Err(io::Error::other(format!(
                     "failed to rename temp file to {path}: termination={:?}, stderr={}",
                     r.termination,
-                    String::from_utf8_lossy(&r.stderr),
+                    String::from_utf8_lossy(stderr),
                 )))
             }
             Err(e) => {
@@ -3876,7 +3880,7 @@ mod tests {
 
         let request = simple_bounded_request("after-timeout", None);
         let result = host.bounded_exec(&request).await.unwrap();
-        assert_eq!(result.stdout, b"ok");
+        assert_host_captured_output(&result.stdout, b"ok", false);
         tokio::time::timeout(Duration::from_secs(5), guest_task)
             .await
             .expect("guest task should finish after follow-up bounded_exec")

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -3826,6 +3826,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_bounded_exec_request_timeout_cleans_up_and_keeps_connection_usable() {
+        let (host_stream, mut guest) = make_pair();
+
+        let guest_task = tokio::spawn(async move {
+            let mut decoder = Decoder::new();
+            mock_handshake(&mut guest, &mut decoder).await;
+
+            let mut saw_timeout_request = false;
+            let mut buf = [0u8; 4096];
+            loop {
+                let n = guest.read(&mut buf).await.unwrap();
+                assert_ne!(n, 0, "connection closed before follow-up bounded_exec");
+                let msgs = decoder.decode(&buf[..n]).unwrap();
+                for msg in msgs {
+                    assert_eq!(msg.msg_type, MSG_BOUNDED_EXEC);
+                    let decoded = vsock_proto::decode_bounded_exec(&msg.payload).unwrap();
+                    if !saw_timeout_request {
+                        assert_eq!(decoded.command, "request-timeout");
+                        saw_timeout_request = true;
+                        continue;
+                    }
+
+                    assert_eq!(decoded.command, "after-timeout");
+                    write_bounded_exec_result(&mut guest, msg.seq, b"ok").await;
+                    return;
+                }
+            }
+        });
+
+        let host = host_from_stream(host_stream).await.unwrap();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let request =
+            simple_bounded_request("request-timeout", Some(bounded_stream_request(event_tx)));
+
+        let err = bounded_exec_on_shared_with_request_timeout(
+            &host.shared,
+            &request,
+            Duration::from_millis(1),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        assert_eq!(
+            registration_counts(&host),
+            (0, 0, 0, 0),
+            "timed-out bounded_exec must clean pending registrations",
+        );
+        drop(request);
+        assert_bounded_event_stream_closed(&mut event_rx);
+
+        let request = simple_bounded_request("after-timeout", None);
+        let result = host.bounded_exec(&request).await.unwrap();
+        assert_eq!(result.stdout, b"ok");
+        tokio::time::timeout(Duration::from_secs(5), guest_task)
+            .await
+            .expect("guest task should finish after follow-up bounded_exec")
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn test_bounded_exec_stream_request_with_no_streams_does_not_register_sender() {
         let (host_stream, mut guest) = make_pair();
         let request_seen = std::sync::Arc::new(Notify::new());


### PR DESCRIPTION
## Summary
- migrate runner internal short guest commands to bounded_exec with explicit per-call output caps and structured termination handling
- convert snapshot prewarm and vsock-host chunked write mv/rm helpers to bounded_exec
- update tests for bounded exec sequencing, caps, truncation, and failure behavior

Closes #12260

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner executor
- cargo test --manifest-path crates/Cargo.toml -p runner -p sandbox-fc -p vsock-host -p sandbox-mock --all-targets
- cargo fmt --all --manifest-path crates/Cargo.toml --check
- cargo clippy --manifest-path crates/Cargo.toml -p runner -p sandbox-fc -p vsock-host -p sandbox-mock --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner -p sandbox-fc -p vsock-host -p sandbox-mock --no-deps --all-features