### PR TITLE
feat(ios): add native voice chat app

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,77 @@
+name: iOS
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/ios.yml"
+      - "ios/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/ios.yml"
+      - "ios/**"
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ios-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (github.event_name == 'merge_group' && format('merge-queue-{0}', github.run_id) || github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Show Xcode version
+        run: |
+          xcode-select -p
+          xcodebuild -version
+
+      - name: Select iOS simulator
+        run: |
+          set -euo pipefail
+
+          simulator_id="$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/ { print $2; exit }')"
+          if [ -z "$simulator_id" ]; then
+            xcrun simctl list devices available
+            exit 1
+          fi
+
+          echo "IOS_SIMULATOR_ID=$simulator_id" >> "$GITHUB_ENV"
+
+      - name: Resolve Swift packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project ios/Zero.xcodeproj \
+            -scheme Zero
+
+      - name: Build for testing
+        run: |
+          xcodebuild build-for-testing \
+            -project ios/Zero.xcodeproj \
+            -scheme Zero \
+            -destination "platform=iOS Simulator,id=${IOS_SIMULATOR_ID}" \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
+            CODE_SIGNING_ALLOWED=NO \
+            CLERK_FRONTEND_API_DOMAIN=ci.vm0.local \
+            CLERK_PUBLISHABLE_KEY=pk_test_Y2kudm0wLmxvY2FsJA== \
+            ZERO_API_BASE_URL=https://api.vm0.ai
+
+      - name: Run XCTest
+        run: |
+          xcodebuild test-without-building \
+            -project ios/Zero.xcodeproj \
+            -scheme Zero \
+            -destination "platform=iOS Simulator,id=${IOS_SIMULATOR_ID}" \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
+            CODE_SIGNING_ALLOWED=NO \
+            CLERK_FRONTEND_API_DOMAIN=ci.vm0.local \
+            CLERK_PUBLISHABLE_KEY=pk_test_Y2kudm0wLmxvY2FsJA== \
+            ZERO_API_BASE_URL=https://api.vm0.ai

--- a/ios/API/VoiceChatDTOs.swift
+++ b/ios/API/VoiceChatDTOs.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+enum NoiseReduction: String, Codable, Equatable {
+    case nearField = "near_field"
+    case farField = "far_field"
+}
+
+enum BargeInMode: Equatable {
+    case speechStarted
+    case transcriptConfirmed
+}
+
+struct VoiceChatAudioConfig: Equatable {
+    let noiseReduction: NoiseReduction
+    let bargeInMode: BargeInMode
+}
+
+enum VoiceChatItemRole: String, Codable, Equatable {
+    case user
+    case assistant
+    case taskResult = "task_result"
+    case systemNote = "system_note"
+}
+
+enum VoiceChatTaskStatus: String, Codable, Equatable {
+    case pending
+    case queued
+    case running
+    case done
+    case failed
+}
+
+struct VoiceChatSession: Codable, Equatable, Identifiable {
+    let id: UUID
+    let orgId: String
+    let userId: String
+    let agentId: UUID?
+    let mode: String
+    let conversationSummary: String?
+    let workingTasksSummary: String?
+    let finishedTasksSummary: String?
+    let summarySeq: Int
+    let summaryVersion: Int
+    let lastSummaryAt: String?
+    let createdAt: String
+}
+
+struct VoiceChatTaskResultEntry: Codable, Equatable {
+    let type: String
+    let content: String
+    let at: String
+}
+
+struct VoiceChatTask: Codable, Equatable, Identifiable {
+    let id: UUID
+    let sessionId: UUID
+    let runId: UUID?
+    let callId: String
+    let prompt: String
+    let status: VoiceChatTaskStatus
+    let result: String?
+    let resultUpdatedAt: String?
+    let assistantMessages: [VoiceChatTaskResultEntry]
+    let error: String?
+    let createdAt: String
+    let startedAt: String?
+    let finishedAt: String?
+}
+
+struct CreateVoiceChatSessionRequest: Encodable, Equatable {
+    let agentId: UUID
+}
+
+struct CreateVoiceChatSessionResponse: Decodable, Equatable {
+    let session: VoiceChatSession
+    let recentTaskLogs: String
+    let finishedTasksFullText: String
+    let talkerInstructions: String
+    let talkerInstructionTokens: Int
+}
+
+struct GetVoiceChatSessionResponse: Decodable, Equatable {
+    let session: VoiceChatSession
+    let recentTaskLogs: String
+    let finishedTasksFullText: String
+    let talkerInstructions: String
+    let talkerInstructionTokens: Int
+}
+
+struct VoiceChatTokenRequest: Encodable, Equatable {
+    let sessionId: UUID
+    let noiseReduction: NoiseReduction?
+}
+
+struct VoiceChatTokenResponse: Decodable, Equatable {
+    struct ClientSecret: Decodable, Equatable {
+        let value: String
+        let expiresAt: Int
+
+        enum CodingKeys: String, CodingKey {
+            case value
+            case expiresAt = "expires_at"
+        }
+    }
+
+    let clientSecret: ClientSecret
+
+    enum CodingKeys: String, CodingKey {
+        case clientSecret = "client_secret"
+    }
+}
+
+struct AppendVoiceChatItemRequest: Encodable, Equatable {
+    let role: VoiceChatItemRole
+    let content: String
+    let realtimeItemId: String
+}
+
+struct CreateVoiceChatTaskRequest: Encodable, Equatable {
+    let prompt: String
+    let callId: String
+}
+
+struct CreateVoiceChatTaskResponse: Decodable, Equatable {
+    let task: VoiceChatTask
+}
+
+struct VoiceChatTaskListResponse: Decodable, Equatable {
+    let tasks: [VoiceChatTask]
+}
+
+struct VoiceChatSessionStartedResponse: Decodable, Equatable {
+    let id: UUID?
+}
+
+struct VoiceChatSessionEndedRequest: Encodable, Equatable {
+    let relaySessionId: UUID
+}
+
+struct VoiceChatOKResponse: Decodable, Equatable {
+    let ok: Bool
+}
+
+enum VoiceChatUsageEventType: String, Codable, Equatable {
+    case responseDone = "response.done"
+    case transcriptionCompleted = "transcription.completed"
+}
+
+struct VoiceChatUsageEvent: Codable, Equatable {
+    let providerEventId: String
+    let eventType: VoiceChatUsageEventType
+    var inputTextTokens: Int?
+    var inputAudioTokens: Int?
+    var inputCachedTextTokens: Int?
+    var inputCachedAudioTokens: Int?
+    var outputTextTokens: Int?
+    var outputAudioTokens: Int?
+}
+
+struct VoiceChatUsageEventResponse: Decodable, Equatable {
+    let creditsExhausted: Bool
+}
+
+struct APIErrorEnvelope: Decodable, Equatable {
+    struct Body: Decodable, Equatable {
+        let message: String
+        let code: String?
+    }
+
+    let error: Body
+}

--- a/ios/API/ZeroAPIClient.swift
+++ b/ios/API/ZeroAPIClient.swift
@@ -1,0 +1,200 @@
+import Foundation
+
+protocol URLSessioning: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: URLSessioning {}
+
+struct ZeroAPIError: LocalizedError, Equatable {
+    let statusCode: Int
+    let code: String?
+    let message: String
+
+    var errorDescription: String? {
+        message
+    }
+}
+
+final class ZeroAPIClient: @unchecked Sendable {
+    private let baseURL: URL
+    private let authTokenProvider: AuthTokenProvider
+    private let urlSession: URLSessioning
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(
+        baseURL: URL,
+        authTokenProvider: AuthTokenProvider,
+        urlSession: URLSessioning = URLSession.shared
+    ) {
+        self.baseURL = baseURL
+        self.authTokenProvider = authTokenProvider
+        self.urlSession = urlSession
+        self.encoder = JSONEncoder()
+        self.decoder = JSONDecoder()
+    }
+
+    func createSession(agentId: UUID) async throws
+        -> CreateVoiceChatSessionResponse
+    {
+        try await send(
+            method: "POST",
+            path: "/api/zero/voice-chat",
+            body: CreateVoiceChatSessionRequest(agentId: agentId)
+        )
+    }
+
+    func getSession(id: UUID) async throws -> GetVoiceChatSessionResponse {
+        try await send(
+            method: "GET",
+            path: "/api/zero/voice-chat/\(id.uuidString)",
+            body: EmptyBody?.none
+        )
+    }
+
+    func mintRealtimeToken(
+        sessionId: UUID,
+        noiseReduction: NoiseReduction?
+    ) async throws -> VoiceChatTokenResponse {
+        try await send(
+            method: "POST",
+            path: "/api/zero/voice-chat/token",
+            body: VoiceChatTokenRequest(
+                sessionId: sessionId,
+                noiseReduction: noiseReduction
+            )
+        )
+    }
+
+    func appendItem(
+        sessionId: UUID,
+        role: VoiceChatItemRole,
+        content: String,
+        realtimeItemId: String
+    ) async throws {
+        try await sendDiscardingResponse(
+            method: "POST",
+            path: "/api/zero/voice-chat/\(sessionId.uuidString)/items",
+            body: AppendVoiceChatItemRequest(
+                role: role,
+                content: content,
+                realtimeItemId: realtimeItemId
+            )
+        )
+    }
+
+    func createTask(
+        sessionId: UUID,
+        prompt: String,
+        callId: String
+    ) async throws -> VoiceChatTask {
+        let response: CreateVoiceChatTaskResponse = try await send(
+            method: "POST",
+            path: "/api/zero/voice-chat/\(sessionId.uuidString)/tasks",
+            body: CreateVoiceChatTaskRequest(prompt: prompt, callId: callId)
+        )
+        return response.task
+    }
+
+    func listTasks(sessionId: UUID) async throws -> [VoiceChatTask] {
+        let response: VoiceChatTaskListResponse = try await send(
+            method: "GET",
+            path: "/api/zero/voice-chat/\(sessionId.uuidString)/tasks",
+            body: EmptyBody?.none
+        )
+        return response.tasks
+    }
+
+    func sessionStarted(sessionId: UUID) async throws
+        -> VoiceChatSessionStartedResponse
+    {
+        try await send(
+            method: "POST",
+            path: "/api/zero/voice-chat/\(sessionId.uuidString)/session-started",
+            body: EmptyBody()
+        )
+    }
+
+    func sessionEnded(sessionId: UUID, relaySessionId: UUID) async throws {
+        let _: VoiceChatOKResponse = try await send(
+            method: "POST",
+            path: "/api/zero/voice-chat/\(sessionId.uuidString)/session-ended",
+            body: VoiceChatSessionEndedRequest(relaySessionId: relaySessionId)
+        )
+    }
+
+    func postUsageEvent(
+        sessionId: UUID,
+        event: VoiceChatUsageEvent
+    ) async throws -> VoiceChatUsageEventResponse {
+        try await send(
+            method: "POST",
+            path: "/api/zero/voice-chat/\(sessionId.uuidString)/usage",
+            body: event
+        )
+    }
+
+    private func send<RequestBody: Encodable, ResponseBody: Decodable>(
+        method: String,
+        path: String,
+        body: RequestBody?
+    ) async throws -> ResponseBody {
+        let request = try await makeRequest(method: method, path: path, body: body)
+        let (data, response) = try await urlSession.data(for: request)
+        try validate(response: response, data: data)
+        return try decoder.decode(ResponseBody.self, from: data)
+    }
+
+    private func sendDiscardingResponse<RequestBody: Encodable>(
+        method: String,
+        path: String,
+        body: RequestBody?
+    ) async throws {
+        let request = try await makeRequest(method: method, path: path, body: body)
+        let (data, response) = try await urlSession.data(for: request)
+        try validate(response: response, data: data)
+    }
+
+    private func makeRequest<RequestBody: Encodable>(
+        method: String,
+        path: String,
+        body: RequestBody?
+    ) async throws -> URLRequest {
+        let url = baseURL.appending(path: path)
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        let token = try await authTokenProvider.bearerToken()
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(
+            "Bearer \(token)",
+            forHTTPHeaderField: "Authorization"
+        )
+        if let body {
+            request.httpBody = try encoder.encode(body)
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        return request
+    }
+
+    private func validate(response: URLResponse, data: Data) throws {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ZeroAPIError(
+                statusCode: 0,
+                code: nil,
+                message: "Invalid response from server"
+            )
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            let error = try? decoder.decode(APIErrorEnvelope.self, from: data)
+            throw ZeroAPIError(
+                statusCode: httpResponse.statusCode,
+                code: error?.error.code,
+                message: error?.error.message
+                    ?? "Request failed with status \(httpResponse.statusCode)"
+            )
+        }
+    }
+}
+
+private struct EmptyBody: Encodable {}

--- a/ios/App/AppConfig.swift
+++ b/ios/App/AppConfig.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+struct AppConfig: Equatable {
+    enum ConfigError: LocalizedError, Equatable {
+        case invalidAPIBaseURL(String)
+        case missingClerkPublishableKey
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidAPIBaseURL(let value):
+                return "Invalid ZERO_API_BASE_URL: \(value)"
+            case .missingClerkPublishableKey:
+                return "Missing CLERK_PUBLISHABLE_KEY build setting"
+            }
+        }
+    }
+
+    let apiBaseURL: URL
+    let clerkPublishableKey: String
+
+    static func load(bundle: Bundle = .main) throws -> AppConfig {
+        let rawBase =
+            normalized(
+                bundle.object(forInfoDictionaryKey: "ZERO_API_BASE_URL")
+                    as? String
+            ) ?? "https://api.vm0.ai"
+        guard
+            let apiBaseURL = URL(string: rawBase),
+            let scheme = apiBaseURL.scheme,
+            let host = apiBaseURL.host,
+            !scheme.isEmpty,
+            !host.isEmpty
+        else {
+            throw ConfigError.invalidAPIBaseURL(rawBase)
+        }
+
+        guard
+            let publishableKey = normalized(
+                bundle.object(forInfoDictionaryKey: "CLERK_PUBLISHABLE_KEY")
+                    as? String
+            )
+        else {
+            throw ConfigError.missingClerkPublishableKey
+        }
+
+        return AppConfig(
+            apiBaseURL: apiBaseURL,
+            clerkPublishableKey: publishableKey
+        )
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty || trimmed.hasPrefix("$(") {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/ios/App/AppEnvironment.swift
+++ b/ios/App/AppEnvironment.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct AppEnvironment {
+    let apiClient: ZeroAPIClient
+    let audioSession: AudioSessionControlling
+    let makeRealtimeTransport: () -> RealtimeTransport
+
+    static func live(config: AppConfig) -> AppEnvironment {
+        let authProvider = ClerkAuthProvider()
+        return AppEnvironment(
+            apiClient: ZeroAPIClient(
+                baseURL: config.apiBaseURL,
+                authTokenProvider: authProvider
+            ),
+            audioSession: AudioSessionController(),
+            makeRealtimeTransport: {
+                OpenAIRealtimeWebRTCClient()
+            }
+        )
+    }
+}

--- a/ios/App/Info.plist
+++ b/ios/App/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Zero</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CLERK_PUBLISHABLE_KEY</key>
+	<string>$(CLERK_PUBLISHABLE_KEY)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Zero uses the microphone for native voice chat.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>ZERO_API_BASE_URL</key>
+	<string>$(ZERO_API_BASE_URL)</string>
+</dict>
+</plist>

--- a/ios/App/Resources/Assets.xcassets/Contents.json
+++ b/ios/App/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}

--- a/ios/App/RootView.swift
+++ b/ios/App/RootView.swift
@@ -1,0 +1,56 @@
+import ClerkKit
+import ClerkKitUI
+import SwiftUI
+
+struct RootView: View {
+    @Environment(Clerk.self) private var clerk
+    @State private var authIsPresented = false
+    @StateObject private var controller: VoiceChatController
+
+    init(environment: AppEnvironment) {
+        _controller = StateObject(
+            wrappedValue: VoiceChatController(
+                apiClient: environment.apiClient,
+                audioSession: environment.audioSession,
+                makeRealtimeTransport: environment.makeRealtimeTransport
+            )
+        )
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if clerk.user == nil {
+                    signedOutView
+                } else {
+                    VoiceChatView(controller: controller)
+                }
+            }
+            .navigationTitle("Zero")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    UserButton(signedOutContent: {
+                        Button("Sign in") {
+                            authIsPresented = true
+                        }
+                    })
+                }
+            }
+        }
+        .prefetchClerkImages()
+        .sheet(isPresented: $authIsPresented) {
+            AuthView()
+        }
+    }
+
+    private var signedOutView: some View {
+        VStack(spacing: 16) {
+            Button("Sign in") {
+                authIsPresented = true
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}

--- a/ios/App/Zero.entitlements
+++ b/ios/App/Zero.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:$(CLERK_FRONTEND_API_DOMAIN)</string>
+	</array>
+</dict>
+</plist>

--- a/ios/App/ZeroApp.swift
+++ b/ios/App/ZeroApp.swift
@@ -1,0 +1,24 @@
+import ClerkKit
+import SwiftUI
+
+@main
+struct ZeroApp: App {
+    private let environment: AppEnvironment
+
+    init() {
+        do {
+            let config = try AppConfig.load()
+            Clerk.configure(publishableKey: config.clerkPublishableKey)
+            environment = AppEnvironment.live(config: config)
+        } catch {
+            fatalError(error.localizedDescription)
+        }
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            RootView(environment: environment)
+                .environment(Clerk.shared)
+        }
+    }
+}

--- a/ios/Audio/AudioSessionController.swift
+++ b/ios/Audio/AudioSessionController.swift
@@ -1,0 +1,72 @@
+import AVFAudio
+import Foundation
+
+protocol AudioSessionControlling: Sendable {
+    func prepareForVoiceChat() async throws -> VoiceChatAudioConfig
+    func deactivate() async
+}
+
+enum AudioSessionError: LocalizedError, Equatable {
+    case microphoneDenied
+
+    var errorDescription: String? {
+        switch self {
+        case .microphoneDenied:
+            return "Microphone access denied. Enable microphone access in Settings."
+        }
+    }
+}
+
+struct AudioSessionController: AudioSessionControlling {
+    func prepareForVoiceChat() async throws -> VoiceChatAudioConfig {
+        guard await requestMicrophonePermission() else {
+            throw AudioSessionError.microphoneDenied
+        }
+
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(
+            .playAndRecord,
+            mode: .voiceChat,
+            options: [.allowBluetooth, .allowBluetoothA2DP, .defaultToSpeaker]
+        )
+        try session.setActive(true)
+
+        let speakerRisk = session.currentRoute.outputs.allSatisfy { output in
+            switch output.portType {
+            case .bluetoothA2DP, .bluetoothHFP, .bluetoothLE,
+                .headphones, .usbAudio, .carAudio:
+                return false
+            default:
+                return true
+            }
+        }
+
+        return VoiceChatAudioConfig(
+            noiseReduction: speakerRisk ? .nearField : .farField,
+            bargeInMode: speakerRisk ? .transcriptConfirmed : .speechStarted
+        )
+    }
+
+    func deactivate() async {
+        try? AVAudioSession.sharedInstance().setActive(
+            false,
+            options: [.notifyOthersOnDeactivation]
+        )
+    }
+
+    private func requestMicrophonePermission() async -> Bool {
+        if #available(iOS 17.0, *) {
+            return await withCheckedContinuation { continuation in
+                AVAudioApplication.requestRecordPermission { granted in
+                    continuation.resume(returning: granted)
+                }
+            }
+        }
+
+        return await withCheckedContinuation { continuation in
+            AVAudioSession.sharedInstance().requestRecordPermission { granted in
+                continuation.resume(returning: granted)
+            }
+        }
+    }
+}

