### PR TITLE
refactor(api): migrate zero chat threads get by id to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-chat-threads.ts
@@ -2,11 +2,17 @@ import { randomUUID } from "node:crypto";
 
 import type { PersistedAttachment } from "@vm0/api-contracts/contracts/chat-threads";
 import { command } from "ccstate";
-import { agentComposes } from "@vm0/db/schema/agent-compose";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { eq } from "drizzle-orm";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { writeDb$ } from "../../../external/db";
 import { nowDate } from "../../../external/time";
@@ -97,9 +103,43 @@ export const deleteZeroChatThread$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const writeDb = set(writeDb$);
+
+    // Find run ids tied to this fixture's user (created by seedRun$ from
+    // helpers/zero-usage-insight.ts). Some tests don't seed runs at all, so
+    // this may be empty.
+    const runRows = await writeDb
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(eq(agentRuns.userId, fixture.userId));
+    signal.throwIfAborted();
+    const runIds = runRows.map((row) => {
+      return row.id;
+    });
+
+    // chat_messages first (FKs into chat_threads + agent_runs).
+    await writeDb
+      .delete(chatMessages)
+      .where(eq(chatMessages.chatThreadId, fixture.threadId));
+    signal.throwIfAborted();
+
+    if (runIds.length > 0) {
+      await writeDb.delete(zeroRuns).where(inArray(zeroRuns.id, runIds));
+      signal.throwIfAborted();
+      await writeDb.delete(agentRuns).where(inArray(agentRuns.id, runIds));
+      signal.throwIfAborted();
+    }
+
+    await writeDb
+      .delete(agentSessions)
+      .where(eq(agentSessions.userId, fixture.userId));
+    signal.throwIfAborted();
     await writeDb
       .delete(chatThreads)
       .where(eq(chatThreads.id, fixture.threadId));
+    signal.throwIfAborted();
+    await writeDb
+      .delete(agentComposeVersions)
+      .where(eq(agentComposeVersions.composeId, fixture.composeId));
     signal.throwIfAborted();
     await writeDb
       .delete(zeroAgents)
