### PR TITLE
feat(api): migrate org/membership-requests accept+reject to api backend (wave 6 #12)

### DIFF
--- a/turbo/apps/api/src/signals/external/clerk-membership-requests.ts
+++ b/turbo/apps/api/src/signals/external/clerk-membership-requests.ts
@@ -46,3 +46,27 @@ export async function fetchClerkMembershipRequests(
   const body = clerkMembershipRequestsResponseSchema.parse(await res.json());
   return body.data;
 }
+
+export async function acceptClerkMembershipRequest(args: {
+  readonly orgId: string;
+  readonly requestId: string;
+}): Promise<{ readonly ok: boolean }> {
+  const secretKey = env("CLERK_SECRET_KEY");
+  const res = await fetch(
+    `${CLERK_API_BASE}/organizations/${args.orgId}/membership_requests/${args.requestId}/accept`,
+    { method: "POST", headers: { Authorization: `Bearer ${secretKey}` } },
+  );
+  return { ok: res.ok };
+}
+
+export async function rejectClerkMembershipRequest(args: {
+  readonly orgId: string;
+  readonly requestId: string;
+}): Promise<{ readonly ok: boolean }> {
+  const secretKey = env("CLERK_SECRET_KEY");
+  const res = await fetch(
+    `${CLERK_API_BASE}/organizations/${args.orgId}/membership_requests/${args.requestId}/reject`,
+    { method: "POST", headers: { Authorization: `Bearer ${secretKey}` } },
+  );
+  return { ok: res.ok };
+}

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -33,6 +33,7 @@ import { zeroModelProvidersRoutes } from "./routes/zero-model-providers";
 import { zeroOnboardingCompleteRoutes } from "./routes/zero-onboarding-complete";
 import { zeroOnboardingStatusRoutes } from "./routes/zero-onboarding-status";
 import { zeroOrgInviteRoutes } from "./routes/zero-org-invite";
+import { zeroOrgMembershipRequestsRoutes } from "./routes/zero-org-membership-requests";
 import { zeroOrgReadRoutes } from "./routes/zero-org-read";
 import { zeroPermissionPoliciesRoutes } from "./routes/zero-permission-policies";
 import { zeroPushSubscriptionsRoutes } from "./routes/zero-push-subscriptions";
@@ -109,6 +110,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroOnboardingCompleteRoutes,
   ...zeroOnboardingStatusRoutes,
   ...zeroOrgInviteRoutes,
+  ...zeroOrgMembershipRequestsRoutes,
   ...zeroOrgReadRoutes,
   ...zeroPermissionPoliciesRoutes,
   ...zeroPushSubscriptionsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-membership-requests.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-membership-requests.test.ts
@@ -1,0 +1,251 @@
+import { randomUUID } from "node:crypto";
+
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { zeroOrgMembershipRequestsContract } from "@vm0/api-contracts/contracts/zero-org-members";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { server } from "../../../mocks/server";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const mocks = createZeroRouteMocks(context);
+
+function apiClient() {
+  return setupApp({ context })(zeroOrgMembershipRequestsContract);
+}
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function mockClerkMembershipAction(
+  action: "accept" | "reject",
+  orgId: string,
+  requestId: string,
+  status: number,
+): { readonly callCount: () => number } {
+  let calls = 0;
+  server.use(
+    http.post(
+      `https://api.clerk.com/v1/organizations/${orgId}/membership_requests/${requestId}/${action}`,
+      () => {
+        calls++;
+        if (status === 200) {
+          return HttpResponse.json({});
+        }
+        return HttpResponse.json({ error: "Not found" }, { status });
+      },
+    ),
+  );
+  return {
+    callCount: () => {
+      return calls;
+    },
+  };
+}
+
+describe("POST /api/zero/org/membership-requests (accept)", () => {
+  it("accepts a membership request for an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    const clerk = mockClerkMembershipAction(
+      "accept",
+      orgId,
+      "req_test123",
+      200,
+    );
+
+    const response = await accept(
+      apiClient().accept({
+        headers: authHeaders(),
+        body: { requestId: "req_test123" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      message: "Membership request accepted",
+    });
+    expect(clerk.callCount()).toBe(1);
+  });
+
+  it("returns 400 when Clerk API rejects the accept request", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    mockClerkMembershipAction("accept", orgId, "req_invalid", 404);
+
+    const response = await accept(
+      apiClient().accept({
+        headers: authHeaders(),
+        body: { requestId: "req_invalid" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid request", code: "BAD_REQUEST" },
+    });
+  });
+
+  it("returns 403 when caller is not an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:member");
+    const clerk = mockClerkMembershipAction(
+      "accept",
+      orgId,
+      "req_test123",
+      200,
+    );
+
+    const response = await accept(
+      apiClient().accept({
+        headers: authHeaders(),
+        body: { requestId: "req_test123" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Access denied", code: "FORBIDDEN" },
+    });
+    expect(clerk.callCount()).toBe(0);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const response = await accept(
+      apiClient().accept({
+        headers: {},
+        body: { requestId: "req_test123" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when authenticated session has no active organization", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const response = await accept(
+      apiClient().accept({
+        headers: authHeaders(),
+        body: { requestId: "req_test123" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+});
+
+describe("DELETE /api/zero/org/membership-requests (reject)", () => {
+  it("rejects a membership request for an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    const clerk = mockClerkMembershipAction(
+      "reject",
+      orgId,
+      "req_test456",
+      200,
+    );
+
+    const response = await accept(
+      apiClient().reject({
+        headers: authHeaders(),
+        body: { requestId: "req_test456" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      message: "Membership request rejected",
+    });
+    expect(clerk.callCount()).toBe(1);
+  });
+
+  it("returns 400 when Clerk API rejects the reject request", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:admin");
+    mockClerkMembershipAction("reject", orgId, "req_invalid", 404);
+
+    const response = await accept(
+      apiClient().reject({
+        headers: authHeaders(),
+        body: { requestId: "req_invalid" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid request", code: "BAD_REQUEST" },
+    });
+  });
+
+  it("returns 403 when caller is not an admin", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId, "org:member");
+    const clerk = mockClerkMembershipAction(
+      "reject",
+      orgId,
+      "req_test456",
+      200,
+    );
+
+    const response = await accept(
+      apiClient().reject({
+        headers: authHeaders(),
+        body: { requestId: "req_test456" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Access denied", code: "FORBIDDEN" },
+    });
+    expect(clerk.callCount()).toBe(0);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const response = await accept(
+      apiClient().reject({
+        headers: {},
+        body: { requestId: "req_test456" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when authenticated session has no active organization", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const response = await accept(
+      apiClient().reject({
+        headers: authHeaders(),
+        body: { requestId: "req_test456" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-org-membership-requests.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-membership-requests.ts
@@ -1,0 +1,113 @@
+import { command } from "ccstate";
+import { zeroOrgMembershipRequestsContract } from "@vm0/api-contracts/contracts/zero-org-members";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import {
+  acceptMembershipRequest$,
+  rejectMembershipRequest$,
+} from "../services/zero-org-membership-requests.service";
+import type { RouteEntry } from "../route";
+
+const adminRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Access denied",
+      code: "FORBIDDEN" as const,
+    }),
+  }),
+});
+
+const clerkFailed = Object.freeze({
+  status: 400 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Invalid request",
+      code: "BAD_REQUEST" as const,
+    }),
+  }),
+});
+
+const acceptBody$ = bodyResultOf(zeroOrgMembershipRequestsContract.accept);
+const rejectBody$ = bodyResultOf(zeroOrgMembershipRequestsContract.reject);
+
+const acceptInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const body = await get(acceptBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  const result = await set(
+    acceptMembershipRequest$,
+    {
+      orgId: auth.orgId,
+      role: auth.orgRole,
+      requestId: body.data.requestId,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "forbidden") {
+    return adminRequired;
+  }
+  if (result.kind === "clerk_failed") {
+    return clerkFailed;
+  }
+  return {
+    status: 200 as const,
+    body: { message: "Membership request accepted" },
+  };
+});
+
+const rejectInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const body = await get(rejectBody$);
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+
+  const result = await set(
+    rejectMembershipRequest$,
+    {
+      orgId: auth.orgId,
+      role: auth.orgRole,
+      requestId: body.data.requestId,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "forbidden") {
+    return adminRequired;
+  }
+  if (result.kind === "clerk_failed") {
+    return clerkFailed;
+  }
+  return {
+    status: 200 as const,
+    body: { message: "Membership request rejected" },
+  };
+});
+
+export const zeroOrgMembershipRequestsRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroOrgMembershipRequestsContract.accept,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      acceptInner$,
+    ),
+  },
+  {
+    route: zeroOrgMembershipRequestsContract.reject,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      rejectInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-org-membership-requests.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-membership-requests.service.ts
@@ -1,0 +1,59 @@
+import { command } from "ccstate";
+
+import {
+  acceptClerkMembershipRequest,
+  rejectClerkMembershipRequest,
+} from "../external/clerk-membership-requests";
+
+type MembershipRequestResult =
+  | { readonly kind: "ok" }
+  | { readonly kind: "forbidden" }
+  | { readonly kind: "clerk_failed" };
+
+interface MembershipRequestArgs {
+  readonly orgId: string;
+  readonly role: string | undefined;
+  readonly requestId: string;
+}
+
+export const acceptMembershipRequest$ = command(
+  async (
+    _ctx,
+    args: MembershipRequestArgs,
+    signal: AbortSignal,
+  ): Promise<MembershipRequestResult> => {
+    if (args.role !== "admin") {
+      return { kind: "forbidden" };
+    }
+    const result = await acceptClerkMembershipRequest({
+      orgId: args.orgId,
+      requestId: args.requestId,
+    });
+    signal.throwIfAborted();
+    if (!result.ok) {
+      return { kind: "clerk_failed" };
+    }
+    return { kind: "ok" };
+  },
+);
+
+export const rejectMembershipRequest$ = command(
+  async (
+    _ctx,
+    args: MembershipRequestArgs,
+    signal: AbortSignal,
+  ): Promise<MembershipRequestResult> => {
+    if (args.role !== "admin") {
+      return { kind: "forbidden" };
+    }
+    const result = await rejectClerkMembershipRequest({
+      orgId: args.orgId,
+      requestId: args.requestId,
+    });
+    signal.throwIfAborted();
+    if (!result.ok) {
+      return { kind: "clerk_failed" };
+    }
+    return { kind: "ok" };
+  },
+);


### PR DESCRIPTION
## Summary
- Migrates `POST /api/zero/org/membership-requests` (accept) and `DELETE /api/zero/org/membership-requests` (reject) from apps/web to apps/api as a paired Wave 6 migration (parent epic #12290, sub-issue #12725).
- Adds `acceptClerkMembershipRequest` / `rejectClerkMembershipRequest` to the existing Clerk REST helper, returning `{ ok: boolean }` (no body parse — web doesn't consume the response body either).
- Adds `zero-org-membership-requests.service.ts` with two Commands returning a discriminated `{ ok | forbidden | clerk_failed }` union; the admin gate stays in the service as a business invariant.
- Adds `zero-org-membership-requests.ts` route file with two `RouteEntry`s wrapped in `authRoute({ requireOrganization: true, missingOrganizationStatus: 401 })`. Preserves web's wrapper-translated `"Access denied"` (403) and `"Invalid request"` (400) envelope messages for byte-equivalent shadow comparison — the service throw messages never reach the client.
- 401-hardens the no-active-organization case (web's `resolveOrg` previously 500'd on this path).

## Test plan
- [x] 10 unit tests pass (`pnpm -F api exec vitest run zero-org-membership-requests.test.ts`) — 8 web-parity cases + 2 no-active-org 401 hardening tests
- [x] Full `apps/api` suite passes (1033/1033)
- [x] Lint, type-check, format, knip all clean
- [ ] CI green

## Rollback
Flip `FeatureSwitchKey.ApiBackendMutations` off — traffic returns to web. No DB migration, no contract changes.

Closes #12725
Refs #12290

🤖 Generated with [Claude Code](https://claude.com/claude-code)