### PR TITLE
refactor(api): migrate voice-chat get session get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-chat-get-session.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-chat-get-session.test.ts
@@ -142,6 +142,38 @@ describe("GET /api/zero/voice-chat/:id (getSession)", () => {
     });
   });
 
+  it("returns 404 when the session belongs to a different org (no existence leak)", async () => {
+    const otherOrgId = `org_${randomUUID()}`;
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        {
+          trinityEnabled: true,
+          sessions: [{ orgId: otherOrgId }],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const otherSessionId = fixture.sessionIds[0]!;
+
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.getSession({
+        params: { id: otherSessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Voice-chat session not found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
   it("returns the session when it belongs to the caller", async () => {
     const fixture = await track(
       store.set(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-chat-get-session.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-chat-get-session.test.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroVoiceChatContract } from "@vm0/api-contracts/contracts/zero-voice-chat";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteVoiceChatFixture$,
+  seedVoiceChatFixture$,
+  type VoiceChatFixture,
+} from "./helpers/zero-voice-chat";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/voice-chat/:id (getSession)", () => {
+  const track = createFixtureTracker<VoiceChatFixture>((fixture) => {
+    return store.set(deleteVoiceChatFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.getSession({ params: { id: randomUUID() }, headers: {} }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        { trinityEnabled: true },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, null);
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.getSession({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 when the trinity feature switch is disabled (avoids leaking existence)", async () => {
+    // Seed a real session for the user but DON'T enable Trinity.
+    // Web pattern: flag-disabled tenants get 404 (not 403) so they cannot
+    // distinguish "session exists" from "feature disabled".
+    const fixture = await track(
+      store.set(seedVoiceChatFixture$, { sessions: [{}] }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const sessionId = fixture.sessionIds[0]!;
+
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.getSession({
+        params: { id: sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Voice-chat session not found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 404 when the session does not exist", async () => {
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        { trinityEnabled: true },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.getSession({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Voice-chat session not found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 404 when the session belongs to a different user (no existence leak)", async () => {
+    const otherUserId = `user_${randomUUID()}`;
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        {
+          trinityEnabled: true,
+          sessions: [{ userId: otherUserId }],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const otherSessionId = fixture.sessionIds[0]!;
+
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.getSession({
+        params: { id: otherSessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Voice-chat session not found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns the session when it belongs to the caller", async () => {
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        { trinityEnabled: true, sessions: [{}] },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const sessionId = fixture.sessionIds[0]!;
+
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.getSession({
+        params: { id: sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.session.id).toBe(sessionId);
+    expect(response.body.session.userId).toBe(fixture.userId);
+    expect(response.body.session.orgId).toBe(fixture.orgId);
+    // Talker payload is currently hardcoded empty in api — see follow-up
+    // issue (deferred from this Stage 2 migration).
+    expect(response.body.recentTaskLogs).toBe("");
+    expect(response.body.finishedTasksFullText).toBe("");
+    expect(response.body.talkerInstructions).toBe("");
+    expect(response.body.talkerInstructionTokens).toBe(0);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-voice-chat.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-chat.ts
@@ -49,6 +49,19 @@ const listSessionsInner$ = computed(async (get) => {
 
 const getSessionInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  const enabled = isFeatureEnabled(FeatureSwitchKey.Trinity, {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    overrides,
+  });
+  if (!enabled) {
+    // Web pattern: collapse flag-disabled into 404 to avoid leaking
+    // session existence (contract does not declare 403 for getSession).
+    return notFound("Voice-chat session not found");
+  }
   const params = get(pathParamsOf(zeroVoiceChatContract.getSession));
   const session = await get(
     voiceChatSessionDetail(auth.orgId, auth.userId, params.id),
@@ -59,7 +72,7 @@ const getSessionInner$ = computed(async (get) => {
   return {
     status: 200 as const,
     body: {
-      session,
+      session: serializeVoiceChatSession(session),
       recentTaskLogs: "",
       finishedTasksFullText: "",
       talkerInstructions: "",
@@ -94,13 +107,10 @@ export const zeroVoiceChatRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroVoiceChatContract.getSession,
-    handler: shadowCompareRoute({
-      route: zeroVoiceChatContract.getSession,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        getSessionInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      getSessionInner$,
+    ),
   },
   {
     route: zeroVoiceChatContract.listTasks,

--- a/turbo/apps/api/src/signals/routes/zero-voice-chat.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-chat.ts
@@ -73,6 +73,9 @@ const getSessionInner$ = computed(async (get) => {
     status: 200 as const,
     body: {
       session: serializeVoiceChatSession(session),
+      // Talker payload deferred — see #12463 (port `buildTalkerPayload`).
+      // Web computes these via `buildTalkerPayload(session)`; API currently
+      // returns empty/zero for Stage 2 scoping.
       recentTaskLogs: "",
       finishedTasksFullText: "",
       talkerInstructions: "",


### PR DESCRIPTION
## Summary

- make `GET /api/zero/voice-chat/:id` (getSession) API-authoritative by removing the `shadowCompareRoute(...)` wrapper around the getSession route entry only
- shared file `zero-voice-chat.ts` goes from 2 → 1 `shadowCompareRoute(...)` invocations (listTasks retained for separate Stage 2 follow-up)
- `shadowCompareRoute` import retained
- **Plan A2 #1 (Trinity gate, 404 not 403)**: collapse flag-disabled into 404 per web's no-existence-leak design — the contract does not declare 403 for getSession (only 401/404). Sibling listSessions returns 403 because its contract DOES declare 403; this is a deliberate contract-driven divergence that this PR mirrors verbatim.
- **Plan A2 #2 (response serializer)**: use `serializeVoiceChatSession` (added in #12448) for ISO date conversion — without it, ts-rest's `validateResponse` would reject the body.
- 6 cases: 5 web 1:1 + api 401 missing-org
- Helper REUSE: `seedVoiceChatFixture$` from `helpers/zero-voice-chat.ts` (created in #12448) — supports per-session userId override for cross-user 404 test

Closes #12451

Part of epic #12290.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-voice-chat-get-session.test.ts` — 6 / 6 passing
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-voice-chat-list-sessions.test.ts` — 7 / 7 passing (sibling sanity)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `grep -c "shadowCompareRoute(" turbo/apps/api/src/signals/routes/zero-voice-chat.ts` — **1** (down from 2)

## Test cases

| # | Case | Mirrors web |
|---|------|-------------|
| 1 | unauthenticated → 401 | "returns 401 when not authenticated" (line 42) |
| 2 | session, no active org → 401 | n/a — added per epic pattern |
| 3 | Trinity disabled, real session exists → 404 (no leak) | "returns 404 when the feature flag is disabled (avoids leaking existence)" (line 53) |
| 4 | random uuid, Trinity enabled → 404 | "returns 404 when the session does not exist" (line 66) |
| 5 | session belongs to other user → 404 (no leak) | "returns 404 when the session belongs to a different user" (line 76) |
| 6 | own session → 200 with serialized session | "returns the session when it belongs to the caller" (line 96) |

## Trinity gate (Plan A2 #1) — 404 vs 403 design

Web pattern from `apps/web/.../[id]/route.ts:24-32`:
> Flag-disabled tenants collapse into 404 rather than 403 here: the GET contract does not list 403 in its response schema (endpoint is a read path), and returning 404 avoids leaking the existence of the session while still satisfying the epic's "every route gates on the flag" rule.

This PR preserves that exact behavior verbatim. The route now performs:
```ts
const overrides = await get(userFeatureSwitchOverrides(auth.orgId, auth.userId));
const enabled = isFeatureEnabled(FeatureSwitchKey.Trinity, {
  orgId: auth.orgId, userId: auth.userId, overrides,
});
if (!enabled) {
  return notFound("Voice-chat session not found");  // ← 404, NOT 403
}
```

## Talker payload divergence (deferred)

API returns hardcoded empty strings + 0 tokens for `recentTaskLogs`, `finishedTasksFullText`, `talkerInstructions`, `talkerInstructionTokens`. Web computes these via `buildTalkerPayload(session)`.

This is **not Plan A2** — porting `buildTalkerPayload` is a feature port (~150+ LOC: voice_chat_items aggregation, finished_tasks query, instruction templating, token counting). Web tests don't assert these fields; the contract accepts both shapes (just `z.string()` and `z.number().int().nonnegative()`).

Will file follow-up issue post-merge: "fix(api): port buildTalkerPayload to populate voice-chat session GET talker fields" (tech-debt, optional priority — same shape as PR #12424 watermark follow-up).

## Behavioral note

Cross-user/cross-org isolation is enforced at the SQL layer in `voiceChatSessionDetail({orgId, userId, id})` — the WHERE filter rejects rows owned by other users/orgs. This is identical to web's post-fetch `session.orgId !== authCtx.orgId || session.userId !== authCtx.userId` check.

## Rollback

Disabling the `apiBackend` feature switch routes traffic back to `apps/web`. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)