### PR TITLE
refactor(api): port runs cancel queue-drain (wave 5 follow-up)

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-cancel.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-cancel.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { zeroRunsCancelContract } from "@vm0/api-contracts/contracts/zero-runs";
+import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
@@ -9,7 +10,7 @@ import { describe, expect, it } from "vitest";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
-import { now } from "../../external/time";
+import { now, nowDate } from "../../external/time";
 import { clearAllDetached } from "../../utils";
 import {
   createFixtureTracker,
@@ -230,5 +231,144 @@ describe("POST /api/zero/runs/:id/cancel", () => {
     // Idempotent path: NO Ably publishes scheduled.
     await clearAllDetached();
     expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+  });
+
+  it("drains the org queue and promotes the next queued run to pending", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId: runningRunId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+    const { runId: queuedRunId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "queued",
+      },
+      context.signal,
+    );
+
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(agentRunQueue).values({
+      runId: queuedRunId,
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      createdAt: nowDate(),
+      expiresAt: new Date(now() + 60_000),
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    await accept(
+      client.cancel({
+        params: { id: runningRunId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    await clearAllDetached();
+
+    // Cancelled run reflects the cancel.
+    const [cancelledRow] = await writeDb
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, runningRunId));
+    expect(cancelledRow?.status).toBe("cancelled");
+
+    // Queue drain promoted the queued run to pending.
+    const [queuedRow] = await writeDb
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, queuedRunId));
+    expect(queuedRow?.status).toBe("pending");
+
+    // Queue entry is gone.
+    const queueRows = await writeDb
+      .select()
+      .from(agentRunQueue)
+      .where(eq(agentRunQueue.runId, queuedRunId));
+    expect(queueRows).toHaveLength(0);
+  });
+
+  it("idempotent path does not drain the queue", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId: cancelledRunId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "cancelled",
+      },
+      context.signal,
+    );
+    const { runId: queuedRunId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "queued",
+      },
+      context.signal,
+    );
+
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(agentRunQueue).values({
+      runId: queuedRunId,
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      createdAt: nowDate(),
+      expiresAt: new Date(now() + 60_000),
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    await accept(
+      client.cancel({
+        params: { id: cancelledRunId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    await clearAllDetached();
+
+    // Idempotent path skipped dispatchCancelSideEffects$ entirely; the
+    // queue entry and queued run are untouched.
+    const [queuedRow] = await writeDb
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, queuedRunId));
+    expect(queuedRow?.status).toBe("queued");
+
+    const queueRows = await writeDb
+      .select()
+      .from(agentRunQueue)
+      .where(eq(agentRunQueue.runId, queuedRunId));
+    expect(queueRows).toHaveLength(1);
   });
 });

--- a/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
@@ -11,6 +11,7 @@ import {
   publishUserSignal,
 } from "../external/realtime";
 import { notFound, runNotCancellable } from "../../lib/error";
