### PR TITLE
refactor(api): migrate api-keys delete to api backend (wave 5)

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-api-keys.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-api-keys.ts
@@ -8,6 +8,7 @@ import { writeDb$ } from "../../../external/db";
 
 export interface ApiKeysFixture {
   readonly userId: string;
+  readonly tokenIds: readonly string[];
 }
 
 interface ApiKeySeedValues {
@@ -24,27 +25,32 @@ export const seedApiKeys$ = command(
     rows: readonly ApiKeySeedValues[],
     signal: AbortSignal,
   ): Promise<ApiKeysFixture> => {
-    const fixture = { userId: `user_${randomUUID()}` };
+    const userId = `user_${randomUUID()}`;
     const writeDb = set(writeDb$);
+    const tokenIds: string[] = [];
 
     if (rows.length > 0) {
-      await writeDb.insert(cliTokens).values(
-        rows.map((row) => {
-          return {
-            id: randomUUID(),
-            userId: fixture.userId,
-            name: row.name,
-            token: row.token,
-            createdAt: row.createdAt,
-            expiresAt: row.expiresAt,
-            lastUsedAt: row.lastUsedAt ?? null,
-          };
+      const inserts = rows.map((row) => {
+        return {
+          id: randomUUID(),
+          userId,
+          name: row.name,
+          token: row.token,
+          createdAt: row.createdAt,
+          expiresAt: row.expiresAt,
+          lastUsedAt: row.lastUsedAt ?? null,
+        };
+      });
+      tokenIds.push(
+        ...inserts.map((row) => {
+          return row.id;
         }),
       );
+      await writeDb.insert(cliTokens).values(inserts);
       signal.throwIfAborted();
     }
 
-    return fixture;
+    return { userId, tokenIds };
   },
 );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-api-keys-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-api-keys-delete.test.ts
@@ -1,0 +1,129 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { apiKeysByIdContract } from "@vm0/api-contracts/contracts/api-keys";
+import { cliTokens } from "@vm0/db/schema/cli-tokens";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteApiKeys$,
+  seedApiKeys$,
+  type ApiKeysFixture,
+} from "./helpers/zero-api-keys";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function seedRow(name: string, suffix: string) {
+  return {
+    name,
+    token: `vm0_pat_${suffix}_${randomUUID().slice(0, 8)}`,
+    createdAt: new Date("2026-03-01T00:00:00.000Z"),
+    expiresAt: new Date("2026-04-01T00:00:00.000Z"),
+  };
+}
+
+describe("DELETE /api/zero/api-keys/:id", () => {
+  const track = createFixtureTracker<ApiKeysFixture>((fixture) => {
+    return store.set(deleteApiKeys$, fixture, context.signal);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(apiKeysByIdContract);
+    const response = await accept(
+      client.delete({ params: { id: randomUUID() }, headers: {} }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("deletes the caller's own key (DB read-after-delete)", async () => {
+    const fixture = await track(
+      store.set(seedApiKeys$, [seedRow("to delete", "del")], context.signal),
+    );
+    const tokenId = fixture.tokenIds[0];
+    expect(tokenId).toBeDefined();
+    mocks.clerk.session(fixture.userId, `org_${randomUUID().slice(0, 8)}`);
+
+    const client = setupApp({ context })(apiKeysByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: tokenId! },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+    expect(response.body).toBeUndefined();
+
+    // DB read-after-delete: row gone.
+    const writeDb = store.set(writeDb$);
+    const survivors = await writeDb
+      .select()
+      .from(cliTokens)
+      .where(eq(cliTokens.id, tokenId!));
+    expect(survivors).toHaveLength(0);
+  });
+
+  it("returns 404 for an unknown id", async () => {
+    const fixture = await track(store.set(seedApiKeys$, [], context.signal));
+    mocks.clerk.session(fixture.userId, `org_${randomUUID().slice(0, 8)}`);
+
+    const client = setupApp({ context })(apiKeysByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "API key not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 404 when another user owns the key (no leak)", async () => {
+    const victim = await track(
+      store.set(
+        seedApiKeys$,
+        [seedRow("victim's key", "victim")],
+        context.signal,
+      ),
+    );
+    const victimTokenId = victim.tokenIds[0];
+    expect(victimTokenId).toBeDefined();
+
+    // Authenticate as a different user; victim is unrelated.
+    const attackerUserId = `user_${randomUUID().slice(0, 8)}`;
+    mocks.clerk.session(attackerUserId, `org_${randomUUID().slice(0, 8)}`);
+
+    const client = setupApp({ context })(apiKeysByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: victimTokenId! },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "API key not found", code: "NOT_FOUND" },
+    });
+
+    // No-leak: victim's row physically still exists.
+    const writeDb = store.set(writeDb$);
+    const [survivor] = await writeDb
+      .select()
+      .from(cliTokens)
+      .where(eq(cliTokens.id, victimTokenId!));
+    expect(survivor).toBeDefined();
+    expect(survivor?.userId).toBe(victim.userId);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-api-keys-delete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-api-keys-delete.ts
@@ -1,0 +1,36 @@
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { apiKeysByIdContract } from "@vm0/api-contracts/contracts/api-keys";
+import { cliTokens } from "@vm0/db/schema/cli-tokens";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import { notFound } from "../../lib/error";
+import type { RouteEntry } from "../route";
+
+const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+  const params = get(pathParamsOf(apiKeysByIdContract.delete));
+  signal.throwIfAborted();
+
+  const writeDb = set(writeDb$);
+  const deleted = await writeDb
+    .delete(cliTokens)
+    .where(and(eq(cliTokens.id, params.id), eq(cliTokens.userId, auth.userId)))
+    .returning({ id: cliTokens.id });
+  signal.throwIfAborted();
+
+  if (deleted.length === 0) {
+    return notFound("API key not found");
+  }
+  return { status: 204 as const, body: undefined };
+});
+
+export const zeroApiKeysDeleteRoutes: readonly RouteEntry[] = [
+  {
+    route: apiKeysByIdContract.delete,
+    handler: authRoute({}, deleteInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-api-keys.ts
+++ b/turbo/apps/api/src/signals/routes/zero-api-keys.ts
@@ -5,6 +5,7 @@ import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import type { RouteEntry } from "../route";
 import { userApiKeys } from "../services/zero-user-data.service";
+import { zeroApiKeysDeleteRoutes } from "./zero-api-keys-delete";
 
 const listApiKeysInner$ = computed(async (get): Promise<unknown> => {
   const auth = get(authContext$);
@@ -20,4 +21,5 @@ export const zeroApiKeysRoutes: readonly RouteEntry[] = [
     route: apiKeysContract.list,
     handler: authRoute({}, listApiKeysInner$),
   },
+  ...zeroApiKeysDeleteRoutes,
 ];


### PR DESCRIPTION
## Summary

- First Wave 5 mutation validator (Stage 3 of #12290) — adds `apps/api` handler for `DELETE /api/zero/api-keys/:id`.
- User-only auth (no org context) — establishes the no-org mutation pattern for subsequent Wave 5 routes.
- Web `apps/web/.../[id]/route.ts` is unchanged; platform routes via `apiBackendMutationsEnabled$`. Dark-launched until the operator flips the flag.

## Implementation

- New: `apps/api/src/signals/routes/zero-api-keys-delete.ts` — single `DELETE … RETURNING` with two-clause WHERE (`id × userId`), 404 if zero rows, 204 on success. `signal.throwIfAborted()` after every `await`. `authRoute({}, …)` (no org).
- Wired into existing `zeroApiKeysRoutes` aggregate after `list`.
- Helper extension: `seedApiKeys$` now returns `tokenIds: readonly string[]` so the DELETE test can assert on the seeded row id. Existing list test reads only `userId` — backward compatible.
- New: 4 integration tests — 1 api-defensive 401 unauth + 3 web cases (success+DB-read-after-delete, 404 unknown id, 404 cross-user with DB-read-after-delete victim row).

## Behaviour parity notes

- 404 on no-row-returned covers both unknown id and cross-user with **no existence leak** — single branch in the WHERE clause does both.
- No realtime publish, no logging, no transaction (web pattern preserved).

## Test plan

- [x] `pnpm -F api exec vitest run signals/routes/__tests__/zero-api-keys-delete` — 4/4 pass
- [x] `pnpm -F api exec vitest run signals/routes/__tests__/zero-api-keys.test` — 4/4 pass (regression check on helper change)
- [x] `pnpm -F api exec vitest run` — 791/791 pass on @vm0/api (94 test files)
- [x] `pnpm turbo run lint --filter=api` — 0 warnings, 0 errors
- [x] `pnpm check-types` — all 11 workspaces clean
- [x] `pnpm format` — no changes
- [x] `pnpm knip` — no findings (only pre-existing config hints)
- [x] `apps/web/**` unchanged

Closes #12538

🤖 Generated with [Claude Code](https://claude.com/claude-code)