### PR TITLE
chore(api): remove unused shadow-compare import from zero-run-detail

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-run-detail.ts
+++ b/turbo/apps/api/src/signals/routes/zero-run-detail.ts
@@ -8,7 +8,6 @@ import {
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf, queryOf } from "../context/request";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { notFound } from "../../lib/error";
 import {
   zeroRunAgentEvents,


### PR DESCRIPTION
Closes #12423

## Summary
Remove the now-unused `shadowCompareRoute` import from `turbo/apps/api/src/signals/routes/zero-run-detail.ts`. After PRs #12420 (context), #12421 (networkLogs), and #12422 (agentEvents) landed, the wrappers were removed from all three route entries but the import line remained. Drop it.

After this PR, `zero-run-detail.ts` has zero `shadowCompareRoute` references — file fully migrated (14th in the batch).

## Test plan
- [x] `grep -c shadowCompareRoute zero-run-detail.ts` returns 0
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] Pre-commit: prettier, knip, `turbo run check-types`, commitlint — all green
- No test changes (existing zero-run-context / zero-run-network-logs / zero-run-agent-events tests already cover the post-migration handlers)

## Rollback
Re-add the import line. No runtime impact.