### PR TITLE
ci: remove rust workflow caches

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -222,12 +222,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: crates -> target
-          shared-key: check
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
       - name: Check formatting
         run: |
           cd crates
@@ -344,13 +338,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: crates -> target
-          # Separate key from runner-build to avoid cache reservation race (#9447)
-          shared-key: aarch64-musl-nbd
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
       - name: Cross-compile nbd-cow tests for ARM64
         run: |
           cd crates
@@ -405,12 +392,6 @@ jobs:
       default-snapshot-hash: ${{ steps.build.outputs.default-snapshot-hash }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: crates -> target
-          shared-key: aarch64-musl-release
-          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # IMPORTANT: these compile settings (--release, default linker, no
       # custom RUSTFLAGS) must match release-please.yml so guest binary bytes

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1459,12 +1459,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: crates -> target
-          shared-key: aarch64-musl-release
-          save-if: false
-
       - name: Notify Slack - Starting
         id: slack-start
         if: ${{ vars.SLACK_RELEASE_CHANNEL_ID != '' }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1406,13 +1406,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: crates -> target
-          shared-key: aarch64-musl-release
-          # Read-only: crates.yml runner-build is the sole writer for this key
-          save-if: false
-
       # IMPORTANT: these compile settings (--release, default linker, no
       # custom RUSTFLAGS) must match release-please.yml so guest binary bytes
       # and rootfs_hash are identical across pipelines. The shared R2


### PR DESCRIPTION
## Summary
- remove `Swatinem/rust-cache@v2` from Rust CI jobs in `crates.yml`
- remove read-only Rust cache restore steps from `turbo.yml` and `release-please.yml`
- keep cargo build, test, doc, and runner image cache behavior unchanged

## Tests
- `git diff --check`
- `rg -n "Swatinem/rust-cache|rust-cache@v2" .github/workflows || true`