### PR TITLE
feat(api): migrate billing/redeem post to api backend (wave 6 #14)

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -70,12 +70,20 @@ export interface ApiTestMocks {
     readonly checkout: {
       readonly sessions: {
         readonly create: AsyncMock;
+        readonly retrieve: AsyncMock;
+        readonly expire: AsyncMock;
       };
     };
     readonly billingPortal: {
       readonly sessions: {
         readonly create: AsyncMock;
       };
+    };
+    readonly coupons: {
+      readonly retrieve: AsyncMock;
+    };
+    readonly prices: {
+      readonly retrieve: AsyncMock;
     };
   };
   readonly telegram: {
@@ -151,12 +159,20 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
     checkout: {
       sessions: {
         create: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+        retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+        expire: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       },
     },
     billingPortal: {
       sessions: {
         create: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       },
+    },
+    coupons: {
+      retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    },
+    prices: {
+      retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
   };
 
@@ -289,9 +305,13 @@ vi.mock("@vercel/otel", () => {
   return apiTestMocks.otel;
 });
 
-vi.mock("stripe", () => {
-  return {
-    default: vi.fn(() => {
+vi.mock("stripe", async (importOriginal) => {
+  // Preserve the real `Stripe.errors.*` classes so route-level `instanceof`
+  // checks (and tests constructing `new Stripe.errors.StripeInvalidRequestError`)
+  // continue to work; only the constructor surface is stubbed.
+  const actual = await importOriginal<typeof import("stripe")>();
+  const MockStripe = Object.assign(
+    vi.fn(() => {
       return {
         invoices: {
           list: apiTestMocks.stripe.invoices.list,
@@ -313,6 +333,8 @@ vi.mock("stripe", () => {
         checkout: {
           sessions: {
             create: apiTestMocks.stripe.checkout.sessions.create,
+            retrieve: apiTestMocks.stripe.checkout.sessions.retrieve,
+            expire: apiTestMocks.stripe.checkout.sessions.expire,
           },
         },
         billingPortal: {
@@ -320,9 +342,17 @@ vi.mock("stripe", () => {
             create: apiTestMocks.stripe.billingPortal.sessions.create,
           },
         },
+        coupons: {
+          retrieve: apiTestMocks.stripe.coupons.retrieve,
+        },
+        prices: {
+          retrieve: apiTestMocks.stripe.prices.retrieve,
+        },
       };
     }),
-  };
+    { errors: actual.default.errors },
+  );
+  return { default: MockStripe };
 });
 
 vi.mock("@slack/web-api", () => {
@@ -444,7 +474,11 @@ export function resetApiTestMocks(): void {
   apiTestMocks.stripe.subscriptions.retrieve.mockReset();
   apiTestMocks.stripe.subscriptions.update.mockReset();
   apiTestMocks.stripe.checkout.sessions.create.mockReset();
+  apiTestMocks.stripe.checkout.sessions.retrieve.mockReset();
+  apiTestMocks.stripe.checkout.sessions.expire.mockReset();
   apiTestMocks.stripe.billingPortal.sessions.create.mockReset();
+  apiTestMocks.stripe.coupons.retrieve.mockReset();
+  apiTestMocks.stripe.prices.retrieve.mockReset();
   // Re-install the Stripe client override so getStripeClient() returns
   // the centralized mock surface (the vi.mock("stripe") factory above
   // doesn't compose with `new StripeSDK()` because vi.fn isn't a real

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -35,6 +35,20 @@ const SCHEMA = {
       }
       return z.record(z.string(), z.array(z.string())).parse(JSON.parse(val));
     }),
+  ZERO_ONE_TIME_CAMPAIGN: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (!val) {
+        return undefined;
+      }
+      return z
+        .record(
+          z.string(),
+          z.object({ priceId: z.string(), couponId: z.string() }),
+        )
+        .parse(JSON.parse(val));
+    }),
   ABLY_API_KEY: z.string().min(1),
   GOOGLE_OAUTH_CLIENT_ID: z.string().min(1).optional(),
   GOOGLE_OAUTH_CLIENT_SECRET: z.string().min(1).optional(),

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -17,6 +17,7 @@ import { zeroBillingCheckoutRoutes } from "./routes/zero-billing-checkout";
 import { zeroBillingDowngradeRoutes } from "./routes/zero-billing-downgrade";
 import { zeroBillingInvoicesRoutes } from "./routes/zero-billing-invoices";
 import { zeroBillingPortalRoutes } from "./routes/zero-billing-portal";
+import { zeroBillingRedeemRoutes } from "./routes/zero-billing-redeem";
 import { zeroBillingStatusRoutes } from "./routes/zero-billing-status";
 import { zeroChatThreadRoutes } from "./routes/zero-chat-threads";
 import { zeroComposesRoutes } from "./routes/zero-composes";
@@ -84,6 +85,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroBillingDowngradeRoutes,
   ...zeroBillingInvoicesRoutes,
   ...zeroBillingPortalRoutes,
+  ...zeroBillingRedeemRoutes,
   ...zeroBillingStatusRoutes,
   ...zeroChatThreadRoutes,
   ...zeroComposesRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-billing-redeem.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-billing-redeem.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from "node:crypto";
+
+import { command } from "ccstate";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { orgPromoRedemption } from "@vm0/db/schema/org-promo-redemption";
+import { and, eq } from "drizzle-orm";
+
+import { writeDb$ } from "../../../external/db";
+
+export interface RedeemFixture {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+interface SeedOrgArgs {
+  readonly stripeCustomerId?: string;
+}
+
+export const seedRedeemOrg$ = command(
+  async (
+    { set },
+    args: SeedOrgArgs,
+    signal: AbortSignal,
+  ): Promise<RedeemFixture> => {
+    const orgId = `org_${randomUUID()}`;
+    const userId = `user_${randomUUID()}`;
+    const writeDb = set(writeDb$);
+    await writeDb.insert(orgMetadata).values({
+      orgId,
+      stripeCustomerId: args.stripeCustomerId ?? null,
+    });
+    signal.throwIfAborted();
+    return { orgId, userId };
+  },
+);
+
+export const deleteRedeemOrg$ = command(
+  async (
+    { set },
+    fixture: RedeemFixture,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(creditExpiresRecord)
+      .where(eq(creditExpiresRecord.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await writeDb
+      .delete(orgPromoRedemption)
+      .where(eq(orgPromoRedemption.orgId, fixture.orgId));
+    signal.throwIfAborted();
+    await writeDb
+      .delete(orgMetadata)
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    signal.throwIfAborted();
+  },
+);
+
+interface PromoRow {
+  readonly orgId: string;
+  readonly campaignKey: string;
+  readonly stripeSessionId: string;
+}
+
+export const seedOrgPromoRedemption$ = command(
+  async ({ set }, args: PromoRow, signal: AbortSignal): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb.insert(orgPromoRedemption).values(args);
+    signal.throwIfAborted();
+  },
+);
+
+export const findOrgPromoRedemption$ = command(
+  async (
+    { set },
+    args: Pick<PromoRow, "orgId" | "campaignKey">,
+  ): Promise<{ stripeSessionId: string } | undefined> => {
+    const writeDb = set(writeDb$);
+    const [row] = await writeDb
+      .select({ stripeSessionId: orgPromoRedemption.stripeSessionId })
+      .from(orgPromoRedemption)
+      .where(
+        and(
+          eq(orgPromoRedemption.orgId, args.orgId),
+          eq(orgPromoRedemption.campaignKey, args.campaignKey),
+        ),
+      )
+      .limit(1);
+    return row;
+  },
+);
+
+interface CreditRow {
+  readonly orgId: string;
+  readonly source: string;
+  readonly stripeInvoiceId: string;
+  readonly amount: number;
+  readonly expiresAt: Date;
+}
+
+export const seedCreditExpiresRecord$ = command(
+  async ({ set }, args: CreditRow, signal: AbortSignal): Promise<void> => {
+    const writeDb = set(writeDb$);
+    await writeDb.insert(creditExpiresRecord).values({
+      orgId: args.orgId,
+      source: args.source,
+      stripeInvoiceId: args.stripeInvoiceId,
+      amount: args.amount,
+      remaining: args.amount,
+      expiresAt: args.expiresAt,
+    });
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-redeem.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-redeem.test.ts
@@ -1,0 +1,820 @@
+import { randomUUID } from "node:crypto";
+
+import StripeSDK from "stripe";
+import { zeroBillingRedeemContract } from "@vm0/api-contracts/contracts/zero-billing";
+import { createStore } from "ccstate";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { now } from "../../../lib/time";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteRedeemOrg$,
+  findOrgPromoRedemption$,
+  seedCreditExpiresRecord$,
+  seedOrgPromoRedemption$,
+  seedRedeemOrg$,
+  type RedeemFixture,
+} from "./helpers/zero-billing-redeem";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+const CAMPAIGN = "ZERO100";
+const PRICE_ID = "price_test_campaign";
+const COUPON_ID = "ZERO100";
+const APP_ORIGIN = "http://app.localhost:3002";
+const SUCCESS_URL = `${APP_ORIGIN}/redeem/${CAMPAIGN}?stripe=success`;
+const CANCEL_URL = `${APP_ORIGIN}/redeem/${CAMPAIGN}`;
+
+function setRedeemEnv(): void {
+  mockOptionalEnv("STRIPE_SECRET_KEY", "sk_test_fake");
+  mockEnv("VM0_WEB_URL", APP_ORIGIN);
+  mockEnv(
+    "ZERO_ONE_TIME_CAMPAIGN",
+    JSON.stringify({ [CAMPAIGN]: { priceId: PRICE_ID, couponId: COUPON_ID } }),
+  );
+}
+
+describe("POST /api/zero/billing/redeem/:campaign", () => {
+  const track = createFixtureTracker<RedeemFixture>((fixture) => {
+    return store.set(deleteRedeemOrg$, fixture, context.signal);
+  });
+
+  beforeEach(() => {
+    setRedeemEnv();
+    // Default-safe coupon/price responses; specific tests override.
+    context.mocks.stripe.coupons.retrieve.mockResolvedValue({
+      id: COUPON_ID,
+      valid: true,
+    });
+    context.mocks.stripe.prices.retrieve.mockResolvedValue({
+      id: PRICE_ID,
+      active: true,
+    });
+    context.mocks.stripe.customers.create.mockResolvedValue({ id: "cus_test" });
+  });
+
+  it("returns 401 when the caller is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: {},
+      }),
+      [401],
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns campaign_misconfigured for an unknown campaign", async () => {
+    const fixture = await track(store.set(seedRedeemOrg$, {}, context.signal));
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: "UNKNOWN" },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "error",
+      reason: "campaign_misconfigured",
+    });
+  });
+
+  it("returns campaign_misconfigured when the campaign is missing from env config", async () => {
+    mockEnv("ZERO_ONE_TIME_CAMPAIGN", JSON.stringify({}));
+    const fixture = await track(store.set(seedRedeemOrg$, {}, context.signal));
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "error",
+      reason: "campaign_misconfigured",
+    });
+  });
+
+  // Web returns 400 when the caller has no active org (resolveOrg throws).
+  // Api hardens to 401 via authRoute({ missingOrganizationStatus: 401 }) —
+  // intentional Wave 6 cutover convention, documented in PR body.
+  it("returns 401 when the caller has no active org", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("lets unexpected (non-Stripe) errors propagate so Sentry captures the full stack", async () => {
+    const fixture = await track(
+      store.set(
+        seedRedeemOrg$,
+        { stripeCustomerId: `cus_${randomUUID()}` },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    context.mocks.stripe.checkout.sessions.create.mockRejectedValue(
+      new Error("boom: database unreachable"),
+    );
+
+    // The service only catches Stripe.errors.StripeError. Plain errors bubble
+    // up to the framework's default error handler and become a generic 500.
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [500],
+    );
+
+    expect(response.status).toBe(500);
+  });
+
+  it("returns admin_required for non-admin org members", async () => {
+    const fixture = await track(store.set(seedRedeemOrg$, {}, context.signal));
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "error",
+      reason: "admin_required",
+    });
+  });
+
+  it("creates a Stripe Checkout session on first visit and records the row", async () => {
+    const customerId = `cus_${randomUUID()}`;
+    const fixture = await track(
+      store.set(
+        seedRedeemOrg$,
+        { stripeCustomerId: customerId },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    context.mocks.stripe.checkout.sessions.create.mockResolvedValue({
+      id: "cs_fresh_1",
+      url: "https://stripe.test/checkout/cs_fresh_1",
+    });
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "ready",
+      checkoutUrl: "https://stripe.test/checkout/cs_fresh_1",
+    });
+
+    expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "payment",
+        line_items: [{ price: PRICE_ID, quantity: 1 }],
+        discounts: [{ coupon: COUPON_ID }],
+        success_url: SUCCESS_URL,
+        cancel_url: CANCEL_URL,
+        metadata: {
+          orgId: fixture.orgId,
+          campaignKey: CAMPAIGN,
+          purpose: "one_time_purchase",
+        },
+      }),
+    );
+
+    const row = await store.set(findOrgPromoRedemption$, {
+      orgId: fixture.orgId,
+      campaignKey: CAMPAIGN,
+    });
+    expect(row?.stripeSessionId).toBe("cs_fresh_1");
+  });
+
+  it("resumes to the same Stripe URL when the existing session is still open", async () => {
+    const fixture = await track(
+      store.set(
+        seedRedeemOrg$,
+        { stripeCustomerId: `cus_${randomUUID()}` },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    await store.set(
+      seedOrgPromoRedemption$,
+      {
+        orgId: fixture.orgId,
+        campaignKey: CAMPAIGN,
+        stripeSessionId: "cs_open_1",
+      },
+      context.signal,
+    );
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: "cs_open_1",
+      status: "open",
+      url: "https://stripe.test/checkout/cs_open_1",
+    });
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "ready",
+      checkoutUrl: "https://stripe.test/checkout/cs_open_1",
+    });
+    expect(
+      context.mocks.stripe.checkout.sessions.create,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("drops the cached session and returns campaign_misconfigured when the coupon was deleted", async () => {
+    const fixture = await track(
+      store.set(
+        seedRedeemOrg$,
+        { stripeCustomerId: `cus_${randomUUID()}` },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    await store.set(
+      seedOrgPromoRedemption$,
+      {
+        orgId: fixture.orgId,
+        campaignKey: CAMPAIGN,
+        stripeSessionId: "cs_open_stale",
+      },
+      context.signal,
+    );
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: "cs_open_stale",
+      status: "open",
+      url: "https://stripe.test/checkout/cs_open_stale",
+    });
+    context.mocks.stripe.coupons.retrieve.mockRejectedValue(
+      new StripeSDK.errors.StripeInvalidRequestError({
+        type: "invalid_request_error",
+        message: `No such coupon: '${COUPON_ID}'`,
+        code: "resource_missing",
+      }),
+    );
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "error",
+      reason: "campaign_misconfigured",
+    });
+    expect(context.mocks.stripe.checkout.sessions.expire).toHaveBeenCalledWith(
+      "cs_open_stale",
+    );
+    const row = await store.set(findOrgPromoRedemption$, {
+      orgId: fixture.orgId,
+      campaignKey: CAMPAIGN,
+    });
+    expect(row).toBeUndefined();
+  });
+
+  it("still drops the cached session row when expiring it in Stripe fails", async () => {
+    const fixture = await track(
+      store.set(
+        seedRedeemOrg$,
+        { stripeCustomerId: `cus_${randomUUID()}` },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    await store.set(
+      seedOrgPromoRedemption$,
+      {
+        orgId: fixture.orgId,
+        campaignKey: CAMPAIGN,
+        stripeSessionId: "cs_open_expire_fails",
+      },
+      context.signal,
+    );
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: "cs_open_expire_fails",
+      status: "open",
+      url: "https://stripe.test/checkout/cs_open_expire_fails",
+    });
+    context.mocks.stripe.coupons.retrieve.mockRejectedValue(
+      new StripeSDK.errors.StripeInvalidRequestError({
+        type: "invalid_request_error",
+        message: `No such coupon: '${COUPON_ID}'`,
+        code: "resource_missing",
+      }),
+    );
+    context.mocks.stripe.checkout.sessions.expire.mockRejectedValue(
+      new StripeSDK.errors.StripeInvalidRequestError({
+        type: "invalid_request_error",
+        message: "Session can no longer be expired",
+        code: "session_expired",
+      }),
+    );
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "error",
+      reason: "campaign_misconfigured",
+    });
+    expect(context.mocks.stripe.checkout.sessions.expire).toHaveBeenCalledWith(
+      "cs_open_expire_fails",
+    );
+    const row = await store.set(findOrgPromoRedemption$, {
+      orgId: fixture.orgId,
+      campaignKey: CAMPAIGN,
+    });
+    expect(row).toBeUndefined();
+  });
+
+  it("drops the cached session and returns campaign_misconfigured when the coupon is no longer valid", async () => {
+    const fixture = await track(
+      store.set(
+        seedRedeemOrg$,
+        { stripeCustomerId: `cus_${randomUUID()}` },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    await store.set(
+      seedOrgPromoRedemption$,
+      {
+        orgId: fixture.orgId,
+        campaignKey: CAMPAIGN,
+        stripeSessionId: "cs_open_invalid",
+      },
+      context.signal,
+    );
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: "cs_open_invalid",
+      status: "open",
+      url: "https://stripe.test/checkout/cs_open_invalid",
+    });
+    context.mocks.stripe.coupons.retrieve.mockResolvedValue({
+      id: COUPON_ID,
+      valid: false,
+      redeem_by: Math.floor(now() / 1000) - 60,
+    });
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "error",
+      reason: "campaign_misconfigured",
+    });
+    expect(context.mocks.stripe.checkout.sessions.expire).toHaveBeenCalledWith(
+      "cs_open_invalid",
+    );
+    const row = await store.set(findOrgPromoRedemption$, {
+      orgId: fixture.orgId,
+      campaignKey: CAMPAIGN,
+    });
+    expect(row).toBeUndefined();
+  });
+
+  it("drops the cached session and returns campaign_misconfigured when the price was deleted", async () => {
+    const fixture = await track(
+      store.set(
+        seedRedeemOrg$,
+        { stripeCustomerId: `cus_${randomUUID()}` },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    await store.set(
+      seedOrgPromoRedemption$,
+      {
+        orgId: fixture.orgId,
+        campaignKey: CAMPAIGN,
+        stripeSessionId: "cs_open_price_gone",
+      },
+      context.signal,
+    );
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: "cs_open_price_gone",
+      status: "open",
+      url: "https://stripe.test/checkout/cs_open_price_gone",
+    });
+    context.mocks.stripe.prices.retrieve.mockRejectedValue(
+      new StripeSDK.errors.StripeInvalidRequestError({
+        type: "invalid_request_error",
+        message: `No such price: '${PRICE_ID}'`,
+        code: "resource_missing",
+      }),
+    );
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "error",
+      reason: "campaign_misconfigured",
+    });
+    expect(context.mocks.stripe.checkout.sessions.expire).toHaveBeenCalledWith(
+      "cs_open_price_gone",
+    );
+    const row = await store.set(findOrgPromoRedemption$, {
+      orgId: fixture.orgId,
+      campaignKey: CAMPAIGN,
+    });
+    expect(row).toBeUndefined();
+  });
+
+  it("drops the cached session and returns campaign_misconfigured when the price is archived", async () => {
+    const fixture = await track(
+      store.set(
+        seedRedeemOrg$,
+        { stripeCustomerId: `cus_${randomUUID()}` },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    await store.set(
+      seedOrgPromoRedemption$,
+      {
+        orgId: fixture.orgId,
+        campaignKey: CAMPAIGN,
+        stripeSessionId: "cs_open_price_archived",
+      },
+      context.signal,
+    );
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: "cs_open_price_archived",
+      status: "open",
+      url: "https://stripe.test/checkout/cs_open_price_archived",
+    });
+    context.mocks.stripe.prices.retrieve.mockResolvedValue({
+      id: PRICE_ID,
+      active: false,
+    });
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "error",
+      reason: "campaign_misconfigured",
+    });
+    expect(context.mocks.stripe.checkout.sessions.expire).toHaveBeenCalledWith(
+      "cs_open_price_archived",
+    );
+    const row = await store.set(findOrgPromoRedemption$, {
+      orgId: fixture.orgId,
+      campaignKey: CAMPAIGN,
+    });
+    expect(row).toBeUndefined();
+  });
+
+  it("rotates to a new Stripe session when the existing one has expired", async () => {
+    const fixture = await track(
+      store.set(
+        seedRedeemOrg$,
+        { stripeCustomerId: `cus_${randomUUID()}` },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    await store.set(
+      seedOrgPromoRedemption$,
+      {
+        orgId: fixture.orgId,
+        campaignKey: CAMPAIGN,
+        stripeSessionId: "cs_expired_1",
+      },
+      context.signal,
+    );
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: "cs_expired_1",
+      status: "expired",
+      url: null,
+    });
+    context.mocks.stripe.checkout.sessions.create.mockResolvedValue({
+      id: "cs_fresh_2",
+      url: "https://stripe.test/checkout/cs_fresh_2",
+    });
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "ready",
+      checkoutUrl: "https://stripe.test/checkout/cs_fresh_2",
+    });
+
+    const row = await store.set(findOrgPromoRedemption$, {
+      orgId: fixture.orgId,
+      campaignKey: CAMPAIGN,
+    });
+    expect(row?.stripeSessionId).toBe("cs_fresh_2");
+  });
+
+  it("returns already_granted when credits have landed", async () => {
+    const fixture = await track(
+      store.set(
+        seedRedeemOrg$,
+        { stripeCustomerId: `cus_${randomUUID()}` },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    await store.set(
+      seedOrgPromoRedemption$,
+      {
+        orgId: fixture.orgId,
+        campaignKey: CAMPAIGN,
+        stripeSessionId: "cs_granted_1",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedCreditExpiresRecord$,
+      {
+        orgId: fixture.orgId,
+        source: "one_time_purchase",
+        stripeInvoiceId: "cs_granted_1",
+        amount: 100_000,
+        expiresAt: new Date(now() + 30 * 24 * 60 * 60 * 1000),
+      },
+      context.signal,
+    );
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ status: "already_granted" });
+    expect(
+      context.mocks.stripe.checkout.sessions.create,
+    ).not.toHaveBeenCalled();
+    expect(
+      context.mocks.stripe.checkout.sessions.retrieve,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns campaign_misconfigured when Stripe rejects the session at create time with a non-invalid-request error", async () => {
+    const fixture = await track(
+      store.set(
+        seedRedeemOrg$,
+        { stripeCustomerId: `cus_${randomUUID()}` },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    context.mocks.stripe.checkout.sessions.create.mockRejectedValue(
+      new StripeSDK.errors.StripeAPIError({
+        type: "api_error",
+        message: "Coupon ZERO100 is expired and cannot be applied.",
+      }),
+    );
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "error",
+      reason: "campaign_misconfigured",
+    });
+  });
+
+  it("returns campaign_misconfigured when Stripe coupon is missing at create time", async () => {
+    const fixture = await track(
+      store.set(
+        seedRedeemOrg$,
+        { stripeCustomerId: `cus_${randomUUID()}` },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    context.mocks.stripe.checkout.sessions.create.mockRejectedValue(
+      new StripeSDK.errors.StripeInvalidRequestError({
+        type: "invalid_request_error",
+        message: "No such coupon: 'ZERO100'",
+        code: "resource_missing",
+        param: "discounts[0][coupon]",
+      }),
+    );
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "error",
+      reason: "campaign_misconfigured",
+    });
+  });
+
+  it("returns processing when Stripe session is complete but webhook hasn't landed yet", async () => {
+    const fixture = await track(
+      store.set(
+        seedRedeemOrg$,
+        { stripeCustomerId: `cus_${randomUUID()}` },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    await store.set(
+      seedOrgPromoRedemption$,
+      {
+        orgId: fixture.orgId,
+        campaignKey: CAMPAIGN,
+        stripeSessionId: "cs_complete_1",
+      },
+      context.signal,
+    );
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: "cs_complete_1",
+      status: "complete",
+      url: null,
+    });
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ status: "processing" });
+  });
+
+  // ---- Test #19 — validates the pre-auth wrap pattern ----
+  // The outer command must short-circuit before authRoute runs, surfacing
+  // 200/billing_unavailable to an unauthenticated caller when
+  // STRIPE_SECRET_KEY is missing.
+  it("returns billing_unavailable before auth when STRIPE_SECRET_KEY is not configured", async () => {
+    mockOptionalEnv("STRIPE_SECRET_KEY", undefined);
+    // No mocks.clerk.session() — caller is unauthenticated.
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: { successUrl: SUCCESS_URL, cancelUrl: CANCEL_URL },
+        headers: {},
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      status: "error",
+      reason: "billing_unavailable",
+    });
+  });
+
+  it("rejects successUrl/cancelUrl whose origin does not match VM0_WEB_URL", async () => {
+    const fixture = await track(store.set(seedRedeemOrg$, {}, context.signal));
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroBillingRedeemContract);
+    const response = await accept(
+      client.create({
+        params: { campaign: CAMPAIGN },
+        body: {
+          successUrl: "https://evil.example.com/redeem/callback?stripe=success",
+          cancelUrl: CANCEL_URL,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "successUrl and cancelUrl must match the platform origin",
+        code: "BAD_REQUEST",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-billing-redeem.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-redeem.ts
@@ -1,0 +1,131 @@
+import { command } from "ccstate";
+import { zeroBillingRedeemContract } from "@vm0/api-contracts/contracts/zero-billing";
+
+import { env, optionalEnv } from "../../lib/env";
+import { badRequestMessage } from "../../lib/error";
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import { getCampaign } from "../services/one-time-products";
+import { startOrResumeRedemption$ } from "../services/zero-billing-redeem.service";
+import type { RouteEntry } from "../route";
+
+const billingUnavailable = Object.freeze({
+  status: 200 as const,
+  body: Object.freeze({
+    status: "error" as const,
+    reason: "billing_unavailable" as const,
+  }),
+});
+
+const adminRequired = Object.freeze({
+  status: 200 as const,
+  body: Object.freeze({
+    status: "error" as const,
+    reason: "admin_required" as const,
+  }),
+});
+
+const campaignMisconfigured = Object.freeze({
+  status: 200 as const,
+  body: Object.freeze({
+    status: "error" as const,
+    reason: "campaign_misconfigured" as const,
+  }),
+});
+
+const redeemAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(zeroBillingRedeemContract.create));
+  const bodyResult = await get(bodyResultOf(zeroBillingRedeemContract.create));
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+  const { successUrl, cancelUrl } = bodyResult.data;
+
+  // Open-redirect guard: client supplies successUrl/cancelUrl and they flow
+  // straight to Stripe. Pin both to the platform origin so an attacker can't
+  // redirect Stripe back to evil.example.com.
+  const appOrigin = new URL(env("VM0_WEB_URL")).origin;
+  if (
+    new URL(successUrl).origin !== appOrigin ||
+    new URL(cancelUrl).origin !== appOrigin
+  ) {
+    return badRequestMessage(
+      "successUrl and cancelUrl must match the platform origin",
+    );
+  }
+
+  if (auth.orgRole !== "admin") {
+    return adminRequired;
+  }
+
+  // Route-level whitelist: unknown campaign keys never reach Stripe.
+  if (!getCampaign(params.campaign)) {
+    return campaignMisconfigured;
+  }
+
+  const result = await set(
+    startOrResumeRedemption$,
+    {
+      orgId: auth.orgId,
+      campaignKey: params.campaign,
+      successUrl,
+      cancelUrl,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  switch (result.kind) {
+    case "stripe_error": {
+      return campaignMisconfigured;
+    }
+    case "redirect": {
+      return {
+        status: 200 as const,
+        body: {
+          status: "ready" as const,
+          checkoutUrl: result.url,
+        },
+      };
+    }
+    case "already_granted": {
+      return {
+        status: 200 as const,
+        body: { status: "already_granted" as const },
+      };
+    }
+    case "processing": {
+      return {
+        status: 200 as const,
+        body: { status: "processing" as const },
+      };
+    }
+  }
+});
+
+// Outer command wraps authRoute so the pre-auth Stripe availability check
+// runs before authentication. The web route returns `billing_unavailable`
+// (HTTP 200) for unauthenticated callers when STRIPE_SECRET_KEY is missing —
+// authRoute always runs auth first, so we cannot put the check inside it.
+const redeem$ = command(async ({ set }, signal: AbortSignal) => {
+  if (!optionalEnv("STRIPE_SECRET_KEY")) {
+    return billingUnavailable;
+  }
+  return await set(
+    authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      redeemAuthed$,
+    ),
+    signal,
+  );
+});
+
+export const zeroBillingRedeemRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroBillingRedeemContract.create,
+    handler: redeem$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/billing-customer.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-customer.service.ts
@@ -1,0 +1,53 @@
+import { command } from "ccstate";
+import { sql, eq } from "drizzle-orm";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+
+import { writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+import { getStripeClient } from "../external/stripe-client";
+
+/**
+ * Get or create a Stripe customer for an org. Serializes per-org via
+ * pg_advisory_xact_lock so concurrent checkout / redeem requests in the
+ * same org cannot mint multiple Stripe customers and orphan webhook events.
+ *
+ * Lock key `stripe_customer_${orgId}` matches apps/web exactly so cross-
+ * process races during the web→api cutover coordinate on the same lock.
+ */
+export const getOrCreateStripeCustomer$ = command(
+  ({ set }, orgId: string, signal: AbortSignal): Promise<string> => {
+    const writeDb = set(writeDb$);
+    return writeDb.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext('stripe_customer_' || ${orgId}))`,
+      );
+      signal.throwIfAborted();
+
+      const [row] = await tx
+        .select({ stripeCustomerId: orgMetadata.stripeCustomerId })
+        .from(orgMetadata)
+        .where(eq(orgMetadata.orgId, orgId))
+        .limit(1);
+      signal.throwIfAborted();
+
+      if (row?.stripeCustomerId) {
+        return row.stripeCustomerId;
+      }
+
+      const stripe = getStripeClient();
+      const customer = await stripe.customers.create({ metadata: { orgId } });
+      signal.throwIfAborted();
+
+      await tx
+        .insert(orgMetadata)
+        .values({ orgId, stripeCustomerId: customer.id, credits: 0 })
+        .onConflictDoUpdate({
+          target: orgMetadata.orgId,
+          set: { stripeCustomerId: customer.id, updatedAt: nowDate() },
+        });
+      signal.throwIfAborted();
+
+      return customer.id;
+    });
+  },
+);

--- a/turbo/apps/api/src/signals/services/one-time-products.ts
+++ b/turbo/apps/api/src/signals/services/one-time-products.ts
@@ -1,0 +1,39 @@
+import { env } from "../../lib/env";
+
+/**
+ * Server-side registry of one-time redemption campaigns.
+ *
+ * A campaign is the unit a user redeems via the platform `/redeem/:campaign`
+ * page (which calls `POST /api/zero/billing/redeem/:campaign`). It bundles:
+ *   - business policy (credits, expiry, source) — hardcoded here so ops can't
+ *     inflate credits by flipping an env var;
+ *   - Stripe identifiers (priceId, couponId) — sourced from env so test and
+ *     live Stripe accounts can point at different prices/coupons without a
+ *     code change.
+ *
+ * The redeem route uses `priceId`/`couponId`; the webhook handler (still on
+ * apps/web in this Wave) uses `credits`/`expiresDays`/`source`. Keep the
+ * full registry shape so future webhook migration is a copy-paste.
+ */
+interface CampaignPolicy {
+  readonly credits: number;
+  readonly expiresDays: number;
+  readonly source: string;
+}
+
+const CAMPAIGN_POLICY = Object.freeze<Record<string, CampaignPolicy>>({
+  ZERO100: Object.freeze({
+    credits: 100_000,
+    expiresDays: 30,
+    source: "one_time_purchase",
+  }),
+});
+
+export function getCampaign(key: string) {
+  const policy = CAMPAIGN_POLICY[key];
+  const config = env("ZERO_ONE_TIME_CAMPAIGN")?.[key];
+  if (!policy || !config) {
+    return undefined;
+  }
+  return { ...policy, ...config };
+}

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -1,11 +1,8 @@
 import { command } from "ccstate";
-import { sql, eq } from "drizzle-orm";
-import { orgMetadata } from "@vm0/db/schema/org-metadata";
 
 import { env } from "../../lib/env";
-import { writeDb$ } from "../external/db";
-import { nowDate } from "../external/time";
 import { getStripeClient } from "../external/stripe-client";
+import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
 
 interface CreateCheckoutSessionArgs {
   readonly orgId: string;
@@ -18,51 +15,6 @@ interface CreateCheckoutSessionArgs {
 export function activePriceId(tier: "pro" | "team"): string | undefined {
   return env("ZERO_PRICE")?.[tier]?.[0];
 }
-
-/**
- * Get or create a Stripe customer for an org. Serializes per-org via
- * advisory transaction lock so concurrent checkout requests cannot
- * mint multiple Stripe customers and orphan webhook events. Lock key
- * `stripe_customer_${orgId}` matches apps/web exactly so cross-process
- * races during the web→api cutover coordinate on the same lock.
- */
-const getOrCreateStripeCustomer$ = command(
-  ({ set }, orgId: string, signal: AbortSignal): Promise<string> => {
-    const writeDb = set(writeDb$);
-    return writeDb.transaction(async (tx) => {
-      await tx.execute(
-        sql`SELECT pg_advisory_xact_lock(hashtext('stripe_customer_' || ${orgId}))`,
-      );
-      signal.throwIfAborted();
-
-      const [row] = await tx
-        .select({ stripeCustomerId: orgMetadata.stripeCustomerId })
-        .from(orgMetadata)
-        .where(eq(orgMetadata.orgId, orgId))
-        .limit(1);
-      signal.throwIfAborted();
-
-      if (row?.stripeCustomerId) {
-        return row.stripeCustomerId;
-      }
-
-      const stripe = getStripeClient();
-      const customer = await stripe.customers.create({ metadata: { orgId } });
-      signal.throwIfAborted();
-
-      await tx
-        .insert(orgMetadata)
-        .values({ orgId, stripeCustomerId: customer.id, credits: 0 })
-        .onConflictDoUpdate({
-          target: orgMetadata.orgId,
-          set: { stripeCustomerId: customer.id, updatedAt: nowDate() },
-        });
-      signal.throwIfAborted();
-
-      return customer.id;
-    });
-  },
-);
 
 /**
  * Create a Stripe Checkout session for subscription. Returns the

--- a/turbo/apps/api/src/signals/services/zero-billing-redeem.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-redeem.service.ts
@@ -1,0 +1,373 @@
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import StripeSDK from "stripe";
+import { orgPromoRedemption } from "@vm0/db/schema/org-promo-redemption";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+
+import { logger } from "../../lib/log";
+import { db$, writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
+import { getStripeClient } from "../external/stripe-client";
+import { safeAsync } from "../utils";
+import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
+import { getCampaign } from "./one-time-products";
+
+const log = logger("zero-billing-redeem");
+
+/**
+ * Result of attempting to start or resume a one-time campaign redemption.
+ *
+ * - `redirect`         — send the user to `url`.
+ * - `already_granted`  — credits already landed in the org ledger.
+ * - `processing`       — Stripe accepted the payment but the webhook hasn't
+ *                        persisted the grant yet; the user should refresh.
+ * - `stripe_error`     — Stripe rejected the create/retrieve/coupon/price
+ *                        call; the route maps this to `campaign_misconfigured`.
+ */
+type RedemptionResult =
+  | { readonly kind: "redirect"; readonly url: string }
+  | { readonly kind: "already_granted" }
+  | { readonly kind: "processing" }
+  | {
+      readonly kind: "stripe_error";
+      readonly type: string;
+      readonly code: string | null;
+      readonly message: string;
+    };
+
+interface RedemptionArgs {
+  readonly orgId: string;
+  readonly campaignKey: string;
+  readonly successUrl: string;
+  readonly cancelUrl: string;
+}
+
+export const startOrResumeRedemption$ = command(
+  async (
+    { set },
+    args: RedemptionArgs,
+    signal: AbortSignal,
+  ): Promise<RedemptionResult> => {
+    const outcome = await safeAsync(async () => {
+      return await runRedemption(args, set, signal);
+    });
+    signal.throwIfAborted();
+    if ("ok" in outcome) {
+      return outcome.ok;
+    }
+    if (outcome.error instanceof StripeSDK.errors.StripeError) {
+      log.error("redeem: stripe error", {
+        orgId: args.orgId,
+        campaignKey: args.campaignKey,
+        type: outcome.error.type,
+        code: outcome.error.code,
+        message: outcome.error.message,
+      });
+      return {
+        kind: "stripe_error",
+        type: outcome.error.type,
+        code: outcome.error.code ?? null,
+        message: outcome.error.message,
+      };
+    }
+    throw outcome.error;
+  },
+);
+
+async function runRedemption(
+  args: RedemptionArgs,
+  set: Parameters<Parameters<typeof command>[0]>[0]["set"],
+  signal: AbortSignal,
+): Promise<RedemptionResult> {
+  // Fast path: row already exists — go straight to resume logic without
+  // paying for a throwaway Stripe session.
+  const existing = await set(selectRedemption$, args, signal);
+  if (existing) {
+    return await set(
+      resumeExisting$,
+      { args, stripeSessionId: existing.stripeSessionId },
+      signal,
+    );
+  }
+
+  // Claim the row by creating a Stripe session and inserting in one go.
+  const session = await set(createOneTimeCheckoutSession$, args, signal);
+  signal.throwIfAborted();
+
+  const writeDb = set(writeDb$);
+  const inserted = await writeDb
+    .insert(orgPromoRedemption)
+    .values({
+      orgId: args.orgId,
+      campaignKey: args.campaignKey,
+      stripeSessionId: session.sessionId,
+    })
+    .onConflictDoNothing()
+    .returning({ stripeSessionId: orgPromoRedemption.stripeSessionId });
+  signal.throwIfAborted();
+
+  if (inserted.length > 0) {
+    return { kind: "redirect", url: session.url };
+  }
+
+  // Lost the race — expire our throwaway and resume against the winner.
+  const stripe = getStripeClient();
+  await stripe.checkout.sessions.expire(session.sessionId);
+  signal.throwIfAborted();
+
+  const winner = await set(selectRedemption$, args, signal);
+  if (!winner) {
+    log.error("one_time_purchase race inconsistency", {
+      orgId: args.orgId,
+      campaignKey: args.campaignKey,
+    });
+    throw new Error(
+      "Redemption state is temporarily inconsistent; please retry in a moment",
+    );
+  }
+  return await set(
+    resumeExisting$,
+    { args, stripeSessionId: winner.stripeSessionId },
+    signal,
+  );
+}
+
+const selectRedemption$ = command(
+  async (
+    { get },
+    args: Pick<RedemptionArgs, "orgId" | "campaignKey">,
+    signal: AbortSignal,
+  ): Promise<{ stripeSessionId: string } | undefined> => {
+    const readDb = get(db$);
+    const [row] = await readDb
+      .select({ stripeSessionId: orgPromoRedemption.stripeSessionId })
+      .from(orgPromoRedemption)
+      .where(
+        and(
+          eq(orgPromoRedemption.orgId, args.orgId),
+          eq(orgPromoRedemption.campaignKey, args.campaignKey),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+    return row;
+  },
+);
+
+const resumeExisting$ = command(
+  async (
+    { get, set },
+    input: { args: RedemptionArgs; stripeSessionId: string },
+    signal: AbortSignal,
+  ): Promise<RedemptionResult> => {
+    const { args, stripeSessionId } = input;
+
+    // Source of truth for "credits granted" is the ledger, not the Stripe session.
+    const readDb = get(db$);
+    const [granted] = await readDb
+      .select({ id: creditExpiresRecord.id })
+      .from(creditExpiresRecord)
+      .where(
+        and(
+          eq(creditExpiresRecord.orgId, args.orgId),
+          eq(creditExpiresRecord.stripeInvoiceId, stripeSessionId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+    if (granted) {
+      return { kind: "already_granted" };
+    }
+
+    const stripe = getStripeClient();
+    const session = await stripe.checkout.sessions.retrieve(stripeSessionId);
+    signal.throwIfAborted();
+
+    if (session.status === "open" && session.url) {
+      await set(
+        ensureCampaignStillAvailable$,
+        { args, stripeSessionId },
+        signal,
+      );
+      return { kind: "redirect", url: session.url };
+    }
+    if (session.status === "complete") {
+      return { kind: "processing" };
+    }
+
+    // status is "expired" (or unrecognised) — rotate the row to a fresh session
+    // so the user can try again.
+    const fresh = await set(createOneTimeCheckoutSession$, args, signal);
+    const writeDb = set(writeDb$);
+    await writeDb
+      .update(orgPromoRedemption)
+      .set({ stripeSessionId: fresh.sessionId, updatedAt: nowDate() })
+      .where(
+        and(
+          eq(orgPromoRedemption.orgId, args.orgId),
+          eq(orgPromoRedemption.campaignKey, args.campaignKey),
+        ),
+      );
+    signal.throwIfAborted();
+    log.debug("one_time_purchase session refreshed", {
+      orgId: args.orgId,
+      campaignKey: args.campaignKey,
+      oldSessionId: stripeSessionId,
+      newSessionId: fresh.sessionId,
+    });
+    return { kind: "redirect", url: fresh.url };
+  },
+);
+
+const ensureCampaignStillAvailable$ = command(
+  async (
+    { set },
+    input: { args: RedemptionArgs; stripeSessionId: string },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const { args, stripeSessionId } = input;
+    const campaign = getCampaign(args.campaignKey);
+    if (!campaign) {
+      // Route already gated unknown campaigns; if we got here, env drifted
+      // mid-request. Surfacing as misconfigured is fine.
+      await set(cleanupStaleRedemption$, { args, stripeSessionId }, signal);
+      throw new StripeSDK.errors.StripeInvalidRequestError({
+        type: "invalid_request_error",
+        code: "resource_missing",
+        message: `Campaign ${args.campaignKey} is no longer configured`,
+      });
+    }
+
+    const stripe = getStripeClient();
+    // Parallel: each is an independent Stripe read; wall time is one RTT.
+    const fetched = await safeAsync(async () => {
+      return await Promise.all([
+        stripe.coupons.retrieve(campaign.couponId),
+        stripe.prices.retrieve(campaign.priceId),
+      ]);
+    });
+    signal.throwIfAborted();
+    if ("error" in fetched) {
+      if (
+        fetched.error instanceof StripeSDK.errors.StripeInvalidRequestError &&
+        fetched.error.code === "resource_missing"
+      ) {
+        log.warn("one_time_purchase stripe resource missing on resume", {
+          orgId: args.orgId,
+          campaignKey: args.campaignKey,
+          couponId: campaign.couponId,
+          priceId: campaign.priceId,
+          stripeMessage: fetched.error.message,
+        });
+        await set(cleanupStaleRedemption$, { args, stripeSessionId }, signal);
+      }
+      throw fetched.error;
+    }
+    signal.throwIfAborted();
+    const [coupon, price] = fetched.ok;
+
+    if (!coupon.valid) {
+      log.warn("one_time_purchase coupon no longer valid on resume", {
+        orgId: args.orgId,
+        campaignKey: args.campaignKey,
+        couponId: campaign.couponId,
+      });
+      await set(cleanupStaleRedemption$, { args, stripeSessionId }, signal);
+      throw new StripeSDK.errors.StripeInvalidRequestError({
+        type: "invalid_request_error",
+        code: "resource_missing",
+        message: `Coupon ${campaign.couponId} is no longer valid`,
+      });
+    }
+
+    if (!price.active) {
+      log.warn("one_time_purchase price no longer active on resume", {
+        orgId: args.orgId,
+        campaignKey: args.campaignKey,
+        priceId: campaign.priceId,
+      });
+      await set(cleanupStaleRedemption$, { args, stripeSessionId }, signal);
+      throw new StripeSDK.errors.StripeInvalidRequestError({
+        type: "invalid_request_error",
+        code: "resource_missing",
+        message: `Price ${campaign.priceId} is no longer active`,
+      });
+    }
+  },
+);
+
+const cleanupStaleRedemption$ = command(
+  async (
+    { set },
+    input: { args: RedemptionArgs; stripeSessionId: string },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const { args, stripeSessionId } = input;
+    const stripe = getStripeClient();
+    // Best-effort: don't let session-already-expired prevent row cleanup.
+    // Sessions auto-expire after 24h anyway; a failure here is cosmetic.
+    const expireOutcome = await safeAsync(async () => {
+      return await stripe.checkout.sessions.expire(stripeSessionId);
+    });
+    signal.throwIfAborted();
+    if ("error" in expireOutcome) {
+      log.debug("one_time_purchase session already expired or un-expirable", {
+        orgId: args.orgId,
+        campaignKey: args.campaignKey,
+        stripeSessionId,
+      });
+    }
+    signal.throwIfAborted();
+    const writeDb = set(writeDb$);
+    await writeDb
+      .delete(orgPromoRedemption)
+      .where(
+        and(
+          eq(orgPromoRedemption.orgId, args.orgId),
+          eq(orgPromoRedemption.campaignKey, args.campaignKey),
+        ),
+      );
+    signal.throwIfAborted();
+  },
+);
+
+const createOneTimeCheckoutSession$ = command(
+  async (
+    { set },
+    args: RedemptionArgs,
+    signal: AbortSignal,
+  ): Promise<{ sessionId: string; url: string }> => {
+    const campaign = getCampaign(args.campaignKey);
+    if (!campaign) {
+      throw new Error(`Unknown campaign: ${args.campaignKey}`);
+    }
+
+    const customerId = await set(
+      getOrCreateStripeCustomer$,
+      args.orgId,
+      signal,
+    );
+    signal.throwIfAborted();
+
+    const stripe = getStripeClient();
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      customer: customerId,
+      line_items: [{ price: campaign.priceId, quantity: 1 }],
+      discounts: [{ coupon: campaign.couponId }],
+      success_url: args.successUrl,
+      cancel_url: args.cancelUrl,
+      metadata: {
+        orgId: args.orgId,
+        campaignKey: args.campaignKey,
+        purpose: "one_time_purchase",
+      },
+    });
+    signal.throwIfAborted();
+
+    if (!session.url) {
+      throw new Error("Stripe checkout session did not return a URL");
+    }
+    return { sessionId: session.id, url: session.url };
+  },
+);


### PR DESCRIPTION
## Summary

- Migrate `POST /api/zero/billing/redeem/[campaign]` from `apps/web` to `apps/api` (Wave 6 #14 of the [API Migration Epic](https://github.com/vm0-ai/vm0/issues/12290)).
- All 20 web test cases ported to `apps/api/src/signals/routes/__tests__/zero-billing-redeem.test.ts` — none skipped.
- Closes #12735.

## Key design choices

| Decision | Choice | Rationale |
| --- | --- | --- |
| Pre-auth Stripe availability check | Outer `command` wraps `authRoute` | `authRoute` always runs auth first; the redeem route needs `billing_unavailable` (HTTP 200 with reason) to surface to unauthenticated callers when `STRIPE_SECRET_KEY` is missing. Validated by writing the pre-auth test #19 first end-to-end. |
| Service shape | Result-union (`redirect` / `already_granted` / `processing` / `stripe_error`) | Aligns with Wave 6 canonical pattern (no `try/catch` in route layer). Stripe errors absorbed at the service boundary via `safeAsync`. |
| `getOrCreateStripeCustomer$` reuse | Extracted to `signals/services/billing-customer.service.ts` | Shared between checkout + redeem so they coordinate on the same `pg_advisory_xact_lock` key (`stripe_customer_${orgId}`). Cross-process race safe with the web route still running during cutover. |
| No-active-org status | 401 (api) vs 400 (web) | Intentional Wave 6 hardening — `authRoute({missingOrganizationStatus: 401})`. Documented inline in the test. |
| Stripe error `instanceof` in tests | `vi.mock("stripe", importOriginal)` exposes real `Stripe.errors.*` | Required so `new StripeSDK.errors.StripeInvalidRequestError(...)` in tests and the service's `instanceof` checks work together. |

## Files

**Created**
- `apps/api/src/signals/routes/zero-billing-redeem.ts`
- `apps/api/src/signals/routes/__tests__/zero-billing-redeem.test.ts` (20 cases)
- `apps/api/src/signals/routes/__tests__/helpers/zero-billing-redeem.ts` (seed/find/delete helpers)
- `apps/api/src/signals/services/zero-billing-redeem.service.ts`
- `apps/api/src/signals/services/one-time-products.ts` (`getCampaign` registry)
- `apps/api/src/signals/services/billing-customer.service.ts` (shared advisory-lock helper)

**Modified**
- `apps/api/src/__tests__/mocks.ts` — extends Stripe mock with `coupons.retrieve`, `prices.retrieve`, `checkout.sessions.retrieve`, `checkout.sessions.expire`; preserves real `Stripe.errors.*` via `importOriginal`.
- `apps/api/src/lib/env.ts` — adds `ZERO_ONE_TIME_CAMPAIGN` schema (verbatim from web).
- `apps/api/src/signals/route.ts` — registers `zeroBillingRedeemRoutes` alphabetically.
- `apps/api/src/signals/services/zero-billing-checkout.service.ts` — imports `getOrCreateStripeCustomer$` from the shared module.

## Cutover

This PR does **not** modify the web route. Cutover is gated by the `ApiBackendMutations` feature switch (separate ops change). Roll-forward and rollback are env-flag-driven.

## Test plan

- [x] All 20 redeem tests pass: `pnpm -F api exec vitest run zero-billing-redeem.test.ts` (20/20)
- [x] Sibling checkout still works after `getOrCreateStripeCustomer$` extraction: `pnpm -F api exec vitest run zero-billing-checkout.test.ts` (7/7)
- [x] All billing tests pass: `pnpm -F api exec vitest run zero-billing` (82/82)
- [x] All Stripe-using tests pass (regression check on mock extension): 99/99
- [x] Lint: `pnpm turbo run lint` — 0 warnings, 0 errors
- [x] Type check: `pnpm check-types` — 11 packages successful
- [x] Format: `pnpm format` — all unchanged
- [x] Knip: clean (`exit code 0`)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)