### PR TITLE
feat(api): port build talker payload to voice-chat session get

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -32,6 +32,7 @@
     "@vm0/db": "workspace:*",
     "ccstate": "^5.3.0",
     "drizzle-orm": "^0.45.2",
+    "gpt-tokenizer": "^3.4.0",
     "hono": "^4.12.18",
     "pg": "^8.20.0",
     "stripe": "^20.4.1",

--- a/turbo/apps/api/src/signals/external/db.ts
+++ b/turbo/apps/api/src/signals/external/db.ts
@@ -13,7 +13,7 @@ type DbWriteMethod =
   | "refreshMaterializedView"
   | "batch";
 
-type ReadonlyDb = Omit<Db, DbWriteMethod>;
+export type ReadonlyDb = Omit<Db, DbWriteMethod>;
 
 export const db$ = computed((): ReadonlyDb => {
   return db();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-voice-chat.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-voice-chat.ts
@@ -64,6 +64,14 @@ export const seedVoiceChatFixture$ = command(
 
 interface TaskSeed {
   readonly status: "pending" | "queued" | "running" | "done" | "failed";
+  readonly prompt?: string;
+  readonly result?: string | null;
+  readonly assistantMessages?: readonly {
+    readonly type: "assistant";
+    readonly content: string;
+    readonly at: string;
+  }[];
+  readonly startedAt?: Date;
   readonly finishedAt?: Date;
 }
 
@@ -80,8 +88,15 @@ export const seedVoiceChatTask$ = command(
       id,
       sessionId,
       callId: `call_${randomUUID()}`,
-      prompt: "test",
+      prompt: values.prompt ?? "test",
       status: values.status,
+      ...(values.result !== undefined ? { result: values.result } : {}),
+      ...(values.assistantMessages !== undefined
+        ? { assistantMessages: [...values.assistantMessages] }
+        : {}),
+      ...(values.startedAt !== undefined
+        ? { startedAt: values.startedAt }
+        : {}),
       ...(values.finishedAt !== undefined
         ? { finishedAt: values.finishedAt }
         : {}),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-chat-get-session.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-chat-get-session.test.ts
@@ -4,6 +4,7 @@ import { zeroVoiceChatContract } from "@vm0/api-contracts/contracts/zero-voice-c
 import { createStore } from "ccstate";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -11,6 +12,7 @@ import {
 import {
   deleteVoiceChatFixture$,
   seedVoiceChatFixture$,
+  seedVoiceChatTask$,
   type VoiceChatFixture,
 } from "./helpers/zero-voice-chat";
 
@@ -197,11 +199,82 @@ describe("GET /api/zero/voice-chat/:id (getSession)", () => {
     expect(response.body.session.id).toBe(sessionId);
     expect(response.body.session.userId).toBe(fixture.userId);
     expect(response.body.session.orgId).toBe(fixture.orgId);
-    // Talker payload is currently hardcoded empty in api — see follow-up
-    // issue (deferred from this Stage 2 migration).
+    // No tasks seeded: lifecycle sections are empty, but the base
+    // instruction is still substantial so tokens are well above zero.
     expect(response.body.recentTaskLogs).toBe("");
     expect(response.body.finishedTasksFullText).toBe("");
-    expect(response.body.talkerInstructions).toBe("");
-    expect(response.body.talkerInstructionTokens).toBe(0);
+    expect(response.body.talkerInstructions).toContain(
+      "You are the Talker brain of Zero",
+    );
+    expect(response.body.talkerInstructions).toContain(
+      "(none — nothing is being worked on)",
+    );
+    expect(response.body.talkerInstructions).toContain(
+      "(none — no tasks have finished yet in this session)",
+    );
+    expect(response.body.talkerInstructionTokens).toBeGreaterThan(500);
+  });
+
+  it("populates the talker payload from in-flight and finished tasks", async () => {
+    const fixture = await track(
+      store.set(
+        seedVoiceChatFixture$,
+        { trinityEnabled: true, sessions: [{}] },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const sessionId = fixture.sessionIds[0]!;
+
+    const inFlightId = await store.set(
+      seedVoiceChatTask$,
+      sessionId,
+      {
+        status: "running",
+        prompt: "draft the launch email",
+        startedAt: new Date(now() - 30_000),
+      },
+      context.signal,
+    );
+    const finishedId = await store.set(
+      seedVoiceChatTask$,
+      sessionId,
+      {
+        status: "done",
+        prompt: "list quarterly goals",
+        result: "Goal 1: ship voice-chat. Goal 2: cut launch email.",
+        finishedAt: new Date(now() - 5000),
+      },
+      context.signal,
+    );
+
+    const client = setupApp({ context })(zeroVoiceChatContract);
+    const response = await accept(
+      client.getSession({
+        params: { id: sessionId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    // Recent lifecycle log: the running task is within the 3-minute window.
+    expect(response.body.recentTaskLogs).toContain(inFlightId);
+    expect(response.body.recentTaskLogs).toContain("draft the launch email");
+
+    // Finished tasks full text: the done task's prompt and id appear.
+    expect(response.body.finishedTasksFullText).toContain(finishedId);
+    expect(response.body.finishedTasksFullText).toContain(
+      "list quarterly goals",
+    );
+
+    // Talker instructions embed both the in-flight prompt and the finished
+    // task's compacted result body.
+    expect(response.body.talkerInstructions).toContain(
+      "draft the launch email",
+    );
+    expect(response.body.talkerInstructions).toContain(
+      "Goal 1: ship voice-chat",
+    );
+    expect(response.body.talkerInstructionTokens).toBeGreaterThan(500);
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-voice-chat.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-chat.ts
@@ -6,10 +6,10 @@ import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf } from "../context/request";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { notFound } from "../../lib/error";
 import type { RouteEntry } from "../route";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import { voiceChatTalkerPayload } from "../services/voice-chat-talker.service";
 import {
   serializeVoiceChatSession,
   serializeVoiceChatTask,
@@ -70,17 +70,12 @@ const getSessionInner$ = computed(async (get) => {
   if (!session) {
     return notFound("Voice-chat session not found");
   }
+  const talker = await get(voiceChatTalkerPayload(session));
   return {
     status: 200 as const,
     body: {
       session: serializeVoiceChatSession(session),
-      // Talker payload deferred — see #12463 (port `buildTalkerPayload`).
-      // Web computes these via `buildTalkerPayload(session)`; API currently
-      // returns empty/zero for Stage 2 scoping.
-      recentTaskLogs: "",
-      finishedTasksFullText: "",
-      talkerInstructions: "",
-      talkerInstructionTokens: 0,
+      ...talker,
     },
   };
 });

--- a/turbo/apps/api/src/signals/services/voice-chat-talker.service.ts
+++ b/turbo/apps/api/src/signals/services/voice-chat-talker.service.ts
@@ -1,0 +1,406 @@
+import { encode } from "gpt-tokenizer/encoding/o200k_base";
+import { computed, type Computed } from "ccstate";
+import { voiceChatSessions, voiceChatTasks } from "@vm0/db/schema/voice-chat";
+import { and, asc, desc, eq, gte, inArray } from "drizzle-orm";
+
+import { now, nowDate } from "../../lib/time";
+import { db$, type ReadonlyDb } from "../external/db";
+
+type SessionRow = typeof voiceChatSessions.$inferSelect;
+type TaskRow = typeof voiceChatTasks.$inferSelect;
+
+const RECENT_WINDOW_MS = 3 * 60 * 1000;
+const RECENT_MAX_EVENTS_PER_TASK = 10;
+const RECENT_MAX_TOTAL_CHARS = 4000;
+const ACTIVE_STATUSES = ["pending", "queued", "running"] as const;
+const FINISHED_STATUSES = ["done", "failed"] as const;
+
+// Copied verbatim from `apps/web/src/lib/zero/voice-chat/talker-instructions.ts`.
+// When the apps/web voice-chat surface is fully retired by epic #12290, that
+// copy is deleted and this becomes the sole source of truth.
+const TALKER_INSTRUCTIONS_BASE = `
+You are the Talker brain of Zero, vm0's AI workspace assistant. You are speaking with the user in real time through voice.
+
+**This is a voice-only interface. The user hears you — nothing else.** They cannot see this instruction, the conversation transcript, the Task board, task results, or any written context. Whatever you don't say out loud, the user doesn't know. So: when a task finishes and its result arrives, you must actually voice the substance; when you reference something, describe it by speech ("the first one", "the PR you merged this morning"), never by position on a screen ("above", "that row", "this list").
+
+You handle the live conversation; a separate "slow brain" handles every action. You have zero ability to act on your own — no tools, no lookups, no writes. Anything that will actually happen has to go through inform_slow_brain.
+
+## What you know vs what the system knows
+
+Below these instructions you'll find **context sections** the system keeps fresh between your turns. Two of them are the ones you reach for most:
+
+- "Conversation context" — a compact summary of what the user and you have established (preferences, stable facts, open questions).
+- "Task board" — the live state of every task in this session: what's in flight right now, what recently finished, and the latest lifecycle events. This is the **source of truth for anything the user asks about tasks** — "what are you working on?", "did that finish?", "how many are running?", "how long has it been?", "what was the result?". Read from the Task board and answer from there. If the "In flight" list is empty, nothing is being worked on — say so plainly.
+
+**Counting and listing tasks.** When a user question requires counting ("how many?") or listing ("what are they?"), literally enumerate the entries you see under "In flight" and "Recently finished" — do not recall from the conversation. If the board has three entries under In flight, the answer is three, and all three need to be spoken, one by one, reading each task's prompt in your own words. It does not matter whether you remember informing about each one; the board is more trustworthy than your memory of the last few turns. Skipping an entry because "I don't remember that" is the specific mistake this section exists to prevent.
+
+The voice transcript only tells you what was **said**. The Task board tells you what is **happening**. Saying you'd do something doesn't put it on the board — an inform_slow_brain call does. So when the user asks about task state, trust the board over your memory of the conversation.
+
+Remember: the user cannot see the Task board either. When they ask "what's running?", translate the board into speech — don't assume they can peek.
+
+## When to call inform_slow_brain(prompt)
+
+Your mouth uttering a commitment word and your hand calling inform_slow_brain are **one action, not two**. A commitment word is anything in the shape of "I'll …", "let me …", "I'll check …", "I'll grab …", "I'll take a look …", "我要 …", "我会 …", "我帮你 …", "给我一下时间 …", "等我一下 …" — anything that promises the user something will be done. If you let the sound come out without calling the tool in the same turn, you've deceived the user — they believe something is happening when nothing is.
+
+Two ways through this:
+- **If you're already committing**, call inform_slow_brain in the same turn, before or as you speak the line. Don't defer, don't reason about whether tools are needed — the slow brain decides.
+- **If you're uncertain whether to commit**, don't utter a commitment word. Say something non-committing instead: ask the user to clarify, or repeat what you heard to confirm. But "I'll look into that" without a call is never an option.
+
+This covers cases you'd normally treat as casual too ("remind me later", "find that email", "update the doc", "what's the status of …"). If in doubt, call — a redundant inform is free.
+
+## Filling in the prompt
+
+Describe the user's ask as the slow brain would need it, in one or two sentences. Include: what the user wants, the specific entities/systems mentioned in this turn, and any already-established context from the conversation that matters. The slow brain has access to the voice transcript and session history too — you don't need to repeat everything, but spell out anything ambiguous from voice ("that PR" → which PR).
+
+## After calling inform_slow_brain
+
+Acknowledge naturally in the same turn:
+- "Let me look into that."
+- "I'll check on that for you."
+- "Give me a moment to work on that."
+- "好，我查一下。" / "稍等我去看看。"
+
+Do NOT say "I can't do that." The slow brain CAN do it — it just takes a moment.
+
+## Receiving task results
+
+When a message starts with \`[Task <id>] result:\`, it is the slow brain reporting back on something you informed it about. **The user hasn't seen the text — it only exists here, in your context.** You must actually speak the substance of the result, not just acknowledge it arrived. How to voice it:
+
+- Short answer: read it in full.
+- Long answer (list, table, multi-paragraph): narrate the top items by spoken position ("the first one is …", "next …"), or summarize into three-to-five spoken sentences hitting the key facts, numbers, names, or conclusions. Offer to go deeper.
+- Error or "not found" result: tell the user plainly what went wrong and what you'd need from them to try again.
+
+Never respond with "here's what came back" and stop — the user has no way to read it.
+
+## If you realize you missed a call
+
+When the user asks something like "did you do that?", "are you working on it?", "现在在做吗?", "有几个任务在跑?" — **check the Task board first**, don't answer from your memory of what you said.
+
+If the user's expectation (something you committed to) doesn't match the Task board ("In flight" is empty or doesn't contain a task for that intent), that is the signature of a missed inform — you committed earlier but didn't call the tool. Two steps, in this order:
+
+1. Call inform_slow_brain now with the original ask — what you should have forwarded earlier. The slow brain's session context will let it catch up.
+2. Tell the user plainly: "I hadn't actually kicked that off yet, but I'm starting it now." Don't pretend it was already running.
+
+Same pattern when the user says "you didn't do it" or "you only promised" — they're right. Apologize briefly, inform, move on.
+
+## Communication style
+
+- Keep responses concise and natural. You are speaking, not writing.
+- No markdown, bullet points, or code blocks.
+- Don't reference things the user can't see ("the list above", "this row", "the image attached") — the user has no screen in this interaction. Describe by speech instead.
+- Be warm and conversational.
+`.trim();
+
+function truncatePrompt(prompt: string, max = 80): string {
+  const trimmed = prompt.trim().replace(/\s+/gu, " ");
+  if (trimmed.length <= max) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, max - 1)}…`;
+}
+
+function truncateEntry(text: string, max = 200): string {
+  const trimmed = text.trim().replace(/\s+/gu, " ");
+  if (trimmed.length <= max) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, max - 1)}…`;
+}
+
+function formatAgo(then: Date, currentTime: Date): string {
+  const diffMs = Math.max(0, currentTime.getTime() - then.getTime());
+  const totalSec = Math.floor(diffMs / 1000);
+  if (totalSec < 60) {
+    return `${String(totalSec)}s ago`;
+  }
+  const totalMin = Math.floor(totalSec / 60);
+  if (totalMin < 60) {
+    const s = totalSec % 60;
+    return `${String(totalMin)}m ${String(s)}s ago`;
+  }
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return `${String(h)}h ${String(m)}m ago`;
+}
+
+function lastResultEntryAt(row: TaskRow): Date | null {
+  const last = row.assistantMessages[row.assistantMessages.length - 1];
+  if (!last) {
+    return null;
+  }
+  const parsed = new Date(last.at);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed;
+}
+
+function taskLastActivityAt(row: TaskRow): Date {
+  return (
+    row.finishedAt ?? lastResultEntryAt(row) ?? row.startedAt ?? row.createdAt
+  );
+}
+
+interface TaskEvent {
+  readonly at: Date;
+  readonly label: string;
+}
+
+function collectEvents(row: TaskRow): TaskEvent[] {
+  const events: TaskEvent[] = [{ at: row.createdAt, label: "created" }];
+  if (row.startedAt) {
+    events.push({ at: row.startedAt, label: "running" });
+  }
+  for (const entry of row.assistantMessages) {
+    const at = new Date(entry.at);
+    if (Number.isNaN(at.getTime())) {
+      continue;
+    }
+    events.push({
+      at,
+      label: `assistant: ${truncateEntry(entry.content)}`,
+    });
+  }
+  if (row.finishedAt) {
+    const label = row.error ? `failed: ${truncateEntry(row.error)}` : "done";
+    events.push({ at: row.finishedAt, label });
+  }
+  events.sort((a, b) => {
+    return a.at.getTime() - b.at.getTime();
+  });
+  return events;
+}
+
+function formatRecentTaskBlock(row: TaskRow, currentTime: Date): string {
+  const events = collectEvents(row);
+  const trimmed = events.slice(-RECENT_MAX_EVENTS_PER_TASK);
+  const header = `[Task ${row.id}] ${row.status} — created ${formatAgo(row.createdAt, currentTime)} — ${truncatePrompt(row.prompt)}`;
+  const lines = trimmed.map((e) => {
+    return `  ${formatAgo(e.at, currentTime)}: ${e.label}`;
+  });
+  return [header, ...lines].join("\n");
+}
+
+async function buildRecentTaskLogs(
+  db: ReadonlyDb,
+  sessionId: string,
+  currentTime: Date,
+): Promise<string> {
+  const cutoff = new Date(currentTime.getTime() - RECENT_WINDOW_MS);
+  const rows = await db
+    .select()
+    .from(voiceChatTasks)
+    .where(
+      and(
+        eq(voiceChatTasks.sessionId, sessionId),
+        gte(voiceChatTasks.createdAt, cutoff),
+      ),
+    )
+    .orderBy(desc(voiceChatTasks.createdAt));
+
+  const recent = rows.filter((row) => {
+    return taskLastActivityAt(row).getTime() >= cutoff.getTime();
+  });
+
+  if (recent.length === 0) {
+    return "";
+  }
+
+  const blocks: string[] = [];
+  let totalChars = 0;
+  for (const row of recent) {
+    const block = formatRecentTaskBlock(row, currentTime);
+    if (totalChars + block.length > RECENT_MAX_TOTAL_CHARS) {
+      break;
+    }
+    blocks.push(block);
+    totalChars += block.length;
+  }
+
+  return blocks.join("\n\n");
+}
+
+function loadFinishedTaskRows(
+  db: ReadonlyDb,
+  sessionId: string,
+): Promise<TaskRow[]> {
+  return db
+    .select()
+    .from(voiceChatTasks)
+    .where(
+      and(
+        eq(voiceChatTasks.sessionId, sessionId),
+        inArray(voiceChatTasks.status, FINISHED_STATUSES),
+      ),
+    )
+    .orderBy(desc(voiceChatTasks.finishedAt));
+}
+
+function flattenAssistantEntries(row: TaskRow): string {
+  return row.assistantMessages
+    .map((e) => {
+      return e.content;
+    })
+    .join("\n");
+}
+
+function renderFinishedRow(row: TaskRow, body: string): string {
+  const header = `[Task ${row.id}] ${row.status}`;
+  const parts = [header, `prompt: ${row.prompt}`];
+  if (body) {
+    parts.push(`result:\n${body}`);
+  }
+  if (row.error) {
+    parts.push(`error: ${row.error}`);
+  }
+  return parts.join("\n");
+}
+
+async function buildFinishedTasksFullText(
+  db: ReadonlyDb,
+  sessionId: string,
+): Promise<string> {
+  const rows = await loadFinishedTaskRows(db, sessionId);
+  if (rows.length === 0) {
+    return "";
+  }
+  return rows
+    .map((row) => {
+      return renderFinishedRow(row, flattenAssistantEntries(row));
+    })
+    .join("\n\n");
+}
+
+async function buildFinishedTasksCompactedText(
+  db: ReadonlyDb,
+  sessionId: string,
+): Promise<string> {
+  const rows = await loadFinishedTaskRows(db, sessionId);
+  if (rows.length === 0) {
+    return "";
+  }
+  return rows
+    .map((row) => {
+      const body = row.result ?? flattenAssistantEntries(row);
+      return renderFinishedRow(row, body);
+    })
+    .join("\n\n");
+}
+
+async function buildInFlightTasksText(
+  db: ReadonlyDb,
+  sessionId: string,
+  currentTimeMs: number,
+): Promise<string> {
+  const rows = await db
+    .select()
+    .from(voiceChatTasks)
+    .where(
+      and(
+        eq(voiceChatTasks.sessionId, sessionId),
+        inArray(voiceChatTasks.status, ACTIVE_STATUSES),
+      ),
+    )
+    .orderBy(asc(voiceChatTasks.createdAt));
+
+  if (rows.length === 0) {
+    return "";
+  }
+
+  return rows
+    .map((row) => {
+      const elapsedSec = Math.round(
+        (currentTimeMs - row.createdAt.getTime()) / 1000,
+      );
+      const header = `[Task ${row.id}] ${row.status} (elapsed ${String(elapsedSec)}s)`;
+      return [header, `prompt: ${row.prompt}`].join("\n");
+    })
+    .join("\n\n");
+}
+
+interface TalkerComposeContext {
+  readonly conversationSummary: string | null;
+  readonly inFlightTasksText: string;
+  readonly finishedTasksCompactedText: string;
+  readonly recentTaskLogs: string;
+}
+
+function composeTalkerInstructions(ctx: TalkerComposeContext): string {
+  const parts: string[] = [TALKER_INSTRUCTIONS_BASE];
+  const conversation = ctx.conversationSummary?.trim() ?? "";
+  const inFlight = ctx.inFlightTasksText.trim();
+  const finished = ctx.finishedTasksCompactedText.trim();
+  const recent = ctx.recentTaskLogs.trim();
+
+  if (conversation) {
+    parts.push(`## Conversation context\n${conversation}`);
+  }
+
+  const board: string[] = [];
+  board.push(
+    `### In flight (working on right now)\n${inFlight || "(none — nothing is being worked on)"}`,
+  );
+  board.push(
+    `### Recently finished\n${finished || "(none — no tasks have finished yet in this session)"}`,
+  );
+  if (recent) {
+    board.push(`### Recent lifecycle events\n${recent}`);
+  }
+  parts.push(`## Task board\n${board.join("\n\n")}`);
+
+  return parts.join("\n\n");
+}
+
+interface TalkerPayload {
+  readonly recentTaskLogs: string;
+  readonly finishedTasksFullText: string;
+  readonly talkerInstructions: string;
+  readonly talkerInstructionTokens: number;
+}
+
+/**
+ * Compute the talker payload for a voice-chat session.
+ *
+ * Mirrors `buildTalkerPayload` in
+ * `apps/web/src/lib/zero/voice-chat/talker-instructions.ts` — the four
+ * sub-builders and `composeTalkerInstructions` are ported verbatim with
+ * minor adjustments for ccstate idioms (Db parameter, `now()`/`nowDate()`
+ * from `lib/time`).
+ *
+ * The four DB reads run in parallel. The UI panel gets the raw
+ * uncompacted finished-tasks log; the Talker instruction embeds the
+ * compacted view so the Realtime prompt doesn't bloat across long
+ * sessions.
+ */
+export function voiceChatTalkerPayload(
+  session: SessionRow,
+): Computed<Promise<TalkerPayload>> {
+  return computed(async (get): Promise<TalkerPayload> => {
+    const db = get(db$);
+    const currentTime = nowDate();
+    const currentTimeMs = now();
+    const [
+      recentTaskLogs,
+      finishedTasksFullText,
+      finishedTasksCompacted,
+      inFlightTasksText,
+    ] = await Promise.all([
+      buildRecentTaskLogs(db, session.id, currentTime),
+      buildFinishedTasksFullText(db, session.id),
+      buildFinishedTasksCompactedText(db, session.id),
+      buildInFlightTasksText(db, session.id, currentTimeMs),
+    ]);
+    const talkerInstructions = composeTalkerInstructions({
+      conversationSummary: session.conversationSummary,
+      inFlightTasksText,
+      finishedTasksCompactedText: finishedTasksCompacted,
+      recentTaskLogs,
+    });
+    return {
+      recentTaskLogs,
+      finishedTasksFullText,
+      talkerInstructions,
+      talkerInstructionTokens: encode(talkerInstructions).length,
+    };
+  });
+}

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/api:
     dependencies:
@@ -157,6 +157,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0)(postgres@3.4.9)
+      gpt-tokenizer:
+        specifier: ^3.4.0
+        version: 3.4.0
       hono:
         specifier: ^4.12.18
         version: 4.12.18
@@ -220,7 +223,7 @@ importers:
         version: 8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/cli:
     dependencies:
@@ -299,7 +302,7 @@ importers:
         version: 6.24.1
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -480,7 +483,7 @@ importers:
         version: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/web:
     dependencies:
@@ -727,7 +730,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/api-contracts:
     dependencies:
@@ -767,7 +770,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/api-services:
     devDependencies:
@@ -791,7 +794,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/connectors:
     dependencies:
@@ -822,7 +825,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/core:
     dependencies:
@@ -856,7 +859,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/db:
     dependencies:
@@ -893,7 +896,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/eslint-config:
     devDependencies:
@@ -947,7 +950,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -1057,7 +1060,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -9078,6 +9081,7 @@ packages:
       '@vitest/ui': 4.1.5
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -13955,7 +13959,7 @@ snapshots:
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -13969,7 +13973,7 @@ snapshots:
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -13985,7 +13989,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -14003,7 +14007,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -14023,9 +14027,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/browser': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -14081,7 +14085,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -18304,7 +18308,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.4)(happy-dom@20.9.0)(jiti@2.6.1)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.10(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -18334,18 +18338,39 @@ snapshots:
       '@vitest/ui': 4.1.5(vitest@4.1.5)
       happy-dom: 20.9.0
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
+
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.3.0
+      '@vitest/browser-playwright': 4.1.5(msw@2.13.2(@types/node@24.3.0)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.3.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/coverage-v8': 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
+      '@vitest/ui': 4.1.5(vitest@4.1.5)
+      happy-dom: 20.9.0
+    transitivePeerDependencies:
+      - msw
 
   vscode-languageserver-textdocument@1.0.12: {}
 


### PR DESCRIPTION
## Summary

Closes #12463 — high-priority follow-up to #12460 (voice-chat getSession migration).

The api `getSession` route currently returns hardcoded empty strings + 0 tokens for the four talker fields (`recentTaskLogs`, `finishedTasksFullText`, `talkerInstructions`, `talkerInstructionTokens`). Web computes them via `buildTalkerPayload(session)` — a four-stage orchestration over `voice_chat_tasks` plus a tokenized instruction template. This PR ports that logic verbatim to apps/api so the response matches web.

### Implementation

- **New service** `signals/services/voice-chat-talker.service.ts` (~280 LOC)
  - `voiceChatTalkerPayload(session)` — top-level Computed factory
  - Four sub-builders run in parallel against `db$` (recent log, finished full text, finished compacted, in-flight)
  - `composeTalkerInstructions` mirrors web's prompt-board layout
  - `gpt-tokenizer/encoding/o200k_base` for token count
  - `TALKER_INSTRUCTIONS_BASE` copied verbatim with a comment pointing back to the web file (both copies collapse when web surface is retired by epic #12290)
- **Route wiring** `signals/routes/zero-voice-chat.ts` — replace the four hardcoded fields with `await get(voiceChatTalkerPayload(session))` + spread; remove now-unused `shadowCompareRoute` import
- **Helper extension** `helpers/zero-voice-chat.ts` — `seedVoiceChatTask$` now accepts `prompt`, `result`, `assistantMessages`, `startedAt`
- **DB type export** `signals/external/db.ts` — `ReadonlyDb` exported so service helpers can take it as a parameter

### Tests

- Existing case 6 (no tasks): now asserts `talkerInstructions` contains the base prefix + the empty in-flight/finished placeholders, with `talkerInstructionTokens > 500` (the base instruction alone is substantial)
- New case 7 (with tasks): seeds a `running` task ("draft the launch email") and a `done` task ("list quarterly goals" with a result body) — asserts task IDs and prompts appear in `recentTaskLogs` / `finishedTasksFullText`, the compacted result body appears in `talkerInstructions`, and tokens are non-trivial

22/22 voice-chat tests pass.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-voice-chat-get-session.test.ts` — 8/8 pass
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-voice-chat-list-sessions.test.ts src/signals/routes/__tests__/zero-voice-chat-list-tasks.test.ts` — 14/14 pass (sibling sanity)
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `pnpm knip --workspace apps/api` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)