### PR TITLE
refactor(api): migrate custom-connectors PATCH [id] (rename) to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-custom-connectors-patch.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-custom-connectors-patch.test.ts
@@ -1,0 +1,211 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+
+import { zeroCustomConnectorByIdContract } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteCustomConnectorOrg$,
+  seedCustomConnectorOrg$,
+  type CustomConnectorFixture,
+} from "./helpers/zero-custom-connectors";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("PATCH /api/zero/custom-connectors/:id", () => {
+  const track = createFixtureTracker<CustomConnectorFixture>((fixture) => {
+    return store.set(deleteCustomConnectorOrg$, fixture, context.signal);
+  });
+
+  async function getDisplayName(
+    connectorId: string,
+  ): Promise<string | undefined> {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ displayName: orgCustomConnectors.displayName })
+      .from(orgCustomConnectors)
+      .where(eq(orgCustomConnectors.id, connectorId));
+    return row?.displayName;
+  }
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroCustomConnectorByIdContract);
+    const response = await accept(
+      client.patch({
+        params: { id: randomUUID() },
+        headers: {},
+        body: { displayName: "Renamed" },
+      }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const fixture = await track(
+      store.set(seedCustomConnectorOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, null);
+
+    const client = setupApp({ context })(zeroCustomConnectorByIdContract);
+    const response = await accept(
+      client.patch({
+        params: { id: fixture.connectorId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { displayName: "Renamed" },
+      }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 for non-admin members", async () => {
+    const fixture = await track(
+      store.set(
+        seedCustomConnectorOrg$,
+        { displayName: "Original" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroCustomConnectorByIdContract);
+    const response = await accept(
+      client.patch({
+        params: { id: fixture.connectorId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { displayName: "Hacked" },
+      }),
+      [403],
+    );
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only org admins can rename custom connectors",
+        code: "FORBIDDEN",
+      },
+    });
+
+    await expect(getDisplayName(fixture.connectorId)).resolves.toBe("Original");
+  });
+
+  it("renames a connector as admin and persists it (read-after-write)", async () => {
+    const fixture = await track(
+      store.set(
+        seedCustomConnectorOrg$,
+        { displayName: "Original", slug: "patch-happy" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroCustomConnectorByIdContract);
+    const response = await accept(
+      client.patch({
+        params: { id: fixture.connectorId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { displayName: "Renamed" },
+      }),
+      [200],
+    );
+
+    expect(response.body.id).toBe(fixture.connectorId);
+    expect(response.body.displayName).toBe("Renamed");
+    expect(response.body.slug).toBe("patch-happy");
+    expect(response.body.hasSecret).toBeFalsy();
+
+    await expect(getDisplayName(fixture.connectorId)).resolves.toBe("Renamed");
+  });
+
+  it("returns 404 for an unknown connector id", async () => {
+    const fixture = await track(
+      store.set(seedCustomConnectorOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    const unknownId = randomUUID();
+
+    const client = setupApp({ context })(zeroCustomConnectorByIdContract);
+    const response = await accept(
+      client.patch({
+        params: { id: unknownId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { displayName: "Renamed" },
+      }),
+      [404],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND", message: "Custom connector not found" },
+    });
+  });
+
+  it("returns 404 when the connector belongs to another org (no existence leak)", async () => {
+    const otherFixture = await track(
+      store.set(
+        seedCustomConnectorOrg$,
+        { displayName: "OtherOrg" },
+        context.signal,
+      ),
+    );
+
+    const myFixture = await track(
+      store.set(seedCustomConnectorOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(myFixture.userId, myFixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroCustomConnectorByIdContract);
+    const response = await accept(
+      client.patch({
+        params: { id: otherFixture.connectorId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { displayName: "Hijacked" },
+      }),
+      [404],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND", message: "Custom connector not found" },
+    });
+
+    await expect(getDisplayName(otherFixture.connectorId)).resolves.toBe(
+      "OtherOrg",
+    );
+  });
+
+  it("rejects empty displayName with 400", async () => {
+    const fixture = await track(
+      store.set(
+        seedCustomConnectorOrg$,
+        { displayName: "Original" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroCustomConnectorByIdContract);
+    const response = await accept(
+      client.patch({
+        params: { id: fixture.connectorId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { displayName: "" },
+      }),
+      [400],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "BAD_REQUEST" },
+    });
+
+    await expect(getDisplayName(fixture.connectorId)).resolves.toBe("Original");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-patch.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-patch.ts
@@ -1,0 +1,107 @@
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { zeroCustomConnectorByIdContract } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+import { notFound } from "../../lib/error";
+import {
+  validateDisplayName,
+  type CustomConnectorRow,
+} from "../services/zero-custom-connector.service";
+import type { RouteEntry } from "../route";
+
+const adminRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Only org admins can rename custom connectors",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+function isBadRequestResponse(
+  value: unknown,
+): value is { readonly status: 400; readonly body: unknown } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "status" in value &&
+    (value as { status: unknown }).status === 400
+  );
+}
+
+function serialiseRow(row: CustomConnectorRow) {
+  return {
+    id: row.id,
+    slug: row.slug,
+    displayName: row.displayName,
+    prefixes: [...row.prefixes],
+    headerName: row.headerName,
+    headerTemplate: row.headerTemplate,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+    hasSecret: false,
+  };
+}
+
+const patchInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  if (auth.orgRole !== "admin") {
+    return adminRequired;
+  }
+
+  const params = get(pathParamsOf(zeroCustomConnectorByIdContract.patch));
+  const bodyResult = await get(
+    bodyResultOf(zeroCustomConnectorByIdContract.patch),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const displayName = validateDisplayName(bodyResult.data.displayName);
+  if (isBadRequestResponse(displayName)) {
+    return displayName;
+  }
+
+  const writeDb = set(writeDb$);
+  const [row] = await writeDb
+    .update(orgCustomConnectors)
+    .set({ displayName, updatedAt: nowDate() })
+    .where(
+      and(
+        eq(orgCustomConnectors.id, params.id),
+        eq(orgCustomConnectors.orgId, auth.orgId),
+      ),
+    )
+    .returning();
+  signal.throwIfAborted();
+
+  if (!row) {
+    return notFound("Custom connector not found");
+  }
+
+  return {
+    status: 200 as const,
+    body: serialiseRow({
+      ...row,
+      prefixes: row.prefixes as readonly string[],
+    }),
+  };
+});
+
+export const zeroCustomConnectorsPatchRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroCustomConnectorByIdContract.patch,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      patchInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors.ts
@@ -7,6 +7,7 @@ import { zeroCustomConnectorList } from "../services/zero-catalog-data.service";
 import type { RouteEntry } from "../route";
 import { zeroCustomConnectorsCreateRoutes } from "./zero-custom-connectors-create";
 import { zeroCustomConnectorsDeleteRoutes } from "./zero-custom-connectors-delete";
+import { zeroCustomConnectorsPatchRoutes } from "./zero-custom-connectors-patch";
 import { zeroCustomConnectorSecretDeleteRoutes } from "./zero-custom-connectors-secret-delete";
 import { zeroCustomConnectorsSecretSetRoutes } from "./zero-custom-connectors-secret-set";
 
@@ -28,6 +29,7 @@ export const zeroCustomConnectorsRoutes: readonly RouteEntry[] = [
   },
   ...zeroCustomConnectorsCreateRoutes,
   ...zeroCustomConnectorsDeleteRoutes,
+  ...zeroCustomConnectorsPatchRoutes,
   ...zeroCustomConnectorSecretDeleteRoutes,
   ...zeroCustomConnectorsSecretSetRoutes,
 ];

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -96,7 +96,7 @@ function randomShortId(): string {
   return randomUUID().replace(/-/g, "").slice(0, 6);
 }
 
-function validateDisplayName(raw: string): string | BadRequestResponse {
+export function validateDisplayName(raw: string): string | BadRequestResponse {
   const displayName = raw.trim();
   if (displayName.length < 1 || displayName.length > 128) {
     return badRequestMessage(


### PR DESCRIPTION
## Summary

- Migrates `PATCH /api/zero/custom-connectors/:id` from `apps/web` to `apps/api`. Wave 4 follow-up to #12524 (create), so the rollout flag flips the create+rename pair together.
- Behavior 1:1 with web: admin-only, trim+length validation reusing `validateDisplayName` from #12524's service, single `UPDATE ... WHERE id AND org_id RETURNING`, 404 when zero rows return (covers both unknown-id and cross-org with no existence leak).
- **No realtime publish** — web doesn't either; renames don't drive any subscribed topic.

## Reuse from #12524

`validateDisplayName` was already implemented in `turbo/apps/api/src/signals/services/zero-custom-connector.service.ts` as a private helper. Per leader's directive, this PR promotes it to `export function` (one-word change) and consumes it from the new route file. No other service-side change.

## Empty-displayName 400 envelope

Verified at impl time per leader's caveat. The contract enforces `displayName: z.string().min(1).max(128)`, so `""` is rejected by `bodyResultOf` before the handler runs and the harness emits `{ error: { code: "BAD_REQUEST", message: <zod message> } }`. This matches web's `createErrorResponse("BAD_REQUEST", ...)` shape exactly — no contract refinement required to upgrade the code to `VALIDATION_ERROR`.

The handler still calls `validateDisplayName` after the contract parse to also catch whitespace-only input that passes `min(1)` but fails the trim — same path web takes.

## Auth

Reuses the create precedent: `authRoute({ requireOrganization: true, missingOrganizationStatus: 401 }, patchInner$)` plus `if (auth.orgRole !== "admin") return adminRequired;` inside the handler. The 403 message reads `"Only org admins can rename custom connectors"` to match web's `requireAdminPermission(member, "rename custom connectors")` text exactly.

## Files

- `turbo/apps/api/src/signals/services/zero-custom-connector.service.ts` — `function validateDisplayName` → `export function validateDisplayName` (one-word change).
- `turbo/apps/api/src/signals/routes/zero-custom-connectors-patch.ts` — new ~100-line file with `patchInner$` + route entry.
- `turbo/apps/api/src/signals/routes/zero-custom-connectors.ts` — one import, one append in `zeroCustomConnectorsRoutes`.
- `turbo/apps/api/src/signals/routes/__tests__/zero-custom-connectors-patch.test.ts` — new test file with seven cases.
- **No contract change.** **No web change.** **No new helper.**

## Tests (7)

| # | Case | Asserts |
|---|---|---|
| 1 | 401 unauthenticated | body `{ error.code: UNAUTHORIZED }` |
| 2 | 401 missing-org | body `{ error.code: UNAUTHORIZED }` |
| 3 | 403 non-admin | body `{ error.code: FORBIDDEN, message: "Only org admins can rename custom connectors" }`; DB row unchanged |
| 4 | 200 admin rename | response.id/displayName/slug/hasSecret correct; DB read-after-write |
| 5 | 404 unknown id | body `{ error.code: NOT_FOUND, message: "Custom connector not found" }` |
| 6 | 404 cross-org | body `{ error.code: NOT_FOUND }`; victim row unchanged |
| 7 | 400 empty displayName | body `{ error.code: BAD_REQUEST }`; DB row unchanged |

## Sibling-PR coordination

`turbo/apps/api/src/signals/routes/zero-custom-connectors.ts` is also touched by:

- a1 `#12528` — DELETE `[id]`
- a3 — PUT `[id]/secret`
- a4 — DELETE `[id]/secret`

Each PR appends a single import line and a single spread to `zeroCustomConnectorsRoutes`. Whoever lands first is a no-op for the others; subsequent PRs rebase by appending in registration order. No other shared file.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-custom-connectors-patch.test.ts` — 7 passed
- [x] `pnpm -F api exec vitest run` — 780 passed
- [x] `pnpm -F api run lint` — clean
- [x] `pnpm -F api run check-types` — clean
- [x] `pnpm format` / `pnpm knip --workspace api` — clean

Closes #12529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)