### PR TITLE
refactor(api): migrate agent custom-connectors get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
@@ -1,0 +1,165 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteTeamCompose$,
+  seedTeamCompose$,
+  type TeamComposeFixture,
+} from "./helpers/zero-team";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+describe("GET /api/zero/agents/:id/custom-connectors", () => {
+  const track = createFixtureTracker<TeamComposeFixture>((fixture) => {
+    return store.set(deleteTeamCompose$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroAgentCustomConnectorsContract);
+    const response = await accept(
+      client.get({ params: { id: randomUUID() }, headers: {} }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+    const client = setupApp({ context })(zeroAgentCustomConnectorsContract);
+    const response = await accept(
+      client.get({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns empty enabledIds for an agent with no enabled custom connectors", async () => {
+    const fixture = await track(
+      store.set(
+        seedTeamCompose$,
+        { composes: [{ displayName: "Test Agent" }] },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const agentId = fixture.composeIds[0]!;
+
+    const client = setupApp({ context })(zeroAgentCustomConnectorsContract);
+    const response = await accept(
+      client.get({
+        params: { id: agentId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ enabledIds: [] });
+  });
+
+  it("returns 404 for a non-existent agent", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const unknownId = randomUUID();
+
+    const client = setupApp({ context })(zeroAgentCustomConnectorsContract);
+    const response = await accept(
+      client.get({
+        params: { id: unknownId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: `Agent not found: ${unknownId}`, code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 404 when the agent belongs to a different org (no existence leak)", async () => {
+    const otherFixture = await track(
+      store.set(
+        seedTeamCompose$,
+        { composes: [{ displayName: "Other Agent" }] },
+        context.signal,
+      ),
+    );
+    const sharedId = otherFixture.composeIds[0]!;
+
+    const myFixture = await track(
+      store.set(seedTeamCompose$, {}, context.signal),
+    );
+    mocks.clerk.session(myFixture.userId, myFixture.orgId);
+
+    const client = setupApp({ context })(zeroAgentCustomConnectorsContract);
+    const response = await accept(
+      client.get({
+        params: { id: sharedId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: `Agent not found: ${sharedId}`, code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 403 for a sandbox token without agent:read capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const runId = `run_${randomUUID()}`;
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId,
+      capabilities: ["file:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const client = setupApp({ context })(zeroAgentCustomConnectorsContract);
+    const response = await accept(
+      client.get({
+        params: { id: randomUUID() },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: agent:read",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -9,7 +9,6 @@ import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-co
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf } from "../context/request";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { notFound } from "../../lib/error";
 import {
   zeroAgentDetail,
@@ -103,9 +102,6 @@ export const zeroAgentsRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroAgentCustomConnectorsContract.get,
-    handler: shadowCompareRoute({
-      route: zeroAgentCustomConnectorsContract.get,
-      handler: authRoute(agentReadAuth, getAgentCustomConnectorsInner$),
-    }),
+    handler: authRoute(agentReadAuth, getAgentCustomConnectorsInner$),
   },
 ];


### PR DESCRIPTION
## Summary

- make `GET /api/zero/agents/:id/custom-connectors` API-authoritative by removing the `shadowCompareRoute(...)` wrapper around the customConnectors route entry
- **`zero-agents.ts` becomes fully migrated** (the 16th file in the epic): a1's #12439 (userConnectors) merged before push, which combined with this PR removes all 4 wrappers — also drops the now-unused `shadowCompareRoute` import per the leader's wave 14 coordination directive
- add api integration tests covering all 3 web GET cases plus 3 api defensive (401 missing-org, cross-org 404, sandbox capability 403) — 6 total
- reuse `seedTeamCompose$` / `deleteTeamCompose$` from existing `helpers/zero-team.ts` — same precedent as PR #12434

Closes #12441

Part of epic #12290.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts` — 6 / 6 passing
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `grep -c "shadowCompareRoute" turbo/apps/api/src/signals/routes/zero-agents.ts` — **0** (file fully migrated)

## Test cases

| # | Case | Mirrors web |
|---|------|-------------|
| 1 | unauthenticated → 401 | "returns 401 without auth" (line 112) |
| 2 | session, no active org → 401 | n/a — added per epic pattern |
| 3 | seeded agent, no enabled connectors → 200 `{enabledIds: []}` | "returns empty enabledIds for new agent" (line 97) |
| 4 | unknown id → 404 | "returns 404 for non-existent agent" (line 106) |
| 5 | cross-org agent → 404 (no existence leak) | n/a — defensive port (per #12390/#12407/#12415/#12425/#12434 precedent) |
| 6 | sandbox token w/o agent:read → 403 | n/a — defensive port (per #12402/#12408/#12422/#12435 precedent) |

## Service parity

API `zeroAgentEnabledCustomConnectorIds` and web's GET handler execute identical SQL: agent-exists check via `eq(zeroAgents.id, agentId) AND eq(zeroAgents.orgId, orgId)`, then enabled-connectors query via `userCustomConnectors WHERE orgId AND userId AND agentId`. Identical not-found message ("Agent not found: \${id}").

## Coordination outcome

Per the wave 14 plan Step 4 coordination logic:
- Pre-rebase: `grep -c "shadowCompareRoute(" zero-agents.ts` = 2 (userConnectors + customConnectors)
- Post-rebase: count = 0 (a1's #12439 already merged, dropping userConnectors wrapper before my push)
- My customConnectors drop combined with a1's already-merged userConnectors drop leaves 0 wrappers + 1 unused import line
- Per leader directive: drop the unused `shadowCompareRoute` import → file fully migrated

## Behavioral note

Web returns 404 if `resolveOrg` rejects. The api implementation skips `resolveOrg` (Clerk-implies-membership simplification) — `zeroAgentExists` queries by `(orgId, agentId)` and returns false → 404 for any non-matching combination. Same accepted gap as PRs #12312 / #12314 / #12315 / #12337 / #12351 / #12363 / #12377 / #12384 / #12388 / #12392 / #12402 / #12408 / #12414 / #12415 / #12422 / #12427 / #12435.

## Rollback

Disabling the `apiBackend` feature switch routes traffic back to `apps/web`. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)