### PR TITLE
feat(api): port secrets DELETE [name] to api backend (Wave 5)

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-secrets-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-secrets-delete.test.ts
@@ -1,0 +1,218 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { zeroSecretsByNameContract } from "@vm0/api-contracts/contracts/zero-secrets";
+import { secrets } from "@vm0/db/schema/secret";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteUserData$,
+  seedOtherSecret$,
+  seedSecrets$,
+  type UserDataFixture,
+} from "./helpers/zero-user-data";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("DELETE /api/zero/secrets/:name", () => {
+  const track = createFixtureTracker<UserDataFixture>((fixture) => {
+    return store.set(deleteUserData$, fixture, context.signal);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(zeroSecretsByNameContract);
+    const response = await accept(
+      client.delete({ params: { name: "ANY_KEY" }, headers: {} }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroSecretsByNameContract);
+    const response = await accept(
+      client.delete({
+        params: { name: "ANY_KEY" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("deletes a secret successfully and removes the row", async () => {
+    const fixture = await track(
+      store.set(
+        seedSecrets$,
+        [{ name: "DELETE_ME", type: "user" }],
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroSecretsByNameContract);
+    const response = await client.delete({
+      params: { name: "DELETE_ME" },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(204);
+
+    // Row removed
+    const writeDb = store.set(writeDb$);
+    const remaining = await writeDb
+      .select({ id: secrets.id })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, fixture.orgId),
+          eq(secrets.userId, fixture.userId),
+          eq(secrets.name, "DELETE_ME"),
+        ),
+      );
+    expect(remaining).toStrictEqual([]);
+  });
+
+  it("returns 404 for a nonexistent secret", async () => {
+    const fixture = await track(store.set(seedSecrets$, [], context.signal));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroSecretsByNameContract);
+    const response = await accept(
+      client.delete({
+        params: { name: "NONEXISTENT" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: {
+        message: 'Secret "NONEXISTENT" not found',
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 404 for a secret owned by another user (cross-user isolation)", async () => {
+    const fixture = await track(store.set(seedSecrets$, [], context.signal));
+    // Another user in the same org has the secret named OTHER_USER_SECRET.
+    await store.set(seedOtherSecret$, fixture, context.signal);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroSecretsByNameContract);
+    const response = await accept(
+      client.delete({
+        params: { name: "OTHER_USER_SECRET" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND" },
+    });
+
+    // Sanity: the victim row is still there (not silently deleted).
+    const writeDb = store.set(writeDb$);
+    const victim = await writeDb
+      .select({ id: secrets.id })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, fixture.orgId),
+          eq(secrets.name, "OTHER_USER_SECRET"),
+        ),
+      );
+    expect(victim).toHaveLength(1);
+  });
+
+  it("returns 404 for a secret in another org (cross-org isolation)", async () => {
+    const orgAFixture = await track(
+      store.set(
+        seedSecrets$,
+        [{ name: "ORG_A_SECRET", type: "user" }],
+        context.signal,
+      ),
+    );
+
+    // Authenticate as a different user in a different org.
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroSecretsByNameContract);
+    const response = await accept(
+      client.delete({
+        params: { name: "ORG_A_SECRET" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND" },
+    });
+
+    // Sanity: the victim row is still there in org A.
+    const writeDb = store.set(writeDb$);
+    const victim = await writeDb
+      .select({ id: secrets.id, orgId: secrets.orgId })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, orgAFixture.orgId),
+          eq(secrets.name, "ORG_A_SECRET"),
+        ),
+      );
+    expect(victim).toHaveLength(1);
+    expect(victim[0]?.orgId).toBe(orgAFixture.orgId);
+  });
+
+  it("does NOT delete non-user-type secrets (type filter regression guard)", async () => {
+    const fixture = await track(
+      store.set(
+        seedSecrets$,
+        [{ name: "CONNECTOR_SECRET", type: "connector" }],
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroSecretsByNameContract);
+    const response = await accept(
+      client.delete({
+        params: { name: "CONNECTOR_SECRET" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND" },
+    });
+
+    // Sanity: the connector secret row is preserved.
+    const writeDb = store.set(writeDb$);
+    const victim = await writeDb
+      .select({ id: secrets.id, type: secrets.type })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, fixture.orgId),
+          eq(secrets.userId, fixture.userId),
+          eq(secrets.name, "CONNECTOR_SECRET"),
+        ),
+      );
+    expect(victim).toHaveLength(1);
+    expect(victim[0]?.type).toBe("connector");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-secrets-delete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-secrets-delete.ts
@@ -1,0 +1,48 @@
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { zeroSecretsByNameContract } from "@vm0/api-contracts/contracts/zero-secrets";
+import { secrets } from "@vm0/db/schema/secret";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import { notFound } from "../../lib/error";
+import type { RouteEntry } from "../route";
+
+const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(zeroSecretsByNameContract.delete));
+  signal.throwIfAborted();
+
+  const writeDb = set(writeDb$);
+  // Match web's filter: only user-type secrets are deletable through this
+  // route. Connector / model-provider secrets are managed via dedicated routes.
+  const deleted = await writeDb
+    .delete(secrets)
+    .where(
+      and(
+        eq(secrets.orgId, auth.orgId),
+        eq(secrets.userId, auth.userId),
+        eq(secrets.name, params.name),
+        eq(secrets.type, "user"),
+      ),
+    )
+    .returning({ id: secrets.id });
+  signal.throwIfAborted();
+
+  if (deleted.length === 0) {
+    return notFound(`Secret "${params.name}" not found`);
+  }
+  return { status: 204 as const, body: undefined };
+});
+
+export const zeroSecretsDeleteRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroSecretsByNameContract.delete,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      deleteInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-secrets.ts
+++ b/turbo/apps/api/src/signals/routes/zero-secrets.ts
@@ -8,6 +8,7 @@ import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import type { RouteEntry } from "../route";
 import { userSecrets, userVariables } from "../services/zero-user-data.service";
+import { zeroSecretsDeleteRoutes } from "./zero-secrets-delete";
 
 const listSecretsInner$ = computed(async (get): Promise<unknown> => {
   const auth = get(organizationAuthContext$);
@@ -46,4 +47,5 @@ export const zeroSecretsRoutes: readonly RouteEntry[] = [
       listVariablesInner$,
     ),
   },
+  ...zeroSecretsDeleteRoutes,
 ];


### PR DESCRIPTION
## Summary

Wave 5 mutation route migration. Ports `DELETE /api/zero/secrets/:name` (org+user scoped per-user secret deletion) from apps/web to apps/api.

- New `apps/api/src/signals/routes/zero-secrets-delete.ts`: `organizationAuthContext\$` + `DELETE … RETURNING` (single roundtrip; `result.length === 0` → 404). Filters by `type='user'` to match web's service — connector / model-provider secrets are not deletable through this route.
- Existing `zero-secrets.ts` route table extended by spreading the new routes.
- 7 integration tests cover: 401 unauth, 401 missing-org (api defensive), 204 success with DB read-after-delete, 404 nonexistent (asserts message text `Secret \"NAME\" not found`), 404 cross-user isolation with victim-row sanity check, 404 cross-org isolation with victim-row sanity check, 404 type-filter regression guard (connector-type secret with same name is NOT deleted by this route).

apps/web DELETE handler **unchanged**. Operator flips `ApiBackendMutations` to switch traffic per-org.

> Note on test count: leader's dispatch said 3 web + 3 api defensive = 6. Added one more api defensive test for the `type='user'` filter regression. Web's service has the filter; this PR preserves it; the test is the regression guard. Cheap (~25 LOC) and high-value.

Closes #12539.

## Pattern conventions reinforced for Wave 5+

| Concern | Convention |
|---|---|
| Single-mutation route with no shared validation | Inline DB in handler — extract to service when ≥2 callers |
| Atomicity-friendly deletes | `DELETE … RETURNING` over SELECT-then-DELETE |
| Type filters | Preserve verbatim from web; add regression test when scope-relevant |
| Cross-user / cross-org tests | Standard for any `[name]/[id]` route |

## Routing matrix (recap)

| `ApiBackend` | `ApiBackendMutations` | DELETE host |
|:------------:|:---------------------:|:-----------:|
| OFF          | OFF                   | www         |
| OFF          | ON                    | api         |
| ON           | *                     | api         |

## Rollout / Rollback

Standard: flag default OFF; staff org flipped first; revert PR or flip flag for instant rollback.

## Test plan

- [x] 7 integration tests pass locally
- [x] DB read-after-delete confirms removal in 204 path
- [x] Cross-user / cross-org / type-filter rows preserved when DELETE returns 404
- [x] 404 message text matches web's interpolated string verbatim
- [x] No \`apps/web/**\` modified
- [x] tests / lint / types / format / knip all pass (full api suite: 95 files / 801 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)