### PR TITLE
refactor(api): migrate skills list get

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
@@ -1,0 +1,57 @@
+import { randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import { zeroSkills } from "@vm0/db/schema/zero-skill";
+import { eq } from "drizzle-orm";
+
+import { writeDb$ } from "../../../external/db";
+
+export interface SkillsFixture {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+export const seedSkillsFixture$ = command(
+  (_, _input: void, _signal: AbortSignal): Promise<SkillsFixture> => {
+    return Promise.resolve({
+      orgId: `org_${randomUUID()}`,
+      userId: `user_${randomUUID()}`,
+    });
+  },
+);
+
+export const deleteSkillsForFixture$ = command(
+  async (
+    { set },
+    fixture: SkillsFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    await db.delete(zeroSkills).where(eq(zeroSkills.orgId, fixture.orgId));
+    signal.throwIfAborted();
+  },
+);
+
+export const seedSkill$ = command(
+  async (
+    { set },
+    args: {
+      orgId: string;
+      userId: string;
+      name: string;
+      displayName?: string | null;
+      description?: string | null;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    await db.insert(zeroSkills).values({
+      orgId: args.orgId,
+      name: args.name,
+      displayName: args.displayName ?? null,
+      description: args.description ?? null,
+      createdBy: args.userId,
+    });
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
@@ -1,0 +1,129 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroSkillsCollectionContract } from "@vm0/api-contracts/contracts/zero-agents";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  deleteSkillsForFixture$,
+  seedSkill$,
+  seedSkillsFixture$,
+  type SkillsFixture,
+} from "./helpers/zero-skills";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function apiClient() {
+  return setupApp({ context })(zeroSkillsCollectionContract);
+}
+
+describe("GET /api/zero/skills", () => {
+  const track = createFixtureTracker<SkillsFixture>((fixture) => {
+    return store.set(deleteSkillsForFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(apiClient().list({ headers: {} }), [401]);
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const response = await accept(
+      apiClient().list({ headers: authHeaders() }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns empty array when no skills exist", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().list({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual([]);
+  });
+
+  it("returns all org skills", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    await store.set(
+      seedSkill$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "skill-one",
+        displayName: "Skill One",
+        description: "First skill",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedSkill$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "skill-two",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().list({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toHaveLength(2);
+    const names = response.body.map((skill) => {
+      return skill.name;
+    });
+    expect(names).toContain("skill-one");
+    expect(names).toContain("skill-two");
+  });
+
+  it("allows org member to list skills", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    await store.set(
+      seedSkill$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "readable-skill",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const response = await accept(
+      apiClient().list({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toHaveLength(1);
+    expect(response.body[0]?.name).toBe("readable-skill");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-skills.ts
+++ b/turbo/apps/api/src/signals/routes/zero-skills.ts
@@ -3,7 +3,6 @@ import { zeroSkillsCollectionContract } from "@vm0/api-contracts/contracts/zero-
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { zeroSkillList } from "../services/zero-catalog-data.service";
 import type { RouteEntry } from "../route";
 
@@ -16,16 +15,13 @@ const listSkillsInner$ = computed(async (get) => {
 export const zeroSkillsRoutes: readonly RouteEntry[] = [
   {
     route: zeroSkillsCollectionContract.list,
-    handler: shadowCompareRoute({
-      route: zeroSkillsCollectionContract.list,
-      handler: authRoute(
-        {
-          requireOrganization: true,
-          missingOrganizationStatus: 401,
-          requiredCapability: "agent:read",
-        },
-        listSkillsInner$,
-      ),
-    }),
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "agent:read",
+      },
+      listSkillsInner$,
+    ),
   },
 ];


### PR DESCRIPTION
Closes #12386

## Summary
- Make `GET /api/zero/skills` (org-level skill list) authoritative in `apps/api` by removing the `shadowCompareRoute(...)` wrapper
- **Removes the `shadowCompareRoute` import** — single-route file. After this PR, `zero-skills.ts` has zero `shadowCompareRoute` references — file fully migrated (5th in the batch).
- Add 2 web GET cases ported 1:1 + 1 cross-cutting member-list case + 2 api-specific 401 cases (5 cases total)
- New helper file `helpers/zero-skills.ts` with fixture seeder, single-row seeder, and per-orgId cleanup
- POST and `/skills/:name` (GET/PUT/DELETE) are out of scope — separate Stage 3 follow-ups

## Behavior parity
The api `zeroSkillList` Computed and the web GET handler both query `zero_skills` by `orgId` and return `{name, displayName, description}` rows. Identical SQL, identical projection. Web's explicit `?? null` coalescing produces the same JSON output as Drizzle's native nullable handling.

## Capability gate
`requiredCapability: "agent:read"` only applies to Zero/CLI tokens (verified at `auth-context.ts:132-141`). Clerk session paths bypass it (`clerk-session.ts:46-67`). The "allows org member to list skills" case uses `mocks.clerk.session(userId, orgId, "org:member")` and confirms the 200 response — the `requiredCapability` config does not block org members on the Clerk path.

The "returns 403 when authenticated session lacks agent:read capability" case from the issue was **omitted** per the issue's guidance — constructing a no-capability auth state requires Zero token plumbing tangential to this migration.

## Scope
- Route + test + new helper. No POST or `/skills/:name` migration. No `apps/web/**` modifications.

## Test cases (all 5)
1. returns 401 when the request is unauthenticated (api-specific)
2. returns 401 when the authenticated session has no organization (api-specific)
3. returns empty array when no skills exist (web port)
4. returns all org skills (web port)
5. allows org member to list skills (cross-cutting from web's "admin permission restriction")

## Test plan
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-skills.test.ts` — 5/5 passed (first run)
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `grep -c shadowCompareRoute zero-skills.ts` returns 0 — file fully migrated (5th in the batch)
- [x] Pre-commit: prettier, knip, `turbo run check-types`, commitlint — all green

## Rollback
Disable the `apiBackend` feature switch — traffic returns to `apps/web`. No DB or schema change.