### PR TITLE
chore: clear remaining code-scanning warnings

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -169,7 +169,7 @@ def _fetch_firewall_headers_sync(
     if not req.full_url.startswith(("http://", "https://")):
         raise ValueError(f"Unexpected URL scheme: {req.full_url!r}")
     try:
-        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+        # nosemgrep: dynamic-urllib-use-detected
         with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -161,9 +161,15 @@ def _fetch_firewall_headers_sync(
         body["forceRefresh"] = True
     data = json.dumps(body).encode()
     req = make_api_request(url, data, sandbox_token)
+    # `req` always targets ctx.options.vm0_api_url (operator-set at mitmdump
+    # launch), never user-controlled input — so the file://-scheme risk that
+    # both S310 and Semgrep's dynamic-urllib-use-detected rule guard against
+    # does not apply. Defense in depth: reject anything that isn't an http(s)
+    # URL before opening it.
+    if not req.full_url.startswith(("http://", "https://")):
+        raise ValueError(f"Unexpected URL scheme: {req.full_url!r}")
     try:
-        # S310 is satisfied by provenance: `req` always targets
-        # ctx.options.vm0_api_url (operator-set at mitmdump launch).
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
         with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:

--- a/turbo/apps/cli/src/commands/zero/computer-use/client.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/client.ts
@@ -1,8 +1,15 @@
 import { Command } from "commander";
 import { writeFile, mkdir } from "fs/promises";
-import { join } from "path";
+import { basename, join } from "path";
 import { withErrorHandler } from "../../../lib/command/with-error-handler";
 import { callHost } from "../../../lib/computer-use/client";
+
+// `data.format` flows from the remote host response into a path; `basename`
+// strips any separators so a hostile value like `../../etc/passwd` cannot
+// escape the screenshot directory.
+function safeFormat(format: string): string {
+  return basename(format);
+}
 
 function mouseClickCommand(
   name: string,
@@ -49,7 +56,10 @@ export const clientScreenshotCommand = new Command()
       await mkdir(dir, { recursive: true });
 
       const timestamp = Date.now();
-      const filePath = join(dir, `screenshot-${timestamp}.${data.format}`);
+      const filePath = join(
+        dir,
+        `screenshot-${timestamp}.${safeFormat(data.format)}`,
+      );
       const buffer = Buffer.from(data.image, "base64");
       await writeFile(filePath, buffer);
 
@@ -96,7 +106,10 @@ export const clientZoomCommand = new Command()
         await mkdir(dir, { recursive: true });
 
         const timestamp = Date.now();
-        const filePath = join(dir, `zoom-${timestamp}.${data.format}`);
+        const filePath = join(
+          dir,
+          `zoom-${timestamp}.${safeFormat(data.format)}`,
+        );
         const buffer = Buffer.from(data.image, "base64");
         await writeFile(filePath, buffer);
 

--- a/turbo/apps/cli/src/commands/zero/slack/download-file.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/download-file.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { basename, join } from "path";
 import { tmpdir } from "os";
 import { Command } from "commander";
 import { downloadSlackFile } from "../../../lib/api";
@@ -8,9 +8,12 @@ import { withErrorHandler } from "../../../lib/command";
  * Derive a local output path for a Slack file id.
  * Uses the system temp directory; extension is appended later once the
  * mimetype is known.
+ *
+ * `basename` strips any path separators from `fileId` so a hostile id like
+ * `../etc/passwd` cannot escape `tmpdir()`.
  */
 function defaultOutPath(fileId: string): string {
-  return join(tmpdir(), `slack-${fileId}`);
+  return join(tmpdir(), `slack-${basename(fileId)}`);
 }
 
 export const downloadFileCommand = new Command()

--- a/turbo/apps/cli/src/commands/zero/telegram/download-file.ts
+++ b/turbo/apps/cli/src/commands/zero/telegram/download-file.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { basename, join } from "path";
 import { tmpdir } from "os";
 import { Command } from "commander";
 import { downloadTelegramFile } from "../../../lib/api";
@@ -7,9 +7,12 @@ import { withErrorHandler } from "../../../lib/command";
 /**
  * Derive a local output path for a Telegram file id.
  * Uses the system temp directory.
+ *
+ * `basename` strips any path separators from `fileId` so a hostile id like
+ * `../etc/passwd` cannot escape `tmpdir()`.
  */
 function defaultOutPath(fileId: string): string {
-  return join(tmpdir(), `telegram-${fileId}`);
+  return join(tmpdir(), `telegram-${basename(fileId)}`);
 }
 
 export const downloadFileCommand = new Command()

--- a/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdirSync, rmSync, writeFileSync } from "fs";
-import { join } from "path";
+import { basename, join } from "path";
 import { tmpdir } from "os";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server";
@@ -227,7 +227,7 @@ describe("zero web upload-file command", () => {
       ["clip.mp3", "audio/mpeg"],
       ["voice.wav", "audio/wav"],
     ])("should infer %s as %s", async (filename, expectedContentType) => {
-      const filePath = join(tmpDir, filename);
+      const filePath = join(tmpDir, basename(filename));
       writeFileSync(filePath, Buffer.from("fake bytes"));
 
       let putReceivedContentType: string | null = null;

--- a/turbo/apps/cli/src/commands/zero/web/download-file.ts
+++ b/turbo/apps/cli/src/commands/zero/web/download-file.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { basename, join } from "path";
 import { tmpdir } from "os";
 import { Command } from "commander";
 import { downloadWebFile } from "../../../lib/api";
@@ -7,9 +7,12 @@ import { withErrorHandler } from "../../../lib/command";
 /**
  * Derive a local output path for a web-uploaded file id.
  * Uses the system temp directory.
+ *
+ * `basename` strips any path separators from `fileId` so a hostile id like
+ * `../etc/passwd` cannot escape `tmpdir()`.
  */
 function defaultOutPath(fileId: string): string {
-  return join(tmpdir(), `web-${fileId}`);
+  return join(tmpdir(), `web-${basename(fileId)}`);
 }
 
 export const downloadFileCommand = new Command()

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -108,10 +108,12 @@ async function openPermissionsDrawer(connectorLabel: string) {
 
   click(screen.getByLabelText(`Manage ${connectorLabel} permissions`));
 
+  const expectedHeading = `${connectorLabel} permissions`.toLowerCase();
   await waitFor(() => {
     expect(
       screen.getByRole("heading", {
-        name: new RegExp(`${connectorLabel} permissions`, "i"),
+        name: (accessibleName) =>
+          accessibleName.toLowerCase().includes(expectedHeading),
       }),
     ).toBeInTheDocument();
   });

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -112,8 +112,9 @@ async function openPermissionsDrawer(connectorLabel: string) {
   await waitFor(() => {
     expect(
       screen.getByRole("heading", {
-        name: (accessibleName) =>
-          accessibleName.toLowerCase().includes(expectedHeading),
+        name: (accessibleName) => {
+          return accessibleName.toLowerCase().includes(expectedHeading);
+        },
       }),
     ).toBeInTheDocument();
   });

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/utils/highlight-text.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/utils/highlight-text.tsx
@@ -28,46 +28,46 @@ export function highlightText(
     return { element: text, matchCount: 0 };
   }
 
-  const escapedTerm = searchTerm.replace(
-    /[.*+?^${}()|[\]\\]/g,
-    String.raw`\$&`,
-  );
-  const regex = new RegExp(`(${escapedTerm})`, "gi");
-  const parts = text.split(regex);
-
-  let matchCount = 0;
+  const lowered = text.toLowerCase();
+  const target = searchTerm.toLowerCase();
   const elements: ReactNode[] = [];
+  let matchCount = 0;
+  let cursor = 0;
 
-  for (let i = 0; i < parts.length; i++) {
-    const part = parts[i];
-    if (!part) {
-      continue;
+  for (;;) {
+    const idx = lowered.indexOf(target, cursor);
+    if (idx === -1) {
+      if (cursor < text.length) {
+        elements.push(text.slice(cursor));
+      }
+      break;
     }
 
-    const isMatch = part.toLowerCase() === searchTerm.toLowerCase();
-
-    if (isMatch) {
-      const globalIndex = matchStartIndex + matchCount;
-      const isCurrent = globalIndex === currentMatchIndex;
-
-      elements.push(
-        <mark
-          key={`match-${globalIndex}-${i}`}
-          data-match-index={globalIndex}
-          data-current-match={isCurrent ? "true" : undefined}
-          className={
-            isCurrent
-              ? "bg-orange-200 text-orange-900 rounded px-0.5"
-              : "bg-orange-100 text-orange-800 rounded px-0.5"
-          }
-        >
-          {part}
-        </mark>,
-      );
-      matchCount++;
-    } else {
-      elements.push(part);
+    if (idx > cursor) {
+      elements.push(text.slice(cursor, idx));
     }
+
+    const part = text.slice(idx, idx + target.length);
+    const globalIndex = matchStartIndex + matchCount;
+    const isCurrent = globalIndex === currentMatchIndex;
+
+    elements.push(
+      <mark
+        key={`match-${globalIndex}-${idx}`}
+        data-match-index={globalIndex}
+        data-current-match={isCurrent ? "true" : undefined}
+        className={
+          isCurrent
+            ? "bg-orange-200 text-orange-900 rounded px-0.5"
+            : "bg-orange-100 text-orange-800 rounded px-0.5"
+        }
+      >
+        {part}
+      </mark>,
+    );
+
+    matchCount++;
+    cursor = idx + target.length;
   }
 
   return {

--- a/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
@@ -180,16 +180,12 @@ export default async function BlogPostPage({
 
   return (
     <>
-      <script
-        type="application/ld+json"
-        suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
-      />
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(breadcrumbJsonLd)}
+      </script>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(articleJsonLd)}
+      </script>
       <Particles />
 
       {/* Post Header */}

--- a/turbo/apps/web/app/[locale]/pricing/page.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/page.tsx
@@ -75,8 +75,9 @@ export default async function PricingPage({ params }: PageProps) {
         id="json-ld-breadcrumb"
         type="application/ld+json"
         suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
-      />
+      >
+        {JSON.stringify(breadcrumbJsonLd)}
+      </script>
       <PricingPageClient />
     </>
   );

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/mention.ts
@@ -278,13 +278,23 @@ function stripBotMention(
 ): string {
   if (!botUsername || !entities) return text;
 
-  // Find mention entities and remove them
-  const mentionText = `@${botUsername}`;
-  return text
-    .replace(new RegExp(`\\s*${escapeRegExp(mentionText)}\\s*`, "gi"), " ")
-    .trim();
-}
-
-function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const mention = `@${botUsername}`;
+  const mentionLower = mention.toLowerCase();
+  const lower = text.toLowerCase();
+  let result = "";
+  let cursor = 0;
+  for (;;) {
+    const idx = lower.indexOf(mentionLower, cursor);
+    if (idx === -1) {
+      result += text.slice(cursor);
+      break;
+    }
+    result += text.slice(cursor, idx).trimEnd();
+    result += " ";
+    cursor = idx + mention.length;
+    while (cursor < text.length && /\s/u.test(text.charAt(cursor))) {
+      cursor++;
+    }
+  }
+  return result.trim();
 }

--- a/turbo/apps/web/src/lib/zero/telegram/handlers/official.ts
+++ b/turbo/apps/web/src/lib/zero/telegram/handlers/official.ts
@@ -628,12 +628,23 @@ function stripBotMention(
 ): string {
   if (!botUsername || !entities) return text;
 
-  const mentionText = `@${botUsername}`;
-  return text
-    .replace(new RegExp(`\\s*${escapeRegExp(mentionText)}\\s*`, "gi"), " ")
-    .trim();
-}
-
-function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const mention = `@${botUsername}`;
+  const mentionLower = mention.toLowerCase();
+  const lower = text.toLowerCase();
+  let result = "";
+  let cursor = 0;
+  for (;;) {
+    const idx = lower.indexOf(mentionLower, cursor);
+    if (idx === -1) {
+      result += text.slice(cursor);
+      break;
+    }
+    result += text.slice(cursor, idx).trimEnd();
+    result += " ";
+    cursor = idx + mention.length;
+    while (cursor < text.length && /\s/u.test(text.charAt(cursor))) {
+      cursor++;
+    }
+  }
+  return result.trim();
 }


### PR DESCRIPTION
## Summary

Clears the 11 open Semgrep alerts on the [security tab](https://github.com/vm0-ai/vm0/security/code-scanning?query=is%3Aopen):

- **5× path-traversal** (`path.join`/`path.resolve`): wrap externally-supplied file ids and screenshot format strings with `path.basename` so they can't escape `tmpdir()` / the screenshot directory.
- **3× non-literal regexp** (potential ReDoS): rewrite `stripBotMention` (telegram `official.ts` + `mention.ts`) and `highlightText` to use `String.indexOf` loops; switch the permissions-dialog test from a dynamic `new RegExp` to a function-form `name` matcher.
- **2× dangerouslySetInnerHTML** (JSON-LD): match the existing convention used in `models/`, `use-cases/`, and `rankings/` pages — render JSON-LD as a `<script type="application/ld+json">` text child instead of via `dangerouslySetInnerHTML`.
- **1× dynamic urllib** (mitm-addon): add an explicit `http(s)://` scheme guard before `urlopen`, plus a `# nosemgrep` line with the same rationale as the existing `# noqa: S310` (URL is operator-set `vm0_api_url`, never user input). Consistent with the existing `// nosemgrep` markers in `proxy.cors.ts` and `spawn.ts`.

Also dismissed the two open secret-scanning alerts (#99, #84) as false positives — both were `Coffee*Safe*Local` placeholder strings, not real keys.

No behavior change for end users.

## Test plan

- [ ] CI Semgrep job is green and reports lower-than-baseline counts
- [ ] CodeQL is green
- [ ] Existing `highlightText` tests in `apps/platform` still pass (case-insensitive substring marking, current-match indicator)
- [ ] Existing telegram handler tests still pass — `stripBotMention` behavior is preserved (case-insensitive `@bot` removal, surrounding whitespace collapsed)
- [ ] Pricing and blog post pages still emit valid JSON-LD (Rich Results test)
- [ ] CLI `zero web/slack/telegram download-file` still resolves a sensible default temp path with a normal id, and rejects/sanitizes path-separator ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)