### PR TITLE
test: align custom connector route parity

### DIFF
--- a/turbo/apps/web/app/api/zero/custom-connectors/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/custom-connectors/[id]/route.ts
@@ -19,6 +19,9 @@ const router = tsr.router(zeroCustomConnectorByIdContract, {
     initServices();
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     try {
       const { org, member } = await resolveOrg(authCtx);
       const forbidden = requireAdminPermission(
@@ -40,6 +43,9 @@ const router = tsr.router(zeroCustomConnectorByIdContract, {
     initServices();
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     try {
       const { org, member } = await resolveOrg(authCtx);
       const forbidden = requireAdminPermission(

--- a/turbo/apps/web/app/api/zero/custom-connectors/[id]/secret/route.ts
+++ b/turbo/apps/web/app/api/zero/custom-connectors/[id]/secret/route.ts
@@ -18,6 +18,9 @@ const router = tsr.router(zeroCustomConnectorSecretContract, {
     initServices();
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
     try {
       const { org } = await resolveOrg(authCtx);
@@ -41,6 +44,9 @@ const router = tsr.router(zeroCustomConnectorSecretContract, {
     initServices();
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
     const { org } = await resolveOrg(authCtx);
     await deleteCustomConnectorSecret(org.orgId, userId, params.id);

--- a/turbo/apps/web/app/api/zero/custom-connectors/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/custom-connectors/__tests__/route.test.ts
@@ -33,8 +33,31 @@ async function setupMemberOrg(userId: string) {
   return { slug, orgId };
 }
 
+async function setupExplicitOrg(
+  userId: string,
+  orgId: string,
+  role: "org:admin" | "org:member" = "org:admin",
+) {
+  const slug = uniqueId("zcc");
+  mockClerk({
+    userId,
+    orgId,
+    orgRole: role,
+    clerkOrgs: [{ id: orgId, slug, name: slug, role }],
+  });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
 function url(path = ""): string {
   return `http://localhost:3000/api/zero/custom-connectors${path}`;
+}
+
+async function expectUnauthorized(res: Response) {
+  expect(res.status).toBe(401);
+  await expect(res.json()).resolves.toStrictEqual({
+    error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+  });
 }
 
 async function createSampleConnector(overrides: Record<string, unknown> = {}) {
@@ -73,7 +96,15 @@ describe("GET /api/zero/custom-connectors", () => {
   it("rejects unauthenticated requests", async () => {
     mockClerk({ userId: null });
     const res = await GET(createTestRequest(url(), { method: "GET" }));
-    expect(res.status).toBe(401);
+    await expectUnauthorized(res);
+  });
+
+  it("returns 401 when authenticated without an active org", async () => {
+    const userId = uniqueId("zcc-list-no-org");
+    mockClerk({ userId, orgId: null });
+
+    const res = await GET(createTestRequest(url(), { method: "GET" }));
+    await expectUnauthorized(res);
   });
 
   it("lists created connectors with hasSecret flag", async () => {
@@ -97,6 +128,21 @@ describe("GET /api/zero/custom-connectors", () => {
 describe("POST /api/zero/custom-connectors", () => {
   beforeEach(() => {
     return context.setupMocks();
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    mockClerk({ userId: null });
+
+    const res = await createSampleConnector();
+    await expectUnauthorized(res);
+  });
+
+  it("returns 401 when authenticated without an active org", async () => {
+    const userId = uniqueId("zcc-create-no-org");
+    mockClerk({ userId, orgId: null });
+
+    const res = await createSampleConnector();
+    await expectUnauthorized(res);
   });
 
   it("creates a connector as admin", async () => {
@@ -174,6 +220,27 @@ describe("DELETE /api/zero/custom-connectors/:id", () => {
     return context.setupMocks();
   });
 
+  it("rejects unauthenticated requests", async () => {
+    mockClerk({ userId: null });
+    const id = "00000000-0000-0000-0000-000000000000";
+
+    const res = await DELETE_BY_ID(
+      createTestRequest(url(`/${id}`), { method: "DELETE" }),
+    );
+    await expectUnauthorized(res);
+  });
+
+  it("returns 401 when authenticated without an active org", async () => {
+    const userId = uniqueId("zcc-delete-no-org");
+    mockClerk({ userId, orgId: null });
+    const id = "00000000-0000-0000-0000-000000000000";
+
+    const res = await DELETE_BY_ID(
+      createTestRequest(url(`/${id}`), { method: "DELETE" }),
+    );
+    await expectUnauthorized(res);
+  });
+
   it("deletes connector as admin and cascades secrets", async () => {
     const userId = uniqueId("zcc-delete");
     await setupAdminOrg(userId);
@@ -221,11 +288,82 @@ describe("DELETE /api/zero/custom-connectors/:id", () => {
     );
     expect(delRes.status).toBe(403);
   });
+
+  it("returns 404 for unknown id", async () => {
+    const userId = uniqueId("zcc-delete-404");
+    await setupAdminOrg(userId);
+    const id = "00000000-0000-0000-0000-000000000000";
+
+    const res = await DELETE_BY_ID(
+      createTestRequest(url(`/${id}`), { method: "DELETE" }),
+    );
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toMatchObject({
+      error: { code: "NOT_FOUND", message: "Custom connector not found" },
+    });
+  });
+
+  it("returns 404 for another org's connector without deleting it", async () => {
+    const adminA = uniqueId("zcc-delete-crossorg-a");
+    await setupAdminOrg(adminA);
+    const created = await createSampleConnector();
+    const { id } = await created.json();
+
+    const adminB = uniqueId("zcc-delete-crossorg-b");
+    await setupAdminOrg(adminB);
+
+    const res = await DELETE_BY_ID(
+      createTestRequest(url(`/${id}`), { method: "DELETE" }),
+    );
+    expect(res.status).toBe(404);
+
+    mockClerk({
+      userId: adminA,
+      orgId: `org_mock_${adminA}`,
+      orgRole: "org:admin",
+    });
+    const listRes = await GET(createTestRequest(url(), { method: "GET" }));
+    const listData = await listRes.json();
+    expect(
+      listData.connectors.map((c: { id: string }) => {
+        return c.id;
+      }),
+    ).toContain(id);
+  });
 });
 
 describe("PATCH /api/zero/custom-connectors/:id", () => {
   beforeEach(() => {
     return context.setupMocks();
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    mockClerk({ userId: null });
+    const id = "00000000-0000-0000-0000-000000000000";
+
+    const res = await PATCH_BY_ID(
+      createTestRequest(url(`/${id}`), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName: "Renamed" }),
+      }),
+    );
+    await expectUnauthorized(res);
+  });
+
+  it("returns 401 when authenticated without an active org", async () => {
+    const userId = uniqueId("zcc-patch-no-org");
+    mockClerk({ userId, orgId: null });
+    const id = "00000000-0000-0000-0000-000000000000";
+
+    const res = await PATCH_BY_ID(
+      createTestRequest(url(`/${id}`), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName: "Renamed" }),
+      }),
+    );
+    await expectUnauthorized(res);
   });
 
   it("renames a connector as admin", async () => {
@@ -332,6 +470,21 @@ describe("PUT /api/zero/custom-connectors/:id/secret", () => {
     return context.setupMocks();
   });
 
+  it("returns 401 when authenticated without an active org", async () => {
+    const userId = uniqueId("zcc-secret-no-org");
+    mockClerk({ userId, orgId: null });
+    const id = "00000000-0000-0000-0000-000000000000";
+
+    const res = await PUT_SECRET(
+      createTestRequest(url(`/${id}/secret`), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "x" }),
+      }),
+    );
+    await expectUnauthorized(res);
+  });
+
   it("stores per-user secret and reflects in hasSecret", async () => {
     const userId = uniqueId("zcc-secret");
     await setupAdminOrg(userId);
@@ -396,6 +549,27 @@ describe("DELETE /api/zero/custom-connectors/:id/secret", () => {
     return context.setupMocks();
   });
 
+  it("rejects unauthenticated requests", async () => {
+    mockClerk({ userId: null });
+    const id = "00000000-0000-0000-0000-000000000000";
+
+    const res = await DELETE_SECRET(
+      createTestRequest(url(`/${id}/secret`), { method: "DELETE" }),
+    );
+    await expectUnauthorized(res);
+  });
+
+  it("returns 401 when authenticated without an active org", async () => {
+    const userId = uniqueId("zcc-delete-secret-no-org");
+    mockClerk({ userId, orgId: null });
+    const id = "00000000-0000-0000-0000-000000000000";
+
+    const res = await DELETE_SECRET(
+      createTestRequest(url(`/${id}/secret`), { method: "DELETE" }),
+    );
+    await expectUnauthorized(res);
+  });
+
   it("clears the user's secret", async () => {
     const userId = uniqueId("zcc-del-secret");
     await setupAdminOrg(userId);
@@ -418,5 +592,141 @@ describe("DELETE /api/zero/custom-connectors/:id/secret", () => {
     const listRes = await GET(createTestRequest(url(), { method: "GET" }));
     const listData = await listRes.json();
     expect(listData.connectors[0].hasSecret).toBe(false);
+  });
+
+  it("is idempotent when deleting the same secret twice", async () => {
+    const userId = uniqueId("zcc-del-secret-idempotent");
+    await setupAdminOrg(userId);
+    const created = await createSampleConnector();
+    const { id } = await created.json();
+
+    for (let i = 0; i < 2; i++) {
+      const delRes = await DELETE_SECRET(
+        createTestRequest(url(`/${id}/secret`), { method: "DELETE" }),
+      );
+      expect(delRes.status).toBe(204);
+    }
+
+    const listRes = await GET(createTestRequest(url(), { method: "GET" }));
+    const listData = await listRes.json();
+    expect(listData.connectors[0].hasSecret).toBe(false);
+  });
+
+  it("does not delete another user's secret for the same connector", async () => {
+    const adminId = uniqueId("zcc-del-secret-user-admin");
+    await setupAdminOrg(adminId);
+    const created = await createSampleConnector();
+    const { id } = await created.json();
+
+    const setAdminRes = await PUT_SECRET(
+      createTestRequest(url(`/${id}/secret`), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "admin-token" }),
+      }),
+    );
+    expect(setAdminRes.status).toBe(204);
+
+    const memberId = uniqueId("zcc-del-secret-user-member");
+    mockClerk({
+      userId: memberId,
+      orgId: `org_mock_${adminId}`,
+      orgRole: "org:member",
+    });
+    const setMemberRes = await PUT_SECRET(
+      createTestRequest(url(`/${id}/secret`), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "member-token" }),
+      }),
+    );
+    expect(setMemberRes.status).toBe(204);
+
+    mockClerk({
+      userId: adminId,
+      orgId: `org_mock_${adminId}`,
+      orgRole: "org:admin",
+    });
+    const delRes = await DELETE_SECRET(
+      createTestRequest(url(`/${id}/secret`), { method: "DELETE" }),
+    );
+    expect(delRes.status).toBe(204);
+
+    const adminListRes = await GET(createTestRequest(url(), { method: "GET" }));
+    const adminListData = await adminListRes.json();
+    expect(adminListData.connectors[0].hasSecret).toBe(false);
+
+    mockClerk({
+      userId: memberId,
+      orgId: `org_mock_${adminId}`,
+      orgRole: "org:member",
+    });
+    const memberListRes = await GET(
+      createTestRequest(url(), { method: "GET" }),
+    );
+    const memberListData = await memberListRes.json();
+    expect(memberListData.connectors[0].hasSecret).toBe(true);
+  });
+
+  it("does not delete the same user's secret in another org", async () => {
+    const userId = uniqueId("zcc-del-secret-org-user");
+    const orgAId = `org_${uniqueId("zcc-secret-org-a")}`;
+    const orgBId = `org_${uniqueId("zcc-secret-org-b")}`;
+
+    await setupExplicitOrg(userId, orgAId);
+    const createdA = await createSampleConnector({ displayName: "Org A" });
+    const { id: idA } = await createdA.json();
+    const setARes = await PUT_SECRET(
+      createTestRequest(url(`/${idA}/secret`), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "org-a-token" }),
+      }),
+    );
+    expect(setARes.status).toBe(204);
+
+    await setupExplicitOrg(userId, orgBId);
+    const createdB = await createSampleConnector({ displayName: "Org B" });
+    const { id: idB } = await createdB.json();
+    const setBRes = await PUT_SECRET(
+      createTestRequest(url(`/${idB}/secret`), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "org-b-token" }),
+      }),
+    );
+    expect(setBRes.status).toBe(204);
+
+    mockClerk({
+      userId,
+      orgId: orgAId,
+      orgRole: "org:admin",
+      clerkOrgs: [
+        { id: orgAId, slug: uniqueId("zcc-a"), name: "Org A" },
+        { id: orgBId, slug: uniqueId("zcc-b"), name: "Org B" },
+      ],
+    });
+    const delRes = await DELETE_SECRET(
+      createTestRequest(url(`/${idA}/secret`), { method: "DELETE" }),
+    );
+    expect(delRes.status).toBe(204);
+
+    const orgAListRes = await GET(createTestRequest(url(), { method: "GET" }));
+    const orgAListData = await orgAListRes.json();
+    expect(orgAListData.connectors[0].hasSecret).toBe(false);
+
+    mockClerk({
+      userId,
+      orgId: orgBId,
+      orgRole: "org:admin",
+      clerkOrgs: [
+        { id: orgAId, slug: uniqueId("zcc-a"), name: "Org A" },
+        { id: orgBId, slug: uniqueId("zcc-b"), name: "Org B" },
+      ],
+    });
+    const orgBListRes = await GET(createTestRequest(url(), { method: "GET" }));
+    const orgBListData = await orgBListRes.json();
+    expect(orgBListData.connectors[0].id).toBe(idB);
+    expect(orgBListData.connectors[0].hasSecret).toBe(true);
   });
 });

--- a/turbo/apps/web/app/api/zero/custom-connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/custom-connectors/route.ts
@@ -19,6 +19,9 @@ const router = tsr.router(zeroCustomConnectorsContract, {
     initServices();
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
     const { org } = await resolveOrg(authCtx);
     const connectors = await listCustomConnectorsWithSecretStatus(
@@ -49,6 +52,9 @@ const router = tsr.router(zeroCustomConnectorsContract, {
     initServices();
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
     const { userId } = authCtx;
     try {
       const { org, member } = await resolveOrg(authCtx);


### PR DESCRIPTION
## Summary

- align web custom-connector routes with the API missing-organization `401` contract
- add web route parity coverage for auth, no-active-org, delete no-leak, and secret delete isolation/idempotency cases

## Tests

- `pnpm -F web exec vitest run app/api/zero/custom-connectors/__tests__/route.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-custom-connectors.test.ts src/signals/routes/__tests__/zero-custom-connectors-create.test.ts src/signals/routes/__tests__/zero-custom-connectors-delete.test.ts src/signals/routes/__tests__/zero-custom-connectors-patch.test.ts src/signals/routes/__tests__/zero-custom-connectors-secret-set.test.ts src/signals/routes/__tests__/zero-custom-connectors-secret-delete.test.ts`
- `pnpm -F web lint`
- `pnpm -F web check-types`

Closes #12624
