### PR TITLE
fix: add missing id field and remove revoke filter from API thread messages

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -393,6 +393,7 @@ function toStoredMessage(
 
       const role = messageRoleSchema.parse(row.role);
       const message = {
+        id: row.id,
         role,
         content: row.content,
         runId: row.runId ?? undefined,
@@ -479,12 +480,7 @@ function chatThreadMessages(
         .select(messageColumns)
         .from(chatMessages)
         .leftJoin(agentRuns, eq(agentRuns.id, chatMessages.runId))
-        .where(
-          and(
-            eq(chatMessages.chatThreadId, threadId),
-            visibleChatMessageCondition(),
-          ),
-        )
+        .where(eq(chatMessages.chatThreadId, threadId))
         .orderBy(asc(chatMessages.createdAt), asc(chatMessages.sequenceNumber));
 
       return await Promise.all(


### PR DESCRIPTION
## Summary

- Fixes two code-path shadow divergences for `GET /api/zero/chat-threads/:id`, accounting for ~230 events/hr (85% of the remaining 268/hr mismatch volume)
- Adds the `id` field to `toStoredMessage` to match the web implementation's `getChatThreadMessages` response
- Removes `visibleChatMessageCondition()` filter from `chatThreadMessages` to match the web's `getMessagesByThreadId` which intentionally does not apply visibility/revoke filters (append-only event stream, client handles display projection)

## Root cause analysis

1. **Missing `id` field**: API `toStoredMessage` constructed `{ role, content, runId, revokesMessageId, error, attachFiles, createdAt }` without `id`, while web's `getChatThreadMessages` included `id: row.id`. Every message triggered a `body.chatMessages[*].id` diff with only a `web` value.

2. **Visibility filter mismatch**: API `chatThreadMessages` applied `visibleChatMessageCondition()` (filters revoked messages from the response), while web's `getMessagesByThreadId` explicitly does not filter — its comment says "intentionally does not apply visibility/revoke filters: chat message APIs are the append-only event stream, and clients derive their own display projection." When a message was revoked, the API returned one fewer row than the web, causing an index shift for all subsequent messages.

## Test plan

- [ ] CI passes (lint + typecheck + test)
- [ ] Post-deploy: verify `chatMessages[*].id` diffs drop to zero in Axiom
- [ ] Post-deploy: verify `GET /api/zero/chat-threads/:id` shadow mismatch rate drops from ~230/hr to near zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)