### PR TITLE
chore(api): extract test-side encrypt helper to shared module

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/encrypt-secret.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/encrypt-secret.ts
@@ -1,0 +1,19 @@
+import { createCipheriv, randomBytes } from "node:crypto";
+
+import { env } from "../../../../lib/env";
+
+export function encryptSecretForTests(plaintext: string): string {
+  const key = Buffer.from(env("SECRETS_ENCRYPTION_KEY"), "hex");
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv, { authTagLength: 16 });
+  const data = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  return [
+    iv.toString("base64"),
+    authTag.toString("base64"),
+    data.toString("base64"),
+  ].join(":");
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-integrations-slack.ts
@@ -1,4 +1,4 @@
-import { createCipheriv, randomBytes, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 
 import { command } from "ccstate";
 import {
@@ -10,8 +10,8 @@ import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { eq } from "drizzle-orm";
 
-import { env } from "../../../../lib/env";
 import { writeDb$ } from "../../../external/db";
+import { encryptSecretForTests } from "./encrypt-secret";
 
 export interface SlackIntegrationFixture {
   readonly orgId: string;
@@ -30,22 +30,6 @@ interface SeedSlackConnectionValues {
   readonly slackWorkspaceId: string;
   readonly vm0UserId: string;
   readonly slackUserId?: string;
-}
-
-function encryptSecretForTests(plaintext: string): string {
-  const key = Buffer.from(env("SECRETS_ENCRYPTION_KEY"), "hex");
-  const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", key, iv, { authTagLength: 16 });
-  const data = Buffer.concat([
-    cipher.update(plaintext, "utf8"),
-    cipher.final(),
-  ]);
-  const authTag = cipher.getAuthTag();
-  return [
-    iv.toString("base64"),
-    authTag.toString("base64"),
-    data.toString("base64"),
-  ].join(":");
 }
 
 function randomSlackId(prefix: string): string {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-model-providers.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-model-providers.ts
@@ -1,12 +1,12 @@
-import { createCipheriv, randomBytes, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 
 import { command } from "ccstate";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { secrets } from "@vm0/db/schema/secret";
 import { and, eq } from "drizzle-orm";
 
-import { env } from "../../../../lib/env";
 import { writeDb$ } from "../../../external/db";
+import { encryptSecretForTests } from "./encrypt-secret";
 
 const ORG_SENTINEL_USER_ID = "__org__";
 
@@ -23,22 +23,6 @@ interface SeedOrgModelProviderValues {
   readonly authMethod?: string | null;
 }
 
-function encryptSecretValueForTests(plaintext: string): string {
-  const key = Buffer.from(env("SECRETS_ENCRYPTION_KEY"), "hex");
-  const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", key, iv, { authTagLength: 16 });
-  const data = Buffer.concat([
-    cipher.update(plaintext, "utf8"),
-    cipher.final(),
-  ]);
-  const authTag = cipher.getAuthTag();
-  return [
-    iv.toString("base64"),
-    authTag.toString("base64"),
-    data.toString("base64"),
-  ].join(":");
-}
-
 export const seedOrgModelProvider$ = command(
   async (
     { set },
@@ -53,7 +37,7 @@ export const seedOrgModelProvider$ = command(
         .insert(secrets)
         .values({
           name: values.secretName,
-          encryptedValue: encryptSecretValueForTests("test-secret-value"),
+          encryptedValue: encryptSecretForTests("test-secret-value"),
           type: "model-provider",
           userId: ORG_SENTINEL_USER_ID,
           orgId: values.orgId,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-channels.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-channels.ts
@@ -1,11 +1,11 @@
-import { createCipheriv, randomBytes, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 
 import { command } from "ccstate";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { eq } from "drizzle-orm";
 
-import { env } from "../../../../lib/env";
 import { writeDb$ } from "../../../external/db";
+import { encryptSecretForTests } from "./encrypt-secret";
 
 export interface SlackInstallationFixture {
   readonly orgId: string;
@@ -16,22 +16,6 @@ interface SeedSlackInstallationValues {
   readonly orgId?: string;
   readonly botToken?: string;
   readonly workspaceName?: string;
-}
-
-function encryptBotTokenForTests(plaintext: string): string {
-  const key = Buffer.from(env("SECRETS_ENCRYPTION_KEY"), "hex");
-  const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", key, iv, { authTagLength: 16 });
-  const data = Buffer.concat([
-    cipher.update(plaintext, "utf8"),
-    cipher.final(),
-  ]);
-  const authTag = cipher.getAuthTag();
-  return [
-    iv.toString("base64"),
-    authTag.toString("base64"),
-    data.toString("base64"),
-  ].join(":");
 }
 
 function randomSlackId(prefix: string): string {
@@ -52,7 +36,7 @@ export const seedSlackInstallation$ = command(
       slackWorkspaceId,
       slackWorkspaceName: values.workspaceName ?? "Test Workspace",
       orgId,
-      encryptedBotToken: encryptBotTokenForTests(
+      encryptedBotToken: encryptSecretForTests(
         values.botToken ?? "xoxb-test-token",
       ),
       botUserId: randomSlackId("U"),

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-telegram.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-telegram.ts
@@ -1,4 +1,4 @@
-import { createCipheriv, randomBytes, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 
 import { command } from "ccstate";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
@@ -9,8 +9,8 @@ import { telegramUserAgentPreferences } from "@vm0/db/schema/telegram-user-agent
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { eq, inArray } from "drizzle-orm";
 
-import { env } from "../../../../lib/env";
 import { writeDb$ } from "../../../external/db";
+import { encryptSecretForTests } from "./encrypt-secret";
 
 export interface TelegramFixture {
   readonly orgId: string;
@@ -56,22 +56,6 @@ interface SeedUserAgentPreferenceValues {
   readonly composeId: string;
 }
 
-function encryptBotTokenForTests(plaintext: string): string {
-  const key = Buffer.from(env("SECRETS_ENCRYPTION_KEY"), "hex");
-  const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", key, iv, { authTagLength: 16 });
-  const data = Buffer.concat([
-    cipher.update(plaintext, "utf8"),
-    cipher.final(),
-  ]);
-  const authTag = cipher.getAuthTag();
-  return [
-    iv.toString("base64"),
-    authTag.toString("base64"),
-    data.toString("base64"),
-  ].join(":");
-}
-
 export const seedTelegramInstallation$ = command(
   async (
     { set },
@@ -107,7 +91,7 @@ export const seedTelegramInstallation$ = command(
         values.botUsername === undefined
           ? `bot_${values.telegramBotId}`
           : values.botUsername,
-      encryptedBotToken: encryptBotTokenForTests("test-bot-token"),
+      encryptedBotToken: encryptSecretForTests("test-bot-token"),
       webhookSecret: `whs_${randomUUID()}`,
       defaultComposeId: composeId,
       ownerUserId: values.ownerUserId,


### PR DESCRIPTION
## Summary

Pure code-shape refactor. Extract the AES-256-GCM test-side encrypt helper from 4 duplicate locations into a single shared module at `__tests__/helpers/encrypt-secret.ts`. Standardize on the canonical name `encryptSecretForTests` across all 4 call sites.

Closes #12403 (the third-occurrence trigger surfaced during PR #12396 — extraction was deliberately deferred there to keep the migration PR focused).

## Affected helpers

| File | Was | Now |
|---|---|---|
| `helpers/zero-slack-channels.ts` | `encryptBotTokenForTests` (local) | `import { encryptSecretForTests } from "./encrypt-secret"` |
| `helpers/zero-telegram.ts` | `encryptBotTokenForTests` (local) | same import |
| `helpers/zero-model-providers.ts` | `encryptSecretValueForTests` (local) | same import |
| `helpers/zero-integrations-slack.ts` | `encryptSecretForTests` (local — already canonical name) | same import |

Each helper drops its local function plus the now-unused `createCipheriv` / `randomBytes` / `env` imports.

## Test plan — verification by no-modification

The verification discipline for a pure code-shape refactor is that **the existing test files pass without modification**.

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-slack-channels.test.ts src/signals/routes/__tests__/zero-telegram-data.service.test.ts src/signals/routes/__tests__/zero-integrations-telegram.test.ts src/signals/routes/__tests__/zero-model-providers.test.ts src/signals/routes/__tests__/zero-integrations-slack-status.test.ts` — **38/38 pass** (5 test files).
- [x] `pnpm -F api lint` — clean.
- [x] `pnpm -F api check-types` — clean.
- [x] Pre-commit hooks — clean.
- [x] No test code changes; no behavior change.

## Diff

5 files touched, **+30 / −75** LoC. Net negative.

## Rollback

`git revert` of the commit. No behavior change to revert.