### PR TITLE
refactor(api): migrate insights get

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-insights.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-insights.ts
@@ -1,0 +1,68 @@
+import { randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import { insightsDaily } from "@vm0/db/schema/insights-daily";
+import { and, eq } from "drizzle-orm";
+
+import { writeDb$ } from "../../../external/db";
+
+export interface InsightsFixture {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+export const seedInsightsFixture$ = command(
+  (_, _input: void, _signal: AbortSignal): Promise<InsightsFixture> => {
+    return Promise.resolve({
+      orgId: `org_${randomUUID()}`,
+      userId: `user_${randomUUID()}`,
+    });
+  },
+);
+
+export const deleteInsightsForFixture$ = command(
+  async (
+    { set },
+    fixture: InsightsFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    await db
+      .delete(insightsDaily)
+      .where(
+        and(
+          eq(insightsDaily.orgId, fixture.orgId),
+          eq(insightsDaily.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+  },
+);
+
+export const seedInsightsDaily$ = command(
+  async (
+    { set },
+    args: {
+      orgId: string;
+      userId: string;
+      date: string;
+      data: Record<string, unknown>;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    await db
+      .insert(insightsDaily)
+      .values({
+        orgId: args.orgId,
+        userId: args.userId,
+        date: args.date,
+        data: args.data,
+      })
+      .onConflictDoUpdate({
+        target: [insightsDaily.orgId, insightsDaily.userId, insightsDaily.date],
+        set: { data: args.data },
+      });
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-insights.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-insights.test.ts
@@ -1,0 +1,359 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroInsightsContract } from "@vm0/api-contracts/contracts/zero-insights";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { nowDate } from "../../../lib/time";
+import {
+  deleteInsightsForFixture$,
+  seedInsightsDaily$,
+  seedInsightsFixture$,
+  type InsightsFixture,
+} from "./helpers/zero-insights";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function apiClient() {
+  return setupApp({ context })(zeroInsightsContract);
+}
+
+function daysAgo(n: number): string {
+  const d = nowDate();
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+function defaultInsightData(
+  overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    agents: [
+      { agentName: "Test Agent", agentId: "agent-1", runs: 5, credits: 100 },
+    ],
+    creditsUsed: 100,
+    creditBalance: 9900,
+    teamUsage: [{ name: "alice", credits: 100 }],
+    topTask: { name: "Send message", count: 10 },
+    services: [
+      {
+        name: "api.slack.com",
+        domain: "api.slack.com",
+        calls: 10,
+        agentNames: ["Test Agent"],
+      },
+    ],
+    permissions: [
+      {
+        label: "chat:write",
+        allowed: 8,
+        denied: 2,
+        agentNames: ["Test Agent"],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("GET /api/zero/insights", () => {
+  const track = createFixtureTracker<InsightsFixture>((fixture) => {
+    return store.set(deleteInsightsForFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      apiClient().get({ query: {}, headers: {} }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns empty days when no insights exist", async () => {
+    const fixture = await track(
+      store.set(seedInsightsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.days).toStrictEqual([]);
+    expect(response.body.totalCredits).toBe(0);
+    expect(response.body.totalRuns).toBe(0);
+    expect(response.body.lastUpdated).toBeNull();
+  });
+
+  it("returns insights with correct structure", async () => {
+    const fixture = await track(
+      store.set(seedInsightsFixture$, undefined, context.signal),
+    );
+    const yesterday = daysAgo(1);
+    await store.set(
+      seedInsightsDaily$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        date: yesterday,
+        data: defaultInsightData(),
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.days).toHaveLength(1);
+    const day = response.body.days[0];
+    expect(day?.date).toBe(yesterday);
+    expect(day?.agents).toHaveLength(1);
+    expect(day?.agents[0]?.agentName).toBe("Test Agent");
+    expect(day?.schedules).toStrictEqual([]);
+    expect(day?.chats).toStrictEqual([]);
+    expect(day?.creditsUsed).toBe(100);
+    expect(response.body.totalCredits).toBe(100);
+    expect(response.body.totalRuns).toBe(5);
+    expect(response.body.lastUpdated).toBeTruthy();
+    expect(
+      Number.isNaN(new Date(response.body.lastUpdated ?? "").getTime()),
+    ).toBeFalsy();
+  });
+
+  it("aggregates totals across multiple days", async () => {
+    const fixture = await track(
+      store.set(seedInsightsFixture$, undefined, context.signal),
+    );
+    await store.set(
+      seedInsightsDaily$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        date: daysAgo(1),
+        data: defaultInsightData(),
+      },
+      context.signal,
+    );
+    await store.set(
+      seedInsightsDaily$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        date: daysAgo(2),
+        data: defaultInsightData({
+          agents: [
+            {
+              agentName: "Agent B",
+              agentId: "agent-2",
+              runs: 3,
+              credits: 200,
+            },
+          ],
+          creditsUsed: 200,
+        }),
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.days).toHaveLength(2);
+    expect(response.body.totalCredits).toBe(300);
+    expect(response.body.totalRuns).toBe(8);
+  });
+
+  it("respects days query parameter", async () => {
+    const fixture = await track(
+      store.set(seedInsightsFixture$, undefined, context.signal),
+    );
+    await store.set(
+      seedInsightsDaily$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        date: daysAgo(1),
+        data: defaultInsightData(),
+      },
+      context.signal,
+    );
+    await store.set(
+      seedInsightsDaily$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        date: daysAgo(2),
+        data: defaultInsightData({ creditsUsed: 50 }),
+      },
+      context.signal,
+    );
+    await store.set(
+      seedInsightsDaily$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        date: daysAgo(5),
+        data: defaultInsightData({ creditsUsed: 75 }),
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ query: { days: 3 }, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.days).toHaveLength(2);
+  });
+
+  it("clamps days parameter between 1 and 90", async () => {
+    const fixture = await track(
+      store.set(seedInsightsFixture$, undefined, context.signal),
+    );
+    await store.set(
+      seedInsightsDaily$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        date: daysAgo(0),
+        data: defaultInsightData(),
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response1 = await accept(
+      apiClient().get({ query: { days: 0 }, headers: authHeaders() }),
+      [200],
+    );
+    expect(response1.body.days).toHaveLength(1);
+
+    const response2 = await accept(
+      apiClient().get({ query: { days: 200 }, headers: authHeaders() }),
+      [200],
+    );
+    expect(response2.status).toBe(200);
+  });
+
+  it("does not return insights from other orgs", async () => {
+    const fixture = await track(
+      store.set(seedInsightsFixture$, undefined, context.signal),
+    );
+    const otherOrgFixture = await track(
+      Promise.resolve<InsightsFixture>({
+        orgId: `org_${randomUUID()}`,
+        userId: fixture.userId,
+      }),
+    );
+    await store.set(
+      seedInsightsDaily$,
+      {
+        orgId: otherOrgFixture.orgId,
+        userId: otherOrgFixture.userId,
+        date: daysAgo(1),
+        data: defaultInsightData(),
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.days).toStrictEqual([]);
+  });
+
+  it("does not return insights from other users", async () => {
+    const fixture = await track(
+      store.set(seedInsightsFixture$, undefined, context.signal),
+    );
+    const otherUserFixture = await track(
+      Promise.resolve<InsightsFixture>({
+        orgId: fixture.orgId,
+        userId: `user_${randomUUID()}`,
+      }),
+    );
+    await store.set(
+      seedInsightsDaily$,
+      {
+        orgId: otherUserFixture.orgId,
+        userId: otherUserFixture.userId,
+        date: daysAgo(1),
+        data: defaultInsightData(),
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.days).toStrictEqual([]);
+  });
+
+  it("orders days by date descending", async () => {
+    const fixture = await track(
+      store.set(seedInsightsFixture$, undefined, context.signal),
+    );
+    const day1 = daysAgo(3);
+    const day2 = daysAgo(1);
+    const day3 = daysAgo(2);
+    for (const date of [day1, day2, day3]) {
+      await store.set(
+        seedInsightsDaily$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          date,
+          data: defaultInsightData(),
+        },
+        context.signal,
+      );
+    }
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.days).toHaveLength(3);
+    expect(response.body.days[0]?.date).toBe(day2);
+    expect(response.body.days[1]?.date).toBe(day3);
+    expect(response.body.days[2]?.date).toBe(day1);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-insights.ts
+++ b/turbo/apps/api/src/signals/routes/zero-insights.ts
@@ -50,9 +50,6 @@ export const zeroInsightsRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroInsightsContract.get,
-    handler: shadowCompareRoute({
-      route: zeroInsightsContract.get,
-      handler: authRoute(orgAuth, getInsightsInner$),
-    }),
+    handler: authRoute(orgAuth, getInsightsInner$),
   },
 ];


### PR DESCRIPTION
Closes #12365

## Summary
- Make `GET /api/zero/insights` authoritative in `apps/api` by removing the `shadowCompareRoute(...)` wrapper from the `zeroInsightsContract.get` entry
- **Leave the `zeroInsightsRangeContract.get` entry untouched** (separate Stage 2 issue) — still wrapped in `shadowCompareRoute` and the `shadowCompareRoute` import remains
- Port all 9 web GET cases 1:1 plus 1 api-specific 401 missing-organization case (10 cases total)
- Introduce `helpers/zero-insights.ts` with the fixture seeder, row seeder, and per-`(orgId, userId)` cleanup

## Behavior parity
The api `zeroInsights` Computed and the web GET handler both query `insights_daily` by `(orgId, userId)` with a date cutoff (1..90 days, default 30, ordered by `date DESC`). The api unpacks the JSONB `data` field into the explicit `DayInsight` contract shape; web spreads `...data` and overrides `schedules`/`chats` defaults. The api unpack is a tightening — only known DayInsight fields are returned — but the seeded test data only includes known fields, so all 10 cases produce identical responses. **Decision: flag-not-fix** (contract is the source of truth; shadow has been running clean).

The contract query schema is permissive (`days: z.coerce.number().optional()` — no min/max), so `?days=0` and `?days=200` reach the service and get clamped by `normalizeDays()`. Behavior parity with web preserved.

## Scope
- Only `zeroInsightsContract.get` migrated. The shared `zeroInsightsRangeContract.get` entry in the same file stays wrapped.
- `shadowCompareRoute` import retained (still used by the range entry).
- Verified post-edit: `grep -c shadowCompareRoute zero-insights.ts` returns 2 (import + range entry usage).

## Test cases (all 10)
1. returns 401 when the request is unauthenticated
2. returns 401 when the authenticated session has no organization (api-specific)
3. returns empty days when no insights exist
4. returns insights with correct structure
5. aggregates totals across multiple days
6. respects days query parameter
7. clamps days parameter between 1 and 90
8. does not return insights from other orgs
9. does not return insights from other users
10. orders days by date descending

## Test plan
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-insights.test.ts` — 10/10 passed (first run, no rework)
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] Pre-commit: prettier, knip, `turbo run check-types`, commitlint — all green

## Rollback
Disable the `apiBackend` feature switch — traffic returns to `apps/web`. No DB or schema change.