--- a/ios/Auth/ClerkAuthProvider.swift
+++ b/ios/Auth/ClerkAuthProvider.swift
@@ -1,0 +1,26 @@
+import ClerkKit
+import Foundation
+
+protocol AuthTokenProvider: Sendable {
+    func bearerToken() async throws -> String
+}
+
+enum AuthProviderError: LocalizedError, Equatable {
+    case signedOut
+
+    var errorDescription: String? {
+        switch self {
+        case .signedOut:
+            return "Sign in before starting voice chat."
+        }
+    }
+}
+
+struct ClerkAuthProvider: AuthTokenProvider {
+    func bearerToken() async throws -> String {
+        guard let token = try await Clerk.shared.auth.getToken() else {
+            throw AuthProviderError.signedOut
+        }
+        return token
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,43 @@
+# Zero iOS
+
+This is a native-only iOS voice chat client for Zero.
+
+The app intentionally does not include a WebView shell, web session bridge, or
+platform page navigation. The only product flow in this target is:
+
+1. Sign in with native Clerk.
+2. Enter an agent ID.
+3. Start a native OpenAI Realtime voice chat against the existing
+   `/api/zero/voice-chat` endpoints.
+
+## Configuration
+
+Set these build settings in Xcode before running on a device:
+
+- `CLERK_PUBLISHABLE_KEY`: Clerk publishable key for the vm0 frontend API.
+- `ZERO_API_BASE_URL`: vm0 API origin. Defaults to `https://api.vm0.ai` when
+  unset.
+
+The app target uses:
+
+- Bundle identifier: `ai.vm0.zero`
+- Minimum iOS version: `17.0`
+- Clerk iOS SDK packages: `ClerkKit`, `ClerkKitUI`
+- WebRTC Swift package: `https://github.com/stasel/WebRTC.git`
+
+## Scope
+
+This target reuses the existing voice chat backend contract:
+
+- `POST /api/zero/voice-chat`
+- `POST /api/zero/voice-chat/token`
+- `POST /api/zero/voice-chat/:id/items`
+- `POST /api/zero/voice-chat/:id/tasks`
+- `GET /api/zero/voice-chat/:id`
+- `GET /api/zero/voice-chat/:id/tasks`
+- `POST /api/zero/voice-chat/:id/session-started`
+- `POST /api/zero/voice-chat/:id/session-ended`
+- `POST /api/zero/voice-chat/:id/usage`
+
+Realtime connects directly to OpenAI with the server-minted client secret and
+POSTs SDP to `https://api.openai.com/v1/realtime/calls`.

--- a/ios/Tests/RealtimeEventParserTests.swift
+++ b/ios/Tests/RealtimeEventParserTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import Zero
+
+final class RealtimeEventParserTests: XCTestCase {
+    func testParsesResponseDoneUsage() throws {
+        let json = """
+        {
+          "type": "response.done",
+          "event_id": "evt_1",
+          "response": {
+            "id": "resp_1",
+            "status": "completed",
+            "usage": {
+              "input_token_details": {
+                "text_tokens": 11,
+                "audio_tokens": 22,
+                "cached_tokens_details": {
+                  "text_tokens": 3,
+                  "audio_tokens": 4
+                }
+              },
+              "output_token_details": {
+                "text_tokens": 5,
+                "audio_tokens": 6
+              }
+            }
+          }
+        }
+        """
+
+        let action = try RealtimeEventParser().parse(json)
+
+        XCTAssertEqual(
+            action,
+            .responseDone(
+                VoiceChatUsageEvent(
+                    providerEventId: "evt_1",
+                    eventType: .responseDone,
+                    inputTextTokens: 11,
+                    inputAudioTokens: 22,
+                    inputCachedTextTokens: 3,
+                    inputCachedAudioTokens: 4,
+                    outputTextTokens: 5,
+                    outputAudioTokens: 6
+                )
+            )
+        )
+    }
+
+    func testParsesTranscriptionCompletedUsage() throws {
+        let json = """
+        {
+          "type": "conversation.item.input_audio_transcription.completed",
+          "item_id": "item_1",
+          "content_index": 0,
+          "transcript": "hello",
+          "usage": {
+            "type": "tokens",
+            "input_token_details": {
+              "text_tokens": 7,
+              "audio_tokens": 8
+            },
+            "output_tokens": 9
+          }
+        }
+        """
+
+        let action = try RealtimeEventParser().parse(json)
+
+        XCTAssertEqual(
+            action,
+            .userTranscriptCompleted(
+                itemId: "item_1",
+                transcript: "hello",
+                usage: VoiceChatUsageEvent(
+                    providerEventId: "item_1:0",
+                    eventType: .transcriptionCompleted,
+                    inputTextTokens: 7,
+                    inputAudioTokens: 8,
+                    inputCachedTextTokens: nil,
+                    inputCachedAudioTokens: nil,
+                    outputTextTokens: 9,
+                    outputAudioTokens: nil
+                )
+            )
+        )
+    }
+
+    func testParsesFunctionCallArguments() throws {
+        let json = """
+        {
+          "type": "response.function_call_arguments.done",
+          "name": "inform_slow_brain",
+          "call_id": "call_1",
+          "arguments": "{\\"prompt\\":\\"make a task\\"}"
+        }
+        """
+
+        let action = try RealtimeEventParser().parse(json)
+
+        XCTAssertEqual(
+            action,
+            .functionCall(
+                name: "inform_slow_brain",
+                callId: "call_1",
+                arguments: "{\"prompt\":\"make a task\"}"
+            )
+        )
+    }
+}

--- a/ios/Tests/ZeroAPIClientTests.swift
+++ b/ios/Tests/ZeroAPIClientTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import XCTest
+@testable import Zero
+
+final class ZeroAPIClientTests: XCTestCase {
+    func testCreateSessionAddsFreshBearerTokenAndJSONBody() async throws {
+        let session = CapturingURLSession(
+            data: """
+            {
+              "session": {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "orgId": "org_1",
+                "userId": "user_1",
+                "agentId": "00000000-0000-0000-0000-000000000002",
+                "mode": "chat",
+                "conversationSummary": null,
+                "workingTasksSummary": null,
+                "finishedTasksSummary": null,
+                "summarySeq": 0,
+                "summaryVersion": 0,
+                "lastSummaryAt": null,
+                "createdAt": "2026-05-11T00:00:00.000Z"
+              },
+              "recentTaskLogs": "",
+              "finishedTasksFullText": "",
+              "talkerInstructions": "talk",
+              "talkerInstructionTokens": 1
+            }
+            """.data(using: .utf8)!
+        )
+        let client = ZeroAPIClient(
+            baseURL: URL(string: "https://api.test")!,
+            authTokenProvider: StaticAuthProvider(token: "clerk-session"),
+            urlSession: session
+        )
+
+        let response = try await client.createSession(
+            agentId: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+        )
+
+        XCTAssertEqual(response.talkerInstructions, "talk")
+        let request = try XCTUnwrap(session.requests.first)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "https://api.test/api/zero/voice-chat"
+        )
+        XCTAssertEqual(
+            request.value(forHTTPHeaderField: "Authorization"),
+            "Bearer clerk-session"
+        )
+        let body = try XCTUnwrap(request.httpBody)
+        let decoded = try JSONSerialization.jsonObject(with: body) as? [String: String]
+        XCTAssertEqual(
+            decoded?["agentId"],
+            "00000000-0000-0000-0000-000000000002"
+        )
+    }
+
+    func testThrowsAPIErrorBody() async throws {
+        let session = CapturingURLSession(
+            statusCode: 403,
+            data: """
+            {
+              "error": {
+                "message": "Voice chat is not enabled",
+                "code": "FORBIDDEN"
+              }
+            }
+            """.data(using: .utf8)!
+        )
+        let client = ZeroAPIClient(
+            baseURL: URL(string: "https://api.test")!,
+            authTokenProvider: StaticAuthProvider(token: "clerk-session"),
+            urlSession: session
+        )
+
+        do {
+            _ = try await client.listTasks(
+                sessionId: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+            )
+            XCTFail("Expected API error")
+        } catch let error as ZeroAPIError {
+            XCTAssertEqual(error.statusCode, 403)
+            XCTAssertEqual(error.code, "FORBIDDEN")
+            XCTAssertEqual(error.message, "Voice chat is not enabled")
+        }
+    }
+}
+
+private struct StaticAuthProvider: AuthTokenProvider {
+    let token: String
+
+    func bearerToken() async throws -> String {
+        token
+    }
+}
+
+private final class CapturingURLSession: URLSessioning, @unchecked Sendable {
+    private let statusCode: Int
+    private let data: Data
+    private(set) var requests: [URLRequest] = []
+
+    init(statusCode: Int = 200, data: Data) {
+        self.statusCode = statusCode
+        self.data = data
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        requests.append(request)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (data, response)
+    }
+}

--- a/ios/VoiceChat/OpenAIRealtimeWebRTCClient.swift
+++ b/ios/VoiceChat/OpenAIRealtimeWebRTCClient.swift
@@ -1,0 +1,277 @@
+import Foundation
+import WebRTC
+
+final class OpenAIRealtimeWebRTCClient: NSObject, RealtimeTransport {
+    weak var delegate: RealtimeTransportDelegate?
+
+    private let callsURL = URL(
+        string: "https://api.openai.com/v1/realtime/calls"
+    )!
+    private let urlSession: URLSessioning
+    private let peerConnectionFactory: RTCPeerConnectionFactory
+    private var peerConnection: RTCPeerConnection?
+    private var dataChannel: RTCDataChannel?
+    private var audioTrack: RTCAudioTrack?
+
+    init(urlSession: URLSessioning = URLSession.shared) {
+        RTCPeerConnectionFactory.initialize()
+        self.urlSession = urlSession
+        peerConnectionFactory = RTCPeerConnectionFactory(
+            encoderFactory: RTCDefaultVideoEncoderFactory(),
+            decoderFactory: RTCDefaultVideoDecoderFactory()
+        )
+        super.init()
+    }
+
+    func connect(clientSecret: String) async throws {
+        let configuration = RTCConfiguration()
+        configuration.sdpSemantics = .unifiedPlan
+        configuration.continualGatheringPolicy = .gatherContinually
+
+        let constraints = RTCMediaConstraints(
+            mandatoryConstraints: nil,
+            optionalConstraints: nil
+        )
+        guard
+            let peerConnection = peerConnectionFactory.peerConnection(
+                with: configuration,
+                constraints: constraints,
+                delegate: self
+            )
+        else {
+            throw RealtimeTransportError.invalidServerResponse
+        }
+        self.peerConnection = peerConnection
+
+        let audioSource = peerConnectionFactory.audioSource(with: constraints)
+        let audioTrack = peerConnectionFactory.audioTrack(
+            with: audioSource,
+            trackId: "zero-audio"
+        )
+        self.audioTrack = audioTrack
+        peerConnection.add(audioTrack, streamIds: ["zero"])
+
+        let dataChannelConfig = RTCDataChannelConfiguration()
+        guard
+            let dataChannel = peerConnection.dataChannel(
+                forLabel: "oai-events",
+                configuration: dataChannelConfig
+            )
+        else {
+            throw RealtimeTransportError.invalidServerResponse
+        }
+        dataChannel.delegate = self
+        self.dataChannel = dataChannel
+
+        let offer = try await offer(peerConnection, constraints: constraints)
+        try await setLocalDescription(offer, peerConnection: peerConnection)
+        guard let localDescription = peerConnection.localDescription else {
+            throw RealtimeTransportError.missingLocalDescription
+        }
+
+        let answerSDP = try await exchangeSDP(
+            localDescription.sdp,
+            clientSecret: clientSecret
+        )
+        let answer = RTCSessionDescription(type: .answer, sdp: answerSDP)
+        try await setRemoteDescription(answer, peerConnection: peerConnection)
+    }
+
+    func send(jsonString: String) throws {
+        guard let dataChannel, dataChannel.readyState == .open else {
+            throw RealtimeTransportError.dataChannelNotOpen
+        }
+        let data = Data(jsonString.utf8)
+        dataChannel.sendData(RTCDataBuffer(data: data, isBinary: false))
+    }
+
+    func setMicrophoneMuted(_ muted: Bool) {
+        audioTrack?.isEnabled = !muted
+    }
+
+    func close() {
+        dataChannel?.close()
+        dataChannel = nil
+        peerConnection?.close()
+        peerConnection = nil
+        audioTrack = nil
+    }
+
+    private func exchangeSDP(
+        _ sdp: String,
+        clientSecret: String
+    ) async throws -> String {
+        var request = URLRequest(url: callsURL)
+        request.httpMethod = "POST"
+        request.httpBody = Data(sdp.utf8)
+        request.setValue(
+            "Bearer \(clientSecret)",
+            forHTTPHeaderField: "Authorization"
+        )
+        request.setValue("application/sdp", forHTTPHeaderField: "Content-Type")
+
+        let (data, response) = try await urlSession.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw RealtimeTransportError.invalidServerResponse
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw RealtimeTransportError.sdpExchangeFailed(
+                httpResponse.statusCode
+            )
+        }
+        guard let answer = String(data: data, encoding: .utf8) else {
+            throw RealtimeTransportError.invalidServerResponse
+        }
+        return answer
+    }
+
+    private func offer(
+        _ peerConnection: RTCPeerConnection,
+        constraints: RTCMediaConstraints
+    ) async throws -> RTCSessionDescription {
+        try await withCheckedThrowingContinuation { continuation in
+            peerConnection.offer(for: constraints) { sdp, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let sdp else {
+                    continuation.resume(
+                        throwing: RealtimeTransportError.missingLocalDescription
+                    )
+                    return
+                }
+                continuation.resume(returning: sdp)
+            }
+        }
+    }
+
+    private func setLocalDescription(
+        _ description: RTCSessionDescription,
+        peerConnection: RTCPeerConnection
+    ) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            peerConnection.setLocalDescription(description) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: ())
+            }
+        }
+    }
+
+    private func setRemoteDescription(
+        _ description: RTCSessionDescription,
+        peerConnection: RTCPeerConnection
+    ) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            peerConnection.setRemoteDescription(description) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: ())
+            }
+        }
+    }
+}
+
+extension OpenAIRealtimeWebRTCClient: RTCDataChannelDelegate {
+    func dataChannelDidChangeState(_ dataChannel: RTCDataChannel) {
+        switch dataChannel.readyState {
+        case .open:
+            delegate?.realtimeTransportDidOpen(self)
+        case .closed:
+            delegate?.realtimeTransportDidClose(self)
+        default:
+            break
+        }
+    }
+
+    func dataChannel(
+        _ dataChannel: RTCDataChannel,
+        didReceiveMessageWith buffer: RTCDataBuffer
+    ) {
+        guard
+            !buffer.isBinary,
+            let text = String(data: buffer.data, encoding: .utf8)
+        else {
+            return
+        }
+        delegate?.realtimeTransport(self, didReceive: text)
+    }
+}
+
+extension OpenAIRealtimeWebRTCClient: RTCPeerConnectionDelegate {
+    func peerConnection(
+        _ peerConnection: RTCPeerConnection,
+        didChange stateChanged: RTCSignalingState
+    ) {}
+
+    func peerConnection(
+        _ peerConnection: RTCPeerConnection,
+        didAdd stream: RTCMediaStream
+    ) {}
+
+    func peerConnection(
+        _ peerConnection: RTCPeerConnection,
+        didRemove stream: RTCMediaStream
+    ) {}
+
+    func peerConnectionShouldNegotiate(
+        _ peerConnection: RTCPeerConnection
+    ) {}
+
+    func peerConnection(
+        _ peerConnection: RTCPeerConnection,
+        didChange newState: RTCIceConnectionState
+    ) {
+        switch newState {
+        case .failed, .disconnected, .closed:
+            delegate?.realtimeTransportDidClose(self)
+        default:
+            break
+        }
+    }
+
+    func peerConnection(
+        _ peerConnection: RTCPeerConnection,
+        didChange newState: RTCPeerConnectionState
+    ) {
+        switch newState {
+        case .failed, .disconnected, .closed:
+            delegate?.realtimeTransportDidClose(self)
+        default:
+            break
+        }
+    }
+
+    func peerConnection(
+        _ peerConnection: RTCPeerConnection,
+        didChange newState: RTCIceGatheringState
+    ) {}
+
+    func peerConnection(
+        _ peerConnection: RTCPeerConnection,
+        didGenerate candidate: RTCIceCandidate
+    ) {}
+
+    func peerConnection(
+        _ peerConnection: RTCPeerConnection,
+        didRemove candidates: [RTCIceCandidate]
+    ) {}
+
+    func peerConnection(
+        _ peerConnection: RTCPeerConnection,
+        didOpen dataChannel: RTCDataChannel
+    ) {
+        dataChannel.delegate = self
+        self.dataChannel = dataChannel
+    }
+
+    func peerConnection(
+        _ peerConnection: RTCPeerConnection,
+        didStartReceivingOn transceiver: RTCRtpTransceiver
+    ) {}
+}