+import { drainOrgQueue$ } from "./zero-run-queue.service";
 
 export interface CancelRunResult {
   readonly runId: string;
@@ -145,17 +146,30 @@ export const cancelRun$ = command(
 );
 
 /**
- * Post-cancel side effects. Mirrors web's `dispatchCancelSideEffects`
- * minus queue drain and credit processing (deferred to follow-up Wave
- * 5/6 PRs; runners reconcile via their existing periodic queue polling
- * fallback, and credit reconciliation happens at the next
- * usage-event batch).
+ * Post-cancel side effects:
+ *  - Notify the runner group to halt the cancelled run (if it was
+ *    running on a runner).
+ *  - Publish org-level `queue:changed` for UI refresh.
+ *  - Publish user-level `runChanged:<runId>` for UI run row refresh.
+ *  - Drain the org queue: promote one queued run to pending if a slot
+ *    is now free. The runner picks up pending runs on its existing
+ *    poll loop; queue dispatch (load compose + start sandbox) lands in
+ *    the Stage 4 run-creation migration.
+ *
+ * Credit reconciliation (`processOrgUsageEvents`) remains deferred to
+ * a sibling follow-up — the credit-deduction chain (deductOrgCredits +
+ * expireCredits + triggerAutoRecharge + evaluateMemberCaps) requires
+ * substantial infrastructure that doesn't yet exist on the api side.
  *
  * Fire-and-forget caller: invoke from the route handler via
  * `waitUntil(set(dispatchCancelSideEffects$, result, signal).catch(log))`.
  */
 export const dispatchCancelSideEffects$ = command(
-  async (_ctx, result: CancelRunResult, signal: AbortSignal): Promise<void> => {
+  async (
+    { set },
+    result: CancelRunResult,
+    signal: AbortSignal,
+  ): Promise<void> => {
     if (result.alreadyCancelled) {
       return;
     }
@@ -168,6 +182,12 @@ export const dispatchCancelSideEffects$ = command(
     await publishUserSignal([result.userId], `runChanged:${result.runId}`, {
       status: "cancelled",
     });
+    signal.throwIfAborted();
+
+    // Promote one queued run to pending; the runner picks it up on its
+    // next poll cycle. Queue dispatch (compose loading + sandbox
+    // provisioning) lands in Stage 4.
+    await set(drainOrgQueue$, { orgId: result.orgId }, signal);
     signal.throwIfAborted();
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -1,0 +1,136 @@
+import { command } from "ccstate";
+import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
+import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { and, count, eq, gt, or, sql } from "drizzle-orm";
+
+import { writeDb$ } from "../external/db";
+import { now, nowDate } from "../external/time";
+import { publishOrgSignal } from "../external/realtime";
+import { logger } from "../../lib/log";
+
+const L = logger("ZeroRunQueue");
+
+const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
+
+const TIER_CONCURRENCY_LIMITS: Readonly<Record<OrgTier, number>> =
+  Object.freeze({
+    free: 1,
+    pro: 2,
+    team: 10,
+  });
+
+function tierLimit(tier: OrgTier | null | undefined): number {
+  if (!tier) {
+    return TIER_CONCURRENCY_LIMITS.free;
+  }
+  return TIER_CONCURRENCY_LIMITS[tier];
+}
+
+/**
+ * Drain the org's queued runs after a concurrency slot frees up.
+ *
+ * Scope: SQL-only port of web's `drainOrgQueue` minus the dispatch
+ * callback (`dispatchQueuedZeroRun`). Web's dispatch callback hands off
+ * to the run-execution path (compose loading, sandbox provisioning,
+ * etc.) which is part of the Stage 4 run-creation migration. The api
+ * side here performs the SQL transition (queued → pending) and
+ * publishes `queue:changed`. Runners pick up pending runs on their
+ * existing poll loop.
+ *
+ * Acquires `pg_advisory_xact_lock(hashtext(orgId))` — same hash key as
+ * web's `drainOrgQueue` so the two backends serialize correctly on the
+ * same org during rollout.
+ *
+ * Returns the number of runs transitioned (0 if queue empty or
+ * concurrency full).
+ */
+export const drainOrgQueue$ = command(
+  async (
+    { set },
+    args: { readonly orgId: string },
+    signal: AbortSignal,
+  ): Promise<number> => {
+    const writeDb = set(writeDb$);
+
+    const transitioned = await writeDb.transaction(async (tx) => {
+      // Serialize all queue operations for this org; same hash as web.
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext(${args.orgId}))`,
+      );
+
+      const [orgRow] = await tx
+        .select({ tier: orgMetadata.tier })
+        .from(orgMetadata)
+        .where(eq(orgMetadata.orgId, args.orgId))
+        .limit(1);
+      const limit = tierLimit(orgRow?.tier as OrgTier | null | undefined);
+
+      const staleThreshold = new Date(now() - PENDING_RUN_TTL_MS);
+      const [activeRow] = await tx
+        .select({ count: count() })
+        .from(agentRuns)
+        .where(
+          and(
+            eq(agentRuns.orgId, args.orgId),
+            or(
+              eq(agentRuns.status, "running"),
+              and(
+                eq(agentRuns.status, "pending"),
+                gt(agentRuns.createdAt, staleThreshold),
+              ),
+            ),
+          ),
+        );
+      const activeCount = Number(activeRow?.count ?? 0);
+      if (activeCount >= limit) {
+        return 0;
+      }
+
+      const queueRows = await tx
+        .select({ runId: agentRunQueue.runId })
+        .from(agentRunQueue)
+        .where(eq(agentRunQueue.orgId, args.orgId))
+        .orderBy(agentRunQueue.createdAt);
+
+      let promoted = 0;
+      for (const row of queueRows) {
+        await tx
+          .delete(agentRunQueue)
+          .where(eq(agentRunQueue.runId, row.runId));
+        const [updated] = await tx
+          .update(agentRuns)
+          .set({ status: "pending", lastHeartbeatAt: nowDate() })
+          .where(
+            and(eq(agentRuns.id, row.runId), eq(agentRuns.status, "queued")),
+          )
+          .returning({ id: agentRuns.id });
+        if (!updated) {
+          // Run was cancelled or otherwise transitioned between enqueue
+          // and drain — skip and try the next entry.
+          L.debug("drainOrgQueue: queued run already transitioned, skipping", {
+            runId: row.runId,
+          });
+          continue;
+        }
+        promoted = 1;
+        // Web's `dequeueNextAtomic` returns after the first successful
+        // transition (one slot freed = one dispatch). Match that to
+        // avoid over-dequeuing.
+        break;
+      }
+
+      return promoted;
+    });
+    signal.throwIfAborted();
+
+    // Publish queue:changed after a drain attempt — either we promoted
+    // a run, or the caller upstream freed the slot (e.g. cancel) and
+    // the queue view must refresh even when the queue was empty.
+    await publishOrgSignal(args.orgId, "queue:changed");
+    signal.throwIfAborted();
+
+    return transitioned;
+  },
+);


### PR DESCRIPTION
## Summary

Wave 5 follow-up to PR #12577. Closes the **queue-drain half** of #12578.

- Adds `drainOrgQueue\$` Command to apps/api (advisory-locked transaction matching web's `hashtext(orgId)` lock; concurrency check using the existing tier-limit pattern; dequeue oldest queue entry; transition queued → pending; publish `queue:changed`).
- Extends `dispatchCancelSideEffects\$` to call `drainOrgQueue\$` after the existing Ably publishes.
- Updates the docblock on `dispatchCancelSideEffects\$` to reflect the new state and remaining gap.

Web stays unchanged behind `apiBackendMutations` flag.

## Scope (explicit)

**In this PR:**
- `drainOrgQueue\$`: SQL-only port of web's `drainOrgQueue` minus the dispatch callback. Performs the queue-state transition and publishes `queue:changed`. Runner picks up pending runs on its existing poll loop.
- Test coverage: 2 new tests verifying queue drain on success path + idempotent path doesn't drain.

**Deferred (filed as further follow-ups):**
- `dispatchQueuedZeroRun` — web's run-execution path (compose loading + sandbox provisioning + token generation). This is Stage 4 (run-creation migration) territory; ~600 LOC of transitive infrastructure.
- `processOrgUsageEvents` + `expireCredits` + `deductOrgCredits` + `triggerAutoRecharge` + `evaluateMemberCaps` — credit reconciliation chain. Each is its own service with substantial schema/state dependencies. A partial port (mark events as processed without deducting) would be **harmful** — it leaves the system in an inconsistent state where credits never get deducted. All-or-nothing; defer cleanly to a sibling follow-up under #12290.

This PR closes the **queue-state-visibility** UX gap (cancel → next queued run becomes pending within milliseconds; UI sees queue depth shrink immediately). The **immediate-dispatch** gap (next queued run starts running within milliseconds) remains in Stage 4 and is gated by runner poll cadence in the meantime.

## Test plan (9 tests total — 7 from #12577 + 2 new)

- [x] (existing) 401 unauthenticated
- [x] (existing) 401 missing-org
- [x] (existing) 403 sandbox token without `agent-run:write`
- [x] (existing) 404 run not found
- [x] (existing) 200 cancels a running run + DB read-after-write + Ably mock asserts
- [x] (existing) 400 RUN_NOT_CANCELLABLE
- [x] (existing) 200 idempotent (no Ably publishes)
- [x] **NEW** drains the org queue and promotes the next queued run to pending — DB read confirms cancelled run \"cancelled\", queued run \"pending\", queue entry deleted
- [x] **NEW** idempotent path does not drain the queue — queued run + queue entry untouched

## Gates

- [x] `pnpm -F api exec vitest run signals/routes/__tests__/zero-runs-cancel` — 9/9 pass
- [x] `pnpm -F api exec vitest run` — 887/887 pass on @vm0/api workspace (107 test files)
- [x] `pnpm turbo run lint --filter=api` — 0 errors (1 pre-existing unrelated warning in zero-chat-threads-patch.test.ts)
- [x] `pnpm check-types` — all 11 workspaces clean
- [x] `pnpm format` — no changes
- [x] `pnpm knip` — no findings (only pre-existing config hints)
- [x] `apps/web/**` unchanged

Closes #12578 (queue-drain half)

🤖 Generated with [Claude Code](https://claude.com/claude-code)