### PR TITLE
refactor(api): migrate run agent events get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-run-agent-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-run-agent-events.test.ts
@@ -1,0 +1,226 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroRunAgentEventsContract } from "@vm0/api-contracts/contracts/zero-runs";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+// Reusing run-seeding helpers from the usage-insight test module — same
+// fixture shape, same precedent as zero-runs-queue.test.ts (PR #12402)
+// and zero-runs-runner.test.ts (PR #12408).
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+describe("GET /api/zero/runs/:id/telemetry/agent", () => {
+  const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroRunAgentEventsContract);
+
+    const response = await accept(
+      client.getAgentEvents({
+        params: { id: randomUUID() },
+        query: { limit: 10, order: "desc" },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+
+    const client = setupApp({ context })(zeroRunAgentEventsContract);
+
+    const response = await accept(
+      client.getAgentEvents({
+        params: { id: randomUUID() },
+        query: { limit: 10, order: "desc" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns agent events for an owned run", async () => {
+    context.mocks.axiom.query.mockResolvedValue([]);
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunAgentEventsContract);
+
+    const response = await accept(
+      client.getAgentEvents({
+        params: { id: runId },
+        query: { limit: 10, order: "desc" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      events: [],
+      hasMore: false,
+      framework: "claude-code",
+    });
+  });
+
+  it("returns 404 when the run does not exist", async () => {
+    context.mocks.axiom.query.mockResolvedValue([]);
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunAgentEventsContract);
+
+    const response = await accept(
+      client.getAgentEvents({
+        params: { id: randomUUID() },
+        query: { limit: 10, order: "desc" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Agent run not found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 404 when the run belongs to a different user (no existence leak)", async () => {
+    context.mocks.axiom.query.mockResolvedValue([]);
+    const ownerFixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: ownerFixture.orgId, userId: ownerFixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: ownerFixture.orgId,
+        userId: ownerFixture.userId,
+        composeId: compose.composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+
+    const otherFixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(otherFixture.userId, otherFixture.orgId);
+
+    const client = setupApp({ context })(zeroRunAgentEventsContract);
+
+    const response = await accept(
+      client.getAgentEvents({
+        params: { id: runId },
+        query: { limit: 10, order: "desc" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Agent run not found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 403 for a sandbox token without agent-run:read capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const runId = `run_${randomUUID()}`;
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId,
+      capabilities: ["file:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const client = setupApp({ context })(zeroRunAgentEventsContract);
+
+    const response = await accept(
+      client.getAgentEvents({
+        params: { id: randomUUID() },
+        query: { limit: 10, order: "desc" },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: agent-run:read",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-run-detail.ts
+++ b/turbo/apps/api/src/signals/routes/zero-run-detail.ts
@@ -92,9 +92,6 @@ export const zeroRunDetailRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroRunAgentEventsContract.getAgentEvents,
-    handler: shadowCompareRoute({
-      route: zeroRunAgentEventsContract.getAgentEvents,
-      handler: authRoute(runReadAuth, getAgentEventsInner$),
-    }),
+    handler: authRoute(runReadAuth, getAgentEventsInner$),
   },
 ];

--- a/turbo/packages/api-contracts/src/contracts/zero-runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-runs.ts
@@ -145,6 +145,7 @@ export const zeroRunAgentEventsContract = c.router({
     responses: {
       200: agentEventsResponseSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
       404: apiErrorSchema,
     },
     summary: "Get agent events with pagination (zero proxy)",


### PR DESCRIPTION
## Summary

- make `GET /api/zero/runs/:id/telemetry/agent` API-authoritative by removing the `shadowCompareRoute(...)` wrapper around the agentEvents route entry only
- shared file `zero-run-detail.ts` goes from 3 → 2 `shadowCompareRoute(...)` invocations (context + networkLogs retained for sibling issues #12416 + #12417 still in flight)
- `shadowCompareRoute` import retained per epic policy — cleanup PR will remove the unused import after all 3 sibling migrations land
- **Plan A2 contract fix**: declare `403: apiErrorSchema` on `zeroRunAgentEventsContract.getAgentEvents` so the capability gate test can pass through `validateResponse` (same precedent as PR #12363 billing-invoices)
- **Repair shared axiom mock**: previous mocks.ts setup replaced the entire axiom module with only `queryAxiom`, breaking `getDatasetName` consumers, AND returned `Promise<unknown>` where ccstate's `get()` requires a `Computed`. Use `importOriginal` to preserve other exports and wrap `queryAxiom` in `computed()` so `context.mocks.axiom.query.mockResolvedValue(...)` works properly
- add api integration tests covering all 4 web GET cases plus an api missing-org 401 + defensive cross-user 404 (6 total)
- reuse `seedRun$` / `seedCompose$` / `deleteUsageInsightFixture$` from existing `helpers/zero-usage-insight.ts`

Closes #12419

Part of epic #12290.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-run-agent-events.test.ts` — 6 / 6 passing
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-queue.test.ts src/signals/routes/__tests__/zero-runs-runner.test.ts src/signals/routes/__tests__/zero-runs-by-id.test.ts src/signals/routes/__tests__/zero-usage-insight.test.ts` — 38 / 38 passing (sibling sanity, helper + mocks.ts edits)
- `pnpm -F api lint`
- `pnpm check-types`
- `grep -c "shadowCompareRoute(" turbo/apps/api/src/signals/routes/zero-run-detail.ts` — **2** (down from 3)

## Test cases

| # | Case | Mirrors web |
|---|------|-------------|
| 1 | unauthenticated → 401 | "should return 401 when not authenticated" (line 63) |
| 2 | session, no active org → 401 | n/a — added per epic pattern |
| 3 | seeded owned run → 200 `{events: [], hasMore: false, framework: "claude-code"}` | "should return agent events for a run" (line 36) |
| 4 | run not found → 404 | "should return 404 when run not found" (line 55) |
| 5 | cross-user → 404 (no existence leak) | n/a — defensive port (per #12408 precedent) |
| 6 | sandbox token w/o agent-run:read → 403 | "should return 403 for sandbox token without agent-run:read capability" (line 74) |

## Watermark divergence (deferred to follow-up)

Web's `getRunAgentEvents` includes `getAgentEventsVisibilityTarget` + `waitForRunEventWatermarkVisible` to mask Axiom's indexing lag for recently-completed runs. The api service skips this — recently-written events may briefly appear stale until Axiom indexes them.

This is **not Plan A2** — porting watermark requires `waitForRunEventWatermarkVisible`, `getAgentEventsVisibilityTarget`, and a `noCache` option on `queryAxiom` (~150 LOC of feature work, deserves dedicated review). Web's tests don't exercise this path either (mock `queryAxiom` directly). Per leader's directive (issue #12419 plan thread), document and defer.

A follow-up issue will be filed: "fix(api): port getAgentEventsVisibilityTarget watermark wait to mask Axiom indexing lag" (optional priority — pickable later).

## Mocks.ts repair

The pre-existing `vi.mock("../signals/external/axiom", () => ({ queryAxiom: ... }))` had two real bugs:
1. **Missing exports**: replaced the entire module without `importOriginal`, so `getDatasetName` was undefined when imported by services
2. **Wrong return shape**: returned `vi.fn<...Promise<unknown>>` directly, but ccstate consumers do `await get(queryAxiom(apl))` which needs a `Computed`

This PR fixes both via `importOriginal` + `computed()` wrapping. Tests now use the canonical `context.mocks.axiom.query.mockResolvedValue([...])` pattern (per the api/no-test-vi-mocks lint rule). All 38 sibling tests still pass — no regression.

## Behavioral note

Web returns 404 if `resolveOrg` rejects. The api implementation skips `resolveOrg` (Clerk-implies-membership simplification) — `zeroRunAgentEvents` queries by `(id, userId, orgId)` and returns null/404 for any non-matching combination. Same accepted gap as PRs #12312 / #12314 / #12315 / #12337 / #12351 / #12363 / #12377 / #12384 / #12388 / #12392 / #12402 / #12408 / #12414 / #12415.

## Rollback

Disabling the `apiBackend` feature switch routes traffic back to `apps/web`. No DB or schema changes. Contract addition (declared 403) is forward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)