### PR TITLE
test: fix vsock guest temp dir permissions

### DIFF
--- a/crates/vsock-guest/src/exec.rs
+++ b/crates/vsock-guest/src/exec.rs
@@ -661,6 +661,7 @@ mod tests {
                 .as_nanos()
         ));
         std::fs::create_dir_all(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
         let guard = TempDirGuard(dir.clone());
         (dir, guard)
     }


### PR DESCRIPTION
## Summary
- set test temp directories to 0700 before exercising env script directory validation
- prevents vsock-guest exec tests from depending on the host umask

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- umask 000 && cargo test --manifest-path crates/Cargo.toml -p vsock-guest exec
- pre-commit: cargo fmt, cargo clippy, cargo doc