### PR TITLE
feat(api): migrate chat-threads patch [id] (update draft) to api backend

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -364,20 +364,24 @@ describe("createApp", () => {
     it.each([204, 205, 304])(
       "forwards null-body status %s without constructing a Response with a stream",
       async (statusCode) => {
+        // Uses a path that has not been migrated to apps/api so the request
+        // hits the legacy fallthrough proxy. Originally targeted PATCH
+        // /api/zero/chat-threads/:id; now that route is handled in api, so
+        // the test re-targets an unmigrated agent path.
         mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
         useUndiciMock()
           .get("https://www.vm0.ai")
           .intercept({
-            path: "/api/zero/chat-threads/abc",
+            path: "/api/agent/runs/abc",
             method: "PATCH",
           })
           .reply(statusCode, "");
 
         const app = createApp({ signal: context.signal });
-        const response = await app.request("/api/zero/chat-threads/abc", {
+        const response = await app.request("/api/agent/runs/abc", {
           method: "PATCH",
           headers: { "content-type": "application/json" },
-          body: '{"draftContent":"hello"}',
+          body: '{"foo":"bar"}',
         });
 
         expect(response.status).toBe(statusCode);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-patch.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-patch.test.ts
@@ -1,0 +1,350 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import {
+  chatThreadByIdContract,
+  type PersistedAttachment,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteZeroChatThread$,
+  seedZeroChatThread$,
+  type ZeroChatThreadFixture,
+} from "./helpers/zero-chat-threads";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("PATCH /api/zero/chat-threads/:id", () => {
+  const track = createFixtureTracker<ZeroChatThreadFixture>((fixture) => {
+    return store.set(deleteZeroChatThread$, fixture, context.signal);
+  });
+
+  async function getThreadDraft(threadId: string) {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({
+        draftContent: chatThreads.draftContent,
+        draftAttachments: chatThreads.draftAttachments,
+      })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, threadId));
+    return row;
+  }
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(chatThreadByIdContract);
+    const response = await accept(
+      client.patch({
+        params: { id: randomUUID() },
+        body: { draftContent: "hello" },
+        headers: {},
+      }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a non-existent thread id", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    const response = await accept(
+      client.patch({
+        params: { id: randomUUID() },
+        body: { draftContent: "hello" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Chat thread not found", code: "NOT_FOUND" },
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("updates draft content and returns 204 (DB read-after-write)", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    const response = await accept(
+      client.patch({
+        params: { id: fixture.threadId },
+        body: { draftContent: "hello world" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+    expect(response.body).toBeUndefined();
+
+    const row = await getThreadDraft(fixture.threadId);
+    expect(row?.draftContent).toBe("hello world");
+    expect(row?.draftAttachments).toBeNull();
+  });
+
+  it("updates draft with attachments and returns 204 (DB read-after-write)", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const attachments: PersistedAttachment[] = [
+      {
+        id: "att-1",
+        url: "https://example.com/file.txt",
+        filename: "file.txt",
+        contentType: "text/plain",
+        size: 100,
+      },
+    ];
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    await accept(
+      client.patch({
+        params: { id: fixture.threadId },
+        body: {
+          draftContent: "with attachment",
+          draftAttachments: attachments,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    const row = await getThreadDraft(fixture.threadId);
+    expect(row?.draftContent).toBe("with attachment");
+    expect(row?.draftAttachments).toStrictEqual(attachments);
+  });
+
+  it("clears draft when patching with null values", async () => {
+    const fixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { draftContent: "to be cleared" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    await accept(
+      client.patch({
+        params: { id: fixture.threadId },
+        body: { draftContent: null },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    const row = await getThreadDraft(fixture.threadId);
+    expect(row?.draftContent).toBeNull();
+  });
+
+  it("returns 404 for a thread owned by another user (victim row preserved)", async () => {
+    const fixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { draftContent: "owner content" },
+        context.signal,
+      ),
+    );
+    const otherUserId = `user_${randomUUID().slice(0, 8)}`;
+    mocks.clerk.session(otherUserId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    const response = await accept(
+      client.patch({
+        params: { id: fixture.threadId },
+        body: { draftContent: "unauthorized" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Chat thread not found", code: "NOT_FOUND" },
+    });
+
+    // Victim row preserved.
+    const row = await getThreadDraft(fixture.threadId);
+    expect(row?.draftContent).toBe("owner content");
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("publishes threadListChanged when draft transitions empty -> non-empty", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    await accept(
+      client.patch({
+        params: { id: fixture.threadId },
+        body: { draftContent: "first keystroke" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+  });
+
+  it("does not publish on continued typing within an existing draft", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+
+    // First write — flips false → true and publishes.
+    await accept(
+      client.patch({
+        params: { id: fixture.threadId },
+        body: { draftContent: "hi" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+    context.mocks.ably.publish.mockClear();
+
+    // Second write — still has draft, no transition, no publish.
+    await accept(
+      client.patch({
+        params: { id: fixture.threadId },
+        body: { draftContent: "hi there" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("publishes threadListChanged when draft is cleared", async () => {
+    const fixture = await track(
+      store.set(
+        seedZeroChatThread$,
+        { draftContent: "existing" },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    await accept(
+      client.patch({
+        params: { id: fixture.threadId },
+        body: { draftContent: null },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+  });
+
+  it("does not publish when patching empty over empty", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    await accept(
+      client.patch({
+        params: { id: fixture.threadId },
+        body: { draftContent: null },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("publishes threadListChanged when only attachments toggle hasDraft", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const attachments: PersistedAttachment[] = [
+      {
+        id: "att-only",
+        url: "https://example.com/file.txt",
+        filename: "file.txt",
+        contentType: "text/plain",
+        size: 100,
+      },
+    ];
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    await accept(
+      client.patch({
+        params: { id: fixture.threadId },
+        body: { draftContent: null, draftAttachments: attachments },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+  });
+
+  it("returns 404 for a malformed UUID without touching the DB", async () => {
+    const fixture = await track(
+      store.set(seedZeroChatThread$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(chatThreadByIdContract);
+    const response = await accept(
+      client.patch({
+        params: { id: "not-a-uuid" },
+        body: { draftContent: "hello" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Chat thread not found", code: "NOT_FOUND" },
+    });
+
+    // Seeded thread untouched (the malformed-id branch short-circuits before DB).
+    const row = await getThreadDraft(fixture.threadId);
+    expect(row?.draftContent).toBeNull();
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-patch.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-patch.ts
@@ -1,0 +1,60 @@
+import { command } from "ccstate";
+import { z } from "zod";
+import { chatThreadByIdContract } from "@vm0/api-contracts/contracts/chat-threads";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import { notFound } from "../../lib/error";
+import { updateChatThreadDraft$ } from "../services/zero-chat-thread.service";
+import type { RouteEntry } from "../route";
+
+const chatThreadIdSchema = z.string().uuid();
+
+function isValidChatThreadId(id: string): boolean {
+  return chatThreadIdSchema.safeParse(id).success;
+}
+
+function chatThreadNotFound() {
+  return notFound("Chat thread not found");
+}
+
+const patchInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+  const params = get(pathParamsOf(chatThreadByIdContract.patch));
+
+  if (!isValidChatThreadId(params.id)) {
+    return chatThreadNotFound();
+  }
+
+  const bodyResult = await get(bodyResultOf(chatThreadByIdContract.patch));
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const result = await set(
+    updateChatThreadDraft$,
+    {
+      threadId: params.id,
+      userId: auth.userId,
+      draftContent: bodyResult.data.draftContent ?? null,
+      draftAttachments: bodyResult.data.draftAttachments ?? null,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (!result.updated) {
+    return chatThreadNotFound();
+  }
+
+  return { status: 204 as const, body: undefined };
+});
+
+export const zeroChatThreadPatchRoutes: readonly RouteEntry[] = [
+  {
+    route: chatThreadByIdContract.patch,
+    handler: authRoute({}, patchInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -29,6 +29,7 @@ import { zeroChatThreadsArtifactsSyncRoutes } from "./zero-chat-threads-artifact
 import { zeroChatThreadCreateRoutes } from "./zero-chat-threads-create";
 import { zeroChatThreadDeleteRoutes } from "./zero-chat-threads-delete";
 import { zeroChatThreadMarkReadRoutes } from "./zero-chat-threads-mark-read";
+import { zeroChatThreadPatchRoutes } from "./zero-chat-threads-patch";
 import { zeroChatThreadPinRoutes } from "./zero-chat-threads-pin";
 import { zeroChatThreadRenameRoutes } from "./zero-chat-threads-rename";
 import { zeroChatThreadUnpinRoutes } from "./zero-chat-threads-unpin";
@@ -197,6 +198,7 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
   ...zeroChatThreadCreateRoutes,
   ...zeroChatThreadDeleteRoutes,
   ...zeroChatThreadMarkReadRoutes,
+  ...zeroChatThreadPatchRoutes,
   ...zeroChatThreadPinRoutes,
   ...zeroChatThreadRenameRoutes,
   ...zeroChatThreadUnpinRoutes,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -41,6 +41,7 @@ import { z } from "zod";
 
 import { env } from "../../lib/env";
 import { db$, writeDb$ } from "../external/db";
+import { publishThreadListChanged } from "../external/realtime";
 import { listS3Objects } from "../external/s3";
 
 const REPORT_ERROR_STREAK_THRESHOLD = 2;
@@ -1063,5 +1064,92 @@ export const deleteChatThread$ = command(
       .returning({ id: chatThreads.id });
     signal.throwIfAborted();
     return { deleted: deleted.length > 0 };
+  },
+);
+
+/**
+ * A thread "has a draft" when its draft text is non-empty OR it has at least
+ * one attachment. Mirrors web's `hasDraftValue` helper exactly so the
+ * conditional `threadListChanged` publish observable from web is preserved
+ * bit-for-bit.
+ */
+function hasDraftValue(
+  content: string | null,
+  attachments: readonly PersistedAttachment[] | null,
+): boolean {
+  return (
+    (content !== null && content !== "") ||
+    (attachments !== null && attachments.length > 0)
+  );
+}
+
+/**
+ * Update a chat thread's draft content + attachments.
+ *
+ * Ownership check via the WHERE clause; missing or cross-user thread → returns
+ * `{ updated: false }` so the route handler emits the correct 404. Publishes
+ * `threadListChanged` only when the boolean `hasDraft` flag flips, so that
+ * continued typing inside an already-drafting thread does not spam the
+ * sidebar — same behaviour as web's `updateChatThreadDraft`.
+ */
+export const updateChatThreadDraft$ = command(
+  async (
+    { set },
+    args: {
+      readonly threadId: string;
+      readonly userId: string;
+      readonly draftContent: string | null;
+      readonly draftAttachments: readonly PersistedAttachment[] | null;
+    },
+    signal: AbortSignal,
+  ): Promise<{ readonly updated: boolean }> => {
+    const writeDb = set(writeDb$);
+
+    const [before] = await writeDb
+      .select({
+        draftContent: chatThreads.draftContent,
+        draftAttachments: chatThreads.draftAttachments,
+      })
+      .from(chatThreads)
+      .where(
+        and(
+          eq(chatThreads.id, args.threadId),
+          eq(chatThreads.userId, args.userId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!before) {
+      return { updated: false };
+    }
+
+    await writeDb
+      .update(chatThreads)
+      .set({
+        draftContent: args.draftContent,
+        draftAttachments: args.draftAttachments
+          ? [...args.draftAttachments]
+          : null,
+      })
+      .where(
+        and(
+          eq(chatThreads.id, args.threadId),
+          eq(chatThreads.userId, args.userId),
+        ),
+      );
+    signal.throwIfAborted();
+
+    const hadDraft = hasDraftValue(
+      before.draftContent,
+      before.draftAttachments as PersistedAttachment[] | null,
+    );
+    const hasDraft = hasDraftValue(args.draftContent, args.draftAttachments);
+    if (hadDraft !== hasDraft) {
+      await publishThreadListChanged(args.userId);
+      signal.throwIfAborted();
+    }
+
+    return { updated: true };
   },
 );


### PR DESCRIPTION
## Summary

- Closes #12566. Wave 5 sibling to a2's open PR #12565 (chat-threads DELETE) — same `authRoute({})` loose-auth, same handler-level UUID-guard returning 404 (not 400), same sibling file pattern.
- Adds `PATCH /api/zero/chat-threads/:id` to apps/api: SELECT before + UPDATE + conditional `threadListChanged` publish on `hasDraft` flip — verbatim port of web's `updateChatThreadDraft`.
- `apps/web` is intentionally untouched.

## Differences from #12565 DELETE template

| Aspect | #12565 DELETE | this PR PATCH |
|---|---|---|
| HTTP method | DELETE | PATCH |
| Body parsing | none (params only) | `bodyResultOf` for `{ draftContent?, draftAttachments? }` |
| Service write | atomic single-statement DELETE | SELECT before + UPDATE |
| Realtime publish | unconditional `publishThreadListChanged` on success | **conditional** publish only when `hasDraft(content, attachments)` flips |

## Discrepancy resolution

The dispatch note for this issue claimed "NO realtime publish (draft updates don't trigger threadListChanged)". Verified against `apps/web/src/lib/zero/chat-thread/chat-thread-service.ts:336-340`: web **does** publish, conditionally on `hasDraft` flip. The describe block at `apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts:566-915` ships **11 PATCH tests**, of which 5 lock down the publish behaviour. The leader confirmed during plan review that the dispatch note was incorrect and migration policy is verbatim parity (logic unchanged); this PR ports web verbatim.

## Implementation

- `apps/api/src/signals/services/zero-chat-thread.service.ts` — appends:
  - `hasDraftValue(content, attachments)` private helper (mirrors web's exact predicate).
  - `updateChatThreadDraft$` Command. SELECT before + UPDATE + conditional `publishThreadListChanged(userId)` only when `hadDraft !== hasDraft`. Returns `{ updated: boolean }` so the route translates a missing/cross-user thread to 404.
- `apps/api/src/signals/routes/zero-chat-threads-patch.ts` — handler. Local `chatThreadIdSchema = z.string().uuid()` short-circuits to 404 for malformed IDs before any DB / publish work. Body parsed via `bodyResultOf`. `signal.throwIfAborted()` after every `await`.
- `apps/api/src/signals/routes/zero-chat-threads.ts` — append `zeroChatThreadPatchRoutes` alphabetically between `MarkRead` and `Pin`.
- `apps/api/src/__tests__/app-factory.test.ts` — fix-up: the null-body fallthrough proxy test was using `PATCH /api/zero/chat-threads/abc` as its unmigrated-path fixture. Now that this route is handled in api, retarget the test at `PATCH /api/agent/runs/abc` (still unmigrated). Same proxy mechanism, different unmigrated path. **No behaviour change to the proxy itself.**

## Tests — 12 cases (11 web 1:1 + 1 api defensive)

| # | Case | Source |
|---|---|---|
| 1 | 401 unauthenticated | web case 1 (line 577) |
| 2 | 404 non-existent thread | web case 2 (line 595) |
| 3 | 204 update draft content + DB read-after-write | web case 3 (line 609) |
| 4 | 204 update draft attachments + DB read-after-write | web case 4 (line 642) |
| 5 | 204 clear draft (null) | web case 5 (line 687) |
| 6 | 404 cross-user (victim row preserved) | web case 6 (line 730) |
| 7 | publish on transition empty -> non-empty | web case 7 (line 757) |
| 8 | no publish on continued typing within an existing draft | web case 8 (line 782) |
| 9 | publish on clear (true -> false) | web case 9 (line 820) |
| 10 | no publish on empty-over-empty | web case 10 (line 856) |
| 11 | publish on attachments-only toggle | web case 11 (line 881) |
| 12 | malformed UUID -> 404 (api defensive) | n/a |

`toStrictEqual` on the 401/404 bodies locks the exact error messages.

## Sibling coordination

- a2's PR #12565 (chat-threads DELETE) is currently open. Both PRs touch:
  - `apps/api/src/signals/routes/zero-chat-threads.ts` (one new import + one new spread each — alphabetic merge: Delete before MarkRead, Patch between MarkRead and Pin)
  - `apps/api/src/signals/services/zero-chat-thread.service.ts` (a2 appends `deleteChatThread$`; I append `updateChatThreadDraft$` — disjoint blocks at file end)
- Whoever lands second appends after the other; rebase is mechanical.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-threads-patch.test.ts` — 12/12 pass
- [x] `pnpm -F api exec vitest run` — 871/871 pass
- [x] `pnpm turbo run lint` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — no diff
- [x] `pnpm knip` — no issues
- [x] No `apps/web/**` modified
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)