### PR TITLE
refactor(api): migrate user connectors get

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
@@ -8,6 +8,7 @@ import {
 import { command } from "ccstate";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { userConnectors } from "@vm0/db/schema/user-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroSkills } from "@vm0/db/schema/zero-skill";
 import { eq } from "drizzle-orm";
@@ -267,5 +268,30 @@ export const seedAgentForInstructions$ = command(
       .onConflictDoNothing();
     signal.throwIfAborted();
     return { agentId };
+  },
+);
+
+export const seedUserConnector$ = command(
+  async (
+    { set },
+    args: {
+      orgId: string;
+      userId: string;
+      agentId: string;
+      connectorType: string;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    await db
+      .insert(userConnectors)
+      .values({
+        orgId: args.orgId,
+        userId: args.userId,
+        agentId: args.agentId,
+        connectorType: args.connectorType,
+      })
+      .onConflictDoNothing();
+    signal.throwIfAborted();
   },
 );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-connectors.test.ts
@@ -1,0 +1,168 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  deleteSkillsForFixture$,
+  seedAgentForInstructions$,
+  seedSkillsFixture$,
+  seedUserConnector$,
+  type SkillsFixture,
+} from "./helpers/zero-skills";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function apiClient() {
+  return setupApp({ context })(zeroUserConnectorsContract);
+}
+
+describe("GET /api/zero/agents/:id/user-connectors", () => {
+  const track = createFixtureTracker<SkillsFixture>((fixture) => {
+    return store.set(deleteSkillsForFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      apiClient().get({ params: { id: randomUUID() }, headers: {} }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const response = await accept(
+      apiClient().get({
+        params: { id: randomUUID() },
+        headers: authHeaders(),
+      }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 for a non-existent agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const fakeId = randomUUID();
+    const response = await accept(
+      apiClient().get({
+        params: { id: fakeId },
+        headers: authHeaders(),
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: `Agent not found: ${fakeId}`, code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 404 when agent belongs to a different org", async () => {
+    const ownerFixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      { orgId: ownerFixture.orgId, userId: ownerFixture.userId },
+      context.signal,
+    );
+
+    const callerFixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(callerFixture.userId, callerFixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        params: { id: agentId },
+        headers: authHeaders(),
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: `Agent not found: ${agentId}`, code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns empty enabledTypes for a new agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        params: { id: agentId },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    expect(response.body).toStrictEqual({ enabledTypes: [] });
+  });
+
+  it("ignores connector grants for removed connector types", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    await store.set(
+      seedUserConnector$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+        connectorType: "nano-banana",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedUserConnector$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+        connectorType: "github",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        params: { id: agentId },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ enabledTypes: ["github"] });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -102,10 +102,7 @@ export const zeroAgentsRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroUserConnectorsContract.get,
-    handler: shadowCompareRoute({
-      route: zeroUserConnectorsContract.get,
-      handler: authRoute(agentReadAuth, getAgentUserConnectorsInner$),
-    }),
+    handler: authRoute(agentReadAuth, getAgentUserConnectorsInner$),
   },
   {
     route: zeroAgentCustomConnectorsContract.get,


### PR DESCRIPTION
Closes #12436

## Summary
- Make `GET /api/zero/agents/:id/user-connectors` authoritative in `apps/api` by removing the `shadowCompareRoute(...)` wrapper from the user-connectors entry in the shared `zero-agents.ts` file
- Other route entries (`agentsByIdContract.get`, `agentCustomConnectorsContract.get`) remain shadow-wrapped (separate Stage 2 follow-ups). `shadowCompareRoute` import retained
- Add 4 web GET cases ported 1:1 + 1 api 401 missing-org + 1 cross-org defensive = 6 cases total
- Extend `helpers/zero-skills.ts` with `seedUserConnector$` command (insert into `user_connectors`)

## Behavior parity
The api `zeroAgentEnabledConnectorTypes` Computed and the web GET handler both query `user_connectors` by `(orgId, userId, agentId)` and filter `connectorType` through `connectorTypeSchema.safeParse` (filters out unknown/legacy types like `nano-banana`). Identical SQL and behavior.

## Capability gate
`requiredCapability: "agent:read"` only applies to Zero/CLI tokens; Clerk session paths bypass per #12388/#12401/#12406 analysis. The api 401 cases cover unauth + missing-org; no separate 403-capability case (issue body doesn't request).

## Scope
- Route + new test + helper extension. **No new helper file.**
- Other 3 routes in `zero-agents.ts` untouched.
- No `apps/web/**` modifications.

## Test cases (all 6)
1. returns 401 when the request is unauthenticated (web port)
2. returns 401 when the authenticated session has no organization (api-specific)
3. returns 404 for a non-existent agent (web port)
4. returns 404 when agent belongs to a different org (cross-org defensive — locks in `zeroAgentExists` org-scoping)
5. returns empty enabledTypes for a new agent (web port)
6. ignores connector grants for removed connector types (web port — exercises `connectorTypeSchema.safeParse` filter)

## Test plan
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-user-connectors.test.ts` — 6/6 passed (first run)
- [x] Existing `zero-skills.test.ts` (16) + `zero-agents-list.test.ts` (5) still pass — helper extension is backward-compatible
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `grep -c shadowCompareRoute zero-agents.ts` returns 3 (down from 4)
- [x] Pre-commit: prettier, knip, `turbo run check-types`, commitlint — all green

## Coordination
Sibling #12435 (byId migration) edits the same file at a different stanza (lines 99-105 byId vs 106-112 user-connectors before this PR). Whichever pushes first sets the line offsets; second rebases cleanly.

## Rollback
Disable the `apiBackend` feature switch — traffic returns to `apps/web`. No DB or schema change.