### PR TITLE
test: align zero insights route parity

### DIFF
--- a/turbo/apps/web/app/api/zero/insights/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/insights/__tests__/route.test.ts
@@ -71,6 +71,20 @@ describe("GET /api/zero/insights", () => {
     expect(data.error.code).toBe("UNAUTHORIZED");
   });
 
+  it("should return 401 when the authenticated session has no organization", async () => {
+    mockClerk({ userId: user.userId, orgId: null });
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
   it("should return empty days when no insights exist", async () => {
     const request = createTestRequest(
       "http://localhost:3000/api/zero/insights",
@@ -112,6 +126,36 @@ describe("GET /api/zero/insights", () => {
     expect(data.totalRuns).toBe(5);
     expect(data.lastUpdated).toBeTruthy();
     expect(new Date(data.lastUpdated).getTime()).not.toBeNaN();
+  });
+
+  it("should normalize sparse insight rows to the full day shape", async () => {
+    const yesterday = daysAgo(1);
+    await seedInsightsDaily(user.orgId, yesterday, {}, user.userId);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.days).toStrictEqual([
+      {
+        date: yesterday,
+        agents: [],
+        creditsUsed: 0,
+        creditBalance: 0,
+        teamUsage: [],
+        topTask: null,
+        services: [],
+        permissions: [],
+        schedules: [],
+        chats: [],
+      },
+    ]);
+    expect(data.totalCredits).toBe(0);
+    expect(data.totalRuns).toBe(0);
+    expect(data.lastUpdated).toBeTruthy();
   });
 
   it("should aggregate totals across multiple days", async () => {

--- a/turbo/apps/web/app/api/zero/insights/range/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/insights/range/__tests__/route.test.ts
@@ -56,6 +56,20 @@ describe("GET /api/zero/insights/range", () => {
     expect(data.error.code).toBe("UNAUTHORIZED");
   });
 
+  it("should return 401 when the authenticated session has no organization", async () => {
+    mockClerk({ userId: user.userId, orgId: null });
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights/range",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
   it("should return nulls when no insights exist", async () => {
     const request = createTestRequest(
       "http://localhost:3000/api/zero/insights/range",

--- a/turbo/apps/web/app/api/zero/insights/range/route.ts
+++ b/turbo/apps/web/app/api/zero/insights/range/route.ts
@@ -22,6 +22,12 @@ export async function GET(request: Request) {
       { status: 401 },
     );
   }
+  if (!authCtx.orgId) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
 
   const { org } = await resolveOrg(authCtx);
 

--- a/turbo/apps/web/app/api/zero/insights/route.ts
+++ b/turbo/apps/web/app/api/zero/insights/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from "next/server";
 import { sql, desc, eq, and, gte } from "drizzle-orm";
+import type { DayInsight } from "@vm0/api-contracts/contracts/zero-insights";
 import { initServices } from "../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
 import { resolveOrg } from "../../../../src/lib/zero/org/resolve-org";
 import { insightsDaily } from "@vm0/db/schema/insights-daily";
+
+type DayData = Partial<Omit<DayInsight, "date">>;
 
 /**
  * GET /api/zero/insights
@@ -18,6 +21,12 @@ export async function GET(request: Request) {
   const authHeader = request.headers.get("authorization");
   const authCtx = await getAuthContext(authHeader ?? undefined);
   if (!authCtx) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+  if (!authCtx.orgId) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
@@ -51,36 +60,31 @@ export async function GET(request: Request) {
     )
     .orderBy(desc(insightsDaily.date));
 
-  interface DayData {
-    agents?: { runs?: number }[];
-    creditsUsed?: number;
-    schedules?: unknown;
-    chats?: unknown;
-    [key: string]: unknown;
-  }
-
-  const daysData = rows.map((row) => {
+  const daysData = rows.map((row): DayInsight => {
     const data = row.data as DayData;
     return {
       date: row.date,
-      ...data,
-      schedules: Array.isArray(data.schedules) ? data.schedules : [],
-      chats: Array.isArray(data.chats) ? data.chats : [],
+      agents: data.agents ?? [],
+      creditsUsed: data.creditsUsed ?? 0,
+      creditBalance: data.creditBalance ?? 0,
+      teamUsage: data.teamUsage ?? [],
+      topTask: data.topTask ?? null,
+      services: data.services ?? [],
+      permissions: data.permissions ?? [],
+      schedules: data.schedules ?? [],
+      chats: data.chats ?? [],
     };
   });
 
-  const totalCredits = rows.reduce((sum, row) => {
-    const data = row.data as DayData;
-    return sum + (data.creditsUsed ?? 0);
+  const totalCredits = daysData.reduce((sum, day) => {
+    return sum + day.creditsUsed;
   }, 0);
 
-  const totalRuns = rows.reduce((sum, row) => {
-    const data = row.data as DayData;
-    const agents = data.agents ?? [];
+  const totalRuns = daysData.reduce((sum, day) => {
     return (
       sum +
-      agents.reduce((s, a) => {
-        return s + (a.runs ?? 0);
+      day.agents.reduce((agentSum, agent) => {
+        return agentSum + agent.runs;
       }, 0)
     );
   }, 0);


### PR DESCRIPTION
## Summary

- Align web zero insights routes with API no-active-org `401` behavior.
- Normalize sparse web insights rows to the full `DayInsight` response shape.
- Add web route tests for no-active-org and sparse-row parity coverage.

## Validation

- `pnpm -F web exec vitest run app/api/zero/insights/__tests__/route.test.ts app/api/zero/insights/range/__tests__/route.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-insights.test.ts`
- `pnpm -F web exec prettier --check app/api/zero/insights/route.ts app/api/zero/insights/range/route.ts app/api/zero/insights/__tests__/route.test.ts app/api/zero/insights/range/__tests__/route.test.ts`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `git diff --check`

Closes #12626
