### PR TITLE
feat(api): migrate auto-recharge put to api backend (wave 6 #9)

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-billing-auto-recharge.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-billing-auto-recharge.ts
@@ -15,6 +15,8 @@ interface AutoRechargeSeedValues {
   readonly enabled?: boolean;
   readonly threshold?: number | null;
   readonly amount?: number | null;
+  readonly tier?: string;
+  readonly pendingAt?: Date | null;
 }
 
 export const seedAutoRechargeOrg$ = command(
@@ -32,6 +34,10 @@ export const seedAutoRechargeOrg$ = command(
       autoRechargeEnabled: values.enabled ?? false,
       autoRechargeThreshold: values.threshold ?? null,
       autoRechargeAmount: values.amount ?? null,
+      ...(values.tier !== undefined ? { tier: values.tier } : {}),
+      ...(values.pendingAt !== undefined
+        ? { autoRechargePendingAt: values.pendingAt }
+        : {}),
     });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts
@@ -2,8 +2,12 @@ import { randomUUID } from "node:crypto";
 
 import { zeroBillingAutoRechargeContract } from "@vm0/api-contracts/contracts/zero-billing";
 import { createStore } from "ccstate";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { eq } from "drizzle-orm";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { nowDate } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
 import {
   deleteAutoRechargeOrg$,
   seedAutoRechargeOrg$,
@@ -84,6 +88,279 @@ describe("GET /api/zero/billing/auto-recharge", () => {
       enabled: false,
       threshold: null,
       amount: null,
+    });
+  });
+});
+
+describe("PUT /api/zero/billing/auto-recharge", () => {
+  const track = createFixtureTracker<AutoRechargeOrgFixture>((fixture) => {
+    return store.set(deleteAutoRechargeOrg$, fixture, context.signal);
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroBillingAutoRechargeContract);
+
+    const response = await accept(
+      client.update({
+        body: { enabled: true, threshold: 1000, amount: 5000 },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("enables auto-recharge for pro tier org", async () => {
+    const fixture = await track(
+      store.set(seedAutoRechargeOrg$, { tier: "pro" }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingAutoRechargeContract);
+
+    const response = await accept(
+      client.update({
+        body: { enabled: true, threshold: 1000, amount: 5000 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      enabled: true,
+      threshold: 1000,
+      amount: 5000,
+    });
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({
+        autoRechargeEnabled: orgMetadata.autoRechargeEnabled,
+        autoRechargeThreshold: orgMetadata.autoRechargeThreshold,
+        autoRechargeAmount: orgMetadata.autoRechargeAmount,
+      })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId))
+      .limit(1);
+    expect(row?.autoRechargeEnabled).toBeTruthy();
+    expect(row?.autoRechargeThreshold).toBe(1000);
+    expect(row?.autoRechargeAmount).toBe(5000);
+  });
+
+  it("disables auto-recharge and clears pending state", async () => {
+    const fixture = await track(
+      store.set(
+        seedAutoRechargeOrg$,
+        {
+          tier: "pro",
+          enabled: true,
+          threshold: 1000,
+          amount: 5000,
+          pendingAt: nowDate(),
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingAutoRechargeContract);
+
+    const response = await accept(
+      client.update({
+        body: { enabled: false },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      enabled: false,
+      threshold: null,
+      amount: null,
+    });
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({
+        autoRechargeEnabled: orgMetadata.autoRechargeEnabled,
+        autoRechargeThreshold: orgMetadata.autoRechargeThreshold,
+        autoRechargeAmount: orgMetadata.autoRechargeAmount,
+        autoRechargePendingAt: orgMetadata.autoRechargePendingAt,
+      })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId))
+      .limit(1);
+    expect(row?.autoRechargeEnabled).toBeFalsy();
+    expect(row?.autoRechargeThreshold).toBeNull();
+    expect(row?.autoRechargeAmount).toBeNull();
+    expect(row?.autoRechargePendingAt).toBeNull();
+  });
+
+  it("returns 400 when enabling on free tier", async () => {
+    const fixture = await track(
+      store.set(seedAutoRechargeOrg$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingAutoRechargeContract);
+
+    const response = await accept(
+      client.update({
+        body: { enabled: true, threshold: 1000, amount: 5000 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Auto-recharge is only available for paid plans (Pro/Max)",
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+
+  it("returns 400 when enabling without threshold and amount", async () => {
+    const fixture = await track(
+      store.set(seedAutoRechargeOrg$, { tier: "pro" }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingAutoRechargeContract);
+
+    await accept(
+      client.update({
+        body: { enabled: true },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+  });
+
+  it("returns 400 when amount is below minimum", async () => {
+    const fixture = await track(
+      store.set(seedAutoRechargeOrg$, { tier: "pro" }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingAutoRechargeContract);
+
+    await accept(
+      client.update({
+        body: { enabled: true, threshold: 1000, amount: 500 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+  });
+
+  it("returns 400 when amount exceeds the maximum", async () => {
+    const fixture = await track(
+      store.set(seedAutoRechargeOrg$, { tier: "pro" }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingAutoRechargeContract);
+
+    await accept(
+      client.update({
+        body: { enabled: true, threshold: 1000, amount: 10_000_001 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+  });
+
+  it("returns 400 when threshold exceeds the maximum", async () => {
+    const fixture = await track(
+      store.set(seedAutoRechargeOrg$, { tier: "pro" }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingAutoRechargeContract);
+
+    await accept(
+      client.update({
+        body: { enabled: true, threshold: 10_000_001, amount: 20_000_000 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+  });
+
+  it("returns 400 when threshold equals amount", async () => {
+    const fixture = await track(
+      store.set(seedAutoRechargeOrg$, { tier: "pro" }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingAutoRechargeContract);
+
+    const response = await accept(
+      client.update({
+        body: { enabled: true, threshold: 5000, amount: 5000 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toMatchObject({
+      error: {
+        message: "threshold must be less than amount to avoid recharge loops",
+      },
+    });
+  });
+
+  it("returns 400 when threshold is greater than amount", async () => {
+    const fixture = await track(
+      store.set(seedAutoRechargeOrg$, { tier: "pro" }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingAutoRechargeContract);
+
+    const response = await accept(
+      client.update({
+        body: { enabled: true, threshold: 6000, amount: 5000 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toMatchObject({
+      error: {
+        message: "threshold must be less than amount to avoid recharge loops",
+      },
+    });
+  });
+
+  it("returns 403 for non-admin member", async () => {
+    const fixture = await track(
+      store.set(seedAutoRechargeOrg$, { tier: "pro" }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroBillingAutoRechargeContract);
+
+    const response = await accept(
+      client.update({
+        body: { enabled: true, threshold: 1000, amount: 5000 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only org admins can update auto-recharge settings",
+        code: "FORBIDDEN",
+      },
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-billing-auto-recharge.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-auto-recharge.ts
@@ -1,10 +1,25 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import { zeroBillingAutoRechargeContract } from "@vm0/api-contracts/contracts/zero-billing";
 
+import { badRequestMessage } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { autoRechargeConfig } from "../services/billing.service";
+import { bodyResultOf } from "../context/request";
+import {
+  autoRechargeConfig,
+  updateAutoRechargeConfig$,
+} from "../services/billing.service";
 import type { RouteEntry } from "../route";
+
+const adminRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Only org admins can update auto-recharge settings",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
 
 const getAutoRechargeInner$ = computed(async (get): Promise<unknown> => {
   const auth = get(organizationAuthContext$);
@@ -15,12 +30,54 @@ const getAutoRechargeInner$ = computed(async (get): Promise<unknown> => {
   };
 });
 
+const updateAutoRechargeInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    if (auth.orgRole !== "admin") {
+      return adminRequired;
+    }
+
+    const bodyResult = await get(
+      bodyResultOf(zeroBillingAutoRechargeContract.update),
+    );
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const result = await set(
+      updateAutoRechargeConfig$,
+      {
+        orgId: auth.orgId,
+        enabled: bodyResult.data.enabled,
+        threshold: bodyResult.data.threshold,
+        amount: bodyResult.data.amount,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (!result.ok) {
+      return badRequestMessage(result.error);
+    }
+
+    return { status: 200 as const, body: result.data };
+  },
+);
+
 export const zeroBillingAutoRechargeRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingAutoRechargeContract.get,
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       getAutoRechargeInner$,
+    ),
+  },
+  {
+    route: zeroBillingAutoRechargeContract.update,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      updateAutoRechargeInner$,
     ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/billing.service.ts
+++ b/turbo/apps/api/src/signals/services/billing.service.ts
@@ -3,7 +3,8 @@ import type { AutoRechargeConfig } from "@vm0/api-contracts/contracts/zero-billi
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { eq } from "drizzle-orm";
 
-import { db$ } from "../external/db";
+import { db$, writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
 import { getStripeClient } from "../external/stripe-client";
 
 export function autoRechargeConfig(
@@ -62,5 +63,78 @@ export const createBillingPortalSession$ = command(
     signal.throwIfAborted();
 
     return session.url;
+  },
+);
+
+type UpdateAutoRechargeResult =
+  | { readonly ok: true; readonly data: AutoRechargeConfig }
+  | { readonly ok: false; readonly error: string };
+
+interface UpdateAutoRechargeArgs {
+  readonly orgId: string;
+  readonly enabled: boolean;
+  readonly threshold?: number;
+  readonly amount?: number;
+}
+
+export const updateAutoRechargeConfig$ = command(
+  async (
+    { set },
+    args: UpdateAutoRechargeArgs,
+    signal: AbortSignal,
+  ): Promise<UpdateAutoRechargeResult> => {
+    const { orgId, enabled, threshold, amount } = args;
+    const writeDb = set(writeDb$);
+
+    if (enabled) {
+      const [row] = await writeDb
+        .select({ tier: orgMetadata.tier })
+        .from(orgMetadata)
+        .where(eq(orgMetadata.orgId, orgId))
+        .limit(1);
+      signal.throwIfAborted();
+
+      const orgTier = row?.tier ?? "free";
+      if (orgTier === "free") {
+        return {
+          ok: false,
+          error: "Auto-recharge is only available for paid plans (Pro/Max)",
+        };
+      }
+      if (threshold === undefined || amount === undefined) {
+        return {
+          ok: false,
+          error:
+            "threshold and amount are required when enabling auto-recharge",
+        };
+      }
+      if (threshold >= amount) {
+        return {
+          ok: false,
+          error: "threshold must be less than amount to avoid recharge loops",
+        };
+      }
+    }
+
+    await writeDb
+      .update(orgMetadata)
+      .set({
+        autoRechargeEnabled: enabled,
+        autoRechargeThreshold: enabled ? threshold : null,
+        autoRechargeAmount: enabled ? amount : null,
+        ...(!enabled ? { autoRechargePendingAt: null } : {}),
+        updatedAt: nowDate(),
+      })
+      .where(eq(orgMetadata.orgId, orgId));
+    signal.throwIfAborted();
+
+    return {
+      ok: true,
+      data: {
+        enabled,
+        threshold: enabled ? (threshold ?? null) : null,
+        amount: enabled ? (amount ?? null) : null,
+      },
+    };
   },
 );


### PR DESCRIPTION
## Summary

- Adds `PUT /api/zero/billing/auto-recharge` handler in `apps/api` alongside the existing GET (#12587). Verbatim port of the `apps/web` implementation.
- New service `updateAutoRechargeConfig$` co-located with `autoRechargeConfig` in `billing.service.ts` — keeps both auto-recharge functions in one file (per existing convention; YAGNI on a separate per-route file).
- 3 byte-equivalent validation gates: tier !== "free", required threshold/amount when enabling, threshold < amount. Frozen `adminRequired` 403 envelope mirrors web's exact "Only org admins can update auto-recharge settings" message.
- Disable path also clears `autoRechargePendingAt` to cancel any pending top-up — verified via DB read-after-write in the test.

## Test plan

- [x] 14 integration tests pass (3 GET preserved + 11 new PUT including 401 hardening)
- [x] `pnpm -F api exec vitest run` — full api workspace (1006 tests) green
- [x] `pnpm turbo run lint --filter=api` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm format` — no changes
- [x] `pnpm knip` — no issues
- [ ] CI (lint, test, deploy, cli-e2e) — to be verified on PR

## Migration scope

- **No `apps/web` changes.** Web PUT route stays as fallback for orgs not yet on the `ApiBackendMutations` switch.
- **No DB migration, no contract changes, no feature-switch changes.**
- Rollback: revert this PR — apps/api falls back to web automatically.

Refs #12290
Closes #12711

🤖 Generated with [Claude Code](https://claude.com/claude-code)