### PR TITLE
refactor(api): migrate runs cancel to api backend (wave 5)

### DIFF
--- a/turbo/apps/api/src/lib/error.ts
+++ b/turbo/apps/api/src/lib/error.ts
@@ -22,6 +22,10 @@ export function conflict(message: string) {
   return httpError(409, "CONFLICT", message);
 }
 
+export function runNotCancellable(message: string) {
+  return httpError(400, "RUN_NOT_CANCELLABLE", message);
+}
+
 export function badRequestMessage(message: string) {
   return httpError(400, "BAD_REQUEST", message);
 }

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -53,3 +53,34 @@ export async function publishUserSignal(
 export async function publishThreadListChanged(userId: string): Promise<void> {
   await publishUserSignal([userId], "threadListChanged");
 }
+
+/**
+ * Publish an org-scoped signal. Used for events that any org member's UI
+ * may want to see (e.g. queue:changed when a run cancels and a queued
+ * run becomes eligible to dispatch).
+ */
+export async function publishOrgSignal(
+  orgId: string,
+  topic: string,
+  payload: unknown = null,
+): Promise<void> {
+  const client = ablyClient();
+  const channel = client.channels.get(`org:${orgId}`);
+  await channel.publish(topic, payload);
+  L.debug(`Published "${topic}" to org:${orgId}`);
+}
+
+/**
+ * Notify a runner-group channel that a run should halt. Mirrors web's
+ * publishCancelNotification; the runner subscribes to its group's
+ * channel and aborts the matching run on receipt.
+ */
+export async function publishCancelToRunnerGroup(
+  group: string,
+  runId: string,
+): Promise<void> {
+  const client = ablyClient();
+  const channel = client.channels.get(`runner-group:${group}`);
+  await channel.publish("cancel", { runId });
+  L.debug(`Published cancel ${runId} to runner-group:${group}`);
+}

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -31,6 +31,7 @@ import { zeroOrgReadRoutes } from "./routes/zero-org-read";
 import { zeroQueuePositionRoutes } from "./routes/zero-queue-position";
 import { zeroRunDetailRoutes } from "./routes/zero-run-detail";
 import { zeroRunsRoutes } from "./routes/zero-runs";
+import { zeroRunsCancelRoutes } from "./routes/zero-runs-cancel";
 import { zeroSchedulesRoutes } from "./routes/zero-schedules";
 import { zeroMeModelProvidersDeleteRoutes } from "./routes/zero-me-model-providers-delete";
 import { zeroMeModelProvidersSetDefaultRoutes } from "./routes/zero-me-model-providers-set-default";
@@ -89,6 +90,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroQueuePositionRoutes,
   ...zeroRunDetailRoutes,
   ...zeroRunsRoutes,
+  ...zeroRunsCancelRoutes,
   ...zeroSchedulesRoutes,
   ...zeroOnboardingStatusRoutes,
   ...zeroOrgReadRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-cancel.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-cancel.test.ts
@@ -1,0 +1,234 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroRunsCancelContract } from "@vm0/api-contracts/contracts/zero-runs";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import { now } from "../../external/time";
+import { clearAllDetached } from "../../utils";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteUsageInsightFixture$,
+  seedCompose$,
+  seedRun$,
+  seedUsageInsightFixture$,
+  type UsageInsightFixture,
+} from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+describe("POST /api/zero/runs/:id/cancel", () => {
+  const track = createFixtureTracker<UsageInsightFixture>((fixture) => {
+    return store.set(deleteUsageInsightFixture$, fixture, context.signal);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    const response = await accept(
+      client.cancel({
+        params: { id: randomUUID() },
+        headers: {},
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({ error: { code: "UNAUTHORIZED" } });
+  });
+
+  it("returns 401 when authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    const response = await accept(
+      client.cancel({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({ error: { code: "UNAUTHORIZED" } });
+  });
+
+  it("returns 403 for sandbox token without agent-run:write capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const runId = `run_${randomUUID()}`;
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "sandbox",
+      userId,
+      orgId,
+      runId,
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    const response = await accept(
+      client.cancel({
+        params: { id: randomUUID() },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+    expect(response.body.error.message).toContain("agent-run:write");
+  });
+
+  it("returns 404 when run not found", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    const response = await accept(
+      client.cancel({
+        params: { id: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("cancels a running run (DB read-after-write + Ably runner cancel)", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    const response = await accept(
+      client.cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(response.body).toStrictEqual({
+      id: runId,
+      status: "cancelled",
+      message: "Run cancelled successfully",
+    });
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, runId));
+    expect(row?.status).toBe("cancelled");
+
+    // Settle the detached waitUntil work then assert Ably publish surface.
+    await clearAllDetached();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "queue:changed",
+      null,
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `runChanged:${runId}`,
+      { status: "cancelled" },
+    );
+  });
+
+  it("returns 400 RUN_NOT_CANCELLABLE when run already completed", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "completed",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    const response = await accept(
+      client.cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+    expect(response.body.error.code).toBe("RUN_NOT_CANCELLABLE");
+    expect(response.body.error.message).toContain("cannot be cancelled");
+  });
+
+  it("returns 200 when run is already cancelled (idempotent; no side effects)", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "cancelled",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    const response = await accept(
+      client.cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(response.body).toStrictEqual({
+      id: runId,
+      status: "cancelled",
+      message: "Run cancelled successfully",
+    });
+
+    // Idempotent path: NO Ably publishes scheduled.
+    await clearAllDetached();
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-runs-cancel.ts
+++ b/turbo/apps/api/src/signals/routes/zero-runs-cancel.ts
@@ -1,0 +1,76 @@
+import { command } from "ccstate";
+import { zeroRunsCancelContract } from "@vm0/api-contracts/contracts/zero-runs";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { waitUntil } from "../context/wait-until";
+import { logger } from "../../lib/log";
+import {
+  cancelRun$,
+  dispatchCancelSideEffects$,
+  type CancelRunResult,
+} from "../services/zero-run-cancel.service";
+import type { RouteEntry } from "../route";
+
+const L = logger("RunCancel");
+
+function isCancelResult(value: NonNullable<unknown>): value is CancelRunResult {
+  return "alreadyCancelled" in value;
+}
+
+const cancelInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(zeroRunsCancelContract.cancel));
+  signal.throwIfAborted();
+
+  const result = await set(
+    cancelRun$,
+    { runId: params.id, userId: auth.userId, orgId: auth.orgId },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (!isCancelResult(result)) {
+    // Frozen httpError response from notFound() or runNotCancellable() —
+    // forward verbatim. The body.error.code differentiates 404 NOT_FOUND
+    // from 400 RUN_NOT_CANCELLABLE for the client.
+    return result;
+  }
+
+  if (!result.alreadyCancelled) {
+    waitUntil(
+      set(dispatchCancelSideEffects$, result, signal).catch(
+        (error: unknown) => {
+          L.error("dispatchCancelSideEffects failed", {
+            runId: result.runId,
+            error,
+          });
+        },
+      ),
+    );
+  }
+
+  return {
+    status: 200 as const,
+    body: {
+      id: result.runId,
+      status: "cancelled" as const,
+      message: "Run cancelled successfully",
+    },
+  };
+});
+
+export const zeroRunsCancelRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroRunsCancelContract.cancel,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "agent-run:write",
+      },
+      cancelInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
@@ -1,0 +1,173 @@
+import { command } from "ccstate";
+import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+import {
+  publishCancelToRunnerGroup,
+  publishOrgSignal,
+  publishUserSignal,
+} from "../external/realtime";
+import { notFound, runNotCancellable } from "../../lib/error";
+
+export interface CancelRunResult {
+  readonly runId: string;
+  readonly previousStatus: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly sandboxId: string | null;
+  readonly runnerGroup: string | null;
+  readonly alreadyCancelled: boolean;
+}
+
+type NotFoundResponse = ReturnType<typeof notFound>;
+type RunNotCancellableResponse = ReturnType<typeof runNotCancellable>;
+
+const ACTIVE_STATUSES = ["queued", "pending", "running"] as const;
+
+/**
+ * Cancel a run. Idempotent for already-cancelled runs (returns success
+ * without dispatching side effects). Returns notFound if the run doesn't
+ * exist or is owned by another (org, user) tuple. Returns
+ * runNotCancellable for non-cancellable terminal statuses.
+ *
+ * The transactional shape (DELETE queue + UPDATE status guarded by
+ * allowed-from list, with a re-read on lost-race) mirrors web's
+ * `cancelRun` and is the correctness anchor for concurrent cancel
+ * attempts.
+ */
+export const cancelRun$ = command(
+  async (
+    { set },
+    args: {
+      readonly runId: string;
+      readonly userId: string;
+      readonly orgId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<
+    NotFoundResponse | RunNotCancellableResponse | CancelRunResult
+  > => {
+    const writeDb = set(writeDb$);
+
+    const [run] = await writeDb
+      .select()
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.id, args.runId),
+          eq(agentRuns.userId, args.userId),
+          eq(agentRuns.orgId, args.orgId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!run) {
+      return notFound(`No such run: '${args.runId}'`);
+    }
+
+    if (run.status === "cancelled") {
+      return {
+        runId: args.runId,
+        previousStatus: run.status,
+        userId: run.userId,
+        orgId: run.orgId,
+        sandboxId: run.sandboxId,
+        runnerGroup: run.runnerGroup,
+        alreadyCancelled: true,
+      };
+    }
+
+    if (!(ACTIVE_STATUSES as readonly string[]).includes(run.status)) {
+      return runNotCancellable(
+        `Run cannot be cancelled: current status is '${run.status}'`,
+      );
+    }
+
+    const cancelled = await writeDb.transaction(async (tx) => {
+      await tx.delete(agentRunQueue).where(eq(agentRunQueue.runId, args.runId));
+      const [updated] = await tx
+        .update(agentRuns)
+        .set({ status: "cancelled", completedAt: nowDate() })
+        .where(
+          and(
+            eq(agentRuns.id, args.runId),
+            inArray(agentRuns.status, [...ACTIVE_STATUSES]),
+          ),
+        )
+        .returning({ id: agentRuns.id });
+      return Boolean(updated);
+    });
+    signal.throwIfAborted();
+
+    if (cancelled) {
+      return {
+        runId: args.runId,
+        previousStatus: run.status,
+        userId: run.userId,
+        orgId: run.orgId,
+        sandboxId: run.sandboxId,
+        runnerGroup: run.runnerGroup,
+        alreadyCancelled: false,
+      };
+    }
+
+    // Lost the race: another writer transitioned the row first. Re-read
+    // and classify — if the winner moved it to cancelled the user's intent
+    // is satisfied and we respond idempotently; any other terminal state
+    // is a genuine error.
+    const [current] = await writeDb
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, args.runId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (current?.status === "cancelled") {
+      return {
+        runId: args.runId,
+        previousStatus: "cancelled",
+        userId: run.userId,
+        orgId: run.orgId,
+        sandboxId: run.sandboxId,
+        runnerGroup: run.runnerGroup,
+        alreadyCancelled: true,
+      };
+    }
+
+    return runNotCancellable(
+      `Run cannot be cancelled: status has already changed`,
+    );
+  },
+);
+
+/**
+ * Post-cancel side effects. Mirrors web's `dispatchCancelSideEffects`
+ * minus queue drain and credit processing (deferred to follow-up Wave
+ * 5/6 PRs; runners reconcile via their existing periodic queue polling
+ * fallback, and credit reconciliation happens at the next
+ * usage-event batch).
+ *
+ * Fire-and-forget caller: invoke from the route handler via
+ * `waitUntil(set(dispatchCancelSideEffects$, result, signal).catch(log))`.
+ */
+export const dispatchCancelSideEffects$ = command(
+  async (_ctx, result: CancelRunResult, signal: AbortSignal): Promise<void> => {
+    if (result.alreadyCancelled) {
+      return;
+    }
+    if (result.previousStatus === "running" && result.runnerGroup) {
+      await publishCancelToRunnerGroup(result.runnerGroup, result.runId);
+      signal.throwIfAborted();
+    }
+    await publishOrgSignal(result.orgId, "queue:changed");
+    signal.throwIfAborted();
+    await publishUserSignal([result.userId], `runChanged:${result.runId}`, {
+      status: "cancelled",
+    });
+    signal.throwIfAborted();
+  },
+);


### PR DESCRIPTION
## Summary

- Wave 5 #14 of #12290 — adds `POST /api/zero/runs/:id/cancel` to apps/api.
- **First lifecycle/cancel route in apps/api.** Establishes the `waitUntil(...).catch(log)` post-commit fire-and-forget pattern (after()-equivalent for the api side).
- Web `apps/web/.../[id]/cancel/route.ts` is unchanged; platform routes via `apiBackendMutationsEnabled\$`. Dark-launched until the operator flips the flag.

## Implementation

- `lib/error.ts`: `runNotCancellable(message)` helper (custom 400 code `RUN_NOT_CANCELLABLE`). One in-PR consumer (the cancelRun\$ Command) — knip-flag rule satisfied per the conflict() precedent in #12548.
- `signals/external/realtime.ts`: `publishOrgSignal(orgId, topic, payload)` and `publishCancelToRunnerGroup(group, runId)` helpers.
- `signals/services/zero-run-cancel.service.ts`: `cancelRun\$` Command (transactional `DELETE agent_run_queue` + `UPDATE agent_runs.status` guarded by allowed-from list + lost-race re-read; mirrors web's cancelRun verbatim) and `dispatchCancelSideEffects\$` Command (post-commit Ably publishes).
- `signals/routes/zero-runs-cancel.ts`: route handler with `requiredCapability: \"agent-run:write\"` + `waitUntil(set(dispatchCancelSideEffects\$, ...).catch(log))` for fire-and-forget side effects.
- 7 integration tests using the centralized Ably mock.

## Wire semantics preserved

| Branch | Wire response |
|--------|---------------|
| Unauthenticated | 401 UNAUTHORIZED |
| Missing org | 401 UNAUTHORIZED |
| Sandbox token without `agent-run:write` | 403 FORBIDDEN (message contains \"agent-run:write\") |
| Run not found | 404 NOT_FOUND |
| Run already completed | 400 RUN_NOT_CANCELLABLE |
| Run already cancelled (idempotent) | 200 + body without firing side effects |
| Successful cancel | 200 + side effects scheduled via waitUntil |

## Scope reduction (deferred to follow-up)

The web after-callback chain has 6 distinct side effects. This PR ports the **post-commit Ably publishes** only:
- `publishCancelToRunnerGroup(group, runId)` — runner cancel signal (critical: VM keeps running otherwise).
- `publishOrgSignal(orgId, \"queue:changed\")` — UI org refresh.
- `publishUserSignal([userId], \"runChanged:<runId>\", { status: \"cancelled\" })` — UI run row refresh.

**Deferred to follow-up Wave 5/6 PRs**:
- `dispatchCallbacks` for cancelled runs (loop schedule advancement).
- `drainOrgQueue` + `dispatchQueuedZeroRun` (queue advancement after a slot frees).
- `processOrgUsageEvents` (immediate credit reconciliation).

Web tests don't assert on any deferred work; runners reconcile via existing periodic queue polling fallback, and credit reconciliation happens at the next usage-event batch. Deferred work tracks under #12290.

## Test plan (7 tests)

- [x] 401 unauthenticated
- [x] 401 missing org (api defensive)
- [x] 403 sandbox token without `agent-run:write` (web case 6) — message contains \"agent-run:write\"
- [x] 404 run not found (web case 4)
- [x] 200 cancels a running run (web case 1) — DB row.status === \"cancelled\" + Ably mock asserts both org and user publishes (after `clearAllDetached()` settles waitUntil work)
- [x] 400 RUN_NOT_CANCELLABLE when run already completed (web case 2) — verbatim message contains \"cannot be cancelled\"
- [x] 200 idempotent when run is already cancelled (web case 3) — Ably mock NOT called (no side effects on idempotent path)

## Gates

- [x] `pnpm -F api exec vitest run signals/routes/__tests__/zero-runs-cancel` — 7/7 pass
- [x] `pnpm -F api exec vitest run` — 873/873 pass on @vm0/api workspace (106 test files)
- [x] `pnpm turbo run lint --filter=api` — 0 warnings, 0 errors
- [x] `pnpm check-types` — all 11 workspaces clean
- [x] `pnpm format` — no changes
- [x] `pnpm knip` — no findings (only pre-existing config hints)
- [x] `apps/web/**` unchanged

Closes #12570

🤖 Generated with [Claude Code](https://claude.com/claude-code)