### PR TITLE
refactor(api): migrate org/invite POST to api backend (Wave 6 #3)

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -24,6 +24,7 @@ export interface ApiTestMocks {
   readonly clerk: {
     readonly authenticateRequest: AsyncMock;
     readonly organizations: {
+      readonly createOrganizationInvitation: AsyncMock;
       readonly getOrganization: AsyncMock;
       readonly getOrganizationDomainList: AsyncMock;
       readonly getOrganizationInvitationList: AsyncMock;
@@ -87,6 +88,8 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   const clerk = {
     authenticateRequest: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     organizations: {
+      createOrganizationInvitation:
+        vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       getOrganization: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       getOrganizationDomainList:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -376,6 +379,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.axiomLogging.error.mockReset();
   apiTestMocks.axiomLogging.flush.mockReset();
   apiTestMocks.clerk.authenticateRequest.mockReset();
+  apiTestMocks.clerk.organizations.createOrganizationInvitation.mockReset();
   apiTestMocks.clerk.organizations.getOrganization.mockReset();
   apiTestMocks.clerk.organizations.getOrganizationDomainList.mockReset();
   apiTestMocks.clerk.organizations.getOrganizationInvitationList.mockReset();

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -27,6 +27,7 @@ import { zeroMemberCreditCapRoutes } from "./routes/zero-member-credit-cap";
 import { zeroModelPoliciesRoutes } from "./routes/zero-model-policies";
 import { zeroModelProvidersRoutes } from "./routes/zero-model-providers";
 import { zeroOnboardingStatusRoutes } from "./routes/zero-onboarding-status";
+import { zeroOrgInviteRoutes } from "./routes/zero-org-invite";
 import { zeroOrgReadRoutes } from "./routes/zero-org-read";
 import { zeroQueuePositionRoutes } from "./routes/zero-queue-position";
 import { zeroRunDetailRoutes } from "./routes/zero-run-detail";
@@ -98,6 +99,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroRunsCancelRoutes,
   ...zeroSchedulesRoutes,
   ...zeroOnboardingStatusRoutes,
+  ...zeroOrgInviteRoutes,
   ...zeroOrgReadRoutes,
   ...zeroUserPreferencesRoutes,
   ...zeroSecretsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-invite.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-invite.test.ts
@@ -1,0 +1,152 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+
+import { zeroOrgInviteContract } from "@vm0/api-contracts/contracts/zero-org-members";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function apiClient() {
+  return setupApp({ context })(zeroOrgInviteContract);
+}
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+describe("POST /api/zero/org/invite", () => {
+  it("invites a member with the default role (org:member)", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    context.mocks.clerk.organizations.createOrganizationInvitation.mockResolvedValueOnce(
+      undefined,
+    );
+
+    const response = await accept(
+      apiClient().invite({
+        headers: authHeaders(),
+        body: { email: "newuser@example.com" },
+      }),
+      [200],
+    );
+
+    expect(response.body.message).toContain("newuser@example.com");
+    expect(
+      context.mocks.clerk.organizations.createOrganizationInvitation,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: orgId,
+        emailAddress: "newuser@example.com",
+        inviterUserId: userId,
+        role: "org:member",
+      }),
+    );
+  });
+
+  it("invites a member with admin role", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    context.mocks.clerk.organizations.createOrganizationInvitation.mockResolvedValueOnce(
+      undefined,
+    );
+
+    const response = await accept(
+      apiClient().invite({
+        headers: authHeaders(),
+        body: { email: "admin@example.com", role: "admin" },
+      }),
+      [200],
+    );
+
+    expect(response.body.message).toContain("admin@example.com");
+    expect(
+      context.mocks.clerk.organizations.createOrganizationInvitation,
+    ).toHaveBeenCalledWith(expect.objectContaining({ role: "org:admin" }));
+  });
+
+  it("returns 403 when the caller is not an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:member");
+
+    const response = await accept(
+      apiClient().invite({
+        headers: authHeaders(),
+        body: { email: "newuser@example.com" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Access denied", code: "FORBIDDEN" },
+    });
+    expect(
+      context.mocks.clerk.organizations.createOrganizationInvitation,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      apiClient().invite({
+        headers: {},
+        body: { email: "newuser@example.com" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+    expect(
+      context.mocks.clerk.organizations.createOrganizationInvitation,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const response = await accept(
+      apiClient().invite({
+        headers: authHeaders(),
+        body: { email: "newuser@example.com" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+    expect(
+      context.mocks.clerk.organizations.createOrganizationInvitation,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an invalid email address", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const response = await accept(
+      apiClient().invite({
+        headers: authHeaders(),
+        body: { email: "not-an-email" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { code: "BAD_REQUEST" },
+    });
+    expect(
+      context.mocks.clerk.organizations.createOrganizationInvitation,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-org-invite.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-invite.ts
@@ -1,0 +1,59 @@
+import { command } from "ccstate";
+import { zeroOrgInviteContract } from "@vm0/api-contracts/contracts/zero-org-members";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { clerk$ } from "../external/clerk";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route";
+
+const adminRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Access denied",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+const inviteBody$ = bodyResultOf(zeroOrgInviteContract.invite);
+
+const inviteInner$ = command(async ({ get }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  if (auth.orgRole !== "admin") {
+    return adminRequired;
+  }
+
+  const body = await get(inviteBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  // Clerk side effect — sends the invitation email server-side.
+  // Mirrors apps/web/src/lib/zero/org/org-member-service.ts:inviteMember.
+  const client = get(clerk$);
+  await client.organizations.createOrganizationInvitation({
+    organizationId: auth.orgId,
+    emailAddress: body.data.email,
+    inviterUserId: auth.userId,
+    role: body.data.role === "admin" ? "org:admin" : "org:member",
+  });
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: { message: `Invitation sent to ${body.data.email}` },
+  };
+});
+
+export const zeroOrgInviteRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroOrgInviteContract.invite,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      inviteInner$,
+    ),
+  },
+];


### PR DESCRIPTION
## Summary

- Migrates `POST /api/zero/org/invite` (admin-gated org member invite) from `apps/web` to `apps/api`. **Wave 6 #3 — first org-admin mutation**. Establishes the admin-gate + Clerk-side-effect mock pattern for sibling Wave 6 routes (org/delete, org/leave, org/logo, org/membership-requests).
- Scope: `invite` (POST) action only. The web file's router also exports DELETE (revoke); `revoke` is in the same `zeroOrgInviteContract` but follows in a separate PR.

## Behavior 1:1 with web

- **Admin gate** via `auth.orgRole !== "admin"` returns a frozen `{ message: "Access denied", code: "FORBIDDEN" }` envelope. Byte-identical to web's caught-forbidden rewrite: web throws `forbidden("Only admins can invite members")` inside `inviteMember`, then catches and re-emits as `"Access denied"` — the inner message never leaves the server.
- **Clerk call** mirrors `inviteMember`: `createOrganizationInvitation({ organizationId, emailAddress, inviterUserId, role })` with mapping `"admin" → "org:admin"`, default `"org:member"`.
- **No DB write** — pure Clerk proxy. Clerk sends the invitation email server-side; no separate `@vm0/email` send.

## Files

- `turbo/apps/api/src/__tests__/mocks.ts` — extends the centralized Clerk mock with `createOrganizationInvitation: AsyncMock` (type + factory + reset, atomic across all three sites).
- `turbo/apps/api/src/signals/routes/zero-org-invite.ts` — new handler with local frozen `adminRequired` constant.
- `turbo/apps/api/src/signals/route.ts` — one import + one spread.
- `turbo/apps/api/src/signals/routes/__tests__/zero-org-invite.test.ts` — 6 cases.
- **No contract change, no service file, no web change.**

## Tests (6)

| # | Source | Case |
|---|---|---|
| 1 | web | invites a member with default role → 200, Clerk called with `role: "org:member"` |
| 2 | web | invites a member with admin role → 200, Clerk called with `role: "org:admin"` |
| 3 | web | non-admin caller → 403 with `{ error.message: "Access denied", error.code: "FORBIDDEN" }`; Clerk NOT called |
| 4 | web | unauthenticated → 401; Clerk NOT called |
| 5 | api defensive | no active org session → 401; Clerk NOT called |
| 6 | api defensive | invalid email body → 400 (zod-emitted); Clerk NOT called |

Error envelopes use `toStrictEqual` to lock the code value verbatim. The 400 zod case uses `toMatchObject` since the zod-generated message field varies by version.

## Pattern note

This PR establishes:
- **Admin-gate template**: early `if (auth.orgRole !== "admin") return adminRequired;` returning a local frozen `{ message: "Access denied", code: "FORBIDDEN" }`.
- **Clerk-side-effect mock template**: extend `apps/api/src/__tests__/mocks.ts` Clerk mock with new `AsyncMock` field on `clerk.organizations`. Tests assert via `context.mocks.clerk.organizations.X.toHaveBeenCalledWith(...)`.
- **Role-mapping**: api `"admin"|"member"` → Clerk `"org:admin"|"org:member"` at the route layer.

Sibling Wave 6 PRs (org/delete, org/leave, org/logo, org/membership-requests) can reuse these templates. When the third sibling lands, lift `adminRequired` to a shared module.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-org-invite.test.ts` — 6 passed
- [x] `pnpm -F api exec vitest run` — 951 passed
- [x] `pnpm -F api run lint` — clean (the 1 unrelated warning in `zero-chat-threads-patch.test.ts` predates this PR)
- [x] `pnpm -F api run check-types` — clean
- [x] `pnpm format` / `pnpm knip --workspace api` — clean

Closes #12597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)