### PR TITLE
feat(chat): render queued messages as composer strip

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-queue-message.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-queue-message.test.tsx
@@ -267,7 +267,7 @@ describe("chat queued user messages", () => {
     await sendQueuedMessage(user, "recall this message");
     await expectQueuedMessages(["recall this message"]);
 
-    click(screen.getByLabelText("Recall message"));
+    click(screen.getByLabelText("Remove queued message"));
 
     await waitFor(() => {
       expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-behavior.test.tsx
@@ -622,6 +622,7 @@ describe("zero chat thread page - opening a thread with a queued message", () =>
         {
           role: "user",
           content: "queued before reload",
+          runId: undefined,
           createdAt: "2026-03-10T00:00:02Z",
         },
       ],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -402,11 +402,18 @@ export function mockChatLifecycle(options?: {
         pagedMessages.push(message);
       }
 
-      // Seed with pre-existing chatMessages (e.g. history on resume)
+      // Seed with pre-existing chatMessages (e.g. history on resume). Seeded
+      // entries represent historical messages, so default `runId` to the mock
+      // run when the test didn't include the key — without it, user messages
+      // would look "unassociated" (runId === undefined) and be treated as
+      // queued. Tests that *want* a queued seed should explicitly pass
+      // `runId: undefined`, which we respect via the `in` check.
       for (let i = 0; i < chatMessages.length; i++) {
+        const seed = chatMessages[i]!;
         pagedMessages.push({
-          id: chatMessages[i]!.id ?? `msg-seed-${i}`,
-          ...chatMessages[i]!,
+          ...seed,
+          id: seed.id ?? `msg-seed-${i}`,
+          runId: "runId" in seed ? seed.runId : MOCK_RUN_ID,
         });
       }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
@@ -13,13 +13,23 @@ import {
 const context = testContext();
 const mockApi = createMockApi(context);
 
+const MOCK_RUN_ID = "d0000000-0000-4000-a000-000000000001";
+
 function makeThreadMocks(threadId: string, messages: PagedChatMessage[]) {
+  // Default runId for seeded user messages so they aren't treated as queued.
+  // Tests that want a queued seed should pass `runId: undefined` explicitly.
+  const seeded = messages.map((message) => {
+    if (message.role !== "user" || "runId" in message) {
+      return message;
+    }
+    return { ...message, runId: MOCK_RUN_ID };
+  });
   server.use(
     mockApi(chatThreadMessagesContract.list, ({ query, respond }) => {
       if (query.sinceId) {
         return respond(200, { messages: [] });
       }
-      return respond(200, { messages });
+      return respond(200, { messages: seeded });
     }),
     mockApi(chatThreadByIdContract.get, ({ respond }) => {
       return respond(200, {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -20,6 +20,7 @@ import {
   IconPlug,
   IconPlus,
   IconTarget,
+  IconX,
 } from "@tabler/icons-react";
 import {
   Dialog,
@@ -220,6 +221,19 @@ interface ZeroChatComposerProps {
     actionLabel: string;
     onAction: () => void;
   };
+  /**
+   * Pending sends that landed while a run was active. Rendered as a compact
+   * strip above the textarea so the user can see what's queued without
+   * having those messages re-appear as bubbles in the conversation.
+   */
+  queuedItems?: QueuedComposerItem[];
+  /** Cancels a queued message (routed to the recall flow by the caller). */
+  onRemoveQueuedItem?: (id: string) => void;
+}
+
+export interface QueuedComposerItem {
+  id: string;
+  text: string;
 }
 
 type ComposerModelPicker = NonNullable<ZeroChatComposerProps["modelPicker"]>;
@@ -388,6 +402,59 @@ function SendOrGoalButton({
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Queued messages strip — compact list of pending sends shown above the
+// textarea while a run is active. Visually low-key so it doesn't compete
+// with the input itself.
+// ---------------------------------------------------------------------------
+
+function QueuedMessagesStrip({
+  items,
+  onRemove,
+}: {
+  items: QueuedComposerItem[];
+  onRemove?: (id: string) => void;
+}) {
+  if (items.length === 0) {
+    return null;
+  }
+  return (
+    <div className="border-b border-border/60 px-4 py-2">
+      <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground/75">
+        <span className="h-1.5 w-1.5 rounded-full bg-primary/70" />
+        <span>Queued {items.length}</span>
+      </div>
+      <div
+        className="mt-1 max-h-24 divide-y divide-border/40 overflow-y-auto"
+        role="list"
+      >
+        {items.map((item) => {
+          return (
+            <div
+              key={item.id}
+              role="listitem"
+              aria-label="Queued message"
+              className="flex min-h-7 items-center gap-2 py-1 text-sm text-muted-foreground"
+            >
+              <span className="min-w-0 flex-1 truncate">{item.text}</span>
+              <button
+                type="button"
+                className="shrink-0 rounded p-1 text-muted-foreground/45 transition-colors hover:bg-muted hover:text-foreground focus-visible:bg-muted focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                onClick={() => {
+                  onRemove?.(item.id);
+                }}
+                aria-label="Remove queued message"
+              >
+                <IconX size={14} stroke={1.5} />
+              </button>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -950,6 +1017,8 @@ export function ZeroChatComposer({
   actionsLoading = false,
   modelPicker,
   submitBlocker,
+  queuedItems,
+  onRemoveQueuedItem,
 }: ZeroChatComposerProps) {
   const showAddDialog = useGet(showAddDialog$);
   const setShowAddDialog = useSet(setShowAddDialog$);
@@ -1342,6 +1411,10 @@ export function ZeroChatComposer({
                 }}
               />
             )}
+            <QueuedMessagesStrip
+              items={queuedItems ?? []}
+              onRemove={onRemoveQueuedItem}
+            />
             <textarea
               ref={(el) => {
                 if (el && autoFocus && !isIOSDevice()) {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1017,7 +1017,7 @@ export function ZeroChatComposer({
   actionsLoading = false,
   modelPicker,
   submitBlocker,
-  queuedItems,
+  queuedItems = [],
   onRemoveQueuedItem,
 }: ZeroChatComposerProps) {
   const showAddDialog = useGet(showAddDialog$);
@@ -1412,7 +1412,7 @@ export function ZeroChatComposer({
               />
             )}
             <QueuedMessagesStrip
-              items={queuedItems ?? []}
+              items={queuedItems}
               onRemove={onRemoveQueuedItem}
             />
             <textarea

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -416,10 +416,10 @@ function QueuedMessagesStrip({
   items,
   onRemove,
 }: {
-  items: QueuedComposerItem[];
+  items: QueuedComposerItem[] | undefined;
   onRemove?: (id: string) => void;
 }) {
-  if (items.length === 0) {
+  if (!items || items.length === 0) {
     return null;
   }
   return (
@@ -1017,7 +1017,7 @@ export function ZeroChatComposer({
   actionsLoading = false,
   modelPicker,
   submitBlocker,
-  queuedItems = [],
+  queuedItems,
   onRemoveQueuedItem,
 }: ZeroChatComposerProps) {
   const showAddDialog = useGet(showAddDialog$);

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -24,7 +24,6 @@ import {
   IconPin,
   IconVolume2,
   IconArrowBarToUp,
-  IconArrowBackUp,
   IconBrandGoogleDrive,
   IconDownload,
   IconFile,
@@ -126,7 +125,10 @@ import type {
 import type { ChatThreadSignals } from "../../signals/chat-page/create-chat-thread.ts";
 import type { ChatThread } from "../../signals/agent-chat.ts";
 import { ATTACH_ONLY_PLACEHOLDER } from "../../signals/chat-page/resolve-draft-attachments.ts";
-import { ZeroChatComposer } from "./zero-chat-composer.tsx";
+import {
+  ZeroChatComposer,
+  type QueuedComposerItem,
+} from "./zero-chat-composer.tsx";
 import type { ModelProviderSelection } from "./components/model-provider-picker.tsx";
 import { composerModelProviders$ } from "../../signals/zero-page/composer-model-providers.ts";
 import { modelFirstPersonalOauthState$ } from "../../signals/zero-page/model-first-personal-oauth.ts";
@@ -1736,8 +1738,7 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
   const sessionError = resolveSessionError(threadDataLoadable, groupsLoadable);
   const messagesLoading = groupsLoadable.state === "loading";
   const groups = groupsLoadable.state === "hasData" ? groupsLoadable.data : [];
-  const { activeGroups, queuedGroups } =
-    splitQueuedMessagesForThinkingIndicator(groups);
+  const { activeGroups } = splitQueuedMessagesForThinkingIndicator(groups);
   const setScrollContainer = useSet(thread.setScrollContainer$);
   const skeletonVisible = useGet(thread.skeletonVisible$);
   const loadingHistory = loadHistoryLoadable.state === "loading";
@@ -1810,15 +1811,6 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
                 );
               })}
               <ThinkingIndicator thread={thread} groups={activeGroups} />
-              {queuedGroups.map((group) => {
-                return (
-                  <PagedGroupRow
-                    key={group.beginMessageId}
-                    group={group}
-                    thread={thread}
-                  />
-                );
-              })}
             </div>
           </main>
         </div>
@@ -1974,8 +1966,27 @@ function ChatThreadComposer({
   const cancelRun = useSet(thread.cancelRun$);
   const setInputRef = useSet(thread.setInputRef$);
   const scheduleDraftSync = useSet(thread.scheduleDraftSync$);
+  const recallMessage = useSet(thread.recallMessage$);
+  const focusInput = useSet(thread.focusInput$);
   const pageSignal = useGet(pageSignal$);
   const rootSignal = useGet(rootSignal$);
+
+  const { queuedGroups } = splitQueuedMessagesForThinkingIndicator(groups);
+  const queuedMessagesById = new Map(
+    queuedGroups.flatMap((group) => {
+      return group.messages.map((message) => {
+        return [message.id, message] as const;
+      });
+    }),
+  );
+  const queuedItems: QueuedComposerItem[] = Array.from(
+    queuedMessagesById.values(),
+  ).map((message) => {
+    return {
+      id: message.id,
+      text: (message.content ?? "").trim(),
+    };
+  });
 
   // Per-thread composer state lives in ccstate signals on the factory so the
   // initial value seeds from threadData once it resolves (a React useState
@@ -2078,6 +2089,20 @@ function ChatThreadComposer({
             actionsLoading={skeletonVisible}
             modelPicker={modelPicker}
             submitBlocker={submitBlockerProps}
+            queuedItems={queuedItems}
+            onRemoveQueuedItem={(id) => {
+              const message = queuedMessagesById.get(id);
+              if (!message) {
+                return;
+              }
+              detach(
+                (async () => {
+                  await recallMessage(message, pageSignal);
+                  focusInput();
+                })(),
+                Reason.DomCallback,
+              );
+            }}
           />
           <PersonalProviderDialog />
           <PersonalCodexAuthPasteDialog />
@@ -2807,71 +2832,32 @@ function UserMessageAttachments({
   );
 }
 
-function userMessageAriaLabel({
-  isQueued,
-}: {
-  isQueued: boolean;
-}): string | undefined {
-  if (isQueued) {
-    return "Queued message";
-  }
-  return undefined;
-}
-
-function UserMessageStatusLabel({ isQueued }: { isQueued: boolean }) {
-  if (!isQueued) {
-    return null;
-  }
-  return (
-    <div className="mb-1 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
-      <span className="h-1.5 w-1.5 rounded-full bg-primary/70" />
-      Queued
-    </div>
-  );
-}
-
 function UserMessageActions({
   canCopy,
-  canRecall,
   copied,
   onCopy,
-  onRecall,
 }: {
   canCopy: boolean;
-  canRecall: boolean;
   copied: boolean;
   onCopy: () => void;
-  onRecall: () => void;
 }) {
-  if (!canCopy && !canRecall) {
+  if (!canCopy) {
     return null;
   }
   return (
     <div className="flex justify-end gap-1 mt-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
-      {canRecall && (
-        <button
-          type="button"
-          onClick={onRecall}
-          className="p-1 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-accent transition-colors duration-150"
-          aria-label="Recall message"
-        >
-          <IconArrowBackUp size={18} stroke={1.5} />
-        </button>
-      )}
-      {canCopy && (
-        <button
-          type="button"
-          onClick={onCopy}
-          className="p-1 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-accent transition-colors duration-150"
-          aria-label="Copy message"
-        >
-          {copied ? (
-            <IconCheck size={18} stroke={1.5} />
-          ) : (
-            <IconCopy size={18} stroke={1.5} />
-          )}
-        </button>
-      )}
+      <button
+        type="button"
+        onClick={onCopy}
+        className="p-1 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-accent transition-colors duration-150"
+        aria-label="Copy message"
+      >
+        {copied ? (
+          <IconCheck size={18} stroke={1.5} />
+        ) : (
+          <IconCopy size={18} stroke={1.5} />
+        )}
+      </button>
     </div>
   );
 }
@@ -2909,17 +2895,10 @@ function PagedUserMessage({
   const copiedId = useGet(thread.copiedMessageId$);
   const copied = copiedId === message.id;
   const copyMessage = useSet(thread.copyMessage$);
-  const recallMessage = useSet(thread.recallMessage$);
-  const focusInput = useSet(thread.focusInput$);
   const allAttachments = resolveAttachments(message, parsed);
   const clipboardAttachments = clipboardAttachmentsFromMessage(message, parsed);
   const copyText = strippedContent;
   const canCopy = copyText.trim().length > 0 || clipboardAttachments.length > 0;
-  const isQueued = message.isQueued;
-  const canRecall =
-    isQueued &&
-    message.runId === undefined &&
-    message.revokesMessageId === undefined;
 
   const handleCopy = () => {
     if (!canCopy) {
@@ -2935,29 +2914,11 @@ function PagedUserMessage({
     );
   };
 
-  const handleRecall = () => {
-    if (!canRecall) {
-      return;
-    }
-    detach(
-      (async () => {
-        await recallMessage(message, pageSignal);
-        focusInput();
-      })(),
-      Reason.DomCallback,
-    );
-  };
-
   return (
-    <div
-      data-role="user"
-      className="group"
-      aria-label={userMessageAriaLabel({ isQueued })}
-    >
+    <div data-role="user" className="group">
       <div className="flex flex-col items-end min-w-0 animate-in fade-in slide-in-from-bottom-2 duration-300 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
         <div className="hidden @[900px]:block @[900px]:w-9 @[900px]:h-9 @[900px]:shrink-0" />
         <div className="flex flex-col items-end w-full">
-          <UserMessageStatusLabel isQueued={isQueued} />
           <div className="zero-chat-bubble-user rounded-xl max-w-[85%] text-sm leading-relaxed [overflow-wrap:anywhere] overflow-hidden">
             {bodyBlocks.length > 0 && (
               <div className="px-4 py-3">
@@ -2975,10 +2936,8 @@ function PagedUserMessage({
           </div>
           <UserMessageActions
             canCopy={canCopy}
-            canRecall={canRecall}
             copied={copied}
             onCopy={handleCopy}
-            onRecall={handleRecall}
           />
         </div>
       </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1963,34 +1963,13 @@ function usePersistModelFirstSelection(
   };
 }
 
-function ChatThreadComposer({
-  thread,
-  autoFocus: autoFocusProp = true,
-}: {
-  thread: ChatThreadSignals;
-  autoFocus?: boolean;
-}) {
-  const groups = useLastResolved(thread.groupedChatMessages$) ?? [];
-  const hasMessages = groups.length > 0;
-  const hasUserMessages = groups.some((g) => {
-    return g.role === "user";
-  });
-  const displayName = useLastResolved(thread.agentDisplayName$) ?? "Zero";
-  const allFinishedLoadable = useLastLoadable(thread.allFinished$);
-  const allFinishedResolved = allFinishedLoadable.state === "hasData";
-  const allFinished = allFinishedResolved ? allFinishedLoadable.data : false;
-  const [sendLoadable, send] = useLoadableSet(thread.sendMessage$);
-  const [, queueMessage] = useLoadableSet(thread.queueMessage$);
-  const sending = !allFinished || sendLoadable.state === "loading";
-  const input = useGet(thread.draft.input$);
-  const setInput = useSet(thread.draft.setInput$);
-  const cancelRun = useSet(thread.cancelRun$);
-  const setInputRef = useSet(thread.setInputRef$);
-  const scheduleDraftSync = useSet(thread.scheduleDraftSync$);
+function useChatComposerQueue(
+  thread: ChatThreadSignals,
+  groups: GroupedChatMessageGroup[],
+) {
   const recallMessage = useSet(thread.recallMessage$);
   const focusInput = useSet(thread.focusInput$);
   const pageSignal = useGet(pageSignal$);
-  const rootSignal = useGet(rootSignal$);
 
   const { queuedGroups } = splitQueuedMessagesForThinkingIndicator(groups);
   const queuedMessagesById = new Map(
@@ -2009,6 +1988,33 @@ function ChatThreadComposer({
     };
   });
 
+  const onRemoveQueuedItem = (id: string) => {
+    const message = queuedMessagesById.get(id);
+    if (!message) {
+      return;
+    }
+    detach(
+      (async () => {
+        await recallMessage(message, pageSignal);
+        focusInput();
+      })(),
+      Reason.DomCallback,
+    );
+  };
+
+  return { queuedItems, onRemoveQueuedItem };
+}
+
+function useChatComposerModel(
+  thread: ChatThreadSignals,
+  {
+    hasUserMessages,
+    pageSignal,
+  }: {
+    hasUserMessages: boolean;
+    pageSignal: AbortSignal;
+  },
+) {
   // Per-thread composer state lives in ccstate signals on the factory so the
   // initial value seeds from threadData once it resolves (a React useState
   // initializer would snapshot `undefined` on first render). `modelSelection$`
@@ -2020,14 +2026,6 @@ function ChatThreadComposer({
   const setModelSelection = useSet(thread.setModelSelection$);
   const agentModelDefault = useLastResolved(thread.agentModelDefault$) ?? null;
   const modelFirstEnabled = useGet(modelFirstModelProviderEnabled$);
-  // During thread switch the thread-level skeleton is visible and
-  // `threadData` / `allFinished$` may still reflect the previous thread;
-  // render the whole action cluster as a skeleton so we don't flash stale
-  // picker state or a wrong send/stop button.
-  const skeletonVisible = useGet(thread.skeletonVisible$);
-  const queueWhileSending = canQueueMessage({
-    sending,
-  });
   const modelFirstOauthState = useLastResolved(modelFirstPersonalOauthState$);
   const openPersonalOauthConfiguration = usePersonalOauthConfigurationAction();
   const persistModelFirstSelection = usePersistModelFirstSelection(
@@ -2058,6 +2056,47 @@ function ChatThreadComposer({
     modelSelection,
     agentModelDefault,
     onAction: openPersonalOauthConfiguration,
+  });
+
+  return { modelPicker, submitBlockerProps, modelSelection };
+}
+
+function ChatThreadComposer({
+  thread,
+  autoFocus: autoFocusProp = true,
+}: {
+  thread: ChatThreadSignals;
+  autoFocus?: boolean;
+}) {
+  const groups = useLastResolved(thread.groupedChatMessages$) ?? [];
+  const hasMessages = groups.length > 0;
+  const hasUserMessages = groups.some((g) => {
+    return g.role === "user";
+  });
+  const displayName = useLastResolved(thread.agentDisplayName$) ?? "Zero";
+  const allFinishedLoadable = useLastLoadable(thread.allFinished$);
+  const allFinishedResolved = allFinishedLoadable.state === "hasData";
+  const allFinished = allFinishedResolved ? allFinishedLoadable.data : false;
+  const [sendLoadable, send] = useLoadableSet(thread.sendMessage$);
+  const [, queueMessage] = useLoadableSet(thread.queueMessage$);
+  const sending = !allFinished || sendLoadable.state === "loading";
+  const input = useGet(thread.draft.input$);
+  const setInput = useSet(thread.draft.setInput$);
+  const cancelRun = useSet(thread.cancelRun$);
+  const setInputRef = useSet(thread.setInputRef$);
+  const scheduleDraftSync = useSet(thread.scheduleDraftSync$);
+  const pageSignal = useGet(pageSignal$);
+  const rootSignal = useGet(rootSignal$);
+
+  const { queuedItems, onRemoveQueuedItem } = useChatComposerQueue(
+    thread,
+    groups,
+  );
+  const { modelPicker, submitBlockerProps, modelSelection } =
+    useChatComposerModel(thread, { hasUserMessages, pageSignal });
+  const skeletonVisible = useGet(thread.skeletonVisible$);
+  const queueWhileSending = canQueueMessage({
+    sending,
   });
 
   const handleInputChange = (text: string) => {
@@ -2122,19 +2161,7 @@ function ChatThreadComposer({
             modelPicker={modelPicker}
             submitBlocker={submitBlockerProps}
             queuedItems={queuedItems}
-            onRemoveQueuedItem={(id) => {
-              const message = queuedMessagesById.get(id);
-              if (!message) {
-                return;
-              }
-              detach(
-                (async () => {
-                  await recallMessage(message, pageSignal);
-                  focusInput();
-                })(),
-                Reason.DomCallback,
-              );
-            }}
+            onRemoveQueuedItem={onRemoveQueuedItem}
           />
           <PersonalProviderDialog />
           <PersonalCodexAuthPasteDialog />


### PR DESCRIPTION
## Summary
- Move queued user messages from the chat log into a compact strip pinned above the composer textarea, reviving the design from the original #11028 exploration.
- Wire the strip's remove button to the existing append-only recall flow (`thread.recallMessage$`) so stop-during-run, refresh rehydration, and recall semantics from #12253 stay intact.
- Default `runId` for seeded historical user messages in `chat-test-helpers.ts` and `zero-session-chat-page.test.tsx` so they aren't classified as queued; tests that *want* a queued seed opt in with an explicit `runId: undefined`.

## Test plan
- [ ] Open a chat with an active run, type and send a message — it appears in the strip above the input, not as a bubble in the log
- [ ] Click the X on a queued strip item — the message is recalled and the textarea regains focus with the original text
- [ ] Click Stop with multiple queued items — all are recalled and the strip clears
- [ ] Refresh mid-run with queued items still pending — strip rehydrates from server-persisted queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)