### PR TITLE
refactor(api): migrate runs queue get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-queue.test.ts
@@ -1,0 +1,169 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroRunsQueueContract } from "@vm0/api-contracts/contracts/zero-runs";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+// Reusing run-seeding helpers from the usage-insight test module — same
+// fixture shape (orgId/userId pair, then compose+run inserts), no need to
+// duplicate. The "usage-insight" name is module-scoped to the helper file
+// itself; the seedRun$ command is a generic agent-run seeder.
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+describe("GET /api/zero/runs/queue", () => {
+  const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroRunsQueueContract);
+
+    const response = await accept(client.getQueue({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+
+    const client = setupApp({ context })(zeroRunsQueueContract);
+
+    const response = await accept(
+      client.getQueue({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns queue status with concurrency info for an empty queue", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunsQueueContract);
+
+    const response = await accept(
+      client.getQueue({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      concurrency: {
+        tier: "free",
+        limit: 1,
+        active: 0,
+        available: 1,
+      },
+      queue: [],
+      runningTasks: [],
+      estimatedTimePerRun: null,
+    });
+  });
+
+  it("includes running tasks owned by the caller in the response", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunsQueueContract);
+
+    const response = await accept(
+      client.getQueue({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.concurrency.active).toBe(1);
+    expect(response.body.runningTasks).toHaveLength(1);
+    const [running] = response.body.runningTasks;
+    expect(running?.isOwner).toBeTruthy();
+  });
+
+  it("returns 403 for a sandbox token without agent-run:read capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const runId = `run_${randomUUID()}`;
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId,
+      capabilities: ["file:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const client = setupApp({ context })(zeroRunsQueueContract);
+
+    const response = await accept(
+      client.getQueue({
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: agent-run:read",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-runs.ts
+++ b/turbo/apps/api/src/signals/routes/zero-runs.ts
@@ -70,10 +70,7 @@ const getRunQueueInner$ = computed(async (get) => {
 export const zeroRunsRoutes: readonly RouteEntry[] = [
   {
     route: zeroRunsQueueContract.getQueue,
-    handler: shadowCompareRoute({
-      route: zeroRunsQueueContract.getQueue,
-      handler: authRoute(runReadAuth, getRunQueueInner$),
-    }),
+    handler: authRoute(runReadAuth, getRunQueueInner$),
   },
   {
     route: zeroRunRunnerContract.getRunner,


### PR DESCRIPTION
## Summary

- make `GET /api/zero/runs/queue` API-authoritative by removing the `shadowCompareRoute(...)` wrapper around the queue route entry only
- shared file `zero-runs.ts` goes from 3 → 2 `shadowCompareRoute(...)` invocations (runner + getById retained for separate Stage 2 follow-ups)
- `shadowCompareRoute` import retained (still consumed by runner + getById wrappers)
- add api integration tests covering all 4 web GET cases plus an api missing-org 401 case (5 total)
- reuse `seedRun$` / `seedCompose$` / `deleteUsageInsightFixture$` from existing `helpers/zero-usage-insight.ts` — no new helper file
- capability gate test ported 1:1 (sandbox-token harness already established in api; PR #12388's omission no longer applies here)

Closes #12400

Part of epic #12290.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-queue.test.ts` — 5 / 5 passing
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-insight.test.ts` — 19 / 19 passing (sanity, helpers reused)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `grep -c "shadowCompareRoute(" turbo/apps/api/src/signals/routes/zero-runs.ts` — **2** (down from 3)
- `grep -n shadowCompareRoute turbo/apps/api/src/signals/routes/zero-runs.ts` — confirms import + 2 wrappers (runner + getById) preserved

## Test cases

| # | Case | Mirrors web |
|---|------|-------------|
| 1 | unauthenticated → 401 | "should return 401 when not authenticated" (line 69) |
| 2 | session, no active org → 401 | n/a — added per epic pattern (PR #12384 / #12377 / #12392) |
| 3 | empty queue → 200 (free tier defaults: limit 1, active 0, available 1) | "should return queue status with concurrency info" (line 35) |
| 4 | running task → 200, runningTasks[0].isOwner=true | "should include running tasks in response" (line 52) |
| 5 | sandbox token without agent-run:read → 403 | "should return 403 for sandbox token without agent-run:read capability" (line 78) |

## Service parity verification

API `zeroRunQueueStatus` and web `getRunQueueStatus` both return the shared contract type `QueueResponse` and execute identical SQL (same JOIN chain on `agentRuns ⨝ zeroRuns ⨝ agentComposeVersions ⨝ agentComposes ⨝ zeroAgents`, same ORDER BY, same WHERE). Concurrency limit constants match (free=1, pro=2, team=10). Privacy filtering for non-owners is identical. No divergence.

## Sandbox-token harness reuse

The api test harness already exposes `signSandboxJwtForTests` (consumed by `chat-threads-v1.test.ts` and heavily by `health-auth-probe.test.ts`). Capability tests in `health-auth-probe.test.ts` use the exact pattern this PR adopts (zero-scope token with explicit `capabilities` array). PR #12388's omission was preemptive; this issue's harness inventory shows the test is portable today, so we port it 1:1 — actually validating the gate rather than relying on parent-Epic infrastructure assertions.

## Behavioral note

Web returns 404 if `resolveOrg` rejects. The api implementation skips `resolveOrg` (Clerk-implies-membership simplification) — `zeroOrgTier` falls back to "free" tier and the queue returns empty. Same accepted gap as PRs #12312 / #12314 / #12315 / #12337 / #12351 / #12363 / #12377 / #12384 / #12388 / #12392.

## Rollback

Disabling the `apiBackend` feature switch routes traffic back to `apps/web`. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)