### PR TITLE
feat(api): migrate permission-policies put to api backend (Wave 6 #6)

### DIFF
--- a/turbo/apps/api/src/lib/require-agent-permission.ts
+++ b/turbo/apps/api/src/lib/require-agent-permission.ts
@@ -1,0 +1,30 @@
+type ForbiddenResponse = {
+  readonly status: 403;
+  readonly body: {
+    readonly error: { readonly message: string; readonly code: string };
+  };
+};
+
+/**
+ * Owner-OR-admin gate for per-agent write operations.
+ *
+ * Returns a 403 envelope when neither condition is met, or null to allow.
+ */
+export function requireAgentPermission(
+  agentOwner: string,
+  member: { readonly userId: string; readonly role: string },
+  action: string,
+): ForbiddenResponse | null {
+  if (member.role === "admin" || member.userId === agentOwner) {
+    return null;
+  }
+  return {
+    status: 403 as const,
+    body: {
+      error: {
+        message: `Only the agent owner or org admin can ${action}`,
+        code: "FORBIDDEN",
+      },
+    },
+  };
+}

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -32,6 +32,7 @@ import { zeroModelProvidersRoutes } from "./routes/zero-model-providers";
 import { zeroOnboardingStatusRoutes } from "./routes/zero-onboarding-status";
 import { zeroOrgInviteRoutes } from "./routes/zero-org-invite";
 import { zeroOrgReadRoutes } from "./routes/zero-org-read";
+import { zeroPermissionPoliciesRoutes } from "./routes/zero-permission-policies";
 import { zeroPushSubscriptionsRoutes } from "./routes/zero-push-subscriptions";
 import { zeroQueuePositionRoutes } from "./routes/zero-queue-position";
 import { zeroRunDetailRoutes } from "./routes/zero-run-detail";
@@ -105,6 +106,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroOnboardingStatusRoutes,
   ...zeroOrgInviteRoutes,
   ...zeroOrgReadRoutes,
+  ...zeroPermissionPoliciesRoutes,
   ...zeroPushSubscriptionsRoutes,
   ...zeroUserPreferencesRoutes,
   ...zeroUserModelPreferenceRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-permission-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-permission-policies.test.ts
@@ -81,6 +81,43 @@ describe("PUT /api/zero/permission-policies", () => {
     expect(response.body.agentId).toBe(agentId);
   });
 
+  it("persists policies across reads (DB read-after-write)", async () => {
+    const fixture = uniqueOrgUser("zpp-persist-db");
+    await store.set(
+      seedOrgMembership$,
+      { orgId: fixture.orgId, userId: fixture.userId, role: "admin" },
+      context.signal,
+    );
+    const { agentId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const policies = {
+      slack: {
+        policies: { "channels:read": "allow", "chat:write": "ask" },
+      },
+    } as const;
+
+    const client = setupApp({ context })(zeroAgentPermissionPoliciesContract);
+    const response = await client.update({
+      body: { agentId, policies },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(200);
+
+    // Direct DB SELECT verifies the row was persisted, independent of the
+    // PUT response body. Mirrors web case "should persist policies across reads".
+    // The DB stores the flat RawPermissionPolicies form (no `policies` wrapper);
+    // toFirewallPolicies reconstructs the nested wire shape on read.
+    const stored = await readStoredPolicies(agentId);
+    expect(stored?.permissionPolicies).toStrictEqual({
+      slack: { "channels:read": "allow", "chat:write": "ask" },
+    });
+  });
+
   it("overwrites previous policies on a second PUT", async () => {
     const fixture = uniqueOrgUser("zpp-overwrite");
     await store.set(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-permission-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-permission-policies.test.ts
@@ -1,0 +1,469 @@
+import { randomUUID } from "node:crypto";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { zeroAgentPermissionPoliciesContract } from "@vm0/api-contracts/contracts/zero-agents";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { seedOrgMembership$ } from "./helpers/zero-org-membership";
+import { seedCompose$ } from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+interface OrgUser {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+function uniqueOrgUser(prefix: string): OrgUser {
+  return {
+    orgId: `org_${prefix}_${randomUUID().slice(0, 8)}`,
+    userId: `user_${prefix}_${randomUUID().slice(0, 8)}`,
+  };
+}
+
+function slackAllow() {
+  return {
+    slack: { policies: { "channels:read": "allow" } },
+  } as const;
+}
+
+async function readStoredPolicies(agentId: string) {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select({
+      permissionPolicies: zeroAgents.permissionPolicies,
+      unknownPermissionPolicies: zeroAgents.unknownPermissionPolicies,
+    })
+    .from(zeroAgents)
+    .where(eq(zeroAgents.id, agentId))
+    .limit(1);
+  return row;
+}
+
+describe("PUT /api/zero/permission-policies", () => {
+  it("persists permission policies for an agent", async () => {
+    const fixture = uniqueOrgUser("zpp-persist");
+    await store.set(
+      seedOrgMembership$,
+      { orgId: fixture.orgId, userId: fixture.userId, role: "admin" },
+      context.signal,
+    );
+    const { agentId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const policies = {
+      slack: {
+        policies: { "channels:read": "allow", "chat:write": "deny" },
+      },
+    } as const;
+
+    const client = setupApp({ context })(zeroAgentPermissionPoliciesContract);
+    const response = await client.update({
+      body: { agentId, policies },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      return;
+    }
+    expect(response.body.permissionPolicies).toStrictEqual(policies);
+    expect(response.body.agentId).toBe(agentId);
+  });
+
+  it("overwrites previous policies on a second PUT", async () => {
+    const fixture = uniqueOrgUser("zpp-overwrite");
+    await store.set(
+      seedOrgMembership$,
+      { orgId: fixture.orgId, userId: fixture.userId, role: "admin" },
+      context.signal,
+    );
+    const { agentId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroAgentPermissionPoliciesContract);
+
+    await client.update({
+      body: {
+        agentId,
+        policies: {
+          slack: { policies: { "channels:read": "allow" } },
+        },
+      },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+
+    const second = {
+      slack: { policies: { "channels:read": "deny" } },
+    } as const;
+    const response = await client.update({
+      body: { agentId, policies: second },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      return;
+    }
+    expect(response.body.permissionPolicies).toStrictEqual(second);
+  });
+
+  it("allows an org admin to update another user's agent", async () => {
+    const ownerFixture = uniqueOrgUser("zpp-owner");
+    const adminFixture = {
+      orgId: ownerFixture.orgId,
+      userId: `user_zpp-other-admin_${randomUUID().slice(0, 8)}`,
+    };
+    await store.set(
+      seedOrgMembership$,
+      {
+        orgId: ownerFixture.orgId,
+        userId: ownerFixture.userId,
+        role: "member",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedOrgMembership$,
+      {
+        orgId: adminFixture.orgId,
+        userId: adminFixture.userId,
+        role: "admin",
+        seedOrgCache: false,
+      },
+      context.signal,
+    );
+    const { agentId } = await store.set(
+      seedCompose$,
+      { orgId: ownerFixture.orgId, userId: ownerFixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(adminFixture.userId, adminFixture.orgId);
+
+    const client = setupApp({ context })(zeroAgentPermissionPoliciesContract);
+    const response = await client.update({
+      body: { agentId, policies: slackAllow() },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      return;
+    }
+    expect(response.body.permissionPolicies).toStrictEqual(slackAllow());
+  });
+
+  it("returns 403 for a non-owner member", async () => {
+    const ownerFixture = uniqueOrgUser("zpp-owner2");
+    const memberFixture = {
+      orgId: ownerFixture.orgId,
+      userId: `user_zpp-other-member_${randomUUID().slice(0, 8)}`,
+    };
+    await store.set(
+      seedOrgMembership$,
+      {
+        orgId: ownerFixture.orgId,
+        userId: ownerFixture.userId,
+        role: "member",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedOrgMembership$,
+      {
+        orgId: memberFixture.orgId,
+        userId: memberFixture.userId,
+        role: "member",
+        seedOrgCache: false,
+      },
+      context.signal,
+    );
+    const { agentId } = await store.set(
+      seedCompose$,
+      { orgId: ownerFixture.orgId, userId: ownerFixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(
+      memberFixture.userId,
+      memberFixture.orgId,
+      "org:member",
+    );
+
+    const client = setupApp({ context })(zeroAgentPermissionPoliciesContract);
+    const response = await accept(
+      client.update({
+        body: { agentId, policies: slackAllow() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+    expect(response.body.error.code).toBe("FORBIDDEN");
+    expect(response.body.error.message).toContain("update permission policies");
+  });
+
+  it("allows the agent owner with member role to update policies", async () => {
+    const fixture = uniqueOrgUser("zpp-owner-member");
+    await store.set(
+      seedOrgMembership$,
+      { orgId: fixture.orgId, userId: fixture.userId, role: "member" },
+      context.signal,
+    );
+    const { agentId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroAgentPermissionPoliciesContract);
+    const response = await client.update({
+      body: { agentId, policies: slackAllow() },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      return;
+    }
+    expect(response.body.permissionPolicies).toStrictEqual(slackAllow());
+  });
+
+  it("returns 400 VALIDATION_ERROR for an unknown connector ref", async () => {
+    const fixture = uniqueOrgUser("zpp-unknown-conn");
+    await store.set(
+      seedOrgMembership$,
+      { orgId: fixture.orgId, userId: fixture.userId, role: "admin" },
+      context.signal,
+    );
+    const { agentId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroAgentPermissionPoliciesContract);
+    const response = await accept(
+      client.update({
+        body: {
+          agentId,
+          policies: {
+            "nonexistent-connector": {
+              policies: { "perm:read": "allow" },
+            },
+          },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+    expect(response.body.error.code).toBe("VALIDATION_ERROR");
+    expect(response.body.error.message).toContain("nonexistent-connector");
+  });
+
+  it("returns 400 VALIDATION_ERROR for an unknown permission name", async () => {
+    const fixture = uniqueOrgUser("zpp-unknown-perm");
+    await store.set(
+      seedOrgMembership$,
+      { orgId: fixture.orgId, userId: fixture.userId, role: "admin" },
+      context.signal,
+    );
+    const { agentId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroAgentPermissionPoliciesContract);
+    const response = await accept(
+      client.update({
+        body: {
+          agentId,
+          policies: {
+            slack: { policies: { "totally-fake-permission": "allow" } },
+          },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+    expect(response.body.error.code).toBe("VALIDATION_ERROR");
+    expect(response.body.error.message).toContain("totally-fake-permission");
+  });
+
+  it("returns 404 for a nonexistent agent", async () => {
+    const fixture = uniqueOrgUser("zpp-missing");
+    await store.set(
+      seedOrgMembership$,
+      { orgId: fixture.orgId, userId: fixture.userId, role: "admin" },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroAgentPermissionPoliciesContract);
+    const response = await accept(
+      client.update({
+        body: {
+          agentId: "00000000-0000-0000-0000-000000000000",
+          policies: slackAllow(),
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 401 without auth", async () => {
+    const client = setupApp({ context })(zeroAgentPermissionPoliciesContract);
+    const response = await accept(
+      client.update({
+        body: {
+          agentId: "00000000-0000-4000-8000-000000000001",
+          policies: {},
+        },
+        headers: {},
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({ error: { code: "UNAUTHORIZED" } });
+  });
+
+  it("returns 401 when authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroAgentPermissionPoliciesContract);
+    const response = await accept(
+      client.update({
+        body: {
+          agentId: "00000000-0000-4000-8000-000000000001",
+          policies: {},
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({ error: { code: "UNAUTHORIZED" } });
+  });
+
+  it("accepts empty policies and stores null", async () => {
+    const fixture = uniqueOrgUser("zpp-empty");
+    await store.set(
+      seedOrgMembership$,
+      { orgId: fixture.orgId, userId: fixture.userId, role: "admin" },
+      context.signal,
+    );
+    const { agentId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroAgentPermissionPoliciesContract);
+    const response = await client.update({
+      body: { agentId, policies: {} },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      return;
+    }
+    expect(response.body.permissionPolicies).toBeNull();
+  });
+
+  it("returns the full agent response shape", async () => {
+    const fixture = uniqueOrgUser("zpp-shape");
+    await store.set(
+      seedOrgMembership$,
+      { orgId: fixture.orgId, userId: fixture.userId, role: "admin" },
+      context.signal,
+    );
+    const { agentId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroAgentPermissionPoliciesContract);
+    const response = await client.update({
+      body: { agentId, policies: slackAllow() },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      return;
+    }
+    expect(response.body).toMatchObject({
+      agentId,
+      ownerId: fixture.userId,
+      description: null,
+      displayName: null,
+      sound: null,
+      avatarUrl: null,
+      permissionPolicies: slackAllow(),
+      customSkills: [],
+      modelProviderId: null,
+      selectedModel: null,
+    });
+  });
+
+  it("isolates policies between different agents in the same org", async () => {
+    const fixture = uniqueOrgUser("zpp-isolation");
+    await store.set(
+      seedOrgMembership$,
+      { orgId: fixture.orgId, userId: fixture.userId, role: "admin" },
+      context.signal,
+    );
+    const agent1 = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const agent2 = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const policies1 = {
+      slack: { policies: { "channels:read": "allow" } },
+    } as const;
+    const policies2 = {
+      slack: { policies: { "channels:read": "deny" } },
+    } as const;
+
+    const client = setupApp({ context })(zeroAgentPermissionPoliciesContract);
+    await client.update({
+      body: { agentId: agent1.agentId, policies: policies1 },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    const second = await client.update({
+      body: { agentId: agent2.agentId, policies: policies2 },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(second.status).toBe(200);
+
+    const stored1 = await readStoredPolicies(agent1.agentId);
+    const stored2 = await readStoredPolicies(agent2.agentId);
+    expect(stored1?.permissionPolicies).not.toBeNull();
+    expect(stored2?.permissionPolicies).not.toBeNull();
+    expect(stored1?.permissionPolicies).not.toStrictEqual(
+      stored2?.permissionPolicies,
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-permission-policies.ts
+++ b/turbo/apps/api/src/signals/routes/zero-permission-policies.ts
@@ -1,0 +1,99 @@
+import { command } from "ccstate";
+import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
+import {
+  getConnectorFirewall,
+  isFirewallConnectorType,
+} from "@vm0/connectors/firewalls";
+import { zeroAgentPermissionPoliciesContract } from "@vm0/api-contracts/contracts/zero-agents";
+
+import { isNotFoundResponse } from "../../lib/error";
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route";
+import { updateAgentPermissionPolicies$ } from "../services/zero-permission-policies.service";
+
+function validatePolicies(policies: FirewallPolicies): string | null {
+  for (const [ref, policy] of Object.entries(policies)) {
+    if (!isFirewallConnectorType(ref)) {
+      return `Unknown connector ref: ${ref}`;
+    }
+    const config = getConnectorFirewall(ref);
+    const validPermNames = new Set<string>();
+    for (const api of config.apis) {
+      if (api.permissions) {
+        for (const p of api.permissions) {
+          validPermNames.add(p.name);
+        }
+      }
+    }
+    for (const permName of Object.keys(policy.policies)) {
+      if (!validPermNames.has(permName)) {
+        return `Unknown permission "${permName}" for connector "${ref}"`;
+      }
+    }
+  }
+  return null;
+}
+
+function validationError(message: string) {
+  return {
+    status: 400 as const,
+    body: {
+      error: { message, code: "VALIDATION_ERROR" },
+    },
+  };
+}
+
+const updateInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+
+  const bodyResult = await get(
+    bodyResultOf(zeroAgentPermissionPoliciesContract.update),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const validationMessage = validatePolicies(bodyResult.data.policies);
+  if (validationMessage) {
+    return validationError(validationMessage);
+  }
+
+  const result = await set(
+    updateAgentPermissionPolicies$,
+    {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      role: auth.orgRole ?? "member",
+      agentId: bodyResult.data.agentId,
+      policies: bodyResult.data.policies,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (isNotFoundResponse(result)) {
+    return result;
+  }
+  if ("status" in result && result.status === 403) {
+    return result;
+  }
+
+  return { status: 200 as const, body: result.agent };
+});
+
+export const zeroPermissionPoliciesRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroAgentPermissionPoliciesContract.update,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "agent:write",
+      },
+      updateInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-agent-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agent-data.service.ts
@@ -11,7 +11,7 @@ import { and, desc, eq, isNull, or } from "drizzle-orm";
 
 import { db$ } from "../external/db";
 
-function agentResponse(row: {
+export function agentResponse(row: {
   readonly agentId: string;
   readonly owner: string;
   readonly composeUserId?: string;

--- a/turbo/apps/api/src/signals/services/zero-permission-policies.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-permission-policies.service.ts
@@ -85,6 +85,7 @@ export const updateAgentPermissionPolicies$ = command(
         modelProviderId: zeroAgents.modelProviderId,
         selectedModel: zeroAgents.selectedModel,
         preferPersonalProvider: zeroAgents.preferPersonalProvider,
+        visibility: zeroAgents.visibility,
       })
       .from(zeroAgents)
       .where(eq(zeroAgents.id, args.agentId))

--- a/turbo/apps/api/src/signals/services/zero-permission-policies.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-permission-policies.service.ts
@@ -1,0 +1,100 @@
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import {
+  fromFirewallPolicies,
+  type FirewallPolicies,
+} from "@vm0/connectors/firewall-types";
+import type { ZeroAgentResponse } from "@vm0/api-contracts/contracts/zero-agents";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+
+import { notFound } from "../../lib/error";
+import { requireAgentPermission } from "../../lib/require-agent-permission";
+import { nowDate } from "../../lib/time";
+import { writeDb$ } from "../external/db";
+import { agentResponse } from "./zero-agent-data.service";
+
+interface UpdatePermissionPoliciesArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly role: string;
+  readonly agentId: string;
+  readonly policies: FirewallPolicies;
+}
+
+type ForbiddenResponse = NonNullable<ReturnType<typeof requireAgentPermission>>;
+
+type UpdateResult =
+  | { readonly kind: "ok"; readonly agent: ZeroAgentResponse }
+  | ReturnType<typeof notFound>
+  | ForbiddenResponse;
+
+export const updateAgentPermissionPolicies$ = command(
+  async (
+    { set },
+    args: UpdatePermissionPoliciesArgs,
+    signal: AbortSignal,
+  ): Promise<UpdateResult> => {
+    const db = set(writeDb$);
+
+    const [existing] = await db
+      .select({ id: zeroAgents.id, owner: zeroAgents.owner })
+      .from(zeroAgents)
+      .where(
+        and(eq(zeroAgents.orgId, args.orgId), eq(zeroAgents.id, args.agentId)),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!existing) {
+      return notFound(`Agent not found: ${args.agentId}`);
+    }
+
+    const forbidden = requireAgentPermission(
+      existing.owner,
+      { userId: args.userId, role: args.role },
+      "update permission policies",
+    );
+    if (forbidden) {
+      return forbidden;
+    }
+
+    const { permissionPolicies, unknownPermissionPolicies } =
+      fromFirewallPolicies(args.policies);
+
+    await db
+      .update(zeroAgents)
+      .set({
+        permissionPolicies,
+        unknownPermissionPolicies,
+        updatedAt: nowDate(),
+      })
+      .where(eq(zeroAgents.id, args.agentId));
+    signal.throwIfAborted();
+
+    const [row] = await db
+      .select({
+        agentId: zeroAgents.id,
+        owner: zeroAgents.owner,
+        displayName: zeroAgents.displayName,
+        description: zeroAgents.description,
+        sound: zeroAgents.sound,
+        avatarUrl: zeroAgents.avatarUrl,
+        permissionPolicies: zeroAgents.permissionPolicies,
+        unknownPermissionPolicies: zeroAgents.unknownPermissionPolicies,
+        customSkills: zeroAgents.customSkills,
+        modelProviderId: zeroAgents.modelProviderId,
+        selectedModel: zeroAgents.selectedModel,
+        preferPersonalProvider: zeroAgents.preferPersonalProvider,
+      })
+      .from(zeroAgents)
+      .where(eq(zeroAgents.id, args.agentId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!row) {
+      return notFound(`Agent not found: ${args.agentId}`);
+    }
+
+    return { kind: "ok", agent: agentResponse(row) };
+  },
+);


### PR DESCRIPTION
## Summary

Wave 6 #6 — migrates `PUT /api/zero/permission-policies` (update agent firewall permission policies) from `apps/web` to `apps/api`. Verbatim parity with web's 158-LOC handler. Contract `zeroAgentPermissionPoliciesContract.update` was pre-defined.

- **Owner-OR-admin gate** via new `requireAgentPermission` helper (`apps/api/src/lib/require-agent-permission.ts`) — first owner-or-admin gate in apps/api; admin-only routes (custom-connectors-create, default-agent) used frozen inline consts, this case needs ownership context so the helper variant is justified
- **`VALIDATION_ERROR` code** preserved for unknown-connector / unknown-permission cases (NOT `BAD_REQUEST` — matches web's specific code)
- **New service `updateAgentPermissionPolicies$`** returns result-union `{kind:"ok", agent} | NotFoundResponse | ForbiddenResponse` (Wave 5/6 convention)
- **Exported `agentResponse`** from `zero-agent-data.service.ts` so the new service reuses the canonical `ZeroAgentResponse` builder (was previously private)
- **`fromFirewallPolicies` / `toFirewallPolicies`** handles the null-conversion: `fromFirewallPolicies({})` writes `{}` to the DB, `toFirewallPolicies({}, {})` reads back as `null` — matches web semantics

### Migration scope

**Logic-unchanged.** Order preserved verbatim: auth → validate → SELECT existing → owner-or-admin gate → UPDATE → re-SELECT → 200.

### Tests (13 total)

12 web cases ported + 1 api defensive (skipped: web's \"persist across reads\" which duplicates the re-SELECT path, and web's \"new agents return null\" which tests the create endpoint not PUT):

1. Persist policies (200 + body match + agentId)
2. Overwrite previous policies (second PUT replaces first)
3. Org admin updates another user's agent (200)
4. Non-owner member → 403 FORBIDDEN with \"update permission policies\" in message
5. Owner with member role → 200 (ownership trumps role)
6. Unknown connector ref → 400 VALIDATION_ERROR + connector name in message
7. Unknown permission name → 400 VALIDATION_ERROR + permission name in message
8. Nonexistent agent → 404 NOT_FOUND
9. No auth → 401
10. Empty `{}` policies → 200 + body.permissionPolicies null
11. Full response shape (agentId, ownerId, description, displayName, sound, avatarUrl, permissionPolicies, customSkills, modelProviderId, selectedModel)
12. Cross-agent isolation (DB read-after-write proves agent A and B have independent policies)
13. **api defensive:** 401 when session has no organization

### Test plan

- [x] `pnpm -F api exec vitest run` — 991 / 991 pass
- [x] `pnpm turbo run lint` — clean (pre-existing main warning in `zero-org-invite.test.ts` unchanged, not introduced here)
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — clean
- [x] `pnpm knip` — clean
- [x] `pnpm -F web run db:migrate` — schema synced

### Pattern conventions reinforced

| Concern | Convention |
|---|---|
| Owner-OR-admin gate | `requireAgentPermission(owner, member, action)` helper returning `ForbiddenResponse | null` (first instance in apps/api) |
| Service result-union | `{kind:\"ok\", agent} | NotFoundResponse | ForbiddenResponse` |
| `VALIDATION_ERROR` vs `BAD_REQUEST` | Preserve domain-specific codes verbatim |
| Helper export trigger | Three callers → extract; second consumer (`agentResponse`) makes the export worthwhile |
| Pure-function validation in route file | Inline when single caller; service handles DB |

Refs #12290
Closes #12681

🤖 Generated with [Claude Code](https://claude.com/claude-code)