### PR TITLE
fix: align v1 chat thread read route parity

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-v1.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-v1.test.ts
@@ -70,6 +70,39 @@ async function seedPatFixture(): Promise<PatFixture> {
   return { token, tokenId, userId, orgId };
 }
 
+async function seedExpiredPatFixture(): Promise<PatFixture> {
+  const tokenId = randomUUID();
+  const userId = `user_${randomUUID()}`;
+  const orgId = `org_${randomUUID()}`;
+  const expiredSeconds = currentSecond() - 60;
+
+  const token = signPatJwtForTests({
+    scope: "cli",
+    userId,
+    orgId,
+    tokenId,
+    iat: expiredSeconds - 60,
+    exp: expiredSeconds,
+  });
+  const writeDb = store.set(writeDb$);
+
+  await writeDb.insert(cliTokens).values({
+    id: tokenId,
+    token,
+    userId,
+    name: "expired test token",
+    expiresAt: new Date(now() - 60_000),
+  });
+  await writeDb.insert(orgMembersCache).values({
+    orgId,
+    userId,
+    role: "admin",
+    cachedAt: new Date(now()),
+  });
+
+  return { token, tokenId, userId, orgId };
+}
+
 async function deletePatFixture(fixture: PatFixture): Promise<void> {
   const writeDb = store.set(writeDb$);
   await writeDb
@@ -262,6 +295,45 @@ describe("GET /api/v1/chat-threads/:threadId", () => {
     });
   });
 
