### PR TITLE
refactor(api): migrate zero queue-position get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-queue-position.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-queue-position.test.ts
@@ -5,7 +5,6 @@ import { createStore } from "ccstate";
 
 import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import {
   deleteQueuePositionRuns$,
   seedQueuePositionRuns$,
@@ -25,6 +24,37 @@ describe("GET /api/zero/queue-position", () => {
     return store.set(deleteQueuePositionRuns$, fixture, context.signal);
   });
 
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroQueuePositionContract);
+
+    const response = await accept(
+      client.getPosition({
+        query: { runId: randomUUID() },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 400 when runId is missing before auth", async () => {
+    const app = createApp({
+      signal: context.signal,
+    });
+
+    const response = await app.request("/api/zero/queue-position", {
+      method: "GET",
+    });
+
+    expect(response.status).toBe(400);
+    const body: unknown = await response.json();
+    expect(body).toMatchObject({
+      error: { code: "BAD_REQUEST" },
+    });
+    expect(JSON.stringify(body)).toContain("runId");
+  });
+
   it("returns the queued run position within the org queue", async () => {
     const fixture = await track(
       store.set(seedQueuePositionRuns$, { queuedRuns: 2 }, context.signal),
@@ -34,7 +64,6 @@ describe("GET /api/zero/queue-position", () => {
     if (!runId) {
       throw new Error("Expected queued run fixture");
     }
-    mockApiShadowCompareRoutes([zeroQueuePositionContract.getPosition]);
 
     const client = setupApp({ context })(zeroQueuePositionContract);
 
@@ -61,7 +90,6 @@ describe("GET /api/zero/queue-position", () => {
     if (!runId) {
       throw new Error("Expected unqueued run fixture");
     }
-    mockApiShadowCompareRoutes([zeroQueuePositionContract.getPosition]);
 
     const client = setupApp({ context })(zeroQueuePositionContract);
 
@@ -88,7 +116,6 @@ describe("GET /api/zero/queue-position", () => {
     if (!runId) {
       throw new Error("Expected queued run fixture");
     }
-    mockApiShadowCompareRoutes([zeroQueuePositionContract.getPosition]);
 
     const client = setupApp({ context })(zeroQueuePositionContract);
 
@@ -103,9 +130,34 @@ describe("GET /api/zero/queue-position", () => {
     expect(response.body.error.code).toBe("NOT_FOUND");
   });
 
-  it("returns 404 for an unknown run", async () => {
-    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
-    mockApiShadowCompareRoutes([zeroQueuePositionContract.getPosition]);
+  it("returns 404 for a run from a different org", async () => {
+    const fixture = await track(
+      store.set(seedQueuePositionRuns$, { queuedRuns: 1 }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, `org_${randomUUID()}`);
+    const runId = fixture.queuedRunIds[0];
+    if (!runId) {
+      throw new Error("Expected queued run fixture");
+    }
+
+    const client = setupApp({ context })(zeroQueuePositionContract);
+
+    const response = await accept(
+      client.getPosition({
+        query: { runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 404 when an authenticated user requests an unknown run", async () => {
+    const fixture = await track(
+      store.set(seedQueuePositionRuns$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(zeroQueuePositionContract);
 
@@ -118,23 +170,5 @@ describe("GET /api/zero/queue-position", () => {
     );
 
     expect(response.body.error.code).toBe("NOT_FOUND");
-  });
-
-  it("returns 400 when runId is missing before auth", async () => {
-    mockApiShadowCompareRoutes([zeroQueuePositionContract.getPosition]);
-    const app = createApp({
-      signal: context.signal,
-    });
-
-    const response = await app.request("/api/zero/queue-position", {
-      method: "GET",
-    });
-
-    expect(response.status).toBe(400);
-    const body: unknown = await response.json();
-    expect(body).toMatchObject({
-      error: { code: "BAD_REQUEST" },
-    });
-    expect(JSON.stringify(body)).toContain("runId");
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-queue-position.ts
+++ b/turbo/apps/api/src/signals/routes/zero-queue-position.ts
@@ -5,7 +5,6 @@ import { notFound } from "../../lib/error";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import type { RouteEntry } from "../route";
 import { queuePosition } from "../services/queue-position.service";
 
@@ -35,9 +34,6 @@ const getQueuePositionInner$ = computed(async (get): Promise<unknown> => {
 export const zeroQueuePositionRoutes: readonly RouteEntry[] = [
   {
     route: zeroQueuePositionContract.getPosition,
-    handler: shadowCompareRoute({
-      route: zeroQueuePositionContract.getPosition,
-      handler: authRoute({}, getQueuePositionInner$),
-    }),
+    handler: authRoute({}, getQueuePositionInner$),
   },
 ];


### PR DESCRIPTION
## Summary

- Promote `GET /api/zero/queue-position` from shadow-compared to api-authoritative under the `apiBackend` feature switch (Stage 2 read-only migration of #12290).
- Drop the `shadowCompareRoute` wrapper from `zero-queue-position.ts`; handler is now `authRoute({}, getQueuePositionInner$)` directly.
- Drop `mockApiShadowCompareRoutes(...)` from every test case in `zero-queue-position.test.ts`.
- Port the missing `apps/web` GET parity cases: 401 unauthenticated and 404 cross-org. Tighten the existing "unknown run" case to mirror web's setup of an authenticated user requesting a random `runId`.

The api `queuePosition` service already mirrors the web route's three-step query (run lookup by `id+userId+orgId?` → queue entry by `runId` → ahead-of count by `orgId+createdAt<=`); no service change required.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-queue-position.test.ts` — 7 tests pass.
- [x] `pnpm -F api lint` — 0 warnings, 0 errors.
- [x] `pnpm -F api check-types` — clean.
- [x] Diff scope verified: only `zero-queue-position.ts` and its test file. No `apps/web/**` changes.

## Rollback

Disable the `apiBackend` feature switch to route traffic back to `apps/web`. No DB or schema changes.

Closes #12332