### PR TITLE
feat(vsock-guest): add command operation worker

### DIFF
--- a/crates/vsock-guest/src/command.rs
+++ b/crates/vsock-guest/src/command.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::io;
 use std::process::Child;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
+use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::Instant;
@@ -142,7 +142,6 @@ impl CommandWorkerRequest {
 }
 
 struct DrainWorker {
-    seq: u32,
     stream: CommandOutputStream,
     policy: OutputSettings,
     output_tx: Option<SyncSender<StreamEvent>>,
@@ -379,7 +378,6 @@ fn run_command_worker<S>(
     let stdout_spawn = spawn_command_drain(
         stdout,
         DrainWorker {
-            seq: request.seq,
             stream: CommandOutputStream::Stdout,
             policy: stdout_settings,
             output_tx: output_tx.clone(),
@@ -407,7 +405,6 @@ fn run_command_worker<S>(
     let stderr_spawn = spawn_command_drain(
         stderr,
         DrainWorker {
-            seq: request.seq,
             stream: CommandOutputStream::Stderr,
             policy: stderr_settings,
             output_tx: output_tx.clone(),
@@ -668,7 +665,6 @@ where
     S: ThreadSpawner,
 {
     let DrainWorker {
-        seq,
         stream,
         policy,
         output_tx,
@@ -693,19 +689,13 @@ where
                     let Some(tx) = &output_tx else {
                         return true;
                     };
-                    match tx.try_send(StreamEvent {
+                    match tx.send(StreamEvent {
                         stream,
                         chunk: chunk.to_vec(),
                         truncated,
                     }) {
                         Ok(()) => true,
-                        Err(TrySendError::Full(_)) => {
-                            log("WARN", &format!("command: output queue full for seq={seq}"));
-                            command_cancel.store(true, Ordering::Release);
-                            drain_cancel.store(true, Ordering::Release);
-                            false
-                        }
-                        Err(TrySendError::Disconnected(_)) => {
+                        Err(_) => {
                             command_cancel.store(true, Ordering::Release);
                             drain_cancel.store(true, Ordering::Release);
                             false
@@ -839,6 +829,17 @@ mod tests {
         }
     }
 
+    fn wait_for_registry_release(registry: &CommandRegistry, seq: u32) {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while Instant::now() < deadline {
+            if registry.register(seq).is_ok() {
+                return;
+            }
+            std::thread::yield_now();
+        }
+        panic!("command registry entry for seq={seq} was not released");
+    }
+
     #[test]
     fn registry_rejects_duplicate_active_sequence_and_cleans_on_drop() {
         let registry = CommandRegistry::default();
@@ -879,7 +880,7 @@ mod tests {
         let result = vsock_proto::decode_command_result(&msg.payload).unwrap();
         assert_eq!(result.termination, CommandTermination::StartFailed);
         assert!(result.diagnostic.contains("command worker thread"));
-        assert!(registry.register(42).is_ok());
+        wait_for_registry_release(&registry, 42);
     }
 
     #[test]
@@ -927,7 +928,7 @@ mod tests {
         let result = vsock_proto::decode_command_result(&msg.payload).unwrap();
         assert_eq!(result.termination, CommandTermination::WaitFailed);
         assert!(result.diagnostic.contains("stdout drain thread"));
-        assert!(registry.register(43).is_ok());
+        wait_for_registry_release(&registry, 43);
     }
 
     #[test]
@@ -957,6 +958,6 @@ mod tests {
         let result = vsock_proto::decode_command_result(&msg.payload).unwrap();
         assert_eq!(result.termination, CommandTermination::WaitFailed);
         assert!(result.diagnostic.contains("output writer thread"));
-        assert!(registry.register(44).is_ok());
+        wait_for_registry_release(&registry, 44);
     }
 }

--- a/crates/vsock-guest/src/command.rs
+++ b/crates/vsock-guest/src/command.rs
@@ -417,6 +417,7 @@ fn run_command_worker<S>(
     let (stderr_handle, stderr_result_rx) = match stderr_spawn {
         Ok(parts) => parts,
         Err(e) => {
+            command_cancel.store(true, Ordering::Release);
             drain_cancel.store(true, Ordering::Release);
             drop(output_tx);
             kill_and_reap_child(child);
@@ -938,6 +939,31 @@ mod tests {
         assert_eq!(result.termination, CommandTermination::WaitFailed);
         assert!(result.diagnostic.contains("stdout drain thread"));
         wait_for_registry_release(&registry, 43);
+    }
+
+    #[test]
+    fn stderr_drain_spawn_failure_returns_wait_failed_and_cleans_registry() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let writer = GuestWriter::new(guest);
+        let registry = CommandRegistry::default();
+
+        start_command_operation_with_spawner(
+            request(45, "sleep 60"),
+            writer,
+            Arc::new(AtomicBool::new(false)),
+            registry.clone(),
+            FailingThreadSpawner::fail_once(THREAD_COMMAND_STDERR),
+        )
+        .unwrap();
+
+        let msg = read_message(&mut host);
+        assert_eq!(msg.msg_type, MSG_COMMAND_RESULT);
+        assert_eq!(msg.seq, 45);
+        let result = vsock_proto::decode_command_result(&msg.payload).unwrap();
+        assert_eq!(result.termination, CommandTermination::WaitFailed);
+        assert!(result.diagnostic.contains("stderr drain thread"));
+        wait_for_registry_release(&registry, 45);
     }
 
     #[test]

--- a/crates/vsock-guest/src/command.rs
+++ b/crates/vsock-guest/src/command.rs
@@ -1,0 +1,962 @@
+use std::collections::HashMap;
+use std::io;
+use std::process::Child;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::Instant;
+
+use vsock_proto::{
+    self, CommandCapturedOutput, CommandOutputPolicy, CommandOutputStream, CommandTermination,
+    MSG_COMMAND_OUTPUT, MSG_COMMAND_RESULT, MSG_ERROR,
+};
+
+use crate::drain::{BoundedDrainResult, BoundedStreamConfig, drain_bounded_cancellable};
+use crate::error::to_io_error;
+use crate::exec::{format_env_diagnostics, spawn_with_pipes, truncate_preview};
+use crate::log::log;
+use crate::process::{extract_exit_code, kill_and_reap_child};
+use crate::threading::{SystemThreadSpawner, ThreadSpawner};
+use crate::wait::{
+    DRAIN_DEADLINE_SECS, WaitOutcome, await_drain_deadline,
+    wait_with_kill_timeout_or_cancelled_either,
+};
+use crate::writer::GuestWriter;
+
+const THREAD_COMMAND_WORKER: &str = "vsock-command-worker";
+const THREAD_COMMAND_STDOUT: &str = "vsock-command-stdout";
+const THREAD_COMMAND_STDERR: &str = "vsock-command-stderr";
+const THREAD_COMMAND_OUTPUT: &str = "vsock-command-output";
+const OUTPUT_CHANNEL_CAPACITY: usize = 32;
+const FRAME_BODY_HEADER_LEN: usize = 1 + 4; // message type + sequence
+const COMMAND_OUTPUT_PAYLOAD_OVERHEAD: usize = 1 + 4 + 1 + 4;
+const COMMAND_RESULT_EXITED_LEN: usize = 1 + 4;
+const COMMAND_RESULT_DURATION_LEN: usize = 4;
+const COMMAND_RESULT_DIAGNOSTIC_LEN_FIELD: usize = 2;
+const COMMAND_RESULT_MAX_DIAGNOSTIC_BYTES: usize = u16::MAX as usize;
+const COMMAND_CAPTURED_OUTPUT_OVERHEAD: usize = 1 + 1 + 4;
+const COMMAND_DISCARDED_OUTPUT_LEN: usize = 1;
+
+#[derive(Clone, Default)]
+pub(crate) struct CommandRegistry {
+    inner: Arc<Mutex<HashMap<u32, Arc<AtomicBool>>>>,
+}
+
+impl CommandRegistry {
+    pub(crate) fn register(&self, seq: u32) -> Result<CommandRegistration, ()> {
+        let mut active = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if active.contains_key(&seq) {
+            return Err(());
+        }
+
+        let cancel = Arc::new(AtomicBool::new(false));
+        active.insert(seq, cancel.clone());
+        Ok(CommandRegistration {
+            registry: self.clone(),
+            seq,
+            cancel,
+        })
+    }
+
+    pub(crate) fn cancel(&self, seq: u32) -> bool {
+        let active = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(cancel) = active.get(&seq) else {
+            return false;
+        };
+        cancel.store(true, Ordering::Release);
+        true
+    }
+
+    fn remove_if_same(&self, seq: u32, cancel: &Arc<AtomicBool>) {
+        let mut active = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if active
+            .get(&seq)
+            .is_some_and(|existing| Arc::ptr_eq(existing, cancel))
+        {
+            active.remove(&seq);
+        }
+    }
+}
+
+pub(crate) struct CommandRegistration {
+    registry: CommandRegistry,
+    seq: u32,
+    cancel: Arc<AtomicBool>,
+}
+
+impl CommandRegistration {
+    fn cancel_token(&self) -> Arc<AtomicBool> {
+        self.cancel.clone()
+    }
+
+    fn complete(&self) {
+        self.registry.remove_if_same(self.seq, &self.cancel);
+    }
+}
+
+impl Drop for CommandRegistration {
+    fn drop(&mut self) {
+        self.complete();
+    }
+}
+
+#[derive(Clone, Copy)]
+struct WaitFailureContext<'a> {
+    seq: u32,
+    started: Instant,
+    stdout_policy: CommandOutputPolicy,
+    stderr_policy: CommandOutputPolicy,
+    registration: &'a CommandRegistration,
+    writer: &'a GuestWriter,
+}
+
+pub(crate) struct CommandWorkerRequest {
+    seq: u32,
+    timeout_ms: u32,
+    command: String,
+    env: Vec<(String, String)>,
+    sudo: bool,
+    stdout: CommandOutputPolicy,
+    stderr: CommandOutputPolicy,
+    label: String,
+}
+
+impl CommandWorkerRequest {
+    pub(crate) fn from_decoded(seq: u32, decoded: vsock_proto::DecodedCommandStart<'_>) -> Self {
+        Self {
+            seq,
+            timeout_ms: decoded.timeout_ms,
+            command: decoded.command.to_owned(),
+            env: decoded
+                .env
+                .iter()
+                .map(|(key, value)| ((*key).to_owned(), (*value).to_owned()))
+                .collect(),
+            sudo: decoded.sudo,
+            stdout: decoded.stdout,
+            stderr: decoded.stderr,
+            label: decoded.label.to_owned(),
+        }
+    }
+}
+
+struct DrainWorker {
+    seq: u32,
+    stream: CommandOutputStream,
+    policy: OutputSettings,
+    output_tx: Option<SyncSender<StreamEvent>>,
+    drain_cancel: Arc<AtomicBool>,
+    command_cancel: Arc<AtomicBool>,
+    drain_done_tx: mpsc::Sender<()>,
+}
+
+struct StreamEvent {
+    stream: CommandOutputStream,
+    chunk: Vec<u8>,
+    truncated: bool,
+}
+
+#[derive(Clone, Copy)]
+struct OutputSettings {
+    capture_limit_bytes: Option<usize>,
+    stream: Option<BoundedStreamConfig>,
+}
+
+struct CommandResultFrame<'a> {
+    seq: u32,
+    termination: CommandTermination,
+    duration_ms: u32,
+    stdout: CommandCapturedOutput<'a>,
+    stderr: CommandCapturedOutput<'a>,
+    diagnostic: &'a str,
+}
+
+pub(crate) fn start_command_operation(
+    request: CommandWorkerRequest,
+    writer: GuestWriter,
+    connection_cancel: Arc<AtomicBool>,
+    registry: CommandRegistry,
+) -> io::Result<()> {
+    start_command_operation_with_spawner(
+        request,
+        writer,
+        connection_cancel,
+        registry,
+        SystemThreadSpawner,
+    )
+}
+
+fn start_command_operation_with_spawner<S>(
+    request: CommandWorkerRequest,
+    writer: GuestWriter,
+    connection_cancel: Arc<AtomicBool>,
+    registry: CommandRegistry,
+    spawner: S,
+) -> io::Result<()>
+where
+    S: ThreadSpawner,
+{
+    let seq = request.seq;
+    let registration = match registry.register(seq) {
+        Ok(registration) => registration,
+        Err(()) => {
+            return send_command_error(seq, "command operation already active", &writer);
+        }
+    };
+    let command_cancel = registration.cancel_token();
+    let stdout_policy = request.stdout;
+    let stderr_policy = request.stderr;
+    let worker_writer = writer.clone();
+    let worker_spawner = spawner.clone();
+    let result = spawner.spawn_unit(
+        THREAD_COMMAND_WORKER,
+        Box::new(move || {
+            run_command_worker(
+                request,
+                worker_writer,
+                connection_cancel,
+                command_cancel,
+                registration,
+                worker_spawner,
+            );
+        }),
+    );
+
+    match result {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let diagnostic = format!("Failed to spawn command worker thread: {e}");
+            send_command_result(
+                CommandResultFrame {
+                    seq,
+                    termination: CommandTermination::StartFailed,
+                    duration_ms: 0,
+                    stdout: empty_output_for_policy(stdout_policy),
+                    stderr: empty_output_for_policy(stderr_policy),
+                    diagnostic: &diagnostic,
+                },
+                &writer,
+            )
+        }
+    }
+}
+
+pub(crate) fn cancel_command_operation(registry: &CommandRegistry, seq: u32) {
+    if registry.cancel(seq) {
+        log("INFO", &format!("command: cancelled seq={seq}"));
+    }
+}
+
+pub(crate) fn send_command_error(seq: u32, message: &str, writer: &GuestWriter) -> io::Result<()> {
+    let payload = vsock_proto::encode_error(message);
+    let response = vsock_proto::encode(MSG_ERROR, seq, &payload).map_err(to_io_error)?;
+    writer.write_frame(&response)
+}
+
+fn run_command_worker<S>(
+    request: CommandWorkerRequest,
+    writer: GuestWriter,
+    connection_cancel: Arc<AtomicBool>,
+    command_cancel: Arc<AtomicBool>,
+    registration: CommandRegistration,
+    spawner: S,
+) where
+    S: ThreadSpawner,
+{
+    log(
+        "INFO",
+        &format!(
+            "command: label={} {} (timeout={}ms, sudo={}, {})",
+            truncate_preview(&request.label),
+            truncate_preview(&request.command),
+            request.timeout_ms,
+            request.sudo,
+            format_env_diagnostics(&request.command, &env_refs(&request.env)),
+        ),
+    );
+
+    let started = Instant::now();
+    if let Err(diagnostic) = validate_request(&request) {
+        send_final_and_complete(
+            &registration,
+            CommandResultFrame {
+                seq: request.seq,
+                termination: CommandTermination::StartFailed,
+                duration_ms: duration_ms(started),
+                stdout: empty_output_for_policy(request.stdout),
+                stderr: empty_output_for_policy(request.stderr),
+                diagnostic: &diagnostic,
+            },
+            &writer,
+        );
+        return;
+    }
+
+    let env_refs = env_refs(&request.env);
+    let spawned = match spawn_with_pipes(&request.command, &env_refs, request.sudo) {
+        Ok(spawned) => spawned,
+        Err(e) => {
+            let diagnostic = format!(
+                "Failed to execute: {e} ({})",
+                format_env_diagnostics(&request.command, &env_refs)
+            );
+            send_final_and_complete(
+                &registration,
+                CommandResultFrame {
+                    seq: request.seq,
+                    termination: CommandTermination::StartFailed,
+                    duration_ms: duration_ms(started),
+                    stdout: empty_output_for_policy(request.stdout),
+                    stderr: empty_output_for_policy(request.stderr),
+                    diagnostic: &diagnostic,
+                },
+                &writer,
+            );
+            return;
+        }
+    };
+
+    let crate::exec::SpawnedCommand {
+        mut child,
+        env_script,
+    } = spawned;
+    let _env_script = env_script;
+    let failure = WaitFailureContext {
+        seq: request.seq,
+        started,
+        stdout_policy: request.stdout,
+        stderr_policy: request.stderr,
+        registration: &registration,
+        writer: &writer,
+    };
+
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            kill_and_send_wait_failed(child, "missing stdout pipe", failure);
+            return;
+        }
+    };
+    let stderr = match child.stderr.take() {
+        Some(stderr) => stderr,
+        None => {
+            kill_and_send_wait_failed(child, "missing stderr pipe", failure);
+            return;
+        }
+    };
+
+    let stdout_settings = output_settings(request.stdout);
+    let stderr_settings = output_settings(request.stderr);
+    let needs_stream = stdout_settings.stream.is_some() || stderr_settings.stream.is_some();
+    let drain_cancel = Arc::new(AtomicBool::new(false));
+    let (drain_done_tx, drain_done_rx) = mpsc::channel::<()>();
+
+    let (output_tx, output_handle) = if needs_stream {
+        let (tx, rx) = mpsc::sync_channel(OUTPUT_CHANNEL_CAPACITY);
+        match spawn_output_writer(
+            request.seq,
+            rx,
+            writer.clone(),
+            command_cancel.clone(),
+            drain_cancel.clone(),
+            spawner.clone(),
+        ) {
+            Ok(handle) => (Some(tx), Some(handle)),
+            Err(e) => {
+                kill_and_send_wait_failed(
+                    child,
+                    &format!("failed to spawn command output writer thread: {e}"),
+                    failure,
+                );
+                return;
+            }
+        }
+    } else {
+        (None, None)
+    };
+
+    let stdout_spawn = spawn_command_drain(
+        stdout,
+        DrainWorker {
+            seq: request.seq,
+            stream: CommandOutputStream::Stdout,
+            policy: stdout_settings,
+            output_tx: output_tx.clone(),
+            drain_cancel: drain_cancel.clone(),
+            command_cancel: command_cancel.clone(),
+            drain_done_tx: drain_done_tx.clone(),
+        },
+        spawner.clone(),
+    );
+    let (stdout_handle, stdout_result_rx) = match stdout_spawn {
+        Ok(parts) => parts,
+        Err(e) => {
+            drain_cancel.store(true, Ordering::Release);
+            drop(output_tx);
+            kill_and_send_wait_failed(
+                child,
+                &format!("failed to spawn stdout drain thread: {e}"),
+                failure,
+            );
+            join_output_writer(output_handle);
+            return;
+        }
+    };
+
+    let stderr_spawn = spawn_command_drain(
+        stderr,
+        DrainWorker {
+            seq: request.seq,
+            stream: CommandOutputStream::Stderr,
+            policy: stderr_settings,
+            output_tx: output_tx.clone(),
+            drain_cancel: drain_cancel.clone(),
+            command_cancel: command_cancel.clone(),
+            drain_done_tx: drain_done_tx.clone(),
+        },
+        spawner.clone(),
+    );
+    let (stderr_handle, stderr_result_rx) = match stderr_spawn {
+        Ok(parts) => parts,
+        Err(e) => {
+            drain_cancel.store(true, Ordering::Release);
+            drop(output_tx);
+            kill_and_reap_child(child);
+            let _ = stdout_handle.join();
+            join_output_writer(output_handle);
+            send_final_and_complete(
+                &registration,
+                CommandResultFrame {
+                    seq: request.seq,
+                    termination: CommandTermination::WaitFailed,
+                    duration_ms: duration_ms(started),
+                    stdout: empty_output_for_policy(request.stdout),
+                    stderr: empty_output_for_policy(request.stderr),
+                    diagnostic: &format!("failed to spawn stderr drain thread: {e}"),
+                },
+                &writer,
+            );
+            return;
+        }
+    };
+    drop(drain_done_tx);
+    drop(output_tx);
+
+    let outcome = wait_with_kill_timeout_or_cancelled_either(
+        child,
+        request.timeout_ms,
+        &connection_cancel,
+        &command_cancel,
+    );
+    if matches!(outcome, WaitOutcome::Cancelled)
+        || connection_cancel.load(Ordering::Acquire)
+        || command_cancel.load(Ordering::Acquire)
+    {
+        drain_cancel.store(true, Ordering::Release);
+    }
+
+    let completed = await_drain_deadline(&drain_done_rx, 2, &drain_cancel);
+    if completed < 2 {
+        log(
+            "WARN",
+            &format!("command: drain deadline reached after {DRAIN_DEADLINE_SECS}s"),
+        );
+    }
+
+    let _ = stdout_handle.join();
+    let _ = stderr_handle.join();
+    join_output_writer(output_handle);
+    let stdout_result = stdout_result_rx.recv().unwrap_or_default();
+    let stderr_result = stderr_result_rx.recv().unwrap_or_default();
+
+    let (termination, diagnostic) = match outcome {
+        WaitOutcome::Exited(status) => (
+            CommandTermination::Exited {
+                exit_code: extract_exit_code(status),
+            },
+            String::new(),
+        ),
+        WaitOutcome::TimedOut => (CommandTermination::TimedOut, String::new()),
+        WaitOutcome::Cancelled => (CommandTermination::Cancelled, String::new()),
+        WaitOutcome::WaitFailed(msg) => (
+            CommandTermination::WaitFailed,
+            format!("Failed to wait: {msg}"),
+        ),
+    };
+
+    log(
+        "INFO",
+        &format!(
+            "command result: seq={}, termination={:?}, stdout_len={}, stderr_len={}, stdout_truncated={}, stderr_truncated={}",
+            request.seq,
+            termination,
+            stdout_result.captured.as_ref().map_or(0, Vec::len),
+            stderr_result.captured.as_ref().map_or(0, Vec::len),
+            stdout_result.capture_truncated,
+            stderr_result.capture_truncated,
+        ),
+    );
+
+    send_final_and_complete(
+        &registration,
+        CommandResultFrame {
+            seq: request.seq,
+            termination,
+            duration_ms: duration_ms(started),
+            stdout: captured_output(&stdout_result),
+            stderr: captured_output(&stderr_result),
+            diagnostic: &diagnostic,
+        },
+        &writer,
+    );
+}
+
+fn validate_request(request: &CommandWorkerRequest) -> Result<(), String> {
+    let stdout_capture = capture_limit_bytes(request.stdout);
+    let stderr_capture = capture_limit_bytes(request.stderr);
+    let capture_total = stdout_capture
+        .unwrap_or(0)
+        .checked_add(stderr_capture.unwrap_or(0))
+        .ok_or_else(|| "command capture limits overflow".to_string())?;
+    let capture_budget = command_result_capture_budget(request.stdout, request.stderr);
+    if capture_total > capture_budget {
+        return Err(format!(
+            "command capture limits exceed protocol result frame budget: {capture_total} > {capture_budget}"
+        ));
+    }
+
+    let max_chunk = vsock_proto::MAX_MESSAGE_SIZE
+        .saturating_sub(FRAME_BODY_HEADER_LEN)
+        .saturating_sub(COMMAND_OUTPUT_PAYLOAD_OVERHEAD);
+    for (name, policy) in [("stdout", request.stdout), ("stderr", request.stderr)] {
+        if let Some(stream) = stream_config(policy)
+            && stream.chunk_limit_bytes > max_chunk
+        {
+            return Err(format!(
+                "command {name} stream chunk limit exceeds protocol frame budget: {} > {max_chunk}",
+                stream.chunk_limit_bytes
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn command_result_capture_budget(
+    stdout_policy: CommandOutputPolicy,
+    stderr_policy: CommandOutputPolicy,
+) -> usize {
+    let fixed = FRAME_BODY_HEADER_LEN
+        + COMMAND_RESULT_EXITED_LEN
+        + COMMAND_RESULT_DURATION_LEN
+        + command_result_output_overhead(stdout_policy)
+        + command_result_output_overhead(stderr_policy)
+        + COMMAND_RESULT_DIAGNOSTIC_LEN_FIELD
+        + COMMAND_RESULT_MAX_DIAGNOSTIC_BYTES;
+    vsock_proto::MAX_MESSAGE_SIZE.saturating_sub(fixed)
+}
+
+fn command_result_output_overhead(policy: CommandOutputPolicy) -> usize {
+    if capture_limit_bytes(policy).is_some() {
+        COMMAND_CAPTURED_OUTPUT_OVERHEAD
+    } else {
+        COMMAND_DISCARDED_OUTPUT_LEN
+    }
+}
+
+fn output_settings(policy: CommandOutputPolicy) -> OutputSettings {
+    OutputSettings {
+        capture_limit_bytes: capture_limit_bytes(policy),
+        stream: stream_config(policy),
+    }
+}
+
+fn capture_limit_bytes(policy: CommandOutputPolicy) -> Option<usize> {
+    match policy {
+        CommandOutputPolicy::Discard | CommandOutputPolicy::Stream { .. } => None,
+        CommandOutputPolicy::Capture { limit_bytes } => Some(limit_bytes as usize),
+        CommandOutputPolicy::CaptureAndStream {
+            capture_limit_bytes,
+            ..
+        } => Some(capture_limit_bytes as usize),
+    }
+}
+
+fn stream_config(policy: CommandOutputPolicy) -> Option<BoundedStreamConfig> {
+    match policy {
+        CommandOutputPolicy::Stream {
+            limit_bytes,
+            chunk_limit_bytes,
+        }
+        | CommandOutputPolicy::CaptureAndStream {
+            stream_limit_bytes: limit_bytes,
+            chunk_limit_bytes,
+            ..
+        } => Some(BoundedStreamConfig {
+            chunk_limit_bytes: chunk_limit_bytes as usize,
+            stream_limit_bytes: limit_bytes as usize,
+        }),
+        CommandOutputPolicy::Discard | CommandOutputPolicy::Capture { .. } => None,
+    }
+}
+
+fn spawn_output_writer<S>(
+    seq: u32,
+    rx: Receiver<StreamEvent>,
+    writer: GuestWriter,
+    command_cancel: Arc<AtomicBool>,
+    drain_cancel: Arc<AtomicBool>,
+    spawner: S,
+) -> io::Result<JoinHandle<()>>
+where
+    S: ThreadSpawner,
+{
+    spawner.spawn_unit(
+        THREAD_COMMAND_OUTPUT,
+        Box::new(move || {
+            let mut output_seq = 0u32;
+            for event in rx {
+                let payload = match vsock_proto::encode_command_output(
+                    event.stream,
+                    output_seq,
+                    &event.chunk,
+                    event.truncated,
+                ) {
+                    Ok(payload) => payload,
+                    Err(e) => {
+                        log("ERROR", &format!("command: failed to encode output: {e}"));
+                        command_cancel.store(true, Ordering::Release);
+                        drain_cancel.store(true, Ordering::Release);
+                        break;
+                    }
+                };
+                output_seq = output_seq.wrapping_add(1);
+                let frame = match vsock_proto::encode(MSG_COMMAND_OUTPUT, seq, &payload) {
+                    Ok(frame) => frame,
+                    Err(e) => {
+                        log(
+                            "ERROR",
+                            &format!("command: failed to encode output frame: {e}"),
+                        );
+                        command_cancel.store(true, Ordering::Release);
+                        drain_cancel.store(true, Ordering::Release);
+                        break;
+                    }
+                };
+                if let Err(e) = writer.write_frame(&frame) {
+                    log(
+                        "WARN",
+                        &format!("command: failed to send output chunk: {e}"),
+                    );
+                    command_cancel.store(true, Ordering::Release);
+                    drain_cancel.store(true, Ordering::Release);
+                    break;
+                }
+            }
+        }),
+    )
+}
+
+fn spawn_command_drain<R, S>(
+    pipe: R,
+    worker: DrainWorker,
+    spawner: S,
+) -> io::Result<(JoinHandle<()>, mpsc::Receiver<BoundedDrainResult>)>
+where
+    R: std::os::unix::io::AsRawFd + Send + 'static,
+    S: ThreadSpawner,
+{
+    let DrainWorker {
+        seq,
+        stream,
+        policy,
+        output_tx,
+        drain_cancel,
+        command_cancel,
+        drain_done_tx,
+    } = worker;
+    let (result_tx, result_rx) = mpsc::channel();
+    let thread_name = match stream {
+        CommandOutputStream::Stdout => THREAD_COMMAND_STDOUT,
+        CommandOutputStream::Stderr => THREAD_COMMAND_STDERR,
+    };
+    let handle = spawner.spawn_unit(
+        thread_name,
+        Box::new(move || {
+            let result = drain_bounded_cancellable(
+                pipe,
+                &drain_cancel,
+                policy.capture_limit_bytes,
+                policy.stream,
+                |chunk, truncated| {
+                    let Some(tx) = &output_tx else {
+                        return true;
+                    };
+                    match tx.try_send(StreamEvent {
+                        stream,
+                        chunk: chunk.to_vec(),
+                        truncated,
+                    }) {
+                        Ok(()) => true,
+                        Err(TrySendError::Full(_)) => {
+                            log("WARN", &format!("command: output queue full for seq={seq}"));
+                            command_cancel.store(true, Ordering::Release);
+                            drain_cancel.store(true, Ordering::Release);
+                            false
+                        }
+                        Err(TrySendError::Disconnected(_)) => {
+                            command_cancel.store(true, Ordering::Release);
+                            drain_cancel.store(true, Ordering::Release);
+                            false
+                        }
+                    }
+                },
+            );
+            let _ = result_tx.send(result);
+            let _ = drain_done_tx.send(());
+        }),
+    )?;
+    Ok((handle, result_rx))
+}
+
+fn kill_and_send_wait_failed(child: Child, diagnostic: &str, failure: WaitFailureContext<'_>) {
+    kill_and_reap_child(child);
+    send_final_and_complete(
+        failure.registration,
+        CommandResultFrame {
+            seq: failure.seq,
+            termination: CommandTermination::WaitFailed,
+            duration_ms: duration_ms(failure.started),
+            stdout: empty_output_for_policy(failure.stdout_policy),
+            stderr: empty_output_for_policy(failure.stderr_policy),
+            diagnostic,
+        },
+        failure.writer,
+    );
+}
+
+fn send_final_and_complete(
+    registration: &CommandRegistration,
+    frame: CommandResultFrame<'_>,
+    writer: &GuestWriter,
+) {
+    let result = send_command_result(frame, writer);
+    registration.complete();
+    if let Err(e) = result {
+        log("ERROR", &format!("Failed to send command_result: {e}"));
+    }
+}
+
+fn send_command_result(frame: CommandResultFrame<'_>, writer: &GuestWriter) -> io::Result<()> {
+    let payload = vsock_proto::encode_command_result(
+        frame.termination,
+        frame.duration_ms,
+        frame.stdout,
+        frame.stderr,
+        frame.diagnostic,
+    )
+    .map_err(to_io_error)?;
+    let encoded =
+        vsock_proto::encode(MSG_COMMAND_RESULT, frame.seq, &payload).map_err(to_io_error)?;
+    writer.write_frame(&encoded)
+}
+
+fn captured_output(result: &BoundedDrainResult) -> CommandCapturedOutput<'_> {
+    match result.captured.as_deref() {
+        Some(bytes) => CommandCapturedOutput::Captured {
+            bytes,
+            truncated: result.capture_truncated,
+        },
+        None => CommandCapturedOutput::Discarded,
+    }
+}
+
+fn empty_output_for_policy(policy: CommandOutputPolicy) -> CommandCapturedOutput<'static> {
+    match policy {
+        CommandOutputPolicy::Capture { .. } | CommandOutputPolicy::CaptureAndStream { .. } => {
+            CommandCapturedOutput::Captured {
+                bytes: &[],
+                truncated: false,
+            }
+        }
+        CommandOutputPolicy::Discard | CommandOutputPolicy::Stream { .. } => {
+            CommandCapturedOutput::Discarded
+        }
+    }
+}
+
+fn env_refs(env: &[(String, String)]) -> Vec<(&str, &str)> {
+    env.iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect()
+}
+
+fn duration_ms(started: Instant) -> u32 {
+    u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX)
+}
+
+fn join_output_writer(handle: Option<JoinHandle<()>>) {
+    if let Some(handle) = handle {
+        let _ = handle.join();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::threading::test_support::FailingThreadSpawner;
+    use std::io::Read;
+    use std::os::unix::net::UnixStream;
+    use std::time::Duration;
+
+    fn read_message(stream: &mut UnixStream) -> vsock_proto::RawMessage {
+        let mut hdr = [0u8; 4];
+        stream.read_exact(&mut hdr).unwrap();
+        let body_len = u32::from_be_bytes(hdr) as usize;
+        let mut body = vec![0u8; body_len];
+        stream.read_exact(&mut body).unwrap();
+
+        let mut full = Vec::with_capacity(4 + body_len);
+        full.extend_from_slice(&hdr);
+        full.extend_from_slice(&body);
+        let mut decoder = vsock_proto::Decoder::new();
+        let mut messages = decoder.decode(&full).unwrap();
+        assert_eq!(messages.len(), 1);
+        messages.remove(0)
+    }
+
+    fn request(seq: u32, command: &str) -> CommandWorkerRequest {
+        CommandWorkerRequest {
+            seq,
+            timeout_ms: 0,
+            command: command.to_string(),
+            env: Vec::new(),
+            sudo: false,
+            stdout: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+            stderr: CommandOutputPolicy::Capture { limit_bytes: 1024 },
+            label: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn registry_rejects_duplicate_active_sequence_and_cleans_on_drop() {
+        let registry = CommandRegistry::default();
+        let first = registry.register(7).unwrap();
+        assert!(registry.register(7).is_err());
+        drop(first);
+        assert!(registry.register(7).is_ok());
+    }
+
+    #[test]
+    fn registry_cancel_sets_token_and_unknown_cancel_is_noop() {
+        let registry = CommandRegistry::default();
+        let registration = registry.register(8).unwrap();
+        assert!(registry.cancel(8));
+        assert!(registration.cancel.load(Ordering::Acquire));
+        assert!(!registry.cancel(9));
+    }
+
+    #[test]
+    fn command_worker_spawn_failure_returns_start_failed_and_cleans_registry() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let writer = GuestWriter::new(guest);
+        let registry = CommandRegistry::default();
+
+        start_command_operation_with_spawner(
+            request(42, "echo should-not-run"),
+            writer,
+            Arc::new(AtomicBool::new(false)),
+            registry.clone(),
+            FailingThreadSpawner::fail_once(THREAD_COMMAND_WORKER),
+        )
+        .unwrap();
+
+        let msg = read_message(&mut host);
+        assert_eq!(msg.msg_type, MSG_COMMAND_RESULT);
+        assert_eq!(msg.seq, 42);
+        let result = vsock_proto::decode_command_result(&msg.payload).unwrap();
+        assert_eq!(result.termination, CommandTermination::StartFailed);
+        assert!(result.diagnostic.contains("command worker thread"));
+        assert!(registry.register(42).is_ok());
+    }
+
+    #[test]
+    fn duplicate_active_command_returns_error() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let writer = GuestWriter::new(guest);
+        let registry = CommandRegistry::default();
+        let _registration = registry.register(11).unwrap();
+
+        start_command_operation_with_spawner(
+            request(11, "echo duplicate"),
+            writer,
+            Arc::new(AtomicBool::new(false)),
+            registry,
+            SystemThreadSpawner,
+        )
+        .unwrap();
+
+        let msg = read_message(&mut host);
+        assert_eq!(msg.msg_type, MSG_ERROR);
+        let error = vsock_proto::decode_error(&msg.payload).unwrap();
+        assert!(error.contains("already active"));
+    }
+
+    #[test]
+    fn stdout_drain_spawn_failure_returns_wait_failed_and_cleans_registry() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let writer = GuestWriter::new(guest);
+        let registry = CommandRegistry::default();
+
+        start_command_operation_with_spawner(
+            request(43, "sleep 60"),
+            writer,
+            Arc::new(AtomicBool::new(false)),
+            registry.clone(),
+            FailingThreadSpawner::fail_once(THREAD_COMMAND_STDOUT),
+        )
+        .unwrap();
+
+        let msg = read_message(&mut host);
+        assert_eq!(msg.msg_type, MSG_COMMAND_RESULT);
+        assert_eq!(msg.seq, 43);
+        let result = vsock_proto::decode_command_result(&msg.payload).unwrap();
+        assert_eq!(result.termination, CommandTermination::WaitFailed);
+        assert!(result.diagnostic.contains("stdout drain thread"));
+        assert!(registry.register(43).is_ok());
+    }
+
+    #[test]
+    fn output_writer_spawn_failure_returns_wait_failed_and_cleans_registry() {
+        let (guest, mut host) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        let writer = GuestWriter::new(guest);
+        let registry = CommandRegistry::default();
+        let mut request = request(44, "sleep 60");
+        request.stdout = CommandOutputPolicy::Stream {
+            limit_bytes: 64,
+            chunk_limit_bytes: 8,
+        };
+
+        start_command_operation_with_spawner(
+            request,
+            writer,
+            Arc::new(AtomicBool::new(false)),
+            registry.clone(),
+            FailingThreadSpawner::fail_once(THREAD_COMMAND_OUTPUT),
+        )
+        .unwrap();
+
+        let msg = read_message(&mut host);
+        assert_eq!(msg.msg_type, MSG_COMMAND_RESULT);
+        assert_eq!(msg.seq, 44);
+        let result = vsock_proto::decode_command_result(&msg.payload).unwrap();
+        assert_eq!(result.termination, CommandTermination::WaitFailed);
+        assert!(result.diagnostic.contains("output writer thread"));
+        assert!(registry.register(44).is_ok());
+    }
+}

--- a/crates/vsock-guest/src/command.rs
+++ b/crates/vsock-guest/src/command.rs
@@ -446,10 +446,11 @@ fn run_command_worker<S>(
         &connection_cancel,
         &command_cancel,
     );
-    if matches!(outcome, WaitOutcome::Cancelled)
+    if matches!(outcome, WaitOutcome::Cancelled | WaitOutcome::TimedOut)
         || connection_cancel.load(Ordering::Acquire)
         || command_cancel.load(Ordering::Acquire)
     {
+        command_cancel.store(true, Ordering::Release);
         drain_cancel.store(true, Ordering::Release);
     }
 
@@ -614,6 +615,9 @@ where
         Box::new(move || {
             let mut output_seq = 0u32;
             for event in rx {
+                if command_cancel.load(Ordering::Acquire) {
+                    break;
+                }
                 let payload = match vsock_proto::encode_command_output(
                     event.stream,
                     output_seq,
@@ -689,6 +693,11 @@ where
                     let Some(tx) = &output_tx else {
                         return true;
                     };
+                    if command_cancel.load(Ordering::Acquire)
+                        || drain_cancel.load(Ordering::Acquire)
+                    {
+                        return false;
+                    }
                     match tx.send(StreamEvent {
                         stream,
                         chunk: chunk.to_vec(),

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -5,8 +5,15 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
-use vsock_proto::{self, MSG_EXEC, MSG_EXEC_RESULT, MSG_READY, MSG_SPAWN_WATCH};
+use vsock_proto::{
+    self, MSG_COMMAND_CANCEL, MSG_COMMAND_START, MSG_EXEC, MSG_EXEC_RESULT, MSG_READY,
+    MSG_SPAWN_WATCH,
+};
 
+use crate::command::{
+    CommandRegistry, CommandWorkerRequest, cancel_command_operation, send_command_error,
+    start_command_operation,
+};
 use crate::error::to_io_error;
 use crate::handlers::{MessageOutcome, handle_exec, handle_message};
 use crate::log::log;
@@ -113,6 +120,7 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
     let writer = GuestWriter::new(stream);
     let connection_cancel = Arc::new(AtomicBool::new(false));
     let _cancel_on_drop = ConnectionCancelGuard(connection_cancel.clone());
+    let command_registry = CommandRegistry::default();
 
     let mut decoder = vsock_proto::Decoder::new();
 
@@ -137,10 +145,38 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
             .decode(buf.get(..n).unwrap_or_default())
             .map_err(to_io_error)?
         {
-            // MSG_EXEC and MSG_SPAWN_WATCH run in background threads to avoid
+            // Command execution messages run in background threads to avoid
             // blocking the event loop. A blocking child process (e.g. reading a
             // pipe fd) would otherwise stall all subsequent messages.
-            if msg.msg_type == MSG_SPAWN_WATCH {
+            if msg.msg_type == MSG_COMMAND_START {
+                log(
+                    "INFO",
+                    &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),
+                );
+                if msg.seq == 0 {
+                    send_command_error(0, "command start requires non-zero sequence", &writer)?;
+                    continue;
+                }
+                let decoded =
+                    vsock_proto::decode_command_start(&msg.payload).map_err(to_io_error)?;
+                start_command_operation(
+                    CommandWorkerRequest::from_decoded(msg.seq, decoded),
+                    writer.clone(),
+                    connection_cancel.clone(),
+                    command_registry.clone(),
+                )?;
+            } else if msg.msg_type == MSG_COMMAND_CANCEL {
+                log(
+                    "INFO",
+                    &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),
+                );
+                if msg.seq == 0 {
+                    send_command_error(0, "command cancel requires non-zero sequence", &writer)?;
+                    continue;
+                }
+                vsock_proto::decode_command_cancel(&msg.payload).map_err(to_io_error)?;
+                cancel_command_operation(&command_registry, msg.seq);
+            } else if msg.msg_type == MSG_SPAWN_WATCH {
                 let d = vsock_proto::decode_spawn_watch(&msg.payload).map_err(to_io_error)?;
                 // handle_spawn_watch writes the response itself (before
                 // spawning the streaming thread) to prevent a race where

--- a/crates/vsock-guest/src/drain.rs
+++ b/crates/vsock-guest/src/drain.rs
@@ -388,6 +388,32 @@ mod tests {
     }
 
     #[test]
+    fn bounded_drain_zero_chunk_limit_emits_truncation_marker_on_data() {
+        let (reader, mut writer) = pipe_pair();
+        writer.write_all(b"abc").unwrap();
+        drop(writer);
+
+        let cancel = AtomicBool::new(false);
+        let mut chunks = Vec::new();
+        let result = drain_bounded_cancellable(
+            reader,
+            &cancel,
+            None,
+            Some(BoundedStreamConfig {
+                chunk_limit_bytes: 0,
+                stream_limit_bytes: 3,
+            }),
+            |chunk, truncated| {
+                chunks.push((chunk.to_vec(), truncated));
+                true
+            },
+        );
+
+        assert_eq!(result.captured, None);
+        assert_eq!(chunks, vec![(Vec::new(), true)]);
+    }
+
+    #[test]
     fn bounded_drain_stream_callback_failure_stops_stream_but_keeps_draining() {
         let (reader, mut writer) = pipe_pair();
         writer.write_all(b"abcdef").unwrap();

--- a/crates/vsock-guest/src/drain.rs
+++ b/crates/vsock-guest/src/drain.rs
@@ -5,6 +5,18 @@ use std::sync::atomic::{AtomicBool, Ordering};
 const STDOUT_CHUNK_SIZE: usize = 8 * 1024;
 const DRAIN_POLL_TIMEOUT_MS: libc::c_int = 100;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct BoundedStreamConfig {
+    pub(crate) chunk_limit_bytes: usize,
+    pub(crate) stream_limit_bytes: usize,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct BoundedDrainResult {
+    pub(crate) captured: Option<Vec<u8>>,
+    pub(crate) capture_truncated: bool,
+}
+
 /// Drain `pipe` until EOF or `cancel` is set, calling `on_chunk` for each
 /// non-empty read.
 ///
@@ -87,6 +99,79 @@ where
     buf
 }
 
+/// Bounded variant of [`drain_until_eof_or_cancelled`].
+///
+/// The helper keeps draining after capture/stream limits are reached so the
+/// child cannot block on a full pipe. `capture_limit_bytes = None` discards the
+/// final captured output. Returning `false` from `on_stream_chunk` disables
+/// further stream forwarding; draining still continues unless `cancel` is set.
+pub(crate) fn drain_bounded_cancellable<R>(
+    pipe: R,
+    cancel: &AtomicBool,
+    capture_limit_bytes: Option<usize>,
+    stream: Option<BoundedStreamConfig>,
+    mut on_stream_chunk: impl FnMut(&[u8], bool) -> bool,
+) -> BoundedDrainResult
+where
+    R: std::os::unix::io::AsRawFd,
+{
+    let mut captured =
+        capture_limit_bytes.map(|limit| Vec::with_capacity(limit.min(STDOUT_CHUNK_SIZE)));
+    let mut capture_truncated = false;
+    let mut stream_emitted = 0usize;
+    let mut stream_truncated = false;
+    let mut stream_enabled = stream.is_some();
+
+    drain_until_eof_or_cancelled(pipe, cancel, |chunk| {
+        if let (Some(limit), Some(output)) = (capture_limit_bytes, captured.as_mut()) {
+            if output.len() < limit {
+                let remaining = limit - output.len();
+                let keep = remaining.min(chunk.len());
+                output.extend_from_slice(chunk.get(..keep).unwrap_or_default());
+                if keep < chunk.len() {
+                    capture_truncated = true;
+                }
+            } else if !chunk.is_empty() {
+                capture_truncated = true;
+            }
+        }
+
+        let Some(config) = stream else {
+            return;
+        };
+        if !stream_enabled || stream_truncated || chunk.is_empty() {
+            return;
+        }
+
+        if stream_emitted >= config.stream_limit_bytes || config.chunk_limit_bytes == 0 {
+            stream_truncated = true;
+            stream_enabled = on_stream_chunk(&[], true);
+            return;
+        }
+
+        let remaining_stream = config.stream_limit_bytes - stream_emitted;
+        let emit_total = remaining_stream.min(chunk.len());
+        let emit = chunk.get(..emit_total).unwrap_or_default();
+        for part in emit.chunks(config.chunk_limit_bytes) {
+            if !on_stream_chunk(part, false) {
+                stream_enabled = false;
+                return;
+            }
+            stream_emitted += part.len();
+        }
+
+        if emit_total < chunk.len() {
+            stream_truncated = true;
+            stream_enabled = on_stream_chunk(&[], true);
+        }
+    });
+
+    BoundedDrainResult {
+        captured,
+        capture_truncated,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -158,5 +243,174 @@ mod tests {
         });
 
         assert!(output.is_empty());
+    }
+
+    #[test]
+    fn bounded_drain_retains_limit_and_reports_truncation() {
+        let (reader, mut writer) = pipe_pair();
+        writer.write_all(b"abcdef").unwrap();
+        drop(writer);
+
+        let cancel = AtomicBool::new(false);
+        let result = drain_bounded_cancellable(reader, &cancel, Some(3), None, |_, _| true);
+
+        assert_eq!(result.captured, Some(b"abc".to_vec()));
+        assert!(result.capture_truncated);
+    }
+
+    #[test]
+    fn bounded_drain_exact_capture_limit_is_not_truncated() {
+        let (reader, mut writer) = pipe_pair();
+        writer.write_all(b"abc").unwrap();
+        drop(writer);
+
+        let cancel = AtomicBool::new(false);
+        let result = drain_bounded_cancellable(reader, &cancel, Some(3), None, |_, _| true);
+
+        assert_eq!(result.captured, Some(b"abc".to_vec()));
+        assert!(!result.capture_truncated);
+    }
+
+    #[test]
+    fn bounded_drain_zero_capture_limit_stores_empty_and_truncates_on_data() {
+        let (reader, mut writer) = pipe_pair();
+        writer.write_all(b"abc").unwrap();
+        drop(writer);
+
+        let cancel = AtomicBool::new(false);
+        let result = drain_bounded_cancellable(reader, &cancel, Some(0), None, |_, _| true);
+
+        assert_eq!(result.captured, Some(Vec::new()));
+        assert!(result.capture_truncated);
+    }
+
+    #[test]
+    fn bounded_drain_discard_capture_stores_no_output() {
+        let (reader, mut writer) = pipe_pair();
+        writer.write_all(b"abc").unwrap();
+        drop(writer);
+
+        let cancel = AtomicBool::new(false);
+        let result = drain_bounded_cancellable(reader, &cancel, None, None, |_, _| true);
+
+        assert_eq!(result.captured, None);
+        assert!(!result.capture_truncated);
+    }
+
+    #[test]
+    fn bounded_drain_splits_stream_chunks_and_marks_stream_truncation() {
+        let (reader, mut writer) = pipe_pair();
+        writer.write_all(b"abcdef").unwrap();
+        drop(writer);
+
+        let cancel = AtomicBool::new(false);
+        let mut chunks = Vec::new();
+        let result = drain_bounded_cancellable(
+            reader,
+            &cancel,
+            Some(10),
+            Some(BoundedStreamConfig {
+                chunk_limit_bytes: 2,
+                stream_limit_bytes: 5,
+            }),
+            |chunk, truncated| {
+                chunks.push((chunk.to_vec(), truncated));
+                true
+            },
+        );
+
+        assert_eq!(result.captured, Some(b"abcdef".to_vec()));
+        assert!(!result.capture_truncated);
+        assert_eq!(
+            chunks,
+            vec![
+                (b"ab".to_vec(), false),
+                (b"cd".to_vec(), false),
+                (b"e".to_vec(), false),
+                (Vec::new(), true),
+            ]
+        );
+    }
+
+    #[test]
+    fn bounded_drain_exact_stream_limit_has_no_truncation_marker() {
+        let (reader, mut writer) = pipe_pair();
+        writer.write_all(b"abcd").unwrap();
+        drop(writer);
+
+        let cancel = AtomicBool::new(false);
+        let mut chunks = Vec::new();
+        let result = drain_bounded_cancellable(
+            reader,
+            &cancel,
+            None,
+            Some(BoundedStreamConfig {
+                chunk_limit_bytes: 2,
+                stream_limit_bytes: 4,
+            }),
+            |chunk, truncated| {
+                chunks.push((chunk.to_vec(), truncated));
+                true
+            },
+        );
+
+        assert_eq!(result.captured, None);
+        assert_eq!(
+            chunks,
+            vec![(b"ab".to_vec(), false), (b"cd".to_vec(), false)]
+        );
+    }
+
+    #[test]
+    fn bounded_drain_zero_stream_limit_emits_truncation_marker_on_data() {
+        let (reader, mut writer) = pipe_pair();
+        writer.write_all(b"abc").unwrap();
+        drop(writer);
+
+        let cancel = AtomicBool::new(false);
+        let mut chunks = Vec::new();
+        let result = drain_bounded_cancellable(
+            reader,
+            &cancel,
+            None,
+            Some(BoundedStreamConfig {
+                chunk_limit_bytes: 2,
+                stream_limit_bytes: 0,
+            }),
+            |chunk, truncated| {
+                chunks.push((chunk.to_vec(), truncated));
+                true
+            },
+        );
+
+        assert_eq!(result.captured, None);
+        assert_eq!(chunks, vec![(Vec::new(), true)]);
+    }
+
+    #[test]
+    fn bounded_drain_stream_callback_failure_stops_stream_but_keeps_draining() {
+        let (reader, mut writer) = pipe_pair();
+        writer.write_all(b"abcdef").unwrap();
+        drop(writer);
+
+        let cancel = AtomicBool::new(false);
+        let mut chunks = Vec::new();
+        let result = drain_bounded_cancellable(
+            reader,
+            &cancel,
+            Some(10),
+            Some(BoundedStreamConfig {
+                chunk_limit_bytes: 2,
+                stream_limit_bytes: 10,
+            }),
+            |chunk, truncated| {
+                chunks.push((chunk.to_vec(), truncated));
+                false
+            },
+        );
+
+        assert_eq!(chunks, vec![(b"ab".to_vec(), false)]);
+        assert_eq!(result.captured, Some(b"abcdef".to_vec()));
+        assert!(!result.capture_truncated);
     }
 }

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! Protocol encoding/decoding is handled by the `vsock-proto` crate.
 
+mod command;
 mod connection;
 mod drain;
 mod error;

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -92,9 +92,31 @@ pub(crate) fn wait_with_kill_timeout(mut child: Child, timeout_ms: u32) -> WaitO
 /// work tied to a disconnected host connection cannot outlive that connection
 /// indefinitely.
 pub(crate) fn wait_with_kill_timeout_or_cancelled(
-    mut child: Child,
+    child: Child,
     timeout_ms: u32,
     cancel: &AtomicBool,
+) -> WaitOutcome {
+    wait_with_kill_timeout_or_cancelled_by(child, timeout_ms, || cancel.load(Ordering::Acquire))
+}
+
+/// Like [`wait_with_kill_timeout_or_cancelled`], but observes either cancel
+/// flag. Command operations have both connection-level cancellation and
+/// request-level cancellation.
+pub(crate) fn wait_with_kill_timeout_or_cancelled_either(
+    child: Child,
+    timeout_ms: u32,
+    first_cancel: &AtomicBool,
+    second_cancel: &AtomicBool,
+) -> WaitOutcome {
+    wait_with_kill_timeout_or_cancelled_by(child, timeout_ms, || {
+        first_cancel.load(Ordering::Acquire) || second_cancel.load(Ordering::Acquire)
+    })
+}
+
+fn wait_with_kill_timeout_or_cancelled_by(
+    mut child: Child,
+    timeout_ms: u32,
+    is_cancelled: impl Fn() -> bool + Copy + Send + Sync,
 ) -> WaitOutcome {
     let child_id = child.id();
     let deadline = if timeout_ms > 0 {
@@ -110,7 +132,7 @@ pub(crate) fn wait_with_kill_timeout_or_cancelled(
     thread::scope(|scope| {
         let (done_tx, done_rx) = mpsc::channel::<()>();
         let watchdog = match spawn_scoped_named(scope, THREAD_WAIT_WATCHDOG, move || {
-            wait_for_done_timeout_or_cancelled(done_rx, deadline, cancel, child_id)
+            wait_for_done_timeout_or_cancelled(done_rx, deadline, is_cancelled, child_id)
         }) {
             Ok(watchdog) => watchdog,
             Err(e) => {
@@ -148,7 +170,7 @@ pub(crate) fn wait_with_kill_timeout_or_cancelled(
 fn wait_for_done_timeout_or_cancelled(
     done_rx: mpsc::Receiver<()>,
     deadline: Option<Instant>,
-    cancel: &AtomicBool,
+    is_cancelled: impl Fn() -> bool,
     child_id: u32,
 ) -> Option<WatchdogKill> {
     let poll_interval = Duration::from_millis(WATCHDOG_CANCEL_POLL_INTERVAL_MS);
@@ -170,7 +192,7 @@ fn wait_for_done_timeout_or_cancelled(
             None => poll_interval,
         };
 
-        if cancel.load(Ordering::Acquire) {
+        if is_cancelled() {
             return kill_child_unless_done(&done_rx, child_id, KillReason::Cancelled);
         }
 
@@ -513,7 +535,7 @@ mod tests {
         let outcome = wait_for_done_timeout_or_cancelled(
             done_rx,
             Some(Instant::now()),
-            &cancel,
+            || cancel.load(Ordering::Acquire),
             i32::MAX as u32,
         );
 
@@ -526,7 +548,12 @@ mod tests {
         let (done_tx, done_rx) = mpsc::channel::<()>();
         done_tx.send(()).unwrap();
 
-        let outcome = wait_for_done_timeout_or_cancelled(done_rx, None, &cancel, i32::MAX as u32);
+        let outcome = wait_for_done_timeout_or_cancelled(
+            done_rx,
+            None,
+            || cancel.load(Ordering::Acquire),
+            i32::MAX as u32,
+        );
 
         assert!(outcome.is_none());
     }

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -11,8 +11,10 @@ use std::time::Duration;
 
 use vsock_guest::{handle_connection, run};
 use vsock_proto::{
-    self, MSG_ERROR, MSG_EXEC, MSG_EXEC_RESULT, MSG_PROCESS_EXIT, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
-    MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK,
+    self, CommandCapturedOutput, CommandOutputPolicy, CommandOutputStream, CommandTermination,
+    MSG_COMMAND_CANCEL, MSG_COMMAND_OUTPUT, MSG_COMMAND_RESULT, MSG_COMMAND_START, MSG_ERROR,
+    MSG_EXEC, MSG_EXEC_RESULT, MSG_PROCESS_EXIT, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH,
+    MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK,
 };
 
 const EXIT_CODE_TIMEOUT: i32 = 124;
@@ -526,6 +528,554 @@ fn read_message(stream: &mut impl std::io::Read) -> vsock_proto::RawMessage {
 /// Read one framed message from the stream and discard it.
 fn read_and_discard_message(stream: &mut impl std::io::Read) {
     let _ = read_message(stream);
+}
+
+#[derive(Debug)]
+struct CommandChunk {
+    stream: CommandOutputStream,
+    output_seq: u32,
+    chunk: Vec<u8>,
+    truncated: bool,
+}
+
+#[derive(Debug)]
+struct CommandResult {
+    termination: CommandTermination,
+    stdout: Option<Vec<u8>>,
+    stderr: Option<Vec<u8>>,
+    stdout_truncated: bool,
+    stderr_truncated: bool,
+    diagnostic: String,
+}
+
+fn start_guest_connection() -> (thread::JoinHandle<()>, std::os::unix::net::UnixStream) {
+    let (guest_stream, mut host_stream) = std::os::unix::net::UnixStream::pair().unwrap();
+    let handle = thread::spawn(move || {
+        let _ = handle_connection(guest_stream);
+    });
+    read_and_discard_message(&mut host_stream);
+    host_stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    (handle, host_stream)
+}
+
+fn finish_guest_connection(
+    handle: thread::JoinHandle<()>,
+    host_stream: std::os::unix::net::UnixStream,
+) {
+    drop(host_stream);
+    let _ = handle.join();
+}
+
+fn send_command_start(
+    stream: &mut impl std::io::Write,
+    seq: u32,
+    command: &str,
+    timeout_ms: u32,
+    stdout: CommandOutputPolicy,
+    stderr: CommandOutputPolicy,
+) {
+    send_command_start_with_env(stream, seq, command, timeout_ms, &[], stdout, stderr);
+}
+
+fn send_command_start_with_env(
+    stream: &mut impl std::io::Write,
+    seq: u32,
+    command: &str,
+    timeout_ms: u32,
+    env: &[(&str, &str)],
+    stdout: CommandOutputPolicy,
+    stderr: CommandOutputPolicy,
+) {
+    let payload =
+        vsock_proto::encode_command_start(timeout_ms, command, env, false, stdout, stderr, "test")
+            .unwrap();
+    let msg = vsock_proto::encode(MSG_COMMAND_START, seq, &payload).unwrap();
+    stream.write_all(&msg).unwrap();
+}
+
+fn send_command_cancel(stream: &mut impl std::io::Write, seq: u32) {
+    let payload = vsock_proto::encode_command_cancel();
+    let msg = vsock_proto::encode(MSG_COMMAND_CANCEL, seq, &payload).unwrap();
+    stream.write_all(&msg).unwrap();
+}
+
+fn read_command_result(
+    stream: &mut impl std::io::Read,
+    seq: u32,
+) -> (Vec<CommandChunk>, CommandResult) {
+    let mut decoder = vsock_proto::Decoder::new();
+    let mut buf = [0u8; 4096];
+    let mut chunks = Vec::new();
+    loop {
+        let n = read_retry_eintr(stream, &mut buf).unwrap();
+        assert!(n > 0, "unexpected EOF waiting for command result");
+        for msg in decoder.decode(buf.get(..n).unwrap_or_default()).unwrap() {
+            if msg.seq != seq {
+                continue;
+            }
+            match msg.msg_type {
+                MSG_COMMAND_OUTPUT => {
+                    let decoded = vsock_proto::decode_command_output(&msg.payload).unwrap();
+                    chunks.push(CommandChunk {
+                        stream: decoded.stream,
+                        output_seq: decoded.output_seq,
+                        chunk: decoded.chunk.to_vec(),
+                        truncated: decoded.truncated,
+                    });
+                }
+                MSG_COMMAND_RESULT => {
+                    let decoded = vsock_proto::decode_command_result(&msg.payload).unwrap();
+                    return (
+                        chunks,
+                        CommandResult {
+                            termination: decoded.termination,
+                            stdout: captured_to_vec(decoded.stdout),
+                            stderr: captured_to_vec(decoded.stderr),
+                            stdout_truncated: captured_truncated(decoded.stdout),
+                            stderr_truncated: captured_truncated(decoded.stderr),
+                            diagnostic: decoded.diagnostic.to_string(),
+                        },
+                    );
+                }
+                MSG_ERROR => {
+                    let error = vsock_proto::decode_error(&msg.payload).unwrap();
+                    panic!("unexpected command error for seq={seq}: {error}");
+                }
+                other => panic!("unexpected command response type: 0x{other:02X}"),
+            }
+        }
+    }
+}
+
+fn captured_to_vec(captured: CommandCapturedOutput<'_>) -> Option<Vec<u8>> {
+    match captured {
+        CommandCapturedOutput::Discarded => None,
+        CommandCapturedOutput::Captured { bytes, .. } => Some(bytes.to_vec()),
+    }
+}
+
+fn captured_truncated(captured: CommandCapturedOutput<'_>) -> bool {
+    match captured {
+        CommandCapturedOutput::Discarded => false,
+        CommandCapturedOutput::Captured { truncated, .. } => truncated,
+    }
+}
+
+fn stdout_data(chunks: &[CommandChunk]) -> Vec<u8> {
+    chunks
+        .iter()
+        .filter(|chunk| chunk.stream == CommandOutputStream::Stdout && !chunk.truncated)
+        .flat_map(|chunk| chunk.chunk.clone())
+        .collect()
+}
+
+fn stderr_data(chunks: &[CommandChunk]) -> Vec<u8> {
+    chunks
+        .iter()
+        .filter(|chunk| chunk.stream == CommandOutputStream::Stderr && !chunk.truncated)
+        .flat_map(|chunk| chunk.chunk.clone())
+        .collect()
+}
+
+#[test]
+fn command_capture_only_stdout_stderr_success() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_command_start(
+        &mut host_stream,
+        101,
+        "printf stdout; printf stderr >&2",
+        5000,
+        CommandOutputPolicy::Capture { limit_bytes: 1024 },
+        CommandOutputPolicy::Capture { limit_bytes: 1024 },
+    );
+    let (chunks, result) = read_command_result(&mut host_stream, 101);
+
+    assert!(chunks.is_empty());
+    assert_eq!(
+        result.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, Some(b"stdout".to_vec()));
+    assert_eq!(result.stderr, Some(b"stderr".to_vec()));
+    assert!(!result.stdout_truncated);
+    assert!(!result.stderr_truncated);
+    assert!(result.diagnostic.is_empty());
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn command_stream_only_stdout_stderr_success() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_command_start(
+        &mut host_stream,
+        102,
+        "printf out; printf err >&2",
+        5000,
+        CommandOutputPolicy::Stream {
+            limit_bytes: 64,
+            chunk_limit_bytes: 8,
+        },
+        CommandOutputPolicy::Stream {
+            limit_bytes: 64,
+            chunk_limit_bytes: 8,
+        },
+    );
+    let (chunks, result) = read_command_result(&mut host_stream, 102);
+
+    assert_eq!(
+        result.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, None);
+    assert_eq!(result.stderr, None);
+    assert_eq!(stdout_data(&chunks), b"out".to_vec());
+    assert_eq!(stderr_data(&chunks), b"err".to_vec());
+    for (expected, chunk) in chunks.iter().enumerate() {
+        assert_eq!(chunk.output_seq, expected as u32);
+    }
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn command_capture_and_stream_success() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_command_start(
+        &mut host_stream,
+        103,
+        "printf visible",
+        5000,
+        CommandOutputPolicy::CaptureAndStream {
+            capture_limit_bytes: 64,
+            stream_limit_bytes: 64,
+            chunk_limit_bytes: 4,
+        },
+        CommandOutputPolicy::Discard,
+    );
+    let (chunks, result) = read_command_result(&mut host_stream, 103);
+
+    assert_eq!(
+        result.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, Some(b"visible".to_vec()));
+    assert_eq!(result.stderr, None);
+    assert_eq!(stdout_data(&chunks), b"visible".to_vec());
+    assert!(chunks.iter().all(|chunk| !chunk.truncated));
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn command_capture_limits_track_exact_and_one_byte_over() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_command_start(
+        &mut host_stream,
+        104,
+        "printf abcd",
+        5000,
+        CommandOutputPolicy::Capture { limit_bytes: 4 },
+        CommandOutputPolicy::Discard,
+    );
+    let (_chunks, exact) = read_command_result(&mut host_stream, 104);
+    assert_eq!(exact.stdout, Some(b"abcd".to_vec()));
+    assert!(!exact.stdout_truncated);
+
+    send_command_start(
+        &mut host_stream,
+        105,
+        "printf abcde",
+        5000,
+        CommandOutputPolicy::Capture { limit_bytes: 4 },
+        CommandOutputPolicy::Discard,
+    );
+    let (_chunks, over) = read_command_result(&mut host_stream, 105);
+    assert_eq!(over.stdout, Some(b"abcd".to_vec()));
+    assert!(over.stdout_truncated);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn command_stream_limits_track_exact_over_and_zero_budget() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_command_start(
+        &mut host_stream,
+        106,
+        "printf abcd",
+        5000,
+        CommandOutputPolicy::Stream {
+            limit_bytes: 4,
+            chunk_limit_bytes: 2,
+        },
+        CommandOutputPolicy::Discard,
+    );
+    let (exact_chunks, exact) = read_command_result(&mut host_stream, 106);
+    assert_eq!(
+        exact.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(stdout_data(&exact_chunks), b"abcd".to_vec());
+    assert!(exact_chunks.iter().all(|chunk| !chunk.truncated));
+
+    send_command_start(
+        &mut host_stream,
+        107,
+        "printf abcde",
+        5000,
+        CommandOutputPolicy::Stream {
+            limit_bytes: 4,
+            chunk_limit_bytes: 2,
+        },
+        CommandOutputPolicy::Discard,
+    );
+    let (over_chunks, over) = read_command_result(&mut host_stream, 107);
+    assert_eq!(
+        over.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(stdout_data(&over_chunks), b"abcd".to_vec());
+    assert!(
+        over_chunks
+            .iter()
+            .any(|chunk| chunk.stream == CommandOutputStream::Stdout
+                && chunk.truncated
+                && chunk.chunk.is_empty())
+    );
+
+    send_command_start(
+        &mut host_stream,
+        108,
+        "printf abc",
+        5000,
+        CommandOutputPolicy::Stream {
+            limit_bytes: 0,
+            chunk_limit_bytes: 2,
+        },
+        CommandOutputPolicy::Discard,
+    );
+    let (zero_chunks, zero) = read_command_result(&mut host_stream, 108);
+    assert_eq!(
+        zero.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(stdout_data(&zero_chunks), Vec::<u8>::new());
+    assert_eq!(zero_chunks.len(), 1);
+    assert_eq!(zero_chunks[0].stream, CommandOutputStream::Stdout);
+    assert!(zero_chunks[0].truncated);
+    assert!(zero_chunks[0].chunk.is_empty());
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn command_timeout_returns_timed_out_with_partial_capture() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_command_start(
+        &mut host_stream,
+        109,
+        "printf before; sleep 60",
+        200,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+    );
+    let (_chunks, result) = read_command_result(&mut host_stream, 109);
+
+    assert_eq!(result.termination, CommandTermination::TimedOut);
+    assert_eq!(result.stdout, Some(b"before".to_vec()));
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn command_invalid_env_returns_start_failed_without_leaking_value() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let secret = "do-not-print-this-secret";
+    send_command_start_with_env(
+        &mut host_stream,
+        110,
+        "echo should-not-run",
+        5000,
+        &[("BAD;KEY", secret)],
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+    );
+    let (chunks, result) = read_command_result(&mut host_stream, 110);
+
+    assert!(chunks.is_empty());
+    assert_eq!(result.termination, CommandTermination::StartFailed);
+    assert!(
+        result
+            .diagnostic
+            .contains("invalid environment variable name")
+    );
+    assert!(!result.diagnostic.contains(secret));
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn command_explicit_cancel_kills_child_and_returns_cancelled() {
+    let pid_path = unique_pid_path("command-cancel");
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let command = format!("echo $$ > '{}'; sleep 60", pid_path.as_str());
+    send_command_start(
+        &mut host_stream,
+        111,
+        &command,
+        0,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+    );
+    let pid = read_pid_file(pid_path.as_str());
+    assert!(
+        pid_alive(pid),
+        "command child should be running before cancel"
+    );
+
+    send_command_cancel(&mut host_stream, 111);
+    let (_chunks, result) = read_command_result(&mut host_stream, 111);
+
+    assert_eq!(result.termination, CommandTermination::Cancelled);
+    wait_for_pid_exit(pid, "command explicit cancel");
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn command_connection_close_cancels_child() {
+    let pid_path = unique_pid_path("command-connection-close");
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let command = format!("echo $$ > '{}'; sleep 60", pid_path.as_str());
+    send_command_start(
+        &mut host_stream,
+        112,
+        &command,
+        0,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+    );
+    let pid = read_pid_file(pid_path.as_str());
+    assert!(
+        pid_alive(pid),
+        "command child should be running before disconnect"
+    );
+
+    drop(host_stream);
+    let _ = handle.join();
+    wait_for_pid_exit(pid, "command host disconnect");
+}
+
+#[test]
+fn command_duplicate_start_returns_error_without_cancelling_active_command() {
+    let pid_path = unique_pid_path("command-duplicate");
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let command = format!("echo $$ > '{}'; sleep 60", pid_path.as_str());
+    send_command_start(
+        &mut host_stream,
+        113,
+        &command,
+        0,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+    );
+    let pid = read_pid_file(pid_path.as_str());
+
+    send_command_start(
+        &mut host_stream,
+        113,
+        "printf duplicate",
+        5000,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Discard,
+    );
+    let msg = read_message(&mut host_stream);
+    assert_eq!(msg.msg_type, MSG_ERROR);
+    assert_eq!(msg.seq, 113);
+    let error = vsock_proto::decode_error(&msg.payload).unwrap();
+    assert!(error.contains("already active"));
+    assert!(
+        pid_alive(pid),
+        "duplicate start should not cancel active child"
+    );
+
+    send_command_cancel(&mut host_stream, 113);
+    let (_chunks, result) = read_command_result(&mut host_stream, 113);
+    assert_eq!(result.termination, CommandTermination::Cancelled);
+    wait_for_pid_exit(pid, "command duplicate cleanup");
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn command_unknown_cancel_is_ignored() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_command_cancel(&mut host_stream, 999);
+    send_command_start(
+        &mut host_stream,
+        114,
+        "printf ok",
+        5000,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Discard,
+    );
+    let (_chunks, result) = read_command_result(&mut host_stream, 114);
+
+    assert_eq!(
+        result.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(result.stdout, Some(b"ok".to_vec()));
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn command_seq_zero_start_and_cancel_return_error() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_command_start(
+        &mut host_stream,
+        0,
+        "printf should-not-run",
+        5000,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Discard,
+    );
+    let start_error = read_message(&mut host_stream);
+    assert_eq!(start_error.msg_type, MSG_ERROR);
+    assert_eq!(start_error.seq, 0);
+    assert!(
+        vsock_proto::decode_error(&start_error.payload)
+            .unwrap()
+            .contains("non-zero sequence")
+    );
+
+    send_command_cancel(&mut host_stream, 0);
+    let cancel_error = read_message(&mut host_stream);
+    assert_eq!(cancel_error.msg_type, MSG_ERROR);
+    assert_eq!(cancel_error.seq, 0);
+    assert!(
+        vsock_proto::decode_error(&cancel_error.payload)
+            .unwrap()
+            .contains("non-zero sequence")
+    );
+
+    finish_guest_connection(handle, host_stream);
 }
 
 /// Like `Read::read`, but retries on EINTR. `read_exact` retries

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -1178,6 +1178,61 @@ fn command_duplicate_start_returns_error_without_cancelling_active_command() {
 }
 
 #[test]
+fn command_different_sequences_run_concurrently_and_cancel_independently() {
+    let pid_path = unique_pid_path("command-concurrent");
+    let fifo_path = unique_tmp_path("command-concurrent", ".fifo");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let blocked_command = format!(
+        "mkfifo '{}'; echo $$ > '{}'; read _ < '{}'",
+        fifo_path.as_str(),
+        pid_path.as_str(),
+        fifo_path.as_str()
+    );
+    send_command_start(
+        &mut host_stream,
+        120,
+        &blocked_command,
+        0,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+    );
+    let pid = child_guard.read_pid();
+    assert!(
+        pid_alive(pid),
+        "first command should remain active while second command starts"
+    );
+
+    send_command_start(
+        &mut host_stream,
+        121,
+        "printf second",
+        5000,
+        CommandOutputPolicy::Capture { limit_bytes: 64 },
+        CommandOutputPolicy::Discard,
+    );
+    let (_chunks, second) = read_command_result(&mut host_stream, 121);
+    assert_eq!(
+        second.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(second.stdout, Some(b"second".to_vec()));
+    assert!(
+        pid_alive(pid),
+        "second command completion should not cancel first command"
+    );
+
+    send_command_cancel(&mut host_stream, 120);
+    let (_chunks, first) = read_command_result(&mut host_stream, 120);
+    assert_eq!(first.termination, CommandTermination::Cancelled);
+    wait_for_pid_exit(pid, "command concurrent cleanup");
+    child_guard.disarm();
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn command_unknown_cancel_is_ignored() {
     let (handle, mut host_stream) = start_guest_connection();
 

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -809,6 +809,7 @@ fn command_stream_handles_more_chunks_than_output_queue_capacity() {
 #[test]
 fn command_stream_disconnect_cancels_child() {
     let pid_path = unique_pid_path("command-stream-disconnect");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
     let (handle, mut host_stream) = start_guest_connection();
 
     let command = format!(
@@ -826,7 +827,7 @@ fn command_stream_disconnect_cancels_child() {
         },
         CommandOutputPolicy::Discard,
     );
-    let pid = read_pid_file(pid_path.as_str());
+    let pid = child_guard.read_pid();
     let chunk = read_command_output_chunk(&mut host_stream, 117);
     assert_eq!(chunk.stream, CommandOutputStream::Stdout);
     assert!(!chunk.chunk.is_empty());
@@ -838,6 +839,7 @@ fn command_stream_disconnect_cancels_child() {
     drop(host_stream);
     let _ = handle.join();
     wait_for_pid_exit(pid, "command stream host disconnect");
+    child_guard.disarm();
 }
 
 #[test]
@@ -1073,6 +1075,7 @@ fn command_invalid_env_returns_start_failed_without_leaking_value() {
 #[test]
 fn command_explicit_cancel_kills_child_and_returns_cancelled() {
     let pid_path = unique_pid_path("command-cancel");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
     let (handle, mut host_stream) = start_guest_connection();
 
     let command = format!("echo $$ > '{}'; sleep 60", pid_path.as_str());
@@ -1084,7 +1087,7 @@ fn command_explicit_cancel_kills_child_and_returns_cancelled() {
         CommandOutputPolicy::Capture { limit_bytes: 64 },
         CommandOutputPolicy::Capture { limit_bytes: 64 },
     );
-    let pid = read_pid_file(pid_path.as_str());
+    let pid = child_guard.read_pid();
     assert!(
         pid_alive(pid),
         "command child should be running before cancel"
@@ -1095,6 +1098,7 @@ fn command_explicit_cancel_kills_child_and_returns_cancelled() {
 
     assert_eq!(result.termination, CommandTermination::Cancelled);
     wait_for_pid_exit(pid, "command explicit cancel");
+    child_guard.disarm();
 
     finish_guest_connection(handle, host_stream);
 }
@@ -1102,6 +1106,7 @@ fn command_explicit_cancel_kills_child_and_returns_cancelled() {
 #[test]
 fn command_connection_close_cancels_child() {
     let pid_path = unique_pid_path("command-connection-close");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
     let (handle, mut host_stream) = start_guest_connection();
 
     let command = format!("echo $$ > '{}'; sleep 60", pid_path.as_str());
@@ -1113,7 +1118,7 @@ fn command_connection_close_cancels_child() {
         CommandOutputPolicy::Capture { limit_bytes: 64 },
         CommandOutputPolicy::Capture { limit_bytes: 64 },
     );
-    let pid = read_pid_file(pid_path.as_str());
+    let pid = child_guard.read_pid();
     assert!(
         pid_alive(pid),
         "command child should be running before disconnect"
@@ -1122,11 +1127,13 @@ fn command_connection_close_cancels_child() {
     drop(host_stream);
     let _ = handle.join();
     wait_for_pid_exit(pid, "command host disconnect");
+    child_guard.disarm();
 }
 
 #[test]
 fn command_duplicate_start_returns_error_without_cancelling_active_command() {
     let pid_path = unique_pid_path("command-duplicate");
+    let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
     let (handle, mut host_stream) = start_guest_connection();
 
     let command = format!("echo $$ > '{}'; sleep 60", pid_path.as_str());
@@ -1138,7 +1145,7 @@ fn command_duplicate_start_returns_error_without_cancelling_active_command() {
         CommandOutputPolicy::Capture { limit_bytes: 64 },
         CommandOutputPolicy::Capture { limit_bytes: 64 },
     );
-    let pid = read_pid_file(pid_path.as_str());
+    let pid = child_guard.read_pid();
 
     send_command_start(
         &mut host_stream,
@@ -1162,6 +1169,7 @@ fn command_duplicate_start_returns_error_without_cancelling_active_command() {
     let (_chunks, result) = read_command_result(&mut host_stream, 113);
     assert_eq!(result.termination, CommandTermination::Cancelled);
     wait_for_pid_exit(pid, "command duplicate cleanup");
+    child_guard.disarm();
 
     finish_guest_connection(handle, host_stream);
 }
@@ -1742,6 +1750,51 @@ fn kill_pid_group(pid: u32) {
     // SAFETY: best-effort cleanup for a pid produced by a test child process.
     unsafe {
         libc::kill(-(pid as i32), libc::SIGKILL);
+    }
+}
+
+struct ProcessGroupFileGuard<'a> {
+    pid_path: &'a str,
+    pid: Option<u32>,
+    armed: bool,
+}
+
+impl<'a> ProcessGroupFileGuard<'a> {
+    fn new(pid_path: &'a str) -> Self {
+        Self {
+            pid_path,
+            pid: None,
+            armed: true,
+        }
+    }
+
+    fn read_pid(&mut self) -> u32 {
+        let pid = read_pid_file(self.pid_path);
+        self.pid = Some(pid);
+        pid
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ProcessGroupFileGuard<'_> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let pid = self.pid.or_else(|| {
+            std::fs::read_to_string(self.pid_path)
+                .ok()
+                .and_then(|contents| contents.trim().parse().ok())
+        });
+        let Some(pid) = pid else {
+            return;
+        };
+        if pid > 0 && pid_alive(pid) {
+            kill_pid_group(pid);
+        }
     }
 }
 

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -649,6 +649,37 @@ fn read_command_result(
     }
 }
 
+fn read_command_output_chunk(stream: &mut impl std::io::Read, seq: u32) -> CommandChunk {
+    let mut decoder = vsock_proto::Decoder::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        let n = read_retry_eintr(stream, &mut buf).unwrap();
+        assert!(n > 0, "unexpected EOF waiting for command output");
+        for msg in decoder.decode(buf.get(..n).unwrap_or_default()).unwrap() {
+            if msg.seq != seq {
+                continue;
+            }
+            match msg.msg_type {
+                MSG_COMMAND_OUTPUT => {
+                    let decoded = vsock_proto::decode_command_output(&msg.payload).unwrap();
+                    return CommandChunk {
+                        stream: decoded.stream,
+                        output_seq: decoded.output_seq,
+                        chunk: decoded.chunk.to_vec(),
+                        truncated: decoded.truncated,
+                    };
+                }
+                MSG_COMMAND_RESULT => panic!("unexpected command result before output"),
+                MSG_ERROR => {
+                    let error = vsock_proto::decode_error(&msg.payload).unwrap();
+                    panic!("unexpected command error for seq={seq}: {error}");
+                }
+                other => panic!("unexpected command response type: 0x{other:02X}"),
+            }
+        }
+    }
+}
+
 fn captured_to_vec(captured: CommandCapturedOutput<'_>) -> Option<Vec<u8>> {
     match captured {
         CommandCapturedOutput::Discarded => None,
@@ -771,6 +802,88 @@ fn command_stream_handles_more_chunks_than_output_queue_capacity() {
     for (expected_seq, chunk) in chunks.iter().enumerate() {
         assert_eq!(chunk.output_seq, expected_seq as u32);
     }
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn command_stream_disconnect_cancels_child() {
+    let pid_path = unique_pid_path("command-stream-disconnect");
+    let (handle, mut host_stream) = start_guest_connection();
+
+    let command = format!(
+        "echo $$ > '{}'; while true; do echo tick; done",
+        pid_path.as_str()
+    );
+    send_command_start(
+        &mut host_stream,
+        117,
+        &command,
+        0,
+        CommandOutputPolicy::Stream {
+            limit_bytes: 1024 * 1024,
+            chunk_limit_bytes: 16,
+        },
+        CommandOutputPolicy::Discard,
+    );
+    let pid = read_pid_file(pid_path.as_str());
+    let chunk = read_command_output_chunk(&mut host_stream, 117);
+    assert_eq!(chunk.stream, CommandOutputStream::Stdout);
+    assert!(!chunk.chunk.is_empty());
+    assert!(
+        pid_alive(pid),
+        "command child should be running before disconnect"
+    );
+
+    drop(host_stream);
+    let _ = handle.join();
+    wait_for_pid_exit(pid, "command stream host disconnect");
+}
+
+#[test]
+fn command_rejects_output_policies_that_cannot_fit_protocol_frames_without_running() {
+    let capture_marker = unique_tmp_path("command-huge-capture-policy", ".marker");
+    let stream_marker = unique_tmp_path("command-huge-stream-policy", ".marker");
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_command_start(
+        &mut host_stream,
+        118,
+        &format!("printf ran > '{}'", capture_marker.as_str()),
+        5000,
+        CommandOutputPolicy::Capture {
+            limit_bytes: u32::MAX,
+        },
+        CommandOutputPolicy::Discard,
+    );
+    let (_chunks, capture_result) = read_command_result(&mut host_stream, 118);
+    assert_eq!(capture_result.termination, CommandTermination::StartFailed);
+    assert!(
+        capture_result
+            .diagnostic
+            .contains("capture limits exceed protocol result frame budget")
+    );
+    assert!(std::fs::metadata(capture_marker.as_str()).is_err());
+
+    send_command_start(
+        &mut host_stream,
+        119,
+        &format!("printf ran > '{}'", stream_marker.as_str()),
+        5000,
+        CommandOutputPolicy::Stream {
+            limit_bytes: 1,
+            chunk_limit_bytes: u32::MAX,
+        },
+        CommandOutputPolicy::Discard,
+    );
+    let (_chunks, stream_result) = read_command_result(&mut host_stream, 119);
+    assert_eq!(stream_result.termination, CommandTermination::StartFailed);
+    assert!(
+        stream_result
+            .diagnostic
+            .contains("stream chunk limit exceeds protocol frame budget")
+    );
+    assert!(std::fs::metadata(stream_marker.as_str()).is_err());
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -743,6 +743,39 @@ fn command_stream_only_stdout_stderr_success() {
 }
 
 #[test]
+fn command_stream_handles_more_chunks_than_output_queue_capacity() {
+    let (handle, mut host_stream) = start_guest_connection();
+    let expected = "x".repeat(96);
+    let command = format!("printf {expected}");
+
+    send_command_start(
+        &mut host_stream,
+        116,
+        &command,
+        5000,
+        CommandOutputPolicy::Stream {
+            limit_bytes: expected.len() as u32,
+            chunk_limit_bytes: 1,
+        },
+        CommandOutputPolicy::Discard,
+    );
+    let (chunks, result) = read_command_result(&mut host_stream, 116);
+
+    assert_eq!(
+        result.termination,
+        CommandTermination::Exited { exit_code: 0 }
+    );
+    assert_eq!(stdout_data(&chunks), expected.as_bytes());
+    assert_eq!(chunks.len(), expected.len());
+    assert!(chunks.iter().all(|chunk| !chunk.truncated));
+    for (expected_seq, chunk) in chunks.iter().enumerate() {
+        assert_eq!(chunk.output_seq, expected_seq as u32);
+    }
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn command_capture_and_stream_success() {
     let (handle, mut host_stream) = start_guest_connection();
 

--- a/crates/vsock-guest/tests/connection.rs
+++ b/crates/vsock-guest/tests/connection.rs
@@ -809,12 +809,15 @@ fn command_stream_handles_more_chunks_than_output_queue_capacity() {
 #[test]
 fn command_stream_disconnect_cancels_child() {
     let pid_path = unique_pid_path("command-stream-disconnect");
+    let fifo_path = unique_tmp_path("command-stream-disconnect", ".fifo");
     let mut child_guard = ProcessGroupFileGuard::new(pid_path.as_str());
     let (handle, mut host_stream) = start_guest_connection();
 
     let command = format!(
-        "echo $$ > '{}'; while true; do echo tick; done",
-        pid_path.as_str()
+        "mkfifo '{}'; echo $$ > '{}'; printf tick; read _ < '{}'",
+        fifo_path.as_str(),
+        pid_path.as_str(),
+        fifo_path.as_str()
     );
     send_command_start(
         &mut host_stream,


### PR DESCRIPTION
## Summary
- add guest-side MSG_COMMAND_START/MSG_COMMAND_CANCEL handling with a per-connection command registry
- implement command workers with bounded capture/stream output policies, request cancellation, timeout handling, and terminal command results
- add focused bounded-drain helpers plus guest connection tests for capture, streaming, truncation, cancel, disconnect, duplicate seq, and seq=0 errors

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto
- pre-commit: crates cargo-fmt, cargo-clippy, cargo-doc

Closes #12689