### PR TITLE
refactor(api): migrate billing/portal POST to api backend (Wave 6 #1)

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -70,6 +70,11 @@ export interface ApiTestMocks {
         readonly create: AsyncMock;
       };
     };
+    readonly billingPortal: {
+      readonly sessions: {
+        readonly create: AsyncMock;
+      };
+    };
   };
   readonly telegram: {
     readonly getMe: AsyncMock;
@@ -139,6 +144,11 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
       retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     checkout: {
+      sessions: {
+        create: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      },
+    },
+    billingPortal: {
       sessions: {
         create: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       },
@@ -299,6 +309,11 @@ vi.mock("stripe", () => {
             create: apiTestMocks.stripe.checkout.sessions.create,
           },
         },
+        billingPortal: {
+          sessions: {
+            create: apiTestMocks.stripe.billingPortal.sessions.create,
+          },
+        },
       };
     }),
   };
@@ -421,6 +436,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.stripe.customers.create.mockReset();
   apiTestMocks.stripe.subscriptions.retrieve.mockReset();
   apiTestMocks.stripe.checkout.sessions.create.mockReset();
+  apiTestMocks.stripe.billingPortal.sessions.create.mockReset();
   // Re-install the Stripe client override so getStripeClient() returns
   // the centralized mock surface (the vi.mock("stripe") factory above
   // doesn't compose with `new StripeSDK()` because vi.fn isn't a real

--- a/turbo/apps/api/src/lib/error.ts
+++ b/turbo/apps/api/src/lib/error.ts
@@ -26,6 +26,10 @@ export function runNotCancellable(message: string) {
   return httpError(400, "RUN_NOT_CANCELLABLE", message);
 }
 
+export function providerUnavailable(message: string) {
+  return httpError(503, "PROVIDER_UNAVAILABLE", message);
+}
+
 export function badRequestMessage(message: string) {
   return httpError(400, "BAD_REQUEST", message);
 }

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -15,6 +15,7 @@ import { zeroApiKeysRoutes } from "./routes/zero-api-keys";
 import { zeroBillingAutoRechargeRoutes } from "./routes/zero-billing-auto-recharge";
 import { zeroBillingCheckoutRoutes } from "./routes/zero-billing-checkout";
 import { zeroBillingInvoicesRoutes } from "./routes/zero-billing-invoices";
+import { zeroBillingPortalRoutes } from "./routes/zero-billing-portal";
 import { zeroBillingStatusRoutes } from "./routes/zero-billing-status";
 import { zeroChatThreadRoutes } from "./routes/zero-chat-threads";
 import { zeroComposesRoutes } from "./routes/zero-composes";
@@ -75,6 +76,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroBillingAutoRechargeRoutes,
   ...zeroBillingCheckoutRoutes,
   ...zeroBillingInvoicesRoutes,
+  ...zeroBillingPortalRoutes,
   ...zeroBillingStatusRoutes,
   ...zeroChatThreadRoutes,
   ...zeroComposesRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-portal.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-portal.test.ts
