### PR TITLE
refactor(api): migrate chat-threads DELETE [id] to api backend (Wave 5 #12)

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-delete.test.ts
@@ -1,0 +1,183 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+
+import { chatThreadByIdContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteZeroChatThread$,
+  seedZeroChatThread$,
+  type ZeroChatThreadFixture,
+} from "./helpers/zero-chat-threads";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("DELETE /api/zero/chat-threads/:id", () => {
+  const track = createFixtureTracker<ZeroChatThreadFixture>((fixture) => {
+    return store.set(deleteZeroChatThread$, fixture, context.signal);
+  });
+
+  async function getThreadRowExists(threadId: string): Promise<boolean> {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, threadId));
+    return Boolean(row);
+  }
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(chatThreadByIdContract);
+
+    const response = await accept(
+      client.delete({ params: { id: randomUUID() }, headers: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for an unknown thread id", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND", message: "Chat thread not found" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("deletes the thread and removes it from the DB (read-after-delete)", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    expect(response.body).toBeUndefined();
+
+    await expect(getThreadRowExists(fixture.threadId)).resolves.toBeFalsy();
+  });
+
+  it("returns 204 with body undefined (c.noBody contract)", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.body).toBeUndefined();
+  });
+
+  it("returns 404 for a thread owned by another user (no existence leak)", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    const otherUserId = `user_${randomUUID().slice(0, 8)}`;
+    mocks.clerk.session(otherUserId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND", message: "Chat thread not found" },
+    });
+
+    // Victim row preserved.
+    await expect(getThreadRowExists(fixture.threadId)).resolves.toBeTruthy();
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("publishes threadListChanged once on a successful delete", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    await accept(
+      client.delete({
+        params: { id: fixture.threadId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+  });
+
+  it("returns 404 for a malformed UUID without touching the DB", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    const response = await accept(
+      client.delete({
+        params: { id: "not-a-uuid" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { code: "NOT_FOUND", message: "Chat thread not found" },
+    });
+
+    // Seeded thread untouched (the malformed-id branch short-circuits before DB).
+    await expect(getThreadRowExists(fixture.threadId)).resolves.toBeTruthy();
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-delete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-delete.ts
@@ -1,0 +1,53 @@
+import { command } from "ccstate";
+import { z } from "zod";
+import { chatThreadByIdContract } from "@vm0/api-contracts/contracts/chat-threads";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { publishThreadListChanged } from "../external/realtime";
+import { notFound } from "../../lib/error";
+import { deleteChatThread$ } from "../services/zero-chat-thread.service";
+import type { RouteEntry } from "../route";
+
+const chatThreadIdSchema = z.string().uuid();
+
+function isValidChatThreadId(id: string): boolean {
+  return chatThreadIdSchema.safeParse(id).success;
+}
+
+function chatThreadNotFound() {
+  return notFound("Chat thread not found");
+}
+
+const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+  const params = get(pathParamsOf(chatThreadByIdContract.delete));
+
+  if (!isValidChatThreadId(params.id)) {
+    return chatThreadNotFound();
+  }
+
+  const result = await set(
+    deleteChatThread$,
+    { threadId: params.id, userId: auth.userId },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (!result.deleted) {
+    return chatThreadNotFound();
+  }
+
+  await publishThreadListChanged(auth.userId);
+  signal.throwIfAborted();
+
+  return { status: 204 as const, body: undefined };
+});
+
+export const zeroChatThreadDeleteRoutes: readonly RouteEntry[] = [
+  {
+    route: chatThreadByIdContract.delete,
+    handler: authRoute({}, deleteInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -26,6 +26,7 @@ import {
 } from "../services/zero-chat-thread.service";
 import type { RouteEntry } from "../route";
 import { zeroChatThreadCreateRoutes } from "./zero-chat-threads-create";
+import { zeroChatThreadDeleteRoutes } from "./zero-chat-threads-delete";
 import { zeroChatThreadMarkReadRoutes } from "./zero-chat-threads-mark-read";
 import { zeroChatThreadPinRoutes } from "./zero-chat-threads-pin";
 import { zeroChatThreadRenameRoutes } from "./zero-chat-threads-rename";
@@ -192,6 +193,7 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
     ),
   },
   ...zeroChatThreadCreateRoutes,
+  ...zeroChatThreadDeleteRoutes,
   ...zeroChatThreadMarkReadRoutes,
   ...zeroChatThreadPinRoutes,
   ...zeroChatThreadRenameRoutes,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -1044,3 +1044,24 @@ export const createChatThread$ = command(
     return thread;
   },
 );
+
+export const deleteChatThread$ = command(
+  async (
+    { set },
+    args: { readonly threadId: string; readonly userId: string },
+    signal: AbortSignal,
+  ): Promise<{ deleted: boolean }> => {
+    const writeDb = set(writeDb$);
+    const deleted = await writeDb
+      .delete(chatThreads)
+      .where(
+        and(
+          eq(chatThreads.id, args.threadId),
+          eq(chatThreads.userId, args.userId),
+        ),
+      )
+      .returning({ id: chatThreads.id });
+    signal.throwIfAborted();
+    return { deleted: deleted.length > 0 };
+  },
+);


### PR DESCRIPTION
## Summary

- Migrates `DELETE /api/zero/chat-threads/:id` from `apps/web` to `apps/api`. Wave 5 #12 — sibling to #12553 (chat-threads create); same `authRoute({})` loose-auth and same `publishThreadListChanged` realtime helper.
- Behavior 1:1 with web. Single `DELETE...WHERE (id, userId)...RETURNING` collapses unknown-id and cross-user 404s into one branch with no existence leak.

## Design choices flagged in plan + epic-review

1. **Malformed UUID stays in handler (returns 404), NOT contract zod (would emit 400)**. Web returns 404 via `isValidChatThreadId`; promoting to a contract `z.string().uuid()` would emit 400 and break shadow-compare. Out of scope to change web's behavior here.
2. **`deleteChatThread$` returns `{ deleted: boolean }`**, no throws across module boundaries. The route handler is the boundary translator that converts `false` to the `notFound(...)` envelope. Cleaner than re-throwing across services.
3. **UUID helpers duplicated in the sibling file** (8 LOC) rather than exported from the parent. Keeps the parent `zero-chat-threads.ts` export surface narrow — same precedent set by Wave 2/3 mutation files.
4. **Sync `await publishThreadListChanged(auth.userId)` after a successful DELETE** — matches web (and Wave 2/3 mark-read/rename precedent). Not fire-and-forget.

## Files

- `turbo/apps/api/src/signals/services/zero-chat-thread.service.ts` — adds `deleteChatThread$` next to `createChatThread$` (added in #12553). ~25 LOC.
- `turbo/apps/api/src/signals/routes/zero-chat-threads-delete.ts` — new sibling route file with `deleteInner$` + private uuid helpers + route entry. ~55 LOC.
- `turbo/apps/api/src/signals/routes/zero-chat-threads.ts` — one new import, one new spread (alphabetical order).
- `turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-delete.test.ts` — new test file with 7 cases.
- **No contract change.** **No web change.** **No new helper file.**

## Tests (7)

| # | Source | Case | Asserts |
|---|---|---|---|
| 1 | web | 401 unauthenticated | body `{ error.code: UNAUTHORIZED }`; no Ably |
| 2 | web | 404 unknown thread id | body `{ error.code: NOT_FOUND, message: "Chat thread not found" }`; no Ably |
| 3 | web | 204 happy path + DB read-after-delete | row removed; response.body `undefined` |
| 4 | web | 204 with body undefined (`c.noBody()` contract) | response.status === 204; body === undefined |
| 5 | web | 404 cross-user (no existence leak) | victim row preserved (DB read confirms); no Ably |
| 6 | web | publishes `threadListChanged` once | called once with `("threadListChanged", null)` after success |
| 7 | api defensive | malformed UUID `"not-a-uuid"` → 404 | seeded thread untouched; no Ably; short-circuits before any DB call |

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-threads-delete.test.ts` — 7 passed
- [x] `pnpm -F api exec vitest run` — 854 passed
- [x] `pnpm -F api run lint` — clean
- [x] `pnpm -F api run check-types` — clean
- [x] `pnpm format` / `pnpm knip --workspace api` — clean

Closes #12564.

🤖 Generated with [Claude Code](https://claude.com/claude-code)