### PR TITLE
fix: mark slack model workspace default inline

### DIFF
--- a/turbo/apps/web/app/api/zero/slack/commands/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/commands/__tests__/route.test.ts
@@ -452,7 +452,10 @@ describe("POST /api/zero/slack/commands", () => {
           callback_id?: string;
           blocks?: Array<{
             element?: {
-              options?: Array<{ value: string }>;
+              options?: Array<{
+                value: string;
+                text?: { text?: string };
+              }>;
               initial_option?: { value: string };
             };
           }>;
@@ -468,10 +471,15 @@ describe("POST /api/zero/slack/commands", () => {
         inputBlock?.element?.options?.map((o) => {
           return o.value;
         }) ?? [];
-      expect(values).toContain("__workspace_default__");
+      const labels =
+        inputBlock?.element?.options?.map((o) => {
+          return o.text?.text;
+        }) ?? [];
+      expect(values).not.toContain("__workspace_default__");
       expect(values).toContain("claude-sonnet-4-6");
       expect(values).toContain("deepseek-v4-pro");
       expect(values).not.toContain("gpt-5.5");
+      expect(labels).toContain("Claude Sonnet 4.6 (workspace default)");
       expect(inputBlock?.element?.initial_option?.value).toBe(
         "deepseek-v4-pro",
       );

--- a/turbo/apps/web/app/api/zero/slack/commands/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/commands/route.ts
@@ -149,7 +149,7 @@ async function handleDisconnect(
 }
 
 const AGENT_PICKER_MAX_OPTIONS = 100;
-const MODEL_PICKER_MAX_OPTIONS = 99;
+const MODEL_PICKER_MAX_OPTIONS = 100;
 
 /**
  * Handle /zero switch command — opens the per-user agent picker modal.
@@ -276,7 +276,6 @@ async function handleModel(
   const modal = buildModelPickerModal({
     options: picker.options.slice(0, MODEL_PICKER_MAX_OPTIONS),
     currentSelectedModel: picker.currentSelectedModel,
-    workspaceDefaultName: picker.workspaceDefaultName,
     privateMetadata: JSON.stringify({ channelId: payload.channel_id }),
   });
 

--- a/turbo/apps/web/app/api/zero/slack/interactive/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/interactive/__tests__/route.test.ts
@@ -381,7 +381,7 @@ describe("POST /api/zero/slack/interactive", () => {
       expect(ephemeralArgs?.text).toContain("DeepSeek V4 Pro");
     });
 
-    it("clears the selected model when user picks the workspace default option", async () => {
+    it("clears the selected model when user picks the workspace default model", async () => {
       const workspaceId = uniqueId("T-ws");
       const slackUserId = uniqueId("U-slack");
       await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
@@ -410,7 +410,7 @@ describe("POST /api/zero/slack/interactive", () => {
         buildModelPickerSubmission({
           workspaceId,
           slackUserId,
-          selectedValue: "__workspace_default__",
+          selectedValue: "claude-sonnet-4-6",
           channelId: "C-origin",
         }),
       );

--- a/turbo/apps/web/app/api/zero/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/interactive/route.ts
@@ -22,7 +22,6 @@ import {
   MODEL_PICKER_ACTION_ID,
   MODEL_PICKER_BLOCK_ID,
   MODEL_PICKER_CALLBACK_ID,
-  MODEL_PICKER_WORKSPACE_DEFAULT_VALUE,
   buildAgentPickerModal,
 } from "../../../../../src/lib/zero/slack/blocks";
 import { refreshOrgAppHome } from "../../../../../src/lib/zero/slack-org/handlers/app-home";
@@ -427,20 +426,6 @@ async function handleModelPickerSubmit(
   );
   const channelId = parseViewChannelId(payload.view?.private_metadata);
 
-  if (selected === MODEL_PICKER_WORKSPACE_DEFAULT_VALUE) {
-    await applyModelSelection({
-      ctx,
-      botToken,
-      slackUserId: payload.user.id,
-      channelId,
-      selectedModel: null,
-      switchedTo: picker.workspaceDefaultName
-        ? `workspace default (${picker.workspaceDefaultName})`
-        : "workspace default",
-    });
-    return new Response("", { status: 200 });
-  }
-
   const option = picker.options.find((candidate) => {
     return candidate.model === selected;
   });
@@ -458,8 +443,10 @@ async function handleModelPickerSubmit(
     botToken,
     slackUserId: payload.user.id,
     channelId,
-    selectedModel: option.model,
-    switchedTo: option.label,
+    selectedModel: option.isDefault ? null : option.model,
+    switchedTo: option.isDefault
+      ? `workspace default (${option.label})`
+      : option.label,
   });
 
   return new Response("", { status: 200 });

--- a/turbo/apps/web/src/lib/zero/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/zero/slack/blocks.ts
@@ -508,7 +508,6 @@ export const AGENT_PICKER_ORG_DEFAULT_VALUE = "__org_default__";
 export const MODEL_PICKER_CALLBACK_ID = "model_preference_modal";
 export const MODEL_PICKER_BLOCK_ID = "model_select_block";
 export const MODEL_PICKER_ACTION_ID = "model_select";
-export const MODEL_PICKER_WORKSPACE_DEFAULT_VALUE = "__workspace_default__";
 
 interface AgentPickerOption {
   composeId: string;
@@ -591,47 +590,46 @@ export function buildAgentPickerModal(args: {
 interface ModelPickerOption {
   model: string;
   label: string;
+  isDefault?: boolean;
 }
 
 /**
  * Build the "Switch Model" modal view.
  *
  * The caller passes only models configured for the workspace and available to
- * the user. The workspace default sentinel clears the personal model
- * preference, matching the platform's "use default" behavior.
+ * the user. The workspace default is annotated on its model option instead of
+ * being rendered as a separate option.
  */
 export function buildModelPickerModal(args: {
   options: ModelPickerOption[];
   currentSelectedModel: string | null;
-  workspaceDefaultName: string | null;
   privateMetadata?: string;
 }): View {
-  const workspaceDefaultLabel = args.workspaceDefaultName
-    ? `Use workspace default (${args.workspaceDefaultName})`
-    : "Use workspace default";
-
-  const selectOptions = [
-    {
+  const selectOptions = args.options.map((option) => {
+    return {
       text: {
         type: "plain_text" as const,
-        text: workspaceDefaultLabel.slice(0, 75),
+        text: formatModelPickerOptionLabel(option),
       },
-      value: MODEL_PICKER_WORKSPACE_DEFAULT_VALUE,
-    },
-    ...args.options.map((option) => {
-      return {
-        text: { type: "plain_text" as const, text: option.label.slice(0, 75) },
-        value: option.model,
-      };
-    }),
-  ];
+      value: option.model,
+    };
+  });
 
-  const initialOptionRaw = args.currentSelectedModel
+  const defaultModel =
+    args.options.find((option) => {
+      return option.isDefault;
+    })?.model ?? null;
+  const currentOption = args.currentSelectedModel
     ? selectOptions.find((option) => {
         return option.value === args.currentSelectedModel;
       })
-    : selectOptions[0];
-  const initialOption = initialOptionRaw ?? selectOptions[0];
+    : undefined;
+  const defaultOption = defaultModel
+    ? selectOptions.find((option) => {
+        return option.value === defaultModel;
+      })
+    : undefined;
+  const initialOption = currentOption ?? defaultOption ?? selectOptions[0];
 
   const view: View = {
     type: "modal",
@@ -664,6 +662,16 @@ export function buildModelPickerModal(args: {
   };
 
   return view;
+}
+
+function formatModelPickerOptionLabel(option: ModelPickerOption): string {
+  if (!option.isDefault) return option.label.slice(0, 75);
+
+  const suffix = " (workspace default)";
+  if (option.label.length + suffix.length <= 75) {
+    return `${option.label}${suffix}`;
+  }
+  return `${option.label.slice(0, 75 - suffix.length)}${suffix}`;
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/slack/model-picker.ts
+++ b/turbo/apps/web/src/lib/zero/slack/model-picker.ts
@@ -21,8 +21,6 @@ interface SlackModelPickerState {
   enabled: boolean;
   options: SlackModelPickerOption[];
   currentSelectedModel: SupportedRunModel | null;
-  workspaceDefaultModel: SupportedRunModel | null;
-  workspaceDefaultName: string | null;
 }
 
 async function canUseModelRoute(params: {
@@ -61,8 +59,6 @@ export async function getSlackModelPickerState(params: {
       enabled: false,
       options: [],
       currentSelectedModel: null,
-      workspaceDefaultModel: null,
-      workspaceDefaultName: null,
     };
   }
 
@@ -97,18 +93,9 @@ export async function getSlackModelPickerState(params: {
     });
   }
 
-  const workspaceDefaultModel =
-    options.find((option) => {
-      return option.isDefault;
-    })?.model ?? null;
-
   return {
     enabled: true,
     options,
     currentSelectedModel,
-    workspaceDefaultModel,
-    workspaceDefaultName: workspaceDefaultModel
-      ? getCanonicalModelDisplayName(workspaceDefaultModel)
-      : null,
   };
 }


### PR DESCRIPTION
## Summary
- remove the separate Slack `/zero model` workspace-default option
- label the default model inline with `(workspace default)`
- clear the personal model preference when the selected model is the workspace default

## Verification
- `pnpm --filter web check-types`
- targeted ESLint for Slack command/interactive routes and Slack picker helpers
- targeted Vitest attempted; blocked by local DB schema drift (`zero_agents.visibility`, `org_model_policies.is_default`) and `db:migrate` is blocked by existing `chat_threads.model_provider_type`