@@ -119,6 +159,7 @@ interface SeedChatMessageOptions {
   readonly createdAt?: Date;
   readonly sequenceNumber?: number | null;
   readonly archivedAt?: Date | null;
+  readonly runId?: string | null;
 }
 
 export const seedZeroChatMessage$ = command(
@@ -137,6 +178,7 @@ export const seedZeroChatMessage$ = command(
       content: options.content,
       attachFiles: options.attachFiles ? [...options.attachFiles] : null,
       sequenceNumber: options.sequenceNumber ?? null,
+      runId: options.runId ?? null,
       createdAt: options.createdAt ?? nowDate(),
       ...(options.archivedAt !== undefined
         ? { archivedAt: options.archivedAt }
@@ -144,5 +186,127 @@ export const seedZeroChatMessage$ = command(
     });
     signal.throwIfAborted();
     return id;
+  },
+);
+
+// Mirrors web's addTestRunToThread: links a previously-seeded run to a thread
+// by inserting the user-side chat_message row and stamping zero_runs.chatThreadId.
+export const addRunToThread$ = command(
+  async (
+    { set },
+    args: {
+      readonly threadId: string;
+      readonly runId: string;
+      readonly prompt?: string;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb.insert(chatMessages).values({
+      chatThreadId: args.threadId,
+      role: "user",
+      content: args.prompt ?? "test prompt",
+      runId: args.runId,
+    });
+    signal.throwIfAborted();
+    await writeDb
+      .update(zeroRuns)
+      .set({ chatThreadId: args.threadId })
+      .where(eq(zeroRuns.id, args.runId));
+    signal.throwIfAborted();
+  },
+);
+
+// Mirrors web's insertTestAssistantEventMessages: bulk-insert assistant
+// chat_message rows backed by realtime events (runId + sequenceNumber). The
+// regression these guard (PR #12372) is that a later run-level error must NOT
+// mask the per-row content during the leftJoin in the read path.
+export const seedAssistantEventMessages$ = command(
+  async (
+    { set },
+    args: {
+      readonly threadId: string;
+      readonly runId: string;
+      readonly items: readonly {
+        readonly sequenceNumber: number;
+        readonly content: string;
+      }[];
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    if (args.items.length === 0) {
+      return;
+    }
+    const writeDb = set(writeDb$);
+    await writeDb
+      .insert(chatMessages)
+      .values(
+        args.items.map((item) => {
+          return {
+            chatThreadId: args.threadId,
+            runId: args.runId,
+            role: "assistant" as const,
+            content: item.content,
+            sequenceNumber: item.sequenceNumber,
+          };
+        }),
+      )
+      .onConflictDoNothing({
+        target: [chatMessages.runId, chatMessages.sequenceNumber],
+      });
+    signal.throwIfAborted();
+  },
+);
+
+// Mirrors web's updateTestChatThreadTitle (used by the AI title-generation
+// webhook). Tests that exercise post-completion title rewrite call this.
+export const updateChatThreadTitle$ = command(
+  async (
+    { set },
+    args: {
+      readonly threadId: string;
+      readonly userId: string;
+      readonly title: string;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .update(chatThreads)
+      .set({ title: args.title, renamedAt: nowDate() })
+      .where(
+        and(
+          eq(chatThreads.id, args.threadId),
+          eq(chatThreads.userId, args.userId),
+        ),
+      );
+    signal.throwIfAborted();
+  },
+);
+
+// Mirrors web's transitionRunStatus: stamps a run with a new status +
+// completedAt + error. Used for the timeout-doesn't-mask-event-content test
+// (the regression #12372 fixed).
+export const transitionRunStatus$ = command(
+  async (
+    { set },
+    args: {
+      readonly runId: string;
+      readonly status: string;
+      readonly completedAt?: Date | null;
+      readonly error?: string | null;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .update(agentRuns)
+      .set({
+        status: args.status,
+        completedAt: args.completedAt ?? null,
+        error: args.error ?? null,
+      })
+      .where(eq(agentRuns.id, args.runId));
+    signal.throwIfAborted();
   },
 );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import {
   chatThreadByIdContract,
   chatThreadMessagesContract,
+  chatThreadsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 
@@ -10,15 +11,21 @@ import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockApiShadowCompareRoutes } from "../../context/shadow-compare";
 import { writeDb$ } from "../../external/db";
 import {
+  addRunToThread$,
   deleteZeroChatThread$,
+  seedAssistantEventMessages$,
   seedZeroChatMessage$,
   seedZeroChatThread$,
+  transitionRunStatus$,
+  updateChatThreadTitle$,
   type ZeroChatThreadFixture,
 } from "./helpers/zero-chat-threads";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
+import { seedRun$ } from "./helpers/zero-usage-insight";
+import { nowDate } from "../../external/time";
 
 const context = testContext();
 const store = createStore();
@@ -176,6 +183,445 @@ describe("GET /api/zero/chat-threads/:id", () => {
     );
 
     expect(response.body.renamedAt).toBe("2025-06-01T12:00:00.000Z");
+  });
+
+  // --- 12 cases ported 1:1 from web's GET /api/zero/chat-threads/:id describe ---
+
+  it("requires authentication", async () => {
+    const client = setupApp({ context })(chatThreadByIdContract);
+    const response = await accept(
+      client.get({ params: { id: randomUUID() }, headers: {} }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 for non-existent thread id", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+    const client = setupApp({ context })(chatThreadByIdContract);
+    const response = await accept(
+      client.get({
+        params: { id: "00000000-0000-0000-0000-000000000000" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Chat thread not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 404 for malformed thread id", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+    const client = setupApp({ context })(chatThreadByIdContract);
+    const response = await accept(
+      client.get({
+        params: { id: "123" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Chat thread not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns thread detail with empty messages", async () => {
+    const fixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { title: "Detail thread" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(chatThreadByIdContract);
+
+    const response = await accept(
+      client.get({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.id).toBe(fixture.threadId);
+    expect(response.body.title).toBe("Detail thread");
+    expect(response.body.agentId).toBe(fixture.composeId);
+    expect(response.body.chatMessages).toStrictEqual([]);
+    expect(response.body.latestSessionId).toBeNull();
+  });
+
+  it("returns chat messages after run completes", async () => {
+    const fixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { title: "Messages thread" },
+        context.signal,
+      ),
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedZeroChatMessage$,
+      fixture,
+      { role: "user", content: "What files changed?" },
+      context.signal,
+    );
+    await store.set(
+      seedZeroChatMessage$,
+      fixture,
+      {
+        role: "assistant",
+        content: "Here are the changed files.",
+        runId,
+      },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(chatThreadByIdContract);
+
+    const response = await accept(
+      client.get({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.chatMessages).toHaveLength(2);
+    const assistantMsg = response.body.chatMessages.find((m) => {
+      return m.role === "assistant";
+    });
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg?.content).toBe("Here are the changed files.");
+    expect(assistantMsg?.runId).toBe(runId);
+  });
+
+  it("returns 404 when accessing another user's thread", async () => {
+    const fixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { title: "Private thread" },
+        context.signal,
+      ),
+    );
+    // Switch to a different user — same orgId, different userId.
+    mocks.clerk.session(`user_${randomUUID()}`, fixture.orgId);
+    const client = setupApp({ context })(chatThreadByIdContract);
+
+    const response = await accept(
+      client.get({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Chat thread not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("reflects updated title after updateChatThreadTitle", async () => {
+    const fixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { title: "Original title" },
+        context.signal,
+      ),
+    );
+    await store.set(
+      updateChatThreadTitle$,
+      {
+        threadId: fixture.threadId,
+        userId: fixture.userId,
+        title: "AI-Generated Title",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(chatThreadByIdContract);
+
+    const response = await accept(
+      client.get({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(response.body.title).toBe("AI-Generated Title");
+  });
+
+  it("returns the updated title in the thread list", async () => {
+    const fixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { title: "Before update" },
+        context.signal,
+      ),
+    );
+    await store.set(
+      updateChatThreadTitle$,
+      {
+        threadId: fixture.threadId,
+        userId: fixture.userId,
+        title: "After AI update",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    // The list route is still shadow-wrapped (separate Stage 2 issue). Mark
+    // it as shadow-compared in this test so the wrapper takes the api side
+    // instead of trying to fetch the (non-existent) web upstream.
+    mockApiShadowCompareRoutes([chatThreadsContract.list]);
+    const listClient = setupApp({ context })(chatThreadsContract);
+
+    const response = await accept(
+      listClient.list({
+        query: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.threads).toHaveLength(1);
+    expect(response.body.threads[0]?.title).toBe("After AI update");
+  });
+
+  it("returns cancelled run as a single user message", async () => {
+    const fixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { title: "Cancelled run thread" },
+        context.signal,
+      ),
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.composeId,
+        status: "cancelled",
+      },
+      context.signal,
+    );
+    await store.set(
+      addRunToThread$,
+      { threadId: fixture.threadId, runId },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(chatThreadByIdContract);
+
+    const response = await accept(
+      client.get({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    // Only the user message is present — no assistant placeholder.
+    expect(response.body.chatMessages).toHaveLength(1);
+    const userMsg = response.body.chatMessages.find((m) => {
+      return m.role === "user";
+    });
+    expect(userMsg).toBeDefined();
+    expect(userMsg?.content).toBe("test prompt");
+  });
+
+  it("does not mask event-backed assistant content with run-level timeout error", async () => {
+    // Regression test for #12372: event-backed assistant rows must keep
+    // their own `content` and NOT inherit the run-level timeout error via
+    // the leftJoin fallback.
+    const fixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { title: "Event-backed rows thread" },
+        context.signal,
+      ),
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+    await store.set(
+      addRunToThread$,
+      {
+        threadId: fixture.threadId,
+        runId,
+        prompt: "multi-step prompt",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedAssistantEventMessages$,
+      {
+        threadId: fixture.threadId,
+        runId,
+        items: [
+          { sequenceNumber: 0, content: "First partial response" },
+          { sequenceNumber: 1, content: "Second partial response" },
+        ],
+      },
+      context.signal,
+    );
+    await store.set(
+      transitionRunStatus$,
+      {
+        runId,
+        status: "timeout",
+        completedAt: nowDate(),
+        error: "Run timed out (no heartbeat)",
+      },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(chatThreadByIdContract);
+
+    const response = await accept(
+      client.get({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const eventRows = response.body.chatMessages.filter((m) => {
+      return m.role === "assistant" && m.content !== null;
+    });
+    expect(eventRows).toHaveLength(2);
+    for (const row of eventRows) {
+      expect(row.content).not.toContain("Run timed out");
+    }
+  });
+
+  it("returns activeRuns with live status for non-terminal runs", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, { title: "Active runs" }, context.signal),
+    );
+    const { runId: queuedRunId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.composeId,
+        status: "queued",
+      },
+      context.signal,
+    );
+    const { runId: runningRunId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+    const { runId: doneRunId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+    await store.set(
+      addRunToThread$,
+      { threadId: fixture.threadId, runId: queuedRunId },
+      context.signal,
+    );
+    await store.set(
+      addRunToThread$,
+      { threadId: fixture.threadId, runId: runningRunId },
+      context.signal,
+    );
+    await store.set(
+      addRunToThread$,
+      { threadId: fixture.threadId, runId: doneRunId },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(chatThreadByIdContract);
+
+    const response = await accept(
+      client.get({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.activeRuns).toHaveLength(2);
+    const byStatus = new Map<string, string>();
+    for (const r of response.body.activeRuns ?? []) {
+      byStatus.set(r.status, r.id);
+    }
+    expect(byStatus.get("queued")).toBe(queuedRunId);
+    expect(byStatus.get("running")).toBe(runningRunId);
+    expect(new Set(response.body.activeRunIds)).toStrictEqual(
+      new Set([queuedRunId, runningRunId]),
+    );
+  });
+
+  it("returns empty activeRuns when all runs are terminal", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, { title: "All done" }, context.signal),
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+    await store.set(
+      addRunToThread$,
+      { threadId: fixture.threadId, runId },
+      context.signal,
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(chatThreadByIdContract);
+
+    const response = await accept(
+      client.get({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.activeRuns).toStrictEqual([]);
+    expect(response.body.activeRunIds).toStrictEqual([]);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -147,10 +147,7 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
   },
   {
     route: chatThreadByIdContract.get,
-    handler: shadowCompareRoute({
-      route: chatThreadByIdContract.get,
-      handler: authRoute({}, getChatThreadInner$),
-    }),
+    handler: authRoute({}, getChatThreadInner$),
   },
   {
     route: chatThreadArtifactsContract.list,


### PR DESCRIPTION
Closes #12484

## Summary
- Drop the \`shadowCompareRoute\` wrapper from \`GET /api/zero/chat-threads/:id\` so \`apps/api\` is now authoritative.
- Extend the existing \`zero-chat-threads.test.ts\` with all 12 in-scope web GET cases (3 existing api cases → 15 total under the same \`describe(\"GET /api/zero/chat-threads/:id\")\` block).
- Extend \`helpers/zero-chat-threads.ts\` with 4 new commands + a wider fixture cleanup + an additive \`runId\` param on \`seedZeroChatMessage\$\`.

## Milestone
\`zero-chat-threads.ts\` goes from 5 → 4 \`shadowCompareRoute\` wrapper calls. The \`shadowCompareRoute\` import is **retained** because list / artifacts / messages / search routes still use it.

## API-specific 401 missing-org case — SKIPPED with rationale
The route uses \`authRoute({}, ...)\` without \`requireOrganization\` (the chat-thread is user-scoped, not org-scoped). A Clerk session without an active org passes auth and reaches the handler. The "401 missing-org" pattern doesn't apply here. Same precedent as #12432 / #12472.

## Final test inventory (15 cases under getById describe)
**Existing (3 cases — kept unchanged)**:
1. returns thread detail with S3-backed attachment metadata
2. strips Clerk user_ prefix from attachment file URLs
3. returns renamedAt as ISO string when thread was renamed

**New (12 cases mapping 1:1 to web)**:
4. requires authentication
5. returns 404 for non-existent thread id
6. returns 404 for malformed thread id
7. returns thread detail with empty messages
8. returns chat messages after run completes
9. returns 404 when accessing another user's thread
10. reflects updated title after updateChatThreadTitle
11. returns the updated title in the thread list (cross-route via \`chatThreadsContract.list\`)
12. returns cancelled run as a single user message
13. **does not mask event-backed assistant content with run-level timeout error** — regression test for #12372
14. returns activeRuns with live status for non-terminal runs
15. returns empty activeRuns when all runs are terminal

## Implementation notes
- **Critical case 13** (regression for #12372): seed a running run with 2 event-backed assistant rows, then transition the run to timeout with a run-level error. Assert the assistant rows keep their own content and don't inherit the timeout error via the leftJoin fallback.
- **Helper additions** are additive: \`addRunToThread\$\`, \`seedAssistantEventMessages\$\`, \`updateChatThreadTitle\$\`, \`transitionRunStatus\$\`, plus optional \`runId\` on \`seedZeroChatMessage\$\` (existing 5 callers unaffected).
- **Cleanup widening**: \`deleteZeroChatThread\$\` now also deletes \`agent_runs / zero_runs / agent_sessions / chat_messages / agent_compose_versions\` for the fixture's compose+user scope. Matches \`deleteUsageInsightFixture\$\` pattern. Defensive — doesn't depend on FK CASCADE behavior I haven't verified.
- **Reuse \`seedRun\$\`** from \`helpers/zero-usage-insight.ts\` (with \`result\`+\`error\` widening from #12478) — no new run helper needed.
- **Cross-route case 11** uses \`mockApiShadowCompareRoutes([chatThreadsContract.list])\` because the list route is still shadow-wrapped (separate Stage 2 issue — a1's #12482 in flight).

## Sibling coordination with #12482
a1's #12482 (list) and this PR both touch \`zero-chat-threads.ts\` but different stanzas. No conflict expected. Whichever lands first → no-op rebase for the other.

## Service parity verification
\`zeroChatThreadDetail\` untouched — verified field-by-field against web after both stabilization fixes (\`#12339\` for the \`id\` field and \`#12372\` for \`visibleChatMessageCondition\`) are present in the current api service.

## Test plan
- [x] \`pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-threads.test.ts\` — 20/20 passing (12 new + 8 existing)
- [x] \`pnpm -F api lint\`
- [x] \`pnpm -F api check-types\`
- [x] \`pnpm format\`
- [x] \`pnpm knip\`
- [x] \`grep -c 'shadowCompareRoute(' src/signals/routes/zero-chat-threads.ts\` → 4 (down from 5)
- [x] \`shadowCompareRoute\` import retained

## Rollback
Disable the \`apiBackend\` feature switch — traffic falls back to web. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)