### PR TITLE
fix: align zero logs no-org parity

### DIFF
--- a/turbo/apps/web/app/api/zero/logs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/[id]/__tests__/route.test.ts
@@ -72,6 +72,21 @@ describe("GET /api/zero/logs/[id]", () => {
     expect(data.error.message).toBe("Not authenticated");
   });
 
+  it("should return 401 when the authenticated session has no organization", async () => {
+    mockClerk({ userId: user.userId, orgId: null });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/zero/logs/${randomUUID()}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
   it("should return 400 for invalid UUID format", async () => {
     const request = createTestRequest(
       "http://localhost:3000/api/zero/logs/invalid-uuid",

--- a/turbo/apps/web/app/api/zero/logs/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/logs/[id]/route.ts
@@ -72,6 +72,15 @@ function notFoundResponse() {
   };
 }
 
+function unauthenticatedResponse() {
+  return {
+    status: 401 as const,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
+
 /**
  * Build the response body from a query result row.
  */
@@ -136,6 +145,7 @@ const router = tsr.router(logsByIdContract, {
       requiredCapability: "agent-run:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
     const { userId } = authCtx;
 
     // Resolve active org from JWT / CLI token / default

--- a/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
@@ -42,6 +42,19 @@ describe("GET /api/zero/logs", () => {
     expect(data.error.message).toBe("Not authenticated");
   });
 
+  it("should return 401 when the authenticated session has no organization", async () => {
+    mockClerk({ userId: user.userId, orgId: null });
+
+    const request = createTestRequest("http://localhost:3000/api/zero/logs");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
   it("should return empty list when user has no runs", async () => {
     const request = createTestRequest("http://localhost:3000/api/zero/logs");
     const response = await GET(request);

--- a/turbo/apps/web/app/api/zero/logs/route.ts
+++ b/turbo/apps/web/app/api/zero/logs/route.ts
@@ -65,6 +65,15 @@ interface LogsQuery {
   limit?: number;
 }
 
+function unauthenticatedResponse() {
+  return {
+    status: 401 as const,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
+
 /**
  * Build agent filter conditions from query params.
  * agentId is the canonical Zero agent ID.
@@ -240,6 +249,7 @@ const router = tsr.router(logsListContract, {
       requiredCapability: "agent-run:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
     const { userId } = authCtx;
 
     const limit = query.limit ?? 20;

--- a/turbo/apps/web/app/api/zero/logs/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/search/__tests__/route.test.ts
@@ -90,6 +90,22 @@ describe("GET /api/zero/logs/search", () => {
     expect(data.error.code).toBe("UNAUTHORIZED");
   });
 
+  it("should return 401 when the authenticated session has no organization", async () => {
+    mockClerk({ userId: user.userId, orgId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/logs/search?keyword=test",
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
   it("should return 403 for sandbox token without agent-run:read", async () => {
     const token = await generateSandboxToken(
       user.userId,

--- a/turbo/apps/web/app/api/zero/logs/search/route.ts
+++ b/turbo/apps/web/app/api/zero/logs/search/route.ts
@@ -17,6 +17,15 @@ import {
 import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
 import { handleSearchLogs } from "../../../../../src/lib/infra/run/log-search-service";
 
+function unauthenticatedResponse() {
+  return {
+    status: 401 as const,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
+
 const router = tsr.router(zeroLogsSearchContract, {
   searchLogs: async ({ query, headers }) => {
     initServices();
@@ -25,6 +34,7 @@ const router = tsr.router(zeroLogsSearchContract, {
       requiredCapability: "agent-run:read",
     });
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
     const { userId } = authCtx;
 
     const { org } = await resolveOrg(authCtx);


### PR DESCRIPTION
## Summary

- Align web zero logs routes with API behavior for authenticated sessions without an active org.
- Add no-active-org 401 coverage for logs list, search, and get-by-id web route tests.

Closes #12629.

## Testing

- `pnpm -F web exec vitest run app/api/zero/logs/__tests__/route.test.ts app/api/zero/logs/search/__tests__/route.test.ts 'app/api/zero/logs/[id]/__tests__/route.test.ts'`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-logs-list.test.ts src/signals/routes/__tests__/zero-logs-search.test.ts src/signals/routes/__tests__/zero-logs-get-by-id.test.ts`
- `pnpm -F web run lint`
- `pnpm -F web exec prettier --check app/api/zero/logs/route.ts app/api/zero/logs/search/route.ts 'app/api/zero/logs/[id]/route.ts' app/api/zero/logs/__tests__/route.test.ts app/api/zero/logs/search/__tests__/route.test.ts 'app/api/zero/logs/[id]/__tests__/route.test.ts'`
- `git diff --check`

## Notes

- Test-first check failed as expected before the route fix: the three new web tests received `400` from `resolveOrg(authCtx)` instead of API-compatible `401`.
- `pnpm -F web run check-types` is blocked by existing unrelated implicit-any errors in other web route files.
- Full pre-commit `pnpm check-types` is blocked by existing unrelated `@vm0/app` type errors.
