### PR TITLE
refactor(api): migrate team get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-team.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-team.ts
@@ -1,0 +1,94 @@
+import { randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { inArray } from "drizzle-orm";
+
+import { writeDb$ } from "../../../external/db";
+
+export interface TeamComposeFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly composeIds: readonly string[];
+}
+
+interface SeedComposeRow {
+  readonly displayName?: string | null;
+  readonly description?: string | null;
+  readonly sound?: string | null;
+  readonly avatarUrl?: string | null;
+  readonly headVersionId?: string | null;
+  readonly withZeroAgent?: boolean;
+}
+
+interface SeedTeamComposeValues {
+  readonly orgId?: string;
+  readonly userId?: string;
+  readonly composes?: readonly SeedComposeRow[];
+}
+
+export const seedTeamCompose$ = command(
+  async (
+    { set },
+    values: SeedTeamComposeValues,
+    signal: AbortSignal,
+  ): Promise<TeamComposeFixture> => {
+    const orgId = values.orgId ?? `org_${randomUUID()}`;
+    const userId = values.userId ?? `user_${randomUUID()}`;
+    const writeDb = set(writeDb$);
+    const composeRows = values.composes ?? [];
+    const composeIds: string[] = [];
+
+    for (const row of composeRows) {
+      const composeId = randomUUID();
+      composeIds.push(composeId);
+
+      await writeDb.insert(agentComposes).values({
+        id: composeId,
+        userId,
+        orgId,
+        name: `agent-${composeId.slice(0, 8)}`,
+        headVersionId: row.headVersionId ?? null,
+      });
+      signal.throwIfAborted();
+
+      if (row.withZeroAgent !== false) {
+        await writeDb.insert(zeroAgents).values({
+          id: composeId,
+          orgId,
+          owner: userId,
+          name: `agent-${composeId.slice(0, 8)}`,
+          displayName: row.displayName ?? null,
+          description: row.description ?? null,
+          sound: row.sound ?? null,
+          avatarUrl: row.avatarUrl ?? null,
+        });
+        signal.throwIfAborted();
+      }
+    }
+
+    return { orgId, userId, composeIds };
+  },
+);
+
+export const deleteTeamCompose$ = command(
+  async (
+    { set },
+    fixture: TeamComposeFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    if (fixture.composeIds.length === 0) {
+      return;
+    }
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(zeroAgents)
+      .where(inArray(zeroAgents.id, [...fixture.composeIds]));
+    signal.throwIfAborted();
+    await writeDb
+      .delete(agentComposes)
+      .where(inArray(agentComposes.id, [...fixture.composeIds]));
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-team.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-team.test.ts
@@ -1,0 +1,162 @@
+import { zeroTeamContract } from "@vm0/api-contracts/contracts/zero-team";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteTeamCompose$,
+  seedTeamCompose$,
+  type TeamComposeFixture,
+} from "./helpers/zero-team";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/team", () => {
+  const track = createFixtureTracker<TeamComposeFixture>((fixture) => {
+    return store.set(deleteTeamCompose$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroTeamContract);
+
+    const response = await accept(client.list({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 403 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, { composes: [] }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+
+    const client = setupApp({ context })(zeroTeamContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "No active organization. Please select an org.",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns an empty list when the active org has no composes", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, { composes: [] }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroTeamContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual([]);
+  });
+
+  it("returns the composes belonging to the active org", async () => {
+    const fixture = await track(
+      store.set(
+        seedTeamCompose$,
+        {
+          composes: [
+            {
+              displayName: "team-agent",
+              description: "team description",
+              sound: "ding",
+              avatarUrl: "https://example.com/avatar.png",
+              headVersionId: "version-1",
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroTeamContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual([
+      {
+        id: fixture.composeIds[0],
+        ownerId: fixture.userId,
+        displayName: "team-agent",
+        description: "team description",
+        sound: "ding",
+        avatarUrl: "https://example.com/avatar.png",
+        headVersionId: "version-1",
+        updatedAt: expect.any(String),
+      },
+    ]);
+  });
+
+  it("does not include composes from other orgs", async () => {
+    const myFixture = await track(
+      store.set(
+        seedTeamCompose$,
+        {
+          composes: [{ displayName: "my-agent" }],
+        },
+        context.signal,
+      ),
+    );
+    const otherFixture = await track(
+      store.set(
+        seedTeamCompose$,
+        {
+          composes: [{ displayName: "other-agent" }],
+        },
+        context.signal,
+      ),
+    );
+
+    mocks.clerk.session(myFixture.userId, myFixture.orgId);
+
+    const client = setupApp({ context })(zeroTeamContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toHaveLength(1);
+    const [only] = response.body;
+    expect(only?.id).toBe(myFixture.composeIds[0]);
+    expect(only?.displayName).toBe("my-agent");
+    expect(
+      response.body.map((c) => {
+        return c.id;
+      }),
+    ).not.toContain(otherFixture.composeIds[0]);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-team.ts
+++ b/turbo/apps/api/src/signals/routes/zero-team.ts
@@ -3,7 +3,6 @@ import { zeroTeamContract } from "@vm0/api-contracts/contracts/zero-team";
 
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { zeroTeam } from "../services/zero-agent-data.service";
 import type { RouteEntry } from "../route";
 
@@ -30,9 +29,6 @@ const listTeamInner$ = computed(async (get) => {
 export const zeroTeamRoutes: readonly RouteEntry[] = [
   {
     route: zeroTeamContract.list,
-    handler: shadowCompareRoute({
-      route: zeroTeamContract.list,
-      handler: authRoute({}, listTeamInner$),
-    }),
+    handler: authRoute({}, listTeamInner$),
   },
 ];


### PR DESCRIPTION
## Summary

- make `GET /api/zero/team` API-authoritative by removing the `shadowCompareRoute(...)` wrapper
- add api-side integration tests (1:1 with the existing web tests)
- introduce `helpers/zero-team.ts` for compose seeding/cleanup

Closes #12334

Part of epic #12290.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-team.test.ts` (5 / 5 passing)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm format`
- `pnpm knip`

## Test cases (1:1 with web)

| # | Case | Expected |
|---|------|----------|
| 1 | unauthenticated | 401 UNAUTHORIZED |
| 2 | session without active org | 403 FORBIDDEN |
| 3 | active org with no composes | 200 `[]` |
| 4 | active org with one compose (full field check) | 200 with strict-equal body |
| 5 | cross-org isolation (two fixtures, two orgs) | 200 returning only the active-org compose |

## Behavioral note

`apps/web` returns 404 if `resolveOrg` rejects with not-found / forbidden. The api implementation skips `resolveOrg` because Clerk only sets active `orgId` on sessions where the user is a member, so the membership check is unreachable in production. Same simplification as PRs #12312 / #12314 / #12315. The contract still declares 404 because `apps/web` may continue to emit it during the rollback window.

## Rollback

Disabling the `apiBackend` feature switch routes traffic back to `apps/web`. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)