### PR TITLE
refactor(api): migrate variables list get

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-variables.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-variables.test.ts
@@ -1,8 +1,9 @@
+import { randomUUID } from "node:crypto";
+
 import { zeroVariablesContract } from "@vm0/api-contracts/contracts/zero-secrets";
 import { createStore } from "ccstate";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -50,7 +51,6 @@ describe("GET /api/zero/variables", () => {
     );
     await store.set(seedOtherVariable$, fixture, context.signal);
     mocks.clerk.session(fixture.userId, fixture.orgId);
-    mockApiShadowCompareRoutes([zeroVariablesContract.list]);
 
     const client = setupApp({ context })(zeroVariablesContract);
 
@@ -83,7 +83,6 @@ describe("GET /api/zero/variables", () => {
   it("returns an empty list when the user has no variables", async () => {
     const fixture = await track(store.set(seedVariables$, [], context.signal));
     mocks.clerk.session(fixture.userId, fixture.orgId);
-    mockApiShadowCompareRoutes([zeroVariablesContract.list]);
 
     const client = setupApp({ context })(zeroVariablesContract);
 
@@ -95,5 +94,32 @@ describe("GET /api/zero/variables", () => {
     );
 
     expect(response.body).toStrictEqual({ variables: [] });
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroVariablesContract);
+
+    const response = await accept(client.list({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroVariablesContract);
+
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-secrets.ts
+++ b/turbo/apps/api/src/signals/routes/zero-secrets.ts
@@ -6,7 +6,6 @@ import {
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import type { RouteEntry } from "../route";
 import { userSecrets, userVariables } from "../services/zero-user-data.service";
 
@@ -42,12 +41,9 @@ export const zeroSecretsRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroVariablesContract.list,
-    handler: shadowCompareRoute({
-      route: zeroVariablesContract.list,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        listVariablesInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      listVariablesInner$,
+    ),
   },
 ];


### PR DESCRIPTION
Closes #12395

## Summary
- Make `GET /api/zero/variables` authoritative in `apps/api` by removing the `shadowCompareRoute(...)` wrapper from the variables route entry in the shared `zero-secrets.ts` file
- **Removes the `shadowCompareRoute` import** — companion to PR #12377 which migrated the secrets route in the same file. After this PR, `zero-secrets.ts` has zero `shadowCompareRoute` references — file fully migrated (9th in the batch)
- Drops the existing `mockApiShadowCompareRoutes(...)` calls and import from `zero-variables.test.ts` (no longer needed once the wrapper is gone)
- Adds 2 new test cases (401 unauthenticated + 401 missing-organization). Existing 2 list cases preserved unchanged.
- POST and `/variables/:name` routes are out of scope — separate Stage 3 follow-ups

## Behavior parity
The api `userVariables` Computed and the web GET handler both query the `variables` table by `(orgId, userId)` ordered by name and return `{variables: [{id, name, value, description, createdAt, updatedAt}]}` with timestamps as ISO strings. Identical SQL, identical projection. Already shadow-compared in production with no drift.

## Scope
- Route + test only. **No new helper file** — `helpers/zero-user-data.ts` already has `seedVariables$`, `seedOtherVariable$`, and `deleteUserData$` from prior PRs.
- Secrets route entry untouched (already migrated by PR #12377).
- No `apps/web/**` modifications.

## Test cases (all 4 in file post-PR)
1. returns current user variables sorted by name (existing — covers web's "should list variables for authenticated user")
2. returns an empty list when the user has no variables (existing — covers web's "should return empty array when no variables exist")
3. returns 401 when the request is unauthenticated (NEW — covers web's "should reject unauthenticated requests")
4. returns 401 when the authenticated session has no organization (NEW — api-specific)

## Test plan
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-variables.test.ts` — 4/4 passed (first run)
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `grep -c shadowCompareRoute zero-secrets.ts` returns 0 — file fully migrated (9th in the batch)
- [x] Pre-commit: prettier, knip, `turbo run check-types`, commitlint — all green

## Rollback
Disable the `apiBackend` feature switch — traffic returns to `apps/web`. No DB or schema change.