### PR TITLE
fix: migrate voice chat to Realtime GA API

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session.test.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/__tests__/voice-chat-session.test.ts
@@ -441,7 +441,7 @@ describe("voice-chat session", () => {
     vi.stubGlobal("Audio", FakeAudio);
 
     server.use(
-      http.post("https://api.openai.com/v1/realtime", () => {
+      http.post("https://api.openai.com/v1/realtime/calls", () => {
         return new HttpResponse("answer-sdp", { status: 200 });
       }),
     );

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -32,11 +32,7 @@ type ConnectionStatus =
   | "error";
 type BargeInMode = "speech_started" | "transcript_confirmed";
 
-// Model used for the SDP exchange URL. Session config (tools / VAD / etc.) is
-// preset server-side in createEphemeralToken — keep this file free of it.
-const TALKER_MODEL = "gpt-realtime-2";
-
-const OPENAI_REALTIME_BASE_URL = "https://api.openai.com/v1/realtime";
+const OPENAI_REALTIME_CALLS_URL = "https://api.openai.com/v1/realtime/calls";
 
 const TALKER_TOOL_NAMES = [
   "inform_slow_brain",
@@ -745,18 +741,15 @@ const setupWebRTC$ = command(
     await pc.setLocalDescription(offer);
     signal.throwIfAborted();
 
-    const sdpRes = await globalThis.fetch(
-      `${OPENAI_REALTIME_BASE_URL}?model=${TALKER_MODEL}`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/sdp",
-        },
-        body: offer.sdp,
-        signal,
+    const sdpRes = await globalThis.fetch(OPENAI_REALTIME_CALLS_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/sdp",
       },
-    );
+      body: offer.sdp,
+      signal,
+    });
     signal.throwIfAborted();
 
     if (!sdpRes.ok) {

--- a/turbo/apps/web/app/api/zero/voice-chat/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/token/__tests__/route.test.ts
@@ -135,29 +135,39 @@ describe("POST /api/zero/voice-chat/token", () => {
     expect(body.error.code).toBe("NOT_FOUND");
   });
 
-  describe("legacy branch (VoiceChatRealtimeBilling = OFF)", () => {
-    it("mints an ephemeral token and presets session config on the upstream", async () => {
+  describe("token minting (VoiceChatRealtimeBilling = OFF)", () => {
+    it("mints a GA ephemeral token and presets session config on the upstream", async () => {
       interface UpstreamBody {
-        model?: string;
-        modalities?: unknown;
-        instructions?: string;
-        input_audio_transcription?: unknown;
-        input_audio_noise_reduction?: unknown;
-        turn_detection?: unknown;
-        tools?: Array<{ name: string }>;
+        session?: {
+          type?: string;
+          model?: string;
+          output_modalities?: unknown;
+          instructions?: string;
+          audio?: {
+            input?: {
+              transcription?: unknown;
+              noise_reduction?: unknown;
+              turn_detection?: unknown;
+            };
+            output?: {
+              voice?: string;
+            };
+          };
+          tools?: Array<{ name: string }>;
+        };
       }
       let received: UpstreamBody | undefined;
+      let safetyIdentifier: string | null = null;
       server.use(
         http.post(
-          "https://api.openai.com/v1/realtime/sessions",
+          "https://api.openai.com/v1/realtime/client_secrets",
           async ({ request }) => {
             received = (await request.json()) as UpstreamBody;
+            safetyIdentifier = request.headers.get("OpenAI-Safety-Identifier");
             return HttpResponse.json({
-              client_secret: {
-                value: "ek_test_value",
-                expires_at: 9999999999,
-              },
-              model: received?.model,
+              value: "ek_test_value",
+              expires_at: 9999999999,
+              session: received?.session,
             });
           },
         ),
@@ -166,41 +176,55 @@ describe("POST /api/zero/voice-chat/token", () => {
       const body = await response.json();
       expect(response.status).toBe(200);
       expect(body.client_secret.value).toBe("ek_test_value");
-      expect(received?.model).toBe("gpt-realtime-2");
-      expect(received?.modalities).toEqual(["text", "audio"]);
-      expect(typeof received?.instructions).toBe("string");
-      expect(received?.instructions?.length ?? 0).toBeGreaterThan(0);
-      expect(received?.input_audio_transcription).toEqual({
+      expect(safetyIdentifier).toHaveLength(64);
+      expect(safetyIdentifier).not.toBe(userId);
+      if (!received?.session) {
+        throw new Error("OpenAI session payload was not captured");
+      }
+      const { session } = received;
+      expect(session.type).toBe("realtime");
+      expect(session.model).toBe("gpt-realtime-2");
+      expect(session.output_modalities).toEqual(["audio"]);
+      expect(typeof session.instructions).toBe("string");
+      expect(session.instructions?.length ?? 0).toBeGreaterThan(0);
+      expect(session.audio?.input?.transcription).toEqual({
         model: "gpt-4o-mini-transcribe",
       });
-      expect(received?.input_audio_noise_reduction).toEqual({
+      expect(session.audio?.input?.noise_reduction).toEqual({
         type: "far_field",
       });
-      expect(received?.turn_detection).toEqual({
+      expect(session.audio?.input?.turn_detection).toEqual({
         type: "semantic_vad",
         eagerness: "medium",
         interrupt_response: false,
       });
-      const toolNames =
-        received?.tools?.map((t) => {
-          return t.name;
-        }) ?? [];
+      expect(session.audio?.output).toEqual({ voice: "verse" });
+      const toolNames = session.tools?.map((t) => {
+        return t.name;
+      });
       expect(toolNames).toContain("inform_slow_brain");
       expect(toolNames).toContain("feel_confused");
     });
 
     it("threads near_field noiseReduction through to the upstream body", async () => {
       interface UpstreamBody {
-        input_audio_noise_reduction?: { type?: string };
+        session?: {
+          audio?: {
+            input?: {
+              noise_reduction?: { type?: string };
+            };
+          };
+        };
       }
       let received: UpstreamBody | undefined;
       server.use(
         http.post(
-          "https://api.openai.com/v1/realtime/sessions",
+          "https://api.openai.com/v1/realtime/client_secrets",
           async ({ request }) => {
             received = (await request.json()) as UpstreamBody;
             return HttpResponse.json({
-              client_secret: { value: "ek_test", expires_at: 9999999999 },
+              value: "ek_test",
+              expires_at: 9999999999,
             });
           },
         ),
@@ -209,14 +233,14 @@ describe("POST /api/zero/voice-chat/token", () => {
         tokenRequest({ sessionId, noiseReduction: "near_field" }),
       );
       expect(response.status).toBe(200);
-      expect(received?.input_audio_noise_reduction).toEqual({
+      expect(received?.session?.audio?.input?.noise_reduction).toEqual({
         type: "near_field",
       });
     });
 
     it("returns 500 when OpenAI returns an error", async () => {
       server.use(
-        http.post("https://api.openai.com/v1/realtime/sessions", () => {
+        http.post("https://api.openai.com/v1/realtime/client_secrets", () => {
           return HttpResponse.json(
             { error: { message: "bad" } },
             { status: 400 },
@@ -231,8 +255,7 @@ describe("POST /api/zero/voice-chat/token", () => {
   });
 
   // Plan D: realtime-billing ON keeps the credit + pricing admission gate
-  // but still mints a legacy OpenAI ephemeral token (the WS relay scaffolding
-  // is retired in #12190).
+  // while minting the same OpenAI GA ephemeral token.
   describe("admission gates (VoiceChatRealtimeBilling = ON)", () => {
     beforeEach(async () => {
       setFlags({
@@ -250,12 +273,13 @@ describe("POST /api/zero/voice-chat/token", () => {
       expect(body.error.code).toBe("INSUFFICIENT_CREDITS");
     });
 
-    it("mints a legacy ephemeral token after the credit + pricing admission passes", async () => {
+    it("mints a GA ephemeral token after the credit + pricing admission passes", async () => {
       await setOrgCredits(orgId, 1000);
       server.use(
-        http.post("https://api.openai.com/v1/realtime/sessions", () => {
+        http.post("https://api.openai.com/v1/realtime/client_secrets", () => {
           return HttpResponse.json({
-            client_secret: { value: "ek_admitted", expires_at: 9999999999 },
+            value: "ek_admitted",
+            expires_at: 9999999999,
           });
         }),
       );

--- a/turbo/apps/web/app/api/zero/voice-chat/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/token/__tests__/route.test.ts
@@ -239,6 +239,9 @@ describe("POST /api/zero/voice-chat/token", () => {
     });
 
     it("returns 500 when OpenAI returns an error", async () => {
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {
+        return undefined;
+      });
       server.use(
         http.post("https://api.openai.com/v1/realtime/client_secrets", () => {
           return HttpResponse.json(
@@ -251,6 +254,14 @@ describe("POST /api/zero/voice-chat/token", () => {
       const body = await response.json();
       expect(response.status).toBe(500);
       expect(body.error.code).toBe("INTERNAL_SERVER_ERROR");
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining("OpenAI token request failed"),
+        expect.objectContaining({
+          status: 400,
+          upstreamBody: expect.stringContaining('"message":"bad"'),
+        }),
+      );
+      consoleError.mockRestore();
     });
   });
 

--- a/turbo/apps/web/app/api/zero/voice-chat/token/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/token/route.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { NextResponse } from "next/server";
 import { isApiError } from "@vm0/api-services/errors";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
@@ -21,6 +22,18 @@ import {
 } from "../_support";
 
 const log = logger("api:zero:voice-chat:token");
+const MAX_UPSTREAM_ERROR_BODY_LENGTH = 2_000;
+
+function safetyIdentifierForUser(userId: string): string {
+  return createHash("sha256").update(userId).digest("hex");
+}
+
+function truncateUpstreamBody(body: string): string {
+  if (body.length <= MAX_UPSTREAM_ERROR_BODY_LENGTH) {
+    return body;
+  }
+  return body.slice(0, MAX_UPSTREAM_ERROR_BODY_LENGTH);
+}
 
 async function handlePost(request: Request): Promise<Response> {
   initServices();
@@ -79,11 +92,15 @@ async function handlePost(request: Request): Promise<Response> {
     const result = await createEphemeralToken({
       instructions: talkerInstructions,
       noiseReduction: parsed.data.noiseReduction,
+      safetyIdentifier: safetyIdentifierForUser(authCtx.userId),
     });
     return NextResponse.json(result);
   } catch (error) {
     if (isOpenAiTokenError(error)) {
-      log.error("OpenAI token request failed", { status: error.status });
+      log.error("OpenAI token request failed", {
+        status: error.status,
+        upstreamBody: truncateUpstreamBody(error.body),
+      });
       return NextResponse.json(
         {
           error: {

--- a/turbo/apps/web/src/lib/zero/voice-chat/openai-token.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/openai-token.ts
@@ -1,7 +1,7 @@
 import {
   DEFAULT_NOISE_REDUCTION,
   INPUT_AUDIO_TRANSCRIPTION_CONFIG,
-  SESSION_MODALITIES,
+  SESSION_OUTPUT_MODALITIES,
   SESSION_TOOLS,
   TALKER_MODEL,
   TALKER_VOICE,
@@ -11,7 +11,8 @@ import {
 
 import { env } from "../../../env";
 
-const OPENAI_REALTIME_URL = "https://api.openai.com/v1/realtime/sessions";
+const OPENAI_REALTIME_CLIENT_SECRETS_URL =
+  "https://api.openai.com/v1/realtime/client_secrets";
 
 interface EphemeralTokenResponse {
   client_secret: {
@@ -20,7 +21,12 @@ interface EphemeralTokenResponse {
   };
 }
 
-// Tagged error raised when the upstream OpenAI realtime session endpoint
+interface OpenAiClientSecretResponse {
+  value: string;
+  expires_at: number;
+}
+
+// Tagged error raised when the upstream OpenAI realtime client-secret endpoint
 // responds with a non-ok status. The route handler uses `isOpenAiTokenError`
 // to narrow the catch and map to HTTP 500 with the documented error body.
 // Plain object + discriminant avoids `class`, which is disallowed by project lint rules.
@@ -57,26 +63,41 @@ export function isOpenAiTokenError(value: unknown): value is OpenAiTokenError {
 export async function createEphemeralToken(options: {
   instructions: string;
   noiseReduction?: NoiseReduction;
+  safetyIdentifier?: string;
 }): Promise<EphemeralTokenResponse> {
   const apiKey = env().OPENAI_API_KEY;
 
-  const response = await fetch(OPENAI_REALTIME_URL, {
+  const headers = new Headers({
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  });
+  if (options.safetyIdentifier) {
+    headers.set("OpenAI-Safety-Identifier", options.safetyIdentifier);
+  }
+
+  const response = await fetch(OPENAI_REALTIME_CLIENT_SECRETS_URL, {
     method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
+    headers,
     body: JSON.stringify({
-      model: TALKER_MODEL,
-      voice: TALKER_VOICE,
-      modalities: SESSION_MODALITIES,
-      instructions: options.instructions,
-      input_audio_transcription: INPUT_AUDIO_TRANSCRIPTION_CONFIG,
-      input_audio_noise_reduction: {
-        type: options.noiseReduction ?? DEFAULT_NOISE_REDUCTION,
+      session: {
+        type: "realtime",
+        model: TALKER_MODEL,
+        output_modalities: SESSION_OUTPUT_MODALITIES,
+        instructions: options.instructions,
+        audio: {
+          input: {
+            transcription: INPUT_AUDIO_TRANSCRIPTION_CONFIG,
+            noise_reduction: {
+              type: options.noiseReduction ?? DEFAULT_NOISE_REDUCTION,
+            },
+            turn_detection: TURN_DETECTION_CONFIG,
+          },
+          output: {
+            voice: TALKER_VOICE,
+          },
+        },
+        tools: SESSION_TOOLS,
       },
-      turn_detection: TURN_DETECTION_CONFIG,
-      tools: SESSION_TOOLS,
     }),
   });
 
@@ -85,5 +106,11 @@ export async function createEphemeralToken(options: {
     throw createOpenAiTokenError(response.status, body);
   }
 
-  return response.json() as Promise<EphemeralTokenResponse>;
+  const data = (await response.json()) as OpenAiClientSecretResponse;
+  return {
+    client_secret: {
+      value: data.value,
+      expires_at: data.expires_at,
+    },
+  };
 }

--- a/turbo/packages/core/src/voice-chat/session-config.ts
+++ b/turbo/packages/core/src/voice-chat/session-config.ts
@@ -83,11 +83,12 @@ export const INPUT_AUDIO_TRANSCRIPTION_CONFIG = {
 export type NoiseReduction = "near_field" | "far_field";
 export const DEFAULT_NOISE_REDUCTION: NoiseReduction = "far_field";
 
-export const SESSION_MODALITIES = ["text", "audio"] as const;
+// Realtime GA supports a single output modality per session. Voice chat needs
+// speech output, while transcripts still arrive through data-channel events.
+export const SESSION_OUTPUT_MODALITIES = ["audio"] as const;
 
-// Talker model and assistant voice are part of the bytewise-equal contract
-// between the legacy ephemeral-token REST body and the relay's `session.update`
-// frame. Both consumers read these constants instead of inlining string
-// literals — ensures a single rename / version-bump touches one place.
+// Talker model and assistant voice are part of the server-minted Realtime
+// session config. Keep these constants centralized so a model or voice change
+// touches one place.
 export const TALKER_MODEL = "gpt-realtime-2";
 export const TALKER_VOICE = "verse";


### PR DESCRIPTION
## Summary

- migrate voice-chat token minting from the legacy Realtime sessions endpoint to the GA `client_secrets` endpoint
- normalize OpenAI's GA response back into the existing vm0 `client_secret` contract
- switch browser WebRTC SDP exchange to `POST /v1/realtime/calls`
- log bounded upstream OpenAI token error bodies for production triage
- add `OpenAI-Safety-Identifier` using a hashed internal user id

## Validation

- `pnpm -F web exec vitest app/api/zero/voice-chat/token/__tests__/route.test.ts`
- `pnpm -F @vm0/app exec vitest src/signals/voice-chat/__tests__/voice-chat-session.test.ts`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/core lint`
- `pnpm -F web lint`
- `pnpm -F @vm0/app lint`
- `pnpm format`
- `git diff --check`
- live schema check: `POST /v1/realtime/client_secrets` accepts the GA voice-chat payload with `output_modalities: ["audio"]`

## Known Local Check Blocker

- `pnpm check-types` fails locally outside this diff with existing `api` / `@vm0/app` errors where route/client responses are inferred as `never`; the same failure blocks the default lefthook typecheck. The focused affected workspaces/tests listed above pass.

Closes #12656
