### PR TITLE
refactor(api): migrate slack channels get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-channels.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-channels.ts
@@ -1,0 +1,80 @@
+import { createCipheriv, randomBytes, randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import { eq } from "drizzle-orm";
+
+import { env } from "../../../../lib/env";
+import { writeDb$ } from "../../../external/db";
+
+export interface SlackInstallationFixture {
+  readonly orgId: string;
+  readonly slackWorkspaceId: string;
+}
+
+interface SeedSlackInstallationValues {
+  readonly orgId?: string;
+  readonly botToken?: string;
+  readonly workspaceName?: string;
+}
+
+function encryptBotTokenForTests(plaintext: string): string {
+  const key = Buffer.from(env("SECRETS_ENCRYPTION_KEY"), "hex");
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv, { authTagLength: 16 });
+  const data = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  return [
+    iv.toString("base64"),
+    authTag.toString("base64"),
+    data.toString("base64"),
+  ].join(":");
+}
+
+function randomSlackId(prefix: string): string {
+  return `${prefix}${randomUUID().replaceAll("-", "").slice(0, 9).toUpperCase()}`;
+}
+
+export const seedSlackInstallation$ = command(
+  async (
+    { set },
+    values: SeedSlackInstallationValues,
+    signal: AbortSignal,
+  ): Promise<SlackInstallationFixture> => {
+    const orgId = values.orgId ?? `org_${randomUUID()}`;
+    const slackWorkspaceId = randomSlackId("T");
+    const writeDb = set(writeDb$);
+
+    await writeDb.insert(slackOrgInstallations).values({
+      slackWorkspaceId,
+      slackWorkspaceName: values.workspaceName ?? "Test Workspace",
+      orgId,
+      encryptedBotToken: encryptBotTokenForTests(
+        values.botToken ?? "xoxb-test-token",
+      ),
+      botUserId: randomSlackId("U"),
+    });
+    signal.throwIfAborted();
+
+    return { orgId, slackWorkspaceId };
+  },
+);
+
+export const deleteSlackInstallation$ = command(
+  async (
+    { set },
+    fixture: SlackInstallationFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(slackOrgInstallations)
+      .where(
+        eq(slackOrgInstallations.slackWorkspaceId, fixture.slackWorkspaceId),
+      );
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-channels.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-channels.test.ts
@@ -1,0 +1,190 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroSlackChannelsContract } from "@vm0/api-contracts/contracts/zero-slack-channels";
+import { createStore } from "ccstate";
+import { http, HttpResponse } from "msw";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { server } from "../../../mocks/server";
+import {
+  type SlackInstallationFixture,
+  deleteSlackInstallation$,
+  seedSlackInstallation$,
+} from "./helpers/zero-slack-channels";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+const SLACK_LIST_URL = "https://slack.com/api/conversations.list";
+
+describe("GET /api/zero/slack/channels", () => {
+  const track = createFixtureTracker<SlackInstallationFixture>((fixture) => {
+    return store.set(deleteSlackInstallation$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroSlackChannelsContract);
+
+    const response = await accept(client.list({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const client = setupApp({ context })(zeroSlackChannelsContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 when no Slack installation exists for the org", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroSlackChannelsContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "No Slack installation found for this org",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns channels where the bot is a member", async () => {
+    const fixture = await track(
+      store.set(seedSlackInstallation$, {}, context.signal),
+    );
+    mocks.clerk.session(`user_${randomUUID()}`, fixture.orgId);
+
+    server.use(
+      http.get(SLACK_LIST_URL, () => {
+        return HttpResponse.json({
+          ok: true,
+          channels: [
+            { id: "C001", name: "general", is_member: true },
+            { id: "C002", name: "random", is_member: true },
+            { id: "C003", name: "not-joined", is_member: false },
+            { id: "C004", name: "alpha", is_member: true },
+          ],
+          response_metadata: { next_cursor: "" },
+        });
+      }),
+    );
+
+    const client = setupApp({ context })(zeroSlackChannelsContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      channels: [
+        { id: "C004", name: "alpha" },
+        { id: "C001", name: "general" },
+        { id: "C002", name: "random" },
+      ],
+    });
+  });
+
+  it("handles pagination across multiple pages", async () => {
+    const fixture = await track(
+      store.set(seedSlackInstallation$, {}, context.signal),
+    );
+    mocks.clerk.session(`user_${randomUUID()}`, fixture.orgId);
+
+    let callCount = 0;
+    server.use(
+      http.get(SLACK_LIST_URL, ({ request }) => {
+        callCount++;
+        const cursor = new URL(request.url).searchParams.get("cursor");
+        if (!cursor) {
+          return HttpResponse.json({
+            ok: true,
+            channels: [{ id: "C001", name: "page-one", is_member: true }],
+            response_metadata: { next_cursor: "cursor_page2" },
+          });
+        }
+        return HttpResponse.json({
+          ok: true,
+          channels: [{ id: "C002", name: "page-two", is_member: true }],
+          response_metadata: { next_cursor: "" },
+        });
+      }),
+    );
+
+    const client = setupApp({ context })(zeroSlackChannelsContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      channels: [
+        { id: "C001", name: "page-one" },
+        { id: "C002", name: "page-two" },
+      ],
+    });
+    expect(callCount).toBe(2);
+  });
+
+  it("returns an empty array when no channels have bot membership", async () => {
+    const fixture = await track(
+      store.set(seedSlackInstallation$, {}, context.signal),
+    );
+    mocks.clerk.session(`user_${randomUUID()}`, fixture.orgId);
+
+    server.use(
+      http.get(SLACK_LIST_URL, () => {
+        return HttpResponse.json({
+          ok: true,
+          channels: [{ id: "C001", name: "no-bot", is_member: false }],
+          response_metadata: { next_cursor: "" },
+        });
+      }),
+    );
+
+    const client = setupApp({ context })(zeroSlackChannelsContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ channels: [] });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-slack-channels.ts
+++ b/turbo/apps/api/src/signals/routes/zero-slack-channels.ts
@@ -3,14 +3,25 @@ import { zeroSlackChannelsContract } from "@vm0/api-contracts/contracts/zero-sla
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { zeroSlackChannels } from "../services/zero-slack-data.service";
 import type { RouteEntry } from "../route";
+
+const slackInstallationNotFound = Object.freeze({
+  status: 404 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "No Slack installation found for this org",
+      code: "NOT_FOUND",
+    }),
+  }),
+});
 
 const getSlackChannelsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const channels = await get(zeroSlackChannels({ orgId: auth.orgId }));
-
+  if (channels === null) {
+    return slackInstallationNotFound;
+  }
   return {
     status: 200 as const,
     body: { channels: [...channels] },
@@ -20,12 +31,9 @@ const getSlackChannelsInner$ = computed(async (get) => {
 export const zeroSlackChannelsRoutes: readonly RouteEntry[] = [
   {
     route: zeroSlackChannelsContract.list,
-    handler: shadowCompareRoute({
-      route: zeroSlackChannelsContract.list,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        getSlackChannelsInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      getSlackChannelsInner$,
+    ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-slack-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-data.service.ts
@@ -218,11 +218,11 @@ interface SlackChannel {
 
 export function zeroSlackChannels(args: {
   readonly orgId: string;
-}): Computed<Promise<readonly SlackChannel[]>> {
+}): Computed<Promise<readonly SlackChannel[] | null>> {
   return computed(async (get) => {
     const installation = await get(zeroSlackOrgInstallation(args));
     if (!installation) {
-      return [];
+      return null;
     }
 
     const channels = await listConversations(installation.botToken);


### PR DESCRIPTION
Closes #12380

## Summary
- Drop the \`shadowCompareRoute\` wrapper from \`GET /api/zero/slack/channels\` so \`apps/api\` is now authoritative.
- **Behavior fix**: api previously returned \`200 { channels: [] }\` when no \`slack_org_installations\` row existed for the org; web returned \`404\`. The contract already allowed 404. After this PR the api returns \`404\` with the same error body shape as web.
- Add the api integration test from scratch (file did not exist) covering all 5 in-scope web GET cases plus an api-specific 401 missing-organization case.
- Add \`seedSlackInstallation\$\` / \`deleteSlackInstallation\$\` helpers using the same aes-256-gcm envelope format as the existing \`encryptBotTokenForTests\` in \`helpers/zero-telegram.ts\`.

POST/connect and other Slack endpoints are out of scope.

## Final test inventory (6 cases)
- \`returns 401 when the request is unauthenticated\` — mirrors web case 1
- \`returns 401 when the authenticated session has no organization\` — api-specific
- \`returns 404 when no Slack installation exists for the org\` — mirrors web case 2; exercises the new \`null\` → 404 path
- \`returns channels where the bot is a member\` — mirrors web case 3; MSW returns mixed \`is_member\` channels; assert filtered + sorted
- \`handles pagination across multiple pages\` — mirrors web case 4; MSW returns first page with \`next_cursor\`, then second page; \`callCount === 2\` proves the do/while loop in \`lib/slack-client.ts\` runs twice
- \`returns an empty array when no channels have bot membership\` — mirrors web case 5

## Implementation notes
- Service \`zeroSlackChannels\` widens its return type from \`readonly SlackChannel[]\` to \`readonly SlackChannel[] | null\`. The route maps \`null\` to a frozen 404 response.
- Slack HTTP is mocked via MSW at \`https://slack.com/api/conversations.list\` (existing api test infrastructure; see \`audio-transcriptions-v1.test.ts\` precedent). Pagination is naturally testable at the HTTP boundary.
- \`encryptBotTokenForTests\` is copy-pasted from the telegram helper (one duplication is fine; extraction is a third-occurrence concern).

## Test plan
- [x] \`pnpm -F api exec vitest run src/signals/routes/__tests__/zero-slack-channels.test.ts\` — 6/6 passing
- [x] \`pnpm -F api lint\`
- [x] \`pnpm -F api check-types\`
- [x] \`pnpm format\`
- [x] \`pnpm knip\`

## Rollback
Disable the \`apiBackend\` feature switch — traffic falls back to web's already-404 behavior. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)