### PR TITLE
fix: align zero agent instructions route parity

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-skills.ts
@@ -3,10 +3,14 @@ import { gzipSync } from "node:zlib";
 
 import {
   getCustomSkillStorageName,
+  getInstructionsStorageName,
   VOLUME_ORG_USER_ID,
 } from "@vm0/core/storage-names";
 import { command } from "ccstate";
-import { agentComposes } from "@vm0/db/schema/agent-compose";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { userConnectors } from "@vm0/db/schema/user-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
@@ -129,6 +133,21 @@ interface SkillContentMockArgs {
   readonly extraFiles?: readonly SkillContentMockExtra[];
 }
 
+type AgentFramework = "claude-code" | "codex";
+
+interface AgentComposeContent {
+  readonly version: string;
+  readonly agents: Readonly<
+    Record<
+      string,
+      {
+        readonly framework: AgentFramework;
+        readonly instructions?: string;
+      }
+    >
+  >;
+}
+
 const TAR_BLOCK_SIZE = 512;
 
 function octal(value: number, length: number): string {
@@ -231,6 +250,102 @@ export function mockSkillContent(
   });
 }
 
+interface InstructionsStorageSeed {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly agentName: string;
+  readonly s3Key: string;
+  readonly headVersionId?: string;
+}
+
+export const seedInstructionsStorage$ = command(
+  async (
+    { set },
+    args: InstructionsStorageSeed,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    const storageId = randomUUID();
+    const storageName = getInstructionsStorageName(args.agentName);
+    const headVersionId = args.headVersionId ?? `head-${randomUUID()}`;
+
+    await db.insert(storages).values({
+      id: storageId,
+      userId: VOLUME_ORG_USER_ID,
+      name: storageName,
+      type: "volume",
+      orgId: args.orgId,
+      s3Prefix: `orgs/${args.orgId}/${storageName}`,
+    });
+    signal.throwIfAborted();
+
+    await db.insert(storageVersions).values({
+      id: headVersionId,
+      storageId,
+      s3Key: args.s3Key,
+      createdBy: args.userId,
+    });
+    signal.throwIfAborted();
+
+    await db
+      .update(storages)
+      .set({ headVersionId })
+      .where(eq(storages.id, storageId));
+    signal.throwIfAborted();
+  },
+);
+
+interface InstructionsContentMockArgs {
+  readonly s3Key: string;
+  readonly filename: string;
+  readonly content: string;
+  readonly manifestPath?: string;
+}
+
+export function mockInstructionsContent(
+  context: TestContext,
+  args: InstructionsContentMockArgs,
+): void {
+  const contentBuffer = Buffer.from(args.content, "utf8");
+  const path = args.manifestPath ?? args.filename;
+  const archive = createSingleFileTarGz(path, contentBuffer);
+
+  const manifest = {
+    version: "test-version",
+    createdAt: new Date(0).toISOString(),
+    files: [
+      { path, hash: "test-hash-instructions", size: contentBuffer.length },
+    ],
+    totalSize: contentBuffer.length,
+    fileCount: 1,
+  };
+  const manifestBuffer = Buffer.from(JSON.stringify(manifest), "utf8");
+
+  context.mocks.s3.send.mockImplementation((cmd: unknown): Promise<unknown> => {
+    const key = commandKey(cmd);
+    if (key === `${args.s3Key}/manifest.json`) {
+      return Promise.resolve({ Body: asyncIterableOf(manifestBuffer) });
+    }
+    if (key === `${args.s3Key}/archive.tar.gz`) {
+      return Promise.resolve({ Body: asyncIterableOf(archive) });
+    }
+    return Promise.resolve({});
+  });
+}
+
+function createAgentComposeContent(
+  name: string,
+  framework: AgentFramework,
+  instructions: string | undefined,
+): AgentComposeContent {
+  return {
+    version: "1",
+    agents: {
+      [name]: instructions ? { framework, instructions } : { framework },
+    },
+  };
+}
+
 export const seedAgentForInstructions$ = command(
   async (
     { set },
@@ -241,9 +356,14 @@ export const seedAgentForInstructions$ = command(
       displayName?: string | null;
       description?: string | null;
       sound?: string | null;
+      framework?: AgentFramework;
+      instructions?: string;
+      composeContent?: unknown;
+      withComposeVersion?: boolean;
+      withZeroAgent?: boolean;
     },
     signal: AbortSignal,
-  ): Promise<{ agentId: string }> => {
+  ): Promise<{ agentId: string; name: string }> => {
     const db = set(writeDb$);
     const agentId = randomUUID();
     const name = args.name ?? `agent-${randomUUID().slice(0, 8)}`;
@@ -254,20 +374,47 @@ export const seedAgentForInstructions$ = command(
       name,
     });
     signal.throwIfAborted();
-    await db
-      .insert(zeroAgents)
-      .values({
-        id: agentId,
-        orgId: args.orgId,
-        owner: args.userId,
-        name,
-        displayName: args.displayName ?? null,
-        description: args.description ?? null,
-        sound: args.sound ?? null,
-      })
-      .onConflictDoNothing();
-    signal.throwIfAborted();
-    return { agentId };
+
+    if (args.composeContent !== undefined || args.withComposeVersion === true) {
+      const versionId = randomUUID().replaceAll("-", "");
+      const content =
+        args.composeContent ??
+        createAgentComposeContent(
+          name,
+          args.framework ?? "claude-code",
+          args.instructions,
+        );
+      await db.insert(agentComposeVersions).values({
+        id: versionId,
+        composeId: agentId,
+        content,
+        createdBy: args.userId,
+      });
+      signal.throwIfAborted();
+      await db
+        .update(agentComposes)
+        .set({ headVersionId: versionId })
+        .where(eq(agentComposes.id, agentId));
+      signal.throwIfAborted();
+    }
+
+    if (args.withZeroAgent !== false) {
+      await db
+        .insert(zeroAgents)
+        .values({
+          id: agentId,
+          orgId: args.orgId,
+          owner: args.userId,
+          name,
+          displayName: args.displayName ?? null,
+          description: args.description ?? null,
+          sound: args.sound ?? null,
+        })
+        .onConflictDoNothing();
+      signal.throwIfAborted();
+    }
+
+    return { agentId, name };
   },
 );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-skills.test.ts
