### PR TITLE
feat(api): port custom-connectors DELETE [id] to api backend (Wave 4)

### DIFF
--- a/turbo/apps/api/src/lib/error.ts
+++ b/turbo/apps/api/src/lib/error.ts
@@ -32,3 +32,32 @@ export function badRequest(issue: ZodLikeIssue) {
   const message = path ? `${path}: ${issue.message}` : issue.message;
   return httpError(400, "BAD_REQUEST", message);
 }
+
+type HttpResponseLike<S extends number> = {
+  readonly status: S;
+  readonly body: unknown;
+};
+
+function isHttpResponse<S extends number>(
+  value: unknown,
+  status: S,
+): value is HttpResponseLike<S> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "status" in value &&
+    (value as { status: unknown }).status === status
+  );
+}
+
+export function isBadRequestResponse(
+  value: unknown,
+): value is HttpResponseLike<400> {
+  return isHttpResponse(value, 400);
+}
+
+export function isNotFoundResponse(
+  value: unknown,
+): value is HttpResponseLike<404> {
+  return isHttpResponse(value, 404);
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-custom-connectors-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-custom-connectors-delete.test.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+
+import { zeroCustomConnectorByIdContract } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
+import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function uniqueOrg(prefix: string) {
+  const userId = `user_${prefix}_${randomUUID().slice(0, 8)}`;
+  const orgId = `org_${prefix}_${randomUUID().slice(0, 8)}`;
+  return { userId, orgId };
+}
+
+async function seedCustomConnector(orgId: string, userId: string) {
+  const id = randomUUID();
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(orgCustomConnectors).values({
+    id,
+    orgId,
+    slug: `seed-${randomUUID().slice(0, 8)}`,
+    displayName: "Seeded",
+    prefixes: ["https://api.example.org/"],
+    headerName: "Authorization",
+    headerTemplate: "Bearer {{secret}}",
+    createdBy: userId,
+  });
+  return id;
+}
+
+async function seedConnectorSecret(
+  orgId: string,
+  userId: string,
+  connectorId: string,
+) {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(orgCustomConnectorSecrets).values({
+    connectorId,
+    userId,
+    orgId,
+    encryptedValue: "fake-encrypted-blob",
+  });
+}
+
+describe("DELETE /api/zero/custom-connectors/:id", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(zeroCustomConnectorByIdContract);
+    const response = await accept(
+      client.delete({ params: { id: randomUUID() }, headers: {} }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 for non-admin members and leaves the row in place", async () => {
+    const { userId, orgId } = uniqueOrg("zcc-del-member");
+    const id = await seedCustomConnector(orgId, userId);
+    mocks.clerk.session(userId, orgId, "org:member");
+
+    const client = setupApp({ context })(zeroCustomConnectorByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only org admins can delete custom connectors",
+        code: "FORBIDDEN",
+      },
+    });
+
+    // Sanity: the row is still there (delete was rejected, not silently performed).
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ id: orgCustomConnectors.id })
+      .from(orgCustomConnectors)
+      .where(eq(orgCustomConnectors.id, id));
+    expect(row?.id).toBe(id);
+  });
+
+  it("returns 404 for an unknown id", async () => {
+    const { userId, orgId } = uniqueOrg("zcc-del-404");
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroCustomConnectorByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND" },
+    });
+  });
+
+  it("deletes connector as admin and cascades secrets", async () => {
+    const { userId, orgId } = uniqueOrg("zcc-del-cascade");
+    const id = await seedCustomConnector(orgId, userId);
+    await seedConnectorSecret(orgId, userId, id);
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    // Pre-condition: secret row exists.
+    const writeDb = store.set(writeDb$);
+    const [secretBefore] = await writeDb
+      .select({ connectorId: orgCustomConnectorSecrets.connectorId })
+      .from(orgCustomConnectorSecrets)
+      .where(eq(orgCustomConnectorSecrets.connectorId, id));
+    expect(secretBefore?.connectorId).toBe(id);
+
+    const client = setupApp({ context })(zeroCustomConnectorByIdContract);
+    const response = await client.delete({
+      params: { id },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(204);
+
+    // Connector row removed
+    const [connectorRow] = await writeDb
+      .select({ id: orgCustomConnectors.id })
+      .from(orgCustomConnectors)
+      .where(eq(orgCustomConnectors.id, id));
+    expect(connectorRow).toBeUndefined();
+
+    // Secret row also removed (cascade)
+    const [secretRow] = await writeDb
+      .select({ connectorId: orgCustomConnectorSecrets.connectorId })
+      .from(orgCustomConnectorSecrets)
+      .where(eq(orgCustomConnectorSecrets.connectorId, id));
+    expect(secretRow).toBeUndefined();
+  });
+
+  it("returns 404 for a connector in another org and leaves the row in place", async () => {
+    const orgA = uniqueOrg("zcc-del-orgA");
+    const id = await seedCustomConnector(orgA.orgId, orgA.userId);
+
+    const orgB = uniqueOrg("zcc-del-orgB");
+    mocks.clerk.session(orgB.userId, orgB.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroCustomConnectorByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND" },
+    });
+
+    // Sanity: the connector is still there in org A.
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ id: orgCustomConnectors.id, orgId: orgCustomConnectors.orgId })
+      .from(orgCustomConnectors)
+      .where(eq(orgCustomConnectors.id, id));
+    expect(row?.orgId).toBe(orgA.orgId);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-create.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-create.ts
@@ -8,6 +8,7 @@ import {
   createCustomConnector$,
   type CustomConnectorRow,
 } from "../services/zero-custom-connector.service";
+import { isBadRequestResponse } from "../../lib/error";
 import type { RouteEntry } from "../route";
 
 const adminRequired = Object.freeze({
@@ -19,17 +20,6 @@ const adminRequired = Object.freeze({
     }),
   }),
 });
