### PR TITLE
refactor(api): migrate custom-connectors list get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-custom-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-custom-connectors.ts
@@ -1,0 +1,78 @@
+import { randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
+import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
+import { eq } from "drizzle-orm";
+
+import { writeDb$ } from "../../../external/db";
+
+export interface CustomConnectorFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly connectorId: string;
+}
+
+interface SeedValues {
+  readonly slug?: string;
+  readonly displayName?: string;
+  readonly prefixes?: readonly string[];
+  readonly headerName?: string;
+  readonly headerTemplate?: string;
+  readonly withSecret?: boolean;
+}
+
+export const seedCustomConnectorOrg$ = command(
+  async (
+    { set },
+    values: SeedValues,
+    signal: AbortSignal,
+  ): Promise<CustomConnectorFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const connectorId = randomUUID();
+    const writeDb = set(writeDb$);
+
+    await writeDb.insert(orgCustomConnectors).values({
+      id: connectorId,
+      orgId,
+      slug: values.slug ?? `connector-${connectorId.slice(0, 8)}`,
+      displayName: values.displayName ?? "Example",
+      prefixes: [...(values.prefixes ?? ["https://api.example.com/"])],
+      headerName: values.headerName ?? "Authorization",
+      headerTemplate: values.headerTemplate ?? "Bearer {{secret}}",
+      createdBy: userId,
+    });
+    signal.throwIfAborted();
+
+    if (values.withSecret) {
+      await writeDb.insert(orgCustomConnectorSecrets).values({
+        connectorId,
+        userId,
+        orgId,
+        encryptedValue: "encrypted-test-secret",
+      });
+      signal.throwIfAborted();
+    }
+
+    return { orgId, userId, connectorId };
+  },
+);
+
+export const deleteCustomConnectorOrg$ = command(
+  async (
+    { set },
+    fixture: CustomConnectorFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(orgCustomConnectorSecrets)
+      .where(eq(orgCustomConnectorSecrets.connectorId, fixture.connectorId));
+    signal.throwIfAborted();
+    await writeDb
+      .delete(orgCustomConnectors)
+      .where(eq(orgCustomConnectors.id, fixture.connectorId));
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-custom-connectors.test.ts
@@ -1,0 +1,163 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteCustomConnectorOrg$,
+  seedCustomConnectorOrg$,
+  type CustomConnectorFixture,
+} from "./helpers/zero-custom-connectors";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/custom-connectors", () => {
+  const track = createFixtureTracker<CustomConnectorFixture>((fixture) => {
+    return store.set(deleteCustomConnectorOrg$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroCustomConnectorsContract);
+
+    const response = await accept(client.list({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedCustomConnectorOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+
+    const client = setupApp({ context })(zeroCustomConnectorsContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns an empty list when the org has no custom connectors", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroCustomConnectorsContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ connectors: [] });
+  });
+
+  it("lists the org connectors with hasSecret: false when no per-user secret is set", async () => {
+    const fixture = await track(
+      store.set(
+        seedCustomConnectorOrg$,
+        {
+          slug: "example-connector",
+          displayName: "Example",
+          prefixes: ["https://api.example.com/"],
+          headerName: "Authorization",
+          headerTemplate: "Bearer {{secret}}",
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroCustomConnectorsContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      connectors: [
+        {
+          id: fixture.connectorId,
+          slug: "example-connector",
+          displayName: "Example",
+          prefixes: ["https://api.example.com/"],
+          headerName: "Authorization",
+          headerTemplate: "Bearer {{secret}}",
+          createdAt: expect.any(String),
+          updatedAt: expect.any(String),
+          hasSecret: false,
+        },
+      ],
+    });
+  });
+
+  it("lists the org connectors with hasSecret: true when the user has a secret", async () => {
+    const fixture = await track(
+      store.set(
+        seedCustomConnectorOrg$,
+        {
+          slug: "example-connector",
+          displayName: "Example",
+          prefixes: ["https://api.example.com/"],
+          headerName: "Authorization",
+          headerTemplate: "Bearer {{secret}}",
+          withSecret: true,
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroCustomConnectorsContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      connectors: [
+        {
+          id: fixture.connectorId,
+          slug: "example-connector",
+          displayName: "Example",
+          prefixes: ["https://api.example.com/"],
+          headerName: "Authorization",
+          headerTemplate: "Bearer {{secret}}",
+          createdAt: expect.any(String),
+          updatedAt: expect.any(String),
+          hasSecret: true,
+        },
+      ],
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors.ts
@@ -3,7 +3,6 @@ import { zeroCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { zeroCustomConnectorList } from "../services/zero-catalog-data.service";
 import type { RouteEntry } from "../route";
 
@@ -18,12 +17,9 @@ const listCustomConnectorsInner$ = computed(async (get) => {
 export const zeroCustomConnectorsRoutes: readonly RouteEntry[] = [
   {
     route: zeroCustomConnectorsContract.list,
-    handler: shadowCompareRoute({
-      route: zeroCustomConnectorsContract.list,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        listCustomConnectorsInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      listCustomConnectorsInner$,
+    ),
   },
 ];


### PR DESCRIPTION
## Summary

- make `GET /api/zero/custom-connectors` API-authoritative by removing the `shadowCompareRoute(...)` wrapper
- 8th fully-migrated single-route file (0 `shadowCompareRoute` occurrences after this PR — verified via `grep -c`)
- add api integration tests covering all 3 web GET cases + 1 api missing-org 401 + 1 defensive hasSecret=true case
- introduce `helpers/zero-custom-connectors.ts` for connector + per-user secret seeding
- POST and `[id]/*` routes remain web-only (Stage 3 follow-ups)

Closes #12390

Part of epic #12290.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-custom-connectors.test.ts` — 5 / 5 passing
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `grep -c shadowCompareRoute turbo/apps/api/src/signals/routes/zero-custom-connectors.ts` — **0**

## hasSecret parity verification

Confirmed before implementation:

| Aspect | API service | Web service |
|--------|-------------|-------------|
| connectors filter | `eq(orgId)` | `eq(orgId)` |
| connectors order | `orderBy(slug)` | `orderBy(slug)` |
| secrets filter | `and(eq(orgId), eq(userId))` | `and(eq(orgId), eq(userId))` |
| Set construction | `new Set(rows.map(r => r.connectorId))` | identical |
| flag derivation | `haveSecret.has(connector.id)` | identical |

No divergence found. Plan A2 from PR #12385 not applicable. Standard mechanical migration.

## Test cases

| # | Case | Mirrors web |
|---|------|-------------|
| 1 | unauthenticated → 401 | "rejects unauthenticated requests" |
| 2 | session, no active org → 401 | n/a — added per epic pattern (PR #12384) |
| 3 | empty list → 200 `{connectors: []}` | "returns empty list when none exist" |
| 4 | seeded connector, no per-user secret → hasSecret: false | "lists created connectors with hasSecret flag" (web's only hasSecret assertion is `=== false`) |
| 5 | seeded connector + per-user secret → hasSecret: true | n/a — added defensively (api becomes authoritative for GET; hasSecret=true was previously only covered by web's PUT-secret integration) |

## Behavioral note

Web returns 404 if `resolveOrg` rejects. The api implementation skips `resolveOrg` because Clerk only sets active `orgId` on sessions where the user is a member. Same simplification as PRs #12312 / #12314 / #12315 / #12337 / #12351 / #12363 / #12377 / #12384.

## Rollback

Disabling the `apiBackend` feature switch routes traffic back to `apps/web`. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)