### PR TITLE
feat(api): migrate billing downgrade endpoint to api backend (#12680)

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -64,6 +64,7 @@ export interface ApiTestMocks {
     };
     readonly subscriptions: {
       readonly retrieve: AsyncMock;
+      readonly update: AsyncMock;
     };
     readonly checkout: {
       readonly sessions: {
@@ -142,6 +143,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
     },
     subscriptions: {
       retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      update: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     checkout: {
       sessions: {
@@ -303,6 +305,7 @@ vi.mock("stripe", () => {
         },
         subscriptions: {
           retrieve: apiTestMocks.stripe.subscriptions.retrieve,
+          update: apiTestMocks.stripe.subscriptions.update,
         },
         checkout: {
           sessions: {
@@ -435,6 +438,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.stripe.customers.retrieve.mockReset();
   apiTestMocks.stripe.customers.create.mockReset();
   apiTestMocks.stripe.subscriptions.retrieve.mockReset();
+  apiTestMocks.stripe.subscriptions.update.mockReset();
   apiTestMocks.stripe.checkout.sessions.create.mockReset();
   apiTestMocks.stripe.billingPortal.sessions.create.mockReset();
   // Re-install the Stripe client override so getStripeClient() returns

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -14,6 +14,7 @@ import { zeroAgentsRoutes } from "./routes/zero-agents";
 import { zeroApiKeysRoutes } from "./routes/zero-api-keys";
 import { zeroBillingAutoRechargeRoutes } from "./routes/zero-billing-auto-recharge";
 import { zeroBillingCheckoutRoutes } from "./routes/zero-billing-checkout";
+import { zeroBillingDowngradeRoutes } from "./routes/zero-billing-downgrade";
 import { zeroBillingInvoicesRoutes } from "./routes/zero-billing-invoices";
 import { zeroBillingPortalRoutes } from "./routes/zero-billing-portal";
 import { zeroBillingStatusRoutes } from "./routes/zero-billing-status";
@@ -76,6 +77,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroApiKeysRoutes,
   ...zeroBillingAutoRechargeRoutes,
   ...zeroBillingCheckoutRoutes,
+  ...zeroBillingDowngradeRoutes,
   ...zeroBillingInvoicesRoutes,
   ...zeroBillingPortalRoutes,
   ...zeroBillingStatusRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-billing-invoices.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-billing-invoices.ts
@@ -17,6 +17,7 @@ interface InvoicesSeedValues {
   readonly stripeSubscriptionId?: string | null;
   readonly subscriptionStatus?: string | null;
   readonly tier?: string;
+  readonly currentPeriodEnd?: Date | null;
 }
 
 export const seedInvoicesOrg$ = command(
@@ -37,6 +38,9 @@ export const seedInvoicesOrg$ = command(
       stripeSubscriptionId: values.stripeSubscriptionId ?? null,
       subscriptionStatus: values.subscriptionStatus ?? null,
       ...(values.tier !== undefined ? { tier: values.tier } : {}),
+      ...(values.currentPeriodEnd !== undefined
+        ? { currentPeriodEnd: values.currentPeriodEnd }
+        : {}),
     });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-downgrade.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-downgrade.test.ts
@@ -7,6 +7,7 @@ import { eq } from "drizzle-orm";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { now } from "../../../lib/time";
 import { writeDb$ } from "../../external/db";
 import {
   deleteInvoicesOrg$,
@@ -217,7 +218,7 @@ describe("POST /api/zero/billing/downgrade", () => {
 
   it("downgrades pro to free via cancel at period end", async () => {
     const subId = `sub-pro-free-${randomUUID().slice(0, 8)}`;
-    const periodEnd = new Date(Date.now() + 30 * 86400 * 1000);
+    const periodEnd = new Date(now() + 30 * 86_400 * 1000);
     const fixture = await track(
       store.set(
         seedInvoicesOrg$,
@@ -263,7 +264,7 @@ describe("POST /api/zero/billing/downgrade", () => {
 
   it("downgrades team to free via cancel at period end", async () => {
     const subId = `sub-team-free-${randomUUID().slice(0, 8)}`;
-    const periodEnd = new Date(Date.now() + 30 * 86400 * 1000);
+    const periodEnd = new Date(now() + 30 * 86_400 * 1000);
     const fixture = await track(
       store.set(
         seedInvoicesOrg$,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-downgrade.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-downgrade.test.ts
@@ -1,0 +1,301 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroBillingDowngradeContract } from "@vm0/api-contracts/contracts/zero-billing";
+import { createStore } from "ccstate";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { eq } from "drizzle-orm";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteInvoicesOrg$,
+  seedInvoicesOrg$,
+  type InvoicesOrgFixture,
+} from "./helpers/zero-billing-invoices";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+const TEST_PRICE_PRO = "price_test_pro";
+const TEST_PRICE_TEAM = "price_test_team";
+
+describe("POST /api/zero/billing/downgrade", () => {
+  const track = createFixtureTracker<InvoicesOrgFixture>((fixture) => {
+    return store.set(deleteInvoicesOrg$, fixture, context.signal);
+  });
+
+  beforeEach(() => {
+    mockEnv(
+      "ZERO_PRICE",
+      JSON.stringify({ pro: [TEST_PRICE_PRO], team: [TEST_PRICE_TEAM] }),
+    );
+  });
+
+  it("returns 503 when STRIPE_SECRET_KEY is not configured", async () => {
+    mockOptionalEnv("STRIPE_SECRET_KEY", undefined);
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroBillingDowngradeContract);
+    const response = await accept(
+      client.create({
+        body: { targetTier: "free" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [503],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Billing not configured",
+        code: "PROVIDER_UNAVAILABLE",
+      },
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroBillingDowngradeContract);
+    const response = await accept(
+      client.create({
+        body: { targetTier: "free" },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin org member", async () => {
+    const fixture = await track(
+      store.set(seedInvoicesOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroBillingDowngradeContract);
+    const response = await accept(
+      client.create({
+        body: { targetTier: "free" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only org admins can manage billing",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 400 for invalid targetTier", async () => {
+    const fixture = await track(
+      store.set(seedInvoicesOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingDowngradeContract);
+    const response = await client.create({
+      body: { targetTier: "team" as "pro" },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 409 when org has no subscription", async () => {
+    const fixture = await track(
+      store.set(seedInvoicesOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingDowngradeContract);
+    const response = await accept(
+      client.create({
+        body: { targetTier: "free" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [409],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Org has no active subscription",
+        code: "CONFLICT",
+      },
+    });
+  });
+
+  it("returns 400 when target tier is same or higher", async () => {
+    const subId = `sub-same-${randomUUID().slice(0, 8)}`;
+    const fixture = await track(
+      store.set(
+        seedInvoicesOrg$,
+        {
+          stripeSubscriptionId: subId,
+          subscriptionStatus: "active",
+          tier: "pro",
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingDowngradeContract);
+    const response = await accept(
+      client.create({
+        body: { targetTier: "pro" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "Cannot downgrade from pro to pro: target tier is same or higher",
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+
+  it("downgrades team to pro via subscription update", async () => {
+    const subId = `sub-team-pro-${randomUUID().slice(0, 8)}`;
+    const fixture = await track(
+      store.set(
+        seedInvoicesOrg$,
+        {
+          stripeSubscriptionId: subId,
+          subscriptionStatus: "active",
+          tier: "team",
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: subId,
+      items: {
+        data: [{ id: "si_item_1", price: { id: TEST_PRICE_TEAM } }],
+      },
+    });
+    context.mocks.stripe.subscriptions.update.mockResolvedValue({
+      id: subId,
+      items: {
+        data: [{ id: "si_item_1", price: { id: TEST_PRICE_PRO } }],
+      },
+    });
+
+    const client = setupApp({ context })(zeroBillingDowngradeContract);
+    const response = await accept(
+      client.create({
+        body: { targetTier: "pro" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      effectiveDate: null,
+    });
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
+      subId,
+      {
+        items: [{ id: "si_item_1", price: TEST_PRICE_PRO }],
+        proration_behavior: "always_invoice",
+      },
+    );
+  });
+
+  it("downgrades pro to free via cancel at period end", async () => {
+    const subId = `sub-pro-free-${randomUUID().slice(0, 8)}`;
+    const periodEnd = new Date(Date.now() + 30 * 86400 * 1000);
+    const fixture = await track(
+      store.set(
+        seedInvoicesOrg$,
+        {
+          stripeSubscriptionId: subId,
+          subscriptionStatus: "active",
+          tier: "pro",
+          currentPeriodEnd: periodEnd,
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    context.mocks.stripe.subscriptions.update.mockResolvedValue({ id: subId });
+
+    const client = setupApp({ context })(zeroBillingDowngradeContract);
+    const response = await accept(
+      client.create({
+        body: { targetTier: "free" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      effectiveDate: periodEnd.toISOString(),
+    });
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
+      subId,
+      { cancel_at_period_end: true },
+    );
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({ cancelAtPeriodEnd: orgMetadata.cancelAtPeriodEnd })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId))
+      .limit(1);
+    expect(row?.cancelAtPeriodEnd).toBeTruthy();
+  });
+
+  it("downgrades team to free via cancel at period end", async () => {
+    const subId = `sub-team-free-${randomUUID().slice(0, 8)}`;
+    const periodEnd = new Date(Date.now() + 30 * 86400 * 1000);
+    const fixture = await track(
+      store.set(
+        seedInvoicesOrg$,
+        {
+          stripeSubscriptionId: subId,
+          subscriptionStatus: "active",
+          tier: "team",
+          currentPeriodEnd: periodEnd,
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    context.mocks.stripe.subscriptions.update.mockResolvedValue({ id: subId });
+
+    const client = setupApp({ context })(zeroBillingDowngradeContract);
+    const response = await accept(
+      client.create({
+        body: { targetTier: "free" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      effectiveDate: periodEnd.toISOString(),
+    });
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
+      subId,
+      { cancel_at_period_end: true },
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-billing-downgrade.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-downgrade.ts
@@ -1,0 +1,76 @@
+import { command } from "ccstate";
+import { zeroBillingDowngradeContract } from "@vm0/api-contracts/contracts/zero-billing";
+
+import { optionalEnv } from "../../lib/env";
+import {
+  badRequestMessage,
+  conflict,
+  providerUnavailable,
+} from "../../lib/error";
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { downgradeSubscription$ } from "../services/zero-billing-downgrade.service";
+import type { RouteEntry } from "../route";
+
+const adminRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Only org admins can manage billing",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+const downgradeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!optionalEnv("STRIPE_SECRET_KEY")) {
+    return providerUnavailable("Billing not configured");
+  }
+
+  const auth = get(organizationAuthContext$);
+  if (auth.orgRole !== "admin") {
+    return adminRequired;
+  }
+  signal.throwIfAborted();
+
+  const bodyResult = await get(
+    bodyResultOf(zeroBillingDowngradeContract.create),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+  const { targetTier } = bodyResult.data;
+
+  const result = await set(
+    downgradeSubscription$,
+    { orgId: auth.orgId, targetTier },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (!result.ok) {
+    if (result.reason === "no_subscription") {
+      return conflict("Org has no active subscription");
+    }
+    return badRequestMessage(
+      `Cannot downgrade from ${result.currentTier} to ${result.targetTier}: target tier is same or higher`,
+    );
+  }
+
+  return {
+    status: 200 as const,
+    body: { success: true, effectiveDate: result.effectiveDate },
+  };
+});
+
+export const zeroBillingDowngradeRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroBillingDowngradeContract.create,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      downgradeInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-billing-downgrade.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-downgrade.service.ts
@@ -11,7 +11,11 @@ import { activePriceId } from "./zero-billing-checkout.service";
 
 const L = logger("BillingDowngrade");
 
-const TIER_RANK: Record<OrgTier, number> = { free: 0, pro: 1, team: 2 };
+const TIER_RANK = Object.freeze<Record<OrgTier, number>>({
+  free: 0,
+  pro: 1,
+  team: 2,
+});
 
 type DowngradeResult =
   | { readonly ok: true; readonly effectiveDate: string | null }
@@ -84,7 +88,7 @@ export const downgradeSubscription$ = command(
       signal.throwIfAborted();
 
       const effectiveDate = org.currentPeriodEnd?.toISOString() ?? null;
-      L.info("subscription cancellation initiated", {
+      L.debug("subscription cancellation initiated", {
         orgId: args.orgId,
         targetTier: args.targetTier,
         effectiveDate,
@@ -113,7 +117,7 @@ export const downgradeSubscription$ = command(
     });
     signal.throwIfAborted();
 
-    L.info("subscription downgraded", {
+    L.debug("subscription downgraded", {
       orgId: args.orgId,
       from: currentTier,
       to: args.targetTier,

--- a/turbo/apps/api/src/signals/services/zero-billing-downgrade.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-downgrade.service.ts
@@ -1,0 +1,123 @@
+import { command } from "ccstate";
+import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { eq } from "drizzle-orm";
+
+import { logger } from "../../lib/log";
+import { writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+import { getStripeClient } from "../external/stripe-client";
+import { activePriceId } from "./zero-billing-checkout.service";
+
+const L = logger("BillingDowngrade");
+
+const TIER_RANK: Record<OrgTier, number> = { free: 0, pro: 1, team: 2 };
+
+type DowngradeResult =
+  | { readonly ok: true; readonly effectiveDate: string | null }
+  | { readonly ok: false; readonly reason: "no_subscription" }
+  | {
+      readonly ok: false;
+      readonly reason: "invalid_target_tier";
+      readonly currentTier: OrgTier;
+      readonly targetTier: "free" | "pro";
+    };
+
+interface DowngradeArgs {
+  readonly orgId: string;
+  readonly targetTier: "free" | "pro";
+}
+
+/**
+ * Downgrade an org's Stripe subscription. Verbatim port of apps/web's
+ * `downgradeSubscription`. Two branches:
+ * - `* → free`: schedules cancel-at-period-end and flips local
+ *   `cancelAtPeriodEnd` flag. effectiveDate = currentPeriodEnd ISO string.
+ * - `team → pro`: immediate tier swap via `stripe.subscriptions.update`
+ *   with `proration_behavior: "always_invoice"`. effectiveDate = null.
+ */
+export const downgradeSubscription$ = command(
+  async (
+    { set },
+    args: DowngradeArgs,
+    signal: AbortSignal,
+  ): Promise<DowngradeResult> => {
+    const writeDb = set(writeDb$);
+
+    const [org] = await writeDb
+      .select({
+        tier: orgMetadata.tier,
+        stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+        currentPeriodEnd: orgMetadata.currentPeriodEnd,
+      })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, args.orgId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!org?.stripeSubscriptionId) {
+      return { ok: false, reason: "no_subscription" };
+    }
+
+    const currentTier = org.tier as OrgTier;
+    if (TIER_RANK[args.targetTier] >= TIER_RANK[currentTier]) {
+      return {
+        ok: false,
+        reason: "invalid_target_tier",
+        currentTier,
+        targetTier: args.targetTier,
+      };
+    }
+
+    const stripe = getStripeClient();
+
+    if (args.targetTier === "free") {
+      await stripe.subscriptions.update(org.stripeSubscriptionId, {
+        cancel_at_period_end: true,
+      });
+      signal.throwIfAborted();
+
+      await writeDb
+        .update(orgMetadata)
+        .set({ cancelAtPeriodEnd: true, updatedAt: nowDate() })
+        .where(eq(orgMetadata.orgId, args.orgId));
+      signal.throwIfAborted();
+
+      const effectiveDate = org.currentPeriodEnd?.toISOString() ?? null;
+      L.info("subscription cancellation initiated", {
+        orgId: args.orgId,
+        targetTier: args.targetTier,
+        effectiveDate,
+      });
+      return { ok: true, effectiveDate };
+    }
+
+    const subscription = await stripe.subscriptions.retrieve(
+      org.stripeSubscriptionId,
+    );
+    signal.throwIfAborted();
+
+    const currentItem = subscription.items.data[0];
+    if (!currentItem) {
+      throw new Error("Subscription has no items");
+    }
+
+    const proPriceId = activePriceId("pro");
+    if (!proPriceId) {
+      throw new Error("Pro plan price ID not configured");
+    }
+
+    await stripe.subscriptions.update(org.stripeSubscriptionId, {
+      items: [{ id: currentItem.id, price: proPriceId }],
+      proration_behavior: "always_invoice",
+    });
+    signal.throwIfAborted();
+
+    L.info("subscription downgraded", {
+      orgId: args.orgId,
+      from: currentTier,
+      to: args.targetTier,
+    });
+    return { ok: true, effectiveDate: null };
+  },
+);


### PR DESCRIPTION
## Summary

Wave 6 #5 — migrates `POST /api/zero/billing/downgrade` (downgrade Stripe subscription tier) from `apps/web` to `apps/api`. Verbatim 1:1 port of web's 63-LOC handler + ~75-LOC service.

Closes #12680.

## Changes

**New files** (3):
- `apps/api/src/signals/services/zero-billing-downgrade.service.ts` — `downgradeSubscription$` Command with `TIER_RANK` and `DowngradeResult` discriminated union (`ok: true | false` + `reason: "no_subscription" | "invalid_target_tier"`).
- `apps/api/src/signals/routes/zero-billing-downgrade.ts` — POST handler with 5-branch dispatch (503 / 401 via authRoute / 403 / 400-body / service-result mapping).
- `apps/api/src/signals/routes/__tests__/zero-billing-downgrade.test.ts` — 9 integration tests (1:1 with web).

**Modified files** (3):
- `apps/api/src/__tests__/mocks.ts` — expose `subscriptions.update` on `apiTestMocks.stripe`.
- `apps/api/src/signals/routes/__tests__/helpers/zero-billing-invoices.ts` — extend `seedInvoicesOrg$` with `currentPeriodEnd` field.
- `apps/api/src/signals/route.ts` — register `zeroBillingDowngradeRoutes` (alphabetic).

## Test plan

- [x] 9 integration tests pass:
  1. 503 when STRIPE_SECRET_KEY not configured
  2. 401 when not authenticated
  3. 403 for non-admin org member
  4. 400 for invalid targetTier (`team` rejected by zod enum)
  5. 409 when org has no subscription
  6. 400 when target tier is same or higher
  7. team → pro via subscription update (asserts proration_behavior + item swap)
  8. pro → free via cancel-at-period-end (asserts cancel_at_period_end=true + DB flip)
  9. team → free via cancel-at-period-end
- [x] Full api workspace test run: 987/987 pass
- [x] `pnpm turbo run lint` — green
- [x] `pnpm check-types` — green
- [x] `pnpm format` — clean
- [x] `pnpm knip` — clean

## Migration notes

### Verbatim parity preserved

- Service union shape (`ok: true | false` + `reason`) byte-identical to web's `downgradeSubscription`
- TIER_RANK ordering preserved (free=0, pro=1, team=2)
- Stripe call sequencing in pro-path: `retrieve` → `activePriceId` check → `update`
- Free-path side effect: stripe update + DB `cancelAtPeriodEnd: true` + `updatedAt`
- effectiveDate semantics: pro target → null; free target → `currentPeriodEnd.toISOString() ?? null`

### 503 path verbatim-portable

Unlike #12606 checkout (which had to drop the 503 test because api's `STRIPE_SECRET_KEY` is required at boot), downgrade reuses #12670 portal's `optionalEnv("STRIPE_SECRET_KEY")` pattern — Test 1 ports verbatim with `mockOptionalEnv("STRIPE_SECRET_KEY", undefined)`.

### Contract amendments

None needed. `zeroBillingDowngradeContract` already declares `200/400/401/403/409/500/503`.

### api-specific adjustments (lint compliance, not logic changes)

- `L.info` → `L.debug` for observability logs (`api/no-logger-info` rule)
- `TIER_RANK` wrapped in `Object.freeze<Record<OrgTier, number>>(...)` (`api/no-package-variable` rule; mirrors `zero-runs.service.ts:45`)
- `Date.now()` → `now()` from `lib/time` in tests (`no-restricted-syntax` rule)

### Helper reuse

- `getStripeClient()` + `mockStripeClient()` (#12606)
- `providerUnavailable("Billing not configured")` (#12670)
- `badRequestMessage(msg)` / `conflict(msg)` (existing)
- `adminRequired` frozen 403 const (matches checkout/portal byte-identical)
- `activePriceId("pro")` single-line import from `zero-billing-checkout.service.ts`
- `seedInvoicesOrg$` extended with `currentPeriodEnd` (3-line delta)

### `apps/web` unchanged

Per epic #12290 verbatim parity policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)