### PR TITLE
feat(api): port member-cap evaluation for runs cancel credit reconciliation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-cancel.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-cancel.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { zeroRunsCancelContract } from "@vm0/api-contracts/contracts/zero-runs";
 import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { usagePricing } from "@vm0/db/schema/usage-pricing";
@@ -799,6 +800,294 @@ describe("POST /api/zero/runs/:id/cancel", () => {
 
     // Already-pending → atomic claim returns no rows → no Stripe.
     expect(context.mocks.stripe.invoices.create).not.toHaveBeenCalled();
+
+    await writeDb
+      .delete(usagePricing)
+      .where(
+        and(
+          eq(usagePricing.kind, "model"),
+          eq(usagePricing.provider, provider),
+          eq(usagePricing.category, "tokens.input"),
+        ),
+      );
+  });
+
+  it("disables a member when processed usage meets the cap on cancel", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+
+    const writeDb = store.set(writeDb$);
+    const provider = `test-provider-${randomUUID().slice(0, 8)}`;
+    // Paid org with billing period set so getOrgBillingPeriod resolves
+    // without hitting Stripe.
+    const periodEnd = new Date(now() + 30 * 24 * 60 * 60 * 1000);
+    await writeDb.insert(orgMetadata).values({
+      orgId: fixture.orgId,
+      credits: 1000,
+      tier: "team",
+      currentPeriodEnd: periodEnd,
+    });
+    // Member with a cap = 8 and creditEnabled = true.
+    await writeDb.insert(orgMembersMetadata).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      creditCap: 8,
+      creditEnabled: true,
+    });
+    // Pricing: 1 credit per 1000 input tokens.
+    await writeDb.insert(usagePricing).values({
+      kind: "model",
+      provider,
+      category: "tokens.input",
+      unitPrice: 1,
+      unitSize: 1000,
+    });
+    // Pre-existing processed usage from earlier in the period — 4 credits.
+    // The cancel will add 5 more → cumulative 9, exceeds cap.
+    await writeDb.insert(usageEvent).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      runId,
+      kind: "model",
+      provider,
+      category: "tokens.input",
+      quantity: 4000,
+      creditsCharged: 4,
+      status: "processed",
+      processedAt: nowDate(),
+      idempotencyKey: randomUUID(),
+    });
+    // Pending usage_event for this cancel: 5000 tokens → 5 credits.
+    await writeDb.insert(usageEvent).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      runId,
+      kind: "model",
+      provider,
+      category: "tokens.input",
+      quantity: 5000,
+      status: "pending",
+      idempotencyKey: randomUUID(),
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    await accept(
+      client.cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    await clearAllDetached();
+
+    const [memberRow] = await writeDb
+      .select({ creditEnabled: orgMembersMetadata.creditEnabled })
+      .from(orgMembersMetadata)
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, fixture.orgId),
+          eq(orgMembersMetadata.userId, fixture.userId),
+        ),
+      );
+    expect(memberRow?.creditEnabled).toBeFalsy();
+
+    await writeDb
+      .delete(usagePricing)
+      .where(
+        and(
+          eq(usagePricing.kind, "model"),
+          eq(usagePricing.provider, provider),
+          eq(usagePricing.category, "tokens.input"),
+        ),
+      );
+  });
+
+  it("does not touch member caps when no usage events are processed", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    // Run in pending state — no usage_events accumulated; cancel triggers
+    // processOrgUsageEvents$ but pendingRecords is empty so the cap path
+    // short-circuits before reaching evaluateMemberCaps$.
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "pending",
+      },
+      context.signal,
+    );
+
+    const writeDb = store.set(writeDb$);
+    const periodEnd = new Date(now() + 30 * 24 * 60 * 60 * 1000);
+    await writeDb.insert(orgMetadata).values({
+      orgId: fixture.orgId,
+      credits: 1000,
+      tier: "team",
+      currentPeriodEnd: periodEnd,
+    });
+    // Member with a cap of 1 and creditEnabled = true. Even though their
+    // usage might already be over cap from prior periods, the cancel path
+    // must NOT re-evaluate when no events are processed.
+    await writeDb.insert(orgMembersMetadata).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      creditCap: 1,
+      creditEnabled: true,
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    await accept(
+      client.cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    await clearAllDetached();
+
+    const [memberRow] = await writeDb
+      .select({ creditEnabled: orgMembersMetadata.creditEnabled })
+      .from(orgMembersMetadata)
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, fixture.orgId),
+          eq(orgMembersMetadata.userId, fixture.userId),
+        ),
+      );
+    expect(memberRow?.creditEnabled).toBeTruthy();
+  });
+
+  it("only re-evaluates the run-owner's cap, not other org members'", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+
+    const writeDb = store.set(writeDb$);
+    const provider = `test-provider-${randomUUID().slice(0, 8)}`;
+    const otherUserId = `user_other_${randomUUID().slice(0, 8)}`;
+    const periodEnd = new Date(now() + 30 * 24 * 60 * 60 * 1000);
+    await writeDb.insert(orgMetadata).values({
+      orgId: fixture.orgId,
+      credits: 1000,
+      tier: "team",
+      currentPeriodEnd: periodEnd,
+    });
+    // Run-owner: high cap, well under usage.
+    await writeDb.insert(orgMembersMetadata).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      creditCap: 1000,
+      creditEnabled: true,
+    });
+    // Other org member: low cap, already over usage from a prior batch
+    // — would normally be flipped off if re-evaluated, but cancel of the
+    // run-owner's run must not include the other user in affectedUserIds.
+    await writeDb.insert(orgMembersMetadata).values({
+      orgId: fixture.orgId,
+      userId: otherUserId,
+      creditCap: 1,
+      creditEnabled: true,
+    });
+    await writeDb.insert(usagePricing).values({
+      kind: "model",
+      provider,
+      category: "tokens.input",
+      unitPrice: 1,
+      unitSize: 1000,
+    });
+    await writeDb.insert(usageEvent).values({
+      orgId: fixture.orgId,
+      userId: otherUserId,
+      runId,
+      kind: "model",
+      provider,
+      category: "tokens.input",
+      quantity: 999_000,
+      creditsCharged: 999,
+      status: "processed",
+      processedAt: nowDate(),
+      idempotencyKey: randomUUID(),
+    });
+    // Pending event for the run-owner only.
+    await writeDb.insert(usageEvent).values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      runId,
+      kind: "model",
+      provider,
+      category: "tokens.input",
+      quantity: 1000,
+      status: "pending",
+      idempotencyKey: randomUUID(),
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(zeroRunsCancelContract);
+    await accept(
+      client.cancel({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    await clearAllDetached();
+
+    // The other user should remain enabled — they were not in the
+    // affectedUserIds set passed to evaluateMemberCaps$.
+    const [otherRow] = await writeDb
+      .select({ creditEnabled: orgMembersMetadata.creditEnabled })
+      .from(orgMembersMetadata)
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, fixture.orgId),
+          eq(orgMembersMetadata.userId, otherUserId),
+        ),
+      );
+    expect(otherRow?.creditEnabled).toBeTruthy();
 
     await writeDb
       .delete(usagePricing)

