### PR TITLE
feat(api): port chat-threads mark-read POST to api backend (Stage 3 first validator)

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -30,6 +30,7 @@
     "@vm0/connectors": "workspace:*",
     "@vm0/core": "workspace:*",
     "@vm0/db": "workspace:*",
+    "ably": "^2.21.0",
     "ccstate": "^5.3.0",
     "drizzle-orm": "^0.45.2",
     "gpt-tokenizer": "^3.4.0",

--- a/turbo/apps/api/src/__tests__/env-stub.ts
+++ b/turbo/apps/api/src/__tests__/env-stub.ts
@@ -30,3 +30,4 @@ vi.stubEnv("AXIOM_TOKEN_SESSIONS", "xaat-test-sessions");
 vi.stubEnv("AXIOM_TOKEN_TELEMETRY", "xaat-test-telemetry");
 vi.stubEnv("AXIOM_DATASET_SUFFIX", "dev");
 vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_dummy_for_unit_tests");
+vi.stubEnv("ABLY_API_KEY", "test-ably-key");

--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -15,6 +15,9 @@ export interface ApiTestMocks {
     readonly error: SyncMock;
     readonly flush: AsyncMock;
   };
+  readonly ably: {
+    readonly publish: AsyncMock;
+  };
   readonly clerk: {
     readonly authenticateRequest: AsyncMock;
     readonly organizations: {
@@ -113,6 +116,9 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   };
 
   return {
+    ably: {
+      publish: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    },
     axiom,
     axiomLogging,
     clerk,
@@ -176,6 +182,18 @@ vi.mock("@clerk/backend", () => {
       return apiTestMocks.clerk;
     },
   };
+});
+
+vi.mock("ably", () => {
+  class MockRest {
+    readonly channels = {
+      get: () => {
+        return { publish: apiTestMocks.ably.publish };
+      },
+    };
+    readonly auth = { createTokenRequest: vi.fn() };
+  }
+  return { default: { Rest: MockRest } };
 });
 
 vi.mock("@sentry/node", () => {
@@ -278,6 +296,8 @@ export function getApiTestMocks(): ApiTestMocks {
 }
 
 export function resetApiTestMocks(): void {
+  apiTestMocks.ably.publish.mockReset();
+  apiTestMocks.ably.publish.mockResolvedValue(undefined);
   apiTestMocks.axiom.query.mockReset();
   apiTestMocks.axiomLogging.debug.mockReset();
   apiTestMocks.axiomLogging.info.mockReset();

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -26,6 +26,7 @@ const SCHEMA = {
   AXIOM_TOKEN_TELEMETRY: z.string().min(1),
   AXIOM_DATASET_SUFFIX: z.enum(["dev", "prod"]),
   STRIPE_SECRET_KEY: z.string().min(1),
+  ABLY_API_KEY: z.string().min(1),
   GOOGLE_OAUTH_CLIENT_ID: z.string().min(1).optional(),
   GOOGLE_OAUTH_CLIENT_SECRET: z.string().min(1).optional(),
   DB_POOL_MAX: z.coerce.number().int().min(1).default(10),

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -1,0 +1,55 @@
+import Ably from "ably";
+
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { singleton } from "../../lib/singleton";
+
+const L = logger("Realtime");
+
+const ablyClient = singleton((): Ably.Rest => {
+  const client = new Ably.Rest({ key: env("ABLY_API_KEY"), queryTime: true });
+  L.debug("Ably client initialised");
+  return client;
+});
+
+function getUserChannelName(userId: string): string {
+  return `user:${userId}`;
+}
+
+/**
+ * Publish a per-user invalidation/notification signal.
+ *
+ * Channel naming and payload shape mirror the existing apps/web helper
+ * (apps/web/src/lib/infra/realtime/client.ts). Platform clients subscribe via
+ * the existing /api/zero/realtime/token endpoint and receive events from
+ * either backend during the rollout window.
+ *
+ * NOT best-effort: rejections from Ably propagate to the caller, matching
+ * web's behaviour. Wave 2/3 mutation handlers should use this directly; if
+ * a non-blocking publish becomes necessary for a future route, prefer
+ * `safeAsync` from ../utils.
+ */
+export async function publishUserSignal(
+  userIds: readonly string[],
+  topic: string,
+  payload: unknown = null,
+): Promise<void> {
+  const client = ablyClient();
+  await Promise.all(
+    userIds.map(async (userId) => {
+      const channel = client.channels.get(getUserChannelName(userId));
+      await channel.publish(topic, payload);
+    }),
+  );
+  L.debug(`Published "${topic}" to ${userIds.length} user(s)`);
+}
+
+/**
+ * Fire the user-level "thread list shape changed" signal. The sidebar
+ * subscribes to this topic and reloads the full list on any delivery —
+ * payload is intentionally empty because the server is authoritative and
+ * the client already has a cheap list endpoint to re-fetch.
+ */
+export async function publishThreadListChanged(userId: string): Promise<void> {
+  await publishUserSignal([userId], "threadListChanged");
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-mark-read.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-mark-read.test.ts
@@ -1,0 +1,257 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { chatThreadMarkReadContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteZeroChatThread$,
+  seedZeroChatMessage$,
+  seedZeroChatThread$,
+  type ZeroChatThreadFixture,
+} from "./helpers/zero-chat-threads";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("POST /api/zero/chat-threads/:id/mark-read", () => {
+  const track = createFixtureTracker<ZeroChatThreadFixture>((fixture) => {
+    return store.set(deleteZeroChatThread$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(chatThreadMarkReadContract);
+
+    const response = await accept(
+      client.markRead({
+        params: { id: randomUUID() },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for an unknown thread id", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadMarkReadContract);
+
+    const response = await accept(
+      client.markRead({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a thread owned by another user (cross-user isolation)", async () => {
+    const otherFixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { userId: `user_${randomUUID().slice(0, 8)}` },
+        context.signal,
+      ),
+    );
+    // Authenticate as a different user — must not see another user's thread.
+    mocks.clerk.session(`user_${randomUUID().slice(0, 8)}`, otherFixture.orgId);
+
+    const client = setupApp({ context })(chatThreadMarkReadContract);
+
+    const response = await accept(
+      client.markRead({
+        params: { id: otherFixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("stores the latest visible message id, persists it, and publishes both signals", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    await store.set(
+      seedZeroChatMessage$,
+      fixture,
+      {
+        role: "assistant",
+        content: "older",
+        createdAt: new Date("2024-01-01T00:00:00Z"),
+      },
+      context.signal,
+    );
+    const latestId = await store.set(
+      seedZeroChatMessage$,
+      fixture,
+      {
+        role: "assistant",
+        content: "latest",
+        createdAt: new Date("2024-01-01T00:01:00Z"),
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadMarkReadContract);
+
+    const response = await accept(
+      client.markRead({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      lastReadMessageId: latestId,
+      changed: true,
+    });
+
+    // DB read-after-write
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ lastReadMessageId: chatThreads.lastReadMessageId })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, fixture.threadId));
+    expect(row?.lastReadMessageId).toBe(latestId);
+
+    // Both Ably signals published with web-equivalent payloads.
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(2);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadReadCursorUpdated:${fixture.threadId}`,
+      { lastReadMessageId: latestId },
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+  });
+
+  it("returns changed:false and does NOT publish when stored already matches latest", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    const messageId = await store.set(
+      seedZeroChatMessage$,
+      fixture,
+      { role: "assistant", content: "only" },
+      context.signal,
+    );
+    // Pre-stamp last-read = latest before the request
+    const writeDb = store.set(writeDb$);
+    await writeDb
+      .update(chatThreads)
+      .set({ lastReadMessageId: messageId })
+      .where(eq(chatThreads.id, fixture.threadId));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadMarkReadContract);
+
+    const response = await accept(
+      client.markRead({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      lastReadMessageId: messageId,
+      changed: false,
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns changed:false with null id when the thread has no messages", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadMarkReadContract);
+
+    const response = await accept(
+      client.markRead({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      lastReadMessageId: null,
+      changed: false,
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent — a second call after a successful mark is a no-op", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    const messageId = await store.set(
+      seedZeroChatMessage$,
+      fixture,
+      { role: "assistant", content: "msg" },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadMarkReadContract);
+
+    const first = await accept(
+      client.markRead({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(first.body).toStrictEqual({
+      lastReadMessageId: messageId,
+      changed: true,
+    });
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(2);
+
+    context.mocks.ably.publish.mockClear();
+
+    const second = await accept(
+      client.markRead({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(second.body).toStrictEqual({
+      lastReadMessageId: messageId,
+      changed: false,
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
@@ -1,0 +1,88 @@
+import { command } from "ccstate";
+import { and, desc, eq } from "drizzle-orm";
+import { chatThreadMarkReadContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import {
+  publishThreadListChanged,
+  publishUserSignal,
+} from "../external/realtime";
+import { notFound } from "../../lib/error";
+import { visibleChatMessageCondition } from "../services/zero-chat-thread.service";
+import type { RouteEntry } from "../route";
+
+const markReadInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+  const params = get(pathParamsOf(chatThreadMarkReadContract.markRead));
+  signal.throwIfAborted();
+
+  const writeDb = set(writeDb$);
+
+  const [thread] = await writeDb
+    .select({ lastReadMessageId: chatThreads.lastReadMessageId })
+    .from(chatThreads)
+    .where(
+      and(eq(chatThreads.id, params.id), eq(chatThreads.userId, auth.userId)),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (!thread) {
+    return notFound("Chat thread not found");
+  }
+
+  const [latest] = await writeDb
+    .select({ id: chatMessages.id })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, params.id),
+        visibleChatMessageCondition(),
+      ),
+    )
+    .orderBy(desc(chatMessages.createdAt), desc(chatMessages.id))
+    .limit(1);
+  signal.throwIfAborted();
+
+  const latestMessageId = latest?.id ?? null;
+  if (thread.lastReadMessageId === latestMessageId) {
+    return {
+      status: 200 as const,
+      body: { lastReadMessageId: latestMessageId, changed: false },
+    };
+  }
+
+  await writeDb
+    .update(chatThreads)
+    .set({ lastReadMessageId: latestMessageId })
+    .where(
+      and(eq(chatThreads.id, params.id), eq(chatThreads.userId, auth.userId)),
+    );
+  signal.throwIfAborted();
+
+  await publishUserSignal(
+    [auth.userId],
+    `chatThreadReadCursorUpdated:${params.id}`,
+    { lastReadMessageId: latestMessageId },
+  );
+  signal.throwIfAborted();
+  await publishThreadListChanged(auth.userId);
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: { lastReadMessageId: latestMessageId, changed: true },
+  };
+});
+
+export const zeroChatThreadMarkReadRoutes: readonly RouteEntry[] = [
+  {
+    route: chatThreadMarkReadContract.markRead,
+    handler: authRoute({}, markReadInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -25,6 +25,7 @@ import {
   zeroChatThreadMessagesPage,
 } from "../services/zero-chat-thread.service";
 import type { RouteEntry } from "../route";
+import { zeroChatThreadMarkReadRoutes } from "./zero-chat-threads-mark-read";
 
 const chatThreadIdSchema = z.string().uuid();
 
@@ -186,4 +187,5 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
       searchChatInner$,
     ),
   },
+  ...zeroChatThreadMarkReadRoutes,
 ];

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -134,7 +134,7 @@ function effectiveChatMessageRunId() {
   return chatMessages.runId;
 }
 
-function visibleChatMessageCondition() {
+export function visibleChatMessageCondition() {
   return sql<boolean>`NOT EXISTS (
       SELECT 1
       FROM ${chatMessages} AS revoker

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       '@vm0/db':
         specifier: workspace:*
         version: link:../../packages/db
+      ably:
+        specifier: ^2.21.0
+        version: 2.21.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ccstate:
         specifier: ^5.3.0
         version: 5.3.0


### PR DESCRIPTION
## Summary

First Stage 3 mutation route migration. Ports `POST /api/zero/chat-threads/:id/mark-read` from `apps/web` to `apps/api`. Foundation #12506/#12507 (per-mutation feature switch + client routing) merged earlier today; this PR is the validator that proves the end-to-end pattern works for an idempotent state-update mutation.

- Idempotent state update on `chat_threads.last_read_message_id`
- Command-typed handler (`set(writeDb$)` rather than a Computed)
- Realtime fan-out (`chatThreadReadCursorUpdated:<id>` + `threadListChanged`) via the new `apps/api/src/signals/external/realtime.ts` (mirror of the web helper, wrapped with the `singleton` helper to satisfy the `api/no-package-variable` rule)
- `ABLY_API_KEY` added to apps/api env schema (already present in `.env.local`)
- Ably mocked centrally in `src/__tests__/mocks.ts` per the repo's `api/no-test-vi-mocks` rule; `ApiTestMocks` now exposes `ably.publish` (`AsyncMock`)
- Seven integration tests cover: 401, 404 unknown, 404 cross-user, 200 changed:true with DB read-after-write + dual publish, 200 changed:false no-publish, null-id no-publish, idempotency

`apps/web` mark-read **unchanged** — continues to serve traffic until `ApiBackendMutations` flag is enabled per-org. Web cleanup is a separate post-rollout sweep.

Closes #12509.

## Pattern conventions for Wave 2/3 mutation migrations

| Concern | Convention |
|---|---|
| Handler type | `command(...)` (not `computed`) |
| DB writes | `const writeDb = set(writeDb\$)` |
| Auth | `authContext\$` (user-only) or `organizationAuthContext\$` (requires org) |
| File location | `apps/api/src/signals/routes/zero-<surface>-<mutation>.ts` exporting `readonly RouteEntry[]` |
| Realtime | Import from `apps/api/src/signals/external/realtime.ts` |
| Test mock | `vi.mock(...)` only in `src/__tests__/mocks.ts`; tests use `context.mocks.<service>.<method>` |
| `signal.throwIfAborted()` | After every `await` per the `api/signal-check-await` rule |
| Web cleanup | Out of migration PR scope — separate post-rollout sweep |

## Verification of leader's pre-push notes

1. **`ABLY_API_KEY` env**: declared as `z.string().min(1)` (required), matching `apps/web`'s declaration. Tradeoff: missing key fails fast at boot, which is preferable to silent degradation in prod and matches web behaviour exactly.
2. **Realtime publish failure handling**: matches web verbatim — errors propagate to the caller (no try/catch, no `safeAsync`). Web's `publishUserSignal` is not best-effort either (verified in `apps/web/src/lib/infra/realtime/client.ts:51-64`); this preserves shadow-comparable semantics during rollout.
3. **File location**: chose `apps/api/src/signals/external/realtime.ts` to match the existing convention for external-dep wrappers (sibling of `db.ts`, `clerk.ts`).

## Routing matrix (recap)

| `ApiBackend` | `ApiBackendMutations` | mark-read host |
|:------------:|:---------------------:|:--------------:|
| OFF          | OFF                   | www (current)  |
| OFF          | ON                    | api (new)      |
| ON           | *                     | api (new)      |

## Rollout

1. Merge — `ApiBackendMutations` defaults OFF; web continues to serve.
2. Operator flips `ApiBackendMutations=ON` for staff org. Production traffic from staff hits the new api handler; non-staff stays on web.
3. Verify production: read-cursor updates, sidebar list refreshes, no error-rate increase. Roll out per-org.
4. After Wave end, separate PR removes web's mark-read route + tests + service helper.

## Rollback

- Revert PR — web continues serving (flag default OFF, nothing to undo).
- Or operator sets `ApiBackendMutations=OFF` for affected orgs — instant return to web; no code change.

## Test plan

- [x] 7 integration tests pass locally
- [x] DB read-after-write verified for `changed:true`
- [x] Realtime publish asserted for `changed:true`; absent for `changed:false` and unauth/404
- [x] Idempotent second call verified (`changed:false` with prior message still set)
- [x] Cross-user 404 verified (different user cannot mark another user's thread)
- [x] No \`apps/web/**\` modified
- [x] tests / lint / types / format / knip all pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)