### PR TITLE
refactor(api): migrate billing status get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-billing-status.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-billing-status.ts
@@ -1,0 +1,114 @@
+import { randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { eq, sql } from "drizzle-orm";
+
+import { writeDb$ } from "../../../external/db";
+
+export interface BillingStatusFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly expiresRecordIds: readonly string[];
+}
+
+interface SubscriptionSeed {
+  readonly tier: string;
+  readonly status: string;
+  readonly currentPeriodEnd: Date;
+  readonly cancelAtPeriodEnd?: boolean;
+  readonly stripeCustomerId?: string;
+  readonly stripeSubscriptionId?: string;
+}
+
+interface ExpiresRecordSeed {
+  readonly source: string;
+  readonly amount: number;
+  readonly remaining?: number;
+  readonly expiresAt: Date;
+  readonly stripeInvoiceId?: string;
+}
+
+interface BillingStatusSeedValues {
+  readonly credits?: number;
+  readonly subscription?: SubscriptionSeed;
+  readonly expiresRecords?: readonly ExpiresRecordSeed[];
+  readonly extraGrantedCredits?: number;
+}
+
+export const seedBillingStatusOrg$ = command(
+  async (
+    { set },
+    values: BillingStatusSeedValues,
+    signal: AbortSignal,
+  ): Promise<BillingStatusFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const writeDb = set(writeDb$);
+
+    const credits = values.credits ?? 0;
+    const sub = values.subscription;
+
+    await writeDb.insert(orgMetadata).values({
+      orgId,
+      credits,
+      tier: sub?.tier ?? "free",
+      stripeCustomerId: sub?.stripeCustomerId ?? null,
+      stripeSubscriptionId: sub?.stripeSubscriptionId ?? null,
+      subscriptionStatus: sub?.status ?? null,
+      currentPeriodEnd: sub?.currentPeriodEnd ?? null,
+      cancelAtPeriodEnd: sub?.cancelAtPeriodEnd ?? false,
+    });
+    signal.throwIfAborted();
+
+    if (values.extraGrantedCredits) {
+      await writeDb
+        .update(orgMetadata)
+        .set({
+          credits: sql`${orgMetadata.credits} + ${values.extraGrantedCredits}`,
+        })
+        .where(eq(orgMetadata.orgId, orgId));
+      signal.throwIfAborted();
+    }
+
+    const expiresRecordIds: string[] = [];
+    for (const record of values.expiresRecords ?? []) {
+      const [row] = await writeDb
+        .insert(creditExpiresRecord)
+        .values({
+          orgId,
+          source: record.source,
+          amount: record.amount,
+          remaining: record.remaining ?? record.amount,
+          expiresAt: record.expiresAt,
+          stripeInvoiceId: record.stripeInvoiceId ?? `inv_${randomUUID()}`,
+        })
+        .returning({ id: creditExpiresRecord.id });
+      signal.throwIfAborted();
+      if (row) {
+        expiresRecordIds.push(row.id);
+      }
+    }
+
+    return { orgId, userId, expiresRecordIds };
+  },
+);
+
+export const deleteBillingStatusOrg$ = command(
+  async (
+    { set },
+    fixture: BillingStatusFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(creditExpiresRecord)
+      .where(eq(creditExpiresRecord.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await writeDb
+      .delete(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts
@@ -1,0 +1,624 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroBillingStatusContract } from "@vm0/api-contracts/contracts/zero-billing";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  deleteBillingStatusOrg$,
+  seedBillingStatusOrg$,
+  type BillingStatusFixture,
+} from "./helpers/zero-billing-status";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/billing/status", () => {
+  const track = createFixtureTracker<BillingStatusFixture>((fixture) => {
+    return store.set(deleteBillingStatusOrg$, fixture, context.signal);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(client.get({ headers: {} }), [401]);
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns billing status for authenticated user", async () => {
+    const fixture = await track(
+      store.set(seedBillingStatusOrg$, { credits: 100_000 }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.tier).toBe("free");
+    expect(response.body.credits).toBe(100_000);
+    expect(response.body.hasSubscription).toBeFalsy();
+    expect(response.body.subscriptionStatus).toBeNull();
+    expect(response.body.currentPeriodEnd).toBeNull();
+  });
+
+  it("returns correct data for subscribed org", async () => {
+    const periodEnd = new Date("2026-04-20T00:00:00Z");
+    const fixture = await track(
+      store.set(
+        seedBillingStatusOrg$,
+        {
+          credits: 100_000,
+          subscription: {
+            tier: "pro",
+            status: "active",
+            currentPeriodEnd: periodEnd,
+            stripeCustomerId: `cus_${randomUUID()}`,
+            stripeSubscriptionId: `sub_${randomUUID()}`,
+          },
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.tier).toBe("pro");
+    expect(response.body.credits).toBe(100_000);
+    expect(response.body.subscriptionStatus).toBe("active");
+    expect(response.body.currentPeriodEnd).toBe(periodEnd.toISOString());
+    expect(response.body.cancelAtPeriodEnd).toBeFalsy();
+    expect(response.body.hasSubscription).toBeTruthy();
+  });
+
+  it("returns cancelAtPeriodEnd true when set", async () => {
+    const periodEnd = new Date("2026-04-20T00:00:00Z");
+    const fixture = await track(
+      store.set(
+        seedBillingStatusOrg$,
+        {
+          subscription: {
+            tier: "pro",
+            status: "active",
+            currentPeriodEnd: periodEnd,
+            cancelAtPeriodEnd: true,
+            stripeCustomerId: `cus_${randomUUID()}`,
+            stripeSubscriptionId: `sub_${randomUUID()}`,
+          },
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.cancelAtPeriodEnd).toBeTruthy();
+  });
+
+  it("returns 200 for non-admin member", async () => {
+    const fixture = await track(
+      store.set(seedBillingStatusOrg$, { credits: 100_000 }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("includes creditExpiry data for paid org with expires records", async () => {
+    const periodEnd = new Date("2026-04-20T00:00:00Z");
+    const expiryDate = new Date("2026-05-20T00:00:00Z");
+    const fixture = await track(
+      store.set(
+        seedBillingStatusOrg$,
+        {
+          subscription: {
+            tier: "pro",
+            status: "active",
+            currentPeriodEnd: periodEnd,
+            stripeCustomerId: `cus_${randomUUID()}`,
+            stripeSubscriptionId: `sub_${randomUUID()}`,
+          },
+          expiresRecords: [
+            {
+              source: "subscription_renewal",
+              amount: 20_000,
+              remaining: 15_000,
+              expiresAt: expiryDate,
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.creditExpiry.expiringNextCycle).toBe(15_000);
+    expect(response.body.creditExpiry.nextExpiryDate).toBe(
+      expiryDate.toISOString(),
+    );
+    expect(response.body.creditGrants).toStrictEqual([
+      expect.objectContaining({
+        source: "subscription_renewal",
+        label: "Pro plan",
+        amount: 20_000,
+        remaining: 15_000,
+        expiresAt: expiryDate.toISOString(),
+      }),
+    ]);
+  });
+
+  it("returns zero creditExpiry for free org", async () => {
+    const fixture = await track(
+      store.set(seedBillingStatusOrg$, { credits: 100_000 }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.creditExpiry.expiringNextCycle).toBe(0);
+    expect(response.body.creditExpiry.nextExpiryDate).toBeNull();
+  });
+
+  it("displays credits minus not-yet-settled expired amount", async () => {
+    // Dormant non-subscription org: a 3k expires record is past its
+    // expiresAt but the inflated ledger has not yet been settled, so the
+    // /status endpoint must subtract the expired amount before reporting.
+    const pastDate = new Date("2026-03-01T00:00:00Z");
+    const fixture = await track(
+      store.set(
+        seedBillingStatusOrg$,
+        {
+          credits: 100_000,
+          expiresRecords: [
+            {
+              source: "subscription_renewal",
+              amount: 3000,
+              expiresAt: pastDate,
+            },
+          ],
+          extraGrantedCredits: 3000,
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    // 100_000 (seeded) + 3000 (granted) − 3000 (expired) = 100_000
+    expect(response.body.credits).toBe(100_000);
+  });
+
+  it("maps auto_recharge expires records to Pay as you go segment", async () => {
+    const fixture = await track(
+      store.set(
+        seedBillingStatusOrg$,
+        {
+          credits: 40_000,
+          subscription: {
+            tier: "pro",
+            status: "active",
+            currentPeriodEnd: new Date("2026-05-20T00:00:00Z"),
+            stripeCustomerId: `cus_${randomUUID()}`,
+            stripeSubscriptionId: `sub_${randomUUID()}`,
+          },
+          expiresRecords: [
+            {
+              source: "subscription_renewal",
+              amount: 20_000,
+              expiresAt: new Date("2026-06-20T00:00:00Z"),
+            },
+            {
+              source: "auto_recharge",
+              amount: 10_000,
+              expiresAt: new Date("2999-12-31T00:00:00Z"),
+            },
+            {
+              source: "auto_recharge",
+              amount: 10_000,
+              expiresAt: new Date("2999-12-31T00:00:00Z"),
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    const payg = response.body.creditBreakdown.find((segment) => {
+      return segment.category === "payAsYouGo";
+    });
+    expect(payg).toStrictEqual({
+      category: "payAsYouGo",
+      label: "Pay as you go",
+      credits: 20_000,
+    });
+    expect(
+      response.body.creditGrants.filter((grant) => {
+        return grant.source === "auto_recharge";
+      }),
+    ).toHaveLength(2);
+  });
+
+  it("maps subscription_renewal at Pro amount to Pro plan segment", async () => {
+    const fixture = await track(
+      store.set(
+        seedBillingStatusOrg$,
+        {
+          credits: 20_000,
+          subscription: {
+            tier: "pro",
+            status: "active",
+            currentPeriodEnd: new Date("2026-05-20T00:00:00Z"),
+            stripeCustomerId: `cus_${randomUUID()}`,
+            stripeSubscriptionId: `sub_${randomUUID()}`,
+          },
+          expiresRecords: [
+            {
+              source: "subscription_renewal",
+              amount: 20_000,
+              expiresAt: new Date("2026-06-20T00:00:00Z"),
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.creditBreakdown).toStrictEqual([
+      {
+        category: "plan",
+        label: "Pro plan",
+        credits: 20_000,
+        tier: "pro",
+      },
+    ]);
+  });
+
+  it("maps subscription_renewal at Team amount to Team plan segment", async () => {
+    const fixture = await track(
+      store.set(
+        seedBillingStatusOrg$,
+        {
+          credits: 120_000,
+          subscription: {
+            tier: "team",
+            status: "active",
+            currentPeriodEnd: new Date("2026-05-20T00:00:00Z"),
+            stripeCustomerId: `cus_${randomUUID()}`,
+            stripeSubscriptionId: `sub_${randomUUID()}`,
+          },
+          expiresRecords: [
+            {
+              source: "subscription_renewal",
+              amount: 120_000,
+              expiresAt: new Date("2026-06-20T00:00:00Z"),
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.creditBreakdown).toStrictEqual([
+      {
+        category: "plan",
+        label: "Team plan",
+        credits: 120_000,
+        tier: "team",
+      },
+    ]);
+  });
+
+  it("shows Team plan leftover alongside current Pro plan for a downgraded org", async () => {
+    // Pro-tier org that still has unused credits from a prior Team renewal.
+    const fixture = await track(
+      store.set(
+        seedBillingStatusOrg$,
+        {
+          credits: 20_000 + 40_000,
+          subscription: {
+            tier: "pro",
+            status: "active",
+            currentPeriodEnd: new Date("2026-05-20T00:00:00Z"),
+            stripeCustomerId: `cus_${randomUUID()}`,
+            stripeSubscriptionId: `sub_${randomUUID()}`,
+          },
+          expiresRecords: [
+            {
+              source: "subscription_renewal",
+              amount: 20_000,
+              expiresAt: new Date("2026-06-20T00:00:00Z"),
+            },
+            {
+              source: "subscription_renewal",
+              amount: 120_000,
+              remaining: 40_000,
+              expiresAt: new Date("2026-07-20T00:00:00Z"),
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.creditBreakdown).toStrictEqual([
+      {
+        category: "plan",
+        label: "Pro plan",
+        credits: 20_000,
+        tier: "pro",
+      },
+      {
+        category: "plan",
+        label: "Team plan",
+        credits: 40_000,
+        tier: "team",
+      },
+    ]);
+  });
+
+  it("maps starter_grant records to Free plan segment", async () => {
+    const fixture = await track(
+      store.set(
+        seedBillingStatusOrg$,
+        {
+          credits: 10_000,
+          expiresRecords: [
+            {
+              source: "starter_grant",
+              amount: 10_000,
+              expiresAt: new Date("2099-12-31T00:00:00Z"),
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    const free = response.body.creditBreakdown.find((segment) => {
+      return segment.category === "free";
+    });
+    expect(free).toStrictEqual({
+      category: "free",
+      label: "Free plan",
+      credits: 10_000,
+    });
+  });
+
+  it("maps one_time_purchase records to Promotional segment", async () => {
+    const fixture = await track(
+      store.set(
+        seedBillingStatusOrg$,
+        {
+          credits: 5000,
+          expiresRecords: [
+            {
+              source: "one_time_purchase",
+              amount: 5000,
+              expiresAt: new Date("2099-12-31T00:00:00Z"),
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    const promo = response.body.creditBreakdown.find((segment) => {
+      return segment.category === "promotional";
+    });
+    expect(promo).toStrictEqual({
+      category: "promotional",
+      label: "Promotional",
+      credits: 5000,
+    });
+  });
+
+  it("surfaces untracked paid-tier balance as Pay as you go fallback", async () => {
+    // Paid-tier org whose ledger shows more credits than any active expires
+    // record accounts for (pre-sentinel top-up / historical drift).
+    const fixture = await track(
+      store.set(
+        seedBillingStatusOrg$,
+        {
+          credits: 25_000,
+          subscription: {
+            tier: "pro",
+            status: "active",
+            currentPeriodEnd: new Date("2026-05-20T00:00:00Z"),
+            stripeCustomerId: `cus_${randomUUID()}`,
+            stripeSubscriptionId: `sub_${randomUUID()}`,
+          },
+          expiresRecords: [
+            {
+              source: "subscription_renewal",
+              amount: 20_000,
+              expiresAt: new Date("2026-06-20T00:00:00Z"),
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.creditBreakdown).toStrictEqual([
+      {
+        category: "plan",
+        label: "Pro plan",
+        credits: 20_000,
+        tier: "pro",
+      },
+      {
+        category: "payAsYouGo",
+        label: "Pay as you go",
+        credits: 5000,
+      },
+    ]);
+    expect(
+      response.body.creditGrants.some((grant) => {
+        return grant.source === "auto_recharge";
+      }),
+    ).toBeFalsy();
+  });
+
+  it("merges untracked balance on free tier into Free plan segment", async () => {
+    // Free-tier org where org_metadata.credits exceeds the starter_grant
+    // record's remaining. The delta should render under "Free plan", not
+    // "Pay as you go".
+    const fixture = await track(
+      store.set(
+        seedBillingStatusOrg$,
+        {
+          credits: 12_000,
+          expiresRecords: [
+            {
+              source: "starter_grant",
+              amount: 10_000,
+              expiresAt: new Date("2099-12-31T00:00:00Z"),
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    const free = response.body.creditBreakdown.find((segment) => {
+      return segment.category === "free";
+    });
+    expect(free).toStrictEqual({
+      category: "free",
+      label: "Free plan",
+      credits: 12_000,
+    });
+    expect(
+      response.body.creditBreakdown.find((segment) => {
+        return segment.category === "payAsYouGo";
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns defaults when org row does not exist", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.tier).toBe("free");
+    expect(response.body.credits).toBe(0);
+    expect(response.body.hasSubscription).toBeFalsy();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-billing-status.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-status.ts
@@ -3,7 +3,6 @@ import { zeroBillingStatusContract } from "@vm0/api-contracts/contracts/zero-bil
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { zeroBillingStatus } from "../services/zero-billing-status.service";
 import type { RouteEntry } from "../route";
 
@@ -16,12 +15,9 @@ const getBillingStatusInner$ = computed(async (get) => {
 export const zeroBillingStatusRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingStatusContract.get,
-    handler: shadowCompareRoute({
-      route: zeroBillingStatusContract.get,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        getBillingStatusInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      getBillingStatusInner$,
+    ),
   },
 ];


### PR DESCRIPTION
## Summary

- Promote `GET /api/zero/billing/status` from shadow-compared to api-authoritative under the `apiBackend` feature switch (Stage 2 of #12290).
- Drop the `shadowCompareRoute` wrapper from `zero-billing-status.ts`; handler is now `authRoute({ requireOrganization: true, missingOrganizationStatus: 401 }, getBillingStatusInner$)`.
- Port all **17 web GET cases 1:1** into a brand-new api test file `__tests__/zero-billing-status.test.ts`.
- Add a fixture-helper Command `seedBillingStatusOrg$` (+ `deleteBillingStatusOrg$`) at `__tests__/helpers/zero-billing-status.ts` taking flat options for credits / subscription / expires records / extra-granted credits.

The api `zeroBillingStatus` service already mirrors the web behavior for every test case in scope. One small divergence flagged during research — api guards `displayedCredits` with `Math.max(... , 0)` while web does not — does not manifest under any of the 17 cases. Not silently fixed.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-status.test.ts` — 17/17 pass.
- [x] `pnpm -F api lint` — clean.
- [x] `pnpm -F api check-types` — clean.
- [x] Pre-commit (prettier / knip / full check-types) — clean.
- [x] Diff scope verified: route + new test + new helper, **no `apps/web/**` changes**.

## Helper design notes

- Single Command with flat options — diversity is in *data* (sources, amounts, tiers), not in *topology*. One seeder reads cleaner than 5+ topical seeders for billing.
- Auto-mints `inv_${randomUUID()}` per expires record when caller omits `stripeInvoiceId`, so a single test can insert multiple records without colliding on the partial `uq_credit_expires_invoice` unique index.
- `extraGrantedCredits` does an atomic `credits + delta` SQL update, mirroring web's `grantCreditsToOrg(orgId, n)` semantics for the unsettled-expired test case.
- Case 17 ("defaults when org row does not exist") inlines a session-only mock — no seed call, no DB row, no cleanup. Cleaner than a `skipOrgMetadata` knob on the seeder.

## Rollback

Disable the `apiBackend` feature switch to route platform traffic back to `apps/web`. No DB or schema changes.

Closes #12345