### PR TITLE
refactor(api): migrate telegram bots list get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram.test.ts
@@ -1,0 +1,221 @@
+import { randomUUID } from "node:crypto";
+
+import { integrationsTelegramBotListContract } from "@vm0/api-contracts/contracts/integrations";
+import { OFFICIAL_TELEGRAM_BOT_ID } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { afterEach, beforeEach } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { mockEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+import { now } from "../../external/time";
+import {
+  deleteTelegramFixture$,
+  freezeTelegramFixture,
+  makeTelegramFixtureBuilder,
+  seedTelegramInstallation$,
+  type TelegramFixture,
+} from "./helpers/zero-telegram";
+
+const context = testContext();
+const store = createStore();
+
+const OFFICIAL_BOT_TOKEN = "9876543210:fake-test-token";
+const OFFICIAL_BOT_USERNAME = "official_zero_bot";
+const OFFICIAL_WEBHOOK_SECRET = "official-test-webhook-secret";
+
+function configureOfficialBotEnv(): void {
+  mockEnv("TELEGRAM_OFFICIAL_BOT_TOKEN", OFFICIAL_BOT_TOKEN);
+  mockEnv("TELEGRAM_OFFICIAL_BOT_USERNAME", OFFICIAL_BOT_USERNAME);
+  mockEnv("TELEGRAM_OFFICIAL_WEBHOOK_SECRET", OFFICIAL_WEBHOOK_SECRET);
+}
+
+function newTelegramBotId(): string {
+  return String(Math.floor(Math.random() * 9_000_000_000) + 1_000_000_000);
+}
+
+function mintZeroToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly capabilities: readonly "telegram:read"[];
+}): string {
+  const nowSeconds = Math.floor(now() / 1000);
+  return signSandboxJwtForTests({
+    scope: "zero" as const,
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: `run_${randomUUID()}`,
+    capabilities: args.capabilities,
+    iat: nowSeconds,
+    exp: nowSeconds + 3600,
+  });
+}
+
+async function seedMembership(orgId: string, userId: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(orgMembersCache).values({
+    orgId,
+    userId,
+    role: "member",
+    cachedAt: new Date(now()),
+  });
+}
+
+async function deleteMembership(orgId: string, userId: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(orgMembersCache)
+    .where(
+      and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
+    );
+}
+
+describe("GET /api/zero/integrations/telegram/bots", () => {
+  const fixtures: TelegramFixture[] = [];
+  const memberships: { orgId: string; userId: string }[] = [];
+
+  beforeEach(() => {
+    configureOfficialBotEnv();
+  });
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await store.set(deleteTelegramFixture$, fixture, context.signal);
+      }
+    }
+    while (memberships.length > 0) {
+      const membership = memberships.pop();
+      if (membership) {
+        await deleteMembership(membership.orgId, membership.userId);
+      }
+    }
+  });
+
+  it("returns 401 when no auth token is provided", async () => {
+    const client = setupApp({ context })(integrationsTelegramBotListContract);
+
+    const response = await accept(client.listBots({ headers: {} }), [401]);
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("lists the official bot and custom Telegram bots in the active org", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const otherOrgId = `org_${randomUUID()}`;
+
+    await seedMembership(orgId, userId);
+    memberships.push({ orgId, userId });
+
+    const ownerBotId = newTelegramBotId();
+    const orgBotId = newTelegramBotId();
+    const otherOrgBotId = newTelegramBotId();
+
+    context.mocks.telegram.getMe.mockResolvedValue({
+      id: 1,
+      is_bot: true,
+      first_name: "Bot",
+      username: "x",
+    });
+
+    const builderA = makeTelegramFixtureBuilder(orgId);
+    const builderB = makeTelegramFixtureBuilder(otherOrgId);
+
+    const ownerInstall = await store.set(
+      seedTelegramInstallation$,
+      { orgId, ownerUserId: userId, telegramBotId: ownerBotId },
+      context.signal,
+    );
+    builderA.composeIds.push(ownerInstall.composeId);
+    builderA.telegramBotIds.push(ownerInstall.telegramBotId);
+
+    const orgInstall = await store.set(
+      seedTelegramInstallation$,
+      {
+        orgId,
+        ownerUserId: `user_${randomUUID()}`,
+        telegramBotId: orgBotId,
+      },
+      context.signal,
+    );
+    builderA.composeIds.push(orgInstall.composeId);
+    builderA.telegramBotIds.push(orgInstall.telegramBotId);
+
+    const otherOrgInstall = await store.set(
+      seedTelegramInstallation$,
+      {
+        orgId: otherOrgId,
+        ownerUserId: userId,
+        telegramBotId: otherOrgBotId,
+      },
+      context.signal,
+    );
+    builderB.composeIds.push(otherOrgInstall.composeId);
+    builderB.telegramBotIds.push(otherOrgInstall.telegramBotId);
+
+    fixtures.push(freezeTelegramFixture(builderA));
+    fixtures.push(freezeTelegramFixture(builderB));
+
+    const token = mintZeroToken({
+      userId,
+      orgId,
+      capabilities: ["telegram:read"],
+    });
+    const client = setupApp({ context })(integrationsTelegramBotListContract);
+
+    const response = await accept(
+      client.listBots({ headers: { authorization: `Bearer ${token}` } }),
+      [200],
+    );
+
+    expect(response.body.bots).toHaveLength(3);
+    expect(response.body.bots).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: OFFICIAL_TELEGRAM_BOT_ID,
+          kind: "official",
+        }),
+        expect.objectContaining({ id: ownerBotId, isOwner: true }),
+        expect.objectContaining({ id: orgBotId, isOwner: false }),
+      ]),
+    );
+    expect(
+      response.body.bots.some((bot) => {
+        return bot.id === otherOrgBotId;
+      }),
+    ).toBeFalsy();
+  });
+
+  it("returns the official bot when the active org has no custom Telegram bots", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+
+    await seedMembership(orgId, userId);
+    memberships.push({ orgId, userId });
+
+    const token = mintZeroToken({
+      userId,
+      orgId,
+      capabilities: ["telegram:read"],
+    });
+    const client = setupApp({ context })(integrationsTelegramBotListContract);
+
+    const response = await accept(
+      client.listBots({ headers: { authorization: `Bearer ${token}` } }),
+      [200],
+    );
+
+    expect(response.body.bots).toHaveLength(1);
+    expect(response.body.bots[0]).toMatchObject({
+      id: OFFICIAL_TELEGRAM_BOT_ID,
+      kind: "official",
+      isOwner: false,
+      official: { linkedTelegramUserId: null },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-integrations-telegram.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-telegram.ts
@@ -8,7 +8,6 @@ import { apiErrorSchema } from "@vm0/api-contracts/contracts/errors";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { buildFileDownloadUrl, getFile } from "../external/telegram-client";
 import {
   zeroTelegramBots,
@@ -134,10 +133,7 @@ const telegramReadAuth = {
 export const zeroIntegrationsTelegramRoutes: readonly RouteEntry[] = [
   {
     route: integrationsTelegramBotListContract.listBots,
-    handler: shadowCompareRoute({
-      route: integrationsTelegramBotListContract.listBots,
-      handler: authRoute(telegramReadAuth, getTelegramBotsInner$),
-    }),
+    handler: authRoute(telegramReadAuth, getTelegramBotsInner$),
   },
   {
     route: telegramDownloadFileContract.download,


### PR DESCRIPTION
## Summary

- Drop the `shadowCompareRoute` wrapper from the `listBots` route in `zero-integrations-telegram.ts`.
- The `download-file` route in the same file was already direct, so this completes the file's migration — **0 `shadowCompareRoute` references post-merge** (11th fully-migrated file).
- Service-layer parity already in place from precursor #12378 (`buildOfficialTelegramBot` + `loadFeatureSwitchOverrides`); this PR is the pure mechanical Stage 2 step.
- Port web's 3 GET test cases 1:1 plus reuse the precursor's `helpers/zero-telegram.ts` (no new helper file).

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-integrations-telegram.test.ts` — 3/3 pass.
- [x] `pnpm -F api lint` — clean.
- [x] `pnpm -F api check-types` — clean.
- [x] `grep -c shadowCompareRoute turbo/apps/api/src/signals/routes/zero-integrations-telegram.ts` → `0`.
- [x] No `apps/web/**` modifications.

## Test inventory (3 cases)

1. `returns 401 when no auth token is provided` *(web 1:1; collapses with the standard api 401-unauth case)*
2. `lists the official bot and custom Telegram bots in the active org` *(web 1:1; seeds 2 in-org installations + 1 cross-org; verifies cross-org bot is filtered out)*
3. `returns the official bot when the active org has no custom Telegram bots` *(web 1:1; verifies official-only fallback)*

## New auth pattern (first Stage 2 to use Zero token directly)

This route is capability-gated (`requiredCapability: "telegram:read"`). Clerk session does not satisfy the gate; only Zero tokens with that capability authenticate. The test file mints them via:

```ts
signSandboxJwtForTests({
  scope: "zero" as const,
  userId, orgId, runId, capabilities: ["telegram:read"], iat, exp,
})
```

The `signSandboxJwtForTests` helper accepts a generic `JwtPayload` and the `scope: "zero"` discriminator drives `verifyZeroToken` to recognize it. Pattern reference: `health-auth-probe.test.ts`.

The api-specific 401-missing-org case used by other Stage 2 PRs is **N/A** for capability-gated routes — Zero tokens carry `orgId` by construction, so the `missingOrganizationStatus: 401` branch is unreachable. Web case 1 (401 no auth) and the api 401-unauth case collapse to a single test.

For case 2 (mixed list), seeded `org_members_cache` rows to short-circuit the Clerk-based role lookup that `zeroAuth$` falls back to when no cache row exists.

## Rollback

`git revert` the commit. Web's `GET /api/zero/integrations/telegram/bots` route stays in place; disabling the `apiBackend` feature switch returns traffic to web. No DB or schema changes.

Closes #12366