### PR TITLE
refactor(api): migrate uploads/complete POST to api backend (Wave 5 #21)

### DIFF
--- a/turbo/apps/api/src/lib/mimetype.ts
+++ b/turbo/apps/api/src/lib/mimetype.ts
@@ -1,0 +1,43 @@
+/**
+ * Map filename extensions to canonical MIME types.
+ *
+ * Used to fill in the `Content-Type` header on uploaded files when the
+ * client does not provide one. Verbatim port of the web-side helper at
+ * apps/web/src/lib/shared/mimetype.ts so the api and web emit the same
+ * content-type for the same filename.
+ */
+const EXT_MIMETYPE_MAP: Readonly<Record<string, string>> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  svg: "image/svg+xml",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+  aac: "audio/aac",
+  flac: "audio/flac",
+  m4a: "audio/mp4",
+  mp3: "audio/mpeg",
+  mpga: "audio/mpeg",
+  oga: "audio/ogg",
+  ogg: "audio/ogg",
+  opus: "audio/opus",
+  wav: "audio/wav",
+  pdf: "application/pdf",
+  txt: "text/plain",
+  csv: "text/csv",
+  md: "text/markdown",
+  html: "text/html",
+  htm: "text/html",
+  json: "application/json",
+};
+
+export function inferMimetype(filename: string): string {
+  const ext = filename.split(".").pop()?.toLowerCase();
+  return ext
+    ? (EXT_MIMETYPE_MAP[ext] ?? "application/octet-stream")
+    : "application/octet-stream";
+}

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -45,6 +45,7 @@ import { zeroIntegrationsTelegramMessageRoutes } from "./routes/zero-integration
 import { zeroSlackChannelsRoutes } from "./routes/zero-slack-channels";
 import { zeroSlackConnectRoutes } from "./routes/zero-slack-connect";
 import { zeroTeamRoutes } from "./routes/zero-team";
+import { zeroUploadsCompleteRoutes } from "./routes/zero-uploads-complete";
 import { zeroUploadsPrepareRoutes } from "./routes/zero-uploads-prepare";
 import { zeroUsageInsightRoutes } from "./routes/zero-usage-insight";
 import { zeroUserPreferencesRoutes } from "./routes/zero-user-preferences";
@@ -107,6 +108,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroIntegrationsTelegramRoutes,
   ...zeroIntegrationsTelegramMessageRoutes,
   ...zeroTeamRoutes,
+  ...zeroUploadsCompleteRoutes,
   ...zeroUploadsPrepareRoutes,
   ...zeroUsageInsightRoutes,
   ...chatThreadsV1Routes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-complete.test.ts
