### PR TITLE
refactor(api): migrate skill detail get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
@@ -1,9 +1,16 @@
 import { randomUUID } from "node:crypto";
+import { gzipSync } from "node:zlib";
 
+import {
+  getCustomSkillStorageName,
+  VOLUME_ORG_USER_ID,
+} from "@vm0/core/storage-names";
 import { command } from "ccstate";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { zeroSkills } from "@vm0/db/schema/zero-skill";
 import { eq } from "drizzle-orm";
 
+import type { TestContext } from "../../../../__tests__/test-helpers";
 import { writeDb$ } from "../../../external/db";
 
 export interface SkillsFixture {
@@ -27,6 +34,9 @@ export const deleteSkillsForFixture$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const db = set(writeDb$);
+    // Storage cascade deletes storage_versions via FK.
+    await db.delete(storages).where(eq(storages.orgId, fixture.orgId));
+    signal.throwIfAborted();
     await db.delete(zeroSkills).where(eq(zeroSkills.orgId, fixture.orgId));
     signal.throwIfAborted();
   },
@@ -55,3 +65,160 @@ export const seedSkill$ = command(
     signal.throwIfAborted();
   },
 );
+
+interface SkillStorageSeed {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly skillName: string;
+  readonly s3Key: string;
+  readonly headVersionId: string;
+}
+
+export const seedSkillStorage$ = command(
+  async (
+    { set },
+    args: SkillStorageSeed,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    const storageId = randomUUID();
+    const storageName = getCustomSkillStorageName(args.skillName);
+
+    await db.insert(storages).values({
+      id: storageId,
+      userId: VOLUME_ORG_USER_ID,
+      name: storageName,
+      type: "volume",
+      orgId: args.orgId,
+      s3Prefix: `orgs/${args.orgId}/${storageName}`,
+    });
+    signal.throwIfAborted();
+
+    await db.insert(storageVersions).values({
+      id: args.headVersionId,
+      storageId,
+      s3Key: args.s3Key,
+      createdBy: args.userId,
+    });
+    signal.throwIfAborted();
+
+    await db
+      .update(storages)
+      .set({ headVersionId: args.headVersionId })
+      .where(eq(storages.id, storageId));
+    signal.throwIfAborted();
+  },
+);
+
+interface SkillContentMockExtra {
+  readonly path: string;
+  readonly size: number;
+}
+
+interface SkillContentMockArgs {
+  readonly s3Key: string;
+  readonly content: string;
+  readonly extraFiles?: readonly SkillContentMockExtra[];
+}
+
+const TAR_BLOCK_SIZE = 512;
+
+function octal(value: number, length: number): string {
+  return value.toString(8).padStart(length - 1, "0") + "\0";
+}
+
+function createSingleFileTarGz(filename: string, content: Buffer): Buffer {
+  // POSIX tar header (USTAR-compatible) — sufficient for extractFileFromTarGz
+  // to parse the filename + size + payload.
+  const header = Buffer.alloc(TAR_BLOCK_SIZE);
+  header.write(filename, 0, 100, "utf8");
+  header.write("0000644\0", 100); // mode
+  header.write("0000000\0", 108); // uid
+  header.write("0000000\0", 116); // gid
+  header.write(octal(content.length, 12), 124); // size
+  header.write(octal(0, 12), 136); // mtime
+  // Checksum placeholder — 8 spaces — required so the checksum sum is correct.
+  header.write("        ", 148);
+  header.write("0", 156); // type flag (regular file)
+
+  let checksum = 0;
+  for (const byte of header) {
+    checksum += byte;
+  }
+  // Final checksum: 6 octal digits, NUL, space.
+  header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148);
+
+  const padding = TAR_BLOCK_SIZE - (content.length % TAR_BLOCK_SIZE);
+  const dataBlocks =
+    padding < TAR_BLOCK_SIZE
+      ? Buffer.concat([content, Buffer.alloc(padding)])
+      : content;
+  const eofBlocks = Buffer.alloc(TAR_BLOCK_SIZE * 2);
+
+  return gzipSync(Buffer.concat([header, dataBlocks, eofBlocks]));
+}
+
+function asyncIterableOf(buffer: Buffer): AsyncIterable<Uint8Array> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield buffer;
+    },
+  };
+}
+
+function commandKey(command: unknown): string {
+  if (
+    typeof command !== "object" ||
+    command === null ||
+    !("input" in command)
+  ) {
+    return "";
+  }
+  const input = (command as { input: unknown }).input;
+  if (
+    typeof input !== "object" ||
+    input === null ||
+    !("Key" in input) ||
+    typeof (input as { Key: unknown }).Key !== "string"
+  ) {
+    return "";
+  }
+  return (input as { Key: string }).Key;
+}
+
+export function mockSkillContent(
+  context: TestContext,
+  args: SkillContentMockArgs,
+): void {
+  const contentBuffer = Buffer.from(args.content, "utf8");
+  const archive = createSingleFileTarGz("SKILL.md", contentBuffer);
+
+  const manifest = {
+    version: "test-version",
+    createdAt: new Date(0).toISOString(),
+    files: [
+      { path: "SKILL.md", hash: "test-hash-skill", size: contentBuffer.length },
+      ...(args.extraFiles ?? []).map((f) => {
+        return { path: f.path, hash: "test-hash-extra", size: f.size };
+      }),
+    ],
+    totalSize:
+      contentBuffer.length +
+      (args.extraFiles ?? []).reduce((sum, f) => {
+        return sum + f.size;
+      }, 0),
+    fileCount: 1 + (args.extraFiles ?? []).length,
+  };
+  const manifestBuffer = Buffer.from(JSON.stringify(manifest), "utf8");
+
+  context.mocks.s3.send.mockImplementation((cmd: unknown): Promise<unknown> => {
+    const key = commandKey(cmd);
+    if (key === `${args.s3Key}/manifest.json`) {
+      return Promise.resolve({ Body: asyncIterableOf(manifestBuffer) });
+    }
+    if (key === `${args.s3Key}/archive.tar.gz`) {
+      return Promise.resolve({ Body: asyncIterableOf(archive) });
+    }
+    return Promise.resolve({});
+  });
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
@@ -1,12 +1,17 @@
 import { randomUUID } from "node:crypto";
 
-import { zeroSkillsCollectionContract } from "@vm0/api-contracts/contracts/zero-agents";
+import {
+  zeroSkillsCollectionContract,
+  zeroSkillsDetailContract,
+} from "@vm0/api-contracts/contracts/zero-agents";
 import { createStore } from "ccstate";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import {
   deleteSkillsForFixture$,
+  mockSkillContent,
   seedSkill$,
+  seedSkillStorage$,
   seedSkillsFixture$,
   type SkillsFixture,
 } from "./helpers/zero-skills";
@@ -23,8 +28,12 @@ function authHeaders() {
   return { authorization: "Bearer clerk-session" };
 }
 
-function apiClient() {
+function listClient() {
   return setupApp({ context })(zeroSkillsCollectionContract);
+}
+
+function detailClient() {
+  return setupApp({ context })(zeroSkillsDetailContract);
 }
 
 describe("GET /api/zero/skills", () => {
@@ -33,7 +42,7 @@ describe("GET /api/zero/skills", () => {
   });
 
   it("returns 401 when the request is unauthenticated", async () => {
-    const response = await accept(apiClient().list({ headers: {} }), [401]);
+    const response = await accept(listClient().list({ headers: {} }), [401]);
     expect(response.body).toStrictEqual({
       error: { message: "Not authenticated", code: "UNAUTHORIZED" },
     });
@@ -42,7 +51,7 @@ describe("GET /api/zero/skills", () => {
   it("returns 401 when the authenticated session has no organization", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, null);
     const response = await accept(
-      apiClient().list({ headers: authHeaders() }),
+      listClient().list({ headers: authHeaders() }),
       [401],
     );
     expect(response.body).toStrictEqual({
@@ -57,7 +66,7 @@ describe("GET /api/zero/skills", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const response = await accept(
-      apiClient().list({ headers: authHeaders() }),
+      listClient().list({ headers: authHeaders() }),
       [200],
     );
 
@@ -91,7 +100,7 @@ describe("GET /api/zero/skills", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const response = await accept(
-      apiClient().list({ headers: authHeaders() }),
+      listClient().list({ headers: authHeaders() }),
       [200],
     );
 
@@ -119,11 +128,193 @@ describe("GET /api/zero/skills", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
     const response = await accept(
-      apiClient().list({ headers: authHeaders() }),
+      listClient().list({ headers: authHeaders() }),
       [200],
     );
 
     expect(response.body).toHaveLength(1);
     expect(response.body[0]?.name).toBe("readable-skill");
+  });
+});
+
+describe("GET /api/zero/skills/:name", () => {
+  const track = createFixtureTracker<SkillsFixture>((fixture) => {
+    return store.set(deleteSkillsForFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      detailClient().get({ headers: {}, params: { name: "any" } }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const response = await accept(
+      detailClient().get({ headers: authHeaders(), params: { name: "any" } }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns skill detail with content", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const skillName = "my-skill";
+    const s3Key = `orgs/${fixture.orgId}/custom-skill@${skillName}/v1`;
+    await store.set(
+      seedSkill$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: skillName,
+        displayName: "My Skill",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedSkillStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        skillName,
+        s3Key,
+        headVersionId: `head-${randomUUID()}`,
+      },
+      context.signal,
+    );
+    mockSkillContent(context, { s3Key, content: "# My Skill Content" });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      detailClient().get({
+        headers: authHeaders(),
+        params: { name: skillName },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      name: "my-skill",
+      displayName: "My Skill",
+      description: null,
+      content: "# My Skill Content",
+      files: [{ path: "SKILL.md", size: 18 }],
+    });
+  });
+
+  it("returns file listing for a multi-file skill", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const skillName = "multi-skill";
+    const s3Key = `orgs/${fixture.orgId}/custom-skill@${skillName}/v1`;
+    await store.set(
+      seedSkill$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: skillName,
+      },
+      context.signal,
+    );
+    await store.set(
+      seedSkillStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        skillName,
+        s3Key,
+        headVersionId: `head-${randomUUID()}`,
+      },
+      context.signal,
+    );
+    mockSkillContent(context, {
+      s3Key,
+      content: "# Multi",
+      extraFiles: [{ path: "templates/prompt.md", size: 42 }],
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      detailClient().get({
+        headers: authHeaders(),
+        params: { name: skillName },
+      }),
+      [200],
+    );
+
+    expect(response.body.files).toStrictEqual([
+      { path: "SKILL.md", size: 7 },
+      { path: "templates/prompt.md", size: 42 },
+    ]);
+    expect(response.body.content).toBe("# Multi");
+  });
+
+  it("returns 404 for a non-existent skill", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      detailClient().get({
+        headers: authHeaders(),
+        params: { name: "no-such-skill" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Skill not found: no-such-skill", code: "NOT_FOUND" },
+    });
+  });
+
+  it("allows org member to read skill detail", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const skillName = "readable-skill";
+    const s3Key = `orgs/${fixture.orgId}/custom-skill@${skillName}/v1`;
+    await store.set(
+      seedSkill$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: skillName,
+      },
+      context.signal,
+    );
+    await store.set(
+      seedSkillStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        skillName,
+        s3Key,
+        headVersionId: `head-${randomUUID()}`,
+      },
+      context.signal,
+    );
+    mockSkillContent(context, { s3Key, content: "# Readable" });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const response = await accept(
+      detailClient().get({
+        headers: authHeaders(),
+        params: { name: skillName },
+      }),
+      [200],
+    );
+
+    expect(response.body.content).toBe("# Readable");
+    expect(response.body.name).toBe("readable-skill");
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-agent-instructions.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agent-instructions.ts
@@ -49,9 +49,6 @@ export const zeroAgentInstructionsRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroSkillsDetailContract.get,
-    handler: shadowCompareRoute({
-      route: zeroSkillsDetailContract.get,
-      handler: authRoute(agentReadAuth, getSkillDetailInner$),
-    }),
+    handler: authRoute(agentReadAuth, getSkillDetailInner$),
   },
 ];


### PR DESCRIPTION
Closes #12398

## Summary
- Drop the \`shadowCompareRoute\` wrapper from \`GET /api/zero/skills/:name\` so \`apps/api\` is now authoritative for the route.
- Extend the existing \`zero-skills.test.ts\` (rename \`apiClient\` → \`listClient\`, add \`detailClient\`) with a new \`describe(\"GET /api/zero/skills/:name\")\` block covering all 3 in-scope web GET cases plus the api-specific 401 unauth + 401 missing-org cases plus a cross-cutting \`allows org member to read skill detail\` case that pins Clerk's bypass-of-capability semantic.
- Extend \`helpers/zero-skills.ts\` with \`seedSkillStorage\$\` (seeds \`storages\` + \`storage_versions\` for a \`custom-skill@<name>\` entry; patches \`storages.headVersionId\` after the version row is inserted to satisfy the FK), \`mockSkillContent\` (programs \`context.mocks.s3.send\` to serve a fake \`manifest.json\` + gzipped tar archive containing SKILL.md), and an inline minimal POSIX/USTAR tar builder.

PUT and DELETE on \`/skills/:name\` remain in \`apps/web\` (separate Stage 3 issues). The \`zeroAgentInstructionsContract.get\` route in this same file is also out of scope (separate follow-up). Service untouched — parity verified.

## Milestone
\`zero-agent-instructions.ts\` goes from 2 → 1 \`shadowCompareRoute\` wrapper call. The \`shadowCompareRoute\` import is **retained** because the agent-instructions GET route still uses it.

## Final test inventory (zero-skills.test.ts)
**Existing list route (5 cases, behavior unchanged — only \`apiClient\` → \`listClient\` rename)**:
- 401 unauth, 401 missing-org, empty list, all org skills, member-can-list

**New skill-detail route (6 cases)**:
- \`returns 401 when the request is unauthenticated\` — api-specific
- \`returns 401 when the authenticated session has no organization\` — api-specific
- \`returns skill detail with content\` — web case at line 255
- \`returns file listing for a multi-file skill\` — web case at line 277
- \`returns 404 for a non-existent skill\` — web case at line 294
- \`allows org member to read skill detail\` — web cross-cutting at line 459 (matches PR #12388 precedent)

## Test plan
- [x] \`pnpm -F api exec vitest run src/signals/routes/__tests__/zero-skills.test.ts\` — 11/11 passing
- [x] \`pnpm -F api lint\`
- [x] \`pnpm -F api check-types\`
- [x] \`pnpm format\`
- [x] \`pnpm knip\`
- [x] \`grep -c 'shadowCompareRoute(' src/signals/routes/zero-agent-instructions.ts\` → 1 (down from 2; agent-instructions wrapper retained)
- [x] \`shadowCompareRoute\` import retained

## Rollback
Disable the \`apiBackend\` feature switch — traffic falls back to web. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)