### PR TITLE
refactor(api): migrate model providers list get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-model-providers.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-model-providers.ts
@@ -1,0 +1,110 @@
+import { createCipheriv, randomBytes, randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import { modelProviders } from "@vm0/db/schema/model-provider";
+import { secrets } from "@vm0/db/schema/secret";
+import { and, eq } from "drizzle-orm";
+
+import { env } from "../../../../lib/env";
+import { writeDb$ } from "../../../external/db";
+
+const ORG_SENTINEL_USER_ID = "__org__";
+
+export interface OrgModelProviderFixture {
+  readonly orgId: string;
+}
+
+interface SeedOrgModelProviderValues {
+  readonly orgId: string;
+  readonly type: string;
+  readonly isDefault?: boolean;
+  readonly selectedModel?: string | null;
+  readonly secretName?: string | null;
+  readonly authMethod?: string | null;
+}
+
+function encryptSecretValueForTests(plaintext: string): string {
+  const key = Buffer.from(env("SECRETS_ENCRYPTION_KEY"), "hex");
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv, { authTagLength: 16 });
+  const data = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  return [
+    iv.toString("base64"),
+    authTag.toString("base64"),
+    data.toString("base64"),
+  ].join(":");
+}
+
+export const seedOrgModelProvider$ = command(
+  async (
+    { set },
+    values: SeedOrgModelProviderValues,
+    signal: AbortSignal,
+  ): Promise<{ readonly id: string }> => {
+    const writeDb = set(writeDb$);
+
+    let secretId: string | null = null;
+    if (values.secretName) {
+      const [secret] = await writeDb
+        .insert(secrets)
+        .values({
+          name: values.secretName,
+          encryptedValue: encryptSecretValueForTests("test-secret-value"),
+          type: "model-provider",
+          userId: ORG_SENTINEL_USER_ID,
+          orgId: values.orgId,
+        })
+        .returning({ id: secrets.id });
+      signal.throwIfAborted();
+      secretId = secret?.id ?? null;
+    }
+
+    const [row] = await writeDb
+      .insert(modelProviders)
+      .values({
+        type: values.type,
+        secretId,
+        authMethod: values.authMethod ?? null,
+        isDefault: values.isDefault ?? false,
+        selectedModel: values.selectedModel ?? null,
+        userId: ORG_SENTINEL_USER_ID,
+        orgId: values.orgId,
+      })
+      .returning({ id: modelProviders.id });
+    signal.throwIfAborted();
+
+    return { id: row?.id ?? randomUUID() };
+  },
+);
+
+export const deleteOrgModelProviders$ = command(
+  async (
+    { set },
+    fixture: OrgModelProviderFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(modelProviders)
+      .where(
+        and(
+          eq(modelProviders.orgId, fixture.orgId),
+          eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+        ),
+      );
+    signal.throwIfAborted();
+    await writeDb
+      .delete(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, fixture.orgId),
+          eq(secrets.userId, ORG_SENTINEL_USER_ID),
+        ),
+      );
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-providers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-providers.test.ts
@@ -1,0 +1,213 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  deleteOrgModelProviders$,
+  seedOrgModelProvider$,
+  type OrgModelProviderFixture,
+} from "./helpers/zero-model-providers";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/model-providers", () => {
+  const track = createFixtureTracker<OrgModelProviderFixture>((fixture) => {
+    return store.set(deleteOrgModelProviders$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroModelProvidersMainContract);
+
+    const response = await accept(client.list({ headers: {} }), [401]);
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const client = setupApp({ context })(zeroModelProvidersMainContract);
+
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns empty list when no org providers exist", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+    await track(Promise.resolve({ orgId }));
+
+    const client = setupApp({ context })(zeroModelProvidersMainContract);
+
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.modelProviders).toStrictEqual([]);
+  });
+
+  it("lists org providers", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await track(Promise.resolve({ orgId }));
+
+    await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId,
+        type: "anthropic-api-key",
+        isDefault: true,
+        secretName: "ANTHROPIC_API_KEY",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroModelProvidersMainContract);
+
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.modelProviders).toHaveLength(1);
+    expect(response.body.modelProviders[0]?.type).toBe("anthropic-api-key");
+  });
+
+  it("shows first provider as default", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await track(Promise.resolve({ orgId }));
+
+    await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId,
+        type: "anthropic-api-key",
+        isDefault: true,
+        secretName: "ANTHROPIC_API_KEY",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroModelProvidersMainContract);
+
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.modelProviders[0]?.isDefault).toBeTruthy();
+  });
+
+  it("does not show second same-framework provider as default", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await track(Promise.resolve({ orgId }));
+
+    await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId,
+        type: "anthropic-api-key",
+        isDefault: true,
+        secretName: "ANTHROPIC_API_KEY",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId,
+        type: "claude-code-oauth-token",
+        isDefault: false,
+        secretName: "CLAUDE_CODE_OAUTH_TOKEN",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroModelProvidersMainContract);
+
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    const anthropic = response.body.modelProviders.find((provider) => {
+      return provider.type === "anthropic-api-key";
+    });
+    const oauth = response.body.modelProviders.find((provider) => {
+      return provider.type === "claude-code-oauth-token";
+    });
+    expect(anthropic?.isDefault).toBeTruthy();
+    expect(oauth?.isDefault).toBeFalsy();
+  });
+
+  it("finds default provider for framework via list", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await track(Promise.resolve({ orgId }));
+
+    await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId,
+        type: "anthropic-api-key",
+        isDefault: true,
+        secretName: "ANTHROPIC_API_KEY",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroModelProvidersMainContract);
+
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    const defaultProvider = response.body.modelProviders.find((provider) => {
+      return provider.isDefault && provider.framework === "claude-code";
+    });
+    expect(defaultProvider).toBeDefined();
+    expect(defaultProvider?.type).toBe("anthropic-api-key");
+    expect(defaultProvider?.isDefault).toBeTruthy();
+  });
+
+  it("has no default for framework when no providers exist", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+    await track(Promise.resolve({ orgId }));
+
+    const client = setupApp({ context })(zeroModelProvidersMainContract);
+
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    const defaultProvider = response.body.modelProviders.find((provider) => {
+      return provider.isDefault && provider.framework === "claude-code";
+    });
+    expect(defaultProvider).toBeUndefined();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-model-providers.ts
+++ b/turbo/apps/api/src/signals/routes/zero-model-providers.ts
@@ -3,7 +3,6 @@ import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zer
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { zeroModelProviders } from "../services/zero-model-provider.service";
 import type { RouteEntry } from "../route";
 
@@ -16,12 +15,9 @@ const listModelProvidersInner$ = computed(async (get) => {
 export const zeroModelProvidersRoutes: readonly RouteEntry[] = [
   {
     route: zeroModelProvidersMainContract.list,
-    handler: shadowCompareRoute({
-      route: zeroModelProvidersMainContract.list,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        listModelProvidersInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      listModelProvidersInner$,
+    ),
   },
 ];


### PR DESCRIPTION
## Summary

- Promote `GET /api/zero/model-providers` (org provider list) from shadow-compared to api-authoritative under the `apiBackend` feature switch (Stage 2 of #12290).
- Drop the `shadowCompareRoute` wrapper from `zero-model-providers.ts`. **Single-route file → 0 `shadowCompareRoute` references** post-merge (verified via `grep -c`).
- Port all 6 web GET cases 1:1 + 2 api-specific 401 cases into a brand-new api test file.
- Add a fixture-helper Command at `__tests__/helpers/zero-model-providers.ts` for seeding `model_providers` rows (with optional `secrets` rows for the LEFT JOIN).

## isDefault parity (per Epic-critical hint)

Verified at research time. Both web's `listOrgModelProviders` and api's `zeroModelProviders` are **pure SELECT pass-through of `model_providers.isDefault`** — same query, same WHERE, same ORDER BY, same column-by-column mapping. The "computation" of `isDefault` happens at the WRITE path (`assignDefaultIfFirst` / set-default / delete-reassign), guarded by the schema's `idx_model_providers_one_default_per_user` partial unique index — fully out of scope for this READ-only migration. **No service-layer changes needed; no Plan A2 bundling required.**

Tests seed `model_providers` rows directly with explicit `isDefault` flags, mirroring the states web's upsert path would have produced. This avoids depending on web's POST handler.

## Flagged-not-fixed (research audit trail)

Api's `modelProviderResponse` silently drops rows whose `type` fails `modelProviderTypeSchema.safeParse`; web casts `row.type as ModelProviderType` unconditionally. Unreachable in practice (DB rows are always valid types) and not exercised by any of the 6 web cases. Recorded for the audit trail per leader's prior guidance ("flag, don't auto-fix").

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-model-providers.test.ts` — 8/8 pass.
- [x] `pnpm -F api lint` — clean.
- [x] `pnpm -F api check-types` — clean.
- [x] Pre-commit hooks (prettier / knip / repo-wide check-types) — clean.
- [x] `grep -c shadowCompareRoute turbo/apps/api/src/signals/routes/zero-model-providers.ts` returns `0`.
- [x] No `apps/web/**` modifications.

## Final test inventory (8 cases)

1. `returns 401 when the request is unauthenticated` *(api-specific)*
2. `returns 401 when the authenticated session has no organization` *(api-specific)*
3. `returns empty list when no org providers exist` *(web 1:1)*
4. `lists org providers` *(web 1:1)*
5. `shows first provider as default` *(web 1:1)*
6. `does not show second same-framework provider as default` *(web 1:1)*
7. `finds default provider for framework via list` *(web 1:1)*
8. `has no default for framework when no providers exist` *(web 1:1)*

## Helper notes

- `seedOrgModelProvider$({ orgId, type, isDefault?, secretName?, ... })`: when `secretName` is provided, mints an encrypted `secrets` row first (`type: "model-provider"`, `userId: ORG_SENTINEL_USER_ID`) and links via `secretId` — mirrors web's `insertTestOrgModelProviderSecret` shape. Returns `{ id }`.
- `deleteOrgModelProviders$({ orgId })`: cascading delete by `(orgId, userId = "__org__")` across `model_providers` and `secrets`.
- `encryptSecretValueForTests` helper is **duplicated** from `helpers/zero-telegram.ts:encryptBotTokenForTests`. Per PR #12385 precedent, extraction is a third-occurrence concern; one duplication is acceptable.

## Rollback

`git revert` the commit. Web's `GET /api/zero/model-providers` route stays in place; disabling the `apiBackend` feature switch returns traffic to web. No DB or schema changes.

Closes #12387