### PR TITLE
refactor(api): migrate run network logs get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-run-network-logs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-run-network-logs.test.ts
@@ -1,0 +1,304 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroRunNetworkLogsContract } from "@vm0/api-contracts/contracts/zero-runs";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function makeAxiomEvent(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    _time: "2026-04-01T10:00:00Z",
+    runId: "test-run",
+    userId: "test-user",
+    type: "http",
+    action: "ALLOW",
+    method: "GET",
+    url: "https://api.example.com/data",
+    host: "api.example.com",
+    port: 443,
+    status: 200,
+    latency_ms: 150,
+    request_size: 100,
+    response_size: 2048,
+    ...overrides,
+  };
+}
+
+describe("GET /api/zero/runs/:id/network", () => {
+  const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroRunNetworkLogsContract);
+
+    const response = await accept(
+      client.getNetworkLogs({
+        params: { id: randomUUID() },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+
+    const client = setupApp({ context })(zeroRunNetworkLogsContract);
+
+    const response = await accept(
+      client.getNetworkLogs({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 for a sandbox token without agent-run:read capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const runId = `run_${randomUUID()}`;
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId,
+      capabilities: ["file:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const client = setupApp({ context })(zeroRunNetworkLogsContract);
+
+    const response = await accept(
+      client.getNetworkLogs({
+        params: { id: randomUUID() },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: agent-run:read",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 404 when the run is not found", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunNetworkLogsContract);
+
+    const response = await accept(
+      client.getNetworkLogs({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns network logs for a run", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+
+    context.mocks.axiom.query.mockResolvedValue([
+      makeAxiomEvent({ runId, userId: fixture.userId }),
+      makeAxiomEvent({
+        runId,
+        userId: fixture.userId,
+        type: "tcp",
+        action: undefined,
+        method: undefined,
+        url: undefined,
+        status: undefined,
+        host: "redis.example.com",
+        port: 6379,
+      }),
+      makeAxiomEvent({
+        runId,
+        userId: fixture.userId,
+        type: "dns",
+        action: undefined,
+        method: undefined,
+        url: undefined,
+        status: undefined,
+        host: "api.github.com",
+        port: 53,
+        dns_event: "reply",
+        dns_result: "140.82.121.4",
+        dns_serial: "42",
+      }),
+    ]);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunNetworkLogsContract);
+
+    const response = await accept(
+      client.getNetworkLogs({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.networkLogs).toHaveLength(3);
+    expect(response.body.hasMore).toBeFalsy();
+    expect(response.body.networkLogs[0]?.type).toBe("http");
+    expect(response.body.networkLogs[0]?.method).toBe("GET");
+    expect(response.body.networkLogs[0]?.url).toBe(
+      "https://api.example.com/data",
+    );
+    expect(response.body.networkLogs[0]?.status).toBe(200);
+    expect(response.body.networkLogs[1]?.type).toBe("tcp");
+    expect(response.body.networkLogs[1]?.host).toBe("redis.example.com");
+    expect(response.body.networkLogs[1]?.port).toBe(6379);
+    expect(response.body.networkLogs[2]?.type).toBe("dns");
+    expect(response.body.networkLogs[2]?.host).toBe("api.github.com");
+    expect(response.body.networkLogs[2]?.dns_event).toBe("reply");
+    expect(response.body.networkLogs[2]?.dns_result).toBe("140.82.121.4");
+    expect(response.body.networkLogs[2]?.dns_serial).toBe("42");
+  });
+
+  it("returns empty array when no logs", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+
+    context.mocks.axiom.query.mockResolvedValue([]);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunNetworkLogsContract);
+
+    const response = await accept(
+      client.getNetworkLogs({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.networkLogs).toStrictEqual([]);
+    expect(response.body.hasMore).toBeFalsy();
+  });
+
+  it("sets hasMore when results exceed limit", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+
+    context.mocks.axiom.query.mockResolvedValue(
+      Array.from({ length: 3 }, (_, index) => {
+        return makeAxiomEvent({
+          runId,
+          userId: fixture.userId,
+          url: `https://api.example.com/${index}`,
+        });
+      }),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunNetworkLogsContract);
+
+    const response = await accept(
+      client.getNetworkLogs({
+        params: { id: runId },
+        query: { limit: 2 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.networkLogs).toHaveLength(2);
+    expect(response.body.hasMore).toBeTruthy();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-run-detail.ts
+++ b/turbo/apps/api/src/signals/routes/zero-run-detail.ts
@@ -85,10 +85,7 @@ export const zeroRunDetailRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroRunNetworkLogsContract.getNetworkLogs,
-    handler: shadowCompareRoute({
-      route: zeroRunNetworkLogsContract.getNetworkLogs,
-      handler: authRoute(runReadAuth, getNetworkLogsInner$),
-    }),
+    handler: authRoute(runReadAuth, getNetworkLogsInner$),
   },
   {
     route: zeroRunAgentEventsContract.getAgentEvents,

--- a/turbo/packages/api-contracts/src/contracts/zero-runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-runs.ts
@@ -246,6 +246,7 @@ export const zeroRunNetworkLogsContract = c.router({
       200: networkLogsResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
       404: apiErrorSchema,
     },
     summary: "Get network logs for a run",


### PR DESCRIPTION
## Summary

- Drop the `shadowCompareRoute(...)` wrapper from the `getNetworkLogs` route in `zero-run-detail.ts`. Sibling routes `getContext` and `getAgentEvents` remain shadow-wrapped (separate Stage 2 PRs). File goes 3 → 2 wrappers post-merge (1 import + 2 wrappers).
- Port all 5 web GET cases 1:1 + 2 api-specific cases (401-missing-org and 403-missing-capability per #12402/#12408 pattern) = **7 tests total**.
- Reuse `helpers/zero-usage-insight.ts` for run seeding (no new helper file).

## Plan A2 micro-fix bundled

Added `403: apiErrorSchema` to `zeroRunNetworkLogsContract.getNetworkLogs.responses`. The api auth flow returns 403 for missing-capability via `sandboxTokenAuthError`, but the contract previously listed only 200/400/401/404. Sibling contracts (`zeroRunByIdContract`, `zeroRunRunnerContract`, `zeroRunsQueueContract`) already list 403 — this brings network-logs to parity. (Sibling contracts `getContext` / `getAgentEvents` share the same omission; their fix lands with their own Stage 2 PRs.)

## Test mock infrastructure update

`apps/api/src/__tests__/mocks.ts` updated:

1. **Added `getDatasetName` stub** returning `vm0-${base}-test`. The previous mock only exposed `queryAxiom`, but the service callers in `zero-run-detail.service.ts` and `zero-logs.service.ts` also import `getDatasetName`. Without this stub the service threw at runtime in tests.
2. **Wrapped `queryAxiom` mock in `computed()`** so it returns `Computed<Promise<...>>` matching the real signature. The service calls `get(queryAxiom(apl))`, which requires a `Computed`, not a raw resolved value.

These mock changes are infrastructure-level (apps/api/src/__tests__/mocks.ts is global). Verified the **full api suite still passes (471/471)** post-change — no other test relied on the old non-Computed shape.

## Pagination hasMore parity

Verified byte-identical between web and api before this PR:
- Both fetch `limit + 1`, slice to `limit`, set `hasMore = events.length > limit`.
- Identical APL string structure (with one flagged-not-fixed variance: web wraps `runId` via `escapeAplString()`, api uses raw value — UUIDs are always APL-safe by construction; unreachable in production).
- Field-by-field record mapping covers identical 35+ fields (timestamp, type, action, ..., response_body_truncated).

No service changes needed.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-run-network-logs.test.ts` — 7/7 pass.
- [x] `pnpm -F api exec vitest run` (full suite) — 471/471 pass.
- [x] `pnpm -F api lint` — clean.
- [x] `pnpm -F api check-types` — clean.
- [x] `grep -c shadowCompareRoute turbo/apps/api/src/signals/routes/zero-run-detail.ts` returns `3` (1 import + 2 wrappers; was 4 = 1 + 3).
- [x] No `apps/web/**` modifications.

## Final test inventory (7 cases)

1. `returns 401 when the request is unauthenticated` *(web 1:1, conflated with api 401-unauth)*
2. `returns 401 when the authenticated session has no active organization` *(api-specific)*
3. `returns 403 for a sandbox token without agent-run:read capability` *(api-specific, per #12402)*
4. `returns 404 when the run is not found` *(web 1:1; subsumes optional cross-user 404 — same code path)*
5. `returns network logs for a run` *(web 1:1; verifies http/tcp/dns event types)*
6. `returns empty array when no logs` *(web 1:1)*
7. `sets hasMore when results exceed limit` *(web 1:1; verifies pagination boundary)*

Optional cross-user 404 case from issue body **skipped** — already subsumed by case 4 (random runId triggers same `verifyRunOwnership` null path).

## Rollback

`git revert` the commit. Web's `GET /api/zero/runs/:id/network` route stays in place; disabling the `apiBackend` feature switch returns traffic to web. No DB or schema changes.

Closes #12417