### PR TITLE
feat(api): migrate chat-threads pin route to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-pin.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-pin.test.ts
@@ -1,0 +1,184 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { delay } from "signal-timers";
+import { chatThreadPinContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteZeroChatThread$,
+  seedZeroChatThread$,
+  type ZeroChatThreadFixture,
+} from "./helpers/zero-chat-threads";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("POST /api/zero/chat-threads/:id/pin", () => {
+  const track = createFixtureTracker<ZeroChatThreadFixture>((fixture) => {
+    return store.set(deleteZeroChatThread$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(chatThreadPinContract);
+
+    const response = await accept(
+      client.pin({
+        params: { id: randomUUID() },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for an unknown thread id", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadPinContract);
+
+    const response = await accept(
+      client.pin({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a thread owned by another user (cross-user isolation)", async () => {
+    const otherFixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { userId: `user_${randomUUID().slice(0, 8)}` },
+        context.signal,
+      ),
+    );
+    // Authenticate as a different user — must not see another user's thread.
+    mocks.clerk.session(`user_${randomUUID().slice(0, 8)}`, otherFixture.orgId);
+
+    const client = setupApp({ context })(chatThreadPinContract);
+
+    const response = await accept(
+      client.pin({
+        params: { id: otherFixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+
+    // No pin leak: the other user's row stays unpinned.
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ pinnedAt: chatThreads.pinnedAt })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, otherFixture.threadId));
+    expect(row?.pinnedAt).toBeNull();
+  });
+
+  it("sets pinned_at and publishes threadListChanged on success", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const beforeAt = now();
+
+    const client = setupApp({ context })(chatThreadPinContract);
+
+    await accept(
+      client.pin({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    // DB read-after-write
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ pinnedAt: chatThreads.pinnedAt })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, fixture.threadId));
+    expect(row?.pinnedAt).toBeInstanceOf(Date);
+    expect(row!.pinnedAt!.getTime()).toBeGreaterThanOrEqual(beforeAt - 1000);
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+  });
+
+  it("re-pinning refreshes pinned_at and publishes again (idempotent)", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadPinContract);
+
+    await accept(
+      client.pin({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+    const writeDb = store.set(writeDb$);
+    const [first] = await writeDb
+      .select({ pinnedAt: chatThreads.pinnedAt })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, fixture.threadId));
+    context.mocks.ably.publish.mockClear();
+
+    await delay(10, { signal: context.signal });
+
+    await accept(
+      client.pin({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    const [second] = await writeDb
+      .select({ pinnedAt: chatThreads.pinnedAt })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, fixture.threadId));
+    expect(second!.pinnedAt!.getTime()).toBeGreaterThan(
+      first!.pinnedAt!.getTime(),
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-pin.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-pin.ts
@@ -1,0 +1,45 @@
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { chatThreadPinContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import { publishThreadListChanged } from "../external/realtime";
+import { notFound } from "../../lib/error";
+import { nowDate } from "../../lib/time";
+import type { RouteEntry } from "../route";
+
+const pinInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+  const params = get(pathParamsOf(chatThreadPinContract.pin));
+  signal.throwIfAborted();
+
+  const writeDb = set(writeDb$);
+  const updated = await writeDb
+    .update(chatThreads)
+    .set({ pinnedAt: nowDate() })
+    .where(
+      and(eq(chatThreads.id, params.id), eq(chatThreads.userId, auth.userId)),
+    )
+    .returning({ id: chatThreads.id });
+  signal.throwIfAborted();
+
+  if (updated.length === 0) {
+    return notFound("Chat thread not found");
+  }
+
+  await publishThreadListChanged(auth.userId);
+  signal.throwIfAborted();
+
+  return { status: 204 as const, body: undefined };
+});
+
+export const zeroChatThreadPinRoutes: readonly RouteEntry[] = [
+  {
+    route: chatThreadPinContract.pin,
+    handler: authRoute({}, pinInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -26,6 +26,7 @@ import {
 } from "../services/zero-chat-thread.service";
 import type { RouteEntry } from "../route";
 import { zeroChatThreadMarkReadRoutes } from "./zero-chat-threads-mark-read";
+import { zeroChatThreadPinRoutes } from "./zero-chat-threads-pin";
 import { zeroChatThreadRenameRoutes } from "./zero-chat-threads-rename";
 
 const chatThreadIdSchema = z.string().uuid();
@@ -189,5 +190,6 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
     ),
   },
   ...zeroChatThreadMarkReadRoutes,
+  ...zeroChatThreadPinRoutes,
   ...zeroChatThreadRenameRoutes,
 ];


### PR DESCRIPTION
## Summary

- Closes #12513. Wave 2 sibling of #12511 mark-read (the canonical Stage 3 mutation reference) and concurrent with the rename / unpin siblings.
- Adds `POST /api/zero/chat-threads/:id/pin` to `apps/api`: a Command-typed inner signal that updates `pinned_at` under the `(id, user_id)` ownership boundary and publishes `threadListChanged` on the user's realtime channel.
- `apps/web` is intentionally untouched — operator flips `ApiBackendMutations` to route traffic.

## Implementation

- `apps/api/src/signals/routes/zero-chat-threads-pin.ts` — new handler. `authRoute({}, pinInner$)` (user-only, no `requireOrganization` — pin is per-user state, identical to web). Single `UPDATE … RETURNING id`; empty result → `notFound`. `await publishThreadListChanged(auth.userId)` in-line (matches web; not best-effort by helper contract). Uses `nowDate()` from `lib/time` so tests can mock time.
- `apps/api/src/signals/routes/zero-chat-threads.ts` — one new import, one new spread in `zeroChatThreadRoutes`. No edit to the top-level `route.ts` (already wires `zeroChatThreadRoutes`).
- `apps/api/src/signals/routes/__tests__/zero-chat-threads-pin.test.ts` — 5 integration tests ported 1:1 from `apps/web`:
  1. 401 unauthenticated
  2. 404 unknown thread
  3. 404 cross-user (asserts `pinnedAt` stays `null` on the other user's row)
  4. 204 success path with DB read-after-write + Ably publish assertion
  5. 204 idempotent re-pin (10ms gap → second `pinnedAt > first`, second publish observed)

## Notes

- ts-rest contract `chatThreadPinContract.pin` was pre-existing; no contract edit.
- `publishThreadListChanged` and the centralized Ably mock from #12511 are reused as-is.
- No defensive missing-org test — pin uses `authContext$`, not `organizationAuthContext$`.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-threads-pin.test.ts` — 5/5 pass
- [x] `pnpm -F api exec vitest run` — 746/746 pass
- [x] `pnpm turbo run lint` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — no diff
- [x] `pnpm knip` — no issues
- [x] `git diff --name-only origin/main...HEAD | grep apps/web | wc -l` — 0
- [ ] CI green (build / lint / test / deploy / cli-e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)