### PR TITLE
feat(api): migrate org/invite delete (revoke) to api backend (wave 6 #11)

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -29,6 +29,7 @@ export interface ApiTestMocks {
       readonly getOrganizationDomainList: AsyncMock;
       readonly getOrganizationInvitationList: AsyncMock;
       readonly getOrganizationMembershipList: AsyncMock;
+      readonly revokeOrganizationInvitation: AsyncMock;
     };
     readonly users: {
       readonly getUserList: AsyncMock;
@@ -108,6 +109,8 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
       getOrganizationInvitationList:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       getOrganizationMembershipList:
+        vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      revokeOrganizationInvitation:
         vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     users: {
@@ -420,6 +423,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.clerk.organizations.getOrganizationDomainList.mockReset();
   apiTestMocks.clerk.organizations.getOrganizationInvitationList.mockReset();
   apiTestMocks.clerk.organizations.getOrganizationMembershipList.mockReset();
+  apiTestMocks.clerk.organizations.revokeOrganizationInvitation.mockReset();
   apiTestMocks.clerk.users.getUserList.mockReset();
   apiTestMocks.clerk.users.getOrganizationMembershipList.mockReset();
   apiTestMocks.s3.send.mockReset();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-invite.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-invite.test.ts
@@ -148,3 +148,114 @@ describe("POST /api/zero/org/invite", () => {
     ).not.toHaveBeenCalled();
   });
 });
