### PR TITLE
feat(api): migrate onboarding/complete POST to api backend (Wave 6 #7)

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -29,6 +29,7 @@ import { zeroLogsRoutes } from "./routes/zero-logs";
 import { zeroMemberCreditCapRoutes } from "./routes/zero-member-credit-cap";
 import { zeroModelPoliciesRoutes } from "./routes/zero-model-policies";
 import { zeroModelProvidersRoutes } from "./routes/zero-model-providers";
+import { zeroOnboardingCompleteRoutes } from "./routes/zero-onboarding-complete";
 import { zeroOnboardingStatusRoutes } from "./routes/zero-onboarding-status";
 import { zeroOrgInviteRoutes } from "./routes/zero-org-invite";
 import { zeroOrgReadRoutes } from "./routes/zero-org-read";
@@ -101,6 +102,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroRunsRoutes,
   ...zeroRunsCancelRoutes,
   ...zeroSchedulesRoutes,
+  ...zeroOnboardingCompleteRoutes,
   ...zeroOnboardingStatusRoutes,
   ...zeroOrgInviteRoutes,
   ...zeroOrgReadRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-complete.test.ts
@@ -1,0 +1,139 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { onboardingCompleteContract } from "@vm0/api-contracts/contracts/onboarding";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteOnboardingStatusOrg$,
+  seedOnboardingStatusOrg$,
+  type OnboardingStatusFixture,
+} from "./helpers/zero-onboarding-status";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function apiClient() {
+  return setupApp({ context })(onboardingCompleteContract);
+}
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+describe("POST /api/zero/onboarding/complete", () => {
+  const track = createFixtureTracker<OnboardingStatusFixture>((fixture) => {
+    return store.set(deleteOnboardingStatusOrg$, fixture, context.signal);
+  });
+
+  async function getOnboardingDone(
+    orgId: string,
+    userId: string,
+  ): Promise<boolean | undefined> {
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ onboardingDone: orgMembersMetadata.onboardingDone })
+      .from(orgMembersMetadata)
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, orgId),
+          eq(orgMembersMetadata.userId, userId),
+        ),
+      );
+    return row?.onboardingDone;
+  }
+
+  async function countOnboardingRows(
+    orgId: string,
+    userId: string,
+  ): Promise<number> {
+    const writeDb = store.set(writeDb$);
+    const rows = await writeDb
+      .select({ orgId: orgMembersMetadata.orgId })
+      .from(orgMembersMetadata)
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, orgId),
+          eq(orgMembersMetadata.userId, userId),
+        ),
+      );
+    return rows.length;
+  }
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      apiClient().complete({ headers: {}, body: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const response = await accept(
+      apiClient().complete({ headers: authHeaders(), body: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("marks onboarding as done for a member (DB read-after-write)", async () => {
+    const fixture = await track(
+      store.set(seedOnboardingStatusOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    await expect(
+      getOnboardingDone(fixture.orgId, fixture.userId),
+    ).resolves.toBeUndefined();
+
+    const response = await accept(
+      apiClient().complete({ headers: authHeaders(), body: {} }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ ok: true });
+    await expect(
+      getOnboardingDone(fixture.orgId, fixture.userId),
+    ).resolves.toBeTruthy();
+  });
+
+  it("is idempotent when called multiple times", async () => {
+    const fixture = await track(
+      store.set(seedOnboardingStatusOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const first = await accept(
+      apiClient().complete({ headers: authHeaders(), body: {} }),
+      [200],
+    );
+    expect(first.body).toStrictEqual({ ok: true });
+
+    const second = await accept(
+      apiClient().complete({ headers: authHeaders(), body: {} }),
+      [200],
+    );
+    expect(second.body).toStrictEqual({ ok: true });
+
+    await expect(
+      countOnboardingRows(fixture.orgId, fixture.userId),
+    ).resolves.toBe(1);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-invite.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-invite.test.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
-import { createStore } from "ccstate";
 
 import { zeroOrgInviteContract } from "@vm0/api-contracts/contracts/zero-org-members";
 
@@ -8,7 +7,6 @@ import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
-const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
 function apiClient() {

--- a/turbo/apps/api/src/signals/routes/zero-onboarding-complete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-onboarding-complete.ts
@@ -1,0 +1,41 @@
+import { command } from "ccstate";
+import { onboardingCompleteContract } from "@vm0/api-contracts/contracts/onboarding";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { completeOnboarding$ } from "../services/onboarding.service";
+import type { RouteEntry } from "../route";
+
+const completeBody$ = bodyResultOf(onboardingCompleteContract.complete);
+
+const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const body = await get(completeBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  await set(
+    completeOnboarding$,
+    {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      selectedConnectors: body.data.selectedConnectors ?? [],
+    },
+    signal,
+  );
+
+  return { status: 200 as const, body: { ok: true } };
+});
+
+export const zeroOnboardingCompleteRoutes: readonly RouteEntry[] = [
+  {
+    route: onboardingCompleteContract.complete,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      completeInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -1,13 +1,16 @@
-import { computed, type Computed } from "ccstate";
+import { command, computed, type Computed } from "ccstate";
 import type { OnboardingStatusResponse } from "@vm0/api-contracts/contracts/onboarding";
+import type { ConnectorType } from "@vm0/connectors/connectors";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { userConnectors } from "@vm0/db/schema/user-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { and, eq } from "drizzle-orm";
 
 import type { AuthContext } from "../../types/auth";
-import { db$ } from "../external/db";
+import { db$, writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
 
 interface DefaultAgentInfo {
   readonly composeId: string;
@@ -129,3 +132,82 @@ export function onboardingStatus(
     };
   });
 }
+
+/**
+ * Mark a member's onboarding as done and (if they picked connectors) bulk-
+ * insert `user_connectors` rows for the org's default agent. Verbatim port
+ * of apps/web/app/api/zero/onboarding/complete/route.ts.
+ *
+ * The composite-PK UPSERT runs outside any transaction; the conditional
+ * DELETE+INSERT on `user_connectors` is the only transactional block. If
+ * the transaction throws after the UPSERT commits, `onboardingDone` stays
+ * set — same crash window as web.
+ */
+export const completeOnboarding$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly selectedConnectors: readonly ConnectorType[];
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    const now = nowDate();
+
+    await db
+      .insert(orgMembersMetadata)
+      .values({
+        orgId: args.orgId,
+        userId: args.userId,
+        onboardingDone: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
+        set: { onboardingDone: true, updatedAt: now },
+      });
+    signal.throwIfAborted();
+
+    if (args.selectedConnectors.length === 0) {
+      return;
+    }
+
+    const [orgRow] = await db
+      .select({ defaultAgentId: orgMetadata.defaultAgentId })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, args.orgId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    const agentId = orgRow?.defaultAgentId;
+    if (!agentId) {
+      return;
+    }
+
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(userConnectors)
+        .where(
+          and(
+            eq(userConnectors.orgId, args.orgId),
+            eq(userConnectors.userId, args.userId),
+            eq(userConnectors.agentId, agentId),
+          ),
+        );
+      await tx.insert(userConnectors).values(
+        args.selectedConnectors.map((connectorType) => {
+          return {
+            orgId: args.orgId,
+            userId: args.userId,
+            agentId,
+            connectorType,
+          };
+        }),
+      );
+    });
+    signal.throwIfAborted();
+  },
+);


### PR DESCRIPTION
## Summary

- Migrates `POST /api/zero/onboarding/complete` (mark member onboarding done + bulk-add `user_connectors` for org's default agent) from `apps/web` to `apps/api`. Wave 6 #7 — single-user mutation pattern (admin-gate-free).
- Behavior 1:1 with web. Composite-PK UPSERT on `org_members_metadata` runs outside any transaction; the conditional DELETE+INSERT on `user_connectors` is the only transactional block, triggered only when `selectedConnectors.length > 0` AND the org has a default agent.

## Deliberate hardening — 401 vs web's 500 on no-org sessions

This PR has one intentional, observable behavior change worth calling out.

- **Web's behavior**: when the authenticated session has no primary org, web's `resolveOrg(authCtx)` throws. The route has no catch for that path, so the throw propagates to the framework and the client sees a `500 Internal Server Error`.
- **API's behavior**: `authRoute({ requireOrganization: true, missingOrganizationStatus: 401 })` emits a clean `401 Unauthorized` instead.

**Justification — verbatim per leader's instruction**:
- Web's 500 is accidental (unhandled exception path).
- Api's 401 is intentional and correct (proper auth gating).
- Mark as **deliberate hardening, not regression**.
- Test #2 (api defensive 401 no-org) pins the corrected behavior.

Future Lancy-readable trail: future similar routes should follow the same hardening (auth layer catches no-org cleanly). If anyone asks "why didn't this preserve web's 500", the answer is here.

## Files

- `turbo/apps/api/src/signals/services/onboarding.service.ts` — adds `completeOnboarding$` command (~80 LOC) next to the existing `onboardingStatus` reader. Single-file domain organization matches existing api convention for small surfaces.
- `turbo/apps/api/src/signals/routes/zero-onboarding-complete.ts` — new route handler. `organizationAuthContext$` + `authRoute({ requireOrganization, missingOrganizationStatus: 401 })`. No admin gate (any member can self-complete).
- `turbo/apps/api/src/signals/route.ts` — one import + one spread.
- `turbo/apps/api/src/signals/routes/__tests__/zero-onboarding-complete.test.ts` — 4 cases.
- Drive-by: removes an unused `createStore`/`store` declaration in `zero-org-invite.test.ts` (from my freshly-merged #12607). Required to satisfy the api lint's `--max-warnings 0` policy after a stricter `no-unused-vars` rule landed alongside this branch.
- **No contract change, no web change, no new test helper.**

## Tests (4)

| # | Source | Case |
|---|---|---|
| 1 | web | 401 unauthenticated |
| 2 | api defensive | 401 no-org session (pins the deliberate-hardening behavior above) |
| 3 | web | marks onboarding as done — 200 `{ ok: true }` + DB read-after-write: `org_members_metadata.onboardingDone === true` |
| 4 | web | idempotent — call twice → both 200 `{ ok: true }`; final row count = 1 (UPSERT collapsed) |

All error envelopes use `toStrictEqual` to lock the code value verbatim per the shadow-compare policy. DB read-after-write directly asserts the underlying UPSERT (stronger than web's pattern of round-tripping through the status route).

## `selectedConnectors` branch

Out of scope per web's test coverage gap (web doesn't test the branch either). The code is byte-identical to web; if coverage is wanted, a follow-up PR can add it.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-onboarding-complete.test.ts` — 4 passed
- [x] `pnpm -F api exec vitest run` — 982 passed
- [x] `pnpm -F api run lint` — clean
- [x] `pnpm -F api run check-types` — clean
- [x] `pnpm format` / `pnpm knip --workspace api` — clean

Closes #12682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)