### PR TITLE
fix(platform): silence MSW handler-lookup AbortError in vitest

### DIFF
--- a/turbo/apps/platform/src/lib/ably-auth.ts
+++ b/turbo/apps/platform/src/lib/ably-auth.ts
@@ -1,7 +1,7 @@
 import type { InitClientArgs, InitClientReturn } from "@ts-rest/core";
 import type { AuthOptions } from "ably";
 import type { platformRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
-import { detach, Reason } from "../signals/utils.ts";
+import { detach, Reason, throwIfAbort } from "../signals/utils.ts";
 import { accept } from "./accept.ts";
 
 type RealtimeTokenClient = InitClientReturn<
@@ -25,6 +25,16 @@ type AuthCallback = NonNullable<AuthOptions["authCallback"]>;
  * the promise (Ably's API is node-style callback, not awaitable) and
  * `try/catch` to bridge that error surface into the callback's error
  * argument — both patterns are restricted inside `signals/`.
+ *
+ * The fetch intentionally does NOT bind `signal` via `fetchOptions: { signal }`.
+ * Aborting the fetch while MSW is still resolving the handler races MSW's
+ * handler-lookup pipeline and surfaces as an "unhandled exception during the
+ * handler lookup" stderr in tests. The signal is honoured at the await
+ * boundary instead (`signal.throwIfAborted()`), and the catch re-throws
+ * abort errors via `throwIfAbort` so `detach`'s abort-aware silencer can
+ * track them — preserving the documented contract that Ably's callback is
+ * not invoked once `setupRealtime$` has called `ably.close()`. The wasted
+ * in-flight POST during teardown is negligible (single-shot, fast endpoint).
  */
 export function createAblyAuthCallback(
   client: RealtimeTokenClient,
@@ -36,19 +46,19 @@ export function createAblyAuthCallback(
         // eslint-disable-next-line no-restricted-syntax -- bridging Ably's node-style auth callback into our promise-based `accept()` helper; justified per eslint.config.js "If genuinely needed (JSON.parse, clipboard, polling), add an inline eslint-disable with justification"
         try {
           const res = await accept(
-            client.create({ body: {}, fetchOptions: { signal } }),
+            client.create({ body: {} }),
             [200],
             { toast: false },
           );
+          // The fetch above does not accept our signal, so check it
+          // explicitly per ccstate skill ("AbortSignal Lifecycle"): aborts
+          // surface as an AbortError that the catch re-throws to detach.
+          signal.throwIfAborted();
           callback(null, res.body);
         } catch (error) {
-          // Signal aborts happen because `setupRealtime$` already called
-          // `ably.close()` — reporting that to Ably's callback would be
-          // spurious noise (and in tests would trip the mock's "failed"
-          // path during teardown).
-          if (signal.aborted) {
-            return;
-          }
+          // Re-throw aborts so detach silences them at the boundary —
+          // Ably's callback must not be invoked after `ably.close()`.
+          throwIfAbort(error);
           callback(
             error instanceof Error ? error.message : String(error),
             null,

--- a/turbo/apps/platform/src/lib/ably-auth.ts
+++ b/turbo/apps/platform/src/lib/ably-auth.ts
@@ -45,11 +45,9 @@ export function createAblyAuthCallback(
       (async () => {
         // eslint-disable-next-line no-restricted-syntax -- bridging Ably's node-style auth callback into our promise-based `accept()` helper; justified per eslint.config.js "If genuinely needed (JSON.parse, clipboard, polling), add an inline eslint-disable with justification"
         try {
-          const res = await accept(
-            client.create({ body: {} }),
-            [200],
-            { toast: false },
-          );
+          const res = await accept(client.create({ body: {} }), [200], {
+            toast: false,
+          });
           // The fetch above does not accept our signal, so check it
           // explicitly per ccstate skill ("AbortSignal Lifecycle"): aborts
           // surface as an AbortError that the catch re-throws to detach.


### PR DESCRIPTION
## Summary
- The Ably auth-token POST in `createAblyAuthCallback` was bound to the bootstrap signal via `fetchOptions: { signal }`. In tests, `test-helpers.ts` `afterEach` aborts the controller before MSW finishes resolving the handler, which surfaces as `[MSW] Encountered an unhandled exception during the handler lookup for POST .../api/zero/realtime/token` in stderr (with the "Aborted due to finished test" AbortError chain attached).
- Fix per ccstate skill (AbortSignal Lifecycle + Detach/Test Cleanup): drop the `fetchOptions.signal` binding, then check `signal.throwIfAborted()` after the await and re-throw aborts via `throwIfAbort` in the catch so `detach`'s abort-aware silencer tracks them.
- Preserves the documented contract — Ably's callback is not invoked after `setupRealtime$` calls `ably.close()` (`realtime.test.ts > skips auth forwarding when signal aborts mid-flight` still passes).

## Test plan
- [x] `pnpm -F @vm0/app exec vitest run src/signals/__tests__/realtime.test.ts` — 10/10 incl. abort-mid-flight contract test
- [x] `pnpm -F @vm0/app exec vitest run src/signals` — 424/424, **0** AbortError/MSW/handler-lookup stderr
- [x] `views/zero-page` (133 files, 1157 tests across 3 chunks) — **0** AbortError/MSW/handler-lookup stderr; 1 unrelated pre-existing `schedule-dialog` timezone-locale failure (already failing on main)
- [x] Other `views/*` dirs (44 files, 382 tests) — **0** noise