### PR TITLE
fix: pin model-first chat thread model

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -11,6 +11,8 @@ import {
   persistedAttachmentSchema,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import {
   modelProviderCredentialScopeSchema,
   modelProviderTypeSchema,
@@ -44,6 +46,7 @@ import { buildFileUrl } from "../../lib/file-url";
 import { db$, writeDb$ } from "../external/db";
 import { publishThreadListChanged } from "../external/realtime";
 import { listS3Objects } from "../external/s3";
+import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
 const REPORT_ERROR_STREAK_THRESHOLD = 2;
 
@@ -126,10 +129,18 @@ type ChatThreadRow = {
   readonly modelProviderType: string | null;
   readonly modelProviderCredentialScope: string | null;
   readonly selectedModel: string | null;
+  readonly orgId: string | null;
   readonly lastReadMessageId: string | null;
   readonly renamedAt: Date | null;
   readonly createdAt: Date;
   readonly updatedAt: Date;
+};
+
+type ChatThreadModelPin = {
+  readonly modelProviderId: string | null;
+  readonly modelProviderType: string | null;
+  readonly modelProviderCredentialScope: string | null;
+  readonly selectedModel: string | null;
 };
 
 function effectiveChatMessageRunId() {
@@ -233,8 +244,24 @@ function ownedChatThread(
   return computed(async (get): Promise<ChatThreadRow | null> => {
     const db = get(db$);
     const [thread] = await db
-      .select()
+      .select({
+        id: chatThreads.id,
+        title: chatThreads.title,
+        agentComposeId: chatThreads.agentComposeId,
+        draftContent: chatThreads.draftContent,
+        draftAttachments: chatThreads.draftAttachments,
+        modelProviderId: chatThreads.modelProviderId,
+        modelProviderType: chatThreads.modelProviderType,
+        modelProviderCredentialScope: chatThreads.modelProviderCredentialScope,
+        selectedModel: chatThreads.selectedModel,
+        orgId: zeroAgents.orgId,
+        lastReadMessageId: chatThreads.lastReadMessageId,
+        renamedAt: chatThreads.renamedAt,
+        createdAt: chatThreads.createdAt,
+        updatedAt: chatThreads.updatedAt,
+      })
       .from(chatThreads)
+      .leftJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
       .where(and(eq(chatThreads.id, threadId), eq(chatThreads.userId, userId)))
       .limit(1);
 
@@ -255,11 +282,79 @@ function ownedChatThread(
       modelProviderType: thread.modelProviderType ?? null,
       modelProviderCredentialScope: thread.modelProviderCredentialScope ?? null,
       selectedModel: thread.selectedModel ?? null,
+      orgId: thread.orgId ?? null,
       lastReadMessageId: thread.lastReadMessageId ?? null,
       renamedAt: thread.renamedAt ?? null,
       createdAt: thread.createdAt,
       updatedAt: thread.updatedAt,
     };
+  });
+}
+
+function firstRunModelPinForThread(
+  threadId: string,
+): Computed<Promise<ChatThreadModelPin | null>> {
+  return computed(async (get): Promise<ChatThreadModelPin | null> => {
+    const [run] = await get(db$)
+      .select({
+        modelProviderId: zeroRuns.modelProviderId,
+        modelProviderType: zeroRuns.modelProvider,
+        modelProviderCredentialScope: zeroRuns.modelProviderCredentialScope,
+        selectedModel: zeroRuns.selectedModel,
+      })
+      .from(chatMessages)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, chatMessages.runId))
+      .where(
+        and(
+          eq(chatMessages.chatThreadId, threadId),
+          eq(chatMessages.role, "user"),
+          isNotNull(chatMessages.runId),
+          isNotNull(zeroRuns.selectedModel),
+        ),
+      )
+      .orderBy(asc(chatMessages.createdAt), asc(chatMessages.id))
+      .limit(1);
+
+    if (!run?.selectedModel) {
+      return null;
+    }
+    return run;
+  });
+}
+
+function effectiveModelFirstThreadPin(params: {
+  readonly thread: ChatThreadRow;
+  readonly userId: string;
+}): Computed<Promise<ChatThreadModelPin | null>> {
+  return computed(async (get): Promise<ChatThreadModelPin | null> => {
+    if (params.thread.selectedModel !== null) {
+      return {
+        modelProviderId: params.thread.modelProviderId,
+        modelProviderType: params.thread.modelProviderType,
+        modelProviderCredentialScope:
+          params.thread.modelProviderCredentialScope,
+        selectedModel: params.thread.selectedModel,
+      };
+    }
+    if (!params.thread.orgId) {
+      return null;
+    }
+
+    const overrides = await get(
+      userFeatureSwitchOverrides(params.thread.orgId, params.userId),
+    );
+    const modelFirstEnabled = isFeatureEnabled(
+      FeatureSwitchKey.ModelFirstModelProvider,
+      {
+        orgId: params.thread.orgId,
+        userId: params.userId,
+        overrides,
+      },
+    );
+    if (!modelFirstEnabled) {
+      return null;
+    }
+    return get(firstRunModelPinForThread(params.thread.id));
   });
 }
 
@@ -566,13 +661,19 @@ export function zeroChatThreadDetail(args: {
       return null;
     }
 
-    const [messages, activeRuns, latestSessionId, latestRunProviderTypeRaw] =
-      await Promise.all([
-        get(chatThreadMessages(args.threadId, args.userId)),
-        get(activeRunsForThread(args.threadId)),
-        get(latestSessionIdForThread(args.threadId)),
-        get(latestRunProviderTypeForThread(args.threadId)),
-      ]);
+    const [
+      messages,
+      activeRuns,
+      latestSessionId,
+      latestRunProviderTypeRaw,
+      modelPin,
+    ] = await Promise.all([
+      get(chatThreadMessages(args.threadId, args.userId)),
+      get(activeRunsForThread(args.threadId)),
+      get(latestSessionIdForThread(args.threadId)),
+      get(latestRunProviderTypeForThread(args.threadId)),
+      get(effectiveModelFirstThreadPin({ thread, userId: args.userId })),
+    ]);
 
     return {
       id: thread.id,
@@ -594,17 +695,19 @@ export function zeroChatThreadDetail(args: {
       draftAttachments: thread.draftAttachments
         ? [...thread.draftAttachments]
         : null,
-      modelProviderId: thread.modelProviderId,
+      modelProviderId: modelPin?.modelProviderId ?? thread.modelProviderId,
       modelProviderType: formatLatestSessionProviderType(
-        thread.modelProviderType,
+        modelPin?.modelProviderType ?? thread.modelProviderType,
       ),
       modelProviderCredentialScope:
-        thread.modelProviderCredentialScope === null
+        (modelPin?.modelProviderCredentialScope ??
+          thread.modelProviderCredentialScope) === null
           ? null
           : (modelProviderCredentialScopeSchema.safeParse(
-              thread.modelProviderCredentialScope,
+              modelPin?.modelProviderCredentialScope ??
+                thread.modelProviderCredentialScope,
             ).data ?? null),
-      selectedModel: thread.selectedModel,
+      selectedModel: modelPin?.selectedModel ?? thread.selectedModel,
       renamedAt: thread.renamedAt?.toISOString() ?? null,
     };
   });

--- a/turbo/apps/platform/src/mocks/handlers/api-user-model-preference.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-user-model-preference.ts
@@ -16,6 +16,12 @@ export function resetMockUserModelPreference(): void {
   };
 }
 
+export function setMockUserModelPreference(
+  preference: UserModelPreferenceResponse,
+): void {
+  mockUserModelPreference = preference;
+}
+
 export const apiUserModelPreferenceHandlers = [
   mockApi(zeroUserModelPreferenceContract.get, ({ respond }) => {
     return respond(200, mockUserModelPreference);

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -16,10 +16,12 @@ import {
   captureNavigationTiming$,
   markRouteSetupBegin$,
 } from "../../lib/posthog.ts";
+import { reloadUserModelPreference$ } from "../external/user-model-preference.ts";
 
 const internalSetupChatPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(markRouteSetupBegin$);
+    set(reloadUserModelPreference$);
     const threadId = get(currentChatThreadId$);
     if (!threadId) {
       throw new Error("threadId is required to load chat page");

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -50,6 +50,7 @@ import { userModelPreference$ } from "../external/user-model-preference.ts";
 import { pinnedAgentIds$ } from "../zero-page/zero-pinned-agents.ts";
 import { composerModelProviders$ } from "../zero-page/composer-model-providers.ts";
 import {
+  MODEL_FIRST_SELECTION_PROVIDER_ID,
   resolveEffectiveAgentDefaultSelection,
   resolveModelFirstUserDefaultSelection,
 } from "../zero-page/model-provider-default.ts";
@@ -336,6 +337,15 @@ function createModelSelection(
       }
       const modelFirstEnabled = get(modelFirstModelProviderEnabled$);
       if (modelFirstEnabled) {
+        const thread = await get(threadData$);
+        if (thread?.selectedModel) {
+          return {
+            modelProviderId: MODEL_FIRST_SELECTION_PROVIDER_ID,
+            selectedModel: thread.selectedModel,
+          };
+        }
+        // Unstarted model-first threads inherit the current user preference;
+        // started threads carry selectedModel on the thread row.
         return null;
       }
       const thread = await get(threadData$);

--- a/turbo/apps/platform/src/signals/external/user-model-preference.ts
+++ b/turbo/apps/platform/src/signals/external/user-model-preference.ts
@@ -23,8 +23,10 @@ interface UserModelPreferenceSnapshot {
 
 const internalUserModelPreferenceSnapshot$ =
   state<UserModelPreferenceSnapshot | null>(null);
+const internalReloadUserModelPreference$ = state(0);
 
 export const userModelPreference$ = computed(async (get) => {
+  get(internalReloadUserModelPreference$);
   const modelFirstEnabled = get(modelFirstModelProviderEnabled$);
   if (!modelFirstEnabled) {
     return emptyUserModelPreference();
@@ -72,3 +74,11 @@ export const updateUserModelPreference$ = command(
     return result.body;
   },
 );
+
+export const reloadUserModelPreference$ = command(({ get, set }) => {
+  set(internalUserModelPreferenceSnapshot$, null);
+  set(
+    internalReloadUserModelPreference$,
+    get(internalReloadUserModelPreference$) + 1,
+  );
+});

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/agent-chat-page-setup.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/agent-chat-page-setup.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   detachedSetupPage,
   setupPage,
@@ -12,9 +13,13 @@ import { setMockOrgModelProviders } from "../../../mocks/handlers/api-org-model-
 import { pathname, search } from "../../location.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import {
+  chatPageAgentModelDefault$,
   chatPageModelSelection$,
   setChatPageModelSelection$,
 } from "../zero-chat-page.ts";
+import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.helpers.ts";
+import { setMockUserModelPreference } from "../../../mocks/handlers/api-user-model-preference.ts";
+import { MODEL_FIRST_SELECTION_PROVIDER_ID } from "../model-provider-default.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -126,6 +131,80 @@ describe("agent chat page setup", () => {
       ).resolves.toStrictEqual({
         modelProviderId: defaultProviderId,
         selectedModel: "claude-sonnet-4-6",
+      });
+    });
+  });
+
+  it("refreshes model-first user preference on entry", async () => {
+    const agentId = "c0000000-0000-4000-a000-000000000001";
+
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.ModelFirstModelProvider]: true,
+    });
+    setMockTeam([
+      {
+        id: agentId,
+        displayName: "Zero",
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+    server.use(
+      mockApi(zeroAgentsByIdContract.get, ({ respond }) => {
+        return respond(200, {
+          agentId,
+          ownerId: "test-user-123",
+          description: null,
+          displayName: "Zero",
+          sound: null,
+          avatarUrl: null,
+          permissionPolicies: null,
+          customSkills: [],
+          modelProviderId: null,
+          selectedModel: null,
+        });
+      }),
+    );
+
+    setMockUserModelPreference({
+      selectedModel: "claude-sonnet-4-6",
+      updatedAt: "2026-03-10T00:00:00Z",
+    });
+
+    await setupPage({
+      context,
+      path: `/agents/${agentId}/chat`,
+      withoutRender: true,
+    });
+    await waitFor(async () => {
+      await expect(
+        context.store.get(chatPageAgentModelDefault$),
+      ).resolves.toStrictEqual({
+        modelProviderId: MODEL_FIRST_SELECTION_PROVIDER_ID,
+        selectedModel: "claude-sonnet-4-6",
+      });
+    });
+
+    setMockUserModelPreference({
+      selectedModel: "glm-5.1",
+      updatedAt: "2026-03-10T00:01:00Z",
+    });
+
+    await setupPage({
+      context,
+      path: `/agents/${agentId}/chat`,
+      withoutRender: true,
+    });
+
+    await waitFor(async () => {
+      await expect(
+        context.store.get(chatPageAgentModelDefault$),
+      ).resolves.toStrictEqual({
+        modelProviderId: MODEL_FIRST_SELECTION_PROVIDER_ID,
+        selectedModel: "glm-5.1",
       });
     });
   });

--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
@@ -22,6 +22,7 @@ import {
   reloadTagline$,
   resetChatPageModelSelection$,
 } from "./zero-chat-page.ts";
+import { reloadUserModelPreference$ } from "../external/user-model-preference.ts";
 import { setupAgentChatPageKeyboard$ } from "./agent-chat-keyboard.ts";
 import { openQueueDrawer$ } from "../queue-page/queue-drawer-state.ts";
 
@@ -35,6 +36,7 @@ export const setupAgentChatPage$ = command(
     // Reset the talk draft on entrance
     set(get(talkDraft$).clear$);
     set(resetChatPageModelSelection$);
+    set(reloadUserModelPreference$);
 
     // Read agent ID from URL immediately (synchronous) and update sidebar
     // highlight early so the UI responds without waiting for async data.

--- a/turbo/apps/platform/src/signals/zero-page/model-provider-default.ts
+++ b/turbo/apps/platform/src/signals/zero-page/model-provider-default.ts
@@ -16,7 +16,7 @@ interface UserModelDefaultSource {
   selectedModel: string | null;
 }
 
-const MODEL_FIRST_SELECTION_PROVIDER_ID =
+export const MODEL_FIRST_SELECTION_PROVIDER_ID =
   "00000000-0000-4000-8000-000000000000";
 
 function createModelFirstSelection(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx
@@ -34,6 +34,7 @@ import {
   setMockOnboardingStatus,
   resetMockOnboardingStatus,
 } from "../../../mocks/handlers/api-onboarding.ts";
+import { setMockUserModelPreference } from "../../../mocks/handlers/api-user-model-preference.ts";
 
 const context = testContext();
 const mockApi = createMockApi(context);
@@ -42,7 +43,12 @@ const PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const THREAD_ID = "thread-readonly-1";
 
-function makeThreadDetail() {
+function makeThreadDetail(
+  overrides: Partial<{
+    modelProviderId: string | null;
+    selectedModel: string | null;
+  }> = {},
+) {
   return {
     id: THREAD_ID,
     title: "My thread",
@@ -57,6 +63,7 @@ function makeThreadDetail() {
     draftAttachments: null,
     modelProviderId: null,
     selectedModel: null,
+    ...overrides,
   };
 }
 
@@ -78,10 +85,13 @@ function makeAssistantMessage(): PagedChatMessage {
   };
 }
 
-function setupMocks(messages: PagedChatMessage[]) {
+function setupMocks(
+  messages: PagedChatMessage[],
+  threadOverrides?: Parameters<typeof makeThreadDetail>[0],
+) {
   server.use(
     mockApi(chatThreadByIdContract.get, ({ respond }) => {
-      return respond(200, makeThreadDetail());
+      return respond(200, makeThreadDetail(threadOverrides));
     }),
     mockApi(chatThreadMessagesContract.list, ({ respond }) => {
       return respond(200, { messages });
@@ -103,6 +113,7 @@ describe("chat thread page — model picker read-only", () => {
     resetMockOnboardingStatus();
     setMockFeatureSwitches({});
     setMockOnboardingStatus({ defaultAgentId: AGENT_ID });
+    setMockUserModelPreference({ selectedModel: null, updatedAt: null });
     setMockOrgModelProviders([
       {
         id: PROVIDER_ID,
@@ -154,17 +165,21 @@ describe("chat thread page — model picker read-only", () => {
     setMockFeatureSwitches({
       [FeatureSwitchKey.ModelFirstModelProvider]: true,
     });
-    setupMocks([makeUserMessage()]);
+    setMockUserModelPreference({
+      selectedModel: "claude-sonnet-4-6",
+      updatedAt: "2026-03-10T00:00:00Z",
+    });
+    setupMocks([makeUserMessage()], {
+      selectedModel: "glm-5.1",
+    });
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
     const label = await waitFor(() => {
-      return screen.getByLabelText("Claude Sonnet 4.6");
+      return screen.getByLabelText("GLM-5.1");
     });
     expect(label.tagName).toBe("SPAN");
-    expect(
-      screen.queryByRole("combobox", { name: "Claude Sonnet 4.6" }),
-    ).toBeNull();
+    expect(screen.queryByRole("combobox", { name: "GLM-5.1" })).toBeNull();
   });
 
   // CHAT-LOCK-004: empty thread keeps the picker interactive.

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -485,13 +485,25 @@ export function AgentChatPage() {
   const rootSignal = useGet(rootSignal$);
   const pageSignal = useGet(pageSignal$);
 
-  const composerProviders = useLastResolved(composerModelProviders$);
-  const modelSelection = useLastResolved(chatPageModelSelection$) ?? null;
+  const composerProvidersLoadable = useLoadable(composerModelProviders$);
+  const modelSelectionLoadable = useLoadable(chatPageModelSelection$);
+  const agentModelDefaultLoadable = useLoadable(chatPageAgentModelDefault$);
+  const composerProviders =
+    composerProvidersLoadable.state === "hasData"
+      ? composerProvidersLoadable.data
+      : undefined;
+  const modelSelection =
+    modelSelectionLoadable.state === "hasData"
+      ? modelSelectionLoadable.data
+      : null;
   const setModelSelection = useSet(setChatPageModelSelection$);
   const updateUserModelPreference = useSet(updateUserModelPreference$);
   const resetModelSelection = useSet(resetChatPageModelSelection$);
   const modelFirstEnabled = useGet(modelFirstModelProviderEnabled$);
-  const agentModelDefault = useLastResolved(chatPageAgentModelDefault$) ?? null;
+  const agentModelDefault =
+    agentModelDefaultLoadable.state === "hasData"
+      ? agentModelDefaultLoadable.data
+      : null;
   const modelFirstOauthState = useLastResolved(modelFirstPersonalOauthState$);
   const openPersonalOauthConfiguration = usePersonalOauthConfigurationAction();
 
@@ -559,6 +571,10 @@ export function AgentChatPage() {
     agentModelDefault,
     onAction: openPersonalOauthConfiguration,
   });
+  const modelPickerLoading =
+    composerProvidersLoadable.state === "loading" ||
+    modelSelectionLoadable.state === "loading" ||
+    agentModelDefaultLoadable.state === "loading";
 
   return (
     <div className="relative flex flex-1 flex-col min-h-0">
@@ -605,6 +621,7 @@ export function AgentChatPage() {
                   }
                 : undefined
             }
+            modelPickerLoading={modelPickerLoading}
             submitBlocker={submitBlockerProps}
           />
 

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -475,16 +475,7 @@ function SuggestedPromptsGrid({
   );
 }
 
-export function AgentChatPage() {
-  const currentChatAgentId = useLastResolved(currentChatAgentId$);
-  const currentChatAgentDisplayName = useLastResolved(
-    currentChatAgentDisplayName$,
-  );
-
-  const sendNewThread = useSet(sendNewThreadOptimistically$);
-  const rootSignal = useGet(rootSignal$);
-  const pageSignal = useGet(pageSignal$);
-
+function useAgentChatComposerModel(pageSignal: AbortSignal) {
   const composerProvidersLoadable = useLoadable(composerModelProviders$);
   const modelSelectionLoadable = useLoadable(chatPageModelSelection$);
   const agentModelDefaultLoadable = useLoadable(chatPageAgentModelDefault$);
@@ -498,7 +489,6 @@ export function AgentChatPage() {
       : null;
   const setModelSelection = useSet(setChatPageModelSelection$);
   const updateUserModelPreference = useSet(updateUserModelPreference$);
-  const resetModelSelection = useSet(resetChatPageModelSelection$);
   const modelFirstEnabled = useGet(modelFirstModelProviderEnabled$);
   const agentModelDefault =
     agentModelDefaultLoadable.state === "hasData"
@@ -506,6 +496,70 @@ export function AgentChatPage() {
       : null;
   const modelFirstOauthState = useLastResolved(modelFirstPersonalOauthState$);
   const openPersonalOauthConfiguration = usePersonalOauthConfigurationAction();
+
+  const handleModelSelectionChange = (
+    selection: typeof modelSelection,
+  ): void => {
+    setModelSelection(selection);
+    if (modelFirstEnabled && isSupportedRunModel(selection?.selectedModel)) {
+      detach(
+        updateUserModelPreference(
+          { selectedModel: selection.selectedModel },
+          pageSignal,
+        ),
+        Reason.DomCallback,
+      );
+    }
+  };
+
+  const modelPicker =
+    composerProviders &&
+    (modelFirstEnabled || composerProviders.providers.length > 0)
+      ? {
+          providers: composerProviders.providers,
+          value: modelSelection,
+          onChange: handleModelSelectionChange,
+          // No prior session exists on the landing page.
+          sessionProviderType: null,
+          agentDefault: agentModelDefault,
+          showUseDefault: !modelFirstEnabled,
+        }
+      : undefined;
+  const submitBlockerProps = resolveChatComposerSubmitBlocker({
+    state: modelFirstOauthState,
+    modelSelection,
+    agentModelDefault,
+    onAction: openPersonalOauthConfiguration,
+  });
+  const modelPickerLoading =
+    composerProvidersLoadable.state === "loading" ||
+    modelSelectionLoadable.state === "loading" ||
+    agentModelDefaultLoadable.state === "loading";
+
+  return {
+    modelSelection,
+    modelPicker,
+    modelPickerLoading,
+    submitBlockerProps,
+  };
+}
+
+export function AgentChatPage() {
+  const currentChatAgentId = useLastResolved(currentChatAgentId$);
+  const currentChatAgentDisplayName = useLastResolved(
+    currentChatAgentDisplayName$,
+  );
+
+  const sendNewThread = useSet(sendNewThreadOptimistically$);
+  const rootSignal = useGet(rootSignal$);
+  const pageSignal = useGet(pageSignal$);
+  const {
+    modelSelection,
+    modelPicker,
+    modelPickerLoading,
+    submitBlockerProps,
+  } = useAgentChatComposerModel(pageSignal);
+  const resetModelSelection = useSet(resetChatPageModelSelection$);
 
   const handleSendMessage = (message: string, options?: { goal?: boolean }) => {
     if (!currentChatAgentId) {
@@ -550,32 +604,6 @@ export function AgentChatPage() {
     resetModelSelection();
   };
 
-  const handleModelSelectionChange = (
-    selection: typeof modelSelection,
-  ): void => {
-    setModelSelection(selection);
-    if (modelFirstEnabled && isSupportedRunModel(selection?.selectedModel)) {
-      detach(
-        updateUserModelPreference(
-          { selectedModel: selection.selectedModel },
-          pageSignal,
-        ),
-        Reason.DomCallback,
-      );
-    }
-  };
-
-  const submitBlockerProps = resolveChatComposerSubmitBlocker({
-    state: modelFirstOauthState,
-    modelSelection,
-    agentModelDefault,
-    onAction: openPersonalOauthConfiguration,
-  });
-  const modelPickerLoading =
-    composerProvidersLoadable.state === "loading" ||
-    modelSelectionLoadable.state === "loading" ||
-    agentModelDefaultLoadable.state === "loading";
-
   return (
     <div className="relative flex flex-1 flex-col min-h-0">
       <header className="hidden md:block shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-2">
@@ -607,20 +635,7 @@ export function AgentChatPage() {
             onSend={handleSend}
             displayName={currentChatAgentDisplayName ?? ""}
             autoFocus
-            modelPicker={
-              composerProviders &&
-              (modelFirstEnabled || composerProviders.providers.length > 0)
-                ? {
-                    providers: composerProviders.providers,
-                    value: modelSelection,
-                    onChange: handleModelSelectionChange,
-                    // No prior session exists on the landing page.
-                    sessionProviderType: null,
-                    agentDefault: agentModelDefault,
-                    showUseDefault: !modelFirstEnabled,
-                  }
-                : undefined
-            }
+            modelPicker={modelPicker}
             modelPickerLoading={modelPickerLoading}
             submitBlocker={submitBlockerProps}
           />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -216,6 +216,8 @@ interface ZeroChatComposerProps {
     /** Hide the "Use default" row in compact chat pickers. */
     showUseDefault?: boolean;
   };
+  /** When true, render a skeleton in the model picker slot. */
+  modelPickerLoading?: boolean;
   submitBlocker?: {
     message: string;
     actionLabel: string;
@@ -1016,6 +1018,7 @@ export function ZeroChatComposer({
   onDraftChange,
   actionsLoading = false,
   modelPicker,
+  modelPickerLoading = false,
   submitBlocker,
   queuedItems,
   onRemoveQueuedItem,
@@ -1473,35 +1476,39 @@ export function ZeroChatComposer({
                   <Skeleton
                     className={cn(
                       "h-9 rounded-md",
-                      modelPicker ? "w-[184px]" : "w-20",
+                      modelPicker || modelPickerLoading ? "w-[184px]" : "w-20",
                     )}
                   />
                 ) : (
                   <>
-                    {submitBlocker && (
+                    {!modelPickerLoading && submitBlocker && (
                       <ModelConfigurationWarning blocker={submitBlocker} />
                     )}
-                    {modelPicker && (
-                      <ModelProviderPicker
-                        providers={modelPicker.providers}
-                        value={modelPicker.value}
-                        onChange={handleModelPickerChange}
-                        placeholder="Default"
-                        triggerClassName={cn(
-                          "h-9 w-9 max-w-none gap-0 border-transparent bg-transparent px-0 text-sm text-muted-foreground transition-colors sm:w-auto sm:max-w-[14rem] sm:gap-1 sm:px-2",
-                          "[&>span]:flex [&>span]:items-center [&>span]:justify-center sm:[&>span]:justify-start [&>svg]:hidden sm:[&>svg]:block",
-                          "hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground",
-                        )}
-                        sessionProviderType={modelPicker.sessionProviderType}
-                        compactTrigger
-                        mobileIconTrigger
-                        open={modelPickerOpen}
-                        onOpenChange={setModelPickerOpen}
-                        disabled={modelPicker.disabled}
-                        agentDefault={modelPicker.agentDefault}
-                        inheritLabel="agent"
-                        showUseDefault={modelPicker.showUseDefault}
-                      />
+                    {modelPickerLoading ? (
+                      <Skeleton className="h-9 w-9 rounded-md sm:w-32" />
+                    ) : (
+                      modelPicker && (
+                        <ModelProviderPicker
+                          providers={modelPicker.providers}
+                          value={modelPicker.value}
+                          onChange={handleModelPickerChange}
+                          placeholder="Default"
+                          triggerClassName={cn(
+                            "h-9 w-9 max-w-none gap-0 border-transparent bg-transparent px-0 text-sm text-muted-foreground transition-colors sm:w-auto sm:max-w-[14rem] sm:gap-1 sm:px-2",
+                            "[&>span]:flex [&>span]:items-center [&>span]:justify-center sm:[&>span]:justify-start [&>svg]:hidden sm:[&>svg]:block",
+                            "hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground",
+                          )}
+                          sessionProviderType={modelPicker.sessionProviderType}
+                          compactTrigger
+                          mobileIconTrigger
+                          open={modelPickerOpen}
+                          onOpenChange={setModelPickerOpen}
+                          disabled={modelPicker.disabled}
+                          agentDefault={modelPicker.agentDefault}
+                          inheritLabel="agent"
+                          showUseDefault={modelPicker.showUseDefault}
+                        />
+                      )
                     )}
                     <div className="mx-0 h-5 w-px bg-border/60 sm:mx-0.5" />
                     <MicButton

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -996,6 +996,67 @@ function ModelConfigurationWarning({
   );
 }
 
+function ComposerModelPickerSlot({
+  actionsLoading,
+  modelPicker,
+  modelPickerLoading,
+  submitBlocker,
+  modelPickerOpen,
+  onModelPickerChange,
+  onModelPickerOpenChange,
+}: {
+  actionsLoading: boolean;
+  modelPicker: ComposerModelPicker | undefined;
+  modelPickerLoading: boolean;
+  submitBlocker: ZeroChatComposerProps["submitBlocker"];
+  modelPickerOpen: boolean;
+  onModelPickerChange: (value: ModelProviderSelection | null) => void;
+  onModelPickerOpenChange: (open: boolean) => void;
+}) {
+  if (actionsLoading) {
+    return (
+      <Skeleton
+        className={cn(
+          "h-9 rounded-md",
+          modelPicker || modelPickerLoading ? "w-[184px]" : "w-20",
+        )}
+      />
+    );
+  }
+
+  if (modelPickerLoading) {
+    return <Skeleton className="h-9 w-9 rounded-md sm:w-32" />;
+  }
+
+  return (
+    <>
+      {submitBlocker && <ModelConfigurationWarning blocker={submitBlocker} />}
+      {modelPicker && (
+        <ModelProviderPicker
+          providers={modelPicker.providers}
+          value={modelPicker.value}
+          onChange={onModelPickerChange}
+          placeholder="Default"
+          triggerClassName={cn(
+            "h-9 w-9 max-w-none gap-0 border-transparent bg-transparent px-0 text-sm text-muted-foreground transition-colors sm:w-auto sm:max-w-[14rem] sm:gap-1 sm:px-2",
+            "[&>span]:flex [&>span]:items-center [&>span]:justify-center sm:[&>span]:justify-start [&>svg]:hidden sm:[&>svg]:block",
+            "hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground",
+          )}
+          sessionProviderType={modelPicker.sessionProviderType}
+          compactTrigger
+          mobileIconTrigger
+          open={modelPickerOpen}
+          onOpenChange={onModelPickerOpenChange}
+          disabled={modelPicker.disabled}
+          agentDefault={modelPicker.agentDefault}
+          inheritLabel="agent"
+          showUseDefault={modelPicker.showUseDefault}
+        />
+      )}
+    </>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Main composer
 // ---------------------------------------------------------------------------
@@ -1472,44 +1533,17 @@ export function ZeroChatComposer({
                 />
               </div>
               <div className="flex items-center gap-1 sm:gap-2">
-                {actionsLoading ? (
-                  <Skeleton
-                    className={cn(
-                      "h-9 rounded-md",
-                      modelPicker || modelPickerLoading ? "w-[184px]" : "w-20",
-                    )}
-                  />
-                ) : (
+                <ComposerModelPickerSlot
+                  actionsLoading={actionsLoading}
+                  modelPicker={modelPicker}
+                  modelPickerLoading={modelPickerLoading}
+                  submitBlocker={submitBlocker}
+                  modelPickerOpen={modelPickerOpen}
+                  onModelPickerChange={handleModelPickerChange}
+                  onModelPickerOpenChange={setModelPickerOpen}
+                />
+                {actionsLoading ? null : (
                   <>
-                    {!modelPickerLoading && submitBlocker && (
-                      <ModelConfigurationWarning blocker={submitBlocker} />
-                    )}
-                    {modelPickerLoading ? (
-                      <Skeleton className="h-9 w-9 rounded-md sm:w-32" />
-                    ) : (
-                      modelPicker && (
-                        <ModelProviderPicker
-                          providers={modelPicker.providers}
-                          value={modelPicker.value}
-                          onChange={handleModelPickerChange}
-                          placeholder="Default"
-                          triggerClassName={cn(
-                            "h-9 w-9 max-w-none gap-0 border-transparent bg-transparent px-0 text-sm text-muted-foreground transition-colors sm:w-auto sm:max-w-[14rem] sm:gap-1 sm:px-2",
-                            "[&>span]:flex [&>span]:items-center [&>span]:justify-center sm:[&>span]:justify-start [&>svg]:hidden sm:[&>svg]:block",
-                            "hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground",
-                          )}
-                          sessionProviderType={modelPicker.sessionProviderType}
-                          compactTrigger
-                          mobileIconTrigger
-                          open={modelPickerOpen}
-                          onOpenChange={setModelPickerOpen}
-                          disabled={modelPicker.disabled}
-                          agentDefault={modelPicker.agentDefault}
-                          inheritLabel="agent"
-                          showUseDefault={modelPicker.showUseDefault}
-                        />
-                      )
-                    )}
                     <div className="mx-0 h-5 w-px bg-border/60 sm:mx-0.5" />
                     <MicButton
                       onTranscribed={(text) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5,6 +5,7 @@ import type {
 } from "react";
 import {
   useGet,
+  useLoadable,
   useSet,
   useLastLoadable,
   useLastResolved,
@@ -2020,11 +2021,27 @@ function useChatComposerModel(
   // initializer would snapshot `undefined` on first render). `modelSelection$`
   // internally flips to a user-override once `setModelSelection$` is called,
   // so unsaved edits survive subsequent threadData$ reloads.
-  const threadData = useLastResolved(thread.threadData$);
-  const composerProviders = useLastResolved(composerModelProviders$);
-  const modelSelection = useLastResolved(thread.modelSelection$) ?? null;
+  const threadDataLoadable = useLoadable(thread.threadData$);
+  const composerProvidersLoadable = useLoadable(composerModelProviders$);
+  const modelSelectionLoadable = useLoadable(thread.modelSelection$);
+  const agentModelDefaultLoadable = useLoadable(thread.agentModelDefault$);
+  const threadData =
+    threadDataLoadable.state === "hasData"
+      ? threadDataLoadable.data
+      : undefined;
+  const composerProviders =
+    composerProvidersLoadable.state === "hasData"
+      ? composerProvidersLoadable.data
+      : undefined;
+  const modelSelection =
+    modelSelectionLoadable.state === "hasData"
+      ? modelSelectionLoadable.data
+      : null;
   const setModelSelection = useSet(thread.setModelSelection$);
-  const agentModelDefault = useLastResolved(thread.agentModelDefault$) ?? null;
+  const agentModelDefault =
+    agentModelDefaultLoadable.state === "hasData"
+      ? agentModelDefaultLoadable.data
+      : null;
   const modelFirstEnabled = useGet(modelFirstModelProviderEnabled$);
   const modelFirstOauthState = useLastResolved(modelFirstPersonalOauthState$);
   const openPersonalOauthConfiguration = usePersonalOauthConfigurationAction();
@@ -2050,6 +2067,11 @@ function useChatComposerModel(
     disabled: hasUserMessages,
     agentDefault: agentModelDefault,
   });
+  const modelPickerLoading =
+    threadDataLoadable.state === "loading" ||
+    composerProvidersLoadable.state === "loading" ||
+    modelSelectionLoadable.state === "loading" ||
+    agentModelDefaultLoadable.state === "loading";
   const submitBlockerProps = resolveChatComposerSubmitBlocker({
     state: modelFirstOauthState,
     modelSelection,
@@ -2057,7 +2079,12 @@ function useChatComposerModel(
     onAction: openPersonalOauthConfiguration,
   });
 
-  return { modelPicker, submitBlockerProps, modelSelection };
+  return {
+    modelPicker,
+    modelPickerLoading,
+    submitBlockerProps,
+    modelSelection,
+  };
 }
 
 function ChatThreadComposer({
@@ -2091,8 +2118,12 @@ function ChatThreadComposer({
     thread,
     groups,
   );
-  const { modelPicker, submitBlockerProps, modelSelection } =
-    useChatComposerModel(thread, { hasUserMessages, pageSignal });
+  const {
+    modelPicker,
+    modelPickerLoading,
+    submitBlockerProps,
+    modelSelection,
+  } = useChatComposerModel(thread, { hasUserMessages, pageSignal });
   const skeletonVisible = useGet(thread.skeletonVisible$);
   const queueWhileSending = canQueueMessage({
     sending,
@@ -2158,6 +2189,7 @@ function ChatThreadComposer({
             setInputRef={setInputRef}
             actionsLoading={skeletonVisible}
             modelPicker={modelPicker}
+            modelPickerLoading={modelPickerLoading}
             submitBlocker={submitBlockerProps}
             queuedItems={queuedItems}
             onRemoveQueuedItem={onRemoveQueuedItem}

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -8,6 +8,11 @@ import {
   updateTestChatThreadTitle,
   insertTestChatMessage,
   setTestChatThreadRenamedAt,
+  setTestRunModelProvider,
+  setTestRunSelectedModel,
+  enableModelFirstModelProviderForUser,
+  insertOrgModelPolicy,
+  insertUserModelPreference,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -24,11 +29,13 @@ const context = testContext();
 describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
   let testComposeId: string;
   let testUserId: string;
+  let testOrgId: string;
 
   beforeEach(async () => {
     context.setupMocks();
     const user = await context.setupUser();
     testUserId = user.userId;
+    testOrgId = user.orgId;
 
     const { composeId } = await createTestCompose(uniqueId("chat-detail"));
     testComposeId = composeId;
@@ -253,6 +260,62 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
 
     expect(response.status).toBe(200);
     expect(data.renamedAt).toBe("2025-06-01T12:00:00.000Z");
+  });
+
+  it("returns the first run model for unpinned model-first threads", async () => {
+    await enableModelFirstModelProviderForUser(testOrgId, testUserId);
+    await insertOrgModelPolicy({
+      orgId: testOrgId,
+      model: "claude-opus-4-7",
+      isDefault: true,
+    });
+    await insertOrgModelPolicy({
+      orgId: testOrgId,
+      model: "claude-sonnet-4-6",
+    });
+    await insertUserModelPreference({
+      orgId: testOrgId,
+      userId: testUserId,
+      model: "claude-sonnet-4-6",
+    });
+
+    const createResponse = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testComposeId,
+          title: "Historical model-first thread",
+        }),
+      }),
+    );
+    const { id: threadId } = await createResponse.json();
+
+    const { runId } = await seedTestRun(testUserId, testComposeId, {
+      status: "completed",
+      prompt: "historical opus prompt",
+      triggerSource: "web",
+    });
+    await setTestRunModelProvider(runId, "vm0");
+    await setTestRunSelectedModel(runId, "claude-opus-4-7");
+    await addTestRunToThread(
+      threadId,
+      runId,
+      testUserId,
+      "historical opus prompt",
+    );
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.selectedModel).toBe("claude-opus-4-7");
+    expect(data.modelProviderId).toBeNull();
+    expect(data.modelProviderType).toBe("vm0");
   });
 
   it("should return chat messages after run completes", async () => {

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/route.ts
@@ -9,6 +9,7 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { getUserId } from "../../../../../src/lib/auth/get-auth-context";
 import {
   getChatThread,
+  getFirstRunModelPinForThread,
   getChatThreadMessages,
   getActiveRunsForThread,
   updateChatThreadDraft,
@@ -18,6 +19,7 @@ import {
   getLatestRunProviderTypeForThread,
   publishThreadListChanged,
 } from "../../../../../src/lib/zero/chat-thread/chat-message-service";
+import { isModelFirstModelProviderEnabled } from "../../../../../src/lib/zero/model-policy/model-first-route-service";
 import { isNotFound } from "@vm0/api-services/errors";
 
 const chatThreadIdParamSchema = z.string().uuid();
@@ -59,10 +61,18 @@ const router = tsr.router(chatThreadByIdContract, {
         { chatMessages, latestSessionId },
         activeRuns,
         latestRunProviderTypeRaw,
+        modelFirstRunPin,
       ] = await Promise.all([
         getChatThreadMessages(params.id, userId),
         getActiveRunsForThread(params.id),
         getLatestRunProviderTypeForThread(params.id),
+        thread.orgId && thread.selectedModel === null
+          ? isModelFirstModelProviderEnabled(thread.orgId, userId).then(
+              async (enabled) => {
+                return enabled ? getFirstRunModelPinForThread(params.id) : null;
+              },
+            )
+          : Promise.resolve(null),
       ]);
       const activeRunIds = activeRuns.map((r) => {
         return r.id;
@@ -74,17 +84,26 @@ const router = tsr.router(chatThreadByIdContract, {
           ? null
           : (modelProviderTypeSchema.safeParse(latestRunProviderTypeRaw).data ??
             null);
-      const threadModelProviderType =
-        thread.modelProviderType === null
-          ? null
-          : (modelProviderTypeSchema.safeParse(thread.modelProviderType).data ??
-            null);
+      const effectiveThreadModelProviderCredentialScope =
+        modelFirstRunPin?.modelProviderCredentialScope ??
+        thread.modelProviderCredentialScope;
       const threadModelProviderCredentialScope =
-        thread.modelProviderCredentialScope === null
+        effectiveThreadModelProviderCredentialScope === null
           ? null
           : (modelProviderCredentialScopeSchema.safeParse(
-              thread.modelProviderCredentialScope,
+              effectiveThreadModelProviderCredentialScope,
             ).data ?? null);
+      const threadModelProviderId =
+        modelFirstRunPin?.modelProviderId ?? thread.modelProviderId;
+      const threadSelectedModel =
+        modelFirstRunPin?.selectedModel ?? thread.selectedModel;
+      const effectiveThreadModelProviderType =
+        modelFirstRunPin?.modelProviderType ?? thread.modelProviderType;
+      const threadModelProviderType =
+        effectiveThreadModelProviderType === null
+          ? null
+          : (modelProviderTypeSchema.safeParse(effectiveThreadModelProviderType)
+              .data ?? null);
 
       return {
         status: 200 as const,
@@ -102,10 +121,10 @@ const router = tsr.router(chatThreadByIdContract, {
           updatedAt: thread.updatedAt.toISOString(),
           draftContent: thread.draftContent,
           draftAttachments: thread.draftAttachments,
-          modelProviderId: thread.modelProviderId,
+          modelProviderId: threadModelProviderId,
           modelProviderType: threadModelProviderType,
           modelProviderCredentialScope: threadModelProviderCredentialScope,
-          selectedModel: thread.selectedModel,
+          selectedModel: threadSelectedModel,
           renamedAt: thread.renamedAt ? thread.renamedAt.toISOString() : null,
         },
       };

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/route.ts
@@ -37,6 +37,61 @@ function chatThreadNotFoundResponse() {
   };
 }
 
+type ChatThreadRecord = Awaited<ReturnType<typeof getChatThread>>;
+type ModelFirstRunPin = Awaited<
+  ReturnType<typeof getFirstRunModelPinForThread>
+>;
+
+async function getModelFirstRunPinForThreadDetail(
+  thread: ChatThreadRecord,
+  threadId: string,
+  userId: string,
+): Promise<ModelFirstRunPin> {
+  if (!thread.orgId || thread.selectedModel !== null) {
+    return null;
+  }
+  const enabled = await isModelFirstModelProviderEnabled(thread.orgId, userId);
+  if (!enabled) {
+    return null;
+  }
+  return getFirstRunModelPinForThread(threadId);
+}
+
+function parseThreadProviderType(value: string | null) {
+  if (value === null) {
+    return null;
+  }
+  return modelProviderTypeSchema.safeParse(value).data ?? null;
+}
+
+function parseThreadCredentialScope(value: string | null) {
+  if (value === null) {
+    return null;
+  }
+  return modelProviderCredentialScopeSchema.safeParse(value).data ?? null;
+}
+
+function resolveThreadModelFields(
+  thread: ChatThreadRecord,
+  modelFirstRunPin: ModelFirstRunPin,
+) {
+  const modelProviderCredentialScope =
+    modelFirstRunPin?.modelProviderCredentialScope ??
+    thread.modelProviderCredentialScope;
+  const modelProviderType =
+    modelFirstRunPin?.modelProviderType ?? thread.modelProviderType;
+
+  return {
+    modelProviderId:
+      modelFirstRunPin?.modelProviderId ?? thread.modelProviderId,
+    modelProviderType: parseThreadProviderType(modelProviderType),
+    modelProviderCredentialScope: parseThreadCredentialScope(
+      modelProviderCredentialScope,
+    ),
+    selectedModel: modelFirstRunPin?.selectedModel ?? thread.selectedModel,
+  };
+}
+
 const router = tsr.router(chatThreadByIdContract, {
   get: async ({ params, headers }) => {
     initServices();
@@ -66,13 +121,7 @@ const router = tsr.router(chatThreadByIdContract, {
         getChatThreadMessages(params.id, userId),
         getActiveRunsForThread(params.id),
         getLatestRunProviderTypeForThread(params.id),
-        thread.orgId && thread.selectedModel === null
-          ? isModelFirstModelProviderEnabled(thread.orgId, userId).then(
-              async (enabled) => {
-                return enabled ? getFirstRunModelPinForThread(params.id) : null;
-              },
-            )
-          : Promise.resolve(null),
+        getModelFirstRunPinForThreadDetail(thread, params.id, userId),
       ]);
       const activeRunIds = activeRuns.map((r) => {
         return r.id;
@@ -84,26 +133,10 @@ const router = tsr.router(chatThreadByIdContract, {
           ? null
           : (modelProviderTypeSchema.safeParse(latestRunProviderTypeRaw).data ??
             null);
-      const effectiveThreadModelProviderCredentialScope =
-        modelFirstRunPin?.modelProviderCredentialScope ??
-        thread.modelProviderCredentialScope;
-      const threadModelProviderCredentialScope =
-        effectiveThreadModelProviderCredentialScope === null
-          ? null
-          : (modelProviderCredentialScopeSchema.safeParse(
-              effectiveThreadModelProviderCredentialScope,
-            ).data ?? null);
-      const threadModelProviderId =
-        modelFirstRunPin?.modelProviderId ?? thread.modelProviderId;
-      const threadSelectedModel =
-        modelFirstRunPin?.selectedModel ?? thread.selectedModel;
-      const effectiveThreadModelProviderType =
-        modelFirstRunPin?.modelProviderType ?? thread.modelProviderType;
-      const threadModelProviderType =
-        effectiveThreadModelProviderType === null
-          ? null
-          : (modelProviderTypeSchema.safeParse(effectiveThreadModelProviderType)
-              .data ?? null);
+      const threadModelFields = resolveThreadModelFields(
+        thread,
+        modelFirstRunPin,
+      );
 
       return {
         status: 200 as const,
@@ -121,10 +154,7 @@ const router = tsr.router(chatThreadByIdContract, {
           updatedAt: thread.updatedAt.toISOString(),
           draftContent: thread.draftContent,
           draftAttachments: thread.draftAttachments,
-          modelProviderId: threadModelProviderId,
-          modelProviderType: threadModelProviderType,
-          modelProviderCredentialScope: threadModelProviderCredentialScope,
-          selectedModel: threadSelectedModel,
+          ...threadModelFields,
           renamedAt: thread.renamedAt ? thread.renamedAt.toISOString() : null,
         },
       };

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -6,14 +6,18 @@ import { POST } from "../route";
 import {
   createTestRequest,
   createTestCompose,
+  enableModelFirstModelProviderForUser,
+  insertOrgModelPolicy,
   insertOrgDefaultModelProvider,
   insertOrgNonDefaultModelProvider,
   insertUserDefaultModelProvider,
+  insertUserModelPreference,
   deleteTestModelProvider,
   setTestZeroAgentModelProvider,
   setOrgCredits,
   findTestCallbacksByRunId,
   findTestRunnerJobEntry,
+  findTestZeroRun,
   getTestRun,
   getTestChatMessagesByThread,
   countUserRows,
@@ -28,6 +32,7 @@ import {
 import {
   getTestChatThreadModelOverride,
   getTestModelProviderIdByType,
+  getTestUserSelectedModel,
 } from "../../../../../../src/__tests__/db-test-assertions/org";
 import { getTestZeroAgentId } from "../../../../../../src/__tests__/db-test-assertions/agents";
 import {
@@ -1310,6 +1315,130 @@ describe("POST /api/zero/chat/messages", () => {
         expect(response.status).toBe(402);
         const data = await response.json();
         expect(data.error.code).toBe("INSUFFICIENT_CREDITS");
+      });
+    });
+
+    describe("model-first thread pin", () => {
+      beforeEach(async () => {
+        await enableModelFirstModelProviderForUser(user.orgId, user.userId);
+        await insertOrgModelPolicy({
+          orgId: user.orgId,
+          model: "claude-opus-4-7",
+          isDefault: true,
+        });
+        await insertOrgModelPolicy({
+          orgId: user.orgId,
+          model: "claude-sonnet-4-6",
+        });
+      });
+
+      it("keeps follow-up chat runs on the first user-message model after user preference changes", async () => {
+        await insertUserModelPreference({
+          orgId: user.orgId,
+          userId: user.userId,
+          model: "claude-opus-4-7",
+        });
+
+        const first = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId,
+              prompt: "first on opus",
+            }),
+          }),
+        );
+        expect(first.status).toBe(201);
+        const { threadId, runId } = await first.json();
+        await context.mocks.flushAfter();
+        await setTestRunStatus(runId, "completed");
+
+        const firstOverride = await getTestChatThreadModelOverride(threadId);
+        expect(firstOverride).toEqual({
+          modelProviderId: null,
+          selectedModel: "claude-opus-4-7",
+        });
+
+        await insertUserModelPreference({
+          orgId: user.orgId,
+          userId: user.userId,
+          model: "claude-sonnet-4-6",
+        });
+
+        const second = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId,
+              prompt: "follow up after preference changes",
+              threadId,
+            }),
+          }),
+        );
+        expect(second.status).toBe(201);
+        const { runId: secondRunId } = await second.json();
+        await context.mocks.flushAfter();
+
+        const secondRun = await findTestZeroRun(secondRunId);
+        expect(secondRun?.selectedModel).toBe("claude-opus-4-7");
+
+        const secondOverride = await getTestChatThreadModelOverride(threadId);
+        expect(secondOverride).toEqual({
+          modelProviderId: null,
+          selectedModel: "claude-opus-4-7",
+        });
+      });
+
+      it("does not rewrite user preference when a pinned thread sends the same modelSelection", async () => {
+        await insertUserModelPreference({
+          orgId: user.orgId,
+          userId: user.userId,
+          model: "claude-opus-4-7",
+        });
+
+        const first = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId,
+              prompt: "first on opus",
+            }),
+          }),
+        );
+        expect(first.status).toBe(201);
+        const { threadId, runId } = await first.json();
+        await context.mocks.flushAfter();
+        await setTestRunStatus(runId, "completed");
+
+        await insertUserModelPreference({
+          orgId: user.orgId,
+          userId: user.userId,
+          model: "claude-sonnet-4-6",
+        });
+
+        const second = await POST(
+          createTestRequest(URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentId,
+              prompt: "follow up with locked picker body",
+              threadId,
+              modelSelection: {
+                modelProviderId: "00000000-0000-4000-8000-000000000000",
+                selectedModel: "claude-opus-4-7",
+              },
+            }),
+          }),
+        );
+        expect(second.status).toBe(201);
+
+        await expect(
+          getTestUserSelectedModel(user.orgId, user.userId),
+        ).resolves.toBe("claude-sonnet-4-6");
       });
     });
 

--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -1321,6 +1321,7 @@ describe("POST /api/zero/chat/messages", () => {
     describe("model-first thread pin", () => {
       beforeEach(async () => {
         await enableModelFirstModelProviderForUser(user.orgId, user.userId);
+        await setOrgCredits(user.orgId, 10_000);
         await insertOrgModelPolicy({
           orgId: user.orgId,
           model: "claude-opus-4-7",

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, asc, eq, inArray, isNotNull, isNull } from "drizzle-orm";
 import { after } from "next/server";
 import { waitUntil } from "@vercel/functions";
 import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
@@ -542,6 +542,10 @@ interface ThreadModelPin {
   selectedModel: string | null;
 }
 
+interface ResolvedThreadModelPin extends ThreadModelPin {
+  explicitModelFirstModelSelection: boolean;
+}
+
 function pinFromModelFirstRoute(
   route: ModelFirstRouteDescriptor,
 ): ThreadModelPin {
@@ -553,11 +557,120 @@ function pinFromModelFirstRoute(
   };
 }
 
+function resolvedPin(
+  pin: ThreadModelPin,
+  explicitModelFirstModelSelection = false,
+): ResolvedThreadModelPin {
+  return {
+    ...pin,
+    explicitModelFirstModelSelection,
+  };
+}
+
+async function getStoredThreadModelPin(
+  threadId: string,
+): Promise<ThreadModelPin | null> {
+  const [thread] = await globalThis.services.db
+    .select({
+      modelProviderId: chatThreads.modelProviderId,
+      modelProviderType: chatThreads.modelProviderType,
+      modelProviderCredentialScope: chatThreads.modelProviderCredentialScope,
+      selectedModel: chatThreads.selectedModel,
+    })
+    .from(chatThreads)
+    .where(eq(chatThreads.id, threadId))
+    .limit(1);
+  if (!thread || thread.selectedModel === null) {
+    return null;
+  }
+  return thread;
+}
+
+async function getFirstRunModelPin(
+  threadId: string,
+): Promise<ThreadModelPin | null> {
+  const [run] = await globalThis.services.db
+    .select({
+      modelProviderId: zeroRuns.modelProviderId,
+      modelProviderType: zeroRuns.modelProvider,
+      modelProviderCredentialScope: zeroRuns.modelProviderCredentialScope,
+      selectedModel: zeroRuns.selectedModel,
+    })
+    .from(chatMessages)
+    .innerJoin(zeroRuns, eq(zeroRuns.id, chatMessages.runId))
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, threadId),
+        eq(chatMessages.role, "user"),
+        isNotNull(chatMessages.runId),
+        isNotNull(zeroRuns.selectedModel),
+      ),
+    )
+    .orderBy(asc(chatMessages.createdAt), asc(chatMessages.id))
+    .limit(1);
+  if (!run?.selectedModel) {
+    return null;
+  }
+  return run;
+}
+
+async function getExistingModelFirstThreadPin(
+  threadId: string,
+): Promise<ThreadModelPin | null> {
+  return (
+    (await getStoredThreadModelPin(threadId)) ??
+    (await getFirstRunModelPin(threadId))
+  );
+}
+
+async function persistModelFirstThreadPinIfUnset(
+  threadId: string,
+  pin: ThreadModelPin,
+): Promise<ThreadModelPin> {
+  if (!pin.selectedModel) {
+    return pin;
+  }
+
+  const [updated] = await globalThis.services.db
+    .update(chatThreads)
+    .set({
+      modelProviderId: pin.modelProviderId,
+      modelProviderType: pin.modelProviderType,
+      modelProviderCredentialScope: pin.modelProviderCredentialScope,
+      selectedModel: pin.selectedModel,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(chatThreads.id, threadId), isNull(chatThreads.selectedModel)))
+    .returning({
+      modelProviderId: chatThreads.modelProviderId,
+      modelProviderType: chatThreads.modelProviderType,
+      modelProviderCredentialScope: chatThreads.modelProviderCredentialScope,
+      selectedModel: chatThreads.selectedModel,
+    });
+  return updated ?? (await getStoredThreadModelPin(threadId)) ?? pin;
+}
+
+async function resolveStoredModelFirstPin(params: {
+  orgId: string;
+  userId: string;
+  pin: ThreadModelPin;
+}): Promise<ThreadModelPin> {
+  const route = await resolveModelFirstRouteDescriptor({
+    orgId: params.orgId,
+    userId: params.userId,
+    selectedModel: params.pin.selectedModel,
+    providerType: params.pin.modelProviderType ?? undefined,
+    credentialScope: params.pin.modelProviderCredentialScope ?? undefined,
+    modelProviderId: params.pin.modelProviderId ?? undefined,
+  });
+  return pinFromModelFirstRoute(route);
+}
+
 /**
  * Persist the composer's per-run override onto the thread row and return the
  * effective override to use for this run (legacy precedence: per-run > thread
- * > agent). Model-first does not use thread/agent pins; no explicit selection
- * means createZeroRun will resolve the user's model preference, then org default.
+ * > agent). Model-first pins the first effective user-message model to the
+ * thread so later sends do not drift with the user's current model preference.
  * `null` or `undefined` for `modelSelection` means "inherit" — older clients
  * that never saw the field and newer clients explicitly choosing "Use default"
  * both get the thread/agent fall-through.
@@ -577,15 +690,28 @@ async function resolveRunModelOverride(
     | { modelProviderId: string; selectedModel: string }
     | null
     | undefined,
-): Promise<ThreadModelPin> {
+): Promise<ResolvedThreadModelPin> {
   if (modelSelection !== undefined && modelSelection !== null) {
     if (modelFirstEnabled) {
+      const storedPin = await getExistingModelFirstThreadPin(threadId);
+      if (storedPin) {
+        const pin = await persistModelFirstThreadPinIfUnset(
+          threadId,
+          await resolveStoredModelFirstPin({ orgId, userId, pin: storedPin }),
+        );
+        return resolvedPin(pin, true);
+      }
+
       const route = await resolveModelFirstRouteDescriptor({
         orgId,
         userId,
         selectedModel: modelSelection.selectedModel,
       });
-      return pinFromModelFirstRoute(route);
+      const pin = await persistModelFirstThreadPinIfUnset(
+        threadId,
+        pinFromModelFirstRoute(route),
+      );
+      return resolvedPin(pin, true);
     }
 
     await globalThis.services.db
@@ -598,20 +724,34 @@ async function resolveRunModelOverride(
         updatedAt: new Date(),
       })
       .where(eq(chatThreads.id, threadId));
-    return {
+    return resolvedPin({
       modelProviderId: modelSelection.modelProviderId,
       modelProviderType: null,
       modelProviderCredentialScope: null,
       selectedModel: modelSelection.selectedModel,
-    };
+    });
   } else {
     if (modelFirstEnabled) {
-      return {
-        modelProviderId: null,
-        modelProviderType: null,
-        modelProviderCredentialScope: null,
-        selectedModel: null,
-      };
+      const storedPin = await getExistingModelFirstThreadPin(threadId);
+      if (storedPin) {
+        const resolvedStoredPin = await resolveStoredModelFirstPin({
+          orgId,
+          userId,
+          pin: storedPin,
+        });
+        const pin = await persistModelFirstThreadPinIfUnset(
+          threadId,
+          resolvedStoredPin,
+        );
+        return resolvedPin(pin, true);
+      }
+
+      const route = await resolveModelFirstRouteDescriptor({ orgId, userId });
+      const pin = await persistModelFirstThreadPinIfUnset(
+        threadId,
+        pinFromModelFirstRoute(route),
+      );
+      return resolvedPin(pin, true);
     }
 
     const [thread] = await globalThis.services.db
@@ -633,21 +773,21 @@ async function resolveRunModelOverride(
       if (!provider) {
         throw providerDeleted();
       }
-      return {
+      return resolvedPin({
         modelProviderId: thread.modelProviderId,
         modelProviderType: null,
         modelProviderCredentialScope: null,
         selectedModel: thread.selectedModel,
-      };
+      });
     }
   }
 
-  return {
+  return resolvedPin({
     modelProviderId: agent.modelProviderId,
     modelProviderType: null,
     modelProviderCredentialScope: null,
     selectedModel: agent.selectedModel,
-  };
+  });
 }
 
 /**
@@ -661,7 +801,13 @@ async function rejectIfThreadModelLocked(
   modelFirstEnabled: boolean,
 ): Promise<boolean> {
   if (modelFirstEnabled) {
-    return false;
+    const existingPin = await getExistingModelFirstThreadPin(threadId);
+    if (!existingPin?.selectedModel) {
+      return false;
+    }
+    return (
+      incoming === null || existingPin.selectedModel !== incoming.selectedModel
+    );
   }
 
   const [existing] = await globalThis.services.db
@@ -813,6 +959,7 @@ function hasExplicitModelFirstSelection(
 async function persistExplicitModelFirstSelection(params: {
   orgId: string;
   userId: string;
+  threadId: string;
   modelFirstEnabled: boolean;
   modelSelection: IncomingModelSelection;
 }): Promise<boolean> {
@@ -824,12 +971,26 @@ async function persistExplicitModelFirstSelection(params: {
   ) {
     return false;
   }
+  const existingPin = await getExistingModelFirstThreadPin(params.threadId);
+  if (existingPin) {
+    return false;
+  }
   await updateUserModelPreference(
     params.orgId,
     params.userId,
     params.modelSelection.selectedModel,
   );
   return true;
+}
+
+function shouldHonorModelFirstSelectionOverride(params: {
+  persistedExplicitSelection: boolean;
+  override: ResolvedThreadModelPin;
+}): boolean {
+  return (
+    params.persistedExplicitSelection ||
+    params.override.explicitModelFirstModelSelection
+  );
 }
 
 /**
@@ -1187,10 +1348,11 @@ const router = tsr.router(chatMessagesContract, {
           dims,
         );
 
-      const explicitModelFirstModelSelection =
+      const persistedExplicitModelFirstSelection =
         await persistExplicitModelFirstSelection({
           orgId: callerOrg.orgId,
           userId: authCtx.userId,
+          threadId,
           modelFirstEnabled,
           modelSelection: body.modelSelection,
         });
@@ -1234,6 +1396,11 @@ const router = tsr.router(chatMessagesContract, {
       });
       emit(CHAT_REQUEST_OPS.resolve_model_override, overrideT.ms);
       const override = overrideT.result;
+      const explicitModelFirstModelSelection =
+        shouldHonorModelFirstSelectionOverride({
+          persistedExplicitSelection: persistedExplicitModelFirstSelection,
+          override,
+        });
 
       // Only generate title when prompt has actual user text. The
       // assistant reply is not yet available at send time — the chat

--- a/turbo/apps/web/src/__tests__/db-test-assertions/org.ts
+++ b/turbo/apps/web/src/__tests__/db-test-assertions/org.ts
@@ -234,3 +234,21 @@ export async function getTestChatThreadModelOverride(
     selectedModel: row?.selectedModel ?? null,
   };
 }
+
+export async function getTestUserSelectedModel(
+  orgId: string,
+  userId: string,
+): Promise<string | null> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({ selectedModel: orgMembersMetadata.selectedModel })
+    .from(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.orgId, orgId),
+        eq(orgMembersMetadata.userId, userId),
+      ),
+    )
+    .limit(1);
+  return row?.selectedModel ?? null;
+}

--- a/turbo/apps/web/src/lib/zero/chat-thread/auto-send-queued-message.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/auto-send-queued-message.ts
@@ -329,6 +329,7 @@ export async function autoSendQueuedMessageOnRunComplete(input: {
     modelProviderCredentialScope:
       queuedMessage.modelProviderCredentialScope ?? undefined,
     selectedModelOverride: queuedMessage.selectedModel ?? undefined,
+    explicitModelFirstModelSelection: queuedMessage.selectedModel !== null,
     preloadedAgent: agent,
   });
 

--- a/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/chat-thread-service.ts
@@ -1,4 +1,14 @@
-import { eq, and, desc, inArray, isNull, asc, or, sql } from "drizzle-orm";
+import {
+  eq,
+  and,
+  desc,
+  inArray,
+  isNull,
+  asc,
+  or,
+  sql,
+  isNotNull,
+} from "drizzle-orm";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
@@ -192,6 +202,42 @@ export async function listChatThreads(
   return threads;
 }
 
+interface ChatThreadModelPin {
+  modelProviderId: string | null;
+  modelProviderType: string | null;
+  modelProviderCredentialScope: string | null;
+  selectedModel: string | null;
+}
+
+export async function getFirstRunModelPinForThread(
+  threadId: string,
+): Promise<ChatThreadModelPin | null> {
+  const [run] = await globalThis.services.db
+    .select({
+      modelProviderId: zeroRuns.modelProviderId,
+      modelProviderType: zeroRuns.modelProvider,
+      modelProviderCredentialScope: zeroRuns.modelProviderCredentialScope,
+      selectedModel: zeroRuns.selectedModel,
+    })
+    .from(chatMessages)
+    .innerJoin(zeroRuns, eq(zeroRuns.id, chatMessages.runId))
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, threadId),
+        eq(chatMessages.role, "user"),
+        isNotNull(chatMessages.runId),
+        isNotNull(zeroRuns.selectedModel),
+      ),
+    )
+    .orderBy(asc(chatMessages.createdAt), asc(chatMessages.id))
+    .limit(1);
+
+  if (!run?.selectedModel) {
+    return null;
+  }
+  return run;
+}
+
 /**
  * Mark a thread read up to its current latest message.
  *
@@ -253,14 +299,31 @@ export async function getChatThread(
   modelProviderType: string | null;
   modelProviderCredentialScope: string | null;
   selectedModel: string | null;
+  orgId: string | null;
   lastReadMessageId: string | null;
   renamedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }> {
   const [thread] = await globalThis.services.db
-    .select()
+    .select({
+      id: chatThreads.id,
+      title: chatThreads.title,
+      agentComposeId: chatThreads.agentComposeId,
+      draftContent: chatThreads.draftContent,
+      draftAttachments: chatThreads.draftAttachments,
+      modelProviderId: chatThreads.modelProviderId,
+      modelProviderType: chatThreads.modelProviderType,
+      modelProviderCredentialScope: chatThreads.modelProviderCredentialScope,
+      selectedModel: chatThreads.selectedModel,
+      orgId: zeroAgents.orgId,
+      lastReadMessageId: chatThreads.lastReadMessageId,
+      renamedAt: chatThreads.renamedAt,
+      createdAt: chatThreads.createdAt,
+      updatedAt: chatThreads.updatedAt,
+    })
     .from(chatThreads)
+    .leftJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
     .where(and(eq(chatThreads.id, threadId), eq(chatThreads.userId, userId)))
     .limit(1);
 
@@ -281,6 +344,7 @@ export async function getChatThread(
     modelProviderType: thread.modelProviderType ?? null,
     modelProviderCredentialScope: thread.modelProviderCredentialScope ?? null,
     selectedModel: thread.selectedModel ?? null,
+    orgId: thread.orgId ?? null,
     lastReadMessageId: thread.lastReadMessageId ?? null,
     renamedAt: thread.renamedAt ?? null,
     createdAt: thread.createdAt,

--- a/turbo/apps/web/src/lib/zero/chat-thread/index.ts
+++ b/turbo/apps/web/src/lib/zero/chat-thread/index.ts
@@ -2,6 +2,7 @@ export {
   createChatThread,
   listChatThreads,
   getChatThread,
+  getFirstRunModelPinForThread,
   getChatThreadMessages,
   getActiveRunsForThread,
   updateChatThreadTitle,

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -211,9 +211,10 @@ const chatThreadDetailSchema = z.object({
   draftContent: z.string().nullable().optional(),
   draftAttachments: z.array(persistedAttachmentSchema).nullable().optional(),
   /**
-   * Per-thread model override. Both fields set together or both null.
-   * When set, the send route uses this combination (overriding the agent
-   * and org defaults) for the next run. Optional for back-compat.
+   * Per-thread model pin. Provider-first threads store modelProviderId +
+   * selectedModel together; model-first threads can store selectedModel with
+   * route metadata and a null modelProviderId. When set, the send route uses
+   * this pin instead of drifting with current defaults.
    */
   modelProviderId: z.string().nullable().optional(),
   modelProviderType: modelProviderTypeSchema.nullable().optional(),


### PR DESCRIPTION
## Summary
- Pin the first effective model-first chat model onto the thread and reuse it for follow-up sends.
- Refresh user model preference when entering agent chat or chat thread pages.
- Show the thread-pinned model in locked model-first thread pickers.

## Testing
- `pnpm -C turbo --filter @vm0/app test src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx src/signals/zero-page/__tests__/agent-chat-page-setup.test.ts -- --runInBand`
- `pnpm -C turbo --filter web exec eslint app/api/zero/chat/messages/route.ts app/api/zero/chat/messages/__tests__/route.test.ts src/lib/zero/chat-thread/auto-send-queued-message.ts src/__tests__/db-test-assertions/org.ts`
- `pnpm -C turbo --filter @vm0/app exec eslint src/signals/chat-page/create-chat-thread.ts src/signals/external/user-model-preference.ts src/signals/zero-page/agent-chat-page-setup.ts src/signals/chat-page/chat-page-setup.ts src/signals/zero-page/__tests__/agent-chat-page-setup.test.ts src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx`
- `pnpm -C turbo --filter web exec oxlint app/api/zero/chat/messages/route.ts app/api/zero/chat/messages/__tests__/route.test.ts src/lib/zero/chat-thread/auto-send-queued-message.ts src/__tests__/db-test-assertions/org.ts`
- `pnpm -C turbo --filter web exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json app/api/zero/chat/messages/route.ts app/api/zero/chat/messages/__tests__/route.test.ts src/lib/zero/chat-thread/auto-send-queued-message.ts src/__tests__/db-test-assertions/org.ts`
- `pnpm -C turbo exec prettier --check apps/web/app/api/zero/chat/messages/route.ts apps/web/app/api/zero/chat/messages/__tests__/route.test.ts apps/web/src/lib/zero/chat-thread/auto-send-queued-message.ts apps/web/src/__tests__/db-test-assertions/org.ts apps/platform/src/signals/chat-page/create-chat-thread.ts apps/platform/src/signals/external/user-model-preference.ts apps/platform/src/signals/zero-page/agent-chat-page-setup.ts apps/platform/src/signals/chat-page/chat-page-setup.ts apps/platform/src/signals/zero-page/__tests__/agent-chat-page-setup.test.ts apps/platform/src/views/zero-page/__tests__/chat-thread-page-model-picker-readonly.test.tsx apps/platform/src/mocks/handlers/api-user-model-preference.ts packages/api-contracts/src/contracts/chat-threads.ts`
- `git diff --check`

## Known local blockers
- `pnpm -C turbo --filter web test app/api/zero/chat/messages/__tests__/route.test.ts -- --runInBand` is blocked before assertions by local DB schema missing `zero_agents.visibility`.
- Full `check-types` is blocked by existing unrelated errors outside this change.