### PR TITLE
fix: clarify personal providers tab copy

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/__tests__/personal-providers-tab.test.tsx
@@ -113,7 +113,7 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          /Manage personal credentials used when workspace model routes/,
+          /Personal Claude Code and ChatGPT credentials, used only in your own runs/,
         ),
       ).toBeInTheDocument();
     });
@@ -134,7 +134,7 @@ describe("personal-providers-tab — OAuth-only configuration", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          /Manage personal credentials used when workspace model routes/,
+          /Personal Claude Code and ChatGPT credentials, used only in your own runs/,
         ),
       ).toBeInTheDocument();
     });

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -72,9 +72,8 @@ function OAuthCredentialsSection() {
   return (
     <section className="flex flex-col gap-3">
       <p className="text-sm text-muted-foreground">
-        Manage personal credentials used when workspace model routes require
-        your Claude Code token
-        {codexOauthEnabled ? " or ChatGPT auth.json" : ""}.
+        Personal Claude Code{codexOauthEnabled ? " and ChatGPT" : ""}{" "}
+        credentials, used only in your own runs.
       </p>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         {isLoading ? (


### PR DESCRIPTION
## Summary

The Settings → Personal Providers section currently reads:

> Manage personal credentials used when workspace model routes require your Claude Code token or ChatGPT auth.json.

The phrase "workspace model routes" implies the token might be re-used to serve other teammates or routed through a vm0-side gateway — neither is true. PR #12375 already rewrote the **Configure Claude Code OAuth dialog** copy for exactly this reason, but the surrounding preferences tab description was missed.

This PR aligns the section description with #12375's framing.

### New copy

> Personal Claude Code{ and ChatGPT} credentials, used only in your own runs.

The two test assertions that grep for the old string are updated to match.

## Test plan

- [ ] Open Settings → Personal providers and confirm the section description renders correctly with both feature switches on and off
- [ ] `pnpm -F @vm0/platform test personal-providers-tab` passes