### PR TITLE
feat(api): migrate schedules enable/disable post to api backend (Wave 6 #10)

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -33,6 +33,7 @@
     "@vm0/db": "workspace:*",
     "ably": "^2.21.0",
     "ccstate": "^5.3.0",
+    "croner": "^9.1.0",
     "drizzle-orm": "^0.45.2",
     "gpt-tokenizer": "^3.4.0",
     "hono": "^4.12.18",

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-schedules.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-schedules.ts
@@ -10,13 +10,31 @@ import { writeDb$ } from "../../../external/db";
 
 interface ScheduleSeed {
   readonly name: string;
-  readonly cronExpression: string;
   readonly prompt: string;
+  readonly cronExpression?: string;
+  readonly atTime?: Date;
+  readonly triggerType?: "cron" | "once" | "loop";
+  readonly enabled?: boolean;
+  readonly retryStartedAt?: Date | null;
+  readonly consecutiveFailures?: number;
 }
 
 interface SchedulesScenarioValues {
   readonly schedules: readonly ScheduleSeed[];
   readonly displayName?: string;
+}
+
+function resolveTriggerType(seed: ScheduleSeed): "cron" | "once" | "loop" {
+  if (seed.triggerType) {
+    return seed.triggerType;
+  }
+  if (seed.cronExpression) {
+    return "cron";
+  }
+  if (seed.atTime) {
+    return "once";
+  }
+  return "loop";
 }
 
 export interface SchedulesFixture {
@@ -65,10 +83,18 @@ export const seedSchedulesScenario$ = command(
         userId,
         orgId,
         name: seed.name,
-        triggerType: "cron",
-        cronExpression: seed.cronExpression,
+        triggerType: resolveTriggerType(seed),
+        cronExpression: seed.cronExpression ?? null,
+        atTime: seed.atTime ?? null,
         prompt: seed.prompt,
         timezone: "UTC",
+        ...(seed.enabled !== undefined && { enabled: seed.enabled }),
+        ...(seed.retryStartedAt !== undefined && {
+          retryStartedAt: seed.retryStartedAt,
+        }),
+        ...(seed.consecutiveFailures !== undefined && {
+          consecutiveFailures: seed.consecutiveFailures,
+        }),
       });
       signal.throwIfAborted();
       scheduleIds.push(scheduleId);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-disable.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-disable.test.ts
@@ -1,0 +1,140 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroSchedulesEnableContract } from "@vm0/api-contracts/contracts/zero-schedules";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  type SchedulesFixture,
+  deleteSchedulesScenario$,
+  seedSchedulesScenario$,
+} from "./helpers/zero-schedules";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("POST /api/zero/schedules/:name/disable", () => {
+  const track = createFixtureTracker<SchedulesFixture>((fixture) => {
+    return store.set(deleteSchedulesScenario$, fixture, context.signal);
+  });
+
+  const client = () => {
+    return setupApp({ context })(zeroSchedulesEnableContract);
+  };
+
+  it("disables an enabled schedule", async () => {
+    const fixture = await track(
+      store.set(
+        seedSchedulesScenario$,
+        {
+          schedules: [
+            {
+              name: "to-disable",
+              cronExpression: "0 9 * * *",
+              prompt: "Disable test",
+              enabled: true,
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      client().disable({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "to-disable" },
+        body: { agentId: fixture.composeId },
+      }),
+      [200],
+    );
+
+    expect(response.body.enabled).toBeFalsy();
+    expect(response.body.retryStartedAt).toBeNull();
+  });
+
+  it("returns 404 for non-existent schedule", async () => {
+    const fixture = await track(
+      store.set(seedSchedulesScenario$, { schedules: [] }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      client().disable({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "non-existent" },
+        body: { agentId: fixture.composeId },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Resource not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("disables schedule looked up by compose agentId", async () => {
+    const fixture = await track(
+      store.set(
+        seedSchedulesScenario$,
+        {
+          schedules: [
+            {
+              name: "dis-agentid",
+              cronExpression: "0 9 * * *",
+              prompt: "Disable via agentId",
+              enabled: true,
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      client().disable({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "dis-agentid" },
+        body: { agentId: fixture.composeId },
+      }),
+      [200],
+    );
+
+    expect(response.body.enabled).toBeFalsy();
+  });
+
+  it("returns 400 for invalid body", async () => {
+    const fixture = await track(
+      store.set(seedSchedulesScenario$, { schedules: [] }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await client().disable({
+      headers: { authorization: "Bearer clerk-session" },
+      params: { name: "any" },
+      body: {} as { agentId: string },
+    });
+    expect(response.status).toBe(400);
+    if (response.status === 400) {
+      expect(response.body.error.code).toBe("BAD_REQUEST");
+    }
+  });
+
+  it("returns 401 for unauthenticated request", async () => {
+    const response = await accept(
+      client().disable({
+        headers: {},
+        params: { name: "any" },
+        body: { agentId: randomUUID() },
+      }),
+      [401],
+    );
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-enable.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-enable.test.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroSchedulesEnableContract } from "@vm0/api-contracts/contracts/zero-schedules";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now, nowDate } from "../../../lib/time";
+import {
+  type SchedulesFixture,
+  deleteSchedulesScenario$,
+  seedSchedulesScenario$,
+} from "./helpers/zero-schedules";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+describe("POST /api/zero/schedules/:name/enable", () => {
+  const track = createFixtureTracker<SchedulesFixture>((fixture) => {
+    return store.set(deleteSchedulesScenario$, fixture, context.signal);
+  });
+
+  const client = () => {
+    return setupApp({ context })(zeroSchedulesEnableContract);
+  };
+
+  it("enables a disabled schedule and resets retry/failure state", async () => {
+    const fixture = await track(
+      store.set(
+        seedSchedulesScenario$,
+        {
+          schedules: [
+            {
+              name: "to-enable",
+              cronExpression: "0 9 * * *",
+              prompt: "Enable test",
+              enabled: false,
+              retryStartedAt: nowDate(),
+              consecutiveFailures: 2,
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      client().enable({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "to-enable" },
+        body: { agentId: fixture.composeId },
+      }),
+      [200],
+    );
+
+    expect(response.body.enabled).toBeTruthy();
+    expect(response.body.retryStartedAt).toBeNull();
+    expect(response.body.consecutiveFailures).toBe(0);
+    expect(response.body.nextRunAt).not.toBeNull();
+  });
+
+  it("returns 404 for non-existent schedule", async () => {
+    const fixture = await track(
+      store.set(seedSchedulesScenario$, { schedules: [] }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      client().enable({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "non-existent" },
+        body: { agentId: fixture.composeId },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Resource not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("enables schedule looked up by compose agentId", async () => {
+    const fixture = await track(
+      store.set(
+        seedSchedulesScenario$,
+        {
+          schedules: [
+            {
+              name: "enable-agentid",
+              cronExpression: "0 9 * * *",
+              prompt: "Enable via agentId",
+              enabled: false,
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      client().enable({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "enable-agentid" },
+        body: { agentId: fixture.composeId },
+      }),
+      [200],
+    );
+
+    expect(response.body.enabled).toBeTruthy();
+  });
+
+  it("returns 400 for invalid body", async () => {
+    const fixture = await track(
+      store.set(seedSchedulesScenario$, { schedules: [] }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await client().enable({
+      headers: { authorization: "Bearer clerk-session" },
+      params: { name: "any" },
+      body: {} as { agentId: string },
+    });
+    expect(response.status).toBe(400);
+    if (response.status === 400) {
+      expect(response.body.error.code).toBe("BAD_REQUEST");
+    }
+  });
+
+  it("returns 401 for unauthenticated request", async () => {
+    const response = await accept(
+      client().enable({
+        headers: {},
+        params: { name: "any" },
+        body: { agentId: randomUUID() },
+      }),
+      [401],
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 SCHEDULE_PAST when one-time schedule atTime has passed", async () => {
+    const pastDate = new Date(now() - 86_400_000);
+    const fixture = await track(
+      store.set(
+        seedSchedulesScenario$,
+        {
+          schedules: [
+            {
+              name: "past-once",
+              prompt: "Past one-time",
+              triggerType: "once",
+              atTime: pastDate,
+              enabled: false,
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      client().enable({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { name: "past-once" },
+        body: { agentId: fixture.composeId },
+      }),
+      [400],
+    );
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Schedule time has already passed",
+        code: "SCHEDULE_PAST",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-schedules.ts
+++ b/turbo/apps/api/src/signals/routes/zero-schedules.ts
@@ -1,9 +1,18 @@
-import { computed } from "ccstate";
-import { zeroSchedulesMainContract } from "@vm0/api-contracts/contracts/zero-schedules";
+import { command, computed } from "ccstate";
+import {
+  zeroSchedulesEnableContract,
+  zeroSchedulesMainContract,
+} from "@vm0/api-contracts/contracts/zero-schedules";
 
+import { notFound } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { zeroScheduleList } from "../services/zero-schedules.service";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import {
+  disableSchedule$,
+  enableSchedule$,
+  zeroScheduleList,
+} from "../services/zero-schedules.service";
 import type { RouteEntry } from "../route";
 
 const listSchedulesInner$ = computed(async (get) => {
@@ -12,6 +21,75 @@ const listSchedulesInner$ = computed(async (get) => {
     zeroScheduleList({ orgId: auth.orgId, userId: auth.userId }),
   );
   return { status: 200 as const, body: result };
+});
+
+const disableInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(zeroSchedulesEnableContract.disable));
+  const bodyResult = await get(
+    bodyResultOf(zeroSchedulesEnableContract.disable),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const result = await set(
+    disableSchedule$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      agentId: bodyResult.data.agentId,
+      name: params.name,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return notFound("Resource not found");
+  }
+  return { status: 200 as const, body: result.response };
+});
+
+const enableInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(zeroSchedulesEnableContract.enable));
+  const bodyResult = await get(
+    bodyResultOf(zeroSchedulesEnableContract.enable),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const result = await set(
+    enableSchedule$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      agentId: bodyResult.data.agentId,
+      name: params.name,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return notFound("Resource not found");
+  }
+  if (result.kind === "schedule_past") {
+    return {
+      status: 400 as const,
+      body: {
+        error: {
+          message: "Schedule time has already passed",
+          code: "SCHEDULE_PAST",
+        },
+      },
+    };
+  }
+  return { status: 200 as const, body: result.response };
 });
 
 export const zeroSchedulesRoutes: readonly RouteEntry[] = [
@@ -24,6 +102,28 @@ export const zeroSchedulesRoutes: readonly RouteEntry[] = [
         requiredCapability: "schedule:read",
       },
       listSchedulesInner$,
+    ),
+  },
+  {
+    route: zeroSchedulesEnableContract.disable,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "schedule:write",
+      },
+      disableInner$,
+    ),
+  },
+  {
+    route: zeroSchedulesEnableContract.enable,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "schedule:write",
+      },
+      enableInner$,
     ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -1,6 +1,6 @@
 import { createDecipheriv } from "node:crypto";
 
-import { computed, type Computed } from "ccstate";
+import { command, computed, type Computed } from "ccstate";
 import type {
   ScheduleListResponse,
   ScheduleResponse,
@@ -8,11 +8,13 @@ import type {
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroAgentSchedules } from "@vm0/db/schema/zero-agent-schedule";
+import { Cron } from "croner";
 import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 
 import { env } from "../../lib/env";
-import { db$ } from "../external/db";
+import { db$, writeDb$, type Db } from "../external/db";
+import { nowDate } from "../external/time";
 
 const secretsMapSchema = z.record(z.string(), z.string());
 
@@ -79,6 +81,173 @@ function scheduleResponse(
     preferPersonalProvider: schedule.preferPersonalProvider ?? false,
   };
 }
+
+function calculateNextRun(
+  cronExpression: string,
+  timezone: string,
+): Date | null {
+  return new Cron(cronExpression, { timezone }).nextRun();
+}
+
+type OwnershipResult =
+  | {
+      readonly ok: true;
+      readonly schedule: typeof zeroAgentSchedules.$inferSelect;
+      readonly displayName: string | null;
+    }
+  | { readonly ok: false };
+
+async function verifyScheduleOwnership(
+  db: Db,
+  userId: string,
+  orgId: string,
+  agentId: string,
+  name: string,
+): Promise<OwnershipResult> {
+  const [agent] = await db
+    .select({
+      id: agentComposes.id,
+      displayName: zeroAgents.displayName,
+    })
+    .from(agentComposes)
+    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+    .where(eq(agentComposes.id, agentId))
+    .limit(1);
+  if (!agent) {
+    return { ok: false };
+  }
+
+  const [schedule] = await db
+    .select()
+    .from(zeroAgentSchedules)
+    .where(
+      and(
+        eq(zeroAgentSchedules.agentId, agentId),
+        eq(zeroAgentSchedules.name, name),
+        eq(zeroAgentSchedules.orgId, orgId),
+        eq(zeroAgentSchedules.userId, userId),
+      ),
+    )
+    .limit(1);
+  if (!schedule) {
+    return { ok: false };
+  }
+
+  return { ok: true, schedule, displayName: agent.displayName ?? null };
+}
+
+type DisableScheduleResult =
+  | { readonly kind: "ok"; readonly response: ScheduleResponse }
+  | { readonly kind: "not_found" };
+
+type EnableScheduleResult =
+  | { readonly kind: "ok"; readonly response: ScheduleResponse }
+  | { readonly kind: "not_found" }
+  | { readonly kind: "schedule_past" };
+
+interface ScheduleMutationArgs {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly agentId: string;
+  readonly name: string;
+}
+
+export const disableSchedule$ = command(
+  async (
+    { set },
+    args: ScheduleMutationArgs,
+    signal: AbortSignal,
+  ): Promise<DisableScheduleResult> => {
+    const db = set(writeDb$);
+    const ownership = await verifyScheduleOwnership(
+      db,
+      args.userId,
+      args.orgId,
+      args.agentId,
+      args.name,
+    );
+    signal.throwIfAborted();
+    if (!ownership.ok) {
+      return { kind: "not_found" };
+    }
+
+    const [updated] = await db
+      .update(zeroAgentSchedules)
+      .set({
+        enabled: false,
+        retryStartedAt: null,
+        updatedAt: nowDate(),
+      })
+      .where(eq(zeroAgentSchedules.id, ownership.schedule.id))
+      .returning();
+    signal.throwIfAborted();
+    if (!updated) {
+      return { kind: "not_found" };
+    }
+
+    return {
+      kind: "ok",
+      response: scheduleResponse(updated, ownership.displayName),
+    };
+  },
+);
+
+export const enableSchedule$ = command(
+  async (
+    { set },
+    args: ScheduleMutationArgs,
+    signal: AbortSignal,
+  ): Promise<EnableScheduleResult> => {
+    const db = set(writeDb$);
+    const ownership = await verifyScheduleOwnership(
+      db,
+      args.userId,
+      args.orgId,
+      args.agentId,
+      args.name,
+    );
+    signal.throwIfAborted();
+    if (!ownership.ok) {
+      return { kind: "not_found" };
+    }
+    const { schedule, displayName } = ownership;
+
+    const now = nowDate();
+    let nextRunAt: Date | null = null;
+    if (schedule.triggerType === "loop") {
+      nextRunAt = now;
+    } else if (schedule.cronExpression) {
+      nextRunAt = calculateNextRun(schedule.cronExpression, schedule.timezone);
+    } else if (schedule.atTime) {
+      if (schedule.atTime > now) {
+        nextRunAt = schedule.atTime;
+      } else {
+        return { kind: "schedule_past" };
+      }
+    }
+
+    const [updated] = await db
+      .update(zeroAgentSchedules)
+      .set({
+        enabled: true,
+        nextRunAt,
+        retryStartedAt: null,
+        consecutiveFailures: 0,
+        updatedAt: now,
+      })
+      .where(eq(zeroAgentSchedules.id, schedule.id))
+      .returning();
+    signal.throwIfAborted();
+    if (!updated) {
+      return { kind: "not_found" };
+    }
+
+    return {
+      kind: "ok",
+      response: scheduleResponse(updated, displayName),
+    };
+  },
+);
 
 export function zeroScheduleList(args: {
   readonly orgId: string;

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       ccstate:
         specifier: ^5.3.0
         version: 5.3.0
+      croner:
+        specifier: ^9.1.0
+        version: 9.1.0
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0)(postgres@3.4.9)


### PR DESCRIPTION
## Summary

- Migrates `POST /api/zero/schedules/:name/{disable,enable}` from `apps/web` to `apps/api`, behavior-equivalent to web (same auth scope `schedule:write`, same 200 envelope, 404 `NOT_FOUND`, 400 `BAD_REQUEST`, 400 `SCHEDULE_PAST` semantics).
- Extends existing `apps/api` infrastructure rather than creating new files: `zero-schedules.service.ts`, `zero-schedules.ts` route, `helpers/zero-schedules.ts` test seeder, and the already-defined `zeroSchedulesEnableContract`.
- Adds `croner` to `apps/api` deps for cron next-run calculation in the enable path.

## Implementation notes

- Service uses the Wave 6 result-union pattern (`{kind: "ok" | "not_found" | "schedule_past"}`) — no try/catch, no exception propagation across the service boundary.
- `verifyScheduleOwnership` ported as a private helper (mirror of web's private function); `calculateNextRun` ported inline as a private 3-line helper. Both stay private until a second consumer needs them.
- `enableSchedule$` resolves `nextRunAt` from the persisted `triggerType` (not the request): `loop → now`, `cron → calculateNextRun`, `once → atTime if future, else schedule_past`. Same logic as web.
- `disableSchedule$` clears `retryStartedAt` unconditionally on every call, preserving web's behavior for re-disable calls.
- Route layer wraps both inner commands with `authRoute({requireOrganization: true, missingOrganizationStatus: 401, requiredCapability: "schedule:write"})`. Body parsing via `bodyResultOf(...)`, path params via `pathParamsOf(...)`.
- `SCHEDULE_PAST` envelope is an inline literal — `lib/error.ts` does not export a `schedulePast()` helper. Inlining is simpler than promoting a single-site helper.

## No web changes

Apps/web routes stay live as the off-path fallback. The `ApiBackendMutations` feature switch (in `apps/platform`) controls per-request routing; no client-call-site changes are needed since `zeroSchedulesEnableContract` already exists in `api-contracts`.

## Test plan

11 integration tests, all asserting on response body (no second DB query needed since `ScheduleResponse` already exposes `enabled`, `retryStartedAt`, `consecutiveFailures`, `nextRunAt`):

- [x] **disable** (5): enables-then-disables; 404 non-existent; lookup by compose `agentId`; 400 invalid body; 401 unauthenticated
- [x] **enable** (6): enables-and-resets-retry-state (asserts `enabled=true && retryStartedAt=null && consecutiveFailures=0 && nextRunAt!=null`); 404 non-existent; lookup by compose `agentId`; 400 invalid body; 401 unauthenticated; **400 SCHEDULE_PAST when one-time schedule's atTime has passed** (the defensive coverage of the error-mapping path that web tests omit)
- [x] No regressions in the 1023-test apps/api suite
- [x] Lint + typecheck + format + knip all clean

Closes #12713

🤖 Generated with [Claude Code](https://claude.com/claude-code)