### PR TITLE
refactor(api): migrate billing invoices get to api backend

### DIFF
--- a/turbo/apps/api/src/__tests__/test-helpers.ts
+++ b/turbo/apps/api/src/__tests__/test-helpers.ts
@@ -12,6 +12,7 @@ import { createApp } from "../app-factory";
 import { closeDbPool } from "../lib/db";
 import { clearMockedEnv } from "../lib/env";
 import { clearMockApiShadowCompareRoutes } from "../signals/context/shadow-compare";
+import { clearMockListStripeInvoices } from "../signals/external/stripe-client";
 import { ROUTES, type RouteEntry } from "../signals/route";
 import { clearAllDetached } from "../signals/utils";
 import { getApiTestMocks, type ApiTestMocks } from "./mocks";
@@ -135,6 +136,7 @@ export function testContext(): TestContext {
     await clearAllDetached();
     clearMockedEnv();
     clearMockApiShadowCompareRoutes();
+    clearMockListStripeInvoices();
   });
 
   afterAll(async () => {

--- a/turbo/apps/api/src/signals/external/stripe-client.ts
+++ b/turbo/apps/api/src/signals/external/stripe-client.ts
@@ -1,5 +1,6 @@
 import StripeSDK from "stripe";
 import { env } from "../../lib/env";
+import { testOverride } from "../../lib/singleton";
 
 interface StripeInvoice {
   readonly id: string;
@@ -10,9 +11,24 @@ interface StripeInvoice {
   readonly hosted_invoice_url: string | null;
 }
 
+const {
+  get: getMockedListInvoices,
+  set: setMockedListInvoices,
+  clear: clearMockedListInvoices,
+} = testOverride<
+  ((customerId: string) => Promise<readonly StripeInvoice[]>) | undefined
+>(() => {
+  return undefined;
+});
+
 export async function listStripeInvoices(
   customerId: string,
 ): Promise<readonly StripeInvoice[]> {
+  const mocked = getMockedListInvoices();
+  if (mocked) {
+    return await mocked(customerId);
+  }
+
   const stripe = new StripeSDK(env("STRIPE_SECRET_KEY"));
   const result = await stripe.invoices.list({
     customer: customerId,
@@ -29,4 +45,14 @@ export async function listStripeInvoices(
       hosted_invoice_url: inv.hosted_invoice_url ?? null,
     };
   });
+}
+
+export function mockListStripeInvoices(
+  fn: (customerId: string) => Promise<readonly StripeInvoice[]>,
+): void {
+  setMockedListInvoices(fn);
+}
+
+export function clearMockListStripeInvoices(): void {
+  clearMockedListInvoices();
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-billing-invoices.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-billing-invoices.ts
@@ -1,0 +1,59 @@
+import { randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { eq } from "drizzle-orm";
+
+import { writeDb$ } from "../../../external/db";
+
+export interface InvoicesOrgFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly stripeCustomerId: string | null;
+}
+
+interface InvoicesSeedValues {
+  readonly stripeCustomerId?: string | null;
+  readonly stripeSubscriptionId?: string | null;
+  readonly subscriptionStatus?: string | null;
+  readonly tier?: string;
+}
+
+export const seedInvoicesOrg$ = command(
+  async (
+    { set },
+    values: InvoicesSeedValues,
+    signal: AbortSignal,
+  ): Promise<InvoicesOrgFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const writeDb = set(writeDb$);
+
+    const stripeCustomerId = values.stripeCustomerId ?? null;
+
+    await writeDb.insert(orgMetadata).values({
+      orgId,
+      stripeCustomerId,
+      stripeSubscriptionId: values.stripeSubscriptionId ?? null,
+      subscriptionStatus: values.subscriptionStatus ?? null,
+      ...(values.tier !== undefined ? { tier: values.tier } : {}),
+    });
+    signal.throwIfAborted();
+
+    return { orgId, userId, stripeCustomerId };
+  },
+);
+
+export const deleteInvoicesOrg$ = command(
+  async (
+    { set },
+    fixture: InvoicesOrgFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-invoices.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-invoices.test.ts
@@ -1,0 +1,179 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroBillingInvoicesContract } from "@vm0/api-contracts/contracts/zero-billing";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockListStripeInvoices } from "../../external/stripe-client";
+import {
+  deleteInvoicesOrg$,
+  seedInvoicesOrg$,
+  type InvoicesOrgFixture,
+} from "./helpers/zero-billing-invoices";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/billing/invoices", () => {
+  const track = createFixtureTracker<InvoicesOrgFixture>((fixture) => {
+    return store.set(deleteInvoicesOrg$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroBillingInvoicesContract);
+
+    const response = await accept(client.get({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 403 for a non-admin org member", async () => {
+    const fixture = await track(
+      store.set(seedInvoicesOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroBillingInvoicesContract);
+
+    const response = await accept(
+      client.get({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only org admins can view invoices",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns invoices for an admin's org with active subscription", async () => {
+    const customerId = `cus-inv-${randomUUID().slice(0, 8)}`;
+    const fixture = await track(
+      store.set(
+        seedInvoicesOrg$,
+        {
+          stripeCustomerId: customerId,
+          stripeSubscriptionId: `sub-inv-${randomUUID().slice(0, 8)}`,
+          subscriptionStatus: "active",
+          tier: "pro",
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    mockListStripeInvoices(() => {
+      return Promise.resolve([
+        {
+          id: "inv_001",
+          number: "INV-2026-001",
+          created: 1_740_000_000,
+          amount_paid: 4000,
+          status: "paid",
+          hosted_invoice_url: "https://stripe.com/invoice/inv_001",
+        },
+        {
+          id: "inv_002",
+          number: "INV-2026-002",
+          created: 1_737_400_000,
+          amount_paid: 4000,
+          status: "paid",
+          hosted_invoice_url: "https://stripe.com/invoice/inv_002",
+        },
+      ]);
+    });
+
+    const client = setupApp({ context })(zeroBillingInvoicesContract);
+
+    const response = await accept(
+      client.get({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      invoices: [
+        {
+          id: "inv_001",
+          number: "INV-2026-001",
+          date: 1_740_000_000,
+          amount: 4000,
+          status: "paid",
+          hostedInvoiceUrl: "https://stripe.com/invoice/inv_001",
+        },
+        {
+          id: "inv_002",
+          number: "INV-2026-002",
+          date: 1_737_400_000,
+          amount: 4000,
+          status: "paid",
+          hostedInvoiceUrl: "https://stripe.com/invoice/inv_002",
+        },
+      ],
+    });
+  });
+
+  it("returns an empty list when the org has no Stripe customer", async () => {
+    const fixture = await track(
+      store.set(seedInvoicesOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingInvoicesContract);
+
+    const response = await accept(
+      client.get({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ invoices: [] });
+  });
+
+  it("returns an empty list when Stripe returns no invoices", async () => {
+    const fixture = await track(
+      store.set(
+        seedInvoicesOrg$,
+        {
+          stripeCustomerId: `cus-empty-${randomUUID().slice(0, 8)}`,
+          stripeSubscriptionId: `sub-empty-${randomUUID().slice(0, 8)}`,
+          subscriptionStatus: "active",
+          tier: "pro",
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    mockListStripeInvoices(() => {
+      return Promise.resolve([]);
+    });
+
+    const client = setupApp({ context })(zeroBillingInvoicesContract);
+
+    const response = await accept(
+      client.get({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ invoices: [] });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-billing-invoices.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-invoices.ts
@@ -3,11 +3,24 @@ import { zeroBillingInvoicesContract } from "@vm0/api-contracts/contracts/zero-b
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { zeroOrgInvoices } from "../services/zero-billing-invoices.service";
 import type { RouteEntry } from "../route";
+
+const adminRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Only org admins can view invoices",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
 const getInvoicesInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
+  if (auth.orgRole !== "admin") {
+    return adminRequired;
+  }
   const invoices = await get(zeroOrgInvoices(auth.orgId));
   return { status: 200 as const, body: invoices };
 });
@@ -15,12 +28,9 @@ const getInvoicesInner$ = computed(async (get) => {
 export const zeroBillingInvoicesRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingInvoicesContract.get,
-    handler: shadowCompareRoute({
-      route: zeroBillingInvoicesContract.get,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        getInvoicesInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      getInvoicesInner$,
+    ),
   },
 ];

--- a/turbo/packages/api-contracts/src/contracts/zero-billing.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-billing.ts
@@ -243,6 +243,7 @@ export const zeroBillingInvoicesContract = c.router({
     responses: {
       200: billingInvoicesResponseSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
       500: apiErrorSchema,
     },
     summary: "Get invoices for current org",


### PR DESCRIPTION
## Summary

- make `GET /api/zero/billing/invoices` API-authoritative by removing the `shadowCompareRoute(...)` wrapper
- add an admin role gate (`auth.orgRole === "admin"`) to match web's 403 behavior
- declare `403: apiErrorSchema` on `zeroBillingInvoicesContract.get`
- add a `testOverride`-based seam to `signals/external/stripe-client.ts` (canonical `lib/time.ts` pattern)
- wire `clearMockListStripeInvoices()` into `testContext().afterEach` so mocks cannot leak across tests
- add api integration tests covering all 4 web GET cases plus the api-specific 401 unauth case
- introduce `helpers/zero-billing-invoices.ts` for stripe customer / subscription seed fixtures

Closes #12359

Part of epic #12290.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-invoices.test.ts` — 5 / 5 passing
- `pnpm -F api exec vitest run src/signals/external/__tests__/` — 3 / 3 passing (regression sanity)
- `pnpm -F api lint`
- `pnpm check-types` (cross-package, picks up the contract change)

## Test cases

| # | Case | Mirrors web |
|---|------|-------------|
| 1 | unauthenticated → 401 | n/a — added for migration parity |
| 2 | non-admin org member → 403 | "returns 403 for non-admin member" |
| 3 | admin with active subscription → 200 with invoices | "returns invoices for org with active subscription" |
| 4 | admin without Stripe customer → 200 `{invoices: []}` | "returns empty array for org without Stripe customer" |
| 5 | admin, Stripe returns no invoices → 200 `{invoices: []}` | "returns empty array when Stripe returns no invoices" |

The non-admin test confirms the admin gate is genuinely exercised: `mocks.clerk.session(userId, orgId, "org:member")` flows through `mapClerkOrgRole` → `auth.orgRole === "member"`, so `if (auth.orgRole !== "admin")` fires and 403 is returned (not bypassed by mock setup).

## Behavioral note — admin gate

The api previously returned 200 for non-admin org members; web returns 403. Without this gate, promoting traffic to api-authoritative would let members read their org's invoices (including `hostedInvoiceUrl`). This PR closes that gap.

## Stripe testOverride pattern

This is the first migration to add a testOverride seam to `signals/external/stripe-client.ts`. The seam is per-function (`mockListStripeInvoices`) rather than full-SDK so tests construct the api-internal `StripeInvoice` shape directly without coupling to the upstream Stripe SDK shape. Future Stripe ops (subscriptions, checkout, webhooks) can add their own `mock<X>` / `clearMock<X>` next to the production function, mirroring how `lib/time.ts` exports `now`/`mockNow`/`clearMockNow`.

## Behavioral note — 404 path

Web returns 404 if `resolveOrg` rejects. The api implementation skips `resolveOrg` because Clerk only sets active `orgId` on sessions where the user is a member. Same simplification as PRs #12312 / #12314 / #12315 / #12337 / #12351.

## Rollback

Disabling the `apiBackend` feature switch routes traffic back to `apps/web`. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)