### PR TITLE
feat(api): port official telegram bot logic for parity with web

### DIFF
--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -29,6 +29,10 @@ const SCHEMA = {
   DB_POOL_MAX: z.coerce.number().int().min(1).default(10),
   DB_POOL_IDLE_TIMEOUT_MS: z.coerce.number().int().min(0).default(5000),
   DB_POOL_CONNECT_TIMEOUT_MS: z.coerce.number().int().min(0).optional(),
+  TELEGRAM_OFFICIAL_BOT_TOKEN: z.string().optional(),
+  TELEGRAM_OFFICIAL_BOT_USERNAME: z.string().optional(),
+  TELEGRAM_OFFICIAL_WEBHOOK_SECRET: z.string().optional(),
+  VM0_DEFAULT_AGENT: z.string().optional(),
 } as const;
 
 const baseEnv = createEnv<undefined, typeof SCHEMA>({

--- a/turbo/apps/api/src/signals/external/telegram-avatar.ts
+++ b/turbo/apps/api/src/signals/external/telegram-avatar.ts
@@ -1,0 +1,37 @@
+import { createHmac } from "node:crypto";
+
+import { env } from "../../lib/env";
+import { now } from "./time";
+
+const AVATAR_URL_TTL_SECONDS = 24 * 60 * 60;
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function computeAvatarHmacSignature(
+  botId: string,
+  secret: string,
+  expiresAt: number,
+): string {
+  return createHmac("sha256", secret)
+    .update(`${expiresAt}.${botId}`)
+    .digest("hex");
+}
+
+export function buildTelegramBotAvatarUrl(botId: string): string {
+  const secretsKey = env("SECRETS_ENCRYPTION_KEY");
+  const apiUrl = env("VM0_API_URL");
+  const path = `/api/integrations/telegram/${encodeURIComponent(botId)}/avatar`;
+  const expiresAt = Math.floor(now() / 1000) + AVATAR_URL_TTL_SECONDS;
+  const signature = computeAvatarHmacSignature(botId, secretsKey, expiresAt);
+  const query = new URLSearchParams({
+    exp: String(expiresAt),
+    sig: signature,
+  });
+  const signedPath = `${path}?${query.toString()}`;
+  if (!apiUrl) {
+    return signedPath;
+  }
+  return `${trimTrailingSlash(apiUrl)}${signedPath}`;
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-telegram.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-telegram.ts
@@ -1,0 +1,296 @@
+import { createCipheriv, randomBytes, randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+import { telegramOfficialUserLinks } from "@vm0/db/schema/telegram-official-user-link";
+import { telegramUserAgentPreferences } from "@vm0/db/schema/telegram-user-agent-preference";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { eq, inArray } from "drizzle-orm";
+
+import { env } from "../../../../lib/env";
+import { writeDb$ } from "../../../external/db";
+
+export interface TelegramFixture {
+  readonly orgId: string;
+  readonly composeIds: readonly string[];
+  readonly telegramBotIds: readonly string[];
+  readonly userIds: readonly string[];
+}
+
+interface TelegramFixtureBuilder {
+  readonly orgId: string;
+  readonly composeIds: string[];
+  readonly telegramBotIds: string[];
+  readonly userIds: string[];
+}
+
+interface SeedTelegramInstallationValues {
+  readonly orgId: string;
+  readonly ownerUserId: string;
+  readonly telegramBotId: string;
+  readonly botUsername?: string | null;
+  readonly defaultComposeId?: string;
+  readonly composeUserId?: string;
+  readonly composeName?: string;
+  readonly agentName?: string;
+}
+
+interface SeedOrgDefaultAgentValues {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly composeName?: string;
+  readonly agentName?: string;
+}
+
+interface SeedOfficialUserLinkValues {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly telegramUserId: string;
+}
+
+interface SeedUserAgentPreferenceValues {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly composeId: string;
+}
+
+interface SeedUserFeatureSwitchValues {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly switches: Record<string, boolean>;
+}
+
+function encryptBotTokenForTests(plaintext: string): string {
+  const key = Buffer.from(env("SECRETS_ENCRYPTION_KEY"), "hex");
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv, { authTagLength: 16 });
+  const data = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  return [
+    iv.toString("base64"),
+    authTag.toString("base64"),
+    data.toString("base64"),
+  ].join(":");
+}
+
+export const seedTelegramInstallation$ = command(
+  async (
+    { set },
+    values: SeedTelegramInstallationValues,
+    signal: AbortSignal,
+  ): Promise<{
+    readonly composeId: string;
+    readonly telegramBotId: string;
+  }> => {
+    const writeDb = set(writeDb$);
+    const composeId = values.defaultComposeId ?? randomUUID();
+    const composeUserId = values.composeUserId ?? values.ownerUserId;
+    const composeName = values.composeName ?? `agent-${composeId.slice(0, 8)}`;
+    const agentName = values.agentName ?? composeName;
+
+    await writeDb.insert(agentComposes).values({
+      id: composeId,
+      userId: composeUserId,
+      orgId: values.orgId,
+      name: composeName,
+    });
+    signal.throwIfAborted();
+    await writeDb.insert(zeroAgents).values({
+      id: composeId,
+      orgId: values.orgId,
+      owner: composeUserId,
+      name: agentName,
+    });
+    signal.throwIfAborted();
+    await writeDb.insert(telegramInstallations).values({
+      telegramBotId: values.telegramBotId,
+      botUsername:
+        values.botUsername === undefined
+          ? `bot_${values.telegramBotId}`
+          : values.botUsername,
+      encryptedBotToken: encryptBotTokenForTests("test-bot-token"),
+      webhookSecret: `whs_${randomUUID()}`,
+      defaultComposeId: composeId,
+      ownerUserId: values.ownerUserId,
+      orgId: values.orgId,
+    });
+    signal.throwIfAborted();
+
+    return { composeId, telegramBotId: values.telegramBotId };
+  },
+);
+
+export const seedOrgDefaultAgent$ = command(
+  async (
+    { set },
+    values: SeedOrgDefaultAgentValues,
+    signal: AbortSignal,
+  ): Promise<{ readonly composeId: string }> => {
+    const writeDb = set(writeDb$);
+    const composeId = randomUUID();
+    const composeName = values.composeName ?? `agent-${composeId.slice(0, 8)}`;
+    const agentName = values.agentName ?? composeName;
+
+    await writeDb.insert(agentComposes).values({
+      id: composeId,
+      userId: values.userId,
+      orgId: values.orgId,
+      name: composeName,
+    });
+    signal.throwIfAborted();
+    await writeDb.insert(zeroAgents).values({
+      id: composeId,
+      orgId: values.orgId,
+      owner: values.userId,
+      name: agentName,
+    });
+    signal.throwIfAborted();
+    await writeDb
+      .insert(orgMetadata)
+      .values({ orgId: values.orgId, defaultAgentId: composeId })
+      .onConflictDoUpdate({
+        target: orgMetadata.orgId,
+        set: { defaultAgentId: composeId },
+      });
+    signal.throwIfAborted();
+
+    return { composeId };
+  },
+);
+
+export const seedOfficialUserLink$ = command(
+  async (
+    { set },
+    values: SeedOfficialUserLinkValues,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb.insert(telegramOfficialUserLinks).values({
+      orgId: values.orgId,
+      vm0UserId: values.userId,
+      telegramUserId: values.telegramUserId,
+    });
+    signal.throwIfAborted();
+  },
+);
+
+export const seedUserAgentPreference$ = command(
+  async (
+    { set },
+    values: SeedUserAgentPreferenceValues,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .insert(telegramUserAgentPreferences)
+      .values({
+        orgId: values.orgId,
+        vm0UserId: values.userId,
+        selectedComposeId: values.composeId,
+      })
+      .onConflictDoUpdate({
+        target: [
+          telegramUserAgentPreferences.vm0UserId,
+          telegramUserAgentPreferences.orgId,
+        ],
+        set: { selectedComposeId: values.composeId },
+      });
+    signal.throwIfAborted();
+  },
+);
+
+export const seedUserFeatureSwitch$ = command(
+  async (
+    { set },
+    values: SeedUserFeatureSwitchValues,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .insert(userFeatureSwitches)
+      .values({
+        orgId: values.orgId,
+        userId: values.userId,
+        switches: values.switches,
+      })
+      .onConflictDoUpdate({
+        target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
+        set: { switches: values.switches },
+      });
+    signal.throwIfAborted();
+  },
+);
+
+export const deleteTelegramFixture$ = command(
+  async (
+    { set },
+    fixture: TelegramFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(userFeatureSwitches)
+      .where(eq(userFeatureSwitches.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await writeDb
+      .delete(telegramOfficialUserLinks)
+      .where(eq(telegramOfficialUserLinks.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await writeDb
+      .delete(telegramUserAgentPreferences)
+      .where(eq(telegramUserAgentPreferences.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    if (fixture.telegramBotIds.length > 0) {
+      await writeDb
+        .delete(telegramInstallations)
+        .where(
+          inArray(telegramInstallations.telegramBotId, [
+            ...fixture.telegramBotIds,
+          ]),
+        );
+      signal.throwIfAborted();
+    }
+    if (fixture.composeIds.length > 0) {
+      await writeDb
+        .delete(zeroAgents)
+        .where(inArray(zeroAgents.id, [...fixture.composeIds]));
+      signal.throwIfAborted();
+      await writeDb
+        .delete(agentComposes)
+        .where(inArray(agentComposes.id, [...fixture.composeIds]));
+      signal.throwIfAborted();
+    }
+    await writeDb
+      .delete(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
+  },
+);
+
+export function makeTelegramFixtureBuilder(
+  orgId: string,
+): TelegramFixtureBuilder {
+  return {
+    orgId,
+    composeIds: [],
+    telegramBotIds: [],
+    userIds: [],
+  };
+}
+
+export function freezeTelegramFixture(
+  builder: TelegramFixtureBuilder,
+): TelegramFixture {
+  return {
+    orgId: builder.orgId,
+    composeIds: [...builder.composeIds],
+    telegramBotIds: [...builder.telegramBotIds],
+    userIds: [...builder.userIds],
+  };
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-telegram-data.service.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-telegram-data.service.test.ts
@@ -1,0 +1,358 @@
+import { randomUUID } from "node:crypto";
+
+import { OFFICIAL_TELEGRAM_BOT_ID } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import { createStore } from "ccstate";
+import { afterEach, beforeEach } from "vitest";
+
+import { testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { zeroTelegramBots } from "../../services/zero-telegram-data.service";
+import {
+  deleteTelegramFixture$,
+  freezeTelegramFixture,
+  makeTelegramFixtureBuilder,
+  seedOfficialUserLink$,
+  seedOrgDefaultAgent$,
+  seedTelegramInstallation$,
+  seedUserAgentPreference$,
+  seedUserFeatureSwitch$,
+  type TelegramFixture,
+} from "./helpers/zero-telegram";
+
+const context = testContext();
+const store = createStore();
+
+const OFFICIAL_BOT_TOKEN = "9876543210:fake-test-token";
+const OFFICIAL_BOT_USERNAME = "official_zero_bot";
+const OFFICIAL_WEBHOOK_SECRET = "official-test-webhook-secret";
+
+function newOrgId(): string {
+  return `org_${randomUUID()}`;
+}
+
+function newUserId(): string {
+  return `user_${randomUUID()}`;
+}
+
+function newTelegramBotId(): string {
+  return String(Math.floor(Math.random() * 9_000_000_000) + 1_000_000_000);
+}
+
+function configureOfficialBotEnv(): void {
+  mockEnv("TELEGRAM_OFFICIAL_BOT_TOKEN", OFFICIAL_BOT_TOKEN);
+  mockEnv("TELEGRAM_OFFICIAL_BOT_USERNAME", OFFICIAL_BOT_USERNAME);
+  mockEnv("TELEGRAM_OFFICIAL_WEBHOOK_SECRET", OFFICIAL_WEBHOOK_SECRET);
+}
+
+describe("zeroTelegramBots service", () => {
+  const fixtures: TelegramFixture[] = [];
+
+  beforeEach(() => {
+    configureOfficialBotEnv();
+  });
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await store.set(deleteTelegramFixture$, fixture, context.signal);
+      }
+    }
+  });
+
+  function trackFixture(fixture: TelegramFixture): void {
+    fixtures.push(fixture);
+  }
+
+  it("returns only the official bot when org has zero custom installations", async () => {
+    const orgId = newOrgId();
+    const userId = newUserId();
+    trackFixture(freezeTelegramFixture(makeTelegramFixtureBuilder(orgId)));
+
+    const bots = await store.get(zeroTelegramBots({ orgId, userId }));
+
+    expect(bots).toHaveLength(1);
+    expect(bots[0]).toMatchObject({
+      id: OFFICIAL_TELEGRAM_BOT_ID,
+      kind: "official",
+      isOwner: false,
+      isConnected: false,
+      tokenStatus: "valid",
+      official: {
+        configured: true,
+        usesDefaultAgent: true,
+        linkedTelegramUserId: null,
+      },
+    });
+    expect(bots[0]?.username).toBe(OFFICIAL_BOT_USERNAME);
+  });
+
+  it("prepends the official bot to a list of custom installations", async () => {
+    const orgId = newOrgId();
+    const userId = newUserId();
+    const builder = makeTelegramFixtureBuilder(orgId);
+    builder.userIds.push(userId);
+
+    const ownerBotId = newTelegramBotId();
+    const otherBotId = newTelegramBotId();
+
+    context.mocks.telegram.getMe.mockResolvedValue({
+      id: 1,
+      is_bot: true,
+      first_name: "Bot",
+      username: "x",
+    });
+
+    const ownerInstall = await store.set(
+      seedTelegramInstallation$,
+      {
+        orgId,
+        ownerUserId: userId,
+        telegramBotId: ownerBotId,
+      },
+      context.signal,
+    );
+    builder.composeIds.push(ownerInstall.composeId);
+    builder.telegramBotIds.push(ownerInstall.telegramBotId);
+
+    const otherInstall = await store.set(
+      seedTelegramInstallation$,
+      {
+        orgId,
+        ownerUserId: `user_${randomUUID()}`,
+        telegramBotId: otherBotId,
+      },
+      context.signal,
+    );
+    builder.composeIds.push(otherInstall.composeId);
+    builder.telegramBotIds.push(otherInstall.telegramBotId);
+
+    trackFixture(freezeTelegramFixture(builder));
+
+    const bots = await store.get(zeroTelegramBots({ orgId, userId }));
+
+    expect(bots).toHaveLength(3);
+    expect(bots[0]).toMatchObject({
+      id: OFFICIAL_TELEGRAM_BOT_ID,
+      kind: "official",
+    });
+    const customBotIds = bots.slice(1).map((bot) => {
+      return bot.id;
+    });
+    expect(customBotIds).toContain(ownerBotId);
+    expect(customBotIds).toContain(otherBotId);
+    const ownerBot = bots.find((bot) => {
+      return bot.id === ownerBotId;
+    });
+    expect(ownerBot?.isOwner).toBeTruthy();
+    const otherBot = bots.find((bot) => {
+      return bot.id === otherBotId;
+    });
+    expect(otherBot?.isOwner).toBeFalsy();
+  });
+
+  it("omits the official bot when the user has overridden the switch off", async () => {
+    const orgId = newOrgId();
+    const userId = newUserId();
+    const builder = makeTelegramFixtureBuilder(orgId);
+    builder.userIds.push(userId);
+
+    context.mocks.telegram.getMe.mockResolvedValue({
+      id: 1,
+      is_bot: true,
+      first_name: "Bot",
+      username: "x",
+    });
+
+    const customBotId = newTelegramBotId();
+    const customInstall = await store.set(
+      seedTelegramInstallation$,
+      { orgId, ownerUserId: userId, telegramBotId: customBotId },
+      context.signal,
+    );
+    builder.composeIds.push(customInstall.composeId);
+    builder.telegramBotIds.push(customInstall.telegramBotId);
+
+    await store.set(
+      seedUserFeatureSwitch$,
+      { orgId, userId, switches: { officialTelegramBot: false } },
+      context.signal,
+    );
+
+    trackFixture(freezeTelegramFixture(builder));
+
+    const bots = await store.get(zeroTelegramBots({ orgId, userId }));
+
+    expect(bots).toHaveLength(1);
+    expect(bots[0]?.id).toBe(customBotId);
+    expect(
+      bots.some((bot) => {
+        return bot.id === OFFICIAL_TELEGRAM_BOT_ID;
+      }),
+    ).toBeFalsy();
+  });
+
+  it("returns the official bot with configured=false when env is unset", async () => {
+    mockEnv("TELEGRAM_OFFICIAL_BOT_TOKEN", undefined);
+    mockEnv("TELEGRAM_OFFICIAL_BOT_USERNAME", undefined);
+    mockEnv("TELEGRAM_OFFICIAL_WEBHOOK_SECRET", undefined);
+
+    const orgId = newOrgId();
+    const userId = newUserId();
+    trackFixture(freezeTelegramFixture(makeTelegramFixtureBuilder(orgId)));
+
+    const bots = await store.get(zeroTelegramBots({ orgId, userId }));
+
+    expect(bots).toHaveLength(1);
+    expect(bots[0]).toMatchObject({
+      id: OFFICIAL_TELEGRAM_BOT_ID,
+      kind: "official",
+      username: null,
+      tokenStatus: "unknown",
+      official: { configured: false },
+    });
+    expect(bots[0]?.avatarUrl).toBe("");
+  });
+
+  it("uses the user's selected compose preference for the official bot agent", async () => {
+    const orgId = newOrgId();
+    const userId = newUserId();
+    const builder = makeTelegramFixtureBuilder(orgId);
+    builder.userIds.push(userId);
+
+    const preferred = await store.set(
+      seedOrgDefaultAgent$,
+      { orgId, userId, composeName: "preferred-agent" },
+      context.signal,
+    );
+    builder.composeIds.push(preferred.composeId);
+
+    await store.set(
+      seedUserAgentPreference$,
+      { orgId, userId, composeId: preferred.composeId },
+      context.signal,
+    );
+
+    trackFixture(freezeTelegramFixture(builder));
+
+    const bots = await store.get(zeroTelegramBots({ orgId, userId }));
+
+    expect(bots[0]?.agent).toStrictEqual({
+      id: preferred.composeId,
+      name: "preferred-agent",
+    });
+    expect(bots[0]?.official?.usesDefaultAgent).toBeFalsy();
+  });
+
+  it("falls back to the org's default agent when the user has no preference", async () => {
+    const orgId = newOrgId();
+    const userId = newUserId();
+    const builder = makeTelegramFixtureBuilder(orgId);
+    builder.userIds.push(userId);
+
+    const defaultAgent = await store.set(
+      seedOrgDefaultAgent$,
+      { orgId, userId, composeName: "default-agent" },
+      context.signal,
+    );
+    builder.composeIds.push(defaultAgent.composeId);
+
+    trackFixture(freezeTelegramFixture(builder));
+
+    const bots = await store.get(zeroTelegramBots({ orgId, userId }));
+
+    expect(bots[0]?.agent).toStrictEqual({
+      id: defaultAgent.composeId,
+      name: "default-agent",
+    });
+    expect(bots[0]?.official?.usesDefaultAgent).toBeTruthy();
+  });
+
+  it("returns null agent when the org has no default and the user has no preference", async () => {
+    const orgId = newOrgId();
+    const userId = newUserId();
+    trackFixture(freezeTelegramFixture(makeTelegramFixtureBuilder(orgId)));
+
+    const bots = await store.get(zeroTelegramBots({ orgId, userId }));
+
+    expect(bots[0]?.agent).toBeNull();
+    expect(bots[0]?.official?.usesDefaultAgent).toBeTruthy();
+  });
+
+  it("marks the official bot connected when the user has a telegram_official_user_links row", async () => {
+    const orgId = newOrgId();
+    const userId = newUserId();
+    const telegramUserId = `tg_${randomUUID()}`;
+    const builder = makeTelegramFixtureBuilder(orgId);
+    builder.userIds.push(userId);
+
+    await store.set(
+      seedOfficialUserLink$,
+      { orgId, userId, telegramUserId },
+      context.signal,
+    );
+
+    trackFixture(freezeTelegramFixture(builder));
+
+    const bots = await store.get(zeroTelegramBots({ orgId, userId }));
+
+    expect(bots[0]?.isConnected).toBeTruthy();
+    expect(bots[0]?.official?.linkedTelegramUserId).toBe(telegramUserId);
+  });
+
+  it("marks the official bot disconnected when the user has no link row", async () => {
+    const orgId = newOrgId();
+    const userId = newUserId();
+    trackFixture(freezeTelegramFixture(makeTelegramFixtureBuilder(orgId)));
+
+    const bots = await store.get(zeroTelegramBots({ orgId, userId }));
+
+    expect(bots[0]?.isConnected).toBeFalsy();
+    expect(bots[0]?.official?.linkedTelegramUserId).toBeNull();
+  });
+
+  it("does not leak preferences or links from a different org", async () => {
+    const orgId = newOrgId();
+    const userId = newUserId();
+    const otherOrgId = newOrgId();
+    const builder = makeTelegramFixtureBuilder(orgId);
+    builder.userIds.push(userId);
+
+    // Cross-org link and preference (must NOT appear in this org's response).
+    await store.set(
+      seedOfficialUserLink$,
+      {
+        orgId: otherOrgId,
+        userId,
+        telegramUserId: `tg_${randomUUID()}`,
+      },
+      context.signal,
+    );
+    const otherCompose = await store.set(
+      seedOrgDefaultAgent$,
+      { orgId: otherOrgId, userId, composeName: "other-org-agent" },
+      context.signal,
+    );
+    await store.set(
+      seedUserAgentPreference$,
+      {
+        orgId: otherOrgId,
+        userId,
+        composeId: otherCompose.composeId,
+      },
+      context.signal,
+    );
+
+    // Track the cross-org rows for cleanup via a separate fixture.
+    const otherBuilder = makeTelegramFixtureBuilder(otherOrgId);
+    otherBuilder.composeIds.push(otherCompose.composeId);
+    trackFixture(freezeTelegramFixture(otherBuilder));
+    trackFixture(freezeTelegramFixture(builder));
+
+    const bots = await store.get(zeroTelegramBots({ orgId, userId }));
+
+    expect(bots[0]?.isConnected).toBeFalsy();
+    expect(bots[0]?.official?.linkedTelegramUserId).toBeNull();
+    expect(bots[0]?.agent).toBeNull();
+  });
+});

--- a/turbo/apps/api/src/signals/services/zero-telegram-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-data.service.ts
@@ -1,27 +1,251 @@
 import { computed, type Computed } from "ccstate";
-import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
-import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { OFFICIAL_TELEGRAM_BOT_ID } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+import { telegramOfficialUserLinks } from "@vm0/db/schema/telegram-official-user-link";
+import { telegramUserAgentPreferences } from "@vm0/db/schema/telegram-user-agent-preference";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { and, desc, eq } from "drizzle-orm";
 
+import { env } from "../../lib/env";
 import { db$ } from "../external/db";
+import { buildTelegramBotAvatarUrl } from "../external/telegram-avatar";
 import { getMe } from "../external/telegram-client";
 import { decryptSecretValue } from "./crypto.utils";
 
 interface TelegramBotListItem {
   readonly id: string;
+  readonly kind?: "custom" | "official";
   readonly username: string | null;
+  readonly avatarUrl: string;
   readonly agent: { readonly id: string; readonly name: string } | null;
   readonly isOwner: boolean;
   readonly isConnected: boolean;
   readonly tokenStatus: "valid" | "invalid" | "unknown";
+  readonly official?: {
+    readonly configured: boolean;
+    readonly usesDefaultAgent: boolean;
+    readonly linkedTelegramUserId: string | null;
+  };
+}
+
+interface OfficialTelegramBotConfig {
+  readonly botId: string | null;
+  readonly botToken: string | null;
+  readonly botUsername: string | null;
+  readonly webhookSecret: string | null;
+  readonly configured: boolean;
+}
+
+function normalizeBotUsername(username: string | undefined): string | null {
+  const normalized = username?.trim().replace(/^@+/, "");
+  return normalized && normalized.length > 0 ? normalized : null;
+}
+
+function parseTelegramBotId(botToken: string | undefined): string | null {
+  const id = botToken?.split(":", 1)[0]?.trim();
+  return id && /^\d+$/.test(id) ? id : null;
+}
+
+function getOfficialTelegramBotConfig(): OfficialTelegramBotConfig {
+  const botToken = env("TELEGRAM_OFFICIAL_BOT_TOKEN") ?? null;
+  const webhookSecret = env("TELEGRAM_OFFICIAL_WEBHOOK_SECRET") ?? null;
+  const botId = parseTelegramBotId(botToken ?? undefined);
+  const botUsername = normalizeBotUsername(
+    env("TELEGRAM_OFFICIAL_BOT_USERNAME"),
+  );
+  return {
+    botId,
+    botToken,
+    botUsername,
+    webhookSecret,
+    configured: Boolean(botToken && botId && webhookSecret),
+  };
+}
+
+function officialUserLink(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Computed<Promise<{ readonly telegramUserId: string } | null>> {
+  return computed(async (get) => {
+    const db = get(db$);
+    const [row] = await db
+      .select({
+        telegramUserId: telegramOfficialUserLinks.telegramUserId,
+      })
+      .from(telegramOfficialUserLinks)
+      .where(
+        and(
+          eq(telegramOfficialUserLinks.vm0UserId, args.userId),
+          eq(telegramOfficialUserLinks.orgId, args.orgId),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  });
+}
+
+interface TelegramComposeRow {
+  readonly id: string;
+  readonly name: string;
+}
+
+function getOrgCompose(args: {
+  readonly composeId: string;
+  readonly orgId: string;
+}): Computed<Promise<TelegramComposeRow | null>> {
+  return computed(async (get) => {
+    const db = get(db$);
+    const [row] = await db
+      .select({ id: agentComposes.id, name: agentComposes.name })
+      .from(agentComposes)
+      .where(
+        and(
+          eq(agentComposes.id, args.composeId),
+          eq(agentComposes.orgId, args.orgId),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  });
+}
+
+function userAgentPreference(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Computed<Promise<string | null>> {
+  return computed(async (get) => {
+    const db = get(db$);
+    const [row] = await db
+      .select({
+        selectedComposeId: telegramUserAgentPreferences.selectedComposeId,
+      })
+      .from(telegramUserAgentPreferences)
+      .where(
+        and(
+          eq(telegramUserAgentPreferences.vm0UserId, args.userId),
+          eq(telegramUserAgentPreferences.orgId, args.orgId),
+        ),
+      )
+      .limit(1);
+    return row?.selectedComposeId ?? null;
+  });
+}
+
+function defaultAgentId(args: {
+  readonly orgId: string;
+}): Computed<Promise<string | null>> {
+  return computed(async (get) => {
+    const db = get(db$);
+    const [row] = await db
+      .select({ defaultAgentId: orgMetadata.defaultAgentId })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, args.orgId))
+      .limit(1);
+    return row?.defaultAgentId ?? env("VM0_DEFAULT_AGENT") ?? null;
+  });
+}
+
+function officialCompose(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Computed<
+  Promise<{
+    readonly compose: TelegramComposeRow | null;
+    readonly usesDefaultAgent: boolean;
+  }>
+> {
+  return computed(async (get) => {
+    const selectedId = await get(userAgentPreference(args));
+    if (selectedId) {
+      const selected = await get(
+        getOrgCompose({ composeId: selectedId, orgId: args.orgId }),
+      );
+      if (selected) {
+        return { compose: selected, usesDefaultAgent: false };
+      }
+    }
+    const defaultId = await get(defaultAgentId({ orgId: args.orgId }));
+    if (!defaultId) {
+      return { compose: null, usesDefaultAgent: true };
+    }
+    return {
+      compose: await get(
+        getOrgCompose({ composeId: defaultId, orgId: args.orgId }),
+      ),
+      usesDefaultAgent: true,
+    };
+  });
+}
+
+function buildOfficialTelegramBot(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Computed<Promise<TelegramBotListItem>> {
+  return computed(async (get): Promise<TelegramBotListItem> => {
+    const config = getOfficialTelegramBotConfig();
+    const [official, userLink] = await Promise.all([
+      get(officialCompose(args)),
+      get(officialUserLink(args)),
+    ]);
+    const hasAvatar = config.botToken !== null && config.botId !== null;
+    return {
+      id: OFFICIAL_TELEGRAM_BOT_ID,
+      kind: "official",
+      username: config.botUsername,
+      avatarUrl: hasAvatar
+        ? buildTelegramBotAvatarUrl(OFFICIAL_TELEGRAM_BOT_ID)
+        : "",
+      agent: official.compose
+        ? { id: official.compose.id, name: official.compose.name }
+        : null,
+      isOwner: false,
+      isConnected: userLink !== null,
+      tokenStatus: config.botToken ? "valid" : "unknown",
+      official: {
+        configured: config.configured,
+        usesDefaultAgent: official.usesDefaultAgent,
+        linkedTelegramUserId: userLink?.telegramUserId ?? null,
+      },
+    };
+  });
+}
+
+function loadFeatureSwitchOverrides(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Computed<Promise<Partial<Record<FeatureSwitchKey, boolean>> | undefined>> {
+  return computed(async (get) => {
+    const db = get(db$);
+    const [row] = await db
+      .select({ switches: userFeatureSwitches.switches })
+      .from(userFeatureSwitches)
+      .where(
+        and(
+          eq(userFeatureSwitches.orgId, args.orgId),
+          eq(userFeatureSwitches.userId, args.userId),
+        ),
+      )
+      .limit(1);
+    if (!row) {
+      return undefined;
+    }
+    const switches = row.switches as Record<string, boolean>;
+    return Object.keys(switches).length > 0
+      ? (switches as Partial<Record<FeatureSwitchKey, boolean>>)
+      : undefined;
+  });
 }
 
 export function zeroTelegramBots(args: {
   readonly orgId: string;
   readonly userId: string;
 }): Computed<Promise<readonly TelegramBotListItem[]>> {
-  return computed(async (get) => {
+  return computed(async (get): Promise<readonly TelegramBotListItem[]> => {
     const db = get(db$);
 
     const installations = await db
@@ -33,11 +257,7 @@ export function zeroTelegramBots(args: {
         desc(telegramInstallations.telegramBotId),
       );
 
-    if (installations.length === 0) {
-      return [];
-    }
-
-    const bots = await Promise.all(
+    const customBots: TelegramBotListItem[] = await Promise.all(
       installations.map(async (installation) => {
         const tokenStatus = await resolveTokenStatus(
           installation.encryptedBotToken,
@@ -57,6 +277,7 @@ export function zeroTelegramBots(args: {
         return {
           id: installation.telegramBotId,
           username: installation.botUsername ?? null,
+          avatarUrl: buildTelegramBotAvatarUrl(installation.telegramBotId),
           agent,
           isOwner: installation.ownerUserId === args.userId,
           isConnected: tokenStatus === "valid",
@@ -65,7 +286,21 @@ export function zeroTelegramBots(args: {
       }),
     );
 
-    return bots;
+    const overrides = await get(loadFeatureSwitchOverrides(args));
+    const officialEnabled = isFeatureEnabled(
+      FeatureSwitchKey.OfficialTelegramBot,
+      {
+        userId: args.userId,
+        orgId: args.orgId,
+        overrides,
+      },
+    );
+    if (!officialEnabled) {
+      return customBots;
+    }
+
+    const official = await get(buildOfficialTelegramBot(args));
+    return [official, ...customBots];
   });
 }
 


### PR DESCRIPTION
## Summary

Bring `apps/api/src/signals/services/zero-telegram-data.service.ts:zeroTelegramBots` to **behavior parity** with the web route at `apps/web/app/api/zero/integrations/telegram/bots/route.ts` by porting `buildOfficialTelegramBot` and its dependencies. **Precursor** for #12366 — the shadow-compare wrapper on `listBots` is NOT removed here.

## What changed

### New helpers in the api service

- `getOfficialTelegramBotConfig` — env-driven config (`TELEGRAM_OFFICIAL_*` vars), parses bot id from token, normalizes username.
- `officialUserLink` — `Computed` reading `telegram_official_user_links` by `(orgId, vm0UserId)`.
- `officialCompose` — `Computed` resolving the user's selected compose preference (`telegram_user_agent_preferences`) → org's default agent (`org_metadata.defaultAgentId`) → `VM0_DEFAULT_AGENT` env fallback → null.
- `buildOfficialTelegramBot` — `Computed` composing the final official-bot list item.
- `loadFeatureSwitchOverrides` — `Computed` reading `user_feature_switches`.

### Service update

`zeroTelegramBots` now:
- adds `avatarUrl` to every custom bot (matches web's wire shape).
- loads per-user feature-switch overrides.
- prepends the official bot when `FeatureSwitchKey.OfficialTelegramBot` is enabled.

### Other

- New module `signals/external/telegram-avatar.ts` for `buildTelegramBotAvatarUrl` (kept separate from `telegram-client.ts` so the global `vi.mock("../signals/external/telegram-client")` doesn't shadow it).
- 4 `.optional()` env vars added to api `SCHEMA`: `TELEGRAM_OFFICIAL_BOT_TOKEN`, `TELEGRAM_OFFICIAL_BOT_USERNAME`, `TELEGRAM_OFFICIAL_WEBHOOK_SECRET`, `VM0_DEFAULT_AGENT`.

## Test plan

10 service-level integration tests covering:
- [x] custom-only org
- [x] official-only org (zero installations, switch enabled)
- [x] mixed (1 official + N custom)
- [x] switch overridden off via `user_feature_switches`
- [x] official bot config not set (`configured: false`, `tokenStatus: "unknown"`, `username: null`, `avatarUrl: ""`)
- [x] user has telegram_user_agent_preferences → preferred compose, `usesDefaultAgent: false`
- [x] user has no preference, org has default → default compose, `usesDefaultAgent: true`
- [x] user has no preference, org has no default → `agent: null`, `usesDefaultAgent: true`
- [x] user has telegram_official_user_links → `isConnected: true`, `linkedTelegramUserId: <id>`
- [x] user has no link → `isConnected: false`, `linkedTelegramUserId: null`
- [x] cross-org isolation — preferences/links from a different org don't leak

Verified locally:
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-telegram-data.service.test.ts` — 10/10 pass.
- [x] `pnpm -F api exec vitest run` (full api suite) — 350/350 pass.
- [x] `pnpm -F api lint` — clean.
- [x] `pnpm -F api check-types` — clean.
- [x] Pre-commit hooks (prettier / knip / full repo check-types) — clean.

## Acceptance criterion for the post-merge observation window

Per leader Q1 decision (option a, documented for reproducibility):

After this PR merges, query shadow-compare divergence logs for `GET /api/zero/integrations/telegram/bots`. Filter to divergences whose path is **not** `body.bots[*].avatarUrl` (or any sub-path of it). That filtered count must be **0 for ≥1 hour** before #12366 can flip the wrapper.

The avatarUrl carve-out is necessary because the signed URL's HMAC depends on `Math.floor(Date.now()/1000) + TTL`, which can differ between web and api when their per-request timestamps land on different seconds. Both URLs are valid; the bytes just won't match. Strict-zero is unachievable without modifying web (out of scope) or shadow-compare (rejected as too invasive). Any non-`avatarUrl` divergence is a real bug and blocks #12366.

## What's intentionally NOT in this PR

- **Removing the `shadowCompareRoute(...)` wrapper for `listBots`** — that flip is #12366.
- **Removing `mockApiShadowCompareRoutes(...)`** references — none exist for this route yet.
- POST/PUT/DELETE Telegram methods — Stage 3 follow-ups.
- `apps/web/**` modifications — preserved as the rollback target.
- Per-route ignore-paths config in `shadow-compare.ts` — not needed under the manual log-filter acceptance bar.

## Rollback

`git revert` of this commit. No traffic flip is performed; api response shape on the route reverts to its pre-PR (smaller) form, but shadow-compare keeps web as authoritative throughout.

Refs #12290
Closes #12370