### PR TITLE
refactor(api): migrate voice-chat list-sessions get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-voice-chat.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-voice-chat.ts
@@ -1,0 +1,88 @@
+import { randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { voiceChatSessions } from "@vm0/db/schema/voice-chat";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { writeDb$ } from "../../../external/db";
+
+export interface VoiceChatFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly sessionIds: readonly string[];
+}
+
+interface SessionSeed {
+  readonly userId?: string;
+  readonly orgId?: string;
+  readonly createdAt?: Date;
+}
+
+interface SeedValues {
+  readonly trinityEnabled?: boolean;
+  readonly sessions?: readonly SessionSeed[];
+}
+
+export const seedVoiceChatFixture$ = command(
+  async (
+    { set },
+    values: SeedValues,
+    signal: AbortSignal,
+  ): Promise<VoiceChatFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const writeDb = set(writeDb$);
+
+    if (values.trinityEnabled) {
+      await writeDb.insert(userFeatureSwitches).values({
+        orgId,
+        userId,
+        switches: { trinity: true },
+      });
+      signal.throwIfAborted();
+    }
+
+    const sessionIds: string[] = [];
+    for (const session of values.sessions ?? []) {
+      const id = randomUUID();
+      sessionIds.push(id);
+      await writeDb.insert(voiceChatSessions).values({
+        id,
+        orgId: session.orgId ?? orgId,
+        userId: session.userId ?? userId,
+        ...(session.createdAt !== undefined
+          ? { createdAt: session.createdAt }
+          : {}),
+      });
+      signal.throwIfAborted();
+    }
+
+    return { orgId, userId, sessionIds };
+  },
+);
+
+export const deleteVoiceChatFixture$ = command(
+  async (
+    { set },
+    fixture: VoiceChatFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    if (fixture.sessionIds.length > 0) {
+      await writeDb
+        .delete(voiceChatSessions)
+        .where(inArray(voiceChatSessions.id, [...fixture.sessionIds]));
+      signal.throwIfAborted();
+    }
+    await writeDb
+      .delete(userFeatureSwitches)
+      .where(
+        and(
+          eq(userFeatureSwitches.orgId, fixture.orgId),
+          eq(userFeatureSwitches.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-chat-list-sessions.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-chat-list-sessions.test.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroVoiceChatContract } from "@vm0/api-contracts/contracts/zero-voice-chat";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteVoiceChatFixture$,
+  seedVoiceChatFixture$,
+  type VoiceChatFixture,
+} from "./helpers/zero-voice-chat";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/voice-chat (listSessions)", () => {
+  const track = createFixtureTracker<VoiceChatFixture>((fixture) => {
+    return store.set(deleteVoiceChatFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(client.listSessions({ headers: {} }), [401]);
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        { trinityEnabled: true },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, null);
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.listSessions({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 when the trinity feature switch is disabled", async () => {
+    const fixture = await track(
+      store.set(seedVoiceChatFixture$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.listSessions({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Voice-chat is not enabled", code: "FORBIDDEN" },
+    });
+  });
+
+  it("returns an empty list when the user has no voice-chat sessions", async () => {
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        { trinityEnabled: true },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.listSessions({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(response.body).toStrictEqual({ sessions: [] });
+  });
+
+  it("returns the user's voice-chat sessions ordered by createdAt desc", async () => {
+    const older = new Date(now() - 100_000);
+    const newer = new Date(now() - 10_000);
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        {
+          trinityEnabled: true,
+          sessions: [{ createdAt: older }, { createdAt: newer }],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.listSessions({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.sessions).toHaveLength(2);
+    const [first, second] = response.body.sessions;
+    expect(first?.id).toBe(fixture.sessionIds[1]);
+    expect(second?.id).toBe(fixture.sessionIds[0]);
+  });
+
+  it("does not include sessions belonging to a different user in the same org", async () => {
+    const otherUserId = `user_${randomUUID()}`;
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        {
+          trinityEnabled: true,
+          sessions: [{}, { userId: otherUserId }],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.listSessions({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.sessions).toHaveLength(1);
+    expect(response.body.sessions[0]?.id).toBe(fixture.sessionIds[0]);
+    expect(
+      response.body.sessions.map((s) => {
+        return s.id;
+      }),
+    ).not.toContain(fixture.sessionIds[1]);
+  });
+
+  it("does not include sessions belonging to a different org", async () => {
+    const otherOrgId = `org_${randomUUID()}`;
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        {
+          trinityEnabled: true,
+          sessions: [{}, { orgId: otherOrgId }],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.listSessions({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.sessions).toHaveLength(1);
+    expect(response.body.sessions[0]?.id).toBe(fixture.sessionIds[0]);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-voice-chat.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-chat.ts
@@ -1,5 +1,7 @@
 import { computed } from "ccstate";
 import { zeroVoiceChatContract } from "@vm0/api-contracts/contracts/zero-voice-chat";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -7,16 +9,58 @@ import { pathParamsOf } from "../context/request";
 import { shadowCompareRoute } from "../context/shadow-compare";
 import { notFound } from "../../lib/error";
 import type { RouteEntry } from "../route";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
   voiceChatSessionList,
   voiceChatSessionDetail,
   voiceChatTaskList,
 } from "../services/zero-voice-chat.service";
 
+const voiceChatDisabled = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Voice-chat is not enabled",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
 const listSessionsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  const enabled = isFeatureEnabled(FeatureSwitchKey.Trinity, {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    overrides,
+  });
+  if (!enabled) {
+    return voiceChatDisabled;
+  }
   const sessions = await get(voiceChatSessionList(auth.orgId, auth.userId));
-  return { status: 200 as const, body: { sessions } };
+  return {
+    status: 200 as const,
+    body: {
+      sessions: sessions.map((session) => {
+        return {
+          id: session.id,
+          orgId: session.orgId,
+          userId: session.userId,
+          agentId: session.agentId,
+          mode: "chat" as const,
+          conversationSummary: session.conversationSummary,
+          workingTasksSummary: session.workingTasksSummary,
+          finishedTasksSummary: session.finishedTasksSummary,
+          summarySeq: session.summarySeq,
+          summaryVersion: session.summaryVersion,
+          lastSummaryAt: session.lastSummaryAt?.toISOString() ?? null,
+          createdAt: session.createdAt.toISOString(),
+        };
+      }),
+    },
+  };
 });
 
 const getSessionInner$ = computed(async (get) => {
@@ -59,13 +103,10 @@ const listTasksInner$ = computed(async (get) => {
 export const zeroVoiceChatRoutes: readonly RouteEntry[] = [
   {
     route: zeroVoiceChatContract.listSessions,
-    handler: shadowCompareRoute({
-      route: zeroVoiceChatContract.listSessions,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        listSessionsInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      listSessionsInner$,
+    ),
   },
   {
     route: zeroVoiceChatContract.getSession,

--- a/turbo/apps/api/src/signals/routes/zero-voice-chat.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-chat.ts
@@ -11,6 +11,7 @@ import { notFound } from "../../lib/error";
 import type { RouteEntry } from "../route";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
+  serializeVoiceChatSession,
   voiceChatSessionList,
   voiceChatSessionDetail,
   voiceChatTaskList,
@@ -42,24 +43,7 @@ const listSessionsInner$ = computed(async (get) => {
   const sessions = await get(voiceChatSessionList(auth.orgId, auth.userId));
   return {
     status: 200 as const,
-    body: {
-      sessions: sessions.map((session) => {
-        return {
-          id: session.id,
-          orgId: session.orgId,
-          userId: session.userId,
-          agentId: session.agentId,
-          mode: "chat" as const,
-          conversationSummary: session.conversationSummary,
-          workingTasksSummary: session.workingTasksSummary,
-          finishedTasksSummary: session.finishedTasksSummary,
-          summarySeq: session.summarySeq,
-          summaryVersion: session.summaryVersion,
-          lastSummaryAt: session.lastSummaryAt?.toISOString() ?? null,
-          createdAt: session.createdAt.toISOString(),
-        };
-      }),
-    },
+    body: { sessions: sessions.map(serializeVoiceChatSession) },
   };
 });
 

--- a/turbo/apps/api/src/signals/services/zero-voice-chat.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-chat.service.ts
@@ -1,4 +1,5 @@
 import { computed, type Computed } from "ccstate";
+import type { VoiceChatSession } from "@vm0/api-contracts/contracts/zero-voice-chat";
 import { voiceChatSessions, voiceChatTasks } from "@vm0/db/schema/voice-chat";
 import { and, asc, desc, eq, inArray } from "drizzle-orm";
 
@@ -7,6 +8,32 @@ import { db$ } from "../external/db";
 const ACTIVE_TASK_STATUSES = ["pending", "queued", "running"] as const;
 const FINISHED_TASK_STATUSES = ["done", "failed"] as const;
 const MAX_FINISHED_TASKS = 3;
+
+/**
+ * Map a `voice_chat_sessions` row to the contract-shaped `VoiceChatSession`
+ * DTO. Mirrors web's `serializeVoiceChatSession` in
+ * `apps/web/app/api/zero/voice-chat/_support.ts` so the contract -> row
+ * mapping has a single source of truth across the api migration. Sibling
+ * routes (`getSession`, `listTasks`) reuse this when they migrate.
+ */
+export function serializeVoiceChatSession(
+  session: typeof voiceChatSessions.$inferSelect,
+): VoiceChatSession {
+  return {
+    id: session.id,
+    orgId: session.orgId,
+    userId: session.userId,
+    agentId: session.agentId,
+    mode: "chat",
+    conversationSummary: session.conversationSummary,
+    workingTasksSummary: session.workingTasksSummary,
+    finishedTasksSummary: session.finishedTasksSummary,
+    summarySeq: session.summarySeq,
+    summaryVersion: session.summaryVersion,
+    lastSummaryAt: session.lastSummaryAt?.toISOString() ?? null,
+    createdAt: session.createdAt.toISOString(),
+  };
+}
 
 export function voiceChatSessionList(
   orgId: string,


### PR DESCRIPTION
## Summary

- make `GET /api/zero/voice-chat` (listSessions) API-authoritative by removing the `shadowCompareRoute(...)` wrapper around the listSessions route entry only
- shared file `zero-voice-chat.ts` goes from 3 → 2 `shadowCompareRoute(...)` invocations (getSession + listTasks retained for separate Stage 2 follow-ups)
- `shadowCompareRoute` import retained
- **Plan A2 #1 (Trinity gate)**: port web's Trinity feature-switch gate — without it, members of orgs without voice-chat enabled would silently get 200 instead of web's 403. Uses the established `userFeatureSwitchOverrides + isFeatureEnabled` pattern from `zero-computer-use.ts`. Contract already declares 403, no contract change needed.
- **Plan A2 #2 (response serializer)**: map `voice_chat_sessions` rows from raw Date columns to ISO strings at the route handler so ts-rest's `validateResponse: true` accepts the body (the contract `voiceChatSessionSchema` declares `createdAt` and `lastSummaryAt` as strings)
- **Special case: web has zero GET tests for this route.** The migration adds fresh api-side coverage rather than ports existing tests
- introduce `helpers/zero-voice-chat.ts` (`seedVoiceChatFixture$` / `deleteVoiceChatFixture$`) — bundles `user_feature_switches` and `voice_chat_sessions` seeding in a single helper, reusable for sibling getSession and listTasks migrations

Closes #12446

Part of epic #12290.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-voice-chat-list-sessions.test.ts` — 7 / 7 passing
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `grep -c "shadowCompareRoute(" turbo/apps/api/src/signals/routes/zero-voice-chat.ts` — **2** (down from 3)

## Test cases (fresh coverage)

| # | Case | Notes |
|---|------|-------|
| 1 | unauthenticated → 401 | api convention |
| 2 | session, no active org → 401 | requireOrganization Stage 2 pattern |
| 3 | Trinity feature switch disabled → 403 | covers the bundled Plan A2 gate; pins the new "Voice-chat is not enabled" message |
| 4 | empty list → 200 `{sessions: []}` | trinity enabled, no sessions seeded |
| 5 | sessions ordered by createdAt desc → 200 | trinity enabled, two sessions with explicit timestamps |
| 6 | cross-user isolation → 200 (other-user session excluded) | helper supports per-session userId override |
| 7 | cross-org isolation → 200 (other-org session excluded) | helper supports per-session orgId override |

## Trinity gate (Plan A2 #1)

The route now performs:
```ts
const overrides = await get(userFeatureSwitchOverrides(auth.orgId, auth.userId));
const enabled = isFeatureEnabled(FeatureSwitchKey.Trinity, {
  orgId: auth.orgId,
  userId: auth.userId,
  overrides,
});
if (!enabled) return voiceChatDisabled;  // 403 with documented message
```

Same pattern as `zero-computer-use.ts:32-44` and `zero-model-policies.ts:48-78`. Trinity defaults to `enabled: false` per `packages/core/src/feature-switch.ts:275-280` (gated, opt-in via per-user override).

## Response serializer (Plan A2 #2)

`voiceChatSessionList` returns raw drizzle rows with `Date` for `createdAt` and `lastSummaryAt`. The contract expects ISO strings. Without serialization, ts-rest's `validateResponse` rejected the response after the shadowCompareRoute wrapper was removed (shadow-compare tolerated the divergence by silently logging). The route now maps the rows to a contract-shaped projection (mirrors web's `serializeVoiceChatSession` in `_support.ts:37`).

Sibling routes (`getSession`, `listTasks`) will need the same serializer treatment when they migrate.

## Helper file

`helpers/zero-voice-chat.ts` exports:
- `seedVoiceChatFixture$({trinityEnabled?, sessions?})` — generates fresh `{orgId, userId}`, optionally inserts a `user_feature_switches` row with `trinity: true`, and inserts N `voice_chat_sessions` rows. Each session can override `userId`/`orgId`/`createdAt`. Used for cross-user / cross-org / ordering tests.
- `deleteVoiceChatFixture$(fixture)` — cleans up sessions then feature-switch row.

Reusable for the two sibling route migrations (getSession, listTasks) — they need the same Trinity gate and session seeding.

## Behavioral note

Web returns 404 if `getAuthContext` returns null (no auth) — but its current handler returns 401 for both no-auth and no-org. API matches the 401 path. The Clerk-implies-membership simplification continues to apply (no resolveOrg attempt).

## Rollback

Disabling the `apiBackend` feature switch routes traffic back to `apps/web`. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)