### PR TITLE
test: align zero compose route parity

### DIFF
--- a/turbo/apps/web/app/api/zero/composes/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/composes/[id]/__tests__/route.test.ts
@@ -5,6 +5,7 @@ import {
   createTestRequest,
   createTestOrg,
   createTestCompose,
+  createTestRun,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -52,6 +53,9 @@ describe("GET /api/zero/composes/:id", () => {
 
     const response = await GET(createTestRequest(composeIdUrl(randomUUID())));
     expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Agent compose not found", code: "NOT_FOUND" },
+    });
   });
 
   it("should return 400 for malformed compose id", async () => {
@@ -73,6 +77,53 @@ describe("GET /api/zero/composes/:id", () => {
 
     const response = await GET(createTestRequest(composeIdUrl(randomUUID())));
     expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("should return 401 when the authenticated session has no active organization", async () => {
+    mockClerk({ userId: uniqueId("zcompid-no-org"), orgId: null });
+
+    const response = await GET(createTestRequest(composeIdUrl(randomUUID())));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("should return 404 for a compose owned by another org", async () => {
+    const ownerUserId = uniqueId("zcompid-owner");
+    await setupOrg(ownerUserId);
+    const compose = await createTestCompose(`agent-${uniqueId("zcompid")}`);
+
+    await setupOrg(uniqueId("zcompid-other"));
+
+    const response = await GET(
+      createTestRequest(composeIdUrl(compose.composeId)),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Agent compose not found", code: "NOT_FOUND" },
+    });
+
+    mockClerk({
+      userId: ownerUserId,
+      orgId: `org_mock_${ownerUserId}`,
+      orgRole: "org:admin",
+    });
+    const ownerResponse = await GET(
+      createTestRequest(composeIdUrl(compose.composeId)),
+    );
+    expect(ownerResponse.status).toBe(200);
   });
 });
 
@@ -100,6 +151,9 @@ describe("DELETE /api/zero/composes/:id", () => {
       createTestRequest(composeIdUrl(randomUUID()), { method: "DELETE" }),
     );
     expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Agent not found", code: "NOT_FOUND" },
+    });
   });
 
   it("should return 401 when not authenticated", async () => {
@@ -109,5 +163,57 @@ describe("DELETE /api/zero/composes/:id", () => {
       createTestRequest(composeIdUrl(randomUUID()), { method: "DELETE" }),
     );
     expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("should return 404 when another user owns the compose", async () => {
+    const ownerUserId = uniqueId("zcompid-owner-del");
+    await setupOrg(ownerUserId);
+    const compose = await createTestCompose(`agent-${uniqueId("zcompid")}`);
+
+    await setupOrg(uniqueId("zcompid-attacker"));
+
+    const response = await DELETE(
+      createTestRequest(composeIdUrl(compose.composeId), { method: "DELETE" }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Agent not found", code: "NOT_FOUND" },
+    });
+
+    mockClerk({
+      userId: ownerUserId,
+      orgId: `org_mock_${ownerUserId}`,
+      orgRole: "org:admin",
+    });
+    const ownerResponse = await GET(
+      createTestRequest(composeIdUrl(compose.composeId)),
+    );
+    expect(ownerResponse.status).toBe(200);
+  });
+
+  it("should return 409 when a pending run references the compose", async () => {
+    const userId = uniqueId("zcompid-running");
+    await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("zcompid")}`);
+    await createTestRun(compose.composeId, "blocking run");
+
+    const response = await DELETE(
+      createTestRequest(composeIdUrl(compose.composeId), { method: "DELETE" }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Cannot delete agent: agent is currently running",
+        code: "CONFLICT",
+      },
+    });
   });
 });

--- a/turbo/apps/web/app/api/zero/composes/[id]/metadata/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/composes/[id]/metadata/__tests__/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { randomUUID } from "crypto";
 import { PATCH } from "../route";
+import { GET as LIST } from "../../../list/route";
 import {
   createTestRequest,
   createTestOrg,
@@ -24,6 +25,29 @@ async function setupOrg(userId: string) {
 
 function metadataUrl(composeId: string): string {
   return `http://localhost:3000/api/zero/composes/${composeId}/metadata`;
+}
+
+async function findComposeMetadata(composeId: string): Promise<{
+  displayName: string | null;
+  description: string | null;
+  sound: string | null;
+}> {
+  const response = await LIST(
+    createTestRequest("http://localhost:3000/api/zero/composes/list"),
+  );
+  expect(response.status).toBe(200);
+  const data = await response.json();
+  const compose = data.composes.find((item: { id: string }) => {
+    return item.id === composeId;
+  });
+  if (!compose) {
+    throw new Error(`Expected compose ${composeId} in list response`);
+  }
+  return {
+    displayName: compose.displayName,
+    description: compose.description,
+    sound: compose.sound,
+  };
 }
 
 describe("PATCH /api/zero/composes/:id/metadata", () => {
@@ -51,6 +75,13 @@ describe("PATCH /api/zero/composes/:id/metadata", () => {
 
     const data = await response.json();
     expect(data.ok).toBe(true);
+    await expect(findComposeMetadata(compose.composeId)).resolves.toStrictEqual(
+      {
+        displayName: "Test Display Name",
+        description: "Test description",
+        sound: null,
+      },
+    );
   });
 
   it("should return 404 when compose not found", async () => {
@@ -66,6 +97,9 @@ describe("PATCH /api/zero/composes/:id/metadata", () => {
       { params: Promise.resolve({ id: randomUUID() }) },
     );
     expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Agent compose not found", code: "NOT_FOUND" },
+    });
   });
 
   it("should return 401 when not authenticated", async () => {
@@ -80,5 +114,144 @@ describe("PATCH /api/zero/composes/:id/metadata", () => {
       { params: Promise.resolve({ id: "some-id" }) },
     );
     expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("should return 401 when the authenticated session has no active organization", async () => {
+    mockClerk({ userId: uniqueId("zmeta-no-org"), orgId: null });
+
+    const response = await PATCH(
+      createTestRequest(metadataUrl(randomUUID()), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName: "Test" }),
+      }),
+      { params: Promise.resolve({ id: randomUUID() }) },
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("should allow a non-owner same-org member to update metadata", async () => {
+    const ownerUserId = uniqueId("zmeta-owner");
+    await setupOrg(ownerUserId);
+    const compose = await createTestCompose(`agent-${uniqueId("zmeta")}`);
+
+    mockClerk({
+      userId: uniqueId("zmeta-member"),
+      orgId: `org_mock_${ownerUserId}`,
+      orgRole: "org:member",
+    });
+
+    const response = await PATCH(
+      createTestRequest(metadataUrl(compose.composeId), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName: "Member Display" }),
+      }),
+      { params: Promise.resolve({ id: compose.composeId }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(findComposeMetadata(compose.composeId)).resolves.toMatchObject(
+      {
+        displayName: "Member Display",
+      },
+    );
+  });
+
+  it("should return 404 for a compose in another org without mutating metadata", async () => {
+    const ownerUserId = uniqueId("zmeta-cross-owner");
+    await setupOrg(ownerUserId);
+    const compose = await createTestCompose(`agent-${uniqueId("zmeta")}`);
+    await PATCH(
+      createTestRequest(metadataUrl(compose.composeId), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          displayName: "Owner Display",
+          description: "Owner description",
+          sound: "owner-sound",
+        }),
+      }),
+      { params: Promise.resolve({ id: compose.composeId }) },
+    );
+
+    await setupOrg(uniqueId("zmeta-cross-attacker"));
+
+    const response = await PATCH(
+      createTestRequest(metadataUrl(compose.composeId), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName: "Hacked" }),
+      }),
+      { params: Promise.resolve({ id: compose.composeId }) },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Agent compose not found", code: "NOT_FOUND" },
+    });
+
+    mockClerk({
+      userId: ownerUserId,
+      orgId: `org_mock_${ownerUserId}`,
+      orgRole: "org:admin",
+    });
+    await expect(findComposeMetadata(compose.composeId)).resolves.toStrictEqual(
+      {
+        displayName: "Owner Display",
+        description: "Owner description",
+        sound: "owner-sound",
+      },
+    );
+  });
+
+  it("should preserve unprovided metadata fields on partial update", async () => {
+    const userId = uniqueId("zmeta-partial");
+    await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("zmeta")}`);
+
+    await PATCH(
+      createTestRequest(metadataUrl(compose.composeId), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          displayName: "Initial Display",
+          description: "Initial description",
+          sound: "initial-sound",
+        }),
+      }),
+      { params: Promise.resolve({ id: compose.composeId }) },
+    );
+
+    const response = await PATCH(
+      createTestRequest(metadataUrl(compose.composeId), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName: "Updated Display" }),
+      }),
+      { params: Promise.resolve({ id: compose.composeId }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(findComposeMetadata(compose.composeId)).resolves.toStrictEqual(
+      {
+        displayName: "Updated Display",
+        description: "Initial description",
+        sound: "initial-sound",
+      },
+    );
   });
 });

--- a/turbo/apps/web/app/api/zero/composes/[id]/metadata/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/[id]/metadata/route.ts
@@ -12,6 +12,13 @@ import { resolveOrg } from "../../../../../../src/lib/zero/org/resolve-org";
 import { updateComposeMetadata } from "../../../../../../src/lib/zero/zero-compose-service";
 import { isNotFound } from "@vm0/api-services/errors";
 
+function unauthorizedResponse() {
+  return NextResponse.json(
+    { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+    { status: 401 },
+  );
+}
+
 export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
@@ -23,11 +30,9 @@ export async function PATCH(
 
   const authCtx = await requireAuth(authorization);
   if (isAuthError(authCtx)) {
-    return NextResponse.json(
-      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
-      { status: 401 },
-    );
+    return unauthorizedResponse();
   }
+  if (!authCtx.orgId) return unauthorizedResponse();
   const { userId } = authCtx;
 
   const { org } = await resolveOrg(authCtx);

--- a/turbo/apps/web/app/api/zero/composes/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/[id]/route.ts
@@ -12,12 +12,22 @@ import {
 } from "../../../../../src/lib/infra/agent-compose/compose-service";
 import { isNotFound, isConflict } from "@vm0/api-services/errors";
 
+function unauthorizedResponse() {
+  return {
+    status: 401 as const,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
+
 const router = tsr.router(zeroComposesByIdContract, {
   getById: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthorizedResponse();
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);

--- a/turbo/apps/web/app/api/zero/composes/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/composes/__tests__/route.test.ts
@@ -53,6 +53,12 @@ describe("GET /api/zero/composes (getByName)", () => {
       createTestRequest(composeUrl(slug, "nonexistent-agent")),
     );
     expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Agent compose not found: nonexistent-agent",
+        code: "NOT_FOUND",
+      },
+    });
   });
 
   it("should return 401 when not authenticated", async () => {
@@ -64,5 +70,47 @@ describe("GET /api/zero/composes (getByName)", () => {
       ),
     );
     expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("should return 401 when the authenticated session has no active organization", async () => {
+    mockClerk({ userId: uniqueId("zcomp-no-org"), orgId: null });
+
+    const response = await GET(
+      createTestRequest(composeUrl("ignored", "any-agent")),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("should return 404 when the same compose name exists in another org", async () => {
+    const sharedName = `agent-${uniqueId("zcomp-shared")}`;
+
+    await setupOrg(uniqueId("zcomp-other"));
+    await createTestCompose(sharedName);
+
+    const userId = uniqueId("zcomp-cross");
+    const { slug } = await setupOrg(userId);
+
+    const response = await GET(createTestRequest(composeUrl(slug, sharedName)));
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: `Agent compose not found: ${sharedName}`,
+        code: "NOT_FOUND",
+      },
+    });
   });
 });

--- a/turbo/apps/web/app/api/zero/composes/list/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/composes/list/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import {
   createTestRequest,
   createTestOrg,
   createTestCompose,
+  createTestSandboxToken,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -44,14 +45,18 @@ describe("GET /api/zero/composes/list", () => {
   it("should return list with composes", async () => {
     const userId = uniqueId("zlist-has");
     await setupOrg(userId);
-    await createTestCompose(`agent-${uniqueId("zlist")}`);
+    const first = await createTestCompose(`agent-${uniqueId("zlist-first")}`);
+    const second = await createTestCompose(`agent-${uniqueId("zlist-second")}`);
 
     const response = await GET(createTestRequest(listUrl()));
     expect(response.status).toBe(200);
 
     const data = await response.json();
-    expect(data.composes.length).toBeGreaterThanOrEqual(1);
-    expect(data.composes[0].name).toBeDefined();
+    expect(
+      data.composes.map((compose: { name: string }) => {
+        return compose.name;
+      }),
+    ).toEqual([second.name, first.name]);
   });
 
   it("should return 401 when not authenticated", async () => {
@@ -61,5 +66,71 @@ describe("GET /api/zero/composes/list", () => {
       createTestRequest("http://localhost:3000/api/zero/composes/list"),
     );
     expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("should return 400 when the authenticated session has no active organization", async () => {
+    mockClerk({ userId: uniqueId("zlist-no-org"), orgId: null });
+
+    const response = await GET(createTestRequest(listUrl()));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Invalid request",
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+
+  it("should not include composes from other orgs", async () => {
+    const userId = uniqueId("zlist-own");
+    await setupOrg(userId);
+    const ownCompose = await createTestCompose(
+      `agent-${uniqueId("zlist-own")}`,
+    );
+
+    await setupOrg(uniqueId("zlist-other"));
+    const otherCompose = await createTestCompose(
+      `agent-${uniqueId("zlist-other")}`,
+    );
+
+    mockClerk({
+      userId,
+      orgId: `org_mock_${userId}`,
+      orgRole: "org:admin",
+    });
+
+    const response = await GET(createTestRequest(listUrl()));
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    const ids = data.composes.map((compose: { id: string }) => {
+      return compose.id;
+    });
+    expect(ids).toContain(ownCompose.composeId);
+    expect(ids).not.toContain(otherCompose.composeId);
+  });
+
+  it("should accept sandbox tokens", async () => {
+    mockClerk({ userId: null });
+    const token = await createTestSandboxToken(
+      uniqueId("zlist-sandbox"),
+      `run_${uniqueId("zlist")}`,
+    );
+
+    const response = await GET(
+      createTestRequest(listUrl(), {
+        headers: { authorization: `Bearer ${token}` },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ composes: [] });
   });
 });

--- a/turbo/apps/web/app/api/zero/composes/list/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/list/route.ts
@@ -9,12 +9,24 @@ import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
 import { listComposes } from "../../../../../src/lib/zero/zero-compose-service";
 import { isNotFound, isForbidden } from "@vm0/api-services/errors";
 
+function invalidRequestResponse() {
+  return {
+    status: 400 as const,
+    body: {
+      error: { message: "Invalid request", code: "BAD_REQUEST" },
+    },
+  };
+}
+
 const router = tsr.router(zeroComposesListContract, {
   list: async ({ headers }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization);
+    const authCtx = await requireAuth(headers.authorization, {
+      acceptAnySandboxCapability: true,
+    });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return invalidRequestResponse();
 
     let orgId: string;
     try {
@@ -22,12 +34,7 @@ const router = tsr.router(zeroComposesListContract, {
       orgId = org.orgId;
     } catch (error) {
       if (isNotFound(error)) {
-        return {
-          status: 400 as const,
-          body: {
-            error: { message: "Invalid request", code: "BAD_REQUEST" },
-          },
-        };
+        return invalidRequestResponse();
       }
       if (isForbidden(error)) {
         return {

--- a/turbo/apps/web/app/api/zero/composes/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/route.ts
@@ -13,12 +13,22 @@ import {
   isBadRequest,
 } from "@vm0/api-services/errors";
 
+function unauthorizedResponse() {
+  return {
+    status: 401 as const,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
+
 const router = tsr.router(zeroComposesMainContract, {
   getByName: async ({ query, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthorizedResponse();
 
     let orgId: string;
     try {


### PR DESCRIPTION
## Summary

- Normalize web zero compose auth/org parity for by-name, list, by-id, and metadata routes.
- Allow sandbox-token access on the web compose list route to match the API route.
- Expand web route integration coverage for no-active-org, cross-org no-leak, sandbox, delete conflict, list ordering/isolation, and metadata update parity.

## Tests

- pnpm -F web exec vitest run app/api/zero/composes/__tests__/route.test.ts app/api/zero/composes/list/__tests__/route.test.ts 'app/api/zero/composes/[id]/__tests__/route.test.ts' 'app/api/zero/composes/[id]/metadata/__tests__/route.test.ts'\n- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-composes-by-name.test.ts src/signals/routes/__tests__/zero-composes-by-id.test.ts src/signals/routes/__tests__/zero-composes-list.test.ts src/signals/routes/__tests__/zero-composes-delete.test.ts src/signals/routes/__tests__/zero-composes-metadata-update.test.ts\n- pnpm -F web check-types\n- pnpm -F web lint\n- pnpm format\n- pnpm knip --workspace web\n\nCloses #12621