### PR TITLE
refactor(api): migrate chat-threads unpin post to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-unpin.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-unpin.test.ts
@@ -1,0 +1,176 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { chatThreadUnpinContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteZeroChatThread$,
+  seedZeroChatThread$,
+  type ZeroChatThreadFixture,
+} from "./helpers/zero-chat-threads";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("POST /api/zero/chat-threads/:id/unpin", () => {
+  const track = createFixtureTracker<ZeroChatThreadFixture>((fixture) => {
+    return store.set(deleteZeroChatThread$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(chatThreadUnpinContract);
+
+    const response = await accept(
+      client.unpin({
+        params: { id: randomUUID() },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for an unknown thread id", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadUnpinContract);
+
+    const response = await accept(
+      client.unpin({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a thread owned by another user without clearing its pinned_at", async () => {
+    const otherPinnedAt = new Date("2024-06-01T00:00:00.000Z");
+    const otherFixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        {
+          userId: `user_${randomUUID().slice(0, 8)}`,
+          pinnedAt: otherPinnedAt,
+        },
+        context.signal,
+      ),
+    );
+    // Authenticate as a different user — must not see another user's thread.
+    mocks.clerk.session(`user_${randomUUID().slice(0, 8)}`, otherFixture.orgId);
+
+    const client = setupApp({ context })(chatThreadUnpinContract);
+
+    const response = await accept(
+      client.unpin({
+        params: { id: otherFixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+
+    // Cross-user-no-leak: the other user's pinned_at must NOT have been cleared.
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ pinnedAt: chatThreads.pinnedAt })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, otherFixture.threadId));
+    expect(row?.pinnedAt).toBeInstanceOf(Date);
+  });
+
+  it("clears pinned_at and publishes threadListChanged on success", async () => {
+    const fixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { pinnedAt: new Date("2024-06-01T00:00:00.000Z") },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadUnpinContract);
+
+    const response = await accept(
+      client.unpin({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    expect(response.body).toBeUndefined();
+
+    // DB read-after-write
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ pinnedAt: chatThreads.pinnedAt })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, fixture.threadId));
+    expect(row?.pinnedAt).toBeNull();
+
+    // Ably publish (single threadListChanged event with null payload).
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+  });
+
+  it("is idempotent — unpinning an already-unpinned thread still succeeds and publishes", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadUnpinContract);
+
+    const response = await accept(
+      client.unpin({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    expect(response.body).toBeUndefined();
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ pinnedAt: chatThreads.pinnedAt })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, fixture.threadId));
+    expect(row?.pinnedAt).toBeNull();
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-unpin.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-unpin.ts
@@ -1,0 +1,45 @@
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { chatThreadUnpinContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import { publishThreadListChanged } from "../external/realtime";
+import { notFound } from "../../lib/error";
+import type { RouteEntry } from "../route";
+
+const unpinInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+  const params = get(pathParamsOf(chatThreadUnpinContract.unpin));
+  signal.throwIfAborted();
+
+  const writeDb = set(writeDb$);
+
+  const updated = await writeDb
+    .update(chatThreads)
+    .set({ pinnedAt: null })
+    .where(
+      and(eq(chatThreads.id, params.id), eq(chatThreads.userId, auth.userId)),
+    )
+    .returning({ id: chatThreads.id });
+  signal.throwIfAborted();
+
+  if (updated.length === 0) {
+    return notFound("Chat thread not found");
+  }
+
+  await publishThreadListChanged(auth.userId);
+  signal.throwIfAborted();
+
+  return { status: 204 as const, body: undefined };
+});
+
+export const zeroChatThreadUnpinRoutes: readonly RouteEntry[] = [
+  {
+    route: chatThreadUnpinContract.unpin,
+    handler: authRoute({}, unpinInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -27,6 +27,7 @@ import {
 import type { RouteEntry } from "../route";
 import { zeroChatThreadMarkReadRoutes } from "./zero-chat-threads-mark-read";
 import { zeroChatThreadRenameRoutes } from "./zero-chat-threads-rename";
+import { zeroChatThreadUnpinRoutes } from "./zero-chat-threads-unpin";
 
 const chatThreadIdSchema = z.string().uuid();
 
@@ -190,4 +191,5 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
   },
   ...zeroChatThreadMarkReadRoutes,
   ...zeroChatThreadRenameRoutes,
+  ...zeroChatThreadUnpinRoutes,
 ];


### PR DESCRIPTION
## Summary

- Adds `apps/api` handler for `POST /api/zero/chat-threads/:id/unpin` mirroring the #12511 mark-read pattern (Stage 3 Wave 2 of #12290).
- Web `apps/web/.../unpin/route.ts` is unchanged; `apps/platform` already routes via `apiBackendMutationsEnabled$`, so this is dark-launched until the operator flips the flag.

## Implementation

- New: `apps/api/src/signals/routes/zero-chat-threads-unpin.ts` — single `UPDATE … RETURNING { id }` (web's shape) under `authRoute({}, …)` user-only auth, then `publishThreadListChanged(auth.userId)`. `signal.throwIfAborted()` after every `await`.
- Wired into existing `zeroChatThreadRoutes` aggregate (no top-level `route.ts` edit).
- New: 5 ported integration tests covering 401, 404 unknown, 404 cross-user (with no-leak DB read-after-write), 204 success, and idempotency.
- Contract entry already existed at `chatThreadUnpinContract` (predates this work). No contract / platform / web changes.

## Test plan

- [x] `pnpm -F api exec vitest run signals/routes/__tests__/zero-chat-threads-unpin` — 5/5 pass
- [x] `pnpm -F api exec vitest run` — 746/746 pass on the @vm0/api workspace
- [x] `pnpm turbo run lint --filter=api` — 0 warnings, 0 errors
- [x] `pnpm check-types` — all 11 workspaces clean
- [x] `pnpm format` — no changes
- [x] `pnpm knip` — no findings (only pre-existing config hints)
- [x] `apps/web/**` unchanged

Closes #12514

🤖 Generated with [Claude Code](https://claude.com/claude-code)