### PR TITLE
refactor(api): migrate zero connectors list get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroConnectorsMainContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { connectors } from "@vm0/db/schema/connector";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+async function seedConnector(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly type: string;
+  readonly authMethod?: string;
+}): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(connectors).values({
+    userId: args.userId,
+    orgId: args.orgId,
+    type: args.type,
+    authMethod: args.authMethod ?? "oauth",
+  });
+}
+
+async function deleteConnectorsByOrg(orgId: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.delete(connectors).where(eq(connectors.orgId, orgId));
+}
+
+describe("GET /api/zero/connectors", () => {
+  const seededFixtures: OrgMembershipFixture[] = [];
+
+  afterEach(async () => {
+    while (seededFixtures.length > 0) {
+      const fixture = seededFixtures.pop();
+      if (fixture) {
+        await deleteConnectorsByOrg(fixture.orgId);
+        await store.set(deleteOrgMembership$, fixture, context.signal);
+      }
+    }
+  });
+
+  it("returns an empty connectors list", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorsMainContract);
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.connectors).toStrictEqual([]);
+    expect(Array.isArray(response.body.configuredTypes)).toBeTruthy();
+    expect(
+      Array.isArray(response.body.connectorProvidedSecretNames),
+    ).toBeTruthy();
+  });
+
+  it("returns connectors when present", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    await seedConnector({ orgId, userId, type: "github" });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorsMainContract);
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.connectors.length).toBeGreaterThanOrEqual(1);
+    expect(
+      response.body.connectors.some((c) => {
+        return c.type === "github";
+      }),
+    ).toBeTruthy();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroConnectorsMainContract);
+    const response = await accept(client.list({ headers: {} }), [401]);
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("skips oauth rows whose type no longer exists in the contract", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    await seedConnector({
+      orgId,
+      userId,
+      type: "__removed_connector__",
+    });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorsMainContract);
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    const orphan = response.body.connectors.find((c) => {
+      return (c.type as string) === "__removed_connector__";
+    });
+    expect(orphan).toBeUndefined();
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorsMainContract);
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -114,10 +114,7 @@ export const zeroConnectorsRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroConnectorsMainContract.list,
-    handler: shadowCompareRoute({
-      route: zeroConnectorsMainContract.list,
-      handler: authRoute(connectorReadAuth, getConnectorListInner$),
-    }),
+    handler: authRoute(connectorReadAuth, getConnectorListInner$),
   },
   {
     route: zeroConnectorScopeDiffContract.getScopeDiff,


### PR DESCRIPTION
## Summary

Migrate `GET /api/zero/connectors` (root list) from `apps/web` to `apps/api`. Drop the `shadowCompareRoute` wrapper from `zeroConnectorsMainContract.list`. No service changes — parity verified (both apps use `connectorTypeSchema.safeParse` for orphan filtering and identical derived-connectors logic).

### Tests

5 cases:
- 4 web GET cases ported 1:1: `returns an empty connectors list`, `returns connectors when present`, `returns 401 when not authenticated`, `skips oauth rows whose type no longer exists in the contract`.
- 1 api-defensive: `returns 401 when the authenticated session has no organization`.

### Helper reuse

First consumer of `helpers/zero-org-membership.ts` (extracted in #12462). Connector seeding stays inline (single use; YAGNI). Cleanup cascades: connectors → org_members_cache → org_cache.

### File state

- `zero-connectors.ts` goes 5 → 4 wrappers.
- `shadowCompareRoute` import retained (computer/get, search, scope-diff/getScopeDiff, [type]/get still wrap).

Closes #12466.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-list.test.ts` — 5/5 pass
- [x] `pnpm -F api lint` clean
- [x] `pnpm -F api check-types` clean
- [x] knip clean (pre-commit)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)