### PR TITLE
chore(api): drop dead shadow-compare-route import in zero-voice-chat.ts

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-voice-chat.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-chat.ts
@@ -6,7 +6,6 @@ import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf } from "../context/request";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { notFound } from "../../lib/error";
 import type { RouteEntry } from "../route";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";


### PR DESCRIPTION
## Summary

All three voice-chat routes are now fully migrated and serving the api response as authoritative:

- `listSessions` — #12448
- `getSession` — #12460
- `listTasks` — #12464

But none of those PRs could safely drop the `shadowCompareRoute` import on its own due to the merge-order race — every PR was rebased against a main where at least one sibling still used the wrapper.

This chore drops the now-dead import. **`zero-voice-chat.ts` is now truly fully-migrated** — the 18th file in EPIC #12290.

Diff: `−1` line.

## Test plan

- [x] `pnpm turbo run lint --filter=api` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `pnpm knip --workspace api` — no issues (would have caught the dead import directly)
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-voice-chat-{list-sessions,get-session,list-tasks}.test.ts` — 21/21 pass across all three test files
- [x] `pnpm format` — applied (no diffs)