### PR TITLE
refactor(api): migrate custom-connectors delete secret to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-custom-connectors-secret-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-custom-connectors-secret-delete.test.ts
@@ -1,0 +1,194 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { zeroCustomConnectorSecretContract } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteCustomConnectorOrg$,
+  seedCustomConnectorOrg$,
+  type CustomConnectorFixture,
+} from "./helpers/zero-custom-connectors";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("DELETE /api/zero/custom-connectors/:id/secret", () => {
+  const track = createFixtureTracker<CustomConnectorFixture>((fixture) => {
+    return store.set(deleteCustomConnectorOrg$, fixture, context.signal);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(zeroCustomConnectorSecretContract);
+    const response = await accept(
+      client.delete({ params: { id: randomUUID() }, headers: {} }),
+      [401],
+    );
+    expect(response.body).toMatchObject({ error: { code: "UNAUTHORIZED" } });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the user has no active organization", async () => {
+    mocks.clerk.session(`user_${randomUUID().slice(0, 8)}`, null);
+    const client = setupApp({ context })(zeroCustomConnectorSecretContract);
+    const response = await accept(
+      client.delete({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({ error: {} });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("clears the caller's secret on success (DB read-after-write)", async () => {
+    const fixture = await track(
+      store.set(seedCustomConnectorOrg$, { withSecret: true }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroCustomConnectorSecretContract);
+    const response = await accept(
+      client.delete({
+        params: { id: fixture.connectorId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+    expect(response.body).toBeUndefined();
+
+    const writeDb = store.set(writeDb$);
+    const rows = await writeDb
+      .select()
+      .from(orgCustomConnectorSecrets)
+      .where(
+        and(
+          eq(orgCustomConnectorSecrets.connectorId, fixture.connectorId),
+          eq(orgCustomConnectorSecrets.userId, fixture.userId),
+        ),
+      );
+    expect(rows).toHaveLength(0);
+
+    // Parity with web: no realtime publish on secret-clear.
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent — second delete still 204 and changes nothing", async () => {
+    const fixture = await track(
+      store.set(seedCustomConnectorOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroCustomConnectorSecretContract);
+    for (let i = 0; i < 2; i++) {
+      const response = await accept(
+        client.delete({
+          params: { id: fixture.connectorId },
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [204],
+      );
+      expect(response.body).toBeUndefined();
+    }
+
+    const writeDb = store.set(writeDb$);
+    const rows = await writeDb
+      .select()
+      .from(orgCustomConnectorSecrets)
+      .where(eq(orgCustomConnectorSecrets.connectorId, fixture.connectorId));
+    expect(rows).toHaveLength(0);
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("does not leak across users sharing a connector", async () => {
+    const fixture = await track(
+      store.set(seedCustomConnectorOrg$, { withSecret: true }, context.signal),
+    );
+    // Seed a second user's secret on the same connector.
+    const otherUserId = `user_${randomUUID().slice(0, 8)}`;
+    const writeDbSeed = store.set(writeDb$);
+    await writeDbSeed.insert(orgCustomConnectorSecrets).values({
+      connectorId: fixture.connectorId,
+      userId: otherUserId,
+      orgId: fixture.orgId,
+      encryptedValue: "other-user-secret",
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroCustomConnectorSecretContract);
+    await accept(
+      client.delete({
+        params: { id: fixture.connectorId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    const writeDb = store.set(writeDb$);
+    const survivors = await writeDb
+      .select()
+      .from(orgCustomConnectorSecrets)
+      .where(eq(orgCustomConnectorSecrets.connectorId, fixture.connectorId));
+    expect(survivors).toHaveLength(1);
+    expect(survivors[0]?.userId).toBe(otherUserId);
+
+    // The fixture tracker only deletes the connector-owned cascade, but the
+    // unmanaged extra row also lives on this connector and is cleaned by
+    // deleteCustomConnectorOrg$ on afterEach. No explicit cleanup needed.
+  });
+
+  it("does not leak across orgs (same userId in two orgs)", async () => {
+    const sharedUserId = `user_${randomUUID().slice(0, 8)}`;
+    const orgAFixture = await track(
+      store.set(
+        seedCustomConnectorOrg$,
+        { userId: sharedUserId, withSecret: true },
+        context.signal,
+      ),
+    );
+    const orgBFixture = await track(
+      store.set(
+        seedCustomConnectorOrg$,
+        { userId: sharedUserId, withSecret: true },
+        context.signal,
+      ),
+    );
+
+    // Authenticate as sharedUser in orgA. DELETE orgA's connector secret.
+    mocks.clerk.session(sharedUserId, orgAFixture.orgId);
+    const client = setupApp({ context })(zeroCustomConnectorSecretContract);
+    await accept(
+      client.delete({
+        params: { id: orgAFixture.connectorId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    // orgA secret gone; orgB secret survives.
+    const writeDb = store.set(writeDb$);
+    const orgARows = await writeDb
+      .select()
+      .from(orgCustomConnectorSecrets)
+      .where(
+        eq(orgCustomConnectorSecrets.connectorId, orgAFixture.connectorId),
+      );
+    expect(orgARows).toHaveLength(0);
+    const orgBRows = await writeDb
+      .select()
+      .from(orgCustomConnectorSecrets)
+      .where(
+        eq(orgCustomConnectorSecrets.connectorId, orgBFixture.connectorId),
+      );
+    expect(orgBRows).toHaveLength(1);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-secret-delete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-secret-delete.ts
@@ -1,0 +1,42 @@
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { zeroCustomConnectorSecretContract } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import type { RouteEntry } from "../route";
+
+const deleteSecretInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const params = get(pathParamsOf(zeroCustomConnectorSecretContract.delete));
+    signal.throwIfAborted();
+
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(orgCustomConnectorSecrets)
+      .where(
+        and(
+          eq(orgCustomConnectorSecrets.connectorId, params.id),
+          eq(orgCustomConnectorSecrets.userId, auth.userId),
+          eq(orgCustomConnectorSecrets.orgId, auth.orgId),
+        ),
+      );
+    signal.throwIfAborted();
+
+    return { status: 204 as const, body: undefined };
+  },
+);
+
+export const zeroCustomConnectorSecretDeleteRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroCustomConnectorSecretContract.delete,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      deleteSecretInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors.ts
@@ -6,6 +6,7 @@ import { authRoute } from "../auth/auth-route";
 import { zeroCustomConnectorList } from "../services/zero-catalog-data.service";
 import type { RouteEntry } from "../route";
 import { zeroCustomConnectorsCreateRoutes } from "./zero-custom-connectors-create";
+import { zeroCustomConnectorSecretDeleteRoutes } from "./zero-custom-connectors-secret-delete";
 
 const listCustomConnectorsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
@@ -24,4 +25,5 @@ export const zeroCustomConnectorsRoutes: readonly RouteEntry[] = [
     ),
   },
   ...zeroCustomConnectorsCreateRoutes,
+  ...zeroCustomConnectorSecretDeleteRoutes,
 ];


### PR DESCRIPTION
## Summary

- Adds `apps/api` handler for `DELETE /api/zero/custom-connectors/:id/secret` (Stage 3 Wave 4 of #12290).
- Strict parity with web: always 204 (after auth), no 404 branch, no realtime publish, no logging.
- Web `apps/web/.../[id]/secret/route.ts` is unchanged. Platform routes via `apiBackendMutationsEnabled$`; this is dark-launched until the operator flips the flag.

## Implementation

- New: `apps/api/src/signals/routes/zero-custom-connectors-secret-delete.ts` — inline three-clause `DELETE WHERE` (connector × user × org) under `organizationAuthContext$` with `requireOrganization: true, missingOrganizationStatus: 401`. `signal.throwIfAborted()` after every `await`.
- Wired into existing `zeroCustomConnectorsRoutes` aggregate after `create`.
- New: 6 integration tests covering 401 unauthenticated, 401 missing-org, 204 success + DB read-after-write, idempotency, cross-user no-leak, cross-org no-leak. Web only had 1 case (success); api side adds 5 defensive isolation/auth tests.
- Contract entry already existed (`zeroCustomConnectorSecretContract.delete`). No contract / platform / web edits.

## Behaviour parity notes

- Web's DELETE is silent on missing target (unknown connector, cross-user, cross-org all yield 204). The api mirrors this — no 404 branch added.
- Web does not publish to Ably; api does not either. The success test asserts `mocks.ably.publish` was NOT called.

## Test plan

- [x] `pnpm -F api exec vitest run signals/routes/__tests__/zero-custom-connectors-secret-delete` — 6/6 pass
- [x] `pnpm -F api exec vitest run` — 779/779 pass on @vm0/api
- [x] `pnpm turbo run lint --filter=api` — 0 warnings, 0 errors
- [x] `pnpm check-types` — all 11 workspaces clean
- [x] `pnpm format` — no changes (after auto-format)
- [x] `pnpm knip` — no findings (only pre-existing config hints)
- [x] `apps/web/**` unchanged

Closes #12531

🤖 Generated with [Claude Code](https://claude.com/claude-code)