### PR TITLE
refactor(api): migrate agents custom-connectors PUT to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-custom-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-custom-connectors.ts
@@ -14,6 +14,8 @@ export interface CustomConnectorFixture {
 }
 
 interface SeedValues {
+  readonly orgId?: string;
+  readonly userId?: string;
   readonly slug?: string;
   readonly displayName?: string;
   readonly prefixes?: readonly string[];
@@ -28,8 +30,8 @@ export const seedCustomConnectorOrg$ = command(
     values: SeedValues,
     signal: AbortSignal,
   ): Promise<CustomConnectorFixture> => {
-    const orgId = `org_${randomUUID()}`;
-    const userId = `user_${randomUUID()}`;
+    const orgId = values.orgId ?? `org_${randomUUID()}`;
+    const userId = values.userId ?? `user_${randomUUID()}`;
     const connectorId = randomUUID();
     const writeDb = set(writeDb$);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
@@ -2,10 +2,18 @@ import { randomUUID } from "node:crypto";
 
 import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteCustomConnectorOrg$,
+  seedCustomConnectorOrg$,
+  type CustomConnectorFixture,
+} from "./helpers/zero-custom-connectors";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -161,5 +169,287 @@ describe("GET /api/zero/agents/:id/custom-connectors", () => {
         code: "FORBIDDEN",
       },
     });
