### PR TITLE
refactor(api): migrate insights range get

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-insights.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-insights.test.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from "node:crypto";
 
-import { zeroInsightsContract } from "@vm0/api-contracts/contracts/zero-insights";
+import {
+  zeroInsightsContract,
+  zeroInsightsRangeContract,
+} from "@vm0/api-contracts/contracts/zero-insights";
 import { createStore } from "ccstate";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -26,6 +29,10 @@ function authHeaders() {
 
 function apiClient() {
   return setupApp({ context })(zeroInsightsContract);
+}
+
+function apiRangeClient() {
+  return setupApp({ context })(zeroInsightsRangeContract);
 }
 
 function daysAgo(n: number): string {
@@ -355,5 +362,167 @@ describe("GET /api/zero/insights", () => {
     expect(response.body.days[0]?.date).toBe(day2);
     expect(response.body.days[1]?.date).toBe(day3);
     expect(response.body.days[2]?.date).toBe(day1);
+  });
+});
+
+describe("GET /api/zero/insights/range", () => {
+  const track = createFixtureTracker<InsightsFixture>((fixture) => {
+    return store.set(deleteInsightsForFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(apiRangeClient().get({ headers: {} }), [401]);
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const response = await accept(
+      apiRangeClient().get({ headers: authHeaders() }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns nulls when no insights exist", async () => {
+    const fixture = await track(
+      store.set(seedInsightsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiRangeClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.minDate).toBeNull();
+    expect(response.body.maxDate).toBeNull();
+    expect(response.body.totalDays).toBe(0);
+  });
+
+  it("returns correct range for a single day", async () => {
+    const fixture = await track(
+      store.set(seedInsightsFixture$, undefined, context.signal),
+    );
+    const date = daysAgo(1);
+    await store.set(
+      seedInsightsDaily$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        date,
+        data: defaultInsightData(),
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiRangeClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.minDate).toBe(date);
+    expect(response.body.maxDate).toBe(date);
+    expect(response.body.totalDays).toBe(1);
+  });
+
+  it("returns correct range for multiple days", async () => {
+    const fixture = await track(
+      store.set(seedInsightsFixture$, undefined, context.signal),
+    );
+    const day1 = daysAgo(5);
+    const day2 = daysAgo(3);
+    const day3 = daysAgo(1);
+    for (const date of [day1, day2, day3]) {
+      await store.set(
+        seedInsightsDaily$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          date,
+          data: defaultInsightData(),
+        },
+        context.signal,
+      );
+    }
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiRangeClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.minDate).toBe(day1);
+    expect(response.body.maxDate).toBe(day3);
+    expect(response.body.totalDays).toBe(3);
+  });
+
+  it("does not include insights from other orgs", async () => {
+    const fixture = await track(
+      store.set(seedInsightsFixture$, undefined, context.signal),
+    );
+    const otherOrgFixture = await track(
+      Promise.resolve<InsightsFixture>({
+        orgId: `org_${randomUUID()}`,
+        userId: fixture.userId,
+      }),
+    );
+    await store.set(
+      seedInsightsDaily$,
+      {
+        orgId: otherOrgFixture.orgId,
+        userId: otherOrgFixture.userId,
+        date: daysAgo(1),
+        data: defaultInsightData(),
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiRangeClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.minDate).toBeNull();
+    expect(response.body.maxDate).toBeNull();
+    expect(response.body.totalDays).toBe(0);
+  });
+
+  it("does not include insights from other users", async () => {
+    const fixture = await track(
+      store.set(seedInsightsFixture$, undefined, context.signal),
+    );
+    const otherUserFixture = await track(
+      Promise.resolve<InsightsFixture>({
+        orgId: fixture.orgId,
+        userId: `user_${randomUUID()}`,
+      }),
+    );
+    await store.set(
+      seedInsightsDaily$,
+      {
+        orgId: otherUserFixture.orgId,
+        userId: otherUserFixture.userId,
+        date: daysAgo(1),
+        data: defaultInsightData(),
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiRangeClient().get({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.minDate).toBeNull();
+    expect(response.body.maxDate).toBeNull();
+    expect(response.body.totalDays).toBe(0);
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-insights.ts
+++ b/turbo/apps/api/src/signals/routes/zero-insights.ts
@@ -7,7 +7,6 @@ import {
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import {
   zeroInsights,
   zeroInsightsRange,
@@ -43,10 +42,7 @@ const getInsightsRangeInner$ = computed(async (get) => {
 export const zeroInsightsRoutes: readonly RouteEntry[] = [
   {
     route: zeroInsightsRangeContract.get,
-    handler: shadowCompareRoute({
-      route: zeroInsightsRangeContract.get,
-      handler: authRoute(orgAuth, getInsightsRangeInner$),
-    }),
+    handler: authRoute(orgAuth, getInsightsRangeInner$),
   },
   {
     route: zeroInsightsContract.get,


### PR DESCRIPTION
Closes #12373

## Summary
- Make `GET /api/zero/insights/range` authoritative in `apps/api` by removing the `shadowCompareRoute(...)` wrapper from the `zeroInsightsRangeContract.get` entry
- **Removes the `shadowCompareRoute` import from `zero-insights.ts`** — no longer needed since the partner route was migrated in PR #12369
- After this PR, `zero-insights.ts` has **zero `shadowCompareRoute` references** — file fully migrated (was 2 before this PR)
- Add 6 web GET cases ported 1:1 + 1 api-specific 401 missing-organization case (7 cases total) as a sibling describe block in the existing `zero-insights.test.ts`, reusing the helpers from PR #12369

## Behavior parity
The api `zeroInsightsRange` Computed and the web GET handler both run the same SQL aggregate (`MIN(date)`, `MAX(date)`, `COUNT(*)::int`) on `insights_daily` filtered by `(orgId, userId)`, returning `{ minDate, maxDate, totalDays }` or `{ null, null, 0 }` when no rows match. Character-for-character identical.

## Scope
- Route + test only. No new helper file (existing `helpers/zero-insights.ts` from PR #12369 already has all 3 seeders this PR needs).
- Existing 10 cases in the test file (insights main route) untouched — only appended a new describe block.
- Verified post-edit: `grep -c shadowCompareRoute zero-insights.ts` returns `0`. File-fully-migrated milestone reached.

## Test cases (all 7 in new describe)
1. returns 401 when the request is unauthenticated
2. returns 401 when the authenticated session has no organization (api-specific)
3. returns nulls when no insights exist
4. returns correct range for a single day
5. returns correct range for multiple days
6. does not include insights from other orgs
7. does not include insights from other users

## Test plan
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-insights.test.ts` — 17/17 passed (10 existing + 7 new)
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `grep -c shadowCompareRoute zero-insights.ts` returns 0 — file fully migrated
- [x] Pre-commit: prettier, knip, `turbo run check-types`, commitlint — all green

## Rollback
Disable the `apiBackend` feature switch — traffic returns to `apps/web`. No DB or schema change.