### PR TITLE
fix: restore model-first picker scroll chevrons

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -765,11 +765,7 @@ function ModelFirstModelPicker({
           />
         </SelectValue>
       </SelectTrigger>
-      <SelectContent
-        className="max-h-none min-w-[260px]"
-        hideScrollButtons
-        viewportClassName="h-auto max-h-none"
-      >
+      <SelectContent className="max-h-[280px] min-w-[260px]">
         {showUseDefault ? (
           <ModelFirstInheritToggleRow
             effectiveDefault={effectiveDefault}


### PR DESCRIPTION
## Summary
- restore the shared SelectContent scroll buttons for the model-first model picker
- keep the dropdown capped at the same 280px height as the legacy provider picker so long chat model lists show up/down chevrons

## Cause
The chat composer uses the model-first picker path behind ModelFirstModelProvider. That path was setting hideScrollButtons and max-h-none, so the previous PR only fixed the legacy provider-first show-more row.

## Testing
- pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-picker-shortcut.test.tsx src/views/zero-page/__tests__/model-provider-picker-show-more.test.tsx src/views/zero-page/__tests__/model-provider-picker-display.test.tsx
- pnpm exec oxlint src/views/zero-page/components/model-provider-picker.tsx
- pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json src/views/zero-page/components/model-provider-picker.tsx
- pnpm exec eslint src/views/zero-page/components/model-provider-picker.tsx --max-warnings 0
- pre-commit: turbo run check-types --concurrency=1