### PR TITLE
refactor(api): migrate zero connectors search get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -1,0 +1,254 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroConnectorsSearchContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorType,
+} from "@vm0/connectors/connectors";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const mocks = createZeroRouteMocks(context);
+
+describe("GET /api/zero/connectors/search", () => {
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({ query: {}, headers: {} }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns connectors array with correct shape", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.connectors).toBeInstanceOf(Array);
+    expect(response.body.connectors.length).toBeGreaterThan(0);
+    for (const connector of response.body.connectors) {
+      expect(connector).toHaveProperty("id");
+      expect(connector).toHaveProperty("label");
+      expect(connector).toHaveProperty("description");
+      expect(connector).toHaveProperty("authMethods");
+      expect(typeof connector.id).toBe("string");
+      expect(typeof connector.label).toBe("string");
+      expect(typeof connector.description).toBe("string");
+      expect(connector.authMethods).toBeInstanceOf(Array);
+    }
+  });
+
+  it("filters connectors by keyword matching label", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({
+        query: { keyword: "GitHub" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.connectors.length).toBeGreaterThan(0);
+    for (const connector of response.body.connectors) {
+      const matchesLabel = connector.label.toLowerCase().includes("github");
+      const matchesDescription = connector.description
+        .toLowerCase()
+        .includes("github");
+      expect(matchesLabel || matchesDescription).toBeTruthy();
+    }
+  });
+
+  it("filters connectors by keyword matching description", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({
+        query: { keyword: "slack" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.connectors.length).toBeGreaterThan(0);
+    for (const connector of response.body.connectors) {
+      const matchesLabel = connector.label.toLowerCase().includes("slack");
+      const matchesDescription = connector.description
+        .toLowerCase()
+        .includes("slack");
+      expect(matchesLabel || matchesDescription).toBeTruthy();
+    }
+  });
+
+  it("returns empty array for non-matching keyword", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({
+        query: { keyword: "zzz_no_match_zzz" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.connectors).toStrictEqual([]);
+  });
+
+  it("performs case-insensitive keyword search", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+
+    const lower = await accept(
+      client.search({
+        query: { keyword: "github" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    const upper = await accept(
+      client.search({
+        query: { keyword: "GITHUB" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(lower.body.connectors).toHaveLength(upper.body.connectors.length);
+  });
+
+  it("hides feature-flagged connectors without api-token for non-enabled users", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const computer = response.body.connectors.find((c) => {
+      return c.id === "computer";
+    });
+    expect(computer).toBeUndefined();
+  });
+
+  it("shows feature-flagged connector with api-token even when flag is disabled", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const neon = response.body.connectors.find((c) => {
+      return c.id === "neon";
+    });
+    expect(neon).toBeDefined();
+    expect(neon?.authMethods).toContain("api-token");
+    expect(neon?.authMethods).not.toContain("oauth");
+  });
+
+  it("hides feature-flagged connector when feature is disabled", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const computer = response.body.connectors.find((c) => {
+      return c.id === "computer";
+    });
+    expect(computer).toBeUndefined();
+  });
+
+  it("includes connectors without feature flags", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const unflaggedTypes = (
+      Object.keys(CONNECTOR_TYPES) as ConnectorType[]
+    ).filter((type) => {
+      return !CONNECTOR_TYPES[type].featureFlag;
+    });
+    expect(unflaggedTypes.length).toBeGreaterThan(0);
+
+    for (const type of unflaggedTypes) {
+      const found = response.body.connectors.find((c) => {
+        return c.id === type;
+      });
+      expect(found).toBeDefined();
+    }
+  });
+
+  it("exposes openai as api-token only", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const openai = response.body.connectors.find((c) => {
+      return c.id === "openai";
+    });
+    expect(openai).toBeDefined();
+    expect(openai?.authMethods).toStrictEqual(["api-token"]);
+  });
+
+  it("shows zapier with api-token even when ZapierConnector flag is disabled", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const response = await accept(
+      client.search({
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const zapier = response.body.connectors.find((c) => {
+      return c.id === "zapier";
+    });
+    expect(zapier).toBeDefined();
+    expect(zapier?.authMethods).toContain("api-token");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -107,10 +107,7 @@ export const zeroConnectorsRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroConnectorsSearchContract.search,
-    handler: shadowCompareRoute({
-      route: zeroConnectorsSearchContract.search,
-      handler: authRoute({}, searchConnectorsInner$),
-    }),
+    handler: authRoute({}, searchConnectorsInner$),
   },
   {
     route: zeroConnectorsMainContract.list,

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -68,7 +68,7 @@ describe("zeroConnectorList", () => {
 });
 
 describe("zeroConnectorSearch", () => {
-  it("hides strict feature-flagged api-token connectors when the flag is disabled", async () => {
+  it("shows feature-flagged api-token connectors even when the flag is disabled", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
 
@@ -76,14 +76,14 @@ describe("zeroConnectorSearch", () => {
       zeroConnectorSearch({ orgId, userId, keyword: undefined }),
     );
 
-    expect(
-      connectors.some((connector) => {
-        return connector.id === "zapier";
-      }),
-    ).toBeFalsy();
+    const zapier = connectors.find((connector) => {
+      return connector.id === "zapier";
+    });
+    expect(zapier).toBeDefined();
+    expect(zapier?.authMethods).toStrictEqual(["api-token"]);
   });
 
-  it("shows strict feature-flagged api-token connectors when an override enables the flag", async () => {
+  it("shows feature-flagged api-token connectors when an override enables the flag", async () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
 

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -362,9 +362,7 @@ export function zeroConnectorSearch(args: {
       const flag = config.featureFlag;
       const flagEnabled = !flag || featureStates[flag];
       const showOauth = flagEnabled && "oauth" in config.authMethods;
-      const showApiToken =
-        "api-token" in config.authMethods &&
-        (flagEnabled || !config.strictFeatureFlag);
+      const showApiToken = "api-token" in config.authMethods;
 
       if (!showOauth && !showApiToken) {
         return [];


### PR DESCRIPTION
## Summary

Migrate `GET /api/zero/connectors/search` from `apps/web` to `apps/api`. Drop the `shadowCompareRoute` wrapper. Bundle a Plan A2 fix to the search service so the migrated endpoint preserves web Next.js behavior for zapier api-token visibility.

### Plan A2 fix: `showApiToken` matches web Next.js

Before:
```ts
const showApiToken =
  "api-token" in config.authMethods &&
  (flagEnabled || !config.strictFeatureFlag);
```

After (matches `apps/web/app/api/zero/connectors/search/route.ts:44`):
```ts
const showApiToken = "api-token" in config.authMethods;
```

**Why**: web Next.js search has never gated `showApiToken` on `strictFeatureFlag`. The api service (and its existing tests) intentionally encoded strict gating, but that diverged from the user-facing dashboard endpoint. After this PR + shadow drop, dashboard users would otherwise lose visibility of zapier's api-token authentication path.

**Caller audit** for `zeroConnectorSearch`: only called from the api route under migration + the api service test. CLI/platform connector code paths keep their independent strict gating untouched.

### Tests

12 cases:
- 11 web GET cases ported 1:1 (auth, shape, label/description keyword, case-insensitive, empty, feature-flag gating, api-token override, openai api-token only)
- 1 new zapier regression test locking in api-token visibility when the flag is disabled
- Existing service test (`zero-connector-data.service.test.ts:71-84`) inverted from "hides zapier" → "shows zapier with api-token" to match the new semantics
- Skipped api-defensive 401 missing-org per #12432 precedent (route uses `authRoute({})` — no org gate)

### File state

- `zero-connectors.ts` goes 4 → 3 wrappers (computer/get, scope-diff, [type]/get remain).
- `shadowCompareRoute` import retained.
- `strictFeatureFlag` field stays on zapier; CLI/platform paths still respect it.

Closes #12472.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-search.test.ts src/signals/services/__tests__/zero-connector-data.service.test.ts` — 17/17 pass
- [x] `pnpm -F api lint` clean
- [x] `pnpm -F api check-types` clean
- [x] knip clean (pre-commit)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)