--- a/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
@@ -9,6 +9,7 @@ import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
 import { logger } from "../../lib/log";
 import { triggerAutoRecharge$ } from "./zero-credit-recharge.service";
+import { evaluateMemberCaps$ } from "./zero-member-credit-cap-evaluator.service";
 
 const L = logger("CreditUsage");
 
@@ -122,120 +123,126 @@ async function deductFromExpiresRecords(
  * verbatim same key string as web so api and web serialize correctly on
  * the same org during rollout.
  *
- * After the transaction commits and credits are deducted, fires
- * `triggerAutoRecharge$` to potentially top up the org via Stripe (only
- * when balance crosses the recharge threshold). Errors in the Stripe
- * path are caught inside the trigger Command (clearPendingFlag in
- * catch); the await here is bounded by the route handler's outer
- * waitUntil envelope so end-user latency is unaffected.
+ * After the transaction commits and credits are deducted, fires two
+ * cascade steps sequentially (both bounded by the route handler's outer
+ * waitUntil envelope so end-user latency is unaffected):
  *
- * Remaining deferral (sibling sub-issue under #12290):
- *  - `evaluateMemberCaps(orgId, affectedUserIds)` — per-user cap
- *    enforcement. Without it, member-cap-disable lags by up to one cron
- *    interval; spend admission still reads the cap on every request, so
- *    over-spend is not allowed in the meantime.
+ *  - `triggerAutoRecharge$` — Stripe top-up when balance crosses the
+ *    recharge threshold. Errors in the Stripe path are caught inside the
+ *    trigger Command (clearPendingFlag in catch).
+ *  - `evaluateMemberCaps$` — per-user spend-cap enforcement. Gated on
+ *    `affectedUserIds.size > 0` so a totalCredits-only-from-fallback-
+ *    pricing path skips the cap pass. Race-safe via the cap-disable
+ *    WHERE predicate that re-checks `creditEnabled = true`.
  */
 export const processOrgUsageEvents$ = command(
   async ({ set }, orgId: string, signal: AbortSignal): Promise<void> => {
     const writeDb = set(writeDb$);
 
-    const totalCredits = await writeDb.transaction(async (tx) => {
-      // Same advisory key as web: 'credit_' prefix + orgId.
-      await tx.execute(
-        sql`SELECT pg_advisory_xact_lock(hashtext('credit_' || ${orgId}))`,
-      );
-
-      const pendingRecords = await tx
-        .select()
-        .from(usageEvent)
-        .where(
-          and(eq(usageEvent.orgId, orgId), eq(usageEvent.status, "pending")),
+    const { totalCredits, affectedUserIds } = await writeDb.transaction(
+      async (tx) => {
+        // Same advisory key as web: 'credit_' prefix + orgId.
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtext('credit_' || ${orgId}))`,
         );
 
-      if (pendingRecords.length === 0) {
-        return 0;
-      }
+        const pendingRecords = await tx
+          .select()
+          .from(usageEvent)
+          .where(
+            and(eq(usageEvent.orgId, orgId), eq(usageEvent.status, "pending")),
+          );
 
-      const pricingRecords = await tx.select().from(usagePricing);
-      const pricingByKey = new Map(
-        pricingRecords.map((p) => {
-          return [`${p.kind}|${p.provider}|${p.category}`, p];
-        }),
-      );
+        if (pendingRecords.length === 0) {
+          return {
+            totalCredits: 0,
+            affectedUserIds: new Set<string>(),
+          };
+        }
 
-      let totalCredits = 0;
-      for (const record of pendingRecords) {
-        const exactPricing = pricingByKey.get(
-          `${record.kind}|${record.provider}|${record.category}`,
+        const pricingRecords = await tx.select().from(usagePricing);
+        const pricingByKey = new Map(
+          pricingRecords.map((p) => {
+            return [`${p.kind}|${p.provider}|${p.category}`, p];
+          }),
         );
-        const pricing =
-          exactPricing ??
-          pricingByKey.get(`${record.kind}|${record.provider}|__fallback__`);
 
-        if (!pricing) {
+        const affectedUserIds = new Set<string>();
+        let totalCredits = 0;
+        for (const record of pendingRecords) {
+          affectedUserIds.add(record.userId);
+          const exactPricing = pricingByKey.get(
+            `${record.kind}|${record.provider}|${record.category}`,
+          );
+          const pricing =
+            exactPricing ??
+            pricingByKey.get(`${record.kind}|${record.provider}|__fallback__`);
+
+          if (!pricing) {
+            await tx
+              .update(usageEvent)
+              .set({
+                creditsCharged: 0,
+                status: "processed",
+                processedAt: nowDate(),
+                billingError: "missing_pricing",
+              })
+              .where(eq(usageEvent.id, record.id));
+            L.error("Missing usage_pricing — charged zero", {
+              orgId,
+              runId: record.runId,
+              idempotencyKey: record.idempotencyKey,
+              userId: record.userId,
+              kind: record.kind,
+              provider: record.provider,
+              category: record.category,
+              quantity: record.quantity,
+            });
+            continue;
+          }
+
+          if (!exactPricing) {
+            L.error("Missing usage_pricing — billed at fallback rate", {
+              orgId,
+              runId: record.runId,
+              idempotencyKey: record.idempotencyKey,
+              userId: record.userId,
+              kind: record.kind,
+              provider: record.provider,
+              category: record.category,
+              quantity: record.quantity,
+              fallbackUnitPrice: pricing.unitPrice,
+            });
+          }
+
+          const creditsCharged = Math.ceil(
+            (record.quantity * pricing.unitPrice) / pricing.unitSize,
+          );
           await tx
             .update(usageEvent)
             .set({
-              creditsCharged: 0,
+              creditsCharged,
               status: "processed",
               processedAt: nowDate(),
-              billingError: "missing_pricing",
+              billingError: exactPricing ? null : "fallback_pricing",
             })
             .where(eq(usageEvent.id, record.id));
-          L.error("Missing usage_pricing — charged zero", {
-            orgId,
-            runId: record.runId,
-            idempotencyKey: record.idempotencyKey,
-            userId: record.userId,
-            kind: record.kind,
-            provider: record.provider,
-            category: record.category,
-            quantity: record.quantity,
-          });
-          continue;
+          totalCredits += creditsCharged;
         }
+        signal.throwIfAborted();
 
-        if (!exactPricing) {
-          L.error("Missing usage_pricing — billed at fallback rate", {
-            orgId,
-            runId: record.runId,
-            idempotencyKey: record.idempotencyKey,
-            userId: record.userId,
-            kind: record.kind,
-            provider: record.provider,
-            category: record.category,
-            quantity: record.quantity,
-            fallbackUnitPrice: pricing.unitPrice,
-          });
+        if (totalCredits > 0) {
+          // Order matters: settle expired credits BEFORE the new
+          // deduction. expireCredits zeros out rows whose expires_at <=
+          // now() so deductFromExpiresRecords doesn't touch them.
+          await expireCredits(tx, orgId);
+          await deductOrgCredits(tx, orgId, totalCredits);
+          await deductFromExpiresRecords(tx, orgId, totalCredits);
         }
-
-        const creditsCharged = Math.ceil(
-          (record.quantity * pricing.unitPrice) / pricing.unitSize,
-        );
-        await tx
-          .update(usageEvent)
-          .set({
-            creditsCharged,
-            status: "processed",
-            processedAt: nowDate(),
-            billingError: exactPricing ? null : "fallback_pricing",
-          })
-          .where(eq(usageEvent.id, record.id));
-        totalCredits += creditsCharged;
-      }
-      signal.throwIfAborted();
-
-      if (totalCredits > 0) {
-        // Order matters: settle expired credits BEFORE the new
-        // deduction. expireCredits zeros out rows whose expires_at <=
-        // now() so deductFromExpiresRecords doesn't touch them.
-        await expireCredits(tx, orgId);
-        await deductOrgCredits(tx, orgId, totalCredits);
-        await deductFromExpiresRecords(tx, orgId, totalCredits);
-      }
-      signal.throwIfAborted();
-      return totalCredits;
-    });
+        signal.throwIfAborted();
+        return { totalCredits, affectedUserIds };
+      },
+    );
     signal.throwIfAborted();
 
     if (totalCredits > 0) {
@@ -243,8 +250,22 @@ export const processOrgUsageEvents$ = command(
       // can't be transactional with DB). triggerAutoRecharge$ catches
       // its own errors (clearPendingFlag in catch); the await here is
       // bounded by the route handler's outer waitUntil envelope.
-      // evaluateMemberCaps still deferred — sibling follow-up.
       await set(triggerAutoRecharge$, orgId, signal);
+      signal.throwIfAborted();
+    }
+
+    if (totalCredits > 0 && affectedUserIds.size > 0) {
+      // Re-evaluate per-user spend caps for users who consumed credits
+      // in this batch. Sequential await mirrors triggerAutoRecharge$
+      // above; the route handler's outer waitUntil envelope keeps end-
+      // user latency unaffected. Race-safe: the cap-disable WHERE
+      // predicate re-checks creditEnabled=true so a concurrent admin
+      // re-enable (or cap change) no-ops the disable.
+      await set(
+        evaluateMemberCaps$,
+        { orgId, affectedUserIds: [...affectedUserIds] },
+        signal,
+      );
       signal.throwIfAborted();
     }
   },

--- a/turbo/apps/api/src/signals/services/zero-member-credit-cap-evaluator.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-member-credit-cap-evaluator.service.ts
@@ -1,0 +1,157 @@
+import { command } from "ccstate";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { and, eq, gte, inArray, lt, sql } from "drizzle-orm";
+
+import { writeDb$, type Db } from "../external/db";
+import { nowDate } from "../external/time";
+import { logger } from "../../lib/log";
+import {
+  getOrgBillingPeriod$,
+  type OrgBillingPeriod,
+} from "./zero-org-billing-period.service";
+
+const L = logger("MemberCapEvaluator");
+
+interface UsageTotalRow {
+  readonly userId: string;
+  readonly total: number;
+}
+
+async function getProcessedUsageTotalsByUser(
+  writeDb: Db,
+  orgId: string,
+  userIds: readonly string[],
+  billingPeriod: OrgBillingPeriod,
+): Promise<Map<string, number>> {
+  const uniqueUserIds = [...new Set(userIds)];
+  const usageMap = new Map<string, number>();
+  if (uniqueUserIds.length === 0) {
+    return usageMap;
+  }
+
+  const eventRows: UsageTotalRow[] = await writeDb
+    .select({
+      userId: usageEvent.userId,
+      total:
+        sql<number>`COALESCE(SUM(${usageEvent.creditsCharged}), 0)::bigint`.as(
+          "total",
+        ),
+    })
+    .from(usageEvent)
+    .where(
+      and(
+        eq(usageEvent.orgId, orgId),
+        inArray(usageEvent.userId, uniqueUserIds),
+        eq(usageEvent.status, "processed"),
+        gte(usageEvent.processedAt, billingPeriod.start),
+        lt(usageEvent.processedAt, billingPeriod.end),
+      ),
+    )
+    .groupBy(usageEvent.userId);
+
+  for (const row of eventRows) {
+    usageMap.set(
+      row.userId,
+      (usageMap.get(row.userId) ?? 0) + Number(row.total),
+    );
+  }
+  return usageMap;
+}
+
+/**
+ * Re-evaluate per-user spend caps for the affected members of an org.
+ *
+ * For any `(orgId, userId)` whose total processed usage in the current
+ * billing period now meets or exceeds their `creditCap`, flip
+ * `creditEnabled` to false. Race-safe via a WHERE predicate that
+ * re-checks `creditEnabled = true` and `creditCap = <observed>`: a
+ * concurrent admin re-enable, or a concurrent cap change, no-ops the
+ * disable.
+ *
+ * Mirrors apps/web's `evaluateMemberCaps`. Caller is expected to gate on
+ * `affectedUserIds.length > 0` upstream — a no-affected call is a no-op
+ * but the upstream gate avoids the empty round-trip.
+ *
+ * Returns void; observable contract is on the DB row.
+ */
+export const evaluateMemberCaps$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly affectedUserIds: readonly string[];
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    if (args.affectedUserIds.length === 0) {
+      return;
+    }
+
+    const billingPeriod = await set(getOrgBillingPeriod$, args.orgId, signal);
+    signal.throwIfAborted();
+    if (!billingPeriod) {
+      return;
+    }
+
+    const writeDb = set(writeDb$);
+
+    const cappedMembers = await writeDb
+      .select({
+        userId: orgMembersMetadata.userId,
+        creditCap: orgMembersMetadata.creditCap,
+        creditEnabled: orgMembersMetadata.creditEnabled,
+      })
+      .from(orgMembersMetadata)
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, args.orgId),
+          inArray(orgMembersMetadata.userId, [...args.affectedUserIds]),
+          sql`${orgMembersMetadata.creditCap} IS NOT NULL`,
+        ),
+      );
+    signal.throwIfAborted();
+
+    const enabledCapped = cappedMembers.filter((m) => {
+      return m.creditEnabled && m.creditCap !== null;
+    });
+    if (enabledCapped.length === 0) {
+      return;
+    }
+
+    const usageMap = await getProcessedUsageTotalsByUser(
+      writeDb,
+      args.orgId,
+      enabledCapped.map((m) => {
+        return m.userId;
+      }),
+      billingPeriod,
+    );
+    signal.throwIfAborted();
+
+    for (const member of enabledCapped) {
+      const totalUsage = usageMap.get(member.userId) ?? 0;
+      const cap = member.creditCap;
+      if (cap !== null && totalUsage >= cap) {
+        await writeDb
+          .update(orgMembersMetadata)
+          .set({ creditEnabled: false, updatedAt: nowDate() })
+          .where(
+            and(
+              eq(orgMembersMetadata.orgId, args.orgId),
+              eq(orgMembersMetadata.userId, member.userId),
+              eq(orgMembersMetadata.creditEnabled, true),
+              eq(orgMembersMetadata.creditCap, cap),
+            ),
+          );
+        signal.throwIfAborted();
+        L.debug("member-cap disabled", {
+          orgId: args.orgId,
+          userId: member.userId,
+          totalUsage,
+          cap,
+        });
+      }
+    }
+  },
+);

--- a/turbo/apps/api/src/signals/services/zero-org-billing-period.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-billing-period.service.ts
@@ -1,0 +1,107 @@
+import { command } from "ccstate";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { eq } from "drizzle-orm";
+
+import { writeDb$ } from "../external/db";
+import { getStripeClient } from "../external/stripe-client";
+import { nowDate } from "../external/time";
+import { logger } from "../../lib/log";
+
+const L = logger("OrgBillingPeriod");
+
+export interface OrgBillingPeriod {
+  readonly start: Date;
+  readonly end: Date;
+}
+
+/**
+ * Resolve an org's current billing period `{ start, end }`.
+ *
+ * Reads `orgMetadata.currentPeriodEnd` first; if missing or expired AND a
+ * `stripeSubscriptionId` exists, falls back to `stripe.subscriptions.retrieve`
+ * and writes the refreshed value back to orgMetadata. Mirrors apps/web's
+ * `getOrgBillingPeriod` exactly (same Stripe-API rationale, same
+ * past-dated guard).
+ *
+ * Returns `null` for free-tier orgs (no subscription, no period). Callers
+ * MUST short-circuit on null — there is no synthetic period for the free
+ * tier; spend admission already handles per-request cap enforcement.
+ *
+ * In Stripe v2025 API, `current_period_end` was removed from the top-level
+ * Subscription object. The replacement is
+ * `subscription.items.data[i].current_period_end` — the end time of the
+ * subscription item's current billing period. Do NOT read
+ * `invoice.period_end` (that's the accrual period for the invoice, not the
+ * subscription period, and for renewal invoices collapses to the invoice
+ * creation moment, which would cause this function to re-fetch Stripe on
+ * every call).
+ */
+export const getOrgBillingPeriod$ = command(
+  async (
+    { set },
+    orgId: string,
+    signal: AbortSignal,
+  ): Promise<OrgBillingPeriod | null> => {
+    const writeDb = set(writeDb$);
+
+    const [orgRow] = await writeDb
+      .select({
+        currentPeriodEnd: orgMetadata.currentPeriodEnd,
+        stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+      })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, orgId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    let periodEnd = orgRow?.currentPeriodEnd ?? null;
+    const now = nowDate();
+
+    if ((!periodEnd || periodEnd < now) && orgRow?.stripeSubscriptionId) {
+      if (periodEnd && periodEnd < now) {
+        L.warn("currentPeriodEnd is stale, refreshing from Stripe", {
+          orgId,
+          currentPeriodEnd: periodEnd,
+        });
+      }
+      const stripe = getStripeClient();
+      const subscription = await stripe.subscriptions.retrieve(
+        orgRow.stripeSubscriptionId,
+      );
+      signal.throwIfAborted();
+      const itemPeriodEnd = subscription.items.data[0]?.current_period_end;
+      if (itemPeriodEnd) {
+        const refreshed = new Date(itemPeriodEnd * 1000);
+        // Don't cache a past-dated period. If Stripe returns a past-dated
+        // current_period_end for a subscription we believe is active,
+        // something is wrong (stale Stripe data, field confusion from a
+        // future code change, or an orphaned subscription). Log at warn
+        // and return null without caching — caching the bad value would
+        // cause an infinite "refresh from Stripe" loop on every call.
+        if (refreshed < now) {
+          L.warn("refreshed periodEnd still in past, not caching", {
+            orgId,
+            stripeSubscriptionId: orgRow.stripeSubscriptionId,
+            periodEnd: refreshed,
+          });
+          return null;
+        }
+        periodEnd = refreshed;
+        await writeDb
+          .update(orgMetadata)
+          .set({ currentPeriodEnd: periodEnd, updatedAt: nowDate() })
+          .where(eq(orgMetadata.orgId, orgId));
+        signal.throwIfAborted();
+      }
+    }
+
+    if (periodEnd) {
+      const periodStart = new Date(periodEnd);
+      periodStart.setMonth(periodStart.getMonth() - 1);
+      L.debug("billing period resolved", { orgId, periodStart, periodEnd });
+      return { start: periodStart, end: periodEnd };
+    }
+
+    return null;
+  },
+);


### PR DESCRIPTION
## Summary

- Closes #12588. **Wave 5 cascade closure** — #12577 → #12582 → #12585 → #12593 → this. Final piece of runs-cancel production parity.
- After credit deduction commits, evaluates per-user spend caps for affected members and disables any user whose total processed usage in the current billing period now meets or exceeds their `creditCap`.
- `apps/web` is intentionally untouched.

## Components

| File | Purpose |
|---|---|
| `signals/services/zero-org-billing-period.service.ts` (new) | `getOrgBillingPeriod$` Command. Reads `orgMetadata.currentPeriodEnd`, falls back to `stripe.subscriptions.retrieve` when missing/expired (and caches the refreshed value back). Returns `null` for free-tier orgs. Verbatim mirror of web's helper, with `nowDate()` for testability. |
| `signals/services/zero-member-credit-cap-evaluator.service.ts` (new) | `evaluateMemberCaps$` Command + `getProcessedUsageTotalsByUser` private helper. SUM(creditsCharged) GROUP BY userId WHERE `(orgId, status='processed', processedAt ∈ billingPeriod)`. Disables members whose totalUsage >= cap. Race-safe via WHERE re-check of `creditEnabled = true AND creditCap = <observed>`. |
| `signals/services/zero-credit-usage.service.ts` (modified) | Track `affectedUserIds` (Set<string>) inside the deduction transaction. After `triggerAutoRecharge$`, gate on `totalCredits > 0 && affectedUserIds.size > 0` and `await set(evaluateMemberCaps$, ...)`. Sequential await mirrors a4's #12593 auto-recharge precedent — the route handler's outer `waitUntil` envelope provides the fire-and-forget guarantee. Docstring updated to document both cascade steps and drop the "Remaining deferral" section. |

## Sequencing decision

Issue body suggested `waitUntil(set(evaluateMemberCaps$, ...).catch(log))` (fire-and-forget). a4's just-merged auto-recharge (#12593) used `await set(triggerAutoRecharge$, ...)` (sequential, with route-level `waitUntil` providing the fire-and-forget envelope). **This PR follows the merged precedent — sequential await** for stylistic consistency in the same file. Confirmed in the issue's plan-review thread.

## Tests — 3 new cases

01. **Disables a member when processed usage meets the cap on cancel** — seed `cap=8` + pre-existing 4 credits + pending 5-credit event; cancel; assert `creditEnabled` flips to false.
02. **Does not touch member caps when no usage events are processed** — cancel a pending run with `cap=1` (would trigger if re-evaluated); assert `creditEnabled` stays true.
03. **Only re-evaluates the run-owner's cap, not other org members'** — seed user A (run-owner, high cap) + user B (low cap, already over via pre-existing usage); cancel A's run; assert B stays enabled (B was not in `affectedUserIds`).

The existing 14 tests in `zero-runs-cancel.test.ts` are unchanged. The cancel test file now exercises all three cascade steps end-to-end.

## Notes

- **Stripe-fallback path** in `getOrgBillingPeriod$` is reachable but not exercised by these 3 tests (they seed `currentPeriodEnd` directly). Future tests for `zero-org-billing-period.service.ts` itself should cover the Stripe path explicitly.
- **`affectedUserIds`** is built inside the deduction loop and returned alongside `totalCredits` from the transaction — Set-based dedup keeps the `inArray` query small.
- **Race-safety** of cap-disable: `eq(creditEnabled, true) AND eq(creditCap, observed)` predicate. A concurrent admin re-enable, or cap change, no-ops the disable — the WHERE filters out the row.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-cancel.test.ts` — 17/17 pass
- [x] `pnpm -F api exec vitest run` — 945/945 pass
- [x] `pnpm turbo run lint` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — no diff
- [x] `pnpm knip` — clean
- [x] No `apps/web/**` modified
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)