### PR TITLE
test: align zero billing read route parity

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts
@@ -36,6 +36,27 @@ describe("GET /api/zero/billing/auto-recharge", () => {
     });
   });
 
+  it("returns 401 when the user has no active org", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const client = setupApp({ context })(zeroBillingAutoRechargeContract);
+
+    const response = await accept(
+      client.get({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
   it("returns the org auto-recharge config from the api implementation", async () => {
     const fixture = await track(
       store.set(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-invoices.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-invoices.test.ts
@@ -37,6 +37,27 @@ describe("GET /api/zero/billing/invoices", () => {
     });
   });
 
+  it("returns 401 when the user has no active org", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const client = setupApp({ context })(zeroBillingInvoicesContract);
+
+    const response = await accept(
+      client.get({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
   it("returns 403 for a non-admin org member", async () => {
     const fixture = await track(
       store.set(seedInvoicesOrg$, {}, context.signal),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts
@@ -31,6 +31,25 @@ describe("GET /api/zero/billing/status", () => {
     expect(response.body.error.code).toBe("UNAUTHORIZED");
   });
 
+  it("returns 401 when the user has no active org", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const client = setupApp({ context })(zeroBillingStatusContract);
+
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
   it("returns billing status for authenticated user", async () => {
     const fixture = await track(
       store.set(seedBillingStatusOrg$, { credits: 100_000 }, context.signal),

--- a/turbo/apps/web/app/api/zero/billing/auto-recharge/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/auto-recharge/__tests__/route.test.ts
@@ -50,6 +50,36 @@ describe("/api/zero/billing/auto-recharge", () => {
   });
 
   describe("GET", () => {
+    it("returns 401 when the request is unauthenticated", async () => {
+      mockClerk({ userId: null });
+
+      const request = createTestRequest(BASE_URL);
+      const response = await GET(request);
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toStrictEqual({
+        error: {
+          message: "Not authenticated",
+          code: "UNAUTHORIZED",
+        },
+      });
+    });
+
+    it("returns 401 when the user has no active org", async () => {
+      mockClerk({ userId: user.userId, orgId: null });
+
+      const request = createTestRequest(BASE_URL);
+      const response = await GET(request);
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toStrictEqual({
+        error: {
+          message: "Not authenticated",
+          code: "UNAUTHORIZED",
+        },
+      });
+    });
+
     it("returns default config for new org", async () => {
       const request = createTestRequest(BASE_URL);
       const response = await GET(request);

--- a/turbo/apps/web/app/api/zero/billing/auto-recharge/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/auto-recharge/route.ts
@@ -18,6 +18,9 @@ const router = tsr.router(zeroBillingAutoRechargeContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
 
     const { org } = await resolveOrg(authCtx);
 

--- a/turbo/apps/web/app/api/zero/billing/invoices/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/invoices/__tests__/route.test.ts
@@ -64,6 +64,40 @@ describe("GET /api/zero/billing/invoices", () => {
     stripeMocks.invoicesList.mockReset();
   });
 
+  it("returns 401 when the request is unauthenticated", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/invoices",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns 401 when the user has no active org", async () => {
+    mockClerk({ userId: uniqueId("no-org-user"), orgId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/invoices",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
   it("returns 403 for non-admin member", async () => {
     const { userId, orgId } = await context.setupUser({
       prefix: "member-invoices",

--- a/turbo/apps/web/app/api/zero/billing/invoices/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/invoices/route.ts
@@ -15,6 +15,9 @@ const router = tsr.router(zeroBillingInvoicesContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
 
     const { org, member } = await resolveOrg(authCtx);
     if (member.role !== "admin") {

--- a/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
@@ -74,6 +74,23 @@ describe("GET /api/zero/billing/status", () => {
     expect(response.status).toBe(401);
   });
 
+  it("returns 401 when the user has no active org", async () => {
+    mockClerk({ userId: uniqueId("no-org-user"), orgId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/status",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
   it("returns billing status for authenticated user", async () => {
     const request = createTestRequest(
       "http://localhost:3000/api/zero/billing/status",

--- a/turbo/apps/web/app/api/zero/billing/status/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/route.ts
@@ -1,5 +1,6 @@
 import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { zeroBillingStatusContract } from "@vm0/api-contracts/contracts/zero-billing";
+import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -14,6 +15,9 @@ const router = tsr.router(zeroBillingStatusContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
 
     const { org } = await resolveOrg(authCtx);
 


### PR DESCRIPTION
## Summary
- align web billing read GET routes with API auth behavior when no active organization is selected
- add API no-active-org coverage for auto-recharge, invoices, and status read routes
- add web unauthenticated/no-active-org regression coverage for the same read routes

## Validation
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts src/signals/routes/__tests__/zero-billing-invoices.test.ts src/signals/routes/__tests__/zero-billing-status.test.ts
- pnpm -F web exec vitest run app/api/zero/billing/auto-recharge/__tests__/route.test.ts app/api/zero/billing/invoices/__tests__/route.test.ts app/api/zero/billing/status/__tests__/route.test.ts
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm knip
- pnpm vitest

Closes #12617