### PR TITLE
refactor(api): migrate chat-threads POST (create thread) to api backend (Wave 5 #7)

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-create.test.ts
@@ -1,0 +1,252 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+
+import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteTeamCompose$,
+  seedTeamCompose$,
+  type TeamComposeFixture,
+} from "./helpers/zero-team";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("POST /api/zero/chat-threads (create)", () => {
+  const track = createFixtureTracker<TeamComposeFixture>((fixture) => {
+    return store.set(deleteTeamCompose$, fixture, context.signal);
+  });
+
+  async function getThreadRow(threadId: string) {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({
+        id: chatThreads.id,
+        userId: chatThreads.userId,
+        agentComposeId: chatThreads.agentComposeId,
+        title: chatThreads.title,
+      })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, threadId));
+    return row;
+  }
+
+  async function countThreadsForCompose(composeId: string): Promise<number> {
+    const writeDb = store.set(writeDb$);
+    const rows = await writeDb
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(eq(chatThreads.agentComposeId, composeId));
+    return rows.length;
+  }
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(chatThreadsContract);
+
+    const response = await accept(
+      client.create({
+        headers: {},
+        body: { agentId: randomUUID(), title: "x" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("creates a chat thread as an org-scoped user (DB read-after-write)", async () => {
+    const fixture = await track(
+      store.set(
+        seedTeamCompose$,
+        { composes: [{ displayName: "Agent" }] },
+        context.signal,
+      ),
+    );
+    const composeId = fixture.composeIds[0]!;
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadsContract);
+    const response = await accept(
+      client.create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentId: composeId, title: "My thread" },
+      }),
+      [201],
+    );
+
+    expect(response.body.id).toBeDefined();
+    expect(response.body.title).toBe("My thread");
+    expect(response.body.createdAt).toBeDefined();
+
+    await expect(getThreadRow(response.body.id)).resolves.toMatchObject({
+      id: response.body.id,
+      userId: fixture.userId,
+      agentComposeId: composeId,
+      title: "My thread",
+    });
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+  });
+
+  it("forwards the provided clientThreadId into the DB row", async () => {
+    const fixture = await track(
+      store.set(
+        seedTeamCompose$,
+        { composes: [{ displayName: "Agent" }] },
+        context.signal,
+      ),
+    );
+    const composeId = fixture.composeIds[0]!;
+    const clientThreadId = randomUUID();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadsContract);
+    const response = await accept(
+      client.create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentId: composeId, clientThreadId },
+      }),
+      [201],
+    );
+
+    expect(response.body.id).toBe(clientThreadId);
+    expect(response.body.title).toBeNull();
+
+    await expect(getThreadRow(clientThreadId)).resolves.toMatchObject({
+      id: clientThreadId,
+      agentComposeId: composeId,
+      title: null,
+    });
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 404 for a compose owned by a different org (no existence leak)", async () => {
+    const otherFixture = await track(
+      store.set(
+        seedTeamCompose$,
+        { composes: [{ displayName: "OtherOrg agent" }] },
+        context.signal,
+      ),
+    );
+    const otherComposeId = otherFixture.composeIds[0]!;
+
+    const myFixture = await track(
+      store.set(
+        seedTeamCompose$,
+        { composes: [{ displayName: "MyOrg agent" }] },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(myFixture.userId, myFixture.orgId);
+
+    const client = setupApp({ context })(chatThreadsContract);
+    const response = await accept(
+      client.create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentId: otherComposeId, title: "Hijacked" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { message: "Agent not found", code: "NOT_FOUND" },
+    });
+    await expect(countThreadsForCompose(otherComposeId)).resolves.toBe(0);
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a non-existent compose id", async () => {
+    const fixture = await track(
+      store.set(seedTeamCompose$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadsContract);
+    const response = await accept(
+      client.create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentId: randomUUID(), title: "x" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { message: "Agent not found", code: "NOT_FOUND" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the authenticated session has no organization (loose-auth defensive)", async () => {
+    const fixture = await track(
+      store.set(
+        seedTeamCompose$,
+        { composes: [{ displayName: "Agent" }] },
+        context.signal,
+      ),
+    );
+    const composeId = fixture.composeIds[0]!;
+    // Authenticate as some user with no active org — web's loose-auth path
+    // returns 404 (NOT 401) because callerOrgId !== compose.orgId.
+    mocks.clerk.session(`user_${randomUUID().slice(0, 8)}`, null);
+
+    const client = setupApp({ context })(chatThreadsContract);
+    const response = await accept(
+      client.create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentId: composeId, title: "x" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { message: "Agent not found", code: "NOT_FOUND" },
+    });
+    await expect(countThreadsForCompose(composeId)).resolves.toBe(0);
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("publishes threadListChanged exactly once with the right args on success", async () => {
+    const fixture = await track(
+      store.set(
+        seedTeamCompose$,
+        { composes: [{ displayName: "Agent" }] },
+        context.signal,
+      ),
+    );
+    const composeId = fixture.composeIds[0]!;
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadsContract);
+    await accept(
+      client.create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { agentId: composeId },
+      }),
+      [201],
+    );
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-create.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-create.ts
@@ -1,0 +1,64 @@
+import { command } from "ccstate";
+import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { publishThreadListChanged } from "../external/realtime";
+import { notFound } from "../../lib/error";
+import { createChatThread$ } from "../services/zero-chat-thread.service";
+import { zeroComposeExists } from "../services/zero-compose-data.service";
+import type { RouteEntry } from "../route";
+
+const createBody$ = bodyResultOf(chatThreadsContract.create);
+
+const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+  const body = await get(createBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  const exists = await get(
+    zeroComposeExists({
+      orgId: auth.orgId ?? "",
+      composeId: body.data.agentId,
+    }),
+  );
+  signal.throwIfAborted();
+  if (!exists) {
+    return notFound("Agent not found");
+  }
+
+  const thread = await set(
+    createChatThread$,
+    {
+      userId: auth.userId,
+      agentComposeId: body.data.agentId,
+      title: body.data.title,
+      clientThreadId: body.data.clientThreadId,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  await publishThreadListChanged(auth.userId);
+  signal.throwIfAborted();
+
+  return {
+    status: 201 as const,
+    body: {
+      id: thread.id,
+      title: body.data.title ?? null,
+      createdAt: thread.createdAt.toISOString(),
+    },
+  };
+});
+
+export const zeroChatThreadCreateRoutes: readonly RouteEntry[] = [
+  {
+    route: chatThreadsContract.create,
+    handler: authRoute({}, createInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -25,6 +25,7 @@ import {
   zeroChatThreadMessagesPage,
 } from "../services/zero-chat-thread.service";
 import type { RouteEntry } from "../route";
+import { zeroChatThreadCreateRoutes } from "./zero-chat-threads-create";
 import { zeroChatThreadMarkReadRoutes } from "./zero-chat-threads-mark-read";
 import { zeroChatThreadPinRoutes } from "./zero-chat-threads-pin";
 import { zeroChatThreadRenameRoutes } from "./zero-chat-threads-rename";
@@ -190,6 +191,7 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
       searchChatInner$,
     ),
   },
+  ...zeroChatThreadCreateRoutes,
   ...zeroChatThreadMarkReadRoutes,
   ...zeroChatThreadPinRoutes,
   ...zeroChatThreadRenameRoutes,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -1,4 +1,4 @@
-import { computed, type Computed } from "ccstate";
+import { command, computed, type Computed } from "ccstate";
 import {
   type ChatSearchMessage,
   type ChatSearchResult,
@@ -40,7 +40,7 @@ import {
 import { z } from "zod";
 
 import { env } from "../../lib/env";
-import { db$ } from "../external/db";
+import { db$, writeDb$ } from "../external/db";
 import { listS3Objects } from "../external/s3";
 
 const REPORT_ERROR_STREAK_THRESHOLD = 2;
@@ -1011,3 +1011,36 @@ export function zeroChatThreadMessagesPage(args: {
     };
   });
 }
+
+export const createChatThread$ = command(
+  async (
+    { set },
+    args: {
+      readonly userId: string;
+      readonly agentComposeId: string;
+      readonly title: string | undefined;
+      readonly clientThreadId: string | undefined;
+    },
+    signal: AbortSignal,
+  ): Promise<{ id: string; createdAt: Date }> => {
+    const writeDb = set(writeDb$);
+    const [thread] = await writeDb
+      .insert(chatThreads)
+      .values({
+        ...(args.clientThreadId !== undefined
+          ? { id: args.clientThreadId }
+          : {}),
+        userId: args.userId,
+        agentComposeId: args.agentComposeId,
+        title: args.title ?? null,
+      })
+      .returning({ id: chatThreads.id, createdAt: chatThreads.createdAt });
+    signal.throwIfAborted();
+
+    if (!thread) {
+      throw new Error("Failed to create chat thread");
+    }
+
+    return thread;
+  },
+);


### PR DESCRIPTION
## Summary

- Migrates `POST /api/zero/chat-threads` (create chat thread) from `apps/web` to `apps/api`. Wave 5 #7 — extends the existing `apps/api/src/signals/routes/zero-chat-threads.ts` aggregator (which already had list, markRead, rename, pin, unpin from Wave 2/3).
- Behavior 1:1 with web: loose auth (`authRoute({})` — no `requireOrganization`), pre-INSERT compose existence + ownership check, single 404 envelope for both unknown-id and cross-org cases (no existence leak), sync `await publishThreadListChanged` after the INSERT.

## Loose-auth shape

Web's POST `create` uses `getAuthContext` — accepts no-org sessions. 401 only when fully unauthenticated. A no-org session against an org-owned compose returns 404 because `callerOrgId !== compose.orgId`. The api side mirrors with `authRoute({}, ...)` and the inline check.

This differs from `list` (`requireOrganization: true, missingOrganizationStatus: 401` — strict). Verified against web's source.

## `zeroComposeExists` collapses both 404 branches

`zeroComposeExists({ orgId: auth.orgId ?? "", composeId })` returns `false` when:
- compose doesn't exist (web's "unknown id" 404), OR
- compose exists but in a different org (web's "cross-org" 404), OR
- caller has no active org (`auth.orgId` is `undefined`, coerces to `""` which never matches a real `agent_composes.org_id`).

All three paths return the same envelope: `{ status: 404, body: { error: { message: "Agent not found", code: "NOT_FOUND" } } }`. No existence leak across orgs.

## Realtime publish

Sync `await publishThreadListChanged(auth.userId)` after a successful INSERT. Matches web's `await` and the Wave 2/3 mark-read/rename/pin/unpin precedent. Not fire-and-forget — Ably publish failures cause a 500, same as web.

## Files

- `turbo/apps/api/src/signals/services/zero-chat-thread.service.ts` — adds `createChatThread$` ccstate `command` (~30 LOC) using `set(writeDb$)`. INSERT with optional `id` (when caller supplies `clientThreadId`), RETURNING `{id, createdAt}`. Existing readers untouched.
- `turbo/apps/api/src/signals/routes/zero-chat-threads-create.ts` — new sibling route file (~65 LOC). Mirrors the Wave 2/3 mutation file pattern.
- `turbo/apps/api/src/signals/routes/zero-chat-threads.ts` — one new import, one new spread in `zeroChatThreadRoutes`.
- `turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-create.test.ts` — new test file with 7 cases.
- **No contract change.** **No web change.** **No new helper file.**

## Tests (7)

| # | Source | Case | Asserts |
|---|---|---|---|
| 1 | web | 401 unauthenticated | body `{ error.code: UNAUTHORIZED }`; no Ably publish |
| 2 | web | 201 happy path with title | response body matches; DB read-after-write confirms `userId/agentComposeId/title`; Ably publish called once with `("threadListChanged", null)` |
| 3 | web | 201 with `clientThreadId` | `response.body.id === clientThreadId`; `title === null`; DB row exists with that id; publish called once |
| 4 | web | 404 cross-org compose | body `{ error.code: NOT_FOUND, message: "Agent not found" }`; no DB row inserted; no Ably publish |
| 5 | web | 404 unknown compose | same envelope; no Ably publish |
| 6 | api defensive | 404 no-org session against org-owned compose | exercises web's loose-auth path that returns 404 (NOT 401) when `callerOrgId !== compose.orgId` |
| 7 | api defensive | publish args assertion | confirms `mocks.ably.publish` called exactly once with `("threadListChanged", null)` on success — the only api-side wiring web doesn't directly cover |

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-threads-create.test.ts` — 7 passed
- [x] `pnpm -F api exec vitest run` — 832 passed
- [x] `pnpm -F api run lint` — clean
- [x] `pnpm -F api run check-types` — clean
- [x] `pnpm format` / `pnpm knip --workspace api` — clean

Closes #12551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)