### PR TITLE
refactor(api): migrate zero chat threads artifacts list get to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-artifacts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-artifacts.test.ts
@@ -1,0 +1,236 @@
+import { randomUUID } from "node:crypto";
+
+import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedChatThread$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+interface RunUploadedFileSeed {
+  readonly runId: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly externalId: string;
+  readonly filename: string;
+  readonly contentType: string;
+  readonly sizeBytes: number;
+  readonly url: string;
+}
+
+async function seedRunUploadedFile(args: RunUploadedFileSeed): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(runUploadedFiles).values({
+    runId: args.runId,
+    source: "web",
+    externalId: args.externalId,
+    userId: args.userId,
+    orgId: args.orgId,
+    filename: args.filename,
+    contentType: args.contentType,
+    sizeBytes: args.sizeBytes,
+    url: args.url,
+  });
+}
+
+async function seedChatMessage(args: {
+  readonly threadId: string;
+  readonly role: "user" | "assistant";
+  readonly content: string;
+  readonly runId: string;
+}): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(chatMessages).values({
+    chatThreadId: args.threadId,
+    role: args.role,
+    content: args.content,
+    runId: args.runId,
+  });
+}
+
+describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
+  const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.list({ params: { threadId: randomUUID() }, headers: {} }),
+      [401],
+    );
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns run uploaded files grouped by run", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const threadId = await store.set(
+      seedChatThread$,
+      { userId: fixture.userId, composeId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "completed",
+        chatThreadId: threadId,
+      },
+      context.signal,
+    );
+    await seedRunUploadedFile({
+      runId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      externalId: "file-1",
+      filename: "data.csv",
+      contentType: "text/csv",
+      sizeBytes: 2048,
+      url: `http://localhost:3000/f/${fixture.userId}/file-1/data.csv`,
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.list({
+        params: { threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.runs).toHaveLength(1);
+    expect(response.body.runs[0]?.runId).toBe(runId);
+    expect(response.body.runs[0]?.files).toHaveLength(1);
+    expect(response.body.runs[0]?.files[0]).toMatchObject({
+      id: "file-1",
+      filename: "data.csv",
+      contentType: "text/csv",
+      size: 2048,
+    });
+    expect(response.body.runs[0]?.files[0]?.url).toContain("/f/");
+  });
+
+  it("uses chat message run ownership when zero run chat thread is missing", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const threadId = await store.set(
+      seedChatThread$,
+      { userId: fixture.userId, composeId },
+      context.signal,
+    );
+    // Run is intentionally NOT linked to threadId on the zeroRuns row;
+    // the chat message below provides the ownership link instead.
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+    await seedChatMessage({
+      threadId,
+      role: "user",
+      content: "Uploaded during the run",
+      runId,
+    });
+    await seedRunUploadedFile({
+      runId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      externalId: "file-fallback",
+      filename: "preview.html",
+      contentType: "text/html",
+      sizeBytes: 512,
+      url: `http://localhost:3000/f/${fixture.userId}/file-fallback/preview.html`,
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.list({
+        params: { threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.runs).toHaveLength(1);
+    expect(response.body.runs[0]?.runId).toBe(runId);
+    expect(response.body.runs[0]?.files[0]).toMatchObject({
+      id: "file-fallback",
+      filename: "preview.html",
+      contentType: "text/html",
+      size: 512,
+    });
+  });
+
+  it("returns 404 when the thread is owned by a different user (no leak)", async () => {
+    const otherUserId = `user_${randomUUID()}`;
+    const otherFixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const callerFixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: otherFixture.orgId, userId: otherUserId },
+      context.signal,
+    );
+    const otherThreadId = await store.set(
+      seedChatThread$,
+      { userId: otherUserId, composeId },
+      context.signal,
+    );
+    mocks.clerk.session(callerFixture.userId, callerFixture.orgId);
+
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.list({
+        params: { threadId: otherThreadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body.error).toStrictEqual({
+      message: "Chat thread not found",
+      code: "NOT_FOUND",
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -157,10 +157,7 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
   },
   {
     route: chatThreadArtifactsContract.list,
-    handler: shadowCompareRoute({
-      route: chatThreadArtifactsContract.list,
-      handler: authRoute({}, listChatThreadArtifactsInner$),
-    }),
+    handler: authRoute({}, listChatThreadArtifactsInner$),
   },
   {
     route: chatThreadMessagesContract.list,


### PR DESCRIPTION
## Summary

Closes #12486. Stage 2 read-only migration under epic #12290.

Drops the `shadowCompareRoute` wrapper from `chatThreadArtifactsContract.list` and adds 4 fresh test cases covering everything except Drive sync status, which is deferred to follow-up #12488.

### Implementation

- **Route** `apps/api/src/signals/routes/zero-chat-threads.ts` — drop `shadowCompareRoute` wrapper from artifacts entry only. Wrapper count: 5 → 4 (list, get, messagesList, search still wrapped). Import retained.
- **Tests** `apps/api/src/signals/routes/__tests__/zero-chat-threads-artifacts.test.ts` (new, 4 cases).

### Scope audit

Web file has 6 cases. Mapped them as:

| Web case | Verb | Status |
|----------|------|--------|
| line 37 (401 unauthenticated) | GET | ✅ ported 1:1 |
| line 49 (run uploaded files grouped) | GET | ✅ ported 1:1 |
| line 95 (Google Drive sync status) | GET | ⚠️ DEFERRED → #12488 |
| line 177 (chat-message run ownership fallback) | GET | ✅ ported 1:1 |
| line 228 (sync to Drive) | POST | ❌ out of scope |
| line 367 (requires connected Drive) | POST | ❌ out of scope |

### Drive sync deferral (tracked in #12488)

apps/api response currently omits the `googleDriveSync` field on each artifact file. Web computes this via `getGoogleDriveArtifactStatusLookup` + `applyGoogleDriveArtifactSyncStatuses` (~150 LOC) plus connector access-token plumbing (`getConnectorAccessToken` / `getConnectorRefreshToken` / `refreshConnectorAccessToken`) that doesn't exist in apps/api yet — total bundle ~400 LOC of new code. Field is contract-`optional`, so the api response is contract-compliant. Filed as **#12488** before pushing this PR (per #12424 / #12463 deferral discipline).

### Test cases (4)

1. **401** unauthenticated (no Authorization header)
2. **200** run uploaded files grouped by run (zeroRuns.chatThreadId path)
3. **200** chat-message run ownership fallback (zeroRuns.chatThreadId is null; chat_message.run_id provides the link)
4. **404** thread owned by a different user (defensive, no existence leak — exercises `ownedChatThread` SQL filter)

Helpers reused: `seedUsageInsightFixture$` / `seedRun$` / `seedCompose$` / `seedChatThread$` from `helpers/zero-usage-insight.ts`. Inline `seedRunUploadedFile` / `seedChatMessage` (single consumer; YAGNI).

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-threads-artifacts.test.ts` — 4/4 pass
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-threads.test.ts` — 8/8 sibling sanity
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `pnpm knip --workspace apps/api` — clean
- [x] `grep -c "shadowCompareRoute(" apps/api/src/signals/routes/zero-chat-threads.ts` → 4

## Sibling coordination

a1's #12482 (list) + a3's #12484 (getById) target the same `zero-chat-threads.ts`. Different stanzas in route array → clean rebase regardless of land order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)