### PR TITLE
refactor(api): migrate member credit cap get

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-member-credit-cap.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-member-credit-cap.test.ts
@@ -1,0 +1,76 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroMemberCreditCapContract } from "@vm0/api-contracts/contracts/zero-member-credit-cap";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const mocks = createZeroRouteMocks(context);
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function apiClient() {
+  return setupApp({ context })(zeroMemberCreditCapContract);
+}
+
+describe("GET /api/zero/org/members/credit-cap", () => {
+  it("returns 401 for unauthenticated request", async () => {
+    const userId = `user_${randomUUID()}`;
+    const response = await accept(
+      apiClient().get({ query: { userId }, headers: {} }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    const sessionUserId = `user_${randomUUID()}`;
+    const targetUserId = `user_${randomUUID()}`;
+    mocks.clerk.session(sessionUserId, null);
+
+    const response = await accept(
+      apiClient().get({
+        query: { userId: targetUserId },
+        headers: authHeaders(),
+      }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns default cap state (null cap, enabled)", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+
+    const response = await accept(
+      apiClient().get({ query: { userId }, headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      userId,
+      creditCap: null,
+      creditEnabled: true,
+    });
+  });
+
+  it("returns 400 when userId is missing", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+
+    const response = await accept(
+      apiClient().get({ query: { userId: "" }, headers: authHeaders() }),
+      [400],
+    );
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-member-credit-cap.ts
+++ b/turbo/apps/api/src/signals/routes/zero-member-credit-cap.ts
@@ -4,7 +4,6 @@ import { zeroMemberCreditCapContract } from "@vm0/api-contracts/contracts/zero-m
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { zeroMemberCreditCap } from "../services/zero-member-credit-cap.service";
 import type { RouteEntry } from "../route";
 
@@ -28,12 +27,9 @@ const getMemberCreditCapInner$ = computed(async (get) => {
 export const zeroMemberCreditCapRoutes: readonly RouteEntry[] = [
   {
     route: zeroMemberCreditCapContract.get,
-    handler: shadowCompareRoute({
-      route: zeroMemberCreditCapContract.get,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        getMemberCreditCapInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      getMemberCreditCapInner$,
+    ),
   },
 ];


### PR DESCRIPTION
Closes #12381

## Summary
- Make `GET /api/zero/org/members/credit-cap` authoritative in `apps/api` by removing the `shadowCompareRoute(...)` wrapper
- **Removes the `shadowCompareRoute` import** — no other usage in this single-route file. After this PR, `zero-member-credit-cap.ts` has zero `shadowCompareRoute` references — file fully migrated.
- Add 3 web GET cases ported 1:1 + 1 api-specific 401 missing-organization case (4 cases total)
- PUT migration not in scope — separate Stage 3 follow-up. The web test file mixes GET (3 cases) and PUT (9 cases) in a single describe block; only the GET cases are in scope here.

## Behavior parity
The api `zeroMemberCreditCap` Computed and the web `getMemberCreditCap` both query `org_members_metadata` by `(orgId, userId)` and fall back to `{ creditCap: null, creditEnabled: true }` when no row exists. Identical SQL, identical defaults.

## 400 path divergence (intentional)
- Web returns `{ error: "Missing required query parameter: userId" }` (string).
- API returns `{ error: { message: "Invalid request", code: "BAD_REQUEST" } }` (structured envelope, generated by the ts-rest contract validator from `query: z.object({ userId: z.string().min(1) })`).

Both correctly reject with status 400. Test asserts the api's structured shape (consistent with PR #12338 / #12356 / #12365 patterns). Status parity at 400 preserved — that's what matters for client behavior.

The test triggers the 400 path with `query: { userId: "" }` — semantically equivalent to "missing userId" (the contract's required-field check is a `min(1)` length check). Avoids type-erasure since the ts-rest client typing requires the field.

## Scope
- Route + test only. **No new helper file** — no test case requires DB seeding (default-state case relies on the absence of an `org_members_metadata` row).
- No `apps/web/**` modifications.

## Test cases (all 4)
1. returns 401 for unauthenticated request
2. returns 401 when the authenticated session has no organization (api-specific)
3. returns default cap state (null cap, enabled)
4. returns 400 when userId is missing

## Test plan
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-member-credit-cap.test.ts` — 4/4 passed (first run)
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `grep -c shadowCompareRoute zero-member-credit-cap.ts` returns 0 — file fully migrated
- [x] Pre-commit: prettier, knip, `turbo run check-types`, commitlint — all green

## Rollback
Disable the `apiBackend` feature switch — traffic returns to `apps/web`. No DB or schema change.