### PR TITLE
fix: clarify Claude Code OAuth token dialog copy

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/personal-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/personal-provider-dialog.tsx
@@ -209,7 +209,7 @@ function getDialogCopy({
     return {
       title: "Configure Claude Code OAuth",
       description:
-        "Paste a Claude Code OAuth token for workspace model routes that use your Claude credentials.",
+        "Paste your personal Claude Code OAuth token. It is stored encrypted and used only to authenticate the official Claude Code CLI in your own runs — requests go directly to Anthropic, and the token is never shared with workspace teammates.",
     };
   }
 


### PR DESCRIPTION
## Summary

The `Configure Claude Code OAuth` dialog currently reads:

> Paste a Claude Code OAuth token for workspace model routes that use your Claude credentials.

The phrase "workspace model routes" is misleading — it implies the token might be re-used to serve other teammates or routed through a vm0-side gateway. Neither is true: the token is stored encrypted, scoped to the owner's user_id, and injected as `CLAUDE_CODE_OAUTH_TOKEN` into the user's own runner where the official Claude Code CLI talks directly to `api.anthropic.com`.

This PR rewrites the description to make that explicit, addressing user concerns about token sharing and aligning the wording with Anthropic's [Claude Code legal-and-compliance](https://code.claude.com/docs/en/legal-and-compliance) framing ("ordinary use of Claude Code").

### New copy

> Paste your personal Claude Code OAuth token. It is stored encrypted and used only to authenticate the official Claude Code CLI in your own runs — requests go directly to Anthropic, and the token is never shared with workspace teammates.

## Test plan

- [ ] Open Settings → Personal providers → Configure Claude Code OAuth and confirm the new description renders correctly
- [ ] Confirm no other tests reference the old copy string