### PR TITLE
refactor(api): migrate slack connect status get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-connect.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-connect.ts
@@ -1,0 +1,76 @@
+import { randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import { eq } from "drizzle-orm";
+
+import { writeDb$ } from "../../../external/db";
+
+export interface SlackConnectFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly slackWorkspaceId: string;
+  readonly slackWorkspaceName: string;
+}
+
+interface SeedValues {
+  readonly withConnection?: boolean;
+  readonly slackWorkspaceName?: string;
+}
+
+export const seedSlackConnectOrg$ = command(
+  async (
+    { set },
+    values: SeedValues,
+    signal: AbortSignal,
+  ): Promise<SlackConnectFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const slackWorkspaceId = `T_${randomUUID().replace(/-/g, "").slice(0, 10)}`;
+    const slackWorkspaceName = values.slackWorkspaceName ?? "Test Workspace";
+    const writeDb = set(writeDb$);
+
+    await writeDb.insert(slackOrgInstallations).values({
+      slackWorkspaceId,
+      slackWorkspaceName,
+      orgId,
+      encryptedBotToken: "encrypted-token",
+      botUserId: "U_BOT_TEST",
+    });
+    signal.throwIfAborted();
+
+    if (values.withConnection) {
+      await writeDb.insert(slackOrgConnections).values({
+        slackUserId: `U_USER_${randomUUID().slice(0, 8)}`,
+        slackWorkspaceId,
+        vm0UserId: userId,
+      });
+      signal.throwIfAborted();
+    }
+
+    return { orgId, userId, slackWorkspaceId, slackWorkspaceName };
+  },
+);
+
+export const deleteSlackConnectOrg$ = command(
+  async (
+    { set },
+    fixture: SlackConnectFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(slackOrgConnections)
+      .where(
+        eq(slackOrgConnections.slackWorkspaceId, fixture.slackWorkspaceId),
+      );
+    signal.throwIfAborted();
+    await writeDb
+      .delete(slackOrgInstallations)
+      .where(
+        eq(slackOrgInstallations.slackWorkspaceId, fixture.slackWorkspaceId),
+      );
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-connect.test.ts
@@ -1,0 +1,143 @@
+import { zeroSlackConnectContract } from "@vm0/api-contracts/contracts/zero-slack-connect";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteSlackConnectOrg$,
+  seedSlackConnectOrg$,
+  type SlackConnectFixture,
+} from "./helpers/zero-slack-connect";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/integrations/slack/connect", () => {
+  const track = createFixtureTracker<SlackConnectFixture>((fixture) => {
+    return store.set(deleteSlackConnectOrg$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroSlackConnectContract);
+
+    const response = await accept(client.getStatus({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedSlackConnectOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns isConnected: false when the user has no slack connection", async () => {
+    const fixture = await track(
+      store.set(seedSlackConnectOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      isConnected: false,
+      isAdmin: true,
+    });
+  });
+
+  it("returns isConnected: true with workspace info when the user is connected", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackConnectOrg$,
+        { withConnection: true, slackWorkspaceName: "Test Workspace" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      isConnected: true,
+      isAdmin: true,
+      workspaceName: "Test Workspace",
+      defaultAgentName: null,
+    });
+  });
+
+  it("returns isAdmin: true for admin users", async () => {
+    const fixture = await track(
+      store.set(seedSlackConnectOrg$, { withConnection: true }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.isAdmin).toBeTruthy();
+  });
+
+  it("returns isAdmin: false for member users", async () => {
+    const fixture = await track(
+      store.set(seedSlackConnectOrg$, { withConnection: true }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroSlackConnectContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.isAdmin).toBeFalsy();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-slack-connect.ts
+++ b/turbo/apps/api/src/signals/routes/zero-slack-connect.ts
@@ -3,7 +3,6 @@ import { zeroSlackConnectContract } from "@vm0/api-contracts/contracts/zero-slac
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { zeroSlackConnectStatus } from "../services/zero-slack-connect.service";
 import type { RouteEntry } from "../route";
 
@@ -22,12 +21,9 @@ const getSlackConnectStatusInner$ = computed(async (get) => {
 export const zeroSlackConnectRoutes: readonly RouteEntry[] = [
   {
     route: zeroSlackConnectContract.getStatus,
-    handler: shadowCompareRoute({
-      route: zeroSlackConnectContract.getStatus,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        getSlackConnectStatusInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      getSlackConnectStatusInner$,
+    ),
   },
 ];


### PR DESCRIPTION
## Summary

- make `GET /api/zero/integrations/slack/connect` API-authoritative by removing the `shadowCompareRoute(...)` wrapper
- add api integration tests covering all 5 web GET cases plus a separate missing-organization 401 case (per leader's pattern note)
- introduce `helpers/zero-slack-connect.ts` for slack installation + connection seed fixtures
- POST migration is out of scope (Stage 3 follow-up; api does not implement POST yet)

Closes #12382

Part of epic #12290.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-slack-connect.test.ts` — 6 / 6 passing
- `pnpm -F api lint`
- `pnpm -F api check-types`

## Test cases

| # | Case | Web equivalent |
|---|------|----------------|
| 1 | unauthenticated → 401 | "returns 401 when not authenticated" (no Auth header) |
| 2 | authenticated session, no active org → 401 | n/a — added per leader's pattern note (exercises the `requireOrganization: true` gate, distinct path from case 1) |
| 3 | installation seeded, no connection → `{isConnected: false, isAdmin: true}` | "returns isConnected=false when user has no connection" |
| 4 | installation + connection → `{isConnected: true, isAdmin: true, workspaceName, defaultAgentName: null}` | "returns isConnected=true with workspace info when connected" |
| 5 | admin role → `isAdmin: true` | "returns isAdmin=true for admin users" |
| 6 | member role → `isAdmin: false` | "returns isAdmin=false for member users" |

Cases 1 and 2 both return 401 but exercise different code paths:
- Case 1 — no Authorization header → auth middleware rejects before any role check
- Case 2 — Authorization present, session has user but no `orgId` → `authRoute({requireOrganization: true})` rejects

## Scope clarification

Web `__tests__/route.test.ts` has GET (5 cases) + POST (11 cases) in nested describes inside a single outer `describe`. POST cases — including the second "returns 401 when not authenticated" — are out of scope for Stage 2 and will be migrated separately (Stage 3 mutation). The api route file `zero-slack-connect.ts` registers only the GET handler today; POST is not implemented in api at all.

## Behavioral note

Web returns 404 if `resolveOrg` rejects. The api implementation skips `resolveOrg` because Clerk only sets active `orgId` on sessions where the user is a member. Same simplification as PRs #12312 / #12314 / #12315 / #12337 / #12351 / #12363 / #12377.

## Rollback

Disabling the `apiBackend` feature switch routes traffic back to `apps/web`. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)