### PR TITLE
feat: add strapi docs site route

### DIFF
--- a/turbo/apps/web/app/[locale]/docs/[...slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/docs/[...slug]/page.tsx
@@ -1,0 +1,208 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import { getTranslations } from "next-intl/server";
+import { Footer } from "../../../components/Footer";
+import { Particles } from "../../../components/Particles";
+import { DocsShell } from "../../../components/docs/DocsShell";
+import {
+  canViewDocs,
+  getDocsAvailableLocales,
+  getDocsBaseUrl,
+  getDocsNavigation,
+  getDocsPage,
+} from "../../../lib/docs";
+import { buildLocaleAlternates } from "../../../lib/seo/alternates";
+import { locales, type Locale } from "../../../../i18n";
+import { Link } from "../../../../navigation";
+
+interface DocsPageProps {
+  params: Promise<{ locale: string; slug: string[] }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export const dynamic = "force-dynamic";
+
+function pathFromSlug(slug: string[]): string {
+  return slug.join("/");
+}
+
+export async function generateMetadata({
+  params,
+  searchParams,
+}: DocsPageProps): Promise<Metadata> {
+  if (!(await canViewDocs())) {
+    return { title: "Not Found" };
+  }
+
+  const { locale, slug } = await params;
+  const { status } = await searchParams;
+  const path = pathFromSlug(slug);
+  const page = await getDocsPage(path, locale, { draft: status === "draft" });
+
+  if (!page) {
+    return { title: "Docs Page Not Found" };
+  }
+
+  return {
+    title: page.title,
+    description: page.description,
+    alternates: buildLocaleAlternates(
+      `/docs/${page.path}`,
+      locale as Locale,
+      (await getDocsAvailableLocales(page.path, locales)) as Locale[],
+    ),
+    openGraph: {
+      title: page.title,
+      description: page.description,
+      type: "article",
+      publishedTime: page.publishedAt,
+      modifiedTime: page.updatedAt,
+      url: `${getDocsBaseUrl()}/${locale}/docs/${page.path}`,
+      images: [
+        {
+          url: "/og-image.png",
+          width: 1200,
+          height: 630,
+          alt: page.title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: page.title,
+      description: page.description,
+      images: ["/og-image.png"],
+      creator: "@vm0_ai",
+      site: "@vm0_ai",
+    },
+  };
+}
+
+export default async function DocsPage({
+  params,
+  searchParams,
+}: DocsPageProps) {
+  if (!(await canViewDocs())) {
+    notFound();
+  }
+
+  const { locale, slug } = await params;
+  const { status } = await searchParams;
+  const path = pathFromSlug(slug);
+  const page = await getDocsPage(path, locale, { draft: status === "draft" });
+
+  if (!page) {
+    notFound();
+  }
+
+  const t = await getTranslations({ locale, namespace: "docs" });
+  const navigation = await getDocsNavigation(locale);
+  const pageUrl = `${getDocsBaseUrl()}/${locale}/docs/${page.path}`;
+
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: `${getDocsBaseUrl()}/${locale}`,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Docs",
+        item: `${getDocsBaseUrl()}/${locale}/docs`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: page.title,
+        item: pageUrl,
+      },
+    ],
+  };
+
+  const articleJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    headline: page.title,
+    description: page.description,
+    url: pageUrl,
+    datePublished: page.publishedAt,
+    dateModified: page.updatedAt,
+    publisher: {
+      "@type": "Organization",
+      name: "VM0",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://www.vm0.ai/assets/vm0-logo.svg",
+      },
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
+      />
+      <Particles />
+      <DocsShell
+        navigation={navigation}
+        homeLabel={t("home")}
+        activePath={page.path}
+      >
+        <header className="docs-article-header">
+          <Link href="/docs" className="blog-post-back">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <line x1="19" y1="12" x2="5" y2="12" />
+              <polyline points="12 19 5 12 12 5" />
+            </svg>
+            {t("backToDocs")}
+          </Link>
+          <span className="docs-kicker">{page.section.title}</span>
+          <h1 className="docs-title">{page.title}</h1>
+          {page.description && (
+            <p className="docs-description">{page.description}</p>
+          )}
+          <p className="docs-updated">
+            {t("lastUpdated", {
+              date: new Date(page.updatedAt).toLocaleDateString(locale, {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              }),
+            })}
+            {" · "}
+            {page.readTime}
+          </p>
+        </header>
+        <article className="docs-article blog-post-content">
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeHighlight]}
+          >
+            {page.content}
+          </ReactMarkdown>
+        </article>
+      </DocsShell>
+      <Footer />
+    </>
+  );
+}

