### PR TITLE
refactor(api): migrate composes by id get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-composes-by-id.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-composes-by-id.test.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroComposesByIdContract } from "@vm0/api-contracts/contracts/zero-composes";
+import { createStore } from "ccstate";
+
+import { createApp } from "../../../app-factory";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  deleteTeamCompose$,
+  seedTeamCompose$,
+  type TeamComposeFixture,
+} from "./helpers/zero-team";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/composes/:id", () => {
+  const track = createFixtureTracker<TeamComposeFixture>((fixture) => {
+    return store.set(deleteTeamCompose$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroComposesByIdContract);
+
+    const response = await accept(
+      client.getById({ params: { id: randomUUID() }, headers: {} }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroComposesByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 400 for a malformed compose id", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request(
+      "/api/zero/composes/91fc0bd84bba673393d9adfc1a0f4dec",
+      {
+        method: "GET",
+        headers: { authorization: "Bearer clerk-session" },
+      },
+    );
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("valid UUID");
+  });
+
+  it("returns 404 when the compose is not found", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroComposesByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns the compose by id", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, { composes: [{}] }, context.signal),
+    );
+    const composeId = fixture.composeIds[0];
+    if (!composeId) {
+      throw new Error("Expected seeded compose");
+    }
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroComposesByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: composeId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.id).toBe(composeId);
+    expect(response.body.name).toBe(`agent-${composeId.slice(0, 8)}`);
+  });
+
+  it("returns 404 for a compose owned by a different org and user", async () => {
+    const otherFixture = await track(
+      store.set(seedTeamCompose$, { composes: [{}] }, context.signal),
+    );
+    const otherComposeId = otherFixture.composeIds[0];
+    if (!otherComposeId) {
+      throw new Error("Expected seeded compose");
+    }
+    const callerUserId = `user_${randomUUID()}`;
+    const callerOrgId = `org_${randomUUID()}`;
+    mocks.clerk.session(callerUserId, callerOrgId);
+
+    const client = setupApp({ context })(zeroComposesByIdContract);
+
+    const response = await accept(
+      client.getById({
+        params: { id: otherComposeId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-composes.ts
+++ b/turbo/apps/api/src/signals/routes/zero-composes.ts
@@ -8,7 +8,6 @@ import {
 import { authContext$, organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf, queryOf } from "../context/request";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { notFound } from "../../lib/error";
 import {
   zeroComposeById,
@@ -83,9 +82,6 @@ export const zeroComposesRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroComposesByIdContract.getById,
-    handler: shadowCompareRoute({
-      route: zeroComposesByIdContract.getById,
-      handler: authRoute(orgAuth, getComposeByIdInner$),
-    }),
+    handler: authRoute(orgAuth, getComposeByIdInner$),
   },
 ];


### PR DESCRIPTION
## Summary

- Drop the `shadowCompareRoute(...)` wrapper from the `getById` route in `zero-composes.ts`.
- **Drop the `shadowCompareRoute` import too** — sibling getByName migration #12427 merged at 18:27:47Z, leaving the import as the last reference. After this PR: `grep -c shadowCompareRoute` returns **0**. **15th fully-migrated file** (file-closer pattern; rebased onto post-#12427 main).
- Port all 4 web GET cases 1:1 + 2 api-specific cases (401-missing-org and cross-org 404 defensive) = **6 tests total**.
- Reuse `helpers/zero-team.ts:seedTeamCompose$` per `zero-composes-list.test.ts` precedent (no new helper file).

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-composes-by-id.test.ts` — 6/6 pass.
- [x] `pnpm -F api lint` — clean (1 pre-existing warning in `zero-run-detail.ts` unrelated to this PR — that file's siblings landed and the now-unused `shadowCompareRoute` import there is leftover tech debt for a separate cleanup).
- [x] `pnpm -F api check-types` — clean.
- [x] `grep -c shadowCompareRoute turbo/apps/api/src/signals/routes/zero-composes.ts` → `0` (file-closer verified).
- [x] No `apps/web/**` modifications.

## Test inventory (6 cases)

1. `returns 401 when the request is unauthenticated` *(web 1:1)*
2. `returns 401 when the authenticated session has no organization` *(api-specific)*
3. `returns 400 for a malformed compose id` *(web 1:1; uses raw `app.request()` to bypass ts-rest type-safety on path params, same pattern as #12332)*
4. `returns 404 when the compose is not found` *(web 1:1)*
5. `returns the compose by id` *(web 1:1)*
6. `returns 404 for a compose owned by a different org and user` *(api-specific defensive)*

## Cross-org 404 defensive case

The api service's `canAccessCompose` predicate returns true if **either** orgId or userId matches:

```ts
function canAccessCompose(userId, orgId, compose): boolean {
  return compose.orgId === orgId || compose.userId === userId;
}
```

So the cross-org test seeds the compose under a different org **and** a different user; both predicates fail; the service returns null → 404. This guards against a regression where `canAccessCompose` is loosened or the user-scope check is dropped.

## Rollback

`git revert` the commit. Web's `GET /api/zero/composes/:id` route stays in place; disabling the `apiBackend` feature switch returns traffic to web. No DB or schema changes.

Closes #12428