### PR TITLE
refactor(api): migrate agents by id get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents-by-id.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents-by-id.test.ts
@@ -1,0 +1,185 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteTeamCompose$,
+  seedTeamCompose$,
+  type TeamComposeFixture,
+} from "./helpers/zero-team";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+describe("GET /api/zero/agents/:id", () => {
+  const track = createFixtureTracker<TeamComposeFixture>((fixture) => {
+    return store.set(deleteTeamCompose$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroAgentsByIdContract);
+    const response = await accept(
+      client.get({ params: { id: randomUUID() }, headers: {} }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+    const client = setupApp({ context })(zeroAgentsByIdContract);
+    const response = await accept(
+      client.get({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns the agent when found in the active org", async () => {
+    const fixture = await track(
+      store.set(
+        seedTeamCompose$,
+        {
+          composes: [
+            {
+              displayName: "Test Agent",
+              description: "Test description",
+              sound: "friendly",
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const agentId = fixture.composeIds[0]!;
+
+    const client = setupApp({ context })(zeroAgentsByIdContract);
+    const response = await accept(
+      client.get({
+        params: { id: agentId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      agentId,
+      ownerId: fixture.userId,
+      displayName: "Test Agent",
+      description: "Test description",
+      sound: "friendly",
+      avatarUrl: null,
+      permissionPolicies: null,
+      customSkills: [],
+      modelProviderId: null,
+      selectedModel: null,
+      preferPersonalProvider: false,
+    });
+  });
+
+  it("returns 404 for an unknown agent id", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const unknownId = randomUUID();
+
+    const client = setupApp({ context })(zeroAgentsByIdContract);
+    const response = await accept(
+      client.get({
+        params: { id: unknownId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: `Agent not found: ${unknownId}`, code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 404 when the agent belongs to a different org (no existence leak)", async () => {
+    const otherFixture = await track(
+      store.set(
+        seedTeamCompose$,
+        { composes: [{ displayName: "Other Org Agent" }] },
+        context.signal,
+      ),
+    );
+    const sharedId = otherFixture.composeIds[0]!;
+
+    const myFixture = await track(
+      store.set(seedTeamCompose$, {}, context.signal),
+    );
+    mocks.clerk.session(myFixture.userId, myFixture.orgId);
+
+    const client = setupApp({ context })(zeroAgentsByIdContract);
+    const response = await accept(
+      client.get({
+        params: { id: sharedId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: `Agent not found: ${sharedId}`, code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 403 for a sandbox token without agent:read capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const runId = `run_${randomUUID()}`;
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId,
+      capabilities: ["file:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const client = setupApp({ context })(zeroAgentsByIdContract);
+    const response = await accept(
+      client.get({
+        params: { id: randomUUID() },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: agent:read",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -95,10 +95,7 @@ export const zeroAgentsRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroAgentsByIdContract.get,
-    handler: shadowCompareRoute({
-      route: zeroAgentsByIdContract.get,
-      handler: authRoute(agentReadAuth, getAgentInner$),
-    }),
+    handler: authRoute(agentReadAuth, getAgentInner$),
   },
   {
     route: zeroUserConnectorsContract.get,


### PR DESCRIPTION
## Summary

- make `GET /api/zero/agents/:id` API-authoritative by removing the `shadowCompareRoute(...)` wrapper around the byId route entry only
- shared file `zero-agents.ts` goes from 4 → 3 `shadowCompareRoute(...)` invocations (or 4 → 2 if sibling PR #12431 list migration merges first)
- `shadowCompareRoute` import retained (still consumed by list, userConnectors, customConnectors wrappers)
- add api integration tests covering both web GET cases plus 4 api defensive (401 unauth, 401 missing-org, cross-org 404, sandbox capability 403) — 6 total
- reuse `seedTeamCompose$` / `deleteTeamCompose$` from existing `helpers/zero-team.ts` — avoids cross-PR helper coupling with a1's #12431 which extends `seedAgentForInstructions$` with the same fields

Closes #12434

Part of epic #12290.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-agents-by-id.test.ts` — 6 / 6 passing
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `grep -c "shadowCompareRoute(" turbo/apps/api/src/signals/routes/zero-agents.ts` — **3** (down from 4)

## Test cases

| # | Case | Mirrors web |
|---|------|-------------|
| 1 | unauthenticated → 401 | n/a — added per epic pattern |
| 2 | session, no active org → 401 | n/a — added per epic pattern |
| 3 | seeded agent → 200 with full body strict-equal | "should return created agent" (line 316) |
| 4 | unknown id → 404 | "should return 404 for unknown agent" (line 342) |
| 5 | cross-org agent → 404 (no existence leak) | n/a — defensive port (per #12390/#12407/#12415/#12425 precedent) |
| 6 | sandbox token w/o agent:read → 403 | n/a — defensive port (per #12402/#12408/#12422 precedent) |

## Service parity

API `zeroAgentDetail` and web `[id]/route.ts:get` execute identical SQL (`SELECT zeroAgents fields, agentComposes.userId FROM zeroAgents INNER JOIN agentComposes WHERE orgId = ? AND id = ? LIMIT 1`). Identical projection (agentId, ownerId, displayName, description, sound, avatarUrl, permissionPolicies, customSkills, modelProviderId, selectedModel, preferPersonalProvider). Identical not-found message ("Agent not found: \${id}").

## Helper choice rationale

The issue body suggested reusing `seedAgentForInstructions$` from `helpers/zero-skills.ts` (extended in a1's open PR #12431). However, a1's extension lives in their unmerged PR — using it requires either duplicating their work or waiting for their merge.

Instead, this PR reuses `seedTeamCompose$` from `helpers/zero-team.ts`, which already supports `displayName`/`description`/`sound` natively. Same precedent as PR #12415 (composes list) and PR #12425 (composes byName). Zero coordination overhead.

## Behavioral note

Web returns 404 if `resolveOrg` rejects. The api implementation skips `resolveOrg` (Clerk-implies-membership simplification) — `zeroAgentDetail` queries by `(orgId, id)` and returns null/404 for any non-matching combination. Same accepted gap as PRs #12312 / #12314 / #12315 / #12337 / #12351 / #12363 / #12377 / #12384 / #12388 / #12392 / #12402 / #12408 / #12414 / #12415 / #12422 / #12427.

## Rollback

Disabling the `apiBackend` feature switch routes traffic back to `apps/web`. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)