### PR TITLE
refactor(api): migrate computer use host get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-computer-use.ts
@@ -1,0 +1,86 @@
+import { randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import { computerUseHosts } from "@vm0/db/schema/computer-use-host";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { and, eq } from "drizzle-orm";
+
+import { writeDb$ } from "../../../external/db";
+import { now } from "../../../external/time";
+
+interface ScenarioHost {
+  readonly domain: string;
+  readonly token: string;
+  readonly expiresAt?: Date;
+}
+
+interface ComputerUseScenarioValues {
+  readonly computerUseEnabled: boolean;
+  readonly host?: ScenarioHost;
+}
+
+export interface ComputerUseScenarioFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly hostId: string | null;
+}
+
+export const seedComputerUseScenario$ = command(
+  async (
+    { set },
+    values: ComputerUseScenarioValues,
+    signal: AbortSignal,
+  ): Promise<ComputerUseScenarioFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const writeDb = set(writeDb$);
+
+    await writeDb.insert(userFeatureSwitches).values({
+      orgId,
+      userId,
+      switches: { computerUse: values.computerUseEnabled },
+    });
+    signal.throwIfAborted();
+
+    let hostId: string | null = null;
+    if (values.host) {
+      hostId = randomUUID();
+      await writeDb.insert(computerUseHosts).values({
+        id: hostId,
+        orgId,
+        userId,
+        domain: values.host.domain,
+        token: values.host.token,
+        expiresAt: values.host.expiresAt ?? new Date(now() + 60 * 60 * 1000),
+      });
+      signal.throwIfAborted();
+    }
+
+    return { orgId, userId, hostId };
+  },
+);
+
+export const deleteComputerUseScenario$ = command(
+  async (
+    { set },
+    fixture: ComputerUseScenarioFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    if (fixture.hostId) {
+      await writeDb
+        .delete(computerUseHosts)
+        .where(eq(computerUseHosts.id, fixture.hostId));
+      signal.throwIfAborted();
+    }
+    await writeDb
+      .delete(userFeatureSwitches)
+      .where(
+        and(
+          eq(userFeatureSwitches.orgId, fixture.orgId),
+          eq(userFeatureSwitches.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
@@ -1,0 +1,127 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroComputerUseHostContract } from "@vm0/api-contracts/contracts/zero-computer-use";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  type ComputerUseScenarioFixture,
+  deleteComputerUseScenario$,
+  seedComputerUseScenario$,
+} from "./helpers/zero-computer-use";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/computer-use/host", () => {
+  const track = createFixtureTracker<ComputerUseScenarioFixture>((fixture) => {
+    return store.set(deleteComputerUseScenario$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroComputerUseHostContract);
+
+    const response = await accept(client.getHost({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const client = setupApp({ context })(zeroComputerUseHostContract);
+
+    const response = await accept(
+      client.getHost({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 when the computer-use feature switch is disabled", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroComputerUseHostContract);
+
+    const response = await accept(
+      client.getHost({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Computer use is not enabled", code: "FORBIDDEN" },
+    });
+  });
+
+  it("returns 404 when no active host is registered", async () => {
+    const fixture = await track(
+      store.set(
+        seedComputerUseScenario$,
+        { computerUseEnabled: true },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroComputerUseHostContract);
+
+    const response = await accept(
+      client.getHost({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "No active computer-use host", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns host details when a host is registered", async () => {
+    const fixture = await track(
+      store.set(
+        seedComputerUseScenario$,
+        {
+          computerUseEnabled: true,
+          host: {
+            domain: "abc.ngrok-free.app",
+            token: "host_token_xyz",
+          },
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroComputerUseHostContract);
+
+    const response = await accept(
+      client.getHost({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      domain: "abc.ngrok-free.app",
+      token: "host_token_xyz",
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/zero-computer-use.ts
@@ -5,7 +5,6 @@ import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import { zeroComputerUseHost } from "../services/zero-computer-use.service";
 import type { RouteEntry } from "../route";
@@ -57,16 +56,13 @@ const getComputerUseHostInner$ = computed(async (get) => {
 export const zeroComputerUseRoutes: readonly RouteEntry[] = [
   {
     route: zeroComputerUseHostContract.getHost,
-    handler: shadowCompareRoute({
-      route: zeroComputerUseHostContract.getHost,
-      handler: authRoute(
-        {
-          requireOrganization: true,
-          missingOrganizationStatus: 401,
-          requiredCapability: "computer-use:write",
-        },
-        getComputerUseHostInner$,
-      ),
-    }),
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "computer-use:write",
+      },
+      getComputerUseHostInner$,
+    ),
   },
 ];


### PR DESCRIPTION
Closes #12367

## Summary
- Drop the `shadowCompareRoute` wrapper from `GET /api/zero/computer-use/host` so `apps/api` is now authoritative for the route.
- Add the api integration test from scratch (file did not exist) covering all 4 in-scope web GET cases plus the api-specific 401 missing-organization case.
- Add `seedComputerUseScenario\$` / `deleteComputerUseScenario\$` helpers that drive both the `user_feature_switches` override and the `computer_use_hosts` row in a single fixture.

POST `/register` and DELETE `/unregister` remain shadow-compared (Stage 3, separate follow-ups). Service (`zeroComputerUseHost`) untouched — behavior parity verified field-by-field against `web/src/lib/zero/computer-use/computer-use-service.ts:339`.

## Final test inventory (5 cases)
- `returns 401 when the request is unauthenticated` — mirrors web GET case 1
- `returns 401 when the authenticated session has no organization` — api-specific (per issue body; \`requireOrganization: true, missingOrganizationStatus: 401\`)
- `returns 403 when the computer-use feature switch is disabled` — mirrors web GET case 2
- `returns 404 when no active host is registered` — mirrors web GET case 3
- `returns host details when a host is registered` — mirrors web GET case 4

## Implementation notes
- `expiresAt` for the seeded host is computed as \`new Date(now() + 60 * 60 * 1000)\` using \`now\` from \`signals/external/time\` (the project's mockable wallclock indirection — bare \`Date.now()\` is forbidden by lint outside \`lib/time.ts\`).
- Feature-switch state is driven via the real \`user_feature_switches\` DB table — no \`vi.mock\` of internal modules.

## Test plan
- [x] \`pnpm -F api exec vitest run src/signals/routes/__tests__/zero-computer-use.test.ts\` — 5/5 passing
- [x] \`pnpm -F api lint\`
- [x] \`pnpm -F api check-types\`
- [x] \`pnpm format\`
- [x] \`pnpm knip\`

## Rollback
Disable the \`apiBackend\` feature switch — traffic falls back to the unchanged \`apps/web\` route. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)