### PR TITLE
feat(api): migrate custom-connectors put [id]/secret to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-custom-connectors-secret-set.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-custom-connectors-secret-set.test.ts
@@ -1,0 +1,106 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { zeroCustomConnectorSecretContract } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import { decryptSecretValue } from "../../services/crypto.utils";
+import {
+  deleteCustomConnectorOrg$,
+  seedCustomConnectorOrg$,
+  type CustomConnectorFixture,
+} from "./helpers/zero-custom-connectors";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("PUT /api/zero/custom-connectors/:id/secret", () => {
+  const track = createFixtureTracker<CustomConnectorFixture>((fixture) => {
+    return store.set(deleteCustomConnectorOrg$, fixture, context.signal);
+  });
+
+  it("stores per-user secret and round-trips through decryptSecretValue", async () => {
+    const fixture = await track(
+      store.set(seedCustomConnectorOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroCustomConnectorSecretContract);
+    await accept(
+      client.set({
+        params: { id: fixture.connectorId },
+        body: { value: "sk_live_xyz" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({
+        encryptedValue: orgCustomConnectorSecrets.encryptedValue,
+        userId: orgCustomConnectorSecrets.userId,
+        orgId: orgCustomConnectorSecrets.orgId,
+      })
+      .from(orgCustomConnectorSecrets)
+      .where(eq(orgCustomConnectorSecrets.connectorId, fixture.connectorId));
+    expect(row).toBeDefined();
+    expect(row!.userId).toBe(fixture.userId);
+    expect(row!.orgId).toBe(fixture.orgId);
+    expect(decryptSecretValue(row!.encryptedValue)).toBe("sk_live_xyz");
+  });
+
+  it("returns 404 for an unknown connector id", async () => {
+    const fixture = await track(
+      store.set(seedCustomConnectorOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroCustomConnectorSecretContract);
+    const response = await accept(
+      client.set({
+        params: { id: randomUUID() },
+        body: { value: "x" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toMatchObject({ error: { code: "NOT_FOUND" } });
+  });
+
+  it("allows an org member (non-admin) to set their own secret", async () => {
+    const fixture = await track(
+      store.set(seedCustomConnectorOrg$, {}, context.signal),
+    );
+    // The connector creator was fixture.userId (the seeding admin). A different
+    // user in the same org should be able to set their own secret.
+    const memberUserId = `user_${randomUUID().slice(0, 8)}`;
+    mocks.clerk.session(memberUserId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroCustomConnectorSecretContract);
+    await accept(
+      client.set({
+        params: { id: fixture.connectorId },
+        body: { value: "member-token" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ encryptedValue: orgCustomConnectorSecrets.encryptedValue })
+      .from(orgCustomConnectorSecrets)
+      .where(eq(orgCustomConnectorSecrets.userId, memberUserId));
+    expect(row).toBeDefined();
+    expect(decryptSecretValue(row!.encryptedValue)).toBe("member-token");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-secret-set.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-secret-set.ts
@@ -1,0 +1,72 @@
+import { command } from "ccstate";
+import { zeroCustomConnectorSecretContract } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import { notFound } from "../../lib/error";
+import { nowDate } from "../../lib/time";
+import { encryptSecretValue } from "../services/crypto.utils";
+import { getCustomConnectorById } from "../services/zero-custom-connector.service";
+import type { RouteEntry } from "../route";
+
+const setSecretInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(zeroCustomConnectorSecretContract.set));
+  signal.throwIfAborted();
+
+  const bodyResult = await get(
+    bodyResultOf(zeroCustomConnectorSecretContract.set),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const connector = await get(
+    getCustomConnectorById({
+      orgId: auth.orgId,
+      connectorId: params.id,
+    }),
+  );
+  signal.throwIfAborted();
+  if (!connector) {
+    return notFound("Custom connector not found");
+  }
+
+  const encryptedValue = encryptSecretValue(bodyResult.data.value);
+  const writeDb = set(writeDb$);
+  await writeDb
+    .insert(orgCustomConnectorSecrets)
+    .values({
+      connectorId: params.id,
+      userId: auth.userId,
+      orgId: auth.orgId,
+      encryptedValue,
+    })
+    .onConflictDoUpdate({
+      target: [
+        orgCustomConnectorSecrets.connectorId,
+        orgCustomConnectorSecrets.userId,
+      ],
+      set: {
+        encryptedValue,
+        updatedAt: nowDate(),
+      },
+    });
+  signal.throwIfAborted();
+
+  return { status: 204 as const, body: undefined };
+});
+
+export const zeroCustomConnectorsSecretSetRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroCustomConnectorSecretContract.set,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      setSecretInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors.ts
@@ -8,6 +8,7 @@ import type { RouteEntry } from "../route";
 import { zeroCustomConnectorsCreateRoutes } from "./zero-custom-connectors-create";
 import { zeroCustomConnectorsDeleteRoutes } from "./zero-custom-connectors-delete";
 import { zeroCustomConnectorSecretDeleteRoutes } from "./zero-custom-connectors-secret-delete";
+import { zeroCustomConnectorsSecretSetRoutes } from "./zero-custom-connectors-secret-set";
 
 const listCustomConnectorsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
@@ -28,4 +29,5 @@ export const zeroCustomConnectorsRoutes: readonly RouteEntry[] = [
   ...zeroCustomConnectorsCreateRoutes,
   ...zeroCustomConnectorsDeleteRoutes,
   ...zeroCustomConnectorSecretDeleteRoutes,
+  ...zeroCustomConnectorsSecretSetRoutes,
 ];

--- a/turbo/apps/api/src/signals/services/crypto.utils.ts
+++ b/turbo/apps/api/src/signals/services/crypto.utils.ts
@@ -1,6 +1,30 @@
-import { createDecipheriv } from "node:crypto";
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 
 import { env } from "../../lib/env";
+
+/**
+ * Encrypt a single secret value using AES-256-GCM.
+ *
+ * Reads `SECRETS_ENCRYPTION_KEY` from env so call sites stay clean — symmetric
+ * counterpart to `decryptSecretValue` below. Output format
+ * `iv:authTag:ciphertext` (all base64) matches what `encryptSecretForTests`
+ * already produces, so encrypt/decrypt round-trip is provably consistent.
+ */
+export function encryptSecretValue(plaintext: string): string {
+  const key = Buffer.from(env("SECRETS_ENCRYPTION_KEY"), "hex");
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv, { authTagLength: 16 });
+  const data = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  return [
+    iv.toString("base64"),
+    authTag.toString("base64"),
+    data.toString("base64"),
+  ].join(":");
+}
 
 export function decryptSecretValue(encrypted: string): string {
   const key = Buffer.from(env("SECRETS_ENCRYPTION_KEY"), "hex");

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -1,4 +1,4 @@
-import { command } from "ccstate";
+import { command, computed, type Computed } from "ccstate";
 import { randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
 import {
@@ -8,7 +8,7 @@ import {
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
 
-import { writeDb$ } from "../external/db";
+import { db$, writeDb$ } from "../external/db";
 import { badRequestMessage, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { safeUrlParse } from "../utils";
@@ -298,3 +298,31 @@ export const deleteCustomConnector$ = command(
     return undefined;
   },
 );
+
+/**
+ * Look up a custom connector by id, scoped to the caller's org so cross-org
+ * ids return null. Reusable by every per-id mutation route in this family
+ * (set-secret here, delete-secret + rename + delete in sibling PRs).
+ */
+export function getCustomConnectorById(args: {
+  readonly orgId: string;
+  readonly connectorId: string;
+}): Computed<Promise<CustomConnectorRow | null>> {
+  return computed(async (get): Promise<CustomConnectorRow | null> => {
+    const db = get(db$);
+    const [row] = await db
+      .select()
+      .from(orgCustomConnectors)
+      .where(
+        and(
+          eq(orgCustomConnectors.id, args.connectorId),
+          eq(orgCustomConnectors.orgId, args.orgId),
+        ),
+      )
+      .limit(1);
+    if (!row) {
+      return null;
+    }
+    return { ...row, prefixes: row.prefixes as readonly string[] };
+  });
+}


### PR DESCRIPTION
## Summary

- Closes #12530. Wave 4 sibling on the custom-connectors family — concurrent with a1+a2+a4 (rename / delete / delete-secret).
- Adds `PUT /api/zero/custom-connectors/:id/secret` to apps/api: encrypts the caller's secret with AES-256-GCM and upserts it into `org_custom_connector_secrets` keyed on `(connectorId, userId)`.
- `apps/web` is intentionally untouched; ops flips traffic via the existing `ApiBackendMutations` switch.

## Reusable additions for sibling PRs

These two additions are deliberately introduced here so a1/a2/a4 can rebase onto this PR and consume them rather than re-derive locally:

| Addition | Location | Reused by |
|----------|----------|-----------|
| `encryptSecretValue(plaintext)` | `apps/api/src/signals/services/crypto.utils.ts` (parallel to existing `decryptSecretValue`; reads `SECRETS_ENCRYPTION_KEY` from env) | Every future per-user secret write (model providers, integrations, etc.) |
| `getCustomConnectorById(args)` Computed | `apps/api/src/signals/services/zero-custom-connector.service.ts` (scoped by `(id, orgId)`; returns `null` for cross-org or missing) | Every per-id custom-connectors mutation route — rename / delete / delete-secret |

## Implementation

- `apps/api/src/signals/routes/zero-custom-connectors-secret-set.ts` — handler. `authRoute({ requireOrganization: true, missingOrganizationStatus: 401 }, …)` matches the merged sibling create handler; **no admin gate** (per-user secrets, member self-management — same as web). 404 when the connector is not visible to the caller's org. UPSERT on the unique `(connectorId, userId)` index. `signal.throwIfAborted()` after every `await`.
- `apps/api/src/signals/routes/zero-custom-connectors.ts` — one new import, one new spread. No edit to top-level `route.ts`.
- 3 tests ported 1:1 from web (`apps/web/app/api/zero/custom-connectors/__tests__/route.test.ts:330-392`):
  1. admin sets secret → 204 + DB read-after-write + `decryptSecretValue` round-trips back to plaintext
  2. unknown connector id → 404
  3. org member (different `userId`) sets own secret → 204

## Notes

- ts-rest contract `zeroCustomConnectorSecretContract.set` was pre-existing — **no contract edit**.
- DB read-after-write decryption proves the encrypt path correctness end-to-end.
- No realtime publish (per-user secret writes don't shape any UI list refresh).

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-custom-connectors-secret-set.test.ts` — 3/3 pass
- [x] `pnpm -F api exec vitest run` — 776/776 pass
- [x] `pnpm turbo run lint` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — no diff
- [x] `pnpm knip` — no issues
- [x] `git diff --name-only origin/main...HEAD | grep apps/web | wc -l` — 0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)