### PR TITLE
refactor(api): migrate runs get-by-id

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-by-id.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-by-id.test.ts
@@ -1,0 +1,234 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroRunsByIdContract } from "@vm0/api-contracts/contracts/zero-runs";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+// Reusing run-seeding helpers from the usage-insight test module — same
+// fixture shape (orgId/userId pair, then compose+run inserts), no need to
+// duplicate. Same precedent as zero-runs-runner.test.ts (PR #12408).
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+describe("GET /api/zero/runs/:id", () => {
+  const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroRunsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: randomUUID() },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+
+    const client = setupApp({ context })(zeroRunsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 400 when id is not a valid UUID", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: "2b9b2303" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 404 when the run does not exist", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Agent run not found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 404 when the run belongs to a different user (no existence leak)", async () => {
+    const ownerFixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: ownerFixture.orgId, userId: ownerFixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: ownerFixture.orgId,
+        userId: ownerFixture.userId,
+        composeId: compose.composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+
+    const otherFixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(otherFixture.userId, otherFixture.orgId);
+
+    const client = setupApp({ context })(zeroRunsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Agent run not found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns the run details", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.runId).toBe(runId);
+    expect(response.body.status).toBe("running");
+    expect(response.body.prompt).toBe("test prompt");
+  });
+
+  it("returns 403 for a sandbox token without agent-run:read capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const runId = `run_${randomUUID()}`;
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId,
+      capabilities: ["file:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const client = setupApp({ context })(zeroRunsByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: randomUUID() },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: agent-run:read",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-runs.ts
+++ b/turbo/apps/api/src/signals/routes/zero-runs.ts
@@ -8,7 +8,6 @@ import {
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf } from "../context/request";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { notFound } from "../../lib/error";
 import {
   zeroOrgTier,
@@ -78,9 +77,6 @@ export const zeroRunsRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroRunsByIdContract.getById,
-    handler: shadowCompareRoute({
-      route: zeroRunsByIdContract.getById,
-      handler: authRoute(runReadAuth, getRunByIdInner$),
-    }),
+    handler: authRoute(runReadAuth, getRunByIdInner$),
   },
 ];


### PR DESCRIPTION
Closes #12411

## Summary
- Make `GET /api/zero/runs/:id` authoritative in `apps/api` by removing the `shadowCompareRoute(...)` wrapper from the getById route entry in the shared `zero-runs.ts` file
- **Removes the `shadowCompareRoute` import** — companion to PR #12402 (queue) and PR #12408 (runner) which migrated the other two routes in the same file. After this PR, `zero-runs.ts` has zero `shadowCompareRoute` references — file fully migrated (13th in the batch)
- Add 5 web GET cases ported 1:1 + 1 api-specific 401 missing-org + 1 cross-user 404 = 7 cases total
- New test file `zero-runs-by-id.test.ts` (sibling to existing `zero-runs-queue.test.ts` and `zero-runs-runner.test.ts`)
- POST/cancel/context/network/telemetry routes are out of scope — separate Stage 3 follow-ups

## Behavior parity
The api `zeroRunById` Computed and the web GET handler both query `agent_runs` by `(id, userId, orgId)` ownership predicate. Returns null → 404 if not found OR if the run belongs to a different user (security: no existence leak). Identical control flow.

## Capability gate
`requiredCapability: "agent-run:read"` enforced via auth-context for Zero/CLI tokens. Test case 7 confirms a sandbox token with `["file:read"]` only is rejected with 403 + structured envelope.

## Scope
- Route + new test only. **No new helper file** — `helpers/zero-usage-insight.ts` already has all needed seeders (per PR #12408 precedent).
- Queue + runner entries in `zero-runs.ts` untouched (already migrated by PR #12402 / #12408).
- No `apps/web/**` modifications.

## Test cases (all 7)
1. returns 401 when the request is unauthenticated (web port)
2. returns 401 when the authenticated session has no active organization (api-specific)
3. returns 400 when id is not a valid UUID (web port — contract validation)
4. returns 404 when the run does not exist (web port)
5. returns 404 when the run belongs to a different user (no existence leak) (cross-user — PR #12408 precedent, locks in security-critical no-leak property)
6. returns the run details (web port)
7. returns 403 for a sandbox token without agent-run:read capability (web port)

## Test plan
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-by-id.test.ts` — 7/7 passed (first run)
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `grep -c shadowCompareRoute zero-runs.ts` returns 0 — file fully migrated (13th in the batch)
- [x] Pre-commit: prettier, knip, `turbo run check-types`, commitlint — all green

## Rollback
Disable the `apiBackend` feature switch — traffic returns to `apps/web`. No DB or schema change.