### PR TITLE
test: align zero queue position route parity

### DIFF
--- a/turbo/apps/web/app/api/zero/queue-position/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/queue-position/__tests__/route.test.ts
@@ -52,6 +52,19 @@ describe("GET /api/zero/queue-position", () => {
     expect(data.error.code).toBe("BAD_REQUEST");
   });
 
+  it("should return 400 when runId is missing before auth", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/queue-position",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.code).toBe("BAD_REQUEST");
+  });
+
   it("should return 404 when run does not belong to user", async () => {
     const request = createTestRequest(
       `http://localhost:3000/api/zero/queue-position?runId=${randomUUID()}`,
@@ -120,5 +133,31 @@ describe("GET /api/zero/queue-position", () => {
     expect(response.status).toBe(200);
     expect(data.position).toBe(1);
     expect(data.total).toBe(1);
+  });
+
+  it("should return the queued run position within the org queue", async () => {
+    const first = await seedTestRun(user.userId, testComposeId, {
+      status: "queued",
+    });
+    const second = await seedTestRun(user.userId, testComposeId, {
+      status: "queued",
+    });
+
+    await insertTestQueueEntry(first.runId, {
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    await insertTestQueueEntry(second.runId, {
+      createdAt: new Date("2026-01-01T00:00:01.000Z"),
+    });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/zero/queue-position?runId=${second.runId}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.position).toBe(2);
+    expect(data.total).toBe(2);
   });
 });

--- a/turbo/apps/web/app/api/zero/queue-position/route.ts
+++ b/turbo/apps/web/app/api/zero/queue-position/route.ts
@@ -15,6 +15,15 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 export async function GET(request: Request) {
   initServices();
 
+  const url = new URL(request.url);
+  const runId = url.searchParams.get("runId");
+  if (!runId) {
+    return NextResponse.json(
+      { error: { message: "runId is required", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+
   const authCtx = await getAuthContext(
     request.headers.get("authorization") ?? undefined,
   );
@@ -25,15 +34,6 @@ export async function GET(request: Request) {
     );
   }
   const { userId } = authCtx;
-
-  const url = new URL(request.url);
-  const runId = url.searchParams.get("runId");
-  if (!runId) {
-    return NextResponse.json(
-      { error: { message: "runId is required", code: "BAD_REQUEST" } },
-      { status: 400 },
-    );
-  }
 
   const org = await resolveOrgOrNull(authCtx);
 


### PR DESCRIPTION
## Summary
- align the web queue-position route with the API by validating missing runId before auth
- add web coverage for missing runId without auth
- add web coverage for queue position depth with two queued runs

Fixes #12634

## Validation
- pnpm -F web exec vitest run app/api/zero/queue-position/__tests__/route.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-queue-position.test.ts
- pnpm -F web lint
- pnpm -F api lint
- pnpm -F web check-types
- pnpm -F api check-types
- pnpm knip --workspace web
- pnpm knip --workspace api
- pnpm format
- git diff --check