-
-function isBadRequestResponse(
-  value: unknown,
-): value is { readonly status: 400; readonly body: unknown } {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "status" in value &&
-    (value as { status: unknown }).status === 400
-  );
-}
 
 function serialiseRow(row: CustomConnectorRow) {
   return {

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-delete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-delete.ts
@@ -1,0 +1,50 @@
+import { command } from "ccstate";
+import { zeroCustomConnectorByIdContract } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { deleteCustomConnector$ } from "../services/zero-custom-connector.service";
+import { isNotFoundResponse } from "../../lib/error";
+import type { RouteEntry } from "../route";
+
+const adminRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Only org admins can delete custom connectors",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  if (auth.orgRole !== "admin") {
+    return adminRequired;
+  }
+  const params = get(pathParamsOf(zeroCustomConnectorByIdContract.delete));
+  signal.throwIfAborted();
+
+  const result = await set(
+    deleteCustomConnector$,
+    { orgId: auth.orgId, id: params.id },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (isNotFoundResponse(result)) {
+    return result;
+  }
+  return { status: 204 as const, body: undefined };
+});
+
+export const zeroCustomConnectorsDeleteRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroCustomConnectorByIdContract.delete,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      deleteInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors.ts
@@ -6,6 +6,7 @@ import { authRoute } from "../auth/auth-route";
 import { zeroCustomConnectorList } from "../services/zero-catalog-data.service";
 import type { RouteEntry } from "../route";
 import { zeroCustomConnectorsCreateRoutes } from "./zero-custom-connectors-create";
+import { zeroCustomConnectorsDeleteRoutes } from "./zero-custom-connectors-delete";
 import { zeroCustomConnectorSecretDeleteRoutes } from "./zero-custom-connectors-secret-delete";
 
 const listCustomConnectorsInner$ = computed(async (get) => {
@@ -25,5 +26,6 @@ export const zeroCustomConnectorsRoutes: readonly RouteEntry[] = [
     ),
   },
   ...zeroCustomConnectorsCreateRoutes,
+  ...zeroCustomConnectorsDeleteRoutes,
   ...zeroCustomConnectorSecretDeleteRoutes,
 ];

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -1,13 +1,15 @@
 import { command } from "ccstate";
 import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
 import {
   getAllBuiltinConnectorHosts,
   getBuiltinConnectorDisplayName,
 } from "@vm0/connectors/firewalls";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
+import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
 
 import { writeDb$ } from "../external/db";
