### PR TITLE
refactor(api): migrate api keys get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-api-keys.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-api-keys.test.ts
@@ -2,7 +2,6 @@ import { apiKeysContract } from "@vm0/api-contracts/contracts/api-keys";
 import { createStore } from "ccstate";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -20,6 +19,16 @@ const mocks = createZeroRouteMocks(context);
 describe("GET /api/zero/api-keys", () => {
   const track = createFixtureTracker<ApiKeysFixture>((fixture) => {
     return store.set(deleteApiKeys$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(apiKeysContract);
+
+    const response = await accept(client.list({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
   });
 
   it("returns the current user's API keys sorted by creation time", async () => {
@@ -59,7 +68,6 @@ describe("GET /api/zero/api-keys", () => {
       ),
     );
     mocks.clerk.session(fixture.userId, null);
-    mockApiShadowCompareRoutes([apiKeysContract.list]);
 
     const client = setupApp({ context })(apiKeysContract);
 
@@ -92,7 +100,6 @@ describe("GET /api/zero/api-keys", () => {
   it("returns an empty list when the user has no API keys", async () => {
     const fixture = await track(store.set(seedApiKeys$, [], context.signal));
     mocks.clerk.session(fixture.userId, null);
-    mockApiShadowCompareRoutes([apiKeysContract.list]);
 
     const client = setupApp({ context })(apiKeysContract);
 
@@ -104,5 +111,43 @@ describe("GET /api/zero/api-keys", () => {
     );
 
     expect(response.body).toStrictEqual({ apiKeys: [] });
+  });
+
+  it("list excludes the full token and only exposes the prefix", async () => {
+    const fixture = await track(
+      store.set(
+        seedApiKeys$,
+        [
+          {
+            name: "Deploy key",
+            token: "vm0_pat_deploy_key_full_token_value",
+            createdAt: new Date("2026-03-04T00:00:00.000Z"),
+            expiresAt: new Date("2026-04-04T00:00:00.000Z"),
+          },
+        ],
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, null);
+
+    const client = setupApp({ context })(apiKeysContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.apiKeys).toStrictEqual([
+      {
+        id: expect.any(String),
+        name: "Deploy key",
+        tokenPrefix: "vm0_pat_depl\u2026",
+        createdAt: "2026-03-04T00:00:00.000Z",
+        expiresAt: "2026-04-04T00:00:00.000Z",
+        lastUsedAt: null,
+      },
+    ]);
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-api-keys.ts
+++ b/turbo/apps/api/src/signals/routes/zero-api-keys.ts
@@ -3,7 +3,6 @@ import { apiKeysContract } from "@vm0/api-contracts/contracts/api-keys";
 
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import type { RouteEntry } from "../route";
 import { userApiKeys } from "../services/zero-user-data.service";
 
@@ -19,9 +18,6 @@ const listApiKeysInner$ = computed(async (get): Promise<unknown> => {
 export const zeroApiKeysRoutes: readonly RouteEntry[] = [
   {
     route: apiKeysContract.list,
-    handler: shadowCompareRoute({
-      route: apiKeysContract.list,
-      handler: authRoute({}, listApiKeysInner$),
-    }),
+    handler: authRoute({}, listApiKeysInner$),
   },
 ];


### PR DESCRIPTION
Closes #12350

## Summary
- Drop the `shadowCompareRoute` wrapper from `GET /api/zero/api-keys` so `apps/api` is now authoritative for the route.
- Port the two missing in-scope web GET cases: `401 unauthenticated` and `list excludes the full token and only exposes the prefix`. The new no-token-leak test uses `toStrictEqual` on the full response shape — any leaked `token` field would fail the assertion.
- Existing api `returns sorted` test retained for bonus user-isolation + sort-order + exact U+2026 character coverage.

POST and DELETE remain shadow-compared and migrate in Stage 3 (separate issues). Service (`userApiKeys`) and helper (`seedApiKeys$`/`deleteApiKeys$`) untouched — behavior parity verified field-by-field.

## Final test inventory (4 cases)
- `returns 401 when the request is unauthenticated` — NEW, mirrors web GET case 1
- `returns the current user's API keys sorted by creation time` — existing (bonus coverage)
- `returns an empty list when the user has no API keys` — existing, mirrors web GET case 2
- `list excludes the full token and only exposes the prefix` — NEW, mirrors web GET case 3

## Test plan
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-api-keys.test.ts` — 4/4 passing
- [x] `pnpm -F api lint`
- [x] `pnpm -F api check-types`
- [x] `pnpm format`
- [x] `pnpm knip`

## Rollback
Disable the `apiBackend` feature switch — traffic falls back to the unchanged `apps/web` route. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)