+  it("returns 401 for an opaque bearer token", async () => {
+    const client = setupApp({ context })(chatThreadV1GetContract);
+    await accept(
+      client.get({
+        params: { threadId: randomUUID() },
+        headers: { authorization: "Bearer ak_unknown_opaque_secret" },
+      }),
+      [401],
+    );
+  });
+
+  it("returns 401 when the PAT row has been revoked", async () => {
+    const pat = await seedPatFixture();
+    await deletePatFixture(pat);
+
+    const client = setupApp({ context })(chatThreadV1GetContract);
+    await accept(
+      client.get({
+        params: { threadId: randomUUID() },
+        headers: { authorization: `Bearer ${pat.token}` },
+      }),
+      [401],
+    );
+  });
+
+  it("returns 401 when the PAT is expired", async () => {
+    const pat = await seedExpiredPatFixture();
+    pats.push(pat);
+
+    const client = setupApp({ context })(chatThreadV1GetContract);
+    await accept(
+      client.get({
+        params: { threadId: randomUUID() },
+        headers: { authorization: `Bearer ${pat.token}` },
+      }),
+      [401],
+    );
+  });
+
   it("returns 403 when authenticated with a sandbox token", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
@@ -350,6 +422,43 @@ describe("GET /api/v1/chat-threads/:threadId/messages", () => {
     ).toStrictEqual([m1, m2]);
     expect(response.body.messages[0]?.content).toBe("first");
     expect(response.body.messages[1]?.role).toBe("assistant");
+  });
+
+  it("returns 401 when no Authorization header is provided", async () => {
+    const client = setupApp({ context })(chatThreadV1MessagesContract);
+    await accept(
+      client.list({
+        params: { threadId: randomUUID() },
+        query: {},
+        headers: {},
+      }),
+      [401],
+    );
+  });
+
+  it("returns 403 when authenticated with a sandbox token", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const runId = randomUUID();
+    const nowSeconds = currentSecond();
+    const sandboxToken = signSandboxJwtForTests({
+      scope: "sandbox",
+      userId,
+      orgId,
+      runId,
+      iat: nowSeconds,
+      exp: nowSeconds + 60,
+    });
+
+    const client = setupApp({ context })(chatThreadV1MessagesContract);
+    await accept(
+      client.list({
+        params: { threadId: randomUUID() },
+        query: {},
+        headers: { authorization: `Bearer ${sandboxToken}` },
+      }),
+      [403],
+    );
   });
 
   it("paginates forward with sinceId", async () => {

--- a/turbo/apps/web/app/api/v1/chat-threads/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/v1/chat-threads/__tests__/route.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../../../../../src/__tests__/db-test-seeders/auth";
 import { updateOrgDefaultAgent } from "../../../../../src/__tests__/db-test-seeders/org";
 import { getTestZeroAgentId } from "../../../../../src/__tests__/db-test-assertions/agents";
+import { generateSandboxToken } from "../../../../../src/lib/auth/sandbox-token";
 import { randomUUID } from "crypto";
 
 const context = testContext();
@@ -101,6 +102,31 @@ describe("GET /api/v1/chat-threads/:threadId", () => {
     expect(res.status).toBe(401);
   });
 
+  it("returns 400 for malformed threadId before API key auth", async () => {
+    const res = await getThread(
+      createTestRequest(GET_THREAD_URL("not-a-uuid"), { method: "GET" }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("threadId");
+  });
+
+  it("returns 403 for sandbox token auth", async () => {
+    const token = await generateSandboxToken(
+      user.userId,
+      randomUUID(),
+      user.orgId,
+    );
+    const res = await getThread(
+      createTestRequest(GET_THREAD_URL(threadId), {
+        method: "GET",
+        headers: bearerHeaders(token),
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
   it("returns 200 with thread detail when PAT owns thread", async () => {
     const token = await mintApiKey(user);
     const res = await getThread(
@@ -135,6 +161,9 @@ describe("GET /api/v1/chat-threads/:threadId", () => {
 describe("GET /api/v1/chat-threads/:threadId/messages", () => {
   let user: UserContext;
   let threadId: string;
+  let baseTimeMs: number;
+  let firstMessageId: string;
+  let secondMessageId: string;
 
   beforeEach(async () => {
     context.setupMocks();
@@ -142,16 +171,21 @@ describe("GET /api/v1/chat-threads/:threadId/messages", () => {
     const compose = await createTestCompose(uniqueId("v1-get-msgs"));
     const agentId = await getTestZeroAgentId(user.orgId, compose.name);
     threadId = await insertTestChatThread(user.userId, agentId, "t");
-    await insertTestChatMessage({
+    baseTimeMs = Date.now() - 10_000;
+    const firstMessage = await insertTestChatMessage({
       chatThreadId: threadId,
       role: "user",
       content: "hello",
+      createdAt: new Date(baseTimeMs),
     });
-    await insertTestChatMessage({
+    firstMessageId = firstMessage.id;
+    const secondMessage = await insertTestChatMessage({
       chatThreadId: threadId,
       role: "assistant",
       content: "world",
+      createdAt: new Date(baseTimeMs + 1000),
     });
+    secondMessageId = secondMessage.id;
   });
 
   it("returns 401 without API key", async () => {
@@ -159,6 +193,21 @@ describe("GET /api/v1/chat-threads/:threadId/messages", () => {
       createTestRequest(GET_MESSAGES_URL(threadId), { method: "GET" }),
     );
     expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for sandbox token auth", async () => {
+    const token = await generateSandboxToken(
+      user.userId,
+      randomUUID(),
+      user.orgId,
+    );
+    const res = await getMessages(
+      createTestRequest(GET_MESSAGES_URL(threadId), {
+        method: "GET",
+        headers: bearerHeaders(token),
+      }),
+    );
+    expect(res.status).toBe(403);
   });
 
   it("returns 200 with messages", async () => {
@@ -178,6 +227,60 @@ describe("GET /api/v1/chat-threads/:threadId/messages", () => {
     expect(body.messages[0].status).toBeUndefined();
     expect(body.messages[1].role).toBe("assistant");
     expect(body.messages[1].content).toBe("world");
+  });
+
+  it("paginates forward with sinceId", async () => {
+    const thirdMessage = await insertTestChatMessage({
+      chatThreadId: threadId,
+      role: "user",
+      content: "again",
+      createdAt: new Date(baseTimeMs + 2000),
+    });
+
+    const token = await mintApiKey(user);
+    const res = await getMessages(
+      createTestRequest(
+        `${GET_MESSAGES_URL(threadId)}?sinceId=${firstMessageId}`,
+        {
+          method: "GET",
+          headers: bearerHeaders(token),
+        },
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(
+      body.messages.map((message: { id: string }) => {
+        return message.id;
+      }),
+    ).toStrictEqual([secondMessageId, thirdMessage.id]);
+  });
+
+  it("paginates backward with beforeId", async () => {
+    const thirdMessage = await insertTestChatMessage({
+      chatThreadId: threadId,
+      role: "user",
+      content: "again",
+      createdAt: new Date(baseTimeMs + 2000),
+    });
+
+    const token = await mintApiKey(user);
+    const res = await getMessages(
+      createTestRequest(
+        `${GET_MESSAGES_URL(threadId)}?beforeId=${thirdMessage.id}`,
+        {
+          method: "GET",
+          headers: bearerHeaders(token),
+        },
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(
+      body.messages.map((message: { id: string }) => {
+        return message.id;
+      }),
+    ).toStrictEqual([firstMessageId, secondMessageId]);
   });
 
   it("returns 404 when thread belongs to another user", async () => {

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
@@ -14,7 +14,10 @@ import {
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { reloadEnv } from "../../../../../../src/env";
 import type { MockInstance } from "vitest";
-import type { ingestToAxiom } from "../../../../../../src/lib/shared/axiom/client";
+import type {
+  flushAxiom,
+  ingestToAxiom,
+} from "../../../../../../src/lib/shared/axiom/client";
 
 const context = testContext();
 
@@ -30,6 +33,7 @@ describe("POST /api/webhooks/agent/telemetry", () => {
   let user: UserContext;
   let testComposeId: string;
   let axiomIngestMock: MockInstance<typeof ingestToAxiom>;
+  let axiomFlushMock: MockInstance<typeof flushAxiom>;
 
   beforeEach(async () => {
     // Stub the telemetry token so ingestSandboxOpLog runs end-to-end into
@@ -40,6 +44,7 @@ describe("POST /api/webhooks/agent/telemetry", () => {
     const mocks = context.setupMocks();
     user = await context.setupUser();
     axiomIngestMock = mocks.axiom.ingestToAxiom;
+    axiomFlushMock = mocks.axiom.flushAxiom;
 
     // setupMocks() installs an arrow-function impl on the global Axiom
     // constructor, which can't be `new`'d. Override it here with a regular
@@ -397,6 +402,10 @@ describe("POST /api/webhooks/agent/telemetry", () => {
           }),
         ]),
       );
+      expect(axiomFlushMock).toHaveBeenCalledWith({
+        client: "telemetry",
+        throwOnError: true,
+      });
     });
 
     it("should send systemLog and metrics to Axiom", async () => {

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
@@ -11,6 +11,7 @@ import { getSandboxAuthForRun } from "../../../../../src/lib/auth/get-sandbox-au
 import { logger } from "../../../../../src/lib/shared/logger";
 import {
   ingestToAxiom,
+  flushAxiom,
   getDatasetName,
   DATASETS,
 } from "../../../../../src/lib/shared/axiom";
@@ -119,6 +120,7 @@ const router = tsr.router(webhookTelemetryContract, {
         },
       );
       ingestToAxiom(axiomDataset, axiomEvents);
+      await flushAxiom({ client: "telemetry", throwOnError: true });
     }
 
     // Record sandbox internal operations as OpenTelemetry metrics (to sandbox-metric-{env} dataset)

--- a/turbo/apps/web/src/lib/auth/require-auth.ts
+++ b/turbo/apps/web/src/lib/auth/require-auth.ts
@@ -132,8 +132,9 @@ export function isAuthError(
  * that the user is still a member of that org — a PAT must not outlive
  * membership.
  *
- * Missing/invalid/revoked/expired keys (or keys whose user left the org)
- * return 401.
+ * Valid sandbox/zero tokens return 403 because the caller is authenticated
+ * with the wrong credential type. Missing/invalid/revoked/expired keys (or
+ * keys whose user left the org) return 401.
  */
 export async function requireApiKeyAuth(
   authHeader: string | undefined,
@@ -146,12 +147,34 @@ export async function requireApiKeyAuth(
       error: { message: "API key required", code: "UNAUTHORIZED" },
     },
   };
+  const forbiddenSandboxToken: AuthErrorResponse = {
+    status: 403 as const,
+    body: {
+      error: {
+        message: "This endpoint is not available for sandbox tokens",
+        code: "FORBIDDEN",
+      },
+    },
+  };
   if (!authHeader?.startsWith("Bearer ")) {
     scheduleShadowCheck(unauthorized, authHeader, cookieHeader, shadowOpts);
     return unauthorized;
   }
   const token = authHeader.substring(7);
   if (!isPatToken(token)) {
+    if (isSandboxToken(token)) {
+      const sandboxAuth = verifySandboxToken(token);
+      const zeroAuth = sandboxAuth ? null : verifyZeroToken(token);
+      if (sandboxAuth || zeroAuth) {
+        scheduleShadowCheck(
+          forbiddenSandboxToken,
+          authHeader,
+          cookieHeader,
+          shadowOpts,
+        );
+        return forbiddenSandboxToken;
+      }
+    }
     scheduleShadowCheck(unauthorized, authHeader, cookieHeader, shadowOpts);
     return unauthorized;
   }


### PR DESCRIPTION
## Summary

- align web PAT-only auth with API behavior by returning 403 for valid sandbox/zero tokens
- add web v1 chat thread read route coverage for malformed thread IDs, sandbox token rejection, and sinceId/beforeId pagination
- keep API-side coverage complete by adding opaque/revoked/expired PAT and messages auth/sandbox cases
- flush telemetry Axiom batches before network-log webhook responses so runner E2E can read network logs after upload (refs #12652)

Closes #12611

## Testing

- `pnpm -F web db:migrate`
- `pnpm install`
- `pnpm -F web exec vitest run app/api/v1/chat-threads/__tests__/route.test.ts` - 20 passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads-v1.test.ts` - 15 passed
- `pnpm -F web exec vitest run app/api/webhooks/agent/telemetry/__tests__/route.test.ts` - 14 passed
- `pnpm -F web run lint`
- `pnpm exec prettier --write apps/web/app/api/webhooks/agent/telemetry/route.ts apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts`
- `git diff --check`
- `pnpm format`
- `pnpm lint` exited 0 with an existing unrelated `zero-org-invite.test.ts` unused-var warning
- `pnpm knip`

Note: local `pnpm -F web run check-types` and the pre-commit `pnpm check-types` are blocked by existing unrelated local type errors in `apps/web`/`apps/api` files outside the telemetry change. The previous CI `lint-types` run was green on this PR before the web-only network-log flush commit; the new CI run is now revalidating the branch.
