### PR TITLE
refactor(api): migrate zero connectors scope diff get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts
@@ -1,0 +1,215 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroConnectorScopeDiffContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { connectors } from "@vm0/db/schema/connector";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+// Mirrors `github.ts` connector OAuth scopes; deterministic so the
+// `toStrictEqual` assertions catch any silent payload drift if the
+// canonical scope list changes upstream.
+const GITHUB_CURRENT_SCOPES = ["repo", "project", "workflow"] as const;
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+async function seedGithubConnector(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly storedScopes: readonly string[];
+}): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(connectors).values({
+    userId: args.userId,
+    orgId: args.orgId,
+    type: "github",
+    authMethod: "oauth",
+    oauthScopes: JSON.stringify([...args.storedScopes]),
+  });
+}
+
+async function deleteConnectorsByOrg(orgId: string): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.delete(connectors).where(eq(connectors.orgId, orgId));
+}
+
+describe("GET /api/zero/connectors/:type/scope-diff", () => {
+  const seededFixtures: OrgMembershipFixture[] = [];
+
+  afterEach(async () => {
+    while (seededFixtures.length > 0) {
+      const fixture = seededFixtures.pop();
+      if (fixture) {
+        await deleteConnectorsByOrg(fixture.orgId);
+        await store.set(deleteOrgMembership$, fixture, context.signal);
+      }
+    }
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroConnectorScopeDiffContract);
+    const response = await accept(
+      client.getScopeDiff({ params: { type: "github" }, headers: {} }),
+      [401],
+    );
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const client = setupApp({ context })(zeroConnectorScopeDiffContract);
+    const response = await accept(
+      client.getScopeDiff({
+        params: { type: "github" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 for a sandbox token without connector:read capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId: `run_${randomUUID()}`,
+      capabilities: ["file:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+    const client = setupApp({ context })(zeroConnectorScopeDiffContract);
+    const response = await accept(
+      client.getScopeDiff({
+        params: { type: "github" },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [403],
+    );
+    expect(response.body.error.message).toBe(
+      "Missing required capability: connector:read",
+    );
+  });
+
+  it("returns 404 when no connector is configured for the type", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    mocks.clerk.session(userId, orgId);
+    const client = setupApp({ context })(zeroConnectorScopeDiffContract);
+    const response = await accept(
+      client.getScopeDiff({
+        params: { type: "github" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns an empty diff when stored scopes match current scopes exactly", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    await seedGithubConnector({
+      orgId,
+      userId,
+      storedScopes: GITHUB_CURRENT_SCOPES,
+    });
+    mocks.clerk.session(userId, orgId);
+    const client = setupApp({ context })(zeroConnectorScopeDiffContract);
+    const response = await accept(
+      client.getScopeDiff({
+        params: { type: "github" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      addedScopes: [],
+      removedScopes: [],
+      currentScopes: GITHUB_CURRENT_SCOPES,
+      storedScopes: GITHUB_CURRENT_SCOPES,
+    });
+  });
+
+  it("returns added scopes when the connector is missing required scopes", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    await seedGithubConnector({
+      orgId,
+      userId,
+      storedScopes: ["repo"],
+    });
+    mocks.clerk.session(userId, orgId);
+    const client = setupApp({ context })(zeroConnectorScopeDiffContract);
+    const response = await accept(
+      client.getScopeDiff({
+        params: { type: "github" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      addedScopes: ["project", "workflow"],
+      removedScopes: [],
+      currentScopes: GITHUB_CURRENT_SCOPES,
+      storedScopes: ["repo"],
+    });
+  });
+
+  it("returns removed scopes when the connector has stale extra scopes", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFixtures.push(
+      await store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    const stored = [...GITHUB_CURRENT_SCOPES, "delete_repo"];
+    await seedGithubConnector({ orgId, userId, storedScopes: stored });
+    mocks.clerk.session(userId, orgId);
+    const client = setupApp({ context })(zeroConnectorScopeDiffContract);
+    const response = await accept(
+      client.getScopeDiff({
+        params: { type: "github" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      addedScopes: [],
+      removedScopes: ["delete_repo"],
+      currentScopes: GITHUB_CURRENT_SCOPES,
+      storedScopes: stored,
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -10,7 +10,6 @@ import {
 import { authContext$, organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf, queryOf } from "../context/request";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { notFound } from "../../lib/error";
 import {
   zeroConnectorByType,

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -112,10 +112,7 @@ export const zeroConnectorsRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroConnectorScopeDiffContract.getScopeDiff,
-    handler: shadowCompareRoute({
-      route: zeroConnectorScopeDiffContract.getScopeDiff,
-      handler: authRoute(connectorReadAuth, getScopeDiffInner$),
-    }),
+    handler: authRoute(connectorReadAuth, getScopeDiffInner$),
   },
   {
     route: zeroConnectorsByTypeContract.get,


### PR DESCRIPTION
## Summary

Closes #12477. Stage 2 read-only migration under epic #12290.

Drops the `shadowCompareRoute` wrapper from `zeroConnectorScopeDiffContract.getScopeDiff` and adds the test coverage that web never had.

### Implementation

- **Route** `apps/api/src/signals/routes/zero-connectors.ts` — drop `shadowCompareRoute` wrapper from `getScopeDiff` entry. Wrapper count: 2 → 1 (byType still wrapped; sibling #12476 will drop it).
- **Tests** `apps/api/src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts` (new, 7 cases). Web has zero coverage — all cases are fresh.

### Test cases (handler audit)

| # | Branch | Status |
|---|--------|--------|
| 1 | No Authorization header | 401 |
| 2 | Bearer with no active org (api-only) | 401 |
| 3 | Sandbox JWT without `connector:read` capability (api-only, in-contract) | 403 |
| 4 | No connector configured for type | 404 |
| 5 | Stored scopes match current exactly → empty diff | 200 |
| 6 | Stored is strict subset → non-empty `addedScopes` | 200 |
| 7 | Stored is strict superset → non-empty `removedScopes` | 200 |

Fixture: github connector (`["repo", "project", "workflow"]` — no feature flag, deterministic). All 200 cases use `toStrictEqual` on the full body so any drift in the canonical scope list surfaces as a test failure.

Helper reuse: `seedOrgMembership$` from `helpers/zero-org-membership.ts` (#12462).

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts` — 7/7 pass
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-list.test.ts src/signals/routes/__tests__/zero-connectors-computer-get.test.ts src/signals/routes/__tests__/zero-connectors-search.test.ts` — 21/21 sibling sanity
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `pnpm knip --workspace apps/api` — clean
- [x] `grep -c "shadowCompareRoute(" apps/api/src/signals/routes/zero-connectors.ts` → 1

## Sibling coordination

Sibling #12476 (byType GET) is in flight on the same routes array. Different routes → no merge conflict. Whichever lands second drops the now-unused `shadowCompareRoute` import (clean closure, no separate cleanup PR needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)