### PR TITLE
fix: restore codex auth.json personal flow

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
@@ -26,8 +26,6 @@ import {
   orgModelPolicies$,
   updateOrgModelPolicies$,
 } from "../../external/org-model-policies.ts";
-import { apiBaseForNavigation$ } from "../../fetch.ts";
-import { createDeferredPromise } from "../../utils.ts";
 
 // ---------------------------------------------------------------------------
 // Codex auth.json paste dialog (personal scope, mirrors org-side dialog from
@@ -247,38 +245,6 @@ const internalPersonalActionPromise$ = state<Promise<unknown> | null>(null);
 export const personalActionPromise$ = computed((get) => {
   return get(internalPersonalActionPromise$);
 });
-
-const CODEX_OAUTH_AUTHORIZE_PATH =
-  "/api/zero/me/model-providers/codex-oauth-token/oauth/authorize";
-const OAUTH_POPUP_CLOSED_POLL_MS = 500;
-
-function waitForOAuthPopupClosed(
-  authWindow: Window,
-  signal: AbortSignal,
-): Promise<void> {
-  const closed = createDeferredPromise<void>(signal);
-  const intervalId = window.setInterval(
-    checkClosed,
-    OAUTH_POPUP_CLOSED_POLL_MS,
-  );
-
-  function cleanup() {
-    window.clearInterval(intervalId);
-    signal.removeEventListener("abort", cleanup);
-  }
-
-  function checkClosed() {
-    if (authWindow.closed && !closed.settled()) {
-      cleanup();
-      closed.resolve();
-    }
-  }
-
-  signal.addEventListener("abort", cleanup, { once: true });
-  checkClosed();
-
-  return closed.promise;
-}
 
 function validatePersonalProviderForm(params: {
   providerType: ModelProviderType;
@@ -577,36 +543,6 @@ export const disconnectPersonalOAuthCredential$ = command(
       await set(deletePersonalModelProvider$, providerType, signal);
       signal.throwIfAborted();
       toast.success(`${providerLabel} disconnected`);
-    })();
-
-    set(internalPersonalActionPromise$, promise);
-    signal.addEventListener("abort", () => {
-      set(internalPersonalActionPromise$, null);
-    });
-
-    await promise;
-    signal.throwIfAborted();
-  },
-);
-
-export const connectPersonalCodexOAuth$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const apiBase = await get(apiBaseForNavigation$);
-    signal.throwIfAborted();
-
-    const promise = (async () => {
-      const authWindow = window.open(
-        `${apiBase}${CODEX_OAUTH_AUTHORIZE_PATH}`,
-        "_blank",
-        "width=600,height=700",
-      );
-      if (!authWindow) {
-        throw new Error("Failed to open OpenAI OAuth window");
-      }
-
-      await waitForOAuthPopupClosed(authWindow, signal);
-      signal.throwIfAborted();
-      set(reloadPersonalModelProviders$);
     })();
 
     set(internalPersonalActionPromise$, promise);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx
@@ -391,7 +391,7 @@ describe("chat composer — default model resolution", () => {
     });
   });
 
