### PR TITLE
refactor(api): port stripe auto-recharge for runs cancel (wave 5 cascade)

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -1,5 +1,8 @@
+import type StripeSDK from "stripe";
 import { computed } from "ccstate";
 import { vi, type Mock } from "vitest";
+
+import { mockStripeClient } from "../signals/external/stripe-client";
 
 type AsyncMock = Mock<(...args: unknown[]) => Promise<unknown>>;
 type SyncMock = Mock<(...args: unknown[]) => void>;
@@ -46,6 +49,18 @@ export interface ApiTestMocks {
   readonly stripe: {
     readonly invoices: {
       readonly list: AsyncMock;
+      readonly create: AsyncMock;
+      readonly finalizeInvoice: AsyncMock;
+      readonly pay: AsyncMock;
+    };
+    readonly invoiceItems: {
+      readonly create: AsyncMock;
+    };
+    readonly customers: {
+      readonly retrieve: AsyncMock;
+    };
+    readonly subscriptions: {
+      readonly retrieve: AsyncMock;
     };
   };
   readonly telegram: {
@@ -99,6 +114,18 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   const stripe = {
     invoices: {
       list: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      create: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      finalizeInvoice: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      pay: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    },
+    invoiceItems: {
+      create: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    },
+    customers: {
+      retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    },
+    subscriptions: {
+      retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
   };
 
@@ -219,6 +246,18 @@ vi.mock("stripe", () => {
       return {
         invoices: {
           list: apiTestMocks.stripe.invoices.list,
+          create: apiTestMocks.stripe.invoices.create,
+          finalizeInvoice: apiTestMocks.stripe.invoices.finalizeInvoice,
+          pay: apiTestMocks.stripe.invoices.pay,
+        },
+        invoiceItems: {
+          create: apiTestMocks.stripe.invoiceItems.create,
+        },
+        customers: {
+          retrieve: apiTestMocks.stripe.customers.retrieve,
+        },
+        subscriptions: {
+          retrieve: apiTestMocks.stripe.subscriptions.retrieve,
         },
       };
     }),
@@ -329,6 +368,17 @@ export function resetApiTestMocks(): void {
   apiTestMocks.slack.files.info.mockReset();
   apiTestMocks.slack.fetchFile.mockReset();
   apiTestMocks.stripe.invoices.list.mockReset();
+  apiTestMocks.stripe.invoices.create.mockReset();
+  apiTestMocks.stripe.invoices.finalizeInvoice.mockReset();
+  apiTestMocks.stripe.invoices.pay.mockReset();
+  apiTestMocks.stripe.invoiceItems.create.mockReset();
+  apiTestMocks.stripe.customers.retrieve.mockReset();
+  apiTestMocks.stripe.subscriptions.retrieve.mockReset();
+  // Re-install the Stripe client override so getStripeClient() returns
+  // the centralized mock surface (the vi.mock("stripe") factory above
+  // doesn't compose with `new StripeSDK()` because vi.fn isn't a real
+  // constructor; we route through the testOverride instead).
+  mockStripeClient(apiTestMocks.stripe as unknown as StripeSDK);
   apiTestMocks.telegram.getMe.mockReset();
   apiTestMocks.telegram.getFile.mockReset();
   apiTestMocks.otel.registerOTel.mockReset();

--- a/turbo/apps/api/src/signals/external/stripe-client.ts
+++ b/turbo/apps/api/src/signals/external/stripe-client.ts
@@ -56,3 +56,32 @@ export function mockListStripeInvoices(
 export function clearMockListStripeInvoices(): void {
   clearMockedListInvoices();
 }
+
+const { get: getMockedStripeClient, set: setMockedStripeClient } = testOverride<
+  StripeSDK | undefined
+>(() => {
+  return undefined;
+});
+
+/**
+ * Per-call Stripe SDK instantiation. Use this when a caller needs the
+ * full SDK surface (e.g. auto-recharge invoice flow); for narrow
+ * operations like list-invoices, prefer the wrapper helpers.
+ *
+ * In tests, override via `mockStripeClient(fakeSdk)` so the wrapper
+ * doesn't construct a real Stripe client. (The centralized `vi.mock("stripe")`
+ * factory in `__tests__/mocks.ts` doesn't compose with `new StripeSDK()`
+ * as a constructor — vi.fn() isn't a real constructor — so we route
+ * through this override instead.)
+ */
+export function getStripeClient(): StripeSDK {
+  const mocked = getMockedStripeClient();
+  if (mocked) {
+    return mocked;
+  }
+  return new StripeSDK(env("STRIPE_SECRET_KEY"));
+}
+
+export function mockStripeClient(fakeSdk: StripeSDK): void {
+  setMockedStripeClient(fakeSdk);
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-cancel.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-cancel.test.ts
@@ -330,6 +330,7 @@ describe("POST /api/zero/runs/:id/cancel", () => {
     );
 
     const writeDb = store.set(writeDb$);
+    const provider = `test-provider-${randomUUID().slice(0, 8)}`;
     // Seed initial credit balance.
     await writeDb.insert(orgMetadata).values({
       orgId: fixture.orgId,
@@ -339,7 +340,7 @@ describe("POST /api/zero/runs/:id/cancel", () => {
     // Seed pricing: 1 credit per 1000 input tokens.
     await writeDb.insert(usagePricing).values({
       kind: "model",
-      provider: "test-provider",
+      provider,
       category: "tokens.input",
       unitPrice: 1,
       unitSize: 1000,
@@ -350,7 +351,7 @@ describe("POST /api/zero/runs/:id/cancel", () => {
       userId: fixture.userId,
       runId,
       kind: "model",
-      provider: "test-provider",
+      provider,
       category: "tokens.input",
       quantity: 5000,
       status: "pending",
@@ -393,7 +394,7 @@ describe("POST /api/zero/runs/:id/cancel", () => {
       .where(
         and(
           eq(usagePricing.kind, "model"),
-          eq(usagePricing.provider, "test-provider"),
+          eq(usagePricing.provider, provider),
           eq(usagePricing.category, "tokens.input"),
         ),
       );
@@ -527,5 +528,286 @@ describe("POST /api/zero/runs/:id/cancel", () => {
       .from(agentRunQueue)
       .where(eq(agentRunQueue.runId, queuedRunId));
     expect(queueRows).toHaveLength(1);
+  });
+
+  it("triggers Stripe auto-recharge when balance crosses threshold", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+
+    const writeDb = store.set(writeDb$);
+    const provider = `test-provider-${randomUUID().slice(0, 8)}`;
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    // Seed paid org with auto-recharge enabled at threshold=500.
+    await writeDb.insert(orgMetadata).values({
+      orgId: fixture.orgId,
+      credits: 600,
+      tier: "team",
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: null,
+      autoRechargeEnabled: true,
+      autoRechargeThreshold: 500,
+      autoRechargeAmount: 10_000,
+    });
+    await writeDb.insert(usagePricing).values({
+      kind: "model",
+      provider,
+      category: "tokens.input",
+      unitPrice: 1,
+      unitSize: 1,
+    });
+    // 200 quantity × $1 / 1 unit = 200 credits → balance drops 600 → 400 (≤ 500).
+    await writeDb.insert(usageEvent).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      runId,
+      kind: "model",
+      provider,
+      category: "tokens.input",
+      quantity: 200,
+      status: "pending",
+      idempotencyKey: randomUUID(),
+    });
+
+    // Stub Stripe responses.
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: customerId,
+      deleted: false,
+      invoice_settings: { default_payment_method: "pm_test" },
+    });
+    context.mocks.stripe.invoices.create.mockResolvedValue({
+      id: "in_test",
+    });
+    context.mocks.stripe.invoiceItems.create.mockResolvedValue({
+      id: "ii_test",
+    });
+    context.mocks.stripe.invoices.finalizeInvoice.mockResolvedValue({
+      id: "in_test",
+    });
+    context.mocks.stripe.invoices.pay.mockResolvedValue({
+      id: "in_test",
+      status: "paid",
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    await accept(
+      client.cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    await clearAllDetached();
+
+    // Stripe invoice created with the expected metadata.
+    expect(context.mocks.stripe.invoices.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: customerId,
+        auto_advance: false,
+        default_payment_method: "pm_test",
+        metadata: expect.objectContaining({
+          type: "auto_recharge",
+          orgId: fixture.orgId,
+          creditsAmount: "10000",
+        }),
+      }),
+    );
+    expect(context.mocks.stripe.invoices.finalizeInvoice).toHaveBeenCalledWith(
+      "in_test",
+    );
+    expect(context.mocks.stripe.invoices.pay).toHaveBeenCalledWith("in_test");
+
+    // pendingAt set by the atomic claim.
+    const [orgRow] = await writeDb
+      .select({ pendingAt: orgMetadata.autoRechargePendingAt })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    expect(orgRow?.pendingAt).toBeInstanceOf(Date);
+
+    await writeDb
+      .delete(usagePricing)
+      .where(
+        and(
+          eq(usagePricing.kind, "model"),
+          eq(usagePricing.provider, provider),
+          eq(usagePricing.category, "tokens.input"),
+        ),
+      );
+  });
+
+  it("does not trigger auto-recharge when balance is above threshold", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+
+    const writeDb = store.set(writeDb$);
+    const provider = `test-provider-${randomUUID().slice(0, 8)}`;
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    await writeDb.insert(orgMetadata).values({
+      orgId: fixture.orgId,
+      credits: 100_000,
+      tier: "team",
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: null,
+      autoRechargeEnabled: true,
+      autoRechargeThreshold: 500,
+      autoRechargeAmount: 10_000,
+    });
+    await writeDb.insert(usagePricing).values({
+      kind: "model",
+      provider,
+      category: "tokens.input",
+      unitPrice: 1,
+      unitSize: 1,
+    });
+    await writeDb.insert(usageEvent).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      runId,
+      kind: "model",
+      provider,
+      category: "tokens.input",
+      quantity: 5,
+      status: "pending",
+      idempotencyKey: randomUUID(),
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    await accept(
+      client.cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    await clearAllDetached();
+
+    // Balance well above threshold → atomic claim returns no rows → no Stripe.
+    expect(context.mocks.stripe.invoices.create).not.toHaveBeenCalled();
+
+    await writeDb
+      .delete(usagePricing)
+      .where(
+        and(
+          eq(usagePricing.kind, "model"),
+          eq(usagePricing.provider, provider),
+          eq(usagePricing.category, "tokens.input"),
+        ),
+      );
+  });
+
+  it("does not re-trigger auto-recharge when claim is already pending", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+
+    const writeDb = store.set(writeDb$);
+    const provider = `test-provider-${randomUUID().slice(0, 8)}`;
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    // pendingAt within the 10-min stale-threshold window → atomic claim
+    // refuses (already-pending).
+    await writeDb.insert(orgMetadata).values({
+      orgId: fixture.orgId,
+      credits: 400,
+      tier: "team",
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: null,
+      autoRechargeEnabled: true,
+      autoRechargeThreshold: 500,
+      autoRechargeAmount: 10_000,
+      autoRechargePendingAt: nowDate(),
+    });
+    await writeDb.insert(usagePricing).values({
+      kind: "model",
+      provider,
+      category: "tokens.input",
+      unitPrice: 1,
+      unitSize: 1,
+    });
+    await writeDb.insert(usageEvent).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      runId,
+      kind: "model",
+      provider,
+      category: "tokens.input",
+      quantity: 50,
+      status: "pending",
+      idempotencyKey: randomUUID(),
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    await accept(
+      client.cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    await clearAllDetached();
+
+    // Already-pending → atomic claim returns no rows → no Stripe.
+    expect(context.mocks.stripe.invoices.create).not.toHaveBeenCalled();
+
+    await writeDb
+      .delete(usagePricing)
+      .where(
+        and(
+          eq(usagePricing.kind, "model"),
+          eq(usagePricing.provider, provider),
+          eq(usagePricing.category, "tokens.input"),
+        ),
+      );
   });
 });

--- a/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
@@ -1,0 +1,196 @@
+import type StripeSDK from "stripe";
+import { command } from "ccstate";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { eq, sql } from "drizzle-orm";
+
+import { writeDb$ } from "../external/db";
+import { getStripeClient } from "../external/stripe-client";
+import { nowDate } from "../external/time";
+import { safeAsync } from "../utils";
+import { logger } from "../../lib/log";
+
+const L = logger("CreditRecharge");
+
+const CREDITS_PER_DOLLAR = 1000;
+const STALE_THRESHOLD_MINUTES = 10;
+
+interface ClaimedRechargeState {
+  readonly credits: number;
+  readonly tier: string;
+  readonly stripeCustomerId: string;
+  readonly stripeSubscriptionId: string | null;
+  readonly autoRechargeEnabled: boolean;
+  readonly autoRechargeThreshold: number;
+  readonly autoRechargeAmount: number;
+  readonly autoRechargePendingAt: Date | null;
+}
+
+function resolvePaymentMethodId(
+  pm: string | StripeSDK.PaymentMethod | null | undefined,
+): string | null {
+  if (typeof pm === "string") {
+    return pm;
+  }
+  return pm?.id ?? null;
+}
+
+async function resolvePaymentMethod(
+  stripe: StripeSDK,
+  org: ClaimedRechargeState,
+): Promise<string | null> {
+  const customer = await stripe.customers.retrieve(org.stripeCustomerId);
+  if ("deleted" in customer && customer.deleted) {
+    L.warn("Stripe customer is deleted, skipping auto-recharge", {
+      stripeCustomerId: org.stripeCustomerId,
+    });
+    return null;
+  }
+  const customerPm = resolvePaymentMethodId(
+    (customer as StripeSDK.Customer).invoice_settings?.default_payment_method,
+  );
+  if (customerPm) {
+    return customerPm;
+  }
+
+  if (org.stripeSubscriptionId) {
+    const subscription = await stripe.subscriptions.retrieve(
+      org.stripeSubscriptionId,
+    );
+    const subPm = resolvePaymentMethodId(subscription.default_payment_method);
+    if (subPm) {
+      return subPm;
+    }
+  }
+
+  L.warn("No payment method found on customer or subscription", {
+    stripeCustomerId: org.stripeCustomerId,
+  });
+  return null;
+}
+
+/**
+ * Trigger a Stripe auto-recharge invoice if the org's balance has
+ * crossed the recharge threshold. Mirrors web's `triggerAutoRecharge`.
+ *
+ * Atomically claims the recharge slot via UPDATE … RETURNING with a
+ * WHERE clause that filters on:
+ *  - autoRechargeEnabled = true
+ *  - tier != 'free'
+ *  - stripeCustomerId / threshold / amount NOT NULL
+ *  - credits <= threshold
+ *  - pendingAt IS NULL OR pendingAt < now() - 10 minutes
+ *
+ * Verbatim same WHERE shape as web so api and web don't double-claim
+ * during rollout. The 10-minute stale-threshold lets a hung Stripe call
+ * release the slot eventually.
+ *
+ * On Stripe error: clearPendingFlag so retry can fire on the next
+ * legitimate processOrgUsageEvents call.
+ *
+ * Note: credits are GRANTED via the Stripe webhook
+ * `handleAutoRechargeInvoicePaid` (separate route surface, out of
+ * scope here). This Command only triggers the invoice; never grant
+ * credits here.
+ */
+export const triggerAutoRecharge$ = command(
+  async ({ set }, orgId: string, signal: AbortSignal): Promise<void> => {
+    const writeDb = set(writeDb$);
+
+    const clearPendingFlag = async (): Promise<void> => {
+      await writeDb
+        .update(orgMetadata)
+        .set({ autoRechargePendingAt: null, updatedAt: nowDate() })
+        .where(eq(orgMetadata.orgId, orgId));
+    };
+
+    const claimed = await writeDb
+      .update(orgMetadata)
+      .set({ autoRechargePendingAt: nowDate(), updatedAt: nowDate() })
+      .where(
+        sql`${orgMetadata.orgId} = ${orgId}
+            AND ${orgMetadata.autoRechargeEnabled} = true
+            AND ${orgMetadata.tier} != 'free'
+            AND ${orgMetadata.stripeCustomerId} IS NOT NULL
+            AND ${orgMetadata.autoRechargeThreshold} IS NOT NULL
+            AND ${orgMetadata.autoRechargeAmount} IS NOT NULL
+            AND ${orgMetadata.credits} <= ${orgMetadata.autoRechargeThreshold}
+            AND (${orgMetadata.autoRechargePendingAt} IS NULL
+                 OR ${orgMetadata.autoRechargePendingAt} < now() - interval '${sql.raw(String(STALE_THRESHOLD_MINUTES))} minutes')`,
+      )
+      .returning({
+        credits: orgMetadata.credits,
+        tier: orgMetadata.tier,
+        stripeCustomerId: orgMetadata.stripeCustomerId,
+        stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+        autoRechargeEnabled: orgMetadata.autoRechargeEnabled,
+        autoRechargeThreshold: orgMetadata.autoRechargeThreshold,
+        autoRechargeAmount: orgMetadata.autoRechargeAmount,
+        autoRechargePendingAt: orgMetadata.autoRechargePendingAt,
+      });
+    signal.throwIfAborted();
+
+    const org = claimed[0] as ClaimedRechargeState | undefined;
+    if (!org) {
+      L.debug("Auto-recharge already pending or conditions unmet", { orgId });
+      return;
+    }
+
+    const creditsAmount = org.autoRechargeAmount;
+    const amountCents = Math.ceil(creditsAmount / CREDITS_PER_DOLLAR) * 100;
+
+    const stripe = getStripeClient();
+
+    const outcome = await safeAsync(async (): Promise<void> => {
+      const paymentMethodId = await resolvePaymentMethod(stripe, org);
+      signal.throwIfAborted();
+      if (!paymentMethodId) {
+        await clearPendingFlag();
+        return;
+      }
+
+      const invoice = await stripe.invoices.create({
+        customer: org.stripeCustomerId,
+        auto_advance: false,
+        default_payment_method: paymentMethodId,
+        metadata: {
+          type: "auto_recharge",
+          orgId,
+          creditsAmount: String(creditsAmount),
+        },
+      });
+      signal.throwIfAborted();
+
+      await stripe.invoiceItems.create({
+        invoice: invoice.id,
+        customer: org.stripeCustomerId,
+        amount: amountCents,
+        currency: "usd",
+        description: `Credit top-up: ${creditsAmount.toLocaleString()} credits`,
+      });
+      signal.throwIfAborted();
+
+      await stripe.invoices.finalizeInvoice(invoice.id);
+      signal.throwIfAborted();
+      await stripe.invoices.pay(invoice.id);
+      signal.throwIfAborted();
+
+      L.debug("Auto-recharge invoice created and paid", {
+        orgId,
+        creditsAmount,
+        amountCents,
+        invoiceId: invoice.id,
+      });
+    });
+
+    signal.throwIfAborted();
+
+    if ("error" in outcome) {
+      const { error } = outcome;
+      L.warn("Auto-recharge Stripe call failed, clearing pending flag", {
+        orgId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      await clearPendingFlag();
+    }
+  },
+);

--- a/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
@@ -8,6 +8,7 @@ import { and, asc, eq, gt, lte, sql } from "drizzle-orm";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
 import { logger } from "../../lib/log";
+import { triggerAutoRecharge$ } from "./zero-credit-recharge.service";
 
 const L = logger("CreditUsage");
 
@@ -121,12 +122,14 @@ async function deductFromExpiresRecords(
  * verbatim same key string as web so api and web serialize correctly on
  * the same org during rollout.
  *
- * Deferrals from web (each tracked as a sibling sub-issue under #12290):
- *  - `triggerAutoRecharge(orgId)` — Stripe-bound; runs as fire-and-
- *    forget after the tx commits. Without it, an api-routed cancel that
- *    crosses the recharge threshold won't trigger an immediate top-up;
- *    the next legitimate processOrgUsageEvents call (web cron or web
- *    cancel) will. Worst case: bounded by cron interval.
+ * After the transaction commits and credits are deducted, fires
+ * `triggerAutoRecharge$` to potentially top up the org via Stripe (only
+ * when balance crosses the recharge threshold). Errors in the Stripe
+ * path are caught inside the trigger Command (clearPendingFlag in
+ * catch); the await here is bounded by the route handler's outer
+ * waitUntil envelope so end-user latency is unaffected.
+ *
+ * Remaining deferral (sibling sub-issue under #12290):
  *  - `evaluateMemberCaps(orgId, affectedUserIds)` — per-user cap
  *    enforcement. Without it, member-cap-disable lags by up to one cron
  *    interval; spend admission still reads the cap on every request, so
@@ -136,7 +139,7 @@ export const processOrgUsageEvents$ = command(
   async ({ set }, orgId: string, signal: AbortSignal): Promise<void> => {
     const writeDb = set(writeDb$);
 
-    await writeDb.transaction(async (tx) => {
+    const totalCredits = await writeDb.transaction(async (tx) => {
       // Same advisory key as web: 'credit_' prefix + orgId.
       await tx.execute(
         sql`SELECT pg_advisory_xact_lock(hashtext('credit_' || ${orgId}))`,
@@ -150,7 +153,7 @@ export const processOrgUsageEvents$ = command(
         );
 
       if (pendingRecords.length === 0) {
-        return;
+        return 0;
       }
 
       const pricingRecords = await tx.select().from(usagePricing);
@@ -231,9 +234,18 @@ export const processOrgUsageEvents$ = command(
         await deductFromExpiresRecords(tx, orgId, totalCredits);
       }
       signal.throwIfAborted();
+      return totalCredits;
     });
+    signal.throwIfAborted();
 
-    // Note: triggerAutoRecharge + evaluateMemberCaps deliberately
-    // skipped — see docblock above. Sibling sub-issues track the gaps.
+    if (totalCredits > 0) {
+      // Auto-recharge runs OUTSIDE the deduction transaction (Stripe
+      // can't be transactional with DB). triggerAutoRecharge$ catches
+      // its own errors (clearPendingFlag in catch); the await here is
+      // bounded by the route handler's outer waitUntil envelope.
+      // evaluateMemberCaps still deferred — sibling follow-up.
+      await set(triggerAutoRecharge$, orgId, signal);
+      signal.throwIfAborted();
+    }
   },
 );


### PR DESCRIPTION
## Summary

Wave 5 cascade follow-up: closes the Stripe auto-recharge half from PR #12585. Cascade chain: PR #12577 → PR #12582 → PR #12585 → **this**.

- Adds `triggerAutoRecharge\$` Command to apps/api with **verbatim same atomic-claim WHERE clause** as web (api+web don't double-claim during rollout).
- Adds `getStripeClient()` to `external/stripe-client.ts` with `mockStripeClient` testOverride pattern (the centralized `vi.mock(\"stripe\")` factory doesn't compose with `new StripeSDK()` because `vi.fn` isn't a real constructor — route through the testOverride instead).
- Extends centralized Stripe mock in `__tests__/mocks.ts` with `customers.retrieve` + `subscriptions.retrieve` + `invoices.create` + `invoiceItems.create` + `invoices.finalizeInvoice` + `invoices.pay`. The `resetApiTestMocks()` re-installs the override on each test so every test starts with the mock wired.
- Wires `triggerAutoRecharge\$` into `processOrgUsageEvents\$` after the credit-deduct transaction commits, when `totalCredits > 0`.
- Updates `processOrgUsageEvents\$` docstring to remove the \"deferred\" wording on auto-recharge.

## Atomic claim invariant

`triggerAutoRecharge\$` uses the same `UPDATE ... RETURNING` pattern as web with the same WHERE clause:

```
WHERE org_id = :orgId
  AND auto_recharge_enabled = true
  AND tier != 'free'
  AND stripe_customer_id IS NOT NULL
  AND auto_recharge_threshold IS NOT NULL
  AND auto_recharge_amount IS NOT NULL
  AND credits <= auto_recharge_threshold
  AND (auto_recharge_pending_at IS NULL
       OR auto_recharge_pending_at < now() - interval '10 minutes')
```

If two callers (e.g. api cancel + web cron) race for the same org, only one's UPDATE returns rows. The losing caller exits silently. The 10-minute stale-threshold lets a hung Stripe call release the slot eventually. **No double-charge.**

## Wire location

Web does `triggerAutoRecharge(orgId).catch(log)` in the route handler after `processOrgUsageEvents` returns. The api side encapsulates: `processOrgUsageEvents\$` calls `await set(triggerAutoRecharge\$, orgId, signal)` after the deduction transaction commits, when `totalCredits > 0`. The await is bounded by the route handler's outer waitUntil envelope, so end-user latency is unaffected. Errors are caught inside the trigger Command via `safeAsync` (centralized try/catch helper) and `clearPendingFlag` runs on failure.

## Webhook handler out of scope

`handleAutoRechargeInvoicePaid` (Stripe webhook → grant credits) is a separate route. Out of scope for this PR.

## Test plan (14 tests total — 11 from #12585 + 3 new)

- [x] (existing 11) all unaffected
- [x] **NEW** triggers auto-recharge when balance crosses threshold — DB confirms `pendingAt` set + `stripe.invoices.create` called with `metadata.type === \"auto_recharge\"` + finalizeInvoice + pay
- [x] **NEW** does not trigger auto-recharge when balance is above threshold — atomic claim returns no rows; `stripe.invoices.create` NOT called
- [x] **NEW** does not re-trigger when claim is already pending — `pendingAt` pre-set; atomic claim returns no rows; `stripe.invoices.create` NOT called

## Gates

- [x] `pnpm -F api exec vitest run signals/routes/__tests__/zero-runs-cancel` — 14/14 pass
- [x] `pnpm -F api exec vitest run` — 907/907 pass on @vm0/api workspace (109 test files)
- [x] `pnpm turbo run lint --filter=api` — 0 errors (1 pre-existing unrelated warning in zero-chat-threads-patch.test.ts)
- [x] `pnpm check-types` — all 11 workspaces clean
- [x] `pnpm format` — auto-applied
- [x] `pnpm knip` — no findings (only pre-existing config hints)
- [x] `apps/web/**` unchanged

## Remaining cascade gap

`evaluateMemberCaps(orgId, affectedUserIds)` — per-user cap enforcement. Without it, member-cap-disable lags by up to one cron interval; spend admission still reads the cap on every request, so over-spend is not allowed in the meantime. Sibling follow-up.

Closes #12587

🤖 Generated with [Claude Code](https://claude.com/claude-code)