### PR TITLE
test: align computer-use host no-org parity

### DIFF
--- a/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
@@ -313,6 +313,17 @@ describe("GET /api/zero/computer-use/host", () => {
     expect(response.status).toBe(401);
   });
 
+  it("should return 401 when the user has no active org", async () => {
+    mockClerk({ userId: uniqueId("zcu-host-no-org"), orgId: null });
+
+    const response = await GET(createTestRequest(hostUrl()));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
   it("should return 403 when feature flag is disabled", async () => {
     const userId = uniqueId("zcu-host-ff");
     await setupOrg(userId);

--- a/turbo/apps/web/app/api/zero/computer-use/host/route.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/host/route.ts
@@ -21,6 +21,9 @@ const router = tsr.router(zeroComputerUseHostContract, {
       requiredCapability: "computer-use:write",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);


### PR DESCRIPTION
## Summary
- return 401 from the web computer-use host route when the authenticated session has no active org
- add web route coverage for the no-active-org case to match API behavior

## Tests
- pnpm -F web exec vitest run app/api/zero/computer-use/__tests__/route.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-computer-use.test.ts
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm knip
- pnpm vitest (full run exposed unrelated platform/web timeout flakes; each failed file/test passed on targeted rerun)
- pnpm -F @vm0/app exec vitest run src/views/queue-page/__tests__/queue-drawer.test.tsx src/views/pwa-install/__tests__/install-banner.test.tsx src/views/org/__tests__/org-usage-tab.test.tsx src/views/zero-page/__tests__/chat-composer-goal-command.test.tsx src/views/zero-page/__tests__/prompt-param-injection.test.tsx
- pnpm -F web exec vitest run app/api/cron/aggregate-insights/__tests__/route.test.ts -t "should be idempotent on rerun"

Closes #12622