### PR TITLE
feat(api): port me/model-providers DELETE [type] to api backend (Wave 5)

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -32,6 +32,7 @@ import { zeroQueuePositionRoutes } from "./routes/zero-queue-position";
 import { zeroRunDetailRoutes } from "./routes/zero-run-detail";
 import { zeroRunsRoutes } from "./routes/zero-runs";
 import { zeroSchedulesRoutes } from "./routes/zero-schedules";
+import { zeroMeModelProvidersDeleteRoutes } from "./routes/zero-me-model-providers-delete";
 import { zeroSecretsRoutes } from "./routes/zero-secrets";
 import { zeroSkillsRoutes } from "./routes/zero-skills";
 import { zeroIntegrationsSlackRoutes } from "./routes/zero-integrations-slack";
@@ -77,6 +78,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroMemberCreditCapRoutes,
   ...zeroModelPoliciesRoutes,
   ...zeroModelProvidersRoutes,
+  ...zeroMeModelProvidersDeleteRoutes,
   ...zeroVoiceChatRoutes,
   ...zeroVoiceIoQuotaRoutes,
   ...zeroWebDownloadRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-model-providers.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-model-providers.ts
@@ -92,3 +92,88 @@ export const deleteOrgModelProviders$ = command(
     signal.throwIfAborted();
   },
 );
