### PR TITLE
refactor(api): migrate chat-threads artifacts sync to api backend (wave 5)

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-artifacts-sync.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-artifacts-sync.test.ts
@@ -1,0 +1,379 @@
+import { randomUUID } from "node:crypto";
+import { Readable } from "node:stream";
+
+import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { connectors } from "@vm0/db/schema/connector";
+import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
+import { secrets } from "@vm0/db/schema/secret";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { http, HttpResponse } from "msw";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { server } from "../../../mocks/server";
+import { writeDb$ } from "../../external/db";
+import { encryptSecretForTests } from "./helpers/encrypt-secret";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedChatThread$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+async function seedRunUploadedFile(args: {
+  readonly runId: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly externalId: string;
+  readonly filename: string;
+  readonly contentType: string;
+  readonly sizeBytes: number;
+  readonly url: string;
+  readonly metadata: Record<string, unknown>;
+}): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(runUploadedFiles).values({
+    runId: args.runId,
+    source: "web",
+    externalId: args.externalId,
+    userId: args.userId,
+    orgId: args.orgId,
+    filename: args.filename,
+    contentType: args.contentType,
+    sizeBytes: args.sizeBytes,
+    url: args.url,
+    metadata: args.metadata,
+  });
+}
+
+async function seedGoogleDriveConnector(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly accessToken: string;
+}): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(connectors).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    type: "google-drive",
+    authMethod: "oauth",
+    needsReconnect: false,
+  });
+  await writeDb.insert(secrets).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    name: "GOOGLE_DRIVE_ACCESS_TOKEN",
+    type: "connector",
+    encryptedValue: encryptSecretForTests(args.accessToken),
+  });
+}
+
+interface S3GetCommandLike {
+  readonly input: { readonly Bucket?: string; readonly Key?: string };
+}
+
+function isS3GetCommandLike(command: unknown): command is S3GetCommandLike {
+  return (
+    typeof command === "object" &&
+    command !== null &&
+    "input" in command &&
+    typeof (command as { input: unknown }).input === "object"
+  );
+}
+
+function stubS3Buffer(buffer: Buffer): void {
+  context.mocks.s3.send.mockImplementation((command: unknown) => {
+    if (!isS3GetCommandLike(command)) {
+      return Promise.resolve({});
+    }
+    const stream = Readable.from([new Uint8Array(buffer)]);
+    return Promise.resolve({ Body: stream });
+  });
+}
+
+describe("POST /api/zero/chat-threads/:threadId/artifacts", () => {
+  const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  // Connectors and secrets aren't cascaded by the usage-insight fixture
+  // tracker; tests that seed Drive credentials track their orgId here for
+  // explicit cleanup so subsequent runs start clean.
+  const seededDriveOrgs: string[] = [];
+  afterEach(async () => {
+    while (seededDriveOrgs.length > 0) {
+      const orgId = seededDriveOrgs.pop();
+      if (!orgId) {
+        continue;
+      }
+      const writeDb = store.set(writeDb$);
+      await writeDb.delete(connectors).where(eq(connectors.orgId, orgId));
+      await writeDb.delete(secrets).where(eq(secrets.orgId, orgId));
+    }
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.syncGoogleDrive({
+        params: { threadId: randomUUID() },
+        body: { runId: randomUUID(), fileId: "file-1" },
+        headers: {},
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({ error: { code: "UNAUTHORIZED" } });
+  });
+
+  it("returns 401 when authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.syncGoogleDrive({
+        params: { threadId: randomUUID() },
+        body: { runId: randomUUID(), fileId: "file-1" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({ error: { code: "UNAUTHORIZED" } });
+  });
+
+  it("returns 400 with NOT_FOUND-equivalent when no Google Drive connector is configured", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const threadId = await store.set(
+      seedChatThread$,
+      { userId: fixture.userId, composeId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.syncGoogleDrive({
+        params: { threadId },
+        body: {
+          runId: "00000000-0000-4000-8000-000000000001",
+          fileId: "file-1",
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Connect Google Drive before syncing artifacts",
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+
+  it("returns 404 when the artifact is unknown to the caller's thread", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    await seedGoogleDriveConnector({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      accessToken: "drive-access-token",
+    });
+    seededDriveOrgs.push(fixture.orgId);
+
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const threadId = await store.set(
+      seedChatThread$,
+      { userId: fixture.userId, composeId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.syncGoogleDrive({
+        params: { threadId },
+        body: { runId: randomUUID(), fileId: "missing-file" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Artifact file not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 400 when the request body is invalid", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.syncGoogleDrive({
+        params: { threadId: randomUUID() },
+        // Missing fileId.
+        body: { runId: randomUUID() } as never,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+    expect(response.body).toMatchObject({ error: { code: "BAD_REQUEST" } });
+  });
+
+  it("syncs an artifact file to Google Drive (full MSW assertion)", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const threadId = await store.set(
+      seedChatThread$,
+      { userId: fixture.userId, composeId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "completed",
+        chatThreadId: threadId,
+      },
+      context.signal,
+    );
+    const s3Key = `uploads/${fixture.userId}/file-1/data.csv`;
+    await seedRunUploadedFile({
+      runId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      externalId: "file-1",
+      filename: "data.csv",
+      contentType: "text/csv",
+      sizeBytes: 2048,
+      url: `http://localhost:3000/f/${fixture.userId}/file-1/data.csv`,
+      metadata: { s3Key },
+    });
+    await seedGoogleDriveConnector({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      accessToken: "drive-access-token",
+    });
+    seededDriveOrgs.push(fixture.orgId);
+
+    stubS3Buffer(Buffer.from("name,value\nalpha,1\n"));
+
+    let authHeader: string | null = null;
+    let contentType: string | null = null;
+    let uploadType: string | null = null;
+    let uploadBody = "";
+    const folderQueries: string[] = [];
+    const createdFolders: unknown[] = [];
+    server.use(
+      http.get("https://www.googleapis.com/drive/v3/files", ({ request }) => {
+        const url = new URL(request.url);
+        folderQueries.push(url.searchParams.get("q") ?? "");
+        return HttpResponse.json({ files: [] });
+      }),
+      http.post(
+        "https://www.googleapis.com/drive/v3/files",
+        async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>;
+          createdFolders.push(body);
+          return HttpResponse.json({
+            id:
+              createdFolders.length === 1
+                ? "drive-folder-vm0-artifact"
+                : "drive-folder-chat-thread",
+            name: typeof body.name === "string" ? body.name : "folder",
+          });
+        },
+      ),
+      http.post(
+        "https://www.googleapis.com/upload/drive/v3/files",
+        async ({ request }) => {
+          const url = new URL(request.url);
+          authHeader = request.headers.get("authorization");
+          contentType = request.headers.get("content-type");
+          uploadType = url.searchParams.get("uploadType");
+          uploadBody = await request.text();
+          return HttpResponse.json({
+            id: "drive-file-id",
+            name: "data.csv",
+            webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+          });
+        },
+      ),
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadArtifactsContract);
+    const response = await accept(
+      client.syncGoogleDrive({
+        params: { threadId },
+        body: { runId, fileId: "file-1" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(response.body).toStrictEqual({
+      id: "drive-file-id",
+      name: "data.csv",
+      webViewLink: "https://drive.google.com/file/d/drive-file-id/view",
+    });
+    expect(authHeader).toBe("Bearer drive-access-token");
+    expect(contentType).toContain("multipart/related");
+    expect(uploadType).toBe("multipart");
+    expect(folderQueries).toHaveLength(2);
+    expect(folderQueries[0]).toContain("name = 'vm0-artifact'");
+    expect(folderQueries[0]).toContain("'root' in parents");
+    expect(folderQueries[1]).toContain(`name = 'chat-${threadId}'`);
+    expect(folderQueries[1]).toContain(
+      "'drive-folder-vm0-artifact' in parents",
+    );
+    expect(createdFolders).toStrictEqual([
+      {
+        name: "vm0-artifact",
+        mimeType: "application/vnd.google-apps.folder",
+      },
+      {
+        name: `chat-${threadId}`,
+        mimeType: "application/vnd.google-apps.folder",
+        parents: ["drive-folder-vm0-artifact"],
+      },
+    ]);
+    expect(uploadBody).toContain('"name":"data.csv"');
+    expect(uploadBody).toContain('"parents":["drive-folder-chat-thread"]');
+    expect(uploadBody).toContain('"vm0Artifact":"true"');
+    expect(uploadBody).toContain(`"vm0ThreadId":"${threadId}"`);
+    expect(uploadBody).toContain(`"vm0RunId":"${runId}"`);
+    expect(uploadBody).toContain('"vm0FileId":"file-1"');
+    expect(uploadBody).toContain("Content-Type: text/csv\r\n\r\nname,value");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-artifacts-sync.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-artifacts-sync.ts
@@ -1,0 +1,53 @@
+import { command } from "ccstate";
+import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import { isBadRequestResponse, isNotFoundResponse } from "../../lib/error";
+import { syncArtifactToGoogleDrive$ } from "../services/google-drive-artifact-sync.service";
+import type { RouteEntry } from "../route";
+
+const syncInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(chatThreadArtifactsContract.syncGoogleDrive));
+  signal.throwIfAborted();
+  const bodyResult = await get(
+    bodyResultOf(chatThreadArtifactsContract.syncGoogleDrive),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const result = await set(
+    syncArtifactToGoogleDrive$,
+    {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      threadId: params.threadId,
+      runId: bodyResult.data.runId,
+      fileId: bodyResult.data.fileId,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (isNotFoundResponse(result)) {
+    return result;
+  }
+  if (isBadRequestResponse(result)) {
+    return result;
+  }
+  return result;
+});
+
+export const zeroChatThreadsArtifactsSyncRoutes: readonly RouteEntry[] = [
+  {
+    route: chatThreadArtifactsContract.syncGoogleDrive,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      syncInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -25,6 +25,7 @@ import {
   zeroChatThreadMessagesPage,
 } from "../services/zero-chat-thread.service";
 import type { RouteEntry } from "../route";
+import { zeroChatThreadsArtifactsSyncRoutes } from "./zero-chat-threads-artifacts-sync";
 import { zeroChatThreadCreateRoutes } from "./zero-chat-threads-create";
 import { zeroChatThreadMarkReadRoutes } from "./zero-chat-threads-mark-read";
 import { zeroChatThreadPinRoutes } from "./zero-chat-threads-pin";
@@ -191,6 +192,7 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
       searchChatInner$,
     ),
   },
+  ...zeroChatThreadsArtifactsSyncRoutes,
   ...zeroChatThreadCreateRoutes,
   ...zeroChatThreadMarkReadRoutes,
   ...zeroChatThreadPinRoutes,

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -1,19 +1,30 @@
-import { computed, type Computed } from "ccstate";
+import { randomUUID } from "node:crypto";
+
+import { command, computed, type Computed } from "ccstate";
 import type {
   ChatThreadArtifactGoogleDriveSync,
   ChatThreadArtifactRun,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { connectors } from "@vm0/db/schema/connector";
+import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { secrets } from "@vm0/db/schema/secret";
-import { and, eq } from "drizzle-orm";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { and, eq, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
-import { optionalEnv } from "../../lib/env";
+import { env, optionalEnv } from "../../lib/env";
+import { badRequestMessage, notFound } from "../../lib/error";
 import { db$, type ReadonlyDb } from "../external/db";
+import { downloadS3Buffer } from "../external/s3";
 import { decryptSecretValue } from "./crypto.utils";
 
 const GOOGLE_DRIVE_FILES_URL = "https://www.googleapis.com/drive/v3/files";
+const GOOGLE_DRIVE_UPLOAD_URL =
+  "https://www.googleapis.com/upload/drive/v3/files";
 const GOOGLE_DRIVE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_DRIVE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder";
 const GOOGLE_DRIVE_STATUS_TIMEOUT_MS = 2000;
 const GOOGLE_DRIVE_ARTIFACT_APP_PROPERTY = "vm0Artifact";
 const GOOGLE_DRIVE_THREAD_APP_PROPERTY = "vm0ThreadId";
@@ -318,3 +329,436 @@ export function googleDriveArtifactStatusLookup(args: {
     );
   });
 }
+
+// =====================================================================
+// Upload-side: sync a single artifact to the user's Google Drive.
+// Mirrors apps/web/src/lib/zero/chat-thread/artifact-google-drive-sync.ts.
+// =====================================================================
+
+const driveFolderSchema = z.object({ id: z.string(), name: z.string() });
+const driveFolderListSchema = z.object({
+  files: z.array(driveFolderSchema),
+});
+const driveUploadResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  webViewLink: z.string().nullable().optional(),
+});
+
+const EXT_MIMETYPE_MAP: Readonly<Record<string, string>> = {
+  csv: "text/csv",
+  txt: "text/plain",
+  json: "application/json",
+  pdf: "application/pdf",
+  html: "text/html",
+  md: "text/markdown",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  webp: "image/webp",
+};
+
+function inferMimetype(filename: string): string {
+  const ext = filename.split(".").pop()?.toLowerCase();
+  const mapped = ext ? EXT_MIMETYPE_MAP[ext] : undefined;
+  return mapped ?? "application/octet-stream";
+}
+
+interface ArtifactFileRow {
+  readonly runId: string;
+  readonly source: string;
+  readonly externalId: string;
+  readonly filename: string | null;
+  readonly contentType: string | null;
+  readonly url: string | null;
+  readonly metadata: Record<string, unknown>;
+}
+
+async function loadArtifactFile(
+  db: ReadonlyDb,
+  args: {
+    readonly threadId: string;
+    readonly runId: string;
+    readonly fileId: string;
+    readonly userId: string;
+  },
+): Promise<ArtifactFileRow | null> {
+  const [thread] = await db
+    .select({ id: chatThreads.id })
+    .from(chatThreads)
+    .where(
+      and(
+        eq(chatThreads.id, args.threadId),
+        eq(chatThreads.userId, args.userId),
+      ),
+    )
+    .limit(1);
+  if (!thread) {
+    return null;
+  }
+
+  const [row] = await db
+    .select({
+      runId: runUploadedFiles.runId,
+      source: runUploadedFiles.source,
+      externalId: runUploadedFiles.externalId,
+      filename: runUploadedFiles.filename,
+      contentType: runUploadedFiles.contentType,
+      url: runUploadedFiles.url,
+      metadata: runUploadedFiles.metadata,
+    })
+    .from(runUploadedFiles)
+    .innerJoin(zeroRuns, eq(zeroRuns.id, runUploadedFiles.runId))
+    .where(
+      and(
+        eq(runUploadedFiles.userId, args.userId),
+        eq(runUploadedFiles.runId, args.runId),
+        eq(runUploadedFiles.externalId, args.fileId),
+        or(
+          eq(zeroRuns.chatThreadId, args.threadId),
+          sql`EXISTS (
+            SELECT 1
+            FROM ${chatMessages}
+            WHERE ${chatMessages.runId} = ${runUploadedFiles.runId}
+              AND ${chatMessages.chatThreadId} = ${args.threadId}
+          )`,
+        ),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+function resolveArtifactS3Key(
+  metadata: Record<string, unknown>,
+  userId: string,
+): string | null {
+  const value = metadata.s3Key;
+  if (typeof value !== "string") {
+    return null;
+  }
+  if (!value.startsWith(`uploads/${userId}/`)) {
+    return null;
+  }
+  return value;
+}
+
+type DriveTokenResult<T> =
+  | { readonly type: "ok"; readonly value: T }
+  | { readonly type: "unauthorized" };
+
+async function findDriveFolder(args: {
+  readonly accessToken: string;
+  readonly parentFolderId: string | null;
+  readonly name: string;
+}): Promise<DriveTokenResult<z.infer<typeof driveFolderSchema> | null>> {
+  const url = new URL(GOOGLE_DRIVE_FILES_URL);
+  url.searchParams.set(
+    "q",
+    [
+      `mimeType = '${GOOGLE_DRIVE_FOLDER_MIME_TYPE}'`,
+      `name = '${escapeQuery(args.name)}'`,
+      "trashed = false",
+      args.parentFolderId
+        ? `'${escapeQuery(args.parentFolderId)}' in parents`
+        : "'root' in parents",
+    ].join(" and "),
+  );
+  url.searchParams.set("fields", "files(id,name)");
+  url.searchParams.set("pageSize", "1");
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${args.accessToken}` },
+  });
+  if (response.status === 401) {
+    return { type: "unauthorized" };
+  }
+  if (!response.ok) {
+    throw badRequestMessage(
+      `Google Drive folder lookup failed with HTTP ${String(response.status)}`,
+    );
+  }
+  const parsed = driveFolderListSchema.parse(await response.json());
+  return { type: "ok", value: parsed.files[0] ?? null };
+}
+
+async function createDriveFolder(args: {
+  readonly accessToken: string;
+  readonly parentFolderId: string | null;
+  readonly name: string;
+}): Promise<DriveTokenResult<z.infer<typeof driveFolderSchema>>> {
+  const url = new URL(GOOGLE_DRIVE_FILES_URL);
+  url.searchParams.set("fields", "id,name");
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${args.accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      name: args.name,
+      mimeType: GOOGLE_DRIVE_FOLDER_MIME_TYPE,
+      ...(args.parentFolderId ? { parents: [args.parentFolderId] } : {}),
+    }),
+  });
+  if (response.status === 401) {
+    return { type: "unauthorized" };
+  }
+  if (!response.ok) {
+    throw badRequestMessage(
+      `Google Drive folder creation failed with HTTP ${String(response.status)}`,
+    );
+  }
+  return {
+    type: "ok",
+    value: driveFolderSchema.parse(await response.json()),
+  };
+}
+
+async function ensureDriveFolder(args: {
+  readonly accessToken: string;
+  readonly parentFolderId: string | null;
+  readonly name: string;
+}): Promise<DriveTokenResult<z.infer<typeof driveFolderSchema>>> {
+  const existing = await findDriveFolder(args);
+  if (existing.type === "unauthorized") {
+    return existing;
+  }
+  if (existing.value) {
+    return { type: "ok", value: existing.value };
+  }
+  return await createDriveFolder(args);
+}
+
+async function ensureArtifactFolder(args: {
+  readonly accessToken: string;
+  readonly threadId: string;
+}): Promise<DriveTokenResult<string>> {
+  let parentFolderId: string | null = null;
+  for (const name of ["vm0-artifact", `chat-${args.threadId}`]) {
+    const folder = await ensureDriveFolder({
+      accessToken: args.accessToken,
+      parentFolderId,
+      name,
+    });
+    if (folder.type === "unauthorized") {
+      return folder;
+    }
+    parentFolderId = folder.value.id;
+  }
+  if (!parentFolderId) {
+    throw badRequestMessage(
+      "Google Drive artifact folder could not be resolved",
+    );
+  }
+  return { type: "ok", value: parentFolderId };
+}
+
+async function uploadDriveFile(args: {
+  readonly accessToken: string;
+  readonly parentFolderId: string;
+  readonly filename: string;
+  readonly threadId: string;
+  readonly runId: string;
+  readonly fileId: string;
+  readonly contentType: string;
+  readonly file: Buffer;
+}): Promise<Response> {
+  const boundary = `vm0-${randomUUID()}`;
+  const metadata = JSON.stringify({
+    name: args.filename,
+    mimeType: args.contentType,
+    parents: [args.parentFolderId],
+    appProperties: {
+      [GOOGLE_DRIVE_ARTIFACT_APP_PROPERTY]: "true",
+      [GOOGLE_DRIVE_THREAD_APP_PROPERTY]: args.threadId,
+      [GOOGLE_DRIVE_RUN_APP_PROPERTY]: args.runId,
+      [GOOGLE_DRIVE_FILE_APP_PROPERTY]: args.fileId,
+    },
+  });
+  const body = Buffer.concat([
+    Buffer.from(
+      [
+        `--${boundary}`,
+        "Content-Type: application/json; charset=UTF-8",
+        "",
+        metadata,
+        `--${boundary}`,
+        `Content-Type: ${args.contentType}`,
+        "",
+        "",
+      ].join("\r\n"),
+      "utf8",
+    ),
+    args.file,
+    Buffer.from(`\r\n--${boundary}--\r\n`, "utf8"),
+  ]);
+
+  const uploadUrl = new URL(GOOGLE_DRIVE_UPLOAD_URL);
+  uploadUrl.searchParams.set("uploadType", "multipart");
+  uploadUrl.searchParams.set("fields", "id,name,webViewLink");
+
+  return await fetch(uploadUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${args.accessToken}`,
+      "Content-Type": `multipart/related; boundary=${boundary}`,
+      "Content-Length": String(body.length),
+    },
+    body,
+  });
+}
+
+async function uploadArtifactWithToken(args: {
+  readonly accessToken: string;
+  readonly threadId: string;
+  readonly runId: string;
+  readonly fileId: string;
+  readonly filename: string;
+  readonly contentType: string;
+  readonly file: Buffer;
+}): Promise<DriveTokenResult<Response>> {
+  const folder = await ensureArtifactFolder({
+    accessToken: args.accessToken,
+    threadId: args.threadId,
+  });
+  if (folder.type === "unauthorized") {
+    return folder;
+  }
+  const response = await uploadDriveFile({
+    accessToken: args.accessToken,
+    parentFolderId: folder.value,
+    filename: args.filename,
+    threadId: args.threadId,
+    runId: args.runId,
+    fileId: args.fileId,
+    contentType: args.contentType,
+    file: args.file,
+  });
+  if (response.status === 401) {
+    return { type: "unauthorized" };
+  }
+  return { type: "ok", value: response };
+}
+
+async function parseUploadResponse(
+  response: Response,
+): Promise<DriveSyncResult> {
+  if (!response.ok) {
+    throw badRequestMessage(
+      `Google Drive upload failed with HTTP ${String(response.status)}`,
+    );
+  }
+  const parsed = driveUploadResponseSchema.parse(await response.json());
+  return {
+    id: parsed.id,
+    name: parsed.name,
+    webViewLink: parsed.webViewLink ?? null,
+  };
+}
+
+type NotFoundResponse = ReturnType<typeof notFound>;
+type BadRequestResponse = ReturnType<typeof badRequestMessage>;
+
+/**
+ * Sync a chat-thread artifact file to the caller's connected Google Drive.
+ * Mirrors apps/web's `syncArtifactToGoogleDrive`.
+ *
+ * Error mapping (matches web verbatim where applicable):
+ *  - 404 "Artifact file not found" — thread missing/cross-user, or no row.
+ *  - 400 "Connect Google Drive before syncing artifacts" — connector
+ *    absent or `needsReconnect`.
+ *  - 400 "This artifact file cannot be synced to Google Drive" — file
+ *    metadata.s3Key is missing or doesn't match the caller's user prefix.
+ *  - 400 "Google Drive upload failed with HTTP <status>" — upload error
+ *    after refresh-token retry exhausted.
+ *  - 200 with `{ id, name, webViewLink }`.
+ */
+export const syncArtifactToGoogleDrive$ = command(
+  async (
+    { get },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly threadId: string;
+      readonly runId: string;
+      readonly fileId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<
+    | NotFoundResponse
+    | BadRequestResponse
+    | { readonly status: 200; readonly body: DriveSyncResult }
+  > => {
+    const db = get(db$);
+
+    const tokens = await loadDriveTokens(db, args.orgId, args.userId);
+    signal.throwIfAborted();
+    if (!tokens || tokens.needsReconnect) {
+      return badRequestMessage("Connect Google Drive before syncing artifacts");
+    }
+
+    const artifact = await loadArtifactFile(db, {
+      threadId: args.threadId,
+      runId: args.runId,
+      fileId: args.fileId,
+      userId: args.userId,
+    });
+    signal.throwIfAborted();
+    if (!artifact) {
+      return notFound("Artifact file not found");
+    }
+
+    const s3Key = resolveArtifactS3Key(artifact.metadata, args.userId);
+    if (!s3Key) {
+      return badRequestMessage(
+        "This artifact file cannot be synced to Google Drive",
+      );
+    }
+
+    const filename = artifact.filename ?? artifact.externalId;
+    const contentType = artifact.contentType ?? inferMimetype(filename);
+    const file = await get(
+      downloadS3Buffer(env("R2_USER_STORAGES_BUCKET_NAME"), s3Key),
+    );
+    signal.throwIfAborted();
+
+    let result = await uploadArtifactWithToken({
+      accessToken: tokens.accessToken,
+      threadId: args.threadId,
+      runId: args.runId,
+      fileId: args.fileId,
+      filename,
+      contentType,
+      file,
+    });
+    signal.throwIfAborted();
+
+    if (result.type === "unauthorized" && tokens.refreshToken) {
+      const refreshed = await refreshDriveAccessToken(tokens.refreshToken);
+      signal.throwIfAborted();
+      if (refreshed) {
+        result = await uploadArtifactWithToken({
+          accessToken: refreshed,
+          threadId: args.threadId,
+          runId: args.runId,
+          fileId: args.fileId,
+          filename,
+          contentType,
+          file,
+        });
+        signal.throwIfAborted();
+      }
+    }
+
+    if (result.type === "unauthorized") {
+      return badRequestMessage("Google Drive upload failed with HTTP 401");
+    }
+
+    return {
+      status: 200 as const,
+      body: await parseUploadResponse(result.value),
+    };
+  },
+);


### PR DESCRIPTION
## Summary

- Wave 5 #11 of #12290 — adds `POST /api/zero/chat-threads/:threadId/artifacts` (sync artifact to user's connected Google Drive) to apps/api.
- **First Wave 5 external-API-integrating route.** Establishes the MSW + external-fetch pattern for future similar routes.
- Web `apps/web/.../[id]/artifacts/route.ts` (syncGoogleDrive branch) is unchanged. Platform routes via `apiBackendMutationsEnabled\$`. Dark-launched until the operator flips the flag.

## Implementation

- `services/google-drive-artifact-sync.service.ts` (extended): adds upload-side helpers — `loadArtifactFile` (DB lookup with thread ownership), `resolveArtifactS3Key`, `inferMimetype`, `findDriveFolder`/`createDriveFolder`/`ensureDriveFolder`/`ensureArtifactFolder`, `uploadDriveFile`, `uploadArtifactWithToken` (with refresh-on-401 retry), `parseUploadResponse`, and the orchestrating `syncArtifactToGoogleDrive\$` Command. Reuses existing `loadDriveTokens` + `refreshDriveAccessToken`.
- `routes/zero-chat-threads-artifacts-sync.ts` (new): `command` handler — org auth → path params → `bodyResultOf` validation → service call → response. `signal.throwIfAborted()` after every `await`.
- `routes/zero-chat-threads.ts`: import + spread of `zeroChatThreadsArtifactsSyncRoutes`.
- 6 integration tests using MSW for Google Drive (folder list/create + multipart upload).

## Wire semantics preserved

| Branch | Wire response | Source |
|--------|---------------|--------|
| Unauthenticated | 401 UNAUTHORIZED | api defensive |
| Missing org | 401 UNAUTHORIZED | api defensive |
| No Google Drive connector | 400 BAD_REQUEST \"Connect Google Drive before syncing artifacts\" | web case 2 (line 367) |
| Unknown thread/artifact | 404 NOT_FOUND \"Artifact file not found\" | api defensive |
| Invalid body (zod) | 400 BAD_REQUEST | api defensive |
| Successful sync | 200 + Drive sync result `{ id, name, webViewLink }` | web case 1 (line 228) |

## On `forbidden()` helper

Leader's brief asked to add it as the precedent for future routes following the `conflict()` pattern from #12548. I added it but knip flagged it as unused — there's no consumer in this PR's code paths because the api auth pipeline handles `resolveOrg`'s equivalent (membership check) at an earlier layer than the service Command. Reverted; will be added when the first real consumer arrives, matching the `conflict()` precedent (which landed with its first caller in #12548).

## Test plan (6 tests)

- [x] 401 unauthenticated
- [x] 401 missing org
- [x] 400 \"Connect Google Drive before syncing artifacts\" — web case 2 ported
- [x] 404 \"Artifact file not found\" — defensive coverage of the unknown-thread/artifact path
- [x] 400 invalid body (missing fileId; zod validation)
- [x] 200 syncs artifact to Google Drive — web case 1 with full MSW assertions (auth header, multipart content type, folder query strings, app properties markers)

## Gates

- [x] `pnpm -F api exec vitest run signals/routes/__tests__/zero-chat-threads-artifacts-sync` — 6/6 pass
- [x] `pnpm -F api exec vitest run` — 848/848 pass on @vm0/api workspace (102 test files)
- [x] `pnpm turbo run lint --filter=api` — 0 warnings, 0 errors
- [x] `pnpm check-types` — all 11 workspaces clean
- [x] `pnpm format` — no changes (after auto-format)
- [x] `pnpm knip` — no findings (only pre-existing config hints)
- [x] `apps/web/**` unchanged

Closes #12562

🤖 Generated with [Claude Code](https://claude.com/claude-code)