-  it("blocks agent chat submit and opens ChatGPT OAuth from the model warning", async () => {
+  it("blocks agent chat submit and opens ChatGPT auth.json paste from the model warning", async () => {
     const user = userEvent.setup();
     const openSpy = vi
       .spyOn(window, "open")
@@ -442,15 +442,11 @@ describe("chat composer — default model resolution", () => {
     );
     await user.click(warning);
 
-    await waitFor(() => {
-      expect(openSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "/api/zero/me/model-providers/codex-oauth-token/oauth/authorize",
-        ),
-        "_blank",
-        expect.any(String),
-      );
-    });
+    await expect(
+      screen.findByTestId("codex-paste-textarea"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByText("Connect Codex")).toBeInTheDocument();
+    expect(openSpy).not.toHaveBeenCalled();
   });
 
   // CHAT-DM-003: Updating the agent's model (e.g. from Opus 4.7 -> 4.6 via
@@ -473,7 +469,7 @@ describe("chat composer — default model resolution", () => {
     await expectComposerShowsModel("Claude Opus 4.6");
   });
 
-  it("blocks thread submit and opens ChatGPT OAuth from the model warning", async () => {
+  it("blocks thread submit and opens ChatGPT auth.json paste from the model warning", async () => {
     const user = userEvent.setup();
     const openSpy = vi
       .spyOn(window, "open")
@@ -524,15 +520,11 @@ describe("chat composer — default model resolution", () => {
     );
     await user.click(warning);
 
-    await waitFor(() => {
-      expect(openSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "/api/zero/me/model-providers/codex-oauth-token/oauth/authorize",
-        ),
-        "_blank",
-        expect.any(String),
-      );
-    });
+    await expect(
+      screen.findByTestId("codex-paste-textarea"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByText("Connect Codex")).toBeInTheDocument();
+    expect(openSpy).not.toHaveBeenCalled();
   });
 
   // CHAT-DM-004: When the agent is reset to "use org default" (both fields

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -490,8 +490,7 @@ export function AgentChatPage() {
   const modelFirstEnabled = useGet(modelFirstModelProviderEnabled$);
   const agentModelDefault = useLastResolved(chatPageAgentModelDefault$) ?? null;
   const modelFirstOauthState = useLastResolved(modelFirstPersonalOauthState$);
-  const openPersonalOauthConfiguration =
-    usePersonalOauthConfigurationAction(pageSignal);
+  const openPersonalOauthConfiguration = usePersonalOauthConfigurationAction();
 
   const handleSendMessage = (message: string, options?: { goal?: boolean }) => {
     if (!currentChatAgentId) {

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
@@ -45,7 +45,7 @@ function makeProvider(
       type === "codex-oauth-token"
         ? "CHATGPT_ACCESS_TOKEN"
         : "CLAUDE_CODE_OAUTH_TOKEN",
-    authMethod: type === "codex-oauth-token" ? "oauth" : null,
+    authMethod: type === "codex-oauth-token" ? "auth_json" : null,
     secretNames:
       type === "codex-oauth-token"
         ? [
@@ -113,7 +113,7 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          /Manage OAuth access used when workspace model routes/,
+          /Manage personal credentials used when workspace model routes/,
         ),
       ).toBeInTheDocument();
     });
@@ -134,7 +134,7 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          /Manage OAuth access used when workspace model routes/,
+          /Manage personal credentials used when workspace model routes/,
         ),
       ).toBeInTheDocument();
     });
@@ -152,9 +152,7 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
     );
     expect(screen.getByText("ChatGPT (Codex)")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Connect a ChatGPT account for Codex-backed model routes.",
-      ),
+      screen.getByText("Paste Codex auth.json for Codex-backed model routes."),
     ).toBeInTheDocument();
     expect(screen.queryByText("Not connected")).not.toBeInTheDocument();
     expect(screen.queryByText("Personal default")).not.toBeInTheDocument();
@@ -255,7 +253,7 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
     expect(screen.queryByText("Reconnect")).not.toBeInTheDocument();
   });
 
