### PR TITLE
refactor(api): migrate schedules list get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-schedules.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-schedules.ts
@@ -1,0 +1,103 @@
+import { randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
+import { eq, inArray } from "drizzle-orm";
+
+import { writeDb$ } from "../../../external/db";
+
+interface ScheduleSeed {
+  readonly name: string;
+  readonly cronExpression: string;
+  readonly prompt: string;
+}
+
+interface SchedulesScenarioValues {
+  readonly schedules: readonly ScheduleSeed[];
+  readonly displayName?: string;
+}
+
+export interface SchedulesFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly composeId: string;
+  readonly scheduleIds: readonly string[];
+}
+
+export const seedSchedulesScenario$ = command(
+  async (
+    { set },
+    values: SchedulesScenarioValues,
+    signal: AbortSignal,
+  ): Promise<SchedulesFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const composeId = randomUUID();
+    const writeDb = set(writeDb$);
+
+    await writeDb.insert(agentComposes).values({
+      id: composeId,
+      userId,
+      orgId,
+      name: `agent-${composeId.slice(0, 8)}`,
+    });
+    signal.throwIfAborted();
+
+    await writeDb.insert(zeroAgents).values({
+      id: composeId,
+      orgId,
+      owner: userId,
+      name: `agent-${composeId.slice(0, 8)}`,
+      displayName: values.displayName ?? "Test Agent",
+      description: null,
+      sound: null,
+    });
+    signal.throwIfAborted();
+
+    const scheduleIds: string[] = [];
+    for (const seed of values.schedules) {
+      const scheduleId = randomUUID();
+      await writeDb.insert(zeroAgentSchedules).values({
+        id: scheduleId,
+        agentId: composeId,
+        userId,
+        orgId,
+        name: seed.name,
+        triggerType: "cron",
+        cronExpression: seed.cronExpression,
+        prompt: seed.prompt,
+        timezone: "UTC",
+      });
+      signal.throwIfAborted();
+      scheduleIds.push(scheduleId);
+    }
+
+    return { orgId, userId, composeId, scheduleIds };
+  },
+);
+
+export const deleteSchedulesScenario$ = command(
+  async (
+    { set },
+    fixture: SchedulesFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    if (fixture.scheduleIds.length > 0) {
+      await writeDb
+        .delete(zeroAgentSchedules)
+        .where(inArray(zeroAgentSchedules.id, [...fixture.scheduleIds]));
+      signal.throwIfAborted();
+    }
+    await writeDb
+      .delete(zeroAgents)
+      .where(eq(zeroAgents.id, fixture.composeId));
+    signal.throwIfAborted();
+    await writeDb
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, fixture.composeId));
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-schedules.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-schedules.test.ts
@@ -1,0 +1,132 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroSchedulesMainContract } from "@vm0/api-contracts/contracts/zero-schedules";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  type SchedulesFixture,
+  deleteSchedulesScenario$,
+  seedSchedulesScenario$,
+} from "./helpers/zero-schedules";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/schedules", () => {
+  const track = createFixtureTracker<SchedulesFixture>((fixture) => {
+    return store.set(deleteSchedulesScenario$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroSchedulesMainContract);
+
+    const response = await accept(client.list({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const client = setupApp({ context })(zeroSchedulesMainContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns the list of schedules for the org member", async () => {
+    const fixture = await track(
+      store.set(
+        seedSchedulesScenario$,
+        {
+          displayName: "Test Agent",
+          schedules: [
+            {
+              name: "list-test-1",
+              cronExpression: "0 9 * * *",
+              prompt: "First",
+            },
+            {
+              name: "list-test-2",
+              cronExpression: "0 10 * * *",
+              prompt: "Second",
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroSchedulesMainContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.schedules).toHaveLength(2);
+    const byName = new Map(
+      response.body.schedules.map((s) => {
+        return [s.name, s] as const;
+      }),
+    );
+    expect(byName.get("list-test-1")).toMatchObject({
+      agentId: fixture.composeId,
+      displayName: "Test Agent",
+      userId: fixture.userId,
+      triggerType: "cron",
+      cronExpression: "0 9 * * *",
+      timezone: "UTC",
+      prompt: "First",
+      enabled: true,
+    });
+    expect(byName.get("list-test-2")).toMatchObject({
+      agentId: fixture.composeId,
+      displayName: "Test Agent",
+      userId: fixture.userId,
+      triggerType: "cron",
+      cronExpression: "0 10 * * *",
+      timezone: "UTC",
+      prompt: "Second",
+      enabled: true,
+    });
+  });
+
+  it("returns an empty array when the user has no schedules", async () => {
+    const fixture = await track(
+      store.set(seedSchedulesScenario$, { schedules: [] }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroSchedulesMainContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ schedules: [] });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-schedules.ts
+++ b/turbo/apps/api/src/signals/routes/zero-schedules.ts
@@ -3,7 +3,6 @@ import { zeroSchedulesMainContract } from "@vm0/api-contracts/contracts/zero-sch
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { zeroScheduleList } from "../services/zero-schedules.service";
 import type { RouteEntry } from "../route";
 
@@ -18,16 +17,13 @@ const listSchedulesInner$ = computed(async (get) => {
 export const zeroSchedulesRoutes: readonly RouteEntry[] = [
   {
     route: zeroSchedulesMainContract.list,
-    handler: shadowCompareRoute({
-      route: zeroSchedulesMainContract.list,
-      handler: authRoute(
-        {
-          requireOrganization: true,
-          missingOrganizationStatus: 401,
-          requiredCapability: "schedule:read",
-        },
-        listSchedulesInner$,
-      ),
-    }),
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "schedule:read",
+      },
+      listSchedulesInner$,
+    ),
   },
 ];


### PR DESCRIPTION
Closes #12389

## Summary
- Drop the \`shadowCompareRoute\` wrapper from \`GET /api/zero/schedules\` (the \`.list\` route) so \`apps/api\` is now authoritative.
- Add the api integration test from scratch (file did not exist) covering all 3 in-scope web GET cases plus the api-specific 401 missing-organization case.
- Add \`seedSchedulesScenario\$\` / \`deleteSchedulesScenario\$\` helpers that wire up an org/user/compose/zero_agent + N schedules in a single fixture.

POST \`/deploy\` and the \`[name]/*\` routes remain shadow-compared (separate Stage 3 follow-ups). Service untouched — \`scheduleResponse\` (api) and \`toResponse\` (web) produce field-for-field identical \`ScheduleResponse\` objects.

## Milestone
After this PR, \`zero-schedules.ts\` has **0 \`shadowCompareRoute\` occurrences** — 7th fully-migrated single-route file.

## Final test inventory (4 cases)
- \`returns 401 when the request is unauthenticated\` — mirrors web case (line 550)
- \`returns 401 when the authenticated session has no organization\` — api-specific (\`requireOrganization: true, missingOrganizationStatus: 401\`)
- \`returns the list of schedules for the org member\` — mirrors web case (line 521); seeds 2 schedules; asserts length 2 + per-schedule \`agentId\`/\`displayName\`/\`triggerType\`/\`cronExpression\`/\`timezone\`/\`prompt\`/\`enabled\`
- \`returns an empty array when the user has no schedules\` — mirrors web case (line 540); seeds compose only; asserts \`toStrictEqual({ schedules: [] })\`

## Test plan
- [x] \`pnpm -F api exec vitest run src/signals/routes/__tests__/zero-schedules.test.ts\` — 4/4 passing
- [x] \`pnpm -F api lint\`
- [x] \`pnpm -F api check-types\`
- [x] \`pnpm format\`
- [x] \`pnpm knip\`
- [x] \`grep -c shadowCompareRoute src/signals/routes/zero-schedules.ts\` → 0

## Rollback
Disable the \`apiBackend\` feature switch — traffic falls back to web. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)