### PR TITLE
refactor(api): migrate usage insight get

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
@@ -1,0 +1,602 @@
+import { randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { writeDb$ } from "../../../external/db";
+import { nowDate } from "../../../../lib/time";
+
+export interface UsageInsightFixture {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+interface ComposeResult {
+  readonly composeId: string;
+  readonly agentId: string;
+}
+
+interface SeedRunArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly composeId: string;
+  readonly triggerSource?: string;
+  readonly scheduleId?: string;
+  readonly chatThreadId?: string;
+  readonly status?: string;
+}
+
+interface SeedScheduleArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly agentId: string;
+  readonly name?: string;
+  readonly description?: string;
+}
+
+interface SeedChatThreadArgs {
+  readonly userId: string;
+  readonly composeId: string;
+  readonly title?: string;
+}
+
+interface ModelUsageEventArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly runId: string;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly cacheReadInputTokens?: number;
+  readonly cacheCreationInputTokens?: number;
+  readonly creditsCharged?: number;
+  readonly status?: string;
+  readonly processedAt?: Date | null;
+}
+
+interface InsertUsageEventArgs {
+  readonly orgId: string;
+  readonly userId?: string;
+  readonly runId?: string | null;
+  readonly kind?: string;
+  readonly provider?: string;
+  readonly category?: string;
+  readonly quantity?: number;
+  readonly status?: string;
+  readonly creditsCharged?: number;
+  readonly idempotencyKey?: string;
+  readonly createdAt?: Date;
+  readonly processedAt?: Date | null;
+}
+
+interface BonusUsageEvent {
+  readonly kind: string;
+  readonly provider: string;
+  readonly category: string;
+  readonly quantity: number;
+  readonly creditsCharged: number;
+  readonly status: string;
+}
+
+interface ScheduleBatchArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly composeId: string;
+  readonly count: number;
+  readonly creditsForIndex: (index: number) => number;
+  readonly bonusUsageEventForIndex?: (index: number) => BonusUsageEvent | null;
+}
+
+export const seedUsageInsightFixture$ = command(
+  (_, _input: void, _signal: AbortSignal): Promise<UsageInsightFixture> => {
+    return Promise.resolve({
+      orgId: `org_${randomUUID()}`,
+      userId: `user_${randomUUID()}`,
+    });
+  },
+);
+
+export const deleteUsageInsightFixture$ = command(
+  async (
+    { set },
+    fixture: UsageInsightFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    const orgId = fixture.orgId;
+    const userId = fixture.userId;
+
+    await db
+      .delete(usageEvent)
+      .where(and(eq(usageEvent.orgId, orgId), eq(usageEvent.userId, userId)));
+    signal.throwIfAborted();
+
+    const runRows = await db
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(and(eq(agentRuns.orgId, orgId), eq(agentRuns.userId, userId)));
+    signal.throwIfAborted();
+    const runIds = runRows.map((row) => {
+      return row.id;
+    });
+    if (runIds.length > 0) {
+      await db.delete(zeroRuns).where(inArray(zeroRuns.id, runIds));
+      signal.throwIfAborted();
+    }
+
+    await db
+      .delete(zeroAgentSchedules)
+      .where(
+        and(
+          eq(zeroAgentSchedules.orgId, orgId),
+          eq(zeroAgentSchedules.userId, userId),
+        ),
+      );
+    signal.throwIfAborted();
+
+    if (runIds.length > 0) {
+      await db.delete(agentRuns).where(inArray(agentRuns.id, runIds));
+      signal.throwIfAborted();
+    }
+
+    await db
+      .delete(agentSessions)
+      .where(
+        and(eq(agentSessions.orgId, orgId), eq(agentSessions.userId, userId)),
+      );
+    signal.throwIfAborted();
+
+    const composeRows = await db
+      .select({ id: agentComposes.id })
+      .from(agentComposes)
+      .where(
+        and(eq(agentComposes.orgId, orgId), eq(agentComposes.userId, userId)),
+      );
+    signal.throwIfAborted();
+    const composeIds = composeRows.map((row) => {
+      return row.id;
+    });
+    if (composeIds.length > 0) {
+      await db
+        .delete(agentComposeVersions)
+        .where(inArray(agentComposeVersions.composeId, composeIds));
+      signal.throwIfAborted();
+    }
+
+    await db.delete(chatThreads).where(eq(chatThreads.userId, userId));
+    signal.throwIfAborted();
+
+    if (composeIds.length > 0) {
+      await db.delete(zeroAgents).where(inArray(zeroAgents.id, composeIds));
+      signal.throwIfAborted();
+    }
+
+    await db
+      .delete(agentComposes)
+      .where(
+        and(eq(agentComposes.orgId, orgId), eq(agentComposes.userId, userId)),
+      );
+    signal.throwIfAborted();
+  },
+);
+
+export const seedCompose$ = command(
+  async (
+    { set },
+    args: { orgId: string; userId: string; name?: string },
+    signal: AbortSignal,
+  ): Promise<ComposeResult> => {
+    const db = set(writeDb$);
+    const name = args.name ?? `compose-${randomUUID().slice(0, 8)}`;
+    const [row] = await db
+      .insert(agentComposes)
+      .values({ userId: args.userId, orgId: args.orgId, name })
+      .returning({ id: agentComposes.id });
+    signal.throwIfAborted();
+    if (!row) {
+      throw new Error("seedCompose$: insert returned no row");
+    }
+    await db
+      .insert(zeroAgents)
+      .values({
+        id: row.id,
+        orgId: args.orgId,
+        owner: args.userId,
+        name,
+      })
+      .onConflictDoNothing();
+    signal.throwIfAborted();
+    return { composeId: row.id, agentId: row.id };
+  },
+);
+
+export const seedRun$ = command(
+  async (
+    { set },
+    args: SeedRunArgs,
+    signal: AbortSignal,
+  ): Promise<{ runId: string }> => {
+    const db = set(writeDb$);
+    const versionId = randomUUID();
+    await db.insert(agentComposeVersions).values({
+      id: versionId,
+      composeId: args.composeId,
+      content: {
+        version: "1.0",
+        agents: { "test-agent": { framework: "claude-code" } },
+      },
+      createdBy: args.userId,
+    });
+    signal.throwIfAborted();
+    await db
+      .update(agentComposes)
+      .set({ headVersionId: versionId })
+      .where(eq(agentComposes.id, args.composeId));
+    signal.throwIfAborted();
+    const [session] = await db
+      .insert(agentSessions)
+      .values({
+        userId: args.userId,
+        orgId: args.orgId,
+        agentComposeId: args.composeId,
+      })
+      .returning({ id: agentSessions.id });
+    signal.throwIfAborted();
+    if (!session) {
+      throw new Error("seedRun$: session insert returned no row");
+    }
+    const [run] = await db
+      .insert(agentRuns)
+      .values({
+        userId: args.userId,
+        orgId: args.orgId,
+        agentComposeVersionId: versionId,
+        prompt: "test prompt",
+        status: args.status ?? "pending",
+        sessionId: session.id,
+      })
+      .returning({ id: agentRuns.id });
+    signal.throwIfAborted();
+    if (!run) {
+      throw new Error("seedRun$: run insert returned no row");
+    }
+    await db.insert(zeroRuns).values({
+      id: run.id,
+      triggerSource: args.triggerSource ?? "cli",
+      scheduleId: args.scheduleId ?? null,
+      chatThreadId: args.chatThreadId ?? null,
+    });
+    signal.throwIfAborted();
+    return { runId: run.id };
+  },
+);
+
+export const seedSchedule$ = command(
+  async (
+    { set },
+    args: SeedScheduleArgs,
+    signal: AbortSignal,
+  ): Promise<string> => {
+    const db = set(writeDb$);
+    const [row] = await db
+      .insert(zeroAgentSchedules)
+      .values({
+        agentId: args.agentId,
+        userId: args.userId,
+        orgId: args.orgId,
+        name: args.name ?? `sched-${randomUUID().slice(0, 8)}`,
+        description: args.description,
+        cronExpression: "0 0 * * *",
+        prompt: "test",
+      })
+      .returning({ id: zeroAgentSchedules.id });
+    signal.throwIfAborted();
+    if (!row) {
+      throw new Error("seedSchedule$: insert returned no row");
+    }
+    return row.id;
+  },
+);
+
+export const seedChatThread$ = command(
+  async (
+    { set },
+    args: SeedChatThreadArgs,
+    signal: AbortSignal,
+  ): Promise<string> => {
+    const db = set(writeDb$);
+    const [row] = await db
+      .insert(chatThreads)
+      .values({
+        userId: args.userId,
+        agentComposeId: args.composeId,
+        title: args.title ?? null,
+      })
+      .returning({ id: chatThreads.id });
+    signal.throwIfAborted();
+    if (!row) {
+      throw new Error("seedChatThread$: insert returned no row");
+    }
+    return row.id;
+  },
+);
+
+const MODEL_TOKEN_CATEGORIES = [
+  "tokens.input",
+  "tokens.output",
+  "tokens.cache_read",
+  "tokens.cache_creation",
+] as const;
+
+interface ModelRowQuantity {
+  readonly category: (typeof MODEL_TOKEN_CATEGORIES)[number];
+  readonly quantity: number;
+}
+
+function buildModelUsageRows(args: ModelUsageEventArgs): {
+  rows: {
+    runId: string;
+    orgId: string;
+    userId: string;
+    kind: string;
+    provider: string;
+    category: string;
+    quantity: number;
+    creditsCharged: number | null;
+    status: string;
+    idempotencyKey: string;
+    createdAt: Date;
+    processedAt: Date | null;
+  }[];
+} {
+  const status = args.status ?? "pending";
+  const createdAt = nowDate();
+  const processedAt =
+    args.processedAt !== undefined
+      ? args.processedAt
+      : status === "processed"
+        ? createdAt
+        : null;
+  const provider = "claude-sonnet-4-6";
+  const quantities: readonly ModelRowQuantity[] = [
+    { category: "tokens.input", quantity: args.inputTokens ?? 0 },
+    { category: "tokens.output", quantity: args.outputTokens ?? 0 },
+    { category: "tokens.cache_read", quantity: args.cacheReadInputTokens ?? 0 },
+    {
+      category: "tokens.cache_creation",
+      quantity: args.cacheCreationInputTokens ?? 0,
+    },
+  ];
+  const billable = quantities.filter((entry, index) => {
+    return index === 0 || entry.quantity > 0;
+  });
+  const rows = billable.map((entry, index) => {
+    return {
+      runId: args.runId,
+      orgId: args.orgId,
+      userId: args.userId,
+      kind: "model",
+      provider,
+      category: entry.category,
+      quantity: entry.quantity,
+      creditsCharged: index === 0 ? (args.creditsCharged ?? null) : null,
+      status,
+      idempotencyKey: randomUUID(),
+      createdAt,
+      processedAt,
+    };
+  });
+  return { rows };
+}
+
+export const insertModelUsageEventForRun$ = command(
+  async (
+    { set },
+    args: ModelUsageEventArgs,
+    signal: AbortSignal,
+  ): Promise<{ id: string }> => {
+    const db = set(writeDb$);
+    const { rows } = buildModelUsageRows({
+      ...args,
+      inputTokens: args.inputTokens ?? 100,
+      outputTokens: args.outputTokens ?? 50,
+    });
+    const [row] = await db
+      .insert(usageEvent)
+      .values(rows)
+      .returning({ id: usageEvent.id });
+    signal.throwIfAborted();
+    if (!row) {
+      throw new Error("insertModelUsageEventForRun$: returned no row");
+    }
+    return { id: row.id };
+  },
+);
+
+export const insertUsageEvent$ = command(
+  async (
+    { set },
+    args: InsertUsageEventArgs,
+    signal: AbortSignal,
+  ): Promise<string> => {
+    const db = set(writeDb$);
+    const status = args.status ?? "pending";
+    const processedAt =
+      args.processedAt !== undefined
+        ? args.processedAt
+        : status === "processed"
+          ? nowDate()
+          : null;
+    const values: typeof usageEvent.$inferInsert = {
+      runId: args.runId ?? null,
+      orgId: args.orgId,
+      userId: args.userId ?? "test-user",
+      kind: args.kind ?? "connector",
+      provider: args.provider ?? "x",
+      category: args.category ?? "tweet.read",
+      quantity: args.quantity ?? 1,
+      status,
+      creditsCharged: args.creditsCharged ?? null,
+      idempotencyKey: args.idempotencyKey ?? randomUUID(),
+      processedAt,
+    };
+    if (args.createdAt) {
+      values.createdAt = args.createdAt;
+    }
+    const [row] = await db
+      .insert(usageEvent)
+      .values(values)
+      .returning({ id: usageEvent.id });
+    signal.throwIfAborted();
+    if (!row) {
+      throw new Error("insertUsageEvent$: insert returned no row");
+    }
+    return row.id;
+  },
+);
+
+export const setUsageEventCreatedAt$ = command(
+  async (
+    { set },
+    args: { id: string; createdAt: Date },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    const [row] = await db
+      .select({
+        runId: usageEvent.runId,
+        originalCreatedAt: usageEvent.createdAt,
+      })
+      .from(usageEvent)
+      .where(eq(usageEvent.id, args.id))
+      .limit(1);
+    signal.throwIfAborted();
+    if (!row) {
+      return;
+    }
+    const where = row.runId
+      ? and(
+          eq(usageEvent.runId, row.runId),
+          eq(usageEvent.createdAt, row.originalCreatedAt),
+        )
+      : eq(usageEvent.id, args.id);
+    await db.update(usageEvent).set({ createdAt: args.createdAt }).where(where);
+    signal.throwIfAborted();
+  },
+);
+
+export const seedScheduleBatch$ = command(
+  async (
+    { set },
+    args: ScheduleBatchArgs,
+    signal: AbortSignal,
+  ): Promise<{ scheduleIds: string[] }> => {
+    const db = set(writeDb$);
+    const indices = Array.from({ length: args.count }, (_, index) => {
+      return index;
+    });
+    const results = await Promise.all(
+      indices.map(async (index) => {
+        const [scheduleRow] = await db
+          .insert(zeroAgentSchedules)
+          .values({
+            agentId: args.composeId,
+            userId: args.userId,
+            orgId: args.orgId,
+            name: `sched-${randomUUID().slice(0, 8)}`,
+            cronExpression: "0 0 * * *",
+            prompt: "test",
+          })
+          .returning({ id: zeroAgentSchedules.id });
+        if (!scheduleRow) {
+          throw new Error(
+            "seedScheduleBatch$: schedule insert returned no row",
+          );
+        }
+        const versionId = randomUUID();
+        await db.insert(agentComposeVersions).values({
+          id: versionId,
+          composeId: args.composeId,
+          content: {
+            version: "1.0",
+            agents: { "test-agent": { framework: "claude-code" } },
+          },
+          createdBy: args.userId,
+        });
+        const [session] = await db
+          .insert(agentSessions)
+          .values({
+            userId: args.userId,
+            orgId: args.orgId,
+            agentComposeId: args.composeId,
+          })
+          .returning({ id: agentSessions.id });
+        if (!session) {
+          throw new Error("seedScheduleBatch$: session insert returned no row");
+        }
+        const [run] = await db
+          .insert(agentRuns)
+          .values({
+            userId: args.userId,
+            orgId: args.orgId,
+            agentComposeVersionId: versionId,
+            prompt: "test prompt",
+            status: "completed",
+            sessionId: session.id,
+          })
+          .returning({ id: agentRuns.id });
+        if (!run) {
+          throw new Error("seedScheduleBatch$: run insert returned no row");
+        }
+        await db.insert(zeroRuns).values({
+          id: run.id,
+          triggerSource: "schedule",
+          scheduleId: scheduleRow.id,
+        });
+        const credits = args.creditsForIndex(index);
+        await db.insert(usageEvent).values({
+          runId: run.id,
+          orgId: args.orgId,
+          userId: args.userId,
+          kind: "model",
+          provider: "claude-sonnet-4-6",
+          category: "tokens.input",
+          quantity: 100,
+          creditsCharged: credits,
+          status: "processed",
+          idempotencyKey: randomUUID(),
+          processedAt: nowDate(),
+        });
+        const bonus = args.bonusUsageEventForIndex?.(index);
+        if (bonus) {
+          await db.insert(usageEvent).values({
+            runId: run.id,
+            orgId: args.orgId,
+            userId: args.userId,
+            kind: bonus.kind,
+            provider: bonus.provider,
+            category: bonus.category,
+            quantity: bonus.quantity,
+            creditsCharged: bonus.creditsCharged,
+            status: bonus.status,
+            idempotencyKey: randomUUID(),
+            processedAt: bonus.status === "processed" ? nowDate() : null,
+          });
+        }
+        return scheduleRow.id;
+      }),
+    );
+    signal.throwIfAborted();
+    return { scheduleIds: results };
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
@@ -1,0 +1,1393 @@
+import { randomUUID } from "node:crypto";
+
+import { triggerSourceSchema } from "@vm0/api-contracts/contracts/logs";
+import {
+  type UsageInsightBucket,
+  zeroUsageInsightContract,
+} from "@vm0/api-contracts/contracts/zero-usage-insight";
+import { createStore } from "ccstate";
+
+import { afterEach } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { clearMockNow, mockNow, nowDate } from "../../../lib/time";
+import {
+  deleteUsageInsightFixture$,
+  insertModelUsageEventForRun$,
+  insertUsageEvent$,
+  seedChatThread$,
+  seedCompose$,
+  seedRun$,
+  seedSchedule$,
+  seedScheduleBatch$,
+  seedUsageInsightFixture$,
+  setUsageEventCreatedAt$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function apiClient() {
+  return setupApp({ context })(zeroUsageInsightContract);
+}
+
+function sumBucketSeries(
+  buckets: readonly UsageInsightBucket[],
+): Record<string, { credits: number; tokens: number }> {
+  const totals: Record<string, { credits: number; tokens: number }> = {};
+  for (const bucket of buckets) {
+    for (const [key, credits] of Object.entries(bucket.series)) {
+      const current = totals[key] ?? { credits: 0, tokens: 0 };
+      current.credits += credits;
+      current.tokens += bucket.tokens[key] ?? 0;
+      totals[key] = current;
+    }
+  }
+  return totals;
+}
+
+describe("GET /api/zero/usage/insight", () => {
+  const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  afterEach(() => {
+    clearMockNow();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", groupBy: "source", tz: "UTC" },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 400 for invalid timezone", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", groupBy: "source", tz: "Not/A/Timezone" },
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 400 when range=day is missing a date", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { range: "day", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("happy path — shape and totals add up for range=7d groupBy=source tz=UTC", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "web",
+        status: "completed",
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsageEventForRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId,
+        inputTokens: 1000,
+        outputTokens: 500,
+        creditsCharged: 100,
+        status: "processed",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(Array.isArray(response.body.buckets)).toBeTruthy();
+    expect(Array.isArray(response.body.schedules)).toBeTruthy();
+    expect(Array.isArray(response.body.chats)).toBeTruthy();
+    expect(typeof response.body.grandTotalCredits).toBe("number");
+    expect(typeof response.body.grandTotalTokens).toBe("number");
+    expect(response.body.grandTotalCredits).toBeGreaterThanOrEqual(100);
+
+    const bucketSum = response.body.buckets.reduce((sum, bucket) => {
+      const seriesSum = Object.values(bucket.series).reduce((s, v) => {
+        return s + v;
+      }, 0);
+      return sum + seriesSum;
+    }, 0);
+    expect(bucketSum).toBeLessThanOrEqual(response.body.grandTotalCredits + 1);
+  });
+
+  it("source mapping — every TriggerSource lands in the correct bucket", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+
+    for (const source of triggerSourceSchema.options) {
+      const { runId } = await store.set(
+        seedRun$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          composeId,
+          triggerSource: source,
+          status: "completed",
+        },
+        context.signal,
+      );
+      await store.set(
+        insertModelUsageEventForRun$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          runId,
+          creditsCharged: 50,
+          status: "processed",
+        },
+        context.signal,
+      );
+    }
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    const totalByBucket: Record<string, number> = {};
+    for (const bucket of response.body.buckets) {
+      for (const [key, val] of Object.entries(bucket.series)) {
+        totalByBucket[key] = (totalByBucket[key] ?? 0) + val;
+      }
+    }
+
+    expect(totalByBucket["chat"]).toBeGreaterThanOrEqual(50);
+    expect(totalByBucket["slack"]).toBeGreaterThanOrEqual(50);
+    expect(totalByBucket["email"]).toBeGreaterThanOrEqual(50);
+    expect(totalByBucket["schedule"]).toBeGreaterThanOrEqual(50);
+    expect(totalByBucket["others"]).toBeGreaterThanOrEqual(250);
+  });
+
+  it("groupBy=agent with 9 agents produces top-7 + others series keys", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+
+    for (let i = 1; i <= 9; i++) {
+      const { composeId } = await store.set(
+        seedCompose$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          name: `agent-${i}-${randomUUID().slice(0, 8)}`,
+        },
+        context.signal,
+      );
+      const { runId } = await store.set(
+        seedRun$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          composeId,
+          triggerSource: "cli",
+          status: "completed",
+        },
+        context.signal,
+      );
+      await store.set(
+        insertModelUsageEventForRun$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          runId,
+          creditsCharged: i * 100,
+          status: "processed",
+        },
+        context.signal,
+      );
+    }
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", groupBy: "agent", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    const seriesKeys = new Set<string>();
+    for (const bucket of response.body.buckets) {
+      for (const key of Object.keys(bucket.series)) {
+        seriesKeys.add(key);
+      }
+    }
+    expect(seriesKeys.size).toBeLessThanOrEqual(8);
+    expect(seriesKeys.has("others")).toBeTruthy();
+  });
+
+  it("today produces hourly bucket strings", async () => {
+    mockNow(new Date("2026-04-23T15:00:00Z"));
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+
+    const todayStart = new Date("2026-04-23T00:00:00Z");
+    const t1 = new Date(todayStart.getTime() + 9 * 3_600_000);
+    const t2 = new Date(todayStart.getTime() + 12 * 3_600_000);
+
+    const { runId: run1 } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "cli",
+        status: "completed",
+      },
+      context.signal,
+    );
+    const { id: cu1Id } = await store.set(
+      insertModelUsageEventForRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: run1,
+        creditsCharged: 10,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      setUsageEventCreatedAt$,
+      { id: cu1Id, createdAt: t1 },
+      context.signal,
+    );
+
+    const { runId: run2 } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "cli",
+        status: "completed",
+      },
+      context.signal,
+    );
+    const { id: cu2Id } = await store.set(
+      insertModelUsageEventForRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: run2,
+        creditsCharged: 10,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      setUsageEventCreatedAt$,
+      { id: cu2Id, createdAt: t2 },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const response = await accept(
+      apiClient().get({
+        query: { range: "today", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.buckets.length).toBeGreaterThanOrEqual(1);
+    for (const bucket of response.body.buckets) {
+      expect(bucket.ts).toMatch(/:00:00/);
+    }
+  });
+
+  it("yesterday produces hourly bucket strings for prior calendar day", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+
+    const now = nowDate();
+    const yesterdayStart = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1),
+    );
+    const t1 = new Date(yesterdayStart.getTime() + 10 * 3_600_000);
+    const t2 = new Date(yesterdayStart.getTime() + 14 * 3_600_000);
+
+    const { runId: run1 } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "cli",
+        status: "completed",
+      },
+      context.signal,
+    );
+    const { id: cu1Id } = await store.set(
+      insertModelUsageEventForRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: run1,
+        creditsCharged: 10,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      setUsageEventCreatedAt$,
+      { id: cu1Id, createdAt: t1 },
+      context.signal,
+    );
+
+    const { runId: run2 } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "cli",
+        status: "completed",
+      },
+      context.signal,
+    );
+    const { id: cu2Id } = await store.set(
+      insertModelUsageEventForRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: run2,
+        creditsCharged: 10,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      setUsageEventCreatedAt$,
+      { id: cu2Id, createdAt: t2 },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const response = await accept(
+      apiClient().get({
+        query: { range: "yesterday", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.buckets.length).toBeGreaterThanOrEqual(2);
+
+    const yesterdayDate = yesterdayStart.toISOString().split("T")[0];
+    expect(yesterdayDate).toBeDefined();
+    for (const bucket of response.body.buckets) {
+      expect(bucket.ts).toMatch(/:00:00/);
+      expect(bucket.ts).toContain(yesterdayDate);
+    }
+
+    const first = response.body.buckets[0];
+    const last = response.body.buckets[response.body.buckets.length - 1];
+    if (first && last) {
+      expect(first.ts).not.toBe(last.ts);
+    }
+  });
+
+  it("7d window includes data from midnight 6 days ago", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+
+    const now = nowDate();
+    const todayStart = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+    );
+    const sixDaysAgo = new Date(todayStart.getTime() - 6 * 86_400_000);
+    const runTime = new Date(sixDaysAgo.getTime() + 3_600_000);
+
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "cli",
+        status: "completed",
+      },
+      context.signal,
+    );
+    const { id: cuId } = await store.set(
+      insertModelUsageEventForRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId,
+        creditsCharged: 42,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      setUsageEventCreatedAt$,
+      { id: cuId, createdAt: runTime },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    const bucket = response.body.buckets.find((b) => {
+      return Object.values(b.series).some((v) => {
+        return v === 42;
+      });
+    });
+    expect(bucket).toBeDefined();
+    const sixDaysAgoDate = sixDaysAgo.toISOString().split("T")[0];
+    expect(sixDaysAgoDate).toBeDefined();
+    expect(bucket?.ts).toContain(sixDaysAgoDate);
+  });
+
+  it("day window includes only the selected calendar day", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+
+    const now = nowDate();
+    const todayStart = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+    );
+    const selectedStart = new Date(todayStart.getTime() - 5 * 86_400_000);
+    const selectedDate = selectedStart.toISOString().split("T")[0];
+    expect(selectedDate).toBeDefined();
+
+    const { runId: selectedRunId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "cli",
+        status: "completed",
+      },
+      context.signal,
+    );
+    const { id: selectedUsageId } = await store.set(
+      insertModelUsageEventForRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: selectedRunId,
+        creditsCharged: 42,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      setUsageEventCreatedAt$,
+      {
+        id: selectedUsageId,
+        createdAt: new Date(selectedStart.getTime() + 3_600_000),
+      },
+      context.signal,
+    );
+
+    const { runId: outsideRunId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "cli",
+        status: "completed",
+      },
+      context.signal,
+    );
+    const { id: outsideUsageId } = await store.set(
+      insertModelUsageEventForRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: outsideRunId,
+        creditsCharged: 99,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      setUsageEventCreatedAt$,
+      {
+        id: outsideUsageId,
+        createdAt: new Date(selectedStart.getTime() + 86_400_000 + 3_600_000),
+      },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const response = await accept(
+      apiClient().get({
+        query: {
+          range: "day",
+          date: selectedDate,
+          groupBy: "source",
+          tz: "UTC",
+        },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.grandTotalCredits).toBe(42);
+    expect(response.body.buckets[0]?.ts).toContain(selectedDate);
+  });
+
+  it("tz shift — same row appears in different date buckets by timezone", async () => {
+    mockNow(new Date("2026-04-23T15:00:00Z"));
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "cli",
+        status: "completed",
+      },
+      context.signal,
+    );
+    const { id: cuId } = await store.set(
+      insertModelUsageEventForRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId,
+        creditsCharged: 42,
+        status: "processed",
+      },
+      context.signal,
+    );
+    const now = new Date("2026-04-23T15:00:00Z");
+    const rowTime = new Date(
+      Date.UTC(
+        now.getUTCFullYear(),
+        now.getUTCMonth(),
+        now.getUTCDate() - 3,
+        0,
+        30,
+      ),
+    );
+    const dateInTimeZone = (date: Date, timeZone: string): string => {
+      const parts = new Intl.DateTimeFormat("en-US", {
+        timeZone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }).formatToParts(date);
+      const value = (type: string): string => {
+        const part = parts.find((entry) => {
+          return entry.type === type;
+        });
+        if (!part) {
+          throw new Error(`Missing date part: ${type}`);
+        }
+        return part.value;
+      };
+      return `${value("year")}-${value("month")}-${value("day")}`;
+    };
+    const expectedUtcDate = dateInTimeZone(rowTime, "UTC");
+    const expectedLaDate = dateInTimeZone(rowTime, "America/Los_Angeles");
+    await store.set(
+      setUsageEventCreatedAt$,
+      { id: cuId, createdAt: rowTime },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const responseUtc = await accept(
+      apiClient().get({
+        query: { range: "7d", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    const responseLa = await accept(
+      apiClient().get({
+        query: {
+          range: "7d",
+          groupBy: "source",
+          tz: "America/Los_Angeles",
+        },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    const findBucketWith42Credits = (
+      buckets: readonly UsageInsightBucket[],
+    ): UsageInsightBucket | undefined => {
+      return buckets.find((bucket) => {
+        const total = Object.values(bucket.series).reduce((s, v) => {
+          return s + v;
+        }, 0);
+        return total === 42;
+      });
+    };
+
+    const utcBucket = findBucketWith42Credits(responseUtc.body.buckets);
+    const laBucket = findBucketWith42Credits(responseLa.body.buckets);
+
+    expect(utcBucket).toBeDefined();
+    expect(laBucket).toBeDefined();
+    expect(utcBucket?.ts).toContain(expectedUtcDate);
+    expect(laBucket?.ts).toContain(expectedLaDate);
+    expect(expectedUtcDate).not.toBe(expectedLaDate);
+  });
+
+  it("top-100 truncation — 105 schedules → schedules.length === 100, otherCount === 5", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+
+    const { scheduleIds } = await store.set(
+      seedScheduleBatch$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        count: 105,
+        creditsForIndex: (i) => {
+          return i + 1;
+        },
+        bonusUsageEventForIndex: (i) => {
+          if (i !== 0) {
+            return null;
+          }
+          return {
+            kind: "connector",
+            provider: "x",
+            category: "tweet.read",
+            quantity: 1,
+            creditsCharged: 10_000,
+            status: "processed",
+          };
+        },
+      },
+      context.signal,
+    );
+    const eventBoostedScheduleId = scheduleIds[0];
+    expect(eventBoostedScheduleId).toBeDefined();
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const response = await accept(
+      apiClient().get({
+        query: { range: "28d", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.schedules).toHaveLength(100);
+    expect(response.body.scheduleOtherCount).toBe(5);
+    expect(response.body.schedules[0]).toMatchObject({
+      scheduleId: eventBoostedScheduleId,
+      credits: 10_001,
+    });
+  });
+
+  it("returns scheduleDescription alongside scheduleName for scheduled runs", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId: agentA } = await store.set(
+      seedCompose$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: `compose-a-${randomUUID().slice(0, 8)}`,
+      },
+      context.signal,
+    );
+    const { composeId: agentB } = await store.set(
+      seedCompose$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: `compose-b-${randomUUID().slice(0, 8)}`,
+      },
+      context.signal,
+    );
+
+    const describedScheduleId = await store.set(
+      seedSchedule$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId: agentA,
+        name: "default",
+        description: "Daily morning brief",
+      },
+      context.signal,
+    );
+    const undescribedScheduleId = await store.set(
+      seedSchedule$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId: agentB,
+        name: "default",
+      },
+      context.signal,
+    );
+
+    for (const [agentId, scheduleId] of [
+      [agentA, describedScheduleId],
+      [agentB, undescribedScheduleId],
+    ] as const) {
+      const { runId } = await store.set(
+        seedRun$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          composeId: agentId,
+          triggerSource: "schedule",
+          scheduleId,
+          status: "completed",
+        },
+        context.signal,
+      );
+      await store.set(
+        insertModelUsageEventForRun$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          runId,
+          creditsCharged: 50,
+          status: "processed",
+        },
+        context.signal,
+      );
+    }
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    const described = response.body.schedules.find((s) => {
+      return s.scheduleId === describedScheduleId;
+    });
+    const undescribed = response.body.schedules.find((s) => {
+      return s.scheduleId === undescribedScheduleId;
+    });
+    expect(described?.scheduleDescription).toBe("Daily morning brief");
+    expect(undescribed?.scheduleDescription).toBeNull();
+  });
+
+  it("scope isolation — other user's activity in same org is invisible", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const otherFixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    // Override otherFixture to use the same org as the main fixture so the
+    // assertion specifically checks user-level scoping (not org-level).
+    const otherUserId = otherFixture.userId;
+
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId: myRunId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "web",
+        status: "completed",
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsageEventForRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: myRunId,
+        creditsCharged: 100,
+        status: "processed",
+      },
+      context.signal,
+    );
+
+    const { composeId: otherComposeId } = await store.set(
+      seedCompose$,
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        name: `other-compose-${randomUUID().slice(0, 8)}`,
+      },
+      context.signal,
+    );
+    const { runId: otherRunId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        composeId: otherComposeId,
+        triggerSource: "web",
+        status: "completed",
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsageEventForRun$,
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        runId: otherRunId,
+        creditsCharged: 999,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        runId: otherRunId,
+        kind: "connector",
+        provider: "x",
+        category: "tweet.read",
+        quantity: 1,
+        creditsCharged: 999,
+        status: "processed",
+      },
+      context.signal,
+    );
+
+    // Track the other user's rows through their own fixture so cleanup
+    // catches them; we explicitly seeded under otherUserId+fixture.orgId.
+    await track(
+      Promise.resolve({
+        orgId: fixture.orgId,
+        userId: otherUserId,
+      }),
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.grandTotalCredits).toBe(100);
+  });
+
+  it("includes usage_event rows in grand totals and source buckets", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "web",
+        status: "completed",
+      },
+      context.signal,
+    );
+
+    await store.set(
+      insertModelUsageEventForRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId,
+        inputTokens: 100,
+        outputTokens: 50,
+        creditsCharged: 10,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.input",
+        quantity: 30,
+        creditsCharged: 3,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.output",
+        quantity: 20,
+        creditsCharged: 2,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.cache_read",
+        quantity: 5,
+        creditsCharged: 1,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.cache_creation",
+        quantity: 10,
+        creditsCharged: 4,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        kind: "connector",
+        provider: "x",
+        category: "tweet.read",
+        quantity: 1,
+        creditsCharged: 7,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.input",
+        quantity: 999,
+        creditsCharged: 999,
+        status: "pending",
+      },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    const totals = sumBucketSeries(response.body.buckets);
+
+    expect(response.body.grandTotalCredits).toBe(27);
+    expect(response.body.grandTotalTokens).toBe(215);
+    expect(totals["chat"]).toStrictEqual({ credits: 20, tokens: 215 });
+    expect(totals["others"]).toStrictEqual({ credits: 7, tokens: 0 });
+  });
+
+  it("buckets usage_event rows by activity time, not billing time", async () => {
+    mockNow(new Date("2026-04-23T15:00:00Z"));
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        kind: "connector",
+        provider: "x",
+        category: "tweet.read",
+        quantity: 1,
+        creditsCharged: 33,
+        status: "processed",
+        createdAt: new Date("2026-04-22T12:00:00Z"),
+        processedAt: new Date("2026-04-23T12:00:00Z"),
+      },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const yesterdayResponse = await accept(
+      apiClient().get({
+        query: { range: "yesterday", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    const yesterdayTotals = sumBucketSeries(yesterdayResponse.body.buckets);
+
+    expect(yesterdayResponse.body.grandTotalCredits).toBe(33);
+    expect(yesterdayTotals["others"]).toStrictEqual({
+      credits: 33,
+      tokens: 0,
+    });
+
+    const todayResponse = await accept(
+      apiClient().get({
+        query: { range: "today", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(todayResponse.body.grandTotalCredits).toBe(0);
+  });
+
+  it("includes run-linked usage_event rows in agent buckets and channel totals", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const agentName = `usage-event-agent-${randomUUID().slice(0, 8)}`;
+    const { composeId } = await store.set(
+      seedCompose$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: agentName,
+      },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "slack",
+        status: "completed",
+      },
+      context.signal,
+    );
+
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId,
+        kind: "connector",
+        provider: "x",
+        category: "tweet.read",
+        quantity: 1,
+        creditsCharged: 40,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.output",
+        quantity: 15,
+        creditsCharged: 5,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        kind: "connector",
+        provider: "x",
+        category: "tweet.read",
+        quantity: 1,
+        creditsCharged: 8,
+        status: "processed",
+      },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", groupBy: "agent", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    const totals = sumBucketSeries(response.body.buckets);
+
+    expect(totals[agentName]).toStrictEqual({ credits: 45, tokens: 15 });
+    expect(totals["others"]).toStrictEqual({ credits: 8, tokens: 0 });
+    expect(response.body.slackCredits).toBe(45);
+    expect(response.body.slackTokens).toBe(15);
+  });
+
+  it("returns chat rows when groupBy=source and there are chat runs", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const threadId = await store.set(
+      seedChatThread$,
+      {
+        userId: fixture.userId,
+        composeId,
+        title: "Test Chat Thread",
+      },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "web",
+        chatThreadId: threadId,
+        status: "completed",
+      },
+      context.signal,
+    );
+
+    await store.set(
+      insertModelUsageEventForRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId,
+        creditsCharged: 200,
+        status: "processed",
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId,
+        kind: "model",
+        provider: "claude-sonnet-4-6",
+        category: "tokens.input",
+        quantity: 12,
+        creditsCharged: 25,
+        status: "processed",
+      },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.chats.length).toBeGreaterThanOrEqual(1);
+    const chat = response.body.chats.find((c) => {
+      return c.threadId === threadId;
+    });
+    expect(chat).toBeDefined();
+    expect(chat?.threadTitle).toBe("Test Chat Thread");
+    expect(chat?.credits).toBe(225);
+    expect(chat?.tokens).toBe(162);
+  });
+
+  it("top-100 truncation — overflow with creditsCharged=0 still reports correct otherCount", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+
+    await store.set(
+      seedScheduleBatch$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        count: 105,
+        creditsForIndex: (i) => {
+          return i < 5 ? 0 : i + 1;
+        },
+      },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const response = await accept(
+      apiClient().get({
+        query: { range: "28d", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.schedules).toHaveLength(100);
+    expect(response.body.scheduleOtherCount).toBe(5);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-usage-insight.ts
+++ b/turbo/apps/api/src/signals/routes/zero-usage-insight.ts
@@ -5,7 +5,6 @@ import { badRequestMessage } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { zeroUsageInsight$ } from "../services/zero-usage-insight.service";
 import type { RouteEntry } from "../route";
 
@@ -48,12 +47,9 @@ const getUsageInsightInner$ = command(
 export const zeroUsageInsightRoutes: readonly RouteEntry[] = [
   {
     route: zeroUsageInsightContract.get,
-    handler: shadowCompareRoute({
-      route: zeroUsageInsightContract.get,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        getUsageInsightInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      getUsageInsightInner$,
+    ),
   },
 ];


### PR DESCRIPTION
Closes #12346

## Summary
- Make `GET /api/zero/usage/insight` authoritative in `apps/api` by removing the `shadowCompareRoute(...)` wrapper
- Port all **19 web GET cases** 1:1 to a new api test file
- Introduce `helpers/zero-usage-insight.ts` with 8 ccstate seeder commands and a per-`(orgId, userId)` cascading cleanup
- POST/DELETE — N/A; this route is GET-only

## Behavior parity
The api `zeroUsageInsight$` Computed re-implements the same SQL queries as the web `getUsageInsight` (which delegates to `usage-insight-ledger.ts`). Spot-checked CTEs, top-100 truncation, agent-name CASE, channel totals — all character-for-character equivalent. 19/19 ported test cases pass against the api service unmodified, confirming structural parity.

## Test cases (all 19 ported)
1. 401 unauthenticated
2. 400 invalid timezone
3. 400 missing date when range=day
4. happy path — shape and totals add up
5. source mapping — every TriggerSource lands in correct bucket
6. groupBy=agent — top-7 + others series keys
7. today produces hourly buckets (`mockNow` 2026-04-23T15Z)
8. yesterday produces hourly buckets for prior day
9. 7d window includes data from midnight 6 days ago
10. day window includes only the selected calendar day
11. tz shift — same row, different date buckets per timezone (`mockNow`)
12. top-100 truncation — 105 schedules → 100 + others=5
13. scheduleDescription returned alongside scheduleName
14. scope isolation — other user's activity invisible
15. usage_event rows in grand totals + source buckets
16. usage_event bucketing by activity time, not billing time (`mockNow`)
17. run-linked usage_event in agent buckets + channel totals
18. chat rows when groupBy=source with chat runs
19. top-100 truncation — overflow with creditsCharged=0 still reports correct otherCount

## Notes on test infrastructure
- Time-mocked cases (7, 11, 16) use `mockNow`/`clearMockNow` from `lib/time.ts`. Cleanup is registered once via a top-level `afterEach(clearMockNow)` instead of per-case `try/finally`, to satisfy the api lint rule that disallows `try/catch` outside `signals/utils.ts`.
- Cleanup is per-`(orgId, userId)`: the fixture tracker deletes rows in FK-respecting order across `usageEvent → zeroRuns → zeroAgentSchedules → agentRuns → agentSessions → agentComposeVersions → chatThreads → zeroAgents → agentComposes`.
- Top-100 truncation cases (12, 19) use a batch helper that inserts 105 schedules + 105 runs + 105 model usage events in parallel via `Promise.all`.

## Test plan
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-insight.test.ts` — 19/19 passed
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] Pre-commit: prettier, knip, `turbo run check-types`, commitlint — all green

## Rollback
Disable the `apiBackend` feature switch — traffic returns to `apps/web`. No DB or schema change.