### PR TITLE
refactor(api): migrate default-agent put to api backend (Wave 6)

### DIFF
--- a/turbo/apps/api/src/lib/error.ts
+++ b/turbo/apps/api/src/lib/error.ts
@@ -69,3 +69,9 @@ export function isNotFoundResponse(
 ): value is HttpResponseLike<404> {
   return isHttpResponse(value, 404);
 }
+
+export function isConflictResponse(
+  value: unknown,
+): value is HttpResponseLike<409> {
+  return isHttpResponse(value, 409);
+}

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -20,6 +20,7 @@ import { zeroComposesRoutes } from "./routes/zero-composes";
 import { zeroComputerUseRoutes } from "./routes/zero-computer-use";
 import { zeroConnectorsRoutes } from "./routes/zero-connectors";
 import { zeroCustomConnectorsRoutes } from "./routes/zero-custom-connectors";
+import { zeroDefaultAgentRoutes } from "./routes/zero-default-agent";
 import { zeroFeatureSwitchesRoutes } from "./routes/zero-feature-switches";
 import { zeroInsightsRoutes } from "./routes/zero-insights";
 import { zeroLogsRoutes } from "./routes/zero-logs";
@@ -79,6 +80,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroComputerUseRoutes,
   ...zeroConnectorsRoutes,
   ...zeroCustomConnectorsRoutes,
+  ...zeroDefaultAgentRoutes,
   ...zeroFeatureSwitchesRoutes,
   ...zeroInsightsRoutes,
   ...zeroLogsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-org-metadata.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-org-metadata.ts
