### PR TITLE
refactor(api): migrate composes delete to api backend (wave 5)

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -163,6 +163,14 @@ vi.mock("@aws-sdk/client-s3", () => {
     }
   }
 
+  class DeleteObjectsCommand {
+    readonly input: unknown;
+
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+
   class S3Client {
     send(command: unknown): Promise<unknown> {
       return apiTestMocks.s3.send(command);
@@ -170,6 +178,7 @@ vi.mock("@aws-sdk/client-s3", () => {
   }
 
   return {
+    DeleteObjectsCommand,
     GetObjectCommand,
     ListObjectsV2Command,
     S3Client,

--- a/turbo/apps/api/src/lib/error.ts
+++ b/turbo/apps/api/src/lib/error.ts
@@ -18,6 +18,10 @@ export function notFound(message: string) {
   return httpError(404, "NOT_FOUND", message);
 }
 
+export function conflict(message: string) {
+  return httpError(409, "CONFLICT", message);
+}
+
 export function badRequestMessage(message: string) {
   return httpError(400, "BAD_REQUEST", message);
 }

--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -1,5 +1,6 @@
 import { computed, type Computed } from "ccstate";
 import {
+  DeleteObjectsCommand,
   GetObjectCommand,
   ListObjectsV2Command,
   S3Client,
@@ -70,6 +71,28 @@ export function listS3Objects(
     } while (continuationToken);
 
     return objects;
+  });
+}
+
+export function deleteS3Objects(
+  bucket: string,
+  keys: readonly string[],
+): Computed<Promise<void>> {
+  return computed(async (get): Promise<void> => {
+    if (keys.length === 0) {
+      return;
+    }
+    const client = get(s3Client$);
+    await client.send(
+      new DeleteObjectsCommand({
+        Bucket: bucket,
+        Delete: {
+          Objects: keys.map((Key) => {
+            return { Key };
+          }),
+        },
+      }),
+    );
   });
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-composes-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-composes-delete.test.ts
@@ -1,0 +1,194 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { zeroComposesByIdContract } from "@vm0/api-contracts/contracts/zero-composes";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteTeamCompose$,
+  seedTeamCompose$,
+  type TeamComposeFixture,
+} from "./helpers/zero-team";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("DELETE /api/zero/composes/:id", () => {
+  const track = createFixtureTracker<TeamComposeFixture>((fixture) => {
+    return store.set(deleteTeamCompose$, fixture, context.signal);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(zeroComposesByIdContract);
+    const response = await accept(
+      client.delete({ params: { id: randomUUID() }, headers: {} }),
+      [401],
+    );
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("deletes the caller's own compose (DB read-after-delete)", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, { composes: [{}] }, context.signal),
+    );
+    const composeId = fixture.composeIds[0];
+    if (!composeId) {
+      throw new Error("Expected seeded compose");
+    }
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    // S3 listObjects returns empty; storages row not seeded so this won't be hit, but defensive.
+    mocks.s3.listObjects([]);
+
+    const client = setupApp({ context })(zeroComposesByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: composeId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+    expect(response.body).toBeUndefined();
+
+    const writeDb = store.set(writeDb$);
+    const composeRows = await writeDb
+      .select()
+      .from(agentComposes)
+      .where(eq(agentComposes.id, composeId));
+    expect(composeRows).toHaveLength(0);
+  });
+
+  it("returns 404 for an unknown id", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, `org_${randomUUID().slice(0, 8)}`);
+    const client = setupApp({ context })(zeroComposesByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Agent not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 404 when another user owns the compose (no-leak)", async () => {
+    const victimFixture = await track(
+      store.set(seedTeamCompose$, { composes: [{}] }, context.signal),
+    );
+    const victimComposeId = victimFixture.composeIds[0];
+    if (!victimComposeId) {
+      throw new Error("Expected seeded compose");
+    }
+
+    const attackerUserId = `user_${randomUUID().slice(0, 8)}`;
+    mocks.clerk.session(attackerUserId, `org_${randomUUID().slice(0, 8)}`);
+
+    const client = setupApp({ context })(zeroComposesByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: victimComposeId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Agent not found", code: "NOT_FOUND" },
+    });
+
+    // No-leak: victim row physically still exists.
+    const writeDb = store.set(writeDb$);
+    const [survivor] = await writeDb
+      .select()
+      .from(agentComposes)
+      .where(eq(agentComposes.id, victimComposeId));
+    expect(survivor).toBeDefined();
+    expect(survivor?.userId).toBe(victimFixture.userId);
+  });
+
+  it("returns 409 when a pending run references the compose", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, { composes: [{}] }, context.signal),
+    );
+    const composeId = fixture.composeIds[0];
+    if (!composeId) {
+      throw new Error("Expected seeded compose");
+    }
+    const writeDb = store.set(writeDb$);
+
+    // Inline seed: a version + session + pending run.
+    const versionId = `v_${randomUUID().slice(0, 16)}`;
+    const sessionId = randomUUID();
+    const runId = randomUUID();
+    await writeDb.insert(agentComposeVersions).values({
+      id: versionId,
+      composeId,
+      content: {},
+      createdBy: fixture.userId,
+    });
+    await writeDb.insert(agentSessions).values({
+      id: sessionId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      agentComposeId: composeId,
+    });
+    await writeDb.insert(agentRuns).values({
+      id: runId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      agentComposeVersionId: versionId,
+      sessionId,
+      status: "pending",
+      prompt: "x",
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroComposesByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: composeId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [409],
+    );
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Cannot delete agent: agent is currently running",
+        code: "CONFLICT",
+      },
+    });
+
+    // No-leak: compose + run still present after 409.
+    const composeRows = await writeDb
+      .select()
+      .from(agentComposes)
+      .where(eq(agentComposes.id, composeId));
+    expect(composeRows).toHaveLength(1);
+    const runRows = await writeDb
+      .select()
+      .from(agentRuns)
+      .where(eq(agentRuns.id, runId));
+    expect(runRows).toHaveLength(1);
+
+    // Manual inline cleanup so deleteTeamCompose$ can drop the compose cleanly.
+    await writeDb.delete(agentRuns).where(eq(agentRuns.id, runId));
+    await writeDb.delete(agentSessions).where(eq(agentSessions.id, sessionId));
+    await writeDb
+      .delete(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, versionId));
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-composes.ts
+++ b/turbo/apps/api/src/signals/routes/zero-composes.ts
@@ -1,4 +1,4 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import {
   zeroComposesByIdContract,
   zeroComposesListContract,
@@ -8,8 +8,9 @@ import {
 import { authContext$, organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf, queryOf } from "../context/request";
-import { notFound } from "../../lib/error";
+import { isNotFoundResponse, notFound } from "../../lib/error";
 import {
+  deleteCompose$,
   zeroComposeById,
   zeroComposeByName,
   zeroComposeList,
@@ -63,6 +64,29 @@ const listComposesInner$ = computed(async (get) => {
   return { status: 200 as const, body: { composes: [...result.composes] } };
 });
 
+const deleteComposeInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(authContext$);
+    const params = get(pathParamsOf(zeroComposesByIdContract.delete));
+    signal.throwIfAborted();
+
+    const result = await set(
+      deleteCompose$,
+      { composeId: params.id, userId: auth.userId },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (isNotFoundResponse(result)) {
+      return result;
+    }
+    if (result?.status === 409) {
+      return result;
+    }
+    return { status: 204 as const, body: undefined };
+  },
+);
+
 const orgAuth = {
   requireOrganization: true,
   missingOrganizationStatus: 401,
@@ -83,5 +107,9 @@ export const zeroComposesRoutes: readonly RouteEntry[] = [
   {
     route: zeroComposesByIdContract.getById,
     handler: authRoute(orgAuth, getComposeByIdInner$),
+  },
+  {
+    route: zeroComposesByIdContract.delete,
+    handler: authRoute({}, deleteComposeInner$),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-compose-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-compose-data.service.ts
@@ -1,4 +1,4 @@
-import { computed, type Computed } from "ccstate";
+import { command, computed, type Computed } from "ccstate";
 import type {
   ComposeListItem,
   ComposeResponse,
@@ -7,10 +7,16 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { storages } from "@vm0/db/schema/storage";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { and, desc, eq } from "drizzle-orm";
+import { getInstructionsStorageName } from "@vm0/core/storage-names";
+import { and, desc, eq, inArray } from "drizzle-orm";
 
-import { db$ } from "../external/db";
+import { db$, writeDb$ } from "../external/db";
+import { deleteS3Objects, listS3Objects } from "../external/s3";
+import { env } from "../../lib/env";
+import { conflict, notFound } from "../../lib/error";
 
 type ComposeContent = ComposeResponse["content"];
 
@@ -158,3 +164,125 @@ export function zeroComposeList(
     };
   });
 }
+
+type NotFoundResponse = ReturnType<typeof notFound>;
+type ConflictResponse = ReturnType<typeof conflict>;
+
+const ACTIVE_RUN_STATUSES = ["pending", "running"] as const;
+
+export const deleteCompose$ = command(
+  async (
+    { get, set },
+    args: { readonly composeId: string; readonly userId: string },
+    signal: AbortSignal,
+  ): Promise<NotFoundResponse | ConflictResponse | undefined> => {
+    const writeDb = set(writeDb$);
+
+    const result = await writeDb.transaction(async (tx) => {
+      const [compose] = await tx
+        .select({
+          id: agentComposes.id,
+          name: agentComposes.name,
+          orgId: agentComposes.orgId,
+        })
+        .from(agentComposes)
+        .where(
+          and(
+            eq(agentComposes.id, args.composeId),
+            eq(agentComposes.userId, args.userId),
+          ),
+        )
+        .limit(1);
+
+      if (!compose) {
+        return { kind: "not-found" as const };
+      }
+
+      const [activeRun] = await tx
+        .select({ id: agentRuns.id })
+        .from(agentRuns)
+        .innerJoin(
+          agentComposeVersions,
+          eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+        )
+        .where(
+          and(
+            eq(agentComposeVersions.composeId, args.composeId),
+            inArray(agentRuns.status, [...ACTIVE_RUN_STATUSES]),
+          ),
+        )
+        .limit(1);
+
+      if (activeRun) {
+        return { kind: "conflict" as const };
+      }
+
+      const versionRows = await tx
+        .select({ id: agentComposeVersions.id })
+        .from(agentComposeVersions)
+        .where(eq(agentComposeVersions.composeId, args.composeId));
+
+      if (versionRows.length > 0) {
+        await tx.delete(agentRuns).where(
+          inArray(
+            agentRuns.agentComposeVersionId,
+            versionRows.map((row) => {
+              return row.id;
+            }),
+          ),
+        );
+      }
+
+      await tx
+        .delete(agentComposes)
+        .where(eq(agentComposes.id, args.composeId));
+
+      const storageName = getInstructionsStorageName(compose.name);
+      const [storage] = await tx
+        .select({ id: storages.id, s3Prefix: storages.s3Prefix })
+        .from(storages)
+        .where(
+          and(
+            eq(storages.orgId, compose.orgId),
+            eq(storages.name, storageName),
+            eq(storages.type, "volume"),
+          ),
+        )
+        .limit(1);
+
+      if (storage) {
+        await tx.delete(storages).where(eq(storages.id, storage.id));
+      }
+
+      return {
+        kind: "deleted" as const,
+        s3Prefix: storage?.s3Prefix ?? null,
+      };
+    });
+    signal.throwIfAborted();
+
+    if (result.kind === "not-found") {
+      return notFound("Agent not found");
+    }
+    if (result.kind === "conflict") {
+      return conflict("Cannot delete agent: agent is currently running");
+    }
+
+    if (result.s3Prefix) {
+      const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+      const objects = await get(listS3Objects(bucket, result.s3Prefix));
+      signal.throwIfAborted();
+      await get(
+        deleteS3Objects(
+          bucket,
+          objects.map((obj) => {
+            return obj.key;
+          }),
+        ),
+      );
+      signal.throwIfAborted();
+    }
+
+    return undefined;
+  },
+);


### PR DESCRIPTION
## Summary

- Wave 5 #4 of #12290 — adds `DELETE /api/zero/composes/:id` to existing `apps/api/src/signals/routes/zero-composes.ts`.
- **First api 409 CONFLICT route.** Introduces `conflict()` primitive to `lib/error.ts` (mirrors `notFound()` shape).
- **First api S3-cleanup route.** Adds `deleteS3Objects` helper to `signals/external/s3.ts`.
- Web `apps/web/.../[id]/route.ts` is unchanged; platform routes via `apiBackendMutationsEnabled\$`. Dark-launched until the operator flips the flag.

## Implementation

- `lib/error.ts`: `conflict(message)` helper (no `isConflictResponse` type guard yet — leader's knip-flag rule, route uses direct `result?.status === 409` check).
- `external/s3.ts`: `deleteS3Objects(bucket, keys)` using `@aws-sdk/client-s3` `DeleteObjectsCommand`. Test mock class added to centralized `__tests__/mocks.ts`.
- `services/zero-compose-data.service.ts`: `deleteCompose\$` Command. Inside a single `writeDb.transaction(...)`: ownership check (404), active-run conflict check (409), agentRuns delete (FK is SET NULL — explicit cleanup), agentComposes delete (cascades versions/schedules), storages-row delete. Post-commit S3 cleanup outside the transaction. `signal.throwIfAborted()` after the transaction and after each S3 call.
- `routes/zero-composes.ts`: `deleteComposeInner\$` command using `authContext\$` (user-only — matches web). 4th entry in `zeroComposesRoutes`. The file now hosts three auth shapes: orgAuth (getByName/getById), `acceptAnySandboxCapability` (list), and `{}` (delete). Acceptable.

## Test plan (5 tests)

- [x] 401 unauthenticated (web case 3)
- [x] 204 deletes caller's compose (web case 1) — DB read-after confirms compose gone
- [x] 404 unknown id (web case 2) — verbatim error body shape
- [x] 404 cross-user (api defensive) — DB read-after confirms victim row preserved
- [x] 409 pending run references compose (api defensive) — verbatim message; DB read-after confirms compose + run preserved

Conflict test inline-seeds `agentComposeVersions + agentSessions + agentRuns(status='pending')` and cleans up at end-of-test. No helper extension.

## Gates

- [x] `pnpm -F api exec vitest run signals/routes/__tests__/zero-composes-delete` — 5/5 pass
- [x] `pnpm -F api exec vitest run` — 803/803 pass on @vm0/api workspace (96 test files)
- [x] `pnpm turbo run lint --filter=api` — 0 warnings, 0 errors
- [x] `pnpm check-types` — all 11 workspaces clean
- [x] `pnpm format` — no changes
- [x] `pnpm knip` — no findings (only pre-existing config hints)
- [x] `apps/web/**` unchanged

Closes #12544

🤖 Generated with [Claude Code](https://claude.com/claude-code)