### PR TITLE
refactor(api): migrate zero logs search get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-logs-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-logs-search.test.ts
@@ -1,0 +1,364 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroLogsSearchContract } from "@vm0/api-contracts/contracts/zero-runs";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function makeAxiomEvent(
+  runId: string,
+  sequenceNumber: number,
+  text: string,
+  timestamp = "2026-01-15T10:30:00Z",
+): Record<string, unknown> {
+  return {
+    _time: timestamp,
+    runId,
+    userId: "test-user",
+    sequenceNumber,
+    eventType: "assistant",
+    eventData: {
+      type: "assistant",
+      message: { content: [{ type: "text", text }] },
+    },
+  };
+}
+
+interface SearchFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly composeId: string;
+  readonly runId: string;
+  readonly token: string;
+}
+
+describe("GET /api/zero/logs/search", () => {
+  const trackUsage = createFixtureTracker<UsageInsightFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+  const trackOrg = createFixtureTracker<OrgMembershipFixture>((fixture) => {
+    return store.set(deleteOrgMembership$, fixture, context.signal);
+  });
+
+  async function setupSearchFixture(): Promise<SearchFixture> {
+    const fixture = await trackUsage(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      fixture,
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      { ...fixture, composeId },
+      context.signal,
+    );
+    await trackOrg(
+      store.set(
+        seedOrgMembership$,
+        { orgId: fixture.orgId, userId: fixture.userId },
+        context.signal,
+      ),
+    );
+
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      runId: `run_${randomUUID()}`,
+      capabilities: ["agent-run:read"],
+      iat: seconds,
+      exp: seconds + 600,
+    });
+
+    return {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      composeId,
+      runId,
+      token,
+    };
+  }
+
+  it("returns 401 when no auth is provided", async () => {
+    const client = setupApp({ context })(zeroLogsSearchContract);
+    const response = await accept(
+      client.searchLogs({ query: { keyword: "test" }, headers: {} }),
+      [401],
+    );
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 for sandbox token without agent-run:read", async () => {
+    const seconds = currentSecond();
+    const sandboxToken = signSandboxJwtForTests({
+      scope: "sandbox",
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      runId: `run_${randomUUID()}`,
+      iat: seconds,
+      exp: seconds + 600,
+    });
+
+    const client = setupApp({ context })(zeroLogsSearchContract);
+    const response = await accept(
+      client.searchLogs({
+        query: { keyword: "test" },
+        headers: { authorization: `Bearer ${sandboxToken}` },
+      }),
+      [403],
+    );
+    expect(response.body.error.message).toContain("agent-run:read");
+  });
+
+  it("returns empty results when no matches", async () => {
+    const f = await setupSearchFixture();
+    context.mocks.axiom.query.mockResolvedValueOnce([]);
+
+    const client = setupApp({ context })(zeroLogsSearchContract);
+    const response = await accept(
+      client.searchLogs({
+        query: { keyword: "nonexistent" },
+        headers: { authorization: `Bearer ${f.token}` },
+      }),
+      [200],
+    );
+    expect(response.body.results).toStrictEqual([]);
+    expect(response.body.hasMore).toBeFalsy();
+  });
+
+  it("returns matched events without context", async () => {
+    const f = await setupSearchFixture();
+    context.mocks.axiom.query.mockResolvedValueOnce([
+      makeAxiomEvent(f.runId, 3, "OOM killed"),
+    ]);
+
+    const client = setupApp({ context })(zeroLogsSearchContract);
+    const response = await accept(
+      client.searchLogs({
+        query: { keyword: "OOM" },
+        headers: { authorization: `Bearer ${f.token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body.results).toHaveLength(1);
+    expect(response.body.results[0]?.runId).toBe(f.runId);
+    expect(response.body.results[0]?.matchedEvent.sequenceNumber).toBe(3);
+    expect(response.body.results[0]?.contextBefore).toStrictEqual([]);
+    expect(response.body.results[0]?.contextAfter).toStrictEqual([]);
+  });
+
+  it("returns matched events with context", async () => {
+    const f = await setupSearchFixture();
+    context.mocks.axiom.query
+      .mockResolvedValueOnce([
+        makeAxiomEvent(f.runId, 5, "Error: OOM killed", "2026-01-15T10:30:05Z"),
+      ])
+      .mockResolvedValueOnce([
+        makeAxiomEvent(f.runId, 4, "Building...", "2026-01-15T10:30:04Z"),
+        makeAxiomEvent(f.runId, 5, "Error: OOM killed", "2026-01-15T10:30:05Z"),
+        makeAxiomEvent(f.runId, 6, "Retrying...", "2026-01-15T10:30:06Z"),
+      ]);
+
+    const client = setupApp({ context })(zeroLogsSearchContract);
+    const response = await accept(
+      client.searchLogs({
+        query: { keyword: "OOM", before: 1, after: 1 },
+        headers: { authorization: `Bearer ${f.token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body.results).toHaveLength(1);
+    expect(response.body.results[0]?.matchedEvent.sequenceNumber).toBe(5);
+    expect(response.body.results[0]?.contextBefore).toHaveLength(1);
+    expect(response.body.results[0]?.contextBefore[0]?.sequenceNumber).toBe(4);
+    expect(response.body.results[0]?.contextAfter).toHaveLength(1);
+    expect(response.body.results[0]?.contextAfter[0]?.sequenceNumber).toBe(6);
+  });
+
+  it("filters by runId when provided", async () => {
+    const f = await setupSearchFixture();
+    context.mocks.axiom.query.mockResolvedValueOnce([
+      makeAxiomEvent(f.runId, 1, "Found it"),
+    ]);
+
+    const client = setupApp({ context })(zeroLogsSearchContract);
+    const response = await accept(
+      client.searchLogs({
+        query: { keyword: "Found", runId: f.runId },
+        headers: { authorization: `Bearer ${f.token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body.results).toHaveLength(1);
+    expect(response.body.results[0]?.runId).toBe(f.runId);
+
+    const aplQuery = context.mocks.axiom.query.mock.calls[0]?.[0] as string;
+    expect(aplQuery).toContain(`runId == "${f.runId}"`);
+  });
+
+  it("uses search operator in axiom query for keyword search", async () => {
+    const f = await setupSearchFixture();
+    context.mocks.axiom.query.mockResolvedValueOnce([
+      makeAxiomEvent(f.runId, 2, "deploy failed with error"),
+    ]);
+
+    const client = setupApp({ context })(zeroLogsSearchContract);
+    const response = await accept(
+      client.searchLogs({
+        query: { keyword: "deploy failed" },
+        headers: { authorization: `Bearer ${f.token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body.results).toHaveLength(1);
+    const aplQuery = context.mocks.axiom.query.mock.calls[0]?.[0] as string;
+    expect(aplQuery).toContain('search "*deploy failed*"');
+  });
+
+  it("filters by agentId via database lookup", async () => {
+    const f = await setupSearchFixture();
+    context.mocks.axiom.query.mockResolvedValueOnce([
+      makeAxiomEvent(f.runId, 1, "Agent scoped event"),
+    ]);
+
+    const client = setupApp({ context })(zeroLogsSearchContract);
+    const response = await accept(
+      client.searchLogs({
+        query: { keyword: "event", agentId: f.composeId },
+        headers: { authorization: `Bearer ${f.token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body.results).toHaveLength(1);
+    expect(response.body.results[0]?.runId).toBe(f.runId);
+
+    const aplQuery = context.mocks.axiom.query.mock.calls[0]?.[0] as string;
+    expect(aplQuery).toContain(`runId == "${f.runId}"`);
+  });
+
+  it("returns empty results when agentId has no runs", async () => {
+    const f = await setupSearchFixture();
+
+    const client = setupApp({ context })(zeroLogsSearchContract);
+    const response = await accept(
+      client.searchLogs({
+        query: { keyword: "test", agentId: randomUUID() },
+        headers: { authorization: `Bearer ${f.token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body.results).toStrictEqual([]);
+    expect(context.mocks.axiom.query).not.toHaveBeenCalled();
+  });
+
+  it("sets hasMore when results exceed limit", async () => {
+    const f = await setupSearchFixture();
+    const events = Array.from({ length: 5 }, (_, i) => {
+      return makeAxiomEvent(f.runId, i, `Match ${i}`);
+    });
+    context.mocks.axiom.query.mockResolvedValueOnce(events);
+
+    const client = setupApp({ context })(zeroLogsSearchContract);
+    const response = await accept(
+      client.searchLogs({
+        query: { keyword: "Match", limit: 2 },
+        headers: { authorization: `Bearer ${f.token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body.results).toHaveLength(2);
+    expect(response.body.hasMore).toBeTruthy();
+  });
+
+  it("does not return runs from a different org", async () => {
+    const main = await setupSearchFixture();
+    const other = await setupSearchFixture();
+    context.mocks.axiom.query.mockResolvedValueOnce([
+      makeAxiomEvent(main.runId, 1, "Default org event"),
+    ]);
+
+    const client = setupApp({ context })(zeroLogsSearchContract);
+    const response = await accept(
+      client.searchLogs({
+        query: { keyword: "event" },
+        headers: { authorization: `Bearer ${main.token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body.results).toHaveLength(1);
+    expect(response.body.results[0]?.runId).toBe(main.runId);
+
+    const aplQuery = context.mocks.axiom.query.mock.calls[0]?.[0] as string;
+    expect(aplQuery).toContain(main.runId);
+    expect(aplQuery).not.toContain(other.runId);
+  });
+
+  it("returns empty when searching by runId from a different org", async () => {
+    const main = await setupSearchFixture();
+    const other = await setupSearchFixture();
+
+    const client = setupApp({ context })(zeroLogsSearchContract);
+    const response = await accept(
+      client.searchLogs({
+        query: { keyword: "test", runId: other.runId },
+        headers: { authorization: `Bearer ${main.token}` },
+      }),
+      [200],
+    );
+
+    expect(response.body.results).toStrictEqual([]);
+    expect(response.body.hasMore).toBeFalsy();
+    expect(context.mocks.axiom.query).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroLogsSearchContract);
+    const response = await accept(
+      client.searchLogs({
+        query: { keyword: "test" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-logs.ts
+++ b/turbo/apps/api/src/signals/routes/zero-logs.ts
@@ -8,7 +8,6 @@ import { zeroLogsSearchContract } from "@vm0/api-contracts/contracts/zero-runs";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf, queryOf } from "../context/request";
-import { shadowCompareRoute } from "../context/shadow-compare";
 import { notFound } from "../../lib/error";
 import {
   zeroLogDetail,
@@ -86,15 +85,14 @@ export const zeroLogsRoutes: readonly RouteEntry[] = [
     route: logsListContract.list,
     handler: authRoute(runReadAuth, getLogsListInner$),
   },
+  // Register the literal `/search` path before `/:id` so Hono matches the
+  // search endpoint instead of treating `search` as a log id.
+  {
+    route: zeroLogsSearchContract.searchLogs,
+    handler: authRoute(runReadAuth, searchLogsInner$),
+  },
   {
     route: logsByIdContract.getById,
     handler: authRoute(runReadAuth, getLogByIdInner$),
-  },
-  {
-    route: zeroLogsSearchContract.searchLogs,
-    handler: shadowCompareRoute({
-      route: zeroLogsSearchContract.searchLogs,
-      handler: authRoute(runReadAuth, searchLogsInner$),
-    }),
   },
 ];


### PR DESCRIPTION
## Summary

Migrate `GET /api/zero/logs/search` from `apps/web` to `apps/api` and **close the file**: drop the last `shadowCompareRoute` wrapper AND the import in the same PR. After merge, `zero-logs.ts` is fully migrated.

### Route ordering fix (revealed by file-closer)

The previous wrapped state masked a route-collision bug: Hono treats `search` as the `:id` segment of `getById` when `getById` registers first. With the wrapper still in place, requests forwarded to web (which had its own router and avoided the collision). Without the wrapper, `/api/zero/logs/search` 400s on the UUID validation in `getById`.

Reordered `zeroLogsRoutes` so the literal `/search` path registers before `/:id`. Tests verify this works for all 13 cases.

### Tests

13 cases:
- 12 web GET cases ported 1:1: 401 unauth, 403 sandbox without `agent-run:read`, empty results, matched events without context, matched events with context, filter by runId, search operator in axiom, filter by agentId via DB, empty when agentId has no runs, hasMore when results exceed limit, cross-org isolation, empty when runId from another org.
- 1 api-defensive 401 missing-org case (route uses `requireOrganization: true` so this branch is reachable).

### Helper reuse

- `helpers/zero-org-membership.ts` (#12462) — membership cache seeding (zero token auth needs the cache hit to resolve org membership).
- `helpers/zero-usage-insight.ts` (#12413/#12478) — compose+run+session seeding via `seedUsageInsightFixture$ → seedCompose$ → seedRun$`.
- `context.mocks.axiom.query` (mocks.ts pattern from #12420) — Axiom APL mocking with `mockResolvedValueOnce`.
- Composite cleanup tracker: `trackUsage` (compose/run via `deleteUsageInsightFixture$`) + `trackOrg` (membership via `deleteOrgMembership$`).

### File state

- `zero-logs.ts` post-PR: 0 `shadowCompareRoute` references (verified via `grep -c shadowCompareRoute → 0`). Fully migrated.
- No `apps/web/**` changes. No service changes — parity verified.

Closes #12481.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-logs-search.test.ts` — 13/13 pass
- [x] Full logs suite (list + get-by-id + search) — 72/72 pass; ordering change doesn't break siblings
- [x] `pnpm -F api lint` clean
- [x] `pnpm -F api check-types` clean
- [x] knip clean (pre-commit)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)