### PR TITLE
feat(api): migrate push-subscriptions POST to api backend (Wave 6 #8)

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -32,6 +32,7 @@ import { zeroModelProvidersRoutes } from "./routes/zero-model-providers";
 import { zeroOnboardingStatusRoutes } from "./routes/zero-onboarding-status";
 import { zeroOrgInviteRoutes } from "./routes/zero-org-invite";
 import { zeroOrgReadRoutes } from "./routes/zero-org-read";
+import { zeroPushSubscriptionsRoutes } from "./routes/zero-push-subscriptions";
 import { zeroQueuePositionRoutes } from "./routes/zero-queue-position";
 import { zeroRunDetailRoutes } from "./routes/zero-run-detail";
 import { zeroRunsRoutes } from "./routes/zero-runs";
@@ -104,6 +105,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroOnboardingStatusRoutes,
   ...zeroOrgInviteRoutes,
   ...zeroOrgReadRoutes,
+  ...zeroPushSubscriptionsRoutes,
   ...zeroUserPreferencesRoutes,
   ...zeroUserModelPreferenceRoutes,
   ...zeroSecretsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-push-subscriptions.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-push-subscriptions.ts
@@ -1,0 +1,15 @@
+import { command } from "ccstate";
+import { pushSubscriptions } from "@vm0/db/schema/push-subscription";
+import { eq } from "drizzle-orm";
+
+import { writeDb$ } from "../../../external/db";
+
+export const clearPushSubscriptionsForUser$ = command(
+  async ({ set }, userId: string, signal: AbortSignal): Promise<void> => {
+    const db = set(writeDb$);
+    await db
+      .delete(pushSubscriptions)
+      .where(eq(pushSubscriptions.userId, userId));
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-push-subscriptions.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-push-subscriptions.test.ts
@@ -1,0 +1,109 @@
+import { randomUUID } from "node:crypto";
+
+import { pushSubscriptionsContract } from "@vm0/api-contracts/contracts/push-subscriptions";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { clearPushSubscriptionsForUser$ } from "./helpers/zero-push-subscriptions";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function validBody() {
+  return {
+    endpoint: "https://fcm.googleapis.com/fcm/send/test-endpoint-123",
+    keys: {
+      p256dh:
+        "BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8p8REfXRI",
+      auth: "tBHItJI5svbpC7hYyKw",
+    },
+  };
+}
+
+describe("POST /api/zero/push-subscriptions", () => {
+  const createdUserIds: string[] = [];
+
+  afterEach(async () => {
+    while (createdUserIds.length > 0) {
+      const userId = createdUserIds.pop();
+      if (userId) {
+        await store.set(clearPushSubscriptionsForUser$, userId, context.signal);
+      }
+    }
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(pushSubscriptionsContract);
+    const response = await accept(
+      client.register({ body: validBody(), headers: {} }),
+      [401],
+    );
+    expect(response.body).toMatchObject({ error: { code: "UNAUTHORIZED" } });
+  });
+
+  it("registers a push subscription and returns 201 success", async () => {
+    const userId = `user_${randomUUID().slice(0, 8)}`;
+    createdUserIds.push(userId);
+    mocks.clerk.session(userId, null);
+
+    const client = setupApp({ context })(pushSubscriptionsContract);
+    const response = await accept(
+      client.register({
+        body: validBody(),
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+
+    expect(response.body).toStrictEqual({ success: true });
+  });
+
+  it("upserts on same endpoint", async () => {
+    const userId = `user_${randomUUID().slice(0, 8)}`;
+    createdUserIds.push(userId);
+    mocks.clerk.session(userId, null);
+
+    const client = setupApp({ context })(pushSubscriptionsContract);
+    const first = await accept(
+      client.register({
+        body: validBody(),
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+    expect(first.body).toStrictEqual({ success: true });
+
+    const second = await accept(
+      client.register({
+        body: {
+          ...validBody(),
+          keys: { p256dh: "updated-p256dh-key", auth: "updated-auth-key" },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+    expect(second.body).toStrictEqual({ success: true });
+  });
+
+  it("returns 400 for invalid body", async () => {
+    const userId = `user_${randomUUID().slice(0, 8)}`;
+    mocks.clerk.session(userId, null);
+
+    const client = setupApp({ context })(pushSubscriptionsContract);
+    const response = await accept(
+      client.register({
+        body: {
+          endpoint: "not-a-url",
+          keys: { p256dh: "", auth: "" },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body.error).toBeDefined();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-push-subscriptions.ts
+++ b/turbo/apps/api/src/signals/routes/zero-push-subscriptions.ts
@@ -1,0 +1,42 @@
+import { command } from "ccstate";
+import { pushSubscriptionsContract } from "@vm0/api-contracts/contracts/push-subscriptions";
+
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { registerPushSubscription$ } from "../services/zero-push-subscriptions.service";
+import type { RouteEntry } from "../route";
+
+const registerInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+
+  const bodyResult = await get(
+    bodyResultOf(pushSubscriptionsContract.register),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+  const { endpoint, keys } = bodyResult.data;
+
+  await set(
+    registerPushSubscription$,
+    {
+      userId: auth.userId,
+      endpoint,
+      p256dh: keys.p256dh,
+      auth: keys.auth,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  return { status: 201 as const, body: { success: true as const } };
+});
+
+export const zeroPushSubscriptionsRoutes: readonly RouteEntry[] = [
+  {
+    route: pushSubscriptionsContract.register,
+    handler: authRoute({}, registerInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-push-subscriptions.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-push-subscriptions.service.ts
@@ -1,0 +1,55 @@
+import { command } from "ccstate";
+import { pushSubscriptions } from "@vm0/db/schema/push-subscription";
+import { and, eq, lt, sql } from "drizzle-orm";
+
+import { now } from "../../lib/time";
+import { writeDb$ } from "../external/db";
+
+const STALE_CUTOFF_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface RegisterPushSubscriptionArgs {
+  readonly userId: string;
+  readonly endpoint: string;
+  readonly p256dh: string;
+  readonly auth: string;
+}
+
+export const registerPushSubscription$ = command(
+  async (
+    { set },
+    args: RegisterPushSubscriptionArgs,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+
+    await db
+      .insert(pushSubscriptions)
+      .values({
+        userId: args.userId,
+        endpoint: args.endpoint,
+        p256dh: args.p256dh,
+        auth: args.auth,
+      })
+      .onConflictDoUpdate({
+        target: pushSubscriptions.endpoint,
+        set: {
+          userId: args.userId,
+          p256dh: args.p256dh,
+          auth: args.auth,
+          createdAt: sql`now()`,
+        },
+      });
+    signal.throwIfAborted();
+
+    const staleCutoff = new Date(now() - STALE_CUTOFF_MS);
+    await db
+      .delete(pushSubscriptions)
+      .where(
+        and(
+          eq(pushSubscriptions.userId, args.userId),
+          lt(pushSubscriptions.createdAt, staleCutoff),
+        ),
+      );
+    signal.throwIfAborted();
+  },
+);


### PR DESCRIPTION
## Summary

Wave 6 #8 of #12290. Ports `POST /api/zero/push-subscriptions` (register Web Push subscription + 7-day stale cleanup) from `apps/web` to `apps/api`. Verbatim parity with web's 64-LOC handler.

- New `zero-push-subscriptions.ts` route handler with `authRoute({}, …)` + `authContext$` (user-only — no admin gate, no `requireOrganization`).
- New `registerPushSubscription$` Command in `services/zero-push-subscriptions.service.ts`: UPSERT on `endpoint` unique-index conflict refreshes `userId/p256dh/auth/createdAt`; follow-on cleanup deletes this user's subscriptions older than 7 days.
- New `clearPushSubscriptionsForUser$` test helper for afterEach cleanup.
- Uses `now()` from `lib/time.ts` for the stale cutoff (test-override-aware; behaviorally identical to web's `Date.now()`).
- Uses `sql\`now()\`` for the conflict-update `createdAt` (DB-clock parity with web).

## Test plan

Ports all 4 web tests 1:1:

- [x] 401 when unauthenticated (`authRoute({})` default 401 with code `UNAUTHORIZED`)
- [x] 201 + `{success: true}` on register
- [x] 201 + `{success: true}` on second call with same endpoint (upsert)
- [x] 400 when body fails zod (`endpoint: "not-a-url"`, empty keys)
- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-push-subscriptions.test.ts` — 4/4 pass
- [x] `pnpm -F api run check-types` — clean
- [x] `pnpm -F api run lint` — clean (1 pre-existing oxlint warning in `zero-org-invite.test.ts`, unrelated)
- [x] `pnpm knip` — clean
- [x] `pnpm format` — clean

Note: full-suite `pnpm -F api exec vitest run` shows 16 pre-existing flaky failures in `zero-user-preferences` / `zero-onboarding-status` / `zero-runs-cancel` that reproduce on bare `main` (verified via `git stash`). Not introduced by this PR. CI is the authoritative signal.

## Out of scope

- Removing the web handler — separate Stage 3 cleanup once `apiBackendMutations` flag flips for push-subscriptions.
- Removing the unused `403` from the contract — declared but never reached; touching contracts cross-cuts the shadow-compare path.
- Time-travel tests for the cleanup branch — web doesn't exercise it either.

Closes #12683
Part of #12290 (Stage 3 Wave 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)