### PR TITLE
fix: link model provider auth errors to settings

### DIFF
--- a/turbo/apps/web/src/lib/zero/context/__tests__/resolve-model-provider.test.ts
+++ b/turbo/apps/web/src/lib/zero/context/__tests__/resolve-model-provider.test.ts
@@ -990,7 +990,10 @@ describe("resolveModelProviderSecrets — model-first policy (#12130)", () => {
     ).rejects.toSatisfy((err: unknown) => {
       return (
         isModelProviderConnectRequired(err) &&
-        err.providerType === "codex-oauth-token"
+        err.providerType === "codex-oauth-token" &&
+        err.message.includes(
+          "[Open Personal Models](http://localhost:3001/settings?tab=model-configuration&connectModelProvider=codex-oauth-token)",
+        )
       );
     });
   });

--- a/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
@@ -40,10 +40,34 @@ import {
   isModelFirstModelProviderEnabled,
   resolveModelFirstRouteDescriptor,
 } from "../model-policy/model-first-route-service";
+import { getAppUrl } from "../url";
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
 import type { ModelProviderInfo } from "../model-provider/model-provider-service";
 
 const log = logger("zero:build-context");
+
+function getModelProviderConnectRequiredUrl(providerType: string): string {
+  const searchParams = new URLSearchParams({
+    tab: "model-configuration",
+    connectModelProvider: providerType,
+  });
+  return `${getAppUrl()}/settings?${searchParams.toString()}`;
+}
+
+function getModelProviderConnectRequiredMessage(providerType: string): string {
+  const url = getModelProviderConnectRequiredUrl(providerType);
+  return [
+    `Connect "${providerType}" before using this workspace model route.`,
+    `[Open Personal Models](${url})`,
+  ].join(" ");
+}
+
+function throwModelProviderConnectRequired(providerType: string): never {
+  throw modelProviderConnectRequired(
+    providerType,
+    getModelProviderConnectRequiredMessage(providerType),
+  );
+}
 
 /**
  * Model provider environment variables that indicate explicit configuration.
@@ -469,7 +493,7 @@ function finalizeMaterializedRoute(
     route.credential.scope === "member" &&
     !decorated.secrets
   ) {
-    throw modelProviderConnectRequired(route.provider.type);
+    throwModelProviderConnectRequired(route.provider.type);
   }
   return decorated;
 }
@@ -791,7 +815,7 @@ async function resolveModelFirstModelRoute(
       descriptor.providerType,
     );
     if (!providerRow) {
-      throw modelProviderConnectRequired(descriptor.providerType);
+      throwModelProviderConnectRequired(descriptor.providerType);
     }
     ownerUserId = params.userId;
   } else if (descriptor.providerType !== "vm0") {


### PR DESCRIPTION
## Summary
- update MODEL_PROVIDER_CONNECT_REQUIRED messages to include a markdown settings link generated from getAppUrl()
- cover the markdown link in the model-provider resolver test

## Tests
- pnpm exec oxlint src/lib/zero/context/resolve-model-provider.ts src/lib/zero/context/__tests__/resolve-model-provider.test.ts
- pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json src/lib/zero/context/resolve-model-provider.ts src/lib/zero/context/__tests__/resolve-model-provider.test.ts
- pnpm exec eslint src/lib/zero/context/resolve-model-provider.ts src/lib/zero/context/__tests__/resolve-model-provider.test.ts --max-warnings 0
- git diff --check

## Not run / blocked
- pnpm --filter web exec vitest run src/lib/zero/context/__tests__/resolve-model-provider.test.ts is blocked locally by the test database schema: org_model_policies.is_default column is missing before the updated assertion runs.