--- a/turbo/apps/web/app/[locale]/docs/page.tsx
+++ b/turbo/apps/web/app/[locale]/docs/page.tsx
@@ -1,0 +1,133 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { Footer } from "../../components/Footer";
+import { Particles } from "../../components/Particles";
+import { DocsShell } from "../../components/docs/DocsShell";
+import {
+  buildDocsNavigation,
+  canViewDocs,
+  getDocsBaseUrl,
+  getDocsPages,
+} from "../../lib/docs";
+import { buildLocaleAlternates } from "../../lib/seo/alternates";
+import { type Locale } from "../../../i18n";
+import { Link } from "../../../navigation";
+
+const BASE_URL = "https://www.vm0.ai";
+
+interface DocsIndexPageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata({
+  params,
+}: DocsIndexPageProps): Promise<Metadata> {
+  if (!(await canViewDocs())) {
+    return { title: "Not Found" };
+  }
+
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "docs" });
+
+  return {
+    title: t("title"),
+    description: t("description"),
+    alternates: buildLocaleAlternates("/docs", locale as Locale),
+    openGraph: {
+      title: `VM0 ${t("title")}`,
+      description: t("description"),
+      url: `${getDocsBaseUrl()}/${locale}/docs`,
+      images: [
+        {
+          url: "/og-image.png",
+          width: 1200,
+          height: 630,
+          alt: `VM0 ${t("title")}`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `VM0 ${t("title")}`,
+      description: t("description"),
+      images: ["/og-image.png"],
+      creator: "@vm0_ai",
+      site: "@vm0_ai",
+    },
+  };
+}
+
+export default async function DocsIndexPage({ params }: DocsIndexPageProps) {
+  if (!(await canViewDocs())) {
+    notFound();
+  }
+
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "docs" });
+  const pages = await getDocsPages(locale);
+  const navigation = buildDocsNavigation(pages);
+
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: `${BASE_URL}/${locale}`,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Docs",
+        item: `${BASE_URL}/${locale}/docs`,
+      },
+    ],
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
+      <Particles />
+      <section className="docs-hero">
+        <div className="container">
+          <p className="docs-kicker">{t("kicker")}</p>
+          <h1 className="docs-title">{t("title")}</h1>
+          <p className="docs-description">{t("description")}</p>
+        </div>
+      </section>
+      <DocsShell navigation={navigation} homeLabel={t("home")}>
+        {pages.length > 0 ? (
+          <div className="docs-index-grid">
+            {pages.map((page) => {
+              return (
+                <Link
+                  key={page.path}
+                  href={`/docs/${page.path}`}
+                  className="docs-index-card"
+                >
+                  <span className="docs-index-section">
+                    {page.section.title}
+                  </span>
+                  <h2>{page.title}</h2>
+                  {page.description && <p>{page.description}</p>}
+                </Link>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="docs-empty">{t("empty")}</p>
+        )}
+      </DocsShell>
+      <Footer />
+    </>
+  );
+}

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -20,13 +20,17 @@ import { isBlogEnabled } from "../../src/env";
 
 interface NavbarProps {
   initialIsSignedIn?: boolean;
+  initialShowDocs?: boolean;
 }
 
 const GITHUB_URL = "https://github.com/vm0-ai/vm0";
 const STATUS_URL = "https://status.vm0.ai";
 const DEMO_URL = "https://calendar.app.google/csdygPrHHyNgxpTPA";
 
-export function Navbar({ initialIsSignedIn = false }: NavbarProps) {
+export function Navbar({
+  initialIsSignedIn = false,
+  initialShowDocs = false,
+}: NavbarProps) {
   const { theme } = useTheme();
   const t = useTranslations("nav");
   const { isSignedIn: clerkIsSignedIn, isLoaded } = useUser();
@@ -77,7 +81,17 @@ export function Navbar({ initialIsSignedIn = false }: NavbarProps) {
       }
     : null;
 
+  const docsItem: NavMenuItem | null = initialShowDocs
+    ? {
+        label: t("docs"),
+        description: t("docsDesc"),
+        href: "/docs",
+        icon: "/assets/nav/docs.svg",
+      }
+    : null;
+
   const resourcesItems: NavMenuItem[] = [
+    ...(docsItem ? [docsItem] : []),
     ...(blogItem ? [blogItem] : []),
     {
       label: t("support"),

--- a/turbo/apps/web/app/components/SiteHeader.tsx
+++ b/turbo/apps/web/app/components/SiteHeader.tsx
@@ -1,12 +1,14 @@
 import { auth } from "@clerk/nextjs/server";
 import { Navbar } from "./Navbar";
+import { canViewDocsForUser } from "../lib/docs";
 
 export async function SiteHeader() {
-  const { userId } = await auth();
+  const { userId, orgId } = await auth();
+  const showDocs = await canViewDocsForUser(userId, orgId);
 
   return (
     <div className="header-container">
-      <Navbar initialIsSignedIn={!!userId} />
+      <Navbar initialIsSignedIn={!!userId} initialShowDocs={showDocs} />
     </div>
   );
 }

--- a/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
+++ b/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import type { ComponentProps } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { ThemeProvider } from "../ThemeProvider";
 import { Navbar } from "../Navbar";
@@ -125,10 +126,10 @@ vi.mock("@radix-ui/react-popover", () => {
   };
 });
 
-function renderNavbar() {
+function renderNavbar(props: ComponentProps<typeof Navbar> = {}) {
   return renderToStaticMarkup(
     <ThemeProvider>
-      <Navbar />
+      <Navbar {...props} />
     </ThemeProvider>,
   );
 }
@@ -148,5 +149,10 @@ describe("Navbar blog link visibility", () => {
     const html = renderNavbar();
 
     expect(html).toContain('href="/blog"');
+  });
+
+  it("renders docs link only when the server-side feature gate allows it", () => {
+    expect(renderNavbar()).not.toContain('href="/docs"');
+    expect(renderNavbar({ initialShowDocs: true })).toContain('href="/docs"');
   });
 });

--- a/turbo/apps/web/app/components/docs/DocsShell.tsx
+++ b/turbo/apps/web/app/components/docs/DocsShell.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+import { Link } from "../../../navigation";
+import type { DocsNavigationSection } from "../../lib/docs";
+
+interface DocsShellProps {
+  navigation: DocsNavigationSection[];
+  homeLabel: string;
+  activePath?: string;
+  children: ReactNode;
+}
+
+export function DocsShell({
+  navigation,
+  homeLabel,
+  activePath,
+  children,
+}: DocsShellProps) {
+  return (
+    <div className="docs-shell">
+      <aside className="docs-sidebar" aria-label="Documentation navigation">
+        <Link
+          href="/docs"
+          className={`docs-nav-home${activePath ? "" : " active"}`}
+        >
+          {homeLabel}
+        </Link>
+        {navigation.map((section) => {
+          return (
+            <nav key={section.slug} className="docs-nav-section">
+              <h2 className="docs-nav-heading">{section.title}</h2>
+              <ul className="docs-nav-list">
+                {section.pages.map((page) => {
+                  return (
+                    <li key={page.path}>
+                      <Link
+                        href={`/docs/${page.path}`}
+                        className={`docs-nav-link${
+                          activePath === page.path ? " active" : ""
+                        }`}
+                      >
+                        {page.title}
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </nav>
+          );
+        })}
+      </aside>
+      <main className="docs-main">{children}</main>
+    </div>
+  );
+}

--- a/turbo/apps/web/app/docs.css
+++ b/turbo/apps/web/app/docs.css
@@ -1,0 +1,238 @@
+/* ===== DOCS LAYOUT ===== */
+
+.docs-hero {
+  padding: calc(var(--total-header-height) + 72px) 0 36px;
+  position: relative;
+  z-index: 1;
+}
+
+.docs-shell {
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 30px 96px;
+  box-sizing: border-box;
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  gap: 56px;
+  position: relative;
+  z-index: 1;
+}
+
+.docs-sidebar {
+  position: sticky;
+  top: calc(var(--total-header-height) + 24px);
+  align-self: start;
+  max-height: calc(100vh - var(--total-header-height) - 48px);
+  overflow-y: auto;
+  padding-right: 20px;
+  border-right: 1px solid var(--border-light);
+}
+
+.docs-main {
+  min-width: 0;
+}
+
+.docs-nav-home,
+.docs-nav-link {
+  display: block;
+  font-family: "Noto Sans", sans-serif;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition:
+    color 0.2s,
+    background 0.2s;
+}
+
+.docs-nav-home {
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 24px;
+  padding: 8px 10px;
+  border-radius: 6px;
+}
+
+.docs-nav-section {
+  margin-bottom: 28px;
+}
+
+.docs-nav-heading {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0;
+  margin: 0 0 10px;
+}
+
+.docs-nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.docs-nav-link {
+  font-size: 14px;
+  line-height: 1.35;
+  padding: 8px 10px;
+  border-radius: 6px;
+  margin-bottom: 2px;
+}
+
+.docs-nav-home:hover,
+.docs-nav-link:hover,
+.docs-nav-home.active,
+.docs-nav-link.active {
+  color: var(--accent-color);
+  background: var(--accent-color-light);
+}
+
+.docs-kicker {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--accent-color);
+  text-transform: uppercase;
+  letter-spacing: 0;
+  margin: 0 0 14px;
+}
+
+.docs-title {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 52px;
+  font-weight: 400;
+  line-height: 1.12;
+  letter-spacing: 0;
+  color: var(--text-primary);
+  margin: 0 0 18px;
+}
+
+.docs-description {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 1.7;
+  color: var(--text-secondary);
+  max-width: 760px;
+  margin: 0;
+}
+
+.docs-index-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.docs-index-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 172px;
+  padding: 22px;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: var(--card-bg);
+  color: inherit;
+  text-decoration: none;
+  transition:
+    border-color 0.2s,
+    transform 0.2s,
+    background 0.2s;
+}
+
+.docs-index-card:hover {
+  border-color: var(--accent-color);
+  background: var(--card-hover-bg);
+  transform: translateY(-2px);
+}
+
+.docs-index-section {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent-color);
+  text-transform: uppercase;
+  letter-spacing: 0;
+  margin-bottom: 14px;
+}
+
+.docs-index-card h2 {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 22px;
+  font-weight: 500;
+  line-height: 1.3;
+  color: var(--text-primary);
+  margin: 0 0 10px;
+}
+
+.docs-index-card p,
+.docs-empty {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.docs-article-header {
+  padding-top: calc(var(--total-header-height) + 48px);
+  margin-bottom: 42px;
+}
+
+.docs-updated {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-muted);
+  margin: 18px 0 0;
+}
+
+.docs-article {
+  max-width: 820px;
+  padding-bottom: 0;
+}
+
+@media (max-width: 960px) {
+  .docs-shell {
+    grid-template-columns: 1fr;
+    gap: 32px;
+    padding-bottom: 72px;
+  }
+
+  .docs-sidebar {
+    position: static;
+    max-height: none;
+    border-right: none;
+    border-bottom: 1px solid var(--border-light);
+    padding: 0 0 24px;
+  }
+
+  .docs-index-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .docs-article-header {
+    padding-top: 24px;
+  }
+}
+
+@media (max-width: 768px) {
+  .docs-hero {
+    padding: calc(var(--total-header-height) + 48px) 0 28px;
+  }
+
+  .docs-title {
+    font-size: 36px;
+    line-height: 1.2;
+  }
+
+  .docs-description {
+    font-size: 16px;
+  }
+
+  .docs-shell {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -19,6 +19,7 @@ import { env } from "../src/env";
 import "./globals.css";
 import "./landing.css";
 import "./blog.css";
+import "./docs.css";
 import "./use-cases.css";
 
 const notoSans = Noto_Sans({

--- a/turbo/apps/web/app/lib/docs/__tests__/data-source.test.ts
+++ b/turbo/apps/web/app/lib/docs/__tests__/data-source.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { buildDocsNavigation } from "../data-source";
+import type { DocsPage } from "../types";
+
+function makePage(overrides: Partial<DocsPage>): DocsPage {
+  return {
+    path: "getting-started",
+    slug: "getting-started",
+    title: "Getting Started",
+    description: "Start here.",
+    content: "Body",
+    section: { title: "Guides", slug: "guides", order: 1 },
+    order: 1,
+    publishedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-02T00:00:00.000Z",
+    readTime: "1 min read",
+    ...overrides,
+  };
+}
+
+describe("docs/data-source", () => {
+  it("groups and sorts docs navigation by section and page order", () => {
+    const navigation = buildDocsNavigation([
+      makePage({
+        path: "reference/api",
+        title: "API",
+        section: { title: "Reference", slug: "reference", order: 2 },
+        order: 1,
+      }),
+      makePage({
+        path: "guides/cli",
+        title: "CLI",
+        section: { title: "Guides", slug: "guides", order: 1 },
+        order: 2,
+      }),
+      makePage({
+        path: "getting-started",
+        title: "Getting Started",
+        section: { title: "Guides", slug: "guides", order: 1 },
+        order: 1,
+      }),
+    ]);
+
+    expect(
+      navigation.map((section) => {
+        return section.slug;
+      }),
+    ).toEqual(["guides", "reference"]);
+    expect(
+      navigation[0]?.pages.map((page) => {
+        return page.path;
+      }),
+    ).toEqual(["getting-started", "guides/cli"]);
+  });
+});

--- a/turbo/apps/web/app/lib/docs/__tests__/strapi.test.ts
+++ b/turbo/apps/web/app/lib/docs/__tests__/strapi.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../src/mocks/server";
+import { reloadEnv } from "../../../../src/env";
+import { getDocsPageByPathFromStrapi, getDocsPagesFromStrapi } from "../strapi";
+
+const STRAPI_URL = "https://test-strapi.example.com";
+
+const mockDocsPages = [
+  {
+    id: 1,
+    documentId: "doc-start",
+    title: "Getting Started",
+    description: "Start building with VM0.",
+    slug: "getting-started",
+    path: "getting-started",
+    order: 1,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-02T00:00:00.000Z",
+    publishedAt: "2026-01-01T12:00:00.000Z",
+    section: { title: "Guides", slug: "guides", order: 1 },
+    body: "# Getting Started\n\nUse VM0 to run agents.",
+  },
+  {
+    id: 2,
+    documentId: "doc-cli",
+    title: "CLI",
+    description: "Install and use the CLI.",
+    slug: "cli",
+    path: "guides/cli",
+    order: 2,
+    createdAt: "2026-01-03T00:00:00.000Z",
+    updatedAt: "2026-01-04T00:00:00.000Z",
+    publishedAt: "2026-01-03T12:00:00.000Z",
+    section: { title: "Guides", slug: "guides", order: 1 },
+    blocks: [
+      {
+        __component: "shared.rich-text",
+        id: 10,
+        body: "Install the CLI and authenticate.",
+      },
+    ],
+  },
+];
+
+beforeEach(() => {
+  vi.stubEnv("NEXT_PUBLIC_STRAPI_URL", STRAPI_URL);
+  reloadEnv();
+
+  server.use(
+    http.get(`${STRAPI_URL}/api/docs-pages`, ({ request }) => {
+      const url = new URL(request.url);
+      const pathFilter = url.searchParams.get("filters[$or][0][path][$eq]");
+      const slugFilter = url.searchParams.get("filters[$or][1][slug][$eq]");
+
+      if (pathFilter || slugFilter) {
+        const page = mockDocsPages.find((item) => {
+          return item.path === pathFilter || item.slug === slugFilter;
+        });
+        return HttpResponse.json({
+          data: page ? [page] : [],
+          meta: {},
+        });
+      }
+
+      return HttpResponse.json({
+        data: mockDocsPages,
+        meta: {},
+      });
+    }),
+  );
+});
+
+describe("docs/strapi", () => {
+  it("fetches docs pages and transforms them", async () => {
+    const pages = await getDocsPagesFromStrapi("en");
+
+    expect(pages).toHaveLength(2);
+    expect(pages[0]).toMatchObject({
+      path: "getting-started",
+      slug: "getting-started",
+      title: "Getting Started",
+      description: "Start building with VM0.",
+      content: "# Getting Started\n\nUse VM0 to run agents.",
+      section: { title: "Guides", slug: "guides", order: 1 },
+      order: 1,
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+    expect(pages[0]?.readTime).toMatch(/\d+ min read/);
+  });
+
+  it("fetches a single docs page by path", async () => {
+    let capturedLocale: string | null = null;
+    let capturedPath: string | null = null;
+
+    server.use(
+      http.get(`${STRAPI_URL}/api/docs-pages`, ({ request }) => {
+        const url = new URL(request.url);
+        capturedLocale = url.searchParams.get("locale");
+        capturedPath = url.searchParams.get("filters[$or][0][path][$eq]");
+        return HttpResponse.json({
+          data: [mockDocsPages[1]],
+          meta: {},
+        });
+      }),
+    );
+
+    const page = await getDocsPageByPathFromStrapi("guides/cli", "en");
+
+    expect(capturedLocale).toBe("en");
+    expect(capturedPath).toBe("guides/cli");
+    expect(page).toMatchObject({
+      path: "guides/cli",
+      slug: "cli",
+      content: "Install the CLI and authenticate.",
+    });
+  });
+
+  it("returns null when a docs page is not found", async () => {
+    const page = await getDocsPageByPathFromStrapi("missing", "en");
+
+    expect(page).toBeNull();
+  });
+
+  it("returns an empty list when the docs collection is not available", async () => {
+    server.use(
+      http.get(`${STRAPI_URL}/api/docs-pages`, () => {
+        return HttpResponse.json(
+          {
+            data: null,
+            error: {
+              status: 404,
+              name: "NotFoundError",
+              message: "Not Found",
+              details: {},
+            },
+          },
+          { status: 404, statusText: "Not Found" },
+        );
+      }),
+    );
+
+    await expect(getDocsPagesFromStrapi("en")).resolves.toEqual([]);
+  });
+
+  it("returns null when the docs collection is not available for a page", async () => {
+    server.use(
+      http.get(`${STRAPI_URL}/api/docs-pages`, () => {
+        return HttpResponse.json(
+          {
+            data: null,
+            error: {
+              status: 404,
+              name: "NotFoundError",
+              message: "Not Found",
+              details: {},
+            },
+          },
+          { status: 404, statusText: "Not Found" },
+        );
+      }),
+    );
+
+    await expect(
+      getDocsPageByPathFromStrapi("getting-started", "en"),
+    ).resolves.toBeNull();
+  });
+
+  it("requests draft content when draft option is set", async () => {
+    let capturedStatus: string | null = null;
+
+    server.use(
+      http.get(`${STRAPI_URL}/api/docs-pages`, ({ request }) => {
+        const url = new URL(request.url);
+        capturedStatus = url.searchParams.get("status");
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+    );
+
+    await getDocsPageByPathFromStrapi("getting-started", "en", {
+      draft: true,
+    });
+
+    expect(capturedStatus).toBe("draft");
+  });
+
+  it("throws when Strapi fetch fails", async () => {
+    server.use(
+      http.get(`${STRAPI_URL}/api/docs-pages`, () => {
+        return new HttpResponse(null, {
+          status: 500,
+          statusText: "Internal Server Error",
+        });
+      }),
+    );
+
+    await expect(getDocsPagesFromStrapi("en")).rejects.toThrow(
+      "Failed to fetch docs pages: 500 Internal Server Error",
+    );
+  });
+});

--- a/turbo/apps/web/app/lib/docs/access.ts
+++ b/turbo/apps/web/app/lib/docs/access.ts
@@ -1,0 +1,30 @@
+import { auth } from "@clerk/nextjs/server";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { env } from "../../../src/env";
+import { loadFeatureSwitchOverrides } from "../../../src/lib/zero/user/feature-switches-service";
+
+export async function canViewDocsForUser(
+  userId: string | null | undefined,
+  orgId: string | null | undefined,
+): Promise<boolean> {
+  if (!userId || !env().NEXT_PUBLIC_STRAPI_URL) {
+    return false;
+  }
+
+  const overrides = await loadFeatureSwitchOverrides(
+    orgId ?? undefined,
+    userId,
+  );
+
+  return isFeatureEnabled(FeatureSwitchKey.DocsSite, {
+    userId,
+    orgId: orgId ?? undefined,
+    overrides,
+  });
+}
+
+export async function canViewDocs(): Promise<boolean> {
+  const { userId, orgId } = await auth();
+  return canViewDocsForUser(userId, orgId);
+}

--- a/turbo/apps/web/app/lib/docs/config.ts
+++ b/turbo/apps/web/app/lib/docs/config.ts
@@ -1,0 +1,5 @@
+import { env } from "../../../src/env";
+
+export function getDocsBaseUrl(): string {
+  return env().NEXT_PUBLIC_BASE_URL || "https://www.vm0.ai";
+}

--- a/turbo/apps/web/app/lib/docs/data-source.ts
+++ b/turbo/apps/web/app/lib/docs/data-source.ts
@@ -1,0 +1,83 @@
+import type {
+  DocsNavigationPage,
+  DocsNavigationSection,
+  DocsPage,
+} from "./types";
+import { getDocsPageByPathFromStrapi, getDocsPagesFromStrapi } from "./strapi";
+
+export async function getDocsPages(locale: string = "en"): Promise<DocsPage[]> {
+  return getDocsPagesFromStrapi(locale);
+}
+
+export async function getDocsPage(
+  path: string,
+  locale: string = "en",
+  options: { draft?: boolean } = {},
+): Promise<DocsPage | null> {
+  return getDocsPageByPathFromStrapi(path, locale, options);
+}
+
+export function buildDocsNavigation(
+  pages: DocsPage[],
+): DocsNavigationSection[] {
+  const sections = new Map<string, DocsNavigationSection>();
+
+  for (const page of pages) {
+    if (!page.path) continue;
+
+    const existing = sections.get(page.section.slug);
+    const section =
+      existing ??
+      ({
+        title: page.section.title,
+        slug: page.section.slug,
+        order: page.section.order,
+        pages: [],
+      } satisfies DocsNavigationSection);
+
+    const navPage: DocsNavigationPage = {
+      path: page.path,
+      title: page.title,
+      description: page.description,
+      order: page.order,
+    };
+
+    section.pages.push(navPage);
+    sections.set(section.slug, section);
+  }
+
+  return Array.from(sections.values())
+    .map((section) => {
+      return {
+        ...section,
+        pages: section.pages.sort((a, b) => {
+          return a.order - b.order || a.title.localeCompare(b.title);
+        }),
+      };
+    })
+    .sort((a, b) => {
+      return a.order - b.order || a.title.localeCompare(b.title);
+    });
+}
+
+export async function getDocsNavigation(
+  locale: string = "en",
+): Promise<DocsNavigationSection[]> {
+  return buildDocsNavigation(await getDocsPages(locale));
+}
+
+export async function getDocsAvailableLocales(
+  path: string,
+  supportedLocales: readonly string[],
+): Promise<string[]> {
+  const checks = await Promise.all(
+    supportedLocales.map(async (locale) => {
+      const page = await getDocsPage(path, locale);
+      return page ? locale : null;
+    }),
+  );
+
+  return checks.filter((locale): locale is string => {
+    return locale !== null;
+  });
+}

--- a/turbo/apps/web/app/lib/docs/index.ts
+++ b/turbo/apps/web/app/lib/docs/index.ts
@@ -1,0 +1,10 @@
+export {
+  buildDocsNavigation,
+  getDocsAvailableLocales,
+  getDocsNavigation,
+  getDocsPage,
+  getDocsPages,
+} from "./data-source";
+export { canViewDocs, canViewDocsForUser } from "./access";
+export { getDocsBaseUrl } from "./config";
+export type { DocsNavigationSection } from "./types";

--- a/turbo/apps/web/app/lib/docs/strapi.ts
+++ b/turbo/apps/web/app/lib/docs/strapi.ts
@@ -1,0 +1,254 @@
+import { env } from "../../../src/env";
+import type { DocsPage, DocsSection } from "./types";
+
+function getStrapiUrl(): string {
+  const url = env().NEXT_PUBLIC_STRAPI_URL;
+  if (!url) {
+    throw new Error(
+      "NEXT_PUBLIC_STRAPI_URL environment variable is not configured",
+    );
+  }
+  return url;
+}
+
+interface StrapiResponse<T> {
+  data: T;
+  meta: {
+    pagination?: {
+      page: number;
+      pageSize: number;
+      pageCount: number;
+      total: number;
+    };
+  };
+}
+
+async function parseJsonResponse<T>(res: Response, url: string): Promise<T> {
+  const text = await res.text();
+  if (!text) {
+    throw new Error(`Strapi returned empty response for ${url}`);
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch (cause) {
+    throw new Error(
+      `Strapi returned invalid JSON for ${url}: ${text.slice(0, 200)}`,
+      { cause },
+    );
+  }
+}
+
+interface StrapiBlock {
+  __component: string;
+  id: number;
+  body?: string;
+  title?: string;
+}
+
+interface StrapiDocsSection {
+  title?: string;
+  name?: string;
+  slug?: string;
+  order?: number;
+}
+
+interface StrapiDocsPage {
+  id: number;
+  documentId?: string;
+  title: string;
+  description?: string;
+  slug?: string;
+  path?: string;
+  body?: string;
+  content?: string;
+  order?: number;
+  createdAt: string;
+  updatedAt?: string;
+  publishedAt?: string;
+  section?: StrapiDocsSection;
+  blocks?: StrapiBlock[];
+}
+
+function normalizeDocsPath(value: string | undefined): string {
+  return (value ?? "")
+    .trim()
+    .replace(/^\/+|\/+$/g, "")
+    .replace(/\/+/g, "/");
+}
+
+function slugify(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "docs";
+}
+
+function getBlockContent(blocks: StrapiBlock[] | undefined): string {
+  if (!blocks?.length) return "";
+
+  return blocks
+    .map((block) => {
+      if (block.__component === "shared.rich-text" && block.body) {
+        return block.body;
+      }
+      if (block.__component === "shared.quote" && block.body) {
+        return `> **${block.title || ""}**\n> ${block.body}`;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function resolvePathAndSlug(page: StrapiDocsPage): {
+  path: string;
+  slug: string;
+} {
+  const fallbackSlug = String(page.id);
+  const path = normalizeDocsPath(
+    page.path || page.slug || page.documentId || fallbackSlug,
+  );
+  const slug =
+    path.split("/").filter(Boolean).at(-1) || page.slug || fallbackSlug;
+  return { path, slug };
+}
+
+function resolveSection(section: StrapiDocsSection | undefined): DocsSection {
+  const sectionTitle = section?.title || section?.name || "Docs";
+  const sectionSlug = section?.slug || slugify(sectionTitle);
+  return {
+    title: sectionTitle,
+    slug: sectionSlug,
+    order: section?.order ?? 0,
+  };
+}
+
+function resolveContent(page: StrapiDocsPage): string {
+  const candidates = [
+    page.body,
+    page.content,
+    getBlockContent(page.blocks),
+    page.description,
+  ];
+  return (
+    candidates.find((candidate) => {
+      return Boolean(candidate);
+    }) || ""
+  );
+}
+
+function transformDocsPage(page: StrapiDocsPage): DocsPage {
+  const { path, slug } = resolvePathAndSlug(page);
+  const content = resolveContent(page);
+  const wordCount = content.trim() ? content.trim().split(/\s+/).length : 0;
+  const readTime = Math.max(1, Math.ceil(wordCount / 200));
+  const updatedAt = page.updatedAt || page.publishedAt || page.createdAt;
+  const publishedAt = page.publishedAt || page.createdAt;
+
+  return {
+    path,
+    slug,
+    title: page.title,
+    description: page.description || "",
+    content,
+    section: resolveSection(page.section),
+    order: page.order ?? 0,
+    publishedAt,
+    updatedAt,
+    readTime: `${readTime} min read`,
+  };
+}
+
+function compareDocsPages(a: DocsPage, b: DocsPage): number {
+  return (
+    a.section.order - b.section.order ||
+    a.section.title.localeCompare(b.section.title) ||
+    a.order - b.order ||
+    a.title.localeCompare(b.title)
+  );
+}
+
+function buildBaseDocsParams(locale: string): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set("locale", locale);
+  params.set("pagination[pageSize]", "100");
+  params.append("populate[0]", "section");
+  params.append("populate[1]", "blocks");
+  params.append("sort[0]", "order:asc");
+  params.append("sort[1]", "title:asc");
+  return params;
+}
+
+export async function getDocsPagesFromStrapi(
+  locale: string = "en",
+): Promise<DocsPage[]> {
+  const params = buildBaseDocsParams(locale);
+  const url = `${getStrapiUrl()}/api/docs-pages?${params.toString()}`;
+
+  const res = await fetch(url, {
+    next: { revalidate: 3600 },
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (res.status === 404) {
+    return [];
+  }
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch docs pages: ${res.status} ${res.statusText}`,
+    );
+  }
+
+  const data = await parseJsonResponse<StrapiResponse<StrapiDocsPage[]>>(
+    res,
+    url,
+  );
+  return data.data.map(transformDocsPage).sort(compareDocsPages);
+}
+
+export async function getDocsPageByPathFromStrapi(
+  path: string,
+  locale: string = "en",
+  options: { draft?: boolean } = {},
+): Promise<DocsPage | null> {
+  const normalizedPath = normalizeDocsPath(path);
+  const params = buildBaseDocsParams(locale);
+  params.set("filters[$or][0][path][$eq]", normalizedPath);
+  params.set("filters[$or][1][slug][$eq]", normalizedPath);
+  if (options.draft) {
+    params.set("status", "draft");
+  }
+
+  const url = `${getStrapiUrl()}/api/docs-pages?${params.toString()}`;
+
+  const res = await fetch(url, {
+    ...(options.draft
+      ? { cache: "no-store" as const }
+      : { next: { revalidate: 3600 } }),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (res.status === 404) {
+    return null;
+  }
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch docs page: ${res.status} ${res.statusText}`,
+    );
+  }
+
+  const data = await parseJsonResponse<StrapiResponse<StrapiDocsPage[]>>(
+    res,
+    url,
+  );
+
+  if (data.data.length === 0) {
+    return null;
+  }
+
+  return transformDocsPage(data.data[0]!);
+}

--- a/turbo/apps/web/app/lib/docs/types.ts
+++ b/turbo/apps/web/app/lib/docs/types.ts
@@ -1,0 +1,32 @@
+export interface DocsSection {
+  title: string;
+  slug: string;
+  order: number;
+}
+
+export interface DocsPage {
+  path: string;
+  slug: string;
+  title: string;
+  description: string;
+  content: string;
+  section: DocsSection;
+  order: number;
+  publishedAt: string;
+  updatedAt: string;
+  readTime: string;
+}
+
+export interface DocsNavigationPage {
+  path: string;
+  title: string;
+  description: string;
+  order: number;
+}
+
+export interface DocsNavigationSection {
+  title: string;
+  slug: string;
+  order: number;
+  pages: DocsNavigationPage[];
+}

--- a/turbo/apps/web/app/sitemap.ts
+++ b/turbo/apps/web/app/sitemap.ts
@@ -25,14 +25,18 @@ function buildAlternates(
   return languages;
 }
 
+async function getDefaultPosts() {
+  if (!isBlogEnabled()) return [];
+
+  return getPosts(defaultLocale).catch(() => {
+    return [];
+  });
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // Pre-fetch blog posts once so we can both emit post URLs and derive a
   // realistic lastmod for the /blog index from the most recent post.
-  const defaultPosts = isBlogEnabled()
-    ? await getPosts(defaultLocale).catch(() => {
-        return [];
-      })
-    : [];
+  const defaultPosts = await getDefaultPosts();
 
   const latestPostDate = defaultPosts.reduce<Date>((latest, post) => {
     const postDate = new Date(post.publishedAt);

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -79,6 +79,7 @@
   },
   "nav": {
     "docs": "Dokumente",
+    "docsDesc": "Anleitungen und Produktdokumentation",
     "blog": "Blog",
     "skills": "Skills",
     "pricing": "Preise",
@@ -279,6 +280,15 @@
       "Utilities": "Dienstprogramme",
       "Other": "Sonstiges"
     }
+  },
+  "docs": {
+    "title": "Dokumente",
+    "kicker": "Dokumentation",
+    "home": "Dokumente",
+    "description": "Anleitungen, Referenzen und Setup-Hinweise für VM0.",
+    "backToDocs": "Zurück zu den Dokumenten",
+    "lastUpdated": "Zuletzt aktualisiert am {date}",
+    "empty": "Die Dokumentation wird vorbereitet."
   },
   "blog": {
     "title": "Blog",

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -79,6 +79,7 @@
   },
   "nav": {
     "docs": "Docs",
+    "docsDesc": "Guides and product documentation",
     "blog": "Blog",
     "skills": "Skills",
     "pricing": "Pricing",
@@ -279,6 +280,15 @@
       "Utilities": "Utilities",
       "Other": "Other"
     }
+  },
+  "docs": {
+    "title": "Docs",
+    "kicker": "Documentation",
+    "home": "Docs home",
+    "description": "Guides, references, and setup notes for building with VM0.",
+    "backToDocs": "Back to docs",
+    "lastUpdated": "Last updated {date}",
+    "empty": "Documentation is being prepared."
   },
   "blog": {
     "title": "Blog",

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -79,6 +79,7 @@
   },
   "nav": {
     "docs": "Documentos",
+    "docsDesc": "Guías y documentación del producto",
     "blog": "Blog",
     "skills": "Skills",
     "pricing": "Precios",
@@ -279,6 +280,15 @@
       "Utilities": "Utilidades",
       "Other": "Otros"
     }
+  },
+  "docs": {
+    "title": "Documentos",
+    "kicker": "Documentación",
+    "home": "Inicio de documentos",
+    "description": "Guías, referencias y notas de configuración para VM0.",
+    "backToDocs": "Volver a documentos",
+    "lastUpdated": "Última actualización: {date}",
+    "empty": "La documentación se está preparando."
   },
   "blog": {
     "title": "Blog",

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -79,6 +79,7 @@
   },
   "nav": {
     "docs": "ドキュメント",
+    "docsDesc": "ガイドと製品ドキュメント",
     "blog": "ブログ",
     "skills": "Skills",
     "pricing": "料金",
@@ -279,6 +280,15 @@
       "Utilities": "ユーティリティ",
       "Other": "その他"
     }
+  },
+  "docs": {
+    "title": "ドキュメント",
+    "kicker": "ドキュメント",
+    "home": "ドキュメントホーム",
+    "description": "VM0 のガイド、リファレンス、セットアップ情報です。",
+    "backToDocs": "ドキュメントに戻る",
+    "lastUpdated": "最終更新日: {date}",
+    "empty": "ドキュメントを準備しています。"
   },
   "blog": {
     "title": "ブログ",

--- a/turbo/apps/web/public/assets/nav/docs.svg
+++ b/turbo/apps/web/public/assets/nav/docs.svg
@@ -1,0 +1,37 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="64"
+  height="64"
+  viewBox="0 0 64 64"
+  fill="none"
+>
+  <rect width="64" height="64" rx="14" fill="#222222" />
+  <path
+    d="M20 14H38L48 24V50H20V14Z"
+    fill="#2D2D2D"
+    stroke="#ED4E01"
+    stroke-width="3"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M38 14V24H48"
+    stroke="#ED4E01"
+    stroke-width="3"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M27 32H41"
+    stroke="#FFFFFF"
+    stroke-opacity="0.85"
+    stroke-width="3"
+    stroke-linecap="round"
+  />
+  <path
+    d="M27 40H37"
+    stroke="#FFFFFF"
+    stroke-opacity="0.55"
+    stroke-width="3"
+    stroke-linecap="round"
+  />
+</svg>

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -45,6 +45,7 @@ export enum FeatureSwitchKey {
   QueueMessage = "queueMessage",
   ChatThreadPin = "chatThreadPin",
   ChatThreadRename = "chatThreadRename",
+  DocsSite = "docsSite",
   FreshdeskConnector = "freshdeskConnector",
   StabilityAiConnector = "stabilityAiConnector",
   ZoomConnector = "zoomConnector",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -80,6 +80,14 @@ describe("isFeatureEnabled", () => {
       }),
     ).toBe(true);
   });
+
+  it("should enable docs site for staff orgs", () => {
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.DocsSite, {
+        orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("getAllFeatureStates", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -246,6 +246,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Adds a Rename chat item to the sidebar thread kebab menu. When the user renames a thread, automated title generation is suppressed for that thread.",
     enabled: false,
   },
+  [FeatureSwitchKey.DocsSite]: {
+    maintainer: "linghan@vm0.ai",
+    description:
+      "Enable the authenticated Strapi-backed docs site routes, navigation entry, and docs pages. Staff-only during rollout; per-user toggle via Lab.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.FreshdeskConnector]: {
     maintainer: "ethan@vm0.ai",
     description: "Enable the Freshdesk helpdesk connector",


### PR DESCRIPTION
## Summary
- add a Strapi-backed authenticated docs data layer with page, navigation, draft, locale, and content rendering support
- add docs routes for `/:locale/docs` and `/:locale/docs/[...slug]`, gated by `FeatureSwitchKey.DocsSite` and Strapi availability
- wire the Docs navbar entry behind the server-side feature gate, add localized copy, styling, and docs nav asset

Refs #12326

## Testing
- `pnpm --filter @vm0/core test feature-switch.test.ts`
- `pnpm --filter web test app/lib/docs/__tests__/strapi.test.ts app/lib/docs/__tests__/data-source.test.ts app/components/__tests__/navbar-blog.test.tsx`
- `pnpm --filter @vm0/connectors check-types`
- `pnpm --filter @vm0/core check-types`
- `pnpm --filter web check-types`
- `pnpm --filter web lint`
- `pnpm --filter @vm0/core lint`
- `pnpm --filter @vm0/connectors lint`
- pre-commit: `prettier`, `knip --cache`, full `turbo run check-types --concurrency=1`
