### PR TITLE
refactor(api): migrate agent instructions get

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
@@ -6,7 +6,9 @@ import {
   VOLUME_ORG_USER_ID,
 } from "@vm0/core/storage-names";
 import { command } from "ccstate";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroSkills } from "@vm0/db/schema/zero-skill";
 import { eq } from "drizzle-orm";
 
@@ -38,6 +40,11 @@ export const deleteSkillsForFixture$ = command(
     await db.delete(storages).where(eq(storages.orgId, fixture.orgId));
     signal.throwIfAborted();
     await db.delete(zeroSkills).where(eq(zeroSkills.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    // agent_composes cascades to zero_agents via FK.
+    await db
+      .delete(agentComposes)
+      .where(eq(agentComposes.orgId, fixture.orgId));
     signal.throwIfAborted();
   },
 );
@@ -222,3 +229,33 @@ export function mockSkillContent(
     return Promise.resolve({});
   });
 }
+
+export const seedAgentForInstructions$ = command(
+  async (
+    { set },
+    args: { orgId: string; userId: string; name?: string },
+    signal: AbortSignal,
+  ): Promise<{ agentId: string }> => {
+    const db = set(writeDb$);
+    const agentId = randomUUID();
+    const name = args.name ?? `agent-${randomUUID().slice(0, 8)}`;
+    await db.insert(agentComposes).values({
+      id: agentId,
+      userId: args.userId,
+      orgId: args.orgId,
+      name,
+    });
+    signal.throwIfAborted();
+    await db
+      .insert(zeroAgents)
+      .values({
+        id: agentId,
+        orgId: args.orgId,
+        owner: args.userId,
+        name,
+      })
+      .onConflictDoNothing();
+    signal.throwIfAborted();
+    return { agentId };
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import {
+  zeroAgentInstructionsContract,
   zeroSkillsCollectionContract,
   zeroSkillsDetailContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
@@ -10,6 +11,7 @@ import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import {
   deleteSkillsForFixture$,
   mockSkillContent,
+  seedAgentForInstructions$,
   seedSkill$,
   seedSkillStorage$,
   seedSkillsFixture$,
@@ -34,6 +36,10 @@ function listClient() {
 
 function detailClient() {
   return setupApp({ context })(zeroSkillsDetailContract);
+}
+
+function instructionsClient() {
+  return setupApp({ context })(zeroAgentInstructionsContract);
 }
 
 describe("GET /api/zero/skills", () => {
@@ -316,5 +322,105 @@ describe("GET /api/zero/skills/:name", () => {
 
     expect(response.body.content).toBe("# Readable");
     expect(response.body.name).toBe("readable-skill");
+  });
+});
+
+describe("GET /api/zero/agents/:id/instructions", () => {
+  const track = createFixtureTracker<SkillsFixture>((fixture) => {
+    return store.set(deleteSkillsForFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      instructionsClient().get({
+        headers: {},
+        params: { id: randomUUID() },
+      }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const response = await accept(
+      instructionsClient().get({
+        headers: authHeaders(),
+        params: { id: randomUUID() },
+      }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns null content when no instructions uploaded", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      instructionsClient().get({
+        headers: authHeaders(),
+        params: { id: agentId },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ content: null, filename: null });
+  });
+
+  it("returns 404 for unknown agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const unknownAgentId = randomUUID();
+    const response = await accept(
+      instructionsClient().get({
+        headers: authHeaders(),
+        params: { id: unknownAgentId },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: `Agent not found: ${unknownAgentId}`,
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("allows org member to read instructions", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const response = await accept(
+      instructionsClient().get({
+        headers: authHeaders(),
+        params: { id: agentId },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ content: null, filename: null });
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-agent-instructions.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agent-instructions.ts
@@ -7,7 +7,6 @@ import {
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf } from "../context/request";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { notFound } from "../../lib/error";
 import { zeroAgentInstructions } from "../services/zero-agent-instructions.service";
 import { zeroSkillDetail } from "../services/zero-skill-detail.service";
@@ -42,10 +41,7 @@ const getSkillDetailInner$ = computed(async (get) => {
 export const zeroAgentInstructionsRoutes: readonly RouteEntry[] = [
   {
     route: zeroAgentInstructionsContract.get,
-    handler: shadowCompareRoute({
-      route: zeroAgentInstructionsContract.get,
-      handler: authRoute(agentReadAuth, getAgentInstructionsInner$),
-    }),
+    handler: authRoute(agentReadAuth, getAgentInstructionsInner$),
   },
   {
     route: zeroSkillsDetailContract.get,


### PR DESCRIPTION
Closes #12406

## Summary
- Make `GET /api/zero/agents/:id/instructions` authoritative in `apps/api` by removing the `shadowCompareRoute(...)` wrapper from the instructions route entry in the shared `zero-agent-instructions.ts` file
- **Removes the `shadowCompareRoute` import** — companion to PR #12401 which migrated the skill-detail route in the same file. After this PR, `zero-agent-instructions.ts` has zero `shadowCompareRoute` references — file fully migrated
- Add 2 web GET cases ported 1:1 + 2 api-specific 401 cases + 1 cross-cutting member-can-read = 5 cases total
- Append a new describe block to existing `zero-skills.test.ts` (keeps tests for the same physical route file co-located, per PR #12401 precedent)
- Extend `helpers/zero-skills.ts` with `seedAgentForInstructions$` + a one-line cleanup extension (`agent_composes` cascades to `zero_agents` via FK)
- PUT and other agents/* routes are out of scope — separate Stage 3 follow-ups

## Behavior parity
The api `zeroAgentInstructions` Computed and the web GET handler both: lookup agent by `(id, orgId)` via `zero_agents JOIN agent_composes` (return null → 404 if not found), look up instructions storage volume (return `{content: null, filename: null}` if no storage row), then extract from the S3 archive. Identical control flow at every step.

## Capability gate
`requiredCapability: "agent:read"` only applies to Zero/CLI tokens; Clerk session paths bypass it (verified at `clerk-session.ts:46-67`). The "allows org member to read instructions" case uses `mocks.clerk.session(userId, orgId, "org:member")` and confirms 200 — pins this semantic.

## Scope
- Route + helper extension + test extension. **No new file.** Skill-detail entry in route file untouched (already migrated by PR #12401).
- No `apps/web/**` modifications.

## Test cases (all 5 in new describe)
1. returns 401 when the request is unauthenticated
2. returns 401 when the authenticated session has no organization (api-specific)
3. returns null content when no instructions uploaded (web port — agent exists, no storage row)
4. returns 404 for unknown agent (web port — no agent row)
5. allows org member to read instructions (cross-cutting — pins Clerk-bypass capability semantic)

None of the 5 cases reach S3 (401 short-circuits before handler; 404 short-circuits at agent lookup; null-content short-circuits at storage lookup; member case = null-content path) — no S3 mocking needed.

## Test plan
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-skills.test.ts` — 16/16 passed (11 existing + 5 new, first run)
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `grep -c shadowCompareRoute zero-agent-instructions.ts` returns 0 — file fully migrated
- [x] Pre-commit: prettier, knip, `turbo run check-types`, commitlint — all green

## Rollback
Disable the `apiBackend` feature switch — traffic returns to `apps/web`. No DB or schema change.