### PR TITLE
feat: add slack model command

### DIFF
--- a/turbo/apps/web/app/api/zero/slack/commands/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/commands/__tests__/route.test.ts
@@ -7,6 +7,9 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import {
   createTestCompose,
+  enableModelFirstModelProviderForUser,
+  insertOrgModelPolicy,
+  insertUserModelPreference,
   updateOrgDefaultAgent,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
@@ -396,6 +399,133 @@ describe("POST /api/zero/slack/commands", () => {
       const data = await response.json();
       expect(JSON.stringify(data.blocks)).not.toContain("/zero switch");
       expect(JSON.stringify(data.blocks)).toContain("/zero connect");
+    });
+  });
+
+  describe("/vm0 model", () => {
+    it("opens the model picker modal for a connected model-first user", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+      await enableModelFirstModelProviderForUser(user.orgId, user.userId);
+      await insertOrgModelPolicy({
+        orgId: user.orgId,
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+      });
+      await insertOrgModelPolicy({
+        orgId: user.orgId,
+        model: "deepseek-v4-pro",
+      });
+      await insertOrgModelPolicy({
+        orgId: user.orgId,
+        model: "gpt-5.5",
+      });
+      await insertUserModelPreference({
+        orgId: user.orgId,
+        userId: user.userId,
+        model: "deepseek-v4-pro",
+      });
+
+      const body = buildCommandBody({
+        team_id: workspaceId,
+        user_id: slackUserId,
+        text: "model",
+      });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.views.open).toHaveBeenCalledOnce();
+      const callArgs = (mockClient.views.open as ReturnType<typeof vi.fn>).mock
+        .calls[0]?.[0] as {
+        trigger_id?: string;
+        view?: {
+          callback_id?: string;
+          blocks?: Array<{
+            element?: {
+              options?: Array<{ value: string }>;
+              initial_option?: { value: string };
+            };
+          }>;
+        };
+      };
+      expect(callArgs?.trigger_id).toBe("trigger-123");
+      expect(callArgs?.view?.callback_id).toBe("model_preference_modal");
+
+      const inputBlock = callArgs?.view?.blocks?.find((b) => {
+        return b.element?.options !== undefined;
+      });
+      const values =
+        inputBlock?.element?.options?.map((o) => {
+          return o.value;
+        }) ?? [];
+      expect(values).toContain("__workspace_default__");
+      expect(values).toContain("claude-sonnet-4-6");
+      expect(values).toContain("deepseek-v4-pro");
+      expect(values).not.toContain("gpt-5.5");
+      expect(inputBlock?.element?.initial_option?.value).toBe(
+        "deepseek-v4-pro",
+      );
+    });
+
+    it("returns an error when model-first is not enabled", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      const body = buildCommandBody({
+        team_id: workspaceId,
+        user_id: slackUserId,
+        text: "model",
+      });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.response_type).toBe("ephemeral");
+      expect(JSON.stringify(data.blocks)).toContain("not available");
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.views.open).not.toHaveBeenCalled();
+    });
+
+    it("help output advertises model only for connected model-first users", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+      await enableModelFirstModelProviderForUser(user.orgId, user.userId);
+
+      const body = buildCommandBody({
+        team_id: workspaceId,
+        user_id: slackUserId,
+        text: "help",
+      });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      const data = await response.json();
+      expect(JSON.stringify(data.blocks)).toContain("/zero model");
     });
   });
 });

--- a/turbo/apps/web/app/api/zero/slack/commands/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/commands/route.ts
@@ -19,6 +19,7 @@ import {
   buildSuccessMessage,
   buildLoginMessage,
   buildAgentPickerModal,
+  buildModelPickerModal,
 } from "../../../../../src/lib/zero/slack/blocks";
 import { disconnect } from "../../../../../src/lib/zero/slack-org/connect-service";
 import { refreshOrgAppHome } from "../../../../../src/lib/zero/slack-org/handlers/app-home";
@@ -29,6 +30,7 @@ import {
   resolveDefaultComposeId,
 } from "../../../../../src/lib/zero/slack-org/handlers/shared";
 import { listComposes } from "../../../../../src/lib/zero/zero-compose-service";
+import { getSlackModelPickerState } from "../../../../../src/lib/zero/slack/model-picker";
 import { getAppUrl } from "../../../../../src/lib/zero/url";
 import { logger } from "../../../../../src/lib/shared/logger";
 
@@ -147,6 +149,7 @@ async function handleDisconnect(
 }
 
 const AGENT_PICKER_MAX_OPTIONS = 100;
+const MODEL_PICKER_MAX_OPTIONS = 99;
 
 /**
  * Handle /zero switch command — opens the per-user agent picker modal.
@@ -222,6 +225,83 @@ async function handleSwitch(
   }
 
   return new NextResponse("", { status: 200 });
+}
+
+/**
+ * Handle /zero model command — opens the per-user model picker modal.
+ */
+async function handleModel(
+  payload: SlackCommandPayload,
+  installation: typeof slackOrgInstallations.$inferSelect,
+  connection: typeof slackOrgConnections.$inferSelect,
+): Promise<NextResponse> {
+  if (!installation.orgId) {
+    return ephemeral(
+      buildErrorMessage(
+        "This workspace is not bound to an org. Please contact your admin.",
+      ),
+    );
+  }
+
+  if (!payload.trigger_id) {
+    return ephemeral(
+      buildErrorMessage("Couldn't open the model picker — please try again."),
+    );
+  }
+
+  const picker = await getSlackModelPickerState({
+    orgId: installation.orgId,
+    userId: connection.vm0UserId,
+  });
+
+  if (!picker.enabled) {
+    return ephemeral(
+      buildErrorMessage("Model switching is not available for this workspace."),
+    );
+  }
+
+  if (picker.options.length === 0) {
+    return ephemeral(
+      buildErrorMessage("No models are configured for this workspace."),
+    );
+  }
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+
+  const modal = buildModelPickerModal({
+    options: picker.options.slice(0, MODEL_PICKER_MAX_OPTIONS),
+    currentSelectedModel: picker.currentSelectedModel,
+    workspaceDefaultName: picker.workspaceDefaultName,
+    privateMetadata: JSON.stringify({ channelId: payload.channel_id }),
+  });
+
+  try {
+    await openView(client, payload.trigger_id, modal);
+  } catch (err) {
+    log.warn("Failed to open model picker modal", { error: err });
+    return ephemeral(
+      buildErrorMessage("Couldn't open the model picker — please try again."),
+    );
+  }
+
+  return new NextResponse("", { status: 200 });
+}
+
+async function isModelCommandAvailable(
+  installation: typeof slackOrgInstallations.$inferSelect | undefined,
+  connection: typeof slackOrgConnections.$inferSelect | undefined,
+): Promise<boolean> {
+  if (!installation?.orgId || !connection) return false;
+  const picker = await getSlackModelPickerState({
+    orgId: installation.orgId,
+    userId: connection.vm0UserId,
+  });
+  return picker.enabled && picker.options.length > 0;
 }
 
 function buildNotInstalledMessage(detail?: string): unknown[] {
@@ -302,9 +382,30 @@ export async function POST(request: Request) {
 
   const canSwitchAgents = Boolean(installation?.orgId);
 
+  const [connection] = installation
+    ? await globalThis.services.db
+        .select()
+        .from(slackOrgConnections)
+        .where(
+          and(
+            eq(slackOrgConnections.slackUserId, payload.user_id),
+            eq(slackOrgConnections.slackWorkspaceId, payload.team_id),
+          ),
+        )
+        .limit(1)
+    : [];
+  const getCanSwitchModels = () => {
+    return isModelCommandAvailable(installation, connection);
+  };
+
   // Handle help command (doesn't require installation)
   if (subCommand === "help" || subCommand === "") {
-    return ephemeral(buildHelpMessage({ canSwitch: canSwitchAgents }));
+    return ephemeral(
+      buildHelpMessage({
+        canSwitch: canSwitchAgents,
+        canModel: await getCanSwitchModels(),
+      }),
+    );
   }
 
   // Handle connect command
@@ -323,18 +424,6 @@ export async function POST(request: Request) {
   if (!installation) {
     return ephemeral(buildNotInstalledMessage());
   }
-
-  // Check if user is connected
-  const [connection] = await globalThis.services.db
-    .select()
-    .from(slackOrgConnections)
-    .where(
-      and(
-        eq(slackOrgConnections.slackUserId, payload.user_id),
-        eq(slackOrgConnections.slackWorkspaceId, payload.team_id),
-      ),
-    )
-    .limit(1);
 
   // Handle disconnect command
   if (subCommand === "disconnect") {
@@ -359,6 +448,16 @@ export async function POST(request: Request) {
     return handleSwitch(payload, installation, connection);
   }
 
+  // Handle model command
+  if (subCommand === "model") {
+    return handleModel(payload, installation, connection);
+  }
+
   // Unknown command
-  return ephemeral(buildHelpMessage({ canSwitch: canSwitchAgents }));
+  return ephemeral(
+    buildHelpMessage({
+      canSwitch: canSwitchAgents,
+      canModel: await getCanSwitchModels(),
+    }),
+  );
 }

--- a/turbo/apps/web/app/api/zero/slack/interactive/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/interactive/__tests__/route.test.ts
@@ -458,7 +458,6 @@ describe("POST /api/zero/slack/interactive", () => {
       const saved = await getOrgMembersEntry(user.orgId, user.userId);
       expect(saved?.selectedModel).toBeFalsy();
     });
-
   });
 
   describe("home_switch_agent block_action", () => {

--- a/turbo/apps/web/app/api/zero/slack/interactive/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/interactive/__tests__/route.test.ts
@@ -7,6 +7,10 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import {
   createTestCompose,
+  enableModelFirstModelProviderForUser,
+  getOrgMembersEntry,
+  insertOrgModelPolicy,
+  insertUserModelPreference,
   updateOrgDefaultAgent,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
@@ -46,6 +50,39 @@ function buildAgentPickerSubmission(opts: {
         values: {
           agent_select_block: {
             agent_select: {
+              selected_option: { value: opts.selectedValue },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function buildModelPickerSubmission(opts: {
+  workspaceId: string;
+  slackUserId: string;
+  selectedValue: string;
+  channelId?: string;
+}): Record<string, unknown> {
+  return {
+    type: "view_submission",
+    user: {
+      id: opts.slackUserId,
+      username: "testuser",
+      team_id: opts.workspaceId,
+    },
+    team: { id: opts.workspaceId, domain: "test" },
+    view: {
+      id: "V-model-picker",
+      callback_id: "model_preference_modal",
+      ...(opts.channelId && {
+        private_metadata: JSON.stringify({ channelId: opts.channelId }),
+      }),
+      state: {
+        values: {
+          model_select_block: {
+            model_select: {
               selected_option: { value: opts.selectedValue },
             },
           },
@@ -295,6 +332,133 @@ describe("POST /api/zero/slack/interactive", () => {
       const saved = await findSlackUserAgentPreference(user.userId, user.orgId);
       expect(saved).toBeUndefined();
     });
+  });
+
+  describe("model_preference_modal view_submission", () => {
+    it("persists the selected model and posts an ephemeral confirmation", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+      await enableModelFirstModelProviderForUser(user.orgId, user.userId);
+      await insertOrgModelPolicy({
+        orgId: user.orgId,
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+      });
+      await insertOrgModelPolicy({
+        orgId: user.orgId,
+        model: "deepseek-v4-pro",
+      });
+
+      const request = createInteractiveRequest(
+        buildModelPickerSubmission({
+          workspaceId,
+          slackUserId,
+          selectedValue: "deepseek-v4-pro",
+          channelId: "C-origin",
+        }),
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const saved = await getOrgMembersEntry(user.orgId, user.userId);
+      expect(saved?.selectedModel).toBe("deepseek-v4-pro");
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postEphemeral).toHaveBeenCalledOnce();
+      const ephemeralArgs = (
+        mockClient.chat.postEphemeral as unknown as {
+          mock: { calls: Array<[Record<string, unknown>]> };
+        }
+      ).mock.calls[0]?.[0];
+      expect(ephemeralArgs?.channel).toBe("C-origin");
+      expect(ephemeralArgs?.text).toContain("DeepSeek V4 Pro");
+    });
+
+    it("clears the selected model when user picks the workspace default option", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+      await enableModelFirstModelProviderForUser(user.orgId, user.userId);
+      await insertOrgModelPolicy({
+        orgId: user.orgId,
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+      });
+      await insertOrgModelPolicy({
+        orgId: user.orgId,
+        model: "deepseek-v4-pro",
+      });
+      await insertUserModelPreference({
+        orgId: user.orgId,
+        userId: user.userId,
+        model: "deepseek-v4-pro",
+      });
+
+      const request = createInteractiveRequest(
+        buildModelPickerSubmission({
+          workspaceId,
+          slackUserId,
+          selectedValue: "__workspace_default__",
+          channelId: "C-origin",
+        }),
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const saved = await getOrgMembersEntry(user.orgId, user.userId);
+      expect(saved?.selectedModel).toBeNull();
+    });
+
+    it("rejects models that are not available to the org", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+      await enableModelFirstModelProviderForUser(user.orgId, user.userId);
+      await insertOrgModelPolicy({
+        orgId: user.orgId,
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+      });
+
+      const request = createInteractiveRequest(
+        buildModelPickerSubmission({
+          workspaceId,
+          slackUserId,
+          selectedValue: "gpt-5.5",
+          channelId: "C-origin",
+        }),
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        response_action?: string;
+        errors?: Record<string, string>;
+      };
+      expect(body.response_action).toBe("errors");
+      expect(body.errors?.model_select_block).toBeTruthy();
+
+      const saved = await getOrgMembersEntry(user.orgId, user.userId);
+      expect(saved?.selectedModel).toBeFalsy();
+    });
+
   });
 
   describe("home_switch_agent block_action", () => {

--- a/turbo/apps/web/app/api/zero/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/interactive/route.ts
@@ -19,6 +19,10 @@ import {
   AGENT_PICKER_BLOCK_ID,
   AGENT_PICKER_CALLBACK_ID,
   AGENT_PICKER_ORG_DEFAULT_VALUE,
+  MODEL_PICKER_ACTION_ID,
+  MODEL_PICKER_BLOCK_ID,
+  MODEL_PICKER_CALLBACK_ID,
+  MODEL_PICKER_WORKSPACE_DEFAULT_VALUE,
   buildAgentPickerModal,
 } from "../../../../../src/lib/zero/slack/blocks";
 import { refreshOrgAppHome } from "../../../../../src/lib/zero/slack-org/handlers/app-home";
@@ -30,6 +34,8 @@ import {
   setUserAgentPreference,
 } from "../../../../../src/lib/zero/slack-org/handlers/shared";
 import { listComposes } from "../../../../../src/lib/zero/zero-compose-service";
+import { getSlackModelPickerState } from "../../../../../src/lib/zero/slack/model-picker";
+import { updateUserModelPreference } from "../../../../../src/lib/zero/model-policy/user-model-preference-service";
 import { logger } from "../../../../../src/lib/shared/logger";
 
 const log = logger("slack-org:interactive");
@@ -135,6 +141,13 @@ export async function POST(request: Request) {
     return handleAgentPickerSubmit(payload);
   }
 
+  if (
+    payload.type === "view_submission" &&
+    payload.view?.callback_id === MODEL_PICKER_CALLBACK_ID
+  ) {
+    return handleModelPickerSubmit(payload);
+  }
+
   if (payload.type === "block_actions") {
     const action = payload.actions?.[0];
     if (!action) {
@@ -208,7 +221,7 @@ function postEphemeralMessage(opts: {
       return;
     })
     .catch((err) => {
-      log.warn("Failed to post switch ephemeral", { error: err });
+      log.warn("Failed to post ephemeral message", { error: err });
     });
 }
 
@@ -339,6 +352,114 @@ async function handleAgentPickerSubmit(
     channelId,
     composeId: agentRow.id,
     switchedTo: agentRow.displayName ?? agentRow.name,
+  });
+
+  return new Response("", { status: 200 });
+}
+
+async function applyModelSelection(opts: {
+  ctx: ConnectionContext;
+  botToken: string;
+  slackUserId: string;
+  channelId: string | undefined;
+  selectedModel: string | null;
+  switchedTo: string;
+}): Promise<void> {
+  await updateUserModelPreference(
+    opts.ctx.orgId,
+    opts.ctx.connection.vm0UserId,
+    opts.selectedModel,
+  );
+
+  if (opts.channelId) {
+    await postEphemeralMessage({
+      botToken: opts.botToken,
+      channel: opts.channelId,
+      slackUserId: opts.slackUserId,
+      text: `Switched to *${opts.switchedTo}*.`,
+    });
+  }
+}
+
+/**
+ * Persist the user's model selection after they submit the model modal.
+ *
+ * The option list is reloaded on submit so stale modals cannot write a model
+ * that is no longer configured or visible for the caller.
+ */
+async function handleModelPickerSubmit(
+  payload: SlackInteractivePayload,
+): Promise<Response> {
+  const selected =
+    payload.view?.state.values[MODEL_PICKER_BLOCK_ID]?.[MODEL_PICKER_ACTION_ID]
+      ?.selected_option?.value;
+
+  if (!selected) {
+    return NextResponse.json({
+      response_action: "errors",
+      errors: { [MODEL_PICKER_BLOCK_ID]: "Please choose a model." },
+    });
+  }
+
+  const ctx = await resolveConnectionContext(payload.user.id, payload.team.id);
+  if (!ctx) {
+    return new Response("", { status: 200 });
+  }
+
+  const picker = await getSlackModelPickerState({
+    orgId: ctx.orgId,
+    userId: ctx.connection.vm0UserId,
+  });
+  if (!picker.enabled) {
+    return NextResponse.json({
+      response_action: "errors",
+      errors: {
+        [MODEL_PICKER_BLOCK_ID]:
+          "Model switching is not available for this workspace.",
+      },
+    });
+  }
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const botToken = decryptSecretValue(
+    ctx.installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const channelId = parseViewChannelId(payload.view?.private_metadata);
+
+  if (selected === MODEL_PICKER_WORKSPACE_DEFAULT_VALUE) {
+    await applyModelSelection({
+      ctx,
+      botToken,
+      slackUserId: payload.user.id,
+      channelId,
+      selectedModel: null,
+      switchedTo: picker.workspaceDefaultName
+        ? `workspace default (${picker.workspaceDefaultName})`
+        : "workspace default",
+    });
+    return new Response("", { status: 200 });
+  }
+
+  const option = picker.options.find((candidate) => {
+    return candidate.model === selected;
+  });
+  if (!option) {
+    return NextResponse.json({
+      response_action: "errors",
+      errors: {
+        [MODEL_PICKER_BLOCK_ID]: "You don't have access to that model.",
+      },
+    });
+  }
+
+  await applyModelSelection({
+    ctx,
+    botToken,
+    slackUserId: payload.user.id,
+    channelId,
+    selectedModel: option.model,
+    switchedTo: option.label,
   });
 
   return new Response("", { status: 200 });

--- a/turbo/apps/web/src/lib/zero/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/zero/slack/blocks.ts
@@ -334,17 +334,23 @@ export function buildWelcomeMessage(
  * Build a help message
  *
  * @param opts.canSwitch - Whether `/zero switch` is available for the caller.
- *   When `false`, the switch line is omitted so users aren't shown a command
- *   they cannot use. Defaults to `false` (the safe choice when the caller has
- *   no user/org context yet, e.g. pre-installation help).
+ * @param opts.canModel - Whether `/zero model` is available for the caller.
+ *   When unavailable, gated command lines are omitted so users aren't shown
+ *   commands they cannot use. Defaults to `false` (the safe choice when the
+ *   caller has no user/org context yet, e.g. pre-installation help).
  * @returns Block Kit blocks
  */
 export function buildHelpMessage(opts?: {
   canSwitch?: boolean;
+  canModel?: boolean;
 }): (Block | KnownBlock)[] {
   const canSwitch = opts?.canSwitch ?? false;
+  const canModel = opts?.canModel ?? false;
   const switchLine = canSwitch
     ? "\n\u2022 `/zero switch` - Choose which agent responds to your messages"
+    : "";
+  const modelLine = canModel
+    ? "\n\u2022 `/zero model` - Choose your personal default model"
     : "";
   return [
     {
@@ -361,7 +367,7 @@ export function buildHelpMessage(opts?: {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*Commands*\n\u2022 \`/zero connect\` - Connect to Zero${switchLine}\n\u2022 \`/zero disconnect\` - Disconnect from Zero`,
+        text: `*Commands*\n\u2022 \`/zero connect\` - Connect to Zero${switchLine}${modelLine}\n\u2022 \`/zero disconnect\` - Disconnect from Zero`,
       },
     },
     {
@@ -499,6 +505,11 @@ export const AGENT_PICKER_BLOCK_ID = "agent_select_block";
 export const AGENT_PICKER_ACTION_ID = "agent_select";
 export const AGENT_PICKER_ORG_DEFAULT_VALUE = "__org_default__";
 
+export const MODEL_PICKER_CALLBACK_ID = "model_preference_modal";
+export const MODEL_PICKER_BLOCK_ID = "model_select_block";
+export const MODEL_PICKER_ACTION_ID = "model_select";
+export const MODEL_PICKER_WORKSPACE_DEFAULT_VALUE = "__workspace_default__";
+
 interface AgentPickerOption {
   composeId: string;
   name: string;
@@ -566,6 +577,84 @@ export function buildAgentPickerModal(args: {
           type: "static_select",
           action_id: AGENT_PICKER_ACTION_ID,
           placeholder: { type: "plain_text", text: "Select an agent" },
+          options: selectOptions,
+          ...(initialOption && { initial_option: initialOption }),
+        },
+      },
+    ],
+    ...(args.privateMetadata && { private_metadata: args.privateMetadata }),
+  };
+
+  return view;
+}
+
+interface ModelPickerOption {
+  model: string;
+  label: string;
+}
+
+/**
+ * Build the "Switch Model" modal view.
+ *
+ * The caller passes only models configured for the workspace and available to
+ * the user. The workspace default sentinel clears the personal model
+ * preference, matching the platform's "use default" behavior.
+ */
+export function buildModelPickerModal(args: {
+  options: ModelPickerOption[];
+  currentSelectedModel: string | null;
+  workspaceDefaultName: string | null;
+  privateMetadata?: string;
+}): View {
+  const workspaceDefaultLabel = args.workspaceDefaultName
+    ? `Use workspace default (${args.workspaceDefaultName})`
+    : "Use workspace default";
+
+  const selectOptions = [
+    {
+      text: {
+        type: "plain_text" as const,
+        text: workspaceDefaultLabel.slice(0, 75),
+      },
+      value: MODEL_PICKER_WORKSPACE_DEFAULT_VALUE,
+    },
+    ...args.options.map((option) => {
+      return {
+        text: { type: "plain_text" as const, text: option.label.slice(0, 75) },
+        value: option.model,
+      };
+    }),
+  ];
+
+  const initialOptionRaw = args.currentSelectedModel
+    ? selectOptions.find((option) => {
+        return option.value === args.currentSelectedModel;
+      })
+    : selectOptions[0];
+  const initialOption = initialOptionRaw ?? selectOptions[0];
+
+  const view: View = {
+    type: "modal",
+    callback_id: MODEL_PICKER_CALLBACK_ID,
+    title: { type: "plain_text", text: "Switch Model" },
+    submit: { type: "plain_text", text: "Switch" },
+    close: { type: "plain_text", text: "Cancel" },
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "Choose your personal default model. This only affects your own runs.",
+        },
+      },
+      {
+        type: "input",
+        block_id: MODEL_PICKER_BLOCK_ID,
+        label: { type: "plain_text", text: "Model" },
+        element: {
+          type: "static_select",
+          action_id: MODEL_PICKER_ACTION_ID,
+          placeholder: { type: "plain_text", text: "Select a model" },
           options: selectOptions,
           ...(initialOption && { initial_option: initialOption }),
         },

--- a/turbo/apps/web/src/lib/zero/slack/model-picker.ts
+++ b/turbo/apps/web/src/lib/zero/slack/model-picker.ts
@@ -1,0 +1,114 @@
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import {
+  getCanonicalModelDisplayName,
+  getVm0VisibleModels,
+  isSupportedRunModel,
+  type SupportedRunModel,
+} from "@vm0/api-contracts/contracts/model-providers";
+import { getAllFeatureStates } from "@vm0/core/feature-switch";
+import { loadFeatureSwitchOverrides } from "../user/feature-switches-service";
+import { ensureOrgModelPolicies } from "../model-policy/org-model-policy-service";
+import { resolveModelFirstRouteDescriptor } from "../model-policy/model-first-route-service";
+import { getUserModelPreferenceModel } from "../model-policy/user-model-preference-service";
+
+interface SlackModelPickerOption {
+  model: SupportedRunModel;
+  label: string;
+  isDefault: boolean;
+}
+
+interface SlackModelPickerState {
+  enabled: boolean;
+  options: SlackModelPickerOption[];
+  currentSelectedModel: SupportedRunModel | null;
+  workspaceDefaultModel: SupportedRunModel | null;
+  workspaceDefaultName: string | null;
+}
+
+async function canUseModelRoute(params: {
+  orgId: string;
+  userId: string;
+  model: SupportedRunModel;
+}): Promise<boolean> {
+  try {
+    await resolveModelFirstRouteDescriptor({
+      orgId: params.orgId,
+      userId: params.userId,
+      selectedModel: params.model,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function getSlackModelPickerState(params: {
+  orgId: string;
+  userId: string;
+}): Promise<SlackModelPickerState> {
+  const overrides = await loadFeatureSwitchOverrides(
+    params.orgId,
+    params.userId,
+  );
+  const featureStates = getAllFeatureStates({
+    orgId: params.orgId,
+    userId: params.userId,
+    overrides,
+  });
+
+  if (!featureStates[FeatureSwitchKey.ModelFirstModelProvider]) {
+    return {
+      enabled: false,
+      options: [],
+      currentSelectedModel: null,
+      workspaceDefaultModel: null,
+      workspaceDefaultName: null,
+    };
+  }
+
+  const visibleModels = new Set(getVm0VisibleModels(featureStates));
+  const policies = await ensureOrgModelPolicies(params.orgId, params.userId);
+  const currentSelectedModel = await getUserModelPreferenceModel(
+    params.orgId,
+    params.userId,
+  );
+
+  const options: SlackModelPickerOption[] = [];
+  for (const policy of policies) {
+    if (
+      !isSupportedRunModel(policy.model) ||
+      !visibleModels.has(policy.model)
+    ) {
+      continue;
+    }
+    if (
+      !(await canUseModelRoute({
+        orgId: params.orgId,
+        userId: params.userId,
+        model: policy.model,
+      }))
+    ) {
+      continue;
+    }
+    options.push({
+      model: policy.model,
+      label: getCanonicalModelDisplayName(policy.model),
+      isDefault: policy.isDefault,
+    });
+  }
+
+  const workspaceDefaultModel =
+    options.find((option) => {
+      return option.isDefault;
+    })?.model ?? null;
+
+  return {
+    enabled: true,
+    options,
+    currentSelectedModel,
+    workspaceDefaultModel,
+    workspaceDefaultName: workspaceDefaultModel
+      ? getCanonicalModelDisplayName(workspaceDefaultModel)
+      : null,
+  };
+}


### PR DESCRIPTION
## Summary
- add /zero model Slack slash command behind modelFirstModelProvider
- open a model picker modal backed by org model policies and current user preference
- persist selected model or clear to workspace default from Slack interactive submissions

## Verification
- pnpm --filter web check-types
- pnpm --filter web exec eslint app/api/zero/slack/commands/route.ts app/api/zero/slack/interactive/route.ts app/api/zero/slack/commands/__tests__/route.test.ts app/api/zero/slack/interactive/__tests__/route.test.ts src/lib/zero/slack/blocks.ts src/lib/zero/slack/model-picker.ts --max-warnings 0
- pnpm --filter web exec vitest run app/api/zero/slack/commands/__tests__/route.test.ts --testNamePattern "returns an error when model-first is not enabled"

## Notes
- Full DB-backed Slack tests were not run locally because the local test database schema is drifted: it is missing org_members_metadata.selected_model, and db:migrate stops on an already-existing chat_threads.model_provider_type column.
- The repo pre-commit root check-types also fails in apps/api in this workspace due unresolved installed dependencies; web check-types passes.