### PR TITLE
refactor(api): migrate feature switches get

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -4,7 +4,6 @@ import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-f
 import { createStore } from "ccstate";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import {
   deleteFeatureSwitches$,
   seedFeatureSwitches$,
@@ -24,6 +23,40 @@ describe("GET /api/zero/feature-switches", () => {
     return store.set(deleteFeatureSwitches$, fixture, context.signal);
   });
 
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroFeatureSwitchesContract);
+
+    const response = await accept(client.get({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const client = setupApp({ context })(zeroFeatureSwitchesContract);
+
+    const response = await accept(
+      client.get({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
   it("returns persisted feature switch overrides", async () => {
     const fixture = await track(
       store.set(
@@ -36,7 +69,6 @@ describe("GET /api/zero/feature-switches", () => {
       ),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
-    mockApiShadowCompareRoutes([zeroFeatureSwitchesContract.get]);
 
     const client = setupApp({ context })(zeroFeatureSwitchesContract);
 
@@ -59,7 +91,6 @@ describe("GET /api/zero/feature-switches", () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
-    mockApiShadowCompareRoutes([zeroFeatureSwitchesContract.get]);
 
     const client = setupApp({ context })(zeroFeatureSwitchesContract);
 

--- a/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
@@ -3,7 +3,6 @@ import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-f
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import type { RouteEntry } from "../route";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 
@@ -21,12 +20,9 @@ const getFeatureSwitchesInner$ = computed(async (get): Promise<unknown> => {
 export const zeroFeatureSwitchesRoutes: readonly RouteEntry[] = [
   {
     route: zeroFeatureSwitchesContract.get,
-    handler: shadowCompareRoute({
-      route: zeroFeatureSwitchesContract.get,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        getFeatureSwitchesInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      getFeatureSwitchesInner$,
+    ),
   },
 ];


### PR DESCRIPTION
Closes #12331

## Summary
- Make `GET /api/zero/feature-switches` authoritative in `apps/api` by removing the `shadowCompareRoute(...)` wrapper
- Add API route coverage for unauthenticated and missing-organization 401 paths
- Preserve existing 200 default `{}` and 200 persisted-switches cases
- POST and DELETE remain on `apps/web` for separate Stage 3 issues — no `apps/web/**` files are modified

## Behavior parity
The api `userFeatureSwitchOverrides` Computed and the web `getUserFeatureSwitches` already query the same `user_feature_switches` table with the same `(orgId, userId)` predicate and return `{}` when no row exists. Removing the shadow wrapper does not change observable behavior — verified before this change.

## Test cases (final)
1. `returns 401 when the request is unauthenticated` (NEW)
2. `returns 401 when the authenticated session has no organization` (NEW)
3. `returns persisted feature switch overrides` (existing)
4. `returns empty switches when no override row exists` (existing)

## Test plan
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feature-switches.test.ts` — 4/4 passed
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] Pre-commit: prettier, knip, `turbo run check-types`, commitlint — all green

## Rollback
Disable the `apiBackend` feature switch — traffic returns to `apps/web`. No DB or schema change.