### PR TITLE
fix: align zero chat search no-org parity

### DIFF
--- a/turbo/apps/web/app/api/zero/chat/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/search/__tests__/route.test.ts
@@ -26,6 +26,13 @@ vi.mock("@axiomhq/js");
 const context = testContext();
 
 const URL_BASE = "http://localhost:3000/api/zero/chat/search";
+const unauthorizedBody = {
+  error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+};
+
+async function expectJsonBody(res: Response, expected: unknown): Promise<void> {
+  expect(await res.json()).toStrictEqual(expected);
+}
 
 describe("GET /api/zero/chat/search", () => {
   beforeEach(() => {
@@ -38,6 +45,16 @@ describe("GET /api/zero/chat/search", () => {
     const response = await GET(createTestRequest(`${URL_BASE}?keyword=hello`));
 
     expect(response.status).toBe(401);
+    await expectJsonBody(response, unauthorizedBody);
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mockClerk({ userId: uniqueId("user"), orgId: null });
+
+    const response = await GET(createTestRequest(`${URL_BASE}?keyword=hello`));
+
+    expect(response.status).toBe(401);
+    await expectJsonBody(response, unauthorizedBody);
   });
 
   it("returns 403 when token lacks chat-message:read capability", async () => {

--- a/turbo/apps/web/app/api/zero/chat/search/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/search/route.ts
@@ -113,6 +113,15 @@ const messageColumns = {
   runId: effectiveChatMessageRunId(),
 };
 
+function unauthenticatedResponse() {
+  return {
+    status: 401 as const,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
+
 const router = tsr.router(chatSearchContract, {
   search: async ({ query, headers }) => {
     initServices();
@@ -121,6 +130,7 @@ const router = tsr.router(chatSearchContract, {
       requiredCapability: "chat-message:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
 
     const { org } = await resolveOrg(authCtx);
     const { userId } = authCtx;


### PR DESCRIPTION
## Summary
- Return the API-compatible 401 UNAUTHORIZED response from the web chat search route when an authenticated session has no active organization.
- Assert the exact 401 body for unauthenticated and no-active-org web chat search cases.

## Validation
- pnpm -F web exec vitest run app/api/zero/chat/search/__tests__/route.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-search.test.ts
- pnpm -F web run lint
- git diff --check

## Notes
- The commit hook full typecheck is currently blocked by unrelated baseline errors outside this change, including apps/web/app/api/runners/poll/route.ts, apps/web/app/api/webhooks/agent/usage-event/route.ts, apps/web/app/api/zero/onboarding/*, apps/web/app/api/zero/skills/[name]/route.ts, apps/web/app/api/zero/usage/runs/route.ts, and apps/platform signal route typing errors.

Closes #12620