### PR TITLE
test: align zero feature-switch route parity

### DIFF
--- a/turbo/apps/web/app/api/zero/feature-switches/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/feature-switches/__tests__/route.test.ts
@@ -41,6 +41,20 @@ describe("GET /api/zero/feature-switches", () => {
     expect(data.error.message).toContain("Not authenticated");
   });
 
+  it("should return 401 when authenticated session has no active organization", async () => {
+    mockClerk({ userId: "user_feature_switches_no_org_get", orgId: null });
+
+    const response = await GET(getRequest());
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
   it("should return empty switches for new user", async () => {
     const user = await context.setupUser();
     mockClerk({ userId: user.userId, orgId: user.orgId });
@@ -66,6 +80,20 @@ describe("POST /api/zero/feature-switches", () => {
 
     expect(response.status).toBe(401);
     expect(data.error.message).toContain("Not authenticated");
+  });
+
+  it("should return 401 when authenticated session has no active organization", async () => {
+    mockClerk({ userId: "user_feature_switches_no_org_post", orgId: null });
+
+    const response = await POST(postRequest({ voiceChat: true }));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
   });
 
   it("should create new switches", async () => {
@@ -130,6 +158,20 @@ describe("DELETE /api/zero/feature-switches", () => {
 
     expect(response.status).toBe(401);
     expect(data.error.message).toContain("Not authenticated");
+  });
+
+  it("should return 401 when authenticated session has no active organization", async () => {
+    mockClerk({ userId: "user_feature_switches_no_org_delete", orgId: null });
+
+    const response = await DELETE(deleteRequest());
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
   });
 
   it("should clear all overrides and subsequent GET returns empty switches", async () => {

--- a/turbo/apps/web/app/api/zero/feature-switches/route.ts
+++ b/turbo/apps/web/app/api/zero/feature-switches/route.ts
@@ -12,12 +12,22 @@ import {
   updateUserFeatureSwitches,
 } from "../../../../src/lib/zero/user/feature-switches-service";
 
+function unauthorizedResponse() {
+  return {
+    status: 401 as const,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
+
 const router = tsr.router(zeroFeatureSwitchesContract, {
   get: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthorizedResponse();
 
     const { org } = await resolveOrg(authCtx);
 
@@ -34,6 +44,7 @@ const router = tsr.router(zeroFeatureSwitchesContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthorizedResponse();
 
     const { org } = await resolveOrg(authCtx);
 
@@ -54,6 +65,7 @@ const router = tsr.router(zeroFeatureSwitchesContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthorizedResponse();
 
     const { org } = await resolveOrg(authCtx);
 


### PR DESCRIPTION
## Summary

- Return an explicit 401 `UNAUTHORIZED` response when the web feature-switch route has an authenticated session without an active org.
- Add web route parity coverage for GET, POST, and DELETE no-active-org requests.

Fixes #12625

## Validation

- `pnpm -F web exec vitest run app/api/zero/feature-switches/__tests__/route.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feature-switches.test.ts`
- `pnpm format`
- `pnpm -F web check-types`
- `pnpm -F web lint`
- `pnpm knip --workspace web`
- pre-commit: prettier, knip --cache, full `pnpm check-types`, commitlint