### PR TITLE
refactor(api): migrate zero connectors computer get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-computer-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-computer-get.test.ts
@@ -1,0 +1,107 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroComputerConnectorContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { connectors } from "@vm0/db/schema/connector";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+async function seedComputerConnector(args: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(connectors).values({
+    userId: args.userId,
+    orgId: args.orgId,
+    type: "computer",
+    authMethod: "api",
+  });
+}
+
+async function deleteConnectorsByOrg(orgId: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.delete(connectors).where(eq(connectors.orgId, orgId));
+}
+
+describe("GET /api/zero/connectors/computer", () => {
+  const seededFixtures: OrgMembershipFixture[] = [];
+
+  afterEach(async () => {
+    while (seededFixtures.length > 0) {
+      const fixture = seededFixtures.pop();
+      if (fixture) {
+        await deleteConnectorsByOrg(fixture.orgId);
+        await store.set(deleteOrgMembership$, fixture, context.signal);
+      }
+    }
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+    const response = await accept(client.get({ headers: {} }), [401]);
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 404 when no computer connector is configured", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns the computer connector when one is configured", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    await seedComputerConnector({ orgId, userId });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroComputerConnectorContract);
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body.type).toBe("computer");
+    expect(response.body.authMethod).toBe("api");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -100,10 +100,7 @@ const searchConnectorsInner$ = computed(async (get) => {
 export const zeroConnectorsRoutes: readonly RouteEntry[] = [
   {
     route: zeroComputerConnectorContract.get,
-    handler: shadowCompareRoute({
-      route: zeroComputerConnectorContract.get,
-      handler: authRoute(connectorReadAuth, getComputerConnectorInner$),
-    }),
+    handler: authRoute(connectorReadAuth, getComputerConnectorInner$),
   },
   {
     route: zeroConnectorsSearchContract.search,


### PR DESCRIPTION
## Summary

Drop the api-side `shadowCompareRoute` wrapper around `zeroComputerConnectorContract.get` so the api response becomes authoritative. Behavior was already byte-equivalent to web during shadow comparison — `getComputerConnectorInner$` correctly returns 404 when no connector exists and 200 with the connector body otherwise (via the existing `zeroConnectorByType(\"computer\")` service signal).

### What this PR does

- **`apps/api/src/signals/routes/zero-connectors.ts`**: Drop the `shadowCompareRoute` wrapper around `zeroComputerConnectorContract.get`. Net diff: -4 / +1.
- **New `apps/api/src/signals/routes/__tests__/zero-connectors-computer-get.test.ts`**: 4 route-level integration cases.

### Test cases (3 web 1:1 + 1 api defensive = 4)

- `returns 401 when not authenticated` (web case 1, line 225)
- `returns 401 when the authenticated session has no organization` (api defensive, mirrors sibling test pattern)
- `returns 404 when no computer connector is configured` (web case 2, line 232)
- `returns the computer connector when one is configured` (web case 3, line 240 — asserts `type=\"computer\"`, `authMethod=\"api\"`)

### Helper reuse

- `helpers/zero-org-membership.ts` (#12462) for `seedOrgMembership$` / `deleteOrgMembership$`
- `helpers/zero-route-test.ts` for `createZeroRouteMocks`
- `seedComputerConnector` is inlined in the test file (second call site for a per-connector seed; sibling `zero-connectors-list.test.ts` does the same — per YAGNI, will extract on the third occurrence)

### `shadowCompareRoute` import retention

Retained — three sibling routes still use it:
- `zeroConnectorsSearchContract.search` (sibling PR #12472, OPEN)
- `zeroConnectorScopeDiffContract.getScopeDiff` (separate downstream)
- `zeroConnectorsByTypeContract.get` (separate downstream)

### Out of scope

- POST/DELETE cases (Stage 2 GET-only)
- No `apps/web/**` changes
- No service or contract changes

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-computer-get.test.ts` — 4/4 pass
- [x] `pnpm -F api exec vitest run` — 615/615 pass (full api suite)
- [x] `pnpm turbo run lint --filter=api` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `pnpm knip --workspace api` — no issues
- [x] `pnpm format` — applied (no diffs)

Closes #12471