-import { badRequestMessage } from "../../lib/error";
+import { badRequestMessage, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { safeUrlParse } from "../utils";
 
@@ -249,5 +251,50 @@ export const createCustomConnector$ = command(
     // Drizzle types `prefixes` as `unknown` (jsonb column); the value at
     // runtime is the string[] we just inserted.
     return { ...row, prefixes: row.prefixes as readonly string[] };
+  },
+);
+
+type NotFoundResponse = ReturnType<typeof notFound>;
+
+export const deleteCustomConnector$ = command(
+  async (
+    { set },
+    args: { readonly orgId: string; readonly id: string },
+    signal: AbortSignal,
+  ): Promise<NotFoundResponse | undefined> => {
+    const writeDb = set(writeDb$);
+    const deleted = await writeDb.transaction(async (tx) => {
+      const [existing] = await tx
+        .select({ id: orgCustomConnectors.id })
+        .from(orgCustomConnectors)
+        .where(
+          and(
+            eq(orgCustomConnectors.id, args.id),
+            eq(orgCustomConnectors.orgId, args.orgId),
+          ),
+        )
+        .limit(1);
+      if (!existing) {
+        return false;
+      }
+      await tx
+        .delete(orgCustomConnectorSecrets)
+        .where(eq(orgCustomConnectorSecrets.connectorId, args.id));
+      await tx
+        .delete(orgCustomConnectors)
+        .where(
+          and(
+            eq(orgCustomConnectors.id, args.id),
+            eq(orgCustomConnectors.orgId, args.orgId),
+          ),
+        );
+      return true;
+    });
+    signal.throwIfAborted();
+    if (!deleted) {
+      return notFound("Custom connector not found");
+    }
+    L.debug("custom connector deleted", { orgId: args.orgId, id: args.id });
+    return undefined;
   },
 );


### PR DESCRIPTION
## Summary

Wave 4 mutation route migration. Ports `DELETE /api/zero/custom-connectors/:id` (admin delete; cascades to per-user secrets) from apps/web to apps/api. Sibling to #12524 (create POST). Promotes the `isBadRequestResponse` predicate from #12524's handler into `apps/api/src/lib/error.ts` (P2 follow-up flagged in the #12524 review) along with a new `isNotFoundResponse` helper consumed by this PR.

- New `apps/api/src/lib/error.ts` predicates: `isBadRequestResponse`, `isNotFoundResponse`. Backed by a private `isHttpResponse(value, status)` type-narrowing primitive that future named predicates derive from. Future `isForbiddenResponse` etc. can be added on demand without re-implementing the type guard.
- `zero-custom-connectors-create.ts` refactored to import `isBadRequestResponse` from `lib/error.ts` (drops its local copy).
- New `deleteCustomConnector\$` Command in `zero-custom-connector.service.ts`: three-step transaction (SELECT existence → DELETE secrets → DELETE connector) returning a `NotFoundResponse | undefined` result-union. Boolean from the tx callback maps cleanly to the outer result-union so the Command stays pure (no thrown errors inside Commands).
- New `apps/api/src/signals/routes/zero-custom-connectors-delete.ts`: admin gate via `organizationAuthContext\$` + frozen 403, delegates to the service, forwards 404 via `isNotFoundResponse` predicate, returns 204 on success.
- 5 integration tests cover: 401 unauth (api defensive), 403 non-admin **with row-still-present sanity check** (catches silent-success regressions), 404 unknown id, 204 cascade **with explicit connector + secret read-after-delete** (catches partial-cascade regressions), 404 cross-org isolation **with row-still-present sanity check** (catches WHERE-clause regressions).

apps/web DELETE handler **unchanged**. Operator flips `ApiBackendMutations` to switch traffic per-org.

> **Issue body correction**: #12528 body uses chat-thread template text (the same stale template that affected #12520). Title and leader's task description are correct: route is `DELETE /api/zero/custom-connectors/:id`.

Closes #12528.

## Pattern conventions reinforced for Wave 4 (PATCH + secret PUT/DELETE)

| Concern | Convention |
|---|---|
| Predicates for response-shapes | Import from `lib/error.ts` (`isBadRequestResponse`, `isNotFoundResponse`, …add as needed via the private `isHttpResponse` primitive) |
| Mutation services | Command returning `Result | ErrorResponse` (or `ErrorResponse | undefined` for void-success cases) — never throw inside Commands |
| Transactions | tx callback returns boolean; outer code maps to result-union |
| Cascade tests | Read both parent and dependent rows after the action (don't trust list-empty alone) |
| Cross-org isolation | Include for any `[id]` route — cheap test, catches WHERE-clause regressions |
| Defensive 403/404 sanity | When asserting 403 or cross-org 404, also confirm the row is still present |

## Routing matrix (recap)

| `ApiBackend` | `ApiBackendMutations` | DELETE host |
|:------------:|:---------------------:|:-----------:|
| OFF          | OFF                   | www         |
| OFF          | ON                    | api         |
| ON           | *                     | api         |

## Rollout / Rollback

Standard: flag default OFF; staff org flipped first; revert PR or flip flag for instant rollback.

## Test plan

- [x] 5 integration tests pass locally
- [x] Cascade verified by explicit `select` on both parent and secret rows
- [x] Cross-org isolation verified
- [x] Refactor of #12524's create.ts: \`zero-custom-connectors-create.test.ts\` re-runs clean (7 tests still pass)
- [x] No \`apps/web/**\` modified
- [x] tests / lint / types / format / knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)