### PR TITLE
feat(api): migrate integrations/telegram/upload-file init+complete to api backend (wave 6 #17)

### DIFF
--- a/turbo/apps/api/src/signals/external/telegram-client.ts
+++ b/turbo/apps/api/src/signals/external/telegram-client.ts
@@ -187,3 +187,99 @@ export async function sendMessage(
     chatId: String(success.result.chat.id),
   };
 }
+
+export interface TelegramDocument {
+  readonly file_id: string;
+  readonly file_unique_id: string;
+  readonly file_name?: string;
+  readonly mime_type?: string;
+  readonly file_size?: number;
+}
+
+interface TelegramSentDocumentMessage {
+  readonly message_id: number;
+  readonly chat: { readonly id: number };
+  readonly document?: TelegramDocument;
+}
+
+export type SendTelegramDocumentResult =
+  | {
+      readonly kind: "ok";
+      readonly messageId: number;
+      readonly chatId: string;
+      readonly document: TelegramDocument | undefined;
+    }
+  | {
+      readonly kind: "telegram-error";
+      readonly status: number;
+      readonly description: string | undefined;
+    };
+
+/**
+ * Send a Telegram document using the bot API and surface upstream HTTP status
+ * via a result-union. Callers map status >= 500 to 502 and status < 500 to 400
+ * (Telegram client error). No exceptions are thrown for HTTP failures so
+ * handlers can stay free of try/catch (per project policy).
+ */
+export async function sendDocument(
+  token: string,
+  chatId: string,
+  document: string,
+  options: {
+    readonly caption?: string;
+    readonly messageThreadId?: number;
+  } = {},
+): Promise<SendTelegramDocumentResult> {
+  const url = `https://api.telegram.org/bot${token}/sendDocument`;
+  const payload: Record<string, unknown> = {
+    chat_id: chatId,
+    document,
+  };
+  if (options.caption !== undefined) {
+    payload.caption = options.caption;
+  }
+  if (options.messageThreadId !== undefined) {
+    payload.message_thread_id = options.messageThreadId;
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  const data: unknown = await response.json();
+
+  if (!response.ok) {
+    const description =
+      data && typeof data === "object" && "description" in data
+        ? typeof (data as { description: unknown }).description === "string"
+          ? ((data as { description: string }).description as string)
+          : undefined
+        : undefined;
+    return {
+      kind: "telegram-error",
+      status: response.status,
+      description,
+    };
+  }
+
+  if (isTelegramApiError(data)) {
+    return {
+      kind: "telegram-error",
+      status: response.status,
+      description: data.description,
+    };
+  }
+
+  const success = data as {
+    readonly ok: true;
+    readonly result: TelegramSentDocumentMessage;
+  };
+  return {
+    kind: "ok",
+    messageId: success.result.message_id,
+    chatId: String(success.result.chat.id),
+    document: success.result.document,
+  };
+}

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -49,6 +49,8 @@ import { zeroSkillsRoutes } from "./routes/zero-skills";
 import { zeroIntegrationsSlackRoutes } from "./routes/zero-integrations-slack";
 import { zeroIntegrationsTelegramRoutes } from "./routes/zero-integrations-telegram";
 import { zeroIntegrationsTelegramMessageRoutes } from "./routes/zero-integrations-telegram-message";
+import { zeroIntegrationsTelegramUploadCompleteRoutes } from "./routes/zero-integrations-telegram-upload-complete";
+import { zeroIntegrationsTelegramUploadInitRoutes } from "./routes/zero-integrations-telegram-upload-init";
 import { zeroSlackChannelsRoutes } from "./routes/zero-slack-channels";
 import { zeroSlackConnectRoutes } from "./routes/zero-slack-connect";
 import { zeroTeamRoutes } from "./routes/zero-team";
@@ -123,6 +125,8 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroSlackChannelsRoutes,
   ...zeroIntegrationsTelegramRoutes,
   ...zeroIntegrationsTelegramMessageRoutes,
+  ...zeroIntegrationsTelegramUploadCompleteRoutes,
+  ...zeroIntegrationsTelegramUploadInitRoutes,
   ...zeroTeamRoutes,
   ...zeroUploadsCompleteRoutes,
   ...zeroUploadsPrepareRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-upload-complete.test.ts
@@ -1,0 +1,311 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { http, HttpResponse } from "msw";
+
+import { integrationsTelegramUploadCompleteContract } from "@vm0/api-contracts/contracts/integrations";
+import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { server } from "../../../mocks/server";
+import { writeDb$ } from "../../external/db";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import {
+  deleteTelegramFixture$,
+  seedTelegramInstallation$,
+  type TelegramFixture,
+} from "./helpers/zero-telegram";
+import { seedRun$ } from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function uniqueBotId(): string {
+  return String(100_000_000 + Math.floor(Math.random() * 899_999_999));
+}
+
+function zeroToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId: string;
+}): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId,
+    capabilities: ["telegram:write"],
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+interface UploadCompleteFixture extends TelegramFixture {
+  readonly composeId: string;
+  readonly telegramBotId: string;
+  readonly userId: string;
+  readonly runId: string;
+  readonly membership: OrgMembershipFixture;
+}
+
+async function seedSendableContext(): Promise<UploadCompleteFixture> {
+  const orgId = `org_${randomUUID().slice(0, 8)}`;
+  const userId = `user_${randomUUID().slice(0, 8)}`;
+  const membership = await store.set(
+    seedOrgMembership$,
+    { orgId, userId, role: "admin" },
+    context.signal,
+  );
+  const telegramBotId = uniqueBotId();
+  const installation = await store.set(
+    seedTelegramInstallation$,
+    { orgId, ownerUserId: userId, telegramBotId },
+    context.signal,
+  );
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId,
+      userId,
+      composeId: installation.composeId,
+      triggerSource: "telegram",
+    },
+    context.signal,
+  );
+  return {
+    orgId,
+    composeIds: [installation.composeId],
+    composeId: installation.composeId,
+    telegramBotIds: [telegramBotId],
+    telegramBotId,
+    userIds: [userId],
+    userId,
+    runId,
+    membership,
+  };
+}
+
+describe("POST /api/zero/integrations/telegram/upload-file/complete", () => {
+  const fixtures: UploadCompleteFixture[] = [];
+  const memberships: OrgMembershipFixture[] = [];
+
+  function findUploadedFiles(externalId: string) {
+    const writeDb = store.set(writeDb$);
+    return writeDb
+      .select()
+      .from(runUploadedFiles)
+      .where(eq(runUploadedFiles.externalId, externalId));
+  }
+
+  afterEach(async () => {
+    while (fixtures.length > 0) {
+      const fixture = fixtures.pop();
+      if (fixture) {
+        await store.set(deleteTelegramFixture$, fixture, context.signal);
+      }
+    }
+    while (memberships.length > 0) {
+      const membership = memberships.pop();
+      if (membership) {
+        await store.set(deleteOrgMembership$, membership, context.signal);
+      }
+    }
+  });
+
+  it("sends the uploaded file URL through the requested Telegram bot", async () => {
+    const fixture = await seedSendableContext();
+    fixtures.push(fixture);
+    memberships.push(fixture.membership);
+
+    const uploadId = randomUUID();
+    const telegramFileId = `tg-doc-${randomUUID().slice(0, 8)}`;
+    const s3Key = `uploads/${fixture.userId}/${uploadId}/report.pdf`;
+    const fileUrl = `http://localhost:3000/f/${encodeURIComponent(fixture.userId.replace(/^user_/, ""))}/${uploadId}/report.pdf`;
+
+    mocks.s3.listObjects([
+      { bucket: "test-user-storages", key: s3Key, size: 1234 },
+    ]);
+
+    let telegramBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post(
+        "https://api.telegram.org/bottest-bot-token/sendDocument",
+        async ({ request }) => {
+          telegramBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({
+            ok: true,
+            result: {
+              message_id: 321,
+              chat: { id: -1_001_234_567_890 },
+              document: {
+                file_id: telegramFileId,
+                file_unique_id: "tg-doc-unique",
+                file_name: "report.pdf",
+                mime_type: "application/pdf",
+                file_size: 1234,
+              },
+            },
+          });
+        },
+      ),
+    );
+
+    const client = setupApp({ context })(
+      integrationsTelegramUploadCompleteContract,
+    );
+    const response = await accept(
+      client.complete({
+        body: {
+          uploadId,
+          botId: fixture.telegramBotId,
+          chatId: "-1001234567890",
+          contentType: "application/pdf",
+          caption: "Daily report",
+          messageThreadId: 42,
+        },
+        headers: {
+          authorization: `Bearer ${zeroToken({
+            userId: fixture.userId,
+            orgId: fixture.orgId,
+            runId: fixture.runId,
+          })}`,
+        },
+      }),
+      [200],
+    );
+
+    expect(telegramBody).toMatchObject({
+      chat_id: "-1001234567890",
+      document: fileUrl,
+      caption: "Daily report",
+      message_thread_id: 42,
+    });
+    expect(response.body).toMatchObject({
+      messageId: 321,
+      chatId: "-1001234567890",
+      fileId: telegramFileId,
+      filename: "report.pdf",
+      mimetype: "application/pdf",
+      size: 1234,
+      url: fileUrl,
+    });
+
+    const rows = await findUploadedFiles(telegramFileId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      runId: fixture.runId,
+      source: "telegram",
+      externalId: telegramFileId,
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      filename: "report.pdf",
+      contentType: "application/pdf",
+      sizeBytes: 1234,
+      url: fileUrl,
+      metadata: {
+        botId: fixture.telegramBotId,
+        chatId: "-1001234567890",
+        uploadId,
+        sourceUrl: fileUrl,
+        caption: "Daily report",
+        messageThreadId: 42,
+        telegramMessage: {
+          id: 321,
+          fileId: telegramFileId,
+        },
+      },
+    });
+  });
+
+  it("returns 404 when the bot id is not owned by the org", async () => {
+    const orgId = `org_${randomUUID().slice(0, 8)}`;
+    const userId = `user_${randomUUID().slice(0, 8)}`;
+    const runId = `run_${randomUUID()}`;
+    const membership = await store.set(
+      seedOrgMembership$,
+      { orgId, userId, role: "admin" },
+      context.signal,
+    );
+    memberships.push(membership);
+
+    const client = setupApp({ context })(
+      integrationsTelegramUploadCompleteContract,
+    );
+    const response = await accept(
+      client.complete({
+        body: {
+          uploadId: randomUUID(),
+          botId: uniqueBotId(),
+          chatId: "-1001234567890",
+        },
+        headers: {
+          authorization: `Bearer ${zeroToken({ userId, orgId, runId })}`,
+        },
+      }),
+      [404],
+    );
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 400 when Telegram rejects the sendDocument call", async () => {
+    const fixture = await seedSendableContext();
+    fixtures.push(fixture);
+    memberships.push(fixture.membership);
+
+    const uploadId = randomUUID();
+    const s3Key = `uploads/${fixture.userId}/${uploadId}/report.pdf`;
+    mocks.s3.listObjects([
+      { bucket: "test-user-storages", key: s3Key, size: 1234 },
+    ]);
+
+    server.use(
+      http.post(
+        "https://api.telegram.org/bottest-bot-token/sendDocument",
+        () => {
+          return HttpResponse.json(
+            { ok: false, description: "Bad Request: chat not found" },
+            { status: 400 },
+          );
+        },
+      ),
+    );
+
+    const client = setupApp({ context })(
+      integrationsTelegramUploadCompleteContract,
+    );
+    const response = await accept(
+      client.complete({
+        body: {
+          uploadId,
+          botId: fixture.telegramBotId,
+          chatId: "-1001234567890",
+          contentType: "application/pdf",
+        },
+        headers: {
+          authorization: `Bearer ${zeroToken({
+            userId: fixture.userId,
+            orgId: fixture.orgId,
+            runId: fixture.runId,
+          })}`,
+        },
+      }),
+      [400],
+    );
+    expect(response.body.error.message).toContain("chat not found");
+    expect(response.body.error.code).toBe("TELEGRAM_ERROR");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-upload-init.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-upload-init.test.ts
@@ -1,0 +1,141 @@
+import { randomUUID } from "node:crypto";
+import { createStore } from "ccstate";
+import { describe, expect, it } from "vitest";
+
+import { integrationsTelegramUploadInitContract } from "@vm0/api-contracts/contracts/integrations";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+
+const context = testContext();
+const store = createStore();
+createZeroRouteMocks(context);
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function zeroToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId: string;
+}): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId,
+    capabilities: ["telegram:write"],
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+describe("POST /api/zero/integrations/telegram/upload-file/init", () => {
+  const track = createFixtureTracker<OrgMembershipFixture>((fixture) => {
+    return store.set(deleteOrgMembership$, fixture, context.signal);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const client = setupApp({ context })(
+      integrationsTelegramUploadInitContract,
+    );
+    const response = await accept(
+      client.init({
+        body: {
+          filename: "report.pdf",
+          contentType: "application/pdf",
+          length: 100,
+        },
+        headers: {},
+      }),
+      [401],
+    );
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns a presigned upload URL and final file URL", async () => {
+    const userId = `user_${randomUUID().slice(0, 8)}`;
+    const orgId = `org_${randomUUID().slice(0, 8)}`;
+    const runId = `run_${randomUUID()}`;
+    await track(
+      store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    const token = zeroToken({ userId, orgId, runId });
+
+    const client = setupApp({ context })(
+      integrationsTelegramUploadInitContract,
+    );
+    const response = await client.init({
+      body: {
+        filename: "daily report.pdf",
+        contentType: "application/pdf",
+        length: 1234,
+      },
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      return;
+    }
+    expect(response.body).toMatchObject({
+      filename: "daily_report.pdf",
+      contentType: "application/pdf",
+      size: 1234,
+    });
+    expect(response.body.uploadId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(response.body.uploadUrl).toMatch(/^https?:\/\//);
+    expect(response.body.fileUrl).toContain(
+      `/f/${encodeURIComponent(userId.replace(/^user_/, ""))}/${response.body.uploadId}/daily_report.pdf`,
+    );
+
+    const calls = context.mocks.s3.getSignedUrl.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const cmd = calls[0]?.[1] as { input: { Key: string } };
+    expect(cmd.input.Key).toBe(
+      `uploads/${userId}/${response.body.uploadId}/daily_report.pdf`,
+    );
+  });
+
+  it("does not apply a VM0-specific size limit before Telegram", async () => {
+    const userId = `user_${randomUUID().slice(0, 8)}`;
+    const orgId = `org_${randomUUID().slice(0, 8)}`;
+    const runId = `run_${randomUUID()}`;
+    await track(
+      store.set(seedOrgMembership$, { orgId, userId }, context.signal),
+    );
+    const token = zeroToken({ userId, orgId, runId });
+
+    const client = setupApp({ context })(
+      integrationsTelegramUploadInitContract,
+    );
+    const response = await client.init({
+      body: {
+        filename: "big.bin",
+        contentType: "application/octet-stream",
+        length: 50 * 1024 * 1024 + 1,
+      },
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      return;
+    }
+    expect(response.body).toMatchObject({
+      filename: "big.bin",
+      contentType: "application/octet-stream",
+      size: 50 * 1024 * 1024 + 1,
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-complete.ts
@@ -1,0 +1,191 @@
+import { command, computed, type Computed } from "ccstate";
+import {
+  integrationsTelegramUploadCompleteContract,
+  type TelegramUploadCompleteBody,
+} from "@vm0/api-contracts/contracts/integrations";
+
+import { env } from "../../lib/env";
+import { buildFileUrl } from "../../lib/file-url";
+import { inferMimetype } from "../../lib/mimetype";
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { listS3Objects } from "../external/s3";
+import {
+  sendDocument,
+  type SendTelegramDocumentResult,
+} from "../external/telegram-client";
+import {
+  getOfficialTelegramBotConfig,
+  isOfficialTelegramBotId,
+} from "../external/telegram-official";
+import { recordTelegramUploadedFile$ } from "../services/run-uploaded-files.service";
+import { zeroTelegramInstallation } from "../services/zero-telegram-data.service";
+import type { RouteEntry } from "../route";
+
+const botNotFound = Object.freeze({
+  status: 404 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Telegram bot not found",
+      code: "NOT_FOUND",
+    }),
+  }),
+});
+
+const uploadedFileNotFound = Object.freeze({
+  status: 404 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Uploaded file not found",
+      code: "NOT_FOUND",
+    }),
+  }),
+});
+
+function buildMetadata(args: {
+  readonly body: TelegramUploadCompleteBody;
+  readonly sourceUrl: string;
+  readonly telegramMessageId: number;
+  readonly telegramFileId: string | undefined;
+}): Record<string, unknown> {
+  const { body, sourceUrl, telegramMessageId, telegramFileId } = args;
+  return {
+    botId: body.botId,
+    chatId: body.chatId,
+    uploadId: body.uploadId,
+    sourceUrl,
+    ...(body.caption ? { caption: body.caption } : {}),
+    ...(body.messageThreadId ? { messageThreadId: body.messageThreadId } : {}),
+    telegramMessage: {
+      id: telegramMessageId,
+      ...(telegramFileId ? { fileId: telegramFileId } : {}),
+    },
+  };
+}
+
+function resolveBotToken(args: {
+  readonly orgId: string;
+  readonly botId: string;
+}): Computed<Promise<string | undefined>> {
+  return computed(async (get): Promise<string | undefined> => {
+    if (isOfficialTelegramBotId(args.botId)) {
+      return getOfficialTelegramBotConfig().botToken ?? undefined;
+    }
+    const installation = await get(zeroTelegramInstallation(args));
+    return installation?.botToken;
+  });
+}
+
+function telegramErrorResponse(
+  result: Extract<SendTelegramDocumentResult, { kind: "telegram-error" }>,
+) {
+  const status = result.status >= 500 ? (502 as const) : (400 as const);
+  const message = `Telegram API error: ${
+    result.description ?? `HTTP ${result.status}`
+  }`;
+  return {
+    status,
+    body: { error: { message, code: "TELEGRAM_ERROR" } },
+  };
+}
+
+const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const orgId = auth.orgId;
+  const userId = auth.userId;
+  const runId =
+    "runId" in auth && typeof auth.runId === "string" ? auth.runId : undefined;
+
+  const bodyResult = await get(
+    bodyResultOf(integrationsTelegramUploadCompleteContract.complete),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+  const body = bodyResult.data;
+
+  const botToken = await get(resolveBotToken({ orgId, botId: body.botId }));
+  signal.throwIfAborted();
+  if (!botToken) {
+    return botNotFound;
+  }
+
+  const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+  const prefix = `uploads/${userId}/${body.uploadId}/`;
+  const objects = await get(listS3Objects(bucket, prefix));
+  signal.throwIfAborted();
+  const s3Object = objects[0];
+  if (!s3Object) {
+    return uploadedFileNotFound;
+  }
+  const filename = s3Object.key.split("/").pop() ?? body.uploadId;
+  const fileUrl = buildFileUrl(userId, body.uploadId, filename);
+
+  const result = await sendDocument(botToken, body.chatId, fileUrl, {
+    caption: body.caption,
+    messageThreadId: body.messageThreadId,
+  });
+  signal.throwIfAborted();
+  if (result.kind === "telegram-error") {
+    return telegramErrorResponse(result);
+  }
+
+  const document = result.document;
+  const mimetype =
+    document?.mime_type ?? body.contentType ?? inferMimetype(filename);
+  const size = document?.file_size ?? s3Object.size;
+  const fileId = document?.file_id;
+  const responseFilename = document?.file_name ?? filename;
+  const externalId = fileId ?? `${body.chatId}:${result.messageId}`;
+
+  await set(
+    recordTelegramUploadedFile$,
+    {
+      runId,
+      externalId,
+      userId,
+      orgId,
+      filename: responseFilename,
+      contentType: mimetype,
+      sizeBytes: size,
+      url: fileUrl,
+      metadata: buildMetadata({
+        body,
+        sourceUrl: fileUrl,
+        telegramMessageId: result.messageId,
+        telegramFileId: fileId,
+      }),
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: {
+      messageId: result.messageId,
+      chatId: result.chatId,
+      fileId,
+      filename: responseFilename,
+      mimetype,
+      size,
+      url: fileUrl,
+    },
+  };
+});
+
+const telegramWriteAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "telegram:write",
+} as const;
+
+export const zeroIntegrationsTelegramUploadCompleteRoutes: readonly RouteEntry[] =
+  [
+    {
+      route: integrationsTelegramUploadCompleteContract.complete,
+      handler: authRoute(telegramWriteAuth, completeInner$),
+    },
+  ];

--- a/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-init.ts
@@ -1,0 +1,53 @@
+import { command } from "ccstate";
+import { integrationsTelegramUploadInitContract } from "@vm0/api-contracts/contracts/integrations";
+
+import { env } from "../../lib/env";
+import { buildFileUrl } from "../../lib/file-url";
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import { generatePresignedPutUrl } from "../external/s3";
+import type { RouteEntry } from "../route";
+
+const PUT_URL_TTL_SECONDS = 3600;
+
+const initInner$ = command(async ({ get }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+
+  const bodyResult = await get(
+    bodyResultOf(integrationsTelegramUploadInitContract.init),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const { filename, contentType, length } = bodyResult.data;
+  const uploadId = crypto.randomUUID();
+  const sanitized = filename.replace(/[^a-zA-Z0-9._-]/g, "_");
+  const s3Key = `uploads/${auth.userId}/${uploadId}/${sanitized}`;
+  const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+  const uploadUrl = await get(
+    generatePresignedPutUrl(bucket, s3Key, contentType, PUT_URL_TTL_SECONDS),
+  );
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: {
+      uploadId,
+      uploadUrl,
+      fileUrl: buildFileUrl(auth.userId, uploadId, sanitized),
+      filename: sanitized,
+      contentType,
+      size: length,
+    },
+  };
+});
+
+export const zeroIntegrationsTelegramUploadInitRoutes: readonly RouteEntry[] = [
+  {
+    route: integrationsTelegramUploadInitContract.init,
+    handler: authRoute({ requiredCapability: "telegram:write" }, initInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
+++ b/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
@@ -151,3 +151,122 @@ export const recordWebUploadedFile$ = command(
     }
   },
 );
+
+interface RecordTelegramUploadedFileArgs {
+  readonly runId: string | undefined;
+  readonly externalId: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly filename: string;
+  readonly contentType: string;
+  readonly sizeBytes: number;
+  readonly url: string;
+  readonly metadata: Record<string, unknown>;
+}
+
+/**
+ * Insert (or upsert) a `run_uploaded_files` row for a Telegram-delivered
+ * upload, then publish the chat-thread artifacts-changed signal if the
+ * run is linked to a thread. No-op when `runId` is undefined (sandbox
+ * callers without a run-scoped token).
+ *
+ * Verbatim port of apps/web/src/lib/zero/uploads/run-uploaded-files.ts
+ * scoped to the `"telegram"` source. Idempotency contract is upsert on
+ * (runId, source, externalId).
+ */
+export const recordTelegramUploadedFile$ = command(
+  async (
+    { set },
+    args: RecordTelegramUploadedFileArgs,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    if (!args.runId) {
+      return;
+    }
+    const writeDb = set(writeDb$);
+
+    const [run] = await writeDb
+      .select({ triggerSource: zeroRuns.triggerSource })
+      .from(zeroRuns)
+      .where(eq(zeroRuns.id, args.runId))
+      .limit(1);
+    signal.throwIfAborted();
+    const source: RunUploadedFileSource = isRunUploadedFileSource(
+      run?.triggerSource,
+    )
+      ? run.triggerSource
+      : "telegram";
+
+    await writeDb
+      .insert(runUploadedFiles)
+      .values({
+        runId: args.runId,
+        source,
+        externalId: args.externalId,
+        userId: args.userId,
+        orgId: args.orgId,
+        filename: args.filename,
+        contentType: args.contentType,
+        sizeBytes: args.sizeBytes,
+        url: args.url,
+        metadata: args.metadata,
+      })
+      .onConflictDoUpdate({
+        target: [
+          runUploadedFiles.runId,
+          runUploadedFiles.source,
+          runUploadedFiles.externalId,
+        ],
+        set: {
+          userId: args.userId,
+          orgId: args.orgId,
+          filename: args.filename,
+          contentType: args.contentType,
+          sizeBytes: args.sizeBytes,
+          url: args.url,
+          metadata: args.metadata,
+          updatedAt: sql`now()`,
+        },
+      });
+    signal.throwIfAborted();
+
+    const [zeroRunThread] = await writeDb
+      .select({
+        chatThreadId: zeroRuns.chatThreadId,
+        userId: chatThreads.userId,
+      })
+      .from(zeroRuns)
+      .innerJoin(chatThreads, eq(zeroRuns.chatThreadId, chatThreads.id))
+      .where(eq(zeroRuns.id, args.runId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (zeroRunThread?.chatThreadId) {
+      await publishUserSignal(
+        [zeroRunThread.userId],
+        `chatThreadArtifactsChanged:${zeroRunThread.chatThreadId}`,
+      );
+      signal.throwIfAborted();
+      return;
+    }
+
+    const [messageThread] = await writeDb
+      .select({
+        chatThreadId: chatMessages.chatThreadId,
+        userId: chatThreads.userId,
+      })
+      .from(chatMessages)
+      .innerJoin(chatThreads, eq(chatMessages.chatThreadId, chatThreads.id))
+      .where(eq(chatMessages.runId, args.runId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (messageThread) {
+      await publishUserSignal(
+        [messageThread.userId],
+        `chatThreadArtifactsChanged:${messageThread.chatThreadId}`,
+      );
+      signal.throwIfAborted();
+    }
+  },
+);


### PR DESCRIPTION
## Summary

- Mirror two `apps/web` routes into `apps/api`:
  - `POST /api/zero/integrations/telegram/upload-file/init` — generates a presigned S3 PUT URL for CLI/browser uploads.
  - `POST /api/zero/integrations/telegram/upload-file/complete` — sends the uploaded file to Telegram via `sendDocument` and records the upload row.
- Add `sendDocument` to the api telegram-client as a result-union (no try/catch in handler — Wave 6 convention).
- Add `recordTelegramUploadedFile$` service: upserts `run_uploaded_files` row and publishes the `chatThreadArtifactsChanged` signal when the run is linked to a chat thread.
- Complete route uses `organizationAuthContext$` + `missingOrganizationStatus: 401` for Wave 6 401-hardening.

Closes #12739. Parent epic: #12290.

## Test plan

- [x] 6 ported tests pass locally (3 init + 3 complete) — byte-equivalent to web's tests
- [x] Full api test suite passes (1064 tests)
- [x] Web tests unchanged and still pass (telegram upload-file routes remain in `apps/web` for parallel dual-write)
- [x] `pnpm turbo run lint`, `pnpm check-types`, `pnpm format`, `pnpm knip` all green

## Notes

- `apps/web` routes intentionally left in place — this is a Wave 6 parallel migration, not a removal.
- Follow-up issue to track: `S3_PUBLIC_ENDPOINT` parity for api's `generatePresignedPutUrl` (existing gap shared with `zero-uploads-prepare`; only affects local-dev, not production R2/SaaS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)