### PR TITLE
feat(runner): use host-initiated control sessions

### DIFF
--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -31,8 +31,9 @@ use tracing::{info, warn};
 use vsock_host::{
     BoundedExecCapturePolicy, BoundedExecOutput, BoundedExecOutputEvent, BoundedExecOutputRequest,
     BoundedExecRequest, BoundedExecStream, BoundedExecStreamPolicy, BoundedExecTermination,
-    VsockHost,
 };
+
+use crate::control_session::ControlSessionManager;
 
 use crate::paths::{RuntimePaths, SockPaths};
 
@@ -160,7 +161,7 @@ async fn read_frame_with_timeout(
 pub(crate) struct BoundControlServer {
     sock_path: Option<SocketPathGuard>,
     listener: Option<UnixListener>,
-    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    control_session: ControlSessionManager,
 }
 
 impl BoundControlServer {
@@ -177,7 +178,7 @@ impl BoundControlServer {
         let task = spawn_bound_server(
             listener,
             sock_path.clone(),
-            Arc::clone(&self.guest),
+            self.control_session.clone(),
             shutdown.clone(),
         );
         ControlServerHandle {
@@ -303,14 +304,14 @@ impl SocketPathGuard {
 /// Bind the control socket before spawning the accept loop.
 pub(crate) fn bind_server(
     sock_path: PathBuf,
-    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    control_session: ControlSessionManager,
 ) -> io::Result<BoundControlServer> {
     let listener = bind_unix_listener(&sock_path)?;
     let sock_path = SocketPathGuard::new(sock_path);
     Ok(BoundControlServer {
         sock_path: Some(sock_path),
         listener: Some(listener),
-        guest,
+        control_session,
     })
 }
 
@@ -334,7 +335,7 @@ fn remove_socket_path(sock_path: &Path) {
 fn spawn_bound_server(
     listener: UnixListener,
     sock_path: SocketPathGuard,
-    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    control_session: ControlSessionManager,
     shutdown: CancellationToken,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -363,10 +364,10 @@ fn spawn_bound_server(
                         }
                     };
 
-                    let guest = Arc::clone(&guest);
+                    let control_session = control_session.clone();
                     let handler_shutdown = shutdown.clone();
                     handlers.spawn(async move {
-                        if let Err(e) = handle_connection(stream, guest, handler_shutdown).await {
+                        if let Err(e) = handle_connection(stream, control_session, handler_shutdown).await {
                             warn!(error = %e, "control connection handler error");
                         }
                     });
@@ -419,7 +420,7 @@ async fn shutdown_handlers(handlers: &mut JoinSet<()>) {
 /// Handle a single control socket connection.
 async fn handle_connection(
     stream: UnixStream,
-    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    control_session: ControlSessionManager,
     shutdown: CancellationToken,
 ) -> io::Result<()> {
     let (mut reader, mut writer) = stream.into_split();
@@ -447,7 +448,7 @@ async fn handle_connection(
         biased;
         () = shutdown.cancelled() => Ok(()),
         () = wait_for_client_disconnect_or_extra_bytes(&mut reader) => Ok(()),
-        result = execute(request, &mut writer, &guest, &shutdown) => result,
+        result = execute(request, &mut writer, &control_session, &shutdown) => result,
     }
 }
 
@@ -489,29 +490,27 @@ async fn wait_for_client_disconnect_or_extra_bytes(reader: &mut (impl AsyncRead 
     let _ = reader.read(&mut buf).await;
 }
 
-/// Execute an [`ExecRequest`] against the sandbox's VsockHost.
+/// Execute an [`ExecRequest`] against the sandbox's active control session.
 async fn execute(
     request: ExecRequest,
     stream: &mut (impl AsyncWrite + Unpin),
-    guest: &Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    control_session: &ControlSessionManager,
     shutdown: &CancellationToken,
 ) -> io::Result<()> {
-    let vsock = {
-        let lock = guest.lock().await;
-        match lock.as_ref() {
-            Some(v) => Arc::clone(v),
-            None => {
-                return write_response_frame(
-                    stream,
-                    &ExecResponseFrame::Error {
-                        error: "sandbox not running".into(),
-                    },
-                    shutdown,
-                )
-                .await;
-            }
+    let operation = match control_session.acquire() {
+        Ok(operation) => operation,
+        Err(e) => {
+            return write_response_frame(
+                stream,
+                &ExecResponseFrame::Error {
+                    error: format!("sandbox not running: {e}"),
+                },
+                shutdown,
+            )
+            .await;
         }
     };
+    let vsock = operation.host();
 
     let timeout_ms = request.timeout_secs.saturating_mul(1000);
     let env: &[(&str, &str)] = &[];
@@ -895,6 +894,7 @@ fn resolve_control_socket_in(
 mod tests {
     use super::*;
     use tokio::sync::oneshot;
+    use vsock_host::VsockHost;
     use vsock_proto::{
         Decoder, MSG_BOUNDED_EXEC, MSG_BOUNDED_EXEC_CANCEL, MSG_BOUNDED_EXEC_OUTPUT_CHUNK,
         MSG_BOUNDED_EXEC_RESULT, MSG_PING, MSG_PONG, MSG_READY, RawMessage,
@@ -1139,9 +1139,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
 
-        // Server with no guest connected.
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        // Server with no active control session.
+        let control_session = ControlSessionManager::new();
+        let mut handle = bind_server(sock_path.clone(), control_session)
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -1369,9 +1369,9 @@ mod tests {
     async fn bound_control_server_close_removes_socket() {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let control_session = ControlSessionManager::new();
 
-        let server = bind_server(sock_path.clone(), guest).unwrap();
+        let server = bind_server(sock_path.clone(), control_session).unwrap();
         assert!(sock_path.exists());
 
         server.close();
@@ -1383,10 +1383,10 @@ mod tests {
     async fn bound_control_server_drop_removes_socket() {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let control_session = ControlSessionManager::new();
 
         {
-            let _server = bind_server(sock_path.clone(), guest).unwrap();
+            let _server = bind_server(sock_path.clone(), control_session).unwrap();
             assert!(sock_path.exists());
         }
 
@@ -1397,8 +1397,8 @@ mod tests {
     async fn control_server_shutdown_removes_socket() {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let control_session = ControlSessionManager::new();
+        let mut handle = bind_server(sock_path.clone(), control_session)
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -1416,9 +1416,9 @@ mod tests {
     async fn control_server_cancel_removes_socket() {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let control_session = ControlSessionManager::new();
         let shutdown = CancellationToken::new();
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let mut handle = bind_server(sock_path.clone(), control_session)
             .unwrap()
             .spawn(shutdown.clone());
 
@@ -1433,9 +1433,9 @@ mod tests {
     async fn control_server_cancel_cancels_pending_connection() {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let control_session = ControlSessionManager::new();
         let shutdown = CancellationToken::new();
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let mut handle = bind_server(sock_path.clone(), control_session)
             .unwrap()
             .spawn(shutdown.clone());
         let mut stream = UnixStream::connect(&sock_path).await.unwrap();
@@ -1454,8 +1454,8 @@ mod tests {
     async fn control_server_shutdown_cancels_pending_connection() {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let control_session = ControlSessionManager::new();
+        let mut handle = bind_server(sock_path.clone(), control_session)
             .unwrap()
             .spawn(CancellationToken::new());
         let mut stream = UnixStream::connect(&sock_path).await.unwrap();
@@ -1491,8 +1491,8 @@ mod tests {
         let vsock = host_task.await.unwrap().unwrap();
 
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let control_session = ControlSessionManager::from_active_host(Arc::new(vsock));
+        let mut handle = bind_server(sock_path.clone(), control_session)
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -1545,8 +1545,8 @@ mod tests {
         let vsock = host_task.await.unwrap().unwrap();
 
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let control_session = ControlSessionManager::from_active_host(Arc::new(vsock));
+        let mut handle = bind_server(sock_path.clone(), control_session)
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -1594,8 +1594,8 @@ mod tests {
         let vsock = host_task.await.unwrap().unwrap();
 
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let control_session = ControlSessionManager::from_active_host(Arc::new(vsock));
+        let mut handle = bind_server(sock_path.clone(), control_session)
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -1648,8 +1648,8 @@ mod tests {
         let vsock = host_task.await.unwrap().unwrap();
 
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let control_session = ControlSessionManager::from_active_host(Arc::new(vsock));
+        let mut handle = bind_server(sock_path.clone(), control_session)
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -1705,8 +1705,8 @@ mod tests {
         let vsock = host_task.await.unwrap().unwrap();
 
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let control_session = ControlSessionManager::from_active_host(Arc::new(vsock));
+        let mut handle = bind_server(sock_path.clone(), control_session)
             .unwrap()
             .spawn(CancellationToken::new());
         let client = tokio::spawn({
@@ -1763,8 +1763,8 @@ mod tests {
         let vsock = host_task.await.unwrap().unwrap();
 
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let control_session = ControlSessionManager::from_active_host(Arc::new(vsock));
+        let mut handle = bind_server(sock_path.clone(), control_session)
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -1812,8 +1812,8 @@ mod tests {
         let vsock = host_task.await.unwrap().unwrap();
 
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let control_session = ControlSessionManager::from_active_host(Arc::new(vsock));
+        let mut handle = bind_server(sock_path.clone(), control_session)
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -1862,8 +1862,8 @@ mod tests {
         let vsock = host_task.await.unwrap().unwrap();
 
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let control_session = ControlSessionManager::from_active_host(Arc::new(vsock));
+        let mut handle = bind_server(sock_path.clone(), control_session)
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -1911,8 +1911,8 @@ mod tests {
         let vsock = host_task.await.unwrap().unwrap();
 
         let sock_path = dir.path().join("control.sock");
-        let guest = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(vsock))));
-        let mut handle = bind_server(sock_path.clone(), guest)
+        let control_session = ControlSessionManager::from_active_host(Arc::new(vsock));
+        let mut handle = bind_server(sock_path.clone(), control_session)
             .unwrap()
             .spawn(CancellationToken::new());
 
@@ -1944,9 +1944,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
         let _existing = UnixListener::bind(&sock_path).unwrap();
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let control_session = ControlSessionManager::new();
 
-        let result = bind_server(sock_path.clone(), guest);
+        let result = bind_server(sock_path.clone(), control_session);
 
         let Err(err) = result else {
             panic!("binding an occupied control socket should fail");

--- a/crates/sandbox-fc/src/control_session.rs
+++ b/crates/sandbox-fc/src/control_session.rs
@@ -1,0 +1,585 @@
+use std::io;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use uuid::Uuid;
+use vsock_host::{ControlHandshake, VsockHost};
+
+const QUIESCE_BUSY_RETRY_DELAY: Duration = Duration::from_millis(10);
+
+#[derive(Clone)]
+pub(crate) struct ControlSessionManager {
+    inner: Arc<Mutex<ControlSessionState>>,
+}
+
+enum ControlSessionState {
+    Disconnected,
+    Dialing,
+    Active {
+        host: Arc<VsockHost>,
+        active_ops: usize,
+    },
+    Quiescing {
+        host: Arc<VsockHost>,
+    },
+    Closed,
+}
+
+pub(crate) struct ControlOperation {
+    manager: ControlSessionManager,
+    host: Arc<VsockHost>,
+}
+
+struct DialingGuard {
+    manager: ControlSessionManager,
+    armed: bool,
+}
+
+struct QuiescingGuard {
+    manager: ControlSessionManager,
+    armed: bool,
+}
+
+impl ControlOperation {
+    pub(crate) fn host(&self) -> &VsockHost {
+        &self.host
+    }
+}
+
+impl DialingGuard {
+    fn new(manager: ControlSessionManager) -> Self {
+        Self {
+            manager,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for DialingGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let mut state = self.manager.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if matches!(&*state, ControlSessionState::Dialing) {
+            *state = ControlSessionState::Disconnected;
+        }
+    }
+}
+
+impl QuiescingGuard {
+    fn new(manager: ControlSessionManager) -> Self {
+        Self {
+            manager,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for QuiescingGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let mut state = self.manager.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if matches!(&*state, ControlSessionState::Quiescing { .. }) {
+            *state = ControlSessionState::Closed;
+        }
+    }
+}
+
+impl Drop for ControlOperation {
+    fn drop(&mut self) {
+        self.manager.release_operation();
+    }
+}
+
+impl Default for ControlSessionManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ControlSessionManager {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(ControlSessionState::Disconnected)),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_active_host(host: Arc<VsockHost>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(ControlSessionState::Active {
+                host,
+                active_ops: 0,
+            })),
+        }
+    }
+
+    pub(crate) async fn connect(
+        &self,
+        vsock_path: &str,
+        timeout: Duration,
+        boot_generation: Option<&str>,
+    ) -> io::Result<()> {
+        {
+            let mut state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            match &*state {
+                ControlSessionState::Disconnected => {
+                    *state = ControlSessionState::Dialing;
+                }
+                ControlSessionState::Dialing => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        "control session already dialing",
+                    ));
+                }
+                ControlSessionState::Active { .. } => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        "control session already active",
+                    ));
+                }
+                ControlSessionState::Quiescing { .. } => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        "control session is quiescing",
+                    ));
+                }
+                ControlSessionState::Closed => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::ConnectionReset,
+                        "control session manager closed",
+                    ));
+                }
+            }
+        }
+        let mut dialing_guard = DialingGuard::new(self.clone());
+
+        let nonce = *Uuid::new_v4().as_bytes();
+        let result = VsockHost::connect_host_initiated(
+            vsock_path,
+            timeout,
+            ControlHandshake {
+                session_nonce: &nonce,
+                boot_generation,
+            },
+        )
+        .await
+        .map(Arc::new);
+
+        let mut state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let result = match (&*state, result) {
+            (ControlSessionState::Dialing, Ok(host)) => {
+                *state = ControlSessionState::Active {
+                    host,
+                    active_ops: 0,
+                };
+                Ok(())
+            }
+            (ControlSessionState::Dialing, Err(error)) => {
+                *state = ControlSessionState::Disconnected;
+                Err(error)
+            }
+            (_, Ok(_host)) => Err(io::Error::new(
+                io::ErrorKind::ConnectionAborted,
+                "control session connect completed after manager state changed",
+            )),
+            (_, Err(error)) => Err(error),
+        };
+        dialing_guard.disarm();
+        result
+    }
+
+    pub(crate) fn acquire(&self) -> io::Result<ControlOperation> {
+        let host = {
+            let mut state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            match &mut *state {
+                ControlSessionState::Active { host, active_ops } => {
+                    *active_ops += 1;
+                    Arc::clone(host)
+                }
+                ControlSessionState::Disconnected => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::NotConnected,
+                        "control session is not connected",
+                    ));
+                }
+                ControlSessionState::Dialing => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        "control session is dialing",
+                    ));
+                }
+                ControlSessionState::Quiescing { .. } => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        "control session is quiescing",
+                    ));
+                }
+                ControlSessionState::Closed => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::ConnectionReset,
+                        "control session manager closed",
+                    ));
+                }
+            }
+        };
+
+        Ok(ControlOperation {
+            manager: self.clone(),
+            host,
+        })
+    }
+
+    pub(crate) async fn quiesce(&self, timeout: Duration) -> io::Result<()> {
+        let host = {
+            let mut state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            match &*state {
+                ControlSessionState::Disconnected => return Ok(()),
+                ControlSessionState::Active { active_ops, .. } if *active_ops > 0 => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        "control session has active host operations",
+                    ));
+                }
+                ControlSessionState::Active { host, .. } => {
+                    let host = Arc::clone(host);
+                    *state = ControlSessionState::Quiescing {
+                        host: Arc::clone(&host),
+                    };
+                    host
+                }
+                ControlSessionState::Dialing => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        "control session is dialing",
+                    ));
+                }
+                ControlSessionState::Quiescing { .. } => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        "control session already quiescing",
+                    ));
+                }
+                ControlSessionState::Closed => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::ConnectionReset,
+                        "control session manager closed",
+                    ));
+                }
+            }
+        };
+
+        let mut quiescing_guard = QuiescingGuard::new(self.clone());
+        let deadline = tokio::time::Instant::now() + timeout;
+        let result = loop {
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                break Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "control session quiesce timed out",
+                ));
+            }
+
+            let remaining = deadline.duration_since(now);
+            match host.quiesce(remaining).await {
+                Ok(()) => break Ok(()),
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    let now = tokio::time::Instant::now();
+                    if now >= deadline {
+                        break Err(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "control session quiesce timed out",
+                        ));
+                    }
+                    tokio::time::sleep(std::cmp::min(
+                        QUIESCE_BUSY_RETRY_DELAY,
+                        deadline.duration_since(now),
+                    ))
+                    .await;
+                }
+                Err(error) => break Err(error),
+            }
+        };
+        let mut state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let result = match (&*state, result) {
+            (ControlSessionState::Quiescing { .. }, Ok(())) => {
+                *state = ControlSessionState::Disconnected;
+                Ok(())
+            }
+            (ControlSessionState::Quiescing { .. }, Err(error)) => {
+                *state = ControlSessionState::Closed;
+                Err(error)
+            }
+            (_, Ok(())) => Err(io::Error::new(
+                io::ErrorKind::ConnectionAborted,
+                "control session quiesce completed after manager state changed",
+            )),
+            (_, Err(error)) => Err(error),
+        };
+        quiescing_guard.disarm();
+        result
+    }
+
+    pub(crate) fn take_for_shutdown(&self) -> Option<Arc<VsockHost>> {
+        let mut state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        match std::mem::replace(&mut *state, ControlSessionState::Closed) {
+            ControlSessionState::Active { host, .. } | ControlSessionState::Quiescing { host } => {
+                Some(host)
+            }
+            ControlSessionState::Disconnected
+            | ControlSessionState::Dialing
+            | ControlSessionState::Closed => None,
+        }
+    }
+
+    pub(crate) fn close(&self) {
+        let mut state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        *state = ControlSessionState::Closed;
+    }
+
+    fn release_operation(&self) {
+        let mut state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if let ControlSessionState::Active { active_ops, .. } = &mut *state {
+            *active_ops = active_ops.saturating_sub(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn read_line(stream: &mut tokio::net::UnixStream) -> Vec<u8> {
+        let mut line = Vec::new();
+        let mut byte = [0u8; 1];
+        loop {
+            let n = stream.read(&mut byte).await.unwrap();
+            assert_ne!(n, 0, "connection closed before line completed");
+            line.push(byte[0]);
+            if byte[0] == b'\n' {
+                return line;
+            }
+        }
+    }
+
+    async fn read_one_message(
+        stream: &mut tokio::net::UnixStream,
+        decoder: &mut vsock_proto::Decoder,
+    ) -> vsock_proto::RawMessage {
+        let mut buf = [0u8; 1024];
+        loop {
+            let n = stream.read(&mut buf).await.unwrap();
+            assert_ne!(n, 0, "connection closed before frame completed");
+            let mut messages = decoder.decode(&buf[..n]).unwrap();
+            if !messages.is_empty() {
+                return messages.remove(0);
+            }
+        }
+    }
+
+    async fn write_quiesce_ack(
+        stream: &mut tokio::net::UnixStream,
+        seq: u32,
+        status: vsock_proto::ControlQuiesceStatus,
+    ) {
+        let payload = vsock_proto::encode_control_quiesce_ack(status);
+        let ack = vsock_proto::encode(vsock_proto::MSG_CONTROL_QUIESCE_ACK, seq, &payload).unwrap();
+        stream.write_all(&ack).await.unwrap();
+    }
+
+    async fn active_manager() -> (ControlSessionManager, tokio::task::JoinHandle<()>) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vsock.sock");
+        let listener = tokio::net::UnixListener::bind(&path).unwrap();
+        let path_string = path.display().to_string();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            assert_eq!(
+                read_line(&mut stream).await,
+                format!("CONNECT {}\n", vsock_proto::VSOCK_PORT).as_bytes()
+            );
+            stream.write_all(b"OK 1073741824\n").await.unwrap();
+
+            let mut decoder = vsock_proto::Decoder::new();
+            let hello = read_one_message(&mut stream, &mut decoder).await;
+            assert_eq!(hello.msg_type, vsock_proto::MSG_CONTROL_HELLO);
+            let decoded = vsock_proto::decode_control_hello(&hello.payload).unwrap();
+            let ack_payload =
+                vsock_proto::encode_control_hello_ack(decoded.version, &decoded.nonce);
+            let ack =
+                vsock_proto::encode(vsock_proto::MSG_CONTROL_HELLO_ACK, hello.seq, &ack_payload)
+                    .unwrap();
+            stream.write_all(&ack).await.unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        let manager = ControlSessionManager::new();
+        manager
+            .connect(&path_string, Duration::from_secs(5), None)
+            .await
+            .unwrap();
+        (manager, server)
+    }
+
+    #[tokio::test]
+    async fn cancelled_connect_resets_dialing_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vsock.sock");
+        let listener = tokio::net::UnixListener::bind(&path).unwrap();
+        let manager = ControlSessionManager::new();
+
+        let task = tokio::spawn({
+            let manager = manager.clone();
+            let path = path.display().to_string();
+            async move { manager.connect(&path, Duration::from_secs(30), None).await }
+        });
+        let (_stream, _) = listener.accept().await.unwrap();
+
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+
+        let err = match manager.acquire() {
+            Ok(_) => panic!("cancelled connect must not leave an active session"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::NotConnected);
+    }
+
+    #[tokio::test]
+    async fn active_operation_blocks_quiesce() {
+        let (manager, server) = active_manager().await;
+        let operation = manager.acquire().unwrap();
+
+        let err = manager.quiesce(Duration::from_secs(5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+
+        drop(operation);
+        manager.close();
+        server.abort();
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn quiesce_retries_busy_until_ready() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vsock.sock");
+        let listener = tokio::net::UnixListener::bind(&path).unwrap();
+        let path_string = path.display().to_string();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            assert_eq!(
+                read_line(&mut stream).await,
+                format!("CONNECT {}\n", vsock_proto::VSOCK_PORT).as_bytes()
+            );
+            stream.write_all(b"OK 1073741824\n").await.unwrap();
+
+            let mut decoder = vsock_proto::Decoder::new();
+            let hello = read_one_message(&mut stream, &mut decoder).await;
+            let decoded = vsock_proto::decode_control_hello(&hello.payload).unwrap();
+            let ack_payload =
+                vsock_proto::encode_control_hello_ack(decoded.version, &decoded.nonce);
+            let ack =
+                vsock_proto::encode(vsock_proto::MSG_CONTROL_HELLO_ACK, hello.seq, &ack_payload)
+                    .unwrap();
+            stream.write_all(&ack).await.unwrap();
+
+            let busy = read_one_message(&mut stream, &mut decoder).await;
+            assert_eq!(busy.msg_type, vsock_proto::MSG_CONTROL_QUIESCE);
+            write_quiesce_ack(
+                &mut stream,
+                busy.seq,
+                vsock_proto::ControlQuiesceStatus::Busy,
+            )
+            .await;
+
+            let ready = read_one_message(&mut stream, &mut decoder).await;
+            assert_eq!(ready.msg_type, vsock_proto::MSG_CONTROL_QUIESCE);
+            write_quiesce_ack(
+                &mut stream,
+                ready.seq,
+                vsock_proto::ControlQuiesceStatus::Ready,
+            )
+            .await;
+        });
+
+        let manager = ControlSessionManager::new();
+        manager
+            .connect(&path_string, Duration::from_secs(5), None)
+            .await
+            .unwrap();
+        manager.quiesce(Duration::from_secs(5)).await.unwrap();
+
+        let err = match manager.acquire() {
+            Ok(_) => panic!("quiesced manager must not allow operations"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::NotConnected);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancelled_quiesce_closes_manager() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vsock.sock");
+        let listener = tokio::net::UnixListener::bind(&path).unwrap();
+        let path_string = path.display().to_string();
+        let (quiesce_seen_tx, quiesce_seen_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            assert_eq!(
+                read_line(&mut stream).await,
+                format!("CONNECT {}\n", vsock_proto::VSOCK_PORT).as_bytes()
+            );
+            stream.write_all(b"OK 1073741824\n").await.unwrap();
+
+            let mut decoder = vsock_proto::Decoder::new();
+            let hello = read_one_message(&mut stream, &mut decoder).await;
+            let decoded = vsock_proto::decode_control_hello(&hello.payload).unwrap();
+            let ack_payload =
+                vsock_proto::encode_control_hello_ack(decoded.version, &decoded.nonce);
+            let ack =
+                vsock_proto::encode(vsock_proto::MSG_CONTROL_HELLO_ACK, hello.seq, &ack_payload)
+                    .unwrap();
+            stream.write_all(&ack).await.unwrap();
+
+            let quiesce = read_one_message(&mut stream, &mut decoder).await;
+            assert_eq!(quiesce.msg_type, vsock_proto::MSG_CONTROL_QUIESCE);
+            let _ = quiesce_seen_tx.send(());
+            let mut byte = [0u8; 1];
+            let _ = stream.read(&mut byte).await;
+        });
+
+        let manager = ControlSessionManager::new();
+        manager
+            .connect(&path_string, Duration::from_secs(5), None)
+            .await
+            .unwrap();
+
+        let quiesce_task = tokio::spawn({
+            let manager = manager.clone();
+            async move { manager.quiesce(Duration::from_secs(30)).await }
+        });
+        quiesce_seen_rx.await.unwrap();
+        quiesce_task.abort();
+        assert!(quiesce_task.await.unwrap_err().is_cancelled());
+
+        let err = match manager.acquire() {
+            Ok(_) => panic!("cancelled quiesce must close the manager"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+        server.await.unwrap();
+    }
+}

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -30,6 +30,7 @@ mod balloon;
 mod command;
 mod config;
 pub mod control;
+mod control_session;
 mod cow_pool;
 mod factory;
 mod network;

--- a/crates/sandbox-fc/src/network/guest.rs
+++ b/crates/sandbox-fc/src/network/guest.rs
@@ -47,11 +47,19 @@ pub(crate) fn generate_guest_network_boot_args() -> String {
 
 /// Generate the full kernel boot args string (base flags + network config).
 pub(crate) fn generate_boot_args() -> String {
+    generate_boot_args_with_boot_generation(None)
+}
+
+pub(crate) fn generate_boot_args_with_boot_generation(boot_generation: Option<&str>) -> String {
+    let boot_generation = boot_generation
+        .map(|value| format!(" vm0.boot_generation={value}"))
+        .unwrap_or_default();
     format!(
         "console=ttyS0 reboot=k panic=1 pci=off nomodules random.trust_cpu=on \
          quiet loglevel=0 nokaslr audit=0 numa=off mitigations=off noresume \
-         root=/dev/vda rootfstype=ext4 rw init=/sbin/guest-init {}",
+         root=/dev/vda rootfstype=ext4 rw init=/sbin/guest-init {}{}",
         generate_guest_network_boot_args(),
+        boot_generation,
     )
 }
 
@@ -78,6 +86,15 @@ mod tests {
         assert!(
             args.contains("init=/sbin/guest-init"),
             "boot args must specify init: {args}"
+        );
+    }
+
+    #[test]
+    fn boot_args_can_include_boot_generation() {
+        let args = generate_boot_args_with_boot_generation(Some("boot-123"));
+        assert!(
+            args.contains("vm0.boot_generation=boot-123"),
+            "boot args must include boot generation: {args}"
         );
     }
 

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -2,6 +2,6 @@ mod error;
 mod guest;
 mod pool;
 
-pub(crate) use guest::generate_boot_args;
 pub(crate) use guest::{GUEST_NETWORK, GuestNetwork};
+pub(crate) use guest::{generate_boot_args, generate_boot_args_with_boot_generation};
 pub use pool::{NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, NetnsPoolHandle};

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1426,27 +1426,44 @@ impl Sandbox for FirecrackerSandbox {
     }
 
     async fn unpark(&mut self) -> sandbox::Result<()> {
-        let was_parked = self.is_parked;
-        unpark_inner(
+        // Keep the sandbox logically parked until the host-initiated control
+        // session is reconnected. If reconnect fails or this future is
+        // cancelled at that await point, a retry repeats the idempotent
+        // resume/deflate path instead of treating the sandbox as usable.
+        let preparation = prepare_unpark_inner(
             &mut self.is_parked,
             self.config.resources.memory_mb,
             self.runtime.balloon_mut(),
             &self.sock_paths.api_sock(),
-            self.state_tx.subscribe(),
             &self.id,
         )
         .await?;
 
-        if was_parked {
+        if preparation.needs_control_session() {
             let vsock_path = self.sock_paths.vsock().display().to_string();
-            self.control_session
-                .connect(&vsock_path, VSOCK_CONNECT_TIMEOUT, None)
-                .await
-                .map_err(|e| SandboxError::IdleTransition {
-                    transition: SandboxIdleTransition::Unpark,
-                    message: format!("vsock control session: {e}"),
-                })?;
+            let boot_generation = self
+                .factory_config
+                .snapshot
+                .is_none()
+                .then(|| self.boot_generation.clone())
+                .flatten();
+            connect_control_session_after_unpark(
+                &self.control_session,
+                &vsock_path,
+                boot_generation.as_deref(),
+            )
+            .await?;
         }
+
+        complete_unpark_inner(
+            preparation,
+            &mut self.is_parked,
+            self.config.resources.memory_mb,
+            self.runtime.balloon_mut(),
+            self.sock_paths.api_sock(),
+            self.state_tx.subscribe(),
+            &self.id,
+        );
 
         Ok(())
     }
@@ -1777,16 +1794,27 @@ async fn park_inner(
     Ok(())
 }
 
-async fn unpark_inner(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UnparkPreparation {
+    Noop,
+    Prepared { park_touched_controller: bool },
+}
+
+impl UnparkPreparation {
+    fn needs_control_session(self) -> bool {
+        matches!(self, Self::Prepared { .. })
+    }
+}
+
+async fn prepare_unpark_inner(
     is_parked: &mut bool,
     memory_mb: u32,
     balloon_controller: &mut Option<balloon::ControllerHandle>,
     api_sock: &std::path::Path,
-    state_rx: watch::Receiver<SandboxState>,
     log_id: &str,
-) -> sandbox::Result<()> {
+) -> sandbox::Result<UnparkPreparation> {
     if !*is_parked {
-        return Ok(());
+        return Ok(UnparkPreparation::Noop);
     }
 
     // Resume vCPUs before any balloon work — the guest needs running
@@ -1841,13 +1869,72 @@ async fn unpark_inner(
                 transition: SandboxIdleTransition::Unpark,
                 message: format!("balloon deflate: {e}"),
             })?;
+    }
 
-        *balloon_controller = Some(balloon::spawn(api_sock.to_path_buf(), memory_mb, state_rx));
+    Ok(UnparkPreparation::Prepared {
+        park_touched_controller,
+    })
+}
+
+fn complete_unpark_inner(
+    preparation: UnparkPreparation,
+    is_parked: &mut bool,
+    memory_mb: u32,
+    balloon_controller: &mut Option<balloon::ControllerHandle>,
+    api_sock: std::path::PathBuf,
+    state_rx: watch::Receiver<SandboxState>,
+    log_id: &str,
+) {
+    let UnparkPreparation::Prepared {
+        park_touched_controller,
+    } = preparation
+    else {
+        return;
+    };
+
+    if park_touched_controller {
+        *balloon_controller = Some(balloon::spawn(api_sock, memory_mb, state_rx));
     }
 
     *is_parked = false;
     info!(id = %log_id, "sandbox unparked (vCPUs resumed)");
+}
+
+#[cfg(test)]
+async fn unpark_inner(
+    is_parked: &mut bool,
+    memory_mb: u32,
+    balloon_controller: &mut Option<balloon::ControllerHandle>,
+    api_sock: &std::path::Path,
+    state_rx: watch::Receiver<SandboxState>,
+    log_id: &str,
+) -> sandbox::Result<()> {
+    let preparation =
+        prepare_unpark_inner(is_parked, memory_mb, balloon_controller, api_sock, log_id).await?;
+    complete_unpark_inner(
+        preparation,
+        is_parked,
+        memory_mb,
+        balloon_controller,
+        api_sock.to_path_buf(),
+        state_rx,
+        log_id,
+    );
     Ok(())
+}
+
+async fn connect_control_session_after_unpark(
+    control_session: &ControlSessionManager,
+    vsock_path: &str,
+    boot_generation: Option<&str>,
+) -> sandbox::Result<()> {
+    control_session
+        .connect(vsock_path, VSOCK_CONNECT_TIMEOUT, boot_generation)
+        .await
+        .map_err(|e| SandboxError::IdleTransition {
+            transition: SandboxIdleTransition::Unpark,
+            message: format!("vsock control session: {e}"),
+        })
 }
 
 #[cfg(test)]
@@ -3393,6 +3480,77 @@ mod tests {
         // Second attempt: resume(204), deflate(204).
         assert_eq!(ps[1].path, "/vm");
         assert_eq!(ps[2].path, "/balloon");
+
+        if let Some(h) = controller.take() {
+            h.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn unpark_control_reconnect_failure_leaves_retryable_state() {
+        // First attempt completes Firecracker resume+deflate, then the
+        // host-initiated control reconnect fails. The sandbox must remain
+        // logically parked so a retry can repeat the idempotent unpark path.
+        let (sock, reqs, _dir) = spawn_mock_fc_api(
+            std::collections::VecDeque::from(vec![204, 204, 400, 204]),
+            None,
+        )
+        .await;
+
+        let mut is_parked = true;
+        let mut controller: Option<balloon::ControllerHandle> = None;
+        let (_state_tx, state_rx) = watch::channel(SandboxState::Running);
+
+        let preparation =
+            prepare_unpark_inner(&mut is_parked, 2048, &mut controller, &sock, "reconnect")
+                .await
+                .unwrap();
+        assert_eq!(
+            preparation,
+            UnparkPreparation::Prepared {
+                park_touched_controller: true
+            }
+        );
+        assert!(is_parked, "flag must remain true until control reconnect");
+        assert!(
+            controller.is_none(),
+            "controller must not restart before control reconnect succeeds"
+        );
+
+        let missing_dir = tempfile::tempdir().unwrap();
+        let missing_vsock = missing_dir.path().join("missing-vsock.sock");
+        let missing_vsock = missing_vsock.display().to_string();
+        let result = connect_control_session_after_unpark(
+            &ControlSessionManager::new(),
+            &missing_vsock,
+            Some("boot-generation"),
+        )
+        .await;
+        assert_idle_transition(result, SandboxIdleTransition::Unpark);
+        assert!(is_parked, "failed reconnect must leave the retry flag set");
+        assert!(controller.is_none());
+
+        unpark_inner(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            &sock,
+            state_rx.clone(),
+            "reconnect",
+        )
+        .await
+        .unwrap();
+        assert!(!is_parked);
+        assert!(controller.is_some(), "retry must finish unpark normally");
+
+        let reqs = reqs.lock().await;
+        let ps = patches(&reqs);
+        assert_eq!(ps.len(), 4);
+        assert_eq!(ps[0].path, "/vm");
+        assert_eq!(ps[1].path, "/balloon");
+        assert_eq!(ps[2].path, "/vm");
+        assert!(ps[2].body.contains("Resumed"));
+        assert_eq!(ps[3].path, "/balloon");
 
         if let Some(h) = controller.take() {
             h.abort();

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -17,13 +17,14 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, trace, warn};
+use uuid::Uuid;
 use vsock_host::{
     BoundedExecOutputEvent as HostBoundedExecOutputEvent,
     BoundedExecOutputRequest as HostBoundedExecOutputRequest,
     BoundedExecRequest as HostBoundedExecRequest, BoundedExecResult as HostBoundedExecResult,
     BoundedExecStream as HostBoundedExecStream,
     BoundedExecStreamPolicy as HostBoundedExecStreamPolicy,
-    BoundedExecTermination as HostBoundedExecTermination, VsockHost,
+    BoundedExecTermination as HostBoundedExecTermination,
 };
 
 use crate::api::ApiError;
@@ -33,12 +34,13 @@ use crate::api::ApiClient;
 use crate::balloon;
 use crate::config::FirecrackerConfig;
 use crate::control;
+use crate::control_session::ControlSessionManager;
 use crate::factory::InvariantConfig;
-use crate::network::{NetnsInfo, NetnsLease};
+use crate::network::{NetnsInfo, NetnsLease, generate_boot_args_with_boot_generation};
 use crate::paths::{SandboxPaths, SockPaths};
 use crate::process::{kill_process_group, kill_process_group_by_pid};
 
-/// Timeout for waiting for the guest to connect via vsock after start.
+/// Timeout for establishing the host-initiated guest control session.
 const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Timeout for graceful shutdown via vsock.
@@ -444,7 +446,7 @@ struct ProcessMonitorContext {
     state: Arc<AtomicU8>,
     state_publish_lock: Arc<Mutex<()>>,
     state_tx: watch::Sender<SandboxState>,
-    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    control_session: ControlSessionManager,
     runtime_cancel: CancellationToken,
 }
 
@@ -477,11 +479,11 @@ pub struct FirecrackerSandbox {
     /// the latest value, which keeps crash/startup-exit classification
     /// deterministic after the process monitor has already observed exit.
     state_tx: watch::Sender<SandboxState>,
-    /// Vsock guest connection, shared with the process monitor so it can
-    /// drop the connection immediately when the process exits unexpectedly.
-    /// Wrapped in `Arc` so operations can clone the handle and release the
-    /// mutex immediately, allowing concurrent vsock operations.
-    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    /// Host-owned vsock control-session manager.
+    control_session: ControlSessionManager,
+    /// Fresh-boot generation passed through kernel args and validated during
+    /// the first host-initiated control handshake.
+    boot_generation: Option<String>,
     /// Sender for leaked resource cleanup. When Drop fires without prior
     /// `factory.destroy()`, pool resources are sent here for async cleanup.
     leak_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::factory::LeakedResources>>,
@@ -542,6 +544,10 @@ impl FirecrackerSandbox {
         leak_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::factory::LeakedResources>>,
     ) -> Self {
         let id = config.id.to_string();
+        let boot_generation = factory_config
+            .snapshot
+            .is_none()
+            .then(|| Uuid::new_v4().to_string());
         Self {
             config,
             factory_config,
@@ -555,7 +561,8 @@ impl FirecrackerSandbox {
             state: Arc::new(AtomicU8::new(SandboxState::Created as u8)),
             state_publish_lock: Arc::new(Mutex::new(())),
             state_tx: watch::channel(SandboxState::Created).0,
-            guest: Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>)),
+            control_session: ControlSessionManager::new(),
+            boot_generation,
             leak_tx,
             delete_workspace_on_leak_cleanup: true,
             destroyed: false,
@@ -581,10 +588,7 @@ impl FirecrackerSandbox {
         SandboxState::from_u8(self.state.load(Ordering::Acquire))
     }
 
-    fn not_running_error(&self, operation: SandboxOperation) -> SandboxError {
-        Self::operation_unavailable_error(operation, self.current_state())
-    }
-
+    #[cfg(test)]
     fn operation_unavailable_error(
         operation: SandboxOperation,
         state: SandboxState,
@@ -636,20 +640,23 @@ impl FirecrackerSandbox {
         publish_process_state(&self.state, &self.state_publish_lock, &self.state_tx, state);
     }
 
-    async fn operation_guest(
+    fn operation_guest(
         &self,
         operation: SandboxOperation,
-    ) -> sandbox::Result<Arc<VsockHost>> {
+    ) -> sandbox::Result<crate::control_session::ControlOperation> {
         if self.has_backend_crashed() {
             return Err(Self::backend_crashed_error(operation));
         }
 
-        let guest = self.guest.lock().await.as_ref().cloned();
+        let guest = self
+            .control_session
+            .acquire()
+            .map_err(|e| Self::operation_error(operation, e, self.has_backend_crashed()))?;
         if self.has_backend_crashed() {
             return Err(Self::backend_crashed_error(operation));
         }
 
-        guest.ok_or_else(|| self.not_running_error(operation))
+        Ok(guest)
     }
 
     /// Atomically transition between states using CAS. Returns `true` if the
@@ -670,11 +677,12 @@ impl FirecrackerSandbox {
         let kernel_path = self.factory_config.kernel_path.display().to_string();
         let cow_device_path = self.cow_device()?.device_path().display().to_string();
         let vsock_path = self.sock_paths.vsock().display().to_string();
+        let boot_args = generate_boot_args_with_boot_generation(self.boot_generation.as_deref());
 
         Ok(serde_json::json!({
             "boot-source": {
                 "kernel_image_path": kernel_path,
-                "boot_args": inv.boot_args,
+                "boot_args": boot_args,
             },
             "drives": [
                 {
@@ -749,7 +757,7 @@ impl FirecrackerSandbox {
             Arc::clone(&self.state),
             Arc::clone(&self.state_publish_lock),
             self.state_tx.clone(),
-            Arc::clone(&self.guest),
+            self.control_session.clone(),
             runtime_cancel,
         ));
 
@@ -866,7 +874,7 @@ impl FirecrackerSandbox {
             Arc::clone(&self.state),
             Arc::clone(&self.state_publish_lock),
             self.state_tx.clone(),
-            Arc::clone(&self.guest),
+            self.control_session.clone(),
             runtime_cancel,
         ));
 
@@ -908,11 +916,6 @@ impl FirecrackerSandbox {
         info!(id = %self.id, "snapshot loaded and resumed");
         Ok(())
     }
-}
-
-async fn abort_and_join<T>(task: tokio::task::JoinHandle<T>) {
-    task.abort();
-    let _ = task.await;
 }
 
 impl Drop for FirecrackerSandbox {
@@ -1022,7 +1025,7 @@ fn monitor_process(
     state: Arc<AtomicU8>,
     state_publish_lock: Arc<Mutex<()>>,
     state_tx: watch::Sender<SandboxState>,
-    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    control_session: ControlSessionManager,
     runtime_cancel: CancellationToken,
 ) -> ProcessMonitorHandle {
     let readers = ProcessLogReaders::from_child(id, &mut child);
@@ -1030,7 +1033,7 @@ fn monitor_process(
         state,
         state_publish_lock,
         state_tx,
-        guest,
+        control_session,
         runtime_cancel,
     };
     monitor_process_with_log_readers(id, child, context, readers)
@@ -1098,7 +1101,7 @@ fn monitor_process_with_log_readers(
                     Ok(status) => warn!(id = %id, %status, "process exited unexpectedly"),
                     Err(error) => warn!(id = %id, %error, "process wait failed unexpectedly"),
                 }
-                context.guest.lock().await.take();
+                context.control_session.close();
             }
             SandboxState::Created | SandboxState::Stopping | SandboxState::Stopped => {}
             SandboxState::Crashed => {}
@@ -1237,13 +1240,6 @@ impl Sandbox for FirecrackerSandbox {
 
         let runtime_cancel = CancellationToken::new();
 
-        // Start the vsock listener BEFORE launching Firecracker.
-        // The UDS must be bound before the guest tries to connect.
-        let vsock_path = self.sock_paths.vsock().display().to_string();
-        let mut vsock_task = tokio::spawn(async move {
-            VsockHost::wait_for_connection(&vsock_path, VSOCK_CONNECT_TIMEOUT).await
-        });
-
         let start_result = if self.factory_config.snapshot.is_some() {
             self.start_from_snapshot(runtime_cancel.clone()).await
         } else {
@@ -1251,47 +1247,40 @@ impl Sandbox for FirecrackerSandbox {
         };
 
         if let Err(e) = start_result {
-            abort_and_join(vsock_task).await;
             self.runtime.kill_process().await;
             return Err(e);
         }
 
-        // Wait for guest to connect via vsock.
-        let vsock_guest = tokio::select! {
-            result = &mut vsock_task => {
-                match result {
-                    Ok(Ok(g)) => g,
-                    Ok(Err(e)) => {
-                        self.runtime.kill_process().await;
-                        return Err(SandboxError::Start {
-                            message: format!("vsock connection: {e}"),
-                        });
-                    }
-                    Err(e) => {
-                        self.runtime.kill_process().await;
-                        return Err(SandboxError::Start {
-                            message: format!("vsock task: {e}"),
-                        });
-                    }
+        let vsock_path = self.sock_paths.vsock().display().to_string();
+        let boot_generation = self
+            .factory_config
+            .snapshot
+            .is_none()
+            .then(|| self.boot_generation.as_deref())
+            .flatten();
+        tokio::select! {
+            result = self.control_session.connect(&vsock_path, VSOCK_CONNECT_TIMEOUT, boot_generation) => {
+                if let Err(e) = result {
+                    self.runtime.kill_process().await;
+                    return Err(SandboxError::Start {
+                        message: format!("vsock control session: {e}"),
+                    });
                 }
             }
             state = wait_for_process_exit(self.state_tx.subscribe()) => {
-                abort_and_join(vsock_task).await;
                 self.runtime.kill_process().await;
                 return Err(SandboxError::Start {
-                    message: format!("process exited before vsock connected (state={state})"),
+                    message: format!("process exited before control session connected (state={state})"),
                 });
             }
-        };
-
-        *self.guest.lock().await = Some(Arc::new(vsock_guest));
+        }
 
         let control_sock_path = self.sock_paths.control_sock();
         let control_server =
-            match control::bind_server(control_sock_path.clone(), Arc::clone(&self.guest)) {
+            match control::bind_server(control_sock_path.clone(), self.control_session.clone()) {
                 Ok(server) => server,
                 Err(e) => {
-                    self.guest.lock().await.take();
+                    self.control_session.close();
                     self.runtime.kill_process().await;
                     return Err(SandboxError::Start {
                         message: format!(
@@ -1303,10 +1292,10 @@ impl Sandbox for FirecrackerSandbox {
             };
 
         // Use CAS to avoid overwriting Stopped if the process crashed between
-        // spawn and vsock connect (the process monitor may have already
+        // spawn and control-session connect (the process monitor may have already
         // recorded process exit).
         if !self.transition(SandboxState::Created, SandboxState::Running) {
-            self.guest.lock().await.take();
+            self.control_session.close();
             control_server.close();
             self.runtime.kill_process().await;
             return Err(SandboxError::Start {
@@ -1333,7 +1322,7 @@ impl Sandbox for FirecrackerSandbox {
         if !self.transition(SandboxState::Running, SandboxState::Stopping) {
             if self.current_state() == SandboxState::Crashed {
                 self.runtime.shutdown_services().await;
-                self.guest.lock().await.take();
+                self.control_session.close();
                 self.runtime.kill_process().await;
             }
             return Ok(());
@@ -1355,7 +1344,7 @@ impl Sandbox for FirecrackerSandbox {
         // Skipping graceful shutdown is still correct — the sandbox was idle
         // with no user workload.
         if !self.is_parked {
-            let guest = self.guest.lock().await.take();
+            let guest = self.control_session.take_for_shutdown();
             if let Some(guest) = guest
                 && !guest.shutdown(SHUTDOWN_TIMEOUT).await
             {
@@ -1373,13 +1362,13 @@ impl Sandbox for FirecrackerSandbox {
         if !self.transition(SandboxState::Running, SandboxState::Stopping) {
             if self.current_state() == SandboxState::Crashed {
                 self.runtime.shutdown_services().await;
-                self.guest.lock().await.take();
+                self.control_session.close();
                 self.runtime.kill_process().await;
             }
             return Ok(());
         }
         self.runtime.shutdown_services().await;
-        self.guest.lock().await.take();
+        self.control_session.close();
         self.runtime.kill_process().await;
         self.publish_state(SandboxState::Stopped);
         info!(id = %self.id, "sandbox killed");
@@ -1416,6 +1405,16 @@ impl Sandbox for FirecrackerSandbox {
     // skip the abort+respawn dance when park was a no-op.
 
     async fn park(&mut self) -> sandbox::Result<()> {
+        if !self.is_parked {
+            self.control_session
+                .quiesce(SHUTDOWN_TIMEOUT)
+                .await
+                .map_err(|e| SandboxError::IdleTransition {
+                    transition: SandboxIdleTransition::Park,
+                    message: format!("control session quiesce: {e}"),
+                })?;
+        }
+
         park_inner(
             &mut self.is_parked,
             self.config.resources.memory_mb,
@@ -1427,6 +1426,7 @@ impl Sandbox for FirecrackerSandbox {
     }
 
     async fn unpark(&mut self) -> sandbox::Result<()> {
+        let was_parked = self.is_parked;
         unpark_inner(
             &mut self.is_parked,
             self.config.resources.memory_mb,
@@ -1435,7 +1435,20 @@ impl Sandbox for FirecrackerSandbox {
             self.state_tx.subscribe(),
             &self.id,
         )
-        .await
+        .await?;
+
+        if was_parked {
+            let vsock_path = self.sock_paths.vsock().display().to_string();
+            self.control_session
+                .connect(&vsock_path, VSOCK_CONNECT_TIMEOUT, None)
+                .await
+                .map_err(|e| SandboxError::IdleTransition {
+                    transition: SandboxIdleTransition::Unpark,
+                    message: format!("vsock control session: {e}"),
+                })?;
+        }
+
+        Ok(())
     }
 
     // -- operations --
@@ -1450,7 +1463,8 @@ impl Sandbox for FirecrackerSandbox {
         // should call bounded_exec so output, termination, streaming, and
         // cancellation semantics are explicit.
         let operation = SandboxOperation::Exec;
-        let guest = self.operation_guest(operation).await?;
+        let operation_guard = self.operation_guest(operation)?;
+        let guest = operation_guard.host();
 
         tokio::select! {
             result = guest.exec(request.cmd, request.timeout_ms(), request.env, request.sudo) => {
@@ -1472,7 +1486,8 @@ impl Sandbox for FirecrackerSandbox {
         request: &BoundedExecRequest<'_>,
     ) -> sandbox::Result<BoundedExecResult> {
         let operation = SandboxOperation::BoundedExec;
-        let guest = self.operation_guest(operation).await?;
+        let operation_guard = self.operation_guest(operation)?;
+        let guest = operation_guard.host();
 
         let mut bridge_tasks = Vec::new();
         let stdout_stream = spawn_bounded_stream_bridge(
@@ -1517,7 +1532,8 @@ impl Sandbox for FirecrackerSandbox {
 
     async fn write_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
         let operation = SandboxOperation::WriteFile;
-        let guest = self.operation_guest(operation).await?;
+        let operation_guard = self.operation_guest(operation)?;
+        let guest = operation_guard.host();
 
         tokio::select! {
             result = guest.write_file(path, content, false) => {
@@ -1535,7 +1551,8 @@ impl Sandbox for FirecrackerSandbox {
         output: sandbox::SpawnOutputMode<'_>,
     ) -> sandbox::Result<SpawnHandle> {
         let operation = SandboxOperation::SpawnWatch;
-        let guest = self.operation_guest(operation).await?;
+        let operation_guard = self.operation_guest(operation)?;
+        let guest = operation_guard.host();
 
         tokio::select! {
             result = guest.spawn_watch(
@@ -1564,7 +1581,8 @@ impl Sandbox for FirecrackerSandbox {
         timeout: Duration,
     ) -> sandbox::Result<ProcessExit> {
         let operation = SandboxOperation::WaitExit;
-        let guest = self.operation_guest(operation).await?;
+        let operation_guard = self.operation_guest(operation)?;
+        let guest = operation_guard.host();
 
         tokio::select! {
             result = guest.wait_for_exit(handle.pid, timeout) => {
@@ -2184,7 +2202,7 @@ mod tests {
         let state = Arc::new(AtomicU8::new(SandboxState::Running as u8));
         let state_publish_lock = Arc::new(Mutex::new(()));
         let (state_tx, state_rx) = watch::channel(SandboxState::Running);
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let control_session = ControlSessionManager::new();
         let runtime_cancel = CancellationToken::new();
         let mut child = monitored_cat_process();
         let stdin = child.stdin.take();
@@ -2195,7 +2213,7 @@ mod tests {
             Arc::clone(&state),
             Arc::clone(&state_publish_lock),
             state_tx,
-            guest,
+            control_session,
             runtime_cancel.clone(),
         );
 
@@ -2222,9 +2240,9 @@ mod tests {
         let state = Arc::new(AtomicU8::new(SandboxState::Running as u8));
         let state_publish_lock = Arc::new(Mutex::new(()));
         let (state_tx, _state_rx) = watch::channel(SandboxState::Running);
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let control_session = ControlSessionManager::new();
         let runtime_cancel = CancellationToken::new();
-        let mut control = crate::control::bind_server(sock_path.clone(), Arc::clone(&guest))
+        let mut control = crate::control::bind_server(sock_path.clone(), control_session.clone())
             .unwrap()
             .spawn(runtime_cancel.clone());
         let mut child = monitored_cat_process();
@@ -2236,7 +2254,7 @@ mod tests {
             Arc::clone(&state),
             Arc::clone(&state_publish_lock),
             state_tx,
-            guest,
+            control_session,
             runtime_cancel,
         );
 
@@ -2252,7 +2270,7 @@ mod tests {
         let state = Arc::new(AtomicU8::new(SandboxState::Created as u8));
         let state_publish_lock = Arc::new(Mutex::new(()));
         let (state_tx, _state_rx) = watch::channel(SandboxState::Created);
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let control_session = ControlSessionManager::new();
         let child = stdout_stderr_writing_process();
 
         let handle = monitor_process(
@@ -2261,7 +2279,7 @@ mod tests {
             Arc::clone(&state),
             Arc::clone(&state_publish_lock),
             state_tx,
-            guest,
+            control_session,
             CancellationToken::new(),
         );
 
@@ -2279,7 +2297,7 @@ mod tests {
         let state = Arc::new(AtomicU8::new(SandboxState::Created as u8));
         let state_publish_lock = Arc::new(Mutex::new(()));
         let (state_tx, _state_rx) = watch::channel(SandboxState::Created);
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let control_session = ControlSessionManager::new();
         let mut child = monitored_cat_process_without_log_pipes();
         let stdin = child.stdin.take();
         let (stdout_reader, stdout_started_rx, stdout_dropped_rx) = pending_log_reader_for_test();
@@ -2298,7 +2316,7 @@ mod tests {
             state: Arc::clone(&state),
             state_publish_lock: Arc::clone(&state_publish_lock),
             state_tx,
-            guest,
+            control_session,
             runtime_cancel: CancellationToken::new(),
         };
         let handle = monitor_process_with_log_readers("test-sandbox", child, context, readers);
@@ -2323,7 +2341,7 @@ mod tests {
         let state = Arc::new(AtomicU8::new(SandboxState::Running as u8));
         let state_publish_lock = Arc::new(Mutex::new(()));
         let (state_tx, _state_rx) = watch::channel(SandboxState::Running);
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let control_session = ControlSessionManager::new();
         let mut child = monitored_cat_process_without_log_pipes();
         let stdin = child.stdin.take();
         let (reader, started_rx, dropped_rx) = pending_log_reader_for_test();
@@ -2337,7 +2355,7 @@ mod tests {
             state: Arc::clone(&state),
             state_publish_lock: Arc::clone(&state_publish_lock),
             state_tx,
-            guest,
+            control_session,
             runtime_cancel: CancellationToken::new(),
         };
         let handle = monitor_process_with_log_readers("test-sandbox", child, context, readers);
@@ -2368,7 +2386,7 @@ mod tests {
         let state = Arc::new(AtomicU8::new(SandboxState::Running as u8));
         let state_publish_lock = Arc::new(Mutex::new(()));
         let (state_tx, _state_rx) = watch::channel(SandboxState::Running);
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let control_session = ControlSessionManager::new();
         let mut child = monitored_cat_process();
         let stdin = child.stdin.take();
 
@@ -2378,7 +2396,7 @@ mod tests {
             Arc::clone(&state),
             Arc::clone(&state_publish_lock),
             state_tx.clone(),
-            guest,
+            control_session,
             CancellationToken::new(),
         );
 
@@ -2403,7 +2421,7 @@ mod tests {
         let state = Arc::new(AtomicU8::new(SandboxState::Stopping as u8));
         let state_publish_lock = Arc::new(Mutex::new(()));
         let (state_tx, _state_rx) = watch::channel(SandboxState::Stopping);
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let control_session = ControlSessionManager::new();
         let mut child = monitored_cat_process();
         let stdin = child.stdin.take();
 
@@ -2413,7 +2431,7 @@ mod tests {
             Arc::clone(&state),
             Arc::clone(&state_publish_lock),
             state_tx.clone(),
-            guest,
+            control_session,
             CancellationToken::new(),
         );
 
@@ -2438,7 +2456,7 @@ mod tests {
         let state = Arc::new(AtomicU8::new(SandboxState::Created as u8));
         let state_publish_lock = Arc::new(Mutex::new(()));
         let (state_tx, _state_rx) = watch::channel(SandboxState::Created);
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let control_session = ControlSessionManager::new();
         let mut child = monitored_cat_process();
         let stdin = child.stdin.take();
 
@@ -2448,7 +2466,7 @@ mod tests {
             Arc::clone(&state),
             Arc::clone(&state_publish_lock),
             state_tx.clone(),
-            guest,
+            control_session,
             CancellationToken::new(),
         );
 
@@ -2473,7 +2491,7 @@ mod tests {
         let state = Arc::new(AtomicU8::new(SandboxState::Running as u8));
         let state_publish_lock = Arc::new(Mutex::new(()));
         let (state_tx, state_rx) = watch::channel(SandboxState::Running);
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let control_session = ControlSessionManager::new();
         let mut child = stdout_closing_process();
         let stdout = child.stdout.take().expect("stdout should be piped");
         let stderr = child.stderr.take().map(|stderr| {
@@ -2486,7 +2504,7 @@ mod tests {
             state: Arc::clone(&state),
             state_publish_lock: Arc::clone(&state_publish_lock),
             state_tx: state_tx.clone(),
-            guest,
+            control_session,
             runtime_cancel: CancellationToken::new(),
         };
 
@@ -2523,7 +2541,7 @@ mod tests {
         let state = Arc::new(AtomicU8::new(SandboxState::Running as u8));
         let state_publish_lock = Arc::new(Mutex::new(()));
         let (state_tx, _state_rx) = watch::channel(SandboxState::Running);
-        let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+        let control_session = ControlSessionManager::new();
         let child = parent_exits_with_child_process(&pid_file);
 
         let handle = monitor_process(
@@ -2532,7 +2550,7 @@ mod tests {
             Arc::clone(&state),
             Arc::clone(&state_publish_lock),
             state_tx,
-            guest,
+            control_session,
             CancellationToken::new(),
         );
 

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use tokio::io::AsyncBufReadExt;
 use tokio::task::JoinHandle;
 use tracing::info;
+use uuid::Uuid;
 
 use nbd_cow::pool::DevicePoolHandle;
 use nbd_cow::{DestroyRetryPolicy, KeptCow, PooledNbdCowDevice};
@@ -19,7 +20,9 @@ use sandbox::{PendingSnapshotPublish, SnapshotCreateConfig, SnapshotOutput, Snap
 use crate::api::{ApiClient, ApiError};
 use crate::config::SnapshotConfig;
 use crate::factory::{InvariantConfig, config_hash};
-use crate::network::{NetnsLease, NetnsPool, NetnsPoolConfig};
+use crate::network::{
+    NetnsLease, NetnsPool, NetnsPoolConfig, generate_boot_args_with_boot_generation,
+};
 use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
 use crate::prerequisites;
 use crate::process::kill_process_group;
@@ -27,7 +30,7 @@ use crate::process::kill_process_group;
 /// Timeout for waiting for the Firecracker API socket after process spawn.
 const API_READY_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Timeout for waiting for the guest to connect via vsock after start.
+/// Timeout for establishing the host-initiated guest control session.
 const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub const SNAPSHOT_COMPLETE_MARKER_CONTENT: &[u8] = b"snapshot-complete-v1\n";
@@ -54,37 +57,6 @@ fn cow_destroy_retry_policy() -> DestroyRetryPolicy {
     DestroyRetryPolicy {
         attempts: DESTROY_RETRIES,
         delay: DESTROY_RETRY_DELAY,
-    }
-}
-
-struct AbortOnDropTask<T> {
-    handle: JoinHandle<T>,
-}
-
-impl<T> AbortOnDropTask<T> {
-    fn new(handle: JoinHandle<T>) -> Self {
-        Self { handle }
-    }
-
-    fn abort(&self) {
-        self.handle.abort();
-    }
-}
-
-impl<T> Future for AbortOnDropTask<T> {
-    type Output = Result<T, tokio::task::JoinError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.get_mut();
-        Pin::new(&mut this.handle).poll(cx)
-    }
-}
-
-impl<T> Drop for AbortOnDropTask<T> {
-    fn drop(&mut self) {
-        if !self.handle.is_finished() {
-            self.handle.abort();
-        }
     }
 }
 
@@ -238,8 +210,7 @@ pub enum SnapshotError {
     /// snapshot state and memory files.
     #[error("api error: {0}")]
     Api(#[from] ApiError),
-    /// The guest did not establish the expected vsock readiness connection, or
-    /// the listener task failed while waiting for it.
+    /// The host could not establish the expected guest control session.
     ///
     /// Firecracker may already be running when this happens, but the snapshot
     /// workflow has not reached the pre-warm, pause, or snapshot stages.
@@ -1709,14 +1680,15 @@ impl Drop for SnapshotAttempt {
 ///  4. Spawn Firecracker with `--api-sock`
 ///  5. Wait for API socket ready
 ///  6. Configure VM via API (6 parallel PUT calls)
-///  7. Bind vsock listener
+///  7. Configure host-initiated vsock
 ///  8. Start instance
-///  9. Wait for guest vsock connection
+///  9. Connect guest control session
 /// 10. Pre-warm guest caches (PAM/nsswitch, CLI modules)
-/// 11. Pause VM
-/// 12. Create snapshot
-/// 13. Cleanup Firecracker/netns/NBD runtime resources and keep the temporary COW
-/// 14. Move COW file + bitmap to output dir and publish the complete marker
+/// 11. Quiesce guest control session
+/// 12. Pause VM
+/// 13. Create snapshot
+/// 14. Cleanup Firecracker/netns/NBD runtime resources and keep the temporary COW
+/// 15. Move COW file + bitmap to output dir and publish the complete marker
 pub async fn create_snapshot(
     config: SnapshotCreateConfig,
 ) -> Result<SnapshotConfig, SnapshotError> {
@@ -1970,12 +1942,14 @@ async fn run_with_firecracker(
     // 6. Configure VM via API (6 parallel PUT calls).
     let inv = InvariantConfig::new();
     let kernel_path = config.kernel_path.display().to_string();
+    let boot_generation = Uuid::new_v4().to_string();
+    let boot_args = generate_boot_args_with_boot_generation(Some(&boot_generation));
     tokio::fs::create_dir_all(&sock_paths.vsock_dir()).await?;
     let vsock_uds_str = sock_paths.vsock().display().to_string();
 
     tokio::try_join!(
         client.configure_machine(config.vcpu_count, config.memory_mb),
-        client.configure_boot_source(&kernel_path, &inv.boot_args),
+        client.configure_boot_source(&kernel_path, &boot_args),
         client.configure_drive("rootfs", &drive_bind_str, true, false),
         client.configure_network_interface(inv.iface_id, inv.guest_mac, inv.tap_name),
         client.configure_vsock(inv.guest_cid, &vsock_uds_str),
@@ -1988,31 +1962,25 @@ async fn run_with_firecracker(
 
     info!("VM configured");
 
-    // 7. Bind vsock listener BEFORE starting the instance (race: guest connects ~300ms after boot).
-    let vsock_path_for_listen = vsock_uds_str.clone();
-    let vsock_task = AbortOnDropTask::new(tokio::spawn(async move {
-        vsock_host::VsockHost::wait_for_connection(&vsock_path_for_listen, VSOCK_CONNECT_TIMEOUT)
-            .await
-    }));
-
     // 8. Start instance.
-    let start_result = client.start_instance().await;
-    if let Err(e) = start_result {
-        vsock_task.abort();
-        let _ = vsock_task.await;
-        return Err(e.into());
-    }
+    client.start_instance().await?;
 
-    info!("instance started, waiting for guest vsock connection");
+    info!("instance started, connecting guest control session");
 
-    // 9. Wait for guest to connect via vsock.
-    let guest = match vsock_task.await {
-        Ok(Ok(g)) => g,
-        Ok(Err(e)) => return Err(SnapshotError::Vsock(e.to_string())),
-        Err(e) => return Err(SnapshotError::Vsock(format!("vsock task: {e}"))),
-    };
+    // 9. Establish host-initiated guest control session.
+    let session_nonce = *Uuid::new_v4().as_bytes();
+    let guest = vsock_host::VsockHost::connect_host_initiated(
+        &vsock_uds_str,
+        VSOCK_CONNECT_TIMEOUT,
+        vsock_host::ControlHandshake {
+            session_nonce: &session_nonce,
+            boot_generation: Some(&boot_generation),
+        },
+    )
+    .await
+    .map_err(|e| SnapshotError::Vsock(e.to_string()))?;
 
-    info!("guest connected");
+    info!("guest control session connected");
 
     // 9.5. Pre-warm caches (PAM/nsswitch, CLI modules) so post-restore calls
     //      are fast. The snapshot captures memory + disk state, so caches
@@ -2063,6 +2031,12 @@ async fn run_with_firecracker(
         }
     }
     info!("pre-warm complete");
+
+    guest
+        .quiesce(VSOCK_CONNECT_TIMEOUT)
+        .await
+        .map_err(|e| SnapshotError::Setup(format!("pre-warm quiesce: {e}")))?;
+    info!("guest control session quiesced");
 
     // 10. Pause VM.
     client.pause().await?;
@@ -3126,70 +3100,6 @@ mod tests {
             .await
             .expect("dropped cleanup finalizer should continue")
             .expect("cleanup finalizer should finish");
-    }
-
-    #[tokio::test]
-    async fn abort_on_drop_task_aborts_vsock_listener() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let base = dir.path().join("snapshot-vsock");
-        let listener =
-            std::path::PathBuf::from(format!("{}_{}", base.display(), vsock_proto::VSOCK_PORT));
-        let base = base.display().to_string();
-
-        let task = AbortOnDropTask::new(tokio::spawn(async move {
-            vsock_host::VsockHost::wait_for_connection(&base, Duration::from_secs(30)).await
-        }));
-
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while !listener.exists() {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("vsock listener should bind");
-
-        drop(task);
-
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while listener.exists() {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("dropped task should abort and remove vsock listener");
-    }
-
-    #[tokio::test]
-    async fn abort_on_drop_task_explicit_abort_removes_vsock_listener() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let base = dir.path().join("snapshot-vsock-explicit-abort");
-        let listener =
-            std::path::PathBuf::from(format!("{}_{}", base.display(), vsock_proto::VSOCK_PORT));
-        let base = base.display().to_string();
-
-        let task = AbortOnDropTask::new(tokio::spawn(async move {
-            vsock_host::VsockHost::wait_for_connection(&base, Duration::from_secs(30)).await
-        }));
-
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while !listener.exists() {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("vsock listener should bind");
-
-        task.abort();
-        let join = task.await;
-        assert!(
-            join.is_err_and(|e| e.is_cancelled()),
-            "explicit abort should cancel the listener task"
-        );
-
-        assert!(
-            !listener.exists(),
-            "explicit abort should remove the vsock listener socket"
-        );
     }
 
     #[tokio::test]

--- a/crates/vsock-guest/src/boot.rs
+++ b/crates/vsock-guest/src/boot.rs
@@ -1,0 +1,37 @@
+use std::io;
+
+const BOOT_GENERATION_KEY: &str = "vm0.boot_generation=";
+
+pub(crate) fn parse_boot_generation(cmdline: &str) -> Option<&str> {
+    cmdline
+        .split_ascii_whitespace()
+        .find_map(|arg| arg.strip_prefix(BOOT_GENERATION_KEY))
+        .filter(|value| !value.is_empty())
+}
+
+pub(crate) fn read_boot_generation() -> io::Result<Option<String>> {
+    let cmdline = std::fs::read_to_string("/proc/cmdline")?;
+    Ok(parse_boot_generation(&cmdline).map(str::to_owned))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_boot_generation_reads_vm0_arg() {
+        assert_eq!(
+            parse_boot_generation("console=ttyS0 root=/dev/vda vm0.boot_generation=boot-123 quiet"),
+            Some("boot-123")
+        );
+    }
+
+    #[test]
+    fn parse_boot_generation_ignores_missing_or_empty_values() {
+        assert_eq!(parse_boot_generation("console=ttyS0 root=/dev/vda"), None);
+        assert_eq!(
+            parse_boot_generation("console=ttyS0 vm0.boot_generation= root=/dev/vda"),
+            None
+        );
+    }
+}

--- a/crates/vsock-guest/src/bounded_exec.rs
+++ b/crates/vsock-guest/src/bounded_exec.rs
@@ -18,6 +18,7 @@ use crate::error::to_io_error;
 use crate::exec::{format_env_diagnostics, spawn_bounded_exec_command, truncate_preview};
 use crate::log::log;
 use crate::process::kill_and_reap_child;
+use crate::session::{PendingWorkGuard, PendingWorkSlot};
 use crate::threading::{SystemThreadSpawner, ThreadSpawner};
 use crate::wait::{
     DRAIN_DEADLINE_SECS, WaitOutcome, await_drain_deadline, wait_with_kill_timeout_or_cancelled_any,
@@ -197,6 +198,7 @@ pub(crate) fn spawn_bounded_exec_worker(
     connection_cancel: Arc<AtomicBool>,
     request_cancel: Arc<AtomicBool>,
     cleanup: BoundedExecCleanup,
+    pending_work: Option<PendingWorkGuard>,
 ) -> io::Result<()> {
     spawn_bounded_exec_worker_with_spawner(
         request,
@@ -204,6 +206,7 @@ pub(crate) fn spawn_bounded_exec_worker(
         connection_cancel,
         request_cancel,
         cleanup,
+        pending_work,
         SystemThreadSpawner,
     )
 }
@@ -214,6 +217,7 @@ fn spawn_bounded_exec_worker_with_spawner<S>(
     connection_cancel: Arc<AtomicBool>,
     request_cancel: Arc<AtomicBool>,
     cleanup: BoundedExecCleanup,
+    pending_work: Option<PendingWorkGuard>,
     spawner: S,
 ) -> io::Result<()>
 where
@@ -224,10 +228,13 @@ where
     let stderr_policy = request.stderr;
     let worker_writer = writer.clone();
     let worker_spawner = spawner.clone();
+    let pending_slot = PendingWorkSlot::new(pending_work);
+    let worker_pending_slot = pending_slot.clone();
     let cleanup_guard = BoundedExecCleanupGuard::new(cleanup);
     let result = spawner.spawn_unit(
         THREAD_BOUNDED_EXEC_WORKER,
         Box::new(move || {
+            let _pending_work = worker_pending_slot.take();
             let _cleanup_guard = cleanup_guard;
             run_bounded_exec(
                 request,
@@ -245,6 +252,7 @@ where
             let diagnostic = format!("Failed to spawn bounded exec worker thread: {e}");
             let stdout = GuestBoundedOutput::empty_for_policy(stdout_policy);
             let stderr = GuestBoundedOutput::empty_for_policy(stderr_policy);
+            let _pending_work = pending_slot.take();
             send_bounded_exec_result(
                 BoundedExecResultFrame {
                     seq,
@@ -1213,6 +1221,7 @@ mod tests {
             Box::new(move || {
                 cleanup_count_for_hook.fetch_add(1, Ordering::SeqCst);
             }),
+            None,
             FailingThreadSpawner::fail_once(THREAD_BOUNDED_EXEC_WORKER),
         )
         .unwrap();

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -1,5 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::io::{self, Read};
+#[cfg(target_os = "linux")]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::os::unix::net::UnixStream;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -7,10 +9,12 @@ use std::thread;
 use std::time::Duration;
 
 use vsock_proto::{
-    self, MSG_BOUNDED_EXEC, MSG_BOUNDED_EXEC_CANCEL, MSG_EXEC, MSG_EXEC_RESULT, MSG_READY,
-    MSG_SPAWN_WATCH,
+    self, ControlQuiesceStatus, MSG_BOUNDED_EXEC, MSG_BOUNDED_EXEC_CANCEL, MSG_CONTROL_HELLO,
+    MSG_CONTROL_HELLO_ACK, MSG_CONTROL_QUIESCE, MSG_CONTROL_QUIESCE_ACK, MSG_ERROR, MSG_EXEC,
+    MSG_EXEC_RESULT, MSG_READY, MSG_SPAWN_WATCH, MSG_WRITE_FILE, RawMessage,
 };
 
+use crate::boot::read_boot_generation;
 use crate::bounded_exec::{
     BoundedExecCleanup, BoundedExecWorkerRequest, spawn_bounded_exec_worker,
 };
@@ -18,19 +22,34 @@ use crate::error::to_io_error;
 use crate::handlers::{MessageOutcome, handle_exec, handle_message};
 use crate::log::log;
 use crate::monitor::{SpawnWatchRequest, handle_spawn_watch};
+use crate::session::{PendingWorkGuard, PendingWorkSlot, SessionWorkTracker};
 use crate::threading::{SystemThreadSpawner, ThreadSpawner};
 use crate::writer::GuestWriter;
 
 // Vsock constants (only used on Linux)
 #[cfg(target_os = "linux")]
 const VSOCK_CID_HOST: u32 = 2;
+#[cfg(target_os = "linux")]
+const VMADDR_CID_ANY: u32 = 0xFFFF_FFFF;
+
+#[cfg(target_os = "linux")]
+struct VsockListener {
+    fd: OwnedFd,
+}
 
 /// Read buffer size for the connection event loop (local tuning constant).
 const READ_BUFFER_SIZE: usize = 64 * 1024; // 64KB
 const THREAD_EXEC_WORKER: &str = "vsock-exec-worker";
 
+#[derive(Debug)]
 enum ConnectionEnd {
     Closed,
+    Shutdown,
+}
+
+enum ControlMessageAction {
+    Continue,
+    CloseSession,
     Shutdown,
 }
 
@@ -48,17 +67,45 @@ struct ExecWorkerRequest {
 /// one.
 struct ConnectionCancelGuard(Arc<AtomicBool>);
 
+type BoundedExecCancelMap = Arc<Mutex<HashMap<u32, Arc<AtomicBool>>>>;
+
 impl Drop for ConnectionCancelGuard {
     fn drop(&mut self) {
         self.0.store(true, Ordering::Release);
     }
 }
 
-/// Connect to vsock (Linux only - this binary runs inside Firecracker VM)
-#[cfg(target_os = "linux")]
-pub fn connect_vsock() -> io::Result<UnixStream> {
-    use std::os::unix::io::FromRawFd;
+fn prepare_bounded_exec_cleanup(
+    seq: u32,
+    bounded_exec_cancels: &BoundedExecCancelMap,
+) -> (Arc<AtomicBool>, BoundedExecCleanup) {
+    let request_cancel = Arc::new(AtomicBool::new(false));
+    {
+        let mut cancels = bounded_exec_cancels
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if let Some(previous) = cancels.insert(seq, request_cancel.clone()) {
+            previous.store(true, Ordering::Release);
+        }
+    }
 
+    let cleanup_cancels = Arc::clone(bounded_exec_cancels);
+    let cleanup_cancel = Arc::clone(&request_cancel);
+    let cleanup: BoundedExecCleanup = Box::new(move || {
+        let mut cancels = cleanup_cancels.lock().unwrap_or_else(|e| e.into_inner());
+        if cancels
+            .get(&seq)
+            .is_some_and(|current| Arc::ptr_eq(current, &cleanup_cancel))
+        {
+            cancels.remove(&seq);
+        }
+    });
+
+    (request_cancel, cleanup)
+}
+
+#[cfg(target_os = "linux")]
+fn listen_vsock() -> io::Result<VsockListener> {
     // SAFETY: Creating a vsock socket with valid constants. fd is checked for errors below.
     let fd = unsafe { libc::socket(libc::AF_VSOCK, libc::SOCK_STREAM | libc::SOCK_CLOEXEC, 0) };
     if fd < 0 {
@@ -69,37 +116,105 @@ pub fn connect_vsock() -> io::Result<UnixStream> {
         svm_family: libc::AF_VSOCK as u16,
         svm_reserved1: 0,
         svm_port: vsock_proto::VSOCK_PORT,
-        svm_cid: VSOCK_CID_HOST,
+        svm_cid: VMADDR_CID_ANY,
         svm_zero: [0; 4],
     };
 
-    // SAFETY: fd is a valid socket from above, addr is properly initialized, and
-    // size_of returns the correct sockaddr_vm size. Errors are checked below.
+    // SAFETY: fd is a valid socket from above, addr is initialized, and length
+    // matches sockaddr_vm. Errors are handled below.
     let ret = unsafe {
-        libc::connect(
+        libc::bind(
             fd,
             &addr as *const libc::sockaddr_vm as *const libc::sockaddr,
-            std::mem::size_of::<libc::sockaddr_vm>() as u32,
+            std::mem::size_of::<libc::sockaddr_vm>() as libc::socklen_t,
         )
     };
-
     if ret < 0 {
-        // SAFETY: fd is a valid open socket descriptor, and we're about to return an error.
+        let err = io::Error::last_os_error();
+        // SAFETY: fd is open and not owned by a Rust object yet.
         unsafe { libc::close(fd) };
-        return Err(io::Error::last_os_error());
+        return Err(err);
     }
 
-    // SAFETY: fd is a valid, connected socket descriptor. Ownership transfers to UnixStream.
-    Ok(unsafe { UnixStream::from_raw_fd(fd) })
+    // SAFETY: fd is a valid bound stream socket.
+    let ret = unsafe { libc::listen(fd, 16) };
+    if ret < 0 {
+        let err = io::Error::last_os_error();
+        // SAFETY: fd is open and not owned by a Rust object yet.
+        unsafe { libc::close(fd) };
+        return Err(err);
+    }
+
+    // SAFETY: fd is a valid listening stream socket owned by this function.
+    Ok(VsockListener {
+        fd: unsafe { OwnedFd::from_raw_fd(fd) },
+    })
 }
 
-/// Stub for non-Linux platforms (for IDE support)
-#[cfg(not(target_os = "linux"))]
-pub fn connect_vsock() -> io::Result<UnixStream> {
-    Err(io::Error::new(
-        io::ErrorKind::Unsupported,
-        "vsock is only supported on Linux",
-    ))
+#[cfg(target_os = "linux")]
+impl VsockListener {
+    fn accept(&self) -> io::Result<UnixStream> {
+        let mut addr = libc::sockaddr_vm {
+            svm_family: 0,
+            svm_reserved1: 0,
+            svm_port: 0,
+            svm_cid: 0,
+            svm_zero: [0; 4],
+        };
+        let mut len = std::mem::size_of::<libc::sockaddr_vm>() as libc::socklen_t;
+        // SAFETY: `addr` and `len` point to valid writable storage for the
+        // kernel-reported sockaddr_vm. The returned fd is checked before use.
+        let fd = unsafe {
+            libc::accept4(
+                self.fd.as_raw_fd(),
+                &mut addr as *mut libc::sockaddr_vm as *mut libc::sockaddr,
+                &mut len,
+                libc::SOCK_CLOEXEC,
+            )
+        };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // SAFETY: fd is a valid connected stream socket returned by accept4.
+        Ok(unsafe { UnixStream::from_raw_fd(fd) })
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn validate_host_peer(stream: &UnixStream) -> io::Result<()> {
+    let mut addr = libc::sockaddr_vm {
+        svm_family: 0,
+        svm_reserved1: 0,
+        svm_port: 0,
+        svm_cid: 0,
+        svm_zero: [0; 4],
+    };
+    let mut len = std::mem::size_of::<libc::sockaddr_vm>() as libc::socklen_t;
+    // SAFETY: `addr` points to valid writable storage and `len` is initialized
+    // to the sockaddr_vm size. getpeername does not retain the pointer.
+    let ret = unsafe {
+        libc::getpeername(
+            stream.as_raw_fd(),
+            &mut addr as *mut libc::sockaddr_vm as *mut libc::sockaddr,
+            &mut len,
+        )
+    };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if addr.svm_family != libc::AF_VSOCK as u16 || addr.svm_cid != VSOCK_CID_HOST {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("unexpected vsock peer cid {}", addr.svm_cid),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn is_recoverable_accept_error(error: &io::Error) -> bool {
+    error.kind() == io::ErrorKind::Interrupted || error.raw_os_error() == Some(libc::ECONNABORTED)
 }
 
 /// Connect to Unix socket (for testing)
@@ -120,7 +235,7 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
     let writer = GuestWriter::new(stream);
     let connection_cancel = Arc::new(AtomicBool::new(false));
     let _cancel_on_drop = ConnectionCancelGuard(connection_cancel.clone());
-    let bounded_exec_cancels = Arc::new(Mutex::new(HashMap::<u32, Arc<AtomicBool>>::new()));
+    let bounded_exec_cancels = BoundedExecCancelMap::default();
 
     let mut decoder = vsock_proto::Decoder::new();
 
@@ -165,6 +280,7 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                     msg.seq,
                     writer.clone(),
                     connection_cancel.clone(),
+                    None,
                 )?;
             } else if msg.msg_type == MSG_BOUNDED_EXEC {
                 log(
@@ -173,33 +289,15 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                 );
                 let decoded =
                     vsock_proto::decode_bounded_exec(&msg.payload).map_err(to_io_error)?;
-                let request_cancel = Arc::new(AtomicBool::new(false));
-                {
-                    let mut cancels = bounded_exec_cancels
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner());
-                    if let Some(previous) = cancels.insert(msg.seq, request_cancel.clone()) {
-                        previous.store(true, Ordering::Release);
-                    }
-                }
-                let cleanup_cancels = Arc::clone(&bounded_exec_cancels);
-                let cleanup_cancel = Arc::clone(&request_cancel);
-                let cleanup_seq = msg.seq;
-                let cleanup: BoundedExecCleanup = Box::new(move || {
-                    let mut cancels = cleanup_cancels.lock().unwrap_or_else(|e| e.into_inner());
-                    if cancels
-                        .get(&cleanup_seq)
-                        .is_some_and(|current| Arc::ptr_eq(current, &cleanup_cancel))
-                    {
-                        cancels.remove(&cleanup_seq);
-                    }
-                });
+                let (request_cancel, cleanup) =
+                    prepare_bounded_exec_cleanup(msg.seq, &bounded_exec_cancels);
                 spawn_bounded_exec_worker(
                     BoundedExecWorkerRequest::from_decoded(msg.seq, decoded),
                     writer.clone(),
                     connection_cancel.clone(),
                     request_cancel,
                     cleanup,
+                    None,
                 )?;
             } else if msg.msg_type == MSG_BOUNDED_EXEC_CANCEL {
                 if let Some(cancel) = bounded_exec_cancels
@@ -236,6 +334,7 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                     },
                     writer.clone(),
                     connection_cancel.clone(),
+                    None,
                 )?;
             } else {
                 match handle_message(&msg)? {
@@ -258,18 +357,293 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
     Ok(ConnectionEnd::Closed)
 }
 
+pub fn handle_control_connection(
+    stream: UnixStream,
+    boot_generation: Option<&str>,
+) -> io::Result<()> {
+    handle_control_connection_with_outcome(stream, boot_generation).map(|_| ())
+}
+
+fn handle_control_connection_with_outcome(
+    stream: UnixStream,
+    boot_generation: Option<&str>,
+) -> io::Result<ConnectionEnd> {
+    let mut reader = stream.try_clone()?;
+    let writer = GuestWriter::new(stream);
+    let connection_cancel = Arc::new(AtomicBool::new(false));
+    let _cancel_on_drop = ConnectionCancelGuard(connection_cancel.clone());
+    let tracker = Arc::new(SessionWorkTracker::default());
+    let bounded_exec_cancels = BoundedExecCancelMap::default();
+
+    let mut decoder = vsock_proto::Decoder::new();
+    let mut pending = control_handshake(&mut reader, &writer, &mut decoder, boot_generation)?;
+
+    let mut buf = [0u8; READ_BUFFER_SIZE];
+    loop {
+        while let Some(msg) = pending.pop_front() {
+            match handle_control_message(
+                &msg,
+                &writer,
+                &connection_cancel,
+                &tracker,
+                &bounded_exec_cancels,
+            )? {
+                ControlMessageAction::Continue => {}
+                ControlMessageAction::CloseSession => return Ok(ConnectionEnd::Closed),
+                ControlMessageAction::Shutdown => return Ok(ConnectionEnd::Shutdown),
+            }
+        }
+
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+
+        pending.extend(
+            decoder
+                .decode(buf.get(..n).unwrap_or_default())
+                .map_err(to_io_error)?,
+        );
+    }
+
+    log("INFO", "Host disconnected");
+    Ok(ConnectionEnd::Closed)
+}
+
+fn control_handshake(
+    reader: &mut UnixStream,
+    writer: &GuestWriter,
+    decoder: &mut vsock_proto::Decoder,
+    boot_generation: Option<&str>,
+) -> io::Result<VecDeque<RawMessage>> {
+    let mut buf = [0u8; READ_BUFFER_SIZE];
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "host disconnected before control hello",
+            ));
+        }
+
+        let mut messages = VecDeque::from(
+            decoder
+                .decode(buf.get(..n).unwrap_or_default())
+                .map_err(to_io_error)?,
+        );
+        let Some(msg) = messages.pop_front() else {
+            continue;
+        };
+        if msg.msg_type != MSG_CONTROL_HELLO {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("expected control hello, got 0x{:02X}", msg.msg_type),
+            ));
+        }
+
+        let decoded = vsock_proto::decode_control_hello(&msg.payload).map_err(to_io_error)?;
+        if decoded.version != vsock_proto::CONTROL_PROTOCOL_VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported control protocol version {}", decoded.version),
+            ));
+        }
+        if let Some(provided) = decoded.boot_generation
+            && boot_generation != Some(provided)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "control hello boot generation mismatch",
+            ));
+        }
+
+        let ack_payload = vsock_proto::encode_control_hello_ack(decoded.version, &decoded.nonce);
+        let ack = vsock_proto::encode(MSG_CONTROL_HELLO_ACK, msg.seq, &ack_payload)
+            .map_err(to_io_error)?;
+        writer.write_frame(&ack)?;
+        log("INFO", "Control handshake complete");
+        return Ok(messages);
+    }
+}
+
+fn handle_control_message(
+    msg: &RawMessage,
+    writer: &GuestWriter,
+    connection_cancel: &Arc<AtomicBool>,
+    tracker: &Arc<SessionWorkTracker>,
+    bounded_exec_cancels: &BoundedExecCancelMap,
+) -> io::Result<ControlMessageAction> {
+    match msg.msg_type {
+        MSG_CONTROL_QUIESCE => {
+            let status = if tracker.begin_quiesce() {
+                ControlQuiesceStatus::Ready
+            } else {
+                ControlQuiesceStatus::Busy
+            };
+            let payload = vsock_proto::encode_control_quiesce_ack(status);
+            let response = vsock_proto::encode(MSG_CONTROL_QUIESCE_ACK, msg.seq, &payload)
+                .map_err(to_io_error)?;
+            writer.write_frame(&response)?;
+            return Ok(if status == ControlQuiesceStatus::Ready {
+                ControlMessageAction::CloseSession
+            } else {
+                ControlMessageAction::Continue
+            });
+        }
+        MSG_SPAWN_WATCH => {
+            let pending = match tracker.begin_work() {
+                Ok(pending) => pending,
+                Err(e) => {
+                    send_error(msg.seq, &e.to_string(), writer)?;
+                    return Ok(ControlMessageAction::Continue);
+                }
+            };
+            let d = vsock_proto::decode_spawn_watch(&msg.payload).map_err(to_io_error)?;
+            handle_spawn_watch(
+                SpawnWatchRequest {
+                    timeout_ms: d.exec.timeout_ms,
+                    command: d.exec.command,
+                    env: &d.exec.env,
+                    sudo: d.exec.sudo,
+                    stream_stdout: d.stream_stdout,
+                    stdout_log_path: d.stdout_log_path,
+                },
+                msg.seq,
+                writer.clone(),
+                connection_cancel.clone(),
+                Some(pending),
+            )?;
+        }
+        MSG_BOUNDED_EXEC => {
+            let pending = match tracker.begin_work() {
+                Ok(pending) => pending,
+                Err(e) => {
+                    send_error(msg.seq, &e.to_string(), writer)?;
+                    return Ok(ControlMessageAction::Continue);
+                }
+            };
+            log(
+                "INFO",
+                &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),
+            );
+            let decoded = vsock_proto::decode_bounded_exec(&msg.payload).map_err(to_io_error)?;
+            let (request_cancel, cleanup) =
+                prepare_bounded_exec_cleanup(msg.seq, bounded_exec_cancels);
+            spawn_bounded_exec_worker(
+                BoundedExecWorkerRequest::from_decoded(msg.seq, decoded),
+                writer.clone(),
+                connection_cancel.clone(),
+                request_cancel,
+                cleanup,
+                Some(pending),
+            )?;
+        }
+        MSG_BOUNDED_EXEC_CANCEL => {
+            if let Some(cancel) = bounded_exec_cancels
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .get(&msg.seq)
+            {
+                cancel.store(true, Ordering::Release);
+            }
+        }
+        MSG_EXEC => {
+            let pending = match tracker.begin_work() {
+                Ok(pending) => pending,
+                Err(e) => {
+                    send_error(msg.seq, &e.to_string(), writer)?;
+                    return Ok(ControlMessageAction::Continue);
+                }
+            };
+            log(
+                "INFO",
+                &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),
+            );
+            let d = vsock_proto::decode_exec(&msg.payload).map_err(to_io_error)?;
+            let timeout_ms = d.timeout_ms;
+            let command = d.command.to_owned();
+            let env: Vec<(String, String)> = d
+                .env
+                .iter()
+                .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+                .collect();
+            spawn_exec_worker(
+                ExecWorkerRequest {
+                    timeout_ms,
+                    command,
+                    env,
+                    sudo: d.sudo,
+                    seq: msg.seq,
+                },
+                writer.clone(),
+                connection_cancel.clone(),
+                Some(pending),
+            )?;
+        }
+        MSG_WRITE_FILE => {
+            let _pending = match tracker.begin_work() {
+                Ok(pending) => pending,
+                Err(e) => {
+                    send_error(msg.seq, &e.to_string(), writer)?;
+                    return Ok(ControlMessageAction::Continue);
+                }
+            };
+            if write_message_response(msg, writer)? {
+                return Ok(ControlMessageAction::Shutdown);
+            }
+        }
+        _ => {
+            if write_message_response(msg, writer)? {
+                return Ok(ControlMessageAction::Shutdown);
+            }
+        }
+    }
+
+    Ok(ControlMessageAction::Continue)
+}
+
+fn write_message_response(msg: &RawMessage, writer: &GuestWriter) -> io::Result<bool> {
+    match handle_message(msg)? {
+        MessageOutcome::Response(response) => {
+            writer.write_frame(&response)?;
+            Ok(false)
+        }
+        MessageOutcome::Shutdown(response) => {
+            if let Err(e) = writer.write_frame(&response) {
+                log("WARN", &format!("Failed to send shutdown_ack: {e}"));
+            }
+            log("INFO", "Shutdown complete, exiting");
+            Ok(true)
+        }
+    }
+}
+
+fn send_error(seq: u32, message: &str, writer: &GuestWriter) -> io::Result<()> {
+    let payload = vsock_proto::encode_error(message);
+    let response = vsock_proto::encode(MSG_ERROR, seq, &payload).map_err(to_io_error)?;
+    writer.write_frame(&response)
+}
+
 fn spawn_exec_worker(
     request: ExecWorkerRequest,
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
+    pending_work: Option<PendingWorkGuard>,
 ) -> io::Result<()> {
-    spawn_exec_worker_with_spawner(request, writer, connection_cancel, SystemThreadSpawner)
+    spawn_exec_worker_with_spawner(
+        request,
+        writer,
+        connection_cancel,
+        pending_work,
+        SystemThreadSpawner,
+    )
 }
 
 fn spawn_exec_worker_with_spawner<S>(
     request: ExecWorkerRequest,
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
+    pending_work: Option<PendingWorkGuard>,
     spawner: S,
 ) -> io::Result<()>
 where
@@ -277,9 +651,12 @@ where
 {
     let worker_writer = writer.clone();
     let seq = request.seq;
+    let pending_slot = PendingWorkSlot::new(pending_work);
+    let worker_pending_slot = pending_slot.clone();
     let result = spawner.spawn_unit(
         THREAD_EXEC_WORKER,
         Box::new(move || {
+            let _pending_work = worker_pending_slot.take();
             let env_refs: Vec<(&str, &str)> = request
                 .env
                 .iter()
@@ -302,6 +679,7 @@ where
         Ok(_) => Ok(()),
         Err(e) => {
             let stderr = format!("Failed to spawn exec worker thread: {e}");
+            let _pending_work = pending_slot.take();
             send_exec_result(seq, 1, &[], stderr.as_bytes(), &writer)
         }
     }
@@ -328,32 +706,27 @@ const MAX_RECONNECT_ATTEMPTS: u32 = 50;
 /// Delay between reconnection attempts (10ms for fast reconnect after snapshot restore)
 const RECONNECT_DELAY_MS: u64 = 10;
 
-/// Run the vsock guest agent with the given options.
-/// Includes reconnection logic for snapshot restore scenarios where
-/// the connection is lost when VM is paused and resumed.
+/// Run the vsock guest control service.
+///
+/// Production mode listens on the fixed vsock control port. Passing a Unix
+/// socket path keeps the legacy guest-initiated handshake available for tests.
 pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
     log("INFO", "Starting vsock guest...");
+
+    let Some(path) = unix_socket else {
+        return run_vsock_listener();
+    };
 
     let mut attempts = 0u32;
 
     loop {
-        let result = if let Some(path) = unix_socket {
-            log("INFO", &format!("Connecting to Unix socket: {}...", path));
-            connect_unix(path).and_then(|stream| {
-                log("INFO", "Connected");
-                // Reset attempts on successful connection
-                attempts = 0;
-                handle_connection_with_outcome(stream)
-            })
-        } else {
-            log("INFO", "Connecting to host (CID=2)...");
-            connect_vsock().and_then(|stream| {
-                log("INFO", "Connected");
-                // Reset attempts on successful connection
-                attempts = 0;
-                handle_connection_with_outcome(stream)
-            })
-        };
+        log("INFO", &format!("Connecting to Unix socket: {}...", path));
+        let result = connect_unix(path).and_then(|stream| {
+            log("INFO", "Connected");
+            // Reset attempts on successful connection
+            attempts = 0;
+            handle_connection_with_outcome(stream)
+        });
 
         attempts += 1;
 
@@ -408,11 +781,63 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
     }
 }
 
+#[cfg(target_os = "linux")]
+fn run_vsock_listener() -> io::Result<()> {
+    let boot_generation = match read_boot_generation() {
+        Ok(value) => value,
+        Err(e) => {
+            log("WARN", &format!("Failed to read boot generation: {e}"));
+            None
+        }
+    };
+    let listener = listen_vsock()?;
+    log(
+        "INFO",
+        &format!(
+            "Listening for host control sessions on port {}",
+            vsock_proto::VSOCK_PORT
+        ),
+    );
+
+    loop {
+        let stream = match listener.accept() {
+            Ok(stream) => stream,
+            Err(e) if is_recoverable_accept_error(&e) => {
+                log("WARN", &format!("Control session accept error: {e}"));
+                continue;
+            }
+            Err(e) => return Err(e),
+        };
+        if let Err(e) = validate_host_peer(&stream) {
+            log("WARN", &format!("Rejected control session: {e}"));
+            continue;
+        }
+
+        match handle_control_connection_with_outcome(stream, boot_generation.as_deref()) {
+            Ok(ConnectionEnd::Shutdown) => return Ok(()),
+            Ok(ConnectionEnd::Closed) => {
+                log("INFO", "Control session closed, returning to listen");
+            }
+            Err(e) => {
+                log("WARN", &format!("Control session error: {e}"));
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn run_vsock_listener() -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "vsock listener is only supported on Linux",
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::threading::test_support::FailingThreadSpawner;
-    use std::io::Read;
+    use std::io::{Read, Write};
     use std::os::unix::net::UnixStream;
     use std::time::Duration;
 
@@ -432,6 +857,89 @@ mod tests {
         messages.remove(0)
     }
 
+    fn send_control_hello(stream: &mut UnixStream, seq: u32, boot_generation: Option<&str>) {
+        let nonce = *b"0123456789abcdef";
+        let payload = vsock_proto::encode_control_hello(
+            vsock_proto::CONTROL_PROTOCOL_VERSION,
+            &nonce,
+            boot_generation,
+        )
+        .unwrap();
+        let frame = vsock_proto::encode(MSG_CONTROL_HELLO, seq, &payload).unwrap();
+        stream.write_all(&frame).unwrap();
+    }
+
+    fn send_control_quiesce(stream: &mut UnixStream, seq: u32) {
+        let frame = vsock_proto::encode(MSG_CONTROL_QUIESCE, seq, &[]).unwrap();
+        stream.write_all(&frame).unwrap();
+    }
+
+    #[test]
+    fn control_connection_accepts_matching_boot_generation_and_quiesces() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let handle =
+            thread::spawn(move || handle_control_connection_with_outcome(guest, Some("boot-1")));
+
+        send_control_hello(&mut host, 1, Some("boot-1"));
+        let ack = read_message(&mut host);
+        assert_eq!(ack.msg_type, MSG_CONTROL_HELLO_ACK);
+        assert_eq!(ack.seq, 1);
+
+        send_control_quiesce(&mut host, 2);
+        let ack = read_message(&mut host);
+        assert_eq!(ack.msg_type, MSG_CONTROL_QUIESCE_ACK);
+        assert_eq!(ack.seq, 2);
+        assert_eq!(
+            vsock_proto::decode_control_quiesce_ack(&ack.payload).unwrap(),
+            ControlQuiesceStatus::Ready
+        );
+
+        assert!(matches!(
+            handle.join().unwrap().unwrap(),
+            ConnectionEnd::Closed
+        ));
+    }
+
+    #[test]
+    fn control_connection_accepts_absent_boot_generation_for_restored_session() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let handle =
+            thread::spawn(move || handle_control_connection_with_outcome(guest, Some("boot-1")));
+
+        send_control_hello(&mut host, 1, None);
+        let ack = read_message(&mut host);
+        assert_eq!(ack.msg_type, MSG_CONTROL_HELLO_ACK);
+        assert_eq!(ack.seq, 1);
+
+        send_control_quiesce(&mut host, 2);
+        let ack = read_message(&mut host);
+        assert_eq!(
+            vsock_proto::decode_control_quiesce_ack(&ack.payload).unwrap(),
+            ControlQuiesceStatus::Ready
+        );
+
+        assert!(matches!(
+            handle.join().unwrap().unwrap(),
+            ConnectionEnd::Closed
+        ));
+    }
+
+    #[test]
+    fn control_connection_rejects_mismatched_boot_generation() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let handle =
+            thread::spawn(move || handle_control_connection_with_outcome(guest, Some("boot-1")));
+
+        send_control_hello(&mut host, 1, Some("boot-2"));
+
+        let err = handle.join().unwrap().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("boot generation mismatch"));
+    }
+
     #[test]
     fn exec_worker_spawn_failure_returns_exec_result() {
         let (guest, mut host) = UnixStream::pair().unwrap();
@@ -448,6 +956,7 @@ mod tests {
             },
             writer,
             Arc::new(AtomicBool::new(false)),
+            None,
             FailingThreadSpawner::fail_once(THREAD_EXEC_WORKER),
         )
         .unwrap();

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! Protocol encoding/decoding is handled by the `vsock-proto` crate.
 
+mod boot;
 mod bounded_exec;
 mod connection;
 mod drain;
@@ -15,13 +16,14 @@ mod handlers;
 mod log;
 mod monitor;
 mod process;
+mod session;
 mod shutdown;
 mod threading;
 mod user;
 mod wait;
 mod writer;
 
-pub use connection::{connect_unix, connect_vsock, handle_connection, run};
+pub use connection::{connect_unix, handle_connection, handle_control_connection, run};
 pub use log::log;
 
 #[cfg(any(debug_assertions, feature = "test-support"))]

--- a/crates/vsock-guest/src/monitor.rs
+++ b/crates/vsock-guest/src/monitor.rs
@@ -11,6 +11,7 @@ use crate::error::to_io_error;
 use crate::exec::{EnvScriptGuard, format_env_diagnostics, spawn_with_pipes, truncate_preview};
 use crate::log::log;
 use crate::process::{ChildReapGuard, kill_and_reap_child};
+use crate::session::{PendingWorkGuard, PendingWorkSlot};
 use crate::threading::{SystemThreadSpawner, ThreadSpawner};
 use crate::wait::{
     DRAIN_DEADLINE_SECS, await_drain_deadline, finalize_buffered_result, finalize_wait_outcome,
@@ -32,6 +33,7 @@ struct StreamingMonitorRequest {
     env_script: Option<EnvScriptGuard>,
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
+    pending_work: Option<PendingWorkGuard>,
 }
 
 struct BufferedMonitorRequest {
@@ -41,6 +43,7 @@ struct BufferedMonitorRequest {
     env_script: Option<EnvScriptGuard>,
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
+    pending_work: Option<PendingWorkGuard>,
 }
 
 struct StreamingSetupFailure {
@@ -52,6 +55,7 @@ struct StreamingSetupFailure {
     stdout_handle: Option<JoinHandle<()>>,
     env_script: Option<EnvScriptGuard>,
     writer: GuestWriter,
+    pending_work: Option<PendingWorkGuard>,
     error: String,
 }
 
@@ -83,8 +87,16 @@ pub(crate) fn handle_spawn_watch(
     seq: u32,
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
+    pending_work: Option<PendingWorkGuard>,
 ) -> io::Result<()> {
-    handle_spawn_watch_with_spawner(request, seq, writer, connection_cancel, SystemThreadSpawner)
+    handle_spawn_watch_with_spawner(
+        request,
+        seq,
+        writer,
+        connection_cancel,
+        pending_work,
+        SystemThreadSpawner,
+    )
 }
 
 fn handle_spawn_watch_with_spawner<S>(
@@ -92,6 +104,7 @@ fn handle_spawn_watch_with_spawner<S>(
     seq: u32,
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
+    pending_work: Option<PendingWorkGuard>,
     spawner: S,
 ) -> io::Result<()>
 where
@@ -165,6 +178,7 @@ where
                 env_script,
                 writer,
                 connection_cancel,
+                pending_work,
             },
             spawner,
         ) {
@@ -184,6 +198,7 @@ where
                 env_script,
                 writer,
                 connection_cancel,
+                pending_work,
             },
             spawner,
         ) {
@@ -226,10 +241,13 @@ where
         env_script,
         writer,
         connection_cancel,
+        pending_work,
     } = request;
     let child_guard = ChildReapGuard::new(child);
     let monitor_spawner = spawner.clone();
     let exit_writer = writer.clone();
+    let pending_slot = PendingWorkSlot::new(pending_work);
+    let monitor_pending_slot = pending_slot.clone();
     let result = spawner.spawn_unit(
         THREAD_STREAM_MONITOR,
         Box::new(move || {
@@ -250,12 +268,14 @@ where
                     env_script,
                     writer,
                     connection_cancel,
+                    pending_work: monitor_pending_slot.take(),
                 },
                 monitor_spawner,
             );
         }),
     );
     if let Err(e) = &result {
+        let _pending_work = pending_slot.take();
         send_process_exit(
             pid,
             1,
@@ -280,7 +300,9 @@ where
         env_script,
         writer,
         connection_cancel,
+        pending_work,
     } = request;
+    let _pending_work = pending_work;
     let _env_script = env_script;
     let cancel = Arc::new(AtomicBool::new(false));
     let (drain_done_tx, drain_done_rx) = std::sync::mpsc::channel::<()>();
@@ -314,6 +336,7 @@ where
                     stdout_handle: None,
                     env_script: _env_script,
                     writer,
+                    pending_work: _pending_work,
                     error: format!("Failed to spawn stderr drain thread: {e}"),
                 });
                 return;
@@ -394,6 +417,7 @@ where
                     stdout_handle: None,
                     env_script: _env_script,
                     writer,
+                    pending_work: _pending_work,
                     error: format!("Failed to spawn stdout drain thread: {e}"),
                 });
                 return;
@@ -461,8 +485,10 @@ fn finish_streaming_setup_failure(failure: StreamingSetupFailure) {
         stdout_handle,
         env_script,
         writer,
+        pending_work,
         error,
     } = failure;
+    let _pending_work = pending_work;
     let _env_script = env_script;
     cancel.store(true, Ordering::Release);
     drop(drain_done_tx);
@@ -489,13 +515,17 @@ where
         env_script,
         writer,
         connection_cancel,
+        pending_work,
     } = request;
     let child_guard = ChildReapGuard::new(child);
     let exit_writer = writer.clone();
     let monitor_spawner = spawner.clone();
+    let pending_slot = PendingWorkSlot::new(pending_work);
+    let monitor_pending_slot = pending_slot.clone();
     let result = spawner.spawn_unit(
         THREAD_BUFFERED_MONITOR,
         Box::new(move || {
+            let _pending_work = monitor_pending_slot.take();
             let Some(child) = child_guard.into_child() else {
                 log(
                     "ERROR",
@@ -528,6 +558,7 @@ where
         }),
     );
     if let Err(e) = &result {
+        let _pending_work = pending_slot.take();
         send_process_exit(
             pid,
             1,
@@ -603,6 +634,7 @@ mod tests {
             7,
             writer,
             cancel,
+            None,
             FailingThreadSpawner::fail_once(THREAD_STREAM_MONITOR),
         )
         .unwrap();
@@ -646,6 +678,7 @@ mod tests {
             8,
             writer,
             cancel,
+            None,
             FailingThreadSpawner::fail_once(THREAD_STREAM_STDOUT),
         )
         .unwrap();
@@ -689,6 +722,7 @@ mod tests {
             10,
             writer,
             cancel,
+            None,
             FailingThreadSpawner::fail_once(THREAD_STREAM_STDERR),
         )
         .unwrap();
@@ -732,6 +766,7 @@ mod tests {
             9,
             writer,
             cancel,
+            None,
             FailingThreadSpawner::fail_once(THREAD_BUFFERED_MONITOR),
         )
         .unwrap();
@@ -775,6 +810,7 @@ mod tests {
             11,
             writer,
             cancel,
+            None,
             FailingThreadSpawner::fail_once(THREAD_DRAIN_STDOUT),
         )
         .unwrap();

--- a/crates/vsock-guest/src/session.rs
+++ b/crates/vsock-guest/src/session.rs
@@ -1,0 +1,108 @@
+use std::io;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+#[derive(Default)]
+pub(crate) struct SessionWorkTracker {
+    pending: AtomicUsize,
+    quiescing: AtomicBool,
+}
+
+impl SessionWorkTracker {
+    pub(crate) fn begin_work(self: &Arc<Self>) -> io::Result<PendingWorkGuard> {
+        if self.quiescing.load(Ordering::Acquire) {
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionAborted,
+                "control session is quiescing",
+            ));
+        }
+
+        self.pending.fetch_add(1, Ordering::AcqRel);
+        if self.quiescing.load(Ordering::Acquire) {
+            self.pending.fetch_sub(1, Ordering::AcqRel);
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionAborted,
+                "control session is quiescing",
+            ));
+        }
+
+        Ok(PendingWorkGuard {
+            tracker: Arc::clone(self),
+        })
+    }
+
+    pub(crate) fn begin_quiesce(&self) -> bool {
+        self.quiescing.store(true, Ordering::Release);
+        self.pending.load(Ordering::Acquire) == 0
+    }
+}
+
+pub(crate) struct PendingWorkGuard {
+    tracker: Arc<SessionWorkTracker>,
+}
+
+impl Drop for PendingWorkGuard {
+    fn drop(&mut self) {
+        self.tracker.pending.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PendingWorkSlot {
+    guard: Arc<Mutex<Option<PendingWorkGuard>>>,
+}
+
+impl PendingWorkSlot {
+    pub(crate) fn new(guard: Option<PendingWorkGuard>) -> Self {
+        Self {
+            guard: Arc::new(Mutex::new(guard)),
+        }
+    }
+
+    pub(crate) fn take(&self) -> Option<PendingWorkGuard> {
+        self.guard.lock().unwrap_or_else(|e| e.into_inner()).take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_slot_holds_guard_until_taken() {
+        let tracker = Arc::new(SessionWorkTracker::default());
+        let slot = PendingWorkSlot::new(Some(tracker.begin_work().unwrap()));
+        let worker_slot = slot.clone();
+        drop(slot);
+
+        assert!(!tracker.begin_quiesce());
+
+        drop(worker_slot.take());
+        assert_eq!(tracker.pending.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn pending_slot_take_is_idempotent() {
+        let tracker = Arc::new(SessionWorkTracker::default());
+        let slot = PendingWorkSlot::new(Some(tracker.begin_work().unwrap()));
+
+        assert!(slot.take().is_some());
+        assert!(slot.take().is_none());
+    }
+
+    #[test]
+    fn quiesce_rejects_new_work_until_session_resets() {
+        let tracker = Arc::new(SessionWorkTracker::default());
+        let work = tracker.begin_work().unwrap();
+
+        assert!(!tracker.begin_quiesce());
+        let err = match tracker.begin_work() {
+            Ok(_) => panic!("quiescing tracker must reject new work"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionAborted);
+
+        drop(work);
+        assert!(tracker.begin_quiesce());
+    }
+}

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1,11 +1,10 @@
 //! Host-side vsock endpoint for Firecracker VM communication.
 //!
-//! Connects to a guest control agent via Unix domain socket. During the
-//! migration away from guest-initiated sockets, this crate supports both the
-//! legacy `{vsock_path}_{port}` listener flow and Firecracker's host-initiated
-//! `CONNECT <port>` flow on the base vsock socket.
+//! Connects to a guest control agent through Firecracker's host-initiated
+//! `CONNECT <port>` flow on the base vsock socket. The legacy
+//! `{vsock_path}_{port}` listener flow remains for tests and local harnesses.
 //!
-//! ## Legacy Guest-Initiated Connection Flow
+//! ## Legacy Test Connection Flow
 //!
 //! 1. Host creates UDS listener at `{vsock_path}_{port}`
 //! 2. Guest boots and vsock-guest connects to CID=2
@@ -45,9 +44,10 @@ use vsock_proto::{
     BoundedExecStream as ProtoBoundedExecStream,
     BoundedExecTermination as ProtoBoundedExecTermination, Decoder, MSG_BOUNDED_EXEC,
     MSG_BOUNDED_EXEC_CANCEL, MSG_BOUNDED_EXEC_OUTPUT_CHUNK, MSG_BOUNDED_EXEC_RESULT,
-    MSG_CONTROL_HELLO, MSG_CONTROL_HELLO_ACK, MSG_ERROR, MSG_EXEC, MSG_EXEC_RESULT, MSG_PING,
-    MSG_PONG, MSG_PROCESS_EXIT, MSG_READY, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH,
-    MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, RawMessage,
+    MSG_CONTROL_HELLO, MSG_CONTROL_HELLO_ACK, MSG_CONTROL_QUIESCE, MSG_CONTROL_QUIESCE_ACK,
+    MSG_ERROR, MSG_EXEC, MSG_EXEC_RESULT, MSG_PING, MSG_PONG, MSG_PROCESS_EXIT, MSG_READY,
+    MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK,
+    MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, RawMessage,
 };
 
 const READ_BUF_SIZE: usize = 64 * 1024;
@@ -2000,6 +2000,25 @@ impl VsockHost {
         let result = self.request(MSG_SHUTDOWN, &[], timeout).await;
         matches!(result, Ok(ref m) if m.msg_type == MSG_SHUTDOWN_ACK)
     }
+
+    pub async fn quiesce(&self, timeout: Duration) -> io::Result<()> {
+        let resp = self.request(MSG_CONTROL_QUIESCE, &[], timeout).await?;
+        if resp.msg_type != MSG_CONTROL_QUIESCE_ACK {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unexpected quiesce response type: 0x{:02X}", resp.msg_type),
+            ));
+        }
+        let status = vsock_proto::decode_control_quiesce_ack(&resp.payload)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        match status {
+            vsock_proto::ControlQuiesceStatus::Ready => Ok(()),
+            vsock_proto::ControlQuiesceStatus::Busy => Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "control session has pending guest work",
+            )),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -2782,6 +2801,47 @@ mod tests {
 
         server.await.unwrap();
         listener_socket.remove();
+    }
+
+    #[tokio::test]
+    async fn quiesce_sends_control_request_and_accepts_ready_ack() {
+        let (host_stream, mut guest_stream) = make_pair();
+        let mut decoder = Decoder::new();
+        let host_task = tokio::spawn(async move { host_from_stream(host_stream).await });
+        mock_handshake(&mut guest_stream, &mut decoder).await;
+        let host = host_task.await.unwrap().unwrap();
+
+        let quiesce_task = tokio::spawn(async move { host.quiesce(Duration::from_secs(5)).await });
+        let request = read_one_message(&mut guest_stream, &mut decoder).await;
+        assert_eq!(request.msg_type, MSG_CONTROL_QUIESCE);
+
+        let ack_payload =
+            vsock_proto::encode_control_quiesce_ack(vsock_proto::ControlQuiesceStatus::Ready);
+        let ack = vsock_proto::encode(MSG_CONTROL_QUIESCE_ACK, request.seq, &ack_payload).unwrap();
+        guest_stream.write_all(&ack).await.unwrap();
+
+        quiesce_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn quiesce_reports_busy_ack_as_would_block() {
+        let (host_stream, mut guest_stream) = make_pair();
+        let mut decoder = Decoder::new();
+        let host_task = tokio::spawn(async move { host_from_stream(host_stream).await });
+        mock_handshake(&mut guest_stream, &mut decoder).await;
+        let host = host_task.await.unwrap().unwrap();
+
+        let quiesce_task = tokio::spawn(async move { host.quiesce(Duration::from_secs(5)).await });
+        let request = read_one_message(&mut guest_stream, &mut decoder).await;
+        assert_eq!(request.msg_type, MSG_CONTROL_QUIESCE);
+
+        let ack_payload =
+            vsock_proto::encode_control_quiesce_ack(vsock_proto::ControlQuiesceStatus::Busy);
+        let ack = vsock_proto::encode(MSG_CONTROL_QUIESCE_ACK, request.seq, &ack_payload).unwrap();
+        guest_stream.write_all(&ack).await.unwrap();
+
+        let err = quiesce_task.await.unwrap().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Switch production guest control from guest-initiated MSG_READY to host-initiated Firecracker CONNECT sessions.
- Add boot-generation handshake validation, guest pending-work accounting, and quiesce handling before park/snapshot.
- Replace sandbox/control-socket VsockHost ownership with a control session manager and wire reconnect after unpark.

## Test Plan
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest
- cargo test --manifest-path crates/Cargo.toml -p vsock-host
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest -p vsock-host -p sandbox-fc --all-targets --all-features -- -D warnings
- cargo check --manifest-path crates/Cargo.toml -p vsock-guest -p vsock-host -p sandbox-fc
- git diff --check

Closes #12572