### PR TITLE
refactor(api): migrate composes by name get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-composes-by-name.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-composes-by-name.test.ts
@@ -1,0 +1,162 @@
+import { zeroComposesMainContract } from "@vm0/api-contracts/contracts/zero-composes";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteTeamCompose$,
+  seedTeamCompose$,
+  type TeamComposeFixture,
+} from "./helpers/zero-team";
+
+const HEAD_VERSION_HEX = "a".repeat(64);
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/composes (getByName)", () => {
+  const track = createFixtureTracker<TeamComposeFixture>((fixture) => {
+    return store.set(deleteTeamCompose$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroComposesMainContract);
+
+    const response = await accept(
+      client.getByName({
+        query: { name: "any-agent" },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+
+    const client = setupApp({ context })(zeroComposesMainContract);
+
+    const response = await accept(
+      client.getByName({
+        query: { name: "any-agent" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns the compose when found by name in the active org", async () => {
+    const fixture = await track(
+      store.set(
+        seedTeamCompose$,
+        {
+          composes: [{ headVersionId: HEAD_VERSION_HEX }],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const composeId = fixture.composeIds[0]!;
+    const expectedName = `agent-${composeId.slice(0, 8)}`;
+
+    const client = setupApp({ context })(zeroComposesMainContract);
+
+    const response = await accept(
+      client.getByName({
+        query: { name: expectedName },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      id: composeId,
+      name: expectedName,
+      headVersionId: HEAD_VERSION_HEX,
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
+      content: null,
+    });
+  });
+
+  it("returns 404 when no compose matches the name", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroComposesMainContract);
+
+    const response = await accept(
+      client.getByName({
+        query: { name: "nonexistent-agent" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Agent compose not found: nonexistent-agent",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 404 when a compose with the same name exists in a different org", async () => {
+    const otherFixture = await track(
+      store.set(
+        seedTeamCompose$,
+        {
+          composes: [{ displayName: "shared-name-agent" }],
+        },
+        context.signal,
+      ),
+    );
+    const sharedComposeId = otherFixture.composeIds[0]!;
+    const sharedName = `agent-${sharedComposeId.slice(0, 8)}`;
+
+    const myFixture = await track(
+      store.set(seedTeamCompose$, {}, context.signal),
+    );
+    mocks.clerk.session(myFixture.userId, myFixture.orgId);
+
+    const client = setupApp({ context })(zeroComposesMainContract);
+
+    const response = await accept(
+      client.getByName({
+        query: { name: sharedName },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: `Agent compose not found: ${sharedName}`,
+        code: "NOT_FOUND",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-composes.ts
+++ b/turbo/apps/api/src/signals/routes/zero-composes.ts
@@ -72,10 +72,7 @@ const orgAuth = {
 export const zeroComposesRoutes: readonly RouteEntry[] = [
   {
     route: zeroComposesMainContract.getByName,
-    handler: shadowCompareRoute({
-      route: zeroComposesMainContract.getByName,
-      handler: authRoute(orgAuth, getComposeByNameInner$),
-    }),
+    handler: authRoute(orgAuth, getComposeByNameInner$),
   },
   {
     route: zeroComposesListContract.list,


### PR DESCRIPTION
## Summary

- make `GET /api/zero/composes` (getByName) API-authoritative by removing the `shadowCompareRoute(...)` wrapper around the getByName route entry only
- shared file `zero-composes.ts` goes from 2 → 1 `shadowCompareRoute(...)` invocations (getById sibling retained for separate Stage 2 follow-up)
- `shadowCompareRoute` import retained (still consumed by getById wrapper)
- add api integration tests covering all 3 web GET cases plus an api missing-org 401 + defensive cross-org isolation 404 (5 total)
- reuse `seedTeamCompose$` / `deleteTeamCompose$` from existing `helpers/zero-team.ts` — no new helper file (same precedent as PR #12415 composes list migration)

Closes #12425

Part of epic #12290.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-composes-by-name.test.ts` — 5 / 5 passing
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-composes-list.test.ts` — 6 / 6 passing (sibling sanity)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `grep -c "shadowCompareRoute(" turbo/apps/api/src/signals/routes/zero-composes.ts` — **1** (down from 2)

## Test cases

| # | Case | Mirrors web |
|---|------|-------------|
| 1 | unauthenticated → 401 | "should return 401 when not authenticated" (line 58) |
| 2 | session, no active org → 401 | n/a — added per epic pattern |
| 3 | seeded compose → 200 with full body strict-equal | "should return compose by name" (line 33) |
| 4 | nonexistent name → 404 | "should return 404 when compose not found" (line 48) |
| 5 | cross-org compose with same name → 404 (no existence leak) | n/a — defensive port (per #12390/#12407/#12415 precedent) |

## Service parity

API `zeroComposeByName` and web `getComposeByName` execute identical SQL (same `from agentComposes leftJoin agentComposeVersions on headVersionId = id where orgId = ? and name = ?`) and identical projection. Not-found message matches verbatim ("Agent compose not found: \${name}").

## Auth divergence (no-orgId, documented)

API returns 401 for sessions without an active organization (via `orgAuth = {requireOrganization: true, missingOrganizationStatus: 401}`). Web returns 404 with the compose-not-found message (web's `resolveOrg` throws on no-org → mapped to 404 with "Agent compose not found: \${name}" — a gentle info-hide that collapses "no org" into "no compose"). Same accepted simplification as PR #12415: api's 401 is structurally cleaner than web's collapsed 404.

## Behavioral note

Web returns 404 if `resolveOrg` rejects. The api implementation skips `resolveOrg` (Clerk-implies-membership simplification) — `zeroComposeByName` queries by `(orgId, name)` and returns null/404 for any non-matching combination. Same accepted gap as PRs #12312 / #12314 / #12315 / #12337 / #12351 / #12363 / #12377 / #12384 / #12388 / #12392 / #12402 / #12408 / #12414 / #12415 / #12422.

## Rollback

Disabling the `apiBackend` feature switch routes traffic back to `apps/web`. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)