### PR TITLE
feat(api): migrate org/members/credit-cap put to api backend (wave 6 #13)

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-member-credit-cap.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-member-credit-cap.ts
@@ -1,0 +1,130 @@
+import { randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { and, eq } from "drizzle-orm";
+
+import { writeDb$ } from "../../../external/db";
+import { nowDate } from "../../../external/time";
+
+export interface MemberCreditCapFixture {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+interface SeedFixtureValues {
+  readonly currentPeriodEnd?: Date | null;
+  readonly creditCap?: number | null;
+  readonly creditEnabled?: boolean;
+}
+
+export const seedMemberCreditCapFixture$ = command(
+  async (
+    { set },
+    values: SeedFixtureValues,
+    signal: AbortSignal,
+  ): Promise<MemberCreditCapFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const writeDb = set(writeDb$);
+
+    if (values.currentPeriodEnd !== undefined) {
+      await writeDb.insert(orgMetadata).values({
+        orgId,
+        currentPeriodEnd: values.currentPeriodEnd,
+      });
+      signal.throwIfAborted();
+    }
+
+    if (values.creditCap !== undefined || values.creditEnabled !== undefined) {
+      await writeDb.insert(orgMembersMetadata).values({
+        orgId,
+        userId,
+        creditCap: values.creditCap ?? null,
+        creditEnabled: values.creditEnabled ?? true,
+      });
+      signal.throwIfAborted();
+    }
+
+    return { orgId, userId };
+  },
+);
+
+export const deleteMemberCreditCapFixture$ = command(
+  async (
+    { set },
+    fixture: MemberCreditCapFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(usageEvent)
+      .where(
+        and(
+          eq(usageEvent.orgId, fixture.orgId),
+          eq(usageEvent.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+    await writeDb
+      .delete(orgMembersMetadata)
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, fixture.orgId),
+          eq(orgMembersMetadata.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+    await writeDb
+      .delete(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
+  },
+);
+
+interface UsageInsert {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly creditsCharged: number;
+  readonly processedAt?: Date;
+}
+
+export const insertProcessedModelUsage$ = command(
+  async ({ set }, args: UsageInsert, signal: AbortSignal): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb.insert(usageEvent).values({
+      orgId: args.orgId,
+      userId: args.userId,
+      kind: "model",
+      provider: "claude-sonnet-4-20250514",
+      category: "tokens.input",
+      quantity: 1,
+      creditsCharged: args.creditsCharged,
+      status: "processed",
+      idempotencyKey: randomUUID(),
+      processedAt: args.processedAt ?? nowDate(),
+    });
+    signal.throwIfAborted();
+  },
+);
+
+export const insertProcessedConnectorUsage$ = command(
+  async ({ set }, args: UsageInsert, signal: AbortSignal): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb.insert(usageEvent).values({
+      orgId: args.orgId,
+      userId: args.userId,
+      kind: "connector",
+      provider: "x",
+      category: "tweet.read",
+      quantity: 1,
+      creditsCharged: args.creditsCharged,
+      status: "processed",
+      idempotencyKey: randomUUID(),
+      processedAt: args.processedAt ?? nowDate(),
+    });
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-member-credit-cap.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-member-credit-cap.test.ts
@@ -1,11 +1,27 @@
 import { randomUUID } from "node:crypto";
 
 import { zeroMemberCreditCapContract } from "@vm0/api-contracts/contracts/zero-member-credit-cap";
+import { createStore } from "ccstate";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { and, eq } from "drizzle-orm";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { writeDb$ } from "../../external/db";
+import { now } from "../../external/time";
+import {
+  deleteMemberCreditCapFixture$,
+  insertProcessedConnectorUsage$,
+  insertProcessedModelUsage$,
+  seedMemberCreditCapFixture$,
+  type MemberCreditCapFixture,
+} from "./helpers/zero-member-credit-cap";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
 
 const context = testContext();
+const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
 function authHeaders() {
@@ -69,6 +85,307 @@ describe("GET /api/zero/org/members/credit-cap", () => {
 
     const response = await accept(
       apiClient().get({ query: { userId: "" }, headers: authHeaders() }),
+      [400],
+    );
+    expect(response.body.error.code).toBe("BAD_REQUEST");
+  });
+});
+
+describe("PUT /api/zero/org/members/credit-cap", () => {
+  const track = createFixtureTracker<MemberCreditCapFixture>((fixture) => {
+    return store.set(deleteMemberCreditCapFixture$, fixture, context.signal);
+  });
+
+  it("sets credit cap as admin", async () => {
+    const fixture = await track(
+      store.set(seedMemberCreditCapFixture$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().set({
+        body: { userId: fixture.userId, creditCap: 5000 },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      userId: fixture.userId,
+      creditCap: 5000,
+      creditEnabled: true,
+    });
+
+    const writeDb = store.set(writeDb$);
+    const [row] = await writeDb
+      .select({
+        creditCap: orgMembersMetadata.creditCap,
+        creditEnabled: orgMembersMetadata.creditEnabled,
+      })
+      .from(orgMembersMetadata)
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, fixture.orgId),
+          eq(orgMembersMetadata.userId, fixture.userId),
+        ),
+      );
+    expect(row?.creditCap).toBe(5000);
+    expect(row?.creditEnabled).toBeTruthy();
+  });
+
+  it("disables member when cap is below current usage", async () => {
+    const periodEnd = new Date(now() + 15 * 24 * 60 * 60 * 1000);
+    const fixture = await track(
+      store.set(
+        seedMemberCreditCapFixture$,
+        { currentPeriodEnd: periodEnd },
+        context.signal,
+      ),
+    );
+    await store.set(
+      insertProcessedModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        creditsCharged: 200,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().set({
+        body: { userId: fixture.userId, creditCap: 100 },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      userId: fixture.userId,
+      creditCap: 100,
+      creditEnabled: false,
+    });
+  });
+
+  it("disables member when usage_event spend exceeds cap", async () => {
+    const periodEnd = new Date(now() + 15 * 24 * 60 * 60 * 1000);
+    const fixture = await track(
+      store.set(
+        seedMemberCreditCapFixture$,
+        { currentPeriodEnd: periodEnd },
+        context.signal,
+      ),
+    );
+    await store.set(
+      insertProcessedModelUsage$,
+      { orgId: fixture.orgId, userId: fixture.userId, creditsCharged: 80 },
+      context.signal,
+    );
+    await store.set(
+      insertProcessedConnectorUsage$,
+      { orgId: fixture.orgId, userId: fixture.userId, creditsCharged: 40 },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().set({
+        body: { userId: fixture.userId, creditCap: 100 },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      userId: fixture.userId,
+      creditCap: 100,
+      creditEnabled: false,
+    });
+  });
+
+  it("disables member when usage_event spend exactly reaches cap", async () => {
+    const periodEnd = new Date(now() + 15 * 24 * 60 * 60 * 1000);
+    const fixture = await track(
+      store.set(
+        seedMemberCreditCapFixture$,
+        { currentPeriodEnd: periodEnd },
+        context.signal,
+      ),
+    );
+    await store.set(
+      insertProcessedModelUsage$,
+      { orgId: fixture.orgId, userId: fixture.userId, creditsCharged: 60 },
+      context.signal,
+    );
+    await store.set(
+      insertProcessedConnectorUsage$,
+      { orgId: fixture.orgId, userId: fixture.userId, creditsCharged: 40 },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().set({
+        body: { userId: fixture.userId, creditCap: 100 },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      userId: fixture.userId,
+      creditCap: 100,
+      creditEnabled: false,
+    });
+  });
+
+  it("ignores processed usage at the billing period end boundary", async () => {
+    const periodEnd = new Date("2099-04-01T00:00:00Z");
+    const fixture = await track(
+      store.set(
+        seedMemberCreditCapFixture$,
+        { currentPeriodEnd: periodEnd },
+        context.signal,
+      ),
+    );
+    await store.set(
+      insertProcessedModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        creditsCharged: 40,
+        processedAt: new Date("2099-03-15T00:00:00Z"),
+      },
+      context.signal,
+    );
+    await store.set(
+      insertProcessedConnectorUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        creditsCharged: 80,
+        processedAt: periodEnd,
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().set({
+        body: { userId: fixture.userId, creditCap: 100 },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      userId: fixture.userId,
+      creditCap: 100,
+      creditEnabled: true,
+    });
+  });
+
+  it("re-enables member when cap is raised above usage", async () => {
+    const periodEnd = new Date(now() + 15 * 24 * 60 * 60 * 1000);
+    const fixture = await track(
+      store.set(
+        seedMemberCreditCapFixture$,
+        { currentPeriodEnd: periodEnd },
+        context.signal,
+      ),
+    );
+    await store.set(
+      insertProcessedModelUsage$,
+      { orgId: fixture.orgId, userId: fixture.userId, creditsCharged: 200 },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const r1 = await accept(
+      apiClient().set({
+        body: { userId: fixture.userId, creditCap: 100 },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    expect(r1.body.creditEnabled).toBeFalsy();
+
+    const r2 = await accept(
+      apiClient().set({
+        body: { userId: fixture.userId, creditCap: 500 },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    expect(r2.body).toStrictEqual({
+      userId: fixture.userId,
+      creditCap: 500,
+      creditEnabled: true,
+    });
+  });
+
+  it("removes cap and re-enables with null", async () => {
+    const fixture = await track(
+      store.set(
+        seedMemberCreditCapFixture$,
+        { creditCap: 100, creditEnabled: false },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().set({
+        body: { userId: fixture.userId, creditCap: null },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      userId: fixture.userId,
+      creditCap: null,
+      creditEnabled: true,
+    });
+  });
+
+  it("returns 403 for non-admin", async () => {
+    const fixture = await track(
+      store.set(seedMemberCreditCapFixture$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const response = await accept(
+      apiClient().set({
+        body: { userId: fixture.userId, creditCap: 5000 },
+        headers: authHeaders(),
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only org admins can update member credit caps",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 400 for invalid body", async () => {
+    const fixture = await track(
+      store.set(seedMemberCreditCapFixture$, {}, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().set({
+        body: { creditCap: 5000 } as unknown as {
+          userId: string;
+          creditCap: number | null;
+        },
+        headers: authHeaders(),
+      }),
       [400],
     );
     expect(response.body.error.code).toBe("BAD_REQUEST");

--- a/turbo/apps/api/src/signals/routes/zero-member-credit-cap.ts
+++ b/turbo/apps/api/src/signals/routes/zero-member-credit-cap.ts
@@ -1,11 +1,24 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import { zeroMemberCreditCapContract } from "@vm0/api-contracts/contracts/zero-member-credit-cap";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { queryOf } from "../context/request";
-import { zeroMemberCreditCap } from "../services/zero-member-credit-cap.service";
+import { bodyResultOf, queryOf } from "../context/request";
+import {
+  setMemberCreditCap$,
+  zeroMemberCreditCap,
+} from "../services/zero-member-credit-cap.service";
 import type { RouteEntry } from "../route";
+
+const adminRequired = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Only org admins can update member credit caps",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
 
 const getMemberCreditCapInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
@@ -24,12 +37,54 @@ const getMemberCreditCapInner$ = computed(async (get) => {
   };
 });
 
+const setMemberCreditCapInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    if (auth.orgRole !== "admin") {
+      return adminRequired;
+    }
+
+    const bodyResult = await get(bodyResultOf(zeroMemberCreditCapContract.set));
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const result = await set(
+      setMemberCreditCap$,
+      {
+        orgId: auth.orgId,
+        userId: bodyResult.data.userId,
+        creditCap: bodyResult.data.creditCap,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: {
+        userId: bodyResult.data.userId,
+        creditCap: result.creditCap,
+        creditEnabled: result.creditEnabled,
+      },
+    };
+  },
+);
+
 export const zeroMemberCreditCapRoutes: readonly RouteEntry[] = [
   {
     route: zeroMemberCreditCapContract.get,
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       getMemberCreditCapInner$,
+    ),
+  },
+  {
+    route: zeroMemberCreditCapContract.set,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      setMemberCreditCapInner$,
     ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-member-credit-cap.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-member-credit-cap.service.ts
@@ -1,8 +1,11 @@
-import { computed, type Computed } from "ccstate";
+import { command, computed, type Computed } from "ccstate";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
-import { and, eq } from "drizzle-orm";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { and, eq, gte, lt, sql } from "drizzle-orm";
 
-import { db$ } from "../external/db";
+import { db$, writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+import { getOrgBillingPeriod$ } from "./zero-org-billing-period.service";
 
 export function zeroMemberCreditCap(args: {
   readonly orgId: string;
@@ -34,3 +37,107 @@ export function zeroMemberCreditCap(args: {
     };
   });
 }
+
+interface MemberUsageArgs {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+// Single-user sum of processed usage_event.creditsCharged in the current
+// billing period. Returns 0 when no billing period is set (free tier).
+// Mirrors apps/web's private getMemberUsageInBillingPeriod.
+const getMemberUsageInBillingPeriod$ = command(
+  async (
+    { set },
+    args: MemberUsageArgs,
+    signal: AbortSignal,
+  ): Promise<number> => {
+    const billingPeriod = await set(getOrgBillingPeriod$, args.orgId, signal);
+    signal.throwIfAborted();
+    if (!billingPeriod) {
+      return 0;
+    }
+    const writeDb = set(writeDb$);
+    const [row] = await writeDb
+      .select({
+        total:
+          sql<number>`COALESCE(SUM(${usageEvent.creditsCharged}), 0)::bigint`.as(
+            "total",
+          ),
+      })
+      .from(usageEvent)
+      .where(
+        and(
+          eq(usageEvent.orgId, args.orgId),
+          eq(usageEvent.userId, args.userId),
+          eq(usageEvent.status, "processed"),
+          gte(usageEvent.processedAt, billingPeriod.start),
+          lt(usageEvent.processedAt, billingPeriod.end),
+        ),
+      );
+    signal.throwIfAborted();
+    return Number(row?.total ?? 0);
+  },
+);
+
+interface SetMemberCreditCapArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly creditCap: number | null;
+}
+
+interface SetMemberCreditCapResult {
+  readonly creditCap: number | null;
+  readonly creditEnabled: boolean;
+}
+
+export const setMemberCreditCap$ = command(
+  async (
+    { set },
+    args: SetMemberCreditCapArgs,
+    signal: AbortSignal,
+  ): Promise<SetMemberCreditCapResult> => {
+    const writeDb = set(writeDb$);
+    const now = nowDate();
+
+    if (args.creditCap === null) {
+      await writeDb
+        .insert(orgMembersMetadata)
+        .values({
+          orgId: args.orgId,
+          userId: args.userId,
+          creditCap: null,
+          creditEnabled: true,
+        })
+        .onConflictDoUpdate({
+          target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
+          set: { creditCap: null, creditEnabled: true, updatedAt: now },
+        });
+      signal.throwIfAborted();
+      return { creditCap: null, creditEnabled: true };
+    }
+
+    const cap = args.creditCap;
+    const usage = await set(
+      getMemberUsageInBillingPeriod$,
+      { orgId: args.orgId, userId: args.userId },
+      signal,
+    );
+    signal.throwIfAborted();
+    const creditEnabled = usage < cap;
+    await writeDb
+      .insert(orgMembersMetadata)
+      .values({
+        orgId: args.orgId,
+        userId: args.userId,
+        creditCap: cap,
+        creditEnabled,
+      })
+      .onConflictDoUpdate({
+        target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
+        set: { creditCap: cap, creditEnabled, updatedAt: now },
+      });
+    signal.throwIfAborted();
+    return { creditCap: cap, creditEnabled };
+  },
+);


### PR DESCRIPTION
## Summary

- Adds `PUT /api/zero/org/members/credit-cap` handler in `apps/api` alongside the existing GET.
- Verbatim port of `apps/web` semantics: null cap unconditionally re-enables; numeric cap re-evaluates `creditEnabled` against current billing-period processed usage (`status='processed' AND processedAt ∈ [start, end)`).
- Admin-only — frozen `adminRequired` 403 envelope at the route layer (matches Wave 6 #9 / #12715 precedent).

## Implementation notes

- `setMemberCreditCap$` Command — plain return shape `{creditCap, creditEnabled}`. Service is pure business logic; the admin-role check lives at the route handler (`auth.orgRole !== "admin"`).
- Private `getMemberUsageInBillingPeriod$` Command composes with the existing `getOrgBillingPeriod$` rather than duplicating its Stripe-fallback logic. Returns `0` when no billing period (free tier) — preserves web's behavior where free-tier orgs are always re-enabled.
- `INSERT ... ON CONFLICT (orgId,userId) DO UPDATE` upsert pattern mirrors web verbatim.

## Tests (9 PUT cases ported from web)

1. sets credit cap as admin (+ DB read-after-write)
2. disables when cap < current usage
3. disables when cap < sum of model + connector usage
4. disables on exact boundary (`usage === cap`, `usage < cap` is false)
5. excludes processed usage at `processedAt === periodEnd` (`lt` boundary)
6. re-enables when cap raised above usage
7. removes cap with null + re-enables
8. 403 for non-admin
9. 400 for invalid body

Existing 4 GET tests still pass.

Refs #12290
Closes #12726

## Test plan

- [ ] CI lint, check-types, knip, format green
- [ ] `pnpm -F api exec vitest run zero-member-credit-cap` — 13 tests pass
- [ ] CI test-migrate green (no schema drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)