### PR TITLE
refactor(api): migrate run context get

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -1,3 +1,4 @@
+import { computed } from "ccstate";
 import { vi, type Mock } from "vitest";
 
 type AsyncMock = Mock<(...args: unknown[]) => Promise<unknown>>;
@@ -224,7 +225,17 @@ vi.mock("../signals/external/telegram-client", () => {
 
 vi.mock("../signals/external/axiom", () => {
   return {
-    queryAxiom: apiTestMocks.axiom.query,
+    // Wrap the underlying vi.fn() in a ccstate `computed` so `get(queryAxiom(apl))`
+    // resolves correctly. Tests configure responses via
+    // `context.mocks.axiom.query.mockResolvedValue(...)`.
+    queryAxiom: (apl: string) => {
+      return computed(() => {
+        return apiTestMocks.axiom.query(apl);
+      });
+    },
+    getDatasetName: (name: string) => {
+      return name;
+    },
   };
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-run-context.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-run-context.test.ts
@@ -1,0 +1,289 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroRunContextContract } from "@vm0/api-contracts/contracts/zero-runs";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+// Reuse run-seeding helpers from the usage-insight test module — same
+// fixture shape, no need to duplicate. Same precedent as PR #12408 / #12414.
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function makeSnapshot(runId: string): Record<string, unknown> {
+  return {
+    runId,
+    prompt: "test prompt",
+    appendSystemPrompt: null,
+    sessionId: null,
+    environment: { NODE_ENV: "production", API_KEY: "***" },
+    firewalls: [
+      {
+        name: "test-fw",
+        apis: [
+          {
+            base: "https://api.example.com",
+            permissions: [{ name: "read", rules: ["GET /users/*"] }],
+          },
+        ],
+      },
+    ],
+    volumes: [
+      {
+        name: "data",
+        mountPath: "/data",
+        vasStorageName: "vol-1",
+        vasVersionId: "ver-1",
+      },
+    ],
+    artifact: {
+      mountPath: "/artifacts",
+      vasStorageName: "art-1",
+      vasVersionId: "art-ver-1",
+    },
+    networkPolicies: null,
+    featureFlags: { computerUse: true, voiceChat: false },
+  };
+}
+
+describe("GET /api/zero/runs/:id/context", () => {
+  const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroRunContextContract);
+
+    const response = await accept(
+      client.getContext({
+        params: { id: randomUUID() },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+
+    const client = setupApp({ context })(zeroRunContextContract);
+
+    const response = await accept(
+      client.getContext({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 when the run does not exist", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunContextContract);
+
+    const response = await accept(
+      client.getContext({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Agent run not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 404 when run belongs to a different user (no existence leak)", async () => {
+    const ownerFixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: ownerFixture.orgId, userId: ownerFixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: ownerFixture.orgId,
+        userId: ownerFixture.userId,
+        composeId: compose.composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+
+    const otherFixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(otherFixture.userId, otherFixture.orgId);
+
+    const client = setupApp({ context })(zeroRunContextContract);
+
+    const response = await accept(
+      client.getContext({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Agent run not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 404 when context not available", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+    context.mocks.axiom.query.mockResolvedValue([]);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunContextContract);
+
+    const response = await accept(
+      client.getContext({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Run context not available", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns the run context snapshot", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+    context.mocks.axiom.query.mockResolvedValue([makeSnapshot(runId)]);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunContextContract);
+
+    const response = await accept(
+      client.getContext({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.runId).toBe(runId);
+    expect(response.body.prompt).toBe("test prompt");
+    expect(response.body.sessionId).toBeNull();
+    expect(response.body.environment).toStrictEqual({
+      NODE_ENV: "production",
+      API_KEY: "***",
+    });
+    expect(response.body.firewalls).toHaveLength(1);
+    expect(response.body.firewalls[0]?.name).toBe("test-fw");
+    expect(response.body.volumes).toHaveLength(1);
+    expect(response.body.artifact).toBeDefined();
+    expect(response.body.networkPolicies).toBeNull();
+    expect(response.body.featureFlags).toStrictEqual({
+      computerUse: true,
+      voiceChat: false,
+    });
+  });
+
+  it("returns 403 for a sandbox token without agent-run:read capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const tokenRunId = `run_${randomUUID()}`;
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId: tokenRunId,
+      capabilities: ["file:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const client = setupApp({ context })(zeroRunContextContract);
+
+    const response = await accept(
+      client.getContext({
+        params: { id: randomUUID() },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: agent-run:read",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-run-detail.ts
+++ b/turbo/apps/api/src/signals/routes/zero-run-detail.ts
@@ -29,10 +29,13 @@ const getContextInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroRunContextContract.getContext));
   const result = await get(zeroRunContext(params.id, auth.userId, auth.orgId));
-  if (!result) {
+  if (result.kind === "not-found") {
     return runNotFound;
   }
-  return { status: 200 as const, body: result };
+  if (result.kind === "no-snapshot") {
+    return notFound("Run context not available");
+  }
+  return { status: 200 as const, body: result.context };
 });
 
 const getNetworkLogsInner$ = computed(async (get) => {
@@ -78,10 +81,7 @@ const getAgentEventsInner$ = computed(async (get) => {
 export const zeroRunDetailRoutes: readonly RouteEntry[] = [
   {
     route: zeroRunContextContract.getContext,
-    handler: shadowCompareRoute({
-      route: zeroRunContextContract.getContext,
-      handler: authRoute(runReadAuth, getContextInner$),
-    }),
+    handler: authRoute(runReadAuth, getContextInner$),
   },
   {
     route: zeroRunNetworkLogsContract.getNetworkLogs,

--- a/turbo/apps/api/src/signals/services/zero-run-detail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-detail.service.ts
@@ -56,17 +56,22 @@ interface NetworkLogsParams {
   order: "asc" | "desc";
 }
 
+type RunContextResult =
+  | { readonly kind: "not-found" }
+  | { readonly kind: "no-snapshot" }
+  | { readonly kind: "ok"; readonly context: RunContextResponse };
+
 export function zeroRunContext(
   runId: string,
   userId: string,
   orgId: string,
-): Computed<Promise<RunContextResponse | null>> {
-  return computed(async (get): Promise<RunContextResponse | null> => {
+): Computed<Promise<RunContextResult>> {
+  return computed(async (get): Promise<RunContextResult> => {
     const db = get(db$);
 
     const owned = await verifyRunOwnership(db, runId, userId, orgId);
     if (!owned) {
-      return null;
+      return { kind: "not-found" };
     }
 
     // Get run metadata for vars
@@ -82,12 +87,12 @@ export function zeroRunContext(
       .limit(1);
 
     if (!run) {
-      return null;
+      return { kind: "not-found" };
     }
 
     const sanitizedRunId = runId.replace(/[^a-zA-Z0-9_-]/g, "");
     if (sanitizedRunId !== runId) {
-      return null;
+      return { kind: "not-found" };
     }
 
     const dataset = getDatasetName("run-context");
@@ -112,25 +117,29 @@ export function zeroRunContext(
       | undefined;
 
     if (!snapshot) {
-      return null;
+      return { kind: "no-snapshot" };
     }
 
     return {
-      prompt: run.prompt,
-      appendSystemPrompt: run.appendSystemPrompt ?? null,
-      runId,
-      sessionId: (snapshot.sessionId as string) ?? null,
-      secretNames: (run.secretNames as string[]) ?? [],
-      vars: (run.vars as Record<string, string> | undefined) ?? null,
-      environment: (snapshot.environment as Record<string, string>) ?? {},
-      firewalls: (snapshot.firewalls as RunContextResponse["firewalls"]) ?? [],
-      networkPolicies:
-        (snapshot.networkPolicies as RunContextResponse["networkPolicies"]) ??
-        null,
-      volumes: (snapshot.volumes as RunContextResponse["volumes"]) ?? [],
-      artifact: (snapshot.artifact as RunContextResponse["artifact"]) ?? null,
-      featureFlags:
-        (snapshot.featureFlags as RunContextResponse["featureFlags"]) ?? null,
+      kind: "ok",
+      context: {
+        prompt: run.prompt,
+        appendSystemPrompt: run.appendSystemPrompt ?? null,
+        runId,
+        sessionId: (snapshot.sessionId as string) ?? null,
+        secretNames: (run.secretNames as string[]) ?? [],
+        vars: (run.vars as Record<string, string> | undefined) ?? null,
+        environment: (snapshot.environment as Record<string, string>) ?? {},
+        firewalls:
+          (snapshot.firewalls as RunContextResponse["firewalls"]) ?? [],
+        networkPolicies:
+          (snapshot.networkPolicies as RunContextResponse["networkPolicies"]) ??
+          null,
+        volumes: (snapshot.volumes as RunContextResponse["volumes"]) ?? [],
+        artifact: (snapshot.artifact as RunContextResponse["artifact"]) ?? null,
+        featureFlags:
+          (snapshot.featureFlags as RunContextResponse["featureFlags"]) ?? null,
+      },
     };
   });
 }

--- a/turbo/packages/api-contracts/src/contracts/zero-runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-runs.ts
@@ -218,6 +218,7 @@ export const zeroRunContextContract = c.router({
       200: runContextResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
       404: apiErrorSchema,
     },
     summary: "Get run execution context snapshot for debugging",


### PR DESCRIPTION
Closes #12416

## Summary
- Make `GET /api/zero/runs/:id/context` authoritative in `apps/api` by removing the `shadowCompareRoute(...)` wrapper from the context route entry in the shared `zero-run-detail.ts` file
- networkLogs and agentEvents entries remain shadow-wrapped (separate Stage 2 follow-ups). `shadowCompareRoute` import retained.
- **Bundles a small service refactor** to fix a 404-message divergence: web emits `"Run context not available"` when the run exists but Axiom has no snapshot; api previously emitted `"Agent run not found"` for both 404 paths. The refactor changes `zeroRunContext` to return a discriminated `RunContextResult` so the route handler can emit the correct message per case (per Plan A2 guidance).
- Adds 7 API route test cases (4 web GET ports + 1 api 401 missing-org + 1 cross-user 404 + 1 api 403 capability gate)
- New test file `zero-run-context.test.ts` reusing `helpers/zero-usage-insight.ts`

## Test infrastructure adjustments
- Wraps mocked `queryAxiom` in a ccstate `computed` so `get(queryAxiom(apl))` resolves correctly (this is the first api test that exercises Axiom)
- Adds `getDatasetName` pass-through to the axiom mock so the service can build APL queries during tests
- Adds `403` to `zeroRunContextContract.responses` for consistency with `zeroRunRunnerContract` (the route legitimately emits 403 via the `agent-run:read` capability gate; was missing from the contract)

## Behavior parity
After this PR's small refactor, **404 messages match web exactly** for both paths:
- Run not owned / doesn't exist → `"Agent run not found"` (matches web's `getRunById` null branch)
- Run exists, Axiom returned no snapshot → `"Run context not available"` (matches web's `queryRunContext` null branch)

## Known data-source divergence (out of scope, documented)
The api maps `secretNames` from the `agent_runs.secretNames` column; web maps it from the Axiom snapshot. For seeded test data, the api returns `[]` (column not seeded) while web returns the snapshot value. This is a pre-existing api implementation choice; the PR does not change it. Test case 6 skips the `secretNames` assertion to avoid coupling. If it surfaces as a user-visible bug, file a precursor.

## Scope
- Service + route + test + test-mock + contract response addition. No new helper file.
- networkLogs + agentEvents entries in `zero-run-detail.ts` untouched (separate Stage 2 issues).
- No `apps/web/**` modifications.

## Test cases (all 7)
1. returns 401 when the request is unauthenticated
2. returns 401 when the authenticated session has no active organization (api-specific)
3. returns 404 when the run does not exist
4. returns 404 when run belongs to a different user (no existence leak) (cross-user — PR #12408/#12414 precedent)
5. returns 404 when context not available (web port — distinct message after service refactor)
6. returns the run context snapshot (web port)
7. returns 403 for a sandbox token without agent-run:read capability (api-specific, per #12402/#12408 pattern)

## Test plan
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-run-context.test.ts` — 7/7 passed (first run after Axiom mock fix)
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `grep -c shadowCompareRoute zero-run-detail.ts` returns 3 (down from 4 — 1 import + 2 wrappers retained for networkLogs + agentEvents)
- [x] Pre-commit: prettier, knip, `turbo run check-types`, commitlint — all green

## Rollback
Disable the `apiBackend` feature switch — traffic returns to `apps/web`. No DB or schema change. The service refactor is internal; the contract addition (403) is backward-compatible.