### PR TITLE
chore(api): extract org membership seeders to shared helper

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-org-membership.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-org-membership.ts
@@ -1,0 +1,61 @@
+import { command } from "ccstate";
+import { orgCache } from "@vm0/db/schema/org-cache";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { eq } from "drizzle-orm";
+
+import { writeDb$ } from "../../../external/db";
+
+interface SeedOrgMembershipValues {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly slug?: string;
+  readonly name?: string;
+  readonly role?: "admin" | "member";
+  readonly seedOrgCache?: boolean;
+}
+
+export interface OrgMembershipFixture {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+export const seedOrgMembership$ = command(
+  async (
+    { set },
+    values: SeedOrgMembershipValues,
+    signal: AbortSignal,
+  ): Promise<OrgMembershipFixture> => {
+    const writeDb = set(writeDb$);
+    if (values.seedOrgCache !== false) {
+      await writeDb.insert(orgCache).values({
+        orgId: values.orgId,
+        slug: values.slug ?? `org-${values.orgId.slice(-8)}`,
+        name: values.name ?? "",
+      });
+      signal.throwIfAborted();
+    }
+    await writeDb.insert(orgMembersCache).values({
+      orgId: values.orgId,
+      userId: values.userId,
+      role: values.role ?? "member",
+    });
+    signal.throwIfAborted();
+    return { orgId: values.orgId, userId: values.userId };
+  },
+);
+
+export const deleteOrgMembership$ = command(
+  async (
+    { set },
+    fixture: OrgMembershipFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(orgMembersCache)
+      .where(eq(orgMembersCache.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await writeDb.delete(orgCache).where(eq(orgCache.orgId, fixture.orgId));
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram.test.ts
@@ -2,16 +2,18 @@ import { randomUUID } from "node:crypto";
 
 import { integrationsTelegramBotListContract } from "@vm0/api-contracts/contracts/integrations";
 import { OFFICIAL_TELEGRAM_BOT_ID } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
-import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { createStore } from "ccstate";
-import { and, eq } from "drizzle-orm";
 import { afterEach, beforeEach } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { mockEnv } from "../../../lib/env";
-import { writeDb$ } from "../../external/db";
 import { now } from "../../external/time";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
 import {
   deleteTelegramFixture$,
   freezeTelegramFixture,
@@ -54,28 +56,9 @@ function mintZeroToken(args: {
   });
 }
 
-async function seedMembership(orgId: string, userId: string): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb.insert(orgMembersCache).values({
-    orgId,
-    userId,
-    role: "member",
-    cachedAt: new Date(now()),
-  });
-}
-
-async function deleteMembership(orgId: string, userId: string): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb
-    .delete(orgMembersCache)
-    .where(
-      and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
-    );
-}
-
 describe("GET /api/zero/integrations/telegram/bots", () => {
   const fixtures: TelegramFixture[] = [];
-  const memberships: { orgId: string; userId: string }[] = [];
+  const memberships: OrgMembershipFixture[] = [];
 
   beforeEach(() => {
     configureOfficialBotEnv();
@@ -91,7 +74,7 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
     while (memberships.length > 0) {
       const membership = memberships.pop();
       if (membership) {
-        await deleteMembership(membership.orgId, membership.userId);
+        await store.set(deleteOrgMembership$, membership, context.signal);
       }
     }
   });
@@ -109,8 +92,12 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
     const userId = `user_${randomUUID()}`;
     const otherOrgId = `org_${randomUUID()}`;
 
-    await seedMembership(orgId, userId);
-    memberships.push({ orgId, userId });
+    const membership = await store.set(
+      seedOrgMembership$,
+      { orgId, userId, seedOrgCache: false },
+      context.signal,
+    );
+    memberships.push(membership);
 
     const ownerBotId = newTelegramBotId();
     const orgBotId = newTelegramBotId();
@@ -195,8 +182,12 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
 
-    await seedMembership(orgId, userId);
-    memberships.push({ orgId, userId });
+    const membership = await store.set(
+      seedOrgMembership$,
+      { orgId, userId, seedOrgCache: false },
+      context.signal,
+    );
+    memberships.push(membership);
 
     const token = mintZeroToken({
       userId,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-domains.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-domains.test.ts
@@ -1,53 +1,29 @@
 import { randomUUID } from "node:crypto";
 
 import { zeroOrgDomainsContract } from "@vm0/api-contracts/contracts/zero-org-domains";
-import { orgCache } from "@vm0/db/schema/org-cache";
-import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { createStore } from "ccstate";
-import { eq } from "drizzle-orm";
 import { afterEach } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { writeDb$ } from "../../external/db";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
-interface SeededOrg {
-  readonly orgId: string;
-  readonly userId: string;
-  readonly role: "admin" | "member";
-}
-
-async function seedOrgMembership(args: SeededOrg): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb.insert(orgCache).values({
-    orgId: args.orgId,
-    slug: `org-${args.orgId.slice(-8)}`,
-  });
-  await writeDb.insert(orgMembersCache).values({
-    orgId: args.orgId,
-    userId: args.userId,
-    role: args.role,
-  });
-}
-
-async function deleteOrgMembership(orgId: string): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb.delete(orgMembersCache).where(eq(orgMembersCache.orgId, orgId));
-  await writeDb.delete(orgCache).where(eq(orgCache.orgId, orgId));
-}
-
 describe("GET /api/zero/org/domains", () => {
-  const seededOrgIds: string[] = [];
+  const seededFixtures: OrgMembershipFixture[] = [];
 
   afterEach(async () => {
-    while (seededOrgIds.length > 0) {
-      const orgId = seededOrgIds.pop();
-      if (orgId) {
-        await deleteOrgMembership(orgId);
+    while (seededFixtures.length > 0) {
+      const fixture = seededFixtures.pop();
+      if (fixture) {
+        await store.set(deleteOrgMembership$, fixture, context.signal);
       }
     }
   });
@@ -76,8 +52,13 @@ describe("GET /api/zero/org/domains", () => {
   it("returns the domain list for an admin", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await seedOrgMembership({ orgId, userId, role: "admin" });
-    seededOrgIds.push(orgId);
+    seededFixtures.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "admin" },
+        context.signal,
+      ),
+    );
     mocks.clerk.session(userId, orgId, "org:admin");
 
     const client = setupApp({ context })(zeroOrgDomainsContract);
@@ -93,8 +74,13 @@ describe("GET /api/zero/org/domains", () => {
   it("returns 403 when caller is not an admin", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await seedOrgMembership({ orgId, userId, role: "member" });
-    seededOrgIds.push(orgId);
+    seededFixtures.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "member" },
+        context.signal,
+      ),
+    );
     mocks.clerk.session(userId, orgId, "org:member");
 
     const client = setupApp({ context })(zeroOrgDomainsContract);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-list.test.ts
@@ -1,51 +1,29 @@
 import { randomUUID } from "node:crypto";
 
 import { zeroOrgListContract } from "@vm0/api-contracts/contracts/zero-org-list";
-import { orgCache } from "@vm0/db/schema/org-cache";
-import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { createStore } from "ccstate";
-import { eq } from "drizzle-orm";
 import { afterEach } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { writeDb$ } from "../../external/db";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
-interface SeededOrg {
-  readonly orgId: string;
-  readonly userId: string;
-  readonly slug: string;
-  readonly role: string;
-}
-
-async function seedOrgMembership(args: SeededOrg): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb.insert(orgCache).values({ orgId: args.orgId, slug: args.slug });
-  await writeDb.insert(orgMembersCache).values({
-    orgId: args.orgId,
-    userId: args.userId,
-    role: args.role,
-  });
-}
-
-async function deleteOrgMembership(orgId: string): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb.delete(orgMembersCache).where(eq(orgMembersCache.orgId, orgId));
-  await writeDb.delete(orgCache).where(eq(orgCache.orgId, orgId));
-}
-
 describe("GET /api/zero/org/list", () => {
-  const seededOrgIds: string[] = [];
+  const seededFixtures: OrgMembershipFixture[] = [];
 
   afterEach(async () => {
-    while (seededOrgIds.length > 0) {
-      const orgId = seededOrgIds.pop();
-      if (orgId) {
-        await deleteOrgMembership(orgId);
+    while (seededFixtures.length > 0) {
+      const fixture = seededFixtures.pop();
+      if (fixture) {
+        await store.set(deleteOrgMembership$, fixture, context.signal);
       }
     }
   });
@@ -62,8 +40,13 @@ describe("GET /api/zero/org/list", () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     const slug = `solo-${randomUUID().slice(0, 8)}`;
-    await seedOrgMembership({ orgId, userId, slug, role: "admin" });
-    seededOrgIds.push(orgId);
+    seededFixtures.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, slug, role: "admin" },
+        context.signal,
+      ),
+    );
 
     mocks.clerk.session(userId, orgId);
 
@@ -83,20 +66,20 @@ describe("GET /api/zero/org/list", () => {
     const userId = `user_${randomUUID()}`;
     const orgIdA = `org_${randomUUID()}`;
     const orgIdB = `org_${randomUUID()}`;
-    await seedOrgMembership({
-      orgId: orgIdA,
-      userId,
-      slug: "team-alpha",
-      role: "admin",
-    });
-    seededOrgIds.push(orgIdA);
-    await seedOrgMembership({
-      orgId: orgIdB,
-      userId,
-      slug: "team-beta",
-      role: "member",
-    });
-    seededOrgIds.push(orgIdB);
+    seededFixtures.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId: orgIdA, userId, slug: "team-alpha", role: "admin" },
+        context.signal,
+      ),
+    );
+    seededFixtures.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId: orgIdB, userId, slug: "team-beta", role: "member" },
+        context.signal,
+      ),
+    );
 
     mocks.clerk.session(userId, orgIdA);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org.test.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 
 import { zeroOrgContract } from "@vm0/api-contracts/contracts/zero-org";
 import { orgCache } from "@vm0/db/schema/org-cache";
-import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
@@ -12,6 +11,11 @@ import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -31,32 +35,38 @@ interface SeedOrgArgs {
   readonly tier?: "free" | "pro" | "team";
 }
 
-async function seedOrg(args: SeedOrgArgs): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb.insert(orgCache).values({
-    orgId: args.orgId,
-    slug: args.slug ?? `org-${args.orgId.slice(-8)}`,
-    name: args.name ?? "",
-  });
-  await writeDb.insert(orgMembersCache).values({
-    orgId: args.orgId,
-    userId: args.userId,
-    role: args.role,
-  });
+async function seedOrg(args: SeedOrgArgs): Promise<OrgMembershipFixture> {
+  const fixture = await store.set(
+    seedOrgMembership$,
+    {
+      orgId: args.orgId,
+      userId: args.userId,
+      role: args.role,
+      slug: args.slug,
+      name: args.name,
+    },
+    context.signal,
+  );
   if (args.tier) {
+    const writeDb = store.set(writeDb$);
     await writeDb.insert(orgMetadata).values({
       orgId: args.orgId,
       tier: args.tier,
     });
   }
+  return fixture;
 }
 
-async function seedOrgCacheOnly(orgId: string, slug?: string): Promise<void> {
+async function seedOrgCacheOnly(
+  orgId: string,
+  slug?: string,
+): Promise<OrgMembershipFixture> {
   const writeDb = store.set(writeDb$);
   await writeDb.insert(orgCache).values({
     orgId,
     slug: slug ?? `org-${orgId.slice(-8)}`,
   });
+  return { orgId, userId: "" };
 }
 
 async function setOrgTier(
@@ -70,21 +80,22 @@ async function setOrgTier(
     .onConflictDoUpdate({ target: orgMetadata.orgId, set: { tier } });
 }
 
-async function deleteOrg(orgId: string): Promise<void> {
+async function deleteOrgComposite(
+  fixture: OrgMembershipFixture,
+): Promise<void> {
   const writeDb = store.set(writeDb$);
-  await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, orgId));
-  await writeDb.delete(orgMembersCache).where(eq(orgMembersCache.orgId, orgId));
-  await writeDb.delete(orgCache).where(eq(orgCache.orgId, orgId));
+  await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
+  await store.set(deleteOrgMembership$, fixture, context.signal);
 }
 
 describe("GET /api/zero/org", () => {
-  const seededOrgIds: string[] = [];
+  const seededFixtures: OrgMembershipFixture[] = [];
 
   afterEach(async () => {
-    while (seededOrgIds.length > 0) {
-      const orgId = seededOrgIds.pop();
-      if (orgId) {
-        await deleteOrg(orgId);
+    while (seededFixtures.length > 0) {
+      const fixture = seededFixtures.pop();
+      if (fixture) {
+        await deleteOrgComposite(fixture);
       }
     }
   });
@@ -93,8 +104,9 @@ describe("GET /api/zero/org", () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     const slug = `org-${randomUUID().slice(0, 8)}`;
-    await seedOrg({ orgId, userId, role: "admin", slug, name: "Test Org" });
-    seededOrgIds.push(orgId);
+    seededFixtures.push(
+      await seedOrg({ orgId, userId, role: "admin", slug, name: "Test Org" }),
+    );
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroOrgContract);
@@ -131,8 +143,7 @@ describe("GET /api/zero/org", () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     const slug = `org-${randomUUID().slice(0, 8)}`;
-    await seedOrg({ orgId, userId, role: "admin", slug });
-    seededOrgIds.push(orgId);
+    seededFixtures.push(await seedOrg({ orgId, userId, role: "admin", slug }));
 
     const seconds = currentSecond();
     const token = signSandboxJwtForTests({
@@ -158,13 +169,13 @@ describe("GET /api/zero/org", () => {
 });
 
 describe("GET /api/zero/org — org resolution", () => {
-  const seededOrgIds: string[] = [];
+  const seededFixtures: OrgMembershipFixture[] = [];
 
   afterEach(async () => {
-    while (seededOrgIds.length > 0) {
-      const orgId = seededOrgIds.pop();
-      if (orgId) {
-        await deleteOrg(orgId);
+    while (seededFixtures.length > 0) {
+      const fixture = seededFixtures.pop();
+      if (fixture) {
+        await deleteOrgComposite(fixture);
       }
     }
   });
@@ -172,8 +183,7 @@ describe("GET /api/zero/org — org resolution", () => {
   it("resolves org from session context", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await seedOrg({ orgId, userId, role: "admin" });
-    seededOrgIds.push(orgId);
+    seededFixtures.push(await seedOrg({ orgId, userId, role: "admin" }));
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroOrgContract);
@@ -201,9 +211,12 @@ describe("GET /api/zero/org — org resolution", () => {
     const userId = `user_${randomUUID()}`;
     const orgId1 = `org_${randomUUID()}`;
     const orgId2 = `org_${randomUUID()}`;
-    await seedOrg({ orgId: orgId1, userId, role: "admin" });
-    await seedOrg({ orgId: orgId2, userId, role: "admin" });
-    seededOrgIds.push(orgId1, orgId2);
+    seededFixtures.push(
+      await seedOrg({ orgId: orgId1, userId, role: "admin" }),
+    );
+    seededFixtures.push(
+      await seedOrg({ orgId: orgId2, userId, role: "admin" }),
+    );
     mocks.clerk.session(userId, orgId2);
 
     const client = setupApp({ context })(zeroOrgContract);
@@ -219,8 +232,9 @@ describe("GET /api/zero/org — org resolution", () => {
   it("returns tier from org table", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await seedOrg({ orgId, userId, role: "admin", tier: "pro" });
-    seededOrgIds.push(orgId);
+    seededFixtures.push(
+      await seedOrg({ orgId, userId, role: "admin", tier: "pro" }),
+    );
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroOrgContract);
@@ -236,8 +250,7 @@ describe("GET /api/zero/org — org resolution", () => {
   it("returns default free tier for new org", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await seedOrg({ orgId, userId, role: "admin" });
-    seededOrgIds.push(orgId);
+    seededFixtures.push(await seedOrg({ orgId, userId, role: "admin" }));
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroOrgContract);
@@ -252,8 +265,7 @@ describe("GET /api/zero/org — org resolution", () => {
   it("reflects updated tier value", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await seedOrg({ orgId, userId, role: "admin" });
-    seededOrgIds.push(orgId);
+    seededFixtures.push(await seedOrg({ orgId, userId, role: "admin" }));
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroOrgContract);
@@ -276,8 +288,7 @@ describe("GET /api/zero/org — org resolution", () => {
   it("returns free tier for brand-new org without metadata", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await seedOrgCacheOnly(orgId);
-    seededOrgIds.push(orgId);
+    seededFixtures.push(await seedOrgCacheOnly(orgId));
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroOrgContract);
@@ -293,8 +304,7 @@ describe("GET /api/zero/org — org resolution", () => {
   it("returns member with correct role", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await seedOrg({ orgId, userId, role: "admin" });
-    seededOrgIds.push(orgId);
+    seededFixtures.push(await seedOrg({ orgId, userId, role: "admin" }));
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroOrgContract);


### PR DESCRIPTION
## Summary

Pure code-shape refactor — extract `seedOrgMembership$` + `deleteOrgMembership$` to `__tests__/helpers/zero-org-membership.ts` and refactor 4 in-scope test files to import from it.

### In scope (refactored)
- `zero-integrations-telegram.test.ts` — uses `seedOrgCache: false` (membership-only)
- `zero-org-list.test.ts`
- `zero-org-domains.test.ts`
- `zero-org.test.ts` — `seedOrg` now delegates cache+members to the helper; `seedOrgCacheOnly`, `setOrgTier`, and the orgMetadata cleanup remain inline.

### Out of scope (per issue's indirect-callers carve-out)
- `chat-threads-v1.test.ts`, `audio-transcriptions-v1.test.ts`, `health-auth-probe.test.ts` — these bundle the membership insert with `cliTokens` inside cohesive `seedPatFixture`-style helpers; refactoring them couples extract-cleanup with PAT-fixture-cleanup that's a separate concern.

### Helper signature

Matches issue body verbatim, **plus** an additional `name?: string` so zero-org's name-asserting test can use the shared helper without keeping a private inline copy.

### Equivalence proof

All affected tests pass without expectation or scope changes — same discipline as #12413 encrypt-secret extraction.

Closes #12438.

## Test plan

- [x] `pnpm -F api exec vitest run` — 71/71 files, 549/549 tests pass
- [x] `pnpm -F api lint` clean
- [x] `pnpm -F api check-types` clean
- [x] knip clean (pre-commit)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)