### PR TITLE
refactor(api): port runs cancel credit reconciliation atomic core (wave 5 follow-up)

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-cancel.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-cancel.test.ts
@@ -3,8 +3,11 @@ import { randomUUID } from "node:crypto";
 import { zeroRunsCancelContract } from "@vm0/api-contracts/contracts/zero-runs";
 import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { usagePricing } from "@vm0/db/schema/usage-pricing";
 import { createStore } from "ccstate";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -304,6 +307,160 @@ describe("POST /api/zero/runs/:id/cancel", () => {
       .from(agentRunQueue)
       .where(eq(agentRunQueue.runId, queuedRunId));
     expect(queueRows).toHaveLength(0);
+  });
+
+  it("processes pending usage_event records and deducts credits on cancel", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+
+    const writeDb = store.set(writeDb$);
+    // Seed initial credit balance.
+    await writeDb.insert(orgMetadata).values({
+      orgId: fixture.orgId,
+      credits: 1000,
+      tier: "free",
+    });
+    // Seed pricing: 1 credit per 1000 input tokens.
+    await writeDb.insert(usagePricing).values({
+      kind: "model",
+      provider: "test-provider",
+      category: "tokens.input",
+      unitPrice: 1,
+      unitSize: 1000,
+    });
+    // Seed pending usage_event: 5000 input tokens → 5 credits.
+    await writeDb.insert(usageEvent).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      runId,
+      kind: "model",
+      provider: "test-provider",
+      category: "tokens.input",
+      quantity: 5000,
+      status: "pending",
+      idempotencyKey: randomUUID(),
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    await accept(
+      client.cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    await clearAllDetached();
+
+    // Event marked processed with creditsCharged.
+    const [eventRow] = await writeDb
+      .select({
+        status: usageEvent.status,
+        creditsCharged: usageEvent.creditsCharged,
+      })
+      .from(usageEvent)
+      .where(eq(usageEvent.runId, runId));
+    expect(eventRow?.status).toBe("processed");
+    expect(eventRow?.creditsCharged).toBe(5);
+
+    // Org credits reduced by 5.
+    const [orgRow] = await writeDb
+      .select({ credits: orgMetadata.credits })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    expect(orgRow?.credits).toBe(995);
+
+    // Cleanup the inserted pricing row to avoid bleed across tests.
+    await writeDb
+      .delete(usagePricing)
+      .where(
+        and(
+          eq(usagePricing.kind, "model"),
+          eq(usagePricing.provider, "test-provider"),
+          eq(usagePricing.category, "tokens.input"),
+        ),
+      );
+  });
+
+  it("does not reconcile credits on the idempotent path (run already cancelled)", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "cancelled",
+      },
+      context.signal,
+    );
+
+    const writeDb = store.set(writeDb$);
+    await writeDb.insert(orgMetadata).values({
+      orgId: fixture.orgId,
+      credits: 1000,
+      tier: "free",
+    });
+    await writeDb.insert(usageEvent).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      runId,
+      kind: "model",
+      provider: "test-provider",
+      category: "tokens.input",
+      quantity: 5000,
+      status: "pending",
+      idempotencyKey: randomUUID(),
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    await accept(
+      client.cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    await clearAllDetached();
+
+    // Idempotent path returns early — usage_event still pending, balance untouched.
+    const [eventRow] = await writeDb
+      .select({ status: usageEvent.status })
+      .from(usageEvent)
+      .where(eq(usageEvent.runId, runId));
+    expect(eventRow?.status).toBe("pending");
+
+    const [orgRow] = await writeDb
+      .select({ credits: orgMetadata.credits })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    expect(orgRow?.credits).toBe(1000);
   });
 
   it("idempotent path does not drain the queue", async () => {

--- a/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
@@ -1,0 +1,239 @@
+import { command } from "ccstate";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { usagePricing } from "@vm0/db/schema/usage-pricing";
+import { and, asc, eq, gt, lte, sql } from "drizzle-orm";
+
+import { writeDb$, type Db } from "../external/db";
+import { nowDate } from "../external/time";
+import { logger } from "../../lib/log";
+
+const L = logger("CreditUsage");
+
+type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+async function deductOrgCredits(
+  tx: WriteTx,
+  orgId: string,
+  amount: number,
+): Promise<void> {
+  await tx.execute(
+    sql`INSERT INTO org_metadata (org_id, credits, created_at, updated_at)
+        VALUES (${orgId}, ${-amount}, now(), now())
+        ON CONFLICT (org_id)
+        DO UPDATE SET credits = org_metadata.credits - ${amount}, updated_at = now()`,
+  );
+}
+
+async function expireCredits(tx: WriteTx, orgId: string): Promise<number> {
+  const expired = await tx
+    .select({
+      id: creditExpiresRecord.id,
+      remaining: creditExpiresRecord.remaining,
+    })
+    .from(creditExpiresRecord)
+    .where(
+      and(
+        eq(creditExpiresRecord.orgId, orgId),
+        lte(creditExpiresRecord.expiresAt, nowDate()),
+        gt(creditExpiresRecord.remaining, 0),
+      ),
+    )
+    .for("update");
+
+  if (expired.length === 0) {
+    return 0;
+  }
+
+  let totalExpired = 0;
+  for (const record of expired) {
+    totalExpired += record.remaining;
+    await tx
+      .update(creditExpiresRecord)
+      .set({ remaining: 0 })
+      .where(eq(creditExpiresRecord.id, record.id));
+  }
+
+  if (totalExpired > 0) {
+    await tx
+      .update(orgMetadata)
+      .set({
+        credits: sql`GREATEST(${orgMetadata.credits} - ${totalExpired}, 0)`,
+        updatedAt: nowDate(),
+      })
+      .where(eq(orgMetadata.orgId, orgId));
+  }
+
+  L.debug("expired credits settled", { orgId, totalExpired });
+  return totalExpired;
+}
+
+async function deductFromExpiresRecords(
+  tx: WriteTx,
+  orgId: string,
+  amount: number,
+): Promise<void> {
+  if (amount <= 0) {
+    return;
+  }
+
+  const records = await tx
+    .select({
+      id: creditExpiresRecord.id,
+      remaining: creditExpiresRecord.remaining,
+    })
+    .from(creditExpiresRecord)
+    .where(
+      and(
+        eq(creditExpiresRecord.orgId, orgId),
+        gt(creditExpiresRecord.remaining, 0),
+        gt(creditExpiresRecord.expiresAt, nowDate()),
+      ),
+    )
+    .orderBy(asc(creditExpiresRecord.expiresAt))
+    .for("update");
+
+  let left = amount;
+  for (const record of records) {
+    if (left <= 0) {
+      break;
+    }
+    const deduct = Math.min(left, record.remaining);
+    await tx
+      .update(creditExpiresRecord)
+      .set({ remaining: record.remaining - deduct })
+      .where(eq(creditExpiresRecord.id, record.id));
+    left -= deduct;
+  }
+  // If left > 0, the excess comes from non-expiring credits — that's fine.
+}
+
+/**
+ * Atomically process pending usage_event records for an org and deduct
+ * the total from the org's credit balance.
+ *
+ * Mirrors apps/web's `processOrgUsageEvents`. The transactional invariant
+ * is critical: events are marked processed IFF the credit deduction
+ * succeeds. If any helper throws, the whole transaction rolls back.
+ *
+ * Acquires `pg_advisory_xact_lock(hashtext('credit_' || orgId))` —
+ * verbatim same key string as web so api and web serialize correctly on
+ * the same org during rollout.
+ *
+ * Deferrals from web (each tracked as a sibling sub-issue under #12290):
+ *  - `triggerAutoRecharge(orgId)` — Stripe-bound; runs as fire-and-
+ *    forget after the tx commits. Without it, an api-routed cancel that
+ *    crosses the recharge threshold won't trigger an immediate top-up;
+ *    the next legitimate processOrgUsageEvents call (web cron or web
+ *    cancel) will. Worst case: bounded by cron interval.
+ *  - `evaluateMemberCaps(orgId, affectedUserIds)` — per-user cap
+ *    enforcement. Without it, member-cap-disable lags by up to one cron
+ *    interval; spend admission still reads the cap on every request, so
+ *    over-spend is not allowed in the meantime.
+ */
+export const processOrgUsageEvents$ = command(
+  async ({ set }, orgId: string, signal: AbortSignal): Promise<void> => {
+    const writeDb = set(writeDb$);
+
+    await writeDb.transaction(async (tx) => {
+      // Same advisory key as web: 'credit_' prefix + orgId.
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext('credit_' || ${orgId}))`,
+      );
+
+      const pendingRecords = await tx
+        .select()
+        .from(usageEvent)
+        .where(
+          and(eq(usageEvent.orgId, orgId), eq(usageEvent.status, "pending")),
+        );
+
+      if (pendingRecords.length === 0) {
+        return;
+      }
+
+      const pricingRecords = await tx.select().from(usagePricing);
+      const pricingByKey = new Map(
+        pricingRecords.map((p) => {
+          return [`${p.kind}|${p.provider}|${p.category}`, p];
+        }),
+      );
+
+      let totalCredits = 0;
+      for (const record of pendingRecords) {
+        const exactPricing = pricingByKey.get(
+          `${record.kind}|${record.provider}|${record.category}`,
+        );
+        const pricing =
+          exactPricing ??
+          pricingByKey.get(`${record.kind}|${record.provider}|__fallback__`);
+
+        if (!pricing) {
+          await tx
+            .update(usageEvent)
+            .set({
+              creditsCharged: 0,
+              status: "processed",
+              processedAt: nowDate(),
+              billingError: "missing_pricing",
+            })
+            .where(eq(usageEvent.id, record.id));
+          L.error("Missing usage_pricing — charged zero", {
+            orgId,
+            runId: record.runId,
+            idempotencyKey: record.idempotencyKey,
+            userId: record.userId,
+            kind: record.kind,
+            provider: record.provider,
+            category: record.category,
+            quantity: record.quantity,
+          });
+          continue;
+        }
+
+        if (!exactPricing) {
+          L.error("Missing usage_pricing — billed at fallback rate", {
+            orgId,
+            runId: record.runId,
+            idempotencyKey: record.idempotencyKey,
+            userId: record.userId,
+            kind: record.kind,
+            provider: record.provider,
+            category: record.category,
+            quantity: record.quantity,
+            fallbackUnitPrice: pricing.unitPrice,
+          });
+        }
+
+        const creditsCharged = Math.ceil(
+          (record.quantity * pricing.unitPrice) / pricing.unitSize,
+        );
+        await tx
+          .update(usageEvent)
+          .set({
+            creditsCharged,
+            status: "processed",
+            processedAt: nowDate(),
+            billingError: exactPricing ? null : "fallback_pricing",
+          })
+          .where(eq(usageEvent.id, record.id));
+        totalCredits += creditsCharged;
+      }
+      signal.throwIfAborted();
+
+      if (totalCredits > 0) {
+        // Order matters: settle expired credits BEFORE the new
+        // deduction. expireCredits zeros out rows whose expires_at <=
+        // now() so deductFromExpiresRecords doesn't touch them.
+        await expireCredits(tx, orgId);
+        await deductOrgCredits(tx, orgId, totalCredits);
+        await deductFromExpiresRecords(tx, orgId, totalCredits);
+      }
+      signal.throwIfAborted();
+    });
+
+    // Note: triggerAutoRecharge + evaluateMemberCaps deliberately
+    // skipped — see docblock above. Sibling sub-issues track the gaps.
+  },
+);

--- a/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
@@ -11,6 +11,7 @@ import {
   publishUserSignal,
 } from "../external/realtime";
 import { notFound, runNotCancellable } from "../../lib/error";
+import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
 import { drainOrgQueue$ } from "./zero-run-queue.service";
 
 export interface CancelRunResult {
@@ -149,17 +150,20 @@ export const cancelRun$ = command(
  * Post-cancel side effects:
  *  - Notify the runner group to halt the cancelled run (if it was
  *    running on a runner).
- *  - Publish org-level `queue:changed` for UI refresh.
- *  - Publish user-level `runChanged:<runId>` for UI run row refresh.
- *  - Drain the org queue: promote one queued run to pending if a slot
- *    is now free. The runner picks up pending runs on its existing
- *    poll loop; queue dispatch (load compose + start sandbox) lands in
- *    the Stage 4 run-creation migration.
+ *  - Publish org-level `queue:changed` and user-level `runChanged`.
+ *  - Drain the org queue: promote one queued run to pending. The
+ *    runner picks up pending runs on its existing poll loop.
+ *  - Reconcile credits via `processOrgUsageEvents$` when the cancelled
+ *    run had been doing credit-relevant work (running/pending). The
+ *    transactional invariant (events marked processed iff credit
+ *    deduction succeeds) is preserved by `processOrgUsageEvents$`.
  *
- * Credit reconciliation (`processOrgUsageEvents`) remains deferred to
- * a sibling follow-up — the credit-deduction chain (deductOrgCredits +
- * expireCredits + triggerAutoRecharge + evaluateMemberCaps) requires
- * substantial infrastructure that doesn't yet exist on the api side.
+ * Deferrals (each tracked under #12290):
+ *  - `dispatchQueuedZeroRun` (drain dispatch path) — Stage 4
+ *    run-creation migration.
+ *  - `triggerAutoRecharge` (Stripe top-up) — sibling follow-up.
+ *  - `evaluateMemberCaps` (per-user cap enforcement) — sibling
+ *    follow-up.
  *
  * Fire-and-forget caller: invoke from the route handler via
  * `waitUntil(set(dispatchCancelSideEffects$, result, signal).catch(log))`.
@@ -189,5 +193,18 @@ export const dispatchCancelSideEffects$ = command(
     // provisioning) lands in Stage 4.
     await set(drainOrgQueue$, { orgId: result.orgId }, signal);
     signal.throwIfAborted();
+
+    // Reconcile credits when the cancelled run had been doing
+    // credit-relevant work. Web's invariant: only invoke when
+    // previousStatus ∈ {running, pending} — queued runs that never
+    // started accumulating usage_event rows skip this (no-op anyway
+    // since the pending-events query returns empty).
+    if (
+      result.previousStatus === "running" ||
+      result.previousStatus === "pending"
+    ) {
+      await set(processOrgUsageEvents$, result.orgId, signal);
+      signal.throwIfAborted();
+    }
   },
 );


### PR DESCRIPTION
## Summary

Wave 5 cascade follow-up: closes the **atomic core** half of #12583. Cascade chain: PR #12577 (runs cancel base) → PR #12582 (queue-drain follow-up) → this PR (credit reconciliation atomic core).

- Adds `processOrgUsageEvents\$` Command to apps/api with the **atomic transaction invariant**: events are marked processed iff credit deduction succeeds. Mirrors web's `pg_advisory_xact_lock(hashtext('credit_' || orgId))` key verbatim.
- Inlines `deductOrgCredits` + `expireCredits` + `deductFromExpiresRecords` as private helpers in the new `zero-credit-usage.service.ts` (extract later if cross-file consumers arrive — same precedent as `conflict()` from #12548).
- Wires into `dispatchCancelSideEffects\$` when `previousStatus ∈ {running, pending}` — matches web's `shouldProcessCredits` condition.
- Updates `dispatchCancelSideEffects\$` docblock to remove the \"deferred\" wording on the credit half and document remaining gaps.

## Atomic invariant

All four mutations happen inside a single `writeDb.transaction(...)`:

1. Acquire `pg_advisory_xact_lock(hashtext('credit_' || orgId))` (same key as web).
2. Mark each pending `usage_event` row as processed (with `creditsCharged`, `processedAt`, `billingError`).
3. If totalCredits > 0: `expireCredits` → settle expired records; `deductOrgCredits` → reduce org balance; `deductFromExpiresRecords` → FEFO deduct from credit_expires_record.

If any helper throws, the entire transaction rolls back. **No leakage path** — events stay pending iff balance is unchanged.

## Wire semantics preserved

Web's flow: `if (shouldProcessCredits) await processOrgUsageEvents(orgId)`. The api side moves the conditional inside `dispatchCancelSideEffects\$` (rather than the route handler) for cohesion — `dispatchCancelSideEffects\$` is the side-effects Command, so all post-cancel side effects live in one place.

## Deferrals (each tracked under #12290)

Both are best-effort post-tx side effects. Web fires them after the transaction commits (`triggerAutoRecharge` is fire-and-forget; `evaluateMemberCaps` is awaited but errors don't cascade). Skipping them here introduces a bounded-delay gap, not data corruption:

- **`triggerAutoRecharge`** (Stripe-bound): without it, an api-routed cancel that crosses the recharge threshold won't trigger an immediate top-up. The next legitimate `processOrgUsageEvents` call (web cron OR web cancel) will. Worst case: balance below threshold for ~one cron interval.
- **`evaluateMemberCaps`** (per-user cap enforcement): without it, member-cap-disable lags by up to one cron interval. Spend admission still reads the cap on every request, so over-spend is not allowed in the meantime.

Sibling sub-issues track both for a follow-up Stripe + member-caps port.

## Test plan (11 tests total — 9 from #12582 + 2 new)

- [x] (existing 9) all unaffected; verified by full @vm0/api suite
- [x] **NEW** processes pending usage_event records and deducts credits on cancel — DB read confirms event status=processed + creditsCharged correct + org_metadata.credits decreased
- [x] **NEW** does not reconcile credits on the idempotent path (run already cancelled) — event stays pending, balance untouched

## Gates

- [x] `pnpm -F api exec vitest run signals/routes/__tests__/zero-runs-cancel` — 11/11 pass
- [x] `pnpm -F api exec vitest run` — 904/904 pass on @vm0/api workspace (109 test files)
- [x] `pnpm turbo run lint --filter=api` — 0 errors (1 pre-existing unrelated warning in zero-chat-threads-patch.test.ts)
- [x] `pnpm check-types` — all 11 workspaces clean
- [x] `pnpm format` — no changes
- [x] `pnpm knip` — no findings (only pre-existing config hints)
- [x] `apps/web/**` unchanged

Closes #12583 (atomic core)

🤖 Generated with [Claude Code](https://claude.com/claude-code)