### PR TITLE
refactor(chat): drop count from queued strip header

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -426,7 +426,7 @@ function QueuedMessagesStrip({
     <div className="border-b border-border/60 px-4 py-2">
       <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground/75">
         <span className="h-1.5 w-1.5 rounded-full bg-primary/70" />
-        <span>Queued {items.length}</span>
+        <span>Queued</span>
       </div>
       <div
         className="mt-1 max-h-24 divide-y divide-border/40 overflow-y-auto"


### PR DESCRIPTION
## Summary
Strip the trailing message count from the queued composer strip header — the row count is already implied by the visible list, and the bare "Queued" label reads cleaner.

## Test plan
- [ ] Queue a few messages during an active run — the strip header reads "Queued" (no number) while the items below still render with delete buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)