-  it("disconnects ChatGPT (Codex) OAuth from the fixed card", async () => {
+  it("disconnects ChatGPT (Codex) auth.json from the fixed card", async () => {
     setMockFeatureSwitches({
       [FeatureSwitchKey.ModelFirstModelProvider]: true,
       [FeatureSwitchKey.CodexOauthProvider]: true,
@@ -327,8 +325,8 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
   });
 });
 
-describe("personal-providers-tab — ChatGPT (Codex) OAuth flow", () => {
-  it("clicking ChatGPT (Codex) connect opens the OpenAI OAuth route", async () => {
+describe("personal-providers-tab — ChatGPT (Codex) auth.json flow", () => {
+  it("clicking ChatGPT (Codex) connect opens the auth.json paste dialog", async () => {
     const openSpy = vi
       .spyOn(window, "open")
       .mockReturnValue({ closed: true } as Window);
@@ -343,21 +341,14 @@ describe("personal-providers-tab — ChatGPT (Codex) OAuth flow", () => {
     await openModelConfiguration();
     click(await screen.findByLabelText("Connect ChatGPT (Codex)"));
 
-    await waitFor(() => {
-      expect(openSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "/api/zero/me/model-providers/codex-oauth-token/oauth/authorize",
-        ),
-        "_blank",
-        expect.any(String),
-      );
-    });
-    expect(
-      screen.queryByTestId("codex-paste-textarea"),
-    ).not.toBeInTheDocument();
+    await expect(
+      screen.findByTestId("codex-paste-textarea"),
+    ).resolves.toBeInTheDocument();
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(screen.getByText("Connect Codex")).toBeInTheDocument();
   });
 
-  it("shows stale ChatGPT (Codex) OAuth without offering reconnect", async () => {
+  it("opens the auth.json reconnect dialog for stale ChatGPT (Codex)", async () => {
     setMockFeatureSwitches({
       [FeatureSwitchKey.ModelFirstModelProvider]: true,
       [FeatureSwitchKey.CodexOauthProvider]: true,
@@ -382,9 +373,13 @@ describe("personal-providers-tab — ChatGPT (Codex) OAuth flow", () => {
       ),
     );
     expect(screen.getByText("Disconnect")).toBeInTheDocument();
+    click(screen.getByText("Replace"));
+    await expect(
+      screen.findByText("Re-connect Codex"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByTestId("codex-paste-textarea")).toBeInTheDocument();
     expect(
       screen.queryByText("Your ChatGPT session expired."),
     ).not.toBeInTheDocument();
-    expect(screen.queryByText("Reconnect")).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -19,11 +19,11 @@ import type {
 } from "@vm0/api-contracts/contracts/model-providers";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
-  connectPersonalCodexOAuth$,
   disconnectPersonalOAuthCredential$,
   personalActionPromise$,
   personalConfiguredProviders$,
   personalOpenOAuthCredentialDialog$,
+  setCodexPasteDialogStatePersonal$,
 } from "../../../../signals/zero-page/settings/personal-model-providers.ts";
 import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
@@ -48,7 +48,7 @@ function OAuthCredentialsSection() {
   const providersLoadable = useLastLoadable(personalConfiguredProviders$);
   const features = useLastResolved(featureSwitch$);
   const openCredentialDialog = useSet(personalOpenOAuthCredentialDialog$);
-  const connectCodexOAuth = useSet(connectPersonalCodexOAuth$);
+  const openCodexPasteDialog = useSet(setCodexPasteDialogStatePersonal$);
   const disconnectCredential = useSet(disconnectPersonalOAuthCredential$);
   const actionLoadable = useLoadable(personalActionPromise$);
   const pageSignal = useGet(pageSignal$);
@@ -63,15 +63,18 @@ function OAuthCredentialsSection() {
   const openAIStatus = getOpenAIStatus(openAI);
   const disconnecting = actionLoadable.state === "loading";
   const connectOpenAI = () => {
-    detach(connectCodexOAuth(pageSignal), Reason.DomCallback);
+    openCodexPasteDialog({
+      open: true,
+      mode: openAI?.needsReconnect ? "reconnect" : "connect",
+    });
   };
 
   return (
     <section className="flex flex-col gap-3">
       <p className="text-sm text-muted-foreground">
-        Manage OAuth access used when workspace model routes require your
-        personal Claude Code
-        {codexOauthEnabled ? " or ChatGPT" : ""} authorization.
+        Manage personal credentials used when workspace model routes require
+        your Claude Code token
+        {codexOauthEnabled ? " or ChatGPT auth.json" : ""}.
       </p>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         {isLoading ? (
@@ -120,7 +123,7 @@ function OAuthCredentialsSection() {
               <OAuthCredentialCard
                 type="codex-oauth-token"
                 title="ChatGPT (Codex)"
-                description="Connect a ChatGPT account for Codex-backed model routes."
+                description="Paste Codex auth.json for Codex-backed model routes."
                 status={openAIStatus}
                 menuItems={
                   openAI

--- a/turbo/apps/platform/src/views/zero-page/model-first-oauth-submit-blocker.ts
+++ b/turbo/apps/platform/src/views/zero-page/model-first-oauth-submit-blocker.ts
@@ -5,19 +5,20 @@ import type {
 } from "@vm0/api-contracts/contracts/model-providers";
 import { useSet } from "ccstate-react";
 import {
-  connectPersonalCodexOAuth$,
   personalOpenOAuthCredentialDialog$,
+  setCodexPasteDialogStatePersonal$,
 } from "../../signals/zero-page/settings/personal-model-providers.ts";
 import type { ModelFirstPersonalOauthState } from "../../signals/zero-page/model-first-personal-oauth.ts";
 import type { ModelProviderSelection } from "./components/model-provider-picker.tsx";
-import { detach, Reason } from "../../signals/utils.ts";
 
 type MemberOauthProviderType = "claude-code-oauth-token" | "codex-oauth-token";
+type CodexPasteDialogMode = "connect" | "reconnect";
 
 interface ModelConfigurationSubmitBlocker {
   message: string;
   actionLabel: string;
   providerType: MemberOauthProviderType;
+  codexPasteMode: CodexPasteDialogMode;
   onAction: () => void;
 }
 
@@ -29,7 +30,7 @@ function isMemberOauthProviderType(
 
 function getMemberOauthProviderLabel(type: MemberOauthProviderType): string {
   return type === "codex-oauth-token"
-    ? "ChatGPT (Codex) OAuth"
+    ? "ChatGPT (Codex) auth.json"
     : "Claude Code OAuth";
 }
 
@@ -91,6 +92,7 @@ function resolveModelConfigurationSubmitBlocker(params: {
   });
   return {
     providerType,
+    codexPasteMode: existingProvider?.needsReconnect ? "reconnect" : "connect",
     message: existingProvider?.needsReconnect
       ? `${label} needs to be reconnected before you can use ${modelLabel}.`
       : `This workspace routes ${modelLabel} through your personal ${label}. Configure it before sending.`,
@@ -102,7 +104,10 @@ export function resolveChatComposerSubmitBlocker(params: {
   state: ModelFirstPersonalOauthState | null | undefined;
   modelSelection: ModelProviderSelection | null;
   agentModelDefault: ModelProviderSelection | null;
-  onAction: (providerType: MemberOauthProviderType) => void;
+  onAction: (
+    providerType: MemberOauthProviderType,
+    codexPasteMode: CodexPasteDialogMode,
+  ) => void;
 }): ModelConfigurationSubmitBlocker | undefined {
   const selectedModel =
     params.modelSelection?.selectedModel ??
@@ -117,18 +122,21 @@ export function resolveChatComposerSubmitBlocker(params: {
     ? {
         ...blocker,
         onAction: () => {
-          params.onAction(blocker.providerType);
+          params.onAction(blocker.providerType, blocker.codexPasteMode);
         },
       }
     : undefined;
 }
 
-export function usePersonalOauthConfigurationAction(signal: AbortSignal) {
-  const connectCodexOAuth = useSet(connectPersonalCodexOAuth$);
+export function usePersonalOauthConfigurationAction() {
+  const openCodexPasteDialog = useSet(setCodexPasteDialogStatePersonal$);
   const openCredentialDialog = useSet(personalOpenOAuthCredentialDialog$);
-  return (providerType: MemberOauthProviderType) => {
+  return (
+    providerType: MemberOauthProviderType,
+    codexPasteMode: CodexPasteDialogMode,
+  ) => {
     if (providerType === "codex-oauth-token") {
-      detach(connectCodexOAuth(signal), Reason.DomCallback);
+      openCodexPasteDialog({ open: true, mode: codexPasteMode });
       return;
     }
     openCredentialDialog(providerType);

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1997,8 +1997,7 @@ function ChatThreadComposer({
     sending,
   });
   const modelFirstOauthState = useLastResolved(modelFirstPersonalOauthState$);
-  const openPersonalOauthConfiguration =
-    usePersonalOauthConfigurationAction(pageSignal);
+  const openPersonalOauthConfiguration = usePersonalOauthConfigurationAction();
 
   const modelPicker = resolveChatComposerModelPicker({
     composerProviders,


### PR DESCRIPTION
## Summary
- Restores the personal ChatGPT (Codex) entry points to open the Codex auth.json paste dialog instead of the OpenAI OAuth popup.
- Updates model-first chat submit blockers to use the same auth.json paste/reconnect dialog.
- Removes the now-unused personal Codex OAuth popup command and updates tests to guard against /oauth/authorize reopening.

## Regression source
- `3e65bac1f` / #12304 introduced `connectPersonalCodexOAuth$` and wired personal ChatGPT (Codex) cards + model warnings to `/api/zero/me/model-providers/codex-oauth-token/oauth/authorize`, overriding the auth.json paste flow from `7c3a30855` / #12027.

## Testing
- `pnpm --filter @vm0/app test -- src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx` (Vitest ran 265 files / 2370 tests; passed)
- `pnpm exec oxlint src/signals/zero-page/settings/personal-model-providers.ts src/views/zero-page/components/preferences/personal-providers-tab.tsx src/views/zero-page/model-first-oauth-submit-blocker.ts src/views/zero-page/agent-chat-page.tsx src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/__tests__/chat-default-model-resolution.test.tsx src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx`
- `pnpm --filter @vm0/app check-types` fails on existing platform baseline errors, starting with `src/lib/ably-auth.ts(43,30): Property body does not exist on type never` and multiple ts-rest/implicit-any errors outside this change.