### PR TITLE
chore(runner): add write_file and guest log copy diagnostics

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3651,6 +3651,7 @@ version = "0.12.0"
 dependencies = [
  "nix",
  "tokio",
+ "tracing",
  "vsock-proto",
 ]
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1068,7 +1068,7 @@ const GUEST_SYSTEM_LOG_PREFIX: &str = "/tmp/vm0-system-";
 const GUEST_SYSTEM_LOG_SUFFIX: &str = ".log";
 const GUEST_METRICS_LOG_PREFIX: &str = "/tmp/vm0-metrics-";
 const GUEST_METRICS_LOG_SUFFIX: &str = ".jsonl";
-const SLOW_GUEST_LOG_COPY_LOG_MS: u128 = 5_000;
+const SLOW_GUEST_LOG_COPY_LOG_MS: u64 = 5_000;
 const GUEST_LOG_COPY_STREAM_LIMIT_BYTES: u32 = 128 * 1024 * 1024;
 const GUEST_LOG_COPY_STREAM_CHUNK_LIMIT_BYTES: u32 = 64 * 1024;
 const GUEST_LOG_COPY_STDERR_PREVIEW_BYTES: u32 = 16 * 1024;
@@ -1158,7 +1158,7 @@ where
 {
     tokio::pin!(future);
     let mut interval = tokio::time::interval_at(
-        tokio::time::Instant::now() + Duration::from_millis(SLOW_GUEST_LOG_COPY_LOG_MS as u64),
+        tokio::time::Instant::now() + Duration::from_millis(SLOW_GUEST_LOG_COPY_LOG_MS),
         Duration::from_secs(30),
     );
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -1221,7 +1221,7 @@ async fn copy_guest_log_file(
         bounded_exec_started_at,
     )
     .await;
-    let bounded_exec_duration_ms = bounded_exec_started_at.elapsed().as_millis();
+    let bounded_exec_duration_ms = bounded_exec_started_at.elapsed().as_millis() as u64;
     if bounded_exec_duration_ms >= SLOW_GUEST_LOG_COPY_LOG_MS {
         info!(
             run_id = %run_id,
@@ -1247,7 +1247,7 @@ async fn copy_guest_log_file(
     .await
     {
         Ok(result) => {
-            let writer_duration_ms = writer_started_at.elapsed().as_millis();
+            let writer_duration_ms = writer_started_at.elapsed().as_millis() as u64;
             if writer_duration_ms >= SLOW_GUEST_LOG_COPY_LOG_MS {
                 info!(
                     run_id = %run_id,

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -15,6 +15,7 @@
 //! user-visible completion signal is not blocked on best-effort uploads.
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -1067,6 +1068,7 @@ const GUEST_SYSTEM_LOG_PREFIX: &str = "/tmp/vm0-system-";
 const GUEST_SYSTEM_LOG_SUFFIX: &str = ".log";
 const GUEST_METRICS_LOG_PREFIX: &str = "/tmp/vm0-metrics-";
 const GUEST_METRICS_LOG_SUFFIX: &str = ".jsonl";
+const SLOW_GUEST_LOG_COPY_LOG_MS: u128 = 5_000;
 const GUEST_LOG_COPY_STREAM_LIMIT_BYTES: u32 = 128 * 1024 * 1024;
 const GUEST_LOG_COPY_STREAM_CHUNK_LIMIT_BYTES: u32 = 64 * 1024;
 const GUEST_LOG_COPY_STDERR_PREVIEW_BYTES: u32 = 16 * 1024;
@@ -1142,6 +1144,44 @@ async fn remove_guest_log_staging_file(run_id: RunId, log_kind: &str, staging_pa
     }
 }
 
+async fn await_guest_log_copy_stage<F>(
+    future: F,
+    run_id: RunId,
+    log_kind: &'static str,
+    stage: &'static str,
+    guest_path: &str,
+    host_path: &Path,
+    started_at: Instant,
+) -> F::Output
+where
+    F: Future,
+{
+    tokio::pin!(future);
+    let mut interval = tokio::time::interval_at(
+        tokio::time::Instant::now() + Duration::from_millis(SLOW_GUEST_LOG_COPY_LOG_MS as u64),
+        Duration::from_secs(30),
+    );
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            biased;
+            result = &mut future => return result,
+            _ = interval.tick() => {
+                info!(
+                    run_id = %run_id,
+                    log_kind,
+                    stage,
+                    guest_path,
+                    host_path = %host_path.display(),
+                    elapsed_ms = started_at.elapsed().as_millis() as u64,
+                    "guest log copy: slow stage still running"
+                );
+            }
+        }
+    }
+}
+
 async fn copy_guest_log_file(
     sandbox: &dyn Sandbox,
     run_id: RunId,
@@ -1156,25 +1196,71 @@ async fn copy_guest_log_file(
         staging_path.clone(),
     ));
     let cat_cmd = format!("cat -- '{guest_path}'");
+    let bounded_exec_started_at = Instant::now();
+    let result = await_guest_log_copy_stage(
+        async {
+            let stdout = guest_log_copy_stdout(event_tx);
+            let stderr = capture_bounded_output(GUEST_LOG_COPY_STDERR_PREVIEW_BYTES);
+            sandbox
+                .bounded_exec(&BoundedExecRequest {
+                    cmd: &cat_cmd,
+                    timeout: DEFAULT_EXEC_TIMEOUT,
+                    env: &[],
+                    sudo: false,
+                    stdin: None,
+                    stdout,
+                    stderr,
+                })
+                .await
+        },
+        run_id,
+        log_kind,
+        "bounded_exec",
+        guest_path,
+        host_path,
+        bounded_exec_started_at,
+    )
+    .await;
+    let bounded_exec_duration_ms = bounded_exec_started_at.elapsed().as_millis();
+    if bounded_exec_duration_ms >= SLOW_GUEST_LOG_COPY_LOG_MS {
+        info!(
+            run_id = %run_id,
+            log_kind,
+            guest_path,
+            host_path = %host_path.display(),
+            duration_ms = bounded_exec_duration_ms,
+            ok = result.is_ok(),
+            "guest log copy: slow bounded_exec returned"
+        );
+    }
 
-    let result = {
-        let stdout = guest_log_copy_stdout(event_tx);
-        let stderr = capture_bounded_output(GUEST_LOG_COPY_STDERR_PREVIEW_BYTES);
-        sandbox
-            .bounded_exec(&BoundedExecRequest {
-                cmd: &cat_cmd,
-                timeout: DEFAULT_EXEC_TIMEOUT,
-                env: &[],
-                sudo: false,
-                stdin: None,
-                stdout,
-                stderr,
-            })
-            .await
-    };
-
-    let writer_result = match writer.await {
-        Ok(result) => result,
+    let writer_started_at = Instant::now();
+    let writer_result = match await_guest_log_copy_stage(
+        writer,
+        run_id,
+        log_kind,
+        "stream_writer",
+        guest_path,
+        host_path,
+        writer_started_at,
+    )
+    .await
+    {
+        Ok(result) => {
+            let writer_duration_ms = writer_started_at.elapsed().as_millis();
+            if writer_duration_ms >= SLOW_GUEST_LOG_COPY_LOG_MS {
+                info!(
+                    run_id = %run_id,
+                    log_kind,
+                    guest_path,
+                    host_path = %host_path.display(),
+                    duration_ms = writer_duration_ms,
+                    ok = result.is_ok(),
+                    "guest log copy: slow stream writer returned"
+                );
+            }
+            result
+        }
         Err(e) => {
             warn!(
                 run_id = %run_id,

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -54,6 +54,7 @@ const GUEST_STAGE_DIR: &str = "/tmp/vm0-storage-cache";
 
 const HEAD_TIMEOUT: Duration = Duration::from_secs(10);
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(120);
+const SLOW_STORAGE_CACHE_LOG_MS: u128 = 1_000;
 
 /// Guest-side filename for a cached archive.
 ///
@@ -125,12 +126,16 @@ struct StorageCacheLockTrace {
 
 impl Drop for StorageCacheLockTrace {
     fn drop(&mut self) {
+        let held_ms = self.acquired_at.elapsed().as_millis();
+        if held_ms < SLOW_STORAGE_CACHE_LOG_MS {
+            return;
+        }
         info!(
             kind = self.kind,
             index = self.index,
             guest_path = %self.guest_path,
             lock_path = %self.lock_path.display(),
-            held_ms = self.acquired_at.elapsed().as_millis(),
+            held_ms,
             "storage_cache: lock released"
         );
     }
@@ -258,13 +263,6 @@ async fn process_one(
     let kind = target.kind.as_str();
     let guest_path = guest_archive_path(&target.name, &target.version);
     let lock_path = home.storage_lock(&target.name, &target.version);
-    info!(
-        kind,
-        index = target.index,
-        guest_path = %guest_path,
-        lock_path = %lock_path.display(),
-        "storage_cache: waiting for lock"
-    );
     let lock_wait_start = Instant::now();
     let guard = match lock::acquire(lock_path.clone()).await {
         Ok(guard) => guard,
@@ -281,14 +279,17 @@ async fn process_one(
             return Err(e);
         }
     };
-    info!(
-        kind,
-        index = target.index,
-        guest_path = %guest_path,
-        lock_path = %lock_path.display(),
-        wait_ms = lock_wait_start.elapsed().as_millis(),
-        "storage_cache: lock acquired"
-    );
+    let lock_wait_ms = lock_wait_start.elapsed().as_millis();
+    if lock_wait_ms >= SLOW_STORAGE_CACHE_LOG_MS {
+        info!(
+            kind,
+            index = target.index,
+            guest_path = %guest_path,
+            lock_path = %lock_path.display(),
+            wait_ms = lock_wait_ms,
+            "storage_cache: lock acquired"
+        );
+    }
     let _guard = StorageCacheLockGuard::new(
         guard,
         StorageCacheLockTrace {
@@ -406,26 +407,21 @@ async fn write_guest_archive(
     cache_state: &'static str,
 ) -> RunnerResult<()> {
     let kind = target.kind.as_str();
-    info!(
-        kind,
-        index = target.index,
-        cache_state,
-        guest_path,
-        bytes = bytes.len(),
-        "storage_cache: guest write_file start"
-    );
     let started_at = Instant::now();
     match sandbox.write_file(guest_path, bytes).await {
         Ok(()) => {
-            info!(
-                kind,
-                index = target.index,
-                cache_state,
-                guest_path,
-                bytes = bytes.len(),
-                duration_ms = started_at.elapsed().as_millis(),
-                "storage_cache: guest write_file complete"
-            );
+            let duration_ms = started_at.elapsed().as_millis();
+            if duration_ms >= SLOW_STORAGE_CACHE_LOG_MS {
+                info!(
+                    kind,
+                    index = target.index,
+                    cache_state,
+                    guest_path,
+                    bytes = bytes.len(),
+                    duration_ms,
+                    "storage_cache: guest write_file complete"
+                );
+            }
             Ok(())
         }
         Err(e) => {

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -23,17 +23,19 @@
 //! `guest-download` understands after #10805. The PR adding this module
 //! must not merge before #10805 is on `main`.
 
+use std::fs::File;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use futures_util::stream::{self, StreamExt};
+use nix::fcntl::Flock;
 use reqwest::Client;
 use sandbox::Sandbox;
 use tokio::fs;
 use tokio::io::AsyncReadExt as _;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
@@ -82,6 +84,15 @@ enum TargetKind {
     Artifact,
 }
 
+impl TargetKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Storage => "storage",
+            Self::Artifact => "artifact",
+        }
+    }
+}
+
 enum TargetOutcome {
     Hit,
     Miss {
@@ -102,6 +113,41 @@ enum TargetOutcome {
 enum DownloadBody {
     Complete(Bytes),
     OverSize { observed_size: u64 },
+}
+
+struct StorageCacheLockTrace {
+    kind: &'static str,
+    index: usize,
+    guest_path: String,
+    lock_path: PathBuf,
+    acquired_at: Instant,
+}
+
+impl Drop for StorageCacheLockTrace {
+    fn drop(&mut self) {
+        info!(
+            kind = self.kind,
+            index = self.index,
+            guest_path = %self.guest_path,
+            lock_path = %self.lock_path.display(),
+            held_ms = self.acquired_at.elapsed().as_millis(),
+            "storage_cache: lock released"
+        );
+    }
+}
+
+struct StorageCacheLockGuard {
+    _guard: Flock<File>,
+    _trace: StorageCacheLockTrace,
+}
+
+impl StorageCacheLockGuard {
+    fn new(guard: Flock<File>, trace: StorageCacheLockTrace) -> Self {
+        Self {
+            _guard: guard,
+            _trace: trace,
+        }
+    }
 }
 
 /// Populate the runner-side cache for eligible entries in `manifest`.
@@ -209,8 +255,50 @@ async fn process_one(
 ) -> RunnerResult<TargetOutcome> {
     // Acquire the per-version flock (blocking, cross-process dedup).
     // Disk-check happens under the lock so we never race with a writer.
+    let kind = target.kind.as_str();
+    let guest_path = guest_archive_path(&target.name, &target.version);
     let lock_path = home.storage_lock(&target.name, &target.version);
-    let _guard = lock::acquire(lock_path).await?;
+    info!(
+        kind,
+        index = target.index,
+        guest_path = %guest_path,
+        lock_path = %lock_path.display(),
+        "storage_cache: waiting for lock"
+    );
+    let lock_wait_start = Instant::now();
+    let guard = match lock::acquire(lock_path.clone()).await {
+        Ok(guard) => guard,
+        Err(e) => {
+            warn!(
+                kind,
+                index = target.index,
+                guest_path = %guest_path,
+                lock_path = %lock_path.display(),
+                wait_ms = lock_wait_start.elapsed().as_millis(),
+                error = %e,
+                "storage_cache: lock acquire failed"
+            );
+            return Err(e);
+        }
+    };
+    info!(
+        kind,
+        index = target.index,
+        guest_path = %guest_path,
+        lock_path = %lock_path.display(),
+        wait_ms = lock_wait_start.elapsed().as_millis(),
+        "storage_cache: lock acquired"
+    );
+    let _guard = StorageCacheLockGuard::new(
+        guard,
+        StorageCacheLockTrace {
+            kind,
+            index: target.index,
+            guest_path: guest_path.clone(),
+            lock_path: lock_path.clone(),
+            acquired_at: Instant::now(),
+        },
+    );
 
     let cache_dir = home.storage_cache_dir(&target.name, &target.version);
     let archive_path = cache_dir.join("archive.tar.gz");
@@ -222,8 +310,7 @@ async fn process_one(
             match read_cached_archive(&archive_path, CACHE_MAX_SIZE).await? {
                 DownloadBody::Complete(bytes) => {
                     touch_mtime(&cache_dir);
-                    let guest_path = guest_archive_path(&target.name, &target.version);
-                    sandbox.write_file(&guest_path, &bytes).await?;
+                    write_guest_archive(target, sandbox, &guest_path, &bytes, "hit").await?;
                     return Ok(TargetOutcome::Hit);
                 }
                 DownloadBody::OverSize { observed_size } => {
@@ -304,12 +391,57 @@ async fn process_one(
         }
     };
     write_to_cache(&cache_dir, &bytes).await?;
-    let guest_path = guest_archive_path(&target.name, &target.version);
-    sandbox.write_file(&guest_path, &bytes).await?;
+    write_guest_archive(target, sandbox, &guest_path, &bytes, "miss").await?;
 
     Ok(TargetOutcome::Miss {
         download_duration: t.elapsed(),
     })
+}
+
+async fn write_guest_archive(
+    target: &CacheTarget,
+    sandbox: &dyn Sandbox,
+    guest_path: &str,
+    bytes: &[u8],
+    cache_state: &'static str,
+) -> RunnerResult<()> {
+    let kind = target.kind.as_str();
+    info!(
+        kind,
+        index = target.index,
+        cache_state,
+        guest_path,
+        bytes = bytes.len(),
+        "storage_cache: guest write_file start"
+    );
+    let started_at = Instant::now();
+    match sandbox.write_file(guest_path, bytes).await {
+        Ok(()) => {
+            info!(
+                kind,
+                index = target.index,
+                cache_state,
+                guest_path,
+                bytes = bytes.len(),
+                duration_ms = started_at.elapsed().as_millis(),
+                "storage_cache: guest write_file complete"
+            );
+            Ok(())
+        }
+        Err(e) => {
+            warn!(
+                kind,
+                index = target.index,
+                cache_state,
+                guest_path,
+                bytes = bytes.len(),
+                duration_ms = started_at.elapsed().as_millis(),
+                error = %e,
+                "storage_cache: guest write_file failed"
+            );
+            Err(e.into())
+        }
+    }
 }
 
 async fn probe_size(http: &Client, url: &str) -> RunnerResult<Option<u64>> {

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -54,7 +54,7 @@ const GUEST_STAGE_DIR: &str = "/tmp/vm0-storage-cache";
 
 const HEAD_TIMEOUT: Duration = Duration::from_secs(10);
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(120);
-const SLOW_STORAGE_CACHE_LOG_MS: u128 = 1_000;
+const SLOW_STORAGE_CACHE_LOG_MS: u64 = 1_000;
 
 /// Guest-side filename for a cached archive.
 ///
@@ -126,7 +126,7 @@ struct StorageCacheLockTrace {
 
 impl Drop for StorageCacheLockTrace {
     fn drop(&mut self) {
-        let held_ms = self.acquired_at.elapsed().as_millis();
+        let held_ms = self.acquired_at.elapsed().as_millis() as u64;
         if held_ms < SLOW_STORAGE_CACHE_LOG_MS {
             return;
         }
@@ -272,14 +272,14 @@ async fn process_one(
                 index = target.index,
                 guest_path = %guest_path,
                 lock_path = %lock_path.display(),
-                wait_ms = lock_wait_start.elapsed().as_millis(),
+                wait_ms = lock_wait_start.elapsed().as_millis() as u64,
                 error = %e,
                 "storage_cache: lock acquire failed"
             );
             return Err(e);
         }
     };
-    let lock_wait_ms = lock_wait_start.elapsed().as_millis();
+    let lock_wait_ms = lock_wait_start.elapsed().as_millis() as u64;
     if lock_wait_ms >= SLOW_STORAGE_CACHE_LOG_MS {
         info!(
             kind,
@@ -410,7 +410,7 @@ async fn write_guest_archive(
     let started_at = Instant::now();
     match sandbox.write_file(guest_path, bytes).await {
         Ok(()) => {
-            let duration_ms = started_at.elapsed().as_millis();
+            let duration_ms = started_at.elapsed().as_millis() as u64;
             if duration_ms >= SLOW_STORAGE_CACHE_LOG_MS {
                 info!(
                     kind,
@@ -431,7 +431,7 @@ async fn write_guest_archive(
                 cache_state,
                 guest_path,
                 bytes = bytes.len(),
-                duration_ms = started_at.elapsed().as_millis(),
+                duration_ms = started_at.elapsed().as_millis() as u64,
                 error = %e,
                 "storage_cache: guest write_file failed"
             );

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -136,7 +136,7 @@ impl Drop for StorageCacheLockTrace {
             guest_path = %self.guest_path,
             lock_path = %self.lock_path.display(),
             held_ms,
-            "storage_cache: lock released"
+            "storage_cache: slow lock released"
         );
     }
 }
@@ -287,7 +287,7 @@ async fn process_one(
             guest_path = %guest_path,
             lock_path = %lock_path.display(),
             wait_ms = lock_wait_ms,
-            "storage_cache: lock acquired"
+            "storage_cache: slow lock acquired"
         );
     }
     let _guard = StorageCacheLockGuard::new(
@@ -419,7 +419,7 @@ async fn write_guest_archive(
                     guest_path,
                     bytes = bytes.len(),
                     duration_ms,
-                    "storage_cache: guest write_file complete"
+                    "storage_cache: slow guest write_file complete"
                 );
             }
             Ok(())

--- a/crates/vsock-guest/src/bounded_exec.rs
+++ b/crates/vsock-guest/src/bounded_exec.rs
@@ -33,6 +33,20 @@ const STDIN_WRITE_POLL_TIMEOUT_MS: libc::c_int = 100;
 
 pub(crate) type BoundedExecCleanup = Box<dyn FnOnce() + Send + 'static>;
 
+pub(crate) fn bounded_exec_command_kind(command: &str) -> &'static str {
+    if command.contains("/tmp/vm0-system-") {
+        "guest-log-system"
+    } else if command.contains("/tmp/vm0-metrics-") {
+        "guest-log-metrics"
+    } else if command.starts_with("mv -f -- ") {
+        "write-file-commit"
+    } else if command.starts_with("rm -f -- ") {
+        "write-file-cleanup"
+    } else {
+        "other"
+    }
+}
+
 pub(crate) struct BoundedExecWorkerRequest {
     pub(crate) seq: u32,
     pub(crate) timeout_ms: u32,
@@ -220,6 +234,8 @@ where
     S: ThreadSpawner,
 {
     let seq = request.seq;
+    let command_kind = bounded_exec_command_kind(&request.command);
+    let command_len = request.command.len();
     let stdout_policy = request.stdout;
     let stderr_policy = request.stderr;
     let worker_writer = writer.clone();
@@ -240,9 +256,23 @@ where
     );
 
     match result {
-        Ok(_) => Ok(()),
+        Ok(_) => {
+            log(
+                "INFO",
+                &format!(
+                    "bounded_exec worker spawned: seq={seq}, command_kind={command_kind}, command_len={command_len}",
+                ),
+            );
+            Ok(())
+        }
         Err(e) => {
             let diagnostic = format!("Failed to spawn bounded exec worker thread: {e}");
+            log(
+                "ERROR",
+                &format!(
+                    "bounded_exec worker spawn failed: seq={seq}, command_kind={command_kind}, command_len={command_len}, error={e}",
+                ),
+            );
             let stdout = GuestBoundedOutput::empty_for_policy(stdout_policy);
             let stderr = GuestBoundedOutput::empty_for_policy(stderr_policy);
             send_bounded_exec_result(
@@ -269,10 +299,15 @@ fn run_bounded_exec<S>(
 ) where
     S: ThreadSpawner,
 {
+    let command_kind = bounded_exec_command_kind(&request.command);
+    let command_len = request.command.len();
     log(
         "INFO",
         &format!(
-            "bounded_exec: {} (timeout={}ms, sudo={}, stdin={}, stdout={}, stderr={}, {})",
+            "bounded_exec started: seq={}, command_kind={}, command_len={}, command={} (timeout={}ms, sudo={}, stdin={}, stdout={}, stderr={}, {})",
+            request.seq,
+            command_kind,
+            command_len,
             truncate_preview(&request.command),
             request.timeout_ms,
             request.sudo,
@@ -347,6 +382,19 @@ fn run_bounded_exec<S>(
         env_script,
     } = spawned;
     let _env_script = env_script;
+    let child_pid = child.id();
+    log(
+        "INFO",
+        &format!(
+            "bounded_exec child spawned: seq={}, command_kind={}, pid={}, stdin_pipe={}, stdout_pipe={}, stderr_pipe={}",
+            request.seq,
+            command_kind,
+            child_pid,
+            request.stdin.is_some(),
+            request.stdout.requires_pipe(),
+            request.stderr.requires_pipe(),
+        ),
+    );
 
     if cancellation_requested(&connection_cancel, &request_cancel) {
         kill_and_send_cancelled(
@@ -555,6 +603,17 @@ fn run_bounded_exec<S>(
             command_cancel.as_ref(),
         ],
     );
+    log(
+        "INFO",
+        &format!(
+            "bounded_exec child wait finished: seq={}, command_kind={}, outcome={}, exit_code={:?}, duration_ms={}",
+            request.seq,
+            command_kind,
+            wait_outcome_label(&outcome),
+            wait_outcome_exit_code(&outcome),
+            duration_ms(started),
+        ),
+    );
     if matches!(outcome, WaitOutcome::Cancelled)
         || connection_cancel.load(Ordering::Acquire)
         || request_cancel.load(Ordering::Acquire)
@@ -591,10 +650,24 @@ fn run_bounded_exec<S>(
     let expected_drains =
         usize::from(stdout_worker.is_some()) + usize::from(stderr_worker.is_some());
     let completed = await_drain_deadline(&drain_done_rx, expected_drains, &drain_cancel);
+    log(
+        "INFO",
+        &format!(
+            "bounded_exec drain finished: seq={}, command_kind={}, completed={}, expected={}, duration_ms={}",
+            request.seq,
+            command_kind,
+            completed,
+            expected_drains,
+            duration_ms(started),
+        ),
+    );
     if completed < expected_drains {
         log(
             "WARN",
-            &format!("bounded_exec: drain deadline reached after {DRAIN_DEADLINE_SECS}s",),
+            &format!(
+                "bounded_exec drain deadline reached: seq={}, command_kind={}, completed={}, expected={}, deadline_secs={}",
+                request.seq, command_kind, completed, expected_drains, DRAIN_DEADLINE_SECS,
+            ),
         );
     }
 
@@ -626,7 +699,9 @@ fn run_bounded_exec<S>(
     log(
         "INFO",
         &format!(
-            "bounded_exec result: termination={termination:?}, stdout_len={}, stderr_len={}, stdout_truncated={}, stderr_truncated={}, diagnostic={}",
+            "bounded_exec result prepared: seq={}, command_kind={}, termination={termination:?}, stdout_len={}, stderr_len={}, stdout_truncated={}, stderr_truncated={}, diagnostic={}",
+            request.seq,
+            command_kind,
             stdout_output.len(),
             stderr_output.len(),
             stdout_output.truncated(),
@@ -644,6 +719,22 @@ fn run_bounded_exec<S>(
         diagnostic.as_deref(),
         &writer,
     );
+}
+
+fn wait_outcome_label(outcome: &WaitOutcome) -> &'static str {
+    match outcome {
+        WaitOutcome::Exited(_) => "exited",
+        WaitOutcome::TimedOut => "timed_out",
+        WaitOutcome::Cancelled => "cancelled",
+        WaitOutcome::WaitFailed(_) => "wait_failed",
+    }
+}
+
+fn wait_outcome_exit_code(outcome: &WaitOutcome) -> Option<i32> {
+    match outcome {
+        WaitOutcome::Exited(status) => Some(crate::process::extract_exit_code(*status)),
+        _ => None,
+    }
 }
 
 fn validate_request(request: &BoundedExecWorkerRequest) -> Result<(), String> {
@@ -1082,14 +1173,14 @@ fn send_bounded_exec_result(
     let BoundedExecResultFrame {
         seq,
         termination,
-        duration_ms,
+        duration_ms: command_duration_ms,
         stdout,
         stderr,
         diagnostic,
     } = frame;
     let payload = match vsock_proto::encode_bounded_exec_result(
         termination,
-        duration_ms,
+        command_duration_ms,
         stdout,
         stderr,
         diagnostic,
@@ -1103,7 +1194,7 @@ fn send_bounded_exec_result(
             let diagnostic = format!("Failed to encode bounded exec result: {e}");
             vsock_proto::encode_bounded_exec_result(
                 BoundedExecTermination::WaitFailed,
-                duration_ms,
+                command_duration_ms,
                 vsock_proto::BoundedExecOutput::Discarded,
                 vsock_proto::BoundedExecOutput::Discarded,
                 Some(&diagnostic),
@@ -1113,7 +1204,33 @@ fn send_bounded_exec_result(
     };
     let encoded =
         vsock_proto::encode(MSG_BOUNDED_EXEC_RESULT, seq, &payload).map_err(to_io_error)?;
-    writer.write_frame(&encoded)
+    let send_started = Instant::now();
+    log(
+        "INFO",
+        &format!(
+            "bounded_exec result send started: seq={seq}, termination={termination:?}, payload_bytes={}, frame_bytes={}",
+            payload.len(),
+            encoded.len(),
+        ),
+    );
+    let result = writer.write_frame(&encoded);
+    match &result {
+        Ok(()) => log(
+            "INFO",
+            &format!(
+                "bounded_exec result send finished: seq={seq}, duration_ms={}",
+                duration_ms(send_started),
+            ),
+        ),
+        Err(e) => log(
+            "ERROR",
+            &format!(
+                "bounded_exec result send failed: seq={seq}, duration_ms={}, error={e}",
+                duration_ms(send_started),
+            ),
+        ),
+    }
+    result
 }
 
 fn send_bounded_exec_output_chunk(

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -242,12 +242,6 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                     MessageOutcome::Response(response) => {
                         let is_write_file = msg.msg_type == vsock_proto::MSG_WRITE_FILE;
                         let response_send_started_at = std::time::Instant::now();
-                        if is_write_file {
-                            log(
-                                "INFO",
-                                &format!("write_file response send start: seq={}", msg.seq),
-                            );
-                        }
                         if let Err(e) = writer.write_frame(&response) {
                             if is_write_file {
                                 log(
@@ -263,14 +257,16 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                             return Err(e);
                         }
                         if is_write_file {
-                            log(
-                                "INFO",
-                                &format!(
-                                    "write_file response send complete: seq={} duration_ms={}",
-                                    msg.seq,
-                                    response_send_started_at.elapsed().as_millis()
-                                ),
-                            );
+                            let duration_ms = response_send_started_at.elapsed().as_millis();
+                            if duration_ms >= 1_000 {
+                                log(
+                                    "INFO",
+                                    &format!(
+                                        "write_file response send complete: seq={} duration_ms={}",
+                                        msg.seq, duration_ms
+                                    ),
+                                );
+                            }
                         }
                     }
                     MessageOutcome::Shutdown(response) => {

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -241,6 +241,7 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                 match handle_message(&msg)? {
                     MessageOutcome::Response(response) => {
                         let is_write_file = msg.msg_type == vsock_proto::MSG_WRITE_FILE;
+                        let response_send_started_at = std::time::Instant::now();
                         if is_write_file {
                             log(
                                 "INFO",
@@ -252,8 +253,10 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                                 log(
                                     "ERROR",
                                     &format!(
-                                        "write_file response send failed: seq={} error={}",
-                                        msg.seq, e
+                                        "write_file response send failed: seq={} duration_ms={} error={}",
+                                        msg.seq,
+                                        response_send_started_at.elapsed().as_millis(),
+                                        e
                                     ),
                                 );
                             }
@@ -262,7 +265,11 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                         if is_write_file {
                             log(
                                 "INFO",
-                                &format!("write_file response send complete: seq={}", msg.seq),
+                                &format!(
+                                    "write_file response send complete: seq={} duration_ms={}",
+                                    msg.seq,
+                                    response_send_started_at.elapsed().as_millis()
+                                ),
                             );
                         }
                     }

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -262,7 +262,7 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                                 log(
                                     "INFO",
                                     &format!(
-                                        "write_file response send complete: seq={} duration_ms={}",
+                                        "slow write_file response send complete: seq={} duration_ms={}",
                                         msg.seq, duration_ms
                                     ),
                                 );

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -169,10 +169,33 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
             } else if msg.msg_type == MSG_BOUNDED_EXEC {
                 log(
                     "INFO",
-                    &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),
+                    &format!(
+                        "bounded_exec frame received: seq={}, payload_bytes={}",
+                        msg.seq,
+                        msg.payload.len(),
+                    ),
                 );
-                let decoded =
-                    vsock_proto::decode_bounded_exec(&msg.payload).map_err(to_io_error)?;
+                let decoded = match vsock_proto::decode_bounded_exec(&msg.payload) {
+                    Ok(decoded) => decoded,
+                    Err(e) => {
+                        log(
+                            "ERROR",
+                            &format!("bounded_exec decode failed: seq={}, error={e}", msg.seq),
+                        );
+                        return Err(to_io_error(e));
+                    }
+                };
+                log(
+                    "INFO",
+                    &format!(
+                        "bounded_exec received: seq={}, command_kind={}, command_len={}, timeout_ms={}, streaming={}",
+                        msg.seq,
+                        crate::bounded_exec::bounded_exec_command_kind(decoded.command),
+                        decoded.command.len(),
+                        decoded.timeout_ms,
+                        decoded.stdout.stream.is_some() || decoded.stderr.stream.is_some(),
+                    ),
+                );
                 let request_cancel = Arc::new(AtomicBool::new(false));
                 {
                     let mut cancels = bounded_exec_cancels
@@ -202,6 +225,10 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
                     cleanup,
                 )?;
             } else if msg.msg_type == MSG_BOUNDED_EXEC_CANCEL {
+                log(
+                    "INFO",
+                    &format!("bounded_exec cancel received: seq={}", msg.seq),
+                );
                 if let Some(cancel) = bounded_exec_cancels
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -240,7 +240,31 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
             } else {
                 match handle_message(&msg)? {
                     MessageOutcome::Response(response) => {
-                        writer.write_frame(&response)?;
+                        let is_write_file = msg.msg_type == vsock_proto::MSG_WRITE_FILE;
+                        if is_write_file {
+                            log(
+                                "INFO",
+                                &format!("write_file response send start: seq={}", msg.seq),
+                            );
+                        }
+                        if let Err(e) = writer.write_frame(&response) {
+                            if is_write_file {
+                                log(
+                                    "ERROR",
+                                    &format!(
+                                        "write_file response send failed: seq={} error={}",
+                                        msg.seq, e
+                                    ),
+                                );
+                            }
+                            return Err(e);
+                        }
+                        if is_write_file {
+                            log(
+                                "INFO",
+                                &format!("write_file response send complete: seq={}", msg.seq),
+                            );
+                        }
                     }
                     MessageOutcome::Shutdown(response) => {
                         if let Err(e) = writer.write_frame(&response) {

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 #[cfg(any(debug_assertions, feature = "test-support"))]
 use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
+use std::time::Instant;
 
 use vsock_proto::{
     self, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
@@ -291,7 +292,19 @@ pub(crate) fn handle_message(msg: &RawMessage) -> io::Result<MessageOutcome> {
         MSG_WRITE_FILE => {
             let (path, content, use_sudo, append) =
                 vsock_proto::decode_write_file(&msg.payload).map_err(to_io_error)?;
+            let started_at = Instant::now();
             let (success, error) = handle_write_file(path, content, use_sudo, append);
+            log(
+                "INFO",
+                &format!(
+                    "write_file result: seq={} path={} success={} duration_ms={} error_len={}",
+                    msg.seq,
+                    path,
+                    success,
+                    started_at.elapsed().as_millis(),
+                    error.len()
+                ),
+            );
             let payload = vsock_proto::encode_write_file_result(success, &error);
             Ok(MessageOutcome::Response(
                 vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload)

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -294,17 +294,20 @@ pub(crate) fn handle_message(msg: &RawMessage) -> io::Result<MessageOutcome> {
                 vsock_proto::decode_write_file(&msg.payload).map_err(to_io_error)?;
             let started_at = Instant::now();
             let (success, error) = handle_write_file(path, content, use_sudo, append);
-            log(
-                "INFO",
-                &format!(
-                    "write_file result: seq={} path={} success={} duration_ms={} error_len={}",
-                    msg.seq,
-                    path,
-                    success,
-                    started_at.elapsed().as_millis(),
-                    error.len()
-                ),
-            );
+            let duration_ms = started_at.elapsed().as_millis();
+            if !success || duration_ms >= 1_000 {
+                log(
+                    if success { "INFO" } else { "WARN" },
+                    &format!(
+                        "write_file result: seq={} path={} success={} duration_ms={} error_len={}",
+                        msg.seq,
+                        path,
+                        success,
+                        duration_ms,
+                        error.len()
+                    ),
+                );
+            }
             let payload = vsock_proto::encode_write_file_result(success, &error);
             Ok(MessageOutcome::Response(
                 vsock_proto::encode(MSG_WRITE_FILE_RESULT, msg.seq, &payload)

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -295,14 +295,25 @@ pub(crate) fn handle_message(msg: &RawMessage) -> io::Result<MessageOutcome> {
             let started_at = Instant::now();
             let (success, error) = handle_write_file(path, content, use_sudo, append);
             let duration_ms = started_at.elapsed().as_millis();
-            if !success || duration_ms >= 1_000 {
+            if !success {
                 log(
-                    if success { "INFO" } else { "WARN" },
+                    "WARN",
                     &format!(
                         "write_file result: seq={} path={} success={} duration_ms={} error_len={}",
                         msg.seq,
                         path,
                         success,
+                        duration_ms,
+                        error.len()
+                    ),
+                );
+            } else if duration_ms >= 1_000 {
+                log(
+                    "INFO",
+                    &format!(
+                        "slow write_file result: seq={} path={} success=true duration_ms={} error_len={}",
+                        msg.seq,
+                        path,
                         duration_ms,
                         error.len()
                     ),

--- a/crates/vsock-host/Cargo.toml
+++ b/crates/vsock-host/Cargo.toml
@@ -7,6 +7,7 @@ description = "Vsock host client for Firecracker VM communication"
 [dependencies]
 nix = { workspace = true, features = ["net"] }
 tokio = { workspace = true, features = ["net", "io-util", "time", "rt", "macros", "sync"] }
+tracing.workspace = true
 vsock-proto.workspace = true
 
 [dev-dependencies]

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1151,7 +1151,7 @@ async fn request_raw_on_shared_with_write_timeout(
                                 response_type = msg.msg_type,
                                 response_wait_ms = response_wait_ms as u64,
                                 duration_ms = duration_ms as u64,
-                                "vsock_host: write_file response received"
+                                "vsock_host: slow write_file response received"
                             );
                         }
                     }
@@ -1950,7 +1950,7 @@ impl VsockHost {
                 path,
                 bytes = content.len(),
                 duration_ms = duration_ms as u64,
-                "vsock_host: write_file chunk complete"
+                "vsock_host: slow write_file chunk complete"
             );
         }
         Ok(())

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -56,6 +56,7 @@ const FIRECRACKER_CONNECT_ACK_MAX_BYTES: usize = 64;
 const FRAME_WRITE_TIMEOUT: Duration = Duration::from_secs(30);
 const BOUNDED_EXEC_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(10);
 const SLOW_WRITE_FILE_LOG_MS: u128 = 1_000;
+const SLOW_BOUNDED_EXEC_LOG_MS: u128 = 5_000;
 
 /// Result of executing a command on the guest.
 #[derive(Debug, Clone)]
@@ -814,6 +815,27 @@ fn has_bounded_stream(request: &BoundedExecRequest<'_>) -> bool {
     request.stdout.stream.is_some() || request.stderr.stream.is_some()
 }
 
+fn bounded_exec_command_kind(command: &str) -> &'static str {
+    if command.contains("/tmp/vm0-system-") {
+        "guest-log-system"
+    } else if command.contains("/tmp/vm0-metrics-") {
+        "guest-log-metrics"
+    } else if command.starts_with("mv -f -- ") {
+        "write-file-commit"
+    } else if command.starts_with("rm -f -- ") {
+        "write-file-cleanup"
+    } else {
+        "other"
+    }
+}
+
+fn proto_output_summary(output: &vsock_proto::BoundedExecOutput<'_>) -> (usize, bool) {
+    match output {
+        vsock_proto::BoundedExecOutput::Discarded => (0, false),
+        vsock_proto::BoundedExecOutput::Captured { bytes, truncated } => (bytes.len(), *truncated),
+    }
+}
+
 fn validate_bounded_exec_request(request: &BoundedExecRequest<'_>) -> io::Result<()> {
     if request.timeout_ms == 0 {
         return Err(io::Error::new(
@@ -1345,6 +1367,10 @@ async fn bounded_exec_on_shared_with_request_timeout(
     request_timeout: Duration,
 ) -> io::Result<BoundedExecResult> {
     validate_bounded_exec_request(request)?;
+    let request_started_at = Instant::now();
+    let command_kind = bounded_exec_command_kind(request.command);
+    let command_len = request.command.len();
+    let has_stream = has_bounded_stream(request);
 
     let proto_request = vsock_proto::BoundedExecRequest {
         timeout_ms: request.timeout_ms,
@@ -1366,6 +1392,16 @@ async fn bounded_exec_on_shared_with_request_timeout(
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
             ConnectionState::Closed { .. } => {
+                warn!(
+                    seq,
+                    command_kind,
+                    command_len,
+                    timeout_ms = request.timeout_ms,
+                    request_timeout_ms = request_timeout.as_millis() as u64,
+                    streaming = has_stream,
+                    duration_ms = request_started_at.elapsed().as_millis() as u64,
+                    "vsock_host: bounded_exec connection closed before request registration"
+                );
                 return Err(io::Error::new(
                     io::ErrorKind::ConnectionReset,
                     "connection closed",
@@ -1377,7 +1413,7 @@ async fn bounded_exec_on_shared_with_request_timeout(
                 ..
             } => {
                 pending.insert(seq, tx);
-                if has_bounded_stream(request) {
+                if has_stream {
                     bounded_output_senders.insert(
                         seq,
                         BoundedOutputRegistration::new(&request.stdout, &request.stderr),
@@ -1387,31 +1423,98 @@ async fn bounded_exec_on_shared_with_request_timeout(
         }
     }
     let mut pending_guard = PendingBoundedExecGuard::new(Arc::clone(shared), seq);
-    let _bounded_output_guard = has_bounded_stream(request)
-        .then(|| PendingBoundedOutputGuard::new(Arc::clone(shared), seq));
+    let _bounded_output_guard =
+        has_stream.then(|| PendingBoundedOutputGuard::new(Arc::clone(shared), seq));
 
-    write_frame_on_shared(shared, &data).await?;
+    let write_started_at = Instant::now();
+    if let Err(e) = write_frame_on_shared(shared, &data).await {
+        warn!(
+            seq,
+            command_kind,
+            command_len,
+            timeout_ms = request.timeout_ms,
+            request_timeout_ms = request_timeout.as_millis() as u64,
+            streaming = has_stream,
+            duration_ms = request_started_at.elapsed().as_millis() as u64,
+            write_ms = write_started_at.elapsed().as_millis() as u64,
+            error = %e,
+            error_kind = ?e.kind(),
+            "vsock_host: bounded_exec frame write failed"
+        );
+        return Err(e);
+    }
 
+    let response_wait_started_at = Instant::now();
     let resp = tokio::select! {
         biased;
         result = rx => {
-            result.map_err(|_| io::Error::new(
-                io::ErrorKind::ConnectionReset,
-                "connection closed",
-            ))?
+            match result {
+                Ok(resp) => resp,
+                Err(_) => {
+                    warn!(
+                        seq,
+                        command_kind,
+                        command_len,
+                        timeout_ms = request.timeout_ms,
+                        request_timeout_ms = request_timeout.as_millis() as u64,
+                        streaming = has_stream,
+                        response_wait_ms = response_wait_started_at.elapsed().as_millis() as u64,
+                        duration_ms = request_started_at.elapsed().as_millis() as u64,
+                        "vsock_host: bounded_exec connection closed before response"
+                    );
+                    return Err(io::Error::new(
+                        io::ErrorKind::ConnectionReset,
+                        "connection closed",
+                    ));
+                }
+            }
         }
         _ = tokio::time::sleep(request_timeout) => {
+            warn!(
+                seq,
+                command_kind,
+                command_len,
+                timeout_ms = request.timeout_ms,
+                request_timeout_ms = request_timeout.as_millis() as u64,
+                streaming = has_stream,
+                response_wait_ms = response_wait_started_at.elapsed().as_millis() as u64,
+                duration_ms = request_started_at.elapsed().as_millis() as u64,
+                "vsock_host: bounded_exec response timeout"
+            );
             return Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"));
         }
     };
+    let response_wait_ms = response_wait_started_at.elapsed().as_millis() as u64;
     if resp.msg_type == MSG_ERROR {
         pending_guard.disarm_cancel();
         let msg = vsock_proto::decode_error(&resp.payload)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        warn!(
+            seq,
+            command_kind,
+            command_len,
+            timeout_ms = request.timeout_ms,
+            request_timeout_ms = request_timeout.as_millis() as u64,
+            streaming = has_stream,
+            duration_ms = request_started_at.elapsed().as_millis() as u64,
+            error = %msg,
+            "vsock_host: bounded_exec guest returned error"
+        );
         return Err(io::Error::other(msg));
     }
 
     if resp.msg_type != MSG_BOUNDED_EXEC_RESULT {
+        warn!(
+            seq,
+            command_kind,
+            command_len,
+            timeout_ms = request.timeout_ms,
+            request_timeout_ms = request_timeout.as_millis() as u64,
+            streaming = has_stream,
+            response_type = resp.msg_type,
+            duration_ms = request_started_at.elapsed().as_millis() as u64,
+            "vsock_host: bounded_exec unexpected response type"
+        );
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("unexpected response type: 0x{:02X}", resp.msg_type),
@@ -1419,11 +1522,48 @@ async fn bounded_exec_on_shared_with_request_timeout(
     }
 
     pending_guard.disarm_cancel();
-    let decoded = vsock_proto::decode_bounded_exec_result(&resp.payload)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    let decoded = vsock_proto::decode_bounded_exec_result(&resp.payload).map_err(|e| {
+        warn!(
+            seq,
+            command_kind,
+            command_len,
+            timeout_ms = request.timeout_ms,
+            request_timeout_ms = request_timeout.as_millis() as u64,
+            streaming = has_stream,
+            response_wait_ms,
+            duration_ms = request_started_at.elapsed().as_millis() as u64,
+            error = %e,
+            "vsock_host: bounded_exec result decode failed"
+        );
+        io::Error::new(io::ErrorKind::InvalidData, e.to_string())
+    })?;
+    let termination = proto_termination_to_host(decoded.termination);
+    let (stdout_bytes, stdout_truncated) = proto_output_summary(&decoded.stdout);
+    let (stderr_bytes, stderr_truncated) = proto_output_summary(&decoded.stderr);
+    let duration_ms = request_started_at.elapsed().as_millis();
+    if duration_ms >= SLOW_BOUNDED_EXEC_LOG_MS {
+        info!(
+            seq,
+            command_kind,
+            command_len,
+            timeout_ms = request.timeout_ms,
+            request_timeout_ms = request_timeout.as_millis() as u64,
+            streaming = has_stream,
+            termination = ?termination,
+            guest_duration_ms = decoded.duration_ms,
+            response_wait_ms,
+            stdout_bytes,
+            stdout_truncated,
+            stderr_bytes,
+            stderr_truncated,
+            diagnostic = decoded.diagnostic.is_some(),
+            duration_ms = duration_ms as u64,
+            "vsock_host: slow bounded_exec completed"
+        );
+    }
 
     Ok(BoundedExecResult {
-        termination: proto_termination_to_host(decoded.termination),
+        termination,
         duration_ms: decoded.duration_ms,
         stdout: proto_output_to_host(decoded.stdout),
         stderr: proto_output_to_host(decoded.stderr),

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -40,6 +40,7 @@ use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{Notify, mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::{self, Instant};
+use tracing::{info, warn};
 
 use vsock_proto::{
     BoundedExecStream as ProtoBoundedExecStream,
@@ -1080,8 +1081,20 @@ async fn request_raw_on_shared_with_write_timeout(
     timeout: Duration,
     write_timeout: Duration,
 ) -> io::Result<RawMessage> {
+    let is_write_file = msg_type == MSG_WRITE_FILE;
+    let request_started_at = Instant::now();
     let data = vsock_proto::encode(msg_type, seq, payload)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    if is_write_file {
+        info!(
+            seq,
+            payload_bytes = payload.len(),
+            frame_bytes = data.len(),
+            timeout_ms = timeout.as_millis() as u64,
+            write_timeout_ms = write_timeout.as_millis() as u64,
+            "vsock_host: write_file request start"
+        );
+    }
 
     // Register under the state lock: `Closed` short-circuits to an
     // immediate error, and insertion into `pending` is serialised with
@@ -1093,6 +1106,13 @@ async fn request_raw_on_shared_with_write_timeout(
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
             ConnectionState::Closed { .. } => {
+                if is_write_file {
+                    warn!(
+                        seq,
+                        duration_ms = request_started_at.elapsed().as_millis() as u64,
+                        "vsock_host: write_file connection closed before request registration"
+                    );
+                }
                 return Err(io::Error::new(
                     io::ErrorKind::ConnectionReset,
                     "connection closed",
@@ -1107,7 +1127,28 @@ async fn request_raw_on_shared_with_write_timeout(
 
     // The guard removes the pending entry on write failure, timeout, or
     // cancellation before reader_loop dispatches a response.
-    write_frame_on_shared_with_timeout(shared, &data, write_timeout).await?;
+    let write_started_at = Instant::now();
+    if let Err(e) = write_frame_on_shared_with_timeout(shared, &data, write_timeout).await {
+        if is_write_file {
+            warn!(
+                seq,
+                duration_ms = request_started_at.elapsed().as_millis() as u64,
+                write_ms = write_started_at.elapsed().as_millis() as u64,
+                error = %e,
+                error_kind = ?e.kind(),
+                "vsock_host: write_file frame write failed"
+            );
+        }
+        return Err(e);
+    }
+    if is_write_file {
+        info!(
+            seq,
+            write_ms = write_started_at.elapsed().as_millis() as u64,
+            "vsock_host: write_file frame write complete"
+        );
+    }
+    let response_wait_started_at = Instant::now();
 
     // `rx` returns `Ok(msg)` when the reader dispatches a response and
     // `Err(RecvError)` when `close()` drops the `Connected` variant. The
@@ -1115,12 +1156,43 @@ async fn request_raw_on_shared_with_write_timeout(
     tokio::select! {
         biased;
         result = rx => {
-            result.map_err(|_| io::Error::new(
-                io::ErrorKind::ConnectionReset,
-                "connection closed",
-            ))
+            match result {
+                Ok(msg) => {
+                    if is_write_file {
+                        info!(
+                            seq,
+                            response_type = msg.msg_type,
+                            response_wait_ms = response_wait_started_at.elapsed().as_millis() as u64,
+                            duration_ms = request_started_at.elapsed().as_millis() as u64,
+                            "vsock_host: write_file response received"
+                        );
+                    }
+                    Ok(msg)
+                }
+                Err(_) => {
+                    if is_write_file {
+                        warn!(
+                            seq,
+                            duration_ms = request_started_at.elapsed().as_millis() as u64,
+                            "vsock_host: write_file connection closed before response"
+                        );
+                    }
+                    Err(io::Error::new(
+                        io::ErrorKind::ConnectionReset,
+                        "connection closed",
+                    ))
+                }
+            }
         }
         _ = tokio::time::sleep(timeout) => {
+            if is_write_file {
+                warn!(
+                    seq,
+                    timeout_ms = timeout.as_millis() as u64,
+                    duration_ms = request_started_at.elapsed().as_millis() as u64,
+                    "vsock_host: write_file response timeout"
+                );
+            }
             Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"))
         }
     }
@@ -1825,15 +1897,38 @@ impl VsockHost {
         let payload = vsock_proto::encode_write_file(path, content, sudo, append)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
         let timeout = Duration::from_secs(300);
-        let resp = self.request(MSG_WRITE_FILE, &payload, timeout).await?;
+        let seq = self.shared.next_seq();
+        info!(
+            seq,
+            path,
+            bytes = content.len(),
+            sudo,
+            append,
+            timeout_ms = timeout.as_millis() as u64,
+            "vsock_host: write_file chunk start"
+        );
+        let resp =
+            request_raw_on_shared(&self.shared, MSG_WRITE_FILE, seq, &payload, timeout).await?;
 
         if resp.msg_type == MSG_ERROR {
             let msg = vsock_proto::decode_error(&resp.payload)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+            warn!(
+                seq,
+                path,
+                error = %msg,
+                "vsock_host: write_file chunk error response"
+            );
             return Err(io::Error::other(msg));
         }
 
         if resp.msg_type != MSG_WRITE_FILE_RESULT {
+            warn!(
+                seq,
+                path,
+                response_type = resp.msg_type,
+                "vsock_host: write_file chunk unexpected response type"
+            );
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("unexpected response type: 0x{:02X}", resp.msg_type),
@@ -1844,9 +1939,16 @@ impl VsockHost {
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
         if !success {
+            warn!(
+                seq,
+                path,
+                error = %error,
+                "vsock_host: write_file chunk failed in guest"
+            );
             return Err(io::Error::other(error));
         }
 
+        info!(seq, path, "vsock_host: write_file chunk complete");
         Ok(())
     }
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -55,8 +55,8 @@ const READ_BUF_SIZE: usize = 64 * 1024;
 const FIRECRACKER_CONNECT_ACK_MAX_BYTES: usize = 64;
 const FRAME_WRITE_TIMEOUT: Duration = Duration::from_secs(30);
 const BOUNDED_EXEC_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(10);
-const SLOW_WRITE_FILE_LOG_MS: u128 = 1_000;
-const SLOW_BOUNDED_EXEC_LOG_MS: u128 = 5_000;
+const SLOW_WRITE_FILE_LOG_MS: u64 = 1_000;
+const SLOW_BOUNDED_EXEC_LOG_MS: u64 = 5_000;
 
 /// Result of executing a command on the guest.
 #[derive(Debug, Clone)]
@@ -1165,14 +1165,15 @@ async fn request_raw_on_shared_with_write_timeout(
             match result {
                 Ok(msg) => {
                     if is_write_file {
-                        let response_wait_ms = response_wait_started_at.elapsed().as_millis();
-                        let duration_ms = request_started_at.elapsed().as_millis();
+                        let response_wait_ms =
+                            response_wait_started_at.elapsed().as_millis() as u64;
+                        let duration_ms = request_started_at.elapsed().as_millis() as u64;
                         if duration_ms >= SLOW_WRITE_FILE_LOG_MS {
                             info!(
                                 seq,
                                 response_type = msg.msg_type,
-                                response_wait_ms = response_wait_ms as u64,
-                                duration_ms = duration_ms as u64,
+                                response_wait_ms,
+                                duration_ms,
                                 "vsock_host: slow write_file response received"
                             );
                         }
@@ -1540,7 +1541,7 @@ async fn bounded_exec_on_shared_with_request_timeout(
     let termination = proto_termination_to_host(decoded.termination);
     let (stdout_bytes, stdout_truncated) = proto_output_summary(&decoded.stdout);
     let (stderr_bytes, stderr_truncated) = proto_output_summary(&decoded.stderr);
-    let duration_ms = request_started_at.elapsed().as_millis();
+    let duration_ms = request_started_at.elapsed().as_millis() as u64;
     if duration_ms >= SLOW_BOUNDED_EXEC_LOG_MS {
         info!(
             seq,
@@ -1557,7 +1558,7 @@ async fn bounded_exec_on_shared_with_request_timeout(
             stderr_bytes,
             stderr_truncated,
             diagnostic = decoded.diagnostic.is_some(),
-            duration_ms = duration_ms as u64,
+            duration_ms,
             "vsock_host: slow bounded_exec completed"
         );
     }
@@ -2083,13 +2084,13 @@ impl VsockHost {
             return Err(io::Error::other(error));
         }
 
-        let duration_ms = started_at.elapsed().as_millis();
+        let duration_ms = started_at.elapsed().as_millis() as u64;
         if duration_ms >= SLOW_WRITE_FILE_LOG_MS {
             info!(
                 seq,
                 path,
                 bytes = content.len(),
-                duration_ms = duration_ms as u64,
+                duration_ms,
                 "vsock_host: slow write_file chunk complete"
             );
         }

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -55,6 +55,7 @@ const READ_BUF_SIZE: usize = 64 * 1024;
 const FIRECRACKER_CONNECT_ACK_MAX_BYTES: usize = 64;
 const FRAME_WRITE_TIMEOUT: Duration = Duration::from_secs(30);
 const BOUNDED_EXEC_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(10);
+const SLOW_WRITE_FILE_LOG_MS: u128 = 1_000;
 
 /// Result of executing a command on the guest.
 #[derive(Debug, Clone)]
@@ -1085,16 +1086,6 @@ async fn request_raw_on_shared_with_write_timeout(
     let request_started_at = Instant::now();
     let data = vsock_proto::encode(msg_type, seq, payload)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
-    if is_write_file {
-        info!(
-            seq,
-            payload_bytes = payload.len(),
-            frame_bytes = data.len(),
-            timeout_ms = timeout.as_millis() as u64,
-            write_timeout_ms = write_timeout.as_millis() as u64,
-            "vsock_host: write_file request start"
-        );
-    }
 
     // Register under the state lock: `Closed` short-circuits to an
     // immediate error, and insertion into `pending` is serialised with
@@ -1141,13 +1132,6 @@ async fn request_raw_on_shared_with_write_timeout(
         }
         return Err(e);
     }
-    if is_write_file {
-        info!(
-            seq,
-            write_ms = write_started_at.elapsed().as_millis() as u64,
-            "vsock_host: write_file frame write complete"
-        );
-    }
     let response_wait_started_at = Instant::now();
 
     // `rx` returns `Ok(msg)` when the reader dispatches a response and
@@ -1159,13 +1143,17 @@ async fn request_raw_on_shared_with_write_timeout(
             match result {
                 Ok(msg) => {
                     if is_write_file {
-                        info!(
-                            seq,
-                            response_type = msg.msg_type,
-                            response_wait_ms = response_wait_started_at.elapsed().as_millis() as u64,
-                            duration_ms = request_started_at.elapsed().as_millis() as u64,
-                            "vsock_host: write_file response received"
-                        );
+                        let response_wait_ms = response_wait_started_at.elapsed().as_millis();
+                        let duration_ms = request_started_at.elapsed().as_millis();
+                        if duration_ms >= SLOW_WRITE_FILE_LOG_MS {
+                            info!(
+                                seq,
+                                response_type = msg.msg_type,
+                                response_wait_ms = response_wait_ms as u64,
+                                duration_ms = duration_ms as u64,
+                                "vsock_host: write_file response received"
+                            );
+                        }
                     }
                     Ok(msg)
                 }
@@ -1898,17 +1886,24 @@ impl VsockHost {
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
         let timeout = Duration::from_secs(300);
         let seq = self.shared.next_seq();
-        info!(
-            seq,
-            path,
-            bytes = content.len(),
-            sudo,
-            append,
-            timeout_ms = timeout.as_millis() as u64,
-            "vsock_host: write_file chunk start"
-        );
-        let resp =
-            request_raw_on_shared(&self.shared, MSG_WRITE_FILE, seq, &payload, timeout).await?;
+        let started_at = Instant::now();
+        let resp = match request_raw_on_shared(&self.shared, MSG_WRITE_FILE, seq, &payload, timeout)
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => {
+                warn!(
+                    seq,
+                    path,
+                    bytes = content.len(),
+                    duration_ms = started_at.elapsed().as_millis() as u64,
+                    error = %e,
+                    error_kind = ?e.kind(),
+                    "vsock_host: write_file chunk request failed"
+                );
+                return Err(e);
+            }
+        };
 
         if resp.msg_type == MSG_ERROR {
             let msg = vsock_proto::decode_error(&resp.payload)
@@ -1948,7 +1943,16 @@ impl VsockHost {
             return Err(io::Error::other(error));
         }
 
-        info!(seq, path, "vsock_host: write_file chunk complete");
+        let duration_ms = started_at.elapsed().as_millis();
+        if duration_ms >= SLOW_WRITE_FILE_LOG_MS {
+            info!(
+                seq,
+                path,
+                bytes = content.len(),
+                duration_ms = duration_ms as u64,
+                "vsock_host: write_file chunk complete"
+            );
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- add slow-path diagnostics around storage cache lock wait/hold and guest archive write_file staging
- add vsock-host write_file timeout/connection/error diagnostics with seq/path/bytes/duration fields
- add guest-side write_file handler and response-send slow/failure diagnostics
- add scoped slow-stage diagnostics for guest log copy so delayed post-job uploads show whether they are waiting on bounded_exec or the host stream writer
- add vsock-host bounded_exec diagnostics for frame write failure, response timeout, connection close, protocol/decode errors, and slow completion without logging full commands
- suppress normal short successful logs; only slow successes and failures/anomalies are emitted

## Tests
- cargo check --manifest-path crates/Cargo.toml -p runner -p vsock-host
- cargo check --manifest-path crates/Cargo.toml -p runner -p vsock-host -p vsock-guest
- cargo test --manifest-path crates/Cargo.toml -p runner storage_cache
- cargo test --manifest-path crates/Cargo.toml -p runner copy_guest_logs
- cargo test --manifest-path crates/Cargo.toml -p vsock-host write_file
- cargo test --manifest-path crates/Cargo.toml -p vsock-host bounded_exec
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest write_file
- cargo clippy --manifest-path crates/Cargo.toml -p runner -p vsock-host --all-targets --all-features -- -D warnings
- pre-commit cargo fmt / clippy / doc