@@ -1,0 +1,181 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroBillingPortalContract } from "@vm0/api-contracts/contracts/zero-billing";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import {
+  deleteInvoicesOrg$,
+  seedInvoicesOrg$,
+  type InvoicesOrgFixture,
+} from "./helpers/zero-billing-invoices";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+const APP_ORIGIN = "http://app.localhost:3002";
+
+describe("POST /api/zero/billing/portal", () => {
+  const track = createFixtureTracker<InvoicesOrgFixture>((fixture) => {
+    return store.set(deleteInvoicesOrg$, fixture, context.signal);
+  });
+
+  it("returns 503 when STRIPE_SECRET_KEY is not configured", async () => {
+    mockOptionalEnv("STRIPE_SECRET_KEY", undefined);
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroBillingPortalContract);
+    const response = await accept(
+      client.create({
+        body: { returnUrl: `${APP_ORIGIN}/settings` },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [503],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Billing not configured",
+        code: "PROVIDER_UNAVAILABLE",
+      },
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroBillingPortalContract);
+
+    const response = await accept(
+      client.create({
+        body: { returnUrl: `${APP_ORIGIN}/settings` },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 400 when returnUrl is missing", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroBillingPortalContract);
+    const response = await accept(
+      client.create({
+        body: {} as never,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error).toBeDefined();
+  });
+
+  it("returns 400 when returnUrl is not a valid URL", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroBillingPortalContract);
+    const response = await accept(
+      client.create({
+        body: { returnUrl: "not-a-url" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error).toBeDefined();
+  });
+
+  it("returns 403 for a non-admin org member", async () => {
+    mocks.clerk.session(
+      `user_${randomUUID()}`,
+      `org_${randomUUID()}`,
+      "org:member",
+    );
+
+    const client = setupApp({ context })(zeroBillingPortalContract);
+    const response = await accept(
+      client.create({
+        body: { returnUrl: `${APP_ORIGIN}/settings` },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only org admins can manage billing",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns portal URL on success", async () => {
+    const fixture = await track(
+      store.set(
+        seedInvoicesOrg$,
+        { stripeCustomerId: `cus-portal-${randomUUID().slice(0, 8)}` },
+        context.signal,
+      ),
+    );
+    mockEnv("VM0_WEB_URL", APP_ORIGIN);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    context.mocks.stripe.billingPortal.sessions.create.mockResolvedValue({
+      url: "https://billing.stripe.com/session/test",
+    });
+
+    const client = setupApp({ context })(zeroBillingPortalContract);
+    const response = await accept(
+      client.create({
+        body: { returnUrl: `${APP_ORIGIN}/settings/billing` },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      url: "https://billing.stripe.com/session/test",
+    });
+    expect(
+      context.mocks.stripe.billingPortal.sessions.create,
+    ).toHaveBeenCalledWith({
+      customer: fixture.stripeCustomerId,
+      return_url: `${APP_ORIGIN}/settings/billing`,
+    });
+  });
+
+  it("returns 400 when returnUrl origin does not match VM0_WEB_URL", async () => {
+    mockEnv("VM0_WEB_URL", APP_ORIGIN);
+    mocks.clerk.session(
+      `user_${randomUUID()}`,
+      `org_${randomUUID()}`,
+      "org:admin",
+    );
+
+    const client = setupApp({ context })(zeroBillingPortalContract);
+    const response = await accept(
+      client.create({
+        body: { returnUrl: "https://evil.example.com/settings/billing" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "returnUrl must match the platform origin",
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-billing-portal.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-portal.ts
@@ -1,0 +1,62 @@
+import { command } from "ccstate";
+import { zeroBillingPortalContract } from "@vm0/api-contracts/contracts/zero-billing";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { env, optionalEnv } from "../../lib/env";
+import { badRequestMessage, providerUnavailable } from "../../lib/error";
+import { createBillingPortalSession$ } from "../services/billing.service";
+import type { RouteEntry } from "../route";
+
+const adminRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Only org admins can manage billing",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+const portalInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!optionalEnv("STRIPE_SECRET_KEY")) {
+    return providerUnavailable("Billing not configured");
+  }
+
+  const auth = get(organizationAuthContext$);
+  if (auth.orgRole !== "admin") {
+    return adminRequired;
+  }
+
+  const bodyResult = await get(bodyResultOf(zeroBillingPortalContract.create));
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+  const { returnUrl } = bodyResult.data;
+
+  const appOrigin = new URL(env("VM0_WEB_URL")).origin;
+  if (new URL(returnUrl).origin !== appOrigin) {
+    return badRequestMessage("returnUrl must match the platform origin");
+  }
+
+  const url = await set(
+    createBillingPortalSession$,
+    { orgId: auth.orgId, returnUrl },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  return { status: 200 as const, body: { url } };
+});
+
+export const zeroBillingPortalRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroBillingPortalContract.create,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      portalInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/billing.service.ts
+++ b/turbo/apps/api/src/signals/services/billing.service.ts
@@ -1,9 +1,10 @@
-import { computed, type Computed } from "ccstate";
+import { command, computed, type Computed } from "ccstate";
 import type { AutoRechargeConfig } from "@vm0/api-contracts/contracts/zero-billing";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { eq } from "drizzle-orm";
 
 import { db$ } from "../external/db";
+import { getStripeClient } from "../external/stripe-client";
 
 export function autoRechargeConfig(
   orgId: string,
@@ -27,3 +28,39 @@ export function autoRechargeConfig(
     };
   });
 }
+
+/**
+ * Create a Stripe Billing Portal session for managing subscriptions.
+ * Mirrors apps/web's `createBillingPortalSession`. Returns the portal URL.
+ *
+ * Throws if the org has no Stripe customer yet (defensive — web's
+ * tests don't exercise this branch either; framework returns 500).
+ */
+export const createBillingPortalSession$ = command(
+  async (
+    { get },
+    args: { readonly orgId: string; readonly returnUrl: string },
+    signal: AbortSignal,
+  ): Promise<string> => {
+    const db = get(db$);
+    const [org] = await db
+      .select({ stripeCustomerId: orgMetadata.stripeCustomerId })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, args.orgId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!org?.stripeCustomerId) {
+      throw new Error("Org has no Stripe customer — subscribe first");
+    }
+
+    const stripe = getStripeClient();
+    const session = await stripe.billingPortal.sessions.create({
+      customer: org.stripeCustomerId,
+      return_url: args.returnUrl,
+    });
+    signal.throwIfAborted();
+
+    return session.url;
+  },
+);


### PR DESCRIPTION
## Summary

First Wave 6 billing-family route migration for #12290. Ports `POST /api/zero/billing/portal` (create Stripe billing portal session) from `apps/web` to `apps/api`.

- New `zero-billing-portal.ts` route handler with admin gate (frozen 403) + defensive 503 env check + `returnUrl` origin match against `VM0_WEB_URL`.
- New `createBillingPortalSession$` Command appended to `services/billing.service.ts` (alongside existing `autoRechargeConfig`). Read-only — `SELECT stripe_customer_id`, throws plain `Error` if null (mirrors web exactly; framework returns 500). No customer creation (portal flow doesn't need it).
- Extends centralized Stripe mock in `__tests__/mocks.ts` with `billingPortal.sessions.create` (non-overlapping with `customers.create` + `checkout.sessions.create` added by #12606).
- New `providerUnavailable()` helper in `lib/error.ts` — one in-PR consumer, mirroring `conflict()` / `runNotCancellable()` knip-flag-rule precedents.
- Reuses Stripe wrapper + testOverride pattern from PR #12593 (`getStripeClient()` / `mockStripeClient(fakeSdk)`).
- Consumes the `+403` amendment to `zeroBillingPortalContract.create` responses from #12606.

## Test plan

Ports all 7 web tests 1:1 (no api-defensive additions — web's coverage already exercises the api surface):

- [x] 503 when `STRIPE_SECRET_KEY` is not configured (via `mockOptionalEnv("STRIPE_SECRET_KEY", undefined)`)
- [x] 401 when not authenticated
- [x] 400 when `returnUrl` is missing (ts-rest zod parse)
- [x] 400 when `returnUrl` is not a valid URL (ts-rest zod parse)
- [x] 403 for a non-admin org member (frozen `adminRequired`)
- [x] 200 returns portal URL on success (verifies `customer` + `return_url` args to `stripe.billingPortal.sessions.create`)
- [x] 400 when `returnUrl` origin does not match `VM0_WEB_URL`
- [x] `pnpm -F api exec vitest run` — 970 tests passed (114 files)
- [x] `pnpm -F api run check-types` — clean
- [x] `pnpm -F api run lint` — clean (warning in `zero-org-invite.test.ts` pre-existing from main, unrelated)
- [x] `pnpm knip` — clean
- [x] `pnpm format` — clean

## Out of scope

- Removing the web handler — separate Stage 3 cleanup once `apiBackendMutations` flag flips for billing.
- `isProviderUnavailableResponse` type guard — no second consumer.

Closes #12595
Part of #12290 (Stage 3 Wave 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)