### PR TITLE
refactor(api): migrate zero connectors by type get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts
@@ -1,0 +1,161 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroConnectorsByTypeContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { connectors } from "@vm0/db/schema/connector";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+async function seedConnector(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly type: string;
+  readonly authMethod?: string;
+}): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(connectors).values({
+    userId: args.userId,
+    orgId: args.orgId,
+    type: args.type,
+    authMethod: args.authMethod ?? "oauth",
+  });
+}
+
+async function deleteConnectorsByOrg(orgId: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.delete(connectors).where(eq(connectors.orgId, orgId));
+}
+
+describe("GET /api/zero/connectors/:type", () => {
+  const seededFixtures: OrgMembershipFixture[] = [];
+
+  afterEach(async () => {
+    while (seededFixtures.length > 0) {
+      const fixture = seededFixtures.pop();
+      if (fixture) {
+        await deleteConnectorsByOrg(fixture.orgId);
+        await store.set(deleteOrgMembership$, fixture, context.signal);
+      }
+    }
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroConnectorsByTypeContract);
+    const response = await accept(
+      client.get({ params: { type: "github" }, headers: {} }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorsByTypeContract);
+    const response = await accept(
+      client.get({
+        params: { type: "github" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 404 when no connector of that type exists", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorsByTypeContract);
+    const response = await accept(
+      client.get({
+        params: { type: "github" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns the connector when one exists for that type", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    await seedConnector({ orgId, userId, type: "github" });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorsByTypeContract);
+    const response = await accept(
+      client.get({
+        params: { type: "github" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.type).toBe("github");
+  });
+
+  it("allows access with a sandbox JWT carrying connector:read capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const runId = `run_${randomUUID()}`;
+    // org_members_cache must be present so org-role resolution hits the cache
+    // path instead of falling back to Clerk (which is not mocked for token-auth
+    // requests).
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    await seedConnector({ orgId, userId, type: "github" });
+
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId,
+      capabilities: ["connector:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const client = setupApp({ context })(zeroConnectorsByTypeContract);
+    const response = await accept(
+      client.get({
+        params: { type: "github" },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body.type).toBe("github");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -122,9 +122,6 @@ export const zeroConnectorsRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroConnectorsByTypeContract.get,
-    handler: shadowCompareRoute({
-      route: zeroConnectorsByTypeContract.get,
-      handler: authRoute(connectorReadAuth, getConnectorByTypeInner$),
-    }),
+    handler: authRoute(connectorReadAuth, getConnectorByTypeInner$),
   },
 ];


### PR DESCRIPTION
## Summary

Drop the api-side `shadowCompareRoute` wrapper around `zeroConnectorsByTypeContract.get` so the api response becomes authoritative. Behavior was already byte-equivalent to web during shadow comparison — `getConnectorByTypeInner$` correctly returns 404 when no connector exists and 200 with the connector body otherwise (via the existing `zeroConnectorByType({ orgId, userId, type })` service signal that #12471 already validated for the computer type).

### What this PR does

- **`apps/api/src/signals/routes/zero-connectors.ts`**: Drop the `shadowCompareRoute` wrapper around `zeroConnectorsByTypeContract.get`. Net diff: -4 / +1.
- **New `apps/api/src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts`**: 5 route-level integration cases.

### Test cases (4 web 1:1 + 1 api defensive = 5)

- `returns 401 when not authenticated` (web case 3)
- `returns 401 when the authenticated session has no organization` (api defensive)
- `returns 404 when no connector of that type exists` (web case 2)
- `returns the connector when one exists for that type` (web case 1, asserts `body.type === \"github\"`)
- `allows access with a sandbox JWT carrying connector:read capability` (web case 4)

### Sandbox-token case implementation

Uses `signSandboxJwtForTests` from `auth/tokens` with `scope: \"zero\"` + `capabilities: [\"connector:read\"]` (pattern from `zero-run-network-logs.test.ts:97-105`). 

Note: this case **also** seeds `org_members_cache` via `seedOrgMembership$` so the org-role resolution in `auth.service.ts` short-circuits on the cache. Without the cache row, the role resolution falls back to Clerk's `getOrganizationMembershipList`, which is not mocked for token-auth flows — and would 500 with `Cannot read properties of undefined (reading 'data')`.

### Helper reuse + extraction deferral

- `helpers/zero-org-membership.ts` (#12462) for `seedOrgMembership$` / `deleteOrgMembership$`
- `helpers/zero-route-test.ts` for `createZeroRouteMocks`
- `signSandboxJwtForTests` from `auth/tokens` for the ZERO_TOKEN case
- `seedConnector` is inlined (third call site, but each existing site uses purpose-named helpers with different defaults — `zero-connectors-list.test.ts: github/oauth`, `zero-connectors-computer-get.test.ts: computer/api` purpose-named, this PR: `github/oauth` again). Extraction deferred to a follow-up cleanup PR if the pattern stabilizes (4th+ occurrence with same shape).

### `shadowCompareRoute` import retention

Retained — two sibling routes still use it:
- `zeroConnectorsSearchContract.search` (line 107)
- `zeroConnectorScopeDiffContract.getScopeDiff` (line 118)

### Out of scope

- DELETE cases (Stage 2 GET-only)
- No `apps/web/**` changes
- No service or contract changes

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts` — 5/5 pass
- [x] \`pnpm -F api exec vitest run\` — 621/621 pass (full api suite)
- [x] `pnpm turbo run lint --filter=api` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `pnpm knip --workspace api` — no issues
- [x] `pnpm format` — applied (no diffs)

Closes #12476