### PR TITLE
fix: align zero connector read parity

### DIFF
--- a/turbo/apps/web/app/api/zero/connectors/[type]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/__tests__/route.test.ts
@@ -60,6 +60,16 @@ describe("GET /api/zero/connectors/:type", () => {
     expect(response.status).toBe(401);
   });
 
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mockClerk({ userId: uniqueId("zcget-no-org"), orgId: null });
+
+    const response = await GET(createTestRequest(connectorUrl("github")));
+
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
   it("should allow access with ZERO_TOKEN (connector:read capability)", async () => {
     const user = await context.setupUser();
 

--- a/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
@@ -13,6 +13,15 @@ import {
 } from "../../../../../src/lib/zero/connector/connector-service";
 import { isNotFound } from "@vm0/api-services/errors";
 
+function unauthenticatedResponse() {
+  return {
+    status: 401 as const,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
+
 const router = tsr.router(zeroConnectorsByTypeContract, {
   get: async ({ params, headers }) => {
     initServices();
@@ -21,6 +30,7 @@ const router = tsr.router(zeroConnectorsByTypeContract, {
       requiredCapability: "connector:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);

--- a/turbo/apps/web/app/api/zero/connectors/[type]/scope-diff/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/scope-diff/__tests__/route.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
+
+const context = testContext();
+
+const GITHUB_CURRENT_SCOPES = ["repo", "project", "workflow"] as const;
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zscope");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function scopeDiffUrl(type: string): string {
+  return `http://localhost:3000/api/zero/connectors/${type}/scope-diff`;
+}
+
+describe("GET /api/zero/connectors/:type/scope-diff", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(createTestRequest(scopeDiffUrl("github")));
+
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mockClerk({ userId: uniqueId("zscope-no-org"), orgId: null });
+
+    const response = await GET(createTestRequest(scopeDiffUrl("github")));
+
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 for a sandbox token without connector:read capability", async () => {
+    const token = await generateSandboxToken(
+      uniqueId("zscope-sandbox-user"),
+      "run-1",
+      "org-test",
+    );
+
+    const response = await GET(
+      createTestRequest(scopeDiffUrl("github"), {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    const data = await response.json();
+    expect(data.error.message).toBe(
+      "Missing required capability: connector:read",
+    );
+  });
+
+  it("returns 404 when no connector is configured for the type", async () => {
+    const userId = uniqueId("zscope-nf");
+    await setupOrg(userId);
+
+    const response = await GET(createTestRequest(scopeDiffUrl("github")));
+
+    expect(response.status).toBe(404);
+    const data = await response.json();
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns an empty diff when stored scopes match current scopes exactly", async () => {
+    const userId = uniqueId("zscope-exact");
+    const { orgId } = await setupOrg(userId);
+    await context.createConnector(orgId, {
+      userId,
+      type: "github",
+      oauthScopes: GITHUB_CURRENT_SCOPES,
+    });
+
+    const response = await GET(createTestRequest(scopeDiffUrl("github")));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toStrictEqual({
+      addedScopes: [],
+      removedScopes: [],
+      currentScopes: GITHUB_CURRENT_SCOPES,
+      storedScopes: GITHUB_CURRENT_SCOPES,
+    });
+  });
+
+  it("returns added scopes when the connector is missing required scopes", async () => {
+    const userId = uniqueId("zscope-added");
+    const { orgId } = await setupOrg(userId);
+    await context.createConnector(orgId, {
+      userId,
+      type: "github",
+      oauthScopes: ["repo"],
+    });
+
+    const response = await GET(createTestRequest(scopeDiffUrl("github")));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toStrictEqual({
+      addedScopes: ["project", "workflow"],
+      removedScopes: [],
+      currentScopes: GITHUB_CURRENT_SCOPES,
+      storedScopes: ["repo"],
+    });
+  });
+
+  it("returns removed scopes when the connector has stale extra scopes", async () => {
+    const userId = uniqueId("zscope-removed");
+    const { orgId } = await setupOrg(userId);
+    const storedScopes = [...GITHUB_CURRENT_SCOPES, "delete_repo"];
+    await context.createConnector(orgId, {
+      userId,
+      type: "github",
+      oauthScopes: storedScopes,
+    });
+
+    const response = await GET(createTestRequest(scopeDiffUrl("github")));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toStrictEqual({
+      addedScopes: [],
+      removedScopes: ["delete_repo"],
+      currentScopes: GITHUB_CURRENT_SCOPES,
+      storedScopes,
+    });
+  });
+});

--- a/turbo/apps/web/app/api/zero/connectors/[type]/scope-diff/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/scope-diff/route.ts
@@ -3,18 +3,31 @@ import { zeroConnectorScopeDiffContract } from "@vm0/api-contracts/contracts/zer
 import { getScopeDiff } from "@vm0/connectors/connector-utils";
 import { createErrorResponse } from "@vm0/api-contracts/contracts/errors";
 import { initServices } from "../../../../../../src/lib/init-services";
-import { getAuthContext } from "../../../../../../src/lib/auth/get-auth-context";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../../src/lib/zero/org/resolve-org";
 import { getConnector } from "../../../../../../src/lib/zero/connector/connector-service";
+
+function unauthenticatedResponse() {
+  return {
+    status: 401 as const,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
 
 const router = tsr.router(zeroConnectorScopeDiffContract, {
   getScopeDiff: async ({ params, headers }) => {
     initServices();
 
-    const authCtx = await getAuthContext(headers.authorization);
-    if (!authCtx) {
-      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
-    }
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "connector:read",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);

--- a/turbo/apps/web/app/api/zero/connectors/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/__tests__/route.test.ts
@@ -68,6 +68,16 @@ describe("GET /api/zero/connectors", () => {
     expect(response.status).toBe(401);
   });
 
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mockClerk({ userId: uniqueId("zcon-no-org"), orgId: null });
+
+    const response = await GET(createTestRequest(connectorsUrl()));
+
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
   it("skips oauth rows whose type no longer exists in the contract", async () => {
     const userId = uniqueId("zcon-orphan-oa");
     const { orgId } = await setupOrg(userId);

--- a/turbo/apps/web/app/api/zero/connectors/computer/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/computer/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import {
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -227,6 +228,36 @@ describe("GET /api/zero/connectors/computer", () => {
 
     const response = await GET(createTestRequest(computerUrl()));
     expect(response.status).toBe(401);
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mockClerk({ userId: uniqueId("zcomp-no-org"), orgId: null });
+
+    const response = await GET(createTestRequest(computerUrl()));
+
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 for a sandbox token without connector:read capability", async () => {
+    const token = await generateSandboxToken(
+      uniqueId("zcomp-sandbox-user"),
+      "run-1",
+      "org-test",
+    );
+
+    const response = await GET(
+      createTestRequest(computerUrl(), {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    const data = await response.json();
+    expect(data.error.message).toBe(
+      "Missing required capability: connector:read",
+    );
   });
 
   it("should return 404 if connector not found", async () => {

--- a/turbo/apps/web/app/api/zero/connectors/computer/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/computer/route.ts
@@ -14,6 +14,15 @@ import {
 } from "../../../../../src/lib/zero/computer-connector/computer-connector-service";
 import { isBadRequest, isConflict, isNotFound } from "@vm0/api-services/errors";
 
+function unauthenticatedResponse() {
+  return {
+    status: 401 as const,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
+
 const router = tsr.router(zeroComputerConnectorContract, {
   create: async ({ headers }) => {
     initServices();
@@ -40,8 +49,11 @@ const router = tsr.router(zeroComputerConnectorContract, {
   get: async ({ headers }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization);
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "connector:read",
+    });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);

--- a/turbo/apps/web/app/api/zero/connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/route.ts
@@ -10,6 +10,15 @@ import { resolveOrg } from "../../../../src/lib/zero/org/resolve-org";
 import { listConnectors } from "../../../../src/lib/zero/connector/connector-service";
 import { getConfiguredConnectorTypes } from "../../../../src/lib/zero/connector/provider-registry";
 
+function unauthenticatedResponse() {
+  return {
+    status: 401 as const,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
+
 const router = tsr.router(zeroConnectorsMainContract, {
   list: async ({ headers }) => {
     initServices();
@@ -18,6 +27,7 @@ const router = tsr.router(zeroConnectorsMainContract, {
       requiredCapability: "connector:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);

--- a/turbo/apps/web/app/api/zero/connectors/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/search/__tests__/route.test.ts
@@ -172,4 +172,16 @@ describe("GET /api/zero/connectors/search", () => {
     expect(openai).toBeDefined();
     expect(openai.authMethods).toEqual(["api-token"]);
   });
+
+  it("shows zapier with api-token even when ZapierConnector flag is disabled", async () => {
+    const response = await searchConnectors();
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const zapier = data.connectors.find((c: { id: string }) => {
+      return c.id === "zapier";
+    });
+    expect(zapier).toBeDefined();
+    expect(zapier.authMethods).toContain("api-token");
+  });
 });

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -182,6 +182,7 @@ interface TestContext {
       userId: string;
       type?: string;
       authMethod?: string;
+      oauthScopes?: readonly string[];
       tokenExpiresAt?: Date | null;
     },
   ): Promise<{ id: string; type: string }>;
@@ -565,6 +566,7 @@ export function testContext(): TestContext {
       userId: string;
       type?: string;
       authMethod?: string;
+      oauthScopes?: readonly string[];
       tokenExpiresAt?: Date | null;
     },
   ): Promise<{ id: string; type: string }> {
@@ -579,6 +581,9 @@ export function testContext(): TestContext {
         orgId,
         type,
         authMethod,
+        oauthScopes: options.oauthScopes
+          ? JSON.stringify([...options.oauthScopes])
+          : undefined,
         tokenExpiresAt: options.tokenExpiresAt ?? undefined,
       })
       .returning();


### PR DESCRIPTION
## Summary
- Align web connector read routes with the API auth boundary for active organization and `connector:read` capability checks.
- Add web route-entrypoint coverage for connector list/by-type/computer no-active-org cases, computer missing capability, and the full scope-diff behavior matrix.
- Add the missing web connector search regression for Zapier api-token visibility when `ZapierConnector` is disabled.

## Validation
- `pnpm -F web exec vitest run app/api/zero/connectors/__tests__/route.test.ts app/api/zero/connectors/search/__tests__/route.test.ts app/api/zero/connectors/computer/__tests__/route.test.ts 'app/api/zero/connectors/[type]/__tests__/route.test.ts' 'app/api/zero/connectors/[type]/scope-diff/__tests__/route.test.ts'`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-list.test.ts src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts src/signals/routes/__tests__/zero-connectors-search.test.ts src/signals/routes/__tests__/zero-connectors-computer-get.test.ts src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts`
- `pnpm -F web run lint`
- `git diff --check`

## Notes
- `pnpm -F web run check-types` is still blocked locally by unrelated baseline implicit-any errors in `app/api/runners/poll/route.ts`, `app/api/webhooks/agent/usage-event/route.ts`, `app/api/zero/onboarding/*`, `app/api/zero/skills/[name]/route.ts`, and `app/api/zero/usage/runs/route.ts`. No type errors remain in this PR's touched files.

Closes #12623
