### PR TITLE
fix: keep default agent as pin dialog lead

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
@@ -18,6 +18,8 @@ import {
   setManagePinnedDialogOpen$,
   setDraftPinnedIds$,
 } from "../../../signals/zero-page/zero-sidebar-state.ts";
+import { setChatAgentId$ } from "../../../signals/agent-chat.ts";
+import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -37,7 +39,7 @@ function mockAPIsWithSubagents({
   setMockTeam([
     {
       id: "c0000000-0000-4000-a000-000000000001",
-      displayName: null,
+      displayName: "Default Agent",
       description: null,
       sound: null,
       avatarUrl: null,
@@ -88,6 +90,45 @@ function mockAPIsWithSubagents({
         id: createdThreadId,
         title: null,
         createdAt: "2026-03-10T00:00:00Z",
+      });
+    }),
+    mockApi(zeroAgentsByIdContract.get, ({ params, respond }) => {
+      const agents: Record<
+        string,
+        { agentId: string; displayName: string; avatarUrl: string | null }
+      > = {
+        "c0000000-0000-4000-a000-000000000001": {
+          agentId: "c0000000-0000-4000-a000-000000000001",
+          displayName: "Default Agent",
+          avatarUrl: null,
+        },
+        "pinned-agent-id": {
+          agentId: "pinned-agent-id",
+          displayName: "Pinned Agent",
+          avatarUrl: "preset:2",
+        },
+        "unpinned-agent-id": {
+          agentId: "unpinned-agent-id",
+          displayName: "Unpinned Agent",
+          avatarUrl: "preset:3",
+        },
+      };
+      const agent = agents[String(params.id)];
+      if (!agent) {
+        return respond(404, {
+          error: { message: "Not found", code: "NOT_FOUND" },
+        });
+      }
+      return respond(200, {
+        ...agent,
+        ownerId: "test-user-123",
+        description: null,
+        sound: null,
+        permissionPolicies: null,
+        customSkills: [],
+        modelProviderId: null,
+        selectedModel: null,
+        preferPersonalProvider: false,
       });
     }),
   );
@@ -202,6 +243,23 @@ describe("chatListDialog", () => {
       expectCreatedThreadRoute(getCreatedThreadId);
     });
   });
+
+  it("keeps the Lead row on the default agent when a sub-agent is selected", async () => {
+    mockAPIsWithSubagents();
+    detachedSetupPage({ context, path: "/agents" });
+    context.store.set(setChatAgentId$, "pinned-agent-id");
+
+    await openChatListDialog();
+
+    const dialog = screen.getByRole("dialog");
+    const leadButton = await waitFor(() => {
+      return within(dialog)
+        .getByText("Your lead assistant, always here for you")
+        .closest("button")!;
+    });
+    expect(leadButton).toHaveTextContent("Default Agent");
+    expect(leadButton).not.toHaveTextContent("Pinned Agent");
+  });
 });
 
 describe("managePinnedAgentsDialog - pinned agents list renders (SIDEBAR-D-026)", () => {
@@ -249,6 +307,23 @@ describe("managePinnedAgentsDialog - lead agent displays distinctly (SIDEBAR-D-0
     await waitFor(() => {
       expect(within(dialog).getByText("Lead")).toBeInTheDocument();
     });
+  });
+
+  it("keeps the Lead row on the default agent when a sub-agent is selected", async () => {
+    mockAPIsWithSubagents();
+    detachedSetupPage({ context, path: "/agents" });
+    context.store.set(setChatAgentId$, "pinned-agent-id");
+    openManagePinnedDialog();
+
+    const dialog = await waitFor(() => {
+      return screen.getByRole("dialog");
+    });
+    const leadBadge = await waitFor(() => {
+      return within(dialog).getByText("Lead");
+    });
+    const leadRow = leadBadge.closest("div");
+    expect(leadRow).toHaveTextContent("Default Agent");
+    expect(leadRow).not.toHaveTextContent("Pinned Agent");
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -19,10 +19,7 @@ import {
   setSidebarExpanded$,
 } from "../../signals/zero-page/zero-nav.ts";
 import { activeRoute$ } from "../../signals/active-route.ts";
-import {
-  currentChatAgentId$,
-  currentChatAgentDisplayName$,
-} from "../../signals/agent-chat.ts";
+import { currentChatAgentId$ } from "../../signals/agent-chat.ts";
 import { pathParams$ } from "../../signals/route.ts";
 import {
   chatListOpen$,
@@ -34,6 +31,7 @@ import {
   reloadAgents$,
   subagents$,
   defaultAgentId$,
+  defaultAgentName$,
 } from "../../signals/agent.ts";
 import {
   pinnedAgentIds$,
@@ -94,7 +92,7 @@ function UnpinButton({
 function AgentListDialogContainer() {
   const open = useGet(chatListOpen$);
   const onOpenChange = useSet(setChatListOpen$);
-  const displayNameLoadable = useLastLoadable(currentChatAgentDisplayName$);
+  const displayNameLoadable = useLastLoadable(defaultAgentName$);
   const displayName =
     displayNameLoadable.state === "hasData"
       ? (displayNameLoadable.data ?? "Zero")

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -47,10 +47,7 @@ import {
 import { activeRoute$ } from "../../signals/active-route.ts";
 import type { RouteKey } from "../../signals/route-paths.ts";
 import { subagents$, defaultAgentName$ } from "../../signals/agent.ts";
-import {
-  currentChatAgentDisplayName$,
-  currentChatAgentId$,
-} from "../../signals/agent-chat.ts";
+import { currentChatAgentId$ } from "../../signals/agent-chat.ts";
 import { updatePinnedAgentIds$ } from "../../signals/zero-page/zero-pinned-agents.ts";
 import {
   managePinnedDialogOpen$,
@@ -160,7 +157,7 @@ function ManagePinnedAgentsDialogContainer() {
   const open = useGet(managePinnedDialogOpen$);
   const setOpen = useSet(setManagePinnedDialogOpen$);
   const pageSignal = useGet(pageSignal$);
-  const displayNameLoadable = useLastLoadable(currentChatAgentDisplayName$);
+  const displayNameLoadable = useLastLoadable(defaultAgentName$);
   const displayName =
     displayNameLoadable.state === "hasData"
       ? (displayNameLoadable.data ?? "Zero")


### PR DESCRIPTION
## Summary
- keep pinned-agent management and talk-to dialogs using the default agent as the Lead row
- add regression coverage for selected sub-agent state

## Verification
- pnpm -C turbo -F @vm0/app test src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
- pnpm -C turbo -F @vm0/app exec eslint src/views/zero-page/zero-sidebar.tsx src/views/zero-page/zero-sidebar-pinned.tsx src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx --max-warnings 0
- git diff --check origin/main...HEAD

Note: full check-types is currently blocked by existing repo-wide TypeScript errors in apps/api/platform; changed files do not appear in filtered type-check output.