### PR TITLE
fix(api): exclude user-revoke ghost rows in visibleChatMessageCondition

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
@@ -99,6 +99,12 @@ describe("GET /api/zero/chat-threads/:id", () => {
         },
       ],
     });
+    // Each chatMessage must carry its DB row id — the contract marks it
+    // optional for back-compat, but production clients dedupe on id, and
+    // omitting it caused a shadow divergence regression (see PR #12339).
+    for (const message of response.body.chatMessages) {
+      expect(message.id).toEqual(expect.any(String));
+    }
   });
 
   it("strips Clerk user_ prefix from attachment file URLs", async () => {
@@ -357,5 +363,70 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
       ],
       hasHistoryBefore: false,
     });
+  });
+
+  it("excludes user-revoke ghost rows that revoke a queued message", async () => {
+    // Queued user messages start with run_id IS NULL. When the queue drains,
+    // a NEW user row (also with run_id IS NULL) is appended pointing at the
+    // queued row via revokes_message_id. The web visibility filter drops
+    // BOTH the original (revoked) row and the ghost revoker row; the api
+    // shadow used to drop only the original, which shifted the page window
+    // by one and surfaced as "response shadow divergence" warnings on
+    // GET /api/zero/chat-threads/:threadId/messages.
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    const writeDb = store.set(writeDb$);
+
+    const queuedId = randomUUID();
+    const revokerId = randomUUID();
+    const visibleId = randomUUID();
+    await writeDb.insert(chatMessages).values([
+      {
+        id: queuedId,
+        chatThreadId: fixture.threadId,
+        role: "user",
+        content: "queued draft",
+        runId: null,
+        createdAt: new Date("2025-01-01T00:00:00.000Z"),
+      },
+      {
+        id: revokerId,
+        chatThreadId: fixture.threadId,
+        role: "user",
+        content: null,
+        runId: null,
+        revokesMessageId: queuedId,
+        createdAt: new Date("2025-01-01T00:00:01.000Z"),
+      },
+      {
+        id: visibleId,
+        chatThreadId: fixture.threadId,
+        role: "user",
+        content: "kept",
+        runId: null,
+        createdAt: new Date("2025-01-01T00:00:02.000Z"),
+      },
+    ]);
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mockApiShadowCompareRoutes([chatThreadMessagesContract.list]);
+
+    const client = setupApp({ context })(chatThreadMessagesContract);
+
+    const response = await accept(
+      client.list({
+        params: { threadId: fixture.threadId },
+        query: { limit: 50 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(
+      response.body.messages.map((m) => {
+        return m.id;
+      }),
+    ).toEqual([visibleId]);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
@@ -103,7 +103,7 @@ describe("GET /api/zero/chat-threads/:id", () => {
     // optional for back-compat, but production clients dedupe on id, and
     // omitting it caused a shadow divergence regression (see PR #12339).
     for (const message of response.body.chatMessages) {
-      expect(message.id).toEqual(expect.any(String));
+      expect(message.id).toStrictEqual(expect.any(String));
     }
   });
 
@@ -427,6 +427,6 @@ describe("GET /api/zero/chat-threads/:threadId/messages", () => {
       response.body.messages.map((m) => {
         return m.id;
       }),
-    ).toEqual([visibleId]);
+    ).toStrictEqual([visibleId]);
   });
 });

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -135,10 +135,15 @@ function effectiveChatMessageRunId() {
 
 function visibleChatMessageCondition() {
   return sql<boolean>`NOT EXISTS (
-    SELECT 1
-    FROM ${chatMessages} AS revoker
-    WHERE revoker.revokes_message_id = ${chatMessages.id}
-  )`;
+      SELECT 1
+      FROM ${chatMessages} AS revoker
+      WHERE revoker.revokes_message_id = ${chatMessages.id}
+    )
+    AND NOT (
+      ${chatMessages.role} = 'user'
+      AND ${chatMessages.runId} IS NULL
+      AND ${chatMessages.revokesMessageId} IS NOT NULL
+    )`;
 }
 
 const messageColumns = {


### PR DESCRIPTION
## Summary

- Add the missing `AND NOT (role='user' AND runId IS NULL AND revokesMessageId IS NOT NULL)` clause to the api-side `visibleChatMessageCondition`, matching `apps/web`'s filter exactly.
- Strengthen the `chat-threads/:id` test so the previously-missing `id` field (#12339) cannot regress under `toMatchObject`'s partial-match semantics.
- Add a regression test that seeds a queued message + revoker ghost row + a normal message, then asserts only the normal one is returned by `GET /api/zero/chat-threads/:threadId/messages`.

## Why

Axiom shows ~150–250 "response shadow divergence" warnings/hour on production after the latest release, all on chat-thread routes. Two distinct bugs were involved:

1. **`chat-threads/:id` (78 events/window)** — api `toStoredMessage` omitted `id`. Already fixed in #12339; this PR adds an explicit `expect(message.id).toEqual(expect.any(String))` so it stays fixed (the existing `toMatchObject` would silently allow a re-omission).
2. **`chat-threads` list + `chat-threads/:threadId/messages` (15 events/window)** — when a user revokes a queued draft, the queue inserts a NEW user row with `run_id IS NULL` pointing at the original via `revokes_message_id`. Web's filter drops both rows; the api filter only dropped the original, so the ghost revoker row leaked through and shifted the page window by one — producing diffs like `body.messages[0].id` mismatches plus several `body.messages[N].content`/`role`/`runId`/`createdAt` divergences (the diff entries that showed `kind=both` in the breakdown).

## Test plan

- [x] apps/api workspace vitest: 8/8 pass (the 2 new assertions exercise the ghost-row filter and the chat-thread-detail id field)
- [x] eslint clean on changed files
- [x] check-types clean
- [x] format no-op on changed files
- [ ] CI green, including cli-e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)