@@ -10,8 +10,10 @@ import { createStore } from "ccstate";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import {
   deleteSkillsForFixture$,
+  mockInstructionsContent,
   mockSkillContent,
   seedAgentForInstructions$,
+  seedInstructionsStorage$,
   seedSkill$,
   seedSkillStorage$,
   seedSkillsFixture$,
@@ -363,7 +365,11 @@ describe("GET /api/zero/agents/:id/instructions", () => {
     );
     const { agentId } = await store.set(
       seedAgentForInstructions$,
-      { orgId: fixture.orgId, userId: fixture.userId },
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        withComposeVersion: true,
+      },
       context.signal,
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
@@ -376,7 +382,10 @@ describe("GET /api/zero/agents/:id/instructions", () => {
       [200],
     );
 
-    expect(response.body).toStrictEqual({ content: null, filename: null });
+    expect(response.body).toStrictEqual({
+      content: null,
+      filename: "CLAUDE.md",
+    });
   });
 
   it("returns 404 for unknown agent", async () => {
@@ -408,7 +417,11 @@ describe("GET /api/zero/agents/:id/instructions", () => {
     );
     const { agentId } = await store.set(
       seedAgentForInstructions$,
-      { orgId: fixture.orgId, userId: fixture.userId },
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        withComposeVersion: true,
+      },
       context.signal,
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
@@ -421,6 +434,321 @@ describe("GET /api/zero/agents/:id/instructions", () => {
       [200],
     );
 
+    expect(response.body).toStrictEqual({
+      content: null,
+      filename: "CLAUDE.md",
+    });
+  });
+
+  it("returns derived filename for compose-only agents", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        withComposeVersion: true,
+        withZeroAgent: false,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      instructionsClient().get({
+        headers: authHeaders(),
+        params: { id: agentId },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      content: null,
+      filename: "CLAUDE.md",
+    });
+  });
+
+  it("returns null filename when compose content cannot be parsed", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeContent: { version: "1" },
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      instructionsClient().get({
+        headers: authHeaders(),
+        params: { id: agentId },
+      }),
+      [200],
+    );
+
     expect(response.body).toStrictEqual({ content: null, filename: null });
+  });
+
+  it("returns explicit compose instructions filename when no storage exists", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId } = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        instructions: "docs/CUSTOM.md",
+        withComposeVersion: true,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      instructionsClient().get({
+        headers: authHeaders(),
+        params: { id: agentId },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      content: null,
+      filename: "docs/CUSTOM.md",
+    });
+  });
+
+  it("reads Claude instructions content and filename", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId, name } = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        withComposeVersion: true,
+      },
+      context.signal,
+    );
+    const s3Key = `orgs/${fixture.orgId}/agent-instructions@${name}/v1`;
+    await store.set(
+      seedInstructionsStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentName: name,
+        s3Key,
+      },
+      context.signal,
+    );
+    mockInstructionsContent(context, {
+      s3Key,
+      filename: "CLAUDE.md",
+      content: "# Claude Instructions",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      instructionsClient().get({
+        headers: authHeaders(),
+        params: { id: agentId },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      content: "# Claude Instructions",
+      filename: "CLAUDE.md",
+    });
+  });
+
+  it("reads Codex instructions content and filename", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId, name } = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        framework: "codex",
+        withComposeVersion: true,
+      },
+      context.signal,
+    );
+    const s3Key = `orgs/${fixture.orgId}/agent-instructions@${name}/v1`;
+    await store.set(
+      seedInstructionsStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentName: name,
+        s3Key,
+      },
+      context.signal,
+    );
+    mockInstructionsContent(context, {
+      s3Key,
+      filename: "AGENTS.md",
+      content: "# Codex Instructions",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      instructionsClient().get({
+        headers: authHeaders(),
+        params: { id: agentId },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      content: "# Codex Instructions",
+      filename: "AGENTS.md",
+    });
+  });
+
+  it("returns empty string instructions content when uploaded file is empty", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId, name } = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        withComposeVersion: true,
+      },
+      context.signal,
+    );
+    const s3Key = `orgs/${fixture.orgId}/agent-instructions@${name}/v1`;
+    await store.set(
+      seedInstructionsStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentName: name,
+        s3Key,
+      },
+      context.signal,
+    );
+    mockInstructionsContent(context, {
+      s3Key,
+      filename: "CLAUDE.md",
+      content: "",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      instructionsClient().get({
+        headers: authHeaders(),
+        params: { id: agentId },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      content: "",
+      filename: "CLAUDE.md",
+    });
+  });
+
+  it("returns derived filename when manifest lacks the instruction file", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId, name } = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        withComposeVersion: true,
+      },
+      context.signal,
+    );
+    const s3Key = `orgs/${fixture.orgId}/agent-instructions@${name}/v1`;
+    await store.set(
+      seedInstructionsStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentName: name,
+        s3Key,
+      },
+      context.signal,
+    );
+    mockInstructionsContent(context, {
+      s3Key,
+      filename: "README.md",
+      content: "# Not Instructions",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      instructionsClient().get({
+        headers: authHeaders(),
+        params: { id: agentId },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      content: null,
+      filename: "CLAUDE.md",
+    });
+  });
+
+  it("strips legacy metadata from instructions content", async () => {
+    const fixture = await track(
+      store.set(seedSkillsFixture$, undefined, context.signal),
+    );
+    const { agentId, name } = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        withComposeVersion: true,
+      },
+      context.signal,
+    );
+    const s3Key = `orgs/${fixture.orgId}/agent-instructions@${name}/v1`;
+    await store.set(
+      seedInstructionsStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        agentName: name,
+        s3Key,
+      },
+      context.signal,
+    );
+    mockInstructionsContent(context, {
+      s3Key,
+      filename: "CLAUDE.md",
+      content: "[AGENT_PROFILE]\nname: legacy\n[/AGENT_PROFILE]\n# Visible",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      instructionsClient().get({
+        headers: authHeaders(),
+        params: { id: agentId },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      content: "# Visible",
+      filename: "CLAUDE.md",
+    });
   });
 });

