### PR TITLE
feat(api): migrate computer-use register+unregister to api backend (wave 6 #16)

### DIFF
--- a/turbo/apps/api/src/signals/external/ngrok-client.ts
+++ b/turbo/apps/api/src/signals/external/ngrok-client.ts
@@ -1,0 +1,381 @@
+/**
+ * ngrok REST API client for computer connector provisioning.
+ *
+ * Handles Bot User and Credential lifecycle for authenticated tunnel access.
+ * Uses plain fetch() — no external SDK dependency.
+ */
+import { logger } from "../../lib/log";
+import { safeAsync, throwIfAbort } from "../utils";
+
+const log = logger("ngrok-client");
+
+const NGROK_API_BASE = "https://api.ngrok.com";
+
+interface NgrokBotUser {
+  id: string;
+  name: string;
+}
+
+interface NgrokBotUsersPage {
+  bot_users: NgrokBotUser[];
+  next_page_uri: string | null;
+}
+
+interface NgrokCredential {
+  id: string;
+  token: string;
+}
+
+interface NgrokEndpoint {
+  id: string;
+  url: string;
+}
+
+interface NgrokEndpointsPage {
+  endpoints: NgrokEndpoint[];
+  next_page_uri: string | null;
+}
+
+interface NgrokDomain {
+  id: string;
+  domain: string;
+  region: string;
+  cname_target: string | null;
+}
+
+/**
+ * Make an authenticated request to the ngrok API.
+ */
+async function ngrokFetch(
+  apiKey: string,
+  path: string,
+  options: RequestInit = {},
+): Promise<Response> {
+  const url = path.startsWith("https://") ? path : `${NGROK_API_BASE}${path}`;
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      "Ngrok-Version": "2",
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    log.error(`ngrok API error: ${response.status} ${path}`, { body });
+    throw new Error(
+      `ngrok API error: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return response;
+}
+
+/**
+ * Create a new Bot User.
+ */
+async function createBotUser(
+  apiKey: string,
+  name: string,
+): Promise<NgrokBotUser> {
+  const response = await ngrokFetch(apiKey, "/bot_users", {
+    method: "POST",
+    body: JSON.stringify({ name }),
+  });
+  return (await response.json()) as NgrokBotUser;
+}
+
+/**
+ * Find a Bot User by name. Paginates through all results.
+ * Returns undefined if not found.
+ */
+async function findBotUserByName(
+  apiKey: string,
+  name: string,
+): Promise<NgrokBotUser | undefined> {
+  let nextPageUri: string | null = "/bot_users";
+
+  while (nextPageUri) {
+    const response = await ngrokFetch(apiKey, nextPageUri);
+    const page = (await response.json()) as NgrokBotUsersPage;
+
+    const found = page.bot_users.find((u) => {
+      return u.name === name;
+    });
+    if (found) {
+      return found;
+    }
+
+    nextPageUri = page.next_page_uri;
+  }
+
+  return undefined;
+}
+
+/**
+ * Find an existing Bot User by name, or create a new one.
+ */
+export async function findOrCreateBotUser(
+  apiKey: string,
+  name: string,
+): Promise<NgrokBotUser> {
+  const existing = await findBotUserByName(apiKey, name);
+  if (existing) {
+    log.debug("Found existing ngrok bot user", { id: existing.id, name });
+    return existing;
+  }
+
+  log.debug("Creating new ngrok bot user", { name });
+  return createBotUser(apiKey, name);
+}
+
+/**
+ * Create a Credential (authtoken) scoped to a Bot User with ACL restrictions.
+ *
+ * Note: The `token` field is only returned once at creation time.
+ */
+export async function createCredential(
+  apiKey: string,
+  ownerId: string,
+  acl: string[],
+): Promise<NgrokCredential> {
+  const response = await ngrokFetch(apiKey, "/credentials", {
+    method: "POST",
+    body: JSON.stringify({ owner_id: ownerId, acl }),
+  });
+  return (await response.json()) as NgrokCredential;
+}
+
+/**
+ * Delete a Credential, revoking the associated authtoken.
+ */
+export async function deleteCredential(
+  apiKey: string,
+  credentialId: string,
+): Promise<void> {
+  await ngrokFetch(apiKey, `/credentials/${credentialId}`, {
+    method: "DELETE",
+  });
+}
+
+/**
+ * Find an existing cloud endpoint by URL.
+ *
+ * The CEL filter `obj.url == "..."` does not reliably match wildcard URLs
+ * (e.g., `https://*.domain`), so we paginate through all endpoints and
+ * match client-side. Cloud endpoint counts are small (one per user), so
+ * this is not a scalability concern.
+ */
+async function findEndpointByUrl(
+  apiKey: string,
+  url: string,
+): Promise<NgrokEndpoint | undefined> {
+  let nextPageUri: string | null = "/endpoints";
+
+  while (nextPageUri) {
+    const response = await ngrokFetch(apiKey, nextPageUri);
+    const page = (await response.json()) as NgrokEndpointsPage;
+
+    const found = page.endpoints.find((ep) => {
+      return ep.url === url;
+    });
+    if (found) {
+      return found;
+    }
+
+    nextPageUri = page.next_page_uri;
+  }
+
+  return undefined;
+}
+
+/**
+ * Ensure a Cloud Endpoint exists with the given traffic policy.
+ *
+ * Finds an existing endpoint by URL (client-side match), then PATCH-updates
+ * the traffic policy if found. Creates a new endpoint if none exists.
+ * This is idempotent — safe to call when orphaned endpoints may exist.
+ */
+export async function ensureCloudEndpoint(
+  apiKey: string,
+  url: string,
+  trafficPolicy: string,
+): Promise<NgrokEndpoint> {
+  const existing = await findEndpointByUrl(apiKey, url);
+
+  if (existing) {
+    log.debug("Found existing cloud endpoint, updating traffic policy", {
+      id: existing.id,
+      url,
+    });
+    const updated = await ngrokFetch(apiKey, `/endpoints/${existing.id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ traffic_policy: trafficPolicy }),
+    });
+    return (await updated.json()) as NgrokEndpoint;
+  }
+
+  log.debug("Creating new cloud endpoint", { url });
+  const created = await ngrokFetch(apiKey, "/endpoints", {
+    method: "POST",
+    body: JSON.stringify({ url, type: "cloud", traffic_policy: trafficPolicy }),
+  });
+  return (await created.json()) as NgrokEndpoint;
+}
+
+/**
+ * Delete a Cloud Endpoint.
+ */
+export async function deleteCloudEndpoint(
+  apiKey: string,
+  endpointId: string,
+): Promise<void> {
+  await ngrokFetch(apiKey, `/endpoints/${endpointId}`, {
+    method: "DELETE",
+  });
+}
+
+/**
+ * Create a reserved domain with ngrok-assigned subdomain.
+ * ngrok will automatically assign a subdomain like "abc123.ngrok-free.app"
+ *
+ * @param apiKey - ngrok API key
+ * @param name - Desired subdomain name (e.g., "vm0-user-abc123")
+ * @param region - Region (e.g., "us", "eu", "ap", "au", "sa", "jp", "in")
+ * @returns The created reserved domain
+ */
+async function createReservedDomain(
+  apiKey: string,
+  name: string,
+  region = "us",
+): Promise<NgrokDomain> {
+  const response = await ngrokFetch(apiKey, "/reserved_domains", {
+    method: "POST",
+    body: JSON.stringify({
+      name, // ngrok will create: {name}.ngrok-free.app
+      region,
+    }),
+  });
+
+  const domain = (await response.json()) as NgrokDomain;
+  log.debug("Created ngrok reserved domain", {
+    id: domain.id,
+    domain: domain.domain,
+  });
+  return domain;
+}
+
+interface NgrokReservedDomainsPage {
+  reserved_domains: NgrokDomain[];
+  next_page_uri: string | null;
+}
+
+/**
+ * Known ngrok domain suffixes. The actual suffix depends on the account
+ * plan (paid vs free) and era (legacy vs current).
+ */
+const NGROK_DOMAIN_SUFFIXES = Object.freeze([
+  "ngrok.app",
+  "ngrok-free.app",
+  "ngrok-free.dev",
+  "ngrok.io",
+] as const);
+
+/**
+ * Find a reserved domain by name using CEL `in` filter.
+ * Queries all known ngrok suffixes in a single API call.
+ */
+async function findReservedDomainByName(
+  apiKey: string,
+  name: string,
+): Promise<NgrokDomain | undefined> {
+  const candidates = NGROK_DOMAIN_SUFFIXES.map((suffix) => {
+    return `"${name}.${suffix}"`;
+  }).join(", ");
+  const filterQuery = encodeURIComponent(`obj.domain in [${candidates}]`);
+  const response = await ngrokFetch(
+    apiKey,
+    `/reserved_domains?filter=${filterQuery}`,
+  );
+  const page = (await response.json()) as NgrokReservedDomainsPage;
+  return page.reserved_domains[0];
+}
+
+/**
+ * Find an existing reserved domain by name, or create a new one.
+ */
+export async function findOrCreateReservedDomain(
+  apiKey: string,
+  name: string,
+  region = "us",
+): Promise<NgrokDomain> {
+  const existing = await findReservedDomainByName(apiKey, name);
+  if (existing) {
+    log.debug("Found existing reserved domain", {
+      id: existing.id,
+      domain: existing.domain,
+    });
+    return existing;
+  }
+
+  log.debug("Creating new reserved domain", { name });
+  return createReservedDomain(apiKey, name, region);
+}
+
+/**
+ * Delete a reserved domain by ID.
+ */
+export async function deleteReservedDomain(
+  apiKey: string,
+  domainId: string,
+): Promise<void> {
+  await ngrokFetch(apiKey, `/reserved_domains/${domainId}`, {
+    method: "DELETE",
+  });
+}
+
+/**
+ * Delete a Bot User by ID.
+ */
+export async function deleteBotUser(
+  apiKey: string,
+  botUserId: string,
+): Promise<void> {
+  await ngrokFetch(apiKey, `/bot_users/${botUserId}`, {
+    method: "DELETE",
+  });
+}
+
+/**
+ * Safely delete an ngrok resource, ignoring 404 (already deleted).
+ *
+ * @param bestEffort - If true, log and swallow all errors (use in cleanup-on-failure paths
+ *   to avoid masking the original error). If false (default), only swallow 404.
+ */
+export async function safeDelete(
+  deleteFn: () => Promise<void>,
+  resourceName: string,
+  resourceId: string,
+  bestEffort = false,
+): Promise<void> {
+  const result = await safeAsync(deleteFn);
+  if ("ok" in result) {
+    return;
+  }
+  const error = result.error;
+  throwIfAbort(error);
+  if (error instanceof Error && error.message.includes("404")) {
+    log.debug(`${resourceName} already deleted`, { id: resourceId });
+    return;
+  }
+  if (bestEffort) {
+    log.warn(`Failed to clean up ${resourceName}`, {
+      id: resourceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+  throw error;
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
@@ -1,9 +1,16 @@
 import { randomUUID } from "node:crypto";
 
-import { zeroComputerUseHostContract } from "@vm0/api-contracts/contracts/zero-computer-use";
+import {
+  zeroComputerUseHostContract,
+  zeroComputerUseRegisterContract,
+  zeroComputerUseUnregisterContract,
+} from "@vm0/api-contracts/contracts/zero-computer-use";
 import { createStore } from "ccstate";
+import { http, HttpResponse } from "msw";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
 import {
   type ComputerUseScenarioFixture,
   deleteComputerUseScenario$,
@@ -17,6 +24,116 @@ import {
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
+
+interface NgrokCalls {
+  createBotUser: string[];
+  listBotUsers: number;
+  filterEndpoints: string[];
+  patchEndpoint: string[];
+  filterReservedDomains: string[];
+  createCredential: string[];
+  deleteCredential: string[];
+  createEndpoint: string[];
+  deleteEndpoint: string[];
+  createReservedDomain: string[];
+  deleteReservedDomain: string[];
+  deleteBotUser: string[];
+}
+
+function setupNgrokMocks(): NgrokCalls {
+  const calls: NgrokCalls = {
+    createBotUser: [],
+    listBotUsers: 0,
+    filterEndpoints: [],
+    patchEndpoint: [],
+    filterReservedDomains: [],
+    createCredential: [],
+    deleteCredential: [],
+    createEndpoint: [],
+    deleteEndpoint: [],
+    createReservedDomain: [],
+    deleteReservedDomain: [],
+    deleteBotUser: [],
+  };
+
+  server.use(
+    http.post("https://api.ngrok.com/bot_users", async ({ request }) => {
+      const body = (await request.json()) as { name: string };
+      calls.createBotUser.push(body.name);
+      return HttpResponse.json({ id: "bot_test_cu_123", name: body.name });
+    }),
+    http.get("https://api.ngrok.com/bot_users", () => {
+      calls.listBotUsers++;
+      return HttpResponse.json({ bot_users: [], next_page_uri: null });
+    }),
+    http.post("https://api.ngrok.com/credentials", async ({ request }) => {
+      const body = (await request.json()) as {
+        owner_id: string;
+        acl: string[];
+      };
+      calls.createCredential.push(body.owner_id);
+      return HttpResponse.json({
+        id: "cr_test_cu_456",
+        token: "2abc_test_ngrok_cu_authtoken",
+      });
+    }),
+    http.delete("https://api.ngrok.com/credentials/:id", ({ params }) => {
+      calls.deleteCredential.push(params.id as string);
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.get("https://api.ngrok.com/reserved_domains", ({ request }) => {
+      const url = new URL(request.url);
+      const filter = url.searchParams.get("filter");
+      calls.filterReservedDomains.push(filter ?? "");
+      return HttpResponse.json({
+        reserved_domains: [],
+        next_page_uri: null,
+      });
+    }),
+    http.post("https://api.ngrok.com/reserved_domains", async ({ request }) => {
+      const body = (await request.json()) as { name: string; region: string };
+      calls.createReservedDomain.push(body.name);
+      return HttpResponse.json({
+        id: "rd_test_cu_abc",
+        domain: `${body.name}.ngrok-free.app`,
+        region: body.region,
+        cname_target: null,
+      });
+    }),
+    http.delete("https://api.ngrok.com/reserved_domains/:id", ({ params }) => {
+      calls.deleteReservedDomain.push(params.id as string);
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.get("https://api.ngrok.com/endpoints", ({ request }) => {
+      const url = new URL(request.url);
+      const filter = url.searchParams.get("filter");
+      calls.filterEndpoints.push(filter ?? "");
+      return HttpResponse.json({ endpoints: [], next_page_uri: null });
+    }),
+    http.patch("https://api.ngrok.com/endpoints/:id", ({ params }) => {
+      calls.patchEndpoint.push(params.id as string);
+      return HttpResponse.json({
+        id: params.id as string,
+        url: "https://*.patched.ngrok-free.app",
+      });
+    }),
+    http.post("https://api.ngrok.com/endpoints", async ({ request }) => {
+      const body = (await request.json()) as { url: string };
+      calls.createEndpoint.push(body.url);
+      return HttpResponse.json({ id: "ep_test_cu_789", url: body.url });
+    }),
+    http.delete("https://api.ngrok.com/endpoints/:id", ({ params }) => {
+      calls.deleteEndpoint.push(params.id as string);
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.delete("https://api.ngrok.com/bot_users/:id", ({ params }) => {
+      calls.deleteBotUser.push(params.id as string);
+      return new HttpResponse(null, { status: 204 });
+    }),
+  );
+
+  return calls;
+}
 
 describe("GET /api/zero/computer-use/host", () => {
   const track = createFixtureTracker<ComputerUseScenarioFixture>((fixture) => {
@@ -122,6 +239,315 @@ describe("GET /api/zero/computer-use/host", () => {
     expect(response.body).toStrictEqual({
       domain: "abc.ngrok-free.app",
       token: "host_token_xyz",
+    });
+  });
+});
+
+describe("POST /api/zero/computer-use/register", () => {
+  const track = createFixtureTracker<ComputerUseScenarioFixture>((fixture) => {
+    return store.set(deleteComputerUseScenario$, fixture, context.signal);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroComputerUseRegisterContract);
+
+    const response = await accept(client.register({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 when the computer-use feature switch is disabled", async () => {
+    const fixture = await track(
+      store.set(
+        seedComputerUseScenario$,
+        { computerUseEnabled: false },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroComputerUseRegisterContract);
+
+    const response = await accept(
+      client.register({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Computer use is not enabled", code: "FORBIDDEN" },
+    });
+  });
+
+  it("registers a computer-use host", async () => {
+    const fixture = await track(
+      store.set(
+        seedComputerUseScenario$,
+        { computerUseEnabled: true },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mockOptionalEnv("NGROK_API_KEY", "test-ngrok-key");
+    const ngrokCalls = setupNgrokMocks();
+
+    const client = setupApp({ context })(zeroComputerUseRegisterContract);
+
+    const response = await accept(
+      client.register({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.id).toBeDefined();
+    expect(response.body.ngrokToken).toBe("2abc_test_ngrok_cu_authtoken");
+    expect(response.body.token).toBeDefined();
+    expect(response.body.endpointPrefix).toContain("vm0-cu-");
+    expect(response.body.domain).toContain(".ngrok-free.app");
+
+    expect(ngrokCalls.createBotUser).toHaveLength(1);
+    expect(ngrokCalls.createCredential).toHaveLength(1);
+    expect(ngrokCalls.filterReservedDomains).toHaveLength(1);
+    expect(ngrokCalls.createReservedDomain).toHaveLength(1);
+    expect(ngrokCalls.filterEndpoints).toHaveLength(1);
+    expect(ngrokCalls.createEndpoint).toHaveLength(1);
+  });
+
+  it("cleans up resources when endpoint creation fails", async () => {
+    const fixture = await track(
+      store.set(
+        seedComputerUseScenario$,
+        { computerUseEnabled: true },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mockOptionalEnv("NGROK_API_KEY", "test-ngrok-key");
+    const ngrokCalls = setupNgrokMocks();
+
+    server.use(
+      http.post("https://api.ngrok.com/endpoints", () => {
+        return HttpResponse.json({ error: "internal error" }, { status: 500 });
+      }),
+    );
+
+    const client = setupApp({ context })(zeroComputerUseRegisterContract);
+
+    await expect(
+      client.register({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+    ).rejects.toThrow();
+
+    expect(ngrokCalls.deleteBotUser).toStrictEqual(["bot_test_cu_123"]);
+    expect(ngrokCalls.deleteCredential).toStrictEqual(["cr_test_cu_456"]);
+    expect(ngrokCalls.deleteReservedDomain).toStrictEqual(["rd_test_cu_abc"]);
+  });
+
+  it("updates an existing orphaned endpoint instead of creating a new one", async () => {
+    const fixture = await track(
+      store.set(
+        seedComputerUseScenario$,
+        { computerUseEnabled: true },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mockOptionalEnv("NGROK_API_KEY", "test-ngrok-key");
+    const ngrokCalls = setupNgrokMocks();
+
+    server.use(
+      http.get("https://api.ngrok.com/reserved_domains", ({ request }) => {
+        const url = new URL(request.url);
+        const filter = url.searchParams.get("filter");
+        ngrokCalls.filterReservedDomains.push(filter ?? "");
+        return HttpResponse.json({
+          reserved_domains: [
+            {
+              id: "rd_orphan_123",
+              domain: "orphan.ngrok-free.app",
+              region: "us",
+              cname_target: null,
+            },
+          ],
+          next_page_uri: null,
+        });
+      }),
+      http.get("https://api.ngrok.com/endpoints", ({ request }) => {
+        const url = new URL(request.url);
+        const filter = url.searchParams.get("filter");
+        ngrokCalls.filterEndpoints.push(filter ?? "");
+        return HttpResponse.json({
+          endpoints: [
+            { id: "ep_orphaned_123", url: "https://*.orphan.ngrok-free.app" },
+          ],
+          next_page_uri: null,
+        });
+      }),
+    );
+
+    const client = setupApp({ context })(zeroComputerUseRegisterContract);
+
+    const response = await accept(
+      client.register({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.id).toBeDefined();
+    expect(ngrokCalls.patchEndpoint).toStrictEqual(["ep_orphaned_123"]);
+    expect(ngrokCalls.createEndpoint).toHaveLength(0);
+  });
+
+  it("returns 200 on re-registration (idempotent)", async () => {
+    const fixture = await track(
+      store.set(
+        seedComputerUseScenario$,
+        { computerUseEnabled: true },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mockOptionalEnv("NGROK_API_KEY", "test-ngrok-key");
+    setupNgrokMocks();
+
+    const client = setupApp({ context })(zeroComputerUseRegisterContract);
+
+    const r1 = await accept(
+      client.register({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(r1.body.id).toBeDefined();
+
+    setupNgrokMocks();
+    const r2 = await accept(
+      client.register({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(r2.body.domain).toBeDefined();
+    expect(r2.body.token).toBeDefined();
+  });
+});
+
+describe("DELETE /api/zero/computer-use/unregister", () => {
+  const track = createFixtureTracker<ComputerUseScenarioFixture>((fixture) => {
+    return store.set(deleteComputerUseScenario$, fixture, context.signal);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroComputerUseUnregisterContract);
+
+    const response = await accept(client.unregister({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 when the computer-use feature switch is disabled", async () => {
+    const fixture = await track(
+      store.set(
+        seedComputerUseScenario$,
+        { computerUseEnabled: false },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroComputerUseUnregisterContract);
+
+    const response = await accept(
+      client.unregister({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Computer use is not enabled", code: "FORBIDDEN" },
+    });
+  });
+
+  it("returns 404 when no host is registered", async () => {
+    const fixture = await track(
+      store.set(
+        seedComputerUseScenario$,
+        { computerUseEnabled: true },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroComputerUseUnregisterContract);
+
+    const response = await accept(
+      client.unregister({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Computer-use host not found", code: "NOT_FOUND" },
+    });
+  });
+
+  it("unregisters the host and cleans up ngrok resources", async () => {
+    const fixture = await track(
+      store.set(
+        seedComputerUseScenario$,
+        { computerUseEnabled: true },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    mockOptionalEnv("NGROK_API_KEY", "test-ngrok-key");
+    const ngrokCalls = setupNgrokMocks();
+
+    const registerClient = setupApp({ context })(
+      zeroComputerUseRegisterContract,
+    );
+    await accept(
+      registerClient.register({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const unregisterClient = setupApp({ context })(
+      zeroComputerUseUnregisterContract,
+    );
+    const response = await accept(
+      unregisterClient.unregister({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [204],
+    );
+    expect(response.body).toBeUndefined();
+
+    expect(ngrokCalls.deleteCredential).toStrictEqual(["cr_test_cu_456"]);
+    expect(ngrokCalls.deleteEndpoint).toStrictEqual(["ep_test_cu_789"]);
+    expect(ngrokCalls.deleteReservedDomain).toStrictEqual(["rd_test_cu_abc"]);
+    expect(ngrokCalls.deleteBotUser).toStrictEqual(["bot_test_cu_123"]);
+
+    const getClient = setupApp({ context })(zeroComputerUseHostContract);
+    const getResponse = await accept(
+      getClient.getHost({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+    expect(getResponse.body).toStrictEqual({
+      error: { message: "No active computer-use host", code: "NOT_FOUND" },
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/zero-computer-use.ts
@@ -1,12 +1,20 @@
-import { computed } from "ccstate";
-import { zeroComputerUseHostContract } from "@vm0/api-contracts/contracts/zero-computer-use";
+import { command, computed } from "ccstate";
+import {
+  zeroComputerUseHostContract,
+  zeroComputerUseRegisterContract,
+  zeroComputerUseUnregisterContract,
+} from "@vm0/api-contracts/contracts/zero-computer-use";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
-import { zeroComputerUseHost } from "../services/zero-computer-use.service";
+import {
+  registerHost$,
+  unregisterHost$,
+  zeroComputerUseHost,
+} from "../services/zero-computer-use.service";
 import type { RouteEntry } from "../route";
 
 const computerUseDisabled = Object.freeze({
@@ -24,6 +32,16 @@ const hostNotFound = Object.freeze({
   body: Object.freeze({
     error: Object.freeze({
       message: "No active computer-use host",
+      code: "NOT_FOUND",
+    }),
+  }),
+});
+
+const unregisterHostNotFound = Object.freeze({
+  status: 404 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Computer-use host not found",
       code: "NOT_FOUND",
     }),
   }),
@@ -53,6 +71,63 @@ const getComputerUseHostInner$ = computed(async (get) => {
   return { status: 200 as const, body: host };
 });
 
+const registerComputerUseHostInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const overrides = await get(
+      userFeatureSwitchOverrides(auth.orgId, auth.userId),
+    );
+    signal.throwIfAborted();
+    const enabled = isFeatureEnabled(FeatureSwitchKey.ComputerUse, {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      overrides,
+    });
+    if (!enabled) {
+      return computerUseDisabled;
+    }
+
+    const result = await set(
+      registerHost$,
+      { orgId: auth.orgId, userId: auth.userId },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body: result };
+  },
+);
+
+const unregisterComputerUseHostInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const overrides = await get(
+      userFeatureSwitchOverrides(auth.orgId, auth.userId),
+    );
+    signal.throwIfAborted();
+    const enabled = isFeatureEnabled(FeatureSwitchKey.ComputerUse, {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      overrides,
+    });
+    if (!enabled) {
+      return computerUseDisabled;
+    }
+
+    const result = await set(
+      unregisterHost$,
+      { orgId: auth.orgId, userId: auth.userId },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (result.kind === "not_found") {
+      return unregisterHostNotFound;
+    }
+    return { status: 204 as const, body: undefined };
+  },
+);
+
 export const zeroComputerUseRoutes: readonly RouteEntry[] = [
   {
     route: zeroComputerUseHostContract.getHost,
@@ -63,6 +138,28 @@ export const zeroComputerUseRoutes: readonly RouteEntry[] = [
         requiredCapability: "computer-use:write",
       },
       getComputerUseHostInner$,
+    ),
+  },
+  {
+    route: zeroComputerUseRegisterContract.register,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "computer-use:write",
+      },
+      registerComputerUseHostInner$,
+    ),
+  },
+  {
+    route: zeroComputerUseUnregisterContract.unregister,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "computer-use:write",
+      },
+      unregisterComputerUseHostInner$,
     ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
@@ -1,14 +1,65 @@
-import { computed, type Computed } from "ccstate";
+import { createHash, randomUUID } from "node:crypto";
+
+import { command, computed, type Computed } from "ccstate";
 import { computerUseHosts } from "@vm0/db/schema/computer-use-host";
 import { and, eq, gt } from "drizzle-orm";
 
+import { optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
-import { db$ } from "../external/db";
+import { db$, writeDb$, type Db } from "../external/db";
+import {
+  createCredential,
+  deleteBotUser,
+  deleteCloudEndpoint,
+  deleteCredential,
+  deleteReservedDomain,
+  ensureCloudEndpoint,
+  findOrCreateBotUser,
+  findOrCreateReservedDomain,
+  safeDelete,
+} from "../external/ngrok-client";
+import { safeAsync } from "../utils";
 
-export function zeroComputerUseHost(args: {
+const log = logger("service:computer-use");
+
+/** Default TTL for a host registration: 1 hour */
+const HOST_TTL_MS = 60 * 60 * 1000;
+
+interface RegisterHostResult {
+  readonly id: string;
+  readonly domain: string;
+  readonly token: string;
+  readonly ngrokToken: string;
+  readonly endpointPrefix: string;
+}
+
+type UnregisterHostResult =
+  | { readonly kind: "ok" }
+  | { readonly kind: "not_found" };
+
+interface HostArgs {
   readonly orgId: string;
   readonly userId: string;
-}): Computed<
+}
+
+type ExistingHost = typeof computerUseHosts.$inferSelect;
+
+interface ReusableDomain {
+  readonly domain: string;
+  readonly id: string;
+}
+
+interface ProvisionedRefs {
+  readonly endpointId?: string;
+  readonly credentialId?: string;
+  readonly domainId?: string;
+  readonly botUserId?: string;
+}
+
+export function zeroComputerUseHost(
+  args: HostArgs,
+): Computed<
   Promise<{ readonly domain: string; readonly token: string } | null>
 > {
   return computed(
@@ -34,3 +85,351 @@ export function zeroComputerUseHost(args: {
     },
   );
 }
+
+async function cleanupExistingHost(
+  db: Db,
+  existing: ExistingHost,
+  apiKey: string,
+): Promise<ReusableDomain | null> {
+  log.debug("Cleaning up existing host registration", {
+    orgId: existing.orgId,
+    userId: existing.userId,
+  });
+
+  if (existing.ngrokCredentialId) {
+    await safeDelete(
+      () => {
+        return deleteCredential(apiKey, existing.ngrokCredentialId!);
+      },
+      "Credential",
+      existing.ngrokCredentialId,
+    );
+  }
+  if (existing.ngrokEndpointId) {
+    await safeDelete(
+      () => {
+        return deleteCloudEndpoint(apiKey, existing.ngrokEndpointId!);
+      },
+      "Cloud endpoint",
+      existing.ngrokEndpointId,
+    );
+  }
+
+  const reusableDomain: ReusableDomain | null =
+    existing.ngrokDomainId && existing.domain
+      ? { domain: existing.domain, id: existing.ngrokDomainId }
+      : null;
+
+  await db.delete(computerUseHosts).where(eq(computerUseHosts.id, existing.id));
+
+  return reusableDomain;
+}
+
+async function rollbackNgrokResources(
+  apiKey: string,
+  refs: ProvisionedRefs,
+  reusableDomain: ReusableDomain | null,
+): Promise<void> {
+  if (refs.endpointId) {
+    const eid = refs.endpointId;
+    await safeDelete(
+      () => {
+        return deleteCloudEndpoint(apiKey, eid);
+      },
+      "Cloud endpoint",
+      eid,
+      true,
+    );
+  }
+  if (refs.credentialId) {
+    const cid = refs.credentialId;
+    await safeDelete(
+      () => {
+        return deleteCredential(apiKey, cid);
+      },
+      "Credential",
+      cid,
+      true,
+    );
+  }
+  if (refs.domainId && !reusableDomain) {
+    const did = refs.domainId;
+    await safeDelete(
+      () => {
+        return deleteReservedDomain(apiKey, did);
+      },
+      "Reserved domain",
+      did,
+      true,
+    );
+  }
+  if (refs.botUserId) {
+    const bid = refs.botUserId;
+    await safeDelete(
+      () => {
+        return deleteBotUser(apiKey, bid);
+      },
+      "Bot user",
+      bid,
+      true,
+    );
+  }
+}
+
+function buildTrafficPolicy(
+  domain: string,
+  endpointPrefix: string,
+  bridgeToken: string,
+): string {
+  return JSON.stringify({
+    on_http_request: [
+      {
+        expressions: [
+          `!('x-vm0-token' in req.headers) || req.headers['x-vm0-token'][0] != '${bridgeToken}'`,
+        ],
+        actions: [{ type: "deny", config: { status_code: 403 } }],
+      },
+      {
+        actions: [
+          {
+            type: "forward-internal",
+            config: {
+              url: `https://$\{conn.server_name.split('.${domain}')[0]}.${endpointPrefix}.internal`,
+              on_error: "continue",
+            },
+          },
+          {
+            type: "custom-response",
+            config: { status_code: 502, body: "Host offline" },
+          },
+        ],
+      },
+    ],
+  });
+}
+
+interface ProvisionContext {
+  readonly db: Db;
+  readonly args: HostArgs;
+  readonly apiKey: string;
+  readonly reusableDomain: ReusableDomain | null;
+  readonly refs: { -readonly [K in keyof ProvisionedRefs]: ProvisionedRefs[K] };
+}
+
+async function provisionAndPersistHost(
+  ctx: ProvisionContext,
+  signal: AbortSignal,
+): Promise<RegisterHostResult> {
+  const { db, args, apiKey, reusableDomain, refs } = ctx;
+  const slug = createHash("sha256")
+    .update(`${args.orgId}:${args.userId}`)
+    .digest("hex")
+    .substring(0, 12);
+  const subdomainName = `vm0-cu-${slug}`;
+  const endpointPrefix = `vm0-cu-${slug}`;
+  const botUserName = `vm0-cu-${slug}`;
+
+  const botUser = await findOrCreateBotUser(apiKey, botUserName);
+  signal.throwIfAborted();
+  refs.botUserId = botUser.id;
+
+  const credential = await createCredential(apiKey, botUser.id, [
+    `bind:*.${endpointPrefix}.internal`,
+  ]);
+  signal.throwIfAborted();
+  refs.credentialId = credential.id;
+
+  let domain: string;
+  if (reusableDomain) {
+    domain = reusableDomain.domain;
+    refs.domainId = reusableDomain.id;
+    log.debug("Reusing existing reserved domain", {
+      domain,
+      domainId: refs.domainId,
+    });
+  } else {
+    const reservedDomain = await findOrCreateReservedDomain(
+      apiKey,
+      subdomainName,
+      "us",
+    );
+    signal.throwIfAborted();
+    domain = reservedDomain.domain;
+    refs.domainId = reservedDomain.id;
+  }
+
+  const bridgeToken = randomUUID();
+  const trafficPolicy = buildTrafficPolicy(domain, endpointPrefix, bridgeToken);
+
+  const cloudEndpoint = await ensureCloudEndpoint(
+    apiKey,
+    `https://*.${domain}`,
+    trafficPolicy,
+  );
+  signal.throwIfAborted();
+  refs.endpointId = cloudEndpoint.id;
+
+  const [hostRow] = await db
+    .insert(computerUseHosts)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      domain,
+      token: bridgeToken,
+      ngrokBotUserId: refs.botUserId,
+      ngrokCredentialId: refs.credentialId,
+      ngrokEndpointId: cloudEndpoint.id,
+      ngrokDomainId: refs.domainId,
+      expiresAt: new Date(nowDate().getTime() + HOST_TTL_MS),
+    })
+    .returning();
+  signal.throwIfAborted();
+
+  if (!hostRow) {
+    throw new Error("Failed to create computer-use host");
+  }
+
+  log.debug("Computer-use host registered", {
+    hostId: hostRow.id,
+    botUserId: refs.botUserId,
+    domain,
+  });
+
+  return {
+    id: hostRow.id,
+    domain,
+    token: bridgeToken,
+    ngrokToken: credential.token,
+    endpointPrefix,
+  };
+}
+
+export const registerHost$ = command(
+  async (
+    { set },
+    args: HostArgs,
+    signal: AbortSignal,
+  ): Promise<RegisterHostResult> => {
+    const apiKey = optionalEnv("NGROK_API_KEY");
+    if (!apiKey) {
+      throw new Error("NGROK_API_KEY is not configured");
+    }
+
+    const db = set(writeDb$);
+
+    const [existing] = await db
+      .select()
+      .from(computerUseHosts)
+      .where(
+        and(
+          eq(computerUseHosts.orgId, args.orgId),
+          eq(computerUseHosts.userId, args.userId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    const reusableDomain = existing
+      ? await cleanupExistingHost(db, existing, apiKey)
+      : null;
+    signal.throwIfAborted();
+
+    const refs: {
+      botUserId?: string;
+      credentialId?: string;
+      domainId?: string;
+      endpointId?: string;
+    } = {};
+
+    const result = await safeAsync(() => {
+      return provisionAndPersistHost(
+        { db, args, apiKey, reusableDomain, refs },
+        signal,
+      );
+    });
+    signal.throwIfAborted();
+    if ("ok" in result) {
+      return result.ok;
+    }
+    log.error("Failed to register host, cleaning up", {
+      orgId: args.orgId,
+      userId: args.userId,
+    });
+    await rollbackNgrokResources(apiKey, refs, reusableDomain);
+    signal.throwIfAborted();
+    throw result.error;
+  },
+);
+
+export const unregisterHost$ = command(
+  async (
+    { set },
+    args: HostArgs,
+    signal: AbortSignal,
+  ): Promise<UnregisterHostResult> => {
+    const db = set(writeDb$);
+
+    const [host] = await db
+      .select()
+      .from(computerUseHosts)
+      .where(
+        and(
+          eq(computerUseHosts.orgId, args.orgId),
+          eq(computerUseHosts.userId, args.userId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!host) {
+      return { kind: "not_found" };
+    }
+
+    const apiKey = optionalEnv("NGROK_API_KEY");
+
+    if (apiKey) {
+      if (host.ngrokCredentialId) {
+        await safeDelete(
+          () => {
+            return deleteCredential(apiKey, host.ngrokCredentialId!);
+          },
+          "Credential",
+          host.ngrokCredentialId,
+        );
+      }
+      if (host.ngrokEndpointId) {
+        await safeDelete(
+          () => {
+            return deleteCloudEndpoint(apiKey, host.ngrokEndpointId!);
+          },
+          "Cloud endpoint",
+          host.ngrokEndpointId,
+        );
+      }
+      if (host.ngrokDomainId) {
+        await safeDelete(
+          () => {
+            return deleteReservedDomain(apiKey, host.ngrokDomainId!);
+          },
+          "Reserved domain",
+          host.ngrokDomainId,
+        );
+      }
+      if (host.ngrokBotUserId) {
+        await safeDelete(
+          () => {
+            return deleteBotUser(apiKey, host.ngrokBotUserId!);
+          },
+          "Bot user",
+          host.ngrokBotUserId,
+        );
+      }
+    }
+
+    await db.delete(computerUseHosts).where(eq(computerUseHosts.id, host.id));
+    signal.throwIfAborted();
+
+    log.debug("Computer-use host unregistered", { orgId: args.orgId });
+    return { kind: "ok" };
+  },
+);


### PR DESCRIPTION
## Summary

- Adds `POST /api/zero/computer-use/register` and `DELETE /api/zero/computer-use/unregister` to `apps/api`, byte-equivalent to web. Closes #12737.
- Duplicates the ngrok REST helper to `apps/api/src/signals/external/ngrok-client.ts` (mirrors the #12728 Clerk REST helper precedent; web copy untouched).
- Adds `registerHost$` (throws on unrecoverable failure → framework 500) and `unregisterHost$` (discriminated `ok | not_found` union — idiomatic api, no try/catch) Commands to `zero-computer-use.service.ts`.
- Reuses existing `computerUseDisabled` 403 envelope; introduces `unregisterHostNotFound` to match web's exact 404 message `"Computer-use host not found"` (distinct from GET's `"No active computer-use host"`).
- Ports all 10 web tests verbatim (6 register + 4 unregister); existing 5 GET tests unchanged.

## What changed

| File | Type | Notes |
|---|---|---|
| `apps/api/src/signals/external/ngrok-client.ts` | new | verbatim copy of web helper, `safeDelete` refactored to use `safeAsync`/`throwIfAbort` from `signals/utils` (no `eslint-disable`) |
| `apps/api/src/signals/services/zero-computer-use.service.ts` | extend | adds 2 Commands; existing `zeroComputerUseHost` Computed untouched |
| `apps/api/src/signals/routes/zero-computer-use.ts` | extend | adds 2 RouteEntries; existing GET RouteEntry untouched |
| `apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts` | extend | adds 2 describes (10 tests); existing 5 GET tests untouched |

No changes to `apps/web/**`, the `db/schema/computer-use-host` schema, or `packages/api-contracts/contracts/zero-computer-use.ts`.

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-computer-use.test.ts` — 15/15 (5 GET + 6 register + 4 unregister)
- [x] `pnpm -F api exec vitest run` — 1068/1068 passing across the api workspace
- [x] `pnpm -F api lint` — clean
- [x] `pnpm -F api check-types` — clean
- [x] `pnpm format` — clean
- [x] `pnpm knip` — clean (no unused exports)
- [ ] CI green (lint + test + deploy + cli-e2e)

## Behavioral parity highlights

- **Idempotent re-register**: existing-host branch deletes credential + endpoint, **preserves reserved domain** for slug stability — `R6 returns 200 on re-registration (idempotent)` exercises this.
- **Cleanup-on-failure preserves the original error**: when ngrok endpoint creation fails mid-flow, all previously-created resources are best-effort deleted and the underlying error rethrows — `R4 cleans up resources when endpoint creation fails` asserts `deleteBotUser`, `deleteCredential`, `deleteReservedDomain`.
- **Orphaned-endpoint PATCH** path: `ensureCloudEndpoint` paginates `/endpoints`, client-side URL matches, and PATCHes existing — `R5 updates an existing orphaned endpoint` asserts `patchEndpoint`, no `createEndpoint`.
- **404-tolerant unregister cleanup**: `safeDelete` swallows 404 silently for each ngrok resource — full round-trip `U4 unregisters the host and cleans up ngrok resources` asserts all 4 delete arrays + 404 from a subsequent GET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)