### PR TITLE
test: align zero agent read route parity

### DIFF
--- a/turbo/apps/web/app/api/zero/agents/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/route.ts
@@ -38,6 +38,15 @@ function createPublicAgentLimitResponse() {
   );
 }
 
+function unauthenticatedResponse() {
+  return {
+    status: 401 as const,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
+
 type AgentUpdateBody = {
   displayName?: string | null;
   description?: string | null;
@@ -232,6 +241,7 @@ const router = tsr.router(zeroAgentsByIdContract, {
       requiredCapability: "agent:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
 
     const { org } = await resolveOrg(authCtx);
 

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -74,6 +74,14 @@ function getAgent(name: string, token: string) {
   );
 }
 
+function getAgentFromSession(name: string) {
+  return GET(
+    createTestRequest(`http://localhost:3000/api/zero/agents/${name}`, {
+      method: "GET",
+    }),
+  );
+}
+
 function putAgent(name: string, body: Record<string, unknown>, token: string) {
   return PUT(
     createTestRequest(`http://localhost:3000/api/zero/agents/${name}`, {
@@ -109,6 +117,14 @@ function listAgentsReq(token: string) {
     createTestRequest(`http://localhost:3000/api/zero/agents`, {
       method: "GET",
       headers: { Authorization: `Bearer ${token}` },
+    }),
+  );
+}
+
+function listAgentsFromSession() {
+  return listAgents(
+    createTestRequest(`http://localhost:3000/api/zero/agents`, {
+      method: "GET",
     }),
   );
 }
@@ -385,14 +401,66 @@ describe("Zero Agents API", () => {
     });
 
     it("should return 404 for unknown agent", async () => {
-      const response = await getAgent(
-        "00000000-0000-0000-0000-000000000000",
-        testCliToken,
-      );
+      const unknownId = "00000000-0000-0000-0000-000000000000";
+      const response = await getAgent(unknownId, testCliToken);
 
       expect(response.status).toBe(404);
       const data = await response.json();
-      expect(data.error.code).toBe("NOT_FOUND");
+      expect(data).toStrictEqual({
+        error: { message: `Agent not found: ${unknownId}`, code: "NOT_FOUND" },
+      });
+    });
+
+    it("should return 401 when the authenticated session has no active organization", async () => {
+      const createResponse = await postAgent(
+        { displayName: "No Org Detail" },
+        testCliToken,
+      );
+      expect(createResponse.status).toBe(201);
+      const created = await createResponse.json();
+      mockClerk({ userId: user.userId, orgId: null });
+
+      const response = await getAgentFromSession(created.agentId);
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toStrictEqual({
+        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+      });
+    });
+
+    it("should return 404 for an agent from another org", async () => {
+      const otherUser = await context.setupUser({ prefix: "other-agent-user" });
+      mockClerk({
+        userId: otherUser.userId,
+        orgId: otherUser.orgId,
+        orgRole: "org:admin",
+      });
+      const otherToken = await createTestCliToken(
+        otherUser.userId,
+        undefined,
+        otherUser.orgId,
+      );
+      const createResponse = await postAgent(
+        { displayName: "Other Org Agent" },
+        otherToken,
+      );
+      expect(createResponse.status).toBe(201);
+      const otherAgent = await createResponse.json();
+      mockClerk({
+        userId: user.userId,
+        orgId: user.orgId,
+        orgRole: "org:admin",
+      });
+
+      const response = await getAgent(otherAgent.agentId, testCliToken);
+
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toStrictEqual({
+        error: {
+          message: `Agent not found: ${otherAgent.agentId}`,
+          code: "NOT_FOUND",
+        },
+      });
     });
 
     it("should only return private agents to their owner", async () => {
@@ -919,6 +987,49 @@ describe("Zero Agents API", () => {
       mockClerk({ userId: null });
       const response = await listAgentsReq("no-token");
       expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toStrictEqual({
+        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+      });
+    });
+
+    it("should return 401 when the authenticated session has no active organization", async () => {
+      mockClerk({ userId: user.userId, orgId: null });
+
+      const response = await listAgentsFromSession();
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toStrictEqual({
+        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+      });
+    });
+
+    it("should only list agents from the active organization", async () => {
+      const otherUser = await context.setupUser({ prefix: "other-agent-user" });
+      mockClerk({
+        userId: otherUser.userId,
+        orgId: otherUser.orgId,
+        orgRole: "org:admin",
+      });
+      const otherToken = await createTestCliToken(
+        otherUser.userId,
+        undefined,
+        otherUser.orgId,
+      );
+      const createResponse = await postAgent(
+        { displayName: "Other Org Agent" },
+        otherToken,
+      );
+      expect(createResponse.status).toBe(201);
+      mockClerk({
+        userId: user.userId,
+        orgId: user.orgId,
+        orgRole: "org:admin",
+      });
+
+      const response = await listAgentsReq(testCliToken);
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toStrictEqual([]);
     });
   });
 

--- a/turbo/apps/web/app/api/zero/agents/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/route.ts
@@ -24,6 +24,15 @@ import { logger } from "../../../../src/lib/shared/logger";
 
 const log = logger("api:zero-agents");
 
+function unauthenticatedResponse() {
+  return {
+    status: 401 as const,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
+
 const router = tsr.router(zeroAgentsMainContract, {
   create: async ({ body, headers }) => {
     initServices();
@@ -157,6 +166,7 @@ const router = tsr.router(zeroAgentsMainContract, {
       requiredCapability: "agent:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);


### PR DESCRIPTION
## Summary

- return the API-compatible 401 response when zero agent list/detail web reads are authenticated without active org context
- add web route parity coverage for no-active-org, cross-org list scoping, cross-org detail no-leak, and exact error bodies

Closes #12615.

## Validation

- `pnpm -F web exec vitest run app/api/zero/agents/__tests__/route.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-agents-list.test.ts src/signals/routes/__tests__/zero-agents-by-id.test.ts`
- `pnpm -F web check-types`
- `pnpm -F web lint`
- `pnpm format`
- `pnpm knip --workspace web`
- pre-commit: `pnpm knip --cache`, `pnpm check-types`