+  });
+});
+
+describe("PUT /api/zero/agents/:id/custom-connectors", () => {
+  const track = createFixtureTracker<TeamComposeFixture>((fixture) => {
+    return store.set(deleteTeamCompose$, fixture, context.signal);
+  });
+  const trackConnector = createFixtureTracker<CustomConnectorFixture>(
+    (fixture) => {
+      return store.set(deleteCustomConnectorOrg$, fixture, context.signal);
+    },
+  );
+
+  async function getEnabledIds(
+    orgId: string,
+    userId: string,
+    agentId: string,
+  ): Promise<readonly string[]> {
+    const writeDb = store.set(writeDb$);
+    const rows = await writeDb
+      .select({ customConnectorId: userCustomConnectors.customConnectorId })
+      .from(userCustomConnectors)
+      .where(
+        and(
+          eq(userCustomConnectors.orgId, orgId),
+          eq(userCustomConnectors.userId, userId),
+          eq(userCustomConnectors.agentId, agentId),
+        ),
+      );
+    return rows.map((r) => {
+      return r.customConnectorId;
+    });
+  }
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroAgentCustomConnectorsContract);
+    const response = await accept(
+      client.update({
+        params: { id: randomUUID() },
+        headers: {},
+        body: { enabledIds: [] },
+      }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+    const client = setupApp({ context })(zeroAgentCustomConnectorsContract);
+    const response = await accept(
+      client.update({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { enabledIds: [] },
+      }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 for a non-existent agent", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const unknownId = randomUUID();
+
+    const client = setupApp({ context })(zeroAgentCustomConnectorsContract);
+    const response = await accept(
+      client.update({
+        params: { id: unknownId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { enabledIds: [] },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: `Agent not found: ${unknownId}`, code: "NOT_FOUND" },
+    });
+  });
+
+  it("sets enabled ids and round-trips via DB read-after-write", async () => {
+    const fixture = await track(
+      store.set(
+        seedTeamCompose$,
+        { composes: [{ displayName: "Test Agent" }] },
+        context.signal,
+      ),
+    );
+    const agentId = fixture.composeIds[0]!;
+
+    const c1 = await trackConnector(
+      store.set(
+        seedCustomConnectorOrg$,
+        { orgId: fixture.orgId, userId: fixture.userId, slug: "round-a" },
+        context.signal,
+      ),
+    );
+    const c2 = await trackConnector(
+      store.set(
+        seedCustomConnectorOrg$,
+        { orgId: fixture.orgId, userId: fixture.userId, slug: "round-b" },
+        context.signal,
+      ),
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroAgentCustomConnectorsContract);
+
+    const response = await accept(
+      client.update({
+        params: { id: agentId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { enabledIds: [c1.connectorId, c2.connectorId] },
+      }),
+      [200],
+    );
+
+    expect(new Set(response.body.enabledIds)).toStrictEqual(
+      new Set([c1.connectorId, c2.connectorId]),
+    );
+
+    const persisted = await getEnabledIds(
+      fixture.orgId,
+      fixture.userId,
+      agentId,
+    );
+    expect(new Set(persisted)).toStrictEqual(
+      new Set([c1.connectorId, c2.connectorId]),
+    );
+  });
+
+  it("replaces the list atomically", async () => {
+    const fixture = await track(
+      store.set(
+        seedTeamCompose$,
+        { composes: [{ displayName: "Test Agent" }] },
+        context.signal,
+      ),
+    );
+    const agentId = fixture.composeIds[0]!;
+
+    const c1 = await trackConnector(
+      store.set(
+        seedCustomConnectorOrg$,
+        { orgId: fixture.orgId, userId: fixture.userId, slug: "rep-1" },
+        context.signal,
+      ),
+    );
+    const c2 = await trackConnector(
+      store.set(
+        seedCustomConnectorOrg$,
+        { orgId: fixture.orgId, userId: fixture.userId, slug: "rep-2" },
+        context.signal,
+      ),
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroAgentCustomConnectorsContract);
+
+    await accept(
+      client.update({
+        params: { id: agentId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { enabledIds: [c1.connectorId] },
+      }),
+      [200],
+    );
+
+    await accept(
+      client.update({
+        params: { id: agentId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { enabledIds: [c2.connectorId] },
+      }),
+      [200],
+    );
+
+    const persisted = await getEnabledIds(
+      fixture.orgId,
+      fixture.userId,
+      agentId,
+    );
+    expect(persisted).toStrictEqual([c2.connectorId]);
+  });
+
+  it("clears authorizations with empty array", async () => {
+    const fixture = await track(
+      store.set(
+        seedTeamCompose$,
+        { composes: [{ displayName: "Test Agent" }] },
+        context.signal,
+      ),
+    );
+    const agentId = fixture.composeIds[0]!;
+
+    const c1 = await trackConnector(
+      store.set(
+        seedCustomConnectorOrg$,
+        { orgId: fixture.orgId, userId: fixture.userId, slug: "clr-1" },
+        context.signal,
+      ),
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroAgentCustomConnectorsContract);
+
+    await accept(
+      client.update({
+        params: { id: agentId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { enabledIds: [c1.connectorId] },
+      }),
+      [200],
+    );
+
+    await accept(
+      client.update({
+        params: { id: agentId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { enabledIds: [] },
+      }),
+      [200],
+    );
+
+    const persisted = await getEnabledIds(
+      fixture.orgId,
+      fixture.userId,
+      agentId,
+    );
+    expect(persisted).toStrictEqual([]);
+  });
+
+  it("returns 400 for a cross-org custom connector id", async () => {
+    const fixture = await track(
+      store.set(
+        seedTeamCompose$,
+        { composes: [{ displayName: "Test Agent" }] },
+        context.signal,
+      ),
+    );
+    const agentId = fixture.composeIds[0]!;
+
+    // Connector seeded in a different org (auto-random orgId).
+    const otherConnector = await trackConnector(
+      store.set(seedCustomConnectorOrg$, { slug: "other-org" }, context.signal),
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroAgentCustomConnectorsContract);
+
+    const response = await accept(
+      client.update({
+        params: { id: agentId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { enabledIds: [otherConnector.connectorId] },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: `Unknown custom connector ids: ${otherConnector.connectorId}`,
+        code: "VALIDATION_ERROR",
+      },
+    });
+
+    const persisted = await getEnabledIds(
+      fixture.orgId,
+      fixture.userId,
+      agentId,
+    );
+    expect(persisted).toStrictEqual([]);
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -1,14 +1,18 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
+import { and, eq, inArray } from "drizzle-orm";
 import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import {
   zeroAgentsByIdContract,
   zeroAgentsMainContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
+import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { pathParamsOf } from "../context/request";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import { writeDb$ } from "../external/db";
 import { notFound } from "../../lib/error";
 import {
   zeroAgentDetail,
@@ -81,6 +85,96 @@ const getAgentCustomConnectorsInner$ = computed(async (get) => {
   return { status: 200 as const, body: { enabledIds: [...enabledIds] } };
 });
 
+const updateAgentCustomConnectorsBody$ = bodyResultOf(
+  zeroAgentCustomConnectorsContract.update,
+);
+
+const updateAgentCustomConnectorsInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const params = get(pathParamsOf(zeroAgentCustomConnectorsContract.update));
+    const body = await get(updateAgentCustomConnectorsBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const exists = await get(
+      zeroAgentExists({ orgId: auth.orgId, agentId: params.id }),
+    );
+    signal.throwIfAborted();
+    if (!exists) {
+      return agentNotFound(params.id);
+    }
+
+    const writeDb = set(writeDb$);
+    const enabledIds = body.data.enabledIds;
+
+    if (enabledIds.length > 0) {
+      const found = await writeDb
+        .select({ id: orgCustomConnectors.id })
+        .from(orgCustomConnectors)
+        .where(
+          and(
+            eq(orgCustomConnectors.orgId, auth.orgId),
+            inArray(orgCustomConnectors.id, enabledIds),
+          ),
+        );
+      signal.throwIfAborted();
+      const foundSet = new Set(
+        found.map((row) => {
+          return row.id;
+        }),
+      );
+      const missing = enabledIds.filter((id) => {
+        return !foundSet.has(id);
+      });
+      if (missing.length > 0) {
+        return {
+          status: 400 as const,
+          body: {
+            error: {
+              message: `Unknown custom connector ids: ${missing.join(", ")}`,
+              code: "VALIDATION_ERROR",
+            },
+          },
+        };
+      }
+    }
+
+    await writeDb.transaction(async (tx) => {
+      await tx
+        .delete(userCustomConnectors)
+        .where(
+          and(
+            eq(userCustomConnectors.orgId, auth.orgId),
+            eq(userCustomConnectors.userId, auth.userId),
+            eq(userCustomConnectors.agentId, params.id),
+          ),
+        );
+
+      if (enabledIds.length > 0) {
+        await tx.insert(userCustomConnectors).values(
+          enabledIds.map((customConnectorId) => {
+            return {
+              orgId: auth.orgId,
+              userId: auth.userId,
+              agentId: params.id,
+              customConnectorId,
+            };
+          }),
+        );
+      }
+    });
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: { enabledIds: [...enabledIds] },
+    };
+  },
+);
+
 const agentReadAuth = {
   requireOrganization: true,
   missingOrganizationStatus: 401,
@@ -103,5 +197,9 @@ export const zeroAgentsRoutes: readonly RouteEntry[] = [
   {
     route: zeroAgentCustomConnectorsContract.get,
     handler: authRoute(agentReadAuth, getAgentCustomConnectorsInner$),
+  },
+  {
+    route: zeroAgentCustomConnectorsContract.update,
+    handler: authRoute(agentReadAuth, updateAgentCustomConnectorsInner$),
   },
 ];


### PR DESCRIPTION
## Summary

- Migrates `PUT /api/zero/agents/:id/custom-connectors` from `apps/web` to `apps/api`. Sibling-of #12511 (mark-read), the canonical Stage 3 mutation pattern. The contract's GET half was already migrated; this PR fills in the `update` half so the rollout flag can flip both at once.
- Behavior mirrors web 1:1: agent-existence + org check (404), `inArray` lookup against `org_custom_connectors` for unknown/cross-org id surfacing (400 with `code: "VALIDATION_ERROR"`), atomic DELETE+INSERT inside `writeDb.transaction(...)` for the replace.
- **No realtime publish.** Web doesn't publish either — custom-connector enablement is a firewall-rule state read per-run, not a subscribed topic.

## Auth — `agent:read` on a write path is intentional

Reuses the existing `agentReadAuth` (`organizationAuthContext$` + `requiredCapability: "agent:read"`). The capability mismatch on a write path is **a verbatim match with web**, not a copy-paste mistake. The reasoning: a `userCustomConnectors` row is per-`(user, agent)` consent, not an agent-config rewrite. The agent itself is not modified. `agent:read` gates *agent visibility*, which is the correct trust boundary; the user is allowed to authorize/revoke their own connectors against any agent they can see. If a future `agent:authorize-connectors` capability is introduced, that's a contract bump, not a behavior change here.

## 400 envelope shape

Constructed inline (not via `badRequestMessage`) to keep `code: "VALIDATION_ERROR"` matching web exactly:

```ts
{ status: 400, body: { error: { message: `Unknown custom connector ids: ${missing.join(", ")}`, code: "VALIDATION_ERROR" } } }
```

`badRequestMessage` would have produced `code: "BAD_REQUEST"` — diverging from web in the rollout-window shadow comparison.

## Files

- `turbo/apps/api/src/signals/routes/zero-agents.ts` — adds `update` inner signal + one route entry. ~110 → ~210 lines.
- `turbo/apps/api/src/signals/routes/__tests__/helpers/zero-custom-connectors.ts` — adds optional `orgId`/`userId` to `SeedValues` (backwards-compatible — existing callers default to auto-random).
- `turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts` — appends a `PUT` describe block with seven cases. Existing six GET cases untouched.
- **No contract change.** `zeroAgentCustomConnectorsContract.update` was already in tree.
- **No web change.** Rollout flag flips orchestrate the cutover.

## Tests (PUT — 7)

| # | Case | Asserts |
|---|---|---|
| 1 | 401 unauthenticated | body `{ error.code: UNAUTHORIZED }` |
| 2 | 401 no active organization | body `{ error.code: UNAUTHORIZED }` |
| 3 | 404 unknown agent | body `{ error.code: NOT_FOUND, message: 'Agent not found: <uuid>' }` |
| 4 | 200 round-trip | response.enabledIds set-equals input; DB read-after-write set-equals input |
| 5 | 200 atomic replace | first PUT [c1] then PUT [c2]; DB final state == `[c2]` |
| 6 | 200 clear with empty array | first PUT [c1] then PUT []; DB final state == `[]` |
| 7 | 400 cross-org connector id | body `{ error.code: VALIDATION_ERROR, message contains the rogue uuid }`; DB state untouched |

GET tests (6) unchanged.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts` — 13 passed (6 GET + 7 PUT)
- [x] `pnpm -F api exec vitest run` — 763 passed
- [x] `pnpm -F api run lint` — clean
- [x] `pnpm -F api run check-types` — clean
- [x] `pnpm format` / `pnpm knip --workspace api` — clean

Closes #12521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)