### PR TITLE
docs: document bounded exec preference

### DIFF
--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1446,6 +1446,9 @@ impl Sandbox for FirecrackerSandbox {
     // already polling.
 
     async fn exec(&self, request: &ExecRequest<'_>) -> sandbox::Result<ExecResult> {
+        // Legacy buffered exec path. New request/response command execution
+        // should call bounded_exec so output, termination, streaming, and
+        // cancellation semantics are explicit.
         let operation = SandboxOperation::Exec;
         let guest = self.operation_guest(operation).await?;
 

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -180,8 +180,15 @@ pub trait Sandbox: Send + Sync + Any {
     // backend process surfaces as a specific error rather than an
     // opaque IPC timeout.
 
-    /// Run `request.cmd` in the guest, block until it exits or the
-    /// request timeout expires, and return the captured output.
+    /// Legacy buffered command execution.
+    ///
+    /// Deprecated for new code: use [`bounded_exec`](Self::bounded_exec) for all
+    /// request/response command execution. Bounded exec returns structured
+    /// termination, bounded final output, optional request-scoped streaming,
+    /// and explicit transport cancellation semantics.
+    ///
+    /// Run `request.cmd` in the guest, block until it exits or the request
+    /// timeout expires, and return the captured output.
     ///
     /// Returns an error if the sandbox is not running or if the backing
     /// process crashes during execution.

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -71,6 +71,10 @@ pub enum BoundedExecOutput {
     Captured { bytes: Vec<u8>, truncated: bool },
 }
 
+/// Command request shared by legacy `exec` and current `spawn_watch`.
+///
+/// New request/response command execution should use [`BoundedExecRequest`]
+/// through `bounded_exec`; this request type remains shared with `spawn_watch`.
 pub struct ExecRequest<'a> {
     pub cmd: &'a str,
     pub timeout: Duration,

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -210,6 +210,8 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                     cancel.store(true, Ordering::Release);
                 }
             } else if msg.msg_type == MSG_EXEC {
+                // Legacy buffered exec path. New request/response command
+                // execution should use MSG_BOUNDED_EXEC.
                 log(
                     "INFO",
                     &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -276,7 +276,7 @@ pub(crate) fn set_debug_guest_write_file_path(path: PathBuf) -> Result<(), PathB
 
 /// Handle incoming message and return the connection-loop outcome.
 ///
-/// `MSG_EXEC` and `MSG_SPAWN_WATCH` are handled separately in
+/// Legacy `MSG_EXEC` and current `MSG_SPAWN_WATCH` are handled separately in
 /// `handle_connection` because they run in background threads.
 pub(crate) fn handle_message(msg: &RawMessage) -> io::Result<MessageOutcome> {
     log(

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1232,6 +1232,9 @@ async fn exec_on_shared_with_request_timeout(
     sudo: bool,
     request_timeout: Duration,
 ) -> io::Result<ExecResult> {
+    // Legacy MSG_EXEC implementation. Keep it for existing callers only; new
+    // request/response command execution should use bounded_exec so output,
+    // termination, streaming, and cancellation semantics are explicit.
     if timeout_ms == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -1672,7 +1675,12 @@ impl VsockHost {
         request_raw_on_shared(&self.shared, msg_type, seq, payload, timeout).await
     }
 
-    /// Execute a command on the guest.
+    /// Legacy buffered command execution.
+    ///
+    /// Deprecated for new code: use [`bounded_exec`](Self::bounded_exec) for
+    /// all request/response command execution. Bounded exec returns structured
+    /// termination, bounded final output, optional request-scoped streaming,
+    /// and explicit transport cancellation semantics.
     ///
     /// `timeout_ms` must be positive. Callers needing unbounded commands
     /// should use [`spawn_watch`](Self::spawn_watch), which decouples the
@@ -1690,9 +1698,10 @@ impl VsockHost {
 
     /// Execute a command on the guest using the bounded exec protocol.
     ///
-    /// This is request/response scoped like [`exec`](Self::exec), but it
-    /// returns structured termination, bounded final buffers, and optional
-    /// request-scoped stdout/stderr stream events.
+    /// This is the preferred request/response command execution API and
+    /// supersedes legacy [`exec`](Self::exec). It returns structured
+    /// termination, bounded final buffers, and optional request-scoped
+    /// stdout/stderr stream events.
     /// [`BoundedExecOutput::Discarded`] means final capture was disabled for
     /// that stream; `diagnostic` carries bounded-exec setup/wait details and is
     /// independent of stdout/stderr capture.

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -48,6 +48,10 @@
 //! `0 = discarded`, `1 = captured`. Termination tags are `0 = exited`,
 //! `1 = timed_out`, `2 = cancelled`, `3 = start_failed`, and
 //! `4 = wait_failed`.
+//!
+//! `exec` / `exec_result` are legacy buffered request/response messages kept
+//! for existing callers. All new request/response command execution should use
+//! `bounded_exec` plus `bounded_exec_result` / `bounded_exec_output_chunk`.
 
 /// Header size (4-byte length prefix).
 pub const HEADER_SIZE: usize = 4;
@@ -318,7 +322,10 @@ pub fn encode_control_quiesce_ack(status: ControlQuiesceStatus) -> Vec<u8> {
     }]
 }
 
-/// Encode exec payload: `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)`.
+/// Encode legacy exec payload: `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)`.
+///
+/// Deprecated for new code: use [`encode_bounded_exec`] for request/response
+/// command execution.
 ///
 /// The env section is only appended when `env` is non-empty, keeping the
 /// payload backward-compatible with old decoders that don't expect it.
@@ -920,7 +927,10 @@ fn decode_exec_inner(payload: &[u8], sudo_flag: u8) -> Result<DecodedExecInner<'
     })
 }
 
-/// Decode exec payload into a [`DecodedExec`] struct.
+/// Decode legacy exec payload into a [`DecodedExec`] struct.
+///
+/// Deprecated for new code: use [`decode_bounded_exec`] for request/response
+/// command execution.
 pub fn decode_exec(payload: &[u8]) -> Result<DecodedExec<'_>, ProtocolError> {
     decode_exec_inner(payload, EXEC_FLAG_SUDO).map(|d| d.exec)
 }


### PR DESCRIPTION
## Summary
- Mark legacy exec APIs and protocol messages as deprecated for new request/response command execution
- Point new callers to bounded_exec and clarify that ExecRequest remains shared with spawn_watch

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml --no-deps -p sandbox -p sandbox-fc -p vsock-host -p vsock-proto
- lefthook pre-commit: cargo-doc, cargo-clippy
