### PR TITLE
test: align agent custom connector route parity

### DIFF
--- a/turbo/apps/web/app/api/zero/agents/[id]/custom-connectors/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/custom-connectors/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { randomUUID } from "node:crypto";
 import { GET, PUT } from "../route";
 import { POST as postAgentRoute } from "../../../route";
 import { POST as postCustomConnectors } from "../../../../custom-connectors/route";
@@ -11,19 +12,20 @@ import {
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
 let user: UserContext;
 let testCliToken: string;
 
-async function createAgent(): Promise<string> {
+async function createAgent(token = testCliToken): Promise<string> {
   const res = await postAgentRoute(
     createTestRequest(`http://localhost:3000/api/zero/agents`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${testCliToken}`,
+        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({}),
     }),
@@ -63,6 +65,15 @@ function getCustomConnectors(agentId: string, token: string) {
   );
 }
 
+function getCustomConnectorsFromSession(agentId: string) {
+  return GET(
+    createTestRequest(
+      `http://localhost:3000/api/zero/agents/${agentId}/custom-connectors`,
+      { method: "GET" },
+    ),
+  );
+}
+
 function putCustomConnectors(
   agentId: string,
   body: { enabledIds: string[] },
@@ -77,6 +88,22 @@ function putCustomConnectors(
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
         },
+        body: JSON.stringify(body),
+      },
+    ),
+  );
+}
+
+function putCustomConnectorsFromSession(
+  agentId: string,
+  body: { enabledIds: string[] },
+) {
+  return PUT(
+    createTestRequest(
+      `http://localhost:3000/api/zero/agents/${agentId}/custom-connectors`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       },
     ),
@@ -107,6 +134,9 @@ describe("Agent Custom Connectors API", () => {
       const fakeId = "00000000-0000-0000-0000-000000000000";
       const res = await getCustomConnectors(fakeId, testCliToken);
       expect(res.status).toBe(404);
+      await expect(res.json()).resolves.toStrictEqual({
+        error: { message: `Agent not found: ${fakeId}`, code: "NOT_FOUND" },
+      });
     });
 
     it("returns 401 without auth", async () => {
@@ -114,6 +144,70 @@ describe("Agent Custom Connectors API", () => {
       mockClerk({ userId: null });
       const res = await getCustomConnectors(agentId, "no-token");
       expect(res.status).toBe(401);
+      await expect(res.json()).resolves.toStrictEqual({
+        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+      });
+    });
+
+    it("returns 401 when the authenticated session has no active organization", async () => {
+      const agentId = await createAgent();
+      mockClerk({ userId: user.userId, orgId: null });
+
+      const res = await getCustomConnectorsFromSession(agentId);
+
+      expect(res.status).toBe(401);
+      await expect(res.json()).resolves.toStrictEqual({
+        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+      });
+    });
+
+    it("returns 403 for a sandbox token without agent:read capability", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(
+        user.userId,
+        "run-1",
+        user.orgId,
+      );
+
+      const res = await getCustomConnectors(randomUUID(), token);
+
+      expect(res.status).toBe(403);
+      await expect(res.json()).resolves.toStrictEqual({
+        error: {
+          message: "Missing required capability: agent:read",
+          code: "FORBIDDEN",
+        },
+      });
+    });
+
+    it("returns 404 when the agent belongs to a different org", async () => {
+      const otherUser = await context.setupUser({ prefix: "other-agent-user" });
+      mockClerk({
+        userId: otherUser.userId,
+        orgId: otherUser.orgId,
+        orgRole: "org:admin",
+      });
+      const otherToken = await createTestCliToken(
+        otherUser.userId,
+        undefined,
+        otherUser.orgId,
+      );
+      const otherAgentId = await createAgent(otherToken);
+
+      mockClerk({
+        userId: user.userId,
+        orgId: user.orgId,
+        orgRole: "org:admin",
+      });
+      const res = await getCustomConnectors(otherAgentId, testCliToken);
+
+      expect(res.status).toBe(404);
+      await expect(res.json()).resolves.toStrictEqual({
+        error: {
+          message: `Agent not found: ${otherAgentId}`,
+          code: "NOT_FOUND",
+        },
+      });
     });
   });
 
@@ -199,6 +293,12 @@ describe("Agent Custom Connectors API", () => {
         testCliToken,
       );
       expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toStrictEqual({
+        error: {
+          message: `Unknown custom connector ids: ${otherConnector.id}`,
+          code: "VALIDATION_ERROR",
+        },
+      });
     });
 
     it("returns 404 for non-existent agent", async () => {
@@ -209,6 +309,23 @@ describe("Agent Custom Connectors API", () => {
         testCliToken,
       );
       expect(res.status).toBe(404);
+      await expect(res.json()).resolves.toStrictEqual({
+        error: { message: `Agent not found: ${fakeId}`, code: "NOT_FOUND" },
+      });
+    });
+
+    it("returns 401 when the authenticated session has no active organization", async () => {
+      const agentId = await createAgent();
+      mockClerk({ userId: user.userId, orgId: null });
+
+      const res = await putCustomConnectorsFromSession(agentId, {
+        enabledIds: [],
+      });
+
+      expect(res.status).toBe(401);
+      await expect(res.json()).resolves.toStrictEqual({
+        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+      });
     });
   });
 });

--- a/turbo/apps/web/app/api/zero/agents/[id]/custom-connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/custom-connectors/route.ts
@@ -11,6 +11,15 @@ import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { eq, and, inArray } from "drizzle-orm";
 
+function unauthenticatedResponse() {
+  return {
+    status: 401 as const,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
+
 const router = tsr.router(zeroAgentCustomConnectorsContract, {
   get: async ({ params, headers }) => {
     initServices();
@@ -19,6 +28,7 @@ const router = tsr.router(zeroAgentCustomConnectorsContract, {
       requiredCapability: "agent:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);
@@ -69,6 +79,7 @@ const router = tsr.router(zeroAgentCustomConnectorsContract, {
       requiredCapability: "agent:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);


### PR DESCRIPTION
Closes #12612

## Summary
- Align the web agent custom connectors route with the API route for authenticated sessions that have no active organization.
- Add web route parity coverage for no-active-org sessions, sandbox tokens missing `agent:read`, cross-org agents, and exact error bodies.

## Tests
- `pnpm -F web exec vitest run 'app/api/zero/agents/[id]/custom-connectors/__tests__/route.test.ts'`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- pre-commit: `pnpm knip --cache`, `pnpm check-types`
