### PR TITLE
refactor(api): migrate onboarding status get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-onboarding-status.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-onboarding-status.ts
@@ -76,6 +76,82 @@ export const seedOnboardingStatusOrg$ = command(
   },
 );
 
+// Seeds an org whose `default_agent_id` points to an `agent_composes` row that
+// has no matching `zero_agents` row — the partial-onboarding state where the
+// admin should re-enter full onboarding.
+export const seedOrphanDefaultAgent$ = command(
+  async (
+    { set },
+    _: void,
+    signal: AbortSignal,
+  ): Promise<OnboardingStatusFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const composeId = randomUUID();
+    const writeDb = set(writeDb$);
+
+    await writeDb.insert(agentComposes).values({
+      id: composeId,
+      userId,
+      orgId,
+      name: `agent-${composeId.slice(0, 8)}`,
+    });
+    signal.throwIfAborted();
+
+    await writeDb.insert(orgMetadata).values({
+      orgId,
+      defaultAgentId: composeId,
+    });
+    signal.throwIfAborted();
+
+    return { orgId, userId, composeId };
+  },
+);
+
+// Seeds an org whose `default_agent_id` points to a fully-formed compose owned
+// by a *different* org. The INNER JOIN filter on `agent_composes.orgId` must
+// reject the row so the target org appears to have no default agent.
+export const seedCrossOrgDefaultAgent$ = command(
+  async (
+    { set },
+    _: void,
+    signal: AbortSignal,
+  ): Promise<OnboardingStatusFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const otherOrgId = `org_${randomUUID()}`;
+    const otherUserId = `user_${randomUUID()}`;
+    const composeId = randomUUID();
+    const writeDb = set(writeDb$);
+
+    await writeDb.insert(agentComposes).values({
+      id: composeId,
+      userId: otherUserId,
+      orgId: otherOrgId,
+      name: `agent-${composeId.slice(0, 8)}`,
+    });
+    signal.throwIfAborted();
+    await writeDb.insert(zeroAgents).values({
+      id: composeId,
+      orgId: otherOrgId,
+      owner: otherUserId,
+      name: `agent-${composeId.slice(0, 8)}`,
+      displayName: null,
+      description: null,
+      sound: null,
+    });
+    signal.throwIfAborted();
+
+    await writeDb.insert(orgMetadata).values({
+      orgId,
+      defaultAgentId: composeId,
+    });
+    signal.throwIfAborted();
+
+    return { orgId, userId, composeId };
+  },
+);
+
 export const deleteOnboardingStatusOrg$ = command(
   async (
     { set },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-status.test.ts
@@ -4,10 +4,11 @@ import { onboardingStatusContract } from "@vm0/api-contracts/contracts/onboardin
 import { createStore } from "ccstate";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import {
   deleteOnboardingStatusOrg$,
+  seedCrossOrgDefaultAgent$,
   seedOnboardingStatusOrg$,
+  seedOrphanDefaultAgent$,
   type OnboardingStatusFixture,
 } from "./helpers/zero-onboarding-status";
 import {
@@ -24,9 +25,18 @@ describe("GET /api/zero/onboarding/status", () => {
     return store.set(deleteOnboardingStatusOrg$, fixture, context.signal);
   });
 
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(onboardingStatusContract);
+
+    const response = await accept(client.getStatus({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
   it("returns onboarding required when the session has no active org", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, null);
-    mockApiShadowCompareRoutes([onboardingStatusContract.getStatus]);
 
     const client = setupApp({ context })(onboardingStatusContract);
 
@@ -52,7 +62,6 @@ describe("GET /api/zero/onboarding/status", () => {
       store.set(seedOnboardingStatusOrg$, {}, context.signal),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    mockApiShadowCompareRoutes([onboardingStatusContract.getStatus]);
 
     const client = setupApp({ context })(onboardingStatusContract);
 
@@ -73,22 +82,188 @@ describe("GET /api/zero/onboarding/status", () => {
     });
   });
 
-  it("returns completed onboarding with default agent metadata", async () => {
+  it("returns completed onboarding for admin with default agent and no metadata", async () => {
+    const fixture = await track(
+      store.set(
+        seedOnboardingStatusOrg$,
+        {
+          defaultAgent: {},
+          onboardingDone: true,
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(onboardingStatusContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      needsOnboarding: false,
+      isAdmin: true,
+      hasOrg: true,
+      hasDefaultAgent: true,
+      defaultAgentId: fixture.composeId,
+      defaultAgentMetadata: null,
+    });
+  });
+
+  it("returns default agent metadata when the compose has metadata", async () => {
     const fixture = await track(
       store.set(
         seedOnboardingStatusOrg$,
         {
           defaultAgent: {
-            displayName: "Support",
-            description: "Handles customer questions",
+            displayName: "My Agent",
+            sound: "friendly",
           },
           onboardingDone: true,
         },
         context.signal,
       ),
     );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(onboardingStatusContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      needsOnboarding: false,
+      isAdmin: true,
+      hasOrg: true,
+      hasDefaultAgent: true,
+      defaultAgentId: fixture.composeId,
+      defaultAgentMetadata: { displayName: "My Agent", sound: "friendly" },
+    });
+  });
+
+  it("returns needsOnboarding=true for admin with default agent but onboarding not completed", async () => {
+    const fixture = await track(
+      store.set(
+        seedOnboardingStatusOrg$,
+        {
+          defaultAgent: {},
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(onboardingStatusContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      needsOnboarding: true,
+      isAdmin: true,
+      hasOrg: true,
+      hasDefaultAgent: true,
+      defaultAgentId: fixture.composeId,
+      defaultAgentMetadata: null,
+    });
+  });
+
+  it("returns needsOnboarding=true for non-admin member who has not completed onboarding", async () => {
+    const fixture = await track(
+      store.set(seedOnboardingStatusOrg$, {}, context.signal),
+    );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
-    mockApiShadowCompareRoutes([onboardingStatusContract.getStatus]);
+
+    const client = setupApp({ context })(onboardingStatusContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      needsOnboarding: true,
+      isAdmin: false,
+      hasOrg: true,
+      hasDefaultAgent: false,
+      defaultAgentId: null,
+      defaultAgentMetadata: null,
+    });
+  });
+
+  it("treats orphan compose (missing zero_agents row) as no default agent", async () => {
+    const fixture = await track(
+      store.set(seedOrphanDefaultAgent$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(onboardingStatusContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      needsOnboarding: true,
+      isAdmin: true,
+      hasOrg: true,
+      hasDefaultAgent: false,
+      defaultAgentId: null,
+      defaultAgentMetadata: null,
+    });
+  });
+
+  it("ignores a default agent row from another org", async () => {
+    const fixture = await track(
+      store.set(seedCrossOrgDefaultAgent$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(onboardingStatusContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      needsOnboarding: true,
+      isAdmin: true,
+      hasOrg: true,
+      hasDefaultAgent: false,
+      defaultAgentId: null,
+      defaultAgentMetadata: null,
+    });
+  });
+
+  it("returns needsOnboarding=false for non-admin member after completing onboarding", async () => {
+    const fixture = await track(
+      store.set(
+        seedOnboardingStatusOrg$,
+        { onboardingDone: true },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
     const client = setupApp({ context })(onboardingStatusContract);
 
@@ -103,12 +278,9 @@ describe("GET /api/zero/onboarding/status", () => {
       needsOnboarding: false,
       isAdmin: false,
       hasOrg: true,
-      hasDefaultAgent: true,
-      defaultAgentId: fixture.composeId,
-      defaultAgentMetadata: {
-        displayName: "Support",
-        description: "Handles customer questions",
-      },
+      hasDefaultAgent: false,
+      defaultAgentId: null,
+      defaultAgentMetadata: null,
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-onboarding-status.ts
+++ b/turbo/apps/api/src/signals/routes/zero-onboarding-status.ts
@@ -3,7 +3,6 @@ import { onboardingStatusContract } from "@vm0/api-contracts/contracts/onboardin
 
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import type { RouteEntry } from "../route";
 import { onboardingStatus } from "../services/onboarding.service";
 
@@ -19,9 +18,6 @@ const getOnboardingStatusInner$ = computed(async (get): Promise<unknown> => {
 export const zeroOnboardingStatusRoutes: readonly RouteEntry[] = [
   {
     route: onboardingStatusContract.getStatus,
-    handler: shadowCompareRoute({
-      route: onboardingStatusContract.getStatus,
-      handler: authRoute({}, getOnboardingStatusInner$),
-    }),
+    handler: authRoute({}, getOnboardingStatusInner$),
   },
 ];


### PR DESCRIPTION
Closes #12333

## Summary
- Drop the `shadowCompareRoute` wrapper from `GET /api/zero/onboarding/status` so `apps/api` is now authoritative for the route.
- Port every web GET test case 1:1 — the api file now mirrors all 10 web cases (was 3, +7 new).
- Extend the test helper with `seedOrphanDefaultAgent$` and `seedCrossOrgDefaultAgent$` for the orphan-compose and cross-org default-agent scenarios.

Service (`onboarding.service.ts`) was verified field-by-field against the inline web logic — no behavior gap, no service change.

## Test plan
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-onboarding-status.test.ts` — 10/10 passing
- [x] `pnpm -F api lint`
- [x] `pnpm -F api check-types`
- [x] `pnpm format`
- [x] `pnpm knip`

## Rollback
Disable the `apiBackend` feature switch — traffic falls back to the unchanged `apps/web` route. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)