--- a/turbo/apps/api/src/signals/services/zero-agent-instructions.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agent-instructions.service.ts
@@ -1,8 +1,12 @@
 import { computed, type Computed } from "ccstate";
+import { agentComposeApiContentSchema } from "@vm0/api-contracts/contracts/composes";
 import { getInstructionsStorageName } from "@vm0/core/storage-names";
 import { getInstructionsFilename } from "@vm0/core/frameworks";
-import { agentComposes } from "@vm0/db/schema/agent-compose";
-import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { stripMetadataFrontmatter } from "@vm0/core/instructions-frontmatter";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { and, eq } from "drizzle-orm";
 
@@ -28,30 +32,52 @@ export function zeroAgentInstructions(
   agentId: string,
 ): Computed<Promise<AgentInstructionsResult | null>> {
   return computed(async (get): Promise<AgentInstructionsResult | null> => {
-    const [agentRow] = await get(db$)
+    const [compose] = await get(db$)
       .select({
         name: agentComposes.name,
+        orgId: agentComposes.orgId,
+        content: agentComposeVersions.content,
       })
-      .from(zeroAgents)
-      .innerJoin(agentComposes, eq(zeroAgents.id, agentComposes.id))
-      .where(and(eq(zeroAgents.orgId, orgId), eq(zeroAgents.id, agentId)))
+      .from(agentComposes)
+      .leftJoin(
+        agentComposeVersions,
+        eq(agentComposes.headVersionId, agentComposeVersions.id),
+      )
+      .where(and(eq(agentComposes.orgId, orgId), eq(agentComposes.id, agentId)))
       .limit(1);
 
-    if (!agentRow) {
+    if (!compose) {
       return null;
     }
 
-    const storageName = getInstructionsStorageName(agentRow.name);
+    const parsed = agentComposeApiContentSchema.safeParse(compose.content);
+    if (!parsed.success) {
+      return { content: null, filename: null };
+    }
+
+    const agentKeys = Object.keys(parsed.data.agents);
+    const firstKey = agentKeys[0];
+    const agentDef = firstKey ? parsed.data.agents[firstKey] : undefined;
+    const instructionsFilename =
+      agentDef?.instructions ?? getInstructionsFilename(agentDef?.framework);
+
+    const storageName = getInstructionsStorageName(compose.name);
     const [storage] = await get(db$)
       .select({
         headVersionId: storages.headVersionId,
       })
       .from(storages)
-      .where(and(eq(storages.orgId, orgId), eq(storages.name, storageName)))
+      .where(
+        and(
+          eq(storages.orgId, compose.orgId),
+          eq(storages.name, storageName),
+          eq(storages.type, "volume"),
+        ),
+      )
       .limit(1);
 
     if (!storage?.headVersionId) {
-      return { content: null, filename: null };
+      return { content: null, filename: instructionsFilename };
     }
 
     const [version] = await get(db$)
@@ -61,61 +87,45 @@ export function zeroAgentInstructions(
       .limit(1);
 
     if (!version) {
-      return { content: null, filename: null };
+      return { content: null, filename: instructionsFilename };
     }
 
     const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
-    if (!bucket) {
-      return { content: null, filename: null };
-    }
-
-    // Download the manifest to discover the instructions file
     const manifest = await get(downloadManifest(bucket, version.s3Key));
     const normalize = (p: string): string => {
       return p.replace(/^\.\//, "");
     };
 
-    // Try the canonical filename for each supported framework
-    const canonicalFilenames = [
-      getInstructionsFilename("claude-code"),
-      getInstructionsFilename("codex"),
-    ];
+    const canonicalFilename = getInstructionsFilename(agentDef?.framework);
+    const instructionFile = manifest.files.find((f) => {
+      return normalize(f.path) === normalize(canonicalFilename);
+    });
 
-    let instructionPath: string | undefined;
-    for (const canonical of canonicalFilenames) {
-      const found = manifest.files.find((f) => {
-        return normalize(f.path) === canonical;
-      });
-      if (found) {
-        instructionPath = found.path;
-        break;
-      }
-    }
-
-    // Also check for "./CANONICAL" prefixed paths
-    if (!instructionPath) {
-      for (const canonical of canonicalFilenames) {
-        const found = manifest.files.find((f) => {
-          return f.path === `./${canonical}`;
-        });
-        if (found) {
-          instructionPath = found.path;
-          break;
-        }
-      }
-    }
-
-    if (!instructionPath) {
-      return { content: null, filename: null };
+    if (!instructionFile) {
+      return { content: null, filename: instructionsFilename };
     }
 
     const archiveKey = `${version.s3Key}/archive.tar.gz`;
     const archiveBuffer = await get(downloadS3Buffer(bucket, archiveKey));
-    const content = extractFileFromTarGz(archiveBuffer, instructionPath);
+    const rawContent = extractFileFromTarGz(
+      archiveBuffer,
+      instructionFile.path,
+    );
+
+    if (rawContent === null) {
+      return { content: null, filename: instructionsFilename };
+    }
+
+    const hasLegacyBlocks =
+      rawContent.includes("[AGENT_PROFILE]") ||
+      rawContent.includes("<!-- ZERO_PROFILE");
+    const content = hasLegacyBlocks
+      ? stripMetadataFrontmatter(rawContent)
+      : rawContent;
 
     return {
       content,
-      filename: normalize(instructionPath),
+      filename: instructionsFilename,
     };
   });
 }


### PR DESCRIPTION
## Summary
- Align apps/api zero agent instructions GET with the legacy web route lookup and response semantics
- Derive filenames from compose content, preserve compose-only agents, and strip legacy metadata blocks
- Add API route coverage for no-upload, compose-only, explicit filename, Claude/Codex, empty content, missing manifest file, and legacy metadata cases

Closes #12613

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-skills.test.ts
- pnpm -F api check-types
- pnpm -F api lint
- pnpm format
- pnpm knip --workspace api
- pre-commit hook: pnpm knip --cache, pnpm check-types
