### PR TITLE
refactor(api): migrate agents user-connectors PUT to api backend (Wave 5 #16)

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-connectors-update.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-connectors-update.test.ts
@@ -1,0 +1,335 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { userConnectors } from "@vm0/db/schema/user-connector";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteSkillsForFixture$,
+  seedAgentForInstructions$,
+  seedSkillsFixture$,
+  seedUserConnector$,
+  type SkillsFixture,
+} from "./helpers/zero-skills";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function apiClient() {
+  return setupApp({ context })(zeroUserConnectorsContract);
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+describe("PUT /api/zero/agents/:id/user-connectors", () => {
+  const track = createFixtureTracker<SkillsFixture>((fixture) => {
+    return store.set(deleteSkillsForFixture$, fixture, context.signal);
+  });
+
+  async function getEnabledTypes(
+    orgId: string,
+    userId: string,
+    agentId: string,
+  ): Promise<string[]> {
+    const writeDb = store.set(writeDb$);
+    const rows = await writeDb
+      .select({ connectorType: userConnectors.connectorType })
+      .from(userConnectors)
+      .where(
+        and(
+          eq(userConnectors.orgId, orgId),
+          eq(userConnectors.userId, userId),
+          eq(userConnectors.agentId, agentId),
+        ),
+      );
+    return rows.map((r) => {
+      return r.connectorType;
+    });
+  }
+
+  async function getAgentHeadVersion(
+    agentId: string,
+  ): Promise<string | null | undefined> {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ headVersionId: agentComposes.headVersionId })
+      .from(agentComposes)
+      .where(eq(agentComposes.id, agentId));
+    return row?.headVersionId;
+  }
+
+  it("sets connector permissions and persists them (read-after-write)", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().update({
+        params: { id: agentId },
+        headers: authHeaders(),
+        body: { enabledTypes: ["github", "slack"] },
+      }),
+      [200],
+    );
+
+    expect(new Set(response.body.enabledTypes)).toStrictEqual(
+      new Set(["github", "slack"]),
+    );
+
+    await expect(
+      getEnabledTypes(fixture.orgId, fixture.userId, agentId),
+    ).resolves.toStrictEqual(expect.arrayContaining(["github", "slack"]));
+  });
+
+  it("replaces existing permissions atomically", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    await accept(
+      apiClient().update({
+        params: { id: agentId },
+        headers: authHeaders(),
+        body: { enabledTypes: ["github", "slack"] },
+      }),
+      [200],
+    );
+
+    const response = await accept(
+      apiClient().update({
+        params: { id: agentId },
+        headers: authHeaders(),
+        body: { enabledTypes: ["linear"] },
+      }),
+      [200],
+    );
+    expect(response.body.enabledTypes).toStrictEqual(["linear"]);
+
+    await expect(
+      getEnabledTypes(fixture.orgId, fixture.userId, agentId),
+    ).resolves.toStrictEqual(["linear"]);
+  });
+
+  it("dedupes duplicate entries in enabledTypes", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().update({
+        params: { id: agentId },
+        headers: authHeaders(),
+        body: { enabledTypes: ["slack", "github", "slack"] },
+      }),
+      [200],
+    );
+
+    expect(new Set(response.body.enabledTypes)).toStrictEqual(
+      new Set(["slack", "github"]),
+    );
+    expect(response.body.enabledTypes).toHaveLength(2);
+
+    await expect(
+      getEnabledTypes(fixture.orgId, fixture.userId, agentId),
+    ).resolves.toHaveLength(2);
+  });
+
+  it("clears all permissions with an empty array", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    await store.set(
+      seedUserConnector$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentId,
+        connectorType: "github",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().update({
+        params: { id: agentId },
+        headers: authHeaders(),
+        body: { enabledTypes: [] },
+      }),
+      [200],
+    );
+
+    expect(response.body.enabledTypes).toStrictEqual([]);
+    await expect(
+      getEnabledTypes(fixture.orgId, fixture.userId, agentId),
+    ).resolves.toStrictEqual([]);
+  });
+
+  it("returns 404 for a non-existent agent", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const fakeId = randomUUID();
+
+    const response = await accept(
+      apiClient().update({
+        params: { id: fakeId },
+        headers: authHeaders(),
+        body: { enabledTypes: ["github"] },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: `Agent not found: ${fakeId}`, code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      apiClient().update({
+        params: { id: randomUUID() },
+        headers: {},
+        body: { enabledTypes: ["github"] },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("recomposes the agent when its compose head version is stale", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const STALE_VERSION = "f".repeat(64);
+    const writeDb = store.set(writeDb$);
+    await writeDb
+      .update(agentComposes)
+      .set({ headVersionId: STALE_VERSION })
+      .where(eq(agentComposes.id, agentId));
+    await expect(getAgentHeadVersion(agentId)).resolves.toBe(STALE_VERSION);
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    await accept(
+      apiClient().update({
+        params: { id: agentId },
+        headers: authHeaders(),
+        body: { enabledTypes: ["github"] },
+      }),
+      [200],
+    );
+
+    const after = await getAgentHeadVersion(agentId);
+    expect(after).not.toBe(STALE_VERSION);
+    expect(after).toMatch(/^[a-f0-9]{64}$/);
+
+    const [versionRow] = await writeDb
+      .select({ id: agentComposeVersions.id })
+      .from(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, after!));
+    expect(versionRow?.id).toBe(after);
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const response = await accept(
+      apiClient().update({
+        params: { id: randomUUID() },
+        headers: authHeaders(),
+        body: { enabledTypes: ["github"] },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 for a sandbox token without agent:read capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const runId = `run_${randomUUID()}`;
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId,
+      capabilities: ["file:read"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    const response = await accept(
+      apiClient().update({
+        params: { id: randomUUID() },
+        headers: { authorization: `Bearer ${token}` },
+        body: { enabledTypes: ["github"] },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: agent:read",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -6,7 +6,10 @@ import {
   zeroAgentsMainContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import { connectorTypeSchema } from "@vm0/connectors/connectors";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
+import { userConnectors } from "@vm0/db/schema/user-connector";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -14,6 +17,7 @@ import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import { writeDb$ } from "../external/db";
 import { notFound } from "../../lib/error";
+import { recomposeAgentIfStale$ } from "../services/agent-compose.service";
 import {
   zeroAgentDetail,
   zeroAgentEnabledConnectorTypes,
@@ -175,6 +179,101 @@ const updateAgentCustomConnectorsInner$ = command(
   },
 );
 
+const updateAgentUserConnectorsBody$ = bodyResultOf(
+  zeroUserConnectorsContract.update,
+);
+
+const updateAgentUserConnectorsInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const params = get(pathParamsOf(zeroUserConnectorsContract.update));
+    const body = await get(updateAgentUserConnectorsBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const writeDb = set(writeDb$);
+    const [agent] = await writeDb
+      .select({
+        id: agentComposes.id,
+        name: agentComposes.name,
+        headVersionId: agentComposes.headVersionId,
+      })
+      .from(agentComposes)
+      .where(
+        and(
+          eq(agentComposes.orgId, auth.orgId),
+          eq(agentComposes.id, params.id),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!agent) {
+      return agentNotFound(params.id);
+    }
+
+    const uniqueTypes = Array.from(new Set(body.data.enabledTypes));
+    const invalidTypes = uniqueTypes.filter((t) => {
+      return !connectorTypeSchema.safeParse(t).success;
+    });
+    if (invalidTypes.length > 0) {
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: `Invalid connector types: ${invalidTypes.join(", ")}`,
+            code: "VALIDATION_ERROR",
+          },
+        },
+      };
+    }
+
+    await writeDb.transaction(async (tx) => {
+      await tx
+        .delete(userConnectors)
+        .where(
+          and(
+            eq(userConnectors.orgId, auth.orgId),
+            eq(userConnectors.userId, auth.userId),
+            eq(userConnectors.agentId, params.id),
+          ),
+        );
+
+      if (uniqueTypes.length > 0) {
+        await tx.insert(userConnectors).values(
+          uniqueTypes.map((connectorType) => {
+            return {
+              orgId: auth.orgId,
+              userId: auth.userId,
+              agentId: params.id,
+              connectorType,
+            };
+          }),
+        );
+      }
+    });
+    signal.throwIfAborted();
+
+    await set(
+      recomposeAgentIfStale$,
+      {
+        userId: auth.userId,
+        agentComposeId: agent.id,
+        agentName: agent.name,
+        currentHeadVersionId: agent.headVersionId,
+      },
+      signal,
+    );
+
+    return {
+      status: 200 as const,
+      body: { enabledTypes: uniqueTypes },
+    };
+  },
+);
+
 const agentReadAuth = {
   requireOrganization: true,
   missingOrganizationStatus: 401,
@@ -201,5 +300,9 @@ export const zeroAgentsRoutes: readonly RouteEntry[] = [
   {
     route: zeroAgentCustomConnectorsContract.update,
     handler: authRoute(agentReadAuth, updateAgentCustomConnectorsInner$),
+  },
+  {
+    route: zeroUserConnectorsContract.update,
+    handler: authRoute(agentReadAuth, updateAgentUserConnectorsInner$),
   },
 ];

--- a/turbo/apps/api/src/signals/services/agent-compose.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-compose.service.ts
@@ -1,0 +1,150 @@
+import { command } from "ccstate";
+import { createHash } from "node:crypto";
+import {
+  getConnectorEnvironmentMapping,
+  getEligibleConnectorTypes,
+} from "@vm0/connectors/connector-utils";
+import { connectorTypeSchema } from "@vm0/connectors/connectors";
+import { getInstructionsFilename } from "@vm0/core/frameworks";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { eq } from "drizzle-orm";
+
+import { writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+
+/**
+ * Build canonical compose content for a zero agent. Pure function — same
+ * inputs always yield the same output. Mirrors
+ * apps/web/src/lib/zero/build-compose-content.ts so the version hash
+ * computed here matches web's for shadow-compare.
+ */
+function buildComposeContent(agentName: string): Record<string, unknown> {
+  const eligibleConnectorTypes = getEligibleConnectorTypes();
+
+  const environment: Record<string, string> = {
+    ZERO_AGENT_ID: `\${{ vars.ZERO_AGENT_ID }}`,
+    ZERO_TOKEN: `\${{ secrets.ZERO_TOKEN }}`,
+  };
+
+  for (const connector of eligibleConnectorTypes) {
+    const parsed = connectorTypeSchema.safeParse(connector);
+    if (!parsed.success) {
+      continue;
+    }
+    const mapping = getConnectorEnvironmentMapping(parsed.data);
+    for (const [envVar, valueRef] of Object.entries(mapping)) {
+      if (envVar in environment) {
+        continue;
+      }
+      if (valueRef.startsWith("$secrets.")) {
+        environment[envVar] = `\${{ secrets.${envVar} }}`;
+      } else if (valueRef.startsWith("$vars.")) {
+        environment[envVar] = `\${{ vars.${envVar} }}`;
+      }
+    }
+  }
+
+  const agentDef: Record<string, unknown> = {
+    framework: "claude-code",
+    instructions: getInstructionsFilename("claude-code"),
+    environment,
+  };
+
+  return {
+    version: "1",
+    agents: { [agentName]: agentDef },
+  };
+}
+
+function sortObjectKeys(obj: unknown): unknown {
+  if (obj === null || typeof obj !== "object") {
+    return obj;
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(sortObjectKeys);
+  }
+  const sorted: Record<string, unknown> = {};
+  const keys = Object.keys(obj as Record<string, unknown>).sort();
+  for (const key of keys) {
+    sorted[key] = sortObjectKeys((obj as Record<string, unknown>)[key]);
+  }
+  return sorted;
+}
+
+/**
+ * SHA-256 of the canonical-JSON form of `content`. Mirrors
+ * apps/web/src/lib/infra/agent-compose/content-hash.ts:computeComposeVersionId
+ * so api and web produce the same hash for the same content during the
+ * shadow-compare rollout window.
+ */
+function computeComposeVersionId(content: Record<string, unknown>): string {
+  const canonical = JSON.stringify(sortObjectKeys(content));
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+/**
+ * Rebuild the agent's compose head if its current head version is stale.
+ *
+ * This is a focused subset of web's `serverSideCompose` helper. Two
+ * branches that web's helper runs are dead code on this caller's path:
+ *
+ * 1. **Skip `extractAgentConfig` validation** (framework + agent-name regex).
+ *    `agentName` comes from `agent_composes.name`, which was regex-validated
+ *    at compose-creation time and stored normalized to lowercase. The
+ *    `framework: "claude-code"` field is a hard-coded constant inside
+ *    `buildComposeContent`. Both checks would always pass — re-running them
+ *    would be defensive duplication.
+ *
+ * 2. **Skip the find-or-create branch on `agent_composes`.** Callers
+ *    (e.g., the user-connectors PUT handler) SELECT the row by
+ *    `(orgId, id)` and 404 if missing before calling here. We go straight
+ *    to the version INSERT + head-pointer UPDATE.
+ *
+ * Like web, runs OUTSIDE any transaction the caller may be holding —
+ * web's `serverSideCompose` is also called outside the user-connectors
+ * DELETE+INSERT transaction. We mirror to preserve identical observable
+ * behavior, including the same crash window: if recompose throws after
+ * the caller's transaction commits, `agent_composes.head` stays stale
+ * until the next mutation.
+ */
+export const recomposeAgentIfStale$ = command(
+  async (
+    { set },
+    args: {
+      readonly userId: string;
+      readonly agentComposeId: string;
+      readonly agentName: string;
+      readonly currentHeadVersionId: string | null;
+    },
+    signal: AbortSignal,
+  ): Promise<{ recomposed: boolean; versionId: string }> => {
+    const content = buildComposeContent(args.agentName);
+    const versionId = computeComposeVersionId(content);
+    if (versionId === args.currentHeadVersionId) {
+      return { recomposed: false, versionId };
+    }
+
+    const writeDb = set(writeDb$);
+    await writeDb
+      .insert(agentComposeVersions)
+      .values({
+        id: versionId,
+        composeId: args.agentComposeId,
+        content,
+        createdBy: args.userId,
+      })
+      .onConflictDoNothing();
+    signal.throwIfAborted();
+
+    await writeDb
+      .update(agentComposes)
+      .set({ headVersionId: versionId, updatedAt: nowDate() })
+      .where(eq(agentComposes.id, args.agentComposeId));
+    signal.throwIfAborted();
+
+    return { recomposed: true, versionId };
+  },
+);


### PR DESCRIPTION
## Summary

- Migrates `PUT /api/zero/agents/:id/user-connectors` (replace per-agent user-connector permissions) from `apps/web` to `apps/api`. **Wave 5 #16 — first agent-domain mutation with a compose-rebuild side-effect**, establishing the recompose-on-mutation pattern.
- Behavior 1:1 with web. Inline `SELECT id, name, headVersionId FROM agent_composes WHERE org_id = ? AND id = ? LIMIT 1`. 0 rows → 404 `Agent not found: <id>`. Body validation rejects unknown connector types with 400 `VALIDATION_ERROR` (verbatim envelope match). DELETE+INSERT inside `writeDb.transaction(...)`; recompose runs OUTSIDE the transaction (matches web's call ordering).

## New service file: `agent-compose.service.ts`

Ports the recompose chain. The two pure helpers (`buildComposeContent`, `computeComposeVersionId` + `sortObjectKeys`) are kept private — used only by `recomposeAgentIfStale$`, the single export. Future migrations that need them can be promoted at that time.

`recomposeAgentIfStale$` is a focused subset of web's `serverSideCompose`. The docstring lists the two preconditions that make web's other branches dead code on this path:

1. **Skip `extractAgentConfig` validation.** `agentName` comes from `agent_composes.name` (regex-validated at compose-creation time, stored normalized to lowercase). The `framework: "claude-code"` field is a hard-coded constant inside `buildComposeContent`. Both checks would always pass.
2. **Skip the find-or-create branch.** Callers SELECT the row and 404 if missing before invoking. We go straight to version INSERT + head-pointer UPDATE.

Same observable result as web's full helper.

## Auth — `agent:read` on a write path

Reuses the existing `agentReadAuth` constant (`organizationAuthContext$` + `requiredCapability: "agent:read"`). Capability mismatch on a write path is **a verbatim match with web** — same anomaly accepted in #12523. Documented for shadow-compare parity. The api defensive 403 test (case #9) locks this down.

## Files

- `turbo/apps/api/src/signals/services/agent-compose.service.ts` — new file, ~150 LOC. Single export: `recomposeAgentIfStale$`.
- `turbo/apps/api/src/signals/routes/zero-agents.ts` — adds `updateAgentUserConnectorsInner$` + one route entry; reuses `agentReadAuth`.
- `turbo/apps/api/src/signals/routes/__tests__/zero-user-connectors-update.test.ts` — new test file, 9 cases.
- **No contract change.** **No web change.** **No new helper file.**

## Tests (9)

| # | Source | Case | Asserts |
|---|---|---|---|
| 1 | web | sets connector permissions | 200 + DB read shows new types |
| 2 | web | replaces existing permissions atomically | DB replaced; old gone |
| 3 | web | dedupes duplicate entries | 200 + dedup applied |
| 4 | web | clears all permissions with empty array | DB row gone |
| 5 | web | 404 for non-existent agent | body `toStrictEqual` `{ error: { message: "Agent not found: <id>", code: "NOT_FOUND" } }` |
| 6 | web | 401 unauthenticated | body `toStrictEqual` `{ error: { message: "Not authenticated", code: "UNAUTHORIZED" } }` |
| 7 | web | recomposes when compose version is stale | `agent_composes.headVersionId` changed; new `agent_compose_versions` row exists |
| 8 | api defensive | 401 missing-org session | body `toStrictEqual` `{ error: { code: "UNAUTHORIZED" } }` |
| 9 | api defensive | 403 sandbox token without `agent:read` | body `toStrictEqual` `{ error: { message: "Missing required capability: agent:read", code: "FORBIDDEN" } }` |

Out-of-scope (web cases 8-9 from the test file): "should skip recompose when current" + "should isolate permissions between users". Per leader's 7+2 spec; revisit in follow-up if needed.

Per leader's review request, all error envelopes use `toStrictEqual` to lock the code value verbatim during the shadow-compare rollout window.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-user-connectors-update.test.ts` — 9 passed
- [x] `pnpm -F api exec vitest run` — 887 passed
- [x] `pnpm -F api run lint` — clean
- [x] `pnpm -F api run check-types` — clean
- [x] `pnpm format` / `pnpm knip --workspace api` — clean

Closes #12579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)