### PR TITLE
refactor(api): migrate secrets get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-secrets.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-secrets.test.ts
@@ -2,7 +2,6 @@ import { zeroSecretsContract } from "@vm0/api-contracts/contracts/zero-secrets";
 import { createStore } from "ccstate";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -21,6 +20,19 @@ const mocks = createZeroRouteMocks(context);
 describe("GET /api/zero/secrets", () => {
   const track = createFixtureTracker<UserDataFixture>((fixture) => {
     return store.set(deleteUserData$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroSecretsContract);
+
+    const response = await accept(client.list({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
   });
 
   it("returns current user secret metadata sorted by name", async () => {
@@ -50,7 +62,6 @@ describe("GET /api/zero/secrets", () => {
     );
     await store.set(seedOtherSecret$, fixture, context.signal);
     mocks.clerk.session(fixture.userId, fixture.orgId);
-    mockApiShadowCompareRoutes([zeroSecretsContract.list]);
 
     const client = setupApp({ context })(zeroSecretsContract);
 
@@ -78,12 +89,15 @@ describe("GET /api/zero/secrets", () => {
         updatedAt: "2026-01-03T03:04:05.000Z",
       },
     ]);
+    for (const secret of response.body.secrets) {
+      expect(secret).not.toHaveProperty("value");
+      expect(secret).not.toHaveProperty("encryptedValue");
+    }
   });
 
   it("returns an empty list when the user has no secrets", async () => {
     const fixture = await track(store.set(seedSecrets$, [], context.signal));
     mocks.clerk.session(fixture.userId, fixture.orgId);
-    mockApiShadowCompareRoutes([zeroSecretsContract.list]);
 
     const client = setupApp({ context })(zeroSecretsContract);
 

--- a/turbo/apps/api/src/signals/routes/zero-secrets.ts
+++ b/turbo/apps/api/src/signals/routes/zero-secrets.ts
@@ -35,13 +35,10 @@ const listVariablesInner$ = computed(async (get): Promise<unknown> => {
 export const zeroSecretsRoutes: readonly RouteEntry[] = [
   {
     route: zeroSecretsContract.list,
-    handler: shadowCompareRoute({
-      route: zeroSecretsContract.list,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        listSecretsInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      listSecretsInner$,
+    ),
   },
   {
     route: zeroVariablesContract.list,


### PR DESCRIPTION
## Summary

- make `GET /api/zero/secrets` API-authoritative by removing the `shadowCompareRoute(...)` wrapper around the secrets entry only
- add a 401 unauthenticated test case for migration parity
- tighten the existing seeded test to explicitly assert no secret value / encryptedValue leak (matches web's defensive check)
- leave the `zeroVariablesContract.list` entry in the same route file shadow-wrapped (separate future migration)

Closes #12374

Part of epic #12290.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-secrets.test.ts` — 3 / 3 passing
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `grep -n shadowCompareRoute turbo/apps/api/src/signals/routes/zero-secrets.ts` — 2 occurrences (1 import + 1 wrapper around variables entry)

## Test cases

| # | Case | Mirrors web |
|---|------|-------------|
| 1 | unauthenticated → 401 | "should reject unauthenticated requests" |
| 2 | seeded secrets sorted + cross-user filtered + value-leak guard → 200 | "should list secrets for authenticated user" (api goes further: also asserts cross-user isolation via `seedOtherSecret$`) |
| 3 | no secrets → 200 `{secrets: []}` | "should return empty array when no secrets exist" |

## Scope clarification

Web file has GET + POST. POST is out of scope (Stage 3 mutation, separate follow-up). The api route file `zero-secrets.ts` registers both `zeroSecretsContract.list` AND `zeroVariablesContract.list`; only the secrets entry is migrated here. The variables entry continues to use `shadowCompareRoute(...)` and will be migrated separately. The `shadowCompareRoute` import line is preserved because it is still consumed by the variables wrapper.

## Defensive value-leak assertion

The existing api seeded case used `toMatchObject` which would not catch a regression where the server started returning `value` or `encryptedValue` (Zod `z.object` strips unknown keys silently — the leak would be invisible to the client even if it occurred on the wire). Web's case 2 explicitly asserts these properties are absent. This PR mirrors that explicit security check.

## Behavioral note

Web returns 404 if `resolveOrg` rejects. The api implementation skips `resolveOrg` because Clerk only sets active `orgId` on sessions where the user is a member. Same simplification as PRs #12312 / #12314 / #12315 / #12337 / #12351 / #12363.

## Rollback

Disabling the `apiBackend` feature switch routes traffic back to `apps/web`. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)