### PR TITLE
refactor(api): migrate org domains list get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-domains.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-domains.test.ts
@@ -1,0 +1,109 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroOrgDomainsContract } from "@vm0/api-contracts/contracts/zero-org-domains";
+import { orgCache } from "@vm0/db/schema/org-cache";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+interface SeededOrg {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly role: "admin" | "member";
+}
+
+async function seedOrgMembership(args: SeededOrg): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(orgCache).values({
+    orgId: args.orgId,
+    slug: `org-${args.orgId.slice(-8)}`,
+  });
+  await writeDb.insert(orgMembersCache).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    role: args.role,
+  });
+}
+
+async function deleteOrgMembership(orgId: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.delete(orgMembersCache).where(eq(orgMembersCache.orgId, orgId));
+  await writeDb.delete(orgCache).where(eq(orgCache.orgId, orgId));
+}
+
+describe("GET /api/zero/org/domains", () => {
+  const seededOrgIds: string[] = [];
+
+  afterEach(async () => {
+    while (seededOrgIds.length > 0) {
+      const orgId = seededOrgIds.pop();
+      if (orgId) {
+        await deleteOrgMembership(orgId);
+      }
+    }
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(client.list({ headers: {} }), [401]);
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns the domain list for an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    await seedOrgMembership({ orgId, userId, role: "admin" });
+    seededOrgIds.push(orgId);
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.domains).toBeInstanceOf(Array);
+  });
+
+  it("returns 403 when caller is not an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    await seedOrgMembership({ orgId, userId, role: "member" });
+    seededOrgIds.push(orgId);
+    mocks.clerk.session(userId, orgId, "org:member");
+
+    const client = setupApp({ context })(zeroOrgDomainsContract);
+
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-org-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-read.ts
@@ -16,6 +16,16 @@ import {
   zeroOrgMembersList,
 } from "../services/zero-org-data.service";
 
+const adminRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Access denied",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
 const getOrgInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const org = await get(zeroOrgDetail(auth.orgId, auth.userId));
@@ -33,6 +43,9 @@ const listOrgsInner$ = computed(async (get) => {
 
 const listDomainsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
+  if (auth.orgRole !== "admin") {
+    return adminRequired;
+  }
   const body = await get(zeroOrgDomainsList(auth.orgId));
   return { status: 200 as const, body };
 });
@@ -60,13 +73,10 @@ export const zeroOrgReadRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroOrgDomainsContract.list,
-    handler: shadowCompareRoute({
-      route: zeroOrgDomainsContract.list,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        listDomainsInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      listDomainsInner$,
+    ),
   },
   {
     route: zeroOrgMembersContract.members,


### PR DESCRIPTION
## Summary

- Drop the `shadowCompareRoute(...)` wrapper from `zeroOrgDomainsContract.list` in `zero-org-read.ts`. File goes **4 → 3 references** (1 import + 2 wrappers; siblings `get` and `members` still wrap, separate Stage 2 PRs).
- **Plan A2 admin-gate fix bundled** — web enforces 403 for non-admin via `getOrgDomains(orgId, role)`'s `ForbiddenError`; api previously had no role check. Without the fix, web test #2 would fail on api.
- Port all 3 web GET cases 1:1 + 1 api-specific 401-missing-org = **4 tests total**.

## Plan A2 fix details

Mirrors `zero-billing-invoices.ts:adminRequired` pattern verbatim:

```ts
const adminRequired = Object.freeze({
  status: 403 as const,
  body: Object.freeze({
    error: Object.freeze({ message: "Access denied", code: "FORBIDDEN" }),
  }),
});

const listDomainsInner$ = computed(async (get) => {
  const auth = get(organizationAuthContext$);
  if (auth.orgRole !== "admin") {
    return adminRequired;
  }
  const body = await get(zeroOrgDomainsList(auth.orgId));
  return { status: 200 as const, body };
});
```

Message `"Access denied"` and code `"FORBIDDEN"` match web's `createErrorResponse("FORBIDDEN", "Access denied")` byte-identical.

## Flagged-not-fixed divergence (audit trail)

API's `zeroOrgDomainsList` service hard-codes `{ domains: [] }` per a deliberate source comment ("API app does not have an `org_domains` table — return an empty list so the contract is satisfied"). Web fetches real Clerk domains. Web test #1 only asserts `data.domains` is an Array (empty array satisfies), so test parity holds.

Wire shape divergence is **preexisting and unchanged by this PR**. Out of scope; recorded for audit trail.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-org-domains.test.ts` — 4/4 pass.
- [x] `pnpm -F api lint` — clean.
- [x] `pnpm -F api check-types` — clean.
- [x] `grep -c shadowCompareRoute turbo/apps/api/src/signals/routes/zero-org-read.ts` returns `3` (1 import + 2 wrappers; was 4).
- [x] No `apps/web/**` modifications.

## Test inventory (4 cases)

1. `returns 401 when not authenticated` *(web 1:1)*
2. `returns 401 when the authenticated session has no organization` *(api-specific)*
3. `returns the domain list for an admin` *(web 1:1)*
4. `returns 403 when caller is not an admin` *(web 1:1; **A2 fix unblocks**)*

## Followup

Inline `seedOrgMembership` / `deleteOrgMembership` helpers — 6th occurrence of this pattern. Extraction tracked in #12438; deferred here to keep this PR focused.

## Rollback

`git revert` the commit. Web's `GET /api/zero/org/domains` route stays in place; disabling the `apiBackend` feature switch returns traffic to web. No DB or schema changes.

Closes #12437