### PR TITLE
fix(nbd-cow): clean up ambiguous connect failures

### DIFF
--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -238,13 +238,18 @@ impl CreateAttemptGuard {
         }
     }
 
-    async fn disconnect_owned_and_retire_uncertain(mut self) {
+    async fn disconnect_owned_and_release(mut self) {
         self.abort_servers().await;
-        if let Some(connected) = self.connected.take() {
-            disconnect_connected_if_owned(connected);
-        }
+        let disconnected = self
+            .connected
+            .take()
+            .is_some_and(disconnect_connected_if_owned);
         if let Some(lease) = self.lease.take() {
-            self.pool.retire_uncertain(lease).await;
+            if disconnected {
+                self.pool.release_clean(lease).await;
+            } else {
+                self.pool.retire_uncertain(lease).await;
+            }
         }
     }
 
@@ -458,7 +463,7 @@ impl NbdCowDevice {
                         // Record a provisional candidate so cleanup can
                         // disconnect only if sysfs still proves we own it.
                         attempt.mark_connected(connect_tid);
-                        attempt.disconnect_owned_and_retire_uncertain().await;
+                        attempt.disconnect_owned_and_release().await;
                         return Err(source);
                     }
                     Err(connect_error) => {

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -238,6 +238,16 @@ impl CreateAttemptGuard {
         }
     }
 
+    async fn disconnect_owned_and_retire_uncertain(mut self) {
+        self.abort_servers().await;
+        if let Some(connected) = self.connected.take() {
+            disconnect_connected_if_owned(connected);
+        }
+        if let Some(lease) = self.lease.take() {
+            self.pool.retire_uncertain(lease).await;
+        }
+    }
+
     async fn disconnect_and_release(mut self) -> bool {
         self.abort_servers().await;
         let disconnected = self
@@ -410,15 +420,19 @@ impl NbdCowDevice {
                     return Err(e);
                 }
 
-                match netlink::connect_device(device_index, &client_fds, size, BLOCK_SIZE as u64) {
-                    Ok(()) => {
-                        // Record the TID of the thread that connected — the kernel
-                        // stores this in /sys/block/nbdN/pid via task_pid_nr().
-                        let tid = unsafe { libc::gettid() } as u32;
-                        attempt.mark_connected(tid);
+                match netlink::connect_device_with_state(
+                    device_index,
+                    &client_fds,
+                    size,
+                    BLOCK_SIZE as u64,
+                ) {
+                    Ok(connected) => {
+                        attempt.mark_connected(connected.connect_tid);
                         break attempt;
                     }
-                    Err(error::NbdCowError::NetlinkErrno { errno, .. }) if errno == libc::EBUSY => {
+                    Err(netlink::ConnectDeviceError::DefiniteAfterSend {
+                        source: error::NbdCowError::NetlinkErrno { errno, .. },
+                    }) if errno == libc::EBUSY => {
                         ebusy_count += 1;
                         tracing::info!(
                             device_index,
@@ -435,12 +449,24 @@ impl NbdCowDevice {
                         attempt.discard().await;
                         continue;
                     }
-                    Err(e) => {
+                    Err(netlink::ConnectDeviceError::AmbiguousAfterSend {
+                        connect_tid,
+                        source,
+                    }) => {
+                        // The kernel may have accepted NBD_CMD_CONNECT even
+                        // though userspace failed while observing completion.
+                        // Record a provisional candidate so cleanup can
+                        // disconnect only if sysfs still proves we own it.
+                        attempt.mark_connected(connect_tid);
+                        attempt.disconnect_owned_and_retire_uncertain().await;
+                        return Err(source);
+                    }
+                    Err(connect_error) => {
                         // Connect failed with non-EBUSY error. Device may be in
                         // an unknown kernel state — retire with cooldown so it
                         // gets re-validated before reuse.
                         attempt.retire_uncertain().await;
-                        return Err(e);
+                        return Err(connect_error.into_source());
                     }
                 }
             };
@@ -633,15 +659,26 @@ fn device_ownership(device_index: u32, connect_tid: u32) -> DeviceOwnership {
     }
 }
 
-fn disconnect_connected_if_owned(connected: ConnectedDevice) {
-    match device_ownership(connected.index, connected.connect_tid) {
+fn disconnect_connected_if_owned(connected: ConnectedDevice) -> bool {
+    disconnect_connected_if_owned_with(connected, device_ownership, netlink::disconnect)
+}
+
+fn disconnect_connected_if_owned_with(
+    connected: ConnectedDevice,
+    ownership: impl FnOnce(u32, u32) -> DeviceOwnership,
+    disconnect: impl FnOnce(u32) -> Result<()>,
+) -> bool {
+    match ownership(connected.index, connected.connect_tid) {
         DeviceOwnership::Ours => {
-            if let Err(e) = netlink::disconnect(connected.index) {
+            if let Err(e) = disconnect(connected.index) {
                 tracing::warn!(
                     device_index = connected.index,
                     error = %e,
                     "NBD disconnect failed during cancelled create"
                 );
+                false
+            } else {
+                true
             }
         }
         DeviceOwnership::Foreign(pid) => {
@@ -650,6 +687,7 @@ fn disconnect_connected_if_owned(connected: ConnectedDevice) {
                 foreign_pid = pid,
                 "skipping cancelled-create disconnect: device recycled by another process"
             );
+            false
         }
         DeviceOwnership::Unknown(err) => {
             tracing::warn!(
@@ -657,6 +695,7 @@ fn disconnect_connected_if_owned(connected: ConnectedDevice) {
                 error = %err,
                 "skipping cancelled-create disconnect: cannot read device pid"
             );
+            false
         }
     }
 }
@@ -1050,6 +1089,92 @@ mod tests {
             .unwrap()
             .unwrap();
         pool.cleanup().await;
+    }
+
+    #[test]
+    fn disconnect_connected_if_owned_disconnects_matching_owner() {
+        let calls = std::cell::Cell::new(0);
+        let connected = ConnectedDevice {
+            index: 7,
+            connect_tid: 42,
+        };
+
+        let disconnected = disconnect_connected_if_owned_with(
+            connected,
+            |index, tid| {
+                assert_eq!(index, 7);
+                assert_eq!(tid, 42);
+                DeviceOwnership::Ours
+            },
+            |index| {
+                assert_eq!(index, 7);
+                calls.set(calls.get() + 1);
+                Ok(())
+            },
+        );
+
+        assert!(disconnected);
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn disconnect_connected_if_owned_skips_foreign_owner() {
+        let connected = ConnectedDevice {
+            index: 7,
+            connect_tid: 42,
+        };
+
+        let disconnected = disconnect_connected_if_owned_with(
+            connected,
+            |index, tid| {
+                assert_eq!(index, 7);
+                assert_eq!(tid, 42);
+                DeviceOwnership::Foreign(100)
+            },
+            |_| panic!("foreign device must not be disconnected"),
+        );
+
+        assert!(!disconnected);
+    }
+
+    #[test]
+    fn disconnect_connected_if_owned_skips_unknown_owner() {
+        let connected = ConnectedDevice {
+            index: 7,
+            connect_tid: 42,
+        };
+
+        let disconnected = disconnect_connected_if_owned_with(
+            connected,
+            |index, tid| {
+                assert_eq!(index, 7);
+                assert_eq!(tid, 42);
+                DeviceOwnership::Unknown(std::io::Error::other("sysfs unavailable"))
+            },
+            |_| panic!("unknown ownership must not be disconnected"),
+        );
+
+        assert!(!disconnected);
+    }
+
+    #[test]
+    fn disconnect_connected_if_owned_reports_disconnect_error() {
+        let connected = ConnectedDevice {
+            index: 7,
+            connect_tid: 42,
+        };
+
+        let disconnected = disconnect_connected_if_owned_with(
+            connected,
+            |_, _| DeviceOwnership::Ours,
+            |_| {
+                Err(error::NbdCowError::Io(std::io::Error::other(
+                    "disconnect failed",
+                )))
+            },
+        );
+
+        assert!(!disconnected);
     }
 
     /// Verify is_our_thread correctly identifies the main thread (TID == TGID).

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -949,6 +949,36 @@ mod tests {
     }
 
     #[test]
+    fn finish_connect_after_send_non_ebusy_errno_is_definite_failure() {
+        let (sock, peer) = test_genl_socket_pair();
+        send_test_nl(&peer, &nlmsg_error_msg(2, -libc::EINVAL));
+
+        let result = finish_connect_after_send(&sock, 2, 1234);
+
+        assert!(matches!(
+            result,
+            Err(ConnectDeviceError::DefiniteAfterSend {
+                source: NbdCowError::NetlinkErrno { errno, .. },
+            }) if errno == libc::EINVAL
+        ));
+    }
+
+    #[test]
+    fn finish_connect_after_send_ignores_stale_error_before_success() {
+        let (sock, peer) = test_genl_socket_pair();
+        let reply = build_genl_msg(0x19, NBD_CMD_CONNECT, NBD_GENL_VERSION, &[], 2, false);
+        send_test_nl(&peer, &nlmsg_error_msg(1, -libc::EBUSY));
+        send_test_nl(&peer, &reply);
+
+        let result = finish_connect_after_send(&sock, 2, 1234);
+
+        assert!(matches!(
+            result,
+            Ok(ConnectDeviceSuccess { connect_tid: 1234 })
+        ));
+    }
+
+    #[test]
     fn classify_connect_completion_io_error_is_ambiguous() {
         let result = classify_connect_completion(
             1234,

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -117,6 +117,58 @@ pub fn device_appears_free(index: u32) -> bool {
     }
 }
 
+/// Successful NBD connect metadata.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ConnectDeviceSuccess {
+    /// TID of the thread that sent `NBD_CMD_CONNECT`.
+    ///
+    /// The kernel records this value in `/sys/block/nbdN/pid` after a
+    /// successful connect. Cleanup uses it to avoid disconnecting a device
+    /// recycled by another process.
+    pub connect_tid: u32,
+}
+
+/// Error state for `NBD_CMD_CONNECT`.
+///
+/// `NBD_CMD_CONNECT` has a kernel commit boundary: after the command is sent,
+/// userspace may fail to observe completion even though the kernel accepted the
+/// connection. Callers that own an NBD device lease need this state to decide
+/// whether ownership-checked cleanup is required.
+#[derive(Debug, thiserror::Error)]
+pub enum ConnectDeviceError {
+    /// The connect command was not sent to the kernel.
+    #[error("NBD connect failed before sending command: {source}")]
+    NotSent {
+        /// Underlying error.
+        source: NbdCowError,
+    },
+    /// The connect command was sent and the kernel returned a definitive error.
+    #[error("NBD connect failed definitively after sending command: {source}")]
+    DefiniteAfterSend {
+        /// Underlying kernel/netlink error.
+        source: NbdCowError,
+    },
+    /// The connect command was sent, but userspace could not observe completion.
+    #[error("NBD connect completion is ambiguous after sending command: {source}")]
+    AmbiguousAfterSend {
+        /// TID of the thread that sent `NBD_CMD_CONNECT`.
+        connect_tid: u32,
+        /// Underlying completion-observation error.
+        source: NbdCowError,
+    },
+}
+
+impl ConnectDeviceError {
+    /// Return the underlying error for legacy callers that do not need state.
+    pub fn into_source(self) -> NbdCowError {
+        match self {
+            Self::NotSent { source }
+            | Self::DefiniteAfterSend { source }
+            | Self::AmbiguousAfterSend { source, .. } => source,
+        }
+    }
+}
+
 /// Connect to a specific NBD device by index.
 ///
 /// The caller provides the device index (typically from a `DevicePool`).
@@ -129,8 +181,21 @@ pub fn connect_device(
     size: u64,
     block_size: u64,
 ) -> Result<()> {
-    let sock = open_genl_socket()?;
-    let family_id = resolve_nbd_family(&sock)?;
+    connect_device_with_state(device_index, client_fds, size, block_size)
+        .map(|_| ())
+        .map_err(ConnectDeviceError::into_source)
+}
+
+/// Connect to a specific NBD device and preserve post-send ambiguity state.
+pub fn connect_device_with_state(
+    device_index: u32,
+    client_fds: &[OwnedFd],
+    size: u64,
+    block_size: u64,
+) -> std::result::Result<ConnectDeviceSuccess, ConnectDeviceError> {
+    let sock = open_genl_socket().map_err(|source| ConnectDeviceError::NotSent { source })?;
+    let family_id =
+        resolve_nbd_family(&sock).map_err(|source| ConnectDeviceError::NotSent { source })?;
 
     let sockets_nla = build_sockets_nla(client_fds);
     let flags =
@@ -151,10 +216,13 @@ pub fn connect_device(
     ));
     attrs.extend_from_slice(&sockets_nla);
 
-    let seq = send_genl_msg(&sock, family_id, NBD_CMD_CONNECT, &attrs)?;
-    recv_genl_completion(&sock, seq)?;
+    // The kernel records the sending task's TID in /sys/block/nbdN/pid on
+    // successful connect. Capture it before crossing the netlink send boundary.
+    let connect_tid = unsafe { libc::gettid() } as u32;
+    let seq = send_genl_msg(&sock, family_id, NBD_CMD_CONNECT, &attrs)
+        .map_err(|source| ConnectDeviceError::NotSent { source })?;
 
-    Ok(())
+    finish_connect_after_send(&sock, seq, connect_tid)
 }
 
 /// Check whether the device has the expected size via sysfs.
@@ -523,6 +591,23 @@ fn recv_genl_completion(sock: &GenlSocket, expected_seq: u32) -> Result<()> {
     parse_genl_completion(&buf, n)
 }
 
+fn finish_connect_after_send(
+    sock: &GenlSocket,
+    expected_seq: u32,
+    connect_tid: u32,
+) -> std::result::Result<ConnectDeviceSuccess, ConnectDeviceError> {
+    match recv_genl_completion(sock, expected_seq) {
+        Ok(()) => Ok(ConnectDeviceSuccess { connect_tid }),
+        Err(source @ NbdCowError::NetlinkErrno { .. }) => {
+            Err(ConnectDeviceError::DefiniteAfterSend { source })
+        }
+        Err(source) => Err(ConnectDeviceError::AmbiguousAfterSend {
+            connect_tid,
+            source,
+        }),
+    }
+}
+
 fn parse_genl_completion(buf: &[u8], n: usize) -> Result<()> {
     match parse_nl_msg(buf, n)? {
         // NBD connect returns a genetlink reply on success; other commands may
@@ -825,6 +910,70 @@ mod tests {
         let result = parse_genl_completion(&msg, msg.len());
 
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn finish_connect_after_send_success_returns_connect_tid() {
+        let (sock, peer) = test_genl_socket_pair();
+        let reply = build_genl_msg(0x19, NBD_CMD_CONNECT, NBD_GENL_VERSION, &[], 2, false);
+        send_test_nl(&peer, &reply);
+
+        let result = finish_connect_after_send(&sock, 2, 1234);
+
+        assert!(matches!(
+            result,
+            Ok(ConnectDeviceSuccess { connect_tid: 1234 })
+        ));
+    }
+
+    #[test]
+    fn finish_connect_after_send_errno_is_definite_failure() {
+        let (sock, peer) = test_genl_socket_pair();
+        send_test_nl(&peer, &nlmsg_error_msg(2, -libc::EBUSY));
+
+        let result = finish_connect_after_send(&sock, 2, 1234);
+
+        assert!(matches!(
+            result,
+            Err(ConnectDeviceError::DefiniteAfterSend {
+                source: NbdCowError::NetlinkErrno { errno, .. },
+            }) if errno == libc::EBUSY
+        ));
+    }
+
+    #[test]
+    fn finish_connect_after_send_closed_peer_is_ambiguous() {
+        let (sock, peer) = test_genl_socket_pair();
+        drop(peer);
+
+        let result = finish_connect_after_send(&sock, 2, 1234);
+
+        assert!(matches!(
+            result,
+            Err(ConnectDeviceError::AmbiguousAfterSend {
+                connect_tid: 1234,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn finish_connect_after_send_malformed_matching_completion_is_ambiguous() {
+        let (sock, peer) = test_genl_socket_pair();
+        let mut malformed = vec![0u8; 16];
+        malformed[0..4].copy_from_slice(&15u32.to_ne_bytes());
+        malformed[8..12].copy_from_slice(&2u32.to_ne_bytes());
+        send_test_nl(&peer, &malformed);
+
+        let result = finish_connect_after_send(&sock, 2, 1234);
+
+        assert!(matches!(
+            result,
+            Err(ConnectDeviceError::AmbiguousAfterSend {
+                connect_tid: 1234,
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -119,13 +119,13 @@ pub fn device_appears_free(index: u32) -> bool {
 
 /// Successful NBD connect metadata.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ConnectDeviceSuccess {
+pub(crate) struct ConnectDeviceSuccess {
     /// TID of the thread that sent `NBD_CMD_CONNECT`.
     ///
     /// The kernel records this value in `/sys/block/nbdN/pid` after a
     /// successful connect. Cleanup uses it to avoid disconnecting a device
     /// recycled by another process.
-    pub connect_tid: u32,
+    pub(crate) connect_tid: u32,
 }
 
 /// Error state for `NBD_CMD_CONNECT`.
@@ -135,7 +135,7 @@ pub struct ConnectDeviceSuccess {
 /// connection. Callers that own an NBD device lease need this state to decide
 /// whether ownership-checked cleanup is required.
 #[derive(Debug, thiserror::Error)]
-pub enum ConnectDeviceError {
+pub(crate) enum ConnectDeviceError {
     /// The connect command was not sent to the kernel.
     #[error("NBD connect failed before sending command: {source}")]
     NotSent {
@@ -160,7 +160,7 @@ pub enum ConnectDeviceError {
 
 impl ConnectDeviceError {
     /// Return the underlying error for legacy callers that do not need state.
-    pub fn into_source(self) -> NbdCowError {
+    pub(crate) fn into_source(self) -> NbdCowError {
         match self {
             Self::NotSent { source }
             | Self::DefiniteAfterSend { source }
@@ -187,7 +187,7 @@ pub fn connect_device(
 }
 
 /// Connect to a specific NBD device and preserve post-send ambiguity state.
-pub fn connect_device_with_state(
+pub(crate) fn connect_device_with_state(
     device_index: u32,
     client_fds: &[OwnedFd],
     size: u64,
@@ -596,7 +596,14 @@ fn finish_connect_after_send(
     expected_seq: u32,
     connect_tid: u32,
 ) -> std::result::Result<ConnectDeviceSuccess, ConnectDeviceError> {
-    match recv_genl_completion(sock, expected_seq) {
+    classify_connect_completion(connect_tid, recv_genl_completion(sock, expected_seq))
+}
+
+fn classify_connect_completion(
+    connect_tid: u32,
+    completion: Result<()>,
+) -> std::result::Result<ConnectDeviceSuccess, ConnectDeviceError> {
+    match completion {
         Ok(()) => Ok(ConnectDeviceSuccess { connect_tid }),
         Err(source @ NbdCowError::NetlinkErrno { .. }) => {
             Err(ConnectDeviceError::DefiniteAfterSend { source })
@@ -942,11 +949,14 @@ mod tests {
     }
 
     #[test]
-    fn finish_connect_after_send_closed_peer_is_ambiguous() {
-        let (sock, peer) = test_genl_socket_pair();
-        drop(peer);
-
-        let result = finish_connect_after_send(&sock, 2, 1234);
+    fn classify_connect_completion_io_error_is_ambiguous() {
+        let result = classify_connect_completion(
+            1234,
+            Err(NbdCowError::Io(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "completion timed out",
+            ))),
+        );
 
         assert!(matches!(
             result,


### PR DESCRIPTION
## Summary

- model NBD connect as explicit success / not-sent / definite-after-send / ambiguous-after-send states
- record the connect TID before sending `NBD_CMD_CONNECT` and use it for ownership-checked cleanup on ambiguous completion failures
- preserve `EBUSY` as a definite no-disconnect discard/retry path
- add deterministic tests for netlink completion classification and ownership-checked disconnect policy

Closes #12303.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow netlink`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow create_attempt_guard`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow disconnect_connected_if_owned`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets -- -D warnings`
- pre-commit lefthook: `cargo-fmt`, workspace `cargo-clippy`, `cargo-doc`
