### PR TITLE
fix: sanitize token inputs before upload

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -11,6 +11,10 @@ import {
 import { triggerAblyEvent, hasSubscription } from "../../../../mocks/ably.ts";
 import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { zeroConnectorsMainContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import {
+  zeroSecretsContract,
+  zeroVariablesContract,
+} from "@vm0/api-contracts/contracts/zero-secrets";
 import { createMockApi } from "../../../../mocks/msw-contract.ts";
 
 const context = testContext();
@@ -325,6 +329,55 @@ describe("connectConnector$", () => {
 });
 
 describe("submitApiToken$", () => {
+  it("strips whitespace from connector API token values before upload", async () => {
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    const submitted: Record<string, string> = {};
+
+    server.use(
+      mockApi(zeroSecretsContract.set, ({ body, respond }) => {
+        submitted[body.name] = body.value;
+        const now = new Date().toISOString();
+        return respond(201, {
+          id: crypto.randomUUID(),
+          name: body.name,
+          type: "user",
+          description: body.description ?? null,
+          createdAt: now,
+          updatedAt: now,
+        });
+      }),
+      mockApi(zeroVariablesContract.set, ({ body, respond }) => {
+        submitted[body.name] = body.value;
+        const now = new Date().toISOString();
+        return respond(201, {
+          id: crypto.randomUUID(),
+          name: body.name,
+          value: body.value,
+          description: body.description ?? null,
+          createdAt: now,
+          updatedAt: now,
+        });
+      }),
+    );
+
+    await context.store.set(
+      submitApiToken$,
+      "strapi",
+      {
+        STRAPI_TOKEN: " strapi\n token ",
+        STRAPI_BASE_URL: " https://strapi.example.com\n",
+      },
+      {},
+      context.signal,
+    );
+
+    expect(submitted).toMatchObject({
+      STRAPI_TOKEN: "strapitoken",
+      STRAPI_BASE_URL: "https://strapi.example.com",
+    });
+  });
+
   it("sets permissionDialogType$ after successful API token submission", async () => {
     detachedSetupPage({ context, path: "/", withoutRender: true });
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/custom-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/custom-connectors.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { zeroCustomConnectorSecretContract } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { server } from "../../../../mocks/server.ts";
+import { createMockApi } from "../../../../mocks/msw-contract.ts";
+import { testContext } from "../../../__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../../__tests__/page-helper.ts";
+import { setCustomConnectorSecret$ } from "../custom-connectors.ts";
+
+const context = testContext();
+const mockApi = createMockApi(context);
+
+describe("custom-connectors", () => {
+  it("strips whitespace from custom connector credentials before upload", async () => {
+    detachedSetupPage({ context, path: "/", withoutRender: true });
+
+    let submittedValue: string | null = null;
+
+    server.use(
+      mockApi(zeroCustomConnectorSecretContract.set, ({ body, respond }) => {
+        submittedValue = body.value;
+        return respond(204);
+      }),
+    );
+
+    await context.store.set(
+      setCustomConnectorSecret$,
+      {
+        id: "a1b2c3d4-e5f6-4890-abcd-ef1234567890",
+        value: " custom\n credential ",
+      },
+      context.signal,
+    );
+
+    expect(submittedValue).toBe("customcredential");
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-model-providers.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-model-providers.test.ts
@@ -6,7 +6,10 @@ import {
   orgSubmitDialog$,
   orgDialogFormValues$,
   orgFormErrors$,
+  orgUpdateFormAuthMethod$,
   orgUpdateFormModel$,
+  orgUpdateFormSecret$,
+  orgUpdateFormSecretField$,
 } from "../org-model-providers.ts";
 import { getProviderShape } from "../../../../views/zero-page/components/settings/provider-ui-config.ts";
 import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
@@ -192,5 +195,86 @@ describe("org-model-providers vm0 provider", () => {
 
     expect(capturedBody).not.toBeNull();
     expect(capturedBody).not.toHaveProperty("selectedModel");
+  });
+
+  it("should strip whitespace from single-secret provider tokens before upload", async () => {
+    const { store, signal } = context;
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      mockApi(zeroModelProvidersMainContract.upsert, ({ body, respond }) => {
+        capturedBody = body as Record<string, unknown>;
+        return respond(201, {
+          provider: {
+            id: "a1b2c3d4-e5f6-4890-abcd-ef1234567890",
+            type: "anthropic-api-key",
+            framework: "claude-code",
+            secretName: "ANTHROPIC_API_KEY",
+            authMethod: null,
+            secretNames: null,
+            isDefault: true,
+            selectedModel: null,
+            needsReconnect: false,
+            lastRefreshErrorCode: null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+          created: true,
+        });
+      }),
+    );
+
+    store.set(orgOpenAddDialog$, "anthropic-api-key");
+    store.set(orgUpdateFormSecret$, " sk-ant\n test key ");
+
+    await store.set(orgSubmitDialog$, signal);
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.secret).toBe("sk-anttestkey");
+  });
+
+  it("should strip whitespace from multi-auth provider secrets before upload", async () => {
+    const { store, signal } = context;
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      mockApi(zeroModelProvidersMainContract.upsert, ({ body, respond }) => {
+        capturedBody = body as Record<string, unknown>;
+        return respond(201, {
+          provider: {
+            id: "a1b2c3d4-e5f6-4890-abcd-ef1234567890",
+            type: "aws-bedrock",
+            framework: "claude-code",
+            secretName: null,
+            authMethod: "api-key",
+            secretNames: ["AWS_BEARER_TOKEN_BEDROCK", "AWS_REGION"],
+            isDefault: true,
+            selectedModel: null,
+            needsReconnect: false,
+            lastRefreshErrorCode: null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+          created: true,
+        });
+      }),
+    );
+
+    store.set(orgOpenAddDialog$, "aws-bedrock");
+    store.set(orgUpdateFormAuthMethod$, "api-key");
+    store.set(
+      orgUpdateFormSecretField$,
+      "AWS_BEARER_TOKEN_BEDROCK",
+      " bedrock\n token ",
+    );
+    store.set(orgUpdateFormSecretField$, "AWS_REGION", " us-east-1\n");
+
+    await store.set(orgSubmitDialog$, signal);
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.secrets).toStrictEqual({
+      AWS_BEARER_TOKEN_BEDROCK: "bedrocktoken",
+      AWS_REGION: "us-east-1",
+    });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/personal-model-providers.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/personal-model-providers.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+import { server } from "../../../../mocks/server.ts";
+import { createMockApi } from "../../../../mocks/msw-contract.ts";
+import { testContext } from "../../../__tests__/test-helpers.ts";
+import {
+  personalOpenOAuthCredentialDialog$,
+  personalSubmitDialog$,
+  personalUpdateFormSecret$,
+} from "../personal-model-providers.ts";
+
+const context = testContext();
+const mockApi = createMockApi(context);
+
+describe("personal-model-providers", () => {
+  it("strips whitespace from personal model provider tokens before upload", async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      mockApi(
+        zeroPersonalModelProvidersMainContract.upsert,
+        ({ body, respond }) => {
+          capturedBody = body as Record<string, unknown>;
+          return respond(201, {
+            provider: {
+              id: "a1b2c3d4-e5f6-4890-abcd-ef1234567890",
+              type: "claude-code-oauth-token",
+              framework: "claude-code",
+              secretName: "CLAUDE_CODE_OAUTH_TOKEN",
+              authMethod: null,
+              secretNames: null,
+              isDefault: false,
+              selectedModel: null,
+              needsReconnect: false,
+              lastRefreshErrorCode: null,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+            created: true,
+          });
+        },
+      ),
+    );
+
+    context.store.set(
+      personalOpenOAuthCredentialDialog$,
+      "claude-code-oauth-token",
+    );
+    context.store.set(personalUpdateFormSecret$, " sk-ant-oat01\n test token ");
+
+    await context.store.set(personalSubmitDialog$, context.signal);
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.secret).toBe("sk-ant-oat01testtoken");
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/token-input.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/token-input.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasTokenInputValue,
+  sanitizeTokenInput,
+  sanitizeTokenInputRecord,
+} from "../token-input.ts";
+
+describe("token-input", () => {
+  it("removes spaces and newlines from token strings", () => {
+    expect(sanitizeTokenInput(" sk-ant\n token\tvalue ")).toBe(
+      "sk-anttokenvalue",
+    );
+    expect(hasTokenInputValue(" \n ")).toBe(false);
+  });
+
+  it("can preserve JSON credential whitespace while trimming the wrapper", () => {
+    const result = sanitizeTokenInputRecord(
+      {
+        CODEX_AUTH_JSON: '  { "tokens": { "access": "abc" } }\n',
+        CHATGPT_ACCESS_TOKEN: " chatgpt\n token ",
+      },
+      { preserveWhitespaceKeys: new Set(["CODEX_AUTH_JSON"]) },
+    );
+
+    expect(result).toStrictEqual({
+      CODEX_AUTH_JSON: '{ "tokens": { "access": "abc" } }',
+      CHATGPT_ACCESS_TOKEN: "chatgpttoken",
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/token-input.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/token-input.test.ts
@@ -10,7 +10,7 @@ describe("token-input", () => {
     expect(sanitizeTokenInput(" sk-ant\n token\tvalue ")).toBe(
       "sk-anttokenvalue",
     );
-    expect(hasTokenInputValue(" \n ")).toBe(false);
+    expect(hasTokenInputValue(" \n ")).toBeFalsy();
   });
 
   it("can preserve JSON credential whitespace while trimming the wrapper", () => {

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -31,6 +31,7 @@ import { jsonParseOr, resetSignal, withCleanup } from "../../utils.ts";
 import { setAblyLoop$ } from "../../realtime.ts";
 import { localStorageSignals } from "../../external/local-storage.ts";
 import { resetPermissionDialog$ } from "./permission-dialog.ts";
+import { sanitizeTokenInputRecord } from "./token-input.ts";
 
 const HIDDEN_CONNECTIONS_STORAGE_KEY = "vm0.connections.hiddenTypes";
 const { get$: hiddenConnectorTypesRaw$, set$: setHiddenConnectorTypes$ } =
@@ -290,7 +291,8 @@ export const submitApiToken$ = command(
     const secretsClient = createClient(zeroSecretsContract);
     const variablesClient = createClient(zeroVariablesContract);
     const apiTokenConfig = CONNECTOR_TYPES[type].authMethods["api-token"];
-    for (const [name, value] of Object.entries(inputSecrets)) {
+    const secrets = sanitizeTokenInputRecord(inputSecrets);
+    for (const [name, value] of Object.entries(secrets)) {
       if (!value) {
         continue;
       }

--- a/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
@@ -8,6 +8,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import { accept } from "../../../lib/accept.ts";
 import { zeroClient$ } from "../../api-client.ts";
+import { sanitizeTokenInput } from "./token-input.ts";
 
 const internalReload$ = state(0);
 
@@ -120,7 +121,7 @@ export const setCustomConnectorSecret$ = command(
     await accept(
       client.set({
         params: { id: args.id },
-        body: { value: args.value },
+        body: { value: sanitizeTokenInput(args.value) },
         fetchOptions: { signal: _signal },
       }),
       [204],

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-model-providers.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-model-providers.ts
@@ -36,8 +36,6 @@ import {
   sanitizeTokenInputRecord,
 } from "./token-input.ts";
 
-const WHITESPACE_PRESERVING_SECRET_KEYS = new Set(["CODEX_AUTH_JSON"]);
-
 // ---------------------------------------------------------------------------
 // Add provider dialog (list of provider type cards)
 // ---------------------------------------------------------------------------
@@ -503,7 +501,7 @@ export const orgSubmitDialog$ = command(
     if (isMultiAuth) {
       request.authMethod = formValues.authMethod;
       request.secrets = sanitizeTokenInputRecord(formValues.secrets, {
-        preserveWhitespaceKeys: WHITESPACE_PRESERVING_SECRET_KEYS,
+        preserveWhitespaceKeys: new Set(["CODEX_AUTH_JSON"]),
       });
     } else if (hasTokenInputValue(formValues.secret)) {
       request.secret = sanitizeTokenInput(formValues.secret);

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-model-providers.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-model-providers.ts
@@ -30,6 +30,13 @@ import { modelFirstModelProviderEnabled$ } from "../../external/feature-switch.t
 import { zeroClient$ } from "../../api-client.ts";
 import { accept } from "../../../lib/accept.ts";
 import { closeModelPolicyDialog$ } from "./org-model-policy-dialog.ts";
+import {
+  hasTokenInputValue,
+  sanitizeTokenInput,
+  sanitizeTokenInputRecord,
+} from "./token-input.ts";
+
+const WHITESPACE_PRESERVING_SECRET_KEYS = new Set(["CODEX_AUTH_JSON"]);
 
 // ---------------------------------------------------------------------------
 // Add provider dialog (list of provider type cards)
@@ -467,7 +474,7 @@ export const orgSubmitDialog$ = command(
           if (config.derived) {
             continue;
           }
-          if (config.required && !formValues.secrets[key]?.trim()) {
+          if (config.required && !hasTokenInputValue(formValues.secrets[key])) {
             errors[key] = `${config.label} is required`;
           }
         }
@@ -476,7 +483,7 @@ export const orgSubmitDialog$ = command(
       dialogState.mode === "add" &&
       getSecretNameForType(providerType)
     ) {
-      if (!formValues.secret.trim()) {
+      if (!hasTokenInputValue(formValues.secret)) {
         errors["secret"] =
           providerType === "claude-code-oauth-token"
             ? "OAuth token is required"
@@ -495,9 +502,11 @@ export const orgSubmitDialog$ = command(
 
     if (isMultiAuth) {
       request.authMethod = formValues.authMethod;
-      request.secrets = formValues.secrets;
-    } else if (formValues.secret.trim()) {
-      request.secret = formValues.secret;
+      request.secrets = sanitizeTokenInputRecord(formValues.secrets, {
+        preserveWhitespaceKeys: WHITESPACE_PRESERVING_SECRET_KEYS,
+      });
+    } else if (hasTokenInputValue(formValues.secret)) {
+      request.secret = sanitizeTokenInput(formValues.secret);
     }
 
     if (

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
@@ -26,6 +26,13 @@ import {
   orgModelPolicies$,
   updateOrgModelPolicies$,
 } from "../../external/org-model-policies.ts";
+import {
+  hasTokenInputValue,
+  sanitizeTokenInput,
+  sanitizeTokenInputRecord,
+} from "./token-input.ts";
+
+const WHITESPACE_PRESERVING_SECRET_KEYS = new Set(["CODEX_AUTH_JSON"]);
 
 // ---------------------------------------------------------------------------
 // Codex auth.json paste dialog (personal scope, mirrors org-side dialog from
@@ -269,7 +276,7 @@ function validatePersonalProviderForm(params: {
       if (config.derived) {
         continue;
       }
-      if (config.required && !formValues.secrets[key]?.trim()) {
+      if (config.required && !hasTokenInputValue(formValues.secrets[key])) {
         errors[key] = `${config.label} is required`;
       }
     }
@@ -277,7 +284,7 @@ function validatePersonalProviderForm(params: {
   }
 
   if ((mode === "add" || requireSecret) && getSecretNameForType(providerType)) {
-    if (!formValues.secret.trim()) {
+    if (!hasTokenInputValue(formValues.secret)) {
       errors["secret"] =
         providerType === "claude-code-oauth-token"
           ? "OAuth token is required"
@@ -297,9 +304,11 @@ function buildPersonalProviderRequest(
 
   if (hasAuthMethods(providerType)) {
     request.authMethod = formValues.authMethod;
-    request.secrets = formValues.secrets;
-  } else if (formValues.secret.trim()) {
-    request.secret = formValues.secret;
+    request.secrets = sanitizeTokenInputRecord(formValues.secrets, {
+      preserveWhitespaceKeys: WHITESPACE_PRESERVING_SECRET_KEYS,
+    });
+  } else if (hasTokenInputValue(formValues.secret)) {
+    request.secret = sanitizeTokenInput(formValues.secret);
   }
 
   if (

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
@@ -32,8 +32,6 @@ import {
   sanitizeTokenInputRecord,
 } from "./token-input.ts";
 
-const WHITESPACE_PRESERVING_SECRET_KEYS = new Set(["CODEX_AUTH_JSON"]);
-
 // ---------------------------------------------------------------------------
 // Codex auth.json paste dialog (personal scope, mirrors org-side dialog from
 // #11980; unified with org via #12024).
@@ -305,7 +303,7 @@ function buildPersonalProviderRequest(
   if (hasAuthMethods(providerType)) {
     request.authMethod = formValues.authMethod;
     request.secrets = sanitizeTokenInputRecord(formValues.secrets, {
-      preserveWhitespaceKeys: WHITESPACE_PRESERVING_SECRET_KEYS,
+      preserveWhitespaceKeys: new Set(["CODEX_AUTH_JSON"]),
     });
   } else if (hasTokenInputValue(formValues.secret)) {
     request.secret = sanitizeTokenInput(formValues.secret);

--- a/turbo/apps/platform/src/signals/zero-page/settings/token-input.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/token-input.ts
@@ -1,0 +1,28 @@
+const TOKEN_WHITESPACE_RE = /\s+/g;
+
+export function sanitizeTokenInput(value: string): string {
+  return value.replace(TOKEN_WHITESPACE_RE, "");
+}
+
+export function hasTokenInputValue(value: string | undefined): boolean {
+  return value !== undefined && sanitizeTokenInput(value).length > 0;
+}
+
+export function sanitizeTokenInputRecord(
+  values: Record<string, string>,
+  options?: { readonly preserveWhitespaceKeys?: ReadonlySet<string> },
+): Record<string, string> {
+  const preserveWhitespaceKeys: ReadonlySet<string> =
+    options?.preserveWhitespaceKeys ?? new Set<string>();
+
+  return Object.fromEntries(
+    Object.entries(values).map(([key, value]) => {
+      return [
+        key,
+        preserveWhitespaceKeys.has(key)
+          ? value.trim()
+          : sanitizeTokenInput(value),
+      ];
+    }),
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -25,6 +25,7 @@ import {
   isStandaloneMode,
   type ConnectorTypeWithStatus,
 } from "../../../../signals/zero-page/settings/connectors.ts";
+import { hasTokenInputValue } from "../../../../signals/zero-page/settings/token-input.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { detach, onDomEventFn, Reason } from "../../../../signals/utils.ts";
@@ -115,7 +116,7 @@ function ApiTokenForm({
 
   const secretEntries = Object.entries(apiTokenConfig.secrets);
   const allFilled = secretEntries.every(([name, cfg]) => {
-    return !cfg.required || secretValues[name];
+    return !cfg.required || hasTokenInputValue(secretValues[name]);
   });
 
   const handleSubmit = onDomEventFn(async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
@@ -18,6 +18,7 @@ import {
   setCustomConnectorConnectInput$,
   setCustomConnectorSecret$,
 } from "../../../../signals/zero-page/settings/custom-connectors.ts";
+import { hasTokenInputValue } from "../../../../signals/zero-page/settings/token-input.ts";
 import { CustomConnectorIcon } from "./custom-connector-icon.tsx";
 
 export function CustomConnectorConnectDialog({
@@ -35,7 +36,7 @@ export function CustomConnectorConnectDialog({
   const signal = useGet(pageSignal$);
 
   const submitting = loadable.state === "loading";
-  const canSubmit = !submitting && value.length > 0;
+  const canSubmit = !submitting && hasTokenInputValue(value);
 
   const close = () => {
     resetValue();


### PR DESCRIPTION
## Summary
- strip whitespace from connector API-token and custom connector credential uploads
- strip whitespace from org and personal model provider token/secret uploads
- keep Codex auth.json paste whitespace-preserving except for outer trim
- treat whitespace-only token input as empty in connector/custom connector forms

## Validation
- pnpm --filter @vm0/app exec vitest run src/signals/zero-page/settings/__tests__/connect-connector.test.ts src/signals/zero-page/settings/__tests__/org-model-providers.test.ts src/signals/zero-page/settings/__tests__/personal-model-providers.test.ts src/signals/zero-page/settings/__tests__/custom-connectors.test.ts src/signals/zero-page/settings/__tests__/token-input.test.ts
- pnpm --filter @vm0/app check-types
- pnpm prettier --check <touched files>
- git diff --check
- pre-commit: knip and turbo check-types