### PR TITLE
fix: align zero model provider route parity

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -43,6 +43,7 @@ import { zeroRunsRoutes } from "./routes/zero-runs";
 import { zeroRunsCancelRoutes } from "./routes/zero-runs-cancel";
 import { zeroSchedulesRoutes } from "./routes/zero-schedules";
 import { zeroMeModelProvidersDeleteRoutes } from "./routes/zero-me-model-providers-delete";
+import { zeroMeModelProvidersListRoutes } from "./routes/zero-me-model-providers-list";
 import { zeroMeModelProvidersUpsertRoutes } from "./routes/zero-me-model-providers-upsert";
 import { zeroSecretsRoutes } from "./routes/zero-secrets";
 import { zeroSkillsRoutes } from "./routes/zero-skills";
@@ -98,6 +99,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroModelPoliciesRoutes,
   ...zeroModelProvidersRoutes,
   ...zeroMeModelProvidersDeleteRoutes,
+  ...zeroMeModelProvidersListRoutes,
   ...zeroMeModelProvidersUpsertRoutes,
   ...zeroVoiceChatRoutes,
   ...zeroVoiceIoQuotaRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-list.test.ts
@@ -1,0 +1,203 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteOrgModelProviders$,
+  deleteUserModelProviders$,
+  seedOrgModelProvider$,
+  seedUserModelProvider$,
+  type UserModelProviderFixture,
+} from "./helpers/zero-model-providers";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function uniqueOrgUser(prefix: string): UserModelProviderFixture {
+  return {
+    orgId: `org_${prefix}_${randomUUID().slice(0, 8)}`,
+    userId: `user_${prefix}_${randomUUID().slice(0, 8)}`,
+  };
+}
+
+async function setPersonalSwitches(
+  orgId: string,
+  userId: string,
+  switches: Partial<Record<FeatureSwitchKey, boolean>>,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .insert(userFeatureSwitches)
+    .values({ orgId, userId, switches })
+    .onConflictDoUpdate({
+      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
+      set: { switches },
+    });
+}
+
+async function deletePersonalSwitches(
+  fixture: UserModelProviderFixture,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb
+    .delete(userFeatureSwitches)
+    .where(
+      and(
+        eq(userFeatureSwitches.orgId, fixture.orgId),
+        eq(userFeatureSwitches.userId, fixture.userId),
+      ),
+    );
+}
+
+async function enableModelFirst(orgId: string, userId: string): Promise<void> {
+  await setPersonalSwitches(orgId, userId, {
+    [FeatureSwitchKey.ModelFirstModelProvider]: true,
+  });
+}
+
+describe("GET /api/zero/me/model-providers", () => {
+  const trackUsers = createFixtureTracker<UserModelProviderFixture>(
+    async (fixture) => {
+      await store.set(deleteUserModelProviders$, fixture, context.signal);
+      await deletePersonalSwitches(fixture);
+    },
+  );
+  const trackOrg = createFixtureTracker<{ readonly orgId: string }>(
+    (fixture) => {
+      return store.set(deleteOrgModelProviders$, fixture, context.signal);
+    },
+  );
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersMainContract,
+    );
+    const response = await accept(client.list({ headers: {} }), [401]);
+    expect(response.body).toMatchObject({
+      error: { code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 401 when authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersMainContract,
+    );
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+    expect(response.body).toMatchObject({
+      error: { code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 404 when ModelFirstModelProvider is off", async () => {
+    const fixture = await trackUsers(
+      Promise.resolve(uniqueOrgUser("zmmp-list-feature-off")),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersMainContract,
+    );
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("returns empty list when no personal providers exist", async () => {
+    const fixture = await trackUsers(
+      Promise.resolve(uniqueOrgUser("zmmp-list-empty")),
+    );
+    await enableModelFirst(fixture.orgId, fixture.userId);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersMainContract,
+    );
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(response.body.modelProviders).toStrictEqual([]);
+  });
+
+  it("lists only the current user's model-first personal providers", async () => {
+    const fixture = await trackUsers(
+      Promise.resolve(uniqueOrgUser("zmmp-list-user")),
+    );
+    await trackOrg(Promise.resolve({ orgId: fixture.orgId }));
+    await enableModelFirst(fixture.orgId, fixture.userId);
+    await store.set(
+      seedOrgModelProvider$,
+      {
+        orgId: fixture.orgId,
+        type: "claude-code-oauth-token",
+        isDefault: true,
+        secretName: "CLAUDE_CODE_OAUTH_TOKEN",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedUserModelProvider$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        type: "anthropic-api-key",
+        isDefault: true,
+        secretName: "ANTHROPIC_API_KEY",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedUserModelProvider$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        type: "claude-code-oauth-token",
+        isDefault: false,
+        secretName: "CLAUDE_CODE_OAUTH_TOKEN",
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(
+      zeroPersonalModelProvidersMainContract,
+    );
+    const response = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.modelProviders).toHaveLength(1);
+    expect(response.body.modelProviders[0]?.type).toBe(
+      "claude-code-oauth-token",
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-me-model-providers-list.ts
+++ b/turbo/apps/api/src/signals/routes/zero-me-model-providers-list.ts
@@ -1,0 +1,71 @@
+import { computed } from "ccstate";
+import type {
+  ModelProviderListResponse,
+  ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
+import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import { zeroUserModelProviders } from "../services/zero-model-provider.service";
+import type { RouteEntry } from "../route";
+
+const featureDisabled = Object.freeze({
+  status: 404 as const,
+  body: Object.freeze({
+    error: Object.freeze({ message: "Not found", code: "NOT_FOUND" }),
+  }),
+});
+
+function isModelFirstPersonalProviderType(type: ModelProviderType): boolean {
+  return type === "claude-code-oauth-token" || type === "codex-oauth-token";
+}
+
+function isModelFirstPersonalProviderApiEnabled(
+  params: Parameters<typeof isFeatureEnabled>[1],
+): boolean {
+  return isFeatureEnabled(FeatureSwitchKey.ModelFirstModelProvider, params);
+}
+
+function visibleModelFirstProviders(
+  result: ModelProviderListResponse,
+): ModelProviderListResponse {
+  return {
+    modelProviders: result.modelProviders.filter((provider) => {
+      return isModelFirstPersonalProviderType(provider.type);
+    }),
+  };
+}
+
+const listInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+
+  if (
+    !isModelFirstPersonalProviderApiEnabled({
+      orgId: auth.orgId,
+      userId: auth.userId,
+      overrides,
+    })
+  ) {
+    return featureDisabled;
+  }
+
+  const result = await get(zeroUserModelProviders(auth.orgId, auth.userId));
+  return { status: 200 as const, body: visibleModelFirstProviders(result) };
+});
+
+export const zeroMeModelProvidersListRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroPersonalModelProvidersMainContract.list,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      listInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-provider.service.ts
@@ -67,8 +67,9 @@ function modelProviderResponse(row: {
   };
 }
 
-export function zeroModelProviders(
+function zeroModelProvidersForUser(
   orgId: string,
+  userId: string,
 ): Computed<Promise<ModelProviderListResponse>> {
   return computed(async (get): Promise<ModelProviderListResponse> => {
     const rows = await get(db$)
@@ -89,10 +90,7 @@ export function zeroModelProviders(
       .from(modelProviders)
       .leftJoin(secrets, eq(modelProviders.secretId, secrets.id))
       .where(
-        and(
-          eq(modelProviders.orgId, orgId),
-          eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
-        ),
+        and(eq(modelProviders.orgId, orgId), eq(modelProviders.userId, userId)),
       )
       .orderBy(modelProviders.type);
 
@@ -103,6 +101,19 @@ export function zeroModelProviders(
       }),
     };
   });
+}
+
+export function zeroModelProviders(
+  orgId: string,
+): Computed<Promise<ModelProviderListResponse>> {
+  return zeroModelProvidersForUser(orgId, ORG_SENTINEL_USER_ID);
+}
+
+export function zeroUserModelProviders(
+  orgId: string,
+  userId: string,
+): Computed<Promise<ModelProviderListResponse>> {
+  return zeroModelProvidersForUser(orgId, userId);
 }
 
 type NotFoundResponse = ReturnType<typeof notFound>;

--- a/turbo/apps/web/app/api/zero/me/model-providers/[type]/route.ts
+++ b/turbo/apps/web/app/api/zero/me/model-providers/[type]/route.ts
@@ -19,6 +19,9 @@ const router = tsr.router(zeroPersonalModelProvidersByTypeContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
 
     const { org } = await resolveOrg(authCtx);
 

--- a/turbo/apps/web/app/api/zero/me/model-providers/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/me/model-providers/__tests__/route.test.ts
@@ -43,6 +43,15 @@ function deleteUrl(type: string): string {
   return `${BASE_URL}/${type}`;
 }
 
+async function expectUnauthorized(
+  responsePromise: Promise<Response> | Response,
+): Promise<void> {
+  const response = await responsePromise;
+  expect(response.status).toBe(401);
+  const data = await response.json();
+  expect(data.error.code).toBe("UNAUTHORIZED");
+}
+
 interface ProviderRow {
   id: string;
   type: string;
@@ -83,6 +92,27 @@ describe("Model-first personal OAuth model provider routes", () => {
     void user;
     mockIsFeatureEnabled.mockImplementation(() => {
       return true;
+    });
+  });
+
+  describe("no active organization", () => {
+    beforeEach(() => {
+      mockClerk({ userId: user.userId, orgId: null });
+    });
+
+    it("GET returns 401", async () => {
+      await expectUnauthorized(GET(createTestRequest(listUrl())));
+    });
+
+    it("POST returns 401", async () => {
+      await expectUnauthorized(createProvider("claude-code-oauth-token", "k"));
+    });
+
+    it("DELETE returns 401", async () => {
+      const request = createTestRequest(deleteUrl("claude-code-oauth-token"), {
+        method: "DELETE",
+      });
+      await expectUnauthorized(DELETE(request));
     });
   });
 

--- a/turbo/apps/web/app/api/zero/me/model-providers/route.ts
+++ b/turbo/apps/web/app/api/zero/me/model-providers/route.ts
@@ -44,6 +44,9 @@ const router = tsr.router(zeroPersonalModelProvidersMainContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
 
     const { org } = await resolveOrg(authCtx);
 
@@ -95,6 +98,9 @@ const router = tsr.router(zeroPersonalModelProvidersMainContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
 
     const { org } = await resolveOrg(authCtx);
 

--- a/turbo/apps/web/app/api/zero/model-providers/[type]/default/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/[type]/default/route.ts
@@ -19,6 +19,9 @@ const router = tsr.router(zeroModelProvidersDefaultContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
 
     const { org, member } = await resolveOrg(authCtx);
 

--- a/turbo/apps/web/app/api/zero/model-providers/[type]/model/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/[type]/model/route.ts
@@ -19,6 +19,9 @@ const router = tsr.router(zeroModelProvidersUpdateModelContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
 
     const { org, member } = await resolveOrg(authCtx);
 

--- a/turbo/apps/web/app/api/zero/model-providers/[type]/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/[type]/route.ts
@@ -19,6 +19,9 @@ const router = tsr.router(zeroModelProvidersByTypeContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
 
     const { org, member } = await resolveOrg(authCtx);
 

--- a/turbo/apps/web/app/api/zero/model-providers/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { GET, POST } from "../route";
 import { DELETE } from "../[type]/route";
 import { POST as setDefaultPOST } from "../[type]/default/route";
+import { PATCH as updateModelPATCH } from "../[type]/model/route";
 import {
   createTestRequest,
   setTestModelProviderNeedsReconnect,
@@ -16,6 +17,7 @@ import {
   testContext,
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import type { ModelProviderType } from "@vm0/api-contracts/contracts/model-providers";
 
 vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
@@ -48,6 +50,19 @@ function deleteUrl(type: string): string {
 
 function setDefaultUrl(type: string): string {
   return `${BASE_URL}/${type}/default`;
+}
+
+function updateModelUrl(type: string): string {
+  return `${BASE_URL}/${type}/model`;
+}
+
+async function expectUnauthorized(
+  responsePromise: Promise<Response> | Response,
+): Promise<void> {
+  const response = await responsePromise;
+  expect(response.status).toBe(401);
+  const data = await response.json();
+  expect(data.error.code).toBe("UNAUTHORIZED");
 }
 
 async function listProviders(): Promise<
@@ -104,6 +119,43 @@ describe("Org-level model provider routes", () => {
     context.setupMocks();
     user = await context.setupUser();
     void user;
+  });
+
+  describe("no active organization", () => {
+    beforeEach(() => {
+      mockClerk({ userId: user.userId, orgId: null });
+    });
+
+    it("GET returns 401", async () => {
+      await expectUnauthorized(GET(createTestRequest(listUrl())));
+    });
+
+    it("POST returns 401", async () => {
+      await expectUnauthorized(createProvider("anthropic-api-key", "test-key"));
+    });
+
+    it("DELETE returns 401", async () => {
+      const request = createTestRequest(deleteUrl("anthropic-api-key"), {
+        method: "DELETE",
+      });
+      await expectUnauthorized(DELETE(request));
+    });
+
+    it("set default returns 401", async () => {
+      const request = createTestRequest(setDefaultUrl("anthropic-api-key"), {
+        method: "POST",
+      });
+      await expectUnauthorized(setDefaultPOST(request));
+    });
+
+    it("update model returns 401", async () => {
+      const request = createTestRequest(updateModelUrl("anthropic-api-key"), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ selectedModel: "claude-3-5-sonnet-latest" }),
+      });
+      await expectUnauthorized(updateModelPATCH(request));
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/turbo/apps/web/app/api/zero/model-providers/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/route.ts
@@ -32,6 +32,9 @@ const router = tsr.router(zeroModelProvidersMainContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
 
     const { org } = await resolveOrg(authCtx);
     const providers = await listOrgModelProviders(org.orgId);
@@ -66,6 +69,9 @@ const router = tsr.router(zeroModelProvidersMainContract, {
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
 
     const { org, member } = await resolveOrg(authCtx);
 


### PR DESCRIPTION
## Summary

- add the missing API `GET /api/zero/me/model-providers` route and parity tests
- align web model-provider routes to return `401 UNAUTHORIZED` when a session has no active organization
- add web no-active-organization coverage for org and personal model-provider handlers

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-model-providers.test.ts src/signals/routes/__tests__/zero-me-model-providers-list.test.ts src/signals/routes/__tests__/zero-me-model-providers-upsert.test.ts src/signals/routes/__tests__/zero-me-model-providers-delete.test.ts`
- `pnpm -F web exec vitest run app/api/zero/model-providers/__tests__/route.test.ts app/api/zero/me/model-providers/__tests__/route.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `pnpm exec prettier --check apps/api/src/signals/routes/zero-me-model-providers-list.ts apps/api/src/signals/routes/__tests__/zero-me-model-providers-list.test.ts apps/api/src/signals/services/zero-model-provider.service.ts apps/web/app/api/zero/model-providers/__tests__/route.test.ts apps/web/app/api/zero/me/model-providers/__tests__/route.test.ts`
- `git diff --check`
- pre-commit hook: prettier, knip, full `pnpm check-types`, commitlint

Closes #12631