### PR TITLE
refactor(api): migrate org list get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-list.test.ts
@@ -1,0 +1,118 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroOrgListContract } from "@vm0/api-contracts/contracts/zero-org-list";
+import { orgCache } from "@vm0/db/schema/org-cache";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+interface SeededOrg {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly slug: string;
+  readonly role: string;
+}
+
+async function seedOrgMembership(args: SeededOrg): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(orgCache).values({ orgId: args.orgId, slug: args.slug });
+  await writeDb.insert(orgMembersCache).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    role: args.role,
+  });
+}
+
+async function deleteOrgMembership(orgId: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.delete(orgMembersCache).where(eq(orgMembersCache.orgId, orgId));
+  await writeDb.delete(orgCache).where(eq(orgCache.orgId, orgId));
+}
+
+describe("GET /api/zero/org/list", () => {
+  const seededOrgIds: string[] = [];
+
+  afterEach(async () => {
+    while (seededOrgIds.length > 0) {
+      const orgId = seededOrgIds.pop();
+      if (orgId) {
+        await deleteOrgMembership(orgId);
+      }
+    }
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroOrgListContract);
+
+    const response = await accept(client.list({ headers: {} }), [401]);
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns list of user orgs", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const slug = `solo-${randomUUID().slice(0, 8)}`;
+    await seedOrgMembership({ orgId, userId, slug, role: "admin" });
+    seededOrgIds.push(orgId);
+
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroOrgListContract);
+
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.orgs.length).toBeGreaterThanOrEqual(1);
+    expect(response.body.orgs[0]).toHaveProperty("slug");
+    expect(response.body.orgs[0]).toHaveProperty("role");
+  });
+
+  it("returns multiple orgs when user belongs to several", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgIdA = `org_${randomUUID()}`;
+    const orgIdB = `org_${randomUUID()}`;
+    await seedOrgMembership({
+      orgId: orgIdA,
+      userId,
+      slug: "team-alpha",
+      role: "admin",
+    });
+    seededOrgIds.push(orgIdA);
+    await seedOrgMembership({
+      orgId: orgIdB,
+      userId,
+      slug: "team-beta",
+      role: "member",
+    });
+    seededOrgIds.push(orgIdB);
+
+    mocks.clerk.session(userId, orgIdA);
+
+    const client = setupApp({ context })(zeroOrgListContract);
+
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.orgs).toHaveLength(2);
+    expect(response.body.orgs).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ slug: "team-alpha", role: "admin" }),
+        expect.objectContaining({ slug: "team-beta", role: "member" }),
+      ]),
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-org-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-read.ts
@@ -56,10 +56,7 @@ export const zeroOrgReadRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroOrgListContract.list,
-    handler: shadowCompareRoute({
-      route: zeroOrgListContract.list,
-      handler: authRoute({}, listOrgsInner$),
-    }),
+    handler: authRoute({}, listOrgsInner$),
   },
   {
     route: zeroOrgDomainsContract.list,


### PR DESCRIPTION
## Summary

- Drop the `shadowCompareRoute(...)` wrapper from the `list` route in `zero-org-read.ts`. File goes **4 → 3 wrappers**; `shadowCompareRoute` import retained (3 sibling routes still wrap).
- Port all 3 web GET cases 1:1. **No api-specific cases** because the route uses `authRoute({}, ...)` with empty options — the inner reads `authContext$.userId` only, not `organizationAuthContext$`. No active org context required, so the 401-missing-org case other Stage 2 PRs add is N/A here.
- Inline `seedOrgMembership` / `deleteOrgMembership` helpers in the test file (no new shared helper).

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-org-list.test.ts` — 3/3 pass.
- [x] `pnpm -F api lint` — clean.
- [x] `pnpm -F api check-types` — clean.
- [x] `grep -c shadowCompareRoute turbo/apps/api/src/signals/routes/zero-org-read.ts` returns `4` (1 import + 3 wrappers; was 5).
- [x] No `apps/web/**` modifications.

## Test inventory (3 cases)

1. `returns 401 when not authenticated` *(web 1:1)*
2. `returns list of user orgs` *(web 1:1; seeds 1 `org_members_cache` + `org_cache` row)*
3. `returns multiple orgs when user belongs to several` *(web 1:1; seeds 2 cache rows; asserts `team-alpha`/`team-beta` slugs and `admin`/`member` roles)*

## Helper extraction note

`org_members_cache` + `org_cache` inline seeds have now appeared in 5+ test files (this PR plus prior #12366, #12417, #12421, #12428). Per "extract on 3rd-occurrence" rule we're already past the threshold; deferred here to keep this PR focused. Will file a follow-up cleanup issue (parallel to the encrypt-secret extraction in PR #12413) when an extraction-worthy moment lands.

## Rollback

`git revert` the commit. Web's `GET /api/zero/org/list` route stays in place; disabling the `apiBackend` feature switch returns traffic to web. No DB or schema changes.

Closes #12432