### PR TITLE
feat: enable Codex memory mounting

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -261,6 +261,10 @@ fn build_codex_developer_instructions_config(append_system_prompt: &str) -> Stri
     format!("developer_instructions={value}")
 }
 
+fn build_codex_memories_config() -> String {
+    "features.memories=true".to_string()
+}
+
 fn build_codex_args(
     working_dir: &str,
     model: &str,
@@ -277,6 +281,9 @@ fn build_codex_args(
         "-C".to_string(),
         working_dir.to_string(),
     ];
+
+    args.push("-c".to_string());
+    args.push(build_codex_memories_config());
 
     if !model.is_empty() {
         args.push("-m".to_string());
@@ -1067,6 +1074,11 @@ mod tests {
         build_codex_args(working_dir, model, resume_id, append_system_prompt, prompt)
     }
 
+    fn codex_args_have_config(args: &[String], config: &str) -> bool {
+        args.windows(2)
+            .any(|window| window[0] == "-c" && window[1] == config)
+    }
+
     fn build_codex_command_for_test(use_mock: bool) -> Vec<String> {
         disable_system_log();
         build_codex_command(use_mock)
@@ -1082,6 +1094,7 @@ mod tests {
         assert!(args.contains(&"--skip-git-repo-check".to_string()));
         let c_idx = args.iter().position(|a| a == "-C").unwrap();
         assert_eq!(args[c_idx + 1], "/workspace");
+        assert!(codex_args_have_config(&args, "features.memories=true"));
         assert_eq!(args.last().unwrap(), "hello");
     }
 
@@ -1140,18 +1153,18 @@ mod tests {
             "Your name is Aria.",
             "analyze this",
         );
-        let c_idx = args.iter().position(|a| a == "-c").unwrap();
-        assert_eq!(
-            args[c_idx + 1],
+        assert!(codex_args_have_config(&args, "features.memories=true"));
+        assert!(codex_args_have_config(
+            &args,
             r#"developer_instructions="Your name is Aria.""#
-        );
+        ));
         assert_eq!(args.last().unwrap(), "analyze this");
     }
 
     #[test]
     fn build_codex_args_empty_append_system_prompt_omitted() {
         let args = build_codex_args_with_append_for_test("/wd", "", "", "", "test");
-        assert!(!args.contains(&"-c".to_string()));
+        assert!(codex_args_have_config(&args, "features.memories=true"));
         assert!(
             !args
                 .iter()
@@ -1163,10 +1176,14 @@ mod tests {
     fn build_codex_args_resume_with_append_system_prompt_order() {
         let args =
             build_codex_args_with_append_for_test("/wd", "", "thread-abc", "Be concise.", "next");
-        let c_idx = args.iter().position(|a| a == "-c").unwrap();
+        let c_idx = args
+            .iter()
+            .position(|a| a == r#"developer_instructions="Be concise.""#)
+            .unwrap();
         let r_idx = args.iter().position(|a| a == "resume").unwrap();
         assert!(c_idx < r_idx);
-        assert_eq!(args[c_idx + 1], r#"developer_instructions="Be concise.""#);
+        assert!(codex_args_have_config(&args, "features.memories=true"));
+        assert_eq!(args[c_idx], r#"developer_instructions="Be concise.""#);
         assert_eq!(args[r_idx + 1], "thread-abc");
         assert_eq!(args[r_idx + 2], "next");
         assert_eq!(args.len(), r_idx + 3);
@@ -1181,11 +1198,10 @@ mod tests {
             "Say \"hi\"\nPath C:\\tmp",
             "prompt",
         );
-        let c_idx = args.iter().position(|a| a == "-c").unwrap();
-        assert_eq!(
-            args[c_idx + 1],
+        assert!(codex_args_have_config(
+            &args,
             r#"developer_instructions="Say \"hi\"\nPath C:\\tmp""#
-        );
+        ));
     }
 
     #[test]

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -162,8 +162,8 @@ async fn execute(
         log_error!(LOG_TAG, "Codex setup failed (non-fatal, continuing): {e}");
     }
 
-    // Memory is now mounted directly at the Claude Code auto-memory path via
-    // manifest.artifacts[] — no runtime symlink needed (see #10602).
+    // Memory is mounted directly through manifest.artifacts[] at the
+    // framework-specific memory path — no runtime symlink needed (see #10602).
 
     let init_elapsed = start.elapsed();
     record_sandbox_op("init_total", init_elapsed, true, None);

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -11,8 +11,9 @@
 //! Usage (mirrors real Codex CLI):
 //! ```text
 //!   guest-mock-codex exec [--json] [--sandbox <mode>] [--skip-git-repo-check]
-//!                          [-C <dir>] [-m <model>] [--append-system-prompt <s>]
-//!                          [--last] [-- <prompt>]
+//!                          [-C <dir>] [-m <model>] [-c <config>]
+//!                          [--append-system-prompt <s>] [--last]
+//!                          [-- <prompt>]
 //!   guest-mock-codex exec resume <thread_id> [-- <prompt>]
 //! ```
 //!
@@ -70,6 +71,10 @@ struct ExecArgs {
     /// Model override (accepted, ignored).
     #[arg(short = 'm', long)]
     model: Option<String>,
+
+    /// Codex config override (accepted, ignored).
+    #[arg(short = 'c', long = "config")]
+    config: Vec<String>,
 
     /// Append-system-prompt (accepted, ignored).
     #[arg(long = "append-system-prompt")]

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -172,6 +172,10 @@ fn accepts_all_no_op_flags_without_failing() {
             "/tmp",
             "-m",
             "gpt-5",
+            "-c",
+            "features.memories=true",
+            "--config",
+            "developer_instructions=\"your name is Aria\"",
             "--append-system-prompt",
             "your name is Aria",
             "--",
@@ -193,6 +197,51 @@ fn prompt_without_double_dash_separator_works() {
     assert_eq!(out.status, 0);
     assert_eq!(out.events.len(), 3);
     assert_eq!(out.events[1]["item"]["text"], "hello world");
+}
+
+#[test]
+fn config_flags_before_prompt_are_not_echoed() {
+    let dir = TempDir::new().unwrap();
+    let out = run(
+        dir.path(),
+        &[
+            "exec",
+            "--json",
+            "-c",
+            "features.memories=true",
+            "hello from codex",
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(out.status, 0);
+    assert_eq!(out.events.len(), 3);
+    assert_eq!(out.events[1]["item"]["text"], "hello from codex");
+}
+
+#[test]
+fn config_flags_before_resume_are_not_echoed() {
+    let dir = TempDir::new().unwrap();
+    let first = run(dir.path(), &["exec", "--json", "--", "turn-1"]).unwrap();
+    let thread_id = first.events[0]["thread_id"].as_str().unwrap().to_string();
+
+    let second = run(
+        dir.path(),
+        &[
+            "exec",
+            "--json",
+            "-c",
+            "features.memories=true",
+            "resume",
+            &thread_id,
+            "turn-2",
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(second.status, 0);
+    assert_eq!(second.events[0]["thread_id"], thread_id);
+    assert_eq!(second.events[1]["item"]["text"], "turn-2");
 }
 
 #[test]

--- a/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
+++ b/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
@@ -12,6 +12,7 @@
 #   401), billableFirewalls covers the firewall → "$" marker present.
 
 load '../../helpers/setup'
+load '../../helpers/codex-zero'
 
 setup_file() {
     if [ -z "$ANTHROPIC_API_KEY" ]; then
@@ -48,6 +49,12 @@ EOF
         echo "# Failed to extract composeId from: $compose_out" >&2
         return 1
     }
+
+    # Seed the zero_agents row (PK = composeId) without creating a persistent
+    # zero agent. vm0 compose only writes agent_composes; zero run requires the
+    # lazy metadata upsert path to materialize zero_agents.
+    _codex_zero_curl "/api/zero/composes/$COMPOSE_ID/metadata" \
+        -X PATCH -d '{"displayName":"Billable firewall e2e"}' >/dev/null
 }
 
 teardown_file() {
@@ -62,6 +69,7 @@ teardown_file() {
 
     RUN_ID=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
     [ -n "$RUN_ID" ] || {
+        echo "$output"
         echo "# Failed to extract Run ID"
         return 1
     }
@@ -78,6 +86,7 @@ teardown_file() {
 
     RUN_ID=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
     [ -n "$RUN_ID" ] || {
+        echo "$output"
         echo "# Failed to extract Run ID"
         return 1
     }

--- a/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
+++ b/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
@@ -2,9 +2,8 @@
 
 # Verify firewall_billable propagation through the full stack.
 #
-# Uses `zero run --model-provider` for per-run provider selection. The test
-# keeps the real zero-agent creation path because it exercises the same compose
-# metadata and environment defaults as user-created agents.
+# Uses `zero run --model-provider` for per-run provider selection — the test
+# never changes the shared e2e org's default, so no race with other chunks.
 #
 # t54-0: no override; resolver uses bootstrap claude-code-oauth-token default.
 #   Mock token 401s upstream but the firewall tag is stamped; "$" marker absent.
@@ -13,23 +12,12 @@
 
 load '../../helpers/setup'
 
-cleanup_stale_billable_agents() {
-    local agents_out
-    agents_out=$($ZERO_CLI agent list 2>/dev/null || true)
-
-    echo "$agents_out" | awk '$0 ~ /e2e-billable-/ { print $1 }' | while read -r agent_id; do
-        [ -n "$agent_id" ] || continue
-        $ZERO_CLI agent delete "$agent_id" --yes >/dev/null 2>&1 || true
-    done
-}
-
 setup_file() {
     if [ -z "$ANTHROPIC_API_KEY" ]; then
         skip "ANTHROPIC_API_KEY not set — required for real Claude calls"
     fi
 
     export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
-    cleanup_stale_billable_agents
 
     # Ensure vm0 provider coexists with bootstrap claude-code-oauth-token.
     # CLI non-interactive mode requires --secret; the API route detects
@@ -39,10 +27,10 @@ setup_file() {
         --secret unused-vm0-is-no-secret \
         --model claude-sonnet-4-6 >/dev/null
 
+    # Create a fresh zero agent for this file
     local create_out
     create_out=$($ZERO_CLI agent create --display-name "e2e-billable-${UNIQUE_ID}")
-    export AGENT_ID
-    AGENT_ID=$(echo "$create_out" | grep -oP 'Agent ID:\s+\K[a-f0-9-]{36}')
+    export AGENT_ID=$(echo "$create_out" | grep -oP 'Agent ID:\s+\K[a-f0-9-]{36}')
     [ -n "$AGENT_ID" ] || {
         echo "# Failed to extract Agent ID from: $create_out" >&2
         return 1
@@ -50,7 +38,7 @@ setup_file() {
 }
 
 teardown_file() {
-    [ -n "$AGENT_ID" ] && $ZERO_CLI agent delete "$AGENT_ID" --yes 2>/dev/null || true
+    [ -n "$AGENT_ID" ] && $ZERO_CLI agent delete "$AGENT_ID" 2>/dev/null || true
     $ZERO_CLI org model-provider remove vm0 2>/dev/null || true
 }
 

--- a/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
+++ b/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
@@ -2,8 +2,9 @@
 
 # Verify firewall_billable propagation through the full stack.
 #
-# Uses `zero run --model-provider` for per-run provider selection — the test
-# never changes the shared e2e org's default, so no race with other chunks.
+# Uses `zero run --model-provider` for per-run provider selection. The test
+# creates a compose-backed agent instead of a persistent zero agent, so it does
+# not depend on the shared e2e org's agent quota.
 #
 # t54-0: no override; resolver uses bootstrap claude-code-oauth-token default.
 #   Mock token 401s upstream but the firewall tag is stamped; "$" marker absent.
@@ -18,6 +19,8 @@ setup_file() {
     fi
 
     export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
+    export AGENT_NAME="e2e-billable-${UNIQUE_ID}"
+    export TEST_DIR="$(mktemp -d)"
 
     # Ensure vm0 provider coexists with bootstrap claude-code-oauth-token.
     # CLI non-interactive mode requires --secret; the API route detects
@@ -27,23 +30,33 @@ setup_file() {
         --secret unused-vm0-is-no-secret \
         --model claude-sonnet-4-6 >/dev/null
 
-    # Create a fresh zero agent for this file
-    local create_out
-    create_out=$($ZERO_CLI agent create --display-name "e2e-billable-${UNIQUE_ID}")
-    export AGENT_ID=$(echo "$create_out" | grep -oP 'Agent ID:\s+\K[a-f0-9-]{36}')
-    [ -n "$AGENT_ID" ] || {
-        echo "# Failed to extract Agent ID from: $create_out" >&2
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  ${AGENT_NAME}:
+    description: "Billable firewall e2e agent"
+    framework: claude-code
+    working_dir: /home/user/workspace
+EOF
+
+    local compose_out
+    compose_out=$($VM0_CLI compose --yes --json "$TEST_DIR/vm0.yaml")
+    export COMPOSE_ID
+    COMPOSE_ID=$(echo "$compose_out" | python3 -c "import sys,json; print(json.load(sys.stdin)['composeId'])")
+    [ -n "$COMPOSE_ID" ] || {
+        echo "# Failed to extract composeId from: $compose_out" >&2
         return 1
     }
 }
 
 teardown_file() {
-    [ -n "$AGENT_ID" ] && $ZERO_CLI agent delete "$AGENT_ID" 2>/dev/null || true
+    [ -n "$TEST_DIR" ] && rm -rf "$TEST_DIR"
     $ZERO_CLI org model-provider remove vm0 2>/dev/null || true
 }
 
 @test "t54-0: bootstrap provider — firewall not billable" {
-    run $ZERO_CLI run "$AGENT_ID" \
+    run $ZERO_CLI run "$COMPOSE_ID" \
         --debug-no-mock-claude \
         "Reply with exactly: DONE"
 
@@ -58,7 +71,7 @@ teardown_file() {
 }
 
 @test "t54-1: vm0 meta-provider — firewall billable" {
-    run $ZERO_CLI run "$AGENT_ID" \
+    run $ZERO_CLI run "$COMPOSE_ID" \
         --model-provider vm0 \
         --debug-no-mock-claude \
         "Reply with exactly: DONE"

--- a/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
+++ b/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
@@ -3,8 +3,8 @@
 # Verify firewall_billable propagation through the full stack.
 #
 # Uses `zero run --model-provider` for per-run provider selection. The test
-# creates a compose-backed agent instead of a persistent zero agent, so it does
-# not depend on the shared e2e org's agent quota.
+# keeps the real zero-agent creation path because it exercises the same compose
+# metadata and environment defaults as user-created agents.
 #
 # t54-0: no override; resolver uses bootstrap claude-code-oauth-token default.
 #   Mock token 401s upstream but the firewall tag is stamped; "$" marker absent.
@@ -12,7 +12,16 @@
 #   401), billableFirewalls covers the firewall → "$" marker present.
 
 load '../../helpers/setup'
-load '../../helpers/codex-zero'
+
+cleanup_stale_billable_agents() {
+    local agents_out
+    agents_out=$($ZERO_CLI agent list 2>/dev/null || true)
+
+    echo "$agents_out" | awk '$0 ~ /e2e-billable-/ { print $1 }' | while read -r agent_id; do
+        [ -n "$agent_id" ] || continue
+        $ZERO_CLI agent delete "$agent_id" --yes >/dev/null 2>&1 || true
+    done
+}
 
 setup_file() {
     if [ -z "$ANTHROPIC_API_KEY" ]; then
@@ -20,8 +29,7 @@ setup_file() {
     fi
 
     export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
-    export AGENT_NAME="e2e-billable-${UNIQUE_ID}"
-    export TEST_DIR="$(mktemp -d)"
+    cleanup_stale_billable_agents
 
     # Ensure vm0 provider coexists with bootstrap claude-code-oauth-token.
     # CLI non-interactive mode requires --secret; the API route detects
@@ -31,45 +39,28 @@ setup_file() {
         --secret unused-vm0-is-no-secret \
         --model claude-sonnet-4-6 >/dev/null
 
-    cat > "$TEST_DIR/vm0.yaml" <<EOF
-version: "1.0"
-
-agents:
-  ${AGENT_NAME}:
-    description: "Billable firewall e2e agent"
-    framework: claude-code
-    working_dir: /home/user/workspace
-EOF
-
-    local compose_out
-    compose_out=$($VM0_CLI compose --yes --json "$TEST_DIR/vm0.yaml")
-    export COMPOSE_ID
-    COMPOSE_ID=$(echo "$compose_out" | python3 -c "import sys,json; print(json.load(sys.stdin)['composeId'])")
-    [ -n "$COMPOSE_ID" ] || {
-        echo "# Failed to extract composeId from: $compose_out" >&2
+    local create_out
+    create_out=$($ZERO_CLI agent create --display-name "e2e-billable-${UNIQUE_ID}")
+    export AGENT_ID
+    AGENT_ID=$(echo "$create_out" | grep -oP 'Agent ID:\s+\K[a-f0-9-]{36}')
+    [ -n "$AGENT_ID" ] || {
+        echo "# Failed to extract Agent ID from: $create_out" >&2
         return 1
     }
-
-    # Seed the zero_agents row (PK = composeId) without creating a persistent
-    # zero agent. vm0 compose only writes agent_composes; zero run requires the
-    # lazy metadata upsert path to materialize zero_agents.
-    _codex_zero_curl "/api/zero/composes/$COMPOSE_ID/metadata" \
-        -X PATCH -d '{"displayName":"Billable firewall e2e"}' >/dev/null
 }
 
 teardown_file() {
-    [ -n "$TEST_DIR" ] && rm -rf "$TEST_DIR"
+    [ -n "$AGENT_ID" ] && $ZERO_CLI agent delete "$AGENT_ID" --yes 2>/dev/null || true
     $ZERO_CLI org model-provider remove vm0 2>/dev/null || true
 }
 
 @test "t54-0: bootstrap provider — firewall not billable" {
-    run $ZERO_CLI run "$COMPOSE_ID" \
+    run $ZERO_CLI run "$AGENT_ID" \
         --debug-no-mock-claude \
         "Reply with exactly: DONE"
 
     RUN_ID=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
     [ -n "$RUN_ID" ] || {
-        echo "$output"
         echo "# Failed to extract Run ID"
         return 1
     }
@@ -79,14 +70,13 @@ teardown_file() {
 }
 
 @test "t54-1: vm0 meta-provider — firewall billable" {
-    run $ZERO_CLI run "$COMPOSE_ID" \
+    run $ZERO_CLI run "$AGENT_ID" \
         --model-provider vm0 \
         --debug-no-mock-claude \
         "Reply with exactly: DONE"
 
     RUN_ID=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
     [ -n "$RUN_ID" ] || {
-        echo "$output"
         echo "# Failed to extract Run ID"
         return 1
     }

--- a/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
@@ -15,6 +15,7 @@ import {
   insertVm0ApiKeys,
   deleteInsertedVm0ApiKeys,
   insertTestConnectorSecret,
+  createTestOrgModelProvider,
 } from "../../../__tests__/api-test-helpers";
 import { getTestZeroAgentId } from "../../../__tests__/db-test-assertions/agents";
 import {
@@ -23,6 +24,7 @@ import {
 } from "../../../__tests__/db-test-seeders/agents";
 import { setOrgCredits } from "../../../__tests__/db-test-seeders/org";
 import { setTestCheckpointArtifactSnapshots } from "../../../__tests__/db-test-seeders/runs";
+import { seedUserFeatureSwitches } from "../../../__tests__/db-test-seeders/feature-switches";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
 import { createZeroRun } from "../zero-run-service";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
@@ -37,7 +39,11 @@ import { setVariable } from "../variable/variable-service";
 import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 import { isNoModelProvider } from "@vm0/api-services/errors";
 import { reloadEnv } from "../../../env";
-import { AUTO_MEMORY_ARTIFACT_NAME, AUTO_MEMORY_MOUNT_PATH } from "../memory";
+import {
+  AUTO_MEMORY_ARTIFACT_NAME,
+  AUTO_MEMORY_MOUNT_PATH,
+  CODEX_AUTO_MEMORY_MOUNT_PATH,
+} from "../memory";
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 
 const context = testContext();
@@ -536,6 +542,30 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
         });
       expect(memoryEntries).toHaveLength(1);
       expect(memoryEntries[0]!.mountPath).toBe(AUTO_MEMORY_MOUNT_PATH);
+    });
+
+    it("new codex run injects memory at CODEX_AUTO_MEMORY_MOUNT_PATH", async () => {
+      const agentName = uniqueId("codex-memory");
+      await createTestCompose(agentName, {
+        skipDefaultApiKey: true,
+      });
+      const codexAgentId = await getTestZeroAgentId(user.orgId, agentName);
+      await seedUserFeatureSwitches(user.orgId, user.userId, {
+        codexBeta: true,
+      });
+      await createTestOrgModelProvider("openai-api-key", "org-openai-key");
+
+      const result = await createZeroRun(baseParams({ agentId: codexAgentId }));
+      await context.mocks.flushAfter();
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      const memoryEntries =
+        job!.executionContext.storageManifest!.artifacts.filter((a) => {
+          return a.vasStorageName === AUTO_MEMORY_ARTIFACT_NAME;
+        });
+      expect(memoryEntries).toHaveLength(1);
+      expect(memoryEntries[0]!.mountPath).toBe(CODEX_AUTO_MEMORY_MOUNT_PATH);
     });
 
     it("checkpoint resume trusts resolution memory entry", async () => {

--- a/turbo/apps/web/src/lib/zero/__tests__/run-queue-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/run-queue-service.test.ts
@@ -31,7 +31,11 @@ import {
 } from "../../../__tests__/db-test-seeders/runs";
 import { insertTestChatThread } from "../../../__tests__/db-test-seeders/agents";
 import { getTestAgentSessionArtifacts } from "../../../__tests__/db-test-assertions/agents";
-import { AUTO_MEMORY_ARTIFACT_NAME, AUTO_MEMORY_MOUNT_PATH } from "../memory";
+import {
+  AUTO_MEMORY_ARTIFACT_NAME,
+  AUTO_MEMORY_MOUNT_PATH,
+  CODEX_AUTO_MEMORY_MOUNT_PATH,
+} from "../memory";
 import { mockAblyPublish } from "../../../__tests__/ably-mock";
 
 const context = testContext();
@@ -108,6 +112,24 @@ describe("run-queue-service", () => {
         {
           name: AUTO_MEMORY_ARTIFACT_NAME,
           mountPath: AUTO_MEMORY_MOUNT_PATH,
+        },
+      ]);
+    });
+
+    it("should seed codex queued sessions with codex memory path", async () => {
+      const result = await enqueueRun(
+        baseParams({ prompt: "Codex memory seed" }),
+        { runtimeFramework: "codex" },
+      );
+
+      const run = await findTestRunRecord(result.runId);
+      expect(run).toBeDefined();
+
+      const artifacts = await getTestAgentSessionArtifacts(run!.sessionId);
+      expect(artifacts).toEqual([
+        {
+          name: AUTO_MEMORY_ARTIFACT_NAME,
+          mountPath: CODEX_AUTO_MEMORY_MOUNT_PATH,
         },
       ]);
     });

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -32,7 +32,11 @@ import {
 } from "../../../__tests__/db-test-assertions/agents";
 // eslint-disable-next-line web/no-direct-db-in-tests -- Service-level exception: no API route
 import { createZeroRun } from "../zero-run-service";
-import { AUTO_MEMORY_ARTIFACT_NAME, AUTO_MEMORY_MOUNT_PATH } from "../memory";
+import {
+  AUTO_MEMORY_ARTIFACT_NAME,
+  AUTO_MEMORY_MOUNT_PATH,
+  CODEX_AUTO_MEMORY_MOUNT_PATH,
+} from "../memory";
 import { reloadEnv } from "../../../env";
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
@@ -699,6 +703,31 @@ describe("createZeroRun() — service-only parameters", () => {
         {
           name: AUTO_MEMORY_ARTIFACT_NAME,
           mountPath: AUTO_MEMORY_MOUNT_PATH,
+        },
+      ]);
+    });
+
+    it("seeds codex agent_sessions.artifacts with codex memory path", async () => {
+      const agentName = uniqueId("codex-memory-session");
+      await createTestCompose(agentName, {
+        overrides: {
+          framework: "codex",
+          instructions: "AGENTS.md",
+          environment: { OPENAI_API_KEY: "test-api-key" },
+        },
+      });
+      const codexAgentId = await getTestZeroAgentId(user.orgId, agentName);
+
+      const result = await createZeroRun(baseParams({ agentId: codexAgentId }));
+
+      const run = await findTestRunRecord(result.runId);
+      expect(run).toBeDefined();
+
+      const artifacts = await getTestAgentSessionArtifacts(run!.sessionId);
+      expect(artifacts).toEqual([
+        {
+          name: AUTO_MEMORY_ARTIFACT_NAME,
+          mountPath: CODEX_AUTO_MEMORY_MOUNT_PATH,
         },
       ]);
     });

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -29,7 +29,7 @@ import type {
 } from "../infra/run/types";
 import type { ConversationResolution } from "../infra/run/resolvers";
 import type { AdditionalVolume } from "../infra/storage/types";
-import { AUTO_MEMORY_ARTIFACT_NAME, AUTO_MEMORY_MOUNT_PATH } from "./memory";
+import { AUTO_MEMORY_ARTIFACT_NAME, buildAutoMemoryArtifact } from "./memory";
 import { expandEnvironmentFromCompose } from "../infra/run/environment";
 import { resolveRuntimeFramework } from "../infra/run/utils";
 import { getUserPreferences } from "./user/user-preferences-service";
@@ -79,15 +79,6 @@ async function captureDuration<T>(
 }
 
 /**
- * Append the auto-memory artifact when this is a new run. On resume paths
- * (checkpoint, session, conversation continue) the resolver already emitted
- * memory at AUTO_MEMORY_MOUNT_PATH in resolution.artifacts — re-injecting here
- * would risk shadowing a divergent user-declared artifact named "memory".
- * When the resolution has no memory entry (very old data that predates
- * memory-as-artifact) we log and skip rather than silently mount over a path
- * the user may have declared for a different purpose.
- */
-/**
  * Merge multiple secretConnectorMap fragments. Used to combine the
  * connector-typed map (post-filter) with the model-provider-derived map
  * (which bypasses the filter — model-provider secrets ARE the source).
@@ -112,16 +103,23 @@ function mergeSecretConnectorMetadataMaps(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
+/**
+ * Append the auto-memory artifact when this is a new run. On resume paths
+ * (checkpoint, session, conversation continue) the resolver already emitted
+ * memory in resolution.artifacts — re-injecting here would risk shadowing a
+ * divergent user-declared artifact named "memory". When the resolution has no
+ * memory entry (very old data that predates memory-as-artifact), we log and
+ * skip rather than silently mount over a path the user may have declared for a
+ * different purpose.
+ */
 function injectAutoMemoryArtifactIfNewRun(
   artifacts: ContextArtifact[],
   resolution: ConversationResolution | null,
+  framework: SupportedFramework,
   logContext: Record<string, string>,
 ): ContextArtifact[] {
   if (resolution === null) {
-    return [
-      ...artifacts,
-      { name: AUTO_MEMORY_ARTIFACT_NAME, mountPath: AUTO_MEMORY_MOUNT_PATH },
-    ];
+    return [...artifacts, buildAutoMemoryArtifact(framework)];
   }
   const hasMemory = artifacts.some((a) => {
     return a.name === AUTO_MEMORY_ARTIFACT_NAME;
@@ -736,12 +734,6 @@ export async function resolveCliRunContext(
     );
   }
 
-  // Memory injection — see injectAutoMemoryArtifactIfNewRun().
-  artifacts = injectAutoMemoryArtifactIfNewRun(artifacts, resolution, {
-    userId: params.userId,
-    orgId: params.orgId,
-  });
-
   // Load compose content if we have a version ID
   if (!agentCompose && agentComposeVersionId) {
     agentCompose =
@@ -750,11 +742,22 @@ export async function resolveCliRunContext(
   }
 
   if (!agentCompose) {
+    const fallbackFramework = resolveRuntimeFramework({ agentCompose });
+    artifacts = injectAutoMemoryArtifactIfNewRun(
+      artifacts,
+      resolution,
+      fallbackFramework,
+      {
+        userId: params.userId,
+        orgId: params.orgId,
+      },
+    );
+
     // No compose available — return only what we can resolve
     return {
       artifacts,
       vars,
-      framework: resolveRuntimeFramework({ agentCompose }),
+      framework: fallbackFramework,
       billableFirewalls: [],
       timings: {
         resolveSource: resolveEnd - resolveStart,
@@ -829,6 +832,17 @@ export async function resolveCliRunContext(
     modelUsageProvider,
   } = secretsResult;
   const userTimezone = userPrefs?.timezone ?? undefined;
+
+  // Memory injection — see injectAutoMemoryArtifactIfNewRun().
+  artifacts = injectAutoMemoryArtifactIfNewRun(
+    artifacts,
+    resolution,
+    resolvedFramework,
+    {
+      userId: params.userId,
+      orgId: params.orgId,
+    },
+  );
 
   // Step 5: Compatibility checks for session continues.
   checkProviderCompatibility(originalModelProvider, resolvedModelProvider);
@@ -928,11 +942,6 @@ export async function buildZeroExecutionContext(
       (await loadAgentComposeForNewRun(agentComposeVersionId));
   }
 
-  // Memory injection — see injectAutoMemoryArtifactIfNewRun().
-  artifacts = injectAutoMemoryArtifactIfNewRun(artifacts, resolution, {
-    runId: params.runId,
-  });
-
   // Validate required fields
   if (!agentComposeVersionId) {
     throw notFound(
@@ -1024,6 +1033,16 @@ export async function buildZeroExecutionContext(
   const runtimeEnvironment = withRuntimeRunEnvironment(
     environment,
     params.triggerSource,
+  );
+
+  // Memory injection — see injectAutoMemoryArtifactIfNewRun().
+  artifacts = injectAutoMemoryArtifactIfNewRun(
+    artifacts,
+    resolution,
+    resolvedFramework,
+    {
+      runId: params.runId,
+    },
   );
 
   // Step 5: Compatibility checks for session continues.

--- a/turbo/apps/web/src/lib/zero/memory.ts
+++ b/turbo/apps/web/src/lib/zero/memory.ts
@@ -1,3 +1,4 @@
+import type { SupportedFramework } from "@vm0/core/frameworks";
 import type { ContextArtifact } from "../infra/run/types";
 
 // AUTO_MEMORY_MOUNT_PATH: derived from Claude Code's project-name encoding
@@ -8,19 +9,33 @@ import type { ContextArtifact } from "../infra/run/types";
 export const AUTO_MEMORY_MOUNT_PATH =
   "/home/user/.claude/projects/-home-user-workspace/memory";
 
+// Codex's native Memories feature reads and writes generated state below
+// ~/.codex/memories. Sharing the same artifact with Claude Code is an
+// experimental compatibility layer and may mix generated memory formats.
+export const CODEX_AUTO_MEMORY_MOUNT_PATH = "/home/user/.codex/memories";
+
 // Storage name used for the auto-synthesized memory artifact. Zero-layer
 // runs always include a ContextArtifact entry with this name mounted at
-// AUTO_MEMORY_MOUNT_PATH so Claude Code finds persistent memory without
-// any in-sandbox symlink bootstrap.
+// the framework's native auto-memory path so agents find persistent memory
+// without any in-sandbox symlink bootstrap.
 export const AUTO_MEMORY_ARTIFACT_NAME = "memory";
+
+function resolveAutoMemoryMountPath(framework: SupportedFramework): string {
+  if (framework === "codex") {
+    return CODEX_AUTO_MEMORY_MOUNT_PATH;
+  }
+  return AUTO_MEMORY_MOUNT_PATH;
+}
 
 // Seed ContextArtifact entry for auto-memory. Zero session insertion sites
 // use this so the row is self-describing from the moment of creation, and
 // resume paths resolve memory from session.artifacts without relying on
 // Zero re-injecting on every run.
-export function buildAutoMemoryArtifact(): ContextArtifact {
+export function buildAutoMemoryArtifact(
+  framework: SupportedFramework = "claude-code",
+): ContextArtifact {
   return {
     name: AUTO_MEMORY_ARTIFACT_NAME,
-    mountPath: AUTO_MEMORY_MOUNT_PATH,
+    mountPath: resolveAutoMemoryMountPath(framework),
   };
 }

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -12,6 +12,7 @@ import {
   avg,
   inArray,
 } from "drizzle-orm";
+import type { SupportedFramework } from "@vm0/core/frameworks";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentSessions } from "@vm0/db/schema/agent-session";
@@ -82,6 +83,7 @@ type QueuedRunDispatcher = (
 ) => Promise<void>;
 
 interface EnqueueRunOptions {
+  runtimeFramework?: SupportedFramework;
   zeroRunMetadata?: ZeroRunMetadataValues;
   onZeroRunMetadataPersisted?: (durationMs: number) => void;
 }
@@ -103,6 +105,7 @@ export async function enqueueRun(
 
   // Org context is required from caller
   const orgId = params.orgId;
+  const runtimeFramework = options.runtimeFramework ?? "claude-code";
 
   // composeId must be present on the zero path (resolved before enqueue).
   // Without it we cannot stamp agent_sessions.agent_compose_id.
@@ -135,7 +138,7 @@ export async function enqueueRun(
           userId,
           orgId,
           agentComposeId,
-          artifacts: [buildAutoMemoryArtifact()],
+          artifacts: [buildAutoMemoryArtifact(runtimeFramework)],
           conversationId: null,
         })
         .returning({ id: agentSessions.id });

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -322,6 +322,7 @@ function buildZeroRunMetadata(
 interface InsertRunWithAdvisoryLockParams {
   resolved: Awaited<ReturnType<typeof resolveStartRunCompose>>;
   runParams: CreateRunParams;
+  runFramework: SupportedFramework;
   orgTier: ReturnType<typeof orgTierSchema.parse>;
   composeId: string;
   params: CreateZeroRunParams;
@@ -346,6 +347,7 @@ async function insertRunWithAdvisoryLock(
   const {
     resolved,
     runParams,
+    runFramework,
     orgTier,
     composeId,
     params,
@@ -382,7 +384,7 @@ async function insertRunWithAdvisoryLock(
           additionalVolumes: runParams.additionalVolumes,
           resumedFromCheckpointId: runParams.resumedFromCheckpointId,
           sessionId: runParams.sessionId,
-          artifacts: [buildAutoMemoryArtifact()],
+          artifacts: [buildAutoMemoryArtifact(runFramework)],
         });
       });
       emit(CHAT_REQUEST_OPS.create_run_insert_run_record, insertT.ms);
@@ -399,6 +401,7 @@ async function insertRunWithAdvisoryLock(
     if (isConcurrentRunLimit(error)) {
       let persistDurationMs: number | undefined;
       const queueResult = await enqueueRun(runParams, {
+        runtimeFramework: runFramework,
         zeroRunMetadata,
         onZeroRunMetadataPersisted: (durationMs) => {
           persistDurationMs = durationMs;
@@ -764,6 +767,7 @@ async function createZeroRunRecord(
   const lockResult = await insertRunWithAdvisoryLock({
     resolved,
     runParams,
+    runFramework,
     orgTier,
     composeId: resolved.composeId,
     params,


### PR DESCRIPTION
## Summary

- make the auto-memory artifact mount path framework-aware, preserving Claude Code at /home/user/.claude/projects/-home-user-workspace/memory and mounting Codex at /home/user/.codex/memories
- seed new synchronous and queued Zero sessions with the resolved framework-specific memory artifact
- enable Codex Memories with the existing config override style: -c features.memories=true
- document that sharing the same memory artifact across Claude Code and Codex is experimental and may mix generated memory state formats

## Testing

- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm knip
- pnpm -F web exec vitest src/lib/zero/__tests__/run-queue-service.test.ts
- pnpm -F web exec vitest src/lib/zero/__tests__/zero-run-service.test.ts
- pnpm -F web exec vitest src/lib/zero/__tests__/build-zero-context.test.ts
- cargo test -p guest-agent build_codex_args
- cargo test -p guest-agent

Refs #12644