### PR TITLE
refactor(api): migrate slack integration status get to api backend

### DIFF
--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -33,6 +33,7 @@ const SCHEMA = {
   TELEGRAM_OFFICIAL_BOT_USERNAME: z.string().optional(),
   TELEGRAM_OFFICIAL_WEBHOOK_SECRET: z.string().optional(),
   VM0_DEFAULT_AGENT: z.string().optional(),
+  SLACK_CLIENT_ID: z.string().optional(),
 } as const;
 
 const baseEnv = createEnv<undefined, typeof SCHEMA>({

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-integrations-slack.ts
@@ -1,0 +1,156 @@
+import { createCipheriv, randomBytes, randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import { eq } from "drizzle-orm";
+
+import { env } from "../../../../lib/env";
+import { writeDb$ } from "../../../external/db";
+
+export interface SlackIntegrationFixture {
+  readonly orgId: string;
+  readonly slackWorkspaceId: string;
+}
+
+interface SeedSlackInstallationValues {
+  readonly orgId: string;
+  readonly slackWorkspaceId?: string;
+  readonly slackWorkspaceName?: string;
+  readonly botScopes?: string | null;
+  readonly botToken?: string;
+}
+
+interface SeedSlackConnectionValues {
+  readonly slackWorkspaceId: string;
+  readonly vm0UserId: string;
+  readonly slackUserId?: string;
+}
+
+function encryptSecretForTests(plaintext: string): string {
+  const key = Buffer.from(env("SECRETS_ENCRYPTION_KEY"), "hex");
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv, { authTagLength: 16 });
+  const data = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  return [
+    iv.toString("base64"),
+    authTag.toString("base64"),
+    data.toString("base64"),
+  ].join(":");
+}
+
+function randomSlackId(prefix: string): string {
+  return `${prefix}${randomUUID().replaceAll("-", "").slice(0, 9).toUpperCase()}`;
+}
+
+export const seedSlackOrgInstallation$ = command(
+  async (
+    { set },
+    values: SeedSlackInstallationValues,
+    signal: AbortSignal,
+  ): Promise<SlackIntegrationFixture> => {
+    const writeDb = set(writeDb$);
+    const slackWorkspaceId = values.slackWorkspaceId ?? randomSlackId("T");
+
+    await writeDb.insert(slackOrgInstallations).values({
+      slackWorkspaceId,
+      slackWorkspaceName: values.slackWorkspaceName ?? "Test Org Workspace",
+      orgId: values.orgId,
+      encryptedBotToken: encryptSecretForTests(
+        values.botToken ?? "xoxb-test-token",
+      ),
+      botUserId: randomSlackId("U"),
+      botScopes: values.botScopes ?? null,
+    });
+    signal.throwIfAborted();
+
+    return { orgId: values.orgId, slackWorkspaceId };
+  },
+);
+
+export const seedSlackOrgConnection$ = command(
+  async (
+    { set },
+    values: SeedSlackConnectionValues,
+    signal: AbortSignal,
+  ): Promise<{ readonly slackUserId: string }> => {
+    const writeDb = set(writeDb$);
+    const slackUserId = values.slackUserId ?? randomSlackId("U");
+
+    await writeDb.insert(slackOrgConnections).values({
+      slackUserId,
+      slackWorkspaceId: values.slackWorkspaceId,
+      vm0UserId: values.vm0UserId,
+    });
+    signal.throwIfAborted();
+
+    return { slackUserId };
+  },
+);
+
+export const seedSlackEnvironmentAgent$ = command(
+  async (
+    { set },
+    args: { readonly orgId: string; readonly userId: string },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    const composeId = randomUUID();
+    const versionId = randomUUID().replaceAll("-", "");
+
+    await writeDb.insert(agentComposes).values({
+      id: composeId,
+      userId: args.userId,
+      orgId: args.orgId,
+      name: `agent-${composeId.slice(0, 8)}`,
+      headVersionId: versionId,
+    });
+    signal.throwIfAborted();
+    await writeDb.insert(agentComposeVersions).values({
+      id: versionId,
+      composeId,
+      content: {},
+      createdBy: args.userId,
+    });
+    signal.throwIfAborted();
+    await writeDb
+      .insert(orgMetadata)
+      .values({ orgId: args.orgId, defaultAgentId: composeId })
+      .onConflictDoUpdate({
+        target: orgMetadata.orgId,
+        set: { defaultAgentId: composeId },
+      });
+    signal.throwIfAborted();
+  },
+);
+
+export const deleteSlackIntegrationFixture$ = command(
+  async (
+    { set },
+    fixture: SlackIntegrationFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(slackOrgConnections)
+      .where(
+        eq(slackOrgConnections.slackWorkspaceId, fixture.slackWorkspaceId),
+      );
+    signal.throwIfAborted();
+    await writeDb
+      .delete(slackOrgInstallations)
+      .where(
+        eq(slackOrgInstallations.slackWorkspaceId, fixture.slackWorkspaceId),
+      );
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-status.test.ts
@@ -1,0 +1,350 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroIntegrationsSlackContract } from "@vm0/api-contracts/contracts/zero-integrations-slack";
+import { createStore } from "ccstate";
+import { beforeEach } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import {
+  deleteSlackIntegrationFixture$,
+  seedSlackEnvironmentAgent$,
+  seedSlackOrgConnection$,
+  seedSlackOrgInstallation$,
+  type SlackIntegrationFixture,
+} from "./helpers/zero-integrations-slack";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/integrations/slack", () => {
+  const track = createFixtureTracker<SlackIntegrationFixture>((fixture) => {
+    return store.set(deleteSlackIntegrationFixture$, fixture, context.signal);
+  });
+
+  beforeEach(() => {
+    mockEnv("SLACK_CLIENT_ID", "test-slack-client-id");
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(client.getStatus({ headers: {} }), [401]);
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns isConnected=false when user has no connection", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await track(
+      store.set(seedSlackOrgInstallation$, { orgId }, context.signal),
+    );
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.isConnected).toBeFalsy();
+  });
+
+  it("returns workspace info for connected user", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const fixture = await track(
+      store.set(seedSlackOrgInstallation$, { orgId }, context.signal),
+    );
+    await store.set(
+      seedSlackOrgConnection$,
+      { slackWorkspaceId: fixture.slackWorkspaceId, vm0UserId: userId },
+      context.signal,
+    );
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.isConnected).toBeTruthy();
+    expect(response.body.workspaceName).toBe("Test Org Workspace");
+  });
+
+  it("returns isAdmin=true for admin members", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const fixture = await track(
+      store.set(seedSlackOrgInstallation$, { orgId }, context.signal),
+    );
+    await store.set(
+      seedSlackOrgConnection$,
+      { slackWorkspaceId: fixture.slackWorkspaceId, vm0UserId: userId },
+      context.signal,
+    );
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.isAdmin).toBeTruthy();
+  });
+
+  it("returns isAdmin=false for non-admin members", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const fixture = await track(
+      store.set(seedSlackOrgInstallation$, { orgId }, context.signal),
+    );
+    await store.set(
+      seedSlackOrgConnection$,
+      { slackWorkspaceId: fixture.slackWorkspaceId, vm0UserId: userId },
+      context.signal,
+    );
+    mocks.clerk.session(userId, orgId, "org:member");
+
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.isAdmin).toBeFalsy();
+  });
+
+  it("returns environment info when connected", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const fixture = await track(
+      store.set(seedSlackOrgInstallation$, { orgId }, context.signal),
+    );
+    await store.set(
+      seedSlackOrgConnection$,
+      { slackWorkspaceId: fixture.slackWorkspaceId, vm0UserId: userId },
+      context.signal,
+    );
+    await store.set(
+      seedSlackEnvironmentAgent$,
+      { orgId, userId },
+      context.signal,
+    );
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.environment).toBeDefined();
+    expect(response.body.environment?.requiredSecrets).toBeDefined();
+    expect(response.body.environment?.requiredVars).toBeDefined();
+    expect(response.body.environment?.missingSecrets).toBeDefined();
+    expect(response.body.environment?.missingVars).toBeDefined();
+  });
+
+  it("returns scopeMismatch=false when installation has all required scopes", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const fullScopes = [
+      "app_mentions:read",
+      "chat:write",
+      "channels:read",
+      "channels:history",
+      "groups:read",
+      "groups:history",
+      "im:history",
+      "im:write",
+      "commands",
+      "users:read",
+      "users:read.email",
+      "reactions:write",
+      "files:read",
+      "files:write",
+    ];
+    const fixture = await track(
+      store.set(
+        seedSlackOrgInstallation$,
+        { orgId, botScopes: JSON.stringify(fullScopes) },
+        context.signal,
+      ),
+    );
+    await store.set(
+      seedSlackOrgConnection$,
+      { slackWorkspaceId: fixture.slackWorkspaceId, vm0UserId: userId },
+      context.signal,
+    );
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.scopeMismatch).toBeFalsy();
+    expect(response.body.reinstallUrl).toBeNull();
+  });
+
+  it("returns scopeMismatch=true when installation is missing scopes", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const fixture = await track(
+      store.set(
+        seedSlackOrgInstallation$,
+        { orgId, botScopes: JSON.stringify(["chat:write", "channels:read"]) },
+        context.signal,
+      ),
+    );
+    await store.set(
+      seedSlackOrgConnection$,
+      { slackWorkspaceId: fixture.slackWorkspaceId, vm0UserId: userId },
+      context.signal,
+    );
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.scopeMismatch).toBeTruthy();
+    expect(response.body.reinstallUrl).toContain(
+      "/api/zero/slack/oauth/install",
+    );
+    expect(response.body.reinstallUrl).toContain("reinstall=1");
+  });
+
+  it("treats null bot_scopes as mismatch (requires reinstall)", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const fixture = await track(
+      store.set(
+        seedSlackOrgInstallation$,
+        { orgId, botScopes: null },
+        context.signal,
+      ),
+    );
+    await store.set(
+      seedSlackOrgConnection$,
+      { slackWorkspaceId: fixture.slackWorkspaceId, vm0UserId: userId },
+      context.signal,
+    );
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.scopeMismatch).toBeTruthy();
+  });
+
+  it("does not expose scopeMismatch to non-admin users", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const fixture = await track(
+      store.set(
+        seedSlackOrgInstallation$,
+        { orgId, botScopes: JSON.stringify(["chat:write"]) },
+        context.signal,
+      ),
+    );
+    await store.set(
+      seedSlackOrgConnection$,
+      { slackWorkspaceId: fixture.slackWorkspaceId, vm0UserId: userId },
+      context.signal,
+    );
+    mocks.clerk.session(userId, orgId, "org:member");
+
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.scopeMismatch).toBeUndefined();
+    expect(response.body.reinstallUrl).toBeUndefined();
+  });
+
+  it("returns scopeMismatch for admin when user is not connected", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await track(
+      store.set(
+        seedSlackOrgInstallation$,
+        { orgId, botScopes: JSON.stringify(["chat:write"]) },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroIntegrationsSlackContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.isConnected).toBeFalsy();
+    expect(response.body.scopeMismatch).toBeTruthy();
+    expect(response.body.reinstallUrl).toContain("reinstall=1");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
@@ -19,7 +19,6 @@ import { eq } from "drizzle-orm";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import {
   zeroSlackOrgInstallation,
   zeroSlackOrgStatus,
@@ -239,10 +238,7 @@ const slackReadAuth = {
 export const zeroIntegrationsSlackRoutes: readonly RouteEntry[] = [
   {
     route: zeroIntegrationsSlackContract.getStatus,
-    handler: shadowCompareRoute({
-      route: zeroIntegrationsSlackContract.getStatus,
-      handler: authRoute(slackReadAuth, getSlackStatusInner$),
-    }),
+    handler: authRoute(slackReadAuth, getSlackStatusInner$),
   },
   {
     route: slackDownloadFileContract.download,

--- a/turbo/apps/api/src/signals/services/zero-slack-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-data.service.ts
@@ -6,6 +6,7 @@ import { orgCache } from "@vm0/db/schema/org-cache";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { and, eq } from "drizzle-orm";
 
+import { env } from "../../lib/env";
 import { db$ } from "../external/db";
 import { listConversations } from "../../lib/slack-client";
 import { decryptSecretValue } from "./crypto.utils";
@@ -38,6 +39,38 @@ function hasAllBotScopes(storedScopes: string | null): boolean {
   return SLACK_BOT_SCOPES.every((s) => {
     return stored.has(s);
   });
+}
+
+function buildSlackInstallUrl(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly reinstall: boolean;
+}): string | null {
+  const clientId = env("SLACK_CLIENT_ID");
+  if (!clientId) {
+    return null;
+  }
+  const url = new URL(`${env("VM0_API_URL")}/api/zero/slack/oauth/install`);
+  url.searchParams.set("orgId", args.orgId);
+  url.searchParams.set("vm0UserId", args.userId);
+  if (args.reinstall) {
+    url.searchParams.set("reinstall", "1");
+  }
+  return url.toString();
+}
+
+function buildSlackConnectUrl(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): string | null {
+  const clientId = env("SLACK_CLIENT_ID");
+  if (!clientId) {
+    return null;
+  }
+  const url = new URL(`${env("VM0_API_URL")}/api/zero/slack/oauth/connect`);
+  url.searchParams.set("orgId", args.orgId);
+  url.searchParams.set("vm0UserId", args.userId);
+  return url.toString();
 }
 
 interface SlackOrgStatusResult {
@@ -102,13 +135,37 @@ export function zeroSlackOrgStatus(args: {
       }
     }
 
+    function computeScopeFields(
+      installationRow: typeof slackOrgInstallations.$inferSelect,
+    ): { scopeMismatch: boolean | null; reinstallUrl: string | null } {
+      if (!isAdmin) {
+        return { scopeMismatch: null, reinstallUrl: null };
+      }
+      const scopeMismatch = !hasAllBotScopes(installationRow.botScopes);
+      const reinstallUrl = scopeMismatch
+        ? buildSlackInstallUrl({
+            orgId: args.orgId,
+            userId: args.userId,
+            reinstall: true,
+          })
+        : null;
+      return { scopeMismatch, reinstallUrl };
+    }
+
     if (!installation) {
+      const installUrl = isAdmin
+        ? buildSlackInstallUrl({
+            orgId: args.orgId,
+            userId: args.userId,
+            reinstall: false,
+          })
+        : null;
       return {
         isConnected: false,
         isInstalled: false,
         isAdmin,
         workspaceName: null,
-        installUrl: null,
+        installUrl,
         connectUrl: null,
         defaultAgentName,
         agentOrgSlug,
@@ -132,15 +189,11 @@ export function zeroSlackOrgStatus(args: {
       .limit(1);
 
     if (!connection) {
-      const scopeFields = isAdmin
-        ? {
-            scopeMismatch: !hasAllBotScopes(installation.botScopes),
-            reinstallUrl: null as string | null,
-          }
-        : {
-            scopeMismatch: null as boolean | null,
-            reinstallUrl: null as string | null,
-          };
+      const scopeFields = computeScopeFields(installation);
+      const connectUrl = buildSlackConnectUrl({
+        orgId: args.orgId,
+        userId: args.userId,
+      });
 
       return {
         isConnected: false,
@@ -148,22 +201,14 @@ export function zeroSlackOrgStatus(args: {
         isAdmin,
         workspaceName: installation.slackWorkspaceName ?? null,
         installUrl: null,
-        connectUrl: null,
+        connectUrl,
         defaultAgentName,
         agentOrgSlug,
         ...scopeFields,
       };
     }
 
-    const scopeFields = isAdmin
-      ? {
-          scopeMismatch: !hasAllBotScopes(installation.botScopes),
-          reinstallUrl: null as string | null,
-        }
-      : {
-          scopeMismatch: null as boolean | null,
-          reinstallUrl: null as string | null,
-        };
+    const scopeFields = computeScopeFields(installation);
 
     return {
       isConnected: true,


### PR DESCRIPTION
## Summary

- Promote `GET /api/zero/integrations/slack` (status + scope-mismatch detection) from shadow-compared to api-authoritative under the `apiBackend` feature switch.
- Drop `shadowCompareRoute` wrapper from `zero-integrations-slack.ts` — file becomes **fully migrated** (0 references; the `download-file` route in the same file was already direct).
- Port all **11 web GET cases** 1:1 (6 main describe + 5 scope-mismatch sub-describe) plus 1 api-specific 401 missing-org case = **12 tests total**.
- **Plan A2 service-layer fix bundled** to unblock 2 of the 11 cases.

## Plan A2 fix — installUrl / connectUrl / reinstallUrl

The api `zeroSlackOrgStatus` service previously hard-coded these three URL fields to `null`. Web computes them as signed redirect URLs from `SLACK_CLIENT_ID` + `VM0_API_URL` env vars when applicable. **Tests #8 and #11 of the web suite assert** `reinstallUrl.toContain("reinstall=1")` — both would not pass against the api today.

This PR adds two private helpers in `zero-slack-data.service.ts` mirroring web's `buildScopeFields` and inline GET handler logic:

```ts
function buildSlackInstallUrl({ orgId, userId, reinstall }): string | null
function buildSlackConnectUrl({ orgId, userId }): string | null
```

Param order matches web's exactly (`orgId`, `vm0UserId`, optional `reinstall=1`) for shadow-compare byte-stable strings. Returns `null` when `SLACK_CLIENT_ID` is unset, mirroring web's `if (SLACK_CLIENT_ID) ... : null` gate. `SLACK_CLIENT_ID` added to api SCHEMA as `.optional()`.

The service now populates all three URL fields per state. Beyond unblocking tests #8 and #11, this also prevents silent regressions on `installUrl`/`connectUrl` when the wrapper drops — the platform UI consuming these for "Install Slack" / "Connect Slack" buttons would otherwise receive `null` post-flip.

## 11 vs 10 case finding (resolved with leader: include all 11)

The issue body listed 10 cases; the actual web test file has **11**. The 5th scope-mismatch case (`returns scopeMismatch for admin when user is not connected`, line 364) covers the admin + no-connection + scopeMismatch=true branch — non-trivial behavior not subsumed by other cases. All 11 ported per leader's call.

## Encrypt-helper extraction (deferred)

The new helper inlines `encryptSecretForTests` (4th occurrence in the codebase). Per leader direction, the third-occurrence-trigger refactor is deferred to a follow-up cleanup PR (`chore(api): extract encryptSecretValueForTests to shared helper`) so the migration PR keeps a single concern. Will file post-merge.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-integrations-slack-status.test.ts` — 12/12 pass.
- [x] `pnpm -F api lint` — clean.
- [x] `pnpm -F api check-types` — clean.
- [x] `grep -c shadowCompareRoute turbo/apps/api/src/signals/routes/zero-integrations-slack.ts` returns `0`.
- [x] No `apps/web/**` modifications.

## Final test inventory (12 cases)

1. `returns 401 when the request is unauthenticated` *(web 1:1 + api unauth conflated)*
2. `returns 401 when the authenticated session has no organization` *(api-specific)*
3. `returns isConnected=false when user has no connection` *(web 1:1)*
4. `returns workspace info for connected user` *(web 1:1)*
5. `returns isAdmin=true for admin members` *(web 1:1)*
6. `returns isAdmin=false for non-admin members` *(web 1:1)*
7. `returns environment info when connected` *(web 1:1; uses new `seedSlackEnvironmentAgent$` to seed the default-agent + compose-version chain `getSlackEnvironment$` requires)*
8. `returns scopeMismatch=false when installation has all required scopes` *(web 1:1)*
9. `returns scopeMismatch=true when installation is missing scopes` *(web 1:1; **A2 fix unblocks**)*
10. `treats null bot_scopes as mismatch (requires reinstall)` *(web 1:1)*
11. `does not expose scopeMismatch to non-admin users` *(web 1:1; privacy gate)*
12. `returns scopeMismatch for admin when user is not connected` *(web 1:1; **A2 fix unblocks**)*

## Rollback

`git revert` the commit. Web's `GET /api/zero/integrations/slack` route stays in place; disabling the `apiBackend` feature switch returns traffic to web. No DB or schema changes.

Closes #12396