### PR TITLE
feat(api): migrate me/model-providers post [type]/default to api backend

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -33,6 +33,7 @@ import { zeroRunDetailRoutes } from "./routes/zero-run-detail";
 import { zeroRunsRoutes } from "./routes/zero-runs";
 import { zeroSchedulesRoutes } from "./routes/zero-schedules";
 import { zeroMeModelProvidersDeleteRoutes } from "./routes/zero-me-model-providers-delete";
+import { zeroMeModelProvidersSetDefaultRoutes } from "./routes/zero-me-model-providers-set-default";
 import { zeroMeModelProvidersUpdateModelRoutes } from "./routes/zero-me-model-providers-update-model";
 import { zeroSecretsRoutes } from "./routes/zero-secrets";
 import { zeroSkillsRoutes } from "./routes/zero-skills";
@@ -80,6 +81,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroModelPoliciesRoutes,
   ...zeroModelProvidersRoutes,
   ...zeroMeModelProvidersDeleteRoutes,
+  ...zeroMeModelProvidersSetDefaultRoutes,
   ...zeroMeModelProvidersUpdateModelRoutes,
   ...zeroVoiceChatRoutes,
   ...zeroVoiceIoQuotaRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-set-default.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-set-default.test.ts
@@ -1,0 +1,199 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { zeroPersonalModelProvidersDefaultContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { modelProviders } from "@vm0/db/schema/model-provider";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteUserModelProviders$,
+  seedUserModelProvider$,
+  type UserModelProviderFixture,
+} from "./helpers/zero-model-providers";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function uniqueOrgUser(prefix: string): UserModelProviderFixture {
+  return {
+    orgId: `org_${prefix}_${randomUUID().slice(0, 8)}`,
+    userId: `user_${prefix}_${randomUUID().slice(0, 8)}`,
+  };
+}
+
+async function enablePersonalProvider(orgId: string, userId: string) {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .insert(userFeatureSwitches)
+    .values({
+      orgId,
+      userId,
+      switches: { [FeatureSwitchKey.PersonalModelProvider]: true },
+    })
+    .onConflictDoUpdate({
+      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
+      set: { switches: { [FeatureSwitchKey.PersonalModelProvider]: true } },
+    });
+}
+
+describe("POST /api/zero/me/model-providers/:type/default", () => {
+  const track = createFixtureTracker<UserModelProviderFixture>((fixture) => {
+    return store.set(deleteUserModelProviders$, fixture, context.signal);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersDefaultContract,
+    );
+    const response = await accept(
+      client.setDefault({
+        params: { type: "anthropic-api-key" },
+        headers: {},
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersDefaultContract,
+    );
+    const response = await accept(
+      client.setDefault({
+        params: { type: "anthropic-api-key" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 with 'Not found' when PersonalModelProvider feature is off", async () => {
+    const fixture = uniqueOrgUser("zmmpsd-feature-off");
+    await track(Promise.resolve(fixture));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersDefaultContract,
+    );
+    const response = await accept(
+      client.setDefault({
+        params: { type: "anthropic-api-key" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("flips the user's default and returns the updated provider", async () => {
+    const fixture = uniqueOrgUser("zmmpsd-flip");
+    await track(Promise.resolve(fixture));
+    await enablePersonalProvider(fixture.orgId, fixture.userId);
+
+    // Seed two providers; anthropic is default, openai is not.
+    await store.set(
+      seedUserModelProvider$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        type: "anthropic-api-key",
+        isDefault: true,
+        secretName: "ANTHROPIC_API_KEY",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedUserModelProvider$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        type: "openai-api-key",
+        isDefault: false,
+        selectedModel: "gpt-5.5",
+        secretName: "OPENAI_API_KEY",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersDefaultContract,
+    );
+    const response = await accept(
+      client.setDefault({
+        params: { type: "openai-api-key" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(response.body).toMatchObject({
+      type: "openai-api-key",
+      isDefault: true,
+      selectedModel: "gpt-5.5",
+      secretName: "OPENAI_API_KEY",
+    });
+
+    // DB read-after-write proves atomic flip: only one row is default and it's
+    // the one we just targeted.
+    const writeDb = store.set(writeDb$);
+    const rows = await writeDb
+      .select({
+        type: modelProviders.type,
+        isDefault: modelProviders.isDefault,
+      })
+      .from(modelProviders)
+      .where(
+        and(
+          eq(modelProviders.orgId, fixture.orgId),
+          eq(modelProviders.userId, fixture.userId),
+        ),
+      );
+    const byType = Object.fromEntries(
+      rows.map((row) => {
+        return [row.type, row.isDefault] as const;
+      }),
+    );
+    expect(byType["openai-api-key"]).toBeTruthy();
+    expect(byType["anthropic-api-key"]).toBeFalsy();
+  });
+
+  it("returns 404 with 'Resource not found' when type doesn't exist for the user", async () => {
+    const fixture = uniqueOrgUser("zmmpsd-missing");
+    await track(Promise.resolve(fixture));
+    await enablePersonalProvider(fixture.orgId, fixture.userId);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersDefaultContract,
+    );
+    const response = await accept(
+      client.setDefault({
+        params: { type: "anthropic-api-key" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Resource not found", code: "NOT_FOUND" },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-me-model-providers-set-default.ts
+++ b/turbo/apps/api/src/signals/routes/zero-me-model-providers-set-default.ts
@@ -1,0 +1,80 @@
+import { command } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { zeroPersonalModelProvidersDefaultContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { isNotFoundResponse } from "../../lib/error";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import {
+  modelProviderResponse,
+  setUserModelProviderDefault$,
+} from "../services/zero-model-provider.service";
+import type { RouteEntry } from "../route";
+
+const featureDisabled = Object.freeze({
+  status: 404 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Not found",
+      code: "NOT_FOUND",
+    }),
+  }),
+});
+
+const setDefaultInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  signal.throwIfAborted();
+  const personalEnabled = isFeatureEnabled(
+    FeatureSwitchKey.PersonalModelProvider,
+    { orgId: auth.orgId, userId: auth.userId, overrides },
+  );
+  if (!personalEnabled) {
+    return featureDisabled;
+  }
+
+  const params = get(
+    pathParamsOf(zeroPersonalModelProvidersDefaultContract.setDefault),
+  );
+  signal.throwIfAborted();
+
+  const result = await set(
+    setUserModelProviderDefault$,
+    { orgId: auth.orgId, userId: auth.userId, type: params.type },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (isNotFoundResponse(result)) {
+    return result;
+  }
+
+  const body = modelProviderResponse(result);
+  if (!body) {
+    // Defensive: should not happen because the contract's pathParam is
+    // validated up-front. Surface a 500 rather than a malformed 200 body.
+    return {
+      status: 500 as const,
+      body: {
+        error: { message: "Internal server error", code: "INTERNAL" },
+      },
+    };
+  }
+
+  return { status: 200 as const, body };
+});
+
+export const zeroMeModelProvidersSetDefaultRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroPersonalModelProvidersDefaultContract.setDefault,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      setDefaultInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
@@ -9,7 +9,7 @@ import {
 } from "@vm0/api-contracts/contracts/model-providers";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { secrets } from "@vm0/db/schema/secret";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, ne } from "drizzle-orm";
 
 import { db$, writeDb$ } from "../external/db";
 import { notFound } from "../../lib/error";
@@ -17,7 +17,7 @@ import { nowDate } from "../external/time";
 
 const ORG_SENTINEL_USER_ID = "__org__";
 
-function modelProviderResponse(row: {
+export function modelProviderResponse(row: {
   readonly id: string;
   readonly type: string;
   readonly isDefault: boolean;
@@ -280,5 +280,109 @@ export const updateUserModelProviderModel$ = command(
       return notFound("Resource not found");
     }
     return { status: 200 as const, body };
+  },
+);
+
+interface ModelProviderRowSnapshot {
+  readonly id: string;
+  readonly type: string;
+  readonly isDefault: boolean;
+  readonly selectedModel: string | null;
+  readonly authMethod: string | null;
+  readonly secretName: string | null;
+  readonly workspaceName: string | null;
+  readonly planType: string | null;
+  readonly needsReconnect: boolean;
+  readonly lastRefreshErrorCode: string | null;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+/**
+ * Set a user-level model provider as the user's default.
+ *
+ * Atomic: clears the user's previous default and stamps this row as default
+ * inside a single transaction. The order (clear → set) is forced by the
+ * partial unique index `idx_model_providers_one_default_per_user` —
+ * reversing would violate the at-most-one-default invariant.
+ *
+ * Fast-path: if the targeted provider is already default, returns the
+ * existing row without writing (matches web's no-op).
+ *
+ * Returns a row snapshot suitable for `modelProviderResponse(row)`. Returns
+ * `notFound("Resource not found")` when the user has no provider of this
+ * type.
+ */
+export const setUserModelProviderDefault$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly type: ModelProviderType;
+    },
+    signal: AbortSignal,
+  ): Promise<NotFoundResponse | ModelProviderRowSnapshot> => {
+    const writeDb = set(writeDb$);
+
+    const [target] = await writeDb
+      .select({
+        id: modelProviders.id,
+        type: modelProviders.type,
+        isDefault: modelProviders.isDefault,
+        selectedModel: modelProviders.selectedModel,
+        authMethod: modelProviders.authMethod,
+        secretName: secrets.name,
+        workspaceName: modelProviders.workspaceName,
+        planType: modelProviders.planType,
+        needsReconnect: modelProviders.needsReconnect,
+        lastRefreshErrorCode: modelProviders.lastRefreshErrorCode,
+        createdAt: modelProviders.createdAt,
+        updatedAt: modelProviders.updatedAt,
+      })
+      .from(modelProviders)
+      .leftJoin(secrets, eq(modelProviders.secretId, secrets.id))
+      .where(
+        and(
+          eq(modelProviders.orgId, args.orgId),
+          eq(modelProviders.userId, args.userId),
+          eq(modelProviders.type, args.type),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!target) {
+      return notFound("Resource not found");
+    }
+
+    if (target.isDefault) {
+      // Fast-path: already default, no write.
+      return target;
+    }
+
+    const updatedAt = nowDate();
+    // Atomic flip: clear other defaults first, then set this one. Order is
+    // forced by the partial unique index `idx_model_providers_one_default_per_user`.
+    await writeDb.transaction(async (tx) => {
+      await tx
+        .update(modelProviders)
+        .set({ isDefault: false, updatedAt })
+        .where(
+          and(
+            eq(modelProviders.orgId, args.orgId),
+            eq(modelProviders.userId, args.userId),
+            eq(modelProviders.isDefault, true),
+            ne(modelProviders.id, target.id),
+          ),
+        );
+      await tx
+        .update(modelProviders)
+        .set({ isDefault: true, updatedAt })
+        .where(eq(modelProviders.id, target.id));
+    });
+    signal.throwIfAborted();
+
+    return { ...target, isDefault: true, updatedAt };
   },
 );


### PR DESCRIPTION
## Summary

- Closes #12555. Wave 5 sibling to PR #12552 (me/model-providers DELETE) — same gate-check-first idiom + frozen `featureDisabled` constant.
- Adds `POST /api/zero/me/model-providers/:type/default` to apps/api: atomic isDefault flip in transaction, fast-path no-op when already default.
- `apps/web` is intentionally untouched.

## Differences from #12552 DELETE template

| Aspect | #12552 DELETE | this PR setDefault |
|---|---|---|
| HTTP method | DELETE | POST |
| Body | none | none (`body: z.undefined()`) |
| Success status | 204 noBody | 200 + `ModelProviderResponse` |
| Service write | cascade delete | atomic isDefault flip in `writeDb.transaction` |
| Fast-path | n/a | when target already isDefault → return target without writing (matches web) |

## Implementation

- `apps/api/src/signals/services/zero-model-provider.service.ts`:
  - **Promote** `modelProviderResponse(row)` from file-private to `export` (1-character diff). Reused by the new handler to shape the 200 body.
  - **Add** `setUserModelProviderDefault$` Command. SELECT target with leftJoin on `secrets` to populate `secretName`; if missing → `notFound("Resource not found")`; if already isDefault → fast-path return; else `writeDb.transaction { clear other defaults; set this one }`. Order is forced by the partial unique index `idx_model_providers_one_default_per_user(orgId, userId) WHERE is_default = true` — reversing would violate the at-most-one-default invariant.
- `apps/api/src/signals/routes/zero-me-model-providers-set-default.ts` (new): handler. Same gate pattern as DELETE — feature switch off → frozen `featureDisabled` 404 with the **shorter** "Not found" message; service notFound surfaces with the **longer** "Resource not found" message. Two distinct 404 messages preserved verbatim from web.
- `apps/api/src/signals/route.ts`: one new import + one spread alongside `zeroMeModelProvidersDeleteRoutes`.
- 5 integration tests (3 web 1:1 + 2 api defensive 401):
  1. 401 unauthenticated
  2. 401 missing-org session
  3. 404 `"Not found"` feature-off (web case 1, line 145)
  4. 200 flips default + DB read-after-write proves atomic flip (web case 2, line 350)
  5. 404 `"Resource not found"` type doesn't exist (web case 3, line 371)

`toStrictEqual` on the two 404 bodies locks the exact message text.

## Notes

- ts-rest contract `zeroPersonalModelProvidersDefaultContract.setDefault` was pre-existing — no contract edit.
- The fast-path no-op (already default → no write) preserves shadow-compare cleanness; without it the `updatedAt` column would drift between web and api on idempotent calls.
- Service helper `modelProviderResponse` is reused unchanged — no duplication of field projection.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-me-model-providers-set-default.test.ts` — 5/5 pass
- [x] `pnpm -F api exec vitest run` — 842/842 pass
- [x] `pnpm turbo run lint` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — no diff
- [x] `pnpm knip` — no issues
- [x] No `apps/web/**` modified
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)