### PR TITLE
refactor(api): migrate me/model-providers patch model to api backend (wave 5)

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -33,6 +33,7 @@ import { zeroRunDetailRoutes } from "./routes/zero-run-detail";
 import { zeroRunsRoutes } from "./routes/zero-runs";
 import { zeroSchedulesRoutes } from "./routes/zero-schedules";
 import { zeroMeModelProvidersDeleteRoutes } from "./routes/zero-me-model-providers-delete";
+import { zeroMeModelProvidersUpdateModelRoutes } from "./routes/zero-me-model-providers-update-model";
 import { zeroSecretsRoutes } from "./routes/zero-secrets";
 import { zeroSkillsRoutes } from "./routes/zero-skills";
 import { zeroIntegrationsSlackRoutes } from "./routes/zero-integrations-slack";
@@ -79,6 +80,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroModelPoliciesRoutes,
   ...zeroModelProvidersRoutes,
   ...zeroMeModelProvidersDeleteRoutes,
+  ...zeroMeModelProvidersUpdateModelRoutes,
   ...zeroVoiceChatRoutes,
   ...zeroVoiceIoQuotaRoutes,
   ...zeroWebDownloadRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-update-model.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-update-model.test.ts
@@ -1,0 +1,171 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { zeroPersonalModelProvidersUpdateModelContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { modelProviders } from "@vm0/db/schema/model-provider";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteUserModelProviders$,
+  seedUserModelProvider$,
+  type UserModelProviderFixture,
+} from "./helpers/zero-model-providers";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function uniqueOrgUser(prefix: string): UserModelProviderFixture {
+  return {
+    orgId: `org_${prefix}_${randomUUID().slice(0, 8)}`,
+    userId: `user_${prefix}_${randomUUID().slice(0, 8)}`,
+  };
+}
+
+async function enablePersonalProvider(orgId: string, userId: string) {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .insert(userFeatureSwitches)
+    .values({
+      orgId,
+      userId,
+      switches: { [FeatureSwitchKey.PersonalModelProvider]: true },
+    })
+    .onConflictDoUpdate({
+      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
+      set: { switches: { [FeatureSwitchKey.PersonalModelProvider]: true } },
+    });
+}
+
+describe("PATCH /api/zero/me/model-providers/:type/model", () => {
+  const track = createFixtureTracker<UserModelProviderFixture>((fixture) => {
+    return store.set(deleteUserModelProviders$, fixture, context.signal);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersUpdateModelContract,
+    );
+    const response = await accept(
+      client.updateModel({
+        params: { type: "anthropic-api-key" },
+        body: { selectedModel: "claude-x" },
+        headers: {},
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({ error: { code: "UNAUTHORIZED" } });
+  });
+
+  it("returns 401 when authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersUpdateModelContract,
+    );
+    const response = await accept(
+      client.updateModel({
+        params: { type: "anthropic-api-key" },
+        body: { selectedModel: "claude-x" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({ error: { code: "UNAUTHORIZED" } });
+  });
+
+  it("returns 404 'Not found' when PersonalModelProvider feature is off", async () => {
+    const fixture = uniqueOrgUser("zmmp-um-feature-off");
+    await track(Promise.resolve(fixture));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersUpdateModelContract,
+    );
+    const response = await accept(
+      client.updateModel({
+        params: { type: "openai-api-key" },
+        body: { selectedModel: "gpt-5.5" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("updates selectedModel and persists (DB read-after-write)", async () => {
+    const fixture = uniqueOrgUser("zmmp-um-update");
+    await track(Promise.resolve(fixture));
+    await enablePersonalProvider(fixture.orgId, fixture.userId);
+    await store.set(
+      seedUserModelProvider$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        type: "openai-api-key",
+        secretName: "OPENAI_API_KEY",
+        selectedModel: "gpt-5",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersUpdateModelContract,
+    );
+    const response = await accept(
+      client.updateModel({
+        params: { type: "openai-api-key" },
+        body: { selectedModel: "gpt-5.5" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(response.body.selectedModel).toBe("gpt-5.5");
+    expect(response.body.type).toBe("openai-api-key");
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ selectedModel: modelProviders.selectedModel })
+      .from(modelProviders)
+      .where(
+        and(
+          eq(modelProviders.orgId, fixture.orgId),
+          eq(modelProviders.userId, fixture.userId),
+          eq(modelProviders.type, "openai-api-key"),
+        ),
+      );
+    expect(row?.selectedModel).toBe("gpt-5.5");
+  });
+
+  it("returns 404 'Resource not found' when the personal provider does not exist", async () => {
+    const fixture = uniqueOrgUser("zmmp-um-missing");
+    await track(Promise.resolve(fixture));
+    await enablePersonalProvider(fixture.orgId, fixture.userId);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersUpdateModelContract,
+    );
+    const response = await accept(
+      client.updateModel({
+        params: { type: "openai-api-key" },
+        body: { selectedModel: "gpt-5.5" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Resource not found", code: "NOT_FOUND" },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-me-model-providers-update-model.ts
+++ b/turbo/apps/api/src/signals/routes/zero-me-model-providers-update-model.ts
@@ -1,0 +1,66 @@
+import { command } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { zeroPersonalModelProvidersUpdateModelContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import { isNotFoundResponse, notFound } from "../../lib/error";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import { updateUserModelProviderModel$ } from "../services/zero-model-provider.service";
+import type { RouteEntry } from "../route";
+
+const updateModelInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  signal.throwIfAborted();
+  const personalEnabled = isFeatureEnabled(
+    FeatureSwitchKey.PersonalModelProvider,
+    { orgId: auth.orgId, userId: auth.userId, overrides },
+  );
+  if (!personalEnabled) {
+    return notFound("Not found");
+  }
+
+  const params = get(
+    pathParamsOf(zeroPersonalModelProvidersUpdateModelContract.updateModel),
+  );
+  signal.throwIfAborted();
+  const bodyResult = await get(
+    bodyResultOf(zeroPersonalModelProvidersUpdateModelContract.updateModel),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const result = await set(
+    updateUserModelProviderModel$,
+    {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      type: params.type,
+      selectedModel: bodyResult.data.selectedModel,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (isNotFoundResponse(result)) {
+    return result;
+  }
+  return result;
+});
+
+export const zeroMeModelProvidersUpdateModelRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroPersonalModelProvidersUpdateModelContract.updateModel,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      updateModelInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
@@ -204,3 +204,81 @@ export const deleteUserModelProvider$ = command(
     return undefined;
   },
 );
+
+/**
+ * Update a personal model provider's `selectedModel`. Single atomic
+ * `UPDATE … RETURNING` keyed on (orgId, userId, type) — strictly fewer
+ * round-trips than web's SELECT-then-UPDATE shape.
+ *
+ * The `secretName` field of the response body comes from a follow-up
+ * SELECT against `secrets.id`, only when `secretId` is non-null
+ * (multi-auth providers store secret references via `authMethod` and
+ * `getSecretNamesForAuthMethod` instead).
+ */
+export const updateUserModelProviderModel$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly type: ModelProviderType;
+      readonly selectedModel: string | undefined;
+    },
+    signal: AbortSignal,
+  ): Promise<
+    | NotFoundResponse
+    | { readonly status: 200; readonly body: ModelProviderResponse }
+  > => {
+    const writeDb = set(writeDb$);
+
+    const [updated] = await writeDb
+      .update(modelProviders)
+      .set({
+        selectedModel: args.selectedModel ?? null,
+        updatedAt: nowDate(),
+      })
+      .where(
+        and(
+          eq(modelProviders.orgId, args.orgId),
+          eq(modelProviders.userId, args.userId),
+          eq(modelProviders.type, args.type),
+        ),
+      )
+      .returning({
+        id: modelProviders.id,
+        type: modelProviders.type,
+        isDefault: modelProviders.isDefault,
+        selectedModel: modelProviders.selectedModel,
+        authMethod: modelProviders.authMethod,
+        secretId: modelProviders.secretId,
+        workspaceName: modelProviders.workspaceName,
+        planType: modelProviders.planType,
+        needsReconnect: modelProviders.needsReconnect,
+        lastRefreshErrorCode: modelProviders.lastRefreshErrorCode,
+        createdAt: modelProviders.createdAt,
+        updatedAt: modelProviders.updatedAt,
+      });
+    signal.throwIfAborted();
+
+    if (!updated) {
+      return notFound("Resource not found");
+    }
+
+    let secretName: string | null = null;
+    if (updated.secretId) {
+      const [secret] = await writeDb
+        .select({ name: secrets.name })
+        .from(secrets)
+        .where(eq(secrets.id, updated.secretId))
+        .limit(1);
+      signal.throwIfAborted();
+      secretName = secret?.name ?? null;
+    }
+
+    const body = modelProviderResponse({ ...updated, secretName });
+    if (!body) {
+      return notFound("Resource not found");
+    }
+    return { status: 200 as const, body };
+  },
+);


### PR DESCRIPTION
## Summary

- Wave 5 #9 of #12290 — adds `PATCH /api/zero/me/model-providers/:type/model` to apps/api.
- Same gate-check-first pattern as merged sibling PR #12552 (delete `:type`).
- **Atomic UPDATE…RETURNING** for the `selectedModel` write (strictly fewer round-trips than web's SELECT-then-UPDATE; no race window).
- Web `apps/web/.../[type]/model/route.ts` is unchanged. Platform routes via `apiBackendMutationsEnabled\$`. Dark-launched until the operator flips the flag.

## Implementation

- New: `services/zero-model-provider.service.ts` — `updateUserModelProviderModel\$` Command. Single `UPDATE…RETURNING` keyed on (orgId, userId, type), 404 on zero rows; secondary SELECT for `secrets.name` only when `secretId !== null` (multi-auth providers don't have one). `signal.throwIfAborted()` after every await.
- New: `routes/zero-me-model-providers-update-model.ts` — `command` handler. Order: org auth → feature-switch gate (404 \"Not found\" if disabled) → path params → `bodyResultOf` validation → service call → response.
- `route.ts`: import + spread of `zeroMeModelProvidersUpdateModelRoutes` after the sibling delete spread.
- 5 integration tests (new file `__tests__/zero-me-model-providers-update-model.test.ts`).

## Wire semantics preserved

| Branch | Wire response | Source |
|--------|---------------|--------|
| Unauthenticated | 401 UNAUTHORIZED | api defensive |
| Missing org | 401 UNAUTHORIZED | api defensive |
| Feature disabled | 404 NOT_FOUND \"Not found\" | web case 1 (line 153) |
| Successful update | 200 + provider response body | web case 2 (line 385) |
| Provider missing | 404 NOT_FOUND \"Resource not found\" | web case 3 (line 400) |

## Test plan (5 tests)

- [x] 401 unauthenticated
- [x] 401 missing org
- [x] 404 \"Not found\" when `PersonalModelProvider` feature off
- [x] 200 success — DB read-after-write proves `selectedModel = 'gpt-5.5'`
- [x] 404 \"Resource not found\" when feature on but no provider for type

## Gates

- [x] `pnpm -F api exec vitest run signals/routes/__tests__/zero-me-model-providers-update-model` — 5/5 pass
- [x] `pnpm -F api exec vitest run` — 842/842 pass on @vm0/api workspace (101 test files)
- [x] `pnpm turbo run lint --filter=api` — 0 warnings, 0 errors
- [x] `pnpm check-types` — all 11 workspaces clean
- [x] `pnpm format` — no changes (after auto-format)
- [x] `pnpm knip` — no findings (only pre-existing config hints)
- [x] `apps/web/**` unchanged

Closes #12556

🤖 Generated with [Claude Code](https://claude.com/claude-code)