### PR TITLE
feat(api): migrate variables delete [name] to api backend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-variables-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-variables-delete.test.ts
@@ -1,0 +1,180 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { zeroVariablesByNameContract } from "@vm0/api-contracts/contracts/zero-secrets";
+import { variables } from "@vm0/db/schema/variable";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteUserData$,
+  seedOtherVariable$,
+  seedVariables$,
+  type UserDataFixture,
+} from "./helpers/zero-user-data";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("DELETE /api/zero/variables/:name", () => {
+  const track = createFixtureTracker<UserDataFixture>((fixture) => {
+    return store.set(deleteUserData$, fixture, context.signal);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(zeroVariablesByNameContract);
+    const response = await accept(
+      client.delete({ params: { name: "ANY_VAR" }, headers: {} }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroVariablesByNameContract);
+    const response = await accept(
+      client.delete({
+        params: { name: "ANY_VAR" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("deletes a variable successfully and removes the row", async () => {
+    const fixture = await track(
+      store.set(
+        seedVariables$,
+        [{ name: "DELETE_ME", value: "to-be-deleted" }],
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroVariablesByNameContract);
+    const response = await client.delete({
+      params: { name: "DELETE_ME" },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(204);
+
+    // Row removed
+    const writeDb = store.set(writeDb$);
+    const remaining = await writeDb
+      .select({ id: variables.id })
+      .from(variables)
+      .where(
+        and(
+          eq(variables.orgId, fixture.orgId),
+          eq(variables.userId, fixture.userId),
+          eq(variables.name, "DELETE_ME"),
+        ),
+      );
+    expect(remaining).toStrictEqual([]);
+  });
+
+  it("returns 404 for a nonexistent variable", async () => {
+    const fixture = await track(store.set(seedVariables$, [], context.signal));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroVariablesByNameContract);
+    const response = await accept(
+      client.delete({
+        params: { name: "NONEXISTENT" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: {
+        message: 'Variable "NONEXISTENT" not found',
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 404 for a variable owned by another user (cross-user isolation)", async () => {
+    const fixture = await track(store.set(seedVariables$, [], context.signal));
+    // Another user in the same org owns OTHER_USER_VAR.
+    await store.set(seedOtherVariable$, fixture, context.signal);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroVariablesByNameContract);
+    const response = await accept(
+      client.delete({
+        params: { name: "OTHER_USER_VAR" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND" },
+    });
+
+    // Sanity: the victim row is still there (not silently deleted).
+    const writeDb = store.set(writeDb$);
+    const victim = await writeDb
+      .select({ id: variables.id })
+      .from(variables)
+      .where(
+        and(
+          eq(variables.orgId, fixture.orgId),
+          eq(variables.name, "OTHER_USER_VAR"),
+        ),
+      );
+    expect(victim).toHaveLength(1);
+  });
+
+  it("returns 404 for a variable in another org (cross-org isolation)", async () => {
+    const orgAFixture = await track(
+      store.set(
+        seedVariables$,
+        [{ name: "ORG_A_VAR", value: "value-a" }],
+        context.signal,
+      ),
+    );
+
+    // Authenticate as a different user in a different org.
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroVariablesByNameContract);
+    const response = await accept(
+      client.delete({
+        params: { name: "ORG_A_VAR" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND" },
+    });
+
+    // Sanity: the victim row is still there in org A.
+    const writeDb = store.set(writeDb$);
+    const victim = await writeDb
+      .select({ id: variables.id, orgId: variables.orgId })
+      .from(variables)
+      .where(
+        and(
+          eq(variables.orgId, orgAFixture.orgId),
+          eq(variables.name, "ORG_A_VAR"),
+        ),
+      );
+    expect(victim).toHaveLength(1);
+    expect(victim[0]?.orgId).toBe(orgAFixture.orgId);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-secrets.ts
+++ b/turbo/apps/api/src/signals/routes/zero-secrets.ts
@@ -9,6 +9,7 @@ import { authRoute } from "../auth/auth-route";
 import type { RouteEntry } from "../route";
 import { userSecrets, userVariables } from "../services/zero-user-data.service";
 import { zeroSecretsDeleteRoutes } from "./zero-secrets-delete";
+import { zeroVariablesDeleteRoutes } from "./zero-variables-delete";
 
 const listSecretsInner$ = computed(async (get): Promise<unknown> => {
   const auth = get(organizationAuthContext$);
@@ -48,4 +49,5 @@ export const zeroSecretsRoutes: readonly RouteEntry[] = [
     ),
   },
   ...zeroSecretsDeleteRoutes,
+  ...zeroVariablesDeleteRoutes,
 ];

--- a/turbo/apps/api/src/signals/routes/zero-variables-delete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-variables-delete.ts
@@ -1,0 +1,47 @@
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { zeroVariablesByNameContract } from "@vm0/api-contracts/contracts/zero-secrets";
+import { variables } from "@vm0/db/schema/variable";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { writeDb$ } from "../external/db";
+import { notFound } from "../../lib/error";
+import type { RouteEntry } from "../route";
+
+const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(zeroVariablesByNameContract.delete));
+  signal.throwIfAborted();
+
+  const writeDb = set(writeDb$);
+  // Atomic single-statement delete + 404 detection. Variables has no `type`
+  // column (unlike secrets), so the WHERE clause is a 3-tuple.
+  const deleted = await writeDb
+    .delete(variables)
+    .where(
+      and(
+        eq(variables.orgId, auth.orgId),
+        eq(variables.userId, auth.userId),
+        eq(variables.name, params.name),
+      ),
+    )
+    .returning({ id: variables.id });
+  signal.throwIfAborted();
+
+  if (deleted.length === 0) {
+    return notFound(`Variable "${params.name}" not found`);
+  }
+  return { status: 204 as const, body: undefined };
+});
+
+export const zeroVariablesDeleteRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroVariablesByNameContract.delete,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      deleteInner$,
+    ),
+  },
+];


### PR DESCRIPTION
## Summary

- Closes #12545. Wave 5 sibling to PR #12542 (secrets DELETE), structurally identical with table swap.
- Adds `DELETE /api/zero/variables/:name` to apps/api: atomic 3-tuple `(orgId, userId, name)` DELETE…RETURNING; empty result → 404.
- `apps/web` is intentionally untouched.

## Differences from #12542 secrets-delete

| Aspect | #12542 secrets | this PR variables |
|---|---|---|
| Table | `secrets` | `variables` |
| WHERE columns | 4-tuple `(orgId, userId, name, type='user')` | 3-tuple `(orgId, userId, name)` |
| `type` discriminator | yes | **no — variables table has no type column** |
| Type-filter regression test | yes (case 7) | **no** — would invent a constraint web doesn't have |
| 404 message | `Secret "${name}" not found` | `Variable "${name}" not found` |

Verified against `packages/db/src/schema/variable.ts` — variables is a single-purpose table; the unique index is `(orgId, userId, name)` with no discriminator column.

## Implementation

- `apps/api/src/signals/routes/zero-variables-delete.ts` — handler. Atomic single DELETE…RETURNING. `signal.throwIfAborted()` after the DELETE await. Auth via `authRoute({ requireOrganization: true, missingOrganizationStatus: 401 }, …)`.
- `apps/api/src/signals/routes/zero-secrets.ts` — one new import, one new spread (alongside `zeroSecretsDeleteRoutes` from #12542).
- 6 tests ported from web's 3 cases plus 3 api-defensive cases:
  1. 401 unauthenticated (web case 3)
  2. 401 missing-org (api defensive)
  3. 204 deletes successfully + DB read-after-delete (web case 1)
  4. 404 nonexistent (web case 2)
  5. 404 cross-user same-org (api defensive — victim row preserved)
  6. 404 cross-org (api defensive — victim row preserved)

All test infrastructure (`seedVariables$`, `seedOtherVariable$`, `deleteUserData$`) was already in `helpers/zero-user-data.ts`.

## Notes

- ts-rest contract `zeroVariablesByNameContract.delete` was pre-existing — no contract edit.
- Atomic DELETE…RETURNING replaces web's read-then-delete-by-id pattern, eliminating the TOCTOU window. Same precedent as #12542.
- 404 message verbatim matches web (covered by `toStrictEqual` in case 4).

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-variables-delete.test.ts` — 6/6 pass
- [x] `pnpm -F api exec vitest run` — 811/811 pass (after `pnpm -F web db:migrate` to sync schema drift from sibling Wave 5 merges)
- [x] `pnpm turbo run lint` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — no diff
- [x] `pnpm knip` — no issues
- [x] No `apps/web/**` modified
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)