@@ -1,0 +1,56 @@
+import { command } from "ccstate";
+import { eq } from "drizzle-orm";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+
+import { writeDb$ } from "../../../external/db";
+
+interface SeedOrgMetadataArgs {
+  readonly orgId: string;
+  readonly defaultAgentId?: string | null;
+}
+
+export const seedOrgMetadata$ = command(
+  async (
+    { set },
+    args: SeedOrgMetadataArgs,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    await db
+      .insert(orgMetadata)
+      .values({
+        orgId: args.orgId,
+        defaultAgentId: args.defaultAgentId ?? null,
+      })
+      .onConflictDoUpdate({
+        target: orgMetadata.orgId,
+        set: { defaultAgentId: args.defaultAgentId ?? null },
+      });
+    signal.throwIfAborted();
+  },
+);
+
+export const getOrgMetadataDefaultAgent$ = command(
+  async (
+    { set },
+    orgId: string,
+    signal: AbortSignal,
+  ): Promise<string | null> => {
+    const db = set(writeDb$);
+    const [row] = await db
+      .select({ defaultAgentId: orgMetadata.defaultAgentId })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, orgId))
+      .limit(1);
+    signal.throwIfAborted();
+    return row?.defaultAgentId ?? null;
+  },
+);
+
+export const deleteOrgMetadata$ = command(
+  async ({ set }, orgId: string, signal: AbortSignal): Promise<void> => {
+    const db = set(writeDb$);
+    await db.delete(orgMetadata).where(eq(orgMetadata.orgId, orgId));
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-default-agent.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-default-agent.test.ts
@@ -1,0 +1,426 @@
+import { randomUUID } from "node:crypto";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { orgDefaultAgentContract } from "@vm0/api-contracts/contracts/orgs";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteOrgMetadata$,
+  getOrgMetadataDefaultAgent$,
+  seedOrgMetadata$,
+} from "./helpers/zero-org-metadata";
+import { seedCompose$ } from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+interface OrgFixture {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+function uniqueOrgUser(prefix: string): OrgFixture {
+  return {
+    orgId: `org_${prefix}_${randomUUID().slice(0, 8)}`,
+    userId: `user_${prefix}_${randomUUID().slice(0, 8)}`,
+  };
+}
+
+async function deleteAgentCompose(composeId: string): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.delete(agentComposes).where(eq(agentComposes.id, composeId));
+}
+
+describe("PUT /api/zero/default-agent", () => {
+  const trackOrg = createFixtureTracker<OrgFixture>((fixture) => {
+    return store.set(deleteOrgMetadata$, fixture.orgId, context.signal);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(orgDefaultAgentContract);
+    const response = await accept(
+      client.setDefaultAgent({
+        query: {},
+        body: { agentId: null },
+        headers: {},
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({ error: { code: "UNAUTHORIZED" } });
+  });
+
+  it("returns 401 when authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(orgDefaultAgentContract);
+    const response = await accept(
+      client.setDefaultAgent({
+        query: {},
+        body: { agentId: null },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({ error: { code: "UNAUTHORIZED" } });
+  });
+
+  it("returns 403 for non-admin members (explicit admin-gate)", async () => {
+    const fixture = uniqueOrgUser("zda-member");
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(orgDefaultAgentContract);
+    const response = await accept(
+      client.setDefaultAgent({
+        query: {},
+        body: { agentId: composeId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only org admins can set the default agent",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("allows admin to set default agent", async () => {
+    const fixture = uniqueOrgUser("zda-admin");
+    await trackOrg(Promise.resolve(fixture));
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(orgDefaultAgentContract);
+    const response = await client.setDefaultAgent({
+      query: {},
+      body: { agentId: composeId },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      return;
+    }
+    expect(response.body.agentId).toBe(composeId);
+  });
+
+  it("writes the default agent to org_metadata (DB read-after-write)", async () => {
+    const fixture = uniqueOrgUser("zda-write");
+    await trackOrg(Promise.resolve(fixture));
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(orgDefaultAgentContract);
+    const response = await client.setDefaultAgent({
+      query: {},
+      body: { agentId: composeId },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(200);
+
+    const stored = await store.set(
+      getOrgMetadataDefaultAgent$,
+      fixture.orgId,
+      context.signal,
+    );
+    expect(stored).toBe(composeId);
+  });
+
+  it("allows setting default agent when none is configured", async () => {
+    const fixture = uniqueOrgUser("zda-none");
+    await trackOrg(Promise.resolve(fixture));
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(orgDefaultAgentContract);
+    const response = await client.setDefaultAgent({
+      query: {},
+      body: { agentId: composeId },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      return;
+    }
+    expect(response.body.agentId).toBe(composeId);
+  });
+
+  it("upsert creates the org_metadata row when missing", async () => {
+    const fixture = uniqueOrgUser("zda-upsert-create");
+    await trackOrg(Promise.resolve(fixture));
+    // Ensure the org_metadata row does NOT exist before the PUT
+    await store.set(deleteOrgMetadata$, fixture.orgId, context.signal);
+
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(orgDefaultAgentContract);
+    const response = await client.setDefaultAgent({
+      query: {},
+      body: { agentId: composeId },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      return;
+    }
+    expect(response.body.agentId).toBe(composeId);
+
+    const stored = await store.set(
+      getOrgMetadataDefaultAgent$,
+      fixture.orgId,
+      context.signal,
+    );
+    expect(stored).toBe(composeId);
+  });
+
+  it("returns 404 when agent does not exist", async () => {
+    const fixture = uniqueOrgUser("zda-missing");
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(orgDefaultAgentContract);
+    const response = await accept(
+      client.setDefaultAgent({
+        query: {},
+        body: { agentId: "00000000-0000-0000-0000-000000000000" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toMatchObject({
+      error: {
+        message: "Agent not found in this org",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 404 when agent belongs to a different org (cross-org isolation)", async () => {
+    const orgAFixture = uniqueOrgUser("zda-org-a");
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: orgAFixture.orgId, userId: orgAFixture.userId },
+      context.signal,
+    );
+
+    // Authenticate as a different user in a different org
+    const orgBFixture = uniqueOrgUser("zda-org-b");
+    mocks.clerk.session(orgBFixture.userId, orgBFixture.orgId);
+
+    const client = setupApp({ context })(orgDefaultAgentContract);
+    const response = await accept(
+      client.setDefaultAgent({
+        query: {},
+        body: { agentId: composeId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toMatchObject({ error: { code: "NOT_FOUND" } });
+  });
+
+  it("returns 409 when trying to unset an already-configured default", async () => {
+    const fixture = uniqueOrgUser("zda-unset");
+    await trackOrg(Promise.resolve(fixture));
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(orgDefaultAgentContract);
+    // First: set the default
+    const first = await client.setDefaultAgent({
+      query: {},
+      body: { agentId: composeId },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(first.status).toBe(200);
+
+    // Second: attempt to unset — blocked by 409 guard
+    const second = await accept(
+      client.setDefaultAgent({
+        query: {},
+        body: { agentId: null },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [409],
+    );
+    expect(second.body).toMatchObject({ error: { code: "CONFLICT" } });
+  });
+
+  it("returns 409 when setting the default agent twice", async () => {
+    const fixture = uniqueOrgUser("zda-twice");
+    await trackOrg(Promise.resolve(fixture));
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(orgDefaultAgentContract);
+    const first = await client.setDefaultAgent({
+      query: {},
+      body: { agentId: composeId },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(first.status).toBe(200);
+
+    const second = await accept(
+      client.setDefaultAgent({
+        query: {},
+        body: { agentId: composeId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [409],
+    );
+    expect(second.body).toMatchObject({ error: { code: "CONFLICT" } });
+  });
+
+  it("does not update org_metadata when 409 conflict prevents unsetting", async () => {
+    const fixture = uniqueOrgUser("zda-no-clobber");
+    await trackOrg(Promise.resolve(fixture));
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(orgDefaultAgentContract);
+    const first = await client.setDefaultAgent({
+      query: {},
+      body: { agentId: composeId },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(first.status).toBe(200);
+
+    // Attempt to unset — should be 409
+    const second = await client.setDefaultAgent({
+      query: {},
+      body: { agentId: null },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(second.status).toBe(409);
+
+    // org_metadata should still hold the original value
+    const stored = await store.set(
+      getOrgMetadataDefaultAgent$,
+      fixture.orgId,
+      context.signal,
+    );
+    expect(stored).toBe(composeId);
+  });
+
+  it("allows re-setting the default agent after the previous compose was deleted", async () => {
+    const fixture = uniqueOrgUser("zda-recover");
+    await trackOrg(Promise.resolve(fixture));
+    const first = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(orgDefaultAgentContract);
+    const set1 = await client.setDefaultAgent({
+      query: {},
+      body: { agentId: first.composeId },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(set1.status).toBe(200);
+
+    // Delete the first compose — FK cascade clears zero_agents,
+    // FK ON DELETE SET NULL clears org_metadata.defaultAgentId.
+    await deleteAgentCompose(first.composeId);
+
+    // A second default agent should now be settable
+    const second = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const set2 = await client.setDefaultAgent({
+      query: {},
+      body: { agentId: second.composeId },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(set2.status).toBe(200);
+    if (set2.status !== 200) {
+      return;
+    }
+    expect(set2.body.agentId).toBe(second.composeId);
+  });
+
+  it("upsert creates the org_metadata row when org_metadata never existed", async () => {
+    // Differs from the "missing row" case by also exercising the
+    // seedOrgMetadata helper for a freshly-seeded org row.
+    const fixture = uniqueOrgUser("zda-fresh-org");
+    await trackOrg(Promise.resolve(fixture));
+    // Seed an empty row first to mimic an org that has only the metadata
+    // shell but no default-agent yet, then immediately overwrite by PUT.
+    await store.set(
+      seedOrgMetadata$,
+      { orgId: fixture.orgId, defaultAgentId: null },
+      context.signal,
+    );
+
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(orgDefaultAgentContract);
+    const response = await client.setDefaultAgent({
+      query: {},
+      body: { agentId: composeId },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      return;
+    }
+    expect(response.body.agentId).toBe(composeId);
+
+    const stored = await store.set(
+      getOrgMetadataDefaultAgent$,
+      fixture.orgId,
+      context.signal,
+    );
+    expect(stored).toBe(composeId);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-default-agent.ts
+++ b/turbo/apps/api/src/signals/routes/zero-default-agent.ts
@@ -1,0 +1,62 @@
+import { command } from "ccstate";
+import { orgDefaultAgentContract } from "@vm0/api-contracts/contracts/orgs";
+
+import { isConflictResponse, isNotFoundResponse } from "../../lib/error";
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route";
+import { setOrgDefaultAgent$ } from "../services/zero-org-default-agent.service";
+
+const adminRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Only org admins can set the default agent",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+const setDefaultAgentInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    if (auth.orgRole !== "admin") {
+      return adminRequired;
+    }
+
+    const bodyResult = await get(
+      bodyResultOf(orgDefaultAgentContract.setDefaultAgent),
+    );
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const result = await set(
+      setOrgDefaultAgent$,
+      { orgId: auth.orgId, agentId: bodyResult.data.agentId },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (isNotFoundResponse(result)) {
+      return result;
+    }
+    if (isConflictResponse(result)) {
+      return result;
+    }
+
+    return { status: 200 as const, body: { agentId: result.agentId } };
+  },
+);
+
+export const zeroDefaultAgentRoutes: readonly RouteEntry[] = [
+  {
+    route: orgDefaultAgentContract.setDefaultAgent,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      setDefaultAgentInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-org-default-agent.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-default-agent.service.ts
@@ -1,0 +1,82 @@
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+
+import { conflict, notFound } from "../../lib/error";
+import { nowDate } from "../../lib/time";
+import { writeDb$ } from "../external/db";
+
+interface SetDefaultAgentArgs {
+  readonly orgId: string;
+  readonly agentId: string | null;
+}
+
+type SetDefaultAgentResult =
+  | { readonly kind: "ok"; readonly agentId: string | null }
+  | ReturnType<typeof notFound>
+  | ReturnType<typeof conflict>;
+
+export const setOrgDefaultAgent$ = command(
+  async (
+    { set },
+    args: SetDefaultAgentArgs,
+    signal: AbortSignal,
+  ): Promise<SetDefaultAgentResult> => {
+    const db = set(writeDb$);
+
+    const [orgRow] = await db
+      .select({ defaultAgentId: orgMetadata.defaultAgentId })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, args.orgId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    const existingAgentId = orgRow?.defaultAgentId ?? null;
+
+    if (existingAgentId) {
+      const [existing] = await db
+        .select({ id: zeroAgents.id })
+        .from(zeroAgents)
+        .where(
+          and(
+            eq(zeroAgents.id, existingAgentId),
+            eq(zeroAgents.orgId, args.orgId),
+          ),
+        )
+        .limit(1);
+      signal.throwIfAborted();
+      if (existing) {
+        return conflict("A default agent is already configured for this org");
+      }
+    }
+
+    if (args.agentId !== null) {
+      const [agent] = await db
+        .select({ id: zeroAgents.id })
+        .from(zeroAgents)
+        .where(
+          and(
+            eq(zeroAgents.id, args.agentId),
+            eq(zeroAgents.orgId, args.orgId),
+          ),
+        )
+        .limit(1);
+      signal.throwIfAborted();
+      if (!agent) {
+        return notFound("Agent not found in this org");
+      }
+    }
+
+    await db
+      .insert(orgMetadata)
+      .values({ orgId: args.orgId, defaultAgentId: args.agentId })
+      .onConflictDoUpdate({
+        target: orgMetadata.orgId,
+        set: { defaultAgentId: args.agentId, updatedAt: nowDate() },
+      });
+    signal.throwIfAborted();
+
+    return { kind: "ok", agentId: args.agentId };
+  },
+);


### PR DESCRIPTION
## Summary

Wave 6 #4 — migrates `PUT /api/zero/default-agent` (set the default agent for an org) from `apps/web` to `apps/api`. Contract `orgDefaultAgentContract.setDefaultAgent` was pre-defined in `packages/api-contracts/src/contracts/orgs.ts` and is now consumed.

- Org-admin gated (frozen `adminRequired` 403 const, matches `zero-custom-connectors-create` precedent)
- Atomic UPSERT into `org_metadata.defaultAgentId` (PK `orgId`); cascading FK behaviour preserved
- New service `setOrgDefaultAgent$` returns a result-union `{ kind:"ok", agentId } | NotFoundResponse | ConflictResponse` (Wave 5 mutation convention)
- New `isConflictResponse` predicate in `lib/error.ts` (mirrors `isNotFoundResponse` / `isBadRequestResponse`)
- New test helper `__tests__/helpers/zero-org-metadata.ts` (seed / assert / clean trio for `org_metadata`)

### Migration scope

**Logic-unchanged.** Preserves web's 4-step sequence:
1. SELECT existing `org_metadata.defaultAgentId`
2. If extant, verify the existing agent still resolves in this org → 409 `CONFLICT`
3. If a new agent is being set (non-null), verify it's in this org → 404 `NOT_FOUND`
4. Atomic `INSERT ... ON CONFLICT DO UPDATE`

No transaction wrapping (matches web; concurrent admins racing is a pre-existing semantic).

### Tests (14 total)

11 web cases ported 1:1 + 1 disambiguating UPSERT case + 2 api defensive:

1. 401 unauthenticated
2. 401 no-org session (api defensive — peer convention)
3. **403 non-admin member (api defensive — explicit admin-gate)**
4. 200 admin sets default
5. 200 + DB read-after-write proves write
6. 200 when nothing previously configured
7. 200 UPSERT creates the row when missing (`deleteOrgMetadata\$` first)
8. 404 when agent does not exist (random UUID)
9. 404 cross-org isolation (compose belongs to a different org)
10. 409 unset already-configured default
11. 409 setting twice
12. 200 → 409 unset attempt does not clobber org_metadata (DB read-after-write)
13. 200 re-set after the prior compose was deleted (FK SET-NULL clears the slot)
14. 200 UPSERT against a freshly-seeded empty-default row (via `seedOrgMetadata\$`)

Note: web's case 4 (\"rejects non-admin members\") actually exercises cross-org isolation in apps/web's fixture pattern. Both behaviours are now covered separately (test #3 pins the admin-gate, test #9 pins cross-org isolation).

### Test plan

- [x] `pnpm -F api exec vitest run` — 959 / 959 tests pass
- [x] `pnpm turbo run lint` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — unchanged
- [x] `pnpm knip` — clean (exit 0)
- [x] `pnpm -F web run db:migrate` — schema sync verified

### Pattern conventions reinforced

| Concern | Convention |
|---|---|
| Admin-gate inside Command | Frozen `adminRequired` const, early return |
| Service result-union | `{ kind:\"ok\", ... } | NotFoundResponse | ConflictResponse` |
| Response predicates | `is<Status>Response(r)` in `lib/error.ts` (no inline `\"status\" in r` checks) |
| Table-scoped test helpers | Sibling file under `__tests__/helpers/` per table |
| `missingOrganizationStatus` | `401` for non-API-key writes (matches web auth shape) |
| Admin-gate explicit coverage | Defensive test pins the gate without cross-org conflation |

Refs #12290
Closes #12598

🤖 Generated with [Claude Code](https://claude.com/claude-code)