### PR TITLE
refactor(api): migrate voice chat list tasks get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-voice-chat.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-voice-chat.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { command } from "ccstate";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
-import { voiceChatSessions } from "@vm0/db/schema/voice-chat";
+import { voiceChatSessions, voiceChatTasks } from "@vm0/db/schema/voice-chat";
 import { and, eq, inArray } from "drizzle-orm";
 
 import { writeDb$ } from "../../../external/db";
@@ -59,6 +59,35 @@ export const seedVoiceChatFixture$ = command(
     }
 
     return { orgId, userId, sessionIds };
+  },
+);
+
+interface TaskSeed {
+  readonly status: "pending" | "queued" | "running" | "done" | "failed";
+  readonly finishedAt?: Date;
+}
+
+export const seedVoiceChatTask$ = command(
+  async (
+    { set },
+    sessionId: string,
+    values: TaskSeed,
+    signal: AbortSignal,
+  ): Promise<string> => {
+    const writeDb = set(writeDb$);
+    const id = randomUUID();
+    await writeDb.insert(voiceChatTasks).values({
+      id,
+      sessionId,
+      callId: `call_${randomUUID()}`,
+      prompt: "test",
+      status: values.status,
+      ...(values.finishedAt !== undefined
+        ? { finishedAt: values.finishedAt }
+        : {}),
+    });
+    signal.throwIfAborted();
+    return id;
   },
 );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-chat-list-tasks.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-chat-list-tasks.test.ts
@@ -1,0 +1,235 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroVoiceChatContract } from "@vm0/api-contracts/contracts/zero-voice-chat";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteVoiceChatFixture$,
+  seedVoiceChatFixture$,
+  seedVoiceChatTask$,
+  type VoiceChatFixture,
+} from "./helpers/zero-voice-chat";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/voice-chat/:id/tasks (listTasks)", () => {
+  const track = createFixtureTracker<VoiceChatFixture>((fixture) => {
+    return store.set(deleteVoiceChatFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.listTasks({ params: { id: randomUUID() }, headers: {} }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        { trinityEnabled: true },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, null);
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.listTasks({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 when the trinity feature switch is disabled (avoids leaking existence)", async () => {
+    // Seed a real session for the user but DON'T enable Trinity.
+    // Web pattern: flag-disabled tenants get 404 (not 403) so they cannot
+    // distinguish "session exists" from "feature disabled".
+    const fixture = await track(
+      store.set(seedVoiceChatFixture$, { sessions: [{}] }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const sessionId = fixture.sessionIds[0]!;
+
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.listTasks({
+        params: { id: sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Voice-chat session not found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 404 when the session belongs to a different user (no existence leak)", async () => {
+    const otherUserId = `user_${randomUUID()}`;
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        {
+          trinityEnabled: true,
+          sessions: [{ userId: otherUserId }],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const otherSessionId = fixture.sessionIds[0]!;
+
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.listTasks({
+        params: { id: otherSessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Voice-chat session not found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns an empty list when the session has no tasks", async () => {
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        { trinityEnabled: true, sessions: [{}] },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const sessionId = fixture.sessionIds[0]!;
+
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.listTasks({
+        params: { id: sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ tasks: [] });
+  });
+
+  it("returns active tasks before finished tasks", async () => {
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        { trinityEnabled: true, sessions: [{}] },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const sessionId = fixture.sessionIds[0]!;
+
+    const doneId = await store.set(
+      seedVoiceChatTask$,
+      sessionId,
+      { status: "done", finishedAt: new Date(now() - 100_000) },
+      context.signal,
+    );
+    const pendingId = await store.set(
+      seedVoiceChatTask$,
+      sessionId,
+      { status: "pending" },
+      context.signal,
+    );
+
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.listTasks({
+        params: { id: sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.tasks).toHaveLength(2);
+    expect(response.body.tasks[0]?.id).toBe(pendingId);
+    expect(response.body.tasks[1]?.id).toBe(doneId);
+  });
+
+  it("caps finished tasks at 3 and excludes the oldest one", async () => {
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        { trinityEnabled: true, sessions: [{}] },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const sessionId = fixture.sessionIds[0]!;
+
+    const baseTime = now();
+    // Insert 4 finished tasks with distinct finishedAt timestamps; the oldest
+    // should be excluded from the card feed (limit=3).
+    const oldestDoneId = await store.set(
+      seedVoiceChatTask$,
+      sessionId,
+      { status: "done", finishedAt: new Date(baseTime - 400_000) },
+      context.signal,
+    );
+    await store.set(
+      seedVoiceChatTask$,
+      sessionId,
+      { status: "done", finishedAt: new Date(baseTime - 300_000) },
+      context.signal,
+    );
+    await store.set(
+      seedVoiceChatTask$,
+      sessionId,
+      { status: "done", finishedAt: new Date(baseTime - 200_000) },
+      context.signal,
+    );
+    await store.set(
+      seedVoiceChatTask$,
+      sessionId,
+      { status: "done", finishedAt: new Date(baseTime - 100_000) },
+      context.signal,
+    );
+
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.listTasks({
+        params: { id: sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.tasks).toHaveLength(3);
+    const returnedIds = response.body.tasks.map((t) => {
+      return t.id;
+    });
+    expect(returnedIds).not.toContain(oldestDoneId);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-voice-chat.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-chat.ts
@@ -12,6 +12,7 @@ import type { RouteEntry } from "../route";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
   serializeVoiceChatSession,
+  serializeVoiceChatTask,
   voiceChatSessionList,
   voiceChatSessionDetail,
   voiceChatTaskList,
@@ -70,18 +71,31 @@ const getSessionInner$ = computed(async (get) => {
 
 const listTasksInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  const enabled = isFeatureEnabled(FeatureSwitchKey.Trinity, {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    overrides,
+  });
+  if (!enabled) {
+    // Web pattern: collapse flag-disabled into 404 to avoid leaking
+    // session existence (contract does not declare 403 for listTasks).
+    return notFound("Voice-chat session not found");
+  }
   const params = get(pathParamsOf(zeroVoiceChatContract.listTasks));
-
-  // Verify the session exists and belongs to the user
   const session = await get(
     voiceChatSessionDetail(auth.orgId, auth.userId, params.id),
   );
   if (!session) {
     return notFound("Voice-chat session not found");
   }
-
   const tasks = await get(voiceChatTaskList(params.id));
-  return { status: 200 as const, body: { tasks } };
+  return {
+    status: 200 as const,
+    body: { tasks: tasks.map(serializeVoiceChatTask) },
+  };
 });
 
 export const zeroVoiceChatRoutes: readonly RouteEntry[] = [
@@ -104,12 +118,9 @@ export const zeroVoiceChatRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroVoiceChatContract.listTasks,
-    handler: shadowCompareRoute({
-      route: zeroVoiceChatContract.listTasks,
-      handler: authRoute(
-        { requireOrganization: true, missingOrganizationStatus: 401 },
-        listTasksInner$,
-      ),
-    }),
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      listTasksInner$,
+    ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-voice-chat.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-chat.service.ts
@@ -1,5 +1,8 @@
 import { computed, type Computed } from "ccstate";
-import type { VoiceChatSession } from "@vm0/api-contracts/contracts/zero-voice-chat";
+import type {
+  VoiceChatSession,
+  VoiceChatTask,
+} from "@vm0/api-contracts/contracts/zero-voice-chat";
 import { voiceChatSessions, voiceChatTasks } from "@vm0/db/schema/voice-chat";
 import { and, asc, desc, eq, inArray } from "drizzle-orm";
 
@@ -74,6 +77,32 @@ export function voiceChatSessionDetail(
       .limit(1);
     return session ?? null;
   });
+}
+
+/**
+ * Map a `voice_chat_tasks` row to the contract-shaped `VoiceChatTask` DTO.
+ * Mirrors web's `serializeVoiceChatTask` in
+ * `apps/web/app/api/zero/voice-chat/_support.ts` so the contract -> row
+ * mapping has a single source of truth across the api migration.
+ */
+export function serializeVoiceChatTask(
+  task: typeof voiceChatTasks.$inferSelect,
+): VoiceChatTask {
+  return {
+    id: task.id,
+    sessionId: task.sessionId,
+    runId: task.runId,
+    callId: task.callId,
+    prompt: task.prompt,
+    status: task.status as VoiceChatTask["status"],
+    result: task.result,
+    resultUpdatedAt: task.resultUpdatedAt?.toISOString() ?? null,
+    assistantMessages: task.assistantMessages,
+    error: task.error,
+    createdAt: task.createdAt.toISOString(),
+    startedAt: task.startedAt?.toISOString() ?? null,
+    finishedAt: task.finishedAt?.toISOString() ?? null,
+  };
 }
 
 export function voiceChatTaskList(


### PR DESCRIPTION
## Summary

Drop the api-side `shadowCompareRoute` wrapper around `zeroVoiceChatContract.listTasks` so the api response becomes authoritative. Bundles two small fixes (Plan A2) needed for parity once the wrapper is gone.

### What this PR does

**Route handler** (`apps/api/src/signals/routes/zero-voice-chat.ts`):
- Add Trinity 404 gate to `listTasksInner$` — Trinity-disabled tenants get 404 (not 403) so they cannot distinguish "session exists" from "feature disabled". Same gate pattern PR #12460 added to `getSessionInner$`.
- Drop the `shadowCompareRoute` wrapper around `zeroVoiceChatContract.listTasks`.
- `shadowCompareRoute` import **retained** — sibling PR #12460 (getSession migration) is still open at time of writing and continues to use it. The owner of #12460 will drop the import when that PR lands, making the file fully migrated (18th).

**Service** (`apps/api/src/signals/services/zero-voice-chat.service.ts`):
- Add `serializeVoiceChatTask` so the route returns contract-shaped DTOs (ISO-string timestamps) instead of raw DB rows. Mirrors web's `serializeVoiceChatTask` and the existing `serializeVoiceChatSession` pattern. **Without this, the unwrapped api response would fail contract validation with 500.**

**Test infra** (`apps/api/src/signals/routes/__tests__/helpers/zero-voice-chat.ts`):
- Add `seedVoiceChatTask$` command. Cleanup is automatic — `voice_chat_tasks.session_id` cascades on the existing fixture's session delete.

**New tests** (`apps/api/src/signals/routes/__tests__/zero-voice-chat-list-tasks.test.ts`, 7 cases):

| # | Case | Web/api |
|---|---|---|
| 1 | `returns 401 when the request is unauthenticated` | api defensive (also covers web case 1) |
| 2 | `returns 401 when the authenticated session has no active organization` | api defensive (mirrors sibling tests) |
| 3 | `returns 404 when the trinity feature switch is disabled (avoids leaking existence)` | web case 2 (1:1) |
| 4 | `returns 404 when the session belongs to a different user (no existence leak)` | web case 3 (1:1) |
| 5 | `returns an empty list when the session has no tasks` | web case 4 (1:1) |
| 6 | `returns active tasks before finished tasks` | web case 5 (1:1) |
| 7 | `caps finished tasks at 3 and excludes the oldest one` | web case 6 (1:1) |

### Out of scope

- No `apps/web/**` changes
- No contract changes
- POST cases (out of EPIC #12290 stage 2 scope)

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-voice-chat-list-tasks.test.ts` — 7/7 pass
- [x] `pnpm -F api exec vitest run` — 556/556 pass (full api suite)
- [x] `pnpm turbo run lint --filter=api` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `pnpm knip --workspace api` — no issues
- [x] `pnpm format` — applied (no diffs)

Closes #12458