### PR TITLE
test: align zero Slack integration route parity

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -340,8 +340,12 @@ vi.mock("@slack/web-api", () => {
   };
 });
 
-vi.mock("../signals/external/slack-file-fetcher", () => {
+vi.mock("../signals/external/slack-file-fetcher", async () => {
+  const actual = await vi.importActual<
+    typeof import("../signals/external/slack-file-fetcher")
+  >("../signals/external/slack-file-fetcher");
   return {
+    ...actual,
     fetchSlackFile: apiTestMocks.slack.fetchFile,
   };
 });

--- a/turbo/apps/api/src/lib/slack-client.ts
+++ b/turbo/apps/api/src/lib/slack-client.ts
@@ -3,6 +3,27 @@ interface SlackApiError {
   error: string;
 }
 
+class SlackApiClientError extends Error {
+  constructor(
+    readonly method: string,
+    readonly code: string,
+    readonly statusCode?: number,
+  ) {
+    super(
+      statusCode
+        ? `Slack API error: ${statusCode} ${code}`
+        : `Slack API error: ${code}`,
+    );
+    this.name = "SlackApiClientError";
+  }
+}
+
+export function isSlackApiClientError(
+  error: unknown,
+): error is SlackApiClientError {
+  return error instanceof SlackApiClientError;
+}
+
 function isSlackApiError(value: unknown): value is SlackApiError {
   return (
     typeof value === "object" &&
@@ -36,8 +57,10 @@ async function callSlackApi<T>(
   });
 
   if (!response.ok) {
-    throw new Error(
-      `Slack API error: ${response.status} ${response.statusText}`,
+    throw new SlackApiClientError(
+      method,
+      response.statusText || "http_error",
+      response.status,
     );
   }
 
@@ -45,7 +68,7 @@ async function callSlackApi<T>(
   signal?.throwIfAborted();
 
   if (isSlackApiError(data)) {
-    throw new Error(`Slack API error: ${data.error}`);
+    throw new SlackApiClientError(method, data.error);
   }
 
   return data as T;

--- a/turbo/apps/api/src/signals/external/slack-file-fetcher.ts
+++ b/turbo/apps/api/src/signals/external/slack-file-fetcher.ts
@@ -2,6 +2,29 @@ const ALLOWED_SLACK_DOWNLOAD_HOSTNAMES: ReadonlySet<string> = Object.freeze(
   new Set(["files.slack.com", "files-pri.slack.com", "cdn.slack.com"]),
 );
 
+type SlackFileFetchErrorCode =
+  | "invalid-url"
+  | "download-failed"
+  | "html-response"
+  | "too-large";
+
+export class SlackFileFetchError extends Error {
+  constructor(
+    readonly code: SlackFileFetchErrorCode,
+    message: string,
+    readonly statusCode?: number,
+  ) {
+    super(message);
+    this.name = "SlackFileFetchError";
+  }
+}
+
+export function isSlackFileFetchError(
+  error: unknown,
+): error is SlackFileFetchError {
+  return error instanceof SlackFileFetchError;
+}
+
 function isValidSlackDownloadUrl(url: string): boolean {
   const parsed = URL.parse(url);
   if (!parsed) {
@@ -13,14 +36,14 @@ function isValidSlackDownloadUrl(url: string): boolean {
   );
 }
 
-const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+export const MAX_SLACK_FILE_SIZE_BYTES = 100 * 1024 * 1024;
 
 export async function fetchSlackFile(
   url: string,
   token: string,
 ): Promise<Response> {
   if (!isValidSlackDownloadUrl(url)) {
-    throw new Error("Invalid Slack download URL");
+    throw new SlackFileFetchError("invalid-url", "Invalid Slack download URL");
   }
 
   const response = await fetch(url, {
@@ -28,16 +51,26 @@ export async function fetchSlackFile(
   });
 
   if (!response.ok) {
-    throw new Error(
+    throw new SlackFileFetchError(
+      "download-failed",
       `Failed to download Slack file: ${response.status} ${response.statusText}`,
+      response.status,
+    );
+  }
+
+  const responseContentType = response.headers.get("content-type") ?? "";
+  if (responseContentType.includes("text/html")) {
+    throw new SlackFileFetchError(
+      "html-response",
+      "Slack returned an unexpected response",
     );
   }
 
   const contentLength = response.headers.get("content-length");
   if (contentLength) {
     const size = Number(contentLength);
-    if (Number.isSafeInteger(size) && size > MAX_FILE_SIZE_BYTES) {
-      throw new Error("File exceeds maximum size limit");
+    if (Number.isSafeInteger(size) && size > MAX_SLACK_FILE_SIZE_BYTES) {
+      throw new SlackFileFetchError("too-large", "File exceeds maximum size");
     }
   }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { createStore } from "ccstate";
 import { zeroIntegrationsSlackContract } from "@vm0/api-contracts/contracts/zero-integrations-slack";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { http, HttpResponse } from "msw";
 import {
   agentComposes,
   agentComposeVersions,
@@ -14,8 +15,28 @@ import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { eq } from "drizzle-orm";
 
+import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { server } from "../../../mocks/server";
+import { now } from "../../external/time";
 import { writeDb$ } from "../../external/db";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { ROUTES } from "../../route";
+import { SlackFileFetchError } from "../../external/slack-file-fetcher";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteSlackIntegrationFixture$,
+  seedSlackOrgInstallation$,
+  type SlackIntegrationFixture,
+} from "./helpers/zero-integrations-slack";
 
 const context = testContext();
 const store = createStore();
@@ -344,5 +365,335 @@ describe("GET /api/zero/integrations/slack", () => {
       expect(response.body.isConnected).toBeFalsy();
       expect(response.body.environment).toBeUndefined();
     });
+  });
+});
+
+type SlackFileMetadata = {
+  readonly id: string;
+  readonly name: string;
+  readonly mimetype: string;
+  readonly size: number;
+  readonly url_private_download?: string;
+  readonly url_private?: string;
+};
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function zeroToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly capabilities: readonly ("slack:write" | "file:read")[];
+}): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: `run_${randomUUID()}`,
+    capabilities: args.capabilities,
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+function mockSlackFilesInfo(
+  response:
+    | { readonly ok: true; readonly file: SlackFileMetadata }
+    | { readonly ok: false; readonly error: string },
+): void {
+  server.use(
+    http.get("https://slack.com/api/files.info", () => {
+      return HttpResponse.json(response);
+    }),
+  );
+}
+
+function defaultSlackFile(
+  overrides: Partial<SlackFileMetadata> = {},
+): SlackFileMetadata {
+  return {
+    id: "F-OK",
+    name: "pic.png",
+    mimetype: "image/png",
+    size: 19,
+    url_private_download:
+      "https://files.slack.com/files-pri/T1-F-OK/download/pic.png",
+    ...overrides,
+  };
+}
+
+function requestDownloadFile(
+  query: string,
+  authorization?: string,
+): Promise<Response> {
+  const app = createApp({ signal: context.signal, routes: ROUTES });
+  const headers: Record<string, string> = authorization
+    ? { authorization }
+    : {};
+  return Promise.resolve(
+    app.request(`/api/zero/integrations/slack/download-file${query}`, {
+      method: "GET",
+      headers,
+    }),
+  );
+}
+
+async function expectErrorResponse(
+  response: Response,
+  status: number,
+  code: string,
+): Promise<void> {
+  expect(response.status).toBe(status);
+  const body = (await response.json()) as {
+    readonly error?: { readonly code?: string };
+  };
+  expect(body.error?.code).toBe(code);
+}
+
+describe("GET /api/zero/integrations/slack/download-file", () => {
+  const trackSlackFixture = createFixtureTracker<SlackIntegrationFixture>(
+    (fixture) => {
+      return store.set(deleteSlackIntegrationFixture$, fixture, context.signal);
+    },
+  );
+  const trackMembership = createFixtureTracker<OrgMembershipFixture>(
+    (fixture) => {
+      return store.set(deleteOrgMembership$, fixture, context.signal);
+    },
+  );
+  const mocks = createZeroRouteMocks(context);
+
+  async function seedDownloadContext(
+    args: {
+      readonly withInstallation?: boolean;
+    } = {},
+  ): Promise<{ readonly token: string }> {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await trackMembership(
+      store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+
+    if (args.withInstallation !== false) {
+      await trackSlackFixture(
+        store.set(seedSlackOrgInstallation$, { orgId }, context.signal),
+      );
+    }
+
+    return {
+      token: zeroToken({ userId, orgId, capabilities: ["slack:write"] }),
+    };
+  }
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await requestDownloadFile("?file_id=F1");
+
+    await expectErrorResponse(response, 401, "UNAUTHORIZED");
+  });
+
+  it("rejects a zero token without slack:write capability", async () => {
+    const token = zeroToken({
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      capabilities: ["file:read"],
+    });
+
+    const response = await requestDownloadFile(
+      "?file_id=F1",
+      `Bearer ${token}`,
+    );
+
+    await expectErrorResponse(response, 403, "FORBIDDEN");
+  });
+
+  it("returns 400 when file_id query param is missing", async () => {
+    const { token } = await seedDownloadContext();
+
+    const response = await requestDownloadFile("", `Bearer ${token}`);
+
+    await expectErrorResponse(response, 400, "BAD_REQUEST");
+  });
+
+  it("returns 404 when no Slack installation exists for org", async () => {
+    const { token } = await seedDownloadContext({ withInstallation: false });
+
+    const response = await requestDownloadFile(
+      "?file_id=F1",
+      `Bearer ${token}`,
+    );
+
+    await expectErrorResponse(response, 404, "NOT_FOUND");
+  });
+
+  it("returns 404 when Slack reports file not found", async () => {
+    const { token } = await seedDownloadContext();
+    mockSlackFilesInfo({ ok: false, error: "file_not_found" });
+
+    const response = await requestDownloadFile(
+      "?file_id=F-MISSING",
+      `Bearer ${token}`,
+    );
+
+    await expectErrorResponse(response, 404, "NOT_FOUND");
+  });
+
+  it("returns 404 when the Slack file has no downloadable URL", async () => {
+    const { token } = await seedDownloadContext();
+    const file = defaultSlackFile();
+    mockSlackFilesInfo({
+      ok: true,
+      file: {
+        id: file.id,
+        name: file.name,
+        mimetype: file.mimetype,
+        size: file.size,
+      },
+    });
+
+    const response = await requestDownloadFile(
+      "?file_id=F1",
+      `Bearer ${token}`,
+    );
+
+    await expectErrorResponse(response, 404, "NOT_FOUND");
+  });
+
+  it("returns 400 for disallowed download hostnames", async () => {
+    const { token } = await seedDownloadContext();
+    mockSlackFilesInfo({
+      ok: true,
+      file: defaultSlackFile({
+        url_private_download: "https://evil.example.com/steal.png",
+      }),
+    });
+    context.mocks.slack.fetchFile.mockRejectedValue(
+      new SlackFileFetchError("invalid-url", "Invalid Slack download URL"),
+    );
+
+    const response = await requestDownloadFile(
+      "?file_id=F-BAD",
+      `Bearer ${token}`,
+    );
+
+    await expectErrorResponse(response, 400, "BAD_REQUEST");
+  });
+
+  it("returns 413 when file metadata exceeds the 100MB limit", async () => {
+    const { token } = await seedDownloadContext();
+    mockSlackFilesInfo({
+      ok: true,
+      file: defaultSlackFile({ size: 200 * 1024 * 1024 }),
+    });
+
+    const response = await requestDownloadFile(
+      "?file_id=F-BIG",
+      `Bearer ${token}`,
+    );
+
+    await expectErrorResponse(response, 413, "PAYLOAD_TOO_LARGE");
+  });
+
+  it("returns 502 when Slack file download fails", async () => {
+    const { token } = await seedDownloadContext();
+    mockSlackFilesInfo({ ok: true, file: defaultSlackFile() });
+    context.mocks.slack.fetchFile.mockRejectedValue(
+      new SlackFileFetchError(
+        "download-failed",
+        "Failed to download Slack file",
+        503,
+      ),
+    );
+
+    const response = await requestDownloadFile(
+      "?file_id=F1",
+      `Bearer ${token}`,
+    );
+
+    await expectErrorResponse(response, 502, "BAD_GATEWAY");
+  });
+
+  it("returns 502 when Slack returns an HTML response", async () => {
+    const { token } = await seedDownloadContext();
+    mockSlackFilesInfo({ ok: true, file: defaultSlackFile() });
+    context.mocks.slack.fetchFile.mockResolvedValue(
+      new Response("<html><body>Login</body></html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    );
+
+    const response = await requestDownloadFile(
+      "?file_id=F1",
+      `Bearer ${token}`,
+    );
+
+    await expectErrorResponse(response, 502, "BAD_GATEWAY");
+  });
+
+  it("returns 400 when Slack files.info returns a platform error", async () => {
+    const { token } = await seedDownloadContext();
+    mockSlackFilesInfo({ ok: false, error: "invalid_auth" });
+
+    const response = await requestDownloadFile(
+      "?file_id=F1",
+      `Bearer ${token}`,
+    );
+
+    await expectErrorResponse(response, 400, "SLACK_ERROR");
+  });
+
+  it("streams file bytes from Slack with file metadata headers", async () => {
+    const { token } = await seedDownloadContext();
+    const fileBytes = Buffer.from("real file contents");
+    mockSlackFilesInfo({ ok: true, file: defaultSlackFile() });
+    context.mocks.slack.fetchFile.mockResolvedValue(
+      new Response(fileBytes, {
+        status: 200,
+        headers: {
+          "content-type": "image/png",
+          "content-length": String(fileBytes.length),
+        },
+      }),
+    );
+
+    const response = await requestDownloadFile(
+      "?file_id=F-OK",
+      `Bearer ${token}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(response.headers.get("x-file-mimetype")).toBe("image/png");
+    expect(response.headers.get("x-file-name")).toBe("pic.png");
+    expect(response.headers.get("content-length")).toBe(
+      String(fileBytes.length),
+    );
+    const receivedBytes = Buffer.from(await response.arrayBuffer());
+    expect(receivedBytes.equals(fileBytes)).toBeTruthy();
+  });
+
+  it("accepts a Clerk session with an active organization", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    await trackSlackFixture(
+      store.set(seedSlackOrgInstallation$, { orgId }, context.signal),
+    );
+    mocks.clerk.session(userId, orgId);
+    mockSlackFilesInfo({ ok: true, file: defaultSlackFile() });
+    context.mocks.slack.fetchFile.mockResolvedValue(
+      new Response(Buffer.from("ok"), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+
+    const response = await requestDownloadFile(
+      "?file_id=F-OK",
+      "Bearer clerk-session",
+    );
+
+    expect(response.status).toBe(200);
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
@@ -23,12 +23,17 @@ import {
   zeroSlackOrgInstallation,
   zeroSlackOrgStatus,
 } from "../services/zero-slack-data.service";
-import { getFileInfo } from "../../lib/slack-client";
-import { fetchSlackFile } from "../external/slack-file-fetcher";
+import { getFileInfo, isSlackApiClientError } from "../../lib/slack-client";
+import {
+  fetchSlackFile,
+  isSlackFileFetchError,
+  MAX_SLACK_FILE_SIZE_BYTES,
+} from "../external/slack-file-fetcher";
 import { db$ } from "../external/db";
 import { zeroConnectorList } from "../services/zero-connector-data.service";
 import { userSecrets, userVariables } from "../services/zero-user-data.service";
 import type { RouteEntry } from "../route";
+import { safeAsync } from "../utils";
 
 const c = initContract();
 
@@ -38,7 +43,7 @@ const slackDownloadFileContract = c.router({
     path: "/api/zero/integrations/slack/download-file",
     headers: authHeadersSchema,
     query: z.object({
-      file_id: z.string().min(1),
+      file_id: z.string().optional(),
     }),
     responses: {
       200: c.otherResponse({
@@ -48,6 +53,7 @@ const slackDownloadFileContract = c.router({
       400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
+      413: apiErrorSchema,
       502: apiErrorSchema,
     },
     summary: "Download a Slack file via org bot token",
@@ -176,52 +182,157 @@ const getSlackStatusInner$ = computed(async (get) => {
   return { status: 200 as const, body };
 });
 
+function jsonErrorResponse(
+  status: number,
+  message: string,
+  code: string,
+): Response {
+  return new Response(JSON.stringify({ error: { message, code } }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function slackApiErrorResponse(error: unknown): Response | null {
+  if (!isSlackApiClientError(error)) {
+    return null;
+  }
+
+  if (error.method === "files.info" && error.code === "file_not_found") {
+    return jsonErrorResponse(
+      404,
+      `Slack file not found: ${error.code}`,
+      "NOT_FOUND",
+    );
+  }
+
+  return jsonErrorResponse(
+    400,
+    `Slack API error: ${error.code}`,
+    "SLACK_ERROR",
+  );
+}
+
+function slackFileFetchErrorResponse(error: unknown): Response | null {
+  if (!isSlackFileFetchError(error)) {
+    return null;
+  }
+
+  switch (error.code) {
+    case "invalid-url": {
+      return jsonErrorResponse(
+        400,
+        "Invalid Slack download URL",
+        "BAD_REQUEST",
+      );
+    }
+    case "too-large": {
+      return jsonErrorResponse(
+        413,
+        `File exceeds maximum size of ${MAX_SLACK_FILE_SIZE_BYTES} bytes`,
+        "PAYLOAD_TOO_LARGE",
+      );
+    }
+    case "download-failed": {
+      return jsonErrorResponse(
+        502,
+        `Failed to download file from Slack: ${error.statusCode ?? "unknown"}`,
+        "BAD_GATEWAY",
+      );
+    }
+    case "html-response": {
+      return jsonErrorResponse(
+        502,
+        "Slack returned an unexpected response (likely expired token)",
+        "BAD_GATEWAY",
+      );
+    }
+  }
+
+  return null;
+}
+
 const getSlackDownloadFileInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const query = get(queryOf(slackDownloadFileContract.download));
+  const fileId = query.file_id;
+
+  if (!fileId) {
+    return jsonErrorResponse(
+      400,
+      "file_id query parameter is required",
+      "BAD_REQUEST",
+    );
+  }
 
   const installation = await get(
     zeroSlackOrgInstallation({ orgId: auth.orgId }),
   );
   if (!installation) {
-    return new Response(
-      JSON.stringify({
-        error: {
-          message: "No Slack installation found for this org",
-          code: "NOT_FOUND",
-        },
-      }),
-      { status: 404, headers: { "Content-Type": "application/json" } },
+    return jsonErrorResponse(
+      404,
+      "No Slack installation found for this org",
+      "NOT_FOUND",
     );
   }
 
-  const fileInfo = await getFileInfo(installation.botToken, query.file_id);
+  const fileInfoResult = await safeAsync(() => {
+    return getFileInfo(installation.botToken, fileId);
+  });
+  if ("error" in fileInfoResult) {
+    const response = slackApiErrorResponse(fileInfoResult.error);
+    if (response) {
+      return response;
+    }
+    throw fileInfoResult.error;
+  }
+  const fileInfo = fileInfoResult.ok;
+
   const downloadUrl = fileInfo.url_private_download ?? fileInfo.url_private;
   if (!downloadUrl) {
-    return new Response(
-      JSON.stringify({
-        error: {
-          message: "File does not have a downloadable URL",
-          code: "NOT_FOUND",
-        },
-      }),
-      { status: 404, headers: { "Content-Type": "application/json" } },
+    return jsonErrorResponse(
+      404,
+      "File does not have a downloadable URL",
+      "NOT_FOUND",
     );
   }
 
-  const fileResponse = await fetchSlackFile(downloadUrl, installation.botToken);
+  if (fileInfo.size > MAX_SLACK_FILE_SIZE_BYTES) {
+    return jsonErrorResponse(
+      413,
+      `File exceeds maximum size of ${MAX_SLACK_FILE_SIZE_BYTES} bytes`,
+      "PAYLOAD_TOO_LARGE",
+    );
+  }
+
+  const fileResponseResult = await safeAsync(() => {
+    return fetchSlackFile(downloadUrl, installation.botToken);
+  });
+  if ("error" in fileResponseResult) {
+    const response = slackFileFetchErrorResponse(fileResponseResult.error);
+    if (response) {
+      return response;
+    }
+    throw fileResponseResult.error;
+  }
+  const fileResponse = fileResponseResult.ok;
+
+  const responseContentType = fileResponse.headers.get("content-type") ?? "";
+  if (responseContentType.includes("text/html")) {
+    return jsonErrorResponse(
+      502,
+      "Slack returned an unexpected response (likely expired token)",
+      "BAD_GATEWAY",
+    );
+  }
+
   const headers = new Headers();
   const contentLength = fileResponse.headers.get("content-length");
   const contentType =
-    fileResponse.headers.get("content-type") ??
-    fileInfo.mimetype ??
-    "application/octet-stream";
+    fileInfo.mimetype || responseContentType || "application/octet-stream";
 
   headers.set("Content-Type", contentType);
-  headers.set(
-    "X-File-Name",
-    encodeURIComponent(fileInfo.name ?? query.file_id),
-  );
+  headers.set("X-File-Name", encodeURIComponent(fileInfo.name ?? fileId));
   headers.set("X-File-Mimetype", contentType);
   if (contentLength) {
     headers.set("Content-Length", contentLength);
@@ -235,6 +346,11 @@ const slackReadAuth = {
   missingOrganizationStatus: 401,
 } as const;
 
+const slackDownloadAuth = {
+  ...slackReadAuth,
+  requiredCapability: "slack:write",
+} as const;
+
 export const zeroIntegrationsSlackRoutes: readonly RouteEntry[] = [
   {
     route: zeroIntegrationsSlackContract.getStatus,
@@ -242,6 +358,6 @@ export const zeroIntegrationsSlackRoutes: readonly RouteEntry[] = [
   },
   {
     route: slackDownloadFileContract.download,
-    handler: authRoute(slackReadAuth, getSlackDownloadFileInner$),
+    handler: authRoute(slackDownloadAuth, getSlackDownloadFileInner$),
   },
 ];

--- a/turbo/apps/web/app/api/zero/integrations/slack/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/__tests__/route.test.ts
@@ -73,6 +73,21 @@ describe("/api/zero/integrations/slack", () => {
       expect(data.error.code).toBe("UNAUTHORIZED");
     });
 
+    it("returns 401 when the authenticated session has no active organization", async () => {
+      mockClerk({ userId: uniqueId("slack-no-org"), orgId: null });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/slack",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data).toStrictEqual({
+        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+      });
+    });
+
     it("returns isConnected=false when user has no connection", async () => {
       await givenOrgSlackSetup({ withConnection: false });
 

--- a/turbo/apps/web/app/api/zero/integrations/slack/connect/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/connect/__tests__/route.test.ts
@@ -82,6 +82,21 @@ describe("/api/zero/integrations/slack/connect", () => {
       expect(data.error.code).toBe("UNAUTHORIZED");
     });
 
+    it("returns 401 when the authenticated session has no active organization", async () => {
+      mockClerk({ userId: uniqueId("slack-connect-no-org"), orgId: null });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/slack/connect",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data).toStrictEqual({
+        error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+      });
+    });
+
     it("returns isConnected=false when user has no connection", async () => {
       await givenBoundWorkspace();
 

--- a/turbo/apps/web/app/api/zero/integrations/slack/connect/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/connect/route.ts
@@ -44,6 +44,13 @@ export async function GET(request: Request) {
   }
 
   const { userId } = authCtx;
+  if (!authCtx.orgId) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
   const { org, member } = await resolveOrg(authCtx);
 
   // Find installation for this org, then find user's connection via workspace

--- a/turbo/apps/web/app/api/zero/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/route.ts
@@ -52,6 +52,13 @@ export async function GET(request: Request) {
   }
 
   const { userId } = authCtx;
+  if (!authCtx.orgId) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
   const { org, member } = await resolveOrg(authCtx);
 
   const db = globalThis.services.db;


### PR DESCRIPTION
## Summary
- add no-active-org 401 coverage and handling for the web Slack status/connect GET routes
- align API Slack download-file behavior for auth capability, missing params, Slack API errors, file-size limits, invalid download URLs, HTML responses, and successful streaming headers
- preserve real Slack file fetch error helpers in API route tests while mocking network fetches

Fixes #12627

## Testing
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm knip
- pnpm -F web exec vitest run app/api/zero/integrations/slack/__tests__/route.test.ts app/api/zero/integrations/slack/connect/__tests__/route.test.ts app/api/zero/integrations/slack/download-file/__tests__/route.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-integrations-slack-status.test.ts src/signals/routes/__tests__/zero-slack-connect.test.ts src/signals/routes/__tests__/zero-integrations-slack.test.ts
- pnpm -F web exec vitest run app/api/zero/slack/events/__tests__/route.test.ts app/api/internal/callbacks/slack/org/__tests__/route.test.ts

## Notes
- Local full `pnpm vitest` was attempted twice and did not pass due broad-suite non-targeted failures/timeouts. The second run ended with 48 failed files / 139 failed tests, dominated by full-suite timeout and MSW/mock-isolation failures. The Slack integration scoped tests and the Slack event/callback files that appeared in the full-suite failures pass when run directly.