### PR TITLE
refactor(api): migrate billing auto-recharge get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts
@@ -4,7 +4,6 @@ import { zeroBillingAutoRechargeContract } from "@vm0/api-contracts/contracts/ze
 import { createStore } from "ccstate";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import {
   deleteAutoRechargeOrg$,
   seedAutoRechargeOrg$,
@@ -24,20 +23,32 @@ describe("GET /api/zero/billing/auto-recharge", () => {
     return store.set(deleteAutoRechargeOrg$, fixture, context.signal);
   });
 
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroBillingAutoRechargeContract);
+
+    const response = await accept(client.get({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
   it("returns the org auto-recharge config from the api implementation", async () => {
     const fixture = await track(
       store.set(
         seedAutoRechargeOrg$,
         {
           enabled: true,
-          threshold: 500,
-          amount: 5000,
+          threshold: 2000,
+          amount: 10_000,
         },
         context.signal,
       ),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
-    mockApiShadowCompareRoutes([zeroBillingAutoRechargeContract.get]);
 
     const client = setupApp({ context })(zeroBillingAutoRechargeContract);
 
@@ -50,8 +61,8 @@ describe("GET /api/zero/billing/auto-recharge", () => {
 
     expect(response.body).toStrictEqual({
       enabled: true,
-      threshold: 500,
-      amount: 5000,
+      threshold: 2000,
+      amount: 10_000,
     });
   });
 
@@ -59,7 +70,6 @@ describe("GET /api/zero/billing/auto-recharge", () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
-    mockApiShadowCompareRoutes([zeroBillingAutoRechargeContract.get]);
 
     const client = setupApp({ context })(zeroBillingAutoRechargeContract);
 

--- a/turbo/apps/api/src/signals/routes/zero-billing-auto-recharge.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-auto-recharge.ts
@@ -3,7 +3,6 @@ import { zeroBillingAutoRechargeContract } from "@vm0/api-contracts/contracts/ze
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { autoRechargeConfig } from "../services/billing.service";
 import type { RouteEntry } from "../route";
 
@@ -19,12 +18,9 @@ const getAutoRechargeInner$ = computed(async (get): Promise<unknown> => {
 export const zeroBillingAutoRechargeRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingAutoRechargeContract.get,
-    handler: shadowCompareRoute({
-      route: zeroBillingAutoRechargeContract.get,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        getAutoRechargeInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      getAutoRechargeInner$,
+    ),
   },
 ];


### PR DESCRIPTION
## Summary

- make `GET /api/zero/billing/auto-recharge` API-authoritative by removing the `shadowCompareRoute(...)` wrapper
- add a 401 unauthenticated case to the api integration tests
- align the seeded values in the existing 200 case with the equivalent web GET test (`threshold: 2_000, amount: 10_000`) for explicit 1:1 parity

Closes #12344

Part of epic #12290.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts` (3 / 3 passing)
- `pnpm -F api lint`
- `pnpm -F api check-types`

## Test cases

| # | Case | Mirrors web case |
|---|------|------------------|
| 1 | unauthenticated | n/a — added for migration parity (matches PRs #12312 / #12314 / #12337) |
| 2 | seeded config returned verbatim | "returns configured auto-recharge settings" |
| 3 | missing org_metadata row → defaults | "returns default config for new org" |

## Scope clarification

The web test file has 2 GET cases + 10 PUT cases. PUT is not implemented in `apps/api` today (no `updateAutoRechargeConfig$` service, no PUT route handler). PUT is a Stage 3 mutation and gets its own follow-up issue per the established epic policy. This PR migrates GET only.

## Behavioral note

Web returns 404 if `resolveOrg` rejects with not-found / forbidden. The api implementation skips `resolveOrg` because Clerk only sets active `orgId` on sessions where the user is a member, so the membership check is unreachable in production. Same simplification as PRs #12312 / #12314 / #12315 / #12337.

## Rollback

Disabling the `apiBackend` feature switch routes traffic back to `apps/web`. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)