+
+export interface UserModelProviderFixture {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+interface SeedUserModelProviderValues {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly type: string;
+  readonly isDefault?: boolean;
+  readonly selectedModel?: string | null;
+  readonly secretName?: string | null;
+  readonly authMethod?: string | null;
+}
+
+export const seedUserModelProvider$ = command(
+  async (
+    { set },
+    values: SeedUserModelProviderValues,
+    signal: AbortSignal,
+  ): Promise<{ readonly id: string }> => {
+    const writeDb = set(writeDb$);
+
+    let secretId: string | null = null;
+    if (values.secretName) {
+      const [secret] = await writeDb
+        .insert(secrets)
+        .values({
+          name: values.secretName,
+          encryptedValue: encryptSecretForTests("test-secret-value"),
+          type: "model-provider",
+          userId: values.userId,
+          orgId: values.orgId,
+        })
+        .returning({ id: secrets.id });
+      signal.throwIfAborted();
+      secretId = secret?.id ?? null;
+    }
+
+    const [row] = await writeDb
+      .insert(modelProviders)
+      .values({
+        type: values.type,
+        secretId,
+        authMethod: values.authMethod ?? null,
+        isDefault: values.isDefault ?? false,
+        selectedModel: values.selectedModel ?? null,
+        userId: values.userId,
+        orgId: values.orgId,
+      })
+      .returning({ id: modelProviders.id });
+    signal.throwIfAborted();
+
+    return { id: row?.id ?? randomUUID() };
+  },
+);
+
+export const deleteUserModelProviders$ = command(
+  async (
+    { set },
+    fixture: UserModelProviderFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(modelProviders)
+      .where(
+        and(
+          eq(modelProviders.orgId, fixture.orgId),
+          eq(modelProviders.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+    await writeDb
+      .delete(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, fixture.orgId),
+          eq(secrets.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-delete.test.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { zeroPersonalModelProvidersByTypeContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { modelProviders } from "@vm0/db/schema/model-provider";
+import { secrets } from "@vm0/db/schema/secret";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteUserModelProviders$,
+  seedUserModelProvider$,
+  type UserModelProviderFixture,
+} from "./helpers/zero-model-providers";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function uniqueOrgUser(prefix: string): UserModelProviderFixture {
+  return {
+    orgId: `org_${prefix}_${randomUUID().slice(0, 8)}`,
+    userId: `user_${prefix}_${randomUUID().slice(0, 8)}`,
+  };
+}
+
+async function enablePersonalProvider(orgId: string, userId: string) {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .insert(userFeatureSwitches)
+    .values({
+      orgId,
+      userId,
+      switches: { [FeatureSwitchKey.PersonalModelProvider]: true },
+    })
+    .onConflictDoUpdate({
+      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
+      set: { switches: { [FeatureSwitchKey.PersonalModelProvider]: true } },
+    });
+}
+
+describe("DELETE /api/zero/me/model-providers/:type", () => {
+  const track = createFixtureTracker<UserModelProviderFixture>((fixture) => {
+    return store.set(deleteUserModelProviders$, fixture, context.signal);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersByTypeContract,
+    );
+    const response = await accept(
+      client.delete({ params: { type: "anthropic-api-key" }, headers: {} }),
+      [401],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersByTypeContract,
+    );
+    const response = await accept(
+      client.delete({
+        params: { type: "anthropic-api-key" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 with 'Not found' when PersonalModelProvider feature is off", async () => {
+    const fixture = uniqueOrgUser("zmmp-feature-off");
+    await track(Promise.resolve(fixture));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersByTypeContract,
+    );
+    const response = await accept(
+      client.delete({
+        params: { type: "anthropic-api-key" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("deletes the user's personal provider and removes the row + secret", async () => {
+    const fixture = uniqueOrgUser("zmmp-delete");
+    await track(Promise.resolve(fixture));
+    await enablePersonalProvider(fixture.orgId, fixture.userId);
+    await store.set(
+      seedUserModelProvider$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        type: "anthropic-api-key",
+        secretName: "ANTHROPIC_API_KEY",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersByTypeContract,
+    );
+    const response = await client.delete({
+      params: { type: "anthropic-api-key" },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(204);
+
+    // model_provider row removed
+    const writeDb = store.set(writeDb$);
+    const remaining = await writeDb
+      .select({ id: modelProviders.id })
+      .from(modelProviders)
+      .where(
+        and(
+          eq(modelProviders.orgId, fixture.orgId),
+          eq(modelProviders.userId, fixture.userId),
+        ),
+      );
+    expect(remaining).toStrictEqual([]);
+
+    // secret row also removed (FK cascade for legacy single-secret providers)
+    const remainingSecrets = await writeDb
+      .select({ id: secrets.id })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, fixture.orgId),
+          eq(secrets.userId, fixture.userId),
+          eq(secrets.name, "ANTHROPIC_API_KEY"),
+        ),
+      );
+    expect(remainingSecrets).toStrictEqual([]);
+  });
+
+  it("returns 404 with 'Resource not found' when deleting a nonexistent provider", async () => {
+    const fixture = uniqueOrgUser("zmmp-missing");
+    await track(Promise.resolve(fixture));
+    await enablePersonalProvider(fixture.orgId, fixture.userId);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersByTypeContract,
+    );
+    const response = await accept(
+      client.delete({
+        params: { type: "anthropic-api-key" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Resource not found", code: "NOT_FOUND" },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-me-model-providers-delete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-me-model-providers-delete.ts
@@ -1,0 +1,64 @@
+import { command } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { zeroPersonalModelProvidersByTypeContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { isNotFoundResponse } from "../../lib/error";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import { deleteUserModelProvider$ } from "../services/zero-model-provider.service";
+import type { RouteEntry } from "../route";
+
+const featureDisabled = Object.freeze({
+  status: 404 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Not found",
+      code: "NOT_FOUND",
+    }),
+  }),
+});
+
+const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  signal.throwIfAborted();
+  const personalEnabled = isFeatureEnabled(
+    FeatureSwitchKey.PersonalModelProvider,
+    { orgId: auth.orgId, userId: auth.userId, overrides },
+  );
+  if (!personalEnabled) {
+    return featureDisabled;
+  }
+
+  const params = get(
+    pathParamsOf(zeroPersonalModelProvidersByTypeContract.delete),
+  );
+  signal.throwIfAborted();
+
+  const result = await set(
+    deleteUserModelProvider$,
+    { orgId: auth.orgId, userId: auth.userId, type: params.type },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (isNotFoundResponse(result)) {
+    return result;
+  }
+  return { status: 204 as const, body: undefined };
+});
+
+export const zeroMeModelProvidersDeleteRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroPersonalModelProvidersByTypeContract.delete,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      deleteInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
@@ -1,16 +1,19 @@
-import { computed, type Computed } from "ccstate";
+import { command, computed, type Computed } from "ccstate";
 import {
   getFrameworkForType,
   getSecretNamesForAuthMethod,
-  modelProviderTypeSchema,
   type ModelProviderListResponse,
   type ModelProviderResponse,
+  type ModelProviderType,
+  modelProviderTypeSchema,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { secrets } from "@vm0/db/schema/secret";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
-import { db$ } from "../external/db";
+import { db$, writeDb$ } from "../external/db";
+import { notFound } from "../../lib/error";
+import { nowDate } from "../external/time";
 
 const ORG_SENTINEL_USER_ID = "__org__";
 
@@ -91,3 +94,113 @@ export function zeroModelProviders(
     };
   });
 }
+
+type NotFoundResponse = ReturnType<typeof notFound>;
+
+/**
+ * Delete a user-level model provider and cascade-delete its secrets.
+ *
+ * Mirrors apps/web's `deleteModelProvider` (via `deleteUserModelProvider`):
+ *   - Legacy single-secret providers: deleting the secret cascades the
+ *     model_provider row via FK (`onDelete: "cascade"` at the schema).
+ *   - Multi-auth providers: deletes the per-auth-method secrets by name,
+ *     then deletes the model_provider row explicitly.
+ *
+ * If the deleted row was the user's default provider, promotes the oldest
+ * remaining (orgId, userId) provider to default — matches web's invariant
+ * that a user always has at most one default and it transitions to a
+ * surviving row when the previous default is removed.
+ *
+ * Non-transactional, matching web. A partial failure (secret-delete
+ * succeeds, provider-delete fails) would leave an orphan provider row —
+ * web has the same gap; transactional rewrite is a separate follow-up.
+ */
+export const deleteUserModelProvider$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly type: ModelProviderType;
+    },
+    signal: AbortSignal,
+  ): Promise<NotFoundResponse | undefined> => {
+    const writeDb = set(writeDb$);
+
+    const [provider] = await writeDb
+      .select({
+        id: modelProviders.id,
+        isDefault: modelProviders.isDefault,
+        secretId: modelProviders.secretId,
+        authMethod: modelProviders.authMethod,
+      })
+      .from(modelProviders)
+      .where(
+        and(
+          eq(modelProviders.orgId, args.orgId),
+          eq(modelProviders.userId, args.userId),
+          eq(modelProviders.type, args.type),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!provider) {
+      return notFound("Resource not found");
+    }
+
+    const wasDefault = provider.isDefault;
+
+    if (provider.secretId) {
+      await writeDb.delete(secrets).where(eq(secrets.id, provider.secretId));
+      signal.throwIfAborted();
+    } else {
+      if (provider.authMethod) {
+        const secretNames = getSecretNamesForAuthMethod(
+          args.type,
+          provider.authMethod,
+        );
+        if (secretNames && secretNames.length > 0) {
+          await writeDb
+            .delete(secrets)
+            .where(
+              and(
+                eq(secrets.orgId, args.orgId),
+                eq(secrets.userId, args.userId),
+                inArray(secrets.name, [...secretNames]),
+              ),
+            );
+          signal.throwIfAborted();
+        }
+      }
+      await writeDb
+        .delete(modelProviders)
+        .where(eq(modelProviders.id, provider.id));
+      signal.throwIfAborted();
+    }
+
+    if (wasDefault) {
+      const [next] = await writeDb
+        .select({ id: modelProviders.id })
+        .from(modelProviders)
+        .where(
+          and(
+            eq(modelProviders.orgId, args.orgId),
+            eq(modelProviders.userId, args.userId),
+          ),
+        )
+        .orderBy(modelProviders.createdAt)
+        .limit(1);
+      signal.throwIfAborted();
+      if (next) {
+        await writeDb
+          .update(modelProviders)
+          .set({ isDefault: true, updatedAt: nowDate() })
+          .where(eq(modelProviders.id, next.id));
+        signal.throwIfAborted();
+      }
+    }
+
+    return undefined;
+  },
+);


### PR DESCRIPTION
## Summary

Wave 5 mutation route migration. Ports `DELETE /api/zero/me/model-providers/:type` (personal-tier per-user model provider deletion with feature-switch gate) from apps/web to apps/api. **First feature-switch-gated mutation in apps/api.**

- New `apps/api/src/signals/routes/zero-me-model-providers-delete.ts`: `organizationAuthContext\$` + `userFeatureSwitchOverrides` + `isFeatureEnabled(PersonalModelProvider, …)` gate. If the flag is off, returns 404 with message `\"Not found\"`. Otherwise delegates to `deleteUserModelProvider\$`.
- Extended `zero-model-provider.service.ts` with `deleteUserModelProvider\$` Command — three-step cascade:
  1. Legacy single-secret path: `DELETE` from `secrets` cascades the `model_providers` row via FK (`onDelete: \"cascade\"` confirmed at `model-provider.ts:33`).
  2. Multi-auth path: `DELETE` per-auth-method secrets by name, then explicit `DELETE` of the `model_providers` row.
  3. Default-promotion: if the deleted row was `isDefault`, promote the oldest remaining `(orgId, userId)` provider so the user keeps a default.
- Service returns `NotFoundResponse | undefined` result-union; type parameter is `ModelProviderType` (narrowed from contract path-param).
- Extended `helpers/zero-model-providers.ts` with `seedUserModelProvider\$` and `deleteUserModelProviders\$` paralleling the existing org-level helpers.
- 5 integration tests cover: 401 unauth, 401 missing-org, 404 feature-off (asserts `\"Not found\"` message verbatim), 204 success with DB read-after-delete on **both** `modelProviders` and `secrets` tables (catches partial-cascade), 404 nonexistent (asserts `\"Resource not found\"` message verbatim).

apps/web DELETE handler **unchanged**. Operator flips `ApiBackendMutations` to switch traffic per-org.

> **Two distinct 404 messages preserved verbatim from web** — `\"Not found\"` (feature off) vs `\"Resource not found\"` (missing row). Both pinned by tests to catch any future \"normalize the messages\" refactor.

> **Cascade is non-transactional, matching web.** If secret-delete succeeds but provider-delete fails, an orphan `model_providers` row would remain. Web has the same gap. Documented as a known parity choice; transactional rewrite is a separate follow-up.

> **Default-promotion** ports verbatim from web for parity. Not asserted by web tests; this PR doesn't add a dedicated default-promotion test either. Could add one if reviewer wants explicit coverage.

Closes #12550.

## Pattern conventions reinforced for Wave 5+ feature-switch gates

| Concern | Convention |
|---|---|
| Feature-switch gate | Inline async helper in handler file: load overrides via \`userFeatureSwitchOverrides\`, call \`isFeatureEnabled(key, ctx)\` |
| Distinct error messages from same status | Pin via test assertions when text differs by branch |
| Non-transactional cascade | Match web for parity; flag in PR body for follow-up |
| Service-level \`type\` parameter | Use the contract's narrowed \`ModelProviderType\` (zod-validated path-param) rather than \`string\` |

## Routing matrix (recap)

| `ApiBackend` | `ApiBackendMutations` | DELETE host |
|:------------:|:---------------------:|:-----------:|
| OFF          | OFF                   | www         |
| OFF          | ON                    | api         |
| ON           | *                     | api         |

## Rollout / Rollback

Standard: flag default OFF; staff org flipped first; revert PR or flip flag for instant rollback.

## Test plan

- [x] 5 integration tests pass locally
- [x] Full \`@vm0/api\` suite green (98 files / 825 tests)
- [x] DB read-after-delete on both tables in success path
- [x] 404 message text matches web verbatim for both branches
- [x] No \`apps/web/**\` modified
- [x] tests / lint / types / format / knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)