### PR TITLE
refactor(api): migrate feature-switches POST + DELETE to api backend (Wave 5 file-closer)

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -2,8 +2,11 @@ import { randomUUID } from "node:crypto";
 
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
 import {
   deleteFeatureSwitches$,
   seedFeatureSwitches$,
@@ -17,6 +20,23 @@ import {
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
+
+async function getRowSwitches(
+  orgId: string,
+  userId: string,
+): Promise<Record<string, boolean> | undefined> {
+  const writeDb = store.set(writeDb$);
+  const [row] = await writeDb
+    .select({ switches: userFeatureSwitches.switches })
+    .from(userFeatureSwitches)
+    .where(
+      and(
+        eq(userFeatureSwitches.orgId, orgId),
+        eq(userFeatureSwitches.userId, userId),
+      ),
+    );
+  return row ? (row.switches as Record<string, boolean>) : undefined;
+}
 
 describe("GET /api/zero/feature-switches", () => {
   const track = createFixtureTracker<FeatureSwitchesFixture>((fixture) => {
@@ -102,5 +122,223 @@ describe("GET /api/zero/feature-switches", () => {
     );
 
     expect(response.body).toStrictEqual({ switches: {} });
+  });
+});
+
+describe("POST /api/zero/feature-switches", () => {
+  const track = createFixtureTracker<FeatureSwitchesFixture>((fixture) => {
+    return store.set(deleteFeatureSwitches$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroFeatureSwitchesContract);
+
+    const response = await accept(
+      client.update({
+        headers: {},
+        body: { switches: { voiceChat: true } },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const client = setupApp({ context })(zeroFeatureSwitchesContract);
+
+    const response = await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { switches: { voiceChat: true } },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("creates new switches for a user with no override row", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await track(Promise.resolve({ orgId, userId }));
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroFeatureSwitchesContract);
+
+    const response = await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { switches: { voiceChat: true } },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ switches: { voiceChat: true } });
+
+    await expect(getRowSwitches(orgId, userId)).resolves.toStrictEqual({
+      voiceChat: true,
+    });
+  });
+
+  it("merges with existing switches (preserves untouched keys)", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await track(Promise.resolve({ orgId, userId }));
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroFeatureSwitchesContract);
+
+    await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { switches: { voiceChat: true } },
+      }),
+      [200],
+    );
+
+    const response = await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { switches: { lab: false } },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      switches: { voiceChat: true, lab: false },
+    });
+
+    await expect(getRowSwitches(orgId, userId)).resolves.toStrictEqual({
+      voiceChat: true,
+      lab: false,
+    });
+  });
+
+  it("overrides existing switch values for the same key", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await track(Promise.resolve({ orgId, userId }));
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroFeatureSwitchesContract);
+
+    await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { switches: { voiceChat: true } },
+      }),
+      [200],
+    );
+
+    const response = await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { switches: { voiceChat: false } },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ switches: { voiceChat: false } });
+
+    await expect(getRowSwitches(orgId, userId)).resolves.toStrictEqual({
+      voiceChat: false,
+    });
+  });
+
+  it("returns updated switches on subsequent GET", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await track(Promise.resolve({ orgId, userId }));
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroFeatureSwitchesContract);
+
+    await accept(
+      client.update({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { switches: { voiceChat: true, lab: false } },
+      }),
+      [200],
+    );
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      switches: { voiceChat: true, lab: false },
+    });
+  });
+});
+
+describe("DELETE /api/zero/feature-switches", () => {
+  const track = createFixtureTracker<FeatureSwitchesFixture>((fixture) => {
+    return store.set(deleteFeatureSwitches$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroFeatureSwitchesContract);
+
+    const response = await accept(client.delete({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const client = setupApp({ context })(zeroFeatureSwitchesContract);
+
+    const response = await accept(
+      client.delete({ headers: { authorization: "Bearer clerk-session" } }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("clears all overrides; subsequent GET returns empty switches", async () => {
+    const fixture = await track(
+      store.set(
+        seedFeatureSwitches$,
+        { voiceChat: true, lab: false },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroFeatureSwitchesContract);
+
+    const deleteResponse = await accept(
+      client.delete({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(deleteResponse.body).toStrictEqual({ deleted: true });
+
+    await expect(
+      getRowSwitches(fixture.orgId, fixture.userId),
+    ).resolves.toBeUndefined();
+
+    const getResponse = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(getResponse.body).toStrictEqual({ switches: {} });
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
@@ -1,10 +1,20 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import {
+  deleteUserFeatureSwitches$,
+  updateUserFeatureSwitches$,
+  userFeatureSwitchOverrides,
+} from "../services/feature-switches.service";
+
+const featureSwitchesAuthOptions = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+} as const;
 
 const getFeatureSwitchesInner$ = computed(async (get): Promise<unknown> => {
   const auth = get(organizationAuthContext$);
@@ -17,12 +27,56 @@ const getFeatureSwitchesInner$ = computed(async (get): Promise<unknown> => {
   };
 });
 
+const updateFeatureSwitchesBody$ = bodyResultOf(
+  zeroFeatureSwitchesContract.update,
+);
+
+const updateFeatureSwitchesInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const bodyResult = await get(updateFeatureSwitchesBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const switches = await set(
+      updateUserFeatureSwitches$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        switches: bodyResult.data.switches,
+      },
+      signal,
+    );
+
+    return { status: 200 as const, body: { switches } };
+  },
+);
+
+const deleteFeatureSwitchesInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    await set(
+      deleteUserFeatureSwitches$,
+      { orgId: auth.orgId, userId: auth.userId },
+      signal,
+    );
+    return { status: 200 as const, body: { deleted: true as const } };
+  },
+);
+
 export const zeroFeatureSwitchesRoutes: readonly RouteEntry[] = [
   {
     route: zeroFeatureSwitchesContract.get,
-    handler: authRoute(
-      { requireOrganization: true, missingOrganizationStatus: 401 },
-      getFeatureSwitchesInner$,
-    ),
+    handler: authRoute(featureSwitchesAuthOptions, getFeatureSwitchesInner$),
+  },
+  {
+    route: zeroFeatureSwitchesContract.update,
+    handler: authRoute(featureSwitchesAuthOptions, updateFeatureSwitchesInner$),
+  },
+  {
+    route: zeroFeatureSwitchesContract.delete,
+    handler: authRoute(featureSwitchesAuthOptions, deleteFeatureSwitchesInner$),
   },
 ];

--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -1,8 +1,9 @@
-import { computed, type Computed } from "ccstate";
+import { command, computed, type Computed } from "ccstate";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { and, eq } from "drizzle-orm";
 
-import { db$ } from "../external/db";
+import { db$, writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
 
 export function userFeatureSwitchOverrides(
   orgId: string,
@@ -24,3 +25,69 @@ export function userFeatureSwitchOverrides(
     return row?.switches ?? {};
   });
 }
+
+export const updateUserFeatureSwitches$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly switches: Record<string, boolean>;
+    },
+    signal: AbortSignal,
+  ): Promise<Record<string, boolean>> => {
+    const writeDb = set(writeDb$);
+
+    const [existingRow] = await writeDb
+      .select({ switches: userFeatureSwitches.switches })
+      .from(userFeatureSwitches)
+      .where(
+        and(
+          eq(userFeatureSwitches.orgId, args.orgId),
+          eq(userFeatureSwitches.userId, args.userId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    const existing =
+      (existingRow?.switches as Record<string, boolean> | undefined) ?? {};
+    const merged: Record<string, boolean> = { ...existing, ...args.switches };
+    const now = nowDate();
+
+    await writeDb
+      .insert(userFeatureSwitches)
+      .values({
+        orgId: args.orgId,
+        userId: args.userId,
+        switches: merged,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
+        set: { switches: merged, updatedAt: now },
+      });
+    signal.throwIfAborted();
+
+    return merged;
+  },
+);
+
+export const deleteUserFeatureSwitches$ = command(
+  async (
+    { set },
+    args: { readonly orgId: string; readonly userId: string },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(userFeatureSwitches)
+      .where(
+        and(
+          eq(userFeatureSwitches.orgId, args.orgId),
+          eq(userFeatureSwitches.userId, args.userId),
+        ),
+      );
+    signal.throwIfAborted();
+  },
+);


### PR DESCRIPTION
## Summary

- Migrates `POST /api/zero/feature-switches` (merge-update) and `DELETE /api/zero/feature-switches` (clear all) from `apps/web` to `apps/api`. **Wave 5 file-closer** — both routes share the same web source file. After this lands and the rollout flag flips, `turbo/apps/web/app/api/zero/feature-switches/route.ts` holds zero routes and can be removed in a follow-up cleanup PR.
- Behavior 1:1 with web — SELECT-then-UPSERT shallow merge for POST; single DELETE for DELETE. No realtime publish (web doesn't either; feature-switch state is per-request, not subscribed).

## Why one PR

Both web routes share the source file and the target file. Splitting into two PRs would generate sibling rebase churn on `apps/api/src/signals/routes/zero-feature-switches.ts`. The 7 web tests + 2 api defensive tests are easier to read in one cohesive describe-block layout.

## Auth

Both routes use the same gate: `{ requireOrganization: true, missingOrganizationStatus: 401 }`. GET, POST, and DELETE now all share a hoisted module-level constant (`featureSwitchesAuthOptions`) — DRY across the three verbs and any future addition.

No admin role check. Feature-switches are user-keyed; any org member can update/clear their own overrides — matches web exactly.

## Lost-update race (web parity, NOT a bug to fix here)

The merge does `SELECT existing → compute merged → INSERT ... ON CONFLICT DO UPDATE`. Two concurrent POSTs on disjoint keys can race: each reads the same `existing`, computes a merged set without the other's key, and the last upsert wins — losing one writer's update. **Web has the same race.** Fixing it (e.g., `INSERT ... ON CONFLICT DO UPDATE SET switches = current.switches || EXCLUDED.switches`) would diverge from web during the rollout-window shadow comparison, masking real differences and surfacing fake ones. Out of scope here; file a follow-up after both backends are aligned and the flag flips.

## DELETE response

`{ status: 200, body: { deleted: true as const } }`. The contract requires `z.literal(true)` on the response — the `as const` keeps the response shape compatible with ts-rest validation.

## Files

- `turbo/apps/api/src/signals/services/feature-switches.service.ts` — adds `updateUserFeatureSwitches$` and `deleteUserFeatureSwitches$` ccstate `command`s; existing reader unchanged.
- `turbo/apps/api/src/signals/routes/zero-feature-switches.ts` — hoists auth options to a constant, adds `updateInner$` and `deleteInner$`, extends `zeroFeatureSwitchesRoutes` from one entry to three.
- `turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts` — appends POST describe (6 cases) and DELETE describe (3 cases) below the existing GET describe (4 cases unchanged).
- **No contract change.** **No web change.** **No new helper.**

## Tests

| # | Verb | Case | Asserts |
|---|---|---|---|
| 1 | POST | 401 unauthenticated | body `{ error.code: UNAUTHORIZED }` |
| 2 | POST | 401 missing-org | body `{ error.code: UNAUTHORIZED }` |
| 3 | POST | creates new switches | body `{ switches: { voiceChat: true } }` + DB read-after-write |
| 4 | POST | merges with existing | POST `{voiceChat:true}` then `{lab:false}` → `{voiceChat:true, lab:false}` + DB |
| 5 | POST | overrides existing key | POST `{voiceChat:true}` then `{voiceChat:false}` → `{voiceChat:false}` + DB |
| 6 | POST | round-trip via GET | POST then GET returns the same switches |
| 7 | DELETE | 401 unauthenticated | body `{ error.code: UNAUTHORIZED }` |
| 8 | DELETE | 401 missing-org | body `{ error.code: UNAUTHORIZED }` |
| 9 | DELETE | clears all + GET empty | body `{ deleted: true }`; DB row removed; subsequent GET returns `{ switches: {} }` |

Existing 4 GET cases unchanged.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feature-switches.test.ts` — 13 passed (4 GET + 6 POST + 3 DELETE)
- [x] `pnpm -F api exec vitest run` — 803 passed
- [x] `pnpm -F api run lint` — clean
- [x] `pnpm -F api run check-types` — clean
- [x] `pnpm format` / `pnpm knip --workspace api` — clean

Closes #12541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)