### PR TITLE
fix: align zero org read parity

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-domains.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-domains.test.ts
@@ -16,6 +16,22 @@ const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
+function mockClerkDomains(): void {
+  context.mocks.clerk.organizations.getOrganizationDomainList.mockResolvedValue(
+    {
+      data: [
+        {
+          id: "domain_test_1",
+          name: "example.com",
+          enrollment_mode: "automatic_invitation",
+          verification: { status: "verified", strategy: "dns" },
+          created_at: 1_700_000_000_000,
+        },
+      ],
+    },
+  );
+}
+
 describe("GET /api/zero/org/domains", () => {
   const seededFixtures: OrgMembershipFixture[] = [];
 
@@ -60,6 +76,7 @@ describe("GET /api/zero/org/domains", () => {
       ),
     );
     mocks.clerk.session(userId, orgId, "org:admin");
+    mockClerkDomains();
 
     const client = setupApp({ context })(zeroOrgDomainsContract);
 
@@ -68,7 +85,18 @@ describe("GET /api/zero/org/domains", () => {
       [200],
     );
 
-    expect(response.body.domains).toBeInstanceOf(Array);
+    expect(response.body.domains).toStrictEqual([
+      {
+        id: "domain_test_1",
+        name: "example.com",
+        enrollmentMode: "automatic_invitation",
+        verification: { status: "verified", strategy: "dns" },
+        createdAt: new Date(1_700_000_000_000).toISOString(),
+      },
+    ]);
+    expect(
+      context.mocks.clerk.organizations.getOrganizationDomainList,
+    ).toHaveBeenCalledWith({ organizationId: orgId });
   });
 
   it("returns 403 when caller is not an admin", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-list.test.ts
@@ -1,33 +1,36 @@
 import { randomUUID } from "node:crypto";
 
 import { zeroOrgListContract } from "@vm0/api-contracts/contracts/zero-org-list";
-import { createStore } from "ccstate";
-import { afterEach } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import {
-  deleteOrgMembership$,
-  seedOrgMembership$,
-  type OrgMembershipFixture,
-} from "./helpers/zero-org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
-const store = createStore();
 const mocks = createZeroRouteMocks(context);
 
-describe("GET /api/zero/org/list", () => {
-  const seededFixtures: OrgMembershipFixture[] = [];
+interface ClerkOrgMembershipFixture {
+  readonly orgId: string;
+  readonly slug: string;
+  readonly role: "org:admin" | "org:member";
+}
 
-  afterEach(async () => {
-    while (seededFixtures.length > 0) {
-      const fixture = seededFixtures.pop();
-      if (fixture) {
-        await store.set(deleteOrgMembership$, fixture, context.signal);
-      }
-    }
+function mockUserOrganizationMemberships(
+  memberships: readonly ClerkOrgMembershipFixture[],
+): void {
+  context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue({
+    data: memberships.map((membership) => {
+      return {
+        organization: {
+          id: membership.orgId,
+          slug: membership.slug,
+        },
+        role: membership.role,
+      };
+    }),
   });
+}
 
+describe("GET /api/zero/org/list", () => {
   it("returns 401 when not authenticated", async () => {
     const client = setupApp({ context })(zeroOrgListContract);
 
@@ -40,14 +43,7 @@ describe("GET /api/zero/org/list", () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     const slug = `solo-${randomUUID().slice(0, 8)}`;
-    seededFixtures.push(
-      await store.set(
-        seedOrgMembership$,
-        { orgId, userId, slug, role: "admin" },
-        context.signal,
-      ),
-    );
-
+    mockUserOrganizationMemberships([{ orgId, slug, role: "org:admin" }]);
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroOrgListContract);
@@ -57,30 +53,21 @@ describe("GET /api/zero/org/list", () => {
       [200],
     );
 
-    expect(response.body.orgs.length).toBeGreaterThanOrEqual(1);
-    expect(response.body.orgs[0]).toHaveProperty("slug");
-    expect(response.body.orgs[0]).toHaveProperty("role");
+    expect(response.body.orgs).toStrictEqual([{ slug, role: "admin" }]);
+    expect(response.body.active).toBeUndefined();
+    expect(
+      context.mocks.clerk.users.getOrganizationMembershipList,
+    ).toHaveBeenCalledWith({ userId });
   });
 
   it("returns multiple orgs when user belongs to several", async () => {
     const userId = `user_${randomUUID()}`;
     const orgIdA = `org_${randomUUID()}`;
     const orgIdB = `org_${randomUUID()}`;
-    seededFixtures.push(
-      await store.set(
-        seedOrgMembership$,
-        { orgId: orgIdA, userId, slug: "team-alpha", role: "admin" },
-        context.signal,
-      ),
-    );
-    seededFixtures.push(
-      await store.set(
-        seedOrgMembership$,
-        { orgId: orgIdB, userId, slug: "team-beta", role: "member" },
-        context.signal,
-      ),
-    );
-
+    mockUserOrganizationMemberships([
+      { orgId: orgIdA, slug: "team-alpha", role: "org:admin" },
+      { orgId: orgIdB, slug: "team-beta", role: "org:member" },
+    ]);
     mocks.clerk.session(userId, orgIdA);
 
     const client = setupApp({ context })(zeroOrgListContract);
@@ -90,12 +77,10 @@ describe("GET /api/zero/org/list", () => {
       [200],
     );
 
-    expect(response.body.orgs).toHaveLength(2);
-    expect(response.body.orgs).toStrictEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ slug: "team-alpha", role: "admin" }),
-        expect.objectContaining({ slug: "team-beta", role: "member" }),
-      ]),
-    );
+    expect(response.body.orgs).toStrictEqual([
+      { slug: "team-alpha", role: "admin" },
+      { slug: "team-beta", role: "member" },
+    ]);
+    expect(response.body.active).toBeUndefined();
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org-members.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org-members.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { zeroOrgMembersContract } from "@vm0/api-contracts/contracts/zero-org-members";
+import type { OrgMember } from "@vm0/api-contracts/contracts/org-members";
 import { http, HttpResponse } from "msw";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -153,6 +154,21 @@ describe("GET /api/zero/org/members", () => {
     expect(response.body.error.code).toBe("UNAUTHORIZED");
   });
 
+  it("returns 401 when the authenticated session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroOrgMembersContract);
+
+    const response = await accept(
+      client.members({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
   it("returns members and admin-only data for an admin caller", async () => {
     const orgId = `org_${randomUUID()}`;
     const adminUserId = `user_${randomUUID()}`;
@@ -221,7 +237,7 @@ describe("GET /api/zero/org/members", () => {
     expect(response.body.slug).toBe("acme");
     expect(response.body.members).toHaveLength(2);
 
-    const admin = response.body.members.find((m) => {
+    const admin = response.body.members.find((m: OrgMember) => {
       return m.userId === adminUserId;
     });
     expect(admin?.email).toBe("admin@acme.com");
@@ -231,7 +247,7 @@ describe("GET /api/zero/org/members", () => {
     expect(admin?.role).toBe("admin");
     expect(admin?.joinedAt).toBe(new Date(1_700_000_000_000).toISOString());
 
-    const member = response.body.members.find((m) => {
+    const member = response.body.members.find((m: OrgMember) => {
       return m.userId === memberUserId;
     });
     expect(member?.email).toBe("member@acme.com");

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-org.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-org.test.ts
@@ -35,6 +35,23 @@ interface SeedOrgArgs {
   readonly tier?: "free" | "pro" | "team";
 }
 
+interface ClerkOrgFixture {
+  readonly orgId: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly createdBy?: string;
+}
+
+function mockClerkOrganization(args: ClerkOrgFixture): void {
+  context.mocks.clerk.organizations.getOrganization.mockResolvedValue({
+    id: args.orgId,
+    slug: args.slug,
+    name: args.name,
+    createdBy: args.createdBy,
+    createdAt: now(),
+  });
+}
+
 async function seedOrg(args: SeedOrgArgs): Promise<OrgMembershipFixture> {
   const fixture = await store.set(
     seedOrgMembership$,
@@ -299,6 +316,54 @@ describe("GET /api/zero/org — org resolution", () => {
 
     expect(response.body.id).toBe(orgId);
     expect(response.body.tier).toBe("free");
+  });
+
+  it("refreshes org identity from Clerk when cache row is missing", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const slug = `clerk-${randomUUID().slice(0, 8)}`;
+    seededFixtures.push({ orgId, userId });
+    mockClerkOrganization({
+      orgId,
+      slug,
+      name: "Clerk Fresh Org",
+      createdBy: userId,
+    });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroOrgContract);
+    const response = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id: orgId,
+      slug,
+      name: "Clerk Fresh Org",
+      tier: "free",
+      role: "member",
+      createdBy: userId,
+    });
+    expect(
+      context.mocks.clerk.organizations.getOrganization,
+    ).toHaveBeenCalledWith({ organizationId: orgId });
+
+    const writeDb = store.set(writeDb$);
+    const [cached] = await writeDb
+      .select({
+        slug: orgCache.slug,
+        name: orgCache.name,
+        createdBy: orgCache.createdBy,
+      })
+      .from(orgCache)
+      .where(eq(orgCache.orgId, orgId))
+      .limit(1);
+    expect(cached).toStrictEqual({
+      slug,
+      name: "Clerk Fresh Org",
+      createdBy: userId,
+    });
   });
 
   it("returns member with correct role", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-org-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-read.ts
@@ -1,4 +1,4 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import { zeroOrgContract } from "@vm0/api-contracts/contracts/zero-org";
 import { zeroOrgListContract } from "@vm0/api-contracts/contracts/zero-org-list";
 import { zeroOrgDomainsContract } from "@vm0/api-contracts/contracts/zero-org-domains";
@@ -9,7 +9,7 @@ import { authRoute } from "../auth/auth-route";
 import { notFound } from "../../lib/error";
 import type { RouteEntry } from "../route";
 import {
-  zeroOrgDetail,
+  zeroOrgDetail$,
   zeroOrgDomainsList,
   zeroOrgList,
   zeroOrgMembersList,
@@ -25,12 +25,17 @@ const adminRequired = Object.freeze({
   }),
 });
 
-const getOrgInner$ = computed(async (get) => {
+const getOrgInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(authContext$);
   if (!auth.orgId) {
     return notFound("Organization not found");
   }
-  const org = await get(zeroOrgDetail(auth.orgId, auth.userId));
+  const org = await set(
+    zeroOrgDetail$,
+    { orgId: auth.orgId, userId: auth.userId },
+    signal,
+  );
+  signal.throwIfAborted();
   if (!org) {
     return notFound("Organization not found");
   }

--- a/turbo/apps/api/src/signals/services/zero-org-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-data.service.ts
@@ -1,5 +1,6 @@
-import { computed, type Computed } from "ccstate";
-import { and, eq, inArray } from "drizzle-orm";
+import { command, computed, type Computed } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
 import { orgCache } from "@vm0/db/schema/org-cache";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
@@ -13,15 +14,60 @@ import type {
 } from "@vm0/api-contracts/contracts/org-members";
 import type { User } from "@clerk/backend";
 
-import { db$ } from "../external/db";
+import { db$, writeDb$ } from "../external/db";
 import { clerk$ } from "../external/clerk";
 import { fetchClerkMembershipRequests } from "../external/clerk-membership-requests";
+import { nowDate } from "../../lib/time";
 
-export function zeroOrgDetail(
-  orgId: string,
-  userId: string,
-): Computed<Promise<OrgResponse | null>> {
-  return computed(async (get): Promise<OrgResponse | null> => {
+const clerkOrgIdentitySchema = z.object({
+  slug: z.string().nullable().optional(),
+  name: z.string().nullable().optional(),
+  createdBy: z.string().nullable().optional(),
+});
+
+const clerkDomainDataSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  enrollment_mode: z.string().optional(),
+  enrollmentMode: z.string().optional(),
+  created_at: z.number().optional(),
+  createdAt: z.number().optional(),
+  verification: z
+    .object({
+      status: z.string(),
+      strategy: z.string(),
+    })
+    .optional(),
+});
+
+interface OrgIdentity {
+  readonly slug: string;
+  readonly name: string;
+  readonly createdBy: string | null;
+}
+
+function isClerkNotFound(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  return (
+    Reflect.get(error, "statusCode") === 404 ||
+    Reflect.get(error, "code") === "NOT_FOUND" ||
+    Reflect.get(error, "name") === "NotFoundError"
+  );
+}
+
+interface ZeroOrgDetailArgs {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+export const zeroOrgDetail$ = command(
+  async (
+    { get, set },
+    args: ZeroOrgDetailArgs,
+    signal: AbortSignal,
+  ): Promise<OrgResponse | null> => {
     const db = get(db$);
 
     const [cached, meta, membership] = await Promise.all([
@@ -32,93 +78,141 @@ export function zeroOrgDetail(
           createdBy: orgCache.createdBy,
         })
         .from(orgCache)
-        .where(eq(orgCache.orgId, orgId))
+        .where(eq(orgCache.orgId, args.orgId))
         .limit(1),
       db
         .select({ tier: orgMetadata.tier })
         .from(orgMetadata)
-        .where(eq(orgMetadata.orgId, orgId))
+        .where(eq(orgMetadata.orgId, args.orgId))
         .limit(1),
       db
         .select({ role: orgMembersCache.role })
         .from(orgMembersCache)
         .where(
           and(
-            eq(orgMembersCache.orgId, orgId),
-            eq(orgMembersCache.userId, userId),
+            eq(orgMembersCache.orgId, args.orgId),
+            eq(orgMembersCache.userId, args.userId),
           ),
         )
         .limit(1),
     ]);
+    signal.throwIfAborted();
 
-    if (!cached[0]) {
-      return null;
+    let identity: OrgIdentity | undefined = cached[0];
+    if (!identity) {
+      const client = get(clerk$);
+      const clerkOrg = await client.organizations
+        .getOrganization({
+          organizationId: args.orgId,
+        })
+        .catch((error: unknown) => {
+          if (isClerkNotFound(error)) {
+            return null;
+          }
+          throw error;
+        });
+      signal.throwIfAborted();
+
+      if (!clerkOrg) {
+        return null;
+      }
+
+      const parsed = clerkOrgIdentitySchema.parse(clerkOrg);
+      if (!parsed.slug) {
+        throw new Error(`Clerk organization ${args.orgId} has no slug`);
+      }
+
+      identity = {
+        slug: parsed.slug,
+        name: parsed.name ?? "",
+        createdBy: parsed.createdBy ?? null,
+      };
+
+      const now = nowDate();
+      const writeDb = set(writeDb$);
+      await writeDb
+        .insert(orgCache)
+        .values({
+          orgId: args.orgId,
+          slug: identity.slug,
+          name: identity.name,
+          createdBy: identity.createdBy,
+          cachedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: orgCache.orgId,
+          set: {
+            slug: identity.slug,
+            name: identity.name,
+            createdBy: identity.createdBy,
+            cachedAt: now,
+          },
+        });
+      signal.throwIfAborted();
     }
 
     return {
-      id: orgId,
-      slug: cached[0].slug,
-      name: cached[0].name,
+      id: args.orgId,
+      slug: identity.slug,
+      name: identity.name,
       tier: meta[0]?.tier ?? "free",
       role: (membership[0]?.role as OrgRole) ?? "member",
-      createdBy: cached[0].createdBy ?? undefined,
+      createdBy: identity.createdBy ?? undefined,
     };
-  });
-}
+  },
+);
 
 export function zeroOrgList(
   userId: string,
 ): Computed<Promise<OrgListResponse>> {
   return computed(async (get): Promise<OrgListResponse> => {
-    const db = get(db$);
-
-    const memberships = await db
-      .select({
-        orgId: orgMembersCache.orgId,
-        role: orgMembersCache.role,
-      })
-      .from(orgMembersCache)
-      .where(eq(orgMembersCache.userId, userId));
-
-    if (memberships.length === 0) {
-      return { orgs: [] };
-    }
-
-    const orgIds = memberships.map((m) => {
-      return m.orgId;
+    const client = get(clerk$);
+    const memberships = await client.users.getOrganizationMembershipList({
+      userId,
     });
-
-    const caches = await db
-      .select({ orgId: orgCache.orgId, slug: orgCache.slug })
-      .from(orgCache)
-      .where(inArray(orgCache.orgId, orgIds));
-
-    const slugMap = new Map<string, string>();
-    for (const c of caches) {
-      slugMap.set(c.orgId, c.slug);
-    }
-
     return {
-      orgs: memberships.map((m) => {
+      orgs: memberships.data.map((membership) => {
         return {
-          slug: slugMap.get(m.orgId) ?? m.orgId,
-          role: m.role,
+          slug: membership.organization.slug,
+          role: mapClerkOrgRole(membership.role),
         };
       }),
+      active: undefined,
     };
   });
 }
 
 export function zeroOrgDomainsList(
-  _orgId: string,
+  orgId: string,
 ): Computed<Promise<OrgDomainsResponse>> {
-  return computed(async (): Promise<OrgDomainsResponse> => {
-    // Domains are sourced from Clerk. The API app does not have an
-    // org_domains table — return an empty list so the contract is satisfied.
-    // Callers that need real domain data should go through the web-side Clerk
-    // integration or the Clerk REST API.
-    await Promise.resolve();
-    return { domains: [] };
+  return computed(async (get): Promise<OrgDomainsResponse> => {
+    const client = get(clerk$);
+    const domains = await client.organizations.getOrganizationDomainList({
+      organizationId: orgId,
+    });
+
+    return {
+      domains: domains.data.map((domain) => {
+        const parsed = clerkDomainDataSchema.parse(domain);
+        const enrollmentMode =
+          parsed.enrollment_mode ?? parsed.enrollmentMode ?? "";
+        const createdAtMs = parsed.created_at ?? parsed.createdAt;
+        return {
+          id: parsed.id,
+          name: parsed.name,
+          enrollmentMode,
+          verification: parsed.verification
+            ? {
+                status: parsed.verification.status,
+                strategy: parsed.verification.strategy,
+              }
+            : { status: "unverified", strategy: "email_code" },
+          createdAt: createdAtMs
+            ? new Date(createdAtMs).toISOString()
+            : new Date(0).toISOString(),
+        };
+      }),
+    };
   });
 }
 

--- a/turbo/apps/web/app/api/zero/org/domains/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/domains/__tests__/route.test.ts
@@ -59,6 +59,15 @@ describe("GET /api/zero/org/domains", () => {
 
     expect(response.status).toBe(401);
   });
+
+  it("should return 401 when no org in session", async () => {
+    const userId = uniqueId("dom-no-org");
+    mockClerk({ userId, orgId: null, clerkOrgs: [] });
+
+    const response = await GET(createTestRequest(domainsUrl()));
+
+    expect(response.status).toBe(401);
+  });
 });
 
 describe("POST /api/zero/org/domains", () => {

--- a/turbo/apps/web/app/api/zero/org/domains/route.ts
+++ b/turbo/apps/web/app/api/zero/org/domains/route.ts
@@ -15,12 +15,17 @@ import {
 } from "../../../../../src/lib/zero/org/org-member-service";
 import { isForbidden } from "@vm0/api-services/errors";
 
+function unauthenticatedResponse() {
+  return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+}
+
 const router = tsr.router(zeroOrgDomainsContract, {
   list: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
 
     try {
       const { org, member } = await resolveOrg(authCtx);

--- a/turbo/apps/web/app/api/zero/org/members/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/members/__tests__/route.test.ts
@@ -93,7 +93,7 @@ describe("GET /api/zero/org/members", () => {
     expect(response.status).toBe(401);
   });
 
-  it("should return 400 when no org in session", async () => {
+  it("should return 401 when no org in session", async () => {
     const userId = uniqueId("mem-nf");
     mockClerk({
       userId,
@@ -103,7 +103,7 @@ describe("GET /api/zero/org/members", () => {
 
     const response = await GET(createTestRequest(membersUrl()));
 
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(401);
   });
 
   it("should not expose pendingInvitations or membershipRequests to non-admin members", async () => {

--- a/turbo/apps/web/app/api/zero/org/members/credit-cap/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/members/credit-cap/__tests__/route.test.ts
@@ -65,6 +65,13 @@ describe("/api/zero/org/members/credit-cap", () => {
       expect(response.status).toBe(401);
     });
 
+    it("returns 401 when the authenticated session has no organization", async () => {
+      mockClerk({ userId: user.userId, orgId: null, clerkOrgs: [] });
+      const request = createTestRequest(`${BASE_URL}?userId=${user.userId}`);
+      const response = await GET(request);
+      expect(response.status).toBe(401);
+    });
+
     it("returns default cap state (null cap, enabled)", async () => {
       const request = createTestRequest(`${BASE_URL}?userId=${user.userId}`);
       const response = await GET(request);

--- a/turbo/apps/web/app/api/zero/org/members/credit-cap/route.ts
+++ b/turbo/apps/web/app/api/zero/org/members/credit-cap/route.ts
@@ -16,6 +16,13 @@ const updateBodySchema = z.object({
   creditCap: z.number().int().positive().nullable(),
 });
 
+function unauthenticatedJsonResponse() {
+  return NextResponse.json(
+    { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+    { status: 401 },
+  );
+}
+
 /**
  * GET /api/zero/org/members/credit-cap?userId={userId}
  *
@@ -30,6 +37,9 @@ export async function GET(request: Request) {
   );
   if (isAuthError(authResult)) {
     return NextResponse.json(authResult.body, { status: authResult.status });
+  }
+  if (!authResult.orgId) {
+    return unauthenticatedJsonResponse();
   }
 
   const url = new URL(request.url);

--- a/turbo/apps/web/app/api/zero/org/members/route.ts
+++ b/turbo/apps/web/app/api/zero/org/members/route.ts
@@ -18,12 +18,17 @@ import {
   isNotFound,
 } from "@vm0/api-services/errors";
 
+function unauthenticatedResponse() {
+  return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+}
+
 const router = tsr.router(zeroOrgMembersContract, {
   members: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
+    if (!authCtx.orgId) return unauthenticatedResponse();
 
     try {
       const { org } = await resolveOrg(authCtx);


### PR DESCRIPTION
## Summary

- align API zero org read routes with web by reading Clerk for org list, org cache-miss identity, and org domains
- add web missing-active-org `401` guards for zero org domains, members, and member credit-cap GET routes
- add route-level integration coverage for the API/web parity scenarios from #12633

Fixes #12633.
Refs #12610.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-org.test.ts src/signals/routes/__tests__/zero-org-list.test.ts src/signals/routes/__tests__/zero-org-domains.test.ts src/signals/routes/__tests__/zero-org-members.test.ts src/signals/routes/__tests__/zero-member-credit-cap.test.ts`
- `pnpm -F web exec vitest run app/api/zero/org/__tests__/route.test.ts app/api/zero/org/list/__tests__/route.test.ts app/api/zero/org/domains/__tests__/route.test.ts app/api/zero/org/members/__tests__/route.test.ts app/api/zero/org/members/credit-cap/__tests__/route.test.ts`
- `pnpm -F api run lint`
- `pnpm -F web run lint`
- `pnpm -F api exec prettier --check src/signals/routes/zero-org-read.ts src/signals/services/zero-org-data.service.ts src/signals/routes/__tests__/zero-org.test.ts src/signals/routes/__tests__/zero-org-list.test.ts src/signals/routes/__tests__/zero-org-domains.test.ts src/signals/routes/__tests__/zero-org-members.test.ts`
- `pnpm -F web exec prettier --check app/api/zero/org/domains/route.ts app/api/zero/org/members/route.ts app/api/zero/org/members/credit-cap/route.ts app/api/zero/org/domains/__tests__/route.test.ts app/api/zero/org/members/__tests__/route.test.ts app/api/zero/org/members/credit-cap/__tests__/route.test.ts`
- `git diff --check`

## Typecheck Notes

- `pnpm -F api run check-types` still fails on existing baseline type errors, including missing `@slack/web-api` types and many pre-existing `Property 'body' does not exist on type 'never'` test errors. The filtered check output has no errors in the files changed by this PR.
- `pnpm -F web run check-types` still fails on existing baseline implicit-any errors in unrelated web routes. The filtered check output has no errors in the files changed by this PR.