@@ -1,0 +1,357 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
+import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import { seedCompose$, seedRun$ } from "./helpers/zero-usage-insight";
+import {
+  deleteZeroChatThread$,
+  seedZeroChatThread$,
+  type ZeroChatThreadFixture,
+} from "./helpers/zero-chat-threads";
+import { seedOrgMembership$ } from "./helpers/zero-org-membership";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+const TEST_BUCKET = "test-user-storages";
+
+function apiClient() {
+  return setupApp({ context })(zeroUploadsContract);
+}
+
+function authHeaders(token: string) {
+  return { authorization: `Bearer ${token}` };
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function zeroToken(args: {
+  userId: string;
+  orgId: string;
+  runId: string;
+}): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId,
+    capabilities: ["file:write"],
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+describe("POST /api/zero/uploads/complete", () => {
+  const trackThread = createFixtureTracker<ZeroChatThreadFixture>((fixture) => {
+    return store.set(deleteZeroChatThread$, fixture, context.signal);
+  });
+
+  function findUploadedFiles(externalId: string) {
+    const writeDb = store.set(writeDb$);
+    return writeDb
+      .select()
+      .from(runUploadedFiles)
+      .where(eq(runUploadedFiles.externalId, externalId));
+  }
+
+  function findUploadedFilesForRun(runId: string, externalId: string) {
+    const writeDb = store.set(writeDb$);
+    return writeDb
+      .select()
+      .from(runUploadedFiles)
+      .where(
+        and(
+          eq(runUploadedFiles.runId, runId),
+          eq(runUploadedFiles.externalId, externalId),
+        ),
+      );
+  }
+
+  /**
+   * Seed compose+agent+run, optionally linked to a chat thread.
+   * Returns { userId, orgId, composeId, runId, threadId? }.
+   */
+  async function seedRunFixture(opts: {
+    withChatThread?: boolean;
+    triggerSource?: string;
+  }): Promise<{
+    userId: string;
+    orgId: string;
+    composeId: string;
+    runId: string;
+    threadId?: string;
+  }> {
+    if (opts.withChatThread) {
+      const fixture = await trackThread(
+        store.set(seedZeroChatThread$, {}, context.signal),
+      );
+      await store.set(
+        seedOrgMembership$,
+        { orgId: fixture.orgId, userId: fixture.userId, role: "admin" },
+        context.signal,
+      );
+      const { runId } = await store.set(
+        seedRun$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          composeId: fixture.composeId,
+          triggerSource: opts.triggerSource ?? "web",
+          chatThreadId: fixture.threadId,
+        },
+        context.signal,
+      );
+      return {
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        composeId: fixture.composeId,
+        runId,
+        threadId: fixture.threadId,
+      };
+    }
+
+    const userId = `user_${randomUUID().slice(0, 8)}`;
+    const orgId = `org_${randomUUID().slice(0, 8)}`;
+    await store.set(
+      seedOrgMembership$,
+      { orgId, userId, role: "admin" },
+      context.signal,
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId, userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId,
+        userId,
+        composeId,
+        triggerSource: opts.triggerSource ?? "web",
+      },
+      context.signal,
+    );
+    return { userId, orgId, composeId, runId };
+  }
+
+  function s3Object(userId: string, fileId: string, ext: string, size = 1234) {
+    return {
+      bucket: TEST_BUCKET,
+      key: `uploads/${userId}/${fileId}/${ext}`,
+      size,
+    };
+  }
+
+  it("records a web upload for a run-scoped zero token after the object exists", async () => {
+    const fixture = await seedRunFixture({});
+    const fileId = randomUUID();
+    mocks.s3.listObjects([s3Object(fixture.userId, fileId, "report.pdf")]);
+
+    const token = zeroToken(fixture);
+    const response = await accept(
+      apiClient().complete({
+        headers: authHeaders(token),
+        body: { id: fileId },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id: fileId,
+      filename: "report.pdf",
+      contentType: "application/pdf",
+      size: 1234,
+    });
+
+    const rows = await findUploadedFiles(fileId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      runId: fixture.runId,
+      source: "web",
+      externalId: fileId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      filename: "report.pdf",
+      contentType: "application/pdf",
+      sizeBytes: 1234,
+    });
+    expect(rows[0]?.metadata).toMatchObject({
+      s3Key: `uploads/${fixture.userId}/${fileId}/report.pdf`,
+    });
+  });
+
+  it("publishes the artifacts changed signal for a chat-thread run upload", async () => {
+    const fixture = await seedRunFixture({ withChatThread: true });
+    const fileId = randomUUID();
+    mocks.s3.listObjects([s3Object(fixture.userId, fileId, "artifact.zip")]);
+
+    const token = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      runId: fixture.runId,
+    });
+    await accept(
+      apiClient().complete({
+        headers: authHeaders(token),
+        body: { id: fileId },
+      }),
+      [200],
+    );
+
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadArtifactsChanged:${fixture.threadId}`,
+      null,
+    );
+  });
+
+  it("does not record a run association for ordinary session auth", async () => {
+    const userId = `user_${randomUUID().slice(0, 8)}`;
+    const orgId = `org_${randomUUID().slice(0, 8)}`;
+    mocks.clerk.session(userId, orgId);
+
+    const fileId = randomUUID();
+    mocks.s3.listObjects([s3Object(userId, fileId, "plain.txt", 5)]);
+
+    const response = await accept(
+      apiClient().complete({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { id: fileId },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id: fileId,
+      filename: "plain.txt",
+      size: 5,
+    });
+    await expect(findUploadedFiles(fileId)).resolves.toHaveLength(0);
+  });
+
+  it("uses the validated complete content type when provided", async () => {
+    const fixture = await seedRunFixture({});
+    const fileId = randomUUID();
+    mocks.s3.listObjects([s3Object(fixture.userId, fileId, "data.bin", 9)]);
+
+    const token = zeroToken(fixture);
+    const response = await accept(
+      apiClient().complete({
+        headers: authHeaders(token),
+        body: { id: fileId, contentType: "text/csv" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id: fileId,
+      filename: "data.bin",
+      contentType: "text/csv",
+    });
+    const rows = await findUploadedFiles(fileId);
+    expect(rows[0]).toMatchObject({ contentType: "text/csv" });
+  });
+
+  it("infers audio content type from uploaded filename", async () => {
+    const fixture = await seedRunFixture({});
+    const fileId = randomUUID();
+    mocks.s3.listObjects([s3Object(fixture.userId, fileId, "clip.mp3", 2048)]);
+
+    const token = zeroToken(fixture);
+    const response = await accept(
+      apiClient().complete({
+        headers: authHeaders(token),
+        body: { id: fileId },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id: fileId,
+      filename: "clip.mp3",
+      contentType: "audio/mpeg",
+      size: 2048,
+    });
+    const rows = await findUploadedFiles(fileId);
+    expect(rows[0]).toMatchObject({
+      runId: fixture.runId,
+      contentType: "audio/mpeg",
+      filename: "clip.mp3",
+    });
+  });
+
+  it("is idempotent for repeated completion calls for the same run file", async () => {
+    const fixture = await seedRunFixture({});
+    const fileId = randomUUID();
+    mocks.s3.listObjects([s3Object(fixture.userId, fileId, "retry.txt", 7)]);
+
+    const token = zeroToken(fixture);
+    await accept(
+      apiClient().complete({
+        headers: authHeaders(token),
+        body: { id: fileId },
+      }),
+      [200],
+    );
+    await accept(
+      apiClient().complete({
+        headers: authHeaders(token),
+        body: { id: fileId },
+      }),
+      [200],
+    );
+
+    await expect(
+      findUploadedFilesForRun(fixture.runId, fileId),
+    ).resolves.toHaveLength(1);
+  });
+
+  it("returns 404 and does not record when the uploaded object cannot be found", async () => {
+    const fixture = await seedRunFixture({});
+    const fileId = randomUUID();
+    mocks.s3.listObjects([]);
+
+    const token = zeroToken(fixture);
+    const response = await accept(
+      apiClient().complete({
+        headers: authHeaders(token),
+        body: { id: fileId },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Uploaded file not found", code: "NOT_FOUND" },
+    });
+    await expect(findUploadedFiles(fileId)).resolves.toHaveLength(0);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      apiClient().complete({
+        headers: {},
+        body: { id: randomUUID() },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-uploads-complete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-uploads-complete.ts
@@ -1,0 +1,93 @@
+import { command } from "ccstate";
+import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { listS3Objects } from "../external/s3";
+import { env } from "../../lib/env";
+import { buildFileUrl } from "../../lib/file-url";
+import { inferMimetype } from "../../lib/mimetype";
+import { isAllowedUploadType } from "../../lib/uploads-constants";
+import { recordWebUploadedFile$ } from "../services/run-uploaded-files.service";
+import type { RouteEntry } from "../route";
+
+const completeBody$ = bodyResultOf(zeroUploadsContract.complete);
+
+const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+  const body = await get(completeBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  const { id, contentType: requestedContentType } = body.data;
+
+  if (requestedContentType && !isAllowedUploadType(requestedContentType)) {
+    return {
+      status: 400 as const,
+      body: {
+        error: {
+          message: `Unsupported file type: ${requestedContentType}`,
+          code: "BAD_REQUEST",
+        },
+      },
+    };
+  }
+
+  const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+  const prefix = `uploads/${auth.userId}/${id}/`;
+  const objects = await get(listS3Objects(bucket, prefix));
+  signal.throwIfAborted();
+  if (objects.length === 0) {
+    return {
+      status: 404 as const,
+      body: {
+        error: { message: "Uploaded file not found", code: "NOT_FOUND" },
+      },
+    };
+  }
+
+  const s3Object = objects[0]!;
+  const filename = s3Object.key.split("/").pop() ?? id;
+  const contentType = requestedContentType ?? inferMimetype(filename);
+  const size = s3Object.size;
+  const url = buildFileUrl(auth.userId, id, filename);
+  const lastModified =
+    s3Object.lastModified instanceof Date
+      ? s3Object.lastModified.toISOString()
+      : undefined;
+
+  const runId = "runId" in auth ? auth.runId : undefined;
+
+  await set(
+    recordWebUploadedFile$,
+    {
+      runId,
+      externalId: id,
+      userId: auth.userId,
+      orgId: "orgId" in auth ? auth.orgId : null,
+      filename,
+      contentType,
+      sizeBytes: size,
+      url,
+      s3Key: s3Object.key,
+      metadata: lastModified ? { lastModified } : {},
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: { id, filename, contentType, size, url },
+  };
+});
+
+export const zeroUploadsCompleteRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroUploadsContract.complete,
+    handler: authRoute({ requiredCapability: "file:write" }, completeInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
+++ b/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
@@ -1,0 +1,153 @@
+import { command } from "ccstate";
+import { eq, sql } from "drizzle-orm";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import {
+  RUN_UPLOADED_FILE_SOURCES,
+  runUploadedFiles,
+  type RunUploadedFileSource,
+} from "@vm0/db/schema/run-uploaded-file";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+
+import { writeDb$ } from "../external/db";
+import { publishUserSignal } from "../external/realtime";
+
+interface RecordWebUploadedFileArgs {
+  readonly runId: string | undefined;
+  readonly externalId: string;
+  readonly userId: string;
+  readonly orgId: string | null | undefined;
+  readonly filename: string;
+  readonly contentType: string;
+  readonly sizeBytes: number;
+  readonly url: string;
+  readonly s3Key: string;
+  readonly metadata: Record<string, unknown>;
+}
+
+function isRunUploadedFileSource(
+  source: string | null | undefined,
+): source is RunUploadedFileSource {
+  if (!source) {
+    return false;
+  }
+  return RUN_UPLOADED_FILE_SOURCES.some((candidate) => {
+    return candidate === source;
+  });
+}
+
+/**
+ * Insert (or upsert) a `run_uploaded_files` row for a successful web
+ * upload, then publish the chat-thread artifacts-changed signal if the
+ * run is linked to a thread. No-op when `runId` is undefined (ordinary
+ * session callers without a run-scoped token).
+ *
+ * Verbatim port of apps/web/src/lib/zero/uploads/run-uploaded-files.ts.
+ * Idempotency contract is upsert on (runId, source, externalId).
+ */
+export const recordWebUploadedFile$ = command(
+  async (
+    { set },
+    args: RecordWebUploadedFileArgs,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    if (!args.runId) {
+      return;
+    }
+    const writeDb = set(writeDb$);
+
+    // Resolve `source` via zero_runs.trigger_source if it's a known value;
+    // else fall back to "web". Mirrors web's resolveRunUploadedFileSource.
+    const [run] = await writeDb
+      .select({ triggerSource: zeroRuns.triggerSource })
+      .from(zeroRuns)
+      .where(eq(zeroRuns.id, args.runId))
+      .limit(1);
+    signal.throwIfAborted();
+    const source: RunUploadedFileSource = isRunUploadedFileSource(
+      run?.triggerSource,
+    )
+      ? run.triggerSource
+      : "web";
+
+    const metadata = {
+      ...args.metadata,
+      s3Key: args.s3Key,
+    };
+
+    await writeDb
+      .insert(runUploadedFiles)
+      .values({
+        runId: args.runId,
+        source,
+        externalId: args.externalId,
+        userId: args.userId,
+        orgId: args.orgId ?? null,
+        filename: args.filename,
+        contentType: args.contentType,
+        sizeBytes: args.sizeBytes,
+        url: args.url,
+        metadata,
+      })
+      .onConflictDoUpdate({
+        target: [
+          runUploadedFiles.runId,
+          runUploadedFiles.source,
+          runUploadedFiles.externalId,
+        ],
+        set: {
+          userId: args.userId,
+          orgId: args.orgId ?? null,
+          filename: args.filename,
+          contentType: args.contentType,
+          sizeBytes: args.sizeBytes,
+          url: args.url,
+          metadata,
+          updatedAt: sql`now()`,
+        },
+      });
+    signal.throwIfAborted();
+
+    // Resolve chat-thread linkage, then publish.
+    // Try zero_runs.chatThreadId first.
+    const [zeroRunThread] = await writeDb
+      .select({
+        chatThreadId: zeroRuns.chatThreadId,
+        userId: chatThreads.userId,
+      })
+      .from(zeroRuns)
+      .innerJoin(chatThreads, eq(zeroRuns.chatThreadId, chatThreads.id))
+      .where(eq(zeroRuns.id, args.runId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (zeroRunThread?.chatThreadId) {
+      await publishUserSignal(
+        [zeroRunThread.userId],
+        `chatThreadArtifactsChanged:${zeroRunThread.chatThreadId}`,
+      );
+      signal.throwIfAborted();
+      return;
+    }
+
+    // Fallback: chat_messages.runId join.
+    const [messageThread] = await writeDb
+      .select({
+        chatThreadId: chatMessages.chatThreadId,
+        userId: chatThreads.userId,
+      })
+      .from(chatMessages)
+      .innerJoin(chatThreads, eq(chatMessages.chatThreadId, chatThreads.id))
+      .where(eq(chatMessages.runId, args.runId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (messageThread) {
+      await publishUserSignal(
+        [messageThread.userId],
+        `chatThreadArtifactsChanged:${messageThread.chatThreadId}`,
+      );
+      signal.throwIfAborted();
+    }
+  },
+);


### PR DESCRIPTION
## Summary

- Migrates `POST /api/zero/uploads/complete` (finalize a presigned R2 upload, record metadata) from `apps/web` to `apps/api`. Wave 5 #21. Sibling to a1's #12586 (uploads/prepare); a1's PR is still open with no PR yet, so this lands standalone with shared scaffolding (lib helpers, test patterns) that a1 will rebase against.
- Behavior 1:1 with web. The contract `zeroUploadsContract` was already in tree with both `prepare` and `complete` defined; this PR binds the `complete` action only.

## Plan + reviewer answers

- **Auth verified**: `authRoute({ requiredCapability: "file:write" })` allows ordinary Clerk sessions through (capability gate applies only to sandbox/zero tokens — verified at `auth-context.ts:131-141`). Session callers always get 200 with no DB record (matches web exactly via the `!runId` early-return inside `recordWebUploadedFile$`).
- **`buildFileUrl` byte-equivalence verified**: web's `getApiUrl()` returns `env().VM0_API_URL ?? "http://localhost:3000"`; api uses `env("VM0_API_URL")`. Both produce identical URLs in production (env always set) and in tests (env-stub sets `VM0_API_URL` to the same fallback). The web fallback is dead code in our shadow-compare window. **Lifted the inline duplicate from `services/zero-chat-thread.service.ts` into `apps/api/src/lib/file-url.ts`**; both call sites now import from there.
- **`VALIDATION_ERROR` semantics**: contract zod-validation handles malformed body (zod-emitted 400). Handler-level 400 with `code: "BAD_REQUEST"` covers the `ALLOWED_UPLOAD_TYPES` rejection — same shape as web's `errorResponse(400, ..., "BAD_REQUEST")`.
- **Knip clean**: helpers kept private when only one caller uses them (`publicFileUserIdSegment` private to `file-url.ts`; `MAX_UPLOAD_SIZE_BYTES`/`MAX_UPLOAD_SIZE_LABEL` deferred to a1's prepare PR which actually consumes them).
- **`Object.freeze` on Set** for the api's `no-package-variable` lint rule (pattern from `apps/api/src/lib/cors.ts:13`).

## Files (8)

- `turbo/apps/api/src/lib/file-url.ts` — new shared helper.
- `turbo/apps/api/src/lib/mimetype.ts` — new helper, verbatim port of web's `inferMimetype`.
- `turbo/apps/api/src/lib/uploads-constants.ts` — `ALLOWED_UPLOAD_TYPES` (Object.freeze'd Set).
- `turbo/apps/api/src/signals/services/run-uploaded-files.service.ts` — `recordWebUploadedFile$` command (verbatim port of web's upsert + thread-lookup + publish chain).
- `turbo/apps/api/src/signals/routes/zero-uploads-complete.ts` — route handler.
- `turbo/apps/api/src/signals/route.ts` — register the route.
- `turbo/apps/api/src/signals/services/zero-chat-thread.service.ts` — DRY refactor: import `buildFileUrl` from the new shared lib instead of the inline duplicate.
- `turbo/apps/api/src/signals/routes/__tests__/zero-uploads-complete.test.ts` — new test file with 8 cases.
- **No contract change** (existing `zeroUploadsContract` already had `complete`).
- **No web change.**

## Tests (8)

| # | Source | Case |
|---|---|---|
| 1 | web | records a web upload for a run-scoped zero token (DB read-after-write incl. `metadata.s3Key`) |
| 2 | web | publishes `chatThreadArtifactsChanged:<threadId>` for a chat-thread run upload |
| 3 | web | does not record for ordinary session auth (200 + 0 DB rows) |
| 4 | web | uses the validated complete content type when provided |
| 5 | web | infers `audio/mpeg` content type from `clip.mp3` |
| 6 | web | idempotent for repeated completion calls (1 DB row after 2 POSTs) |
| 7 | web | 404 + 0 DB rows when the uploaded object is missing |
| 8 | api defensive | 401 unauthenticated (`toStrictEqual` envelope) |

Test setup pre-seeds `org_members_cache` via `seedOrgMembership$` so the zero-token auth flow short-circuits the Clerk membership lookup (60s TTL cache hit).

## Sibling-PR coordination (#12586 prepare)

If #12586 lands first:
- Delete duplicate `MAX_UPLOAD_SIZE_BYTES`/`MAX_UPLOAD_SIZE_LABEL` (a1 will have added them).
- Drop my `mimetype.ts` if a1 added one.
- Trivial rebase.

If this lands first:
- a1 imports `ALLOWED_UPLOAD_TYPES` and `buildFileUrl` from my new lib files; adds the size constants to `uploads-constants.ts`; binds `zeroUploadsContract.prepare`.
- Trivial 3-way merge on `route.ts`.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-uploads-complete.test.ts` — 8 passed
- [x] `pnpm -F api exec vitest run` — 912 passed
- [x] `pnpm -F api run lint` — clean
- [x] `pnpm -F api run check-types` — clean
- [x] `pnpm format` / `pnpm knip --workspace api` — clean

Closes #12589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)