### PR TITLE
test: align chat thread route parity

### DIFF
--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import {
   addTestRunToThread,
   updateTestChatThreadTitle,
   insertTestChatMessage,
+  setTestChatThreadRenamedAt,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -95,6 +96,163 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     expect(data.latestSessionId).toBeNull();
     expect(data.createdAt).toBeDefined();
     expect(data.updatedAt).toBeDefined();
+  });
+
+  it("returns thread detail with S3-backed attachment metadata", async () => {
+    const createResponse = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testComposeId,
+          title: "Uploads",
+        }),
+      }),
+    );
+    const { id: threadId } = await createResponse.json();
+    await insertTestChatMessage({
+      chatThreadId: threadId,
+      userId: testUserId,
+      role: "user",
+      content: "see attached file",
+      attachFiles: ["file_123"],
+      createdAt: new Date("2025-01-01T00:00:00.000Z"),
+    });
+    context.mocks.s3.listS3Objects.mockImplementation(
+      async (_bucket: string, prefix: string) => {
+        if (prefix.includes("file_123")) {
+          return [
+            {
+              key: `uploads/${testUserId}/file_123/report.pdf`,
+              size: 42,
+            },
+          ];
+        }
+        return [];
+      },
+    );
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toMatchObject({
+      id: threadId,
+      title: "Uploads",
+      agentId: testComposeId,
+      latestSessionId: null,
+      activeRunIds: [],
+      activeRuns: [],
+      draftContent: null,
+      draftAttachments: null,
+      modelProviderId: null,
+      modelProviderType: null,
+      modelProviderCredentialScope: null,
+      selectedModel: null,
+      renamedAt: null,
+      chatMessages: [
+        {
+          role: "user",
+          content: "see attached file",
+          attachFiles: [
+            {
+              id: "file_123",
+              filename: "report.pdf",
+              contentType: "application/pdf",
+              size: 42,
+              url: `http://localhost:3000/f/${encodeURIComponent(
+                testUserId.replace(/^user_/, ""),
+              )}/file_123/report.pdf`,
+            },
+          ],
+        },
+      ],
+    });
+    for (const message of data.chatMessages as { id: string }[]) {
+      expect(message.id).toStrictEqual(expect.any(String));
+    }
+  });
+
+  it("strips Clerk user_ prefix from attachment file URLs", async () => {
+    const clerkUser = await context.setupUser({ prefix: "user_clerk" });
+    testUserId = clerkUser.userId;
+    const { composeId } = await createTestCompose(uniqueId("clerk-upload"));
+
+    const createResponse = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: composeId, title: "Attachment" }),
+      }),
+    );
+    const { id: threadId } = await createResponse.json();
+    await insertTestChatMessage({
+      chatThreadId: threadId,
+      userId: testUserId,
+      role: "user",
+      content: "attachment",
+      attachFiles: ["file_abc"],
+      createdAt: new Date("2025-01-01T00:00:00.000Z"),
+    });
+    context.mocks.s3.listS3Objects.mockImplementation(
+      async (_bucket: string, prefix: string) => {
+        if (prefix.includes("file_abc")) {
+          return [
+            {
+              key: `uploads/${testUserId}/file_abc/photo.png`,
+              size: 256,
+            },
+          ];
+        }
+        return [];
+      },
+    );
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.chatMessages[0].attachFiles[0].url).toBe(
+      `http://localhost:3000/f/${encodeURIComponent(
+        testUserId.replace(/^user_/, ""),
+      )}/file_abc/photo.png`,
+    );
+  });
+
+  it("returns renamedAt as ISO string when thread was renamed", async () => {
+    const createResponse = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testComposeId,
+          title: "Custom Name",
+        }),
+      }),
+    );
+    const { id: threadId } = await createResponse.json();
+    await setTestChatThreadRenamedAt(
+      threadId,
+      new Date("2025-06-01T12:00:00.000Z"),
+    );
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.renamedAt).toBe("2025-06-01T12:00:00.000Z");
   });
 
   it("should return chat messages after run completes", async () => {
@@ -456,6 +614,20 @@ describe("DELETE /api/zero/chat-threads/:id - Delete Thread", () => {
     expect(response.status).toBe(404);
   });
 
+  it("returns 404 for a malformed UUID without touching the DB", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/chat-threads/not-a-uuid",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data).toStrictEqual({
+      error: { message: "Chat thread not found", code: "NOT_FOUND" },
+    });
+  });
+
   it("should delete a thread and remove it from the list", async () => {
     // Create a thread
     const createResponse = await POST(
@@ -604,6 +776,24 @@ describe("PATCH /api/zero/chat-threads/:id - Update Thread Draft", () => {
     const response = await PATCH(request);
 
     expect(response.status).toBe(404);
+  });
+
+  it("returns 404 for a malformed UUID without touching the DB", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/chat-threads/not-a-uuid",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ draftContent: "hello" }),
+      },
+    );
+    const response = await PATCH(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data).toStrictEqual({
+      error: { message: "Chat thread not found", code: "NOT_FOUND" },
+    });
   });
 
   it("should update draft content and return 204", async () => {

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { GET, POST as SYNC_POST } from "../route";
 import { POST } from "../../../route";
@@ -16,6 +16,7 @@ import { seedTestRun } from "../../../../../../../src/__tests__/db-test-seeders/
 import { insertTestConnectorSecret } from "../../../../../../../src/__tests__/db-test-seeders/connectors";
 import { recordRunUploadedFile } from "../../../../../../../src/lib/zero/uploads/run-uploaded-files";
 import { server } from "../../../../../../../src/mocks/server";
+import { reloadEnv } from "../../../../../../../src/env";
 
 const context = testContext();
 
@@ -225,6 +226,114 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
     });
   });
 
+  it("returns 404 when the thread is owned by a different user", async () => {
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+    const { runId } = await seedTestRun(testUserId, testComposeId, {
+      status: "completed",
+      prompt: "Use the attached file",
+      chatThreadId: threadId,
+    });
+    await recordRunUploadedFile({
+      runId,
+      source: "web",
+      externalId: "file-private",
+      userId: testUserId,
+      orgId: testOrgId,
+      filename: "secret.txt",
+      contentType: "text/plain",
+      sizeBytes: 128,
+      url: `http://localhost:3000/f/${testUserId}/file-private/secret.txt`,
+    });
+
+    await context.setupUser({ prefix: "other-user" });
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}/artifacts`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data).toStrictEqual({
+      error: { message: "Chat thread not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns googleDriveSync status unknown when Drive rejects the access token and refresh fails", async () => {
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+    const { runId } = await seedTestRun(testUserId, testComposeId, {
+      status: "completed",
+      prompt: "Use the attached file",
+      chatThreadId: threadId,
+    });
+    await context.createConnector(testOrgId, {
+      userId: testUserId,
+      type: "google-drive",
+      authMethod: "oauth",
+    });
+    await insertTestConnectorSecret(
+      testOrgId,
+      testUserId,
+      "GOOGLE_DRIVE_ACCESS_TOKEN",
+      "stale-token",
+    );
+    await insertTestConnectorSecret(
+      testOrgId,
+      testUserId,
+      "GOOGLE_DRIVE_REFRESH_TOKEN",
+      "refresh-token",
+    );
+    await recordRunUploadedFile({
+      runId,
+      source: "web",
+      externalId: "file-1",
+      userId: testUserId,
+      orgId: testOrgId,
+      filename: "data.csv",
+      contentType: "text/csv",
+      sizeBytes: 2048,
+      url: `http://localhost:3000/f/${testUserId}/file-1/data.csv`,
+    });
+
+    vi.stubEnv("GOOGLE_OAUTH_CLIENT_ID", "test-client-id");
+    vi.stubEnv("GOOGLE_OAUTH_CLIENT_SECRET", "test-client-secret");
+    reloadEnv();
+    server.use(
+      http.get("https://www.googleapis.com/drive/v3/files", () => {
+        return new HttpResponse(null, { status: 401 });
+      }),
+      http.post("https://oauth2.googleapis.com/token", () => {
+        return new HttpResponse(null, { status: 401 });
+      }),
+    );
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}/artifacts`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.runs[0].files[0].googleDriveSync).toStrictEqual({
+      status: "unknown",
+    });
+  });
+
   it("syncs a thread artifact file to Google Drive", async () => {
     const createRes = await POST(
       createTestRequest("http://localhost:3000/api/zero/chat-threads", {
@@ -393,5 +502,114 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
     expect(data.error.message).toBe(
       "Connect Google Drive before syncing artifacts",
     );
+  });
+
+  it("returns 401 when unauthenticated during artifact sync", async () => {
+    mockClerk({ userId: null });
+
+    const response = await SYNC_POST(
+      createTestRequest(
+        "http://localhost:3000/api/zero/chat-threads/00000000-0000-4000-8000-000000000001/artifacts",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            runId: "00000000-0000-4000-8000-000000000002",
+            fileId: "file-1",
+          }),
+        },
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when authenticated session has no organization during artifact sync", async () => {
+    mockClerk({ userId: testUserId, orgId: null });
+
+    const response = await SYNC_POST(
+      createTestRequest(
+        "http://localhost:3000/api/zero/chat-threads/00000000-0000-4000-8000-000000000001/artifacts",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            runId: "00000000-0000-4000-8000-000000000002",
+            fileId: "file-1",
+          }),
+        },
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 400 when the artifact sync body is invalid", async () => {
+    const response = await SYNC_POST(
+      createTestRequest(
+        "http://localhost:3000/api/zero/chat-threads/00000000-0000-4000-8000-000000000001/artifacts",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            runId: "00000000-0000-4000-8000-000000000002",
+          }),
+        },
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("returns 404 when the artifact is unknown to the caller's thread", async () => {
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+    await context.createConnector(testOrgId, {
+      userId: testUserId,
+      type: "google-drive",
+      authMethod: "oauth",
+    });
+    await insertTestConnectorSecret(
+      testOrgId,
+      testUserId,
+      "GOOGLE_DRIVE_ACCESS_TOKEN",
+      "drive-access-token",
+    );
+
+    const response = await SYNC_POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}/artifacts`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            runId: "00000000-0000-4000-8000-000000000002",
+            fileId: "missing-file",
+          }),
+        },
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data).toStrictEqual({
+      error: { message: "Artifact file not found", code: "NOT_FOUND" },
+    });
   });
 });

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/artifacts/route.ts
@@ -72,6 +72,10 @@ const router = tsr.router(chatThreadArtifactsContract, {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
 
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+
     try {
       const { org } = await resolveOrg(authCtx);
       const result = await syncArtifactToGoogleDrive({

--- a/turbo/apps/web/app/api/zero/chat-threads/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/__tests__/route.test.ts
@@ -9,6 +9,7 @@ import {
   setTestChatThreadLastReadMessageId,
   setTestChatThreadDraft,
   setTestChatThreadPinnedAt,
+  setTestChatThreadRenamedAt,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -152,6 +153,31 @@ describe("POST /api/zero/chat-threads - Create Thread", () => {
 
     expect(response.status).toBe(404);
   });
+
+  it("returns 404 without publishing when authenticated session has no organization", async () => {
+    mockClerk({ userId: user.userId, orgId: null });
+    mockAblyPublish.mockClear();
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/chat-threads",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testComposeId,
+          title: "No active org",
+        }),
+      },
+    );
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data).toStrictEqual({
+      error: { message: "Agent not found", code: "NOT_FOUND" },
+    });
+    expect(mockAblyPublish).not.toHaveBeenCalled();
+  });
 });
 
 describe("GET /api/zero/chat-threads - List Threads", () => {
@@ -177,6 +203,21 @@ describe("GET /api/zero/chat-threads - List Threads", () => {
 
     expect(response.status).toBe(401);
     expect(data.error.message).toContain("Not authenticated");
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mockClerk({ userId: user.userId, orgId: null });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/zero/chat-threads?agentId=${testComposeId}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
   });
 
   it("should return 404 for compose from a different org", async () => {
@@ -574,6 +615,65 @@ describe("GET /api/zero/chat-threads - List Threads", () => {
       return t.id === secondId;
     });
     expect(unpinnedRow.pinnedAt).toBeNull();
+  });
+
+  it("returns pinnedAt and renamedAt as ISO strings when set", async () => {
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testComposeId,
+          title: "Pinned and renamed",
+        }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+    await setTestChatThreadPinnedAt(
+      threadId,
+      new Date("2025-05-01T10:00:00.000Z"),
+    );
+    await setTestChatThreadRenamedAt(
+      threadId,
+      new Date("2025-06-01T12:00:00.000Z"),
+    );
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads?agentId=${testComposeId}`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.threads).toHaveLength(1);
+    expect(data.threads[0].pinnedAt).toBe("2025-05-01T10:00:00.000Z");
+    expect(data.threads[0].renamedAt).toBe("2025-06-01T12:00:00.000Z");
+  });
+
+  it("returns pinnedAt and renamedAt as null when not set", async () => {
+    await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testComposeId,
+          title: "Not pinned or renamed",
+        }),
+      }),
+    );
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads?agentId=${testComposeId}`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.threads).toHaveLength(1);
+    expect(data.threads[0].pinnedAt).toBeNull();
+    expect(data.threads[0].renamedAt).toBeNull();
   });
 
   it("keeps a thread visible when only an earlier message is archived", async () => {


### PR DESCRIPTION
Closes #12619

## Summary
- add missing web route parity coverage for chat-thread create/list/detail/by-id/artifacts routes
- align web artifact sync no-active-org behavior with API by returning `UNAUTHORIZED` before org resolution

## Validation
- `pnpm -F web exec vitest run app/api/zero/chat-threads/__tests__/route.test.ts 'app/api/zero/chat-threads/[id]/__tests__/route.test.ts' 'app/api/zero/chat-threads/[id]/artifacts/__tests__/route.test.ts'`\n- `pnpm exec vitest run src/signals/routes/__tests__/zero-chat-threads*.test.ts` from `turbo/apps/api`\n- `pnpm -F web lint`\n- `pnpm -F web check-types`\n\nNote: after pulling main, local tests initially failed because the local DB was missing the new `zero_agents.visibility` migration. `pnpm -F web db:migrate` fixed the local schema, then the focused tests passed.