### PR TITLE
refactor(api): migrate org members get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-members.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-members.test.ts
@@ -5,7 +5,6 @@ import { http, HttpResponse } from "msw";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
-import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -147,7 +146,6 @@ function mockClerkMembershipRequestsStatus(
 
 describe("GET /api/zero/org/members", () => {
   it("returns 401 when not authenticated", async () => {
-    mockApiShadowCompareRoutes([zeroOrgMembersContract.members]);
     const client = setupApp({ context })(zeroOrgMembersContract);
 
     const response = await accept(client.members({ headers: {} }), [401]);
@@ -210,7 +208,6 @@ describe("GET /api/zero/org/members", () => {
       },
     ]);
     mocks.clerk.session(adminUserId, orgId, "org:admin");
-    mockApiShadowCompareRoutes([zeroOrgMembersContract.members]);
 
     const client = setupApp({ context })(zeroOrgMembersContract);
     const response = await accept(
@@ -274,7 +271,6 @@ describe("GET /api/zero/org/members", () => {
       },
     ]);
     mocks.clerk.session(userId, orgId, "org:member");
-    mockApiShadowCompareRoutes([zeroOrgMembersContract.members]);
 
     const client = setupApp({ context })(zeroOrgMembersContract);
     const response = await accept(
@@ -301,7 +297,6 @@ describe("GET /api/zero/org/members", () => {
     mockClerkNoInvitations();
     mockClerkMembershipRequests(orgId, []);
     mocks.clerk.session(userId, orgId, "org:admin");
-    mockApiShadowCompareRoutes([zeroOrgMembersContract.members]);
 
     const client = setupApp({ context })(zeroOrgMembersContract);
     const response = await accept(
@@ -341,7 +336,6 @@ describe("GET /api/zero/org/members", () => {
     ]);
     mockClerkMembershipRequestsStatus(orgId, 404);
     mocks.clerk.session(adminUserId, orgId, "org:admin");
-    mockApiShadowCompareRoutes([zeroOrgMembersContract.members]);
 
     const client = setupApp({ context })(zeroOrgMembersContract);
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/zero-org-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-read.ts
@@ -6,7 +6,6 @@ import { zeroOrgMembersContract } from "@vm0/api-contracts/contracts/zero-org-me
 
 import { authContext$, organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { notFound } from "../../lib/error";
 import type { RouteEntry } from "../route";
 import {
@@ -85,12 +84,9 @@ export const zeroOrgReadRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroOrgMembersContract.members,
-    handler: shadowCompareRoute({
-      route: zeroOrgMembersContract.members,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        membersInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      membersInner$,
+    ),
   },
 ];


### PR DESCRIPTION
## Summary

Drop the api-side `shadowCompareRoute` wrapper around `zeroOrgMembersContract.members` so the api response becomes authoritative. The api side has been byte-equivalent to web during shadow comparison since precursor #12444 (PR #12447) brought `zeroOrgMembersList` to full Clerk parity and shipped 5 route-level integration tests.

This is the trivial wrapper-drop counterpart that #12443 was reduced to once the precursor merged.

### What this PR does

- **`apps/api/src/signals/routes/zero-org-read.ts`**:
  - Drop the `shadowCompareRoute` wrapper around `zeroOrgMembersContract.members` (-4 / +1)
  - Remove the now-unused `shadowCompareRoute` import — sibling PR #12449 (orgGet migration) merged just before this and dropped its own usage, so members was the last consumer in this file. **The file is now fully migrated.**
- **`apps/api/src/signals/routes/__tests__/zero-org-members.test.ts`**:
  - Strip the 5 `mockApiShadowCompareRoutes(...)` calls and the import — the route no longer runs in shadow mode, so the helpers are no-ops

### Coverage

The 5 cases in `zero-org-members.test.ts` (added by precursor #12447) continue to pass without the shadow-mode mock helpers:

- `returns 401 when not authenticated` (web case 3, 1:1)
- `returns members and admin-only data for an admin caller` (web cases 1+2 combined)
- `does not call membership_requests endpoint or return admin-only data for non-admin` (web case 5, 1:1 — plus security guarantee that the admin-only REST call is not made)
- `returns empty members and skips getUserList when memberships are empty` (api defensive)
- `treats Clerk membership_requests 404 as empty (feature disabled)` (api defensive)

Web case 4 (no org in session, web 400) intentionally not ported: api convention is **401 missing-org** (`requireOrganization: true, missingOrganizationStatus: 401`), centrally enforced by `authRoute` and exhaustively covered by the auth-route test file. Consistent with prior migrations (#12431, #12440, #12442).

### Out of scope

- No web changes (`apps/web/app/api/zero/org/members/route.ts` stays — web-route cleanup is a downstream effort per EPIC #12290)
- No service or contract changes
- No new tests (precursor #12447 already wrote them)

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-org-members.test.ts` — 5/5 pass
- [x] `pnpm -F api exec vitest run` — 549/549 pass (full api suite)
- [x] `pnpm turbo run lint --filter=api` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `pnpm knip --workspace api` — no issues
- [x] `pnpm format` — applied (no diffs)

Closes #12443