### PR TITLE
fix(api): port google drive artifact sync status to chat-threads artifacts get

### DIFF
--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -26,6 +26,8 @@ const SCHEMA = {
   AXIOM_TOKEN_TELEMETRY: z.string().min(1),
   AXIOM_DATASET_SUFFIX: z.enum(["dev", "prod"]),
   STRIPE_SECRET_KEY: z.string().min(1),
+  GOOGLE_OAUTH_CLIENT_ID: z.string().min(1).optional(),
+  GOOGLE_OAUTH_CLIENT_SECRET: z.string().min(1).optional(),
   DB_POOL_MAX: z.coerce.number().int().min(1).default(10),
   DB_POOL_IDLE_TIMEOUT_MS: z.coerce.number().int().min(0).default(5000),
   DB_POOL_CONNECT_TIMEOUT_MS: z.coerce.number().int().min(0).optional(),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-artifacts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-artifacts.test.ts
@@ -2,11 +2,19 @@ import { randomUUID } from "node:crypto";
 
 import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { chatMessages } from "@vm0/db/schema/chat-message";
+import { connectors } from "@vm0/db/schema/connector";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
+import { secrets } from "@vm0/db/schema/secret";
 import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { http, HttpResponse } from "msw";
+import { afterEach } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
+import { encryptSecretForTests } from "./helpers/encrypt-secret";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -65,9 +73,57 @@ async function seedChatMessage(args: {
   });
 }
 
+async function seedGoogleDriveConnector(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly accessToken: string;
+  readonly refreshToken?: string;
+}): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(connectors).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    type: "google-drive",
+    authMethod: "oauth",
+    needsReconnect: false,
+  });
+  await writeDb.insert(secrets).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    name: "GOOGLE_DRIVE_ACCESS_TOKEN",
+    type: "connector",
+    encryptedValue: encryptSecretForTests(args.accessToken),
+  });
+  if (args.refreshToken) {
+    await writeDb.insert(secrets).values({
+      orgId: args.orgId,
+      userId: args.userId,
+      name: "GOOGLE_DRIVE_REFRESH_TOKEN",
+      type: "connector",
+      encryptedValue: encryptSecretForTests(args.refreshToken),
+    });
+  }
+}
+
 describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
   const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
     return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  // connectors + secrets are NOT cascaded by deleteUsageInsightFixture$;
+  // tests that seed Drive credentials track their orgId here for explicit
+  // cleanup so subsequent runs start clean.
+  const seededDriveOrgs: string[] = [];
+  afterEach(async () => {
+    while (seededDriveOrgs.length > 0) {
+      const orgId = seededDriveOrgs.pop();
+      if (!orgId) {
+        continue;
+      }
+      const writeDb = store.set(writeDb$);
+      await writeDb.delete(connectors).where(eq(connectors.orgId, orgId));
+      await writeDb.delete(secrets).where(eq(secrets.orgId, orgId));
+    }
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -135,6 +191,9 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
       size: 2048,
     });
     expect(response.body.runs[0]?.files[0]?.url).toContain("/f/");
+    expect(response.body.runs[0]?.files[0]?.googleDriveSync).toStrictEqual({
+      status: "disconnected",
+    });
   });
 
   it("uses chat message run ownership when zero run chat thread is missing", async () => {
@@ -198,6 +257,9 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
       contentType: "text/html",
       size: 512,
     });
+    expect(response.body.runs[0]?.files[0]?.googleDriveSync).toStrictEqual({
+      status: "disconnected",
+    });
   });
 
   it("returns 404 when the thread is owned by a different user (no leak)", async () => {
@@ -231,6 +293,167 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
     expect(response.body.error).toStrictEqual({
       message: "Chat thread not found",
       code: "NOT_FOUND",
+    });
+  });
+
+  it("returns googleDriveSync status synced when the artifact is mirrored to Drive", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const threadId = await store.set(
+      seedChatThread$,
+      { userId: fixture.userId, composeId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "completed",
+        chatThreadId: threadId,
+      },
+      context.signal,
+    );
+    await seedRunUploadedFile({
+      runId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      externalId: "file-1",
+      filename: "data.csv",
+      contentType: "text/csv",
+      sizeBytes: 2048,
+      url: `http://localhost:3000/f/${fixture.userId}/file-1/data.csv`,
+    });
+    await seedGoogleDriveConnector({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      accessToken: "drive-access-token",
+    });
+    seededDriveOrgs.push(fixture.orgId);
+
+    let observedAuth: string | null = null;
+    let observedQuery = "";
+    server.use(
+      http.get("https://www.googleapis.com/drive/v3/files", ({ request }) => {
+        const url = new URL(request.url);
+        observedAuth = request.headers.get("authorization");
+        observedQuery = url.searchParams.get("q") ?? "";
+        return HttpResponse.json({
+          files: [
+            {
+              id: "drive-file-id",
+              name: "data.csv",
+              webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+              appProperties: {
+                vm0Artifact: "true",
+                vm0ThreadId: threadId,
+                vm0RunId: runId,
+                vm0FileId: "file-1",
+              },
+            },
+          ],
+        });
+      }),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.list({
+        params: { threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(observedAuth).toBe("Bearer drive-access-token");
+    expect(observedQuery).toContain("vm0Artifact");
+    expect(observedQuery).toContain(`value='${threadId}'`);
+    expect(response.body.runs[0]?.files[0]?.googleDriveSync).toStrictEqual({
+      status: "synced",
+      id: "drive-file-id",
+      name: "data.csv",
+      webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+    });
+  });
+
+  it("returns googleDriveSync status unknown when Drive rejects the access token and refresh fails", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const threadId = await store.set(
+      seedChatThread$,
+      { userId: fixture.userId, composeId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "completed",
+        chatThreadId: threadId,
+      },
+      context.signal,
+    );
+    await seedRunUploadedFile({
+      runId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      externalId: "file-1",
+      filename: "data.csv",
+      contentType: "text/csv",
+      sizeBytes: 2048,
+      url: `http://localhost:3000/f/${fixture.userId}/file-1/data.csv`,
+    });
+    await seedGoogleDriveConnector({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      accessToken: "stale-token",
+      refreshToken: "refresh-token",
+    });
+    seededDriveOrgs.push(fixture.orgId);
+
+    // Mock OAuth client credentials so the refresh attempt actually runs;
+    // without them refreshDriveAccessToken short-circuits to null without
+    // exercising the upstream POST.
+    mockEnv("GOOGLE_OAUTH_CLIENT_ID", "test-client-id");
+    mockEnv("GOOGLE_OAUTH_CLIENT_SECRET", "test-client-secret");
+
+    server.use(
+      http.get("https://www.googleapis.com/drive/v3/files", () => {
+        return new HttpResponse(null, { status: 401 });
+      }),
+      http.post("https://oauth2.googleapis.com/token", () => {
+        return new HttpResponse(null, { status: 401 });
+      }),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.list({
+        params: { threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.runs[0]?.files[0]?.googleDriveSync).toStrictEqual({
+      status: "unknown",
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -15,6 +15,10 @@ import { shadowCompareRoute } from "../context/shadow-compare";
 import { notFound } from "../../lib/error";
 import { zeroComposeExists } from "../services/zero-compose-data.service";
 import {
+  applyGoogleDriveArtifactSyncStatuses,
+  googleDriveArtifactStatusLookup,
+} from "../services/google-drive-artifact-sync.service";
+import {
   zeroChatSearch,
   zeroChatThreadArtifacts,
   zeroChatThreadDetail,
@@ -105,14 +109,29 @@ const listChatThreadsInner$ = computed(async (get) => {
 const listChatThreadArtifactsInner$ = computed(async (get) => {
   const auth = get(authContext$);
   const params = get(pathParamsOf(chatThreadArtifactsContract.list));
-  const runs = await get(
-    zeroChatThreadArtifacts({ threadId: params.threadId, userId: auth.userId }),
-  );
+  const [runs, lookup] = await Promise.all([
+    get(
+      zeroChatThreadArtifacts({
+        threadId: params.threadId,
+        userId: auth.userId,
+      }),
+    ),
+    get(
+      googleDriveArtifactStatusLookup({
+        threadId: params.threadId,
+        orgId: auth.orgId,
+        userId: auth.userId,
+      }),
+    ),
+  ]);
   if (!runs) {
     return chatThreadNotFound();
   }
 
-  return { status: 200 as const, body: { runs: [...runs] } };
+  return {
+    status: 200 as const,
+    body: { runs: applyGoogleDriveArtifactSyncStatuses(runs, lookup) },
+  };
 });
 
 const searchChatInner$ = computed(async (get) => {

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -1,0 +1,320 @@
+import { computed, type Computed } from "ccstate";
+import type {
+  ChatThreadArtifactGoogleDriveSync,
+  ChatThreadArtifactRun,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { connectors } from "@vm0/db/schema/connector";
+import { secrets } from "@vm0/db/schema/secret";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { optionalEnv } from "../../lib/env";
+import { db$, type ReadonlyDb } from "../external/db";
+import { decryptSecretValue } from "./crypto.utils";
+
+const GOOGLE_DRIVE_FILES_URL = "https://www.googleapis.com/drive/v3/files";
+const GOOGLE_DRIVE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_DRIVE_STATUS_TIMEOUT_MS = 2000;
+const GOOGLE_DRIVE_ARTIFACT_APP_PROPERTY = "vm0Artifact";
+const GOOGLE_DRIVE_THREAD_APP_PROPERTY = "vm0ThreadId";
+const GOOGLE_DRIVE_RUN_APP_PROPERTY = "vm0RunId";
+const GOOGLE_DRIVE_FILE_APP_PROPERTY = "vm0FileId";
+const ACCESS_SECRET = "GOOGLE_DRIVE_ACCESS_TOKEN";
+const REFRESH_SECRET = "GOOGLE_DRIVE_REFRESH_TOKEN";
+const SECRET_TYPE = "connector";
+
+const driveFileSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  webViewLink: z.string().nullable().optional(),
+  appProperties: z.record(z.string(), z.string()).optional(),
+});
+const driveFileListSchema = z.object({ files: z.array(driveFileSchema) });
+const refreshResponseSchema = z.object({
+  access_token: z.string().optional(),
+  expires_in: z.number().optional(),
+  error: z.string().optional(),
+});
+
+interface DriveSyncResult {
+  readonly id: string;
+  readonly name: string;
+  readonly webViewLink: string | null;
+}
+
+type DriveStatusLookup =
+  | {
+      readonly type: "ready";
+      readonly syncedByKey: ReadonlyMap<string, DriveSyncResult>;
+    }
+  | { readonly type: "disconnected" }
+  | { readonly type: "unknown" };
+
+interface ConnectorTokens {
+  readonly accessToken: string;
+  readonly refreshToken: string | null;
+  readonly needsReconnect: boolean;
+}
+
+function artifactKey(runId: string, fileId: string): string {
+  return `${runId}:${fileId}`;
+}
+
+function escapeQuery(value: string): string {
+  return value.replace(/\\/g, String.raw`\\`).replace(/'/g, String.raw`\'`);
+}
+
+async function loadDriveTokens(
+  db: ReadonlyDb,
+  orgId: string,
+  userId: string,
+): Promise<ConnectorTokens | null> {
+  const [connector] = await db
+    .select({ needsReconnect: connectors.needsReconnect })
+    .from(connectors)
+    .where(
+      and(
+        eq(connectors.orgId, orgId),
+        eq(connectors.userId, userId),
+        eq(connectors.type, "google-drive"),
+      ),
+    )
+    .limit(1);
+  if (!connector) {
+    return null;
+  }
+
+  const secretRows = await db
+    .select({ name: secrets.name, encryptedValue: secrets.encryptedValue })
+    .from(secrets)
+    .where(
+      and(
+        eq(secrets.orgId, orgId),
+        eq(secrets.userId, userId),
+        eq(secrets.type, SECRET_TYPE),
+      ),
+    );
+
+  let accessEncrypted: string | undefined;
+  let refreshEncrypted: string | undefined;
+  for (const row of secretRows) {
+    if (row.name === ACCESS_SECRET) {
+      accessEncrypted = row.encryptedValue;
+    }
+    if (row.name === REFRESH_SECRET) {
+      refreshEncrypted = row.encryptedValue;
+    }
+  }
+  if (!accessEncrypted) {
+    return null;
+  }
+
+  return {
+    accessToken: decryptSecretValue(accessEncrypted),
+    refreshToken: refreshEncrypted
+      ? decryptSecretValue(refreshEncrypted)
+      : null,
+    needsReconnect: connector.needsReconnect,
+  };
+}
+
+async function refreshDriveAccessToken(
+  refreshToken: string,
+): Promise<string | null> {
+  const clientId = optionalEnv("GOOGLE_OAUTH_CLIENT_ID");
+  const clientSecret = optionalEnv("GOOGLE_OAUTH_CLIENT_SECRET");
+  if (!clientId || !clientSecret) {
+    return null;
+  }
+  const response = await fetch(GOOGLE_DRIVE_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+  if (!response.ok) {
+    return null;
+  }
+  const parsed = refreshResponseSchema.safeParse(await response.json());
+  if (!parsed.success || !parsed.data.access_token) {
+    return null;
+  }
+  return parsed.data.access_token;
+}
+
+type DriveListResult =
+  | { readonly type: "ok"; readonly files: z.infer<typeof driveFileSchema>[] }
+  | { readonly type: "unauthorized" };
+
+async function listArtifactFiles(args: {
+  readonly accessToken: string;
+  readonly threadId: string;
+  readonly signal: AbortSignal;
+}): Promise<DriveListResult> {
+  const url = new URL(GOOGLE_DRIVE_FILES_URL);
+  url.searchParams.set(
+    "q",
+    [
+      `appProperties has { key='${GOOGLE_DRIVE_ARTIFACT_APP_PROPERTY}' and value='true' }`,
+      `appProperties has { key='${GOOGLE_DRIVE_THREAD_APP_PROPERTY}' and value='${escapeQuery(args.threadId)}' }`,
+      "trashed = false",
+    ].join(" and "),
+  );
+  url.searchParams.set("fields", "files(id,name,webViewLink,appProperties)");
+  url.searchParams.set("pageSize", "1000");
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${args.accessToken}` },
+    signal: args.signal,
+  });
+  if (response.status === 401) {
+    return { type: "unauthorized" };
+  }
+  if (!response.ok) {
+    throw new Error(
+      `Google Drive lookup failed with HTTP ${String(response.status)}`,
+    );
+  }
+  const parsed = driveFileListSchema.parse(await response.json());
+  return { type: "ok", files: parsed.files };
+}
+
+async function listArtifactFilesWithRefresh(args: {
+  readonly tokens: ConnectorTokens;
+  readonly threadId: string;
+  readonly signal: AbortSignal;
+}): Promise<z.infer<typeof driveFileSchema>[] | "unauthorized"> {
+  const first = await listArtifactFiles({
+    accessToken: args.tokens.accessToken,
+    threadId: args.threadId,
+    signal: args.signal,
+  });
+  if (first.type === "ok") {
+    return first.files;
+  }
+  if (!args.tokens.refreshToken) {
+    return "unauthorized";
+  }
+  const refreshedAccessToken = await refreshDriveAccessToken(
+    args.tokens.refreshToken,
+  );
+  if (!refreshedAccessToken) {
+    return "unauthorized";
+  }
+  const second = await listArtifactFiles({
+    accessToken: refreshedAccessToken,
+    threadId: args.threadId,
+    signal: args.signal,
+  });
+  if (second.type === "unauthorized") {
+    return "unauthorized";
+  }
+  return second.files;
+}
+
+function buildStatusMap(
+  files: readonly z.infer<typeof driveFileSchema>[],
+): ReadonlyMap<string, DriveSyncResult> {
+  const map = new Map<string, DriveSyncResult>();
+  for (const file of files) {
+    const runId = file.appProperties?.[GOOGLE_DRIVE_RUN_APP_PROPERTY];
+    const fileId = file.appProperties?.[GOOGLE_DRIVE_FILE_APP_PROPERTY];
+    if (!runId || !fileId) {
+      continue;
+    }
+    map.set(artifactKey(runId, fileId), {
+      id: file.id,
+      name: file.name,
+      webViewLink: file.webViewLink ?? null,
+    });
+  }
+  return map;
+}
+
+function resolveSyncStatus(
+  lookup: DriveStatusLookup,
+  runId: string,
+  fileId: string,
+): ChatThreadArtifactGoogleDriveSync {
+  if (lookup.type === "disconnected") {
+    return { status: "disconnected" };
+  }
+  if (lookup.type === "unknown") {
+    return { status: "unknown" };
+  }
+  const synced = lookup.syncedByKey.get(artifactKey(runId, fileId));
+  return synced ? { status: "synced", ...synced } : { status: "not_synced" };
+}
+
+export function applyGoogleDriveArtifactSyncStatuses(
+  runs: readonly ChatThreadArtifactRun[],
+  lookup: DriveStatusLookup,
+): ChatThreadArtifactRun[] {
+  return runs.map((run) => {
+    return {
+      ...run,
+      files: run.files.map((file) => {
+        return {
+          ...file,
+          googleDriveSync: resolveSyncStatus(lookup, run.runId, file.id),
+        };
+      }),
+    };
+  });
+}
+
+/**
+ * Compute the Drive sync status lookup for a chat thread's artifacts.
+ *
+ * Mirrors `getGoogleDriveArtifactStatusLookup` in
+ * `apps/web/src/lib/zero/chat-thread/artifact-google-drive-sync.ts` —
+ * scoped to Google Drive only (no generic provider registry) since this
+ * is the sole api consumer of OAuth refresh today.
+ *
+ * Token persistence is intentionally deferred. When the in-flight access
+ * token is rejected and the refresh succeeds, the new token is used for
+ * the retry but is NOT written back to `secrets`; the next request will
+ * refresh again. Keeps the route handler a read-only `computed`. Drive
+ * status check is a UI poll, not a hot path; refresh tokens don't rotate
+ * (Google), so the cost is one extra RTT per stale-token request.
+ * Track in epic #12290 follow-up if telemetry shows this matters.
+ */
+export function googleDriveArtifactStatusLookup(args: {
+  readonly threadId: string;
+  readonly orgId: string | undefined;
+  readonly userId: string;
+}): Computed<Promise<DriveStatusLookup>> {
+  return computed(async (get): Promise<DriveStatusLookup> => {
+    if (!args.orgId) {
+      return { type: "disconnected" };
+    }
+    const db = get(db$);
+    const tokens = await loadDriveTokens(db, args.orgId, args.userId);
+    if (!tokens || tokens.needsReconnect) {
+      return { type: "disconnected" };
+    }
+    return listArtifactFilesWithRefresh({
+      tokens,
+      threadId: args.threadId,
+      signal: AbortSignal.timeout(GOOGLE_DRIVE_STATUS_TIMEOUT_MS),
+    }).then(
+      (result): DriveStatusLookup => {
+        if (result === "unauthorized") {
+          return { type: "unknown" };
+        }
+        return { type: "ready", syncedByKey: buildStatusMap(result) };
+      },
+      // Timeout, schema-parse failure, transient network error — treat as
+      // "unknown" rather than failing the whole artifacts response. The 2s
+      // timeout is the explicit abort source here, so AbortError is part
+      // of the expected swallow set.
+      (): DriveStatusLookup => {
+        return { type: "unknown" };
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Closes #12488. Restores production parity with web for the chat-threads artifacts GET — apps/api now populates the `googleDriveSync` field on each artifact file (was omitted from #12489 deferral).

### Implementation

- **New service** `apps/api/src/signals/services/google-drive-artifact-sync.service.ts` (~280 LOC):
  - `googleDriveArtifactStatusLookup({threadId, orgId, userId})` — Computed factory; loads `google-drive` connector + encrypted secrets, fetches `https://www.googleapis.com/drive/v3/files` filtered by `appProperties.vm0Artifact = 'true'` AND `vm0ThreadId = :threadId`, returns `ready` / `disconnected` / `unknown` lookup state. 2s `AbortSignal.timeout` with `.then(success, error)` swallow → `unknown` on timeout / parse / network error.
  - `applyGoogleDriveArtifactSyncStatuses(runs, lookup)` — pure function; wraps each file with `googleDriveSync` resolved from the lookup.
  - Internal: `loadDriveTokens`, `listArtifactFiles`, `listArtifactFilesWithRefresh`, `refreshDriveAccessToken`, `buildStatusMap`. 401 → refresh against `oauth2.googleapis.com/token` → retry once.
- **Route** `apps/api/src/signals/routes/zero-chat-threads.ts` — `listChatThreadArtifactsInner$` now does `Promise.all([artifacts, lookup])` then spreads `applyGoogleDriveArtifactSyncStatuses`.
- **Env** `apps/api/src/lib/env.ts` — adds `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` as `.optional()`. Missing creds → refresh short-circuits → `unknown` (matches credentials-not-configured path).

### Drive-specific implementation

Rather than porting web's generic `PROVIDER_HANDLERS` registry (40+ providers, ~1000 LOC), the service hardcodes the google-drive secret names + tokenUrl. Drive is the only api consumer of OAuth refresh today. When a second connector arrives, refactor into a shared helper.

### Token persistence deferred

Refreshed access tokens are used in-flight only and **not** written back to `secrets`. Keeps the route handler a read-only `computed`. Drive status check is a UI poll, refresh tokens don't rotate (Google), so the cost is at most one extra RTT per stale-token request. Documented in the service file with an epic-#12290 follow-up note.

### Tests (4 → 6 cases)

| # | Case | Status |
|---|------|--------|
| 1 | 401 unauthenticated | unchanged |
| 2 | run uploaded files grouped (no Drive connector) | **strengthened**: explicit `disconnected` assertion |
| 3 | chat-message ownership fallback (no Drive connector) | **strengthened**: explicit `disconnected` assertion |
| 4 | 404 cross-user thread | unchanged |
| 5 | **NEW** Drive connected + matching file | `googleDriveSync.status === "synced"`; assert outgoing `Authorization: Bearer drive-access-token` + query contains `vm0Artifact` and `value='${threadId}'` |
| 7 | **NEW** Drive 401 + refresh 401 | `googleDriveSync.status === "unknown"` |

MSW handlers (`http.get/post`) per-test via `server.use`. Helper `seedGoogleDriveConnector` inline (single consumer; YAGNI). `seededDriveOrgs` + `afterEach` cleanup since `deleteUsageInsightFixture$` doesn't cascade through `connectors` / `secrets`.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-threads-artifacts.test.ts` — 6/6 pass
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-threads.test.ts src/signals/routes/__tests__/zero-chat-threads-list.test.ts` — 44/44 sibling sanity
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `pnpm knip --workspace apps/api` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)