### PR TITLE
fix: align zero schedules route parity

### DIFF
--- a/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
@@ -504,11 +504,13 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
 
 describe("GET /api/zero/schedules - List Schedules", () => {
   let orgId: string;
+  let userId: string;
   let testComposeId: string;
 
   beforeEach(async () => {
     context.setupMocks();
     const user = await context.setupUser();
+    userId = user.userId;
     const { orgId: oid } = await setupOrg(user.userId);
     orgId = oid;
 
@@ -537,7 +539,7 @@ describe("GET /api/zero/schedules - List Schedules", () => {
     expect(data.schedules.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("should return empty array for invalid org", async () => {
+  it("should return empty array when org has no schedules", async () => {
     const response = await GET(
       createTestRequest(`http://localhost:3000/api/zero/schedules`),
     );
@@ -555,5 +557,19 @@ describe("GET /api/zero/schedules - List Schedules", () => {
     );
 
     expect(response.status).toBe(401);
+  });
+
+  it("should return 401 when the authenticated session has no organization", async () => {
+    mockClerk({ userId, orgId: null });
+
+    const response = await GET(
+      createTestRequest(`http://localhost:3000/api/zero/schedules`),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
   });
 });

--- a/turbo/apps/web/app/api/zero/schedules/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/route.ts
@@ -99,7 +99,15 @@ const router = tsr.router(zeroSchedulesMainContract, {
       const { org } = await resolveOrg(authCtx);
       orgId = org.orgId;
     } catch (error) {
-      if (isNotFound(error) || isForbidden(error) || isBadRequest(error)) {
+      if (isBadRequest(error)) {
+        return {
+          status: 401 as const,
+          body: {
+            error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+          },
+        };
+      }
+      if (isNotFound(error) || isForbidden(error)) {
         return {
           status: 200 as const,
           body: { schedules: [] },


### PR DESCRIPTION
## Summary

- Align web `GET /api/zero/schedules` no-active-org handling with the API route's `401 UNAUTHORIZED` behavior.
- Add explicit web route coverage for authenticated sessions without an active organization.
- Rename the existing web empty-list test so it matches the actual setup.

## Scope note

Current main already has API registrations for schedule enable/disable routes. This PR keeps #12636 scoped to the parent epic row for `GET /api/zero/schedules`; web deploy, delete, and run-now schedule mutations remain separate migration surface.

Closes #12636.
Updates #12610.

## Tests

- `pnpm -F web exec vitest run app/api/zero/schedules/__tests__/route.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-schedules.test.ts src/signals/routes/__tests__/zero-schedules-enable.test.ts src/signals/routes/__tests__/zero-schedules-disable.test.ts`
- `pnpm prettier --write apps/web/app/api/zero/schedules/route.ts apps/web/app/api/zero/schedules/__tests__/route.test.ts`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `git diff --check`
