### PR TITLE
refactor(api): migrate agents list get

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
@@ -233,7 +233,14 @@ export function mockSkillContent(
 export const seedAgentForInstructions$ = command(
   async (
     { set },
-    args: { orgId: string; userId: string; name?: string },
+    args: {
+      orgId: string;
+      userId: string;
+      name?: string;
+      displayName?: string | null;
+      description?: string | null;
+      sound?: string | null;
+    },
     signal: AbortSignal,
   ): Promise<{ agentId: string }> => {
     const db = set(writeDb$);
@@ -253,6 +260,9 @@ export const seedAgentForInstructions$ = command(
         orgId: args.orgId,
         owner: args.userId,
         name,
+        displayName: args.displayName ?? null,
+        description: args.description ?? null,
+        sound: args.sound ?? null,
       })
       .onConflictDoNothing();
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents-list.test.ts
@@ -1,0 +1,122 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroAgentsMainContract } from "@vm0/api-contracts/contracts/zero-agents";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  deleteSkillsForFixture$,
+  seedAgentForInstructions$,
+  seedSkillsFixture$,
+  type SkillsFixture,
+} from "./helpers/zero-skills";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function apiClient() {
+  return setupApp({ context })(zeroAgentsMainContract);
+}
+
+describe("GET /api/zero/agents", () => {
+  const track = createFixtureTracker<SkillsFixture>((fixture) => {
+    return store.set(deleteSkillsForFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(apiClient().list({ headers: {} }), [401]);
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const response = await accept(
+      apiClient().list({ headers: authHeaders() }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns empty array when no agents exist", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().list({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual([]);
+  });
+
+  it("returns the list with the seeded agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        displayName: "Listed Agent",
+        description: "desc",
+        sound: "friendly",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().list({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toHaveLength(1);
+    expect(response.body[0]?.agentId).toBe(agentId);
+    expect(response.body[0]?.ownerId).toBe(fixture.userId);
+    expect(response.body[0]?.displayName).toBe("Listed Agent");
+    expect(response.body[0]?.description).toBe("desc");
+    expect(response.body[0]?.sound).toBe("friendly");
+  });
+
+  it("returns agents only scoped to caller's org", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const otherFixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: otherFixture.orgId,
+        userId: otherFixture.userId,
+        displayName: "Foreign Agent",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().list({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual([]);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -91,10 +91,7 @@ const agentReadAuth = {
 export const zeroAgentsRoutes: readonly RouteEntry[] = [
   {
     route: zeroAgentsMainContract.list,
-    handler: shadowCompareRoute({
-      route: zeroAgentsMainContract.list,
-      handler: authRoute(agentReadAuth, listAgentsInner$),
-    }),
+    handler: authRoute(agentReadAuth, listAgentsInner$),
   },
   {
     route: zeroAgentsByIdContract.get,


### PR DESCRIPTION
Closes #12430

## Summary
- Make `GET /api/zero/agents` (agents list) authoritative in `apps/api` by removing the `shadowCompareRoute(...)` wrapper from the list entry in the shared `zero-agents.ts` file
- Other 3 entries (`agentsByIdContract.get`, `userConnectorsContract.get`, `agentCustomConnectorsContract.get`) remain shadow-wrapped (separate Stage 2 follow-ups). `shadowCompareRoute` import retained
- Add 3 web GET cases ported 1:1 + 1 api 401 missing-org + 1 cross-org defensive = 5 cases total
- Extend `helpers/zero-skills.ts` `seedAgentForInstructions$` with optional `displayName`/`description`/`sound` (backward-compatible)

## Behavior parity
The api `zeroAgentList` Computed and the web GET handler both query `zero_agents JOIN agent_composes` by `orgId`, ordered by `desc(zeroAgents.updatedAt)`, returning the standard `ZeroAgentResponse` shape. Already shadow-compared in production.

## Capability gate
`requiredCapability: "agent:read"` only applies to Zero/CLI tokens; Clerk session paths bypass per #12388/#12401/#12406 analysis. The api 401 cases cover unauth + missing-org; no separate 403-capability case (the issue body doesn't request one).

## Scope
- Route + new test + helper extension. **No new helper file.**
- Other 3 routes in `zero-agents.ts` untouched (separate Stage 2 issues).
- No `apps/web/**` modifications.

## Test cases (all 5)
1. returns 401 when the request is unauthenticated (web port)
2. returns 401 when the authenticated session has no organization (api-specific)
3. returns empty array when no agents exist (web port)
4. returns the list with the seeded agent (web port — asserts `agentId/ownerId/displayName/description/sound`)
5. returns agents only scoped to caller's org (cross-org defensive — locks in `WHERE orgId = ?` predicate)

## Test plan
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-agents-list.test.ts` — 5/5 passed (first run)
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-skills.test.ts` — 16/16 passed (existing instructions test still passes after helper extension)
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `grep -c shadowCompareRoute zero-agents.ts` returns 4 (down from 5)
- [x] Pre-commit: prettier, knip, `turbo run check-types`, commitlint — all green

## Rollback
Disable the `apiBackend` feature switch — traffic returns to `apps/web`. No DB or schema change.