+
+describe("DELETE /api/zero/org/invite", () => {
+  it("revokes an invitation for an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const invitationId = `inv_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    context.mocks.clerk.organizations.revokeOrganizationInvitation.mockResolvedValueOnce(
+      undefined,
+    );
+
+    const response = await accept(
+      apiClient().revoke({
+        headers: authHeaders(),
+        body: { invitationId },
+      }),
+      [200],
+    );
+
+    expect(response.body.message).toBe("Invitation revoked");
+    expect(
+      context.mocks.clerk.organizations.revokeOrganizationInvitation,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: orgId,
+        invitationId,
+      }),
+    );
+  });
+
+  it("returns 403 when the caller is not an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:member");
+
+    const response = await accept(
+      apiClient().revoke({
+        headers: authHeaders(),
+        body: { invitationId: "inv_test123" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Access denied", code: "FORBIDDEN" },
+    });
+    expect(
+      context.mocks.clerk.organizations.revokeOrganizationInvitation,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      apiClient().revoke({
+        headers: {},
+        body: { invitationId: "inv_test123" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+    expect(
+      context.mocks.clerk.organizations.revokeOrganizationInvitation,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the authenticated session has no active organization", async () => {
+    // Deliberate hardening: web returns 400 (resolveOrg throw → isBadRequest);
+    // api returns 401 (authRoute's missingOrganizationStatus). See PR body.
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const response = await accept(
+      apiClient().revoke({
+        headers: authHeaders(),
+        body: { invitationId: "inv_test123" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+    expect(
+      context.mocks.clerk.organizations.revokeOrganizationInvitation,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an invalid body (missing invitationId)", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+
+    const response = await accept(
+      apiClient().revoke({
+        headers: authHeaders(),
+        body: {} as { invitationId: string },
+      }),
+      [400],
+    );
+
+    expect(response.body).toMatchObject({
+      error: { code: "BAD_REQUEST" },
+    });
+    expect(
+      context.mocks.clerk.organizations.revokeOrganizationInvitation,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-org-invite.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-invite.ts
@@ -48,12 +48,48 @@ const inviteInner$ = command(async ({ get }, signal: AbortSignal) => {
   };
 });
 
+const revokeBody$ = bodyResultOf(zeroOrgInviteContract.revoke);
+
+const revokeInner$ = command(async ({ get }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  if (auth.orgRole !== "admin") {
+    return adminRequired;
+  }
+
+  const body = await get(revokeBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  // Clerk side effect — revokes the pending invitation server-side.
+  // Mirrors apps/web/src/lib/zero/org/org-member-service.ts:revokeInvitation.
+  const client = get(clerk$);
+  await client.organizations.revokeOrganizationInvitation({
+    organizationId: auth.orgId,
+    invitationId: body.data.invitationId,
+  });
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: { message: "Invitation revoked" },
+  };
+});
+
 export const zeroOrgInviteRoutes: readonly RouteEntry[] = [
   {
     route: zeroOrgInviteContract.invite,
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       inviteInner$,
+    ),
+  },
+  {
+    route: zeroOrgInviteContract.revoke,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      revokeInner$,
     ),
   },
 ];


### PR DESCRIPTION
## Summary

- Migrates `DELETE /api/zero/org/invite` (revoke pending invitation) from `apps/web` to `apps/api`. Wave 6 #11 — second handler on the route file extended in #12607.
- Behavior 1:1 with web, except a deliberate 401 hardening for sessions without an active organization (matches #12695, wave 6 #7).
- Closes #12716.

## Deliberate hardening — 401 vs web's 400 on no-org sessions

One intentional, observable behavior change worth calling out.

- **Web's behavior**: when the authenticated session has no primary org, web's `resolveOrg(authCtx)` throws a `badRequest`. The route's try/catch matches `isBadRequest(error)` and returns `400 BAD_REQUEST`.
- **API's behavior**: `authRoute({ requireOrganization: true, missingOrganizationStatus: 401 })` emits a clean `401 Unauthorized` instead.

**Justification**:
- Web's 400 is an accidental classification — `resolveOrg`'s "no active organization" condition is auth state, not user input.
- Api's 401 is intentional and correct (proper auth gating).
- Mark as **deliberate hardening, not regression**.
- Test #4 pins the corrected behavior.

This matches the pattern established by #12695 — future similar routes follow the same hardening.

## No try/catch — mirroring web's true behavior

Web's `revokeInvitation` service (`apps/web/src/lib/zero/org/org-member-service.ts:317-333`) is short:

```ts
if (role !== "admin") throw forbidden("Only admins can revoke invitations");
const client = await clerkClient();
await client.organizations.revokeOrganizationInvitation({ organizationId: orgId, invitationId });
```

The web route's `isNotFound`/`isBadRequest` translators are defensive boilerplate; the underlying service never raises `notFound` locally. The api port mirrors web's actual behavior (no result-union, no try/catch). Clerk SDK errors propagate to a framework 500 — matching web 1:1 for that path. The contract already declares 500 in `responses`.

## Files

- `turbo/apps/api/src/__tests__/mocks.ts` — adds `revokeOrganizationInvitation` to the Clerk mock (type + factory + reset, 3 lines).
- `turbo/apps/api/src/signals/routes/zero-org-invite.ts` — adds `revokeInner$` command + second `RouteEntry`. Inline pattern matching #12607.
- `turbo/apps/api/src/signals/routes/__tests__/zero-org-invite.test.ts` — adds `describe("DELETE /api/zero/org/invite")` block with 5 cases.

**No contract change, no web change, no dispatch table edit, no new test helper.**

## Tests (5)

| # | Source | Case |
|---|---|---|
| 1 | web (strengthened) | admin revokes — 200 + asserts Clerk called with `{ organizationId, invitationId }` |
| 2 | web | 403 when caller is `org:member` (frozen `Access denied` envelope) |
| 3 | web | 401 unauthenticated |
| 4 | api defensive | 401 no-org session (pins the deliberate-hardening behavior above) |
| 5 | api defensive | 400 invalid body (missing `invitationId`) — catches contract/schema drift |

Strengthening test #1 with the `toHaveBeenCalledWith` assertion mirrors the precedent set by #12607's `createOrganizationInvitation` test.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-org-invite.test.ts` — 11 passed (6 POST + 5 DELETE)
- [x] `pnpm -F api exec vitest run` — 1017 passed across 118 files
- [x] `pnpm -F api run lint` — 0 warnings, 0 errors
- [x] `pnpm -F api run check-types` — clean
- [x] `pnpm format` — clean
- [x] `pnpm knip --workspace api` — clean

## Rollback

Flip `FeatureSwitchKey.ApiBackendMutations` off → traffic returns to web's DELETE handler (still in place). No DB migration to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)