### PR TITLE
fix: gate codex oauth ui surfaces

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
@@ -215,6 +215,24 @@ describe("org-providers-tab — stale banner reconnect", () => {
     expect(screen.queryByText("Default provider")).not.toBeInTheDocument();
   });
 
+  it("hides the stale Codex reconnect banner when the Codex OAuth provider switch is off", async () => {
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.ModelFirstModelProvider]: true,
+      [FeatureSwitchKey.CodexOauthProvider]: false,
+    });
+    setMockOrgModelProviders([makeStaleProvider()]);
+
+    await openProvidersPage();
+
+    await expect(
+      screen.findByText(/Manage workspace models/i),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.queryByText(/ChatGPT session needs reconnection/i),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Re-paste auth.json")).not.toBeInTheDocument();
+  });
+
   it("changes the default model from the default selector", async () => {
     setMockFeatureSwitches({
       [FeatureSwitchKey.ModelFirstModelProvider]: true,
@@ -463,6 +481,9 @@ describe("org-providers-tab — stale banner reconnect", () => {
   });
 
   it("opens the paste dialog in reconnect mode when Re-paste button is clicked", async () => {
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.CodexOauthProvider]: true,
+    });
     setMockOrgModelProviders([makeStaleProvider()]);
     await openProvidersPage();
 
@@ -474,6 +495,9 @@ describe("org-providers-tab — stale banner reconnect", () => {
   });
 
   it("clears the stale banner after a successful re-paste", async () => {
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.CodexOauthProvider]: true,
+    });
     setMockOrgModelProviders([makeStaleProvider()]);
     server.use(
       mockApi(zeroModelProvidersMainContract.upsert, ({ respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
@@ -7,6 +7,7 @@ import {
   type ModelProviderResponse,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   cn,
   Button,
@@ -43,7 +44,10 @@ import {
 import { PersonalProviderDialog } from "../settings/personal-provider-dialog.tsx";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
-import { modelFirstModelProviderEnabled$ } from "../../../../signals/external/feature-switch.ts";
+import {
+  featureSwitch$,
+  modelFirstModelProviderEnabled$,
+} from "../../../../signals/external/feature-switch.ts";
 import { OrgModelPoliciesSection } from "./org-model-policies-section.tsx";
 
 export function OrgProvidersTab() {
@@ -91,7 +95,14 @@ export function OrgProvidersTab() {
  * pill so users see the failed row at a glance.
  */
 function StaleBannerSection() {
+  const features = useGet(featureSwitch$);
   const providersLoadable = useLoadable(orgConfiguredProviders$);
+  const codexOauthEnabled =
+    features?.[FeatureSwitchKey.CodexOauthProvider] ?? false;
+  if (!codexOauthEnabled) {
+    return null;
+  }
+
   const providers =
     providersLoadable.state === "hasData" ? providersLoadable.data : [];
   return <StaleProviderBanner providers={providers} />;

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
@@ -178,6 +178,31 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("hides ChatGPT OAuth when the Codex OAuth provider switch is off", async () => {
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.ModelFirstModelProvider]: true,
+      [FeatureSwitchKey.CodexOauthProvider]: false,
+    });
+    mockPreferences();
+    setMockPersonalModelProviders([makeProvider("codex-oauth-token")]);
+    detachedSetupPage({ context, path: "/settings" });
+
+    await openModelConfiguration();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("oauth-card-claude-code-oauth-token"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("oauth-card-codex-oauth-token"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("ChatGPT (Codex)")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/ChatGPT authorization/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("opens the Claude Code OAuth write dialog without a model selector", async () => {
     setMockFeatureSwitches({
       [FeatureSwitchKey.ModelFirstModelProvider]: true,

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -32,7 +32,7 @@ import { ProviderIcon } from "../settings/provider-icons.tsx";
 import { PersonalProviderDialog } from "../settings/personal-provider-dialog.tsx";
 import { PersonalCodexAuthPasteDialog } from "../settings/codex-auth-paste-dialog.tsx";
 
-type OAuthStatus = "connected" | "stale" | "missing" | "unavailable";
+type OAuthStatus = "connected" | "stale" | "missing";
 
 export function PersonalProvidersTab() {
   return (
@@ -60,7 +60,7 @@ function OAuthCredentialsSection() {
     features?.[FeatureSwitchKey.CodexOauthProvider] ?? false;
   const claudeCode = findProvider(providers, "claude-code-oauth-token");
   const openAI = findProvider(providers, "codex-oauth-token");
-  const openAIStatus = getOpenAIStatus(openAI, codexOauthEnabled);
+  const openAIStatus = getOpenAIStatus(openAI);
   const disconnecting = actionLoadable.state === "loading";
   const connectOpenAI = () => {
     detach(connectCodexOAuth(pageSignal), Reason.DomCallback);
@@ -70,13 +70,14 @@ function OAuthCredentialsSection() {
     <section className="flex flex-col gap-3">
       <p className="text-sm text-muted-foreground">
         Manage OAuth access used when workspace model routes require your
-        personal Claude Code or ChatGPT authorization.
+        personal Claude Code
+        {codexOauthEnabled ? " or ChatGPT" : ""} authorization.
       </p>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         {isLoading ? (
           <>
             <OAuthCardSkeleton />
-            <OAuthCardSkeleton />
+            {codexOauthEnabled && <OAuthCardSkeleton />}
           </>
         ) : (
           <>
@@ -115,38 +116,39 @@ function OAuthCredentialsSection() {
               }}
               testId="oauth-card-claude-code-oauth-token"
             />
-            <OAuthCredentialCard
-              type="codex-oauth-token"
-              title="ChatGPT (Codex)"
-              description="Connect a ChatGPT account for Codex-backed model routes."
-              status={openAIStatus}
-              disabled={openAIStatus === "unavailable"}
-              menuItems={
-                openAI
-                  ? [
-                      {
-                        label: "Replace",
-                        onSelect: connectOpenAI,
-                      },
-                      {
-                        label: "Disconnect",
-                        disabled: disconnecting,
-                        onSelect: () => {
-                          detach(
-                            disconnectCredential(
-                              "codex-oauth-token",
-                              pageSignal,
-                            ),
-                            Reason.DomCallback,
-                          );
+            {codexOauthEnabled && (
+              <OAuthCredentialCard
+                type="codex-oauth-token"
+                title="ChatGPT (Codex)"
+                description="Connect a ChatGPT account for Codex-backed model routes."
+                status={openAIStatus}
+                menuItems={
+                  openAI
+                    ? [
+                        {
+                          label: "Replace",
+                          onSelect: connectOpenAI,
                         },
-                      },
-                    ]
-                  : []
-              }
-              onAction={connectOpenAI}
-              testId="oauth-card-codex-oauth-token"
-            />
+                        {
+                          label: "Disconnect",
+                          disabled: disconnecting,
+                          onSelect: () => {
+                            detach(
+                              disconnectCredential(
+                                "codex-oauth-token",
+                                pageSignal,
+                              ),
+                              Reason.DomCallback,
+                            );
+                          },
+                        },
+                      ]
+                    : []
+                }
+                onAction={connectOpenAI}
+                testId="oauth-card-codex-oauth-token"
+              />
+            )}
           </>
         )}
       </div>
@@ -165,22 +167,11 @@ function findProvider(
 
 function getOpenAIStatus(
   provider: ModelProviderResponse | undefined,
-  enabled: boolean,
 ): OAuthStatus {
-  if (!enabled) {
-    return "unavailable";
-  }
   if (provider?.needsReconnect) {
     return "stale";
   }
   return provider ? "connected" : "missing";
-}
-
-function getOpenAIActionLabel(status: OAuthStatus): string {
-  if (status === "unavailable") {
-    return "Unavailable";
-  }
-  return "Connect";
 }
 
 interface OAuthMenuItem {
@@ -334,7 +325,7 @@ function OAuthFooterStatus({ status }: { status: OAuthStatus }) {
   }
   return (
     <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
-      {getOpenAIActionLabel(status)}
+      Connect
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- Hide the Personal Models ChatGPT (Codex) OAuth card when CodexOauthProvider is disabled
- Hide the org-level stale Codex reconnect banner when CodexOauthProvider is disabled
- Add regression coverage for both feature-switch-off states

## Verification
- pnpm exec prettier --check apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx apps/platform/src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
- pnpm exec eslint src/views/zero-page/components/preferences/personal-providers-tab.tsx src/views/zero-page/components/org-manage/org-providers-tab.tsx src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx --max-warnings 0
- pnpm exec oxlint src/views/zero-page/components/preferences/personal-providers-tab.tsx src/views/zero-page/components/org-manage/org-providers-tab.tsx src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
- pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json src/views/zero-page/components/preferences/personal-providers-tab.tsx src/views/zero-page/components/org-manage/org-providers-tab.tsx src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx
- pnpm test src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx src/views/zero-page/components/org-manage/__tests__/org-providers-tab.test.tsx

## Note
- Normal pre-commit was blocked by existing unrelated web type errors in apps/web routes; the scoped platform checks above passed.