### PR TITLE
fix: target telegram reply handling to current bot

### DIFF
--- a/turbo/apps/web/app/api/telegram/webhook/[telegramBotId]/route.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/[telegramBotId]/route.ts
@@ -29,6 +29,7 @@ import {
 import {
   formatTelegramUserDisplayName,
   hasTelegramMessageContextContent,
+  isTelegramReplyToBotUsername,
   storeTelegramMessage,
 } from "../../../../../src/lib/zero/telegram/handlers/shared";
 import { logger } from "../../../../../src/lib/shared/logger";
@@ -164,8 +165,11 @@ export async function POST(
           );
         });
 
-      // Check if reply to bot's message
-      const isReplyToBot = message.reply_to_message?.from?.is_bot === true;
+      // Check if reply to this bot's message
+      const isReplyToBot = isTelegramReplyToBotUsername(
+        message,
+        installation.botUsername,
+      );
 
       if (hasBotMention || isReplyToBot) {
         await handleTelegramMention({ message }, telegramBotId, apiStartTime);
@@ -291,7 +295,7 @@ function isOfficialMentionOrReply(
   message: TelegramHandlerUpdate["message"],
   botUsername: string | null,
 ): boolean {
-  const isReplyToBot = message.reply_to_message?.from?.is_bot === true;
+  const isReplyToBot = isTelegramReplyToBotUsername(message, botUsername);
   if (isReplyToBot) return true;
   if (!botUsername) return false;
 

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../../../src/__tests__/test-helpers";
 import {
   createTestCompose,
+  createTelegramCallbackInstallation,
   createTelegramInstallation,
   createTelegramPendingLinkInstallation,
   findTestRunCallbacks,
@@ -48,6 +49,30 @@ const WEBHOOK_SECRET = "webhook-secret";
 const TEST_BOT_TOKEN = "123456:ABC-pending-test";
 const OFFICIAL_BOT_TOKEN = "777000:official-route-test";
 const OFFICIAL_WEBHOOK_SECRET = "official-webhook-secret";
+
+interface TelegramSendMessageBody {
+  chat_id: string | number;
+  text: string;
+  reply_markup?: {
+    inline_keyboard: Array<Array<{ text: string; url: string }>>;
+  };
+  reply_parameters?: { message_id: number };
+}
+
+function telegramSendMessage(botToken: string) {
+  const calls: TelegramSendMessageBody[] = [];
+  const handler = http.post(
+    `https://api.telegram.org/bot${botToken}/sendMessage`,
+    async ({ request }) => {
+      calls.push((await request.json()) as TelegramSendMessageBody);
+      return HttpResponse.json({
+        ok: true,
+        result: { message_id: 999, chat: { id: 123 } },
+      });
+    },
+  );
+  return { ...handler, calls };
+}
 
 function createWebhookRequest(
   body: Record<string, unknown>,
@@ -207,6 +232,43 @@ describe("POST /api/telegram/webhook/[telegramBotId]", () => {
     expect(response.status).toBe(400);
   });
 
+  it("should ignore group replies to a different bot", async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const installation = await createTelegramCallbackInstallation(
+      composeId,
+      user.userId,
+      TEST_BOT_TOKEN,
+    );
+    const sendMsg = telegramSendMessage(TEST_BOT_TOKEN);
+    server.use(sendMsg.handler);
+
+    const request = createWebhookRequest({
+      update_id: 2,
+      message: {
+        message_id: 2,
+        chat: { id: -100123456, type: "group" },
+        from: { id: 99999, username: "unlinked_user" },
+        text: "following up",
+        reply_to_message: {
+          message_id: 55,
+          chat: { id: -100123456, type: "group" },
+          from: { id: 123, is_bot: true, username: "other_bot" },
+          text: "message from another bot",
+        },
+      },
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ telegramBotId: installation.installationId }),
+    });
+
+    expect(response.status).toBe(200);
+    await flushAfterCallbacks();
+    expect(sendMsg.calls).toHaveLength(0);
+  });
+
   describe("auto-complete pending link", () => {
     it("should complete pending link on first DM from admin", async () => {
       context.setupMocks();
@@ -278,6 +340,96 @@ describe("POST /api/telegram/webhook/[telegramBotId]", () => {
   });
 
   describe("official bot inbound messages", () => {
+    it("does not send a connect prompt for group replies to a different bot", async () => {
+      context.setupMocks();
+      vi.stubEnv("TELEGRAM_OFFICIAL_BOT_TOKEN", OFFICIAL_BOT_TOKEN);
+      vi.stubEnv("TELEGRAM_OFFICIAL_BOT_USERNAME", "zero_vm0_bot");
+      vi.stubEnv("TELEGRAM_OFFICIAL_WEBHOOK_SECRET", OFFICIAL_WEBHOOK_SECRET);
+      reloadEnv();
+
+      const sendMsg = telegramSendMessage(OFFICIAL_BOT_TOKEN);
+      server.use(sendMsg.handler);
+
+      const response = await POST(
+        createWebhookRequest(
+          {
+            update_id: 201,
+            message: {
+              message_id: 18,
+              chat: { id: -100123456, type: "group" },
+              from: {
+                id: Number(uniqueNumericId()),
+                username: "unlinked_user",
+              },
+              text: "following up",
+              reply_to_message: {
+                message_id: 77,
+                chat: { id: -100123456, type: "group" },
+                from: { id: 777, is_bot: true, username: "other_bot" },
+                text: "message from another bot",
+              },
+            },
+          },
+          OFFICIAL_WEBHOOK_SECRET,
+        ),
+        {
+          params: Promise.resolve({
+            telegramBotId: OFFICIAL_TELEGRAM_BOT_ID,
+          }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+      expect(sendMsg.calls).toHaveLength(0);
+    });
+
+    it("sends a connect prompt for group replies to the official bot", async () => {
+      context.setupMocks();
+      vi.stubEnv("TELEGRAM_OFFICIAL_BOT_TOKEN", OFFICIAL_BOT_TOKEN);
+      vi.stubEnv("TELEGRAM_OFFICIAL_BOT_USERNAME", "zero_vm0_bot");
+      vi.stubEnv("TELEGRAM_OFFICIAL_WEBHOOK_SECRET", OFFICIAL_WEBHOOK_SECRET);
+      reloadEnv();
+
+      const sendMsg = telegramSendMessage(OFFICIAL_BOT_TOKEN);
+      server.use(sendMsg.handler);
+
+      const response = await POST(
+        createWebhookRequest(
+          {
+            update_id: 202,
+            message: {
+              message_id: 19,
+              chat: { id: -100123456, type: "group" },
+              from: {
+                id: Number(uniqueNumericId()),
+                username: "unlinked_user",
+              },
+              text: "following up",
+              reply_to_message: {
+                message_id: 78,
+                chat: { id: -100123456, type: "group" },
+                from: { id: 777000, is_bot: true, username: "zero_vm0_bot" },
+                text: "message from zero",
+              },
+            },
+          },
+          OFFICIAL_WEBHOOK_SECRET,
+        ),
+        {
+          params: Promise.resolve({
+            telegramBotId: OFFICIAL_TELEGRAM_BOT_ID,
+          }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+      expect(sendMsg.calls).toHaveLength(1);
+      expect(sendMsg.calls[0]?.text).toContain("connect your account");
+      expect(sendMsg.calls[0]?.reply_parameters).toEqual({ message_id: 19 });
+    });
+
     it("routes a linked official DM to the user's org default agent", async () => {
       context.setupMocks();
       vi.stubEnv("TELEGRAM_OFFICIAL_BOT_TOKEN", OFFICIAL_BOT_TOKEN);

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/mention.ts
@@ -20,6 +20,7 @@ import {
   formatTelegramPrivateConnectPrompt,
   formatTelegramUserDisplayName,
   getWorkspaceAgentDisplayLabel,
+  isTelegramReplyToBotUsername,
 } from "./shared";
 import { fetchTelegramContext } from "../context";
 import { runAgentForTelegram } from "./run-agent";
@@ -151,6 +152,7 @@ export async function handleTelegramMention(
       userLink.id,
       userLink.vm0UserId,
       composeId,
+      installation.botUsername,
     );
 
   // 9. Fetch context (exclude current message to avoid duplication with prompt)
@@ -224,17 +226,16 @@ async function resolveThreadSession(
   userLinkId: string,
   vm0UserId: string,
   composeId: string,
+  botUsername: string | null,
 ): Promise<{
   rootMessageId: string | undefined;
   existingSessionId: string | undefined;
   lastProcessedMessageId: string | undefined;
 }> {
   let rootMessageId: string | undefined;
-  if (
-    message.reply_to_message?.from?.is_bot &&
-    message.reply_to_message.message_id
-  ) {
-    rootMessageId = String(message.reply_to_message.message_id);
+  const replyToMessage = message.reply_to_message;
+  if (isTelegramReplyToBotUsername(message, botUsername) && replyToMessage) {
+    rootMessageId = String(replyToMessage.message_id);
   }
 
   let existingSessionId: string | undefined;

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/official.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/official.ts
@@ -32,6 +32,7 @@ import {
   formatTelegramUserDisplayName,
   getAgentDisplayLabel,
   getWorkspaceAgent,
+  isTelegramReplyToBotUsername,
   lookupTelegramThreadSession,
   resolveSessionCompose,
   resolveTelegramAuditLogsUrl,
@@ -359,6 +360,7 @@ export async function handleOfficialTelegramMention(
       chatId,
       userLink,
       agent.composeId,
+      runtime.botUsername,
     );
 
   const { executionContext } = await fetchTelegramContext(
@@ -425,17 +427,16 @@ async function resolveOfficialThreadSession(
   chatId: string,
   userLink: OfficialUserLink,
   composeId: string,
+  botUsername: string | null,
 ): Promise<{
   rootMessageId: string | undefined;
   existingSessionId: string | undefined;
   lastProcessedMessageId: string | undefined;
 }> {
   let rootMessageId: string | undefined;
-  if (
-    message.reply_to_message?.from?.is_bot &&
-    message.reply_to_message.message_id
-  ) {
-    rootMessageId = String(message.reply_to_message.message_id);
+  const replyToMessage = message.reply_to_message;
+  if (isTelegramReplyToBotUsername(message, botUsername) && replyToMessage) {
+    rootMessageId = String(replyToMessage.message_id);
   }
 
   let existingSessionId: string | undefined;

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/shared.ts
@@ -670,6 +670,19 @@ function normalizedBotUsername(botUsername: string | null | undefined): string {
   return botUsername?.replace(/^@/, "").trim() ?? "";
 }
 
+export function isTelegramReplyToBotUsername(
+  message: Pick<TelegramHandlerUpdate["message"], "reply_to_message">,
+  botUsername: string | null | undefined,
+): boolean {
+  const username = normalizedBotUsername(botUsername).toLowerCase();
+  if (!username) return false;
+
+  const replyFrom = message.reply_to_message?.from;
+  if (replyFrom?.is_bot !== true) return false;
+
+  return normalizedBotUsername(replyFrom.username).toLowerCase() === username;
+}
+
 export function formatTelegramConnectPrompt(
   agentName: string = "Zero",
 ): string {


### PR DESCRIPTION
## Summary
- only treat Telegram replies as bot continuations when the replied-to message is from the current bot username
- apply the same current-bot check to Telegram thread session anchoring
- add webhook regression coverage for replies to another bot and replies to the official Zero bot

## Verification
- pnpm exec prettier --check 'apps/web/app/api/telegram/webhook/[telegramBotId]/route.ts' apps/web/app/api/telegram/webhook/__tests__/route.test.ts apps/web/src/lib/zero/telegram/handlers/shared.ts apps/web/src/lib/zero/telegram/handlers/mention.ts apps/web/src/lib/zero/telegram/handlers/official.ts
- pnpm exec eslint 'app/api/telegram/webhook/[telegramBotId]/route.ts' app/api/telegram/webhook/__tests__/route.test.ts src/lib/zero/telegram/handlers/shared.ts src/lib/zero/telegram/handlers/mention.ts src/lib/zero/telegram/handlers/official.ts --max-warnings 0 (from apps/web)
- pnpm exec oxlint 'app/api/telegram/webhook/[telegramBotId]/route.ts' app/api/telegram/webhook/__tests__/route.test.ts src/lib/zero/telegram/handlers/shared.ts src/lib/zero/telegram/handlers/mention.ts src/lib/zero/telegram/handlers/official.ts (from apps/web)
- pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json 'app/api/telegram/webhook/[telegramBotId]/route.ts' app/api/telegram/webhook/__tests__/route.test.ts src/lib/zero/telegram/handlers/shared.ts src/lib/zero/telegram/handlers/mention.ts src/lib/zero/telegram/handlers/official.ts (from apps/web)

## Local blockers
- pnpm --filter web test app/api/telegram/webhook/__tests__/route.test.ts currently fails before assertions because the local test DB is behind schema: telegram_installations.owner_user_id does not exist.
- pnpm --filter web db:migrate is also blocked by existing local DB/migration drift: redemption_codes already exists.
- pnpm --filter web check-types and the pre-commit full check-types fail on unrelated existing errors outside the touched Telegram files; the Telegram nullable narrowing errors from this patch were fixed.