--- a/ios/VoiceChat/OpenAIRealtimeWebRTCClient.swift
+++ b/ios/VoiceChat/OpenAIRealtimeWebRTCClient.swift
@@ -150,7 +150,8 @@ final class OpenAIRealtimeWebRTCClient: NSObject, RealtimeTransport {
         _ description: RTCSessionDescription,
         peerConnection: RTCPeerConnection
     ) async throws {
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, Error>) in
             peerConnection.setLocalDescription(description) { error in
                 if let error {
                     continuation.resume(throwing: error)
@@ -165,7 +166,8 @@ final class OpenAIRealtimeWebRTCClient: NSObject, RealtimeTransport {
         _ description: RTCSessionDescription,
         peerConnection: RTCPeerConnection
     ) async throws {
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, Error>) in
             peerConnection.setRemoteDescription(description) { error in
                 if let error {
                     continuation.resume(throwing: error)

--- a/ios/VoiceChat/RealtimeEventParser.swift
+++ b/ios/VoiceChat/RealtimeEventParser.swift
@@ -1,0 +1,272 @@
+import Foundation
+
+enum RealtimeEventAction: Equatable {
+    case assistantMessageStarted(itemId: String)
+    case assistantTranscriptDelta(String)
+    case assistantTranscriptDone(itemId: String, transcript: String)
+    case functionCall(name: String, callId: String, arguments: String)
+    case responseDone(VoiceChatUsageEvent)
+    case speechStarted
+    case userTranscriptCompleted(
+        itemId: String,
+        transcript: String,
+        usage: VoiceChatUsageEvent?
+    )
+}
+
+struct RealtimeEventParser {
+    private let decoder = JSONDecoder()
+
+    func parse(_ text: String) throws -> RealtimeEventAction? {
+        guard let data = text.data(using: .utf8) else {
+            return nil
+        }
+        return try parse(data)
+    }
+
+    func parse(_ data: Data) throws -> RealtimeEventAction? {
+        let event = try decoder.decode(RealtimeServerEvent.self, from: data)
+        switch event.type {
+        case "conversation.item.created":
+            guard
+                event.item?.type == "message",
+                event.item?.role == "assistant",
+                let itemId = event.item?.id
+            else {
+                return nil
+            }
+            return .assistantMessageStarted(itemId: itemId)
+
+        case "conversation.item.input_audio_transcription.completed":
+            guard let itemId = event.itemId else {
+                return nil
+            }
+            return .userTranscriptCompleted(
+                itemId: itemId,
+                transcript: event.transcript ?? "",
+                usage: extractTranscriptionUsage(event)
+            )
+
+        case "response.audio_transcript.delta":
+            guard let delta = event.delta, !delta.isEmpty else {
+                return nil
+            }
+            return .assistantTranscriptDelta(delta)
+
+        case "response.audio_transcript.done":
+            guard let itemId = event.itemId ?? event.responseId else {
+                return nil
+            }
+            return .assistantTranscriptDone(
+                itemId: itemId,
+                transcript: event.transcript ?? ""
+            )
+
+        case "input_audio_buffer.speech_started":
+            return .speechStarted
+
+        case "response.function_call_arguments.done":
+            guard
+                let name = event.name,
+                let callId = event.callId,
+                let arguments = event.arguments
+            else {
+                return nil
+            }
+            return .functionCall(
+                name: name,
+                callId: callId,
+                arguments: arguments
+            )
+
+        case "response.done":
+            guard let usage = extractResponseDoneUsage(event) else {
+                return nil
+            }
+            return .responseDone(usage)
+
+        default:
+            return nil
+        }
+    }
+
+    private func extractResponseDoneUsage(
+        _ event: RealtimeServerEvent
+    ) -> VoiceChatUsageEvent? {
+        guard let usage = event.response?.usage else {
+            return nil
+        }
+        return VoiceChatUsageEvent(
+            providerEventId: deriveProviderEventId(
+                event,
+                fallbackPrefix: "response.done"
+            ),
+            eventType: .responseDone,
+            inputTextTokens: usage.inputTokenDetails?.textTokens,
+            inputAudioTokens: usage.inputTokenDetails?.audioTokens,
+            inputCachedTextTokens:
+                usage.inputTokenDetails?.cachedTokensDetails?.textTokens,
+            inputCachedAudioTokens:
+                usage.inputTokenDetails?.cachedTokensDetails?.audioTokens,
+            outputTextTokens: usage.outputTokenDetails?.textTokens,
+            outputAudioTokens: usage.outputTokenDetails?.audioTokens
+        )
+    }
+
+    private func extractTranscriptionUsage(
+        _ event: RealtimeServerEvent
+    ) -> VoiceChatUsageEvent? {
+        guard let usage = event.usage, usage.type == "tokens" else {
+            return nil
+        }
+        return VoiceChatUsageEvent(
+            providerEventId: deriveProviderEventId(
+                event,
+                fallbackPrefix: "transcription"
+            ),
+            eventType: .transcriptionCompleted,
+            inputTextTokens: usage.inputTokenDetails?.textTokens,
+            inputAudioTokens: usage.inputTokenDetails?.audioTokens,
+            inputCachedTextTokens: nil,
+            inputCachedAudioTokens: nil,
+            outputTextTokens: usage.outputTokens,
+            outputAudioTokens: nil
+        )
+    }
+
+    private func deriveProviderEventId(
+        _ event: RealtimeServerEvent,
+        fallbackPrefix: String
+    ) -> String {
+        if let eventId = event.eventId {
+            return eventId
+        }
+        if let responseId = event.response?.id {
+            return responseId
+        }
+        if let itemId = event.itemId {
+            return "\(itemId):\(event.contentIndex ?? 0)"
+        }
+        return "\(fallbackPrefix):\(UUID().uuidString)"
+    }
+}
+
+private struct RealtimeServerEvent: Decodable {
+    struct Item: Decodable {
+        let id: String
+        let type: String
+        let role: String?
+    }
+
+    struct Response: Decodable {
+        let id: String?
+        let status: String?
+        let usage: RealtimeUsageBreakdown?
+    }
+
+    let type: String
+    let eventId: String?
+    let itemId: String?
+    let item: Item?
+    let transcript: String?
+    let responseId: String?
+    let delta: String?
+    let callId: String?
+    let name: String?
+    let arguments: String?
+    let contentIndex: Int?
+    let response: Response?
+    let usage: TranscriptionUsage?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case eventId = "event_id"
+        case itemId = "item_id"
+        case item
+        case transcript
+        case responseId = "response_id"
+        case delta
+        case callId = "call_id"
+        case name
+        case arguments
+        case contentIndex = "content_index"
+        case response
+        case usage
+    }
+}
+
+private struct RealtimeUsageBreakdown: Decodable {
+    struct InputTokenDetails: Decodable {
+        struct CachedTokensDetails: Decodable {
+            let textTokens: Int?
+            let audioTokens: Int?
+
+            enum CodingKeys: String, CodingKey {
+                case textTokens = "text_tokens"
+                case audioTokens = "audio_tokens"
+            }
+        }
+
+        let textTokens: Int?
+        let audioTokens: Int?
+        let cachedTokens: Int?
+        let cachedTokensDetails: CachedTokensDetails?
+
+        enum CodingKeys: String, CodingKey {
+            case textTokens = "text_tokens"
+            case audioTokens = "audio_tokens"
+            case cachedTokens = "cached_tokens"
+            case cachedTokensDetails = "cached_tokens_details"
+        }
+    }
+
+    struct OutputTokenDetails: Decodable {
+        let textTokens: Int?
+        let audioTokens: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case textTokens = "text_tokens"
+            case audioTokens = "audio_tokens"
+        }
+    }
+
+    let totalTokens: Int?
+    let inputTokens: Int?
+    let outputTokens: Int?
+    let inputTokenDetails: InputTokenDetails?
+    let outputTokenDetails: OutputTokenDetails?
+
+    enum CodingKeys: String, CodingKey {
+        case totalTokens = "total_tokens"
+        case inputTokens = "input_tokens"
+        case outputTokens = "output_tokens"
+        case inputTokenDetails = "input_token_details"
+        case outputTokenDetails = "output_token_details"
+    }
+}
+
+private struct TranscriptionUsage: Decodable {
+    struct InputTokenDetails: Decodable {
+        let textTokens: Int?
+        let audioTokens: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case textTokens = "text_tokens"
+            case audioTokens = "audio_tokens"
+        }
+    }
+
+    let type: String?
+    let inputTokens: Int?
+    let outputTokens: Int?
+    let totalTokens: Int?
+    let inputTokenDetails: InputTokenDetails?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case inputTokens = "input_tokens"
+        case outputTokens = "output_tokens"
+        case totalTokens = "total_tokens"
+        case inputTokenDetails = "input_token_details"
+    }
+}

--- a/ios/VoiceChat/RealtimeTransport.swift
+++ b/ios/VoiceChat/RealtimeTransport.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+protocol RealtimeTransportDelegate: AnyObject {
+    func realtimeTransportDidOpen(_ transport: RealtimeTransport)
+    func realtimeTransportDidClose(_ transport: RealtimeTransport)
+    func realtimeTransport(_ transport: RealtimeTransport, didReceive text: String)
+    func realtimeTransport(_ transport: RealtimeTransport, didFail error: Error)
+}
+
+protocol RealtimeTransport: AnyObject {
+    var delegate: RealtimeTransportDelegate? { get set }
+
+    func connect(clientSecret: String) async throws
+    func send(jsonString: String) throws
+    func setMicrophoneMuted(_ muted: Bool)
+    func close()
+}
+
+enum RealtimeTransportError: LocalizedError, Equatable {
+    case missingLocalDescription
+    case invalidServerResponse
+    case dataChannelNotOpen
+    case sdpExchangeFailed(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingLocalDescription:
+            return "Failed to create a local WebRTC offer."
+        case .invalidServerResponse:
+            return "OpenAI Realtime returned an invalid response."
+        case .dataChannelNotOpen:
+            return "Realtime data channel is not open."
+        case .sdpExchangeFailed(let statusCode):
+            return "OpenAI Realtime SDP exchange failed with status \(statusCode)."
+        }
+    }
+}
+
+struct RealtimeClientEvents {
+    struct SessionUpdate: Encodable {
+        struct Session: Encodable {
+            let instructions: String
+        }
+
+        let type = "session.update"
+        let session: Session
+    }
+
+    struct FunctionOutput: Encodable {
+        struct Item: Encodable {
+            let type = "function_call_output"
+            let callId: String
+            let output: String
+
+            enum CodingKeys: String, CodingKey {
+                case type
+                case callId = "call_id"
+                case output
+            }
+        }
+
+        let type = "conversation.item.create"
+        let item: Item
+    }
+
+    struct TruncateAssistantAudio: Encodable {
+        let type = "conversation.item.truncate"
+        let itemId: String
+        let contentIndex: Int
+        let audioEndMs: Int
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case itemId = "item_id"
+            case contentIndex = "content_index"
+            case audioEndMs = "audio_end_ms"
+        }
+    }
+
+    static func encode<Event: Encodable>(_ event: Event) throws -> String {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(event)
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/ios/VoiceChat/VoiceChatController.swift
+++ b/ios/VoiceChat/VoiceChatController.swift
@@ -1,0 +1,462 @@
+import Foundation
+
+enum VoiceChatConnectionState: Equatable {
+    case idle
+    case connecting
+    case connected
+    case disconnected
+    case failed(String)
+
+    var label: String {
+        switch self {
+        case .idle:
+            return "Idle"
+        case .connecting:
+            return "Connecting"
+        case .connected:
+            return "Connected"
+        case .disconnected:
+            return "Disconnected"
+        case .failed:
+            return "Failed"
+        }
+    }
+}
+
+@MainActor
+final class VoiceChatController: NSObject, ObservableObject {
+    @Published private(set) var state: VoiceChatConnectionState = .idle
+    @Published private(set) var sessionId: UUID?
+    @Published private(set) var lastUserTranscript = ""
+    @Published private(set) var lastAssistantTranscript = ""
+    @Published private(set) var tasks: [VoiceChatTask] = []
+    @Published var isMuted = false {
+        didSet {
+            transport?.setMicrophoneMuted(isMuted)
+        }
+    }
+
+    private let apiClient: ZeroAPIClient
+    private let audioSession: AudioSessionControlling
+    private let makeRealtimeTransport: () -> RealtimeTransport
+    private let parser = RealtimeEventParser()
+    private let supportedToolNames = Set([
+        "inform_slow_brain",
+        "feel_confused",
+        "feel_unable",
+        "want_to_ask_user",
+        "want_to_reject",
+        "want_to_apologize",
+    ])
+
+    private var audioConfig = VoiceChatAudioConfig(
+        noiseReduction: .farField,
+        bargeInMode: .speechStarted
+    )
+    private var transport: RealtimeTransport?
+    private var connectTask: Task<Void, Never>?
+    private var pollTask: Task<Void, Never>?
+    private var relaySessionId: UUID?
+    private var lastTalkerInstructions = ""
+    private var currentAssistantAudio: AssistantAudioState?
+
+    init(
+        apiClient: ZeroAPIClient,
+        audioSession: AudioSessionControlling,
+        makeRealtimeTransport: @escaping () -> RealtimeTransport
+    ) {
+        self.apiClient = apiClient
+        self.audioSession = audioSession
+        self.makeRealtimeTransport = makeRealtimeTransport
+    }
+
+    func start(agentId: UUID) {
+        endLocalResources()
+        state = .connecting
+        lastUserTranscript = ""
+        lastAssistantTranscript = ""
+        tasks = []
+        sessionId = nil
+        relaySessionId = nil
+        isMuted = false
+
+        connectTask = Task { [weak self] in
+            guard let self else {
+                return
+            }
+            await self.connect(agentId: agentId)
+        }
+    }
+
+    func end() {
+        let currentSessionId = sessionId
+        let currentRelaySessionId = relaySessionId
+        endLocalResources()
+        state = .idle
+        sessionId = nil
+        relaySessionId = nil
+        currentAssistantAudio = nil
+
+        Task { [apiClient, audioSession] in
+            if let currentSessionId, let currentRelaySessionId {
+                try? await apiClient.sessionEnded(
+                    sessionId: currentSessionId,
+                    relaySessionId: currentRelaySessionId
+                )
+            }
+            await audioSession.deactivate()
+        }
+    }
+
+    private func connect(agentId: UUID) async {
+        do {
+            audioConfig = try await audioSession.prepareForVoiceChat()
+
+            let sessionResponse = try await apiClient.createSession(
+                agentId: agentId
+            )
+            sessionId = sessionResponse.session.id
+            lastTalkerInstructions = sessionResponse.talkerInstructions
+
+            let tokenResponse = try await apiClient.mintRealtimeToken(
+                sessionId: sessionResponse.session.id,
+                noiseReduction: audioConfig.noiseReduction
+            )
+
+            let started = try? await apiClient.sessionStarted(
+                sessionId: sessionResponse.session.id
+            )
+            relaySessionId = started?.id
+
+            let transport = makeRealtimeTransport()
+            transport.delegate = self
+            self.transport = transport
+            transport.setMicrophoneMuted(isMuted)
+            try await transport.connect(
+                clientSecret: tokenResponse.clientSecret.value
+            )
+
+            startPolling()
+        } catch is CancellationError {
+            state = .idle
+        } catch {
+            state = .failed(error.localizedDescription)
+            try? await apiClient.sessionEndedIfPossible(
+                sessionId: sessionId,
+                relaySessionId: relaySessionId
+            )
+            await audioSession.deactivate()
+            endLocalResources()
+        }
+    }
+
+    private func startPolling() {
+        pollTask?.cancel()
+        pollTask = Task { [weak self] in
+            guard let self else {
+                return
+            }
+            await self.refreshServerState()
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 5_000_000_000)
+                await self.refreshServerState()
+            }
+        }
+    }
+
+    private func refreshServerState() async {
+        guard let sessionId, state == .connected else {
+            return
+        }
+
+        async let session = apiClient.getSession(id: sessionId)
+        async let taskList = apiClient.listTasks(sessionId: sessionId)
+
+        if let response = try? await session {
+            await pushInstructionsIfNeeded(response.talkerInstructions)
+        }
+        if let taskList = try? await taskList {
+            tasks = taskList
+        }
+    }
+
+    private func pushInstructionsIfNeeded(_ instructions: String) async {
+        guard
+            instructions != lastTalkerInstructions,
+            let transport
+        else {
+            return
+        }
+        lastTalkerInstructions = instructions
+        let event = RealtimeClientEvents.SessionUpdate(
+            session: .init(instructions: instructions)
+        )
+        if let json = try? RealtimeClientEvents.encode(event) {
+            try? transport.send(jsonString: json)
+        }
+    }
+
+    private func handleRealtimeMessage(_ text: String) async {
+        guard let action = try? parser.parse(text) else {
+            return
+        }
+
+        switch action {
+        case .assistantMessageStarted(let itemId):
+            currentAssistantAudio = AssistantAudioState(
+                itemId: itemId,
+                startedAt: Date(),
+                transcript: ""
+            )
+
+        case .assistantTranscriptDelta(let delta):
+            currentAssistantAudio?.transcript += delta
+
+        case .assistantTranscriptDone(let itemId, let transcript):
+            let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, let sessionId else {
+                return
+            }
+            lastAssistantTranscript = transcript
+            try? await apiClient.appendItem(
+                sessionId: sessionId,
+                role: .assistant,
+                content: transcript,
+                realtimeItemId: itemId
+            )
+
+        case .userTranscriptCompleted(let itemId, let transcript, let usage):
+            if audioConfig.bargeInMode == .transcriptConfirmed,
+                !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                await truncateCurrentAssistantAudio()
+            }
+            guard let sessionId else {
+                return
+            }
+            if !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                lastUserTranscript = transcript
+                try? await apiClient.appendItem(
+                    sessionId: sessionId,
+                    role: .user,
+                    content: transcript,
+                    realtimeItemId: itemId
+                )
+            }
+            if let usage {
+                await postUsage(usage)
+            }
+
+        case .speechStarted:
+            if audioConfig.bargeInMode == .speechStarted {
+                await truncateCurrentAssistantAudio()
+            }
+
+        case .functionCall(let name, let callId, let arguments):
+            await handleToolCall(name: name, callId: callId, arguments: arguments)
+
+        case .responseDone(let usage):
+            await postUsage(usage)
+        }
+    }
+
+    private func handleToolCall(
+        name: String,
+        callId: String,
+        arguments: String
+    ) async {
+        guard supportedToolNames.contains(name), let sessionId else {
+            return
+        }
+
+        let prompt: String
+        do {
+            let payload = try JSONDecoder().decode(
+                TalkerToolArguments.self,
+                from: Data(arguments.utf8)
+            )
+            prompt = payload.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            sendFunctionOutput(
+                callId: callId,
+                output: "Inform failed: invalid args."
+            )
+            return
+        }
+
+        guard !prompt.isEmpty else {
+            sendFunctionOutput(callId: callId, output: "Inform failed: empty prompt.")
+            return
+        }
+
+        do {
+            let task = try await apiClient.createTask(
+                sessionId: sessionId,
+                prompt: prompt,
+                callId: callId
+            )
+            upsertTask(task)
+            sendFunctionOutput(
+                callId: callId,
+                output:
+                    "Slow brain informed: '\(shortPrompt(prompt))'. It will decide what to do and report back."
+            )
+        } catch {
+            sendFunctionOutput(
+                callId: callId,
+                output: "Failed to reach the slow brain. Please try again or rephrase."
+            )
+        }
+    }
+
+    private func sendFunctionOutput(callId: String, output: String) {
+        let event = RealtimeClientEvents.FunctionOutput(
+            item: .init(callId: callId, output: output)
+        )
+        guard let json = try? RealtimeClientEvents.encode(event) else {
+            return
+        }
+        try? transport?.send(jsonString: json)
+    }
+
+    private func truncateCurrentAssistantAudio() async {
+        guard let currentAssistantAudio, let transport else {
+            return
+        }
+        let playedMs = max(
+            0,
+            Int(Date().timeIntervalSince(currentAssistantAudio.startedAt) * 1000)
+        )
+        let truncate = RealtimeClientEvents.TruncateAssistantAudio(
+            itemId: currentAssistantAudio.itemId,
+            contentIndex: 0,
+            audioEndMs: playedMs
+        )
+        if let json = try? RealtimeClientEvents.encode(truncate) {
+            try? transport.send(jsonString: json)
+        }
+
+        if let sessionId {
+            let note = AssistantInterruptedNote(
+                assistantRealtimeItemId: currentAssistantAudio.itemId,
+                heardText: currentAssistantAudio.transcript
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                audioEndMs: playedMs
+            )
+            if let noteData = try? JSONEncoder().encode(note),
+                let noteJSON = String(data: noteData, encoding: .utf8)
+            {
+                try? await apiClient.appendItem(
+                    sessionId: sessionId,
+                    role: .systemNote,
+                    content: noteJSON,
+                    realtimeItemId: "truncate:\(currentAssistantAudio.itemId)"
+                )
+            }
+        }
+
+        self.currentAssistantAudio = nil
+    }
+
+    private func postUsage(_ usage: VoiceChatUsageEvent) async {
+        guard let sessionId else {
+            return
+        }
+        let response = try? await apiClient.postUsageEvent(
+            sessionId: sessionId,
+            event: usage
+        )
+        if response?.creditsExhausted == true {
+            let message = "Voice-chat credits exhausted; the session has ended."
+            end()
+            state = .failed(message)
+        }
+    }
+
+    private func upsertTask(_ task: VoiceChatTask) {
+        if let index = tasks.firstIndex(where: { $0.id == task.id }) {
+            tasks[index] = task
+        } else {
+            tasks.insert(task, at: 0)
+        }
+    }
+
+    private func endLocalResources() {
+        connectTask?.cancel()
+        connectTask = nil
+        pollTask?.cancel()
+        pollTask = nil
+        transport?.close()
+        transport = nil
+    }
+
+    private func shortPrompt(_ prompt: String, max: Int = 60) -> String {
+        if prompt.count <= max {
+            return prompt
+        }
+        return "\(prompt.prefix(max - 1))..."
+    }
+}
+
+extension VoiceChatController: RealtimeTransportDelegate {
+    nonisolated func realtimeTransportDidOpen(_ transport: RealtimeTransport) {
+        Task { @MainActor in
+            state = .connected
+        }
+    }
+
+    nonisolated func realtimeTransportDidClose(_ transport: RealtimeTransport) {
+        Task { @MainActor in
+            if state == .connected {
+                state = .disconnected
+            }
+        }
+    }
+
+    nonisolated func realtimeTransport(
+        _ transport: RealtimeTransport,
+        didReceive text: String
+    ) {
+        Task { @MainActor in
+            await handleRealtimeMessage(text)
+        }
+    }
+
+    nonisolated func realtimeTransport(
+        _ transport: RealtimeTransport,
+        didFail error: Error
+    ) {
+        Task { @MainActor in
+            state = .failed(error.localizedDescription)
+        }
+    }
+}
+
+private extension ZeroAPIClient {
+    func sessionEndedIfPossible(
+        sessionId: UUID?,
+        relaySessionId: UUID?
+    ) async throws {
+        guard let sessionId, let relaySessionId else {
+            return
+        }
+        try await sessionEnded(sessionId: sessionId, relaySessionId: relaySessionId)
+    }
+}
+
+private struct AssistantAudioState {
+    let itemId: String
+    let startedAt: Date
+    var transcript: String
+}
+
+private struct TalkerToolArguments: Decodable {
+    let prompt: String
+}
+
+private struct AssistantInterruptedNote: Encodable {
+    let type = "assistant_interrupted"
+    let assistantRealtimeItemId: String
+    let heardText: String
+    let audioEndMs: Int
+}

--- a/ios/VoiceChat/VoiceChatView.swift
+++ b/ios/VoiceChat/VoiceChatView.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+
+struct VoiceChatView: View {
+    @ObservedObject var controller: VoiceChatController
+    @State private var agentIdText = ""
+
+    private var parsedAgentId: UUID? {
+        UUID(uuidString: agentIdText.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    private var isActive: Bool {
+        switch controller.state {
+        case .connecting, .connected:
+            return true
+        case .idle, .disconnected, .failed:
+            return false
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Form {
+                Section {
+                    TextField("Agent ID", text: $agentIdText)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .disabled(isActive)
+
+                    HStack {
+                        Button {
+                            if let parsedAgentId {
+                                controller.start(agentId: parsedAgentId)
+                            }
+                        } label: {
+                            Label("Start", systemImage: "mic.fill")
+                        }
+                        .disabled(parsedAgentId == nil || isActive)
+
+                        Button {
+                            controller.end()
+                        } label: {
+                            Label("End", systemImage: "phone.down.fill")
+                        }
+                        .disabled(!isActive)
+
+                        Toggle(isOn: $controller.isMuted) {
+                            Label("Mute", systemImage: "mic.slash.fill")
+                        }
+                        .disabled(!isActive)
+                    }
+                }
+
+                Section("Status") {
+                    HStack {
+                        Text(controller.state.label)
+                        Spacer()
+                        if case .connecting = controller.state {
+                            ProgressView()
+                        }
+                    }
+
+                    if let sessionId = controller.sessionId {
+                        Text(sessionId.uuidString)
+                            .font(.footnote.monospaced())
+                            .textSelection(.enabled)
+                    }
+
+                    if case .failed(let message) = controller.state {
+                        Text(message)
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Section("Conversation") {
+                    TranscriptRow(
+                        title: "You",
+                        text: controller.lastUserTranscript
+                    )
+                    TranscriptRow(
+                        title: "Zero",
+                        text: controller.lastAssistantTranscript
+                    )
+                }
+
+                Section("Tasks") {
+                    if controller.tasks.isEmpty {
+                        Text("No active tasks")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(controller.tasks) { task in
+                            VStack(alignment: .leading, spacing: 6) {
+                                HStack {
+                                    Text(task.status.rawValue.capitalized)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                    Spacer()
+                                    Text(String(task.id.uuidString.prefix(8)))
+                                        .font(.caption.monospaced())
+                                        .foregroundStyle(.secondary)
+                                }
+                                Text(task.prompt)
+                                    .font(.body)
+                                if let result = task.result,
+                                    !result.isEmpty
+                                {
+                                    Text(result)
+                                        .font(.footnote)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct TranscriptRow: View {
+    let title: String
+    let text: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(text.isEmpty ? "..." : text)
+                .textSelection(.enabled)
+                .foregroundStyle(text.isEmpty ? .secondary : .primary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/ios/Zero.xcodeproj/project.pbxproj
+++ b/ios/Zero.xcodeproj/project.pbxproj
@@ -1,0 +1,593 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 60;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A10000000000000000000001 /* ZeroApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000001 /* ZeroApp.swift */; };
+		A10000000000000000000002 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000002 /* AppConfig.swift */; };
+		A10000000000000000000003 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000003 /* AppEnvironment.swift */; };
+		A10000000000000000000004 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000004 /* RootView.swift */; };
+		A10000000000000000000005 /* ClerkAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000005 /* ClerkAuthProvider.swift */; };
+		A10000000000000000000006 /* VoiceChatDTOs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000006 /* VoiceChatDTOs.swift */; };
+		A10000000000000000000007 /* ZeroAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000007 /* ZeroAPIClient.swift */; };
+		A10000000000000000000008 /* AudioSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000008 /* AudioSessionController.swift */; };
+		A10000000000000000000009 /* RealtimeTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000009 /* RealtimeTransport.swift */; };
+		A1000000000000000000000A /* RealtimeEventParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000000000000000000000A /* RealtimeEventParser.swift */; };
+		A1000000000000000000000B /* OpenAIRealtimeWebRTCClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000000000000000000000B /* OpenAIRealtimeWebRTCClient.swift */; };
+		A1000000000000000000000C /* VoiceChatController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000000000000000000000C /* VoiceChatController.swift */; };
+		A1000000000000000000000D /* VoiceChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000000000000000000000D /* VoiceChatView.swift */; };
+		A1000000000000000000000E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A2000000000000000000000E /* Assets.xcassets */; };
+		A1000000000000000000000F /* RealtimeEventParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000000000000000000000F /* RealtimeEventParserTests.swift */; };
+		A10000000000000000000010 /* ZeroAPIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000010 /* ZeroAPIClientTests.swift */; };
+		A10000000000000000000011 /* ClerkKit in Frameworks */ = {isa = PBXBuildFile; productRef = A70000000000000000000001 /* ClerkKit */; };
+		A10000000000000000000012 /* ClerkKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = A70000000000000000000002 /* ClerkKitUI */; };
+		A10000000000000000000013 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = A70000000000000000000003 /* WebRTC */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A30000000000000000000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A90000000000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A80000000000000000000001;
+			remoteInfo = Zero;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A20000000000000000000001 /* ZeroApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZeroApp.swift; sourceTree = "<group>"; };
+		A20000000000000000000002 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
+		A20000000000000000000003 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
+		A20000000000000000000004 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		A20000000000000000000005 /* ClerkAuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClerkAuthProvider.swift; sourceTree = "<group>"; };
+		A20000000000000000000006 /* VoiceChatDTOs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceChatDTOs.swift; sourceTree = "<group>"; };
+		A20000000000000000000007 /* ZeroAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZeroAPIClient.swift; sourceTree = "<group>"; };
+		A20000000000000000000008 /* AudioSessionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionController.swift; sourceTree = "<group>"; };
+		A20000000000000000000009 /* RealtimeTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeTransport.swift; sourceTree = "<group>"; };
+		A2000000000000000000000A /* RealtimeEventParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeEventParser.swift; sourceTree = "<group>"; };
+		A2000000000000000000000B /* OpenAIRealtimeWebRTCClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIRealtimeWebRTCClient.swift; sourceTree = "<group>"; };
+		A2000000000000000000000C /* VoiceChatController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceChatController.swift; sourceTree = "<group>"; };
+		A2000000000000000000000D /* VoiceChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceChatView.swift; sourceTree = "<group>"; };
+		A2000000000000000000000E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Resources/Assets.xcassets; sourceTree = "<group>"; };
+		A2000000000000000000000F /* RealtimeEventParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeEventParserTests.swift; sourceTree = "<group>"; };
+		A20000000000000000000010 /* ZeroAPIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZeroAPIClientTests.swift; sourceTree = "<group>"; };
+		A20000000000000000000011 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A20000000000000000000012 /* Zero.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Zero.entitlements; sourceTree = "<group>"; };
+		A20000000000000000000013 /* Zero.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Zero.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A20000000000000000000014 /* ZeroTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ZeroTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A40000000000000000000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000011 /* ClerkKit in Frameworks */,
+				A10000000000000000000012 /* ClerkKitUI in Frameworks */,
+				A10000000000000000000013 /* WebRTC in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A40000000000000000000002 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A50000000000000000000001 = {
+			isa = PBXGroup;
+			children = (
+				A50000000000000000000003 /* App */,
+				A50000000000000000000004 /* Auth */,
+				A50000000000000000000005 /* API */,
+				A50000000000000000000006 /* Audio */,
+				A50000000000000000000007 /* VoiceChat */,
+				A50000000000000000000008 /* Tests */,
+				A50000000000000000000002 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A50000000000000000000002 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A20000000000000000000013 /* Zero.app */,
+				A20000000000000000000014 /* ZeroTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A50000000000000000000003 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				A20000000000000000000001 /* ZeroApp.swift */,
+				A20000000000000000000002 /* AppConfig.swift */,
+				A20000000000000000000003 /* AppEnvironment.swift */,
+				A20000000000000000000004 /* RootView.swift */,
+				A20000000000000000000011 /* Info.plist */,
+				A20000000000000000000012 /* Zero.entitlements */,
+				A2000000000000000000000E /* Assets.xcassets */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		A50000000000000000000004 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				A20000000000000000000005 /* ClerkAuthProvider.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		A50000000000000000000005 /* API */ = {
+			isa = PBXGroup;
+			children = (
+				A20000000000000000000006 /* VoiceChatDTOs.swift */,
+				A20000000000000000000007 /* ZeroAPIClient.swift */,
+			);
+			path = API;
+			sourceTree = "<group>";
+		};
+		A50000000000000000000006 /* Audio */ = {
+			isa = PBXGroup;
+			children = (
+				A20000000000000000000008 /* AudioSessionController.swift */,
+			);
+			path = Audio;
+			sourceTree = "<group>";
+		};
+		A50000000000000000000007 /* VoiceChat */ = {
+			isa = PBXGroup;
+			children = (
+				A20000000000000000000009 /* RealtimeTransport.swift */,
+				A2000000000000000000000A /* RealtimeEventParser.swift */,
+				A2000000000000000000000B /* OpenAIRealtimeWebRTCClient.swift */,
+				A2000000000000000000000C /* VoiceChatController.swift */,
+				A2000000000000000000000D /* VoiceChatView.swift */,
+			);
+			path = VoiceChat;
+			sourceTree = "<group>";
+		};
+		A50000000000000000000008 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				A2000000000000000000000F /* RealtimeEventParserTests.swift */,
+				A20000000000000000000010 /* ZeroAPIClientTests.swift */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A80000000000000000000001 /* Zero */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B10000000000000000000002 /* Build configuration list for PBXNativeTarget "Zero" */;
+			buildPhases = (
+				A60000000000000000000001 /* Sources */,
+				A40000000000000000000001 /* Frameworks */,
+				A60000000000000000000002 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Zero;
+			packageProductDependencies = (
+				A70000000000000000000001 /* ClerkKit */,
+				A70000000000000000000002 /* ClerkKitUI */,
+				A70000000000000000000003 /* WebRTC */,
+			);
+			productName = Zero;
+			productReference = A20000000000000000000013 /* Zero.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A80000000000000000000002 /* ZeroTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B10000000000000000000005 /* Build configuration list for PBXNativeTarget "ZeroTests" */;
+			buildPhases = (
+				A60000000000000000000003 /* Sources */,
+				A40000000000000000000002 /* Frameworks */,
+				A60000000000000000000004 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A30000000000000000000002 /* PBXTargetDependency */,
+			);
+			name = ZeroTests;
+			packageProductDependencies = (
+			);
+			productName = ZeroTests;
+			productReference = A20000000000000000000014 /* ZeroTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A90000000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					A80000000000000000000001 = {
+						CreatedOnToolsVersion = 16.0;
+					};
+					A80000000000000000000002 = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = A80000000000000000000001;
+					};
+				};
+			};
+			buildConfigurationList = B10000000000000000000001 /* Build configuration list for PBXProject "Zero" */;
+			compatibilityVersion = "Xcode 15.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A50000000000000000000001;
+			packageReferences = (
+				A70000000000000000000004 /* XCRemoteSwiftPackageReference "clerk-ios" */,
+				A70000000000000000000005 /* XCRemoteSwiftPackageReference "WebRTC" */,
+			);
+			productRefGroup = A50000000000000000000002 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A80000000000000000000001 /* Zero */,
+				A80000000000000000000002 /* ZeroTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A60000000000000000000002 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1000000000000000000000E /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A60000000000000000000004 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A60000000000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000001 /* ZeroApp.swift in Sources */,
+				A10000000000000000000002 /* AppConfig.swift in Sources */,
+				A10000000000000000000003 /* AppEnvironment.swift in Sources */,
+				A10000000000000000000004 /* RootView.swift in Sources */,
+				A10000000000000000000005 /* ClerkAuthProvider.swift in Sources */,
+				A10000000000000000000006 /* VoiceChatDTOs.swift in Sources */,
+				A10000000000000000000007 /* ZeroAPIClient.swift in Sources */,
+				A10000000000000000000008 /* AudioSessionController.swift in Sources */,
+				A10000000000000000000009 /* RealtimeTransport.swift in Sources */,
+				A1000000000000000000000A /* RealtimeEventParser.swift in Sources */,
+				A1000000000000000000000B /* OpenAIRealtimeWebRTCClient.swift in Sources */,
+				A1000000000000000000000C /* VoiceChatController.swift in Sources */,
+				A1000000000000000000000D /* VoiceChatView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A60000000000000000000003 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1000000000000000000000F /* RealtimeEventParserTests.swift in Sources */,
+				A10000000000000000000010 /* ZeroAPIClientTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A30000000000000000000002 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A80000000000000000000001 /* Zero */;
+			targetProxy = A30000000000000000000001 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		B20000000000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+			};
+			name = Debug;
+		};
+		B20000000000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		B20000000000000000000003 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLERK_FRONTEND_API_DOMAIN = "";
+				CLERK_PUBLISHABLE_KEY = "";
+				CODE_SIGN_ENTITLEMENTS = App/Zero.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = App/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.vm0.zero;
+				PRODUCT_NAME = Zero;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.10;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				ZERO_API_BASE_URL = "https://api.vm0.ai";
+			};
+			name = Debug;
+		};
+		B20000000000000000000004 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLERK_FRONTEND_API_DOMAIN = "";
+				CLERK_PUBLISHABLE_KEY = "";
+				CODE_SIGN_ENTITLEMENTS = App/Zero.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = App/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.vm0.zero;
+				PRODUCT_NAME = Zero;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.10;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				ZERO_API_BASE_URL = "https://api.vm0.ai";
+			};
+			name = Release;
+		};
+		B20000000000000000000005 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = ai.vm0.zero.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.10;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Zero.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Zero";
+			};
+			name = Debug;
+		};
+		B20000000000000000000006 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = ai.vm0.zero.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.10;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Zero.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Zero";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		B10000000000000000000001 /* Build configuration list for PBXProject "Zero" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B20000000000000000000001 /* Debug */,
+				B20000000000000000000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B10000000000000000000002 /* Build configuration list for PBXNativeTarget "Zero" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B20000000000000000000003 /* Debug */,
+				B20000000000000000000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B10000000000000000000005 /* Build configuration list for PBXNativeTarget "ZeroTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B20000000000000000000005 /* Debug */,
+				B20000000000000000000006 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		A70000000000000000000004 /* XCRemoteSwiftPackageReference "clerk-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/clerk/clerk-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
+		A70000000000000000000005 /* XCRemoteSwiftPackageReference "WebRTC" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/stasel/WebRTC.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 147.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A70000000000000000000001 /* ClerkKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A70000000000000000000004 /* XCRemoteSwiftPackageReference "clerk-ios" */;
+			productName = ClerkKit;
+		};
+		A70000000000000000000002 /* ClerkKitUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A70000000000000000000004 /* XCRemoteSwiftPackageReference "clerk-ios" */;
+			productName = ClerkKitUI;
+		};
+		A70000000000000000000003 /* WebRTC */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A70000000000000000000005 /* XCRemoteSwiftPackageReference "WebRTC" */;
+			productName = WebRTC;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = A90000000000000000000001 /* Project object */;
+}

--- a/ios/Zero.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/Zero.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios/Zero.xcodeproj/xcshareddata/xcschemes/Zero.xcscheme
+++ b/ios/Zero.xcodeproj/xcshareddata/xcschemes/Zero.xcscheme
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A80000000000000000000001"
+               BuildableName = "Zero.app"
+               BlueprintName = "Zero"
+               ReferencedContainer = "container:Zero.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A80000000000000000000002"
+               BuildableName = "ZeroTests.xctest"
+               BlueprintName = "ZeroTests"
+               ReferencedContainer = "container:Zero.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A80000000000000000000001"
+            BuildableName = "Zero.app"
+            BlueprintName = "Zero"
+            ReferencedContainer = "container:Zero.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A80000000000000000000001"
+            BuildableName = "Zero.app"
+            BlueprintName = "Zero"
+            ReferencedContainer = "container:Zero.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary
- Add the native-only Zero iOS app scaffold for voice chat, including SwiftUI entry points, Clerk auth, vm0 API client, audio session handling, and Realtime WebRTC transport.
- Add focused XCTest coverage for the Realtime event parser and API client auth/request behavior.
- Add an iOS GitHub Actions workflow on macOS that resolves Swift packages, builds for testing, and runs XCTest through a shared Xcode scheme.

## Testing
- `git diff --check`
- `python3` YAML parse for `.github/workflows/ios.yml`
- `python3` XML parse for `ios/Zero.xcodeproj/xcshareddata/xcschemes/Zero.xcscheme`

## Notes
- `xcodebuild` is not available in the Linux devcontainer, so the new GitHub Actions workflow is the first real Xcode build/test gate.
- This PR intentionally does not add the WebView shell or web session bridge; the iOS scope is native voice chat only.