### PR TITLE
test: align zero Telegram integration route parity

### DIFF
--- a/turbo/apps/api/src/signals/external/telegram-client.ts
+++ b/turbo/apps/api/src/signals/external/telegram-client.ts
@@ -55,7 +55,8 @@ export async function getMe(token: string): Promise<TelegramBotInfo> {
 
 interface TelegramFile {
   readonly file_id: string;
-  readonly file_path: string;
+  readonly file_path?: string;
+  readonly file_size?: number;
 }
 
 export async function getFile(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-message.test.ts
@@ -24,10 +24,12 @@ import {
   seedTelegramInstallation$,
   type TelegramFixture,
 } from "./helpers/zero-telegram";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { seedRun$ } from "./helpers/zero-usage-insight";
 
 const context = testContext();
 const store = createStore();
+const mocks = createZeroRouteMocks(context);
 
 function uniqueBotId(): string {
   // 9-digit numeric matches parseTelegramBotId's /^\d+$/ check.
@@ -181,6 +183,30 @@ describe("POST /api/zero/integrations/telegram/message", () => {
       [401],
     );
     expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const client = setupApp({ context })(integrationsTelegramMessageContract);
+
+    const response = await accept(
+      client.sendMessage({
+        body: {
+          botId: "tg-bot",
+          chatId: "-100",
+          text: "hi",
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
   });
 
   it("sends a Telegram message and appends the audit footer", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram.test.ts
@@ -4,8 +4,11 @@ import { integrationsTelegramBotListContract } from "@vm0/api-contracts/contract
 import { OFFICIAL_TELEGRAM_BOT_ID } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import { createStore } from "ccstate";
 import { afterEach, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
 
+import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { mockEnv } from "../../../lib/env";
 import { now } from "../../external/time";
@@ -21,9 +24,11 @@ import {
   seedTelegramInstallation$,
   type TelegramFixture,
 } from "./helpers/zero-telegram";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
 const store = createStore();
+const mocks = createZeroRouteMocks(context);
 
 const OFFICIAL_BOT_TOKEN = "9876543210:fake-test-token";
 const OFFICIAL_BOT_USERNAME = "official_zero_bot";
@@ -37,6 +42,15 @@ function configureOfficialBotEnv(): void {
 
 function newTelegramBotId(): string {
   return String(Math.floor(Math.random() * 9_000_000_000) + 1_000_000_000);
+}
+
+function expectUnauthorized(body: unknown): void {
+  expect(body).toStrictEqual({
+    error: {
+      message: "Not authenticated",
+      code: "UNAUTHORIZED",
+    },
+  });
 }
 
 function mintZeroToken(args: {
@@ -85,6 +99,20 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
     const response = await accept(client.listBots({ headers: {} }), [401]);
 
     expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const client = setupApp({ context })(integrationsTelegramBotListContract);
+
+    const response = await accept(
+      client.listBots({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expectUnauthorized(response.body);
   });
 
   it("lists the official bot and custom Telegram bots in the active org", async () => {
@@ -207,6 +235,405 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
       kind: "official",
       isOwner: false,
       official: { linkedTelegramUserId: null },
+    });
+  });
+});
+
+describe("GET /api/zero/integrations/telegram/download-file", () => {
+  const fixtures: TelegramFixture[] = [];
+  const memberships: OrgMembershipFixture[] = [];
+  const downloadPath = "/api/zero/integrations/telegram/download-file";
+
+  beforeEach(() => {
+    configureOfficialBotEnv();
+  });
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await store.set(deleteTelegramFixture$, fixture, context.signal);
+      }
+    }
+    while (memberships.length > 0) {
+      const membership = memberships.pop();
+      if (membership) {
+        await store.set(deleteOrgMembership$, membership, context.signal);
+      }
+    }
+  });
+
+  function requestDownload(args: {
+    readonly search: string;
+    readonly token?: string;
+    readonly authorization?: string;
+  }): Response | Promise<Response> {
+    const headers: Record<string, string> = {};
+    if (args.token) {
+      headers.authorization = `Bearer ${args.token}`;
+    }
+    if (args.authorization) {
+      headers.authorization = args.authorization;
+    }
+    const app = createApp({ signal: context.signal });
+    return app.request(`${downloadPath}${args.search}`, { headers });
+  }
+
+  async function seedDownloadContext(): Promise<{
+    readonly token: string;
+    readonly botId: string;
+  }> {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const membership = await store.set(
+      seedOrgMembership$,
+      { orgId, userId, seedOrgCache: false },
+      context.signal,
+    );
+    memberships.push(membership);
+
+    const builder = makeTelegramFixtureBuilder(orgId);
+    const installation = await store.set(
+      seedTelegramInstallation$,
+      {
+        orgId,
+        ownerUserId: userId,
+        telegramBotId: newTelegramBotId(),
+      },
+      context.signal,
+    );
+    builder.composeIds.push(installation.composeId);
+    builder.telegramBotIds.push(installation.telegramBotId);
+    fixtures.push(freezeTelegramFixture(builder));
+
+    return {
+      token: mintZeroToken({
+        userId,
+        orgId,
+        capabilities: ["telegram:read"],
+      }),
+      botId: installation.telegramBotId,
+    };
+  }
+
+  async function seedReadToken(): Promise<string> {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const membership = await store.set(
+      seedOrgMembership$,
+      { orgId, userId, seedOrgCache: false },
+      context.signal,
+    );
+    memberships.push(membership);
+    return mintZeroToken({
+      userId,
+      orgId,
+      capabilities: ["telegram:read"],
+    });
+  }
+
+  function expectJson(response: Response): Promise<unknown> {
+    expect(response.headers.get("content-type")).toContain("application/json");
+    return response.json();
+  }
+
+  it("returns 401 when no auth token is provided", async () => {
+    const response = await requestDownload({
+      search: "?file_id=tg-file-1&bot_id=tg-bot",
+    });
+
+    expect(response.status).toBe(401);
+    expectUnauthorized(await expectJson(response));
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const response = await requestDownload({
+      search: "?file_id=tg-file-1&bot_id=tg-bot",
+      authorization: "Bearer clerk-session",
+    });
+
+    expect(response.status).toBe(401);
+    expectUnauthorized(await expectJson(response));
+  });
+
+  it("returns 400 when file_id query param is missing", async () => {
+    const token = await seedReadToken();
+
+    const response = await requestDownload({
+      search: "?bot_id=tg-bot",
+      token,
+    });
+
+    expect(response.status).toBe(400);
+    const body = await expectJson(response);
+    expect(body).toMatchObject({ error: { code: "BAD_REQUEST" } });
+    expect(JSON.stringify(body)).toContain("file_id");
+  });
+
+  it("returns 400 when bot_id query param is missing", async () => {
+    const token = await seedReadToken();
+
+    const response = await requestDownload({
+      search: "?file_id=tg-file-1",
+      token,
+    });
+
+    expect(response.status).toBe(400);
+    const body = await expectJson(response);
+    expect(body).toMatchObject({ error: { code: "BAD_REQUEST" } });
+    expect(JSON.stringify(body)).toContain("bot_id");
+  });
+
+  it("returns 404 when the custom bot id is not known in the org", async () => {
+    const token = await seedReadToken();
+
+    const response = await requestDownload({
+      search: "?file_id=tg-missing&bot_id=unknown-bot",
+      token,
+    });
+
+    expect(response.status).toBe(404);
+    await expect(expectJson(response)).resolves.toStrictEqual({
+      error: { message: "Telegram bot not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("streams files for the official Telegram bot", async () => {
+    const token = await seedReadToken();
+    const fileBytes = Buffer.from("official telegram bytes");
+    context.mocks.telegram.getFile.mockResolvedValue({
+      file_id: "tg-official",
+      file_size: fileBytes.length,
+      file_path: "photos/official.jpg",
+    });
+    server.use(
+      http.get(
+        `https://api.telegram.org/file/bot${OFFICIAL_BOT_TOKEN}/photos/official.jpg`,
+        () => {
+          return new HttpResponse(fileBytes, {
+            status: 200,
+            headers: {
+              "content-type": "image/jpeg",
+              "content-length": String(fileBytes.length),
+            },
+          });
+        },
+      ),
+    );
+
+    const response = await requestDownload({
+      search: `?file_id=tg-official&bot_id=${OFFICIAL_TELEGRAM_BOT_ID}`,
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    expect(context.mocks.telegram.getFile).toHaveBeenCalledWith(
+      OFFICIAL_BOT_TOKEN,
+      "tg-official",
+    );
+    expect(response.headers.get("content-type")).toBe("image/jpeg");
+    expect(response.headers.get("x-file-name")).toBe("official.jpg");
+    const receivedBytes = Buffer.from(await response.arrayBuffer());
+    expect(receivedBytes.equals(fileBytes)).toBeTruthy();
+  });
+
+  it("streams files for a custom Telegram bot", async () => {
+    const { token, botId } = await seedDownloadContext();
+    const fileBytes = Buffer.from("custom telegram bytes");
+    context.mocks.telegram.getFile.mockResolvedValue({
+      file_id: "tg-custom",
+      file_size: fileBytes.length,
+      file_path: "photos/custom.jpg",
+    });
+    server.use(
+      http.get(
+        "https://api.telegram.org/file/bottest-bot-token/photos/custom.jpg",
+        () => {
+          return new HttpResponse(fileBytes, {
+            status: 200,
+            headers: {
+              "content-type": "image/jpeg",
+              "content-length": String(fileBytes.length),
+            },
+          });
+        },
+      ),
+    );
+
+    const response = await requestDownload({
+      search: `?file_id=tg-custom&bot_id=${botId}`,
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    expect(context.mocks.telegram.getFile).toHaveBeenCalledWith(
+      "test-bot-token",
+      "tg-custom",
+    );
+    expect(response.headers.get("content-type")).toBe("image/jpeg");
+    expect(response.headers.get("x-file-mimetype")).toBe("image/jpeg");
+    expect(response.headers.get("x-file-name")).toBe("custom.jpg");
+    const receivedBytes = Buffer.from(await response.arrayBuffer());
+    expect(receivedBytes.equals(fileBytes)).toBeTruthy();
+  });
+
+  it("returns 404 when Telegram file metadata has no downloadable path", async () => {
+    const { token, botId } = await seedDownloadContext();
+    context.mocks.telegram.getFile.mockResolvedValue({
+      file_id: "tg-no-path",
+    });
+
+    const response = await requestDownload({
+      search: `?file_id=tg-no-path&bot_id=${botId}`,
+      token,
+    });
+
+    expect(response.status).toBe(404);
+    await expect(expectJson(response)).resolves.toStrictEqual({
+      error: {
+        message: "Telegram file does not have a downloadable path",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 413 when Telegram reports a file over the proxy limit", async () => {
+    const { token, botId } = await seedDownloadContext();
+    context.mocks.telegram.getFile.mockResolvedValue({
+      file_id: "tg-file-big",
+      file_size: 200 * 1024 * 1024,
+      file_path: "documents/big.bin",
+    });
+
+    const response = await requestDownload({
+      search: `?file_id=tg-file-big&bot_id=${botId}`,
+      token,
+    });
+
+    expect(response.status).toBe(413);
+    await expect(expectJson(response)).resolves.toStrictEqual({
+      error: {
+        message: "File exceeds maximum size of 104857600 bytes",
+        code: "PAYLOAD_TOO_LARGE",
+      },
+    });
+  });
+
+  it("returns 413 when download content-length exceeds the proxy limit", async () => {
+    const { token, botId } = await seedDownloadContext();
+    context.mocks.telegram.getFile.mockResolvedValue({
+      file_id: "tg-huge-response",
+      file_path: "documents/huge-response.bin",
+    });
+    server.use(
+      http.get(
+        "https://api.telegram.org/file/bottest-bot-token/documents/huge-response.bin",
+        () => {
+          return new HttpResponse(Buffer.from("not actually huge"), {
+            status: 200,
+            headers: {
+              "content-type": "application/octet-stream",
+              "content-length": String(200 * 1024 * 1024),
+            },
+          });
+        },
+      ),
+    );
+
+    const response = await requestDownload({
+      search: `?file_id=tg-huge-response&bot_id=${botId}`,
+      token,
+    });
+
+    expect(response.status).toBe(413);
+    await expect(expectJson(response)).resolves.toStrictEqual({
+      error: {
+        message: "File exceeds maximum size of 104857600 bytes",
+        code: "PAYLOAD_TOO_LARGE",
+      },
+    });
+  });
+
+  it("returns 502 when Telegram returns HTML for a file download", async () => {
+    const { token, botId } = await seedDownloadContext();
+    context.mocks.telegram.getFile.mockResolvedValue({
+      file_id: "tg-html",
+      file_path: "documents/html.bin",
+    });
+    server.use(
+      http.get(
+        "https://api.telegram.org/file/bottest-bot-token/documents/html.bin",
+        () => {
+          return new HttpResponse("<html></html>", {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          });
+        },
+      ),
+    );
+
+    const response = await requestDownload({
+      search: `?file_id=tg-html&bot_id=${botId}`,
+      token,
+    });
+
+    expect(response.status).toBe(502);
+    await expect(expectJson(response)).resolves.toStrictEqual({
+      error: {
+        message: "Telegram returned an unexpected response",
+        code: "BAD_GATEWAY",
+      },
+    });
+  });
+
+  it("returns 502 when Telegram file download returns a non-OK response", async () => {
+    const { token, botId } = await seedDownloadContext();
+    context.mocks.telegram.getFile.mockResolvedValue({
+      file_id: "tg-download-fail",
+      file_path: "documents/fail.bin",
+    });
+    server.use(
+      http.get(
+        "https://api.telegram.org/file/bottest-bot-token/documents/fail.bin",
+        () => {
+          return new HttpResponse("unavailable", { status: 503 });
+        },
+      ),
+    );
+
+    const response = await requestDownload({
+      search: `?file_id=tg-download-fail&bot_id=${botId}`,
+      token,
+    });
+
+    expect(response.status).toBe(502);
+    await expect(expectJson(response)).resolves.toStrictEqual({
+      error: {
+        message: "Failed to download file from Telegram: 503",
+        code: "BAD_GATEWAY",
+      },
+    });
+  });
+
+  it("returns a generic 502 body when Telegram file lookup throws", async () => {
+    const { token, botId } = await seedDownloadContext();
+    context.mocks.telegram.getFile.mockRejectedValue(
+      new Error("upstream detail"),
+    );
+
+    const response = await requestDownload({
+      search: `?file_id=tg-throws&bot_id=${botId}`,
+      token,
+    });
+
+    expect(response.status).toBe(502);
+    await expect(expectJson(response)).resolves.toStrictEqual({
+      error: {
+        message: "Failed to download file from Telegram",
+        code: "BAD_GATEWAY",
+      },
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-integrations-telegram.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-telegram.ts
@@ -10,9 +10,14 @@ import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
 import { buildFileDownloadUrl, getFile } from "../external/telegram-client";
 import {
+  getOfficialTelegramBotConfig,
+  isOfficialTelegramBotId,
+} from "../external/telegram-official";
+import {
   zeroTelegramBots,
   zeroTelegramInstallation,
 } from "../services/zero-telegram-data.service";
+import { inferMimetype } from "../../lib/mimetype";
 import type { RouteEntry } from "../route";
 
 const c = initContract();
@@ -35,6 +40,7 @@ const telegramDownloadFileContract = c.router({
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
+      413: apiErrorSchema,
       502: apiErrorSchema,
     },
     summary: "Download a Telegram file via org bot token",
@@ -50,6 +56,27 @@ function errorResponse(
     status,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+
+function parseContentLength(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const size = Number(value);
+  if (!Number.isSafeInteger(size) || size < 0) {
+    return undefined;
+  }
+  return size;
+}
+
+function payloadTooLargeResponse(): Response {
+  return errorResponse(
+    413,
+    `File exceeds maximum size of ${MAX_FILE_SIZE_BYTES} bytes`,
+    "PAYLOAD_TOO_LARGE",
+  );
 }
 
 const getTelegramBotsInner$ = computed(async (get) => {
@@ -68,15 +95,22 @@ const getTelegramDownloadFileInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const query = get(queryOf(telegramDownloadFileContract.download));
 
-  const installation = await get(
-    zeroTelegramInstallation({ orgId: auth.orgId, botId: query.bot_id }),
-  );
-  if (!installation) {
+  let botToken: string | null | undefined;
+  if (isOfficialTelegramBotId(query.bot_id)) {
+    botToken = getOfficialTelegramBotConfig().botToken;
+  } else {
+    const installation = await get(
+      zeroTelegramInstallation({ orgId: auth.orgId, botId: query.bot_id }),
+    );
+    botToken = installation?.botToken;
+  }
+
+  if (!botToken) {
     return errorResponse(404, "Telegram bot not found", "NOT_FOUND");
   }
 
-  return getFile(installation.botToken, query.file_id)
-    .then((file) => {
+  return getFile(botToken, query.file_id)
+    .then(async (file) => {
       if (!file.file_path) {
         return errorResponse(
           404,
@@ -84,41 +118,55 @@ const getTelegramDownloadFileInner$ = computed(async (get) => {
           "NOT_FOUND",
         );
       }
+      if (file.file_size && file.file_size > MAX_FILE_SIZE_BYTES) {
+        return payloadTooLargeResponse();
+      }
 
-      const downloadUrl = buildFileDownloadUrl(
-        installation.botToken,
-        file.file_path,
-      );
-      return fetch(downloadUrl).then((fileResponse) => {
-        if (!fileResponse.ok) {
-          return errorResponse(
-            502,
-            `Failed to download file from Telegram: ${fileResponse.status}`,
-            "BAD_GATEWAY",
-          );
-        }
+      const fileName = file.file_path.split("/").pop() ?? query.file_id;
+      const downloadUrl = buildFileDownloadUrl(botToken, file.file_path);
+      const fileResponse = await fetch(downloadUrl);
+      if (!fileResponse.ok) {
+        return errorResponse(
+          502,
+          `Failed to download file from Telegram: ${fileResponse.status}`,
+          "BAD_GATEWAY",
+        );
+      }
 
-        const responseContentType =
-          fileResponse.headers.get("content-type") ??
-          "application/octet-stream";
-        const contentLength = fileResponse.headers.get("content-length");
-        const fileName = file.file_path!.split("/").pop() ?? query.file_id;
+      const responseContentType =
+        fileResponse.headers.get("content-type") ?? "";
+      if (responseContentType.includes("text/html")) {
+        return errorResponse(
+          502,
+          "Telegram returned an unexpected response",
+          "BAD_GATEWAY",
+        );
+      }
 
-        const headers = new Headers();
-        headers.set("Content-Type", responseContentType);
-        headers.set("X-File-Name", encodeURIComponent(fileName));
-        headers.set("X-File-Mimetype", responseContentType);
-        if (contentLength) {
-          headers.set("Content-Length", contentLength);
-        }
+      const contentLength = fileResponse.headers.get("content-length");
+      const contentLengthBytes = parseContentLength(contentLength);
+      if (
+        contentLengthBytes !== undefined &&
+        contentLengthBytes > MAX_FILE_SIZE_BYTES
+      ) {
+        return payloadTooLargeResponse();
+      }
 
-        return new Response(fileResponse.body, { status: 200, headers });
-      });
+      const mimetype = responseContentType || inferMimetype(fileName);
+      const headers = new Headers();
+      headers.set("Content-Type", mimetype);
+      headers.set("X-File-Name", encodeURIComponent(fileName));
+      headers.set("X-File-Mimetype", mimetype);
+      if (contentLength) {
+        headers.set("Content-Length", contentLength);
+      }
+
+      return new Response(fileResponse.body, { status: 200, headers });
     })
-    .catch((error) => {
+    .catch(() => {
       return errorResponse(
         502,
-        error instanceof Error ? error.message : "Failed to download file",
+        "Failed to download file from Telegram",
         "BAD_GATEWAY",
       );
     });

--- a/turbo/apps/web/app/api/zero/integrations/telegram/bots/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/bots/__tests__/route.test.ts
@@ -54,6 +54,20 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
     expect(response.status).toBe(401);
   });
 
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mockClerk({ userId: user.userId, orgId: null });
+
+    const response = await GET(createTestRequest(URL, { method: "GET" }));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
   const officialBotExpectation = expect.objectContaining({
     id: OFFICIAL_TELEGRAM_BOT_ID,
     kind: "official",

--- a/turbo/apps/web/app/api/zero/integrations/telegram/bots/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/bots/route.ts
@@ -27,8 +27,8 @@ const router = tsr.router(integrationsTelegramBotListContract, {
 
     if (!authCtx.orgId) {
       return {
-        status: 403 as const,
-        body: errorBody("Organization context is required", "FORBIDDEN"),
+        status: 401 as const,
+        body: errorBody("Not authenticated", "UNAUTHORIZED"),
       };
     }
 

--- a/turbo/apps/web/app/api/zero/integrations/telegram/download-file/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/download-file/__tests__/route.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { http, HttpResponse } from "msw";
+import { OFFICIAL_TELEGRAM_BOT_ID } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import { GET } from "../route";
 import {
   createTestRequest,
@@ -14,11 +15,20 @@ import {
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import { generateZeroToken } from "../../../../../../../src/lib/auth/sandbox-token";
 import { server } from "../../../../../../../src/mocks/server";
+import { reloadEnv } from "../../../../../../../src/env";
 
 const URL =
   "http://localhost:3000/api/zero/integrations/telegram/download-file";
 
 const context = testContext();
+const OFFICIAL_BOT_TOKEN = "9876543210:fake-test-token";
+
+function configureOfficialBotEnv(): void {
+  vi.stubEnv("TELEGRAM_OFFICIAL_BOT_TOKEN", OFFICIAL_BOT_TOKEN);
+  vi.stubEnv("TELEGRAM_OFFICIAL_BOT_USERNAME", "official_zero_bot");
+  vi.stubEnv("TELEGRAM_OFFICIAL_WEBHOOK_SECRET", "official-test-secret");
+  reloadEnv();
+}
 
 describe("GET /api/zero/integrations/telegram/download-file", () => {
   let user: UserContext;
@@ -57,6 +67,26 @@ describe("GET /api/zero/integrations/telegram/download-file", () => {
     const response = await GET(request as never);
 
     expect(response.status).toBe(401);
+  });
+
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mockClerk({ userId: user.userId, orgId: null });
+
+    const request = createTestRequest(
+      `${URL}?file_id=tg-file-1&bot_id=tg-bot`,
+      {
+        method: "GET",
+      },
+    );
+    const response = await GET(request as never);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
   });
 
   it("returns 400 when file_id query param is missing", async () => {
@@ -159,6 +189,54 @@ describe("GET /api/zero/integrations/telegram/download-file", () => {
     expect(receivedBytes.equals(fileBytes)).toBe(true);
   });
 
+  it("streams Telegram file bytes for the official bot", async () => {
+    configureOfficialBotEnv();
+    const fileBytes = Buffer.from("official telegram image bytes");
+    server.use(
+      http.post(
+        `https://api.telegram.org/bot${OFFICIAL_BOT_TOKEN}/getFile`,
+        async ({ request }) => {
+          const body = (await request.json()) as { file_id?: string };
+          expect(body.file_id).toBe("tg-official-file");
+          return HttpResponse.json({
+            ok: true,
+            result: {
+              file_id: "tg-official-file",
+              file_unique_id: "official-1",
+              file_size: fileBytes.length,
+              file_path: "photos/official-file.jpg",
+            },
+          });
+        },
+      ),
+      http.get(
+        `https://api.telegram.org/file/bot${OFFICIAL_BOT_TOKEN}/photos/official-file.jpg`,
+        () => {
+          return new HttpResponse(fileBytes, {
+            status: 200,
+            headers: {
+              "content-type": "image/jpeg",
+              "content-length": String(fileBytes.length),
+            },
+          });
+        },
+      ),
+    );
+
+    const request = await authedRequest(
+      "tg-official-file",
+      OFFICIAL_TELEGRAM_BOT_ID,
+    );
+    const response = await GET(request as never);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/jpeg");
+    expect(response.headers.get("x-file-name")).toBe("official-file.jpg");
+
+    const receivedBytes = Buffer.from(await response.arrayBuffer());
+    expect(receivedBytes.equals(fileBytes)).toBe(true);
+  });
+
   it("returns 413 when Telegram reports a file over the proxy limit", async () => {
     const botId = await createTestTelegramInstallation({
       telegramBotId: uniqueId("tg-bot-big"),
@@ -226,5 +304,118 @@ describe("GET /api/zero/integrations/telegram/download-file", () => {
 
     expect(response.status).toBe(413);
     expect(data.error.code).toBe("PAYLOAD_TOO_LARGE");
+  });
+
+  it("returns 502 when Telegram returns HTML for a file download", async () => {
+    const botId = await createTestTelegramInstallation({
+      telegramBotId: uniqueId("tg-bot-html"),
+      orgId: user.orgId,
+      ownerUserId: user.userId,
+    });
+
+    server.use(
+      http.post("https://api.telegram.org/bottest-bot-token/getFile", () => {
+        return HttpResponse.json({
+          ok: true,
+          result: {
+            file_id: "tg-file-html",
+            file_unique_id: "unique-html",
+            file_path: "documents/html.bin",
+          },
+        });
+      }),
+      http.get(
+        "https://api.telegram.org/file/bottest-bot-token/documents/html.bin",
+        () => {
+          return new HttpResponse("<html></html>", {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          });
+        },
+      ),
+    );
+
+    const request = await authedRequest("tg-file-html", botId);
+    const response = await GET(request as never);
+    const data = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(data).toStrictEqual({
+      error: {
+        message: "Telegram returned an unexpected response",
+        code: "BAD_GATEWAY",
+      },
+    });
+  });
+
+  it("returns 502 when Telegram file download returns a non-OK response", async () => {
+    const botId = await createTestTelegramInstallation({
+      telegramBotId: uniqueId("tg-bot-download-fail"),
+      orgId: user.orgId,
+      ownerUserId: user.userId,
+    });
+
+    server.use(
+      http.post("https://api.telegram.org/bottest-bot-token/getFile", () => {
+        return HttpResponse.json({
+          ok: true,
+          result: {
+            file_id: "tg-file-download-fail",
+            file_unique_id: "unique-download-fail",
+            file_path: "documents/fail.bin",
+          },
+        });
+      }),
+      http.get(
+        "https://api.telegram.org/file/bottest-bot-token/documents/fail.bin",
+        () => {
+          return new HttpResponse("unavailable", { status: 503 });
+        },
+      ),
+    );
+
+    const request = await authedRequest("tg-file-download-fail", botId);
+    const response = await GET(request as never);
+    const data = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(data).toStrictEqual({
+      error: {
+        message: "Failed to download file from Telegram: 503",
+        code: "BAD_GATEWAY",
+      },
+    });
+  });
+
+  it("returns a generic 502 body when Telegram file lookup fails", async () => {
+    const botId = await createTestTelegramInstallation({
+      telegramBotId: uniqueId("tg-bot-getfile-fail"),
+      orgId: user.orgId,
+      ownerUserId: user.userId,
+    });
+
+    server.use(
+      http.post("https://api.telegram.org/bottest-bot-token/getFile", () => {
+        return HttpResponse.json(
+          {
+            ok: false,
+            description: "upstream detail",
+          },
+          { status: 500 },
+        );
+      }),
+    );
+
+    const request = await authedRequest("tg-file-getfile-fail", botId);
+    const response = await GET(request as never);
+    const data = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(data).toStrictEqual({
+      error: {
+        message: "Failed to download file from Telegram",
+        code: "BAD_GATEWAY",
+      },
+    });
   });
 });

--- a/turbo/apps/web/app/api/zero/integrations/telegram/download-file/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/download-file/route.ts
@@ -135,7 +135,7 @@ export async function GET(request: NextRequest): Promise<Response> {
   }
 
   if (!authCtx.orgId) {
-    return errorResponse(403, "Organization context is required", "FORBIDDEN");
+    return errorResponse(401, "Not authenticated", "UNAUTHORIZED");
   }
 
   const fileId = request.nextUrl.searchParams.get("file_id");

--- a/turbo/apps/web/app/api/zero/integrations/telegram/message/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/message/__tests__/route.test.ts
@@ -81,6 +81,26 @@ describe("POST /api/zero/integrations/telegram/message", () => {
     expect(response.status).toBe(401);
   });
 
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mockClerk({ userId: user.userId, orgId: null });
+
+    const response = await POST(
+      messageRequest({
+        botId: "tg-bot-message",
+        chatId: "-1001234567890",
+        text: "hello",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
   it("sends a Telegram message and appends the Slack-aligned footer", async () => {
     const { token, runId } = await zeroTokenWithRun();
     await setTestRunSelectedModel(runId, "claude-opus-4-7");
@@ -253,6 +273,46 @@ describe("POST /api/zero/integrations/telegram/message", () => {
 
     expect(response.status).toBe(400);
     expect(body.error.message).toContain("chat not found");
+    expect(body.error.code).toBe("TELEGRAM_ERROR");
+  });
+
+  it("returns 502 when Telegram returns a 5xx", async () => {
+    const { token } = await zeroTokenWithRun();
+    const botId = await createTestTelegramInstallation({
+      telegramBotId: uniqueId("tg-bot-5xx-message"),
+      orgId: user.orgId,
+      ownerUserId: user.userId,
+    });
+
+    server.use(
+      http.post(
+        "https://api.telegram.org/bottest-bot-token/sendMessage",
+        () => {
+          return HttpResponse.json(
+            {
+              ok: false,
+              description: "Service Unavailable",
+            },
+            { status: 503 },
+          );
+        },
+      ),
+    );
+
+    const response = await POST(
+      messageRequest(
+        {
+          botId,
+          chatId: "-1001234567890",
+          text: "hello",
+        },
+        token,
+      ),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body.error.message).toContain("Service Unavailable");
     expect(body.error.code).toBe("TELEGRAM_ERROR");
   });
 });

--- a/turbo/apps/web/app/api/zero/integrations/telegram/message/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/message/route.ts
@@ -121,8 +121,8 @@ const router = tsr.router(integrationsTelegramMessageContract, {
 
     if (!authCtx.orgId) {
       return {
-        status: 403 as const,
-        body: errorBody("Organization context is required", "FORBIDDEN"),
+        status: 401 as const,
+        body: errorBody("Not authenticated", "UNAUTHORIZED"),
       };
     }
 


### PR DESCRIPTION
## Summary
- align Telegram zero route unauthenticated org handling between web and API
- add API parity coverage for bot listing, file download, and message send edge cases
- support official Telegram bot downloads and mirror web download failure handling in the API route

Fixes #12628

## Validation
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-integrations-telegram.test.ts src/signals/routes/__tests__/zero-integrations-telegram-message.test.ts
- pnpm -F web exec vitest run app/api/zero/integrations/telegram/bots/__tests__/route.test.ts app/api/zero/integrations/telegram/download-file/__tests__/route.test.ts app/api/zero/integrations/telegram/message/__tests__/route.test.ts
- pnpm -F api check-types
- pnpm -F web check-types
- pnpm -F api lint
- pnpm -F web lint
- pnpm knip --workspace api
- pnpm knip --workspace web
- pnpm format
- git diff --check
- pre-commit: pnpm check-types, pnpm knip --cache, prettier on staged files