### PR TITLE
refactor(api): migrate chat-threads rename POST to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-rename.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-rename.test.ts
@@ -1,0 +1,190 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { delay } from "signal-timers";
+import { chatThreadRenameContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteZeroChatThread$,
+  seedZeroChatThread$,
+  type ZeroChatThreadFixture,
+} from "./helpers/zero-chat-threads";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+async function getThreadRow(threadId: string) {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select({
+      title: chatThreads.title,
+      renamedAt: chatThreads.renamedAt,
+    })
+    .from(chatThreads)
+    .where(eq(chatThreads.id, threadId));
+  return row;
+}
+
+describe("POST /api/zero/chat-threads/:id/rename", () => {
+  const track = createFixtureTracker<ZeroChatThreadFixture>((fixture) => {
+    return store.set(deleteZeroChatThread$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(chatThreadRenameContract);
+
+    const response = await accept(
+      client.rename({
+        params: { id: randomUUID() },
+        headers: {},
+        body: { title: "Renamed" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for an unknown thread id", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadRenameContract);
+
+    const response = await accept(
+      client.rename({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { title: "Renamed" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a thread owned by another user (cross-user isolation)", async () => {
+    const otherFixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { userId: `user_${randomUUID().slice(0, 8)}` },
+        context.signal,
+      ),
+    );
+    // Authenticate as a different user — must not see another user's thread.
+    mocks.clerk.session(`user_${randomUUID().slice(0, 8)}`, otherFixture.orgId);
+
+    const client = setupApp({ context })(chatThreadRenameContract);
+
+    const response = await accept(
+      client.rename({
+        params: { id: otherFixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { title: "Hijacked" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND" },
+    });
+
+    // Title must remain untouched.
+    const row = await getThreadRow(otherFixture.threadId);
+    expect(row?.title).not.toBe("Hijacked");
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("sets title and renamed_at and publishes threadListChanged on success", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadRenameContract);
+
+    await accept(
+      client.rename({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { title: "Renamed" },
+      }),
+      [204],
+    );
+
+    const row = await getThreadRow(fixture.threadId);
+    expect(row?.title).toBe("Renamed");
+    expect(row?.renamedAt).toBeInstanceOf(Date);
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+  });
+
+  it("renaming again refreshes renamed_at and publishes again", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadRenameContract);
+
+    await accept(
+      client.rename({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { title: "First rename" },
+      }),
+      [204],
+    );
+    const firstRow = await getThreadRow(fixture.threadId);
+    const firstRenamedAt = firstRow?.renamedAt;
+    expect(firstRow?.title).toBe("First rename");
+    expect(firstRenamedAt).toBeInstanceOf(Date);
+
+    context.mocks.ably.publish.mockClear();
+    // Sleep so the second renamed_at is strictly greater than the first.
+    await delay(10, { signal: context.signal });
+
+    await accept(
+      client.rename({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { title: "Second rename" },
+      }),
+      [204],
+    );
+
+    const secondRow = await getThreadRow(fixture.threadId);
+    expect(secondRow?.title).toBe("Second rename");
+    expect(secondRow?.renamedAt).toBeInstanceOf(Date);
+    expect(secondRow!.renamedAt!.getTime()).toBeGreaterThan(
+      firstRenamedAt!.getTime(),
+    );
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-rename.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-rename.ts
@@ -1,0 +1,52 @@
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { chatThreadRenameContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+import { publishThreadListChanged } from "../external/realtime";
+import { notFound } from "../../lib/error";
+import type { RouteEntry } from "../route";
+
+const renameBody$ = bodyResultOf(chatThreadRenameContract.rename);
+
+const renameInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+  const params = get(pathParamsOf(chatThreadRenameContract.rename));
+  const body = await get(renameBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  const writeDb = set(writeDb$);
+
+  const updated = await writeDb
+    .update(chatThreads)
+    .set({ title: body.data.title, renamedAt: nowDate() })
+    .where(
+      and(eq(chatThreads.id, params.id), eq(chatThreads.userId, auth.userId)),
+    )
+    .returning({ id: chatThreads.id });
+  signal.throwIfAborted();
+
+  if (updated.length === 0) {
+    return notFound("Chat thread not found");
+  }
+
+  await publishThreadListChanged(auth.userId);
+  signal.throwIfAborted();
+
+  return { status: 204 as const, body: undefined };
+});
+
+export const zeroChatThreadRenameRoutes: readonly RouteEntry[] = [
+  {
+    route: chatThreadRenameContract.rename,
+    handler: authRoute({}, renameInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -26,6 +26,7 @@ import {
 } from "../services/zero-chat-thread.service";
 import type { RouteEntry } from "../route";
 import { zeroChatThreadMarkReadRoutes } from "./zero-chat-threads-mark-read";
+import { zeroChatThreadRenameRoutes } from "./zero-chat-threads-rename";
 
 const chatThreadIdSchema = z.string().uuid();
 
@@ -188,4 +189,5 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
     ),
   },
   ...zeroChatThreadMarkReadRoutes,
+  ...zeroChatThreadRenameRoutes,
 ];


### PR DESCRIPTION
## Summary

- Migrates `POST /api/zero/chat-threads/:id/rename` from `apps/web` to `apps/api`. Sibling-of #12511 (mark-read), the canonical Stage 3 mutation pattern.
- Single `UPDATE ... WHERE id AND user_id ... RETURNING` covers both unknown-id and cross-user 404 in one round-trip — mirrors web behavior 1:1.
- After a successful update, publishes `threadListChanged` via the realtime helper introduced in #12511 and returns 204.

## Why mirror, not optimize

A short-circuit "title unchanged → skip update + publish" was considered (Option B in the deep-dive `innovate.md`) and rejected. During the dual-serve rollout window the operator compares web and api shadow traffic; any behavioral skew in the publish path (e.g. one backend publishing on no-op rename, the other not) breaks that safety net. mark-read paid that cost only because read-cursor noise was real; rename has no such pressure. YAGNI.

## Auth

User-only via `authContext$`, matching web's `getUserId(...)`. The thread is owned by a user; the cross-user 404 is enforced purely via the `WHERE chat_threads.user_id = auth.userId` clause. **No `requireOrganization`**, so no missing-org defensive 401 — that conditional in the issue body does not apply here.

## Files

- New: `turbo/apps/api/src/signals/routes/zero-chat-threads-rename.ts` — `command(...)` handler.
- New: `turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-rename.test.ts` — 5 cases ported 1:1.
- Edit: `turbo/apps/api/src/signals/routes/zero-chat-threads.ts` — one import + one append in `zeroChatThreadRoutes`.
- **No contract change.** `chatThreadRenameContract` was already in tree at `turbo/packages/api-contracts/src/contracts/chat-threads.ts:406-420`.
- **No web change.** Rollout flag flips orchestrate the cutover.

## Tests (5)

| # | Case | Asserts |
|---|---|---|
| 1 | 401 unauthenticated | body `{ error.code: UNAUTHORIZED }`, no Ably publish |
| 2 | 404 unknown thread id | body `{ error.code: NOT_FOUND }`, no Ably publish |
| 3 | 404 cross-user (no leak) | body `{ error.code: NOT_FOUND }`, untouched title in DB, no Ably publish |
| 4 | 204 happy path | DB read-after-write (`title === "Renamed"`, `renamedAt instanceof Date`), Ably publish called once with `("threadListChanged", null)` |
| 5 | 204 repeat rename refreshes renamed_at | Second call's `renamedAt > firstRenamedAt`, title updated, Ably publish called again — explicitly NOT idempotent |

## Sibling-PR coordination (a3 / a4)

a3 (pin) and a4 (unpin) also append one line each to `zeroChatThreadRoutes` in `zero-chat-threads.ts`. Whoever lands second/third resolves by appending in registration order. No other shared-file overlap.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-threads-rename.test.ts` — 5 passed
- [x] `pnpm -F api exec vitest run` — 746 passed
- [x] `pnpm -F api run lint` — clean
- [x] `pnpm -F api run check-types` — clean
- [x] `pnpm format` / `pnpm knip` — clean

Closes #12512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)