### PR TITLE
test(sandbox-mock): add durable lifecycle gates

### DIFF
--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -23,7 +23,7 @@ use super::orphan_reap::OrphanedActiveRuns;
 use super::ownership::{OwnershipTransitions, RunSandbox};
 use super::sandbox_finalization::{FinalizeContext, finalize_sandbox_for_completion};
 #[cfg(test)]
-use super::{OuterJobPanicPoint, maybe_panic_outer_job};
+use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
 use crate::executor::{self, ExecutorConfig};
 use crate::idle_pool::{ParkingGate, ReusableIdleSandbox};
 use crate::ids::RunId;
@@ -63,6 +63,8 @@ pub(super) struct SpawnContext {
     pub(super) park_notify: Arc<tokio::sync::Notify>,
     #[cfg(test)]
     pub(super) outer_job_panic: Option<OuterJobPanicPoint>,
+    #[cfg(test)]
+    pub(super) test_observer: StartLoopTestObserver,
 }
 
 /// Spawn a job executor task.
@@ -121,6 +123,8 @@ pub(super) fn spawn_job(
     let orphaned_active_runs_for_panic = ctx.orphaned_active_runs.clone();
     #[cfg(test)]
     let outer_job_panic = ctx.outer_job_panic;
+    #[cfg(test)]
+    let test_observer = ctx.test_observer.clone();
 
     // Captured for the post-complete deferred work below: the panic-arm
     // empty `JobTelemetry` construction, the final `telemetry.flush()`, and
@@ -248,6 +252,8 @@ pub(super) fn spawn_job(
                     cleanup_state: cleanup_state_for_body.clone(),
                     #[cfg(test)]
                     outer_job_panic,
+                    #[cfg(test)]
+                    test_observer,
                 },
             )
             .await;

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -726,6 +726,31 @@ mod start_loop_observer_tests {
             )
             .await;
     }
+
+    #[tokio::test]
+    async fn start_loop_observer_wait_before_idle_pool_ownership_transfer_observes_existing_event()
+    {
+        let observer = StartLoopTestObserver::default();
+        let run_id = RunId::new_v4();
+
+        observer.notify_before_idle_pool_ownership_transfer(run_id);
+        observer
+            .wait_before_idle_pool_ownership_transfer(run_id, Duration::from_secs(1))
+            .await;
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "runner did not observe idle-pool ownership transfer attempt")]
+    async fn start_loop_observer_wait_before_idle_pool_ownership_transfer_ignores_other_runs() {
+        let observer = StartLoopTestObserver::default();
+        let run_id = RunId::new_v4();
+        let other_run_id = RunId::new_v4();
+
+        observer.notify_before_idle_pool_ownership_transfer(other_run_id);
+        observer
+            .wait_before_idle_pool_ownership_transfer(run_id, Duration::ZERO)
+            .await;
+    }
 }
 
 #[cfg(test)]

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -524,6 +524,7 @@ enum SignalSource {
 enum StartLoopEvent {
     BudgetExhaustedReactorEntered,
     IdleCleanupProcessed { expired_count: usize },
+    BeforeIdlePoolOwnershipTransfer { run_id: RunId },
 }
 
 #[cfg(test)]
@@ -624,6 +625,10 @@ impl StartLoopTestObserver {
         self.record(StartLoopEvent::BudgetExhaustedReactorEntered);
     }
 
+    fn notify_before_idle_pool_ownership_transfer(&self, run_id: RunId) {
+        self.record(StartLoopEvent::BeforeIdlePoolOwnershipTransfer { run_id });
+    }
+
     async fn wait_budget_exhausted_reactor(&self, timeout: Duration) {
         self.wait_for(timeout, "budget-exhausted reactor entry", |event| {
             matches!(event, StartLoopEvent::BudgetExhaustedReactorEntered).then_some(())
@@ -639,6 +644,20 @@ impl StartLoopTestObserver {
                 StartLoopEvent::IdleCleanupProcessed { expired_count } if *expired_count > 0 => {
                     Some(*expired_count)
                 }
+                _ => None,
+            },
+        )
+        .await
+    }
+
+    async fn wait_before_idle_pool_ownership_transfer(&self, run_id: RunId, timeout: Duration) {
+        self.wait_for(
+            timeout,
+            "idle-pool ownership transfer attempt",
+            |event| match event {
+                StartLoopEvent::BeforeIdlePoolOwnershipTransfer {
+                    run_id: observed_run_id,
+                } if *observed_run_id == run_id => Some(()),
                 _ => None,
             },
         )
@@ -869,6 +888,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         park_notify: Arc::clone(&park_notify),
         #[cfg(test)]
         outer_job_panic,
+        #[cfg(test)]
+        test_observer: test_observer.clone(),
     };
     let mut draining_idle_pool_drained = false;
     loop {

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -20,7 +20,7 @@ use super::job_lifecycle::{
 };
 use super::ownership::OwnershipTransitions;
 #[cfg(test)]
-use super::{OuterJobPanicPoint, maybe_panic_outer_job};
+use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
 use crate::idle_pool::{
     DestroyOutcome, ParkCandidate, ParkCandidateParts, ParkResult, ParkingGate, StorageFingerprints,
 };
@@ -49,6 +49,8 @@ pub(super) struct FinalizeContext {
     pub(super) cleanup_state: RunCleanupState,
     #[cfg(test)]
     pub(super) outer_job_panic: Option<OuterJobPanicPoint>,
+    #[cfg(test)]
+    pub(super) test_observer: StartLoopTestObserver,
 }
 
 pub(super) async fn finalize_sandbox_for_completion(
@@ -81,6 +83,8 @@ pub(super) async fn finalize_sandbox_for_completion(
         cleanup_state,
         #[cfg(test)]
         outer_job_panic,
+        #[cfg(test)]
+        test_observer,
     } = ctx;
 
     let cancelled = cancel.is_cancelled();
@@ -163,6 +167,8 @@ pub(super) async fn finalize_sandbox_for_completion(
             BudgetOwnership::active(active_lease)
         } else {
             close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
+            #[cfg(test)]
+            test_observer.notify_before_idle_pool_ownership_transfer(run_id);
             let mut pool = idle_pool.lock().await;
             if cancel.is_cancelled() {
                 info!(
@@ -502,6 +508,7 @@ mod tests {
                 cancel: CancellationToken::new(),
                 cleanup_state: RunCleanupState::new(),
                 outer_job_panic: None,
+                test_observer: StartLoopTestObserver::default(),
             },
         )
         .await;
@@ -571,6 +578,7 @@ mod tests {
                 cancel,
                 cleanup_state: RunCleanupState::new(),
                 outer_job_panic: None,
+                test_observer: StartLoopTestObserver::default(),
             },
         )
         .await;

--- a/crates/runner/src/cmd/start/tests/failure_panic.rs
+++ b/crates/runner/src/cmd/start/tests/failure_panic.rs
@@ -7,7 +7,7 @@ use crate::provider::mock::MockJobProvider;
 use crate::types::SandboxReuseResult;
 use async_trait::async_trait;
 use sandbox::{Sandbox, SandboxFactory, SandboxRuntime};
-use sandbox_mock::MockSandbox;
+use sandbox_mock::{MockLifecycleGate, MockSandbox};
 
 struct PanickingDestroyFactory;
 
@@ -483,12 +483,8 @@ async fn outer_job_panic_active_unknown_reconciles_on_shutdown_final_scan() {
 #[tokio::test(start_paused = true)]
 async fn outer_job_panic_after_destroy_completed_cleans_token_and_active_status() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    let destroy_entered = Arc::new(tokio::sync::Notify::new());
-    let destroy_release = Arc::new(tokio::sync::Notify::new());
-    overrides.set_destroy_gate(Arc::clone(&destroy_entered), Arc::clone(&destroy_release));
-    let destroy_entered_wait = destroy_entered.notified();
-    tokio::pin!(destroy_entered_wait);
-    destroy_entered_wait.as_mut().enable();
+    let destroy_gate = MockLifecycleGate::new();
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
 
     let (mut config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
     config.outer_job_panic = Some(OuterJobPanicPoint::DestroyCompleted);
@@ -499,11 +495,15 @@ async fn outer_job_panic_after_destroy_completed_cleans_token_and_active_status(
     let run_id = RunId::new_v4();
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
 
-    tokio::time::timeout(Duration::from_secs(5), destroy_entered_wait)
-        .await
-        .expect("active destroy should start");
+    assert_eq!(
+        destroy_gate
+            .wait_entered(1, Duration::from_secs(5))
+            .await
+            .expect("active destroy should enter gate"),
+        1
+    );
     let _token = wait_cancel_token(&cancel_tokens, run_id, Duration::from_secs(5)).await;
-    destroy_release.notify_one();
+    destroy_gate.release_one();
 
     wait_cancel_token_removed(&cancel_tokens, run_id, Duration::from_secs(5)).await;
     wait_status_idle_sessions_and_active_runs(&status_path, &[], &[], Duration::from_secs(5)).await;
@@ -600,19 +600,10 @@ async fn pool_full_rejected_vm_keeps_budget_until_destroy_and_completion() {
 #[tokio::test(start_paused = true)]
 async fn parking_gate_closing_after_sandbox_park_rejects_and_waits_for_destroy() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    let park_entered = Arc::new(tokio::sync::Notify::new());
-    let park_release = Arc::new(tokio::sync::Notify::new());
-    let destroy_entered = Arc::new(tokio::sync::Notify::new());
-    let destroy_release = Arc::new(tokio::sync::Notify::new());
-    overrides.set_park_gate(Arc::clone(&park_entered), Arc::clone(&park_release));
-    overrides.set_destroy_gate(Arc::clone(&destroy_entered), Arc::clone(&destroy_release));
-
-    let park_entered_wait = park_entered.notified();
-    tokio::pin!(park_entered_wait);
-    park_entered_wait.as_mut().enable();
-    let destroy_entered_wait = destroy_entered.notified();
-    tokio::pin!(destroy_entered_wait);
-    destroy_entered_wait.as_mut().enable();
+    let park_gate = MockLifecycleGate::new();
+    let destroy_gate = MockLifecycleGate::new();
+    overrides.set_park_lifecycle_gate(park_gate.clone());
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
 
     let counter = Arc::clone(&overrides);
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
@@ -628,19 +619,27 @@ async fn parking_gate_closing_after_sandbox_park_rejects_and_waits_for_destroy()
         Some(context_with_session(run_id, "sess-race-rejected")),
     );
 
-    tokio::time::timeout(Duration::from_secs(5), park_entered_wait)
-        .await
-        .expect("sandbox park should start");
+    assert_eq!(
+        park_gate
+            .wait_entered(1, Duration::from_secs(5))
+            .await
+            .expect("sandbox park should enter gate"),
+        1
+    );
     assert_eq!(counter.park_call_count(), 1);
     assert_eq!(env.parking_gate.state(), ParkingState::Open);
 
     env.drain();
     assert_eq!(env.parking_gate.state(), ParkingState::SoftDraining);
 
-    park_release.notify_one();
-    tokio::time::timeout(Duration::from_secs(5), destroy_entered_wait)
-        .await
-        .expect("rejected parked sandbox should be destroyed");
+    park_gate.release_one();
+    assert_eq!(
+        destroy_gate
+            .wait_entered(1, Duration::from_secs(5))
+            .await
+            .expect("rejected parked sandbox should enter destroy gate"),
+        1
+    );
     assert_eq!(
         counter.destroy_call_count(),
         1,
@@ -664,7 +663,7 @@ async fn parking_gate_closing_after_sandbox_park_rejects_and_waits_for_destroy()
         );
     }
 
-    destroy_release.notify_one();
+    destroy_gate.release_one();
     let c = env
         .handle
         .wait_completion(run_id, Duration::from_secs(5))
@@ -681,19 +680,10 @@ async fn parking_gate_closing_after_sandbox_park_rejects_and_waits_for_destroy()
 #[tokio::test(start_paused = true)]
 async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parking() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    let park_entered = Arc::new(tokio::sync::Notify::new());
-    let park_release = Arc::new(tokio::sync::Notify::new());
-    let destroy_entered = Arc::new(tokio::sync::Notify::new());
-    let destroy_release = Arc::new(tokio::sync::Notify::new());
-    overrides.set_park_gate(Arc::clone(&park_entered), Arc::clone(&park_release));
-    overrides.set_destroy_gate(Arc::clone(&destroy_entered), Arc::clone(&destroy_release));
-
-    let park_entered_wait = park_entered.notified();
-    tokio::pin!(park_entered_wait);
-    park_entered_wait.as_mut().enable();
-    let destroy_entered_wait = destroy_entered.notified();
-    tokio::pin!(destroy_entered_wait);
-    destroy_entered_wait.as_mut().enable();
+    let park_gate = MockLifecycleGate::new();
+    let destroy_gate = MockLifecycleGate::new();
+    overrides.set_park_lifecycle_gate(park_gate.clone());
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
 
     let counter = Arc::clone(&overrides);
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
@@ -711,11 +701,15 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
     );
     let token = wait_cancel_token(&cancel_tokens, run_id, Duration::from_secs(5)).await;
 
-    tokio::time::timeout(Duration::from_secs(5), park_entered_wait)
-        .await
-        .expect("sandbox park should start");
+    assert_eq!(
+        park_gate
+            .wait_entered(1, Duration::from_secs(5))
+            .await
+            .expect("sandbox park should enter gate"),
+        1
+    );
     let pool_guard = idle_pool.lock().await;
-    park_release.notify_one();
+    park_gate.release_one();
     // Let the job observe the first post-park cancel check, then block on
     // the held pool lock. This opens the specific lock-wait window without
     // relying on wall-clock sleeps.
@@ -723,9 +717,13 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
     token.cancel();
     drop(pool_guard);
 
-    tokio::time::timeout(Duration::from_secs(5), destroy_entered_wait)
-        .await
-        .expect("cancelled lock-waiting sandbox should be destroyed");
+    assert_eq!(
+        destroy_gate
+            .wait_entered(1, Duration::from_secs(5))
+            .await
+            .expect("cancelled lock-waiting sandbox should enter destroy gate"),
+        1
+    );
     assert_eq!(
         counter.destroy_call_count(),
         1,
@@ -742,7 +740,7 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
         "cancelled VM must not enter the idle pool after waiting for the lock"
     );
 
-    destroy_release.notify_one();
+    destroy_gate.release_one();
     let c = env
         .handle
         .wait_completion(run_id, Duration::from_secs(5))
@@ -761,19 +759,10 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
 #[tokio::test(start_paused = true)]
 async fn cancellation_during_sandbox_park_destroys_instead_of_parking() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    let park_entered = Arc::new(tokio::sync::Notify::new());
-    let park_release = Arc::new(tokio::sync::Notify::new());
-    let destroy_entered = Arc::new(tokio::sync::Notify::new());
-    let destroy_release = Arc::new(tokio::sync::Notify::new());
-    overrides.set_park_gate(Arc::clone(&park_entered), Arc::clone(&park_release));
-    overrides.set_destroy_gate(Arc::clone(&destroy_entered), Arc::clone(&destroy_release));
-
-    let park_entered_wait = park_entered.notified();
-    tokio::pin!(park_entered_wait);
-    park_entered_wait.as_mut().enable();
-    let destroy_entered_wait = destroy_entered.notified();
-    tokio::pin!(destroy_entered_wait);
-    destroy_entered_wait.as_mut().enable();
+    let park_gate = MockLifecycleGate::new();
+    let destroy_gate = MockLifecycleGate::new();
+    overrides.set_park_lifecycle_gate(park_gate.clone());
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
 
     let counter = Arc::clone(&overrides);
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
@@ -791,17 +780,25 @@ async fn cancellation_during_sandbox_park_destroys_instead_of_parking() {
     );
     let token = wait_cancel_token(&cancel_tokens, run_id, Duration::from_secs(5)).await;
 
-    tokio::time::timeout(Duration::from_secs(5), park_entered_wait)
-        .await
-        .expect("sandbox park should start");
+    assert_eq!(
+        park_gate
+            .wait_entered(1, Duration::from_secs(5))
+            .await
+            .expect("sandbox park should enter gate"),
+        1
+    );
     assert_eq!(counter.park_call_count(), 1);
 
     token.cancel();
-    park_release.notify_one();
+    park_gate.release_one();
 
-    tokio::time::timeout(Duration::from_secs(5), destroy_entered_wait)
-        .await
-        .expect("cancelled parked sandbox should be destroyed");
+    assert_eq!(
+        destroy_gate
+            .wait_entered(1, Duration::from_secs(5))
+            .await
+            .expect("cancelled parked sandbox should enter destroy gate"),
+        1
+    );
     assert_eq!(
         counter.destroy_call_count(),
         1,
@@ -825,7 +822,7 @@ async fn cancellation_during_sandbox_park_destroys_instead_of_parking() {
         );
     }
 
-    destroy_release.notify_one();
+    destroy_gate.release_one();
     let c = env
         .handle
         .wait_completion(run_id, Duration::from_secs(5))

--- a/crates/runner/src/cmd/start/tests/failure_panic.rs
+++ b/crates/runner/src/cmd/start/tests/failure_panic.rs
@@ -710,10 +710,9 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
     );
     let pool_guard = idle_pool.lock().await;
     park_gate.release_one();
-    // Let the job observe the first post-park cancel check, then block on
-    // the held pool lock. This opens the specific lock-wait window without
-    // relying on wall-clock sleeps.
-    tokio::task::yield_now().await;
+    env.start_observer
+        .wait_before_idle_pool_ownership_transfer(run_id, Duration::from_secs(5))
+        .await;
     token.cancel();
     drop(pool_guard);
 

--- a/crates/sandbox-mock/Cargo.toml
+++ b/crates/sandbox-mock/Cargo.toml
@@ -10,7 +10,7 @@ tokio = { workspace = true, features = ["sync", "time"] }
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/sandbox-mock/Cargo.toml
+++ b/crates/sandbox-mock/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [dependencies]
 async-trait.workspace = true
 sandbox = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -195,6 +195,10 @@ impl MockLifecycleGate {
     /// Release `count` lifecycle entries by advancing the durable release count.
     pub fn release_many(&self, count: usize) {
         let release_count = u64::try_from(count).unwrap_or(u64::MAX);
+        if release_count == 0 {
+            return;
+        }
+
         let mut state = self.inner.state.lock_ignoring_poison();
         state.released_count = state.released_count.saturating_add(release_count);
         self.inner.release_tx.send_replace(state.released_count);
@@ -1357,6 +1361,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn lifecycle_gate_release_zero_does_not_release_entry() {
+        let gate = MockLifecycleGate::new();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.set_park_lifecycle_gate(gate.clone());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let mut sandbox = factory.create(test_sandbox_config()).await.unwrap();
+
+        let park_task = tokio::spawn(async move { sandbox.park().await });
+        assert_eq!(gate.wait_entered(1, test_timeout()).await.unwrap(), 1);
+
+        gate.release_many(0);
+        tokio::task::yield_now().await;
+        assert!(
+            !park_task.is_finished(),
+            "zero release count must not let the entry through"
+        );
+
+        gate.release_one();
+        park_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn lifecycle_gate_early_release_many_releases_only_that_many_entries() {
+        let gate = MockLifecycleGate::new();
+        gate.release_many(2);
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.set_park_lifecycle_gate(gate.clone());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let (done_tx, mut done_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut park_tasks = Vec::new();
+
+        for idx in 0..3 {
+            let mut sandbox = factory.create(test_sandbox_config()).await.unwrap();
+            let done_tx = done_tx.clone();
+            park_tasks.push(tokio::spawn(async move {
+                sandbox.park().await.unwrap();
+                done_tx.send(idx).unwrap();
+            }));
+        }
+        drop(done_tx);
+
+        assert_eq!(gate.wait_entered(3, test_timeout()).await.unwrap(), 3);
+        for _ in 0..2 {
+            tokio::time::timeout(test_timeout(), done_rx.recv())
+                .await
+                .expect("early releases should complete two entries")
+                .expect("completion channel should remain open");
+        }
+        assert!(
+            matches!(
+                done_rx.try_recv(),
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+            ),
+            "third entry must remain blocked until another release"
+        );
+
+        gate.release_one();
+        tokio::time::timeout(test_timeout(), done_rx.recv())
+            .await
+            .expect("final release should complete third entry")
+            .expect("completion channel should remain open");
+        for task in park_tasks {
+            task.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
     async fn lifecycle_gate_release_after_cancelled_entry_does_not_release_future_entry() {
         let gate = MockLifecycleGate::new();
         let overrides = Arc::new(MockSandboxOverrides::new());
@@ -1455,6 +1526,42 @@ mod tests {
 
         let second_factory = runtime.create_factory(test_factory_config()).await.unwrap();
         second_factory.create(test_sandbox_config()).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shared_create_result_is_consumed_once_across_concurrent_factories() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.push_create_result(Err(SandboxError::Initialization {
+            phase: SandboxInitializationPhase::SandboxAllocation,
+            message: "out of resources".into(),
+        }));
+        let first_factory = Arc::new(MockSandboxFactory::with_overrides(Arc::clone(&overrides)));
+        let second_factory = Arc::new(MockSandboxFactory::with_overrides(Arc::clone(&overrides)));
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+        let first = tokio::spawn({
+            let barrier = Arc::clone(&barrier);
+            async move {
+                barrier.wait().await;
+                first_factory.create(test_sandbox_config()).await.is_err()
+            }
+        });
+        let second = tokio::spawn({
+            let barrier = Arc::clone(&barrier);
+            async move {
+                barrier.wait().await;
+                second_factory.create(test_sandbox_config()).await.is_err()
+            }
+        });
+
+        let failure_count = [first.await.unwrap(), second.await.unwrap()]
+            .into_iter()
+            .filter(|failed| *failed)
+            .count();
+        assert_eq!(
+            failure_count, 1,
+            "shared create result should be consumed by exactly one concurrent factory"
+        );
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -1258,6 +1258,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn lifecycle_gate_wait_entered_timeout_reports_observed_count() {
+        let gate = MockLifecycleGate::new();
+        gate.release_one();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.set_park_lifecycle_gate(gate.clone());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let mut sandbox = factory.create(test_sandbox_config()).await.unwrap();
+
+        sandbox.park().await.unwrap();
+        let err = gate
+            .wait_entered(2, Duration::ZERO)
+            .await
+            .expect_err("second entry should time out");
+
+        assert_eq!(err.target_count(), 2);
+        assert_eq!(err.actual_count(), 1);
+        assert_eq!(err.timeout(), Duration::ZERO);
+        assert_eq!(gate.entered_count(), 1);
+    }
+
+    #[tokio::test]
     async fn lifecycle_gate_wakes_multiple_waiters_for_same_entry() {
         let gate = MockLifecycleGate::new();
         let first_waiter = tokio::spawn({
@@ -1422,6 +1443,31 @@ mod tests {
             0,
             "early release permit should be consumed by one lifecycle entry"
         );
+    }
+
+    #[tokio::test]
+    async fn destroy_lifecycle_gate_waits_for_nth_destroy_entry() {
+        let gate = MockLifecycleGate::new();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.set_destroy_lifecycle_gate(gate.clone());
+        let factory = Arc::new(MockSandboxFactory::with_overrides(Arc::clone(&overrides)));
+
+        let mut destroy_tasks = Vec::new();
+        for _ in 0..3 {
+            let sandbox = factory.create(test_sandbox_config()).await.unwrap();
+            let factory = Arc::clone(&factory);
+            destroy_tasks.push(tokio::spawn(async move {
+                factory.destroy(sandbox).await;
+            }));
+        }
+
+        assert_eq!(gate.wait_entered(3, test_timeout()).await.unwrap(), 3);
+        assert_eq!(overrides.destroy_call_count(), 3);
+
+        gate.release_many(destroy_tasks.len());
+        for task in destroy_tasks {
+            task.await.unwrap();
+        }
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -783,8 +783,7 @@ impl SandboxFactory for MockSandboxFactory {
     async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>> {
         if let Some(result) = self.create_results.lock_ignoring_poison().pop_front() {
             result?;
-        }
-        if let Some(overrides) = &self.overrides
+        } else if let Some(overrides) = &self.overrides
             && let Some(result) = overrides.create_results.lock_ignoring_poison().pop_front()
         {
             result?;
@@ -1021,6 +1020,10 @@ mod tests {
         }
     }
 
+    fn test_timeout() -> Duration {
+        Duration::from_secs(5)
+    }
+
     #[tokio::test]
     async fn snapshot_provider_can_discard_uncommitted_snapshot() {
         let provider = MockSnapshotProvider;
@@ -1235,18 +1238,9 @@ mod tests {
         let mut sandbox = factory.create(test_sandbox_config()).await.unwrap();
 
         let park_task = tokio::spawn(async move { sandbox.park().await });
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while gate.entered_count() == 0 {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("park should enter lifecycle gate");
+        assert_eq!(gate.wait_entered(1, test_timeout()).await.unwrap(), 1);
 
-        assert_eq!(
-            gate.wait_entered(1, Duration::from_secs(1)).await.unwrap(),
-            1
-        );
+        assert_eq!(gate.wait_entered(1, test_timeout()).await.unwrap(), 1);
         assert_eq!(overrides.park_call_count(), 1);
 
         gate.release_one();
@@ -1262,13 +1256,25 @@ mod tests {
         let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
         let mut sandbox = factory.create(test_sandbox_config()).await.unwrap();
 
-        tokio::time::timeout(Duration::from_secs(1), sandbox.park())
+        tokio::time::timeout(test_timeout(), sandbox.park())
             .await
             .expect("early release permit should let park finish")
             .unwrap();
 
         assert_eq!(gate.entered_count(), 1);
         assert_eq!(overrides.park_call_count(), 1);
+
+        let mut second_sandbox = factory.create(test_sandbox_config()).await.unwrap();
+        let second_park = tokio::spawn(async move { second_sandbox.park().await });
+        assert_eq!(gate.wait_entered(2, test_timeout()).await.unwrap(), 2);
+        tokio::task::yield_now().await;
+        assert!(
+            !second_park.is_finished(),
+            "early release permit should be consumed by one lifecycle entry"
+        );
+
+        gate.release_one();
+        second_park.await.unwrap().unwrap();
     }
 
     #[tokio::test]
@@ -1284,10 +1290,7 @@ mod tests {
             park_tasks.push(tokio::spawn(async move { sandbox.park().await }));
         }
 
-        assert_eq!(
-            gate.wait_entered(3, Duration::from_secs(1)).await.unwrap(),
-            3
-        );
+        assert_eq!(gate.wait_entered(3, test_timeout()).await.unwrap(), 3);
         assert_eq!(overrides.park_call_count(), 3);
 
         gate.release_many(park_tasks.len());
@@ -1320,6 +1323,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn factory_local_create_result_takes_precedence_over_shared_overrides() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.push_create_result(Err(SandboxError::Initialization {
+            phase: SandboxInitializationPhase::SandboxAllocation,
+            message: "shared failure".into(),
+        }));
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        factory.push_create_result(Ok(()));
+
+        factory.create(test_sandbox_config()).await.unwrap();
+        let result = factory.create(test_sandbox_config()).await;
+
+        assert!(matches!(
+            result,
+            Err(SandboxError::Initialization {
+                phase: SandboxInitializationPhase::SandboxAllocation,
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
     async fn destroy_lifecycle_gate_blocks_before_destroy_panic() {
         let gate = MockLifecycleGate::new();
         let overrides = Arc::new(MockSandboxOverrides::new());
@@ -1331,10 +1356,7 @@ mod tests {
         let destroy_task = tokio::spawn(async move {
             factory.destroy(sandbox).await;
         });
-        assert_eq!(
-            gate.wait_entered(1, Duration::from_secs(1)).await.unwrap(),
-            1
-        );
+        assert_eq!(gate.wait_entered(1, test_timeout()).await.unwrap(), 1);
         assert_eq!(overrides.destroy_call_count(), 1);
         assert!(
             !destroy_task.is_finished(),

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -111,39 +111,48 @@ impl std::fmt::Display for MockLifecycleGateTimeout {
 impl std::error::Error for MockLifecycleGateTimeout {}
 
 struct MockLifecycleGateInner {
-    entered_count: Mutex<u64>,
+    state: Mutex<MockLifecycleGateState>,
     entered_tx: tokio::sync::watch::Sender<u64>,
-    release: Arc<tokio::sync::Semaphore>,
+    release_tx: tokio::sync::watch::Sender<u64>,
+}
+
+struct MockLifecycleGateState {
+    entered_count: u64,
+    released_count: u64,
 }
 
 /// Durable lifecycle gate for tests that need to block mock sandbox lifecycle
 /// operations at deterministic points.
 ///
-/// Unlike raw [`tokio::sync::Notify`] pairs, entries are counted durably and
-/// releases are counted as permits. A test can wait for an entry after it has
-/// already happened, and a release issued before the lifecycle operation blocks
-/// is consumed by that next operation instead of being lost.
+/// Unlike raw [`tokio::sync::Notify`] pairs, entries and releases are counted
+/// durably. A test can wait for an entry after it has already happened, and a
+/// release issued before the lifecycle operation blocks is consumed by that
+/// entry instead of being lost.
 #[derive(Clone)]
 pub struct MockLifecycleGate {
     inner: Arc<MockLifecycleGateInner>,
 }
 
 impl MockLifecycleGate {
-    /// Create a gate with zero recorded entries and no release permits.
+    /// Create a gate with zero recorded entries and no releases.
     pub fn new() -> Self {
         let (entered_tx, _) = tokio::sync::watch::channel(0);
+        let (release_tx, _) = tokio::sync::watch::channel(0);
         Self {
             inner: Arc::new(MockLifecycleGateInner {
-                entered_count: Mutex::new(0),
+                state: Mutex::new(MockLifecycleGateState {
+                    entered_count: 0,
+                    released_count: 0,
+                }),
                 entered_tx,
-                release: Arc::new(tokio::sync::Semaphore::new(0)),
+                release_tx,
             }),
         }
     }
 
     /// Return the number of lifecycle entries recorded by this gate.
     pub fn entered_count(&self) -> u64 {
-        *self.inner.entered_count.lock_ignoring_poison()
+        self.inner.state.lock_ignoring_poison().entered_count
     }
 
     /// Wait until at least `target_count` lifecycle entries have been recorded.
@@ -183,19 +192,32 @@ impl MockLifecycleGate {
         self.release_many(1);
     }
 
-    /// Add `count` release permits for blocked or future lifecycle operations.
+    /// Release `count` lifecycle entries by advancing the durable release count.
     pub fn release_many(&self, count: usize) {
-        self.inner.release.add_permits(count);
+        let release_count = u64::try_from(count).unwrap_or(u64::MAX);
+        let mut state = self.inner.state.lock_ignoring_poison();
+        state.released_count = state.released_count.saturating_add(release_count);
+        self.inner.release_tx.send_replace(state.released_count);
     }
 
     async fn enter_and_wait(&self) {
-        {
-            let mut entered_count = self.inner.entered_count.lock_ignoring_poison();
-            *entered_count += 1;
-            self.inner.entered_tx.send_replace(*entered_count);
-        }
-        if let Ok(permit) = Arc::clone(&self.inner.release).acquire_owned().await {
-            permit.forget();
+        let ticket = {
+            let mut state = self.inner.state.lock_ignoring_poison();
+            state.entered_count = state.entered_count.saturating_add(1);
+            self.inner.entered_tx.send_replace(state.entered_count);
+            state.entered_count
+        };
+        let mut release_rx = self.inner.release_tx.subscribe();
+        loop {
+            let released_count = *release_rx.borrow_and_update();
+            if released_count >= ticket {
+                return;
+            }
+            if release_rx.changed().await.is_err() {
+                // The waiter owns a gate clone, so sender closure should not
+                // happen. Keep waiting rather than letting this entry through.
+                std::future::pending::<()>().await;
+            }
         }
     }
 }
@@ -1322,11 +1344,42 @@ mod tests {
 
         assert_eq!(gate.entered_count(), 1);
         assert_eq!(overrides.park_call_count(), 1);
-        assert_eq!(
-            gate.inner.release.available_permits(),
-            0,
-            "early release permit should be consumed by one lifecycle entry"
+
+        let mut next_sandbox = factory.create(test_sandbox_config()).await.unwrap();
+        let next_park_task = tokio::spawn(async move { next_sandbox.park().await });
+        assert_eq!(gate.wait_entered(2, test_timeout()).await.unwrap(), 2);
+        assert!(
+            !next_park_task.is_finished(),
+            "early release permit should be consumed by only one lifecycle entry"
         );
+        gate.release_one();
+        next_park_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn lifecycle_gate_release_after_cancelled_entry_does_not_release_future_entry() {
+        let gate = MockLifecycleGate::new();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.set_park_lifecycle_gate(gate.clone());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let mut first_sandbox = factory.create(test_sandbox_config()).await.unwrap();
+
+        let first_park_task = tokio::spawn(async move { first_sandbox.park().await });
+        assert_eq!(gate.wait_entered(1, test_timeout()).await.unwrap(), 1);
+        first_park_task.abort();
+        assert!(first_park_task.await.unwrap_err().is_cancelled());
+
+        gate.release_one();
+        let mut second_sandbox = factory.create(test_sandbox_config()).await.unwrap();
+        let second_park_task = tokio::spawn(async move { second_sandbox.park().await });
+        assert_eq!(gate.wait_entered(2, test_timeout()).await.unwrap(), 2);
+        assert!(
+            !second_park_task.is_finished(),
+            "release for a cancelled entry must not pass a future entry"
+        );
+
+        gate.release_one();
+        second_park_task.await.unwrap().unwrap();
     }
 
     #[tokio::test]
@@ -1441,11 +1494,18 @@ mod tests {
 
         assert_eq!(gate.entered_count(), 1);
         assert_eq!(overrides.destroy_call_count(), 1);
-        assert_eq!(
-            gate.inner.release.available_permits(),
-            0,
-            "early release permit should be consumed by one lifecycle entry"
+
+        let next_sandbox = factory.create(test_sandbox_config()).await.unwrap();
+        let next_destroy_task = tokio::spawn(async move {
+            factory.destroy(next_sandbox).await;
+        });
+        assert_eq!(gate.wait_entered(2, test_timeout()).await.unwrap(), 2);
+        assert!(
+            !next_destroy_task.is_finished(),
+            "early release permit should be consumed by only one lifecycle entry"
         );
+        gate.release_one();
+        next_destroy_task.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -7,8 +7,9 @@
 //!
 //! For advanced control, create [`MockSandboxOverrides`] and pass it via
 //! [`MockSandboxRuntime::with_overrides`]. This enables pattern-matched exec
-//! results, custom `wait_exit` exit codes, and blocking gates for lifecycle
-//! and cancellation testing.
+//! results, shared lifecycle behavior queues, custom `wait_exit` exit codes,
+//! and durable [`MockLifecycleGate`] gates for lifecycle and cancellation
+//! testing.
 //!
 //! ```toml
 //! [dev-dependencies]
@@ -17,6 +18,7 @@
 
 use std::collections::VecDeque;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
@@ -67,17 +69,154 @@ enum LifecycleBehavior {
     Panic(String),
 }
 
+enum DestroyBehavior {
+    Panic(String),
+}
+
+/// Error returned when a [`MockLifecycleGate`] does not record enough entries
+/// before the caller's timeout expires.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct MockLifecycleGateTimeout {
+    target_count: u64,
+    actual_count: u64,
+    timeout: Duration,
+}
+
+impl MockLifecycleGateTimeout {
+    /// Entry count that the caller was waiting for.
+    pub fn target_count(&self) -> u64 {
+        self.target_count
+    }
+
+    /// Entry count observed when the timeout expired.
+    pub fn actual_count(&self) -> u64 {
+        self.actual_count
+    }
+
+    /// Timeout used by the wait operation.
+    pub fn timeout(&self) -> Duration {
+        self.timeout
+    }
+}
+
+impl std::fmt::Display for MockLifecycleGateTimeout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "mock lifecycle gate did not reach entry count {} within {:?} (actual: {})",
+            self.target_count, self.timeout, self.actual_count
+        )
+    }
+}
+
+impl std::error::Error for MockLifecycleGateTimeout {}
+
+struct MockLifecycleGateInner {
+    entered_count: AtomicU64,
+    entered_tx: tokio::sync::watch::Sender<u64>,
+    release: Arc<tokio::sync::Semaphore>,
+}
+
+/// Durable lifecycle gate for tests that need to block mock sandbox lifecycle
+/// operations at deterministic points.
+///
+/// Unlike raw [`tokio::sync::Notify`] pairs, entries are counted durably and
+/// releases are counted as permits. A test can wait for an entry after it has
+/// already happened, and a release issued before the lifecycle operation blocks
+/// is consumed by that next operation instead of being lost.
 #[derive(Clone)]
-struct BlockingGate {
-    entered: Arc<tokio::sync::Notify>,
-    release: Arc<tokio::sync::Notify>,
+pub struct MockLifecycleGate {
+    inner: Arc<MockLifecycleGateInner>,
+}
+
+impl MockLifecycleGate {
+    /// Create a gate with zero recorded entries and no release permits.
+    pub fn new() -> Self {
+        let (entered_tx, _) = tokio::sync::watch::channel(0);
+        Self {
+            inner: Arc::new(MockLifecycleGateInner {
+                entered_count: AtomicU64::new(0),
+                entered_tx,
+                release: Arc::new(tokio::sync::Semaphore::new(0)),
+            }),
+        }
+    }
+
+    /// Return the number of lifecycle entries recorded by this gate.
+    pub fn entered_count(&self) -> u64 {
+        self.inner.entered_count.load(Ordering::SeqCst)
+    }
+
+    /// Wait until at least `target_count` lifecycle entries have been recorded.
+    pub async fn wait_entered(
+        &self,
+        target_count: u64,
+        timeout: Duration,
+    ) -> std::result::Result<u64, MockLifecycleGateTimeout> {
+        let gate = self.clone();
+        let wait = async move {
+            let mut entered_rx = gate.inner.entered_tx.subscribe();
+            loop {
+                let current = *entered_rx.borrow_and_update();
+                if current >= target_count {
+                    return current;
+                }
+                if entered_rx.changed().await.is_err() {
+                    return gate.entered_count();
+                }
+            }
+        };
+
+        tokio::time::timeout(timeout, wait)
+            .await
+            .map_err(|_| MockLifecycleGateTimeout {
+                target_count,
+                actual_count: self.entered_count(),
+                timeout,
+            })
+    }
+
+    /// Release one blocked lifecycle operation.
+    pub fn release_one(&self) {
+        self.release_many(1);
+    }
+
+    /// Release up to `count` blocked or future lifecycle operations.
+    pub fn release_many(&self, count: usize) {
+        self.inner.release.add_permits(count);
+    }
+
+    async fn enter_and_wait(&self) {
+        let entered = self.inner.entered_count.fetch_add(1, Ordering::SeqCst) + 1;
+        self.inner.entered_tx.send_replace(entered);
+        if let Ok(permit) = Arc::clone(&self.inner.release).acquire_owned().await {
+            permit.forget();
+        }
+    }
+}
+
+impl Default for MockLifecycleGate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone)]
+enum BlockingGate {
+    LegacyNotify {
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    },
+    Lifecycle(MockLifecycleGate),
 }
 
 /// Shared behavior overrides propagated from runtime → factory → sandbox.
 ///
 /// Tests create this via [`MockSandboxRuntime::with_overrides`] so every
 /// sandbox produced by the factory checks these overrides before falling
-/// back to the default FIFO-queue behaviour.
+/// back to the default FIFO-queue behaviour. Queue fields on this type are
+/// shared globally by every factory and sandbox that receives the same
+/// `Arc<MockSandboxOverrides>`.
 pub struct MockSandboxOverrides {
     /// Pattern-matched exec results. First matching pattern wins and is
     /// consumed (one-shot).
@@ -91,6 +230,9 @@ pub struct MockSandboxOverrides {
     /// simulate timeout or crash. The stdout channel sender is also kept alive
     /// in `MockSandbox` so the drain task would block without the fix.
     wait_exit_error: Option<String>,
+    /// FIFO queue of create results consumed by every factory built with
+    /// these overrides. Empty queue → default Ok(()).
+    create_results: Mutex<VecDeque<Result<()>>>,
     /// FIFO queue of start results consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
     start_results: Mutex<VecDeque<Result<()>>>,
@@ -108,6 +250,9 @@ pub struct MockSandboxOverrides {
     /// When set, factory `destroy` notifies `entered` and then blocks until
     /// `release`.
     destroy_gate: Mutex<Option<BlockingGate>>,
+    /// FIFO queue of destroy behaviours consumed by every factory built with
+    /// these overrides. Empty queue → default successful destroy.
+    destroy_behaviors: Mutex<VecDeque<DestroyBehavior>>,
     /// Recorded spawn_watch output modes across all sandboxes built from
     /// this override set.
     spawn_watch_calls: Mutex<Vec<SpawnWatchCall>>,
@@ -127,12 +272,14 @@ impl MockSandboxOverrides {
             wait_exit_code: None,
             wait_exit_gate: None,
             wait_exit_error: None,
+            create_results: Mutex::new(VecDeque::new()),
             start_results: Mutex::new(VecDeque::new()),
             stop_behaviors: Mutex::new(VecDeque::new()),
             park_behaviors: Mutex::new(VecDeque::new()),
             park_gate: Mutex::new(None),
             unpark_behaviors: Mutex::new(VecDeque::new()),
             destroy_gate: Mutex::new(None),
+            destroy_behaviors: Mutex::new(VecDeque::new()),
             spawn_watch_calls: Mutex::new(Vec::new()),
             park_calls: Mutex::new(0),
             unpark_calls: Mutex::new(0),
@@ -169,6 +316,13 @@ impl MockSandboxOverrides {
     /// Register a pattern matcher consumed on first match.
     pub fn add_exec_matcher(&self, matcher: ExecMatcher) {
         self.exec_matchers.lock_ignoring_poison().push(matcher);
+    }
+
+    /// Queue a factory `create()` result applied to the next factory create
+    /// call made through these overrides. Consumed FIFO across all factories;
+    /// empty queue → default Ok(()).
+    pub fn push_create_result(&self, result: Result<()>) {
+        self.create_results.lock_ignoring_poison().push_back(result);
     }
 
     /// Queue a `start()` result applied to the next factory-created sandbox.
@@ -209,14 +363,26 @@ impl MockSandboxOverrides {
             .push_back(LifecycleBehavior::Panic(message.into()));
     }
 
-    /// Block every `park()` call after recording entry until `release` is
-    /// notified. Used by tests to open deterministic race windows.
+    /// Block every `park()` call with a durable lifecycle gate.
+    ///
+    /// Prefer this over [`Self::set_park_gate`]: entries and releases are
+    /// durable, so tests do not need to pre-arm `Notify` futures.
+    pub fn set_park_lifecycle_gate(&self, gate: MockLifecycleGate) {
+        *self.park_gate.lock_ignoring_poison() = Some(BlockingGate::Lifecycle(gate));
+    }
+
+    /// Legacy `Notify`-pair park gate.
+    ///
+    /// New tests should use [`Self::set_park_lifecycle_gate`] because this
+    /// edge-triggered API can lose entry or release notifications if the test
+    /// does not pre-arm the corresponding `notified()` future.
     pub fn set_park_gate(
         &self,
         entered: Arc<tokio::sync::Notify>,
         release: Arc<tokio::sync::Notify>,
     ) {
-        *self.park_gate.lock_ignoring_poison() = Some(BlockingGate { entered, release });
+        *self.park_gate.lock_ignoring_poison() =
+            Some(BlockingGate::LegacyNotify { entered, release });
     }
 
     /// Queue an `unpark()` result applied to the next factory-created sandbox.
@@ -235,14 +401,34 @@ impl MockSandboxOverrides {
             .push_back(LifecycleBehavior::Panic(message.into()));
     }
 
-    /// Block every factory `destroy()` call after recording entry until
-    /// `release` is notified.
+    /// Block every factory `destroy()` call with a durable lifecycle gate.
+    ///
+    /// Prefer this over [`Self::set_destroy_gate`]: entries and releases are
+    /// durable, so tests do not need to pre-arm `Notify` futures.
+    pub fn set_destroy_lifecycle_gate(&self, gate: MockLifecycleGate) {
+        *self.destroy_gate.lock_ignoring_poison() = Some(BlockingGate::Lifecycle(gate));
+    }
+
+    /// Legacy `Notify`-pair destroy gate.
+    ///
+    /// New tests should use [`Self::set_destroy_lifecycle_gate`] because this
+    /// edge-triggered API can lose entry or release notifications if the test
+    /// does not pre-arm the corresponding `notified()` future.
     pub fn set_destroy_gate(
         &self,
         entered: Arc<tokio::sync::Notify>,
         release: Arc<tokio::sync::Notify>,
     ) {
-        *self.destroy_gate.lock_ignoring_poison() = Some(BlockingGate { entered, release });
+        *self.destroy_gate.lock_ignoring_poison() =
+            Some(BlockingGate::LegacyNotify { entered, release });
+    }
+
+    /// Queue a factory `destroy()` panic applied to the next destroy call made
+    /// through these overrides. Consumed FIFO across all factories.
+    pub fn push_destroy_panic(&self, message: impl Into<String>) {
+        self.destroy_behaviors
+            .lock_ignoring_poison()
+            .push_back(DestroyBehavior::Panic(message.into()));
     }
 
     /// Total `park()` calls across all sandboxes built from this override set.
@@ -271,8 +457,13 @@ impl MockSandboxOverrides {
 async fn wait_blocking_gate(gate: &Mutex<Option<BlockingGate>>) {
     let gate = gate.lock_ignoring_poison().clone();
     if let Some(gate) = gate {
-        gate.entered.notify_waiters();
-        gate.release.notified().await;
+        match gate {
+            BlockingGate::LegacyNotify { entered, release } => {
+                entered.notify_waiters();
+                release.notified().await;
+            }
+            BlockingGate::Lifecycle(gate) => gate.enter_and_wait().await,
+        }
     }
 }
 
@@ -538,7 +729,9 @@ impl Sandbox for MockSandbox {
 /// A mock [`SandboxFactory`] that creates [`MockSandbox`] instances.
 ///
 /// Queue custom `create` results with [`push_create_result`](Self::push_create_result).
-/// When the queue is empty, `create` returns a default `MockSandbox`.
+/// When the factory-local queue is empty, `create` checks shared
+/// [`MockSandboxOverrides`] create results. When both queues are empty,
+/// `create` returns a default `MockSandbox`.
 pub struct MockSandboxFactory {
     create_results: Mutex<VecDeque<Result<()>>>,
     overrides: Option<Arc<MockSandboxOverrides>>,
@@ -559,9 +752,9 @@ impl MockSandboxFactory {
         }
     }
 
-    /// Queue a create result. `Ok(())` creates a normal `MockSandbox`;
-    /// `Err(...)` makes `create` return that error.
-    /// Results are consumed in FIFO order.
+    /// Queue a factory-local create result. `Ok(())` creates a normal
+    /// `MockSandbox`; `Err(...)` makes `create` return that error.
+    /// Results are consumed in FIFO order before shared override results.
     pub fn push_create_result(&self, result: Result<()>) {
         self.create_results.lock_ignoring_poison().push_back(result);
     }
@@ -591,6 +784,11 @@ impl SandboxFactory for MockSandboxFactory {
         if let Some(result) = self.create_results.lock_ignoring_poison().pop_front() {
             result?;
         }
+        if let Some(overrides) = &self.overrides
+            && let Some(result) = overrides.create_results.lock_ignoring_poison().pop_front()
+        {
+            result?;
+        }
         let sandbox = match &self.overrides {
             Some(o) => MockSandbox::with_overrides(config.id.to_string(), Arc::clone(o)),
             None => MockSandbox::new(config.id.to_string()),
@@ -602,6 +800,11 @@ impl SandboxFactory for MockSandboxFactory {
         if let Some(o) = &self.overrides {
             *o.destroy_calls.lock_ignoring_poison() += 1;
             wait_blocking_gate(&o.destroy_gate).await;
+            match o.destroy_behaviors.lock_ignoring_poison().pop_front() {
+                #[allow(clippy::panic)]
+                Some(DestroyBehavior::Panic(message)) => panic!("{message}"),
+                None => {}
+            }
         }
     }
 
@@ -804,6 +1007,17 @@ mod tests {
                 cpu_count: 2,
                 memory_mb: 1024,
             },
+        }
+    }
+
+    fn test_factory_config() -> FactoryConfig {
+        FactoryConfig {
+            profile: "test".into(),
+            binary_path: "/bin/test".into(),
+            kernel_path: "/boot/test".into(),
+            rootfs_path: "/rootfs/test".into(),
+            base_dir: "/tmp/test".into(),
+            snapshot: None,
         }
     }
 
@@ -1010,6 +1224,126 @@ mod tests {
         factory.destroy(second).await;
 
         assert_eq!(overrides.destroy_call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn lifecycle_gate_observes_park_entry_after_it_already_happened() {
+        let gate = MockLifecycleGate::new();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.set_park_lifecycle_gate(gate.clone());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let mut sandbox = factory.create(test_sandbox_config()).await.unwrap();
+
+        let park_task = tokio::spawn(async move { sandbox.park().await });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while gate.entered_count() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("park should enter lifecycle gate");
+
+        assert_eq!(
+            gate.wait_entered(1, Duration::from_secs(1)).await.unwrap(),
+            1
+        );
+        assert_eq!(overrides.park_call_count(), 1);
+
+        gate.release_one();
+        park_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn lifecycle_gate_release_before_park_entry_is_not_lost() {
+        let gate = MockLifecycleGate::new();
+        gate.release_one();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.set_park_lifecycle_gate(gate.clone());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let mut sandbox = factory.create(test_sandbox_config()).await.unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), sandbox.park())
+            .await
+            .expect("early release permit should let park finish")
+            .unwrap();
+
+        assert_eq!(gate.entered_count(), 1);
+        assert_eq!(overrides.park_call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn lifecycle_gate_waits_for_nth_park_entry() {
+        let gate = MockLifecycleGate::new();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.set_park_lifecycle_gate(gate.clone());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+
+        let mut park_tasks = Vec::new();
+        for _ in 0..3 {
+            let mut sandbox = factory.create(test_sandbox_config()).await.unwrap();
+            park_tasks.push(tokio::spawn(async move { sandbox.park().await }));
+        }
+
+        assert_eq!(
+            gate.wait_entered(3, Duration::from_secs(1)).await.unwrap(),
+            3
+        );
+        assert_eq!(overrides.park_call_count(), 3);
+
+        gate.release_many(park_tasks.len());
+        for task in park_tasks {
+            task.await.unwrap().unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn overrides_share_create_results_across_runtime_factories() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.push_create_result(Err(SandboxError::Initialization {
+            phase: SandboxInitializationPhase::SandboxAllocation,
+            message: "out of resources".into(),
+        }));
+        let runtime = MockSandboxRuntime::with_overrides(Arc::clone(&overrides));
+
+        let first_factory = runtime.create_factory(test_factory_config()).await.unwrap();
+        let result = first_factory.create(test_sandbox_config()).await;
+        assert!(matches!(
+            result,
+            Err(SandboxError::Initialization {
+                phase: SandboxInitializationPhase::SandboxAllocation,
+                ..
+            })
+        ));
+
+        let second_factory = runtime.create_factory(test_factory_config()).await.unwrap();
+        second_factory.create(test_sandbox_config()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn destroy_lifecycle_gate_blocks_before_destroy_panic() {
+        let gate = MockLifecycleGate::new();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.set_destroy_lifecycle_gate(gate.clone());
+        overrides.push_destroy_panic("simulated destroy panic");
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let sandbox = factory.create(test_sandbox_config()).await.unwrap();
+
+        let destroy_task = tokio::spawn(async move {
+            factory.destroy(sandbox).await;
+        });
+        assert_eq!(
+            gate.wait_entered(1, Duration::from_secs(1)).await.unwrap(),
+            1
+        );
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert!(
+            !destroy_task.is_finished(),
+            "destroy behavior should not run until the gate is released"
+        );
+
+        gate.release_one();
+        let err = destroy_task.await.expect_err("destroy should panic");
+        assert!(err.is_panic());
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -1272,6 +1272,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn legacy_notify_gates_still_block_lifecycle_until_released() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        let park_entered = Arc::new(tokio::sync::Notify::new());
+        let park_release = Arc::new(tokio::sync::Notify::new());
+        let destroy_entered = Arc::new(tokio::sync::Notify::new());
+        let destroy_release = Arc::new(tokio::sync::Notify::new());
+        overrides.set_park_gate(Arc::clone(&park_entered), Arc::clone(&park_release));
+        overrides.set_destroy_gate(Arc::clone(&destroy_entered), Arc::clone(&destroy_release));
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+
+        let mut sandbox = factory.create(test_sandbox_config()).await.unwrap();
+        let park_entered_wait = park_entered.notified();
+        tokio::pin!(park_entered_wait);
+        park_entered_wait.as_mut().enable();
+        let park_task = tokio::spawn(async move { sandbox.park().await });
+
+        tokio::time::timeout(test_timeout(), park_entered_wait)
+            .await
+            .expect("legacy park gate should report entry");
+        assert_eq!(overrides.park_call_count(), 1);
+        assert!(
+            !park_task.is_finished(),
+            "legacy park gate should block until release is notified"
+        );
+        park_release.notify_one();
+        park_task.await.unwrap().unwrap();
+
+        let sandbox = factory.create(test_sandbox_config()).await.unwrap();
+        let destroy_entered_wait = destroy_entered.notified();
+        tokio::pin!(destroy_entered_wait);
+        destroy_entered_wait.as_mut().enable();
+        let destroy_task = tokio::spawn(async move {
+            factory.destroy(sandbox).await;
+        });
+
+        tokio::time::timeout(test_timeout(), destroy_entered_wait)
+            .await
+            .expect("legacy destroy gate should report entry");
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert!(
+            !destroy_task.is_finished(),
+            "legacy destroy gate should block until release is notified"
+        );
+        destroy_release.notify_one();
+        destroy_task.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn lifecycle_gate_observes_park_entry_after_it_already_happened() {
         let gate = MockLifecycleGate::new();
         let overrides = Arc::new(MockSandboxOverrides::new());

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -18,7 +18,6 @@
 
 use std::collections::VecDeque;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
@@ -112,7 +111,7 @@ impl std::fmt::Display for MockLifecycleGateTimeout {
 impl std::error::Error for MockLifecycleGateTimeout {}
 
 struct MockLifecycleGateInner {
-    entered_count: AtomicU64,
+    entered_count: Mutex<u64>,
     entered_tx: tokio::sync::watch::Sender<u64>,
     release: Arc<tokio::sync::Semaphore>,
 }
@@ -135,7 +134,7 @@ impl MockLifecycleGate {
         let (entered_tx, _) = tokio::sync::watch::channel(0);
         Self {
             inner: Arc::new(MockLifecycleGateInner {
-                entered_count: AtomicU64::new(0),
+                entered_count: Mutex::new(0),
                 entered_tx,
                 release: Arc::new(tokio::sync::Semaphore::new(0)),
             }),
@@ -144,7 +143,7 @@ impl MockLifecycleGate {
 
     /// Return the number of lifecycle entries recorded by this gate.
     pub fn entered_count(&self) -> u64 {
-        self.inner.entered_count.load(Ordering::SeqCst)
+        *self.inner.entered_count.lock_ignoring_poison()
     }
 
     /// Wait until at least `target_count` lifecycle entries have been recorded.
@@ -187,8 +186,11 @@ impl MockLifecycleGate {
     }
 
     async fn enter_and_wait(&self) {
-        let entered = self.inner.entered_count.fetch_add(1, Ordering::SeqCst) + 1;
-        self.inner.entered_tx.send_replace(entered);
+        {
+            let mut entered_count = self.inner.entered_count.lock_ignoring_poison();
+            *entered_count += 1;
+            self.inner.entered_tx.send_replace(*entered_count);
+        }
         if let Ok(permit) = Arc::clone(&self.inner.release).acquire_owned().await {
             permit.forget();
         }

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -161,7 +161,10 @@ impl MockLifecycleGate {
                     return current;
                 }
                 if entered_rx.changed().await.is_err() {
-                    return gate.entered_count();
+                    // The waiter owns a gate clone, so sender closure should not
+                    // happen. Let the outer timeout report failure instead of
+                    // returning a below-target count as success.
+                    return std::future::pending().await;
                 }
             }
         };

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -180,7 +180,7 @@ impl MockLifecycleGate {
         self.release_many(1);
     }
 
-    /// Release up to `count` blocked or future lifecycle operations.
+    /// Add `count` release permits for blocked or future lifecycle operations.
     pub fn release_many(&self, count: usize) {
         self.inner.release.add_permits(count);
     }
@@ -244,13 +244,13 @@ pub struct MockSandboxOverrides {
     /// FIFO queue of park results consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
     park_behaviors: Mutex<VecDeque<LifecycleBehavior>>,
-    /// When set, `park` notifies `entered` and then blocks until `release`.
+    /// Optional gate that records and blocks every `park()` entry until released.
     park_gate: Mutex<Option<BlockingGate>>,
     /// FIFO queue of unpark results consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
     unpark_behaviors: Mutex<VecDeque<LifecycleBehavior>>,
-    /// When set, factory `destroy` notifies `entered` and then blocks until
-    /// `release`.
+    /// Optional gate that records and blocks every factory `destroy()` entry
+    /// until released.
     destroy_gate: Mutex<Option<BlockingGate>>,
     /// FIFO queue of destroy behaviours consumed by every factory built with
     /// these overrides. Empty queue → default successful destroy.

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -127,7 +127,9 @@ struct MockLifecycleGateState {
 /// Unlike raw [`tokio::sync::Notify`] pairs, entries and releases are counted
 /// durably. A test can wait for an entry after it has already happened, and a
 /// release issued before the lifecycle operation blocks is consumed by that
-/// entry instead of being lost.
+/// entry instead of being lost. Releases advance entry tickets, so a cancelled
+/// entry still consumes its ticket instead of transferring that release to a
+/// later lifecycle operation.
 #[derive(Clone)]
 pub struct MockLifecycleGate {
     inner: Arc<MockLifecycleGateInner>,
@@ -187,12 +189,17 @@ impl MockLifecycleGate {
             })
     }
 
-    /// Release one blocked lifecycle operation.
+    /// Release the next lifecycle entry ticket.
     pub fn release_one(&self) {
         self.release_many(1);
     }
 
-    /// Release `count` lifecycle entries by advancing the durable release count.
+    /// Release `count` lifecycle entry tickets by advancing the durable
+    /// release count.
+    ///
+    /// Cancelled entries still occupy tickets. If a blocked lifecycle future is
+    /// cancelled, a later release advances past that cancelled ticket instead of
+    /// being reused by a future entry.
     pub fn release_many(&self, count: usize) {
         let release_count = u64::try_from(count).unwrap_or(u64::MAX);
         if release_count == 0 {
@@ -1055,6 +1062,10 @@ mod tests {
         Duration::from_secs(5)
     }
 
+    fn lifecycle_gate_released_count(gate: &MockLifecycleGate) -> u64 {
+        gate.inner.state.lock_ignoring_poison().released_count
+    }
+
     #[tokio::test]
     async fn snapshot_provider_can_discard_uncommitted_snapshot() {
         let provider = MockSnapshotProvider;
@@ -1372,7 +1383,7 @@ mod tests {
         assert_eq!(gate.wait_entered(1, test_timeout()).await.unwrap(), 1);
 
         gate.release_many(0);
-        tokio::task::yield_now().await;
+        assert_eq!(lifecycle_gate_released_count(&gate), 0);
         assert!(
             !park_task.is_finished(),
             "zero release count must not let the entry through"
@@ -1403,6 +1414,7 @@ mod tests {
         drop(done_tx);
 
         assert_eq!(gate.wait_entered(3, test_timeout()).await.unwrap(), 3);
+        assert_eq!(lifecycle_gate_released_count(&gate), 2);
         for _ in 0..2 {
             tokio::time::timeout(test_timeout(), done_rx.recv())
                 .await

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -1265,18 +1265,11 @@ mod tests {
 
         assert_eq!(gate.entered_count(), 1);
         assert_eq!(overrides.park_call_count(), 1);
-
-        let mut second_sandbox = factory.create(test_sandbox_config()).await.unwrap();
-        let second_park = tokio::spawn(async move { second_sandbox.park().await });
-        assert_eq!(gate.wait_entered(2, test_timeout()).await.unwrap(), 2);
-        tokio::task::yield_now().await;
-        assert!(
-            !second_park.is_finished(),
+        assert_eq!(
+            gate.inner.release.available_permits(),
+            0,
             "early release permit should be consumed by one lifecycle entry"
         );
-
-        gate.release_one();
-        second_park.await.unwrap().unwrap();
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -1327,6 +1327,36 @@ mod tests {
         }
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn lifecycle_gate_counts_concurrent_park_entries_on_multithread_runtime() {
+        const ENTRY_COUNT: usize = 32;
+
+        let gate = MockLifecycleGate::new();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.set_park_lifecycle_gate(gate.clone());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+
+        let mut park_tasks = Vec::with_capacity(ENTRY_COUNT);
+        for _ in 0..ENTRY_COUNT {
+            let mut sandbox = factory.create(test_sandbox_config()).await.unwrap();
+            park_tasks.push(tokio::spawn(async move { sandbox.park().await }));
+        }
+
+        assert_eq!(
+            gate.wait_entered(ENTRY_COUNT as u64, test_timeout())
+                .await
+                .unwrap(),
+            ENTRY_COUNT as u64
+        );
+        assert_eq!(gate.entered_count(), ENTRY_COUNT as u64);
+        assert_eq!(overrides.park_call_count(), ENTRY_COUNT as u32);
+
+        gate.release_many(ENTRY_COUNT);
+        for task in park_tasks {
+            task.await.unwrap().unwrap();
+        }
+    }
+
     #[tokio::test]
     async fn overrides_share_create_results_across_runtime_factories() {
         let overrides = Arc::new(MockSandboxOverrides::new());

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -1758,13 +1758,19 @@ mod tests {
             }
         });
 
-        let panic_count = [first.await, second.await]
-            .into_iter()
+        let results = [first.await, second.await];
+        let panic_count = results
+            .iter()
             .filter(|result| matches!(result, Err(err) if err.is_panic()))
             .count();
+        let success_count = results.iter().filter(|result| result.is_ok()).count();
         assert_eq!(
             panic_count, 1,
             "shared destroy panic should be consumed by exactly one concurrent factory"
+        );
+        assert_eq!(
+            success_count, 1,
+            "the factory that did not consume the shared destroy panic should complete"
         );
         assert_eq!(overrides.destroy_call_count(), 2);
     }

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -1628,6 +1628,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn destroy_lifecycle_gate_release_after_cancelled_entry_does_not_release_future_entry() {
+        let gate = MockLifecycleGate::new();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.set_destroy_lifecycle_gate(gate.clone());
+        let factory = Arc::new(MockSandboxFactory::with_overrides(Arc::clone(&overrides)));
+        let first_sandbox = factory.create(test_sandbox_config()).await.unwrap();
+
+        let first_destroy_task = tokio::spawn({
+            let factory = Arc::clone(&factory);
+            async move {
+                factory.destroy(first_sandbox).await;
+            }
+        });
+        assert_eq!(gate.wait_entered(1, test_timeout()).await.unwrap(), 1);
+        first_destroy_task.abort();
+        assert!(first_destroy_task.await.unwrap_err().is_cancelled());
+
+        gate.release_one();
+        let second_sandbox = factory.create(test_sandbox_config()).await.unwrap();
+        let second_destroy_task = tokio::spawn({
+            let factory = Arc::clone(&factory);
+            async move {
+                factory.destroy(second_sandbox).await;
+            }
+        });
+        assert_eq!(gate.wait_entered(2, test_timeout()).await.unwrap(), 2);
+        assert!(
+            !second_destroy_task.is_finished(),
+            "release for a cancelled destroy entry must not pass a future entry"
+        );
+
+        gate.release_one();
+        second_destroy_task.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn destroy_lifecycle_gate_waits_for_nth_destroy_entry() {
         let gate = MockLifecycleGate::new();
         let overrides = Arc::new(MockSandboxOverrides::new());
@@ -1694,6 +1730,42 @@ mod tests {
         let second_sandbox = second_factory.create(test_sandbox_config()).await.unwrap();
         second_factory.destroy(second_sandbox).await;
 
+        assert_eq!(overrides.destroy_call_count(), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shared_destroy_panic_is_consumed_once_across_concurrent_factories() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.push_destroy_panic("simulated destroy panic");
+        let first_factory = Arc::new(MockSandboxFactory::with_overrides(Arc::clone(&overrides)));
+        let second_factory = Arc::new(MockSandboxFactory::with_overrides(Arc::clone(&overrides)));
+        let first_sandbox = first_factory.create(test_sandbox_config()).await.unwrap();
+        let second_sandbox = second_factory.create(test_sandbox_config()).await.unwrap();
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+        let first = tokio::spawn({
+            let barrier = Arc::clone(&barrier);
+            async move {
+                barrier.wait().await;
+                first_factory.destroy(first_sandbox).await;
+            }
+        });
+        let second = tokio::spawn({
+            let barrier = Arc::clone(&barrier);
+            async move {
+                barrier.wait().await;
+                second_factory.destroy(second_sandbox).await;
+            }
+        });
+
+        let panic_count = [first.await, second.await]
+            .into_iter()
+            .filter(|result| matches!(result, Err(err) if err.is_panic()))
+            .count();
+        assert_eq!(
+            panic_count, 1,
+            "shared destroy panic should be consumed by exactly one concurrent factory"
+        );
         assert_eq!(overrides.destroy_call_count(), 2);
     }
 

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -1758,12 +1758,15 @@ mod tests {
             }
         });
 
-        let results = [first.await, second.await];
-        let panic_count = results
-            .iter()
-            .filter(|result| matches!(result, Err(err) if err.is_panic()))
-            .count();
-        let success_count = results.iter().filter(|result| result.is_ok()).count();
+        let classify = |result: std::result::Result<(), tokio::task::JoinError>| match result {
+            Ok(()) => (1, 0),
+            Err(err) if err.is_panic() => (0, 1),
+            Err(err) => panic!("destroy task should not be cancelled: {err}"),
+        };
+        let (first_success_count, first_panic_count) = classify(first.await);
+        let (second_success_count, second_panic_count) = classify(second.await);
+        let panic_count = first_panic_count + second_panic_count;
+        let success_count = first_success_count + second_success_count;
         assert_eq!(
             panic_count, 1,
             "shared destroy panic should be consumed by exactly one concurrent factory"

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -1250,6 +1250,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn lifecycle_gate_wait_entered_zero_returns_immediately() {
+        let gate = MockLifecycleGate::new();
+
+        assert_eq!(gate.wait_entered(0, test_timeout()).await.unwrap(), 0);
+        assert_eq!(gate.entered_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn lifecycle_gate_wakes_multiple_waiters_for_same_entry() {
+        let gate = MockLifecycleGate::new();
+        let first_waiter = tokio::spawn({
+            let gate = gate.clone();
+            async move { gate.wait_entered(1, test_timeout()).await.unwrap() }
+        });
+        let second_waiter = tokio::spawn({
+            let gate = gate.clone();
+            async move { gate.wait_entered(1, test_timeout()).await.unwrap() }
+        });
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.set_park_lifecycle_gate(gate.clone());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let mut sandbox = factory.create(test_sandbox_config()).await.unwrap();
+
+        let park_task = tokio::spawn(async move { sandbox.park().await });
+        assert_eq!(gate.wait_entered(1, test_timeout()).await.unwrap(), 1);
+        assert_eq!(first_waiter.await.unwrap(), 1);
+        assert_eq!(second_waiter.await.unwrap(), 1);
+
+        gate.release_one();
+        park_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
     async fn lifecycle_gate_release_before_park_entry_is_not_lost() {
         let gate = MockLifecycleGate::new();
         gate.release_one();
@@ -1340,6 +1373,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn destroy_lifecycle_gate_release_before_entry_is_not_lost() {
+        let gate = MockLifecycleGate::new();
+        gate.release_one();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.set_destroy_lifecycle_gate(gate.clone());
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let sandbox = factory.create(test_sandbox_config()).await.unwrap();
+
+        tokio::time::timeout(test_timeout(), factory.destroy(sandbox))
+            .await
+            .expect("early release permit should let destroy finish");
+
+        assert_eq!(gate.entered_count(), 1);
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert_eq!(
+            gate.inner.release.available_permits(),
+            0,
+            "early release permit should be consumed by one lifecycle entry"
+        );
+    }
+
+    #[tokio::test]
     async fn destroy_lifecycle_gate_blocks_before_destroy_panic() {
         let gate = MockLifecycleGate::new();
         let overrides = Arc::new(MockSandboxOverrides::new());
@@ -1361,6 +1416,27 @@ mod tests {
         gate.release_one();
         let err = destroy_task.await.expect_err("destroy should panic");
         assert!(err.is_panic());
+    }
+
+    #[tokio::test]
+    async fn destroy_panic_override_is_consumed_once_across_factories() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.push_destroy_panic("simulated destroy panic");
+        let first_factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let first_sandbox = first_factory.create(test_sandbox_config()).await.unwrap();
+
+        let err = tokio::spawn(async move {
+            first_factory.destroy(first_sandbox).await;
+        })
+        .await
+        .expect_err("first destroy should panic");
+        assert!(err.is_panic());
+
+        let second_factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let second_sandbox = second_factory.create(test_sandbox_config()).await.unwrap();
+        second_factory.destroy(second_sandbox).await;
+
+        assert_eq!(overrides.destroy_call_count(), 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add `MockLifecycleGate` with durable entry counts and counted release permits
- wire durable park/destroy gates into `MockSandboxOverrides` while keeping legacy Notify gates
- add shared override queues for create failures and destroy panics, plus focused sandbox-mock tests

Closes #12741

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-mock --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner cmd::start::tests::failure_panic`
- `cargo doc --manifest-path crates/Cargo.toml -p sandbox-mock --no-deps`
- pre-commit lefthook: cargo-fmt, cargo-doc, cargo-clippy