### PR TITLE
refactor(api): migrate runs runner get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
@@ -35,6 +35,7 @@ interface SeedRunArgs {
   readonly scheduleId?: string;
   readonly chatThreadId?: string;
   readonly status?: string;
+  readonly sandboxReuseResult?: string | null;
 }
 
 interface SeedScheduleArgs {
@@ -264,6 +265,7 @@ export const seedRun$ = command(
         prompt: "test prompt",
         status: args.status ?? "pending",
         sessionId: session.id,
+        sandboxReuseResult: args.sandboxReuseResult ?? null,
       })
       .returning({ id: agentRuns.id });
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-runner.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-runner.test.ts
@@ -1,0 +1,249 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroRunRunnerContract } from "@vm0/api-contracts/contracts/zero-runs";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+// Reusing run-seeding helpers from the usage-insight test module — same
+// fixture shape (orgId/userId pair, then compose+run inserts), no need to
+// duplicate. Same precedent as zero-runs-queue.test.ts (PR #12402).
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+describe("GET /api/zero/runs/:id/runner", () => {
+  const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroRunRunnerContract);
+
+    const response = await accept(
+      client.getRunner({
+        params: { id: randomUUID() },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+
+    const client = setupApp({ context })(zeroRunRunnerContract);
+
+    const response = await accept(
+      client.getRunner({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns the sandboxReuseResult when set on the run", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "completed",
+        sandboxReuseResult: "reused",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunRunnerContract);
+
+    const response = await accept(
+      client.getRunner({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ sandboxReuseResult: "reused" });
+  });
+
+  it("returns null sandboxReuseResult for runs that never set the field", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunRunnerContract);
+
+    const response = await accept(
+      client.getRunner({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ sandboxReuseResult: null });
+  });
+
+  it("returns 404 when the run does not exist", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunRunnerContract);
+
+    const response = await accept(
+      client.getRunner({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Agent run not found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 404 when the run belongs to a different user (no existence leak)", async () => {
+    const ownerFixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: ownerFixture.orgId, userId: ownerFixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: ownerFixture.orgId,
+        userId: ownerFixture.userId,
+        composeId: compose.composeId,
+        status: "completed",
+        sandboxReuseResult: "poolMiss",
+      },
+      context.signal,
+    );
+
+    const otherFixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(otherFixture.userId, otherFixture.orgId);
+
+    const client = setupApp({ context })(zeroRunRunnerContract);
+
+    const response = await accept(
+      client.getRunner({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Agent run not found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 403 for a sandbox token without agent-run:read capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const runId = `run_${randomUUID()}`;
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId,
+      capabilities: ["file:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const client = setupApp({ context })(zeroRunRunnerContract);
+
+    const response = await accept(
+      client.getRunner({
+        params: { id: randomUUID() },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: agent-run:read",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-runs.ts
+++ b/turbo/apps/api/src/signals/routes/zero-runs.ts
@@ -74,10 +74,7 @@ export const zeroRunsRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroRunRunnerContract.getRunner,
-    handler: shadowCompareRoute({
-      route: zeroRunRunnerContract.getRunner,
-      handler: authRoute(runReadAuth, getRunRunnerInner$),
-    }),
+    handler: authRoute(runReadAuth, getRunRunnerInner$),
   },
   {
     route: zeroRunsByIdContract.getById,


### PR DESCRIPTION
## Summary

- make `GET /api/zero/runs/:id/runner` API-authoritative by removing the `shadowCompareRoute(...)` wrapper around the runner route entry only
- shared file `zero-runs.ts` goes from 2 → 1 `shadowCompareRoute(...)` invocations (getById retained for separate Stage 2 follow-up)
- `shadowCompareRoute` import retained (still consumed by getById wrapper)
- add api integration tests covering all 5 web GET cases plus an api missing-org 401 + sandbox capability gate 403 (7 total)
- extend `seedRun$` in `helpers/zero-usage-insight.ts` with optional `sandboxReuseResult` field (additive — defaults to null, no impact on existing tests)
- strengthen the cross-user 404 case beyond web's baseline by pinning the response message to enforce the no-existence-leak contract

Closes #12407

Part of epic #12290.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-runner.test.ts` — 7 / 7 passing
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-insight.test.ts src/signals/routes/__tests__/zero-runs-queue.test.ts` — 24 / 24 passing (helper-extension sanity)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `grep -c "shadowCompareRoute(" turbo/apps/api/src/signals/routes/zero-runs.ts` — **1** (down from 2)

## Test cases

| # | Case | Mirrors web |
|---|------|-------------|
| 1 | unauthenticated → 401 | "returns 401 when not authenticated" (line 96) |
| 2 | session, no active org → 401 | n/a — added per epic pattern |
| 3 | sandboxReuseResult set → 200 `{sandboxReuseResult: "reused"}` | "returns sandboxReuseResult when set" (line 38) |
| 4 | sandboxReuseResult null → 200 `{sandboxReuseResult: null}` | "returns null sandboxReuseResult for older runs" (line 54) |
| 5 | run not found → 404 with NOT_FOUND code | "returns 404 when run not found" (line 69) |
| 6 | cross-user → 404 with same message as not-found (no existence leak) | "returns 404 when run belongs to a different user" (line 80) — **strengthened** |
| 7 | sandbox token w/o agent-run:read → 403 | n/a — added per #12402 pattern |

## Service parity

API `zeroRunRunner` and web `getRunner` execute identical SQL (same `WHERE id = ? AND userId = ? AND orgId = ?` filter, same column selection, same `sandboxReuseResultSchema.nullable().parse(...)` validation). Cross-user queries return null/404 via the SQL-level `userId` filter — no information leak via 403.

## Cross-user 404 strengthening

Web's case 4 only asserts `response.status === 404`. This PR additionally asserts the response body matches the same `"Agent run not found"` message used for genuine not-found. Pinning the message explicitly enforces the no-existence-leak contract — a regression that returned `"Agent run owned by different user"` would still pass web's assertion but would fail this one. Now that api is authoritative for this endpoint, the contract should be explicit.

## Helper extension

`seedRun$` in `helpers/zero-usage-insight.ts` gains an optional `sandboxReuseResult: string | null` field. The default null is the current observable behavior (the column is nullable and not previously inserted), so existing usage-insight and runs-queue tests are unaffected. Sanity-tested via the verification step above.

## Behavioral note

Web returns 404 if `resolveOrg` rejects. The api implementation skips `resolveOrg` (Clerk-implies-membership simplification) — `zeroRunRunner` queries by `(id, userId, orgId)` and returns null/404 for any non-matching combination. Same accepted gap as PRs #12312 / #12314 / #12315 / #12337 / #12351 / #12363 / #12377 / #12384 / #12388 / #12392 / #12402.

## Rollback

Disabling the `apiBackend` feature switch routes traffic back to `apps/web`. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)