### PR TITLE
fix: restore model picker expand chevrons

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -1,6 +1,6 @@
 import type { MouseEvent, ReactNode } from "react";
 import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
-import { IconCpu } from "@tabler/icons-react";
+import { IconChevronDown, IconChevronUp, IconCpu } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   Select,
@@ -862,12 +862,16 @@ function ShowMoreToggleRow({
   hiddenCount: number;
   onToggle: () => void;
 }) {
+  const label = expanded
+    ? "Show fewer models"
+    : `Show all models (+${hiddenCount})`;
+
   return (
     <div
       role="button"
       tabIndex={0}
       aria-expanded={expanded}
-      className="rounded-md px-2 py-1.5 text-sm text-muted-foreground cursor-pointer hover:bg-accent transition-colors"
+      className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground cursor-pointer hover:bg-accent transition-colors"
       onClick={(e) => {
         e.preventDefault();
         onToggle();
@@ -879,7 +883,12 @@ function ShowMoreToggleRow({
         }
       }}
     >
-      {expanded ? "Show fewer models" : `Show all models (+${hiddenCount})`}
+      <span>{label}</span>
+      {expanded ? (
+        <IconChevronUp size={14} className="shrink-0" aria-hidden="true" />
+      ) : (
+        <IconChevronDown size={14} className="shrink-0" aria-hidden="true" />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- restore the up/down chevron on the VM0 model picker show-more row
- keep the existing show all / show fewer behavior unchanged

## Testing
- pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/model-provider-picker-show-more.test.tsx
- pnpm exec oxlint src/views/zero-page/components/model-provider-picker.tsx
- pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json src/views/zero-page/components/model-provider-picker.tsx
- pnpm exec eslint src/views/zero-page/components/model-provider-picker.tsx --max-warnings 0
- pre-commit: turbo run check-types --concurrency=1