### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.3"
-CLAUDE_CODE_VERSION="2.1.137"
+CLAUDE_CODE_VERSION="2.1.138"
 CODEX_CLI_VERSION="0.130.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Summary
- Bump Claude Code CLI from 2.1.137 to 2.1.138

## Details
Checked all pinned versions in `crates/runner/scripts/build-template.sh`:

| Package | Old | New |
|---------|-----|-----|
| `CLAUDE_CODE_VERSION` | 2.1.137 | 2.1.138 |
| `GO_VERSION` | 1.26.3 | (latest) |
| `CODEX_CLI_VERSION` | 0.130.0 | (latest) |
| `GWS_CLI_VERSION` | 0.22.5 | (latest) |
| `XURL_VERSION` | 1.0.3 | (latest) |
| `AGENT_BROWSER_VERSION` | 0.27.0 | (latest) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)