### PR TITLE
refactor(api): migrate composes list get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-composes-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-composes-list.test.ts
@@ -1,0 +1,220 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroComposesListContract } from "@vm0/api-contracts/contracts/zero-composes";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+// Reusing compose-seeding helper from the team test module — same fixture
+// shape (org/user/composes), no need to duplicate. Same precedent as
+// zero-runs-queue.test.ts (PR #12402) reusing usage-insight helpers.
+import {
+  deleteTeamCompose$,
+  seedTeamCompose$,
+  type TeamComposeFixture,
+} from "./helpers/zero-team";
+
+const HEAD_VERSION_HEX = "a".repeat(64);
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+describe("GET /api/zero/composes/list", () => {
+  const track = createFixtureTracker<TeamComposeFixture>((fixture) => {
+    return store.set(deleteTeamCompose$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroComposesListContract);
+
+    const response = await accept(
+      client.list({ query: {}, headers: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 400 when the authenticated session has no active organization", async () => {
+    // The list route preserves authRoute({acceptAnySandboxCapability: true})
+    // and manually returns 400 with "Invalid request" to mirror web's
+    // wording verbatim — switching to authRoute's built-in
+    // requireOrganization check would change the message.
+    const fixture = await track(
+      store.set(seedTeamCompose$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+
+    const client = setupApp({ context })(zeroComposesListContract);
+
+    const response = await accept(
+      client.list({
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Invalid request",
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+
+  it("returns an empty list when the org has no composes", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroComposesListContract);
+
+    const response = await accept(
+      client.list({
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ composes: [] });
+  });
+
+  it("returns the org composes ordered by updatedAt desc", async () => {
+    const fixture = await track(
+      store.set(
+        seedTeamCompose$,
+        {
+          composes: [
+            {
+              displayName: "First Agent",
+              description: "first",
+              sound: "ding",
+              headVersionId: HEAD_VERSION_HEX,
+            },
+            {
+              displayName: "Second Agent",
+              description: "second",
+              sound: "pong",
+              headVersionId: HEAD_VERSION_HEX,
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroComposesListContract);
+
+    const response = await accept(
+      client.list({
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.composes).toHaveLength(2);
+    const names = response.body.composes.map((c) => {
+      return c.name;
+    });
+    const expectedFirstName = `agent-${fixture.composeIds[0]?.slice(0, 8) ?? ""}`;
+    const expectedSecondName = `agent-${fixture.composeIds[1]?.slice(0, 8) ?? ""}`;
+    expect(names).toContain(expectedFirstName);
+    expect(names).toContain(expectedSecondName);
+    for (const compose of response.body.composes) {
+      expect(compose.headVersionId).toBe(HEAD_VERSION_HEX);
+      expect(typeof compose.updatedAt).toBe("string");
+      expect(compose.id).toBeDefined();
+    }
+  });
+
+  it("does not include composes from other orgs", async () => {
+    const myFixture = await track(
+      store.set(
+        seedTeamCompose$,
+        {
+          composes: [{ displayName: "my-agent" }],
+        },
+        context.signal,
+      ),
+    );
+    const otherFixture = await track(
+      store.set(
+        seedTeamCompose$,
+        {
+          composes: [{ displayName: "other-agent" }],
+        },
+        context.signal,
+      ),
+    );
+
+    mocks.clerk.session(myFixture.userId, myFixture.orgId);
+
+    const client = setupApp({ context })(zeroComposesListContract);
+
+    const response = await accept(
+      client.list({
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.composes).toHaveLength(1);
+    const [only] = response.body.composes;
+    expect(only?.id).toBe(myFixture.composeIds[0]);
+    expect(only?.displayName).toBe("my-agent");
+    expect(
+      response.body.composes.map((c) => {
+        return c.id;
+      }),
+    ).not.toContain(otherFixture.composeIds[0]);
+  });
+
+  it("accepts sandbox tokens (matches web's acceptAnySandboxCapability behavior)", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const runId = `run_${randomUUID()}`;
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "sandbox",
+      userId,
+      orgId,
+      runId,
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const client = setupApp({ context })(zeroComposesListContract);
+
+    const response = await accept(
+      client.list({
+        query: {},
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+
+    // No composes seeded for the sandbox-derived orgId — empty list proves
+    // the sandbox token reached the inner handler.
+    expect(response.body).toStrictEqual({ composes: [] });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-composes.ts
+++ b/turbo/apps/api/src/signals/routes/zero-composes.ts
@@ -79,10 +79,10 @@ export const zeroComposesRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroComposesListContract.list,
-    handler: shadowCompareRoute({
-      route: zeroComposesListContract.list,
-      handler: authRoute({}, listComposesInner$),
-    }),
+    handler: authRoute(
+      { acceptAnySandboxCapability: true },
+      listComposesInner$,
+    ),
   },
   {
     route: zeroComposesByIdContract.getById,


### PR DESCRIPTION
## Summary

- make `GET /api/zero/composes/list` API-authoritative by removing the `shadowCompareRoute(...)` wrapper around the list route entry only
- shared file `zero-composes.ts` goes from 3 → 2 `shadowCompareRoute(...)` invocations (getByName + getById retained for separate Stage 2 follow-ups)
- `shadowCompareRoute` import retained (still consumed by getByName + getById wrappers)
- **Plan A2 fix**: add `acceptAnySandboxCapability: true` to the route's auth options to preserve web's sandbox-token acceptance — without this, the migration would tighten security (sandbox tokens get 401 on api vs 200 on web) which the migration policy treats as a divergence
- preserve the `authRoute({...}) + manual orgId check` pattern so api returns 400 with the verbatim "Invalid request" wording web emits (authRoute's built-in `requireOrganization` would emit "Explicit org context required" instead)
- add api integration tests covering all 3 in-scope web GET cases plus an api missing-org 400, cross-org isolation, and sandbox-token acceptance (6 total)
- reuse `seedTeamCompose$` / `deleteTeamCompose$` from existing `helpers/zero-team.ts` — no new helper file

Closes #12412

Part of epic #12290.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-composes-list.test.ts` — 6 / 6 passing
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-team.test.ts` — 5 / 5 passing (sanity, helper reused)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `grep -c "shadowCompareRoute(" turbo/apps/api/src/signals/routes/zero-composes.ts` — **2** (down from 3)

## Plan A2 — sandbox-token gap closed

Web's `requireAuth` was called with `acceptAnySandboxCapability: true`, so sandbox tokens reached the list handler. API's previous `authRoute({}, ...)` did NOT accept sandbox tokens (they fell through to the 401 path). Per migration policy, "behavior parity must be preserved" — api being more restrictive is a regression even if no current consumer hits the path.

This PR closes the gap with `authRoute({acceptAnySandboxCapability: true}, listComposesInner$)` (1-line change). Test 6 covers the new path: a sandbox-scope token reaches the inner handler and gets `{composes: []}` back (no composes seeded for the sandbox-derived orgId).

## Test cases

| # | Case | Mirrors web |
|---|------|-------------|
| 1 | unauthenticated → 401 | "should return 401 when not authenticated" (line 25) |
| 2 | session, no active org → 400 "Invalid request" | n/a — added; exercises the manual `if (!auth.orgId)` check + pins web-equivalent message |
| 3 | empty list → 200 `{composes: []}` | "should return no own composes when none exist in org" (line 38) |
| 4 | seeded composes → 200 with names + headVersionId | "should return all composes for the user's default org" (line 49) |
| 5 | cross-org isolation → 200 returns only active-org composes | "should filter by org correctly - not show other user's composes" (line 83) — defensive port for security boundary coverage |
| 6 | sandbox token (any capability) → 200 | n/a — covers the new `acceptAnySandboxCapability: true` flag |

## Service parity

API `zeroComposeList(orgId)` and web `listComposes(orgId)` execute identical SQL (same `from agentComposes leftJoin zeroAgents on id where orgId = ? order by updatedAt desc`) and identical projection. Web's `?? null` coalescing is cosmetic — the columns are nullable-typed; observable JSON output is identical.

## 403 FORBIDDEN gap

Web returns 403 when user is not member of resolved org. API skips this check. Same accepted gap as all prior epic PRs (Clerk-implies-membership simplification): #12312 / #12314 / #12315 / #12337 / #12351 / #12363 / #12377 / #12384 / #12388 / #12392 / #12402 / #12408.

## Rollback

Disabling the `apiBackend` feature switch routes